### PR TITLE
Preserve assistant message phases in events

### DIFF
--- a/crates/nanocodex-core/src/responses/event.rs
+++ b/crates/nanocodex-core/src/responses/event.rs
@@ -36,8 +36,18 @@ pub struct OutputTokenDetails {
 pub enum ServerEvent {
     #[serde(rename = "response.created")]
     Created,
+    #[serde(rename = "response.output_item.added")]
+    OutputItemAdded {
+        #[serde(default)]
+        output_index: Option<u32>,
+        item: ResponseItem,
+    },
     #[serde(rename = "response.output_text.delta")]
-    OutputTextDelta { delta: String },
+    OutputTextDelta {
+        #[serde(default)]
+        output_index: Option<u32>,
+        delta: String,
+    },
     #[serde(rename = "response.reasoning_summary_text.delta")]
     ReasoningSummaryTextDelta { delta: String },
     #[serde(rename = "response.reasoning_summary.delta")]

--- a/crates/nanocodex-service/src/stream.rs
+++ b/crates/nanocodex-service/src/stream.rs
@@ -1,5 +1,7 @@
+use std::collections::HashMap;
+
 use nanocodex_core::{
-    AgentEventKind, ContentItem, EventSink, ResponseItem,
+    AgentEventKind, ContentItem, EventSink, MessagePhase, MessageRole, ResponseItem,
     responses::{ServerEvent, Usage},
 };
 use serde::Serialize;
@@ -49,6 +51,21 @@ pub enum CodeCallKind {
 }
 
 #[derive(Serialize)]
+struct AssistantTextDelta<'a> {
+    model_call_index: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    item_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    phase: Option<MessagePhase>,
+    text: &'a str,
+}
+
+struct AssistantStreamItem {
+    item_id: Option<Box<str>>,
+    phase: Option<MessagePhase>,
+}
+
+#[derive(Serialize)]
 struct TextDelta<'a> {
     model_call_index: u32,
     text: &'a str,
@@ -77,16 +94,38 @@ pub(crate) async fn receive(
     started_at: Instant,
 ) -> Result<TurnResult, ResponsesServiceError> {
     let mut done_items = Vec::with_capacity(2);
+    let mut assistant_items = HashMap::new();
     let mut timing = StreamTiming::new(started_at);
 
     loop {
         match next_event(socket, events, "generation", call_index, &mut timing).await? {
-            ServerEvent::OutputTextDelta { delta } => {
+            ServerEvent::OutputItemAdded { output_index, item } => {
+                let Some(output_index) = output_index else {
+                    continue;
+                };
+                let ResponseItem::Message {
+                    id,
+                    role: MessageRole::Assistant,
+                    phase,
+                    ..
+                } = item
+                else {
+                    continue;
+                };
+                assistant_items.insert(output_index, AssistantStreamItem { item_id: id, phase });
+            }
+            ServerEvent::OutputTextDelta {
+                output_index,
+                delta,
+            } => {
                 let payload_bytes = delta.len();
+                let item = output_index.and_then(|index| assistant_items.get(&index));
                 let seq = events.emit_with_sequence(
                     AgentEventKind::AssistantDelta,
-                    TextDelta {
+                    AssistantTextDelta {
                         model_call_index: call_index,
+                        item_id: item.and_then(|item| item.item_id.as_deref()),
+                        phase: item.and_then(|item| item.phase),
                         text: &delta,
                     },
                 )?;
@@ -218,6 +257,7 @@ async fn next_event(
         ServerEvent::OutputTextDelta { .. }
             | ServerEvent::ReasoningSummaryTextDelta { .. }
             | ServerEvent::ReasoningSummaryDelta { .. }
+            | ServerEvent::OutputItemAdded { .. }
             | ServerEvent::OutputItemDone { .. }
     ) {
         timing.first_output_ns.get_or_insert(elapsed);

--- a/crates/nanocodex/src/model/agent.rs
+++ b/crates/nanocodex/src/model/agent.rs
@@ -1,8 +1,8 @@
 use std::{path::Path, sync::Arc};
 
 use nanocodex_core::{
-    AgentEventKind, EventSink, MODEL, ModelConfig, Prompt, ReasoningSummary, ResponseItem,
-    ToolDefinition, Usage, responses::RequestProfile,
+    AgentEventKind, EventSink, MODEL, MessagePhase, ModelConfig, Prompt, ReasoningSummary,
+    ResponseItem, ToolDefinition, Usage, responses::RequestProfile,
 };
 use nanocodex_service::{
     CodeCall, CodeCallKind, ResponsesAttempt, ResponsesAttemptFactory, ResponsesClient,
@@ -320,7 +320,10 @@ where
             Ok(message) => {
                 self.events.emit(
                     AgentEventKind::AssistantMessage,
-                    AssistantMessage { text: &message },
+                    AssistantMessage {
+                        text: &message,
+                        phase: MessagePhase::FinalAnswer,
+                    },
                 )?;
                 self.stats
                     .apply_transport(self.transport_stats.since(transport_before));

--- a/crates/nanocodex/src/model/agent_tests.rs
+++ b/crates/nanocodex/src/model/agent_tests.rs
@@ -70,6 +70,109 @@ async fn follow_on_prompts_reuse_the_session_socket_and_context() -> Result<()> 
 }
 
 #[tokio::test]
+async fn assistant_events_preserve_commentary_and_final_answer_phases() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("ws://{}", listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await?;
+        let mut socket = accept_async(stream).await?;
+        assert_warmup(&next_json(&mut socket).await?);
+        send_warmup(&mut socket, "resp-warmup").await?;
+
+        let initial = next_json(&mut socket).await?;
+        assert_eq!(initial["previous_response_id"], "resp-warmup");
+        let commentary = send_assistant_output(
+            &mut socket,
+            0,
+            "msg-commentary",
+            "commentary",
+            "I’ll verify.",
+        )
+        .await?;
+        send_json(
+            &mut socket,
+            completed_response(
+                "resp-commentary",
+                &[
+                    commentary,
+                    json!({
+                        "id": "call-item",
+                        "type": "custom_tool_call",
+                        "call_id": "call-exec",
+                        "name": "exec",
+                        "input": "text(\"observed\");"
+                    }),
+                ],
+            ),
+        )
+        .await?;
+
+        let continuation = next_json(&mut socket).await?;
+        assert_eq!(continuation["previous_response_id"], "resp-commentary");
+        let final_answer =
+            send_assistant_output(&mut socket, 0, "msg-final", "final_answer", "Done.").await?;
+        send_json(
+            &mut socket,
+            completed_response("resp-final", &[final_answer]),
+        )
+        .await
+    });
+
+    let workspace = temporary_workspace("assistant-phases")?;
+    let responses = Responses::builder().websocket_url(endpoint).build();
+    let (agent, mut events) = Nanocodex::builder("test-key")
+        .thinking(Thinking::Low)
+        .workspace(&workspace)
+        .responses(responses)
+        .session_id("model-test")
+        .build()?;
+    let turn = agent.prompt("check the live state").await?;
+    assert_eq!(turn.result().await?.final_message, "Done.");
+    drop(agent);
+
+    let mut deltas = Vec::new();
+    let mut final_message = None;
+    while let Some(event) = events.recv().await {
+        match event.kind {
+            nanocodex_core::AgentEventKind::AssistantDelta => {
+                deltas.push(event.decode_payload::<Value>()?);
+            }
+            nanocodex_core::AgentEventKind::AssistantMessage => {
+                final_message = Some(event.decode_payload::<Value>()?);
+            }
+            _ => {}
+        }
+    }
+    assert_eq!(
+        deltas,
+        [
+            json!({
+                "model_call_index": 1,
+                "item_id": "msg-commentary",
+                "phase": "commentary",
+                "text": "I’ll verify."
+            }),
+            json!({
+                "model_call_index": 2,
+                "item_id": "msg-final",
+                "phase": "final_answer",
+                "text": "Done."
+            })
+        ]
+    );
+    assert_eq!(
+        final_message,
+        Some(json!({ "text": "Done.", "phase": "final_answer" }))
+    );
+
+    timeout(std::time::Duration::from_secs(5), server)
+        .await
+        .map_err(|_| eyre!("mock Responses server did not finish"))???;
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn steering_is_bounded_fifo_and_joins_at_the_next_model_boundary() -> Result<()> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let endpoint = format!("ws://{}", listener.local_addr()?);
@@ -1485,6 +1588,62 @@ where
         ),
     )
     .await
+}
+
+async fn send_assistant_output<S>(
+    socket: &mut WebSocketStream<S>,
+    output_index: u32,
+    item_id: &str,
+    phase: &str,
+    text: &str,
+) -> Result<Value>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let completed = json!({
+        "id": item_id,
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "phase": phase,
+        "content": [{ "type": "output_text", "text": text }]
+    });
+    send_json(
+        socket,
+        json!({
+            "type": "response.output_item.added",
+            "output_index": output_index,
+            "item": {
+                "id": item_id,
+                "type": "message",
+                "role": "assistant",
+                "status": "in_progress",
+                "phase": phase,
+                "content": []
+            }
+        }),
+    )
+    .await?;
+    send_json(
+        socket,
+        json!({
+            "type": "response.output_text.delta",
+            "output_index": output_index,
+            "content_index": 0,
+            "delta": text
+        }),
+    )
+    .await?;
+    send_json(
+        socket,
+        json!({
+            "type": "response.output_item.done",
+            "output_index": output_index,
+            "item": completed.clone()
+        }),
+    )
+    .await?;
+    Ok(completed)
 }
 
 fn completed_response(response_id: &str, output: &[Value]) -> Value {

--- a/crates/nanocodex/src/model/telemetry.rs
+++ b/crates/nanocodex/src/model/telemetry.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 #[cfg(not(target_family = "wasm"))]
 use std::path::PathBuf;
 
-use nanocodex_core::{ModelConfig, Usage};
+use nanocodex_core::{MessagePhase, ModelConfig, Usage};
 use serde::Serialize;
 use serde_json::value::RawValue;
 use web_time::Instant;
@@ -255,6 +255,7 @@ pub(super) struct RunSteered {
 #[derive(Serialize)]
 pub(super) struct AssistantMessage<'a> {
     pub(super) text: &'a str,
+    pub(super) phase: MessagePhase,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
## Summary

- correlate streamed assistant deltas with their Responses output item
- include API-visible commentary/final-answer phase and item ID in assistant delta events
- mark the canonical assistant message as final-answer output

## Why

Embedders such as Centaur need to render final answers without exposing commentary as user-facing answer text. The typed event stream previously discarded the phase metadata before consumers could make that distinction.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- Harbor adapter unit tests and config validation
- live Responses API smoke showing commentary and final-answer deltas retain distinct phases