### PR TITLE
feat(cli): route OpenAI through Tempo MPP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           cache-on-failure: true
       - run: cargo test --workspace --locked
+        if: matrix.rust != '1.88'
+      - run: cargo test --workspace --exclude nanocodex-bin --locked
+        if: matrix.rust == '1.88'
 
   quality:
     name: rustfmt, clippy, and docs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=441e3114abb705e1e613272a62047e5c7b671ef9#441e3114abb705e1e613272a62047e5c7b671ef9"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=186ca59f5cbd1b450cf2e252089ff68e3d13ca28#186ca59f5cbd1b450cf2e252089ff68e3d13ca28"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=441e3114abb705e1e613272a62047e5c7b671ef9#441e3114abb705e1e613272a62047e5c7b671ef9"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=186ca59f5cbd1b450cf2e252089ff68e3d13ca28#186ca59f5cbd1b450cf2e252089ff68e3d13ca28"
 dependencies = [
  "alloy",
  "async-stream",
@@ -3936,7 +3936,7 @@ dependencies = [
 
 [[package]]
 name = "mpp-egress"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=e59900080f5cd36ec8992673924aad1a74b96950#e59900080f5cd36ec8992673924aad1a74b96950"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=0cb2025d2ce1eb211f7a6d3c684ed5268a99edbc#0cb2025d2ce1eb211f7a6d3c684ed5268a99edbc"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=e59900080f5cd36ec8992673924aad1a74b96950#e59900080f5cd36ec8992673924aad1a74b96950"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=0cb2025d2ce1eb211f7a6d3c684ed5268a99edbc#0cb2025d2ce1eb211f7a6d3c684ed5268a99edbc"
 dependencies = [
  "alloy",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=ef9f2f59b553b6cf7ca11746eb48687d451c7dbe#ef9f2f59b553b6cf7ca11746eb48687d451c7dbe"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=a91163d46aa614df33bf3214c8aef557abf6e9b7#a91163d46aa614df33bf3214c8aef557abf6e9b7"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=ef9f2f59b553b6cf7ca11746eb48687d451c7dbe#ef9f2f59b553b6cf7ca11746eb48687d451c7dbe"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=a91163d46aa614df33bf3214c8aef557abf6e9b7#a91163d46aa614df33bf3214c8aef557abf6e9b7"
 dependencies = [
  "alloy",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=0cb2025d2ce1eb211f7a6d3c684ed5268a99edbc#0cb2025d2ce1eb211f7a6d3c684ed5268a99edbc"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=ef9f2f59b553b6cf7ca11746eb48687d451c7dbe#ef9f2f59b553b6cf7ca11746eb48687d451c7dbe"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=0cb2025d2ce1eb211f7a6d3c684ed5268a99edbc#0cb2025d2ce1eb211f7a6d3c684ed5268a99edbc"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=ef9f2f59b553b6cf7ca11746eb48687d451c7dbe#ef9f2f59b553b6cf7ca11746eb48687d451c7dbe"
 dependencies = [
  "alloy",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=a91163d46aa614df33bf3214c8aef557abf6e9b7#a91163d46aa614df33bf3214c8aef557abf6e9b7"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=441e3114abb705e1e613272a62047e5c7b671ef9#441e3114abb705e1e613272a62047e5c7b671ef9"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=a91163d46aa614df33bf3214c8aef557abf6e9b7#a91163d46aa614df33bf3214c8aef557abf6e9b7"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=441e3114abb705e1e613272a62047e5c7b671ef9#441e3114abb705e1e613272a62047e5c7b671ef9"
 dependencies = [
  "alloy",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,726 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alloy"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bdf7932042b511ad4ad67f7eeac896df62439ac91a8c516d678b79cbe3f9c27"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-core",
+ "alloy-eips",
+ "alloy-ens",
+ "alloy-genesis",
+ "alloy-network",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-transport",
+ "alloy-transport-http",
+ "alloy-trie",
+]
+
+[[package]]
+name = "alloy-chains"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c36ddb69f5e41407e7a93aead3480f7c8ff076e73d01a951ae8f7ea4542c1ca0"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "phf 0.14.0",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f0f42ee16e9eaffa4df5aa3a17b1df88dd222310d13152ab91357a2551fd054"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-trie",
+ "alloy-tx-macros",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "k256",
+ "once_cell",
+ "rand 0.8.7",
+ "secp256k1 0.30.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db388e804269d977d60fa7530ccfefe9184ca48d4055dad3ec7e649a29186a06"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-contract"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69937abc65310c6eb739e540b107688943b61f38e7dcf9fde769367d3608d657"
+dependencies = [
+ "alloy-consensus",
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "alloy-transport",
+ "futures",
+ "futures-util",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-core"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8421a5ee9019b6d89f92935d0f8facd9f6ca088b41d7cc47244a02ccde4545f"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
+]
+
+[[package]]
+name = "alloy-dyn-abi"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a04eb4abc2b5074a18e687ee63918f407cc7990083cba9b999445f839796060"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "itoa",
+ "serde",
+ "serde_json",
+ "winnow",
+]
+
+[[package]]
+name = "alloy-eip2124"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eip2930"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "k256",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eip7928"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52010e7c255f45b0ef3ca18144cbfbe0c044b055fe53f59323f3df5d95f265b1"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "alloy-ens"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88c3d803649b2023413a5b84892ed3874977dfa8b8d5481dea05488f20f6f4ef"
+dependencies = [
+ "alloy-contract",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-sol-types",
+ "async-trait",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60fa6337a6af8bae818de3030448827bf55c1321c90c7d1f6f3b79257ead2a"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "alloy-trie",
+ "borsh",
+ "serde",
+ "serde_with",
+]
+
+[[package]]
+name = "alloy-hardforks"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
+dependencies = [
+ "alloy-chains",
+ "alloy-eip2124",
+ "alloy-primitives",
+ "auto_impl",
+ "dyn-clone",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cee30dd4c2f4b23f434fdf675e7bf9681b86768141277266c6f548ef25cba0a"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d7ff4d7f1503d12edda9b241904a309d6e1d5bcee3f0ffdc4d3d3f16f366b8"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "http",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-network"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44ff1439d901b44f6ff840545f82d65e66830ee33fb33cae495a566d66e0ccc8"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "derive_more",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb920286c4a71fb0ff3bbb207a640a531a42fceef5b43d4a943f7d5265789876"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f007e257069855bdf21d27762fd3f3705a613f805c9a08309bf353503f081d71"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "fixed-cache",
+ "foldhash 0.2.0",
+ "getrandom 0.4.3",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand 0.9.5",
+ "rapidhash",
+ "ruint",
+ "rustc-hash",
+ "secp256k1 0.31.1",
+ "serde",
+ "sha3",
+]
+
+[[package]]
+name = "alloy-provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "329375f50202cc6b2dcc8c6b1e53b716cbbebbeea54e931befc4f3b628dfc469"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-signer",
+ "alloy-sol-types",
+ "alloy-transport",
+ "alloy-transport-http",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "either",
+ "futures",
+ "futures-utils-wasm",
+ "lru 0.16.4",
+ "parking_lot",
+ "pin-project",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-pubsub"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71044e076a7c243454619e36279fc4654bc1ff846fbf666663ef574388859c84"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-transport",
+ "auto_impl",
+ "bimap",
+ "futures",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
+dependencies = [
+ "alloy-rlp-derive",
+ "arrayvec",
+ "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d4311c03125e8a18296504560b9de3d75ecbd0dcda7f71e6cf2a196d57e6fba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52bffef2c5714f578f267bb959b47908b95728f1f3e2073a96d928f4441c148d"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-transport",
+ "alloy-transport-http",
+ "futures",
+ "pin-project",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64449cae1cf37c4907b10ccca1613b71809f9a1f3ad6e2b4cc14d08e2e4947f"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe7fa70c3af4b2de7f670b50d680700e0f979ce3a0ab7725958b51ffc3b16c2"
+dependencies = [
+ "alloy-consensus-any",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04f60a196df184facc9acbb61bd765a36cfb3c9d27eb6b43d5bd26340df1b96a"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-sol-types",
+ "itertools 0.13.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07758cbde42596b66da52bb661d77e253c3f7f9b3f553faf07adbadeb6419502"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc43a73bc1bf7044898e1b0dcefaba45d0cfac3e379bb5ca29cc3e3a04c61451"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "either",
+ "elliptic-curve",
+ "k256",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372ff9be2b61c2cd6d33cfcef9bd5865962c0628c932767f5154443aba2c9746"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand 0.8.7",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5655c38d5f84955bf727b2eeb62fddd91ebb98fd1d7ae6eb77f73ea88f9b9cf"
+dependencies = [
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "proc-macro-error3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6277c780e07b76951e09a59788dde230d1582612324177d11a43a61e21a6bb83"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-sol-macro-input",
+ "const-hex",
+ "heck",
+ "indexmap 2.14.0",
+ "proc-macro-error3",
+ "proc-macro2",
+ "quote",
+ "sha3",
+ "syn 2.0.119",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9762b2ad3e5a0c09886de54fe549ab0056681df843cb082e2df7e1c0eb270d30"
+dependencies = [
+ "alloy-json-abi",
+ "const-hex",
+ "dunce",
+ "heck",
+ "macro-string",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.119",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da4c7130f0f01f4719678bda3db3bc7267fc2f7f9d0565e3bd964cd2bb45050d"
+dependencies = [
+ "serde",
+ "winnow",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96e74d6213180f78dbdccddce8af02a639c160c94b0a543fa35c77c58b8a7fc"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "serde",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830c87b05870c80c8d2cfb9245feaff36468893f19fc124c7ff563cabda6386c"
+dependencies = [
+ "alloy-json-rpc",
+ "auto_impl",
+ "base64",
+ "derive_more",
+ "futures",
+ "futures-utils-wasm",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ecd298fb0e6a31bd90c72efba2728e3d7569f1c89a3719576fb0e4e40b0fc8"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "itertools 0.13.0",
+ "reqwest 0.13.4",
+ "serde_json",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-transport-mpp"
+version = "0.2.0"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=e59900080f5cd36ec8992673924aad1a74b96950#e59900080f5cd36ec8992673924aad1a74b96950"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-pubsub",
+ "alloy-transport",
+ "alloy-transport-ws",
+ "futures",
+ "http",
+ "mpp",
+ "reqwest 0.13.4",
+ "rustls",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite 0.28.0",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-transport-ws"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67177a75a6e8a44f39ccbbc64a3e3a70186ef401d7313285b56735d4285aa34"
+dependencies = [
+ "alloy-pubsub",
+ "alloy-transport",
+ "futures",
+ "http",
+ "rustls",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite 0.28.0",
+ "tracing",
+ "url",
+ "ws_stream_wasm",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more",
+ "nybbles",
+ "serde",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e50185b84799c8b5f016a0c9da74309fe28d1c70fbe590a4e8d9cae6df3eebb0"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +848,454 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-bls12-381"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-r1cs-std",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-poly",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.1",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "ark-r1cs-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-relations",
+ "ark-std 0.5.0",
+ "educe",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "tracing",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
+dependencies = [
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+ "tracing",
+ "tracing-subscriber 0.2.25",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-serialize-derive 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint",
+ "serde_with",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
+dependencies = [
+ "num-traits",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,10 +1307,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version 0.4.1",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "aurora-engine-modexp"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518bc5745a6264b5fd7b09dffb9667e400ee9e2bbe18555fac75e1fe9afa0df9"
+dependencies = [
+ "hex",
+ "num",
+]
+
+[[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "autocfg"
@@ -151,10 +1351,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bincode"
@@ -171,7 +1465,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -179,6 +1473,51 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-consensus-encoding"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "207311705279250ba465076a1bac4b1ac982855fff73fc5f67e22158ac58cdc9"
+dependencies = [
+ "bitcoin-internals",
+ "hex-conservative 1.2.0",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d573f4cf32996a8dce612e4348cece65a241f1882ed594047c9ba348e8869fa5"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
+dependencies = [
+ "bitcoin-consensus-encoding",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative 0.2.2",
+]
 
 [[package]]
 name = "bitflags"
@@ -191,6 +1530,31 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "serde",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -211,6 +1575,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "blst"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
 name = "bm25"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,10 +1601,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases 0.2.1",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bstr"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
@@ -253,6 +1679,24 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "c-kzg"
+version = "2.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d04308254695569fdb9bfe3bacc1c91837a670d0806605eb82d63748fbd3a6"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "once_cell",
+ "serde",
+]
 
 [[package]]
 name = "cached"
@@ -315,6 +1759,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -438,6 +1884,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,10 +1935,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -514,6 +2032,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,7 +2066,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools",
+ "itertools 0.13.0",
  "num-traits",
  "oorandom",
  "plotters",
@@ -553,7 +2086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -623,6 +2156,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +2184,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.6.4",
+ "subtle-ng",
+ "zeroize",
 ]
 
 [[package]]
@@ -684,6 +2251,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "serde",
  "strsim",
  "syn 2.0.119",
 ]
@@ -711,16 +2279,103 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "syn 2.0.119",
+ "unicode-xid",
+]
 
 [[package]]
 name = "deunicode"
@@ -730,12 +2385,23 @@ checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -745,8 +2411,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
- "const-oid",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -783,16 +2450,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "serdect",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519-consensus"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
+dependencies = [
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core 0.6.4",
+ "sha2 0.9.9",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "serdect",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "equivalent"
@@ -817,6 +2575,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,6 +2604,18 @@ dependencies = [
  "indenter",
  "once_cell",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
@@ -842,6 +2633,28 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
 
 [[package]]
 name = "faststr"
@@ -871,6 +2684,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +2709,28 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixed-cache"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe63500644ef0269fe6b744e7e5dc5c20b5eebf3d881bc2be53f194636f6583"
+dependencies = [
+ "equivalent",
+ "rapidhash",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
+ "byteorder",
+ "rand 0.8.7",
+ "rustc-hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "flate2"
@@ -925,6 +2770,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,6 +2792,18 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1022,12 +2894,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-utils-wasm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
 ]
 
 [[package]]
@@ -1038,6 +2931,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1102,6 +2996,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +3035,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1135,9 +3058,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1145,10 +3068,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "http"
@@ -1190,6 +3183,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hudsucker"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a1d7c1c828ff6db12ddafb16768ecbac920df6301778d0eb78e95da0e44d94b"
+dependencies = [
+ "bstr",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tungstenite",
+ "hyper-util",
+ "moka",
+ "rand 0.10.2",
+ "rcgen",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-graceful",
+ "tokio-rustls",
+ "tokio-tungstenite 0.30.0",
+ "tracing",
+]
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +3236,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1227,11 +3253,43 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
+ "log",
  "rustls",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee7ba11c4933715ee2c2fea1d8932f19356d31648c0a1bb65223ef5d7962c4c"
+dependencies = [
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-tungstenite 0.30.0",
+ "tungstenite 0.30.0",
 ]
 
 [[package]]
@@ -1420,10 +3478,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -1433,6 +3522,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1468,6 +3559,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1509,7 +3609,7 @@ checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.1",
  "simd_cesu8",
  "syn 2.0.119",
 ]
@@ -1534,6 +3634,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,6 +3653,55 @@ dependencies = [
  "futures-util",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "serdect",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5dc2c0d691cbf7595cde551ced329cca99c2387c2cbc97754c5d0cd045d3ee"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
+]
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"
@@ -1555,6 +3714,23 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1590,6 +3766,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "pin-utils",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,10 +3791,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "macro-string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "matchers"
@@ -1614,10 +3826,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1642,6 +3872,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,6 +3899,59 @@ checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "mpp"
+version = "0.11.0"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=e59900080f5cd36ec8992673924aad1a74b96950#e59900080f5cd36ec8992673924aad1a74b96950"
+dependencies = [
+ "alloy",
+ "async-stream",
+ "async-trait",
+ "base64",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hmac 0.13.0",
+ "http",
+ "p256",
+ "rand 0.10.2",
+ "reqwest 0.13.4",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "serde_json_canonicalizer",
+ "sha2 0.11.0",
+ "subtle",
+ "tempo-alloy",
+ "tempo-contracts",
+ "tempo-primitives",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-tungstenite 0.29.0",
+ "uuid",
+]
+
+[[package]]
+name = "mpp-egress"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "base64",
+ "futures-util",
+ "http-body-util",
+ "hudsucker",
+ "mpp",
+ "rand 0.9.5",
+ "reqwest 0.13.4",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -1690,18 +3993,18 @@ dependencies = [
  "nanocodex-service",
  "nanocodex-tools",
  "reqwest 0.12.28",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
- "sha1",
- "sha2",
+ "sha1 0.11.0",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.30.0",
  "tower",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
  "url",
  "uuid",
  "wasm-bindgen",
@@ -1713,6 +4016,7 @@ dependencies = [
 name = "nanocodex-bin"
 version = "0.1.1"
 dependencies = [
+ "alloy-transport-mpp",
  "arboard",
  "base64",
  "chrono",
@@ -1723,21 +4027,24 @@ dependencies = [
  "eyre",
  "futures-util",
  "image",
+ "mpp",
+ "mpp-egress",
  "nanocodex",
  "nanocodex-observability",
  "pulldown-cmark",
  "ratatui",
  "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "self-replace",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "shlex",
  "syntect",
  "tempfile",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.30.0",
  "tracing",
  "two-face",
  "unicode-segmentation",
@@ -1772,7 +4079,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.30.0",
  "tower",
 ]
 
@@ -1819,7 +4126,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-opentelemetry",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -1852,7 +4159,7 @@ dependencies = [
  "sonic-rs",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.30.0",
  "tower",
  "tracing",
  "wasm-bindgen",
@@ -1875,14 +4182,14 @@ dependencies = [
  "portable-pty",
  "reqwest 0.12.28",
  "rquickjs",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.11.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -1893,6 +4200,23 @@ version = "0.1.1"
 dependencies = [
  "nanocodex",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -1932,6 +4256,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1941,10 +4284,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1953,6 +4359,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1962,6 +4400,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "nybbles"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
+dependencies = [
+ "alloy-rlp",
+ "cfg-if",
+ "proptest",
+ "ruint",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -2038,6 +4490,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2056,10 +4517,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -2141,6 +4645,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "serdect",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
+dependencies = [
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
+ "const_format",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "rustversion",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,10 +4721,110 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version 0.4.1",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_shared 0.14.0",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -2200,6 +4851,28 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -2294,12 +4967,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+ "serdect",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "uint",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr3"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82366fd7d8b7a440d66d13418820c69df9b3908bcb1a0476d7f5ce5d12f5a04d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error3"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b511283ea8a74b4b39447b128c5d00f03a356b7424554b13e298a5550100d9ac"
+dependencies = [
+ "proc-macro-error-attr3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2318,11 +5034,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
- "indexmap",
+ "indexmap 2.14.0",
  "nix 0.31.3",
  "tokio",
  "tracing",
  "windows",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags 2.13.1",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
 ]
 
 [[package]]
@@ -2342,7 +5073,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -2474,6 +5205,7 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -2526,6 +5258,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rancor"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2536,12 +5274,25 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "serde",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+ "serde",
 ]
 
 [[package]]
@@ -2557,6 +5308,16 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
@@ -2567,11 +5328,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+ "serde",
 ]
 
 [[package]]
@@ -2590,6 +5361,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
+dependencies = [
+ "getrandom 0.3.4",
+ "rustversion",
+]
+
+[[package]]
 name = "ratatui"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2601,8 +5391,8 @@ dependencies = [
  "crossterm",
  "indoc",
  "instability",
- "itertools",
- "lru",
+ "itertools 0.13.0",
+ "lru 0.12.5",
  "paste",
  "strum",
  "unicode-segmentation",
@@ -2628,6 +5418,20 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
 ]
 
 [[package]]
@@ -2740,7 +5544,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -2758,11 +5562,14 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -2770,6 +5577,7 @@ dependencies = [
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -2783,6 +5591,209 @@ dependencies = [
 ]
 
 [[package]]
+name = "revm"
+version = "40.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "823da6e5509bb8e5dcd91295870e494917a030ad506fc83301f3f08ad8b15b17"
+dependencies = [
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-inspector",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "11.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b378c2653331fe60969d9745e802cd773d82a20d8aaced914dfcf26ab8f0d9"
+dependencies = [
+ "bitvec",
+ "phf 0.13.1",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "revm-context"
+version = "18.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafa298114f3cab706945de14c04e73e6e6d7896302e4183dae273f968e52f80"
+dependencies = [
+ "bitvec",
+ "cfg-if",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-context-interface"
+version = "19.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db9c13f1dfc79425931fd184b6bd373dfac7baba50859b01107d5c0e20549cbb"
+dependencies = [
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "auto_impl",
+ "either",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database"
+version = "15.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69c3ce73454a09ef89a66177239d7c4f5f697227ae27254c99451866603b19d"
+dependencies = [
+ "alloy-eips",
+ "derive_more",
+ "revm-bytecode",
+ "revm-database-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-database-interface"
+version = "12.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a2656187f9f9c22ef9dd9300ed71aeaeca3506a6a0a229a07f264649b960d68"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "revm-handler"
+version = "20.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ce1d66037ca1394128313bb995fa9f50d834927a389386bb34f8f0ef914648f"
+dependencies = [
+ "auto_impl",
+ "derive-where",
+ "revm-bytecode",
+ "revm-context",
+ "revm-context-interface",
+ "revm-database-interface",
+ "revm-interpreter",
+ "revm-precompile",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-inspector"
+version = "21.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe3635d3411e8318849546570ca0220e783443319e28f5397c9f80b05bf4344"
+dependencies = [
+ "auto_impl",
+ "either",
+ "revm-context",
+ "revm-database-interface",
+ "revm-handler",
+ "revm-interpreter",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "revm-interpreter"
+version = "37.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae56c57ddca1f5c4abd443f826f1b3e49a86a528e7e1ea0fc207cdc4671a37e"
+dependencies = [
+ "revm-bytecode",
+ "revm-context-interface",
+ "revm-primitives",
+ "revm-state",
+ "serde",
+]
+
+[[package]]
+name = "revm-precompile"
+version = "36.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "191db865091e07ecb80b12ce3048192c76071ca3d2b0a315b111b271cd4ced37"
+dependencies = [
+ "ark-bls12-381",
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "arrayref",
+ "aurora-engine-modexp",
+ "blst",
+ "c-kzg",
+ "cfg-if",
+ "k256",
+ "p256",
+ "revm-context-interface",
+ "revm-primitives",
+ "ripemd",
+ "secp256k1 0.31.1",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "revm-primitives"
+version = "24.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5102d804892908d4ebf68da29b8562895922dffa26c230ff2c4dadcf93916f"
+dependencies = [
+ "alloy-primitives",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
+version = "12.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40eff6067185cf80932e06f6a9c8045b012ecb6f99a8d6edc618ec2792373e14"
+dependencies = [
+ "alloy-eip7928",
+ "bitflags 2.13.1",
+ "nonmax",
+ "revm-bytecode",
+ "revm-primitives",
+ "serde",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2792,8 +5803,17 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2804,7 +5824,7 @@ checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
  "bytes",
  "hashbrown 0.17.1",
- "indexmap",
+ "indexmap 2.14.0",
  "munge",
  "ptr_meta",
  "rancor",
@@ -2823,6 +5843,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "rlp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
 ]
 
 [[package]]
@@ -2878,6 +5908,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ruint"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
+ "bytes",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "proptest",
+ "rand 0.8.7",
+ "rand 0.9.5",
+ "rlp",
+ "ruint-macro",
+ "serde_core",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
+name = "rusqlite"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
+dependencies = [
+ "bitflags 2.13.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
 name = "rust-stemmers"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2892,6 +5982,24 @@ name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+dependencies = [
+ "rand 0.9.5",
+]
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
 
 [[package]]
 name = "rustc_version"
@@ -2899,7 +6007,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.28",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -2934,6 +6051,8 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2997,9 +6116,10 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3013,6 +6133,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "ryu-js"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
 
 [[package]]
 name = "same-file"
@@ -3045,6 +6171,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3057,10 +6207,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "serdect",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.7",
+ "secp256k1-sys 0.10.1",
+ "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.5",
+ "secp256k1-sys 0.11.0",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "security-framework"
@@ -3098,9 +6310,33 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -3149,11 +6385,34 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_json_canonicalizer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3165,6 +6424,48 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
  "serde",
 ]
 
@@ -3181,6 +6482,17 @@ dependencies = [
 
 [[package]]
 name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
@@ -3192,6 +6504,19 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
@@ -3199,6 +6524,37 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6287fd675f713484342a89cbf0a386abef5f15919cfad607e5e1f19e1e15331"
+dependencies = [
+ "cc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -3264,6 +6620,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3290,7 +6656,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.1",
  "simdutf8",
 ]
 
@@ -3299,6 +6665,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3362,6 +6734,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f99e664ecd2d85a68c87e3c7a3cfe691f647ea9e835de984aba4d54a41f817d4"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3433,10 +6827,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+
+[[package]]
 name = "symlink"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -3458,6 +6869,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-solidity"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "083be3061e64d362cbe6ef12cfe1307ba3884326d8856448fe8a120fa2c44ebf"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3499,6 +6922,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3515,6 +6950,93 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tempo-alloy"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb465280b2c333bc99803fc42d4367adcd0bb7113c6fffc19b8768f36e80cb8"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer-local",
+ "alloy-sol-types",
+ "alloy-transport",
+ "async-trait",
+ "dashmap",
+ "derive_more",
+ "futures",
+ "http",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "tempo-chainspec",
+ "tempo-contracts",
+ "tempo-primitives",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "tempo-chainspec"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce3e0f0d214f3bbf9d0f6b7e464e1b3b76297d4b3f29a3946f82f639e3447af"
+dependencies = [
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-hardforks",
+ "alloy-primitives",
+ "once_cell",
+ "paste",
+ "serde",
+ "serde_json",
+ "tempo-primitives",
+]
+
+[[package]]
+name = "tempo-contracts"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a163690a85ff88c8cb98b42490fa95a33b114d6d90c653b7be2c9f794f7b2ab9"
+dependencies = [
+ "alloy-contract",
+ "alloy-primitives",
+ "alloy-sol-types",
+ "serde",
+]
+
+[[package]]
+name = "tempo-primitives"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63f9919c82a4c68531609cd015994e1a81c48d4c84eeaa92a9d86651a0e6ec41"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "aws-lc-rs",
+ "base64",
+ "derive_more",
+ "ed25519-consensus",
+ "once_cell",
+ "p256",
+ "revm",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempo-contracts",
 ]
 
 [[package]]
@@ -3564,6 +7086,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -3664,6 +7195,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-graceful"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45740b38b48641855471cd402922e89156bdfbd97b69b45eeff170369cc18c7d"
+dependencies = [
+ "loom",
+ "pin-project-lite",
+ "slab",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3672,6 +7216,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -3693,6 +7247,35 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.28.0",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -3708,7 +7291,8 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.30.0",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3739,7 +7323,7 @@ version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -3839,6 +7423,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3854,7 +7439,7 @@ dependencies = [
  "symlink",
  "thiserror 2.0.18",
  "time",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -3901,7 +7486,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
  "web-time",
 ]
 
@@ -3912,6 +7497,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
  "tracing-core",
 ]
 
@@ -3944,6 +7538,41 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "rustls",
+ "rustls-pki-types",
+ "sha1 0.10.7",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "sha1 0.10.7",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
@@ -3956,7 +7585,7 @@ dependencies = [
  "rand 0.10.2",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.11.0",
  "thiserror 2.0.18",
 ]
 
@@ -3976,6 +7605,30 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "uint"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
@@ -4001,7 +7654,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "unicode-segmentation",
  "unicode-width 0.1.14",
 ]
@@ -4019,6 +7672,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,7 +7699,14 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -4076,6 +7748,12 @@ dependencies = [
  "itoa",
  "ryu",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
@@ -4198,6 +7876,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4224,6 +7916,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -4495,6 +8196,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "ws_stream_wasm"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version 0.4.1",
+ "send_wrapper",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "x11rb"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4510,6 +8239,34 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
+]
 
 [[package]]
 name = "yoke"
@@ -4580,6 +8337,20 @@ name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=186ca59f5cbd1b450cf2e252089ff68e3d13ca28#186ca59f5cbd1b450cf2e252089ff68e3d13ca28"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=3a689a1b1c194f54ad7a1afcbfa9be388706a94e#3a689a1b1c194f54ad7a1afcbfa9be388706a94e"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=186ca59f5cbd1b450cf2e252089ff68e3d13ca28#186ca59f5cbd1b450cf2e252089ff68e3d13ca28"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=3a689a1b1c194f54ad7a1afcbfa9be388706a94e#3a689a1b1c194f54ad7a1afcbfa9be388706a94e"
 dependencies = [
  "alloy",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["bin/nanocodex", "crates/nanocodex", "crates/nanocodex-core", "crates/nanocodex-macros", "crates/nanocodex-mcp", "crates/nanocodex-observability", "crates/nanocodex-service", "crates/nanocodex-tools", "examples", "js/bindings", "py/bindings"]
+members = ["bin/nanocodex", "crates/mpp-egress", "crates/nanocodex", "crates/nanocodex-core", "crates/nanocodex-macros", "crates/nanocodex-mcp", "crates/nanocodex-observability", "crates/nanocodex-service", "crates/nanocodex-tools", "examples", "js/bindings", "py/bindings"]
 default-members = ["bin/nanocodex"]
 resolver = "2"
 
@@ -30,6 +30,10 @@ eyre = "0.6.12"
 futures-util = "0.3.31"
 getrandom = "0.3.4"
 http = "1.3.1"
+http-body-util = "0.1.3"
+hudsucker = { version = "0.25.0", default-features = false, features = ["rcgen-ca", "rustls-client"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "e59900080f5cd36ec8992673924aad1a74b96950", default-features = false }
+mpp-egress = { version = "0.1.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.1.1", path = "crates/nanocodex" }
 nanocodex-core = { version = "0.1.1", path = "crates/nanocodex-core" }
 nanocodex-macros = { version = "0.1.1", path = "crates/nanocodex-macros" }
@@ -37,6 +41,7 @@ nanocodex-mcp = { version = "0.1.1", path = "crates/nanocodex-mcp" }
 nanocodex-observability = { version = "0.1.1", path = "crates/nanocodex-observability" }
 nanocodex-service = { version = "0.1.1", path = "crates/nanocodex-service" }
 nanocodex-tools = { version = "0.1.1", path = "crates/nanocodex-tools" }
+rand = "0.9.2"
 image = { version = "0.25.9", default-features = false, features = ["gif", "jpeg", "png", "pnm", "webp"] }
 iana-time-zone = "0.1.64"
 js-sys = "0.3.82"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ getrandom = "0.3.4"
 http = "1.3.1"
 http-body-util = "0.1.3"
 hudsucker = { version = "0.25.0", default-features = false, features = ["rcgen-ca", "rustls-client"] }
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "a91163d46aa614df33bf3214c8aef557abf6e9b7", default-features = false }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "441e3114abb705e1e613272a62047e5c7b671ef9", default-features = false }
 mpp-egress = { version = "0.1.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.1.1", path = "crates/nanocodex" }
 nanocodex-core = { version = "0.1.1", path = "crates/nanocodex-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ getrandom = "0.3.4"
 http = "1.3.1"
 http-body-util = "0.1.3"
 hudsucker = { version = "0.25.0", default-features = false, features = ["rcgen-ca", "rustls-client"] }
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "441e3114abb705e1e613272a62047e5c7b671ef9", default-features = false }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "186ca59f5cbd1b450cf2e252089ff68e3d13ca28", default-features = false }
 mpp-egress = { version = "0.1.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.1.1", path = "crates/nanocodex" }
 nanocodex-core = { version = "0.1.1", path = "crates/nanocodex-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ getrandom = "0.3.4"
 http = "1.3.1"
 http-body-util = "0.1.3"
 hudsucker = { version = "0.25.0", default-features = false, features = ["rcgen-ca", "rustls-client"] }
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "e59900080f5cd36ec8992673924aad1a74b96950", default-features = false }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "0cb2025d2ce1eb211f7a6d3c684ed5268a99edbc", default-features = false }
 mpp-egress = { version = "0.1.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.1.1", path = "crates/nanocodex" }
 nanocodex-core = { version = "0.1.1", path = "crates/nanocodex-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ getrandom = "0.3.4"
 http = "1.3.1"
 http-body-util = "0.1.3"
 hudsucker = { version = "0.25.0", default-features = false, features = ["rcgen-ca", "rustls-client"] }
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "186ca59f5cbd1b450cf2e252089ff68e3d13ca28", default-features = false }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "3a689a1b1c194f54ad7a1afcbfa9be388706a94e", default-features = false }
 mpp-egress = { version = "0.1.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.1.1", path = "crates/nanocodex" }
 nanocodex-core = { version = "0.1.1", path = "crates/nanocodex-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ getrandom = "0.3.4"
 http = "1.3.1"
 http-body-util = "0.1.3"
 hudsucker = { version = "0.25.0", default-features = false, features = ["rcgen-ca", "rustls-client"] }
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "0cb2025d2ce1eb211f7a6d3c684ed5268a99edbc", default-features = false }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "ef9f2f59b553b6cf7ca11746eb48687d451c7dbe", default-features = false }
 mpp-egress = { version = "0.1.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.1.1", path = "crates/nanocodex" }
 nanocodex-core = { version = "0.1.1", path = "crates/nanocodex-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ getrandom = "0.3.4"
 http = "1.3.1"
 http-body-util = "0.1.3"
 hudsucker = { version = "0.25.0", default-features = false, features = ["rcgen-ca", "rustls-client"] }
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "ef9f2f59b553b6cf7ca11746eb48687d451c7dbe", default-features = false }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "a91163d46aa614df33bf3214c8aef557abf6e9b7", default-features = false }
 mpp-egress = { version = "0.1.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.1.1", path = "crates/nanocodex" }
 nanocodex-core = { version = "0.1.1", path = "crates/nanocodex-core" }

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 arboard.workspace = true
 base64.workspace = true
-alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "ef9f2f59b553b6cf7ca11746eb48687d451c7dbe" }
+alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "a91163d46aa614df33bf3214c8aef557abf6e9b7" }
 clap.workspace = true
 crossterm.workspace = true
 dotenvy.workspace = true
@@ -24,7 +24,7 @@ image.workspace = true
 nanocodex.workspace = true
 nanocodex-observability.workspace = true
 pulldown-cmark.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "ef9f2f59b553b6cf7ca11746eb48687d451c7dbe", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "a91163d46aa614df33bf3214c8aef557abf6e9b7", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
 mpp-egress.workspace = true
 ratatui.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 arboard.workspace = true
 base64.workspace = true
-alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "0cb2025d2ce1eb211f7a6d3c684ed5268a99edbc" }
+alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "ef9f2f59b553b6cf7ca11746eb48687d451c7dbe" }
 clap.workspace = true
 crossterm.workspace = true
 dotenvy.workspace = true
@@ -24,7 +24,7 @@ image.workspace = true
 nanocodex.workspace = true
 nanocodex-observability.workspace = true
 pulldown-cmark.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "0cb2025d2ce1eb211f7a6d3c684ed5268a99edbc", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "ef9f2f59b553b6cf7ca11746eb48687d451c7dbe", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
 mpp-egress.workspace = true
 ratatui.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 arboard.workspace = true
 base64.workspace = true
-alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "441e3114abb705e1e613272a62047e5c7b671ef9" }
+alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "186ca59f5cbd1b450cf2e252089ff68e3d13ca28" }
 clap.workspace = true
 crossterm.workspace = true
 dotenvy.workspace = true
@@ -24,7 +24,7 @@ image.workspace = true
 nanocodex.workspace = true
 nanocodex-observability.workspace = true
 pulldown-cmark.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "441e3114abb705e1e613272a62047e5c7b671ef9", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "186ca59f5cbd1b450cf2e252089ff68e3d13ca28", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
 mpp-egress.workspace = true
 ratatui.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 arboard.workspace = true
 base64.workspace = true
-alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "a91163d46aa614df33bf3214c8aef557abf6e9b7" }
+alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "441e3114abb705e1e613272a62047e5c7b671ef9" }
 clap.workspace = true
 crossterm.workspace = true
 dotenvy.workspace = true
@@ -24,7 +24,7 @@ image.workspace = true
 nanocodex.workspace = true
 nanocodex-observability.workspace = true
 pulldown-cmark.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "a91163d46aa614df33bf3214c8aef557abf6e9b7", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "441e3114abb705e1e613272a62047e5c7b671ef9", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
 mpp-egress.workspace = true
 ratatui.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 arboard.workspace = true
 base64.workspace = true
-alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "186ca59f5cbd1b450cf2e252089ff68e3d13ca28" }
+alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "3a689a1b1c194f54ad7a1afcbfa9be388706a94e" }
 clap.workspace = true
 crossterm.workspace = true
 dotenvy.workspace = true
@@ -24,7 +24,7 @@ image.workspace = true
 nanocodex.workspace = true
 nanocodex-observability.workspace = true
 pulldown-cmark.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "186ca59f5cbd1b450cf2e252089ff68e3d13ca28", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "3a689a1b1c194f54ad7a1afcbfa9be388706a94e", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
 mpp-egress.workspace = true
 ratatui.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -14,6 +14,7 @@ build = "build.rs"
 [dependencies]
 arboard.workspace = true
 base64.workspace = true
+alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "e59900080f5cd36ec8992673924aad1a74b96950" }
 clap.workspace = true
 crossterm.workspace = true
 dotenvy.workspace = true
@@ -23,8 +24,11 @@ image.workspace = true
 nanocodex.workspace = true
 nanocodex-observability.workspace = true
 pulldown-cmark.workspace = true
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "e59900080f5cd36ec8992673924aad1a74b96950", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
+mpp-egress.workspace = true
 ratatui.workspace = true
-reqwest.workspace = true
+reqwest = { workspace = true, features = ["blocking"] }
+reqwest13 = { package = "reqwest", version = "0.13", default-features = false, features = ["rustls"] }
 self-replace.workspace = true
 semver.workspace = true
 serde.workspace = true
@@ -35,6 +39,7 @@ sha2.workspace = true
 shlex.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
+tokio-tungstenite.workspace = true
 tracing.workspace = true
 unicode-segmentation.workspace = true
 unicode-width.workspace = true

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 arboard.workspace = true
 base64.workspace = true
-alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "e59900080f5cd36ec8992673924aad1a74b96950" }
+alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "0cb2025d2ce1eb211f7a6d3c684ed5268a99edbc" }
 clap.workspace = true
 crossterm.workspace = true
 dotenvy.workspace = true
@@ -24,7 +24,7 @@ image.workspace = true
 nanocodex.workspace = true
 nanocodex-observability.workspace = true
 pulldown-cmark.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "e59900080f5cd36ec8992673924aad1a74b96950", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "0cb2025d2ce1eb211f7a6d3c684ed5268a99edbc", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
 mpp-egress.workspace = true
 ratatui.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -11,12 +11,14 @@ use nanocodex::{
 };
 
 use crate::mcp::McpArgs;
+use crate::mpp::{MppAdapter, MppArgs};
 use crate::subagents::{self, ChildAgents};
 
 pub(crate) struct ConfiguredAgent {
     pub(crate) handle: Nanocodex,
     pub(crate) events: AgentEvents,
     pub(crate) child_agents: Option<Arc<ChildAgents>>,
+    pub(crate) mpp_adapter: Option<MppAdapter>,
 }
 
 #[derive(Args)]
@@ -105,12 +107,15 @@ pub(crate) struct AgentArgs {
     #[arg(long, env = "NANOCODEX_STORE_RESPONSES", action = ArgAction::Set)]
     store_responses: Option<bool>,
 
-    /// `OpenAI` HTTP API base used by HTTPS Responses and standalone web search.
+    /// `OpenAI` HTTP API base used by HTTPS Responses and in-process remote tools.
     #[arg(long, env = "OPENAI_API_BASE_URL")]
     api_base_url: Option<String>,
 
     #[command(flatten)]
     mcp: McpArgs,
+
+    #[command(flatten)]
+    mpp: MppArgs,
 }
 
 impl AgentArgs {
@@ -118,21 +123,39 @@ impl AgentArgs {
         &self.cwd
     }
 
-    pub(crate) fn build(self) -> Result<ConfiguredAgent> {
+    #[cfg(test)]
+    pub(crate) const fn uses_tempo(&self) -> bool {
+        self.mpp.is_enabled()
+    }
+
+    pub(crate) async fn build(self) -> Result<ConfiguredAgent> {
         let codex_home = default_codex_home()?;
         let rollout = self.rollouts.then(|| codex_home.clone());
-        let auth = select_auth(self.api_key, self.auth_file, environment_api_key()?)?;
-        let mut responses = Responses::builder().transport(self.responses_transport);
+        let mpp_enabled = self.mpp.is_enabled();
+        let auth = if mpp_enabled {
+            OpenAiAuth::api_key("tempo-proxy")
+        } else {
+            select_auth(self.api_key, self.auth_file, environment_api_key()?)?
+        };
+        let direct_websocket_url = self
+            .websocket_url
+            .unwrap_or_else(|| "wss://api.openai.com/v1/responses".to_owned());
+        let (websocket_url, mpp_adapter) = self.mpp.start(direct_websocket_url).await?;
+        let mut responses = Responses::builder()
+            .transport(self.responses_transport)
+            .websocket_url(websocket_url);
         if let Some(history) = self.responses_history {
             responses = responses.history(history);
         }
         if let Some(store) = self.store_responses {
             responses = responses.store(store);
         }
-        if let Some(websocket_url) = self.websocket_url {
-            responses = responses.websocket_url(websocket_url);
-        }
-        if let Some(api_base_url) = self.api_base_url {
+        let api_base_url = self.api_base_url.or_else(|| {
+            mpp_adapter
+                .as_ref()
+                .map(|adapter| adapter.api_base_url().to_owned())
+        });
+        if let Some(api_base_url) = api_base_url {
             responses = responses.api_base_url(api_base_url);
         }
         let responses = responses.build();
@@ -141,6 +164,11 @@ impl AgentArgs {
             .image_generation(self.image_generation);
         if let Some(mcp) = self.mcp.build()? {
             tools = tools.provider(mcp);
+        }
+        if let Some(mpp_adapter) = &mpp_adapter {
+            tools = tools
+                .process_environment(mpp_adapter.tool_environment())
+                .remote_http_client(mpp_adapter.tool_http_client()?);
         }
         let tools = tools.build()?;
         let child_agents = self.subagents.then(|| Arc::new(ChildAgents::default()));
@@ -174,6 +202,7 @@ impl AgentArgs {
             handle,
             events,
             child_agents,
+            mpp_adapter,
         })
     }
 }

--- a/bin/nanocodex/src/main.rs
+++ b/bin/nanocodex/src/main.rs
@@ -1,6 +1,7 @@
 mod auth;
 mod config;
 mod mcp;
+mod mpp;
 mod observability;
 mod run;
 mod subagents;
@@ -77,5 +78,57 @@ async fn main() -> Result<()> {
             let _observability = cli.observability.install(true, cli.agent.cwd())?;
             tui::run(cli.agent, cli.prompt).await
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tempo_flag_selects_the_tui_transport() {
+        let cli = Cli::try_parse_from([
+            "nanocodex",
+            "--provider.tempo",
+            "--provider.tempo.wallet-store",
+            "/tmp/tempo-wallet.json",
+        ])
+        .unwrap();
+
+        assert!(cli.command.is_none());
+        assert!(cli.agent.uses_tempo());
+    }
+
+    #[test]
+    fn tempo_flag_selects_the_one_shot_transport() {
+        let cli = Cli::try_parse_from([
+            "nanocodex",
+            "run",
+            "reply with ok",
+            "--provider.tempo",
+            "--provider.tempo.wallet-store",
+            "/tmp/tempo-wallet.json",
+        ])
+        .unwrap();
+
+        assert!(matches!(cli.command, Some(Command::Run(_))));
+        assert!(cli.agent.uses_tempo());
+    }
+
+    #[test]
+    fn openai_provider_is_explicitly_selectable() {
+        let cli = Cli::try_parse_from(["nanocodex", "--provider.openai", "--api-key", "test-key"])
+            .unwrap();
+
+        assert!(!cli.agent.uses_tempo());
+    }
+
+    #[test]
+    fn provider_selection_is_exclusive() {
+        let error = Cli::try_parse_from(["nanocodex", "--provider.openai", "--provider.tempo"])
+            .err()
+            .unwrap();
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 }

--- a/bin/nanocodex/src/mpp.rs
+++ b/bin/nanocodex/src/mpp.rs
@@ -15,7 +15,7 @@ use futures_util::{SinkExt, StreamExt};
 use mpp::{
     MppError, PaymentChallenge, PaymentCredential,
     client::{
-        MultiProvider, PaymentProvider, TempoProvider, TempoSessionProvider,
+        MultiProvider, PaymentContext, PaymentProvider, TempoProvider, TempoSessionProvider,
         tempo::{
             AutoswapConfig,
             session::store::{
@@ -261,7 +261,6 @@ impl MppArgs {
             .wrap_err("failed to start the local MPP WebSocket adapter")?;
         let config = Arc::new(BridgeConfig {
             endpoint: self.mpp_websocket_url,
-            bootstrap_url: endpoint.to_string(),
             api_key: self.mpp_api_key,
             payment,
         });
@@ -442,6 +441,36 @@ impl PaymentProvider for NativeSession {
             .await
     }
 
+    async fn pay_with_context(
+        &self,
+        challenge: &PaymentChallenge,
+        context: PaymentContext,
+    ) -> Result<PaymentCredential, MppError> {
+        self.session
+            .application_websocket_credential_with_top_up(
+                &self.client,
+                context.url.as_str(),
+                context.headers,
+                challenge,
+            )
+            .await
+    }
+
+    async fn prepare_application_websocket_challenge(
+        &self,
+        challenge: &PaymentChallenge,
+        context: PaymentContext,
+    ) -> Result<PaymentChallenge, MppError> {
+        self.session
+            .recover_application_websocket_challenge_with_headers(
+                &self.client,
+                context.url.as_str(),
+                context.headers,
+                challenge,
+            )
+            .await
+    }
+
     fn accept_payment_header(&self) -> Option<String> {
         self.session.accept_payment_header()
     }
@@ -525,7 +554,6 @@ impl CloseProvider for NativeSession {
 
 struct BridgeConfig {
     endpoint: String,
-    bootstrap_url: String,
     api_key: Option<String>,
     payment: NativeSession,
 }
@@ -598,24 +626,6 @@ async fn bridge(
         .map_err(|_| eyre!("local Responses WebSocket header capture was poisoned"))?
         .take()
         .ok_or_else(|| eyre!("local Responses WebSocket headers were not captured"))?;
-
-    let mut bootstrap_headers = reqwest13::header::HeaderMap::new();
-    if let Some(api_key) = &config.api_key {
-        bootstrap_headers.insert(
-            reqwest13::header::HeaderName::from_static("x-api-key"),
-            reqwest13::header::HeaderValue::from_str(api_key)?,
-        );
-    }
-    config
-        .payment
-        .session
-        .bootstrap_with_headers(
-            &reqwest13::Client::new(),
-            &config.bootstrap_url,
-            bootstrap_headers,
-        )
-        .await
-        .wrap_err("failed to rehydrate the Tempo MPP session")?;
 
     let mut connector = MppApplicationWsConnect::new(
         &config.endpoint,

--- a/bin/nanocodex/src/mpp.rs
+++ b/bin/nanocodex/src/mpp.rs
@@ -17,6 +17,7 @@ use mpp::{
     client::{
         MultiProvider, PaymentProvider, TempoProvider, TempoSessionProvider,
         tempo::{
+            AutoswapConfig,
             session::store::{
                 SqliteChannelStore, SqliteChannelStoreOptions, default_channel_database_path,
             },
@@ -44,6 +45,8 @@ use tokio_tungstenite::{
 
 const DEFAULT_MPP_WEBSOCKET_URL: &str = "wss://openai.mpp.tempo.xyz/v1/responses";
 const DEFAULT_TEMPO_RPC_URL: &str = "https://rpc.mainnet.tempo.xyz";
+const DEFAULT_TEMPO_PAY_WITH: &str = "0x20c0000000000000000000000000000000000000";
+const DEFAULT_TEMPO_SWAP_SLIPPAGE_BPS: u16 = 100;
 // Five $5 refill quanta while retaining a finite client-side authorization cap.
 const DEFAULT_MAX_DEPOSIT: u128 = 25_000_000;
 const DEFAULT_MAX_EGRESS_CHARGE: u128 = 100_000;
@@ -108,6 +111,25 @@ pub(crate) struct MppArgs {
     )]
     rpc_url: String,
 
+    /// Stablecoin used to acquire the MPP service's requested currency.
+    #[arg(
+        long = "provider.tempo.pay-with",
+        global = true,
+        env = "NANOCODEX_PROVIDER_TEMPO_PAY_WITH",
+        default_value = DEFAULT_TEMPO_PAY_WITH,
+        value_parser = NonEmptyStringValueParser::new()
+    )]
+    pay_with: String,
+
+    /// Maximum slippage for automatic stablecoin swaps, in basis points.
+    #[arg(
+        long = "provider.tempo.swap-slippage-bps",
+        global = true,
+        env = "NANOCODEX_PROVIDER_TEMPO_SWAP_SLIPPAGE_BPS",
+        default_value_t = DEFAULT_TEMPO_SWAP_SLIPPAGE_BPS
+    )]
+    swap_slippage_bps: u16,
+
     /// Maximum total native session deposit in token atomic units.
     #[arg(
         long = "provider.tempo.max-deposit",
@@ -165,25 +187,33 @@ impl MppArgs {
         })
         .map_err(|error| eyre!(error))
         .wrap_err("failed to open the Tempo session channel store")?;
+        let autoswap = AutoswapConfig::new(
+            self.pay_with
+                .parse()
+                .wrap_err("invalid provider.tempo.pay-with token address")?,
+            self.swap_slippage_bps,
+        );
         let charge = TempoProvider::new(wallet.signer.clone(), &self.rpc_url)
             .wrap_err("failed to configure the native Tempo charge provider")?
             .with_signing_mode(TempoSigningMode::Keychain {
                 wallet: wallet.account,
-                key_authorization: None,
+                key_authorization: wallet.key_authorization.clone(),
                 version: KeychainVersion::V2,
             })
-            .with_expected_chain_id(wallet.chain_id);
+            .with_expected_chain_id(wallet.chain_id)
+            .with_autoswap(autoswap.clone());
         let session = TempoSessionProvider::new(wallet.signer, &self.rpc_url)
             .wrap_err("failed to configure the native Tempo session provider")?
             .with_signing_mode(TempoSigningMode::Keychain {
                 wallet: wallet.account,
-                key_authorization: None,
+                key_authorization: wallet.key_authorization,
                 version: KeychainVersion::V2,
             })
             .with_authorized_signer(wallet.access_key)
             .with_channel_store(Arc::new(store))
             .with_default_deposit(self.max_deposit)
-            .with_max_deposit(self.max_deposit);
+            .with_max_deposit(self.max_deposit)
+            .with_autoswap(autoswap);
         let mut management_headers = reqwest13::header::HeaderMap::new();
         if let Some(api_key) = &self.mpp_api_key {
             management_headers.insert(
@@ -710,6 +740,8 @@ mod tests {
             wallet_store: None,
             channel_store: None,
             rpc_url: DEFAULT_TEMPO_RPC_URL.to_owned(),
+            pay_with: DEFAULT_TEMPO_PAY_WITH.to_owned(),
+            swap_slippage_bps: DEFAULT_TEMPO_SWAP_SLIPPAGE_BPS,
             max_deposit: DEFAULT_MAX_DEPOSIT,
             egress_max_charge: DEFAULT_MAX_EGRESS_CHARGE,
             mpp_api_key: None,

--- a/bin/nanocodex/src/mpp.rs
+++ b/bin/nanocodex/src/mpp.rs
@@ -1,0 +1,769 @@
+use std::{
+    net::TcpListener as StdTcpListener,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use alloy_transport_mpp::{
+    CloseProvider, CloseRequest, MppApplicationWs, MppApplicationWsConnect, VoucherProvider,
+    VoucherRequest,
+};
+use clap::{ArgAction, Args, builder::NonEmptyStringValueParser};
+use eyre::{Context, Result, eyre};
+use futures_util::{SinkExt, StreamExt};
+use mpp::{
+    MppError, PaymentChallenge, PaymentCredential,
+    client::{
+        MultiProvider, PaymentProvider, TempoProvider, TempoSessionProvider,
+        tempo::{
+            session::store::{
+                SqliteChannelStore, SqliteChannelStoreOptions, default_channel_database_path,
+            },
+            signing::{KeychainVersion, TempoSigningMode},
+            wallet::TempoWallet,
+        },
+    },
+    protocol::intents::ChargeRequest,
+};
+use mpp_egress::{EgressPolicy, MppEgress};
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::{oneshot, watch},
+    task::{JoinHandle, JoinSet},
+    time::timeout,
+};
+use tokio_tungstenite::{
+    WebSocketStream, accept_hdr_async,
+    tungstenite::{
+        Message,
+        handshake::server::{Request, Response},
+        http::{HeaderName, HeaderValue},
+    },
+};
+
+const DEFAULT_MPP_WEBSOCKET_URL: &str = "wss://openai.mpp.tempo.xyz/v1/responses";
+const DEFAULT_TEMPO_RPC_URL: &str = "https://rpc.mainnet.tempo.xyz";
+// Five $5 refill quanta while retaining a finite client-side authorization cap.
+const DEFAULT_MAX_DEPOSIT: u128 = 25_000_000;
+const DEFAULT_MAX_EGRESS_CHARGE: u128 = 100_000;
+
+#[derive(Args, Clone)]
+pub(crate) struct MppArgs {
+    /// Connect directly to `OpenAI`. This is the default provider.
+    #[arg(
+        long = "provider.openai",
+        global = true,
+        env = "NANOCODEX_PROVIDER_OPENAI",
+        default_value_t = false,
+        action = ArgAction::SetTrue,
+        conflicts_with = "tempo"
+    )]
+    openai: bool,
+
+    /// Pay for the Responses WebSocket through MPP.
+    #[arg(
+        long = "provider.tempo",
+        id = "tempo",
+        global = true,
+        env = "NANOCODEX_PROVIDER_TEMPO",
+        default_value_t = false,
+        action = ArgAction::SetTrue
+    )]
+    enabled: bool,
+
+    /// Paid MPP WebSocket endpoint.
+    #[arg(
+        long = "provider.tempo.responses-websocket-url",
+        global = true,
+        env = "NANOCODEX_PROVIDER_TEMPO_RESPONSES_WEBSOCKET_URL",
+        default_value = DEFAULT_MPP_WEBSOCKET_URL,
+        value_parser = NonEmptyStringValueParser::new()
+    )]
+    mpp_websocket_url: String,
+
+    /// Tempo Wallet state containing the logged-in account and access key.
+    #[arg(
+        long = "provider.tempo.wallet-store",
+        global = true,
+        env = "NANOCODEX_PROVIDER_TEMPO_WALLET_STORE"
+    )]
+    wallet_store: Option<PathBuf>,
+
+    /// `SQLite` channel store shared with Tempo Wallet and `MPPx` CLIs.
+    #[arg(
+        long = "provider.tempo.channel-store",
+        global = true,
+        env = "NANOCODEX_PROVIDER_TEMPO_CHANNEL_STORE"
+    )]
+    channel_store: Option<PathBuf>,
+
+    /// Tempo RPC used for native TIP-1034 channel operations.
+    #[arg(
+        long = "provider.tempo.rpc-url",
+        global = true,
+        env = "NANOCODEX_PROVIDER_TEMPO_RPC_URL",
+        default_value = DEFAULT_TEMPO_RPC_URL,
+        value_parser = NonEmptyStringValueParser::new()
+    )]
+    rpc_url: String,
+
+    /// Maximum total native session deposit in token atomic units.
+    #[arg(
+        long = "provider.tempo.max-deposit",
+        global = true,
+        env = "NANOCODEX_PROVIDER_TEMPO_MAX_DEPOSIT",
+        default_value_t = DEFAULT_MAX_DEPOSIT
+    )]
+    max_deposit: u128,
+
+    /// Maximum one-shot egress charge in token atomic units.
+    #[arg(
+        long = "provider.tempo.egress-max-charge",
+        global = true,
+        env = "NANOCODEX_PROVIDER_TEMPO_EGRESS_MAX_CHARGE",
+        default_value_t = DEFAULT_MAX_EGRESS_CHARGE
+    )]
+    egress_max_charge: u128,
+
+    /// Optional access key for gated MPP deployments such as Moderato staging.
+    #[arg(
+        long = "provider.tempo.api-key",
+        global = true,
+        env = "NANOCODEX_PROVIDER_TEMPO_API_KEY",
+        hide_env_values = true,
+        value_parser = NonEmptyStringValueParser::new()
+    )]
+    mpp_api_key: Option<String>,
+}
+
+impl MppArgs {
+    pub(crate) const fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub(crate) async fn start(
+        self,
+        direct_websocket_url: String,
+    ) -> Result<(String, Option<MppAdapter>)> {
+        if self.openai || !self.enabled {
+            return Ok((direct_websocket_url, None));
+        }
+        let wallet_path = self.wallet_store.unwrap_or(
+            default_channel_database_path()
+                .map_err(|error| eyre!(error))?
+                .with_file_name("store.json"),
+        );
+        let wallet = TempoWallet::load(&wallet_path)?;
+        let endpoint = payment_http_url(&self.mpp_websocket_url)?;
+        let api_base_url = openai_api_base_url(&self.mpp_websocket_url)?;
+        let namespace = websocket_origin(&self.mpp_websocket_url)?;
+        let store = SqliteChannelStore::open(SqliteChannelStoreOptions {
+            namespace,
+            path: self.channel_store,
+            request_url: Some(self.mpp_websocket_url.clone()),
+        })
+        .map_err(|error| eyre!(error))
+        .wrap_err("failed to open the Tempo session channel store")?;
+        let charge = TempoProvider::new(wallet.signer.clone(), &self.rpc_url)
+            .wrap_err("failed to configure the native Tempo charge provider")?
+            .with_signing_mode(TempoSigningMode::Keychain {
+                wallet: wallet.account,
+                key_authorization: None,
+                version: KeychainVersion::V2,
+            })
+            .with_expected_chain_id(wallet.chain_id);
+        let session = TempoSessionProvider::new(wallet.signer, &self.rpc_url)
+            .wrap_err("failed to configure the native Tempo session provider")?
+            .with_signing_mode(TempoSigningMode::Keychain {
+                wallet: wallet.account,
+                key_authorization: None,
+                version: KeychainVersion::V2,
+            })
+            .with_authorized_signer(wallet.access_key)
+            .with_channel_store(Arc::new(store))
+            .with_default_deposit(self.max_deposit)
+            .with_max_deposit(self.max_deposit);
+        let mut management_headers = reqwest13::header::HeaderMap::new();
+        if let Some(api_key) = &self.mpp_api_key {
+            management_headers.insert(
+                reqwest13::header::HeaderName::from_static("x-api-key"),
+                reqwest13::header::HeaderValue::from_str(api_key)?,
+            );
+        }
+        let payment = NativeSession {
+            session,
+            client: reqwest13::Client::new(),
+            management_url: endpoint.to_string(),
+            management_headers,
+        };
+        let provider = MultiProvider::new()
+            .with(CappedChargeProvider {
+                provider: charge,
+                max_charge: self.egress_max_charge,
+            })
+            .with(payment.session.clone());
+        let egress = MppEgress::start(provider, EgressPolicy::default())
+            .await
+            .wrap_err("failed to start the embedded MPP egress proxy")?;
+
+        let listener = StdTcpListener::bind("127.0.0.1:0")
+            .wrap_err("failed to bind the local MPP WebSocket adapter")?;
+        listener
+            .set_nonblocking(true)
+            .wrap_err("failed to configure the local MPP WebSocket adapter")?;
+        let address = listener
+            .local_addr()
+            .wrap_err("failed to read the local MPP WebSocket adapter address")?;
+        let listener = TcpListener::from_std(listener)
+            .wrap_err("failed to start the local MPP WebSocket adapter")?;
+        let config = Arc::new(BridgeConfig {
+            endpoint: self.mpp_websocket_url,
+            bootstrap_url: endpoint.to_string(),
+            api_key: self.mpp_api_key,
+            payment,
+        });
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let task = tokio::spawn(serve(listener, config, shutdown_rx));
+        Ok((
+            format!("ws://{address}/v1/responses"),
+            Some(MppAdapter {
+                api_base_url,
+                shutdown_tx: Some(shutdown_tx),
+                task: Some(task),
+                egress: Some(egress),
+            }),
+        ))
+    }
+}
+
+#[derive(Clone)]
+struct CappedChargeProvider<P> {
+    provider: P,
+    max_charge: u128,
+}
+
+impl<P> PaymentProvider for CappedChargeProvider<P>
+where
+    P: PaymentProvider,
+{
+    fn supports(&self, method: &str, intent: &str) -> bool {
+        self.provider.supports(method, intent)
+    }
+
+    async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+        challenge
+            .request
+            .decode::<ChargeRequest>()?
+            .validate_max_amount(&self.max_charge.to_string())?;
+        self.provider.pay(challenge).await
+    }
+
+    fn accept_payment_header(&self) -> Option<String> {
+        self.provider.accept_payment_header()
+    }
+}
+
+fn payment_http_url(websocket_url: &str) -> Result<reqwest13::Url> {
+    let mut url = reqwest13::Url::parse(websocket_url)
+        .wrap_err("Tempo Responses WebSocket URL is invalid")?;
+    let scheme = match url.scheme() {
+        "ws" => "http",
+        "wss" => "https",
+        scheme => return Err(eyre!("unsupported Tempo WebSocket URL scheme {scheme}")),
+    };
+    url.set_scheme(scheme)
+        .map_err(|()| eyre!("failed to derive the Tempo payment bootstrap URL"))?;
+    Ok(url)
+}
+
+fn openai_api_base_url(websocket_url: &str) -> Result<String> {
+    let mut url = payment_http_url(websocket_url)?;
+    let api_path = url
+        .path()
+        .strip_suffix("/responses")
+        .filter(|path| !path.is_empty())
+        .ok_or_else(|| eyre!("Tempo Responses WebSocket URL must end in /responses"))?
+        .to_owned();
+    url.set_path(&api_path);
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url.to_string().trim_end_matches('/').to_owned())
+}
+
+fn websocket_origin(websocket_url: &str) -> Result<String> {
+    let url = reqwest13::Url::parse(websocket_url)
+        .wrap_err("Tempo Responses WebSocket URL is invalid")?;
+    match url.scheme() {
+        "ws" | "wss" => Ok(url.origin().ascii_serialization()),
+        scheme => Err(eyre!("unsupported Tempo WebSocket URL scheme {scheme}")),
+    }
+}
+
+pub(crate) struct MppAdapter {
+    api_base_url: String,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    task: Option<JoinHandle<Result<()>>>,
+    egress: Option<MppEgress>,
+}
+
+impl MppAdapter {
+    pub(crate) fn api_base_url(&self) -> &str {
+        &self.api_base_url
+    }
+
+    pub(crate) fn tool_environment(&self) -> Vec<(std::ffi::OsString, std::ffi::OsString)> {
+        self.egress
+            .as_ref()
+            .map_or_else(Vec::new, MppEgress::environment)
+    }
+
+    pub(crate) fn tool_http_client(&self) -> Result<reqwest::Client> {
+        let egress = self
+            .egress
+            .as_ref()
+            .ok_or_else(|| eyre!("MPP egress proxy is not running"))?;
+        let certificate = std::fs::read(egress.certificate_path())
+            .wrap_err("failed to read the MPP egress CA certificate")?;
+        let certificate = reqwest::Certificate::from_pem(&certificate)
+            .wrap_err("failed to parse the MPP egress CA certificate")?;
+        let proxy = reqwest::Proxy::all(egress.proxy_url())
+            .wrap_err("failed to configure the MPP egress proxy")?;
+        reqwest::Client::builder()
+            .proxy(proxy)
+            .add_root_certificate(certificate)
+            .build()
+            .wrap_err("failed to configure the MPP-aware tool HTTP client")
+    }
+
+    pub(crate) async fn shutdown(mut self) -> Result<()> {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
+        let websocket_result = match self.task.take() {
+            Some(mut task) => match timeout(Duration::from_secs(30), &mut task).await {
+                Ok(Ok(completed)) => completed.wrap_err("MPP WebSocket adapter failed"),
+                Ok(Err(error)) => Err(error).wrap_err("MPP WebSocket adapter task failed"),
+                Err(error) => {
+                    task.abort();
+                    Err(error).wrap_err("timed out closing the paid MPP session")
+                }
+            },
+            None => Err(eyre!("MPP WebSocket adapter task is missing")),
+        };
+        let egress_result = if let Some(egress) = self.egress.take() {
+            egress
+                .shutdown()
+                .await
+                .wrap_err("failed to stop the embedded MPP egress proxy")
+        } else {
+            Ok(())
+        };
+        websocket_result?;
+        egress_result
+    }
+}
+
+impl Drop for MppAdapter {
+    fn drop(&mut self) {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+        drop(self.egress.take());
+    }
+}
+
+#[derive(Clone)]
+struct NativeSession {
+    session: TempoSessionProvider,
+    client: reqwest13::Client,
+    management_url: String,
+    management_headers: reqwest13::header::HeaderMap,
+}
+
+impl PaymentProvider for NativeSession {
+    fn supports(&self, method: &str, intent: &str) -> bool {
+        self.session.supports(method, intent)
+    }
+
+    async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+        self.session
+            .application_websocket_credential_with_top_up(
+                &self.client,
+                &self.management_url,
+                self.management_headers.clone(),
+                challenge,
+            )
+            .await
+    }
+
+    fn accept_payment_header(&self) -> Option<String> {
+        self.session.accept_payment_header()
+    }
+}
+
+impl VoucherProvider for NativeSession {
+    async fn next_voucher(&self, request: &VoucherRequest) -> Result<PaymentCredential, MppError> {
+        let cumulative = request.required_cumulative.parse().map_err(|error| {
+            MppError::InvalidConfig(format!(
+                "invalid required cumulative voucher amount: {error}"
+            ))
+        })?;
+        let deposit = request.deposit.parse().map_err(|error| {
+            MppError::InvalidConfig(format!("invalid channel deposit amount: {error}"))
+        })?;
+        self.session
+            .voucher_credential_with_top_up(
+                &self.client,
+                &self.management_url,
+                self.management_headers.clone(),
+                &request.channel_id,
+                cumulative,
+                deposit,
+            )
+            .await
+    }
+
+    async fn next_voucher_for_challenge(
+        &self,
+        challenge: &PaymentChallenge,
+        request: &VoucherRequest,
+    ) -> Result<PaymentCredential, MppError> {
+        let cumulative = request.required_cumulative.parse().map_err(|error| {
+            MppError::InvalidConfig(format!(
+                "invalid required cumulative voucher amount: {error}"
+            ))
+        })?;
+        let deposit = request.deposit.parse().map_err(|error| {
+            MppError::InvalidConfig(format!("invalid channel deposit amount: {error}"))
+        })?;
+        self.session
+            .voucher_credential_with_top_up_for_challenge(
+                &self.client,
+                &self.management_url,
+                self.management_headers.clone(),
+                challenge,
+                &request.channel_id,
+                cumulative,
+                deposit,
+            )
+            .await
+    }
+}
+
+impl CloseProvider for NativeSession {
+    async fn close_credential(
+        &self,
+        request: &CloseRequest,
+    ) -> Result<PaymentCredential, MppError> {
+        let cumulative = request.cumulative_amount.parse().map_err(|error| {
+            MppError::InvalidConfig(format!("invalid close-ready cumulative amount: {error}"))
+        })?;
+        self.session
+            .close_credential_at(&request.channel_id, cumulative)
+            .await
+    }
+
+    async fn close_credential_for_challenge(
+        &self,
+        challenge: &PaymentChallenge,
+        request: &CloseRequest,
+    ) -> Result<PaymentCredential, MppError> {
+        let cumulative = request.cumulative_amount.parse().map_err(|error| {
+            MppError::InvalidConfig(format!("invalid close-ready cumulative amount: {error}"))
+        })?;
+        self.session
+            .close_credential_at_for_challenge(challenge, &request.channel_id, cumulative)
+            .await
+    }
+}
+
+struct BridgeConfig {
+    endpoint: String,
+    bootstrap_url: String,
+    api_key: Option<String>,
+    payment: NativeSession,
+}
+
+async fn serve(
+    listener: TcpListener,
+    config: Arc<BridgeConfig>,
+    mut shutdown: oneshot::Receiver<()>,
+) -> Result<()> {
+    let mut bridges = JoinSet::new();
+    let (bridge_shutdown_tx, _) = watch::channel(false);
+    loop {
+        tokio::select! {
+            _ = &mut shutdown => break,
+            accepted = listener.accept() => {
+                let Ok((stream, _)) = accepted else {
+                    break;
+                };
+                let config = Arc::clone(&config);
+                let bridge_shutdown = bridge_shutdown_tx.subscribe();
+                bridges.spawn(async move { bridge(stream, &config, bridge_shutdown).await });
+            }
+            completed = bridges.join_next(), if !bridges.is_empty() => {
+                record_bridge_result(completed);
+            }
+        }
+    }
+    let _ = bridge_shutdown_tx.send(true);
+    while let Some(completed) = bridges.join_next().await {
+        record_bridge_result(Some(completed));
+    }
+    Ok(())
+}
+
+fn record_bridge_result(
+    completed: Option<std::result::Result<Result<()>, tokio::task::JoinError>>,
+) {
+    match completed {
+        Some(Ok(Err(error))) => {
+            tracing::warn!(error = ?error, "MPP WebSocket adapter closed");
+        }
+        Some(Err(error)) => {
+            tracing::warn!(%error, "MPP WebSocket adapter task failed");
+        }
+        Some(Ok(Ok(()))) | None => {}
+    }
+}
+
+#[expect(
+    clippy::result_large_err,
+    reason = "tungstenite fixes the handshake callback's rejection response type"
+)]
+async fn bridge(
+    stream: TcpStream,
+    config: &BridgeConfig,
+    shutdown: watch::Receiver<bool>,
+) -> Result<()> {
+    let downstream_headers = Arc::new(Mutex::new(None));
+    let captured = Arc::clone(&downstream_headers);
+    let downstream = accept_hdr_async(stream, move |request: &Request, response: Response| {
+        if let Ok(mut headers) = captured.lock() {
+            *headers = Some(request.headers().clone());
+        }
+        Ok(response)
+    })
+    .await
+    .wrap_err("local Responses WebSocket handshake failed")?;
+    let headers = downstream_headers
+        .lock()
+        .map_err(|_| eyre!("local Responses WebSocket header capture was poisoned"))?
+        .take()
+        .ok_or_else(|| eyre!("local Responses WebSocket headers were not captured"))?;
+
+    let mut bootstrap_headers = reqwest13::header::HeaderMap::new();
+    if let Some(api_key) = &config.api_key {
+        bootstrap_headers.insert(
+            reqwest13::header::HeaderName::from_static("x-api-key"),
+            reqwest13::header::HeaderValue::from_str(api_key)?,
+        );
+    }
+    config
+        .payment
+        .session
+        .bootstrap_with_headers(
+            &reqwest13::Client::new(),
+            &config.bootstrap_url,
+            bootstrap_headers,
+        )
+        .await
+        .wrap_err("failed to rehydrate the Tempo MPP session")?;
+
+    let mut connector = MppApplicationWsConnect::new(
+        &config.endpoint,
+        config.payment.clone(),
+        config.payment.clone(),
+    );
+    for name in [
+        "openai-beta",
+        "x-openai-internal-codex-responses-lite",
+        "session-id",
+        "thread-id",
+        "x-client-request-id",
+        "x-responsesapi-include-timing-metrics",
+        "user-agent",
+    ] {
+        if let Some(value) = headers.get(name) {
+            connector = connector.with_header(
+                HeaderName::from_static(name),
+                HeaderValue::from_bytes(value.as_bytes())?,
+            );
+        }
+    }
+    if let Some(api_key) = &config.api_key {
+        connector = connector.with_header(
+            HeaderName::from_static("x-api-key"),
+            HeaderValue::from_str(api_key)?,
+        );
+    }
+    let upstream = connector
+        .connect()
+        .await
+        .wrap_err("failed to open the paid MPP WebSocket")?;
+    relay(downstream, upstream, shutdown).await
+}
+
+async fn relay(
+    mut downstream: WebSocketStream<TcpStream>,
+    mut upstream: MppApplicationWs<NativeSession>,
+    mut shutdown: watch::Receiver<bool>,
+) -> Result<()> {
+    let relay_result = loop {
+        tokio::select! {
+            _ = shutdown.changed() => break Ok(()),
+            inbound = downstream.next() => match inbound {
+                Some(Ok(Message::Text(text))) => {
+                    if let Err(error) = upstream.send(text.to_string()).await {
+                        return Err(error.into());
+                    }
+                }
+                Some(Ok(Message::Ping(payload))) => {
+                    if let Err(error) = downstream.send(Message::Pong(payload)).await {
+                        if *shutdown.borrow() {
+                            break Ok(());
+                        }
+                        break Err(error.into());
+                    }
+                }
+                Some(Ok(Message::Close(_))) | None => break Ok(()),
+                Some(Ok(Message::Pong(_) | Message::Frame(_))) => {}
+                Some(Ok(Message::Binary(_))) => {
+                    break Err(eyre!("Responses WebSocket sent a binary frame"));
+                }
+                Some(Err(error)) => {
+                    if *shutdown.borrow() {
+                        break Ok(());
+                    }
+                    break Err(error.into());
+                }
+            },
+            outbound = upstream.next() => {
+                let text = outbound.wrap_err("paid MPP WebSocket receive failed")?;
+                if let Err(error) = downstream.send(Message::Text(text.into())).await {
+                    if *shutdown.borrow() {
+                        break Ok(());
+                    }
+                    break Err(error.into());
+                }
+            }
+        }
+    };
+    upstream
+        .disconnect()
+        .await
+        .wrap_err("failed to disconnect the paid MPP WebSocket")?;
+    relay_result
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use mpp::{Base64UrlJson, PaymentPayload};
+
+    use super::*;
+
+    #[derive(Clone, Default)]
+    struct MockChargeProvider {
+        payments: Arc<AtomicUsize>,
+    }
+
+    impl PaymentProvider for MockChargeProvider {
+        fn supports(&self, method: &str, intent: &str) -> bool {
+            method == "tempo" && intent == "charge"
+        }
+
+        async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+            self.payments.fetch_add(1, Ordering::SeqCst);
+            Ok(PaymentCredential::new(
+                challenge.to_echo(),
+                PaymentPayload::hash("paid"),
+            ))
+        }
+    }
+
+    fn charge_challenge(amount: &str) -> PaymentChallenge {
+        PaymentChallenge::new(
+            "charge-id",
+            "service.example",
+            "tempo",
+            "charge",
+            Base64UrlJson::from_value(&serde_json::json!({
+                "amount": amount,
+                "currency": "0x20c000000000000000000000b9537d11c60e8b50"
+            }))
+            .unwrap(),
+        )
+    }
+
+    fn args(enabled: bool) -> MppArgs {
+        MppArgs {
+            openai: false,
+            enabled,
+            mpp_websocket_url: DEFAULT_MPP_WEBSOCKET_URL.to_owned(),
+            wallet_store: None,
+            channel_store: None,
+            rpc_url: DEFAULT_TEMPO_RPC_URL.to_owned(),
+            max_deposit: DEFAULT_MAX_DEPOSIT,
+            egress_max_charge: DEFAULT_MAX_EGRESS_CHARGE,
+            mpp_api_key: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn mpp_is_opt_in() {
+        let (url, adapter) = args(false)
+            .start("wss://api.openai.com/v1/responses".to_owned())
+            .await
+            .unwrap();
+        assert_eq!(url, "wss://api.openai.com/v1/responses");
+        assert!(adapter.is_none());
+    }
+
+    #[tokio::test]
+    async fn egress_charge_cap_is_checked_before_payment() {
+        let inner = MockChargeProvider::default();
+        let payments = Arc::clone(&inner.payments);
+        let provider = CappedChargeProvider {
+            provider: inner,
+            max_charge: 100,
+        };
+
+        provider.pay(&charge_challenge("100")).await.unwrap();
+        let error = provider.pay(&charge_challenge("101")).await.unwrap_err();
+
+        assert!(matches!(error, MppError::AmountExceedsMax { .. }));
+        assert_eq!(payments.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn derives_payment_bootstrap_url() {
+        let url = payment_http_url("wss://openai.mpp.tempo.xyz/v1/responses").unwrap();
+        assert_eq!(url.as_str(), "https://openai.mpp.tempo.xyz/v1/responses");
+    }
+
+    #[test]
+    fn derives_openai_api_base_url() {
+        let url = openai_api_base_url("wss://openai.mpp.tempo.xyz/v1/responses").unwrap();
+        assert_eq!(url, "https://openai.mpp.tempo.xyz/v1");
+    }
+
+    #[test]
+    fn rejects_non_responses_mpp_endpoint() {
+        let error =
+            openai_api_base_url("wss://openai.mpp.tempo.xyz/v1/chat/completions").unwrap_err();
+        assert!(error.to_string().contains("must end in /responses"));
+    }
+
+    #[test]
+    fn preserves_mppx_websocket_namespace() {
+        let namespace = websocket_origin("wss://openai.mpp.tempo.xyz/v1/responses").unwrap();
+        assert_eq!(namespace, "wss://openai.mpp.tempo.xyz");
+    }
+}

--- a/bin/nanocodex/src/mpp.rs
+++ b/bin/nanocodex/src/mpp.rs
@@ -47,6 +47,8 @@ const DEFAULT_MPP_WEBSOCKET_URL: &str = "wss://openai.mpp.tempo.xyz/v1/responses
 const DEFAULT_TEMPO_RPC_URL: &str = "https://rpc.mainnet.tempo.xyz";
 const DEFAULT_TEMPO_PAY_WITH: &str = "0x20c0000000000000000000000000000000000000";
 const DEFAULT_TEMPO_SWAP_SLIPPAGE_BPS: u16 = 100;
+const DEFAULT_SESSION_DEPOSIT: u128 = 5_000_000;
+const DEFAULT_TOP_UP_AMOUNT: u128 = 5_000_000;
 // Five $5 refill quanta while retaining a finite client-side authorization cap.
 const DEFAULT_MAX_DEPOSIT: u128 = 25_000_000;
 const DEFAULT_MAX_EGRESS_CHARGE: u128 = 100_000;
@@ -139,6 +141,15 @@ pub(crate) struct MppArgs {
     )]
     max_deposit: u128,
 
+    /// Preferred automatic session top-up in token atomic units.
+    #[arg(
+        long = "provider.tempo.top-up-amount",
+        global = true,
+        env = "NANOCODEX_PROVIDER_TEMPO_TOP_UP_AMOUNT",
+        default_value_t = DEFAULT_TOP_UP_AMOUNT
+    )]
+    top_up_amount: u128,
+
     /// Maximum one-shot egress charge in token atomic units.
     #[arg(
         long = "provider.tempo.egress-max-charge",
