### PR TITLE
Add opt-in same-session completion audits

### DIFF
--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -194,6 +194,7 @@ pub(crate) fn default_auth_file() -> Result<PathBuf> {
 mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
 
+    use clap::CommandFactory;
     use nanocodex::OpenAiAuthMode;
 
     use super::select_auth;
@@ -206,6 +207,17 @@ mod tests {
             std::process::id(),
             NEXT_PATH.fetch_add(1, Ordering::Relaxed)
         ))
+    }
+
+    #[test]
+    fn subagents_are_opt_in() {
+        let command = crate::Cli::command();
+        let subagents = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "subagents")
+            .expect("the CLI should expose the subagents argument");
+
+        assert_eq!(subagents.get_default_values(), ["false"]);
     }
 
     #[test]

--- a/bin/nanocodex/src/run.rs
+++ b/bin/nanocodex/src/run.rs
@@ -5,6 +5,14 @@ use eyre::Result;
 
 use crate::config::AgentArgs;
 
+const COMPLETION_AUDIT: &str = r"Perform the required final audit now. Do not merely summarize previous checks.
+
+Re-read the original task below verbatim and compare every literal path, field name, version, port, boundary, representation convention, lifecycle requirement, and caller-facing command against the actual final state. Validation derived from your own implementation is not independent: use the original contract, installed library behavior, or a separately written caller. Run the exact external workflow or the closest possible equivalent, fix every discrepancy you find, and leave the verified passing state intact.
+
+<original_task>
+{original_task}
+</original_task>";
+
 #[derive(Args)]
 pub(crate) struct Run {
     /// Prompt submitted to the agent.
@@ -14,6 +22,10 @@ pub(crate) struct Run {
     /// Submit the same prompt as sequential follow-on turns on one owned session.
     #[arg(long, default_value_t = 1, value_parser = clap::value_parser!(u16).range(1..=100))]
     repeat: u16,
+
+    /// Audit and repair the completed task in one same-session follow-on turn.
+    #[arg(long)]
+    completion_audit: bool,
 }
 
 impl Run {
@@ -23,9 +35,10 @@ impl Run {
         let mut events = configured.events;
         let result = async {
             for _ in 0..self.repeat {
-                let turn = handle.prompt(self.prompt.clone()).await?;
-                events.write_turn_jsonl(io::stdout()).await?;
-                turn.result().await?;
+                run_turn(&handle, &mut events, self.prompt.clone()).await?;
+                if self.completion_audit {
+                    run_turn(&handle, &mut events, completion_audit_prompt(&self.prompt)).await?;
+                }
             }
             Ok(())
         }
@@ -35,5 +48,37 @@ impl Run {
             child_agents.shutdown().await;
         }
         result
+    }
+}
+
+async fn run_turn(
+    handle: &nanocodex::Nanocodex,
+    events: &mut nanocodex::AgentEvents,
+    prompt: String,
+) -> Result<()> {
+    let turn = handle.prompt(prompt).await?;
+    events.write_turn_jsonl(io::stdout()).await?;
+    turn.result().await?;
+    Ok(())
+}
+
+fn completion_audit_prompt(original_task: &str) -> String {
+    COMPLETION_AUDIT.replace("{original_task}", original_task)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::completion_audit_prompt;
+
+    #[test]
+    fn audit_replays_the_original_task_verbatim_without_task_specific_hints() {
+        let original = "write value at /app/result.txt\nthen keep port 8080 alive";
+        let audit = completion_audit_prompt(original);
+
+        assert!(audit.contains(original));
+        assert!(audit.contains("Do not merely summarize previous checks"));
+        assert!(audit.contains("leave the verified passing state intact"));
+        assert!(!audit.contains("T2Retrieval"));
+        assert!(!audit.contains("sshd"));
     }
 }

--- a/evals/tb21-completion-audit-four-k5.yaml
+++ b/evals/tb21-completion-audit-four-k5.yaml
@@ -1,0 +1,32 @@
+# Focused same-session completion-audit diagnostic. Tasks and verifiers remain
+# canonical; web search and subagents are deliberately absent.
+jobs_dir: .nanocodex/harbor/jobs
+
+agents:
+  - import_path: harbor_adapter.agent:NanocodexAgent
+    model_name: openai/gpt-5.6-sol
+    env:
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+    kwargs:
+      binary_path: .nanocodex/installed/daytona-amd64/nanocodex
+      effort: high
+      web_search: false
+      subagents: false
+      completion_audit: true
+      install_node: true
+      system_prompt_path: crates/nanocodex-core/prompts/system.md
+
+datasets:
+  - name: terminal-bench/terminal-bench-2-1
+    ref: sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0ea7c4186773687d177ad3a0699a
+    task_names:
+      - terminal-bench/mteb-retrieve
+      - terminal-bench/configure-git-webserver
+      - terminal-bench/dna-insert
+      - terminal-bench/kv-store-grpc
+
+environment:
+  type: daytona
+
+n_attempts: 5
+n_concurrent_trials: 20

--- a/harbor_adapter/agent.py
+++ b/harbor_adapter/agent.py
@@ -40,6 +40,14 @@ RUN_METRIC_FIELDS = (
     "tool_wall_duration_ns",
 )
 USAGE_METRIC_FIELDS = ("cache_write_input_tokens", "reasoning_output_tokens")
+USAGE_TOTAL_FIELDS = (
+    "input_tokens",
+    "cached_input_tokens",
+    "cache_write_input_tokens",
+    "output_tokens",
+    "reasoning_output_tokens",
+    "total_tokens",
+)
 
 
 def _cli_tools_install_command(*, install_node: bool) -> str:
@@ -90,6 +98,7 @@ class NanocodexAgent(BaseInstalledAgent):
         effort: str = "low",
         web_search: bool = True,
         subagents: bool = False,
+        completion_audit: bool = False,
         install_node: bool = False,
         system_prompt_path: str | Path | None = None,
         agents_md_path: str | Path | None = None,
@@ -113,6 +122,7 @@ class NanocodexAgent(BaseInstalledAgent):
         self._effort = effort
         self._web_search = web_search
         self._subagents = subagents
+        self._completion_audit = completion_audit
         self._install_node = install_node
         self._system_prompt_path = self._resolve_context_file(
             system_prompt_path, "system prompt"
@@ -239,7 +249,7 @@ class NanocodexAgent(BaseInstalledAgent):
             print(result.stderr, end="", file=sys.stderr, flush=True)
 
     def _run_arguments(self, prompt: str) -> list[str]:
-        return [
+        arguments = [
             self._BINARY,
             "run",
             "--thinking",
@@ -248,9 +258,11 @@ class NanocodexAgent(BaseInstalledAgent):
             str(self._web_search).lower(),
             "--subagents",
             str(getattr(self, "_subagents", False)).lower(),
-            "--",
-            prompt,
         ]
+        if getattr(self, "_completion_audit", False):
+            arguments.append("--completion-audit")
+        arguments.extend(("--", prompt))
+        return arguments
 
     def _classify_exec_error(self, command: str, result: Any) -> Exception:
         # BaseInstalledAgent classifies and raises before returning a nonzero
@@ -303,14 +315,22 @@ class NanocodexAgent(BaseInstalledAgent):
         self._verify_model_context(events)
 
         terminals = [event for event in events if event["type"] in TERMINAL_EVENTS]
-        if len(terminals) != 1:
-            raise RuntimeError(
-                f"expected exactly one terminal event, found {len(terminals)}"
+        expected_terminals = (
+            2 if getattr(self, "_completion_audit", False) else 1
+        )
+        if len(terminals) != expected_terminals:
+            expected = (
+                "exactly one terminal event"
+                if expected_terminals == 1
+                else f"exactly {expected_terminals} terminal events"
             )
-        terminal = terminals[0]
+            raise RuntimeError(
+                f"expected {expected}, found {len(terminals)}"
+            )
+        terminal = terminals[-1]
         if terminal["seq"] != events[-1]["seq"]:
             raise RuntimeError("the terminal event must be the final event")
-        terminal_payload = terminal["payload"]
+        terminal_payload = self._aggregate_terminal_payload(terminals)
         model_calls = terminal_payload.get("model_calls", 0)
         tool_calls = sum(event["type"] == "tool.call" for event in events)
         usage = terminal_payload.get("usage")
@@ -386,6 +406,7 @@ class NanocodexAgent(BaseInstalledAgent):
                     extra={
                         "terminal_event_type": terminal["type"],
                         "terminal_payload": terminal_payload,
+                        "completion_audit": expected_terminals == 2,
                     },
                 ),
             ],
@@ -400,6 +421,7 @@ class NanocodexAgent(BaseInstalledAgent):
                     "model_calls": model_calls,
                     "tool_calls": tool_calls,
                     "duration_ns": terminal_payload.get("duration_ns"),
+                    "completion_audit": expected_terminals == 2,
                     **runtime_metrics,
                 },
             ),
