### PR TITLE
feat: harden Code Mode and observability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
             rust: "1.88"
           - os: macos-latest
             rust: stable
-          - os: windows-latest
-            rust: stable
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,6 +1545,7 @@ dependencies = [
  "nanocodex",
  "nanocodex-observability",
  "ratatui",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -1611,7 +1612,9 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
+ "reqwest 0.12.28",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
  "tracing-appender",
  "tracing-opentelemetry",
@@ -1674,6 +1677,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -1845,6 +1849,8 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.5",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,9 @@ js-sys = "0.3.82"
 nix = { version = "0.30.1", default-features = false, features = ["process", "signal", "user"] }
 portable-pty = "0.9.0"
 opentelemetry = { version = "0.31.0", features = ["trace"] }
-opentelemetry-otlp = { version = "0.31.0", default-features = false, features = ["http-proto", "reqwest-blocking-client", "reqwest-rustls-webpki-roots", "trace"] }
+opentelemetry-otlp = { version = "0.31.0", default-features = false, features = ["http-proto", "reqwest-blocking-client", "reqwest-client", "reqwest-rustls-webpki-roots", "trace"] }
 opentelemetry-semantic-conventions = "0.31.0"
-opentelemetry_sdk = { version = "0.31.0", features = ["trace"] }
+opentelemetry_sdk = { version = "0.31.0", features = ["experimental_trace_batch_span_processor_with_async_runtime", "rt-tokio", "trace"] }
 pyo3 = "0.29.0"
 proc-macro-crate = "3"
 proc-macro2 = "1.0.106"

--- a/Justfile
+++ b/Justfile
@@ -80,6 +80,56 @@ dev-react-example:
 smoke-mcp:
     cargo run --quiet -p nanocodex-examples --bin mcp
 
+# Start the ephemeral localhost Jaeger backend used by the OTLP trace demo.
+otel-up:
+    @docker compose -f docker-compose.otel.yml up --detach
+    @for attempt in {1..50}; do \
+        if curl --fail --silent http://127.0.0.1:16686/ >/dev/null; then exit 0; fi; \
+        if [ "$attempt" -eq 50 ]; then echo "Jaeger did not become ready within 10 seconds" >&2; exit 1; fi; \
+        sleep 0.2; \
+    done
+    @echo "Jaeger UI: http://127.0.0.1:16686"
+
+# Run a tool-using turn and retain events and diagnostic logs independently.
+otel-demo:
+    @test -n "${OPENAI_API_KEY:-}" || { echo "set OPENAI_API_KEY in .env or the environment" >&2; exit 2; }
+    @curl --fail --silent --show-error http://127.0.0.1:16686/ >/dev/null || { echo "run 'just otel-up' first" >&2; exit 2; }
+    @mkdir -p .nanocodex/otel-demo
+    @rm -f .nanocodex/otel-demo/events.jsonl .nanocodex/otel-demo/tracing.jsonl
+    @cargo run --quiet --manifest-path bin/nanocodex/Cargo.toml -- \
+        --otel-endpoint http://127.0.0.1:4318 \
+        --otel-environment local-demo \
+        --log-format json \
+        --log-file .nanocodex/otel-demo/tracing.jsonl \
+        run --thinking=low "Use the available exec tool to run pwd exactly once without modifying anything, then report the path." \
+        > .nanocodex/otel-demo/events.jsonl
+    @jq --compact-output 'select(.type == "assistant.message" or .type == "tool.started" or .type == "tool.result" or .type == "run.completed") | {type, payload}' .nanocodex/otel-demo/events.jsonl
+    @echo "Open http://127.0.0.1:16686 and select service 'nanocodex'."
+
+# Run the deterministic retained-session and hostile-tool observability stress.
+otel-stress turns="32" parallel_calls="16":
+    @curl --fail --silent --show-error http://127.0.0.1:16686/ >/dev/null || { echo "run 'just otel-up' first" >&2; exit 2; }
+    NANOCODEX_STRESS_TURNS="{{turns}}" \
+        NANOCODEX_STRESS_PARALLEL_CALLS="{{parallel_calls}}" \
+        cargo test --locked --manifest-path bin/nanocodex/Cargo.toml \
+        --test observability_stress -- \
+        --ignored --exact retained_turns_and_hostile_tools_preserve_trace_topology \
+        --nocapture --test-threads=1
+
+# Run the identical workload without installing the OTLP layer for comparison.
+otel-stress-baseline turns="32" parallel_calls="16":
+    NANOCODEX_STRESS_EXPORT=false \
+        NANOCODEX_STRESS_TURNS="{{turns}}" \
+        NANOCODEX_STRESS_PARALLEL_CALLS="{{parallel_calls}}" \
+        cargo test --locked --manifest-path bin/nanocodex/Cargo.toml \
+        --test observability_stress -- \
+        --ignored --exact retained_turns_and_hostile_tools_preserve_trace_topology \
+        --nocapture --test-threads=1
+
+# Stop Jaeger and discard its in-memory trace data.
+otel-down:
+    @docker compose -f docker-compose.otel.yml down
+
 # Tight inner loop: native model process with local code mode, no Harbor or Docker.
 run:
     @cargo run --quiet --manifest-path bin/nanocodex/Cargo.toml -- run --thinking=low "Use the available exec tool to run pwd exactly once without modifying anything, then report the path."

--- a/PLAN.md
+++ b/PLAN.md
@@ -133,8 +133,10 @@ Outcomes:
 
 1. Define stable tracing spans for agent session, turn, model call, Responses
    attempt, reconnect/backoff, and tool execution. Include IDs, durations,
-   replay mode, error class, token usage, and cache usage; never include secrets
-   or full prompt bodies.
+   replay mode, error class, token/cache usage, structural prompt/tool metadata,
+   process outcomes, and API-visible reasoning summaries. Never attach full
+   prompts, Code Mode source, tool argument values, hidden reasoning, or
+   authentication credentials.
 2. Keep subscriber choice outside the library. The CLI may install a sensible
    stderr subscriber, while embedders can install OpenTelemetry, metrics, or
    their own tracing stack.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Lifecycle tracing is written to stderr for headless runs and to
 `.nanocodex/logs/tui.log` for the TUI. `--log-format json` selects structured
 local logs, `RUST_LOG` or `--log-filter` controls filtering, and
 `--otel-endpoint http://localhost:4318` exports spans over OTLP/HTTP.
+`OTEL_LEVEL` or `--otel-filter` controls export independently from local logs.
+Run `just otel-up` followed by `just otel-demo` for a local Jaeger waterfall;
+use `just otel-stress` for the deterministic hostile-tool pressure gate. The
+complete walkthrough is in [`docs/OBSERVABILITY.md`](docs/OBSERVABILITY.md).
 
 ## Use it as a library
 
@@ -252,6 +256,7 @@ use nanocodex_observability::{LogFormat, ObservabilityBuilder};
 # fn install() -> Result<(), Box<dyn std::error::Error>> {
 let _guard = ObservabilityBuilder::new("my-agent", env!("CARGO_PKG_VERSION"))
     .filter("warn,nanocodex=info,nanocodex_service=info,nanocodex_mcp=info")
+    .otel_filter("warn,nanocodex=info,nanocodex_service=info,nanocodex_mcp=info")
     .format(LogFormat::Json)
     .otlp_endpoint("http://localhost:4318")
     .install()?;
@@ -261,8 +266,10 @@ let _guard = ObservabilityBuilder::new("my-agent", env!("CARGO_PKG_VERSION"))
 
 Keep the returned guard alive for the application lifetime so non-blocking
 formatting and batched trace export are flushed during shutdown. Spans include
-IDs, attempt/replay state, durations, status, token usage, and cache usage, but
-not API keys or full prompt bodies.
+IDs, attempt/replay state, durations, status, token/cache usage, structural
+prompt/tool metadata, process outcomes, and API-visible reasoning summaries.
+Full prompts, Code Mode source, tool argument values, hidden reasoning, and API
+keys are never attached.
 
 ### Embed from Python, Node.js, or a browser Worker
 

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "proce
 unicode-width.workspace = true
 
 [dev-dependencies]
+reqwest.workspace = true
 tokio-tungstenite.workspace = true
 
 [[bin]]

--- a/bin/nanocodex/src/observability.rs
+++ b/bin/nanocodex/src/observability.rs
@@ -19,6 +19,16 @@ pub(crate) struct ObservabilityArgs {
     )]
     log_filter: String,
 
+    /// Tracing filter applied only to exported OpenTelemetry spans.
+    #[arg(
+        long,
+        global = true,
+        env = "OTEL_LEVEL",
+        default_value = DEFAULT_FILTER,
+        value_parser = NonEmptyStringValueParser::new()
+    )]
+    otel_filter: String,
+
     /// Local tracing output format.
     #[arg(
         long,
@@ -75,6 +85,7 @@ impl ObservabilityArgs {
         );
         let mut builder = ObservabilityBuilder::new("nanocodex", env!("CARGO_PKG_VERSION"))
             .filter(self.log_filter)
+            .otel_filter(self.otel_filter)
             .format(self.log_format.into())
             .output(output)
             .environment(self.otel_environment);