@@ -211,8 +222,9 @@ impl MppArgs {
             })
             .with_authorized_signer(wallet.access_key)
             .with_channel_store(Arc::new(store))
-            .with_default_deposit(self.max_deposit)
+            .with_default_deposit(DEFAULT_SESSION_DEPOSIT)
             .with_max_deposit(self.max_deposit)
+            .with_top_up_amount(self.top_up_amount)
             .with_autoswap(autoswap);
         let mut management_headers = reqwest13::header::HeaderMap::new();
         if let Some(api_key) = &self.mpp_api_key {
@@ -743,6 +755,7 @@ mod tests {
             pay_with: DEFAULT_TEMPO_PAY_WITH.to_owned(),
             swap_slippage_bps: DEFAULT_TEMPO_SWAP_SLIPPAGE_BPS,
             max_deposit: DEFAULT_MAX_DEPOSIT,
+            top_up_amount: DEFAULT_TOP_UP_AMOUNT,
             egress_max_charge: DEFAULT_MAX_EGRESS_CHARGE,
             mpp_api_key: None,
         }

--- a/bin/nanocodex/src/observability.rs
+++ b/bin/nanocodex/src/observability.rs
@@ -4,8 +4,7 @@ use clap::{Args, ValueEnum, builder::NonEmptyStringValueParser};
 use eyre::Result;
 use nanocodex_observability::{LogFormat, LogOutput, ObservabilityBuilder, ObservabilityGuard};
 
-const DEFAULT_FILTER: &str =
-    "warn,nanocodex=info,nanocodex_service=info,nanocodex_tools=info,nanocodex_mcp=info";
+const DEFAULT_FILTER: &str = "warn,nanocodex=info,nanocodex_service=info,nanocodex_tools=info,nanocodex_mcp=info,mpp_egress=info";
 
 #[derive(Args)]
 pub(crate) struct ObservabilityArgs {

--- a/bin/nanocodex/src/run.rs
+++ b/bin/nanocodex/src/run.rs
@@ -18,10 +18,10 @@ pub(crate) struct Run {
 
 impl Run {
     pub(crate) async fn run(self, config: AgentArgs) -> Result<()> {
-        let configured = config.build()?;
+        let configured = config.build().await?;
         let handle = configured.handle;
         let mut events = configured.events;
-        let result = async {
+        let run_result: Result<()> = async {
             for _ in 0..self.repeat {
                 let turn = handle.prompt(self.prompt.clone()).await?;
                 events.write_turn_jsonl(io::stdout()).await?;
@@ -32,9 +32,16 @@ impl Run {
         }
         .await;
         drop(handle);
+        drop(events);
         if let Some(child_agents) = configured.child_agents {
             child_agents.shutdown().await;
         }
-        result
+        let shutdown_result = if let Some(adapter) = configured.mpp_adapter {
+            adapter.shutdown().await
+        } else {
+            Ok(())
+        };
+        run_result?;
+        shutdown_result
     }
 }

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -14,6 +14,7 @@ mod view;
 
 use std::{
     collections::VecDeque,
+    path::PathBuf,
     process::{Command, Stdio},
     sync::Arc,
     time::{Duration, Instant},
@@ -444,19 +445,21 @@ enum Submission {
     Trace,
 }
 
+#[allow(
+    clippy::too_many_lines,
+    reason = "the ordered terminal, agent, worker, and render event loop is intentionally cohesive"
+)]
 pub(crate) async fn run(config: AgentArgs, initial_prompt: Option<String>) -> Result<()> {
-    let cwd = config
-        .cwd()
-        .canonicalize()
-        .wrap_err("failed to resolve the working directory")?;
-    let configured = config.build()?;
+    let cwd = resolve_cwd(&config)?;
+    let configured = config.build().await?;
     let agent = configured.handle;
     let mut agent_events = configured.events;
     let root_session_id = Arc::<str>::from(agent_events.request_id());
-    let _child_agents = configured.child_agents;
+    let child_agents = configured.child_agents;
+    let mpp_adapter = configured.mpp_adapter;
     let (worker_tx, worker_rx) = mpsc::unbounded_channel();
     let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-    spawn_agent_worker(agent, Arc::clone(&root_session_id), worker_rx, update_tx);
+    let worker = spawn_agent_worker(agent, Arc::clone(&root_session_id), worker_rx, update_tx);
 
     let mut terminal = TerminalSession::enter().wrap_err("failed to initialize the terminal")?;
     let mut input_events = EventStream::new();
@@ -469,18 +472,19 @@ pub(crate) async fn run(config: AgentArgs, initial_prompt: Option<String>) -> Re
 
     submit_initial_prompt(&mut ui.app, &root_session_id, &worker_tx, initial_prompt)?;
 
-    loop {
-        view_telemetry.observe(&ui.app);
-        render_due_frame(
-            &mut ui,
-            &mut terminal,
-            &mut scheduler,
-            &mut stream_telemetry,
-            &mut notifier,
-        )?;
+    let loop_result: Result<()> = async {
+        loop {
+            view_telemetry.observe(&ui.app);
+            render_due_frame(
+                &mut ui,
+                &mut terminal,
+                &mut scheduler,
+                &mut stream_telemetry,
+                &mut notifier,
+            )?;
 
-        let render_deadline = scheduler.deadline();
-        tokio::select! {
+            let render_deadline = scheduler.deadline();
+            tokio::select! {
             () = async {
                 if let Some(deadline) = render_deadline {
                     sleep_until(deadline.into()).await;
@@ -495,7 +499,7 @@ pub(crate) async fn run(config: AgentArgs, initial_prompt: Option<String>) -> Re
                     input_events = run_external_editor(input_events, &mut terminal, &mut ui.app).await?;
                     scheduler.request_immediate(Instant::now());
                 } else if apply_update(update, &mut scheduler) {
-                    return Ok(());
+                    break Ok(());
                 }
             }
             event = agent_events.recv_timed(), if ui.agent_events_open => {
@@ -528,18 +532,56 @@ pub(crate) async fn run(config: AgentArgs, initial_prompt: Option<String>) -> Re
                     );
                 }
                 if apply_update(update, &mut scheduler) {
-                    return Ok(());
+                    break Ok(());
                 }
             }
             _ = ticker.tick(), if ui.app.main.running
                 || ui.app.btw.as_ref().is_some_and(|btw| btw.conversation.running)
                 || ui.app.mouse_selection_needs_redraw() => {
                 if apply_update(ui.update(UiAction::Tick, &worker_tx)?, &mut scheduler) {
-                    return Ok(());
+                    break Ok(());
                 }
+            }
             }
         }
     }
+    .await;
+
+    // Restore the terminal before disconnecting the paid WebSocket session.
+    drop((terminal, worker_tx, agent_events));
+    let shutdown_result = shutdown_runtime(worker, child_agents, mpp_adapter).await;
+    loop_result?;
+    shutdown_result
+}
+
+fn resolve_cwd(config: &AgentArgs) -> Result<PathBuf> {
+    config
+        .cwd()
+        .canonicalize()
+        .wrap_err("failed to resolve the working directory")
+}
+
+async fn shutdown_runtime(
+    worker: tokio::task::JoinHandle<()>,
+    child_agents: Option<std::sync::Arc<crate::subagents::ChildAgents>>,
+    mpp_adapter: Option<crate::mpp::MppAdapter>,
+) -> Result<()> {
+    worker.abort();
+    let worker_result = worker.await;
+    if let Some(child_agents) = child_agents {
+        child_agents.shutdown().await;
+    }
+    let shutdown_result = if let Some(adapter) = mpp_adapter {
+        adapter.shutdown().await
+    } else {
+        Ok(())
+    };
+    match worker_result {
+        Ok(()) => {}
+        Err(error) if error.is_cancelled() => {}
+        Err(error) => return Err(error).wrap_err("TUI agent worker failed"),
+    }
+    shutdown_result
 }
 
 fn apply_main_agent_event_batch(
@@ -779,7 +821,7 @@ fn spawn_agent_worker(
     root_session_id: Arc<str>,
     mut commands: mpsc::UnboundedReceiver<WorkerCommand>,
     updates: mpsc::UnboundedSender<WorkerEvent>,
-) {
+) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let (finished_tx, mut finished_rx) = mpsc::unbounded_channel::<FinishedTurn>();
         let mut worker = AgentWorker {
@@ -810,7 +852,7 @@ fn spawn_agent_worker(
                 }
             }
         }
-    });
+    })
 }
 
 struct AgentWorker {

--- a/crates/mpp-egress/Cargo.toml
+++ b/crates/mpp-egress/Cargo.toml
@@ -15,7 +15,7 @@ base64.workspace = true
 futures-util.workspace = true
 http-body-util.workspace = true
 hudsucker.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "e59900080f5cd36ec8992673924aad1a74b96950", default-features = false, features = ["client"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "0cb2025d2ce1eb211f7a6d3c684ed5268a99edbc", default-features = false, features = ["client"] }
 rand.workspace = true
 reqwest = { package = "reqwest", version = "0.13", default-features = false, features = ["native-tls", "stream"] }
 tempfile.workspace = true

--- a/crates/mpp-egress/Cargo.toml
+++ b/crates/mpp-egress/Cargo.toml
@@ -15,7 +15,7 @@ base64.workspace = true
 futures-util.workspace = true
 http-body-util.workspace = true
 hudsucker.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "0cb2025d2ce1eb211f7a6d3c684ed5268a99edbc", default-features = false, features = ["client"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "ef9f2f59b553b6cf7ca11746eb48687d451c7dbe", default-features = false, features = ["client"] }
 rand.workspace = true
 reqwest = { package = "reqwest", version = "0.13", default-features = false, features = ["native-tls", "stream"] }
 tempfile.workspace = true

--- a/crates/mpp-egress/Cargo.toml
+++ b/crates/mpp-egress/Cargo.toml
@@ -15,7 +15,7 @@ base64.workspace = true
 futures-util.workspace = true
 http-body-util.workspace = true
 hudsucker.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "a91163d46aa614df33bf3214c8aef557abf6e9b7", default-features = false, features = ["client"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "441e3114abb705e1e613272a62047e5c7b671ef9", default-features = false, features = ["client"] }
 rand.workspace = true
 reqwest = { package = "reqwest", version = "0.13", default-features = false, features = ["native-tls", "stream"] }
 tempfile.workspace = true

--- a/crates/mpp-egress/Cargo.toml
+++ b/crates/mpp-egress/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "mpp-egress"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Private embedded MPP-aware HTTP egress proxy for Nanocodex"
+
+[dependencies]
+base64.workspace = true
+futures-util.workspace = true
+http-body-util.workspace = true
+hudsucker.workspace = true
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "e59900080f5cd36ec8992673924aad1a74b96950", default-features = false, features = ["client"] }
+rand.workspace = true
+reqwest = { package = "reqwest", version = "0.13", default-features = false, features = ["native-tls", "stream"] }
+tempfile.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["fs", "net", "rt", "sync"] }
+tracing.workspace = true
+
+[dev-dependencies]
+axum = "0.8"
+serde_json.workspace = true
+tracing-subscriber.workspace = true
+
+[lints]
+workspace = true