@@ -415,6 +437,7 @@ class NanocodexAgent(BaseInstalledAgent):
         context.metadata = {
             "protocol_version": PROTOCOL_VERSION,
             "terminal_event_type": terminal["type"],
+            "completion_audit": expected_terminals == 2,
             "model_calls": model_calls,
             "tool_calls": tool_calls,
             "model": terminal_payload.get("model"),
@@ -427,6 +450,35 @@ class NanocodexAgent(BaseInstalledAgent):
             "last_response_id": terminal_payload.get("last_response_id"),
             "cost_status": terminal_payload.get("cost_status"),
         }
+
+    @classmethod
+    def _aggregate_terminal_payload(
+        cls, terminals: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        payloads = [terminal["payload"] for terminal in terminals]
+        aggregate = dict(payloads[-1])
+        for field in ("model_calls", "duration_ms", "duration_ns", *RUN_METRIC_FIELDS):
+            values = [cls._optional_int(payload.get(field)) for payload in payloads]
+            present = [value for value in values if value is not None]
+            aggregate[field] = sum(present) if present else None
+        for field in ("usage", "warmup_usage"):
+            maps = [
+                value
+                for payload in payloads
+                if isinstance((value := payload.get(field)), dict)
+            ]
+            aggregate[field] = {
+                metric: sum(
+                    value
+                    for mapping in maps
+                    if (value := cls._optional_int(mapping.get(metric))) is not None
+                )
+                for metric in USAGE_TOTAL_FIELDS
+            }
+        costs = [cls._optional_float(payload.get("cost_usd")) for payload in payloads]
+        present_costs = [cost for cost in costs if cost is not None]
+        aggregate["cost_usd"] = sum(present_costs) if present_costs else None
+        return aggregate
 
     def _verify_model_context(self, events: list[dict[str, Any]]) -> None:
         system_prompt_path = getattr(self, "_system_prompt_path", None)
@@ -450,7 +502,7 @@ class NanocodexAgent(BaseInstalledAgent):
 
         if system_prompt_path is not None:
             expected = system_prompt_path.read_text(encoding="utf-8").strip()
-            if expected not in input_texts:
+            if expected not in (text.strip() for text in input_texts):
                 raise RuntimeError(
                     "the nanocodex request did not contain the configured system prompt "
                     "byte-for-byte; rebuild the installed agent"

--- a/harbor_adapter/nanocodex.Dockerfile
+++ b/harbor_adapter/nanocodex.Dockerfile
@@ -22,6 +22,7 @@ COPY examples/Cargo.toml examples/Cargo.toml
 # Keep dependency compilation in a manifest-only layer. Source-only edits reuse
 # this layer, while the cache mounts retain Cargo downloads and target outputs.
 RUN mkdir bin/nanocodex/src \
+        bin/nanocodex/benches \
         bindings/python/src \
         bindings/wasm/src \
         crates/nanocodex/src \
@@ -34,6 +35,7 @@ RUN mkdir bin/nanocodex/src \
         crates/nanocodex-service/benches \
         crates/nanocodex-tools/src && \
     printf 'fn main() {}\n' > bin/nanocodex/src/main.rs && \
+    printf 'fn main() {}\n' > bin/nanocodex/benches/tui_render.rs && \
     printf '\n' > bindings/python/src/lib.rs && \
     printf '\n' > bindings/wasm/src/lib.rs && \
     printf '\n' > crates/nanocodex/src/lib.rs && \

--- a/harbor_adapter/test_agent.py
+++ b/harbor_adapter/test_agent.py
@@ -86,6 +86,7 @@ class WebSearchContractTests(unittest.TestCase):
 
         agent._web_search = True
         agent._subagents = False
+        agent._completion_audit = False
         self.assertEqual(
             agent._run_arguments("test prompt")[-6:],
             ["--web-search", "true", "--subagents", "false", "--", "test prompt"],
@@ -98,12 +99,28 @@ class WebSearchContractTests(unittest.TestCase):
             ["--web-search", "false", "--subagents", "true", "--", "test prompt"],
         )
 
+        agent._subagents = False
+        agent._completion_audit = True
+        self.assertEqual(
+            agent._run_arguments("test prompt")[-7:],
+            [
+                "--web-search",
+                "false",
+                "--subagents",
+                "false",
+                "--completion-audit",
+                "--",
+                "test prompt",
+            ],
+        )
+
     def test_run_arguments_protect_a_prompt_that_starts_with_a_hyphen(self) -> None:
         agent = object.__new__(NanocodexAgent)
         agent._model = "test-model"
         agent._effort = "low"
         agent._web_search = False
         agent._subagents = False
+        agent._completion_audit = False
 
         self.assertEqual(
             agent._run_arguments("- benchmark instruction")[-2:],
@@ -828,6 +845,62 @@ class InterruptedRunContractTests(unittest.TestCase):
                 NanocodexAgent._read_jsonl(path)
 
             self.assertLess(time.monotonic() - started, 0.5)
+
+
+class CompletionAuditContractTests(unittest.TestCase):
+    def test_terminal_metrics_cover_both_same_session_turns(self) -> None:
+        terminals = [
+            {
+                "payload": {
+                    "model_calls": 3,
+                    "duration_ms": 100,
+                    "duration_ns": 100_000_000,
+                    "model_duration_ns": 80_000_000,
+                    "usage": {
+                        "input_tokens": 1000,
+                        "cached_input_tokens": 800,
+                        "output_tokens": 100,
+                        "total_tokens": 1100,
+                    },
+                    "warmup_usage": {
+                        "input_tokens": 50,
+                        "total_tokens": 50,
+                    },
+                    "cost_usd": 0.25,
+                    "last_response_id": "draft",
+                }
+            },
+            {
+                "payload": {
+                    "model_calls": 2,
+                    "duration_ms": 40,
+                    "duration_ns": 40_000_000,
+                    "model_duration_ns": 30_000_000,
+                    "usage": {
+                        "input_tokens": 700,
+                        "cached_input_tokens": 650,
+                        "output_tokens": 60,
+                        "total_tokens": 760,
+                    },
+                    "warmup_usage": {},
+                    "cost_usd": 0.10,
+                    "last_response_id": "audited",
+                }
+            },
+        ]
+
+        aggregate = NanocodexAgent._aggregate_terminal_payload(terminals)
+
+        self.assertEqual(aggregate["model_calls"], 5)
+        self.assertEqual(aggregate["duration_ms"], 140)
+        self.assertEqual(aggregate["duration_ns"], 140_000_000)
+        self.assertEqual(aggregate["model_duration_ns"], 110_000_000)
+        self.assertEqual(aggregate["usage"]["input_tokens"], 1700)
+        self.assertEqual(aggregate["usage"]["cached_input_tokens"], 1450)
+        self.assertEqual(aggregate["usage"]["output_tokens"], 160)
+        self.assertEqual(aggregate["warmup_usage"]["input_tokens"], 50)
+        self.assertAlmostEqual(aggregate["cost_usd"], 0.35)
+        self.assertEqual(aggregate["last_response_id"], "audited")
 
 
 class RunCancellationContractTests(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary

- add an opt-in second-turn completion audit on the same agent session
- aggregate both turns in the Harbor adapter and record audit metadata
- keep subagents disabled by default and add a native CLI regression test
- keep the hosted Docker manifest build complete

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p nanocodex-bin config::tests::subagents_are_opt_in`
- `cargo clippy -p nanocodex-bin --all-targets --all-features -- -D warnings`
- 38 Harbor adapter unit tests
- Daytona Terminal Bench diagnostic: 16/20 without subagents