--- a/bin/nanocodex/tests/observability_stress.rs
+++ b/bin/nanocodex/tests/observability_stress.rs
@@ -1,0 +1,487 @@
+use std::{collections::HashSet, path::PathBuf, time::Duration};
+
+use eyre::{Context, Result, bail, eyre};
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{Value, json};
+use tokio::{net::TcpListener, process::Command, time::timeout};
+use tokio_tungstenite::{WebSocketStream, accept_async, tungstenite::Message};
+
+const DEFAULT_TURNS: usize = 32;
+const DEFAULT_PARALLEL_CALLS: usize = 16;
+const PROMPT_SENTINEL: &str = "NANOCODEX_OBSERVABILITY_STRESS_PROMPT_DO_NOT_EXPORT";
+const API_KEY_SENTINEL: &str = "stress-secret-api-key-do-not-export";
+const REASONING_SENTINEL: &str = "NANOCODEX_VISIBLE_REASONING_SUMMARY";
+const REASONING_CONTENT_SENTINEL: &str = "NANOCODEX_HIDDEN_REASONING_CONTENT_DO_NOT_EXPORT";
+
+#[tokio::test]
+#[ignore = "manual high-volume observability stress; run `just otel-stress`"]
+async fn retained_turns_and_hostile_tools_preserve_trace_topology() -> Result<()> {
+    let turns = bounded_env("NANOCODEX_STRESS_TURNS", DEFAULT_TURNS, 1, 100)?;
+    let parallel_calls = bounded_env(
+        "NANOCODEX_STRESS_PARALLEL_CALLS",
+        DEFAULT_PARALLEL_CALLS,
+        1,
+        128,
+    )?;
+    let jaeger_url = std::env::var("NANOCODEX_STRESS_JAEGER_URL")
+        .unwrap_or_else(|_| "http://127.0.0.1:16686".to_owned());
+    let otlp_endpoint = std::env::var("NANOCODEX_STRESS_OTLP_ENDPOINT")
+        .unwrap_or_else(|_| "http://127.0.0.1:4318".to_owned());
+    let export_traces =
+        std::env::var("NANOCODEX_STRESS_EXPORT").map_or(true, |value| value != "false");
+    if export_traces {
+        require_jaeger(&jaeger_url).await?;
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let websocket_url = format!("ws://{}", listener.local_addr()?);
+    let server = tokio::spawn(serve_responses(listener, turns, parallel_calls));
+    let workspace = temporary_workspace()?;
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../crates/nanocodex-mcp/tests/fixtures/stdio-server.mjs");
+    let process_timeout = Duration::from_secs(
+        u64::try_from(turns)
+            .unwrap_or(u64::MAX)
+            .saturating_mul(3)
+            .clamp(60, 600),
+    );
+    let started = std::time::Instant::now();
+    let mut command = stress_command(
+        &websocket_url,
+        &workspace,
+        &fixture,
+        turns,
+        export_traces.then_some(otlp_endpoint.as_str()),
+    );
+    let output = timeout(process_timeout, command.output())
+        .await
+        .map_err(|_| eyre!("stress CLI exceeded {process_timeout:?}"))??;
+
+    timeout(Duration::from_secs(10), server)
+        .await
+        .map_err(|_| eyre!("mock Responses server did not finish"))???;
+    let workload_elapsed = started.elapsed();
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    if !output.status.success() {
+        bail!("stress CLI failed:\n{stderr}\n{stdout}");
+    }
+    let events = stdout
+        .lines()
+        .map(serde_json::from_str::<Value>)
+        .collect::<Result<Vec<_>, _>>()?;
+    let session_id = events
+        .first()
+        .and_then(|event| event["request_id"].as_str())
+        .ok_or_else(|| eyre!("first event had no request_id"))?;
+    assert_eq!(event_count(&events, "run.completed", None), turns);
+    assert_eq!(event_count(&events, "tool.result", Some("exec")), turns);
+    assert_eq!(
+        event_count(&events, "tool.result", Some("tool_search")),
+        turns
+    );
+    assert_eq!(
+        event_count(&events, "tool.result", Some("mcp__fixture__echo")),
+        turns * (parallel_calls + 1)
+    );
+    assert_eq!(
+        event_count(&events, "tool.result", Some("apply_patch")),
+        turns
+    );
+    assert!(
+        event_count(&events, "tool.result", Some("exec_command")) >= turns * 3,
+        "expected at least three shell calls per turn"
+    );
+    assert_eq!(
+        event_count(&events, "tool.result", Some("write_stdin")),
+        turns,
+        "every yielded shell command must be resumed through write_stdin"
+    );
+
+    if export_traces {
+        let traces = wait_for_traces(&jaeger_url, session_id, turns).await?;
+        validate_traces(&traces, turns, parallel_calls)?;
+        let encoded_traces = serde_json::to_string(&traces)?;
+        assert!(!encoded_traces.contains(PROMPT_SENTINEL));
+        assert!(encoded_traces.contains(REASONING_SENTINEL));
+        assert!(!encoded_traces.contains(REASONING_CONTENT_SENTINEL));
+        assert!(!encoded_traces.contains("turn-0-call-"));
+        assert!(encoded_traces.contains("assistant.output.bytes"));
+        assert!(encoded_traces.contains("model.input.bytes"));
+        assert!(encoded_traces.contains("model.output.bytes"));
+        assert!(encoded_traces.contains("tool.arguments.bytes"));
+        assert!(!encoded_traces.contains(API_KEY_SENTINEL));
+    }
+    std::fs::remove_dir_all(workspace)?;
+    eprintln!(
+        "observability stress passed: turns={turns} parallel_mcp_calls={parallel_calls} events={} exported_traces={} workload_elapsed={workload_elapsed:?} validation_elapsed={:?}",
+        events.len(),
+        if export_traces { turns } else { 0 },
+        started.elapsed().saturating_sub(workload_elapsed)
+    );
+    Ok(())
+}
+
+fn stress_command(
+    websocket_url: &str,
+    workspace: &std::path::Path,
+    fixture: &std::path::Path,
+    turns: usize,
+    otlp_endpoint: Option<&str>,
+) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_nanocodex"));
+    command
+        .arg("--api-key")
+        .arg(API_KEY_SENTINEL)
+        .arg("--websocket-url")
+        .arg(websocket_url)
+        .arg("--cwd")
+        .arg(workspace)
+        .arg("--mcp-stdio")
+        .arg("fixture=node")
+        .arg("--mcp-arg")
+        .arg(format!("fixture={}", fixture.display()))
+        .arg("--log-filter")
+        .arg("warn");
+    if let Some(endpoint) = otlp_endpoint {
+        command
+            .arg("--otel-filter")
+            .arg(
+                "warn,nanocodex=info,nanocodex_service=info,nanocodex_tools=info,nanocodex_mcp=info",
+            )
+            .arg("--otel-endpoint")
+            .arg(endpoint)
+            .arg("--otel-environment")
+            .arg("stress");
+    }
+    command
+        .arg("run")
+        .arg("--repeat")
+        .arg(turns.to_string())
+        .arg(PROMPT_SENTINEL);
+    command
+}
+
+async fn serve_responses(listener: TcpListener, turns: usize, parallel_calls: usize) -> Result<()> {
+    let (stream, _) = listener.accept().await?;
+    let mut socket = accept_async(stream).await?;
+    let warmup = next_json(&mut socket).await?;
+    assert!(warmup["input"].is_array());
+    send_completed(&mut socket, "response-warmup", &[]).await?;
+
+    let mut previous_response = "response-warmup".to_owned();
+    for turn in 0..turns {
+        let generation = next_json(&mut socket).await?;
+        assert_eq!(generation["previous_response_id"], previous_response);
+        let tool_response = format!("response-tool-{turn}");
+        send_completed(
+            &mut socket,
+            &tool_response,
+            &[json!({
+                "type": "custom_tool_call",
+                "call_id": format!("call-exec-{turn}"),
+                "name": "exec",
+                "input": stress_source(turn, parallel_calls)
+            })],
+        )
+        .await?;
+
+        let continuation = next_json(&mut socket).await?;
+        assert_eq!(continuation["previous_response_id"], tool_response);
+        assert_eq!(continuation["input"][0]["type"], "custom_tool_call_output");
+        previous_response = format!("response-final-{turn}");
+        send_completed(
+            &mut socket,
+            &previous_response,
+            &[
+                json!({
+                    "type": "reasoning",
+                    "summary": [{
+                        "type": "summary_text",
+                        "text": format!("{REASONING_SENTINEL} turn {turn}")
+                    }],
+                    "content": [{
+                        "type": "reasoning_text",
+                        "text": format!("{REASONING_CONTENT_SENTINEL} turn {turn}")
+                    }]
+                }),
+                json!({
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": format!("stress turn {turn} complete") }]
+                }),
+            ],
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+fn stress_source(turn: usize, parallel_calls: usize) -> String {
+    format!(
+        r#"
+const found = await tools.tool_search({{ query: "echo message", limit: 8 }});
+const remote = found.tools[0].name;
+const successful = await Promise.all(Array.from({{ length: {parallel_calls} }}, (_, index) =>
+  tools[remote]({{ message: "turn-{turn}-call-" + index }})
+));
+const failures = await Promise.allSettled([
+  tools[remote]({{ message: "__fail__" }}),
+  tools.apply_patch("definitely not a patch"),
+  tools.exec_command({{ cmd: "exit 23", login: false }}),
+  tools.exec_command({{ cmd: "yes x | head -c 65536", login: false, max_output_tokens: 256 }})
+]);
+const yielded = await tools.exec_command({{
+  cmd: "printf start; sleep 1; printf end",
+  login: false,
+  yield_time_ms: 250
+}});
+if (!yielded.session_id) {{
+  throw new Error("exec_command completed before exercising write_stdin");
+}}
+const resumed = await tools.write_stdin({{
+  session_id: yielded.session_id,
+  yield_time_ms: 1000
+}});
+if (resumed.exit_code !== 0) {{
+  throw new Error("write_stdin did not observe a clean process exit");
+}}
+let unknownRejected = false;
+try {{
+  await tools.__nanocodex_missing_tool__({{}});
+}} catch (_) {{
+  unknownRejected = true;
+}}
+text(JSON.stringify({{
+  successful: successful.length,
+  rejected: failures.filter((result) => result.status === "rejected").length,
+  resumed: resumed.exit_code ?? null,
+  unknownRejected
+}}));
+"#
+    )
+}
+
+async fn require_jaeger(base_url: &str) -> Result<()> {
+    reqwest::Client::new()
+        .get(base_url)
+        .send()
+        .await
+        .wrap_err_with(|| format!("Jaeger is unavailable at {base_url}; run `just otel-up`"))?
+        .error_for_status()
+        .wrap_err("Jaeger UI health check failed")?;
+    Ok(())
+}
+
+async fn wait_for_traces(base_url: &str, session_id: &str, turns: usize) -> Result<Vec<Value>> {
+    let client = reqwest::Client::new();
+    let endpoint = format!("{}/api/traces", base_url.trim_end_matches('/'));
+    let tags = json!({ "session.id": session_id }).to_string();
+    for _ in 0..100 {
+        let response = client
+            .get(&endpoint)
+            .query(&[
+                ("service", "nanocodex".to_owned()),
+                ("limit", (turns + 8).to_string()),
+                ("tags", tags.clone()),
+            ])
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<Value>()
+            .await?;
+        let traces = response["data"].as_array().cloned().unwrap_or_default();
+        if traces.len() == turns {
+            return Ok(traces);
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    bail!("Jaeger did not retain all {turns} traces for session {session_id}")
+}
+
+fn validate_traces(traces: &[Value], turns: usize, parallel_calls: usize) -> Result<()> {
+    assert_eq!(traces.len(), turns);
+    let mut trace_ids = HashSet::with_capacity(turns);
+    let mut operations = Vec::new();
+    let mut error_spans = 0_usize;
+    let mut yielded_exec_spans = 0_usize;
+    let mut write_stdin_spans = 0_usize;
+    for trace in traces {
+        let trace_id = trace["traceID"]
+            .as_str()
+            .ok_or_else(|| eyre!("trace had no traceID"))?;
+        assert!(trace_ids.insert(trace_id.to_owned()));
+        let spans = trace["spans"]
+            .as_array()
+            .ok_or_else(|| eyre!("trace {trace_id} had no spans"))?;
+        let span_ids = spans
+            .iter()
+            .filter_map(|span| span["spanID"].as_str())
+            .collect::<HashSet<_>>();
+        let roots = spans
+            .iter()
+            .filter(|span| span["references"].as_array().is_none_or(Vec::is_empty))
+            .collect::<Vec<_>>();
+        assert_eq!(roots.len(), 1, "trace {trace_id} did not have one root");
+        assert_eq!(roots[0]["operationName"], "agent.turn");
+        for span in spans {
+            let operation = span["operationName"]
+                .as_str()
+                .ok_or_else(|| eyre!("span had no operationName"))?;
+            assert_ne!(operation, "agent.session");
+            operations.push(operation.to_owned());
+            if operation == "code_mode.cell_actor" {
+                assert!(has_tag_key(span, "runtime.first_event_ns"));
+                assert!(has_tag_key(span, "runtime.event_count"));
+                assert!(has_tag_key(span, "host.reused"));
+                assert!(has_tag_key(span, "host.wait_ns"));
+            }
+            if operation == "tool.execute" && has_tag(span, "tool.name", "exec_command") {
+                if has_tag_key(span, "shell.session.id") {
+                    yielded_exec_spans += 1;
+                    assert!(has_tag_key(span, "process.running"));
+                    assert!(has_tag_key(span, "tool.output.bytes"));
+                }
+            }
+            if operation == "tool.execute" && has_tag(span, "tool.name", "write_stdin") {
+                write_stdin_spans += 1;
+                assert!(has_tag_key(span, "process.exit.code"));
+                assert!(has_tag_key(span, "process.running"));
+                assert!(has_tag_key(span, "tool.output.bytes"));
+            }
+            for reference in span["references"].as_array().into_iter().flatten() {
+                assert_eq!(reference["traceID"], trace_id);
+                assert!(
+                    reference["spanID"]
+                        .as_str()
+                        .is_some_and(|parent| span_ids.contains(parent)),
+                    "span {operation} in trace {trace_id} had a missing parent"
+                );
+            }
+            if has_tag(span, "otel.status_code", "ERROR") {
+                error_spans += 1;
+            }
+        }
+    }
+    assert_eq!(operation_count(&operations, "agent.turn"), turns);
+    assert_eq!(operation_count(&operations, "tool.call"), turns);
+    assert_eq!(operation_count(&operations, "code_mode.cell"), turns);
+    assert_eq!(operation_count(&operations, "code_mode.host_spawn"), 1);
+    assert_eq!(operation_count(&operations, "code_mode.cell_actor"), turns);
+    assert_eq!(yielded_exec_spans, turns);
+    assert_eq!(write_stdin_spans, turns);
+    assert_eq!(
+        operation_count(&operations, "mcp.tool_call"),
+        turns * (parallel_calls + 1)
+    );
+    assert!(
+        operation_count(&operations, "tool.execute") >= turns * (parallel_calls + 5),
+        "too few nested tool spans: {}",
+        operation_count(&operations, "tool.execute")
+    );
+    assert!(
+        error_spans >= turns * 4,
+        "expected at least four error spans per turn, saw {error_spans}"
+    );
+    Ok(())
+}
+
+fn has_tag(span: &Value, key: &str, value: &str) -> bool {
+    span["tags"].as_array().is_some_and(|tags| {
+        tags.iter()
+            .any(|tag| tag["key"] == key && tag["value"] == value)
+    })
+}
+
+fn has_tag_key(span: &Value, key: &str) -> bool {
+    span["tags"]
+        .as_array()
+        .is_some_and(|tags| tags.iter().any(|tag| tag["key"] == key))
+}
+
+fn operation_count(operations: &[String], operation: &str) -> usize {
+    operations
+        .iter()
+        .filter(|name| name.as_str() == operation)
+        .count()
+}
+
+fn event_count(events: &[Value], event_type: &str, tool: Option<&str>) -> usize {
+    events
+        .iter()
+        .filter(|event| {
+            event["type"] == event_type && tool.is_none_or(|tool| event["payload"]["tool"] == tool)
+        })
+        .count()
+}
+
+fn bounded_env(name: &str, default: usize, minimum: usize, maximum: usize) -> Result<usize> {
+    let value = std::env::var(name).map_or(Ok(default), |value| {
+        value
+            .parse::<usize>()
+            .wrap_err_with(|| format!("{name} must be an integer"))
+    })?;
+    if !(minimum..=maximum).contains(&value) {
+        bail!("{name} must be in {minimum}..={maximum}");
+    }
+    Ok(value)
+}
+
+async fn next_json<S>(socket: &mut WebSocketStream<S>) -> Result<Value>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    loop {
+        let message = socket
+            .next()
+            .await
+            .ok_or_else(|| eyre!("client closed before sending a request"))??;
+        if let Message::Text(text) = message {
+            return Ok(serde_json::from_str(text.as_str())?);
+        }
+    }
+}
+
+async fn send_completed<S>(
+    socket: &mut WebSocketStream<S>,
+    response_id: &str,
+    output: &[Value],
+) -> Result<()>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    socket
+        .send(Message::Text(
+            json!({
+                "type": "response.completed",
+                "response": {
+                    "id": response_id,
+                    "status": "completed",
+                    "output": output,
+                    "usage": {
+                        "input_tokens": 10,
+                        "input_tokens_details": { "cached_tokens": 5 },
+                        "output_tokens": 2,
+                        "output_tokens_details": { "reasoning_tokens": 1 },
+                        "total_tokens": 12
+                    }
+                }
+            })
+            .to_string()
+            .into(),
+        ))
+        .await?;
+    Ok(())
+}
+
+fn temporary_workspace() -> Result<PathBuf> {
+    let path = std::env::temp_dir().join(format!(
+        "nanocodex-observability-stress-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&path)?;
+    Ok(path)
+}

--- a/bin/nanocodex/tests/observability_stress.rs
+++ b/bin/nanocodex/tests/observability_stress.rs
@@ -101,16 +101,7 @@ async fn retained_turns_and_hostile_tools_preserve_trace_topology() -> Result<()
     if export_traces {
         let traces = wait_for_traces(&jaeger_url, session_id, turns).await?;
         validate_traces(&traces, turns, parallel_calls)?;
-        let encoded_traces = serde_json::to_string(&traces)?;
-        assert!(!encoded_traces.contains(PROMPT_SENTINEL));
-        assert!(encoded_traces.contains(REASONING_SENTINEL));
-        assert!(!encoded_traces.contains(REASONING_CONTENT_SENTINEL));
-        assert!(!encoded_traces.contains("turn-0-call-"));
-        assert!(encoded_traces.contains("assistant.output.bytes"));
-        assert!(encoded_traces.contains("model.input.bytes"));
-        assert!(encoded_traces.contains("model.output.bytes"));
-        assert!(encoded_traces.contains("tool.arguments.bytes"));
-        assert!(!encoded_traces.contains(API_KEY_SENTINEL));
+        validate_trace_content(&traces)?;
     }
     std::fs::remove_dir_all(workspace)?;
     eprintln!(
@@ -336,12 +327,13 @@ fn validate_traces(traces: &[Value], turns: usize, parallel_calls: usize) -> Res
                 assert!(has_tag_key(span, "host.reused"));
                 assert!(has_tag_key(span, "host.wait_ns"));
             }
-            if operation == "tool.execute" && has_tag(span, "tool.name", "exec_command") {
-                if has_tag_key(span, "shell.session.id") {
-                    yielded_exec_spans += 1;
-                    assert!(has_tag_key(span, "process.running"));
-                    assert!(has_tag_key(span, "tool.output.bytes"));
-                }
+            if operation == "tool.execute"
+                && has_tag(span, "tool.name", "exec_command")
+                && has_tag_key(span, "shell.session.id")
+            {
+                yielded_exec_spans += 1;
+                assert!(has_tag_key(span, "process.running"));
+                assert!(has_tag_key(span, "tool.output.bytes"));
             }
             if operation == "tool.execute" && has_tag(span, "tool.name", "write_stdin") {
                 write_stdin_spans += 1;
@@ -383,6 +375,20 @@ fn validate_traces(traces: &[Value], turns: usize, parallel_calls: usize) -> Res
         error_spans >= turns * 4,
         "expected at least four error spans per turn, saw {error_spans}"
     );
+    Ok(())
+}
+
+fn validate_trace_content(traces: &[Value]) -> Result<()> {
+    let encoded = serde_json::to_string(traces)?;
+    assert!(!encoded.contains(PROMPT_SENTINEL));
+    assert!(encoded.contains(REASONING_SENTINEL));
+    assert!(!encoded.contains(REASONING_CONTENT_SENTINEL));
+    assert!(!encoded.contains("turn-0-call-"));
+    assert!(encoded.contains("assistant.output.bytes"));
+    assert!(encoded.contains("model.input.bytes"));
+    assert!(encoded.contains("model.output.bytes"));
+    assert!(encoded.contains("tool.arguments.bytes"));
+    assert!(!encoded.contains(API_KEY_SENTINEL));
     Ok(())
 }
 

--- a/crates/nanocodex-mcp/src/lib.rs
+++ b/crates/nanocodex-mcp/src/lib.rs
@@ -138,7 +138,10 @@ impl DynamicToolProvider for Mcp {
             let state = Arc::clone(&self.state);
             let span = info_span!(
                 target: "nanocodex_mcp",
+                parent: None,
                 "mcp.server_start",
+                otel.kind = "client",
+                otel.status_code = tracing::field::Empty,
                 mcp.server = %name,
                 status = tracing::field::Empty,
                 tool.count = tracing::field::Empty,
@@ -167,6 +170,10 @@ impl DynamicToolProvider for Mcp {
                         } else {
                             "failed"
                         },
+                    );
+                    current.record(
+                        "otel.status_code",
+                        if result.is_ok() { "OK" } else { "ERROR" },
                     );
                     if let Ok(tools) = &result {
                         current.record("tool.count", tools.len());
@@ -198,13 +205,25 @@ impl DynamicToolProvider for Mcp {
                 "MCP tool {name} requires an object argument"
             )));
         };
+        let argument_bytes = serde_json::to_vec(&arguments).map_or(0, |encoded| encoded.len());
+        let argument_keys = arguments
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .join(",");
+        let argument_count = arguments.len();
         let params =
             CallToolRequestParams::new(entry.remote_name.clone()).with_arguments(arguments);
         let span = info_span!(
             target: "nanocodex_mcp",
             "mcp.tool_call",
+            otel.kind = "client",
+            otel.status_code = tracing::field::Empty,
             mcp.server = %entry.server_name,
             mcp.tool = %entry.remote_name,
+            mcp.arguments.bytes = argument_bytes,
+            mcp.arguments.keys = argument_keys,
+            mcp.arguments.count = argument_count,
             status = tracing::field::Empty,
         );
         let result = match tokio::time::timeout(
@@ -216,6 +235,7 @@ impl DynamicToolProvider for Mcp {
             Ok(Ok(result)) => result,
             Ok(Err(error)) => {
                 span.record("status", "failed");
+                span.record("otel.status_code", "ERROR");
                 return Some(ToolExecution::error(format!(
                     "MCP tool {}/{} failed: {error}",
                     entry.server_name, entry.remote_name
@@ -223,6 +243,7 @@ impl DynamicToolProvider for Mcp {
             }
             Err(_) => {
                 span.record("status", "timeout");
+                span.record("otel.status_code", "ERROR");
                 return Some(ToolExecution::error(format!(
                     "MCP tool {}/{} exceeded {:.1} seconds",
                     entry.server_name,
@@ -233,9 +254,12 @@ impl DynamicToolProvider for Mcp {
         };
         let success = !result.is_error.unwrap_or(false);
         span.record("status", if success { "completed" } else { "failed" });
+        span.record("otel.status_code", if success { "OK" } else { "ERROR" });
         let value = match serde_json::to_value(result) {
             Ok(value) => value,
             Err(error) => {
+                span.record("status", "failed");
+                span.record("otel.status_code", "ERROR");
                 return Some(ToolExecution::error(format!(
                     "failed to encode MCP tool result: {error}"
                 )));

--- a/crates/nanocodex-mcp/tests/fixtures/stdio-server.mjs
+++ b/crates/nanocodex-mcp/tests/fixtures/stdio-server.mjs
@@ -37,13 +37,17 @@ lines.on("line", (line) => {
     });
   } else if (request.method === "tools/call") {
     const message = request.params.arguments?.message;
+    const failed = message === "__fail__";
     send({
       jsonrpc: "2.0",
       id: request.id,
       result: {
-        content: [{ type: "text", text: `fixture:${message}` }],
+        content: [{
+          type: "text",
+          text: failed ? "fixture:synthetic failure" : `fixture:${message}`,
+        }],
         structuredContent: { echoed: message },
-        isError: false,
+        isError: failed,
       },
     });
   }

--- a/crates/nanocodex-observability/Cargo.toml
+++ b/crates/nanocodex-observability/Cargo.toml
@@ -15,7 +15,9 @@ opentelemetry.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry-semantic-conventions.workspace = true
 opentelemetry_sdk.workspace = true
+reqwest.workspace = true
 thiserror.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing.workspace = true
 tracing-appender.workspace = true
 tracing-opentelemetry.workspace = true

--- a/crates/nanocodex-observability/src/lib.rs
+++ b/crates/nanocodex-observability/src/lib.rs
@@ -3,12 +3,21 @@
 use std::{fs::OpenOptions, io, path::PathBuf};
 
 use opentelemetry::trace::TracerProvider as _;
-use opentelemetry_otlp::{Protocol, SpanExporter, WithExportConfig};
-use opentelemetry_sdk::{Resource, trace::SdkTracerProvider};
+use opentelemetry_otlp::{Protocol, SpanExporter, WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::{
+    Resource, runtime,
+    trace::{
+        SdkTracerProvider,
+        span_processor_with_async_runtime::BatchSpanProcessor as TokioBatchSpanProcessor,
+    },
+};
+use opentelemetry_semantic_conventions::{SCHEMA_URL, attribute::SERVICE_VERSION};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{
     EnvFilter, Layer, fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt,
 };
+
+const DEPLOYMENT_ENVIRONMENT_NAME: &str = "deployment.environment.name";
 
 /// Human-readable or structured local tracing output.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -31,6 +40,7 @@ pub enum LogOutput {
 #[derive(Clone, Debug)]
 pub struct ObservabilityBuilder {
     filter: String,
+    otel_filter: String,
     format: LogFormat,
     output: LogOutput,
     service_name: String,
@@ -53,6 +63,8 @@ pub enum ObservabilityError {
     Output(#[from] io::Error),
     #[error("failed to configure OTLP exporter: {0}")]
     Otlp(#[from] opentelemetry_otlp::ExporterBuildError),
+    #[error("failed to flush or shut down the OpenTelemetry exporter: {0}")]
+    OTelSdk(#[from] opentelemetry_sdk::error::OTelSdkError),
     #[error("a global tracing subscriber is already installed")]
     Subscriber,
 }
@@ -60,10 +72,12 @@ pub enum ObservabilityError {
 impl ObservabilityBuilder {
     #[must_use]
     pub fn new(service_name: impl Into<String>, service_version: impl Into<String>) -> Self {
+        let filter =
+            "warn,nanocodex=info,nanocodex_service=info,nanocodex_tools=info,nanocodex_mcp=info"
+                .to_owned();
         Self {
-            filter:
-                "warn,nanocodex=info,nanocodex_service=info,nanocodex_tools=info,nanocodex_mcp=info"
-                    .to_owned(),
+            otel_filter: filter.clone(),
+            filter,
             format: LogFormat::Compact,
             output: LogOutput::Stderr,
             service_name: service_name.into(),
@@ -76,6 +90,13 @@ impl ObservabilityBuilder {
     #[must_use]
     pub fn filter(mut self, filter: impl Into<String>) -> Self {
         self.filter = filter.into();
+        self
+    }
+
+    /// Sets the independent filter applied only to exported OpenTelemetry spans.
+    #[must_use]
+    pub fn otel_filter(mut self, filter: impl Into<String>) -> Self {
+        self.otel_filter = filter.into();
         self
     }
 
@@ -117,6 +138,7 @@ impl ObservabilityBuilder {
     pub fn install(self) -> Result<ObservabilityGuard, ObservabilityError> {
         let (writer, writer_guard) = tracing_appender::non_blocking(self.writer()?);
         let filter = EnvFilter::try_new(self.filter.as_str())?;
+        let otel_filter = EnvFilter::try_new(self.otel_filter.as_str())?;
         let fmt_layer = match self.format {
             LogFormat::Pretty => tracing_subscriber::fmt::layer()
                 .pretty()
@@ -132,6 +154,8 @@ impl ObservabilityBuilder {
                 .boxed(),
             LogFormat::Json => tracing_subscriber::fmt::layer()
                 .json()
+                .with_span_list(true)
+                .with_current_span(false)
                 .with_writer(writer)
                 .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
                 .with_filter(filter)
@@ -139,7 +163,9 @@ impl ObservabilityBuilder {
         };
         let tracer_provider = self.tracer_provider()?;
         let tracing_layer = tracer_provider.as_ref().map(|provider| {
-            tracing_opentelemetry::layer().with_tracer(provider.tracer(self.service_name))
+            tracing_opentelemetry::layer()
+                .with_tracer(provider.tracer(self.service_name))
+                .with_filter(otel_filter)
         });
         tracing_subscriber::registry()
             .with(fmt_layer)
@@ -171,24 +197,32 @@ impl ObservabilityBuilder {
         let Some(endpoint) = self.otlp_endpoint.as_deref() else {
             return Ok(None);
         };
+        let resource = self.resource();
+        if current_tokio_runtime_is_multi_thread() {
+            let exporter = SpanExporter::builder()
+                .with_http()
+                .with_endpoint(endpoint)
+                .with_protocol(Protocol::HttpBinary)
+                .with_http_client(reqwest::Client::new())
+                .build()?;
+            let processor = TokioBatchSpanProcessor::builder(exporter, runtime::Tokio).build();
+            return Ok(Some(
+                SdkTracerProvider::builder()
+                    .with_resource(resource)
+                    .with_span_processor(processor)
+                    .build(),
+            ));
+        }
+
+        // The async processor's synchronous flush waits for work scheduled on
+        // Tokio. Keep the SDK's dedicated-thread processor when no runtime is
+        // active or when a current-thread runtime could deadlock that flush.
         let exporter = SpanExporter::builder()
             .with_http()
             .with_endpoint(endpoint)
             .with_protocol(Protocol::HttpBinary)
+            .with_http_client(reqwest::blocking::Client::new())
             .build()?;
-        let resource = Resource::builder()
-            .with_service_name(self.service_name.clone())
-            .with_attribute(opentelemetry::KeyValue::new(
-                opentelemetry_semantic_conventions::attribute::SERVICE_VERSION,
-                self.service_version.clone(),
-            ))
-            .with_attribute(opentelemetry::KeyValue::new(
-                "deployment.environment.name",
-                self.environment
-                    .clone()
-                    .unwrap_or_else(|| "development".to_owned()),
-            ))
-            .build();
         let processor = opentelemetry_sdk::trace::BatchSpanProcessor::builder(exporter).build();
         Ok(Some(
             SdkTracerProvider::builder()
@@ -197,6 +231,29 @@ impl ObservabilityBuilder {
                 .build(),
         ))
     }
+
+    fn resource(&self) -> Resource {
+        Resource::builder()
+            .with_service_name(self.service_name.clone())
+            .with_schema_url(
+                [
+                    opentelemetry::KeyValue::new(SERVICE_VERSION, self.service_version.clone()),
+                    opentelemetry::KeyValue::new(
+                        DEPLOYMENT_ENVIRONMENT_NAME,
+                        self.environment
+                            .clone()
+                            .unwrap_or_else(|| "development".to_owned()),
+                    ),
+                ],
+                SCHEMA_URL,
+            )
+            .build()
+    }
+}
+
+fn current_tokio_runtime_is_multi_thread() -> bool {
+    tokio::runtime::Handle::try_current()
+        .is_ok_and(|handle| handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread)
 }
 
 fn trace_endpoint(endpoint: &str) -> String {
@@ -210,17 +267,22 @@ fn trace_endpoint(endpoint: &str) -> String {
 
 impl ObservabilityGuard {
     /// Flushes pending spans and shuts down the exporter. Later calls are no-ops.
-    pub fn shutdown(&mut self) {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the exporter cannot flush or shut down cleanly.
+    pub fn shutdown(&mut self) -> Result<(), ObservabilityError> {
         if let Some(provider) = self.tracer_provider.take() {
-            drop(provider.force_flush());
-            drop(provider.shutdown());
+            provider.force_flush()?;
+            provider.shutdown()?;
         }
+        Ok(())
     }
 }
 
 impl Drop for ObservabilityGuard {
     fn drop(&mut self) {
-        self.shutdown();
+        drop(self.shutdown());
     }
 }
 
@@ -236,6 +298,45 @@ mod tests {
 
     use super::*;
 
+    const OTLP_TEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+    #[test]
+    fn resource_uses_configured_service_identity_and_semantic_schema() {
+        let resource = ObservabilityBuilder::new("nanocodex-test", "1.2.3")
+            .environment("test")
+            .resource();
+
+        assert_eq!(
+            resource.get(&opentelemetry::Key::new("service.name")),
+            Some(opentelemetry::Value::from("nanocodex-test"))
+        );
+        assert_eq!(
+            resource.get(&opentelemetry::Key::new(SERVICE_VERSION)),
+            Some(opentelemetry::Value::from("1.2.3"))
+        );
+        assert_eq!(
+            resource.get(&opentelemetry::Key::new(DEPLOYMENT_ENVIRONMENT_NAME)),
+            Some(opentelemetry::Value::from("test"))
+        );
+        assert_eq!(resource.schema_url(), Some(SCHEMA_URL));
+    }
+
+    #[test]
+    fn async_export_requires_a_multithreaded_tokio_runtime() {
+        assert!(!current_tokio_runtime_is_multi_thread());
+
+        let current_thread = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        assert!(!current_thread.block_on(async { current_tokio_runtime_is_multi_thread() }));
+
+        let multi_thread = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .build()
+            .unwrap();
+        assert!(multi_thread.block_on(async { current_tokio_runtime_is_multi_thread() }));
+    }
+
     #[test]
     fn formatting_and_otlp_export_share_the_installed_span_stream() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -243,7 +344,7 @@ mod tests {
         let address = listener.local_addr().unwrap();
         let (request_seen, request_received) = mpsc::channel();
         let server = thread::spawn(move || {
-            let deadline = Instant::now() + Duration::from_secs(10);
+            let deadline = Instant::now() + OTLP_TEST_TIMEOUT;
             loop {
                 assert!(Instant::now() < deadline, "OTLP exporter did not connect");
                 match listener.accept() {
@@ -299,10 +400,8 @@ mod tests {
             let _entered = span.enter();
             tracing::info!("test event");
         }
-        guard.shutdown();
-        let request = request_received
-            .recv_timeout(Duration::from_secs(10))
-            .unwrap();
+        guard.shutdown().unwrap();
+        let request = request_received.recv_timeout(OTLP_TEST_TIMEOUT).unwrap();
         assert!(
             request.starts_with(b"POST ")
                 && request

--- a/crates/nanocodex-service/src/service.rs
+++ b/crates/nanocodex-service/src/service.rs
@@ -115,6 +115,10 @@ impl ResponsesService {
                 "failed"
             },
         );
+        tracing::Span::current().record(
+            "otel.status_code",
+            if result.is_ok() { "OK" } else { "ERROR" },
+        );
         tracing::Span::current().record("duration_ns", elapsed_ns(started_at));
         connection.capture_turn_state();
         if let Err(failure) = &result {
@@ -320,6 +324,8 @@ impl ResponsesService {
         let connect_span = info_span!(
             target: "nanocodex_service",
             "responses.connect",
+            otel.kind = "client",
+            otel.status_code = tracing::field::Empty,
             purpose = ?purpose,
             connection.generation = generation,
             status = tracing::field::Empty,
@@ -340,6 +346,10 @@ impl ResponsesService {
             } else {
                 "failed"
             },
+        );
+        connect_span.record(
+            "otel.status_code",
+            if result.is_ok() { "OK" } else { "ERROR" },
         );
         connect_span.record("duration_ns", duration_ns(elapsed));
         request
@@ -389,14 +399,20 @@ impl Service<ResponsesAttempt> for ResponsesService {
 
     fn call(&mut self, request: ResponsesAttempt) -> Self::Future {
         let service = self.clone();
+        let input_item_count = request.input_item_count();
+        let input_bytes = serde_json::to_vec(&request.input()).map_or(0, |encoded| encoded.len());
         let span = info_span!(
             target: "nanocodex_service",
             "responses.attempt",
+            otel.kind = "client",
+            otel.status_code = tracing::field::Empty,
             phase = request.kind.phase(),
             model.call_index = request.call_index,
             attempt = request.attempt,
             max_attempts = request.max_attempts,
             replay.mode = request.replay_mode(),
+            model.input.item_count = input_item_count,
+            model.input.bytes = input_bytes,
             status = tracing::field::Empty,
             duration_ns = tracing::field::Empty,
         );

--- a/crates/nanocodex-tools/Cargo.toml
+++ b/crates/nanocodex-tools/Cargo.toml
@@ -38,6 +38,7 @@ wasm-bindgen-futures.workspace = true
 
 [dev-dependencies]
 eyre.workspace = true
+tracing-subscriber.workspace = true
 
 [lints]
 workspace = true

--- a/crates/nanocodex-tools/src/code_mode/mod.rs
+++ b/crates/nanocodex-tools/src/code_mode/mod.rs
@@ -3,7 +3,7 @@ mod output;
 mod protocol;
 mod spec;
 
-use std::{collections::HashMap, process::Stdio, sync::Arc, time::Instant};
+use std::{collections::HashMap, path::PathBuf, process::Stdio, sync::Arc, time::Instant};
 
 use futures_util::{FutureExt, StreamExt, future::BoxFuture, stream::FuturesUnordered};
 use serde::{Deserialize, Serialize};
@@ -15,6 +15,7 @@ use tokio::{
     task::JoinHandle,
     time::Duration,
 };
+use tracing::{Instrument, info_span};
 
 use nanocodex_core::ResponseItem;
 use serde_json::value::RawValue;
@@ -36,6 +37,12 @@ const EXEC_PRAGMA_PREFIX: &str = "// @exec:";
 pub(crate) struct CodeModeRuntime {
     cells: Mutex<CellRegistry>,
     stored: Arc<Mutex<HashMap<String, Value>>>,
+    host: Arc<Mutex<SharedNodeHost>>,
+}
+
+struct SharedNodeHost {
+    workspace: PathBuf,
+    host: Option<NodeHost>,
 }
 
 struct CellRegistry {
@@ -196,13 +203,17 @@ struct HostFailure {
 }
 
 impl CodeModeRuntime {
-    pub(super) fn new() -> Self {
+    pub(super) fn new(workspace: PathBuf) -> Self {
         Self {
             cells: Mutex::new(CellRegistry {
                 next_cell_id: 1,
                 live_cells: HashMap::new(),
             }),
             stored: Arc::new(Mutex::new(HashMap::new())),
+            host: Arc::new(Mutex::new(SharedNodeHost {
+                workspace,
+                host: None,
+            })),
         }
     }
 
@@ -213,6 +224,51 @@ impl CodeModeRuntime {
         context: ToolContext<'_>,
     ) -> CodeModeExecution {
         let started_at = Instant::now();
+        let span = info_span!(
+            target: "nanocodex_tools",
+            "code_mode.cell",
+            otel.kind = "internal",
+            otel.status_code = tracing::field::Empty,
+            cell.id = tracing::field::Empty,
+            source.bytes = source.len(),
+            source.lines = source.lines().count(),
+            output.max_tokens = tracing::field::Empty,
+            nested.count = tracing::field::Empty,
+            running = tracing::field::Empty,
+            status = tracing::field::Empty,
+            duration_ns = tracing::field::Empty,
+        );
+        let execution = self
+            .execute_inner(source, tools, context, started_at)
+            .instrument(span.clone())
+            .await;
+        span.record(
+            "status",
+            if execution.success {
+                "completed"
+            } else {
+                "failed"
+            },
+        );
+        span.record(
+            "otel.status_code",
+            if execution.success { "OK" } else { "ERROR" },
+        );
+        span.record("nested.count", execution.nested_calls.len());
+        span.record(
+            "duration_ns",
+            u64::try_from(started_at.elapsed().as_nanos()).unwrap_or(u64::MAX),
+        );
+        execution
+    }
+
+    async fn execute_inner(
+        &self,
+        source: &str,
+        tools: Arc<ToolRegistry>,
+        context: ToolContext<'_>,
+        started_at: Instant,
+    ) -> CodeModeExecution {
         let source = match parse_exec_source(source) {
             Ok(source) => source,
             Err(message) => return failed_execution(started_at, &message, Vec::new()),
@@ -221,24 +277,24 @@ impl CodeModeRuntime {
             .max_output_tokens
             .unwrap_or(context.output_token_budget)
             .max(1);
+        tracing::Span::current().record("output.max_tokens", output_token_budget);
         let context = ToolContext {
             output_token_budget,
             ..context
         };
         let cell_id = self.cells.lock().await.allocate_cell_id();
+        tracing::Span::current().record("cell.id", cell_id);
         let stored = self.stored.lock().await.clone();
-        let mut cell = match LiveCell::spawn(
+        let mut cell = LiveCell::spawn(
             cell_id,
             source.code,
             tools,
             OwnedToolContext::from(context),
             stored,
             Arc::clone(&self.stored),
+            Arc::clone(&self.host),
             output_token_budget,
-        ) {
-            Ok(cell) => cell,
-            Err(message) => return failed_execution(started_at, &message, Vec::new()),
-        };
+        );
         let yield_after = source
             .yield_time_ms
             .map_or(INITIAL_YIELD, Duration::from_millis);
@@ -249,6 +305,7 @@ impl CodeModeRuntime {
             Some(output_token_budget),
         )
         .await;
+        tracing::Span::current().record("running", running);
         if running {
             self.cells.lock().await.live_cells.insert(cell_id, cell);
         } else {
@@ -470,29 +527,46 @@ impl LiveCell {
         context: OwnedToolContext,
         stored: HashMap<String, Value>,
         shared_stored: Arc<Mutex<HashMap<String, Value>>>,
+        host: Arc<Mutex<SharedNodeHost>>,
         output_token_budget: usize,
-    ) -> Result<Self, String> {
-        let host = NodeHost::spawn(&tools.workspace)?;
+    ) -> Self {
         let (updates_tx, updates) = mpsc::unbounded_channel();
         let (terminate, terminate_rx) = oneshot::channel();
-        let task = tokio::spawn(run_cell_actor(
-            host,
-            id,
-            source,
-            tools,
-            context,
-            stored,
-            shared_stored,
-            updates_tx,
-            terminate_rx,
-        ));
-        Ok(Self {
+        let actor_span = info_span!(
+            target: "nanocodex_tools",
+            "code_mode.cell_actor",
+            otel.kind = "internal",
+            otel.status_code = tracing::field::Empty,
+            cell.id = id,
+            runtime.first_event_ns = tracing::field::Empty,
+            runtime.event_count = tracing::field::Empty,
+            host.reused = tracing::field::Empty,
+            host.wait_ns = tracing::field::Empty,
+            host.termination_ns = tracing::field::Empty,
+            status = tracing::field::Empty,
+            duration_ns = tracing::field::Empty,
+        );
+        let task = tokio::spawn(
+            run_cell_actor(
+                host,
+                id,
+                source,
+                tools,
+                context,
+                stored,
+                shared_stored,
+                updates_tx,
+                terminate_rx,
+            )
+            .instrument(actor_span),
+        );
+        Self {
             id,
             output_token_budget,
             updates,
             terminate: Some(terminate),
             task: Some(task),
-        })
+        }
     }
 
     async fn terminate(&mut self) {
@@ -516,7 +590,10 @@ impl Drop for LiveCell {
             let _ = terminate.send(());
         }
         if let Some(task) = self.task.take() {
-            task.abort();
+            // The detached actor observes `terminate` and shuts down the shared
+            // host. Aborting here could leave JavaScript running in a process
+            // that a later cell is about to reuse.
+            drop(task);
         }
     }
 }
@@ -668,6 +745,36 @@ fn observed_execution(
 
 impl NodeHost {
     fn spawn(workspace: &std::path::Path) -> Result<Self, String> {
+        let started_at = Instant::now();
+        let span = info_span!(
+            target: "nanocodex_tools",
+            "code_mode.host_spawn",
+            otel.kind = "internal",
+            otel.status_code = tracing::field::Empty,
+            status = tracing::field::Empty,
+            duration_ns = tracing::field::Empty,
+        );
+        let result = span.in_scope(|| Self::spawn_inner(workspace));
+        span.record(
+            "status",
+            if result.is_ok() {
+                "completed"
+            } else {
+                "failed"
+            },
+        );
+        span.record(
+            "otel.status_code",
+            if result.is_ok() { "OK" } else { "ERROR" },
+        );
+        span.record(
+            "duration_ns",
+            u64::try_from(started_at.elapsed().as_nanos()).unwrap_or(u64::MAX),
+        );
+        result
+    }
+
+    fn spawn_inner(workspace: &std::path::Path) -> Result<Self, String> {
         let mut child = Command::new("node")
             .args(["--input-type=module", "--eval", RUNTIME])
             .current_dir(workspace)
@@ -723,9 +830,11 @@ impl NodeHost {
         tools: &ToolRegistry,
         context: &OwnedToolContext,
         updates: &mpsc::UnboundedSender<CellUpdate>,
+        actor_started_at: Instant,
     ) -> Result<CellTerminal, HostFailure> {
         let mut pending_calls: FuturesUnordered<BoxFuture<'_, CompletedNestedCall>> =
             FuturesUnordered::new();
+        let mut event_count = 0_u64;
         loop {
             tokio::select! {
                 completed = pending_calls.next(), if !pending_calls.is_empty() => {
@@ -738,6 +847,14 @@ impl NodeHost {
                 }
                 event = self.read_event() => {
                     let event = event?;
+                    event_count = event_count.saturating_add(1);
+                    if event_count == 1 {
+                        tracing::Span::current().record(
+                            "runtime.first_event_ns",
+                            u64::try_from(actor_started_at.elapsed().as_nanos())
+                                .unwrap_or(u64::MAX),
+                        );
+                    }
                     let event_cell_id = event.cell_id();
                     if event_cell_id != cell_id {
                         return Err(HostFailure::new(format!(
@@ -767,6 +884,7 @@ impl NodeHost {
                             stored,
                             ..
                         } => {
+                            tracing::Span::current().record("runtime.event_count", event_count);
                             return Ok(CellTerminal::Completed {
                                 content,
                                 stored,
@@ -778,6 +896,7 @@ impl NodeHost {
                             stored,
                             ..
                         } => {
+                            tracing::Span::current().record("runtime.event_count", event_count);
                             return Ok(CellTerminal::ScriptFailed {
                                 message,
                                 content,
@@ -840,7 +959,7 @@ impl NodeHost {
 
 #[allow(clippy::too_many_arguments)]
 async fn run_cell_actor(
-    mut host: NodeHost,
+    shared_host: Arc<Mutex<SharedNodeHost>>,
     cell_id: u64,
     source: String,
     tools: Arc<ToolRegistry>,
@@ -850,6 +969,31 @@ async fn run_cell_actor(
     updates: mpsc::UnboundedSender<CellUpdate>,
     mut terminate: oneshot::Receiver<()>,
 ) {
+    let started_at = Instant::now();
+    let host_wait_started_at = Instant::now();
+    let mut shared_host = shared_host.lock().await;
+    tracing::Span::current().record(
+        "host.wait_ns",
+        u64::try_from(host_wait_started_at.elapsed().as_nanos()).unwrap_or(u64::MAX),
+    );
+    let reused = shared_host.host.is_some();
+    tracing::Span::current().record("host.reused", reused);
+    let mut host = match shared_host.host.take() {
+        Some(host) => host,
+        None => match NodeHost::spawn(&shared_host.workspace) {
+            Ok(host) => host,
+            Err(message) => {
+                tracing::Span::current().record("status", "failed");
+                tracing::Span::current().record("otel.status_code", "ERROR");
+                tracing::Span::current().record(
+                    "duration_ns",
+                    u64::try_from(started_at.elapsed().as_nanos()).unwrap_or(u64::MAX),
+                );
+                let _ = updates.send(CellUpdate::HostFailed(message));
+                return;
+            }
+        },
+    };
     let run = async {
         host.start_cell(cell_id, &source, stored, tools.as_ref())
             .await?;
@@ -859,17 +1003,33 @@ async fn run_cell_actor(
             tools.as_ref(),
             &context,
             &updates,
+            started_at,
         )
         .await
     };
     let terminal = tokio::select! {
         biased;
         _ = &mut terminate => {
+            let termination_started_at = Instant::now();
             host.terminate().await;
+            tracing::Span::current().record(
+                "host.termination_ns",
+                u64::try_from(termination_started_at.elapsed().as_nanos()).unwrap_or(u64::MAX),
+            );
+            tracing::Span::current().record("status", "cancelled");
+            tracing::Span::current().record("otel.status_code", "ERROR");
+            tracing::Span::current().record(
+                "duration_ns",
+                u64::try_from(started_at.elapsed().as_nanos()).unwrap_or(u64::MAX),
+            );
             return;
         }
         terminal = run => terminal,
     };
+    let success = matches!(terminal, Ok(CellTerminal::Completed { .. }));
+    tracing::Span::current().record("status", if success { "completed" } else { "failed" });
+    tracing::Span::current().record("otel.status_code", if success { "OK" } else { "ERROR" });
+    let host_healthy = terminal.is_ok();
     match terminal {
         Ok(CellTerminal::Completed { content, stored }) => {
             shared_stored.lock().await.extend(stored);
@@ -887,7 +1047,20 @@ async fn run_cell_actor(
             let _ = updates.send(CellUpdate::HostFailed(failure.message));
         }
     }
-    host.terminate().await;
+    if host_healthy {
+        shared_host.host = Some(host);
+    } else {
+        let termination_started_at = Instant::now();
+        host.terminate().await;
+        tracing::Span::current().record(
+            "host.termination_ns",
+            u64::try_from(termination_started_at.elapsed().as_nanos()).unwrap_or(u64::MAX),
+        );
+    }
+    tracing::Span::current().record(
+        "duration_ns",
+        u64::try_from(started_at.elapsed().as_nanos()).unwrap_or(u64::MAX),
+    );
 }
 
 impl CodeModeNotification {

--- a/crates/nanocodex-tools/src/code_mode/tests.rs
+++ b/crates/nanocodex-tools/src/code_mode/tests.rs
@@ -8,8 +8,8 @@ use super::{CodeModeExecution, NestedToolCall, parse_exec_source};
 use crate::{ToolContext, ToolOutputBody, ToolOutputContent, ToolRuntime, WebSearchConfig};
 
 #[tokio::test]
-async fn starts_each_cell_in_a_fresh_node_host() -> Result<()> {
-    let workspace = temporary_workspace("fresh-node-host")?;
+async fn reuses_one_node_host_across_cells() -> Result<()> {
+    let workspace = temporary_workspace("persistent-node-host")?;
     let tools = test_tools(&workspace);
     let history = Vec::new();
     let context = test_context(&history);
@@ -19,7 +19,7 @@ async fn starts_each_cell_in_a_fresh_node_host() -> Result<()> {
 
     assert!(first.success);
     assert!(second.success);
-    assert_ne!(emitted_text(&first)?, emitted_text(&second)?);
+    assert_eq!(emitted_text(&first)?, emitted_text(&second)?);
     std::fs::remove_dir_all(workspace)?;
     Ok(())
 }

--- a/crates/nanocodex-tools/src/image_generation/mod.rs
+++ b/crates/nanocodex-tools/src/image_generation/mod.rs
@@ -106,6 +106,7 @@ impl ImageGenerationHandler {
             success: true,
             code_mode_value: Some(code_mode_value),
             metadata: None,
+            process_trace: None,
         }
     }
 

--- a/crates/nanocodex-tools/src/runtime.rs
+++ b/crates/nanocodex-tools/src/runtime.rs
@@ -424,7 +424,7 @@ impl ToolRuntime {
         let workspace = workspace.into();
         let sessions = Arc::new(ShellSessions::new());
         let default_shell_name = sessions.default_shell_name();
-        let registry_workspace = workspace.clone();
+        let code_mode_workspace = workspace.clone();
         let mut handlers: Vec<Arc<dyn Tool>> = vec![
             Arc::new(shell::ExecCommandHandler::new(
                 workspace.clone(),
@@ -444,8 +444,8 @@ impl ToolRuntime {
             )));
         }
         Self {
-            registry: Arc::new(ToolRegistry::from_ordered(registry_workspace, handlers)),
-            code_mode: code_mode::CodeModeRuntime::new(),
+            registry: Arc::new(ToolRegistry::from_ordered(handlers)),
+            code_mode: code_mode::CodeModeRuntime::new(code_mode_workspace),
             default_shell_name,
         }
     }
@@ -482,7 +482,6 @@ impl ToolRuntime {
 
 #[derive(Clone)]
 pub(crate) struct ToolRegistry {
-    pub(crate) workspace: PathBuf,
     ordered: Vec<Arc<dyn Tool>>,
     definitions: Vec<ToolDefinition>,
     by_name: HashMap<Box<str>, usize>,
@@ -577,7 +576,7 @@ impl ToolRegistry {
         }
         metadata
     }
-    fn from_ordered(workspace: PathBuf, ordered: Vec<Arc<dyn Tool>>) -> Self {
+    fn from_ordered(ordered: Vec<Arc<dyn Tool>>) -> Self {
         let definitions = ordered.iter().map(|tool| tool.definition()).collect();
         let by_name = ordered
             .iter()
@@ -585,7 +584,6 @@ impl ToolRegistry {
             .map(|(index, tool)| (tool.name().into(), index))
             .collect();
         Self {
-            workspace,
             ordered,
             definitions,
             by_name,

--- a/crates/nanocodex-tools/src/runtime.rs
+++ b/crates/nanocodex-tools/src/runtime.rs
@@ -42,6 +42,15 @@ pub struct ToolExecution {
     pub success: bool,
     pub(crate) code_mode_value: Option<Value>,
     pub metadata: Option<Box<RawValue>>,
+    pub(crate) process_trace: Option<ProcessTrace>,
+}
+
+pub(crate) struct ProcessTrace {
+    exit_code: Option<i32>,
+    session_id: Option<i64>,
+    original_token_count: Option<usize>,
+    output_bytes: usize,
+    wall_time_seconds: f64,
 }
 
 impl ToolExecution {
@@ -52,6 +61,7 @@ impl ToolExecution {
             success: true,
             code_mode_value: None,
             metadata: None,
+            process_trace: None,
         }
     }
 
@@ -62,6 +72,7 @@ impl ToolExecution {
             success: false,
             code_mode_value: None,
             metadata: None,
+            process_trace: None,
         }
     }
 
@@ -83,6 +94,7 @@ impl ToolExecution {
                 success,
                 code_mode_value: Some(output),
                 metadata: None,
+                process_trace: None,
             },
             Err(error) => Self::error(format!("failed to encode tool result: {error}")),
         }
@@ -96,6 +108,7 @@ impl ToolExecution {
             success: true,
             code_mode_value: None,
             metadata: None,
+            process_trace: None,
         }
     }
 
@@ -128,6 +141,24 @@ impl ToolExecution {
                 self.success = false;
             }
         }
+        self
+    }
+
+    pub(crate) fn with_process_trace(
+        mut self,
+        exit_code: Option<i32>,
+        session_id: Option<i64>,
+        original_token_count: Option<usize>,
+        output_bytes: usize,
+        wall_time_seconds: f64,
+    ) -> Self {
+        self.process_trace = Some(ProcessTrace {
+            exit_code,
+            session_id,
+            original_token_count,
+            output_bytes,
+            wall_time_seconds,
+        });
         self
     }
 }
@@ -495,12 +526,47 @@ impl ToolRegistry {
         input: Value,
         context: ToolContext<'_>,
     ) -> ToolExecution {
+        let arguments_bytes = serde_json::to_vec(&input).map_or(0, |encoded| encoded.len());
+        let arguments_kind = match &input {
+            Value::Null => "null",
+            Value::Bool(_) => "boolean",
+            Value::Number(_) => "number",
+            Value::String(_) => "string",
+            Value::Array(_) => "array",
+            Value::Object(_) => "object",
+        };
+        let arguments_count = input.as_object().map_or_else(
+            || input.as_array().map_or(1, Vec::len),
+            serde_json::Map::len,
+        );
+        let argument_keys = input
+            .as_object()
+            .map(|object| {
+                object
+                    .keys()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
+                    .join(",")
+            })
+            .unwrap_or_default();
         let span = info_span!(
             target: "nanocodex_tools",
             "tool.execute",
+            otel.kind = "internal",
+            otel.status_code = tracing::field::Empty,
             tool.name = name,
             session.id = context.session_id,
             tool.call_id = context.call_id,
+            tool.arguments.bytes = arguments_bytes,
+            tool.arguments.kind = arguments_kind,
+            tool.arguments.count = arguments_count,
+            tool.arguments.keys = argument_keys,
+            process.exit.code = tracing::field::Empty,
+            process.running = tracing::field::Empty,
+            process.wall_time_ms = tracing::field::Empty,
+            shell.session.id = tracing::field::Empty,
+            tool.output.bytes = tracing::field::Empty,
+            tool.output.original_tokens = tracing::field::Empty,
             status = tracing::field::Empty,
             duration_ns = tracing::field::Empty,
         );
@@ -518,9 +584,27 @@ impl ToolRegistry {
             },
         );
         span.record(
+            "otel.status_code",
+            if execution.success { "OK" } else { "ERROR" },
+        );
+        span.record(
             "duration_ns",
             u64::try_from(started_at.elapsed().as_nanos()).unwrap_or(u64::MAX),
         );
+        if let Some(process) = &execution.process_trace {
+            if let Some(exit_code) = process.exit_code {
+                span.record("process.exit.code", exit_code);
+            }
+            span.record("process.running", process.session_id.is_some());
+            span.record("process.wall_time_ms", process.wall_time_seconds * 1_000.0);
+            if let Some(session_id) = process.session_id {
+                span.record("shell.session.id", session_id);
+            }
+            span.record("tool.output.bytes", process.output_bytes);
+            if let Some(original_token_count) = process.original_token_count {
+                span.record("tool.output.original_tokens", original_token_count);
+            }
+        }
         execution
     }
 

--- a/crates/nanocodex-tools/src/shell/tool.rs
+++ b/crates/nanocodex-tools/src/shell/tool.rs
@@ -83,7 +83,7 @@ impl Tool for ExecCommandHandler {
             arguments.max_output_tokens,
         );
         let result = self.sessions.execute(command, &self.workspace).await;
-        ToolExecution::json(&result)
+        shell_execution(&result)
     }
 }
 
@@ -146,8 +146,18 @@ impl Tool for WriteStdinHandler {
             arguments.max_output_tokens,
         );
         let result = self.sessions.write_stdin(request).await;
-        ToolExecution::json(&result)
+        shell_execution(&result)
     }
+}
+
+fn shell_execution(result: &super::ExecCommandResult) -> ToolExecution {
+    ToolExecution::json(&result).with_process_trace(
+        result.exit_code,
+        result.session_id,
+        result.original_token_count,
+        result.output.len(),
+        result.wall_time_seconds,
+    )
 }
 
 #[derive(Deserialize)]

--- a/crates/nanocodex-tools/src/view_image.rs
+++ b/crates/nanocodex-tools/src/view_image.rs
@@ -111,6 +111,7 @@ impl Tool for ViewImageHandler {
                 "detail": detail,
             })),
             metadata: None,
+            process_trace: None,
         }
     }
 }

--- a/crates/nanocodex-tools/tests/tracing.rs
+++ b/crates/nanocodex-tools/tests/tracing.rs
@@ -1,0 +1,79 @@
+use std::sync::{Arc, Mutex};
+
+use nanocodex_tools::{ToolContext, ToolRuntime};
+use tracing::{Instrument, Subscriber, span::Attributes};
+use tracing_subscriber::{Layer, layer::Context as LayerContext, prelude::*, registry::LookupSpan};
+
+#[derive(Clone)]
+struct ToolSpanAncestor(Arc<Mutex<bool>>);
+
+impl<S> Layer<S> for ToolSpanAncestor
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_new_span(
+        &self,
+        attributes: &Attributes<'_>,
+        _id: &tracing::Id,
+        context: LayerContext<'_, S>,
+    ) {
+        if attributes.metadata().name() != "tool.execute" {
+            return;
+        }
+        let parent_id = attributes.parent().cloned().or_else(|| {
+            attributes
+                .is_contextual()
+                .then(|| context.current_span().id().cloned())
+                .flatten()
+        });
+        let has_tool_call_ancestor = parent_id
+            .as_ref()
+            .and_then(|id| context.span(id))
+            .is_some_and(|span| {
+                span.scope()
+                    .any(|ancestor| ancestor.metadata().name() == "test.tool_call")
+            });
+        *self.0.lock().unwrap() = has_tool_call_ancestor;
+    }
+}
+
+#[test]
+fn spawned_cell_preserves_the_parent_span_for_nested_tools() {
+    let has_tool_call_ancestor = Arc::new(Mutex::new(false));
+    let subscriber =
+        tracing_subscriber::registry().with(ToolSpanAncestor(Arc::clone(&has_tool_call_ancestor)));
+    let dispatch = tracing::Dispatch::new(subscriber);
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let workspace = std::env::temp_dir().join(format!(
+        "nanocodex-code-mode-trace-parent-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&workspace).unwrap();
+    let tools = ToolRuntime::new(&workspace, None, None);
+    let history = Vec::new();
+    let context = ToolContext {
+        model: "test-model",
+        session_id: "test-session",
+        call_id: "test-call",
+        history: &history,
+        output_token_budget: nanocodex_tools::DEFAULT_TOOL_OUTPUT_TOKENS,
+    };
+
+    let execution = tracing::dispatcher::with_default(&dispatch, || {
+        runtime.block_on(
+            tools
+                .execute_code(
+                    r#"await tools.exec_command({ cmd: "pwd", login: false });"#,
+                    context,
+                )
+                .instrument(tracing::info_span!("test.tool_call")),
+        )
+    });
+
+    assert!(execution.success);
+    assert!(*has_tool_call_ancestor.lock().unwrap());
+    std::fs::remove_dir_all(workspace).unwrap();
+}

--- a/crates/nanocodex/src/agent.rs
+++ b/crates/nanocodex/src/agent.rs
@@ -264,14 +264,9 @@ where
     ///
     /// Returns an infrastructure error while receiving or starting a command.
     async fn run(mut self) -> Result<()> {
-        let session_span = info_span!(
-            target: "nanocodex",
-            "agent.session",
-            session.id = self.events.request_id(),
-            model = nanocodex_core::MODEL,
-            thinking = self.config.thinking.as_str(),
-        );
         self.tools.start_providers();
+        let session_id = self.events.request_id().to_owned();
+        let thinking = self.config.thinking;
         let mut model = ModelRun::new(
             self.events,
             self.config,
@@ -284,8 +279,13 @@ where
             turn_index += 1;
             let turn_span = info_span!(
                 target: "nanocodex",
-                parent: &session_span,
+                parent: None,
                 "agent.turn",
+                otel.kind = "internal",
+                otel.status_code = tracing::field::Empty,
+                session.id = session_id.as_str(),
+                model = nanocodex_core::MODEL,
+                thinking = thinking.as_str(),
                 turn.index = turn_index,
                 prompt.bytes = prompt.instruction.text_bytes(),
                 status = tracing::field::Empty,
@@ -302,6 +302,10 @@ where
                 } else {
                     "failed"
                 },
+            );
+            turn_span.record(
+                "otel.status_code",
+                if outcome.is_ok() { "OK" } else { "ERROR" },
             );
             drop(result.send(outcome));
         }

--- a/crates/nanocodex/src/model/agent.rs
+++ b/crates/nanocodex/src/model/agent.rs
@@ -911,8 +911,7 @@ fn record_model_response(span: &tracing::Span, response: &TurnResult) {
 fn record_response_reasoning(span: &tracing::Span, items: &[ResponseItem]) {
     let mut summaries = Vec::new();
     for item in items {
-        let ResponseItem::Reasoning { summary, .. } = item
-        else {
+        let ResponseItem::Reasoning { summary, .. } = item else {
             continue;
         };
         summaries.extend(summary.iter().map(|summary| match summary {

--- a/crates/nanocodex/src/model/agent.rs
+++ b/crates/nanocodex/src/model/agent.rs
@@ -1,8 +1,8 @@
 use std::{path::Path, sync::Arc};
 
 use nanocodex_core::{
-    AgentEventKind, EventSink, MODEL, ModelConfig, Prompt, ResponseItem, ToolDefinition, Usage,
-    responses::RequestProfile,
+    AgentEventKind, EventSink, MODEL, ModelConfig, Prompt, ReasoningSummary, ResponseItem,
+    ToolDefinition, Usage, responses::RequestProfile,
 };
 use nanocodex_service::{
     CodeCall, CodeCallKind, ResponsesAttempt, ResponsesAttemptFactory, ResponsesClient,
@@ -430,8 +430,11 @@ where
         let tool_span = info_span!(
             target: "nanocodex",
             "tool.call",
+            otel.kind = "internal",
+            otel.status_code = tracing::field::Empty,
             tool.name = %call.name,
             tool.call_id = %call.call_id,
+            tool.arguments.bytes = call.input.len(),
             model.call_index = call_index,
             status = tracing::field::Empty,
             duration_ns = tracing::field::Empty,
@@ -447,14 +450,8 @@ where
         .await;
         prepare_output_images(&mut execution.output).await;
         let duration_ns = elapsed_ns(started_at);
-        tool_span.record(
-            "status",
-            if execution.success {
-                "completed"
-            } else {
-                "failed"
-            },
-        );
+        tool_span.record("status", status(execution.success));
+        tool_span.record("otel.status_code", otel_status(execution.success));
         tool_span.record("duration_ns", duration_ns);
         self.stats.tool_wall_duration_ns += duration_ns;
         for nested in &execution.nested_calls {
@@ -569,7 +566,10 @@ where
         let span = info_span!(
             target: "nanocodex",
             "model.warmup",
+            otel.kind = "internal",
+            otel.status_code = tracing::field::Empty,
             model = MODEL,
+            system_prompt.bytes = self.config.system_prompt().len(),
             status = tracing::field::Empty,
             duration_ns = tracing::field::Empty,
         );
@@ -582,6 +582,7 @@ where
             Ok(success) => success,
             Err(error) => {
                 span.record("status", "failed");
+                span.record("otel.status_code", "ERROR");
                 span.record("duration_ns", elapsed_ns(started_at));
                 return self.warmup_failed(started_at, error.into());
             }
@@ -590,6 +591,8 @@ where
         let connection_generation = success.connection_generation();
         self.server_reasoning_included |= success.server_reasoning_included();
         let ResponsesOutput::Warmup(response) = success.into_output() else {
+            span.record("status", "failed");
+            span.record("otel.status_code", "ERROR");
             return Err(AgentError::InvalidAttemptState {
                 detail: "warmup returned a non-warmup response",
             }
@@ -597,6 +600,7 @@ where
         };
         let duration_ns = elapsed_ns(started_at);
         span.record("status", "completed");
+        span.record("otel.status_code", "OK");
         span.record("duration_ns", duration_ns);
         self.stats.warmup_duration_ns += duration_ns;
         if let Some(usage) = &response.usage {
@@ -655,22 +659,18 @@ where
             conversation.delta_start,
             previous_response_id,
         );
-        let span = info_span!(
-            target: "nanocodex",
-            "model.call",
-            model = MODEL,
-            model.call_index = call_index,
-            previous_response = previous_response_id.is_some(),
-            status = tracing::field::Empty,
-            duration_ns = tracing::field::Empty,
-            input_tokens = tracing::field::Empty,
-            cached_input_tokens = tracing::field::Empty,
-            output_tokens = tracing::field::Empty,
+        let (input_item_count, input_bytes) = trace_model_input(&request);
+        let span = model_call_span(
+            call_index,
+            previous_response_id.is_some(),
+            input_item_count,
+            input_bytes,
         );
         let success = match self.client.execute(request).instrument(span.clone()).await {
             Ok(success) => success,
             Err(error) => {
                 span.record("status", "failed");
+                span.record("otel.status_code", "ERROR");
                 span.record("duration_ns", elapsed_ns(started_at));
                 return self.model_call_failed(call_index, started_at, error.into());
             }
@@ -679,13 +679,17 @@ where
         let connection_generation = success.connection_generation();
         self.server_reasoning_included |= success.server_reasoning_included();
         let ResponsesOutput::Generation(response) = success.into_output() else {
+            span.record("status", "failed");
+            span.record("otel.status_code", "ERROR");
             return Err(AgentError::InvalidAttemptState {
                 detail: "generation returned a non-generation response",
             }
             .into());
         };
         let duration_ns = elapsed_ns(started_at);
+        record_model_response(&span, &response);
         span.record("status", "completed");
+        span.record("otel.status_code", "OK");
         span.record("duration_ns", duration_ns);
         if let Some(usage) = &response.usage {
             span.record("input_tokens", usage.input_tokens);
@@ -847,6 +851,80 @@ fn unsupported_tool_message(call: &CodeCall) -> Option<String> {
     })
 }
 
+fn trace_model_input(request: &ResponsesAttempt) -> (usize, usize) {
+    let item_count = request.input_item_count();
+    let items = request.input_items().collect::<Vec<_>>();
+    let bytes = serde_json::to_vec(&items).map_or(0, |encoded| encoded.len());
+    (item_count, bytes)
+}
+
+fn model_call_span(
+    call_index: u32,
+    previous_response: bool,
+    input_item_count: usize,
+    input_bytes: usize,
+) -> tracing::Span {
+    info_span!(
+        target: "nanocodex",
+        "model.call",
+        otel.kind = "internal",
+        otel.status_code = tracing::field::Empty,
+        model = MODEL,
+        model.call_index = call_index,
+        previous_response,
+        model.input.item_count = input_item_count,
+        model.input.bytes = input_bytes,
+        model.response.id = tracing::field::Empty,
+        model.response.status = tracing::field::Empty,
+        model.response.end_turn = tracing::field::Empty,
+        model.output.item_count = tracing::field::Empty,
+        model.output.bytes = tracing::field::Empty,
+        model.tool_call_count = tracing::field::Empty,
+        assistant.output.bytes = tracing::field::Empty,
+        status = tracing::field::Empty,
+        duration_ns = tracing::field::Empty,
+        input_tokens = tracing::field::Empty,
+        cached_input_tokens = tracing::field::Empty,
+        output_tokens = tracing::field::Empty,
+        reasoning.summary_count = tracing::field::Empty,
+        reasoning.summary = tracing::field::Empty,
+    )
+}
+
+fn record_model_response(span: &tracing::Span, response: &TurnResult) {
+    span.record("model.response.id", response.id.as_str());
+    span.record("model.response.status", response.status.as_str());
+    if let Some(end_turn) = response.end_turn {
+        span.record("model.response.end_turn", end_turn);
+    }
+    span.record("model.output.item_count", response.output_items.len());
+    span.record("model.tool_call_count", response.code_calls.len());
+    let output_bytes =
+        serde_json::to_vec(&response.output_items).map_or(0, |encoded| encoded.len());
+    span.record("model.output.bytes", output_bytes);
+    if let Some(message) = &response.final_message {
+        span.record("assistant.output.bytes", message.len());
+    }
+    record_response_reasoning(span, &response.output_items);
+}
+
+fn record_response_reasoning(span: &tracing::Span, items: &[ResponseItem]) {
+    let mut summaries = Vec::new();
+    for item in items {
+        let ResponseItem::Reasoning { summary, .. } = item
+        else {
+            continue;
+        };
+        summaries.extend(summary.iter().map(|summary| match summary {
+            ReasoningSummary::SummaryText { text } => text.as_ref(),
+        }));
+    }
+    span.record("reasoning.summary_count", summaries.len());
+    if !summaries.is_empty() {
+        span.record("reasoning.summary", summaries.join("\n\n"));
+    }
+}
+
 fn strip_item_id(mut item: ResponseItem) -> ResponseItem {
     item.strip_id();
     item
@@ -873,6 +951,10 @@ fn request_profile(
 
 const fn status(success: bool) -> &'static str {
     if success { "completed" } else { "failed" }
+}
+
+const fn otel_status(success: bool) -> &'static str {
+    if success { "OK" } else { "ERROR" }
 }
 
 #[cfg(test)]

--- a/docker-compose.otel.yml
+++ b/docker-compose.otel.yml
@@ -1,0 +1,7 @@
+services:
+  jaeger:
+    image: jaegertracing/all-in-one:1.76.0
+    container_name: nanocodex-jaeger
+    ports:
+      - "127.0.0.1:4318:4318"
+      - "127.0.0.1:16686:16686"

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,146 @@
+# Visualizing Nanocodex traces
+
+Nanocodex emits OpenTelemetry spans independently from its contractual typed
+events. The quickest local visualization uses Jaeger: OTLP/HTTP spans enter on
+port 4318 and the trace UI is available on port 16686. The checked-in Compose
+service is ephemeral, binds only to localhost, and loses its trace data when it
+is removed.
+
+## Quick start
+
+Start Jaeger:
+
+```sh
+just otel-up
+```
+
+Run one live turn that makes a model call, executes the built-in `exec` tool,
+and makes a follow-up model call:
+
+```sh
+just otel-demo
+```
+
+`OPENAI_API_KEY` must be present in the environment or the repository `.env`.
+The demo writes the two independent diagnostic surfaces to:
+
+- `.nanocodex/otel-demo/events.jsonl`: contractual `AgentEvents` encoded by the
+  headless process adapter.
+- `.nanocodex/otel-demo/tracing.jsonl`: local structured `tracing` output.
+
+Open <http://localhost:16686>, choose the `nanocodex` service, and select **Find
+Traces**. Open the newest trace and expand the waterfall. A successful tool turn
+has this general shape:
+
+```text
+agent.turn
+├── model.call
+│   └── responses.attempt
+│       └── responses.connect
+├── tool.call
+│   └── tool.execute
+└── model.call
+    └── responses.attempt
+```
+
+With MCP configured, `mcp.server_start` and `mcp.tool_call` spans appear around
+background discovery and remote dispatch. Useful fields include session and
+model-call identity, response replay mode, connection purpose/generation,
+attempt count, status, duration, input/output tokens, cached input tokens, and
+tool name. Diagnostic spans retain structural metadata such as byte and item
+counts, argument kinds and keys, process exit state, and API-visible reasoning
+summaries. They never include full prompt bodies, hidden reasoning content,
+tool argument values, raw response frames, or the API key.
+
+Each turn is its own root unit of work so a long-lived embedded agent does not
+produce one unbounded trace. Sequential turns remain searchable as a session
+through their shared `session.id` attribute. Local logging and OTLP export have
+independent filters: use `RUST_LOG`/`--log-filter` for the formatter and
+`OTEL_LEVEL`/`--otel-filter` for exported spans.
+
+Stop and remove the ephemeral backend when finished:
+
+```sh
+just otel-down
+```
+
+## Stress the complete path
+
+The manual stress gate uses a deterministic local Responses WebSocket rather
+than spending model tokens. It still drives the real CLI, retained Nanocodex
+session, the session-persistent Code Mode Node host, shell process lifecycle, MCP stdio transport,
+local tracing subscriber, batch OTLP exporter, and Jaeger backend:
+
+```sh
+just otel-stress
+```
+
+The default workload runs 32 sequential prompts on one session. Every turn
+fans out 16 concurrent MCP calls, then mixes in a synthetic MCP error, malformed
+patch, non-zero shell, bounded high-volume output, yielded/resumed process, and
+unknown JavaScript tool. The gate verifies event counts, exactly one trace root
+per accepted prompt, all parent references, expected success/error span volume,
+presence of structural model/tool fields and API-visible reasoning summaries,
+and absence of prompt, hidden-reasoning, tool-argument, and API-key sentinels
+from exported trace data.
+
+Scale it up without changing code:
+
+```sh
+just otel-stress 100 128
+```
+
+That maximum profile drives 100 retained turns and 12,800 successful concurrent
+MCP dispatches plus the failure and process cases. The test is ignored during
+the normal workspace suite because it requires the local Jaeger service and is
+intentionally expensive. Its Responses side remains deterministic so failures
+indicate library, tool, exporter, or topology regressions rather than model
+sampling variance.
+
+To measure the cost of span collection/export against the identical workload,
+run the no-OTLP twin with the same arguments:
+
+```sh
+just otel-stress-baseline 100 128
+```
+
+Compare its reported `workload_elapsed` with `just otel-stress 100 128`. This
+keeps model responses, tool inputs, process work, and event validation
+identical; only the OTLP layer and Jaeger export are removed. The separate
+`validation_elapsed` covers querying and checking Jaeger, whose cost grows with
+the in-memory demo backend's retained trace volume and is not agent runtime.
+
+## Run a different prompt
+
+The CLI accepts the same exporter configuration directly:
+
+```sh
+cargo run --quiet --manifest-path bin/nanocodex/Cargo.toml -- \
+  --otel-endpoint http://127.0.0.1:4318 \
+  --otel-environment local-demo \
+  --log-format json \
+  --log-file .nanocodex/otel-demo/tracing.jsonl \
+  run --thinking=low "Inspect the repository and summarize it."
+```
+
+`--otel-endpoint` is a collector base URL. Nanocodex appends `/v1/traces`
+unless it is already present. Keep the returned `ObservabilityGuard` alive when
+using `nanocodex-observability` as a library; dropping or explicitly shutting
+down the guard flushes its batched exporter.
+
+## Troubleshooting
+
+Check that the backend is running and the two local ports are reachable:
+
+```sh
+docker compose -f docker-compose.otel.yml ps
+curl --fail http://127.0.0.1:16686/
+```
+
+If the service does not appear immediately, wait a moment and refresh after the
+CLI exits. Export is batched and is flushed during observability shutdown. On a
+multithreaded Tokio runtime, OTLP/HTTP export uses Tokio's asynchronous batch
+processor; current-thread runtimes and applications without Tokio use the
+dedicated-thread blocking fallback so synchronous shutdown cannot deadlock the
+runtime. Use `docker compose -f docker-compose.otel.yml logs jaeger` to inspect
+collector errors.


### PR DESCRIPTION
## What changed

- reuse one persistent Node Code Mode host per agent instead of spawning Node for every call
- add structured end-to-end OTLP spans with asynchronous Tokio export and a safe blocking fallback
- trace model, tool, MCP, shell, and write-stdin lifecycle metadata without prompt bodies, hidden reasoning, secrets, or raw arguments
- add retained-session/hostile-tool observability stress coverage and a local Jaeger workflow

## Why

This lowers Code Mode process overhead while making retained agent work inspectable across model calls, tool dispatch, MCP traffic, and subprocess lifecycles.

## Validation

- cargo fmt --all -- --check
- cargo test --workspace --locked
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps
- typos
- cargo deny check
- just otel-stress 2 3