### PR TITLE
Emit completed assistant items from Responses

### DIFF
--- a/crates/nanocodex-service/src/stream.rs
+++ b/crates/nanocodex-service/src/stream.rs
@@ -60,6 +60,16 @@ struct AssistantTextDelta<'a> {
     text: &'a str,
 }
 
+#[derive(Serialize)]
+struct AssistantMessage<'a> {
+    model_call_index: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    item_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    phase: Option<MessagePhase>,
+    text: String,
+}
+
 struct AssistantStreamItem {
     item_id: Option<Box<str>>,
     phase: Option<MessagePhase>,
@@ -161,7 +171,10 @@ pub(crate) async fn receive(
                     "Responses reasoning delta entered the agent event stream"
                 );
             }
-            ServerEvent::OutputItemDone { item } => done_items.push(item),
+            ServerEvent::OutputItemDone { item } => {
+                emit_assistant_message(events, call_index, &item)?;
+                done_items.push(item);
+            }
             ServerEvent::Completed { mut response } => {
                 let output_items = if response.output.is_empty() {
                     done_items
@@ -185,6 +198,33 @@ pub(crate) async fn receive(
             _ => {}
         }
     }
+}
+
+fn emit_assistant_message(
+    events: &EventSink,
+    call_index: u32,
+    item: &ResponseItem,
+) -> Result<(), ResponsesServiceError> {
+    let ResponseItem::Message {
+        id,
+        role: MessageRole::Assistant,
+        content,
+        phase,
+        ..
+    } = item
+    else {
+        return Ok(());
+    };
+    events.emit(
+        AgentEventKind::AssistantMessage,
+        AssistantMessage {
+            model_call_index: call_index,
+            item_id: id.as_deref(),
+            phase: *phase,
+            text: output_text(content),
+        },
+    )?;
+    Ok(())
 }
 
 pub(crate) async fn receive_compaction(
@@ -325,16 +365,18 @@ fn final_message(items: &[ResponseItem]) -> Option<String> {
         let ResponseItem::Message { content, .. } = item else {
             return None;
         };
-        Some(
-            content
-                .iter()
-                .filter_map(|part| match part {
-                    ContentItem::OutputText { text, .. } => Some(text.as_ref()),
-                    ContentItem::InputText { .. }
-                    | ContentItem::InputImage { .. }
-                    | ContentItem::InputAudio { .. } => None,
-                })
-                .collect(),
-        )
+        Some(output_text(content))
     })
+}
+
+fn output_text(content: &[ContentItem]) -> String {
+    content
+        .iter()
+        .filter_map(|part| match part {
+            ContentItem::OutputText { text, .. } => Some(text.as_ref()),
+            ContentItem::InputText { .. }
+            | ContentItem::InputImage { .. }
+            | ContentItem::InputAudio { .. } => None,
+        })
+        .collect()
 }