--- a/crates/mpp-egress/Cargo.toml
+++ b/crates/mpp-egress/Cargo.toml
@@ -15,7 +15,7 @@ base64.workspace = true
 futures-util.workspace = true
 http-body-util.workspace = true
 hudsucker.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "ef9f2f59b553b6cf7ca11746eb48687d451c7dbe", default-features = false, features = ["client"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "a91163d46aa614df33bf3214c8aef557abf6e9b7", default-features = false, features = ["client"] }
 rand.workspace = true
 reqwest = { package = "reqwest", version = "0.13", default-features = false, features = ["native-tls", "stream"] }
 tempfile.workspace = true

--- a/crates/mpp-egress/Cargo.toml
+++ b/crates/mpp-egress/Cargo.toml
@@ -15,7 +15,7 @@ base64.workspace = true
 futures-util.workspace = true
 http-body-util.workspace = true
 hudsucker.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "441e3114abb705e1e613272a62047e5c7b671ef9", default-features = false, features = ["client"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "186ca59f5cbd1b450cf2e252089ff68e3d13ca28", default-features = false, features = ["client"] }
 rand.workspace = true
 reqwest = { package = "reqwest", version = "0.13", default-features = false, features = ["native-tls", "stream"] }
 tempfile.workspace = true

--- a/crates/mpp-egress/Cargo.toml
+++ b/crates/mpp-egress/Cargo.toml
@@ -15,7 +15,7 @@ base64.workspace = true
 futures-util.workspace = true
 http-body-util.workspace = true
 hudsucker.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "186ca59f5cbd1b450cf2e252089ff68e3d13ca28", default-features = false, features = ["client"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "3a689a1b1c194f54ad7a1afcbfa9be388706a94e", default-features = false, features = ["client"] }
 rand.workspace = true
 reqwest = { package = "reqwest", version = "0.13", default-features = false, features = ["native-tls", "stream"] }
 tempfile.workspace = true