--- a/crates/nanocodex/src/model/agent.rs
+++ b/crates/nanocodex/src/model/agent.rs
@@ -1,8 +1,8 @@
 use std::{path::Path, sync::Arc};
 
 use nanocodex_core::{
-    AgentEventKind, EventSink, MODEL, MessagePhase, ModelConfig, Prompt, ReasoningSummary,
-    ResponseItem, ToolDefinition, Usage, responses::RequestProfile,
+    AgentEventKind, EventSink, MODEL, ModelConfig, Prompt, ReasoningSummary, ResponseItem,
+    ToolDefinition, Usage, responses::RequestProfile,
 };
 use nanocodex_service::{
     CodeCall, CodeCallKind, ResponsesAttempt, ResponsesAttemptFactory, ResponsesClient,
@@ -14,10 +14,9 @@ use tracing::{Instrument, info_span};
 use web_time::Instant;
 
 use super::{
-    AssistantMessage, CompactionCompleted, CompactionFailed, CompactionStarted, ModelCallCompleted,
-    ModelCallFailed, ModelCallStarted, RunError, RunStarted, RunStats, RunSteered,
-    ToolCallArguments, ToolCallEvent, ToolResultEvent, WarmupCompleted, WarmupFailed,
-    WarmupStarted,
+    CompactionCompleted, CompactionFailed, CompactionStarted, ModelCallCompleted, ModelCallFailed,
+    ModelCallStarted, RunError, RunStarted, RunStats, RunSteered, ToolCallArguments, ToolCallEvent,
+    ToolResultEvent, WarmupCompleted, WarmupFailed, WarmupStarted,
     agents_md::load_project_instructions,
     compaction,
     context_manager::ContextManager,
@@ -318,13 +317,6 @@ where
         let elapsed = self.started_at.elapsed();
         match outcome {
             Ok(message) => {
-                self.events.emit(
-                    AgentEventKind::AssistantMessage,
-                    AssistantMessage {
-                        text: &message,
-                        phase: MessagePhase::FinalAnswer,
-                    },
-                )?;
                 self.stats
                     .apply_transport(self.transport_stats.since(transport_before));
                 self.events.emit(

--- a/crates/nanocodex/src/model/agent_tests.rs
+++ b/crates/nanocodex/src/model/agent_tests.rs
@@ -131,45 +131,62 @@ async fn assistant_events_preserve_commentary_and_final_answer_phases() -> Resul
     drop(agent);
 
     let mut deltas = Vec::new();
-    let mut final_message = None;
+    let mut messages = Vec::new();
+    let mut timeline = Vec::new();
     while let Some(event) = events.recv().await {
         match event.kind {
             nanocodex_core::AgentEventKind::AssistantDelta => {
                 deltas.push(event.decode_payload::<Value>()?);
             }
             nanocodex_core::AgentEventKind::AssistantMessage => {
-                final_message = Some(event.decode_payload::<Value>()?);
+                let message = event.decode_payload::<Value>()?;
+                timeline.push(message["phase"].clone());
+                messages.push(message);
+            }
+            nanocodex_core::AgentEventKind::ToolCall => {
+                timeline.push(json!("tool.call"));
+            }
+            nanocodex_core::AgentEventKind::ToolResult => {
+                timeline.push(json!("tool.result"));
             }
             _ => {}
         }
     }
-    assert_eq!(
-        deltas,
-        [
-            json!({
-                "model_call_index": 1,
-                "item_id": "msg-commentary",
-                "phase": "commentary",
-                "text": "I’ll verify."
-            }),
-            json!({
-                "model_call_index": 2,
-                "item_id": "msg-final",
-                "phase": "final_answer",
-                "text": "Done."
-            })
-        ]
-    );
-    assert_eq!(
-        final_message,
-        Some(json!({ "text": "Done.", "phase": "final_answer" }))
-    );
+    assert_assistant_phase_events(&deltas, &messages, &timeline);
 
     timeout(std::time::Duration::from_secs(5), server)
         .await
         .map_err(|_| eyre!("mock Responses server did not finish"))???;
     std::fs::remove_dir_all(workspace)?;
     Ok(())
+}
+
+fn assert_assistant_phase_events(deltas: &[Value], messages: &[Value], timeline: &[Value]) {
+    let expected_messages = [
+        json!({
+            "model_call_index": 1,
+            "item_id": "msg-commentary",
+            "phase": "commentary",
+            "text": "I’ll verify."
+        }),
+        json!({
+            "model_call_index": 2,
+            "item_id": "msg-final",
+            "phase": "final_answer",
+            "text": "Done."
+        }),
+    ];
+    assert_eq!(deltas, expected_messages);
+    assert_eq!(messages, expected_messages);
+    assert_eq!(
+        timeline,
+        [
+            json!("commentary"),
+            json!("tool.call"),
+            json!("tool.result"),
+            json!("final_answer")
+        ]
+    );
 }
 
 #[tokio::test]

--- a/crates/nanocodex/src/model/mod.rs
+++ b/crates/nanocodex/src/model/mod.rs
@@ -10,8 +10,8 @@ mod input;
 mod telemetry;
 
 use telemetry::{
-    AssistantMessage, CompactionCompleted, CompactionFailed, CompactionStarted, ModelCallCompleted,
-    ModelCallFailed, ModelCallStarted, RunError, RunStarted, RunStats, RunSteered,
-    ToolCallArguments, ToolCallEvent, ToolResultEvent, WarmupCompleted, WarmupFailed,
-    WarmupStarted, display_endpoint, elapsed_ns, resolve_workspace, terminal_payload,
+    CompactionCompleted, CompactionFailed, CompactionStarted, ModelCallCompleted, ModelCallFailed,
+    ModelCallStarted, RunError, RunStarted, RunStats, RunSteered, ToolCallArguments, ToolCallEvent,
+    ToolResultEvent, WarmupCompleted, WarmupFailed, WarmupStarted, display_endpoint, elapsed_ns,
+    resolve_workspace, terminal_payload,
 };

--- a/crates/nanocodex/src/model/telemetry.rs
+++ b/crates/nanocodex/src/model/telemetry.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 #[cfg(not(target_family = "wasm"))]
 use std::path::PathBuf;
 
-use nanocodex_core::{MessagePhase, ModelConfig, Usage};
+use nanocodex_core::{ModelConfig, Usage};
 use serde::Serialize;
 use serde_json::value::RawValue;
 use web_time::Instant;
@@ -250,12 +250,6 @@ pub(super) struct RunStarted<'a> {
 pub(super) struct RunSteered {
     pub(super) steer_index: u32,
     pub(super) instruction_bytes: usize,
-}
-
-#[derive(Serialize)]
-pub(super) struct AssistantMessage<'a> {
-    pub(super) text: &'a str,
-    pub(super) phase: MessagePhase,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
## Summary
- emit every completed assistant response item with its canonical item ID, phase, and text
- preserve the stock Codex ordering invariant: deltas are keyed by the added item and canonical completion comes from `response.output_item.done`
- remove the later final-answer-only synthesis so commentary and final answers share one direct event path

## Validation
- `just check` Rust formatting, Clippy, workspace tests, examples, and doc tests passed
- `just check` then stopped at the Python adapter step because this clean worktree has no `.venv`
- focused assistant phase/interleaving test passed