--- a/crates/mpp-egress/src/lib.rs
+++ b/crates/mpp-egress/src/lib.rs
@@ -1,0 +1,1069 @@
+//! Embedded HTTP egress proxy that handles MPP payment challenges.
+//!
+//! The proxy listens only on loopback. Callers pass [`MppEgress::environment`]
+//! to untrusted child processes; the payment provider and its signing material
+//! remain in the embedding process.
+
+use std::{
+    collections::HashSet,
+    ffi::OsString,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use futures_util::TryStreamExt;
+use http_body_util::{BodyExt, Limited};
+use hudsucker::{
+    Body, HttpContext, HttpHandler, Proxy, RequestOrResponse,
+    certificate_authority::CertificateAuthority,
+    hyper::{
+        Method, Request, Response, StatusCode,
+        header::{
+            CONNECTION, HOST, PROXY_AUTHENTICATE, PROXY_AUTHORIZATION, TRANSFER_ENCODING, UPGRADE,
+        },
+        http::uri::Authority,
+    },
+    rcgen::{
+        BasicConstraints, CertificateParams, DistinguishedName, DnType, ExtendedKeyUsagePurpose,
+        IsCa, Issuer, KeyPair, KeyUsagePurpose, SanType, string::Ia5String,
+    },
+    rustls::{
+        ServerConfig,
+        crypto::aws_lc_rs,
+        pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
+    },
+};
+use mpp::client::{AcceptPaymentPolicy, ClientEvent, ClientEvents, Fetch, PaymentProvider};
+use tempfile::TempDir;
+use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
+use tracing::Instrument as _;
+
+const DEFAULT_MAX_REQUEST_BYTES: usize = 16 * 1024 * 1024;
+const DEFAULT_MAX_PAYMENT_RETRIES: usize = 4;
+const CA_FILENAME: &str = "mpp-egress-ca.pem";
+
+/// Policy owned by one embedded proxy instance.
+#[derive(Clone, Debug)]
+pub struct EgressPolicy {
+    /// Maximum replayable request-body size accepted from a child process.
+    pub max_request_bytes: usize,
+    /// Maximum number of distinct payment challenges accepted for one request.
+    pub max_payment_retries: usize,
+}
+
+impl Default for EgressPolicy {
+    fn default() -> Self {
+        Self {
+            max_request_bytes: DEFAULT_MAX_REQUEST_BYTES,
+            max_payment_retries: DEFAULT_MAX_PAYMENT_RETRIES,
+        }
+    }
+}
+
+/// A running loopback proxy and its ephemeral certificate authority.
+pub struct MppEgress {
+    proxy_url: String,
+    proxy_password: String,
+    proxy_authorization: String,
+    temp_dir: TempDir,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    task: Option<JoinHandle<Result<(), hudsucker::Error>>>,
+}
+
+impl MppEgress {
+    /// Starts an MPP-aware HTTP(S) proxy on an ephemeral loopback port.
+    ///
+    /// The provider is never shared with child processes. It should enforce
+    /// currency-specific spend/deposit limits before signing a credential.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the policy is invalid or the proxy listener, HTTP
+    /// client, temporary CA, or background proxy task cannot be initialized.
+    pub async fn start<P>(provider: P, policy: EgressPolicy) -> Result<Self, EgressError>
+    where
+        P: PaymentProvider + 'static,
+    {
+        if policy.max_request_bytes == 0 {
+            return Err(EgressError::InvalidPolicy(
+                "max_request_bytes must be greater than zero",
+            ));
+        }
+        if policy.max_payment_retries == 0 {
+            return Err(EgressError::InvalidPolicy(
+                "max_payment_retries must be greater than zero",
+            ));
+        }
+
+        let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+            .await
+            .map_err(EgressError::Bind)?;
+        let address = listener.local_addr().map_err(EgressError::LocalAddress)?;
+        let (authority, certificate_pem) = ephemeral_authority()?;
+        let temp_dir = tempfile::Builder::new()
+            .prefix("nanocodex-mpp-egress-")
+            .tempdir()
+            .map_err(EgressError::TempDir)?;
+        std::fs::write(temp_dir.path().join(CA_FILENAME), certificate_pem)
+            .map_err(EgressError::WriteCertificate)?;
+
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(EgressError::Client)?;
+        let proxy_password = random_proxy_password();
+        let proxy_authorization = format!(
+            "Basic {}",
+            STANDARD.encode(format!("nanocodex:{proxy_password}"))
+        );
+        let proxy_url = format!("http://nanocodex:{proxy_password}@{address}");
+        let handler = PaymentHandler {
+            provider,
+            client,
+            policy,
+            proxy_authorization: proxy_authorization.clone(),
+            authenticated_clients: Arc::new(Mutex::new(HashSet::new())),
+            request_ids: Arc::new(AtomicU64::new(1)),
+        };
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let proxy = Proxy::builder()
+            .with_listener(listener)
+            .with_ca(authority)
+            .with_rustls_connector(aws_lc_rs::default_provider())
+            .with_http_handler(handler)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .build()?;
+        let task = tokio::spawn(proxy.start());
+
+        Ok(Self {
+            proxy_url,
+            proxy_password,
+            proxy_authorization,
+            temp_dir,
+            shutdown_tx: Some(shutdown_tx),
+            task: Some(task),
+        })
+    }
+
+    /// Returns the HTTP proxy URL listened on by this instance.
+    #[must_use]
+    pub fn proxy_url(&self) -> String {
+        self.proxy_url.clone()
+    }
+
+    /// Returns environment overrides for curl and common HTTP runtimes.
+    ///
+    /// These values should be applied only to tool child processes, not to the
+    /// embedding process, so model/control-plane traffic is not intercepted.
+    #[must_use]
+    pub fn environment(&self) -> Vec<(OsString, OsString)> {
+        let proxy = OsString::from(self.proxy_url());
+        let certificate = self.temp_dir.path().join(CA_FILENAME).into_os_string();
+        [
+            ("http_proxy", proxy.clone()),
+            ("https_proxy", proxy.clone()),
+            ("HTTP_PROXY", proxy.clone()),
+            ("HTTPS_PROXY", proxy),
+            ("no_proxy", OsString::new()),
+            ("NO_PROXY", OsString::new()),
+            ("CURL_CA_BUNDLE", certificate.clone()),
+            ("SSL_CERT_FILE", certificate.clone()),
+            ("REQUESTS_CA_BUNDLE", certificate.clone()),
+            ("NODE_EXTRA_CA_CERTS", certificate),
+            (
+                "NANOCODEX_MPP_EGRESS_PASSWORD",
+                OsString::from(&self.proxy_password),
+            ),
+            (
+                "NANOCODEX_MPP_EGRESS_AUTHORIZATION",
+                OsString::from(&self.proxy_authorization),
+            ),
+        ]
+        .into_iter()
+        .map(|(name, value)| (OsString::from(name), value))
+        .collect()
+    }
+
+    /// Stops accepting traffic and waits for active proxy connections to drain.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the proxy task fails or cannot be joined.
+    pub async fn shutdown(mut self) -> Result<(), EgressError> {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
+        if let Some(task) = self.task.take() {
+            task.await.map_err(EgressError::Join)??;
+        }
+        Ok(())
+    }
+
+    /// Path to the public ephemeral CA certificate.
+    #[must_use]
+    pub fn certificate_path(&self) -> std::path::PathBuf {
+        self.temp_dir.path().join(CA_FILENAME)
+    }
+}
+
+impl Drop for MppEgress {
+    fn drop(&mut self) {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+#[derive(Clone)]
+struct PaymentHandler<P> {
+    provider: P,
+    client: reqwest::Client,
+    policy: EgressPolicy,
+    proxy_authorization: String,
+    authenticated_clients: Arc<Mutex<HashSet<SocketAddr>>>,
+    request_ids: Arc<AtomicU64>,
+}
+
+impl<P> HttpHandler for PaymentHandler<P>
+where
+    P: PaymentProvider + 'static,
+{
+    async fn handle_request(
+        &mut self,
+        context: &HttpContext,
+        mut request: Request<Body>,
+    ) -> RequestOrResponse {
+        let request_id = self.request_ids.fetch_add(1, Ordering::Relaxed);
+        let span = tracing::info_span!(
+            target: "mpp_egress",
+            "mpp.egress.request",
+            request.id = request_id,
+            client.address = %context.client_addr,
+            http.request.method = %request.method(),
+            url.full = %request.uri(),
+            request.upgrade = is_upgrade(&request),
+        );
+        async move {
+            tracing::info!(
+                target: "mpp_egress",
+                content_kind = "mpp.egress.request.headers",
+                content = ?request.headers(),
+                "trace content"
+            );
+            if !self.authorize(context, &request) {
+                tracing::warn!(
+                    target: "mpp_egress",
+                    stage = "mpp.egress.proxy_authentication.rejected",
+                    http.response.status_code = StatusCode::PROXY_AUTHENTICATION_REQUIRED.as_u16(),
+                    "MPP egress rejected an unauthenticated client"
+                );
+                return proxy_authentication_required().into();
+            }
+            tracing::info!(
+                target: "mpp_egress",
+                stage = "mpp.egress.proxy_authentication.accepted",
+                "MPP egress authenticated its child client"
+            );
+            request.headers_mut().remove(PROXY_AUTHORIZATION);
+            if request.method() == Method::CONNECT || is_upgrade(&request) {
+                tracing::info!(
+                    target: "mpp_egress",
+                    stage = "mpp.egress.tunnel.forwarded",
+                    "MPP egress forwarded a protocol tunnel without payment handling"
+                );
+                return request.into();
+            }
+
+            match self.forward(request).await {
+                Ok(response) => response.into(),
+                Err(ForwardError::RequestTooLarge) => {
+                    tracing::warn!(
+                        target: "mpp_egress",
+                        stage = "mpp.egress.request.failed",
+                        failure.kind = "request_too_large",
+                        http.response.status_code = StatusCode::PAYLOAD_TOO_LARGE.as_u16(),
+                        "MPP egress rejected an unreplayable request body"
+                    );
+                    error_response(
+                        StatusCode::PAYLOAD_TOO_LARGE,
+                        "request body exceeds the MPP egress replay limit",
+                    )
+                    .into()
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        target: "mpp_egress",
+                        stage = "mpp.egress.request.failed",
+                        failure.kind = "payment_or_forwarding",
+                        http.response.status_code = StatusCode::BAD_GATEWAY.as_u16(),
+                        error = %error,
+                        "MPP egress request failed"
+                    );
+                    error_response(StatusCode::BAD_GATEWAY, &error.to_string()).into()
+                }
+            }
+        }
+        .instrument(span)
+        .await
+    }
+}
+
+impl<P> PaymentHandler<P>
+where
+    P: PaymentProvider,
+{
+    fn authorize(&self, context: &HttpContext, request: &Request<Body>) -> bool {
+        if self
+            .authenticated_clients
+            .lock()
+            .is_ok_and(|clients| clients.contains(&context.client_addr))
+        {
+            return true;
+        }
+        let authorized = request
+            .headers()
+            .get(PROXY_AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value == self.proxy_authorization);
+        if authorized && let Ok(mut clients) = self.authenticated_clients.lock() {
+            clients.insert(context.client_addr);
+        }
+        authorized
+    }
+
+    async fn forward(&self, request: Request<Body>) -> Result<Response<Body>, ForwardError> {
+        let (mut parts, body) = request.into_parts();
+        let body = Limited::new(body, self.policy.max_request_bytes)
+            .collect()
+            .await
+            .map_err(|_| ForwardError::RequestTooLarge)?
+            .to_bytes();
+        record_body_content("mpp.egress.request.body", &body);
+        remove_hop_by_hop_request_headers(&mut parts.headers);
+        tracing::info!(
+            target: "mpp_egress",
+            stage = "mpp.egress.origin.request.started",
+            http.request.body.size = body.len(),
+            payment.max_retries = self.policy.max_payment_retries,
+            "MPP egress sent the original request"
+        );
+
+        let builder = self
+            .client
+            .request(parts.method, parts.uri.to_string())
+            .headers(parts.headers)
+            .body(body);
+        let events = payment_events();
+        let _subscription = events.on_any(|event| async move {
+            record_payment_event(&event);
+        });
+        let response = builder
+            .send_with_payment_options_max_retries(
+                &self.provider,
+                &AcceptPaymentPolicy::Never,
+                events,
+                self.policy.max_payment_retries,
+            )
+            .await
+            .map_err(ForwardError::Payment)?;
+
+        let status = response.status();
+        tracing::info!(
+            target: "mpp_egress",
+            stage = "mpp.egress.request.completed",
+            http.response.status_code = status.as_u16(),
+            "MPP egress completed the request"
+        );
+        Ok(convert_response(response, &tracing::Span::current()))
+    }
+}
+
+fn payment_events() -> ClientEvents {
+    ClientEvents::default()
+}
+
+fn record_payment_event(event: &ClientEvent) {
+    match event {
+        ClientEvent::ChallengeReceived(context) => {
+            tracing::info!(
+                target: "mpp_egress",
+                stage = "mpp.egress.challenge.received",
+                challenge.id = %context.challenge.id,
+                challenge.realm = %context.challenge.realm,
+                payment.method = %context.challenge.method,
+                payment.intent = %context.challenge.intent,
+                challenge.count = context.challenges.len(),
+                "MPP egress selected a 402 payment challenge"
+            );
+            tracing::info!(
+                target: "mpp_egress",
+                content_kind = "mpp.egress.challenge",
+                content = ?context,
+                "trace content"
+            );
+        }
+        ClientEvent::CredentialCreated(context) => {
+            tracing::info!(
+                target: "mpp_egress",
+                stage = "mpp.egress.credential.created",
+                challenge.id = %context.challenge.id,
+                payment.method = %context.challenge.method,
+                payment.intent = %context.challenge.intent,
+                "MPP egress created a payment credential for replay"
+            );
+            tracing::info!(
+                target: "mpp_egress",
+                content_kind = "mpp.egress.credential",
+                content = ?context.credential,
+                "trace content"
+            );
+        }
+        ClientEvent::PaymentResponse(context) => {
+            tracing::info!(
+                target: "mpp_egress",
+                stage = "mpp.egress.payment.response",
+                challenge.id = %context.challenge.id,
+                payment.method = %context.challenge.method,
+                payment.intent = %context.challenge.intent,
+                http.response.status_code = context.status.as_u16(),
+                "MPP egress received the paid replay response"
+            );
+            tracing::info!(
+                target: "mpp_egress",
+                content_kind = "mpp.egress.payment.response.credential",
+                content = ?context.credential,
+                "trace content"
+            );
+        }
+        ClientEvent::PaymentFailed(context) => {
+            let challenge_id = context
+                .challenge
+                .as_ref()
+                .map_or("", |challenge| challenge.id.as_str());
+            tracing::warn!(
+                target: "mpp_egress",
+                stage = "mpp.egress.payment.failed",
+                challenge.id = challenge_id,
+                error = %context.error,
+                reason = ?context.reason,
+                "MPP egress payment handling failed"
+            );
+            tracing::info!(
+                target: "mpp_egress",
+                content_kind = "mpp.egress.payment.failure",
+                content = ?context,
+                "trace content"
+            );
+        }
+    }
+}
+
+fn record_body_content(kind: &'static str, body: &[u8]) {
+    if let Ok(content) = std::str::from_utf8(body) {
+        tracing::info!(
+            target: "mpp_egress",
+            content_kind = kind,
+            content,
+            "trace content"
+        );
+    } else {
+        tracing::info!(
+            target: "mpp_egress",
+            content_kind = kind,
+            content = ?body,
+            "trace content"
+        );
+    }
+}
+
+fn convert_response(response: reqwest::Response, span: &tracing::Span) -> Response<Body> {
+    let status = response.status();
+    let version = response.version();
+    let mut headers = response.headers().clone();
+    remove_hop_by_hop_response_headers(&mut headers);
+    span.in_scope(|| {
+        tracing::info!(
+            target: "mpp_egress",
+            content_kind = "mpp.egress.response.headers",
+            content = ?headers,
+            "trace content"
+        );
+    });
+    let content_span = span.clone();
+    let mut chunk_index = 0_u64;
+    let body = Body::from_stream(
+        response
+            .bytes_stream()
+            .map_ok(move |chunk| {
+                content_span.in_scope(|| {
+                    if let Ok(content) = std::str::from_utf8(&chunk) {
+                        tracing::info!(
+                            target: "mpp_egress",
+                            content_kind = "mpp.egress.response.body",
+                            response.chunk.index = chunk_index,
+                            response.chunk.size = chunk.len(),
+                            content,
+                            "trace content"
+                        );
+                    } else {
+                        tracing::info!(
+                            target: "mpp_egress",
+                            content_kind = "mpp.egress.response.body",
+                            response.chunk.index = chunk_index,
+                            response.chunk.size = chunk.len(),
+                            content = ?chunk.as_ref(),
+                            "trace content"
+                        );
+                    }
+                });
+                chunk_index = chunk_index.saturating_add(1);
+                chunk
+            })
+            .map_err(|_| hudsucker::Error::Unknown),
+    );
+    let mut response = Response::new(body);
+    *response.status_mut() = status;
+    *response.version_mut() = version;
+    *response.headers_mut() = headers;
+    response
+}
+
+fn is_upgrade(request: &Request<Body>) -> bool {
+    request.headers().contains_key(UPGRADE)
+        || request
+            .headers()
+            .get(CONNECTION)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| {
+                value
+                    .split(',')
+                    .any(|token| token.trim().eq_ignore_ascii_case("upgrade"))
+            })
+}
+
+fn remove_hop_by_hop_request_headers(headers: &mut hudsucker::hyper::HeaderMap) {
+    remove_connection_named_headers(headers);
+    for name in [
+        CONNECTION,
+        HOST,
+        PROXY_AUTHORIZATION,
+        TRANSFER_ENCODING,
+        UPGRADE,
+    ] {
+        headers.remove(name);
+    }
+}
+
+fn remove_hop_by_hop_response_headers(headers: &mut hudsucker::hyper::HeaderMap) {
+    remove_connection_named_headers(headers);
+    for name in [CONNECTION, TRANSFER_ENCODING, UPGRADE] {
+        headers.remove(name);
+    }
+}
+
+fn remove_connection_named_headers(headers: &mut hudsucker::hyper::HeaderMap) {
+    let names = headers
+        .get_all(CONNECTION)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(','))
+        .filter_map(|name| {
+            name.trim()
+                .parse::<hudsucker::hyper::header::HeaderName>()
+                .ok()
+        })
+        .collect::<Vec<_>>();
+    for name in names {
+        headers.remove(name);
+    }
+}
+
+fn error_response(status: StatusCode, message: &str) -> Response<Body> {
+    let mut response = Response::new(Body::from(message.to_owned()));
+    *response.status_mut() = status;
+    response
+}
+
+fn proxy_authentication_required() -> Response<Body> {
+    let mut response = error_response(
+        StatusCode::PROXY_AUTHENTICATION_REQUIRED,
+        "proxy authentication required",
+    );
+    response.headers_mut().insert(
+        PROXY_AUTHENTICATE,
+        hudsucker::hyper::header::HeaderValue::from_static("Basic realm=\"nanocodex-mpp-egress\""),
+    );
+    response
+}
+
+fn random_proxy_password() -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut password = String::with_capacity(64);
+    for byte in rand::random::<[u8; 32]>() {
+        password.push(char::from(HEX[usize::from(byte >> 4)]));
+        password.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    password
+}
+
+struct EphemeralAuthority {
+    issuer: Issuer<'static, KeyPair>,
+    private_key: PrivateKeyDer<'static>,
+    cache: Mutex<std::collections::HashMap<Authority, Arc<ServerConfig>>>,
+}
+
+impl CertificateAuthority for EphemeralAuthority {
+    async fn gen_server_config(&self, authority: &Authority) -> Arc<ServerConfig> {
+        if let Ok(cache) = self.cache.lock()
+            && let Some(config) = cache.get(authority)
+        {
+            return Arc::clone(config);
+        }
+
+        let mut params = CertificateParams::default();
+        params.serial_number = Some(rand::random::<u64>().into());
+        let mut distinguished_name = DistinguishedName::new();
+        distinguished_name.push(DnType::CommonName, authority.host());
+        params.distinguished_name = distinguished_name;
+        params
+            .subject_alt_names
+            .push(authority.host().parse::<IpAddr>().map_or_else(
+                |_| {
+                    SanType::DnsName(
+                        Ia5String::try_from(authority.host())
+                            .expect("HTTP authority host must be a valid DNS IA5 string"),
+                    )
+                },
+                SanType::IpAddress,
+            ));
+        params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+        params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+        params.use_authority_key_identifier_extension = true;
+        let certificate = params
+            .signed_by(self.issuer.key(), &self.issuer)
+            .expect("valid CA parameters must sign an ephemeral leaf certificate");
+        let mut config = ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(
+                vec![CertificateDer::from(certificate)],
+                self.private_key.clone_key(),
+            )
+            .expect("generated leaf certificate and private key must match");
+        config.alpn_protocols = vec![b"http/1.1".to_vec()];
+        let config = Arc::new(config);
+
+        if let Ok(mut cache) = self.cache.lock()
+            && cache.len() < 1_024
+        {
+            cache.insert(authority.clone(), Arc::clone(&config));
+        }
+        config
+    }
+}
+
+fn ephemeral_authority() -> Result<(EphemeralAuthority, String), EgressError> {
+    let key_pair = KeyPair::generate().map_err(EgressError::Certificate)?;
+    let mut params = CertificateParams::default();
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let mut distinguished_name = DistinguishedName::new();
+    distinguished_name.push(DnType::CommonName, "Nanocodex ephemeral MPP egress");
+    params.distinguished_name = distinguished_name;
+    params.key_usages = vec![
+        KeyUsagePurpose::DigitalSignature,
+        KeyUsagePurpose::KeyCertSign,
+        KeyUsagePurpose::CrlSign,
+    ];
+    let certificate = params
+        .self_signed(&key_pair)
+        .map_err(EgressError::Certificate)?;
+    let certificate_pem = certificate.pem();
+    let private_key = PrivateKeyDer::from(PrivatePkcs8KeyDer::from(key_pair.serialize_der()));
+    let issuer =
+        Issuer::from_ca_cert_pem(&certificate_pem, key_pair).map_err(EgressError::Certificate)?;
+    Ok((
+        EphemeralAuthority {
+            issuer,
+            private_key,
+            cache: Mutex::new(std::collections::HashMap::new()),
+        },
+        certificate_pem,
+    ))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum EgressError {
+    #[error("invalid MPP egress policy: {0}")]
+    InvalidPolicy(&'static str),
+    #[error("failed to bind the MPP egress listener")]
+    Bind(#[source] std::io::Error),
+    #[error("failed to read the MPP egress listener address")]
+    LocalAddress(#[source] std::io::Error),
+    #[error("failed to create the ephemeral MPP egress directory")]
+    TempDir(#[source] std::io::Error),
+    #[error("failed to write the ephemeral MPP egress CA certificate")]
+    WriteCertificate(#[source] std::io::Error),
+    #[error("failed to generate the ephemeral MPP egress CA")]
+    Certificate(#[source] hudsucker::rcgen::Error),
+    #[error("failed to build the MPP egress HTTP client")]
+    Client(#[source] reqwest::Error),
+    #[error("MPP egress proxy failed")]
+    Proxy(#[from] hudsucker::Error),
+    #[error("MPP egress proxy task failed")]
+    Join(#[source] tokio::task::JoinError),
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ForwardError {
+    #[error("request body is too large to replay")]
+    RequestTooLarge,
+    #[error("MPP payment request failed: {0}")]
+    Payment(#[source] mpp::client::HttpError),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc, Mutex as StdMutex,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use axum::{
+        Router,
+        body::Body as AxumBody,
+        extract::Request,
+        http::{StatusCode as AxumStatus, header::WWW_AUTHENTICATE},
+        response::IntoResponse,
+        routing::{get, post},
+    };
+    use mpp::{
+        Base64UrlJson, MppError, PaymentChallenge, PaymentCredential, PaymentPayload,
+        format_www_authenticate,
+    };
+
+    use super::*;
+
+    #[derive(Clone, Default)]
+    struct LogBuffer(Arc<StdMutex<Vec<u8>>>);
+
+    struct LogWriter(Arc<StdMutex<Vec<u8>>>);
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for LogBuffer {
+        type Writer = LogWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            LogWriter(Arc::clone(&self.0))
+        }
+    }
+
+    impl std::io::Write for LogWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().write(bytes)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct MockProvider {
+        payments: Arc<AtomicUsize>,
+    }
+
+    impl PaymentProvider for MockProvider {
+        fn supports(&self, method: &str, intent: &str) -> bool {
+            method == "test" && intent == "charge"
+        }
+
+        async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+            self.payments.fetch_add(1, Ordering::SeqCst);
+            Ok(PaymentCredential::new(
+                challenge.to_echo(),
+                PaymentPayload::hash("test-payment"),
+            ))
+        }
+    }
+
+    async fn spawn_origin(app: Router) -> String {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{address}")
+    }
+
+    fn challenge_header() -> String {
+        let request = Base64UrlJson::from_value(&serde_json::json!({
+            "amount": "1",
+            "currency": "test"
+        }))
+        .unwrap();
+        format_www_authenticate(&PaymentChallenge::new(
+            "challenge-1",
+            "test.local",
+            "test",
+            "charge",
+            request,
+        ))
+        .unwrap()
+    }
+
+    fn proxied_client(egress: &MppEgress) -> reqwest::Client {
+        reqwest::Client::builder()
+            .proxy(reqwest::Proxy::all(egress.proxy_url()).unwrap())
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn rejects_clients_without_the_ephemeral_proxy_credential() {
+        let egress = MppEgress::start(MockProvider::default(), EgressPolicy::default())
+            .await
+            .unwrap();
+        let mut proxy: reqwest::Url = egress.proxy_url().parse().unwrap();
+        proxy.set_username("").unwrap();
+        proxy.set_password(None).unwrap();
+        let client = reqwest::Client::builder()
+            .proxy(reqwest::Proxy::all(proxy).unwrap())
+            .build()
+            .unwrap();
+
+        let response = client.get("http://example.invalid/").send().await.unwrap();
+
+        assert_eq!(response.status(), AxumStatus::PROXY_AUTHENTICATION_REQUIRED);
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn passes_unpaid_http_responses_through() {
+        let origin = spawn_origin(Router::new().route("/plain", get(|| async { "plain" }))).await;
+        let egress = MppEgress::start(MockProvider::default(), EgressPolicy::default())
+            .await
+            .unwrap();
+
+        let response = proxied_client(&egress)
+            .get(format!("{origin}/plain"))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), AxumStatus::OK);
+        assert_eq!(response.text().await.unwrap(), "plain");
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn pays_and_replays_the_exact_request_body() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_route = Arc::clone(&calls);
+        let challenge = challenge_header();
+        let app = Router::new().route(
+            "/paid",
+            post(move |request: Request<AxumBody>| {
+                let calls = Arc::clone(&calls_for_route);
+                let challenge = challenge.clone();
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    let paid = request.headers().contains_key("authorization");
+                    let body = axum::body::to_bytes(request.into_body(), 1024)
+                        .await
+                        .unwrap();
+                    if paid {
+                        assert_eq!(body.as_ref(), b"same-body");
+                        (AxumStatus::OK, "paid").into_response()
+                    } else {
+                        assert_eq!(body.as_ref(), b"same-body");
+                        (
+                            AxumStatus::PAYMENT_REQUIRED,
+                            [(WWW_AUTHENTICATE, challenge)],
+                            "payment required",
+                        )
+                            .into_response()
+                    }
+                }
+            }),
+        );
+        let origin = spawn_origin(app).await;
+        let provider = MockProvider::default();
+        let payments = Arc::clone(&provider.payments);
+        let egress = MppEgress::start(provider, EgressPolicy::default())
+            .await
+            .unwrap();
+
+        let response = proxied_client(&egress)
+            .post(format!("{origin}/paid"))
+            .body("same-body")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), AxumStatus::OK);
+        assert_eq!(response.text().await.unwrap(), "paid");
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(payments.load(Ordering::SeqCst), 1);
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn traces_the_complete_payment_retry_sequence() {
+        let logs = LogBuffer::default();
+        let subscriber = tracing_subscriber::fmt()
+            .json()
+            .with_writer(logs.clone())
+            .finish();
+        tracing::subscriber::set_global_default(subscriber).unwrap();
+        let challenge = challenge_header();
+        let app = Router::new().route(
+            "/paid",
+            post(move |request: Request<AxumBody>| {
+                let challenge = challenge.clone();
+                async move {
+                    if request.headers().contains_key("authorization") {
+                        (AxumStatus::OK, "paid").into_response()
+                    } else {
+                        (
+                            AxumStatus::PAYMENT_REQUIRED,
+                            [(WWW_AUTHENTICATE, challenge)],
+                            "payment required",
+                        )
+                            .into_response()
+                    }
+                }
+            }),
+        );
+        let origin = spawn_origin(app).await;
+        let egress = MppEgress::start(MockProvider::default(), EgressPolicy::default())
+            .await
+            .unwrap();
+
+        let response = proxied_client(&egress)
+            .post(format!("{origin}/paid"))
+            .body("audit-body")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.text().await.unwrap(), "paid");
+        egress.shutdown().await.unwrap();
+
+        let output = String::from_utf8(logs.0.lock().unwrap().clone()).unwrap();
+        let stages = [
+            "mpp.egress.origin.request.started",
+            "mpp.egress.challenge.received",
+            "mpp.egress.credential.created",
+            "mpp.egress.payment.response",
+            "mpp.egress.request.completed",
+        ];
+        let mut previous = 0;
+        for stage in stages {
+            let position = output[previous..].find(stage).unwrap() + previous;
+            previous = position;
+        }
+        assert!(output.contains("mpp.egress.request.body"));
+        assert!(output.contains("audit-body"));
+        assert!(output.contains("mpp.egress.response.body"));
+        assert!(output.contains("paid"));
+    }
+
+    #[tokio::test]
+    async fn rejects_request_bodies_above_the_replay_limit() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_route = Arc::clone(&calls);
+        let origin = spawn_origin(Router::new().route(
+            "/upload",
+            post(move || {
+                let calls = Arc::clone(&calls_for_route);
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    "unexpected"
+                }
+            }),
+        ))
+        .await;
+        let egress = MppEgress::start(
+            MockProvider::default(),
+            EgressPolicy {
+                max_request_bytes: 4,
+                ..EgressPolicy::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let response = proxied_client(&egress)
+            .post(format!("{origin}/upload"))
+            .body("too-large")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), AxumStatus::PAYLOAD_TOO_LARGE);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn child_environment_points_at_the_ephemeral_proxy_and_ca() {
+        let egress = MppEgress::start(MockProvider::default(), EgressPolicy::default())
+            .await
+            .unwrap();
+        let environment = egress.environment();
+        let value = |name: &str| {
+            environment
+                .iter()
+                .find(|(candidate, _)| candidate == name)
+                .map(|(_, value)| value.clone())
+                .unwrap()
+        };
+
+        assert_eq!(value("https_proxy"), OsString::from(egress.proxy_url()));
+        assert!(value("NO_PROXY").is_empty());
+        assert_eq!(
+            std::path::PathBuf::from(value("CURL_CA_BUNDLE")),
+            egress.certificate_path()
+        );
+        assert!(egress.certificate_path().is_file());
+        assert_eq!(
+            value("NANOCODEX_MPP_EGRESS_PASSWORD"),
+            OsString::from(&egress.proxy_password)
+        );
+        assert_eq!(
+            value("NANOCODEX_MPP_EGRESS_AUTHORIZATION"),
+            OsString::from(&egress.proxy_authorization)
+        );
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore = "manual public-network HTTPS smoke"]
+    async fn live_https_mitm_smoke() {
+        let egress = MppEgress::start(MockProvider::default(), EgressPolicy::default())
+            .await
+            .unwrap();
+        let environment = egress.environment();
+        let output = tokio::task::spawn_blocking(move || {
+            std::process::Command::new("curl")
+                .args(["--fail", "--silent", "--show-error", "https://example.com/"])
+                .envs(environment)
+                .output()
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stdout).contains("Example Domain"));
+        egress.shutdown().await.unwrap();
+    }
+}

--- a/crates/nanocodex-observability/src/lib.rs
+++ b/crates/nanocodex-observability/src/lib.rs
@@ -72,9 +72,7 @@ pub enum ObservabilityError {
 impl ObservabilityBuilder {
     #[must_use]
     pub fn new(service_name: impl Into<String>, service_version: impl Into<String>) -> Self {
-        let filter =
-            "warn,nanocodex=info,nanocodex_service=info,nanocodex_tools=info,nanocodex_mcp=info"
-                .to_owned();
+        let filter = "warn,nanocodex=info,nanocodex_service=info,nanocodex_tools=info,nanocodex_mcp=info,mpp_egress=info".to_owned();
         Self {
             otel_filter: filter.clone(),
             filter,

--- a/crates/nanocodex-tools/src/image_generation/mod.rs
+++ b/crates/nanocodex-tools/src/image_generation/mod.rs
@@ -32,10 +32,15 @@ pub(super) struct ImageGenerationHandler {
 }
 
 impl ImageGenerationHandler {
+    #[cfg(test)]
     pub(super) fn new(config: ImageGenerationConfig) -> Self {
+        Self::with_client(config, reqwest::Client::new())
+    }
+
+    pub(super) fn with_client(config: ImageGenerationConfig, client: reqwest::Client) -> Self {
         let api_base_url = config.api_base_url.trim_end_matches('/');
         Self {
-            client: reqwest::Client::new(),
+            client,
             generation_endpoint: format!("{api_base_url}/images/generations"),
             edit_endpoint: format!("{api_base_url}/images/edits"),
             auth: config.auth,

--- a/crates/nanocodex-tools/src/runtime.rs
+++ b/crates/nanocodex-tools/src/runtime.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt, path::PathBuf, sync::Arc};
+use std::{collections::HashMap, ffi::OsString, fmt, path::PathBuf, sync::Arc};
 
 use async_trait::async_trait;
 use nanocodex_core::{ImageDetail, OpenAiAuth, ResponseItem, ToolDefinition};
@@ -436,6 +436,9 @@ pub struct Tools {
     image_generation: bool,
     working_directory: Option<Arc<str>>,
     default_shell: Option<Arc<str>>,
+    process_environment: Arc<Vec<(OsString, OsString)>>,
+    #[cfg(feature = "remote-tools")]
+    remote_http_client: Option<reqwest::Client>,
     registered: Vec<Arc<dyn Tool>>,
     providers: Vec<Arc<dyn DynamicToolProvider>>,
 }
@@ -448,6 +451,9 @@ impl Default for Tools {
             image_generation: true,
             working_directory: None,
             default_shell: None,
+            process_environment: Arc::new(Vec::new()),
+            #[cfg(feature = "remote-tools")]
+            remote_http_client: None,
             registered: Vec::new(),
             providers: Vec::new(),
         }
@@ -456,6 +462,10 @@ impl Default for Tools {
 
 impl fmt::Debug for Tools {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[cfg(feature = "remote-tools")]
+        let remote_http_client_configured = self.remote_http_client.is_some();
+        #[cfg(not(feature = "remote-tools"))]
+        let remote_http_client_configured = false;
         formatter
             .debug_struct("Tools")
             .field("workspace", &self.workspace)
@@ -463,6 +473,11 @@ impl fmt::Debug for Tools {
             .field("image_generation", &self.image_generation)
             .field("working_directory", &self.working_directory)
             .field("default_shell", &self.default_shell)
+            .field("process_environment_count", &self.process_environment.len())
+            .field(
+                "remote_http_client_configured",
+                &remote_http_client_configured,
+            )
             .field(
                 "registered",
                 &self
@@ -505,6 +520,15 @@ impl Tools {
     #[must_use]
     pub const fn image_generation_enabled(&self) -> bool {
         self.image_generation
+    }
+
+    fn process_environment(&self) -> Arc<Vec<(OsString, OsString)>> {
+        Arc::clone(&self.process_environment)
+    }
+
+    #[cfg(feature = "remote-tools")]
+    fn remote_http_client(&self) -> Option<reqwest::Client> {
+        self.remote_http_client.clone()
     }
 
     /// Starts all dynamic providers without waiting for their handshakes.
@@ -585,6 +609,34 @@ impl ToolsBuilder {
     #[must_use]
     pub fn default_shell(mut self, shell: impl Into<Arc<str>>) -> Self {
         self.tools.default_shell = Some(shell.into());
+        self
+    }
+
+    /// Adds explicit environment overrides to workspace-tool child processes.
+    ///
+    /// Overrides are scoped to commands spawned by this tool selection and do
+    /// not mutate the embedding process. A later value for the same name wins.
+    #[must_use]
+    pub fn process_environment<I, K, V>(mut self, variables: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<OsString>,
+        V: Into<OsString>,
+    {
+        let environment = Arc::make_mut(&mut self.tools.process_environment);
+        for (name, value) in variables {
+            let name = name.into();
+            environment.retain(|(candidate, _)| candidate != &name);
+            environment.push((name, value.into()));
+        }
+        self
+    }
+
+    /// Overrides the HTTP client used by in-process remote tools.
+    #[cfg(feature = "remote-tools")]
+    #[must_use]
+    pub fn remote_http_client(mut self, client: reqwest::Client) -> Self {
+        self.tools.remote_http_client = Some(client);
         self
     }
 
@@ -685,7 +737,15 @@ impl ToolRuntime {
         web_search: Option<WebSearchConfig>,
         image_generation: Option<ImageGenerationConfig>,
     ) -> Self {
-        Self::new_inner(workspace, web_search, image_generation, true)
+        Self::new_inner(
+            workspace,
+            web_search,
+            image_generation,
+            true,
+            Arc::new(Vec::new()),
+            #[cfg(feature = "remote-tools")]
+            None,
+        )
     }
 
     /// Builds the runtime from one complete declarative tool selection.
@@ -701,6 +761,9 @@ impl ToolRuntime {
             web_search,
             image_generation,
             tools.workspace_enabled(),
+            tools.process_environment(),
+            #[cfg(feature = "remote-tools")]
+            tools.remote_http_client(),
         )
         .with_tools(tools)
     }
@@ -710,9 +773,11 @@ impl ToolRuntime {
         web_search: Option<WebSearchConfig>,
         image_generation: Option<ImageGenerationConfig>,
         workspace_enabled: bool,
+        process_environment: Arc<Vec<(OsString, OsString)>>,
+        #[cfg(feature = "remote-tools")] remote_http_client: Option<reqwest::Client>,
     ) -> Self {
         let workspace = workspace.into();
-        let sessions = Arc::new(ShellSessions::new());
+        let sessions = Arc::new(ShellSessions::with_environment(process_environment));
         let default_shell_name = Arc::from(sessions.default_shell_name());
         let working_directory = Arc::from(workspace.to_string_lossy().into_owned());
         #[cfg(feature = "code-mode")]
@@ -732,13 +797,20 @@ impl ToolRuntime {
         }
         #[cfg(feature = "remote-tools")]
         {
+            let remote_http_client = remote_http_client.unwrap_or_default();
             if let Some(web_search) = web_search {
-                handlers.push(Arc::new(web_search::WebSearchHandler::new(web_search)));
+                handlers.push(Arc::new(web_search::WebSearchHandler::with_client(
+                    web_search,
+                    remote_http_client.clone(),
+                )));
             }
             if let Some(image_generation) = image_generation {
-                handlers.push(Arc::new(image_generation::ImageGenerationHandler::new(
-                    image_generation,
-                )));
+                handlers.push(Arc::new(
+                    image_generation::ImageGenerationHandler::with_client(
+                        image_generation,
+                        remote_http_client,
+                    ),
+                ));
             }
         }
         #[cfg(not(feature = "remote-tools"))]

--- a/crates/nanocodex-tools/src/shell/mod.rs
+++ b/crates/nanocodex-tools/src/shell/mod.rs
@@ -7,6 +7,7 @@ pub(crate) use tool::{ExecCommandHandler, WriteStdinHandler};
 
 use std::{
     collections::{HashMap, VecDeque},
+    ffi::OsString,
     path::{Path, PathBuf},
     sync::{
         Arc,
@@ -98,14 +99,21 @@ pub(crate) struct ShellSessions {
     sessions: Mutex<SessionStore>,
     next_session_id: AtomicI64,
     default_shell: selection::Shell,
+    environment: Arc<Vec<(OsString, OsString)>>,
 }
 
 impl ShellSessions {
+    #[cfg(test)]
     pub(crate) fn new() -> Self {
+        Self::with_environment(Arc::new(Vec::new()))
+    }
+
+    pub(crate) fn with_environment(environment: Arc<Vec<(OsString, OsString)>>) -> Self {
         Self {
             sessions: Mutex::new(SessionStore::default()),
             next_session_id: AtomicI64::new(1),
             default_shell: selection::default_user_shell(),
+            environment,
         }
     }
 
@@ -125,7 +133,7 @@ impl ShellSessions {
             || self.default_shell.clone(),
             selection::get_shell_by_model_provided_path,
         );
-        let (environment, secrets) = process::sanitized_environment();
+        let (environment, secrets) = process::sanitized_environment(&self.environment);
         let spawned = match process::spawn(
             &command.script,
             &workdir,
@@ -545,7 +553,11 @@ fn duration_ms(requested: Option<i64>, default: u64, minimum: u64, maximum: u64)
 #[cfg(test)]
 mod tests {
     #[cfg(unix)]
-    use std::time::{Duration, SystemTime};
+    use std::{
+        ffi::OsString,
+        sync::Arc,
+        time::{Duration, SystemTime},
+    };
 
     #[cfg(unix)]
     use super::WriteStdin;
@@ -563,6 +575,46 @@ mod tests {
         captured.push(b"next", 4);
         let second = captured.take();
         assert_eq!(second.with_omission_marker(), b"next");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn child_process_receives_explicit_environment_overrides() {
+        let sessions = ShellSessions::with_environment(Arc::new(vec![
+            (
+                OsString::from("NANOCODEX_EGRESS_TEST"),
+                OsString::from("injected"),
+            ),
+            (
+                OsString::from("HTTPS_PROXY"),
+                OsString::from("http://nanocodex:proxy-secret-value@127.0.0.1:1234"),
+            ),
+            (
+                OsString::from("NANOCODEX_MPP_EGRESS_PASSWORD"),
+                OsString::from("proxy-secret-value"),
+            ),
+        ]));
+
+        let result = sessions
+            .execute(
+                ExecCommand::new(
+                    "printf '%s|%s' \"$NANOCODEX_EGRESS_TEST\" \"$HTTPS_PROXY\"".to_owned(),
+                    None,
+                    Some("/bin/sh".to_owned()),
+                    Some(false),
+                    false,
+                    Some(1_000),
+                    None,
+                ),
+                std::path::Path::new("/"),
+            )
+            .await;
+
+        assert_eq!(result.exit_code, Some(0));
+        assert_eq!(
+            result.output,
+            "injected|http://nanocodex:[REDACTED]@127.0.0.1:1234"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/nanocodex-tools/src/shell/process.rs
+++ b/crates/nanocodex-tools/src/shell/process.rs
@@ -304,7 +304,9 @@ impl Drop for ProcessGroupGuard {
     }
 }
 
-pub(super) fn sanitized_environment() -> (Vec<(OsString, OsString)>, Vec<String>) {
+pub(super) fn sanitized_environment(
+    overrides: &[(OsString, OsString)],
+) -> (Vec<(OsString, OsString)>, Vec<String>) {
     let mut environment = Vec::new();
     let mut secrets = Vec::new();
     for (name, value) in env::vars_os() {
@@ -317,6 +319,15 @@ pub(super) fn sanitized_environment() -> (Vec<(OsString, OsString)>, Vec<String>
         }
     }
     normalize_environment(&mut environment);
+    for (name, value) in overrides {
+        environment.retain(|(candidate, _)| candidate != name);
+        environment.push((name.clone(), value.clone()));
+        if is_sensitive_name(name)
+            && let Some(value) = value.to_str().filter(|value| value.len() >= 8)
+        {
+            secrets.push(value.to_owned());
+        }
+    }
     secrets.sort_unstable_by_key(|secret| std::cmp::Reverse(secret.len()));
     secrets.dedup();
     (environment, secrets)
@@ -340,7 +351,7 @@ fn is_sensitive_name(name: &OsStr) -> bool {
 mod tests {
     use std::ffi::OsString;
 
-    use super::{NORMALIZED_ENVIRONMENT, normalize_environment};
+    use super::{NORMALIZED_ENVIRONMENT, normalize_environment, sanitized_environment};
 
     #[test]
     fn normalized_environment_overrides_terminal_and_pager_values() {
@@ -363,5 +374,18 @@ mod tests {
                 vec![&OsString::from(value)]
             );
         }
+    }
+
+    #[test]
+    fn explicit_environment_overrides_are_retained_and_redacted() {
+        let value = OsString::from("proxy-secret-value");
+        let (environment, secrets) = sanitized_environment(&[
+            (OsString::from("TERM"), OsString::from("mpp-terminal")),
+            (OsString::from("NANOCODEX_PROXY_TOKEN"), value.clone()),
+        ]);
+
+        assert!(environment.contains(&(OsString::from("TERM"), OsString::from("mpp-terminal"))));
+        assert!(environment.contains(&(OsString::from("NANOCODEX_PROXY_TOKEN"), value,)));
+        assert!(secrets.iter().any(|secret| secret == "proxy-secret-value"));
     }
 }

--- a/crates/nanocodex-tools/src/web_search/mod.rs
+++ b/crates/nanocodex-tools/src/web_search/mod.rs
@@ -30,9 +30,14 @@ pub(super) struct WebSearchHandler {
 }
 
 impl WebSearchHandler {
+    #[cfg(test)]
     pub(super) fn new(config: WebSearchConfig) -> Self {
+        Self::with_client(config, reqwest::Client::new())
+    }
+
+    pub(super) fn with_client(config: WebSearchConfig, client: reqwest::Client) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client,
             endpoint: config.endpoint,
             auth: config.auth,
         }
@@ -346,10 +351,21 @@ mod tests {
     #[tokio::test]
     async fn posts_codex_search_request_and_returns_plaintext_output() -> Result<()> {
         let (endpoint, server) = spawn_search_server().await?;
-        let handler = WebSearchHandler::new(WebSearchConfig {
-            endpoint,
-            auth: subscription_auth(),
-        });
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            "x-injected-client",
+            reqwest::header::HeaderValue::from_static("true"),
+        );
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()?;
+        let handler = WebSearchHandler::with_client(
+            WebSearchConfig {
+                endpoint,
+                auth: subscription_auth(),
+            },
+            client,
+        );
         let history = serde_json::from_value::<Vec<nanocodex_core::ResponseItem>>(json!([
             json!({
                 "type": "message",
@@ -441,6 +457,9 @@ mod tests {
             }
             if !headers.contains("x-openai-fedramp: true") {
                 return Err(eyre!("search request did not contain FedRAMP routing"));
+            }
+            if !headers.contains("x-injected-client: true") {
+                return Err(eyre!("search request did not use the injected HTTP client"));
             }
             let response = serde_json::to_vec(&json!({
                 "encrypted_output": "ciphertext",

--- a/deny.toml
+++ b/deny.toml
@@ -22,9 +22,10 @@ allow = [
     "0BSD",
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
+    "BSL-1.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
-    "BSL-1.0",
+    "CC0-1.0",
     "CDLA-Permissive-2.0",
     "ISC",
     "MIT",
@@ -48,4 +49,5 @@ required-git-spec = "rev"
 allow-git = [
     "https://github.com/openai-oss-forks/tokio-tungstenite",
     "https://github.com/openai-oss-forks/tungstenite-rs",
+    "https://github.com/tempoxyz/mpp-rs",
 ]

--- a/docs/MPP.md
+++ b/docs/MPP.md
@@ -1,0 +1,256 @@
+# MPP Responses WebSocket integration
+
+## Boundary
+
+MPP is composed by `bin/nanocodex` and the private, non-published `mpp-egress`
+support crate. No public Nanocodex library crate depends on or contains payment
+code. The CLI starts an in-process loopback WebSocket adapter and gives its URL
+to the normal Nanocodex Responses configuration.
+Consequently the existing persistent socket, typed stream processing, retry
+policy, retained history, `previous_response_id`, and `store: false` behavior
+remain unchanged.
+
+```text
+Nanocodex ResponsesService (unchanged)
+               |
+       ordinary OpenAI frames
+               |
+      CLI loopback WS adapter
+               |
+ alloy-transport-mpp application socket
+               |
+ canonical MPP frames + native TIP-1034 vouchers
+               |
+          mpp-proxy/mppx
+               |
+      OpenAI Responses WebSocket
+```
+
+The loopback adapter does not forward Nanocodex's OpenAI bearer credential.
+It forwards only the Responses beta, cache/session identity, timing, and user
+agent headers needed by the upstream proxy.
+
+## Canonical paid socket
+
+The generic application transport belongs in `alloy-transport-mpp`, below its
+Alloy JSON-RPC adapter. It carries arbitrary UTF-8 application data and owns the
+payment framing:
+
+1. Convert the `ws:`/`wss:` endpoint to `http:`/`https:` and issue an HTTP GET
+   probe.
+2. Parse every `WWW-Authenticate: Payment` challenge and choose the first one
+   supported by the configured `PaymentProvider`.
+3. Upgrade the WebSocket and send
+   `{"mpp":"authorization","authorization":"Payment …"}`.
+4. Wait for `payment-receipt` before exposing the socket.
+5. Wrap application data as `{"mpp":"message","data":"…"}` and unwrap the
+   same server envelope.
+6. Intercept `payment-need-voucher`, obtain the requested cumulative voucher,
+   and send it as another in-band authorization.
+7. On shutdown, request `payment-close-ready`, sign a descriptor-bearing native
+   close credential for the receipt's exact `spent` amount, and wait for the
+   final receipt. The client rejects a close amount above its locally signed
+   voucher ceiling.
+8. Keep receipts and payment errors out of the application stream.
+
+Receipt payloads remain opaque JSON at this layer. That permits any
+MPP-compatible provider or future receipt extension; only the CLI's Tempo
+session wrapper understands native voucher requests.
+
+The old `alloy-transport-mpp` implementation waits for a noncanonical
+in-socket `challenge` frame and uses `type`/`credential` envelopes. Current MPP
+uses the HTTP 402 probe and `mpp`/`authorization` envelopes. Nanocodex must use
+the canonical application socket, not that legacy dialect.
+
+## Native Tempo sessions
+
+The CLI reads the active account and extractable P-256 access key written by
+Tempo Wallet login at `~/.tempo/wallet/store.json`. It uses Alloy's generic
+signer interface with a Tempo keychain-v2 envelope; there is no Nanocodex
+signer abstraction and no raw private-key CLI option. The same access key can
+therefore open and voucher sessions from Wallet CLI, MPPx, or Rust.
+
+`mpp::TempoSessionProvider` owns channel recovery and cumulative voucher state.
+Its `ChannelStore` is deliberately persistence-only. Nanocodex opts into the
+MPPx-compatible SQLite implementation at `~/.tempo/wallet/channels.db`; a
+library caller that does not configure persistence gets the in-memory store.
+Before the paid WebSocket probe, the provider performs the server's
+authenticated `HEAD` bootstrap, reconciles the returned session snapshot with
+TIP-1034 on-chain state, and then updates SQLite and its live registry. A new
+process can consequently resume a server-known session even when its local
+database starts empty.
+
+The OpenAI proxy offers native v2 before legacy v1. The v2 challenge uses:
+
+- Moderato chain ID `42431` or Tempo mainnet chain ID `4217`;
+- TIP-1034 reserve precompile
+  `0x4d50500000000000000000000000000000000000`;
+- cumulative off-chain vouchers;
+- optional server fee sponsorship.
+
+`TempoSessionProvider::voucher_credential` returns a signed credential for
+in-band transports without performing an unrelated HTTP POST. Its existing SSE
+helper delegates to that method and then performs the POST.
+
+Native session dependencies require Rust 1.93, newer than Nanocodex's Rust
+1.88 library baseline. The executable declares that higher MSRV while the MPP
+integration stays out of the library crates and their dependency graph.
+
+## OpenAI proxy
+
+`mpp-proxy` adds `GET /v1/responses` as a paid WebSocket endpoint while keeping
+the existing HTTP POST route. The GET without an upgrade is the HTTP payment
+probe. The upgrade path:
+
+- uses `mppx`/`tempo.Ws.serve` for canonical session authorization and voucher
+  verification;
+- opens an outbound WebSocket to `https://api.openai.com/v1/responses`;
+- accepts only `response.create` application frames;
+- incrementally tokenizes output text with `o200k_base`, retaining a conservative
+  128-token suffix so later deltas cannot change an already charged boundary;
+- calls `stream.charge(incremental_output_amount)` before releasing each output
+  delta, causing mppx to request the next cumulative native session voucher;
+- forwards the caller's request and OpenAI events byte-for-byte, so the
+  Nanocodex wire stream and retained history remain unchanged;
+- prices the terminal event from OpenAI's authoritative usage counters;
+- accounts independently for uncached input, cached input, cache writes,
+  visible and reasoning output, the 272K long-context tier, service tier, and
+  supported paid tools;
+- charges only the remaining difference before releasing the terminal event;
+- allows one response in flight and resets that state only on an OpenAI
+  terminal event;
+- reuses the upstream WebSocket for every sequential response;
+- caps queued upstream data at 64 MiB while a voucher is being obtained;
+- observes mppx's cancellation signal so native session close cannot deadlock
+  behind an idle application generator.
+
+Output remains live: only a delta that makes a sufficiently old group of output
+tokens stable pauses for payment, and that delta is released as soon as its
+cumulative voucher is verified. The retained tokenizer suffix is charged during
+terminal reconciliation. OpenAI does not stream input, cache-write, hidden
+reasoning, paid-tool, or final long-context accounting as individual tokens, so
+the authoritative terminal usage event reconciles those amounts without double
+charging. The persistent WebSocket and retained response chain are unchanged.
+
+For `gpt-5.6-sol`, standard short-context prices per million tokens are $5
+uncached input, $0.50 cached input, $6.25 cache writes, and $30 output. The
+resolver also contains the published Terra and Luna tables, Flex and Priority
+tiers, long-context multipliers, and Web/File Search call fees. Amounts round
+up to the proxy currency's one-micro-dollar atomic unit.
+
+MPP sessions require a positive base tick, so the route advertises one atomic
+unit. Every actual OpenAI request supplies its explicit dynamically calculated
+amount; the base tick is not used as the request price.
+
+Dynamic WebSocket charging requires `mppx`'s session controller to accept an
+optional explicit amount. Calling `charge()` without an amount preserves the
+existing fixed-tick behavior.
+
+## CLI
+
+Enable the adapter with:
+
+```text
+--provider.openai
+--provider.tempo
+--provider.tempo.egress                    # opt-in HTTP(S) tool egress
+--provider.tempo.responses-websocket-url <ws-or-wss-url>
+--provider.tempo.wallet-store <path>       # default ~/.tempo/wallet/store.json
+--provider.tempo.channel-store <path>      # default ~/.tempo/wallet/channels.db
+--provider.tempo.rpc-url <url>
+--provider.tempo.max-deposit <atomic-units>
+--provider.tempo.egress-max-charge <atomic-units> # default 100000 ($0.10 USDC.e)
+--provider.tempo.api-key <key>             # optional gated deployment key
+```
+
+These are global CLI flags. They select the same paid transport for both the
+interactive TUI and the headless one-shot runner:
+
+```text
+nanocodex --provider.tempo --prompt "say hello"
+nanocodex run "say hello" --provider.tempo
+```
+
+The defaults target Tempo mainnet and
+`wss://openai.mpp.tempo.xyz/v1/responses`. Direct OpenAI is the default;
+`--provider.openai` makes that selection explicit. `--provider.tempo` does not
+require an OpenAI API key because the proxy owns the upstream credential.
+
+The eventual login surface follows the same namespace: `nanocodex login`
+defaults to OpenAI OAuth, while `nanocodex login --provider.tempo` runs the
+Tempo Wallet login flow and writes the shared Accounts SDK store. OpenAI OAuth
+is intentionally not stubbed by this integration.
+
+Both paths retain the adapter until the agent handle is dropped and then
+perform the canonical signed session close. TUI teardown restores the terminal
+before waiting for that network handshake.
+
+## HTTP(S) tool egress
+
+`--provider.tempo.egress` starts a private HTTP forward proxy on an ephemeral
+loopback port. Nanocodex injects authenticated `HTTP_PROXY`/`HTTPS_PROXY`
+variants and an ephemeral CA path into workspace-tool child processes only.
+It clears inherited proxy-bypass lists for those children, but does not change
+the parent process environment, the model WebSocket, web search, image
+generation, or MCP transports. Ordinary commands such as `curl` therefore need
+no MPP-specific wrapper:
+
+```text
+nanocodex --provider.tempo --provider.tempo.egress \
+  --prompt "curl the paid endpoint and summarize the response"
+```
+
+For HTTPS, the proxy terminates the child's TLS connection with the ephemeral
+CA, forwards the request with redirects disabled, and streams the final
+response back. It buffers each request body up to 16 MiB so the exact method,
+headers, and body can be replayed after a valid MPP 402 challenge. At most four
+payment challenges are accepted per request. Protocol upgrades are tunneled
+without MPP handling.
+
+The signing provider and wallet material remain inside the binary. The
+loopback proxy rejects requests without a random per-process credential, which
+is injected only into tool children. Its CA and proxy credential disappear
+when the adapter is dropped.
+
+The proxy library is generic over `mpp::client::PaymentProvider`, so it is not
+tied to curl, Code Mode, Tempo, or a particular MPP intent. The current binary
+wires in both Tempo charge and session providers. One-shot `tempo.charge`
+challenges are rejected above `--provider.tempo.egress-max-charge`; the default
+ceiling is 100,000 atomic units ($0.10 for USDC.e). Session deposits remain
+bounded by `--provider.tempo.max-deposit`. Unsupported, over-limit, or malformed
+402 challenges fail the proxied request rather than being paid blindly.
+
+Each proxied request emits a correlated `mpp.egress.request` span. Its ordered
+events record the original request, selected 402 challenge, created credential,
+paid replay status, final response headers, and streamed response body. Persist
+the record as structured JSON with:
+
+```text
+nanocodex run "curl the paid endpoint" \
+  --provider.tempo --provider.tempo.egress \
+  --log-format json --log-file .nanocodex/logs/mpp-egress.jsonl
+```
+
+These traces are full-fidelity operational records. They contain request and
+response content plus payment credentials, so operators must protect and retain
+them like the corresponding wallet and agent conversation data.
+
+The endpoint is configurable, so the same transport can call other compatible
+MPP WebSocket services. A local proxy uses a service subdomain, for example
+`ws://openai.localhost:8787/v1/responses`. Discovery remains a caller/tool
+concern; the egress proxy only makes ordinary HTTP clients payment-aware.
+
+## Validation
+
+Required validation before merging:
+
+- `mppx`: explicit dynamic charge reservation/commit test.
+- `mpp-rs`: cumulative native voucher credential test and canonical
+  probe/authorization/application-frame integration test.
+- `mpp-proxy`: format, lint, typecheck, full unit suite, and an OpenAI WS bridge
+  test.
+- Nanocodex: rustfmt, Clippy with warnings denied, CLI tests, and unchanged
+  library tests.
+- Live: use the logged-in mainnet wallet access key, rehydrate or open a native
+  v2 channel, and complete two sequential real OpenAI Responses turns through
+  one paid WebSocket without exposing either the wallet JWK or OpenAI secret.


### PR DESCRIPTION
## Summary

- keep Tempo MPP entirely in `bin/nanocodex` as CLI-owned WebSocket and HTTP middleware; library crates remain provider-agnostic
- support `--provider.tempo` in one-shot runs and the TUI, using the access key from `~/.tempo/wallet/store.json` and persistent sessions from `~/.tempo/wallet/channels.db`
- use `alloy-transport-mpp` and native TIP-1034 v2 sessions for WebSocket authorization, cumulative vouchers, cold rehydration, expiring nonces, autoswap, and automatic top-up
- always enable MPP egress when Tempo is selected, including Code Mode child processes and in-process OpenAI HTTP tools
- start sessions at $5, refill in configurable $5 batches through `--provider.tempo.top-up-amount`, and retain the independent $25 authorization cap
- keep direct OpenAI as the default and require no `OPENAI_API_KEY` for Tempo
- resume populated session stores through the server-signed `Payment-Session` snapshot instead of performing an authenticated HEAD bootstrap on every cold process

## Upstream

- pins merged `tempoxyz/mpp-rs@3a689a1b1c194f54ad7a1afcbfa9be388706a94e`
- `tempoxyz/mpp-rs#335` adds HTTP management top-ups, synchronized voucher creation, and configurable refill batching
- `tempoxyz/mpp-rs#336` adds safe hinted WebSocket session recovery with stale-store reconciliation
- `tempoxyz/mpp-proxy#255` makes the deployed OpenAI service resolve and return the signed snapshot for a valid `Payment-Session` hint
- `wevm/mppx#698` is the matching TypeScript refill-batching change

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p nanocodex-bin` (178 unit tests and the MCP CLI integration test passed)
- `cargo test -p mpp-egress` (6 passed, 1 manual live test ignored)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- live mainnet `gpt-5.6-sol` run with `OPENAI_API_KEY` removed: paid Responses WebSocket plus a Code Mode curl through Nanocodex MPP egress returned HTTP 200 and Tempo chain ID `0x1079`
- 2,048-request Code Mode stress run from `nanocodex run --provider.tempo`: 1,566 HTTP 200, 482 rate-limited HTTP 429, and zero transport/payment/server failures
- live stale-store recovery advanced the existing session from cumulative `8,327,861` to `8,400,089` using an initial challenge plus the signed `Payment-Session` probe and no authenticated HEAD
- the final live trace completed in 6.13s: 4.39s warmup and 1.73s generation; the removed authenticated HEAD previously cost about 2.9s on an empty identity bootstrap

All seven commits have GitHub-verified SSH signatures. Head `9d3692f2` is rebased directly onto current master.