### PR TITLE
feat(agent): support changing thinking between turns

### DIFF
--- a/crates/nanocodex-core/src/responses/request.rs
+++ b/crates/nanocodex-core/src/responses/request.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use serde::{Serialize, ser::SerializeSeq};
 
 use super::ResponseItem;
-use crate::ModelConfig;
+use crate::{ModelConfig, Thinking};
 
 /// Stable request metadata and prefix shared by every operation in a session.
 #[derive(Clone)]
@@ -354,11 +354,13 @@ impl<'a> ResponseCreate<'a> {
     #[must_use]
     pub fn warmup(
         config: &'a ModelConfig,
+        thinking: Thinking,
         profile: &'a RequestProfile,
         turn_state: Option<&'a str>,
     ) -> Self {
         Self::new(
             config,
+            thinking,
             ResponsesInput::new(profile.prefix(), &[], None),
             None,
             Some(false),
@@ -370,6 +372,7 @@ impl<'a> ResponseCreate<'a> {
     #[must_use]
     pub fn generation(
         config: &'a ModelConfig,
+        thinking: Thinking,
         input: ResponsesInput<'a>,
         previous_response_id: Option<&'a str>,
         profile: &'a RequestProfile,
@@ -377,6 +380,7 @@ impl<'a> ResponseCreate<'a> {
     ) -> Self {
         Self::new(
             config,
+            thinking,
             input,
             previous_response_id,
             None,
@@ -387,6 +391,7 @@ impl<'a> ResponseCreate<'a> {
 
     fn new(
         config: &'a ModelConfig,
+        thinking: Thinking,
         input: ResponsesInput<'a>,
         previous_response_id: Option<&'a str>,
         generate: Option<bool>,
@@ -402,7 +407,7 @@ impl<'a> ResponseCreate<'a> {
             parallel_tool_calls: false,
             reasoning: ReasoningControls {
                 mode: config.reasoning_mode.request_value(),
-                effort: config.thinking.as_str(),
+                effort: thinking.as_str(),
                 summary: "detailed",
                 context: "all_turns",
             },
@@ -467,7 +472,7 @@ mod tests {
             }],
         )]);
         let profile = RequestProfile::new("branch-a", "lineage-a", prefix);
-        let request = ResponseCreate::warmup(&config, &profile, None);
+        let request = ResponseCreate::warmup(&config, Thinking::Low, &profile, None);
         let request = serde_json::to_value(request).expect("request should serialize");
 
         assert_eq!(request["prompt_cache_key"], json!("lineage-a"));
@@ -511,8 +516,9 @@ mod tests {
                 thinking,
                 ..ModelConfig::default()
             };
-            let request = serde_json::to_value(ResponseCreate::warmup(&config, &profile, None))
-                .expect("request should serialize");
+            let request =
+                serde_json::to_value(ResponseCreate::warmup(&config, thinking, &profile, None))
+                    .expect("request should serialize");
 
             assert_eq!(request["reasoning"]["mode"], json!("pro"));
             assert_eq!(request["reasoning"]["effort"], json!(expected));

--- a/crates/nanocodex-service/src/attempt.rs
+++ b/crates/nanocodex-service/src/attempt.rs
@@ -4,7 +4,7 @@ use std::sync::{
 };
 
 use nanocodex_core::{
-    AgentEventKind, EventError, EventSink, ResponseItem,
+    AgentEventKind, EventError, EventSink, ResponseItem, Thinking,
     responses::{RequestProfile, ResponseHistory, ResponsesInput, WarmupResponse},
 };
 use serde::Serialize;
@@ -129,6 +129,7 @@ pub struct ResponsesAttempt {
     incremental_start: usize,
     tail: Option<ResponseItem>,
     previous_response_id: Option<String>,
+    thinking: Thinking,
     pub(crate) profile: Arc<RequestProfile>,
     pub(crate) observer: ResponsesObserver,
     pub(crate) attempt: u32,
@@ -137,7 +138,11 @@ pub struct ResponsesAttempt {
 }
 
 impl ResponsesAttempt {
-    fn warmup(profile: Arc<RequestProfile>, observer: ResponsesObserver) -> Self {
+    fn warmup(
+        thinking: Thinking,
+        profile: Arc<RequestProfile>,
+        observer: ResponsesObserver,
+    ) -> Self {
         Self {
             kind: ResponsesAttemptKind::Warmup,
             call_index: None,
@@ -146,6 +151,7 @@ impl ResponsesAttempt {
             incremental_start: 0,
             tail: None,
             previous_response_id: None,
+            thinking,
             profile,
             observer,
             attempt: 1,
@@ -154,12 +160,14 @@ impl ResponsesAttempt {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn generation(
         call_index: u32,
         full_history: ResponseHistory,
         incremental_history: ResponseHistory,
         incremental_start: usize,
         previous_response_id: Option<&str>,
+        thinking: Thinking,
         profile: Arc<RequestProfile>,
         observer: ResponsesObserver,
     ) -> Self {
@@ -171,6 +179,7 @@ impl ResponsesAttempt {
             incremental_start,
             tail: None,
             previous_response_id: previous_response_id.map(str::to_owned),
+            thinking,
             profile,
             observer,
             attempt: 1,
@@ -187,6 +196,7 @@ impl ResponsesAttempt {
         incremental_start: usize,
         previous_response_id: &str,
         trigger: ResponseItem,
+        thinking: Thinking,
         profile: Arc<RequestProfile>,
         observer: ResponsesObserver,
     ) -> Self {
@@ -198,6 +208,7 @@ impl ResponsesAttempt {
             incremental_start,
             tail: Some(trigger),
             previous_response_id: Some(previous_response_id.to_owned()),
+            thinking,
             profile,
             observer,
             attempt: 1,
@@ -234,6 +245,12 @@ impl ResponsesAttempt {
     #[must_use]
     pub const fn model_call_index(&self) -> Option<u32> {
         self.call_index
+    }
+
+    /// Returns the reasoning effort fixed for this replayable attempt.
+    #[must_use]
+    pub const fn thinking(&self) -> Thinking {
+        self.thinking
     }
 
     #[must_use]
@@ -335,8 +352,8 @@ impl ResponsesAttemptFactory {
     }
 
     #[must_use]
-    pub fn warmup(&self) -> ResponsesAttempt {
-        ResponsesAttempt::warmup(Arc::clone(&self.profile), self.observer.clone())
+    pub fn warmup(&self, thinking: Thinking) -> ResponsesAttempt {
+        ResponsesAttempt::warmup(thinking, Arc::clone(&self.profile), self.observer.clone())
     }
 
     #[must_use]
@@ -347,6 +364,7 @@ impl ResponsesAttemptFactory {
         incremental_history: ResponseHistory,
         incremental_start: usize,
         previous_response_id: Option<&str>,
+        thinking: Thinking,
     ) -> ResponsesAttempt {
         ResponsesAttempt::generation(
             call_index,
@@ -354,6 +372,7 @@ impl ResponsesAttemptFactory {
             incremental_history,
             incremental_start,
             previous_response_id,
+            thinking,
             Arc::clone(&self.profile),
             self.observer.clone(),
         )
@@ -369,6 +388,7 @@ impl ResponsesAttemptFactory {
         incremental_start: usize,
         previous_response_id: &str,
         trigger: ResponseItem,
+        thinking: Thinking,
     ) -> ResponsesAttempt {
         ResponsesAttempt::compaction(
             call_index,
@@ -377,8 +397,38 @@ impl ResponsesAttemptFactory {
             incremental_start,
             previous_response_id,
             trigger,
+            thinking,
             Arc::clone(&self.profile),
             self.observer.clone(),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ResponseHistory, ResponsesAttemptFactory, TransportStats};
+    use nanocodex_core::{EventSink, Thinking, responses::RequestProfile};
+    use std::sync::Arc;
+
+    #[test]
+    fn retry_preserves_the_attempts_thinking_level() {
+        let (events, _receiver) = EventSink::channel("attempt-test".to_owned());
+        let factory = ResponsesAttemptFactory::new(
+            RequestProfile::new("attempt-test", "attempt-test", Arc::from([])),
+            events,
+            Arc::new(TransportStats::default()),
+        );
+        let mut attempt = factory.generation(
+            1,
+            ResponseHistory::default(),
+            ResponseHistory::default(),
+            0,
+            Some("resp-previous"),
+            Thinking::High,
+        );
+
+        assert_eq!(attempt.thinking(), Thinking::High);
+        assert!(attempt.prepare_retry());
+        assert_eq!(attempt.thinking(), Thinking::High);
     }
 }

--- a/crates/nanocodex-service/src/service.rs
+++ b/crates/nanocodex-service/src/service.rs
@@ -258,12 +258,14 @@ impl ResponsesService {
         let encoded = match request.kind {
             ResponsesAttemptKind::Warmup => EncodedRequest::new(&ResponseCreate::warmup(
                 &self.config,
+                request.thinking(),
                 &request.profile,
                 connection.turn_state.as_deref(),
             )),
             ResponsesAttemptKind::Generation | ResponsesAttemptKind::Compaction => {
                 EncodedRequest::new(&ResponseCreate::generation(
                     &self.config,
+                    request.thinking(),
                     request.input(),
                     request.previous_response_id(),
                     &request.profile,

--- a/crates/nanocodex/src/agent.rs
+++ b/crates/nanocodex/src/agent.rs
@@ -179,6 +179,7 @@ enum Command {
     Prompt {
         key: TurnKey,
         prompt: Prompt,
+        thinking: Option<Thinking>,
         parent: Option<tracing::Span>,
         result: oneshot::Sender<Result<TurnResult>>,
     },
@@ -198,17 +199,23 @@ enum Command {
     Spawn {
         result: oneshot::Sender<Result<(Nanocodex, AgentEvents)>>,
     },
+    SetThinking {
+        thinking: Thinking,
+        result: oneshot::Sender<Result<()>>,
+    },
 }
 
 enum QueuedTurn {
     Pending {
         key: TurnKey,
         prompt: Prompt,
+        thinking: Thinking,
         parent: Option<tracing::Span>,
         result: oneshot::Sender<Result<TurnResult>>,
     },
     Cancelled {
         prompt: Prompt,
+        thinking: Thinking,
         parent: Option<tracing::Span>,
         result: oneshot::Sender<Result<TurnResult>>,
     },
@@ -349,6 +356,7 @@ impl Nanocodex {
             .send(Command::Prompt {
                 key,
                 prompt,
+                thinking: None,
                 parent,
                 result,
             })
@@ -364,6 +372,22 @@ impl Nanocodex {
             },
             result: receiver,
         })
+    }
+
+    /// Changes the reasoning effort for subsequently accepted turns.
+    ///
+    /// An active turn and prompts already queued by the driver retain the
+    /// effort they captured when accepted.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the agent driver has stopped.
+    pub async fn set_thinking(&self, thinking: Thinking) -> Result<()> {
+        request_command(&self.commands, |result| Command::SetThinking {
+            thinking,
+            result,
+        })
+        .await
     }
 
     /// Starts a clean sibling agent with the same private configuration,
@@ -763,10 +787,7 @@ where
         self.tools.start_providers();
         let session_id = self.events.request_id().to_owned();
         let rollout = self.rollout.take();
-        let reasoning = ReasoningSettings {
-            mode: self.spawner.config.reasoning_mode,
-            effort: self.spawner.config.thinking,
-        };
+        let mut default_thinking = self.spawner.config.thinking;
         let inherited_checkpoint = self.initial_checkpoint.as_ref().map(|checkpoint| {
             Arc::new(CommittedCheckpoint {
                 lineage_id: Arc::clone(&self.spawner.lineage_id),
@@ -812,18 +833,21 @@ where
                         QueuedTurn::Pending {
                             key,
                             prompt,
+                            thinking,
                             parent,
                             result,
                         } => {
                             break Command::Prompt {
                                 key,
                                 prompt,
+                                thinking: Some(thinking),
                                 parent,
                                 result,
                             };
                         }
                         QueuedTurn::Cancelled {
                             prompt,
+                            thinking,
                             parent,
                             result,
                         } => {
@@ -839,7 +863,10 @@ where
                                 session_id.as_str(),
                                 self.spawner.lineage_id.as_ref(),
                                 &self.origin,
-                                reasoning,
+                                ReasoningSettings {
+                                    mode: self.spawner.config.reasoning_mode,
+                                    effort: thinking,
+                                },
                                 turn_index,
                                 prompt.instruction.text_bytes(),
                             );
@@ -857,8 +884,11 @@ where
                                 });
                             }
                             let _guard = turn_span.enter();
-                            model
-                                .emit_cancelled_before_start(&prompt, self.workspace.as_deref())?;
+                            model.emit_cancelled_before_start(
+                                &prompt,
+                                self.workspace.as_deref(),
+                                thinking,
+                            )?;
                             drop(result.send(Err(NanocodexError::TurnCancelled)));
                             continue;
                         }
@@ -876,19 +906,27 @@ where
             let Command::Prompt {
                 key,
                 prompt,
+                thinking,
                 parent,
                 result,
             } = command
             else {
+                if let Command::SetThinking { thinking, result } = command {
+                    default_thinking = thinking;
+                    drop(result.send(Ok(())));
+                    continue;
+                }
                 handle_idle_command(
                     command,
                     latest_fork_checkpoint.as_ref(),
                     &self.spawner,
+                    default_thinking,
                     session_id.as_str(),
                     self.workspace.clone(),
                 );
                 continue;
             };
+            let thinking = thinking.unwrap_or(default_thinking);
             turn_index += 1;
             let prompt_content = tracing::enabled!(
                 target: "nanocodex",
@@ -901,7 +939,10 @@ where
                 session_id.as_str(),
                 self.spawner.lineage_id.as_ref(),
                 &self.origin,
-                reasoning,
+                ReasoningSettings {
+                    mode: self.spawner.config.reasoning_mode,
+                    effort: thinking,
+                },
                 turn_index,
                 prompt.instruction.text_bytes(),
             );
@@ -928,6 +969,7 @@ where
                     .execute(
                         prompt,
                         self.workspace.clone(),
+                        thinking,
                         steer_rx,
                         cancel_rx,
                         fork_snapshots,
@@ -958,12 +1000,14 @@ where
                             Some(Command::Prompt {
                                 key,
                                 prompt,
+                                thinking: _,
                                 parent,
                                 result,
                             }) => {
                                 queued_turns.push_back(QueuedTurn::Pending {
                                     key,
                                     prompt,
+                                    thinking: default_thinking,
                                     parent,
                                     result,
                                 });
@@ -1009,9 +1053,14 @@ where
                                     command,
                                     latest_fork_checkpoint.as_ref(),
                                     &self.spawner,
+                                    default_thinking,
                                     session_id.as_str(),
                                     self.workspace.clone(),
                                 );
+                            }
+                            Some(Command::SetThinking { thinking, result }) => {
+                                default_thinking = thinking;
+                                drop(result.send(Ok(())));
                             }
                             None => commands_open = false,
                         }
@@ -1166,6 +1215,7 @@ fn cancel_queued_turn(queued_turns: &mut VecDeque<QueuedTurn>, target: TurnKey) 
     };
     let QueuedTurn::Pending {
         prompt,
+        thinking,
         parent,
         result,
         ..
@@ -1177,6 +1227,7 @@ fn cancel_queued_turn(queued_turns: &mut VecDeque<QueuedTurn>, target: TurnKey) 
         position,
         QueuedTurn::Cancelled {
             prompt,
+            thinking,
             parent,
             result,
         },
@@ -1188,6 +1239,7 @@ fn handle_idle_command<S>(
     command: Command,
     latest: Option<&Arc<CommittedCheckpoint>>,
     spawner: &BranchSpawner<S>,
+    thinking: Thinking,
     session_id: &str,
     workspace: Option<Arc<str>>,
 ) where
@@ -1200,17 +1252,20 @@ fn handle_idle_command<S>(
             let checkpoint = checkpoint.or_else(|| latest.cloned());
             let outcome = checkpoint
                 .ok_or(NanocodexError::ForkBeforeCompletedTurn)
-                .and_then(|checkpoint| spawner.spawn_fork(&checkpoint, session_id));
+                .and_then(|checkpoint| spawner.spawn_fork(&checkpoint, session_id, thinking));
             drop(result.send(outcome));
         }
         Command::Spawn { result } => {
-            drop(result.send(spawner.spawn_clean(workspace, session_id)));
+            drop(result.send(spawner.spawn_clean(workspace, session_id, thinking)));
         }
         Command::Steer { result, .. } => {
             drop(result.send(Err(NanocodexError::TurnNotSteerable)));
         }
         Command::Cancel { result, .. } => {
             drop(result.send(Err(NanocodexError::TurnNotCancellable)));
+        }
+        Command::SetThinking { result, .. } => {
+            drop(result.send(Ok(())));
         }
         Command::Prompt { .. } => {}
     }
@@ -1226,10 +1281,14 @@ where
         &self,
         checkpoint: &CommittedCheckpoint,
         parent_session_id: &str,
+        thinking: Thinking,
     ) -> Result<(Nanocodex, AgentEvents)> {
         let session_id = new_session_id();
         let workspace = Some(Arc::<str>::from(checkpoint.model.workspace()));
         let mut spawner = self.clone();
+        let mut config = (*spawner.config).clone();
+        config.thinking = thinking;
+        spawner.config = Arc::new(config);
         spawner.depth = self.depth.saturating_add(1);
         spawn_agent_driver(
             spawner,
@@ -1250,11 +1309,14 @@ where
         &self,
         workspace: Option<Arc<str>>,
         parent_session_id: &str,
+        thinking: Thinking,
     ) -> Result<(Nanocodex, AgentEvents)> {
         let session_id = new_session_id();
         let depth = self.depth.saturating_add(1);
+        let mut config = (*self.config).clone();
+        config.thinking = thinking;
         let spawner = Self {
-            config: Arc::clone(&self.config),
+            config: Arc::new(config),
             tools: self.tools.clone(),
             lineage_id: Arc::from(session_id.as_str()),
             prompt_cache_key: self.prompt_cache_key.as_ref().map(Arc::clone),

--- a/crates/nanocodex/src/model/agent.rs
+++ b/crates/nanocodex/src/model/agent.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, path::Path, sync::Arc};
 
 use nanocodex_core::{
-    AgentEventKind, EventSink, MODEL, ModelConfig, Prompt, ResponseItem, ToolDefinition, Usage,
-    responses::RequestProfile,
+    AgentEventKind, EventSink, MODEL, ModelConfig, Prompt, ResponseItem, Thinking, ToolDefinition,
+    Usage, responses::RequestProfile,
 };
 use nanocodex_service::{
     CodeCall, CodeCallKind, ResponsesAttempt, ResponsesAttemptFactory, ResponsesClient,
@@ -39,6 +39,7 @@ use nanocodex_tools::{
 pub(crate) struct ModelRun<S> {
     events: EventSink,
     config: Arc<ModelConfig>,
+    thinking: Thinking,
     client: ResponsesClient<S>,
     transport_stats: Arc<TransportStats>,
     started_at: Instant,
@@ -228,9 +229,11 @@ impl<S> ModelRun<S> {
         prompt_cache: ModelPromptCache,
         global_instructions: Option<Arc<str>>,
     ) -> Self {
+        let thinking = config.thinking;
         Self {
             events,
             config,
+            thinking,
             client,
             transport_stats,
             started_at: Instant::now(),
@@ -264,9 +267,11 @@ impl<S> ModelRun<S> {
             &runtime,
             config.system_prompt(),
         );
+        let thinking = config.thinking;
         Self {
             events,
             config,
+            thinking,
             client,
             transport_stats,
             started_at: Instant::now(),
@@ -313,7 +318,9 @@ where
         &mut self,
         task: &Prompt,
         workspace: Option<&str>,
+        thinking: Thinking,
     ) -> Result<()> {
+        self.thinking = thinking;
         self.started_at = Instant::now();
         self.stats = RunStats::default();
         self.events.emit(
@@ -322,7 +329,7 @@ where
                 mode: "openai_model",
                 model: MODEL,
                 reasoning_mode: self.config.reasoning_mode.as_str(),
-                effort: self.config.thinking.as_str(),
+                effort: self.thinking.as_str(),
                 transport: TRANSPORT,
                 orchestration: ModelConfig::orchestration(),
                 websocket_url: display_endpoint(&self.config.websocket_url),
@@ -340,6 +347,7 @@ where
                 "cancelled",
                 self.started_at.elapsed(),
                 &self.config,
+                self.thinking,
                 &self.stats,
             ),
         )?;
@@ -350,10 +358,12 @@ where
         &mut self,
         task: Prompt,
         workspace: Option<Arc<str>>,
+        thinking: Thinking,
         steers: tokio::sync::mpsc::Receiver<Prompt>,
         mut cancel: tokio::sync::oneshot::Receiver<()>,
         fork_snapshots: watch::Sender<Option<ModelCheckpoint>>,
     ) -> Result<ModelTurnOutcome> {
+        self.thinking = thinking;
         self.started_at = Instant::now();
         self.stats = RunStats::default();
         let transport_before = self.transport_stats.snapshot();
@@ -363,7 +373,7 @@ where
                 mode: "openai_model",
                 model: MODEL,
                 reasoning_mode: self.config.reasoning_mode.as_str(),
-                effort: self.config.thinking.as_str(),
+                effort: self.thinking.as_str(),
                 transport: TRANSPORT,
                 orchestration: ModelConfig::orchestration(),
                 websocket_url: display_endpoint(&self.config.websocket_url),
@@ -382,7 +392,13 @@ where
                     .apply_transport(self.transport_stats.since(transport_before));
                 self.events.emit(
                     AgentEventKind::RunCompleted,
-                    terminal_payload("completed", elapsed, &self.config, &self.stats),
+                    terminal_payload(
+                        "completed",
+                        elapsed,
+                        &self.config,
+                        self.thinking,
+                        &self.stats,
+                    ),
                 )?;
                 let checkpoint = self.commit_checkpoint()?;
                 Ok(ModelTurnOutcome::Completed(CompletedModelTurn {
@@ -404,7 +420,13 @@ where
                     .apply_transport(self.transport_stats.since(transport_before));
                 self.events.emit(
                     AgentEventKind::RunFailed,
-                    terminal_payload("cancelled", elapsed, &self.config, &self.stats),
+                    terminal_payload(
+                        "cancelled",
+                        elapsed,
+                        &self.config,
+                        self.thinking,
+                        &self.stats,
+                    ),
                 )?;
                 Ok(ModelTurnOutcome::Cancelled(checkpoint))
             }
@@ -416,7 +438,7 @@ where
                     .apply_transport(self.transport_stats.since(transport_before));
                 self.events.emit(
                     AgentEventKind::RunFailed,
-                    terminal_payload("failed", elapsed, &self.config, &self.stats),
+                    terminal_payload("failed", elapsed, &self.config, self.thinking, &self.stats),
                 )?;
                 Err(error)
             }
@@ -1017,7 +1039,7 @@ where
     ) -> Result<WarmupExecution> {
         let success = self
             .client
-            .execute(factory.warmup())
+            .execute(factory.warmup(self.thinking))
             .instrument(span.clone())
             .await
             .map_err(Into::into)?;
@@ -1069,7 +1091,7 @@ where
                 call_index,
                 model: MODEL,
                 reasoning_mode: self.config.reasoning_mode.as_str(),
-                effort: self.config.thinking.as_str(),
+                effort: self.thinking.as_str(),
                 previous_response_id,
             },
         )?;
@@ -1079,12 +1101,13 @@ where
             conversation.shared_history(),
             conversation.delta_start,
             previous_response_id,
+            self.thinking,
         );
         let (input_item_count, input_bytes, input_content) = trace_model_input(&request);
         let span = model_call_span(
             call_index,
             self.config.reasoning_mode.as_str(),
-            self.config.thinking.as_str(),
+            self.thinking.as_str(),
             previous_response_id.is_some(),
             input_item_count,
             input_bytes,
@@ -1184,6 +1207,7 @@ where
             incremental_start,
             previous_response_id,
             trigger,
+            self.thinking,
         );
         let (input_item_count, input_bytes, input_content) = trace_model_input(&request);
         let span = info_span!(

--- a/crates/nanocodex/src/model/agent_tests.rs
+++ b/crates/nanocodex/src/model/agent_tests.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 #[tokio::test]
-async fn follow_on_prompts_reuse_the_session_socket_and_context() -> Result<()> {
+async fn follow_on_prompts_can_change_thinking_without_restarting_the_session() -> Result<()> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let endpoint = format!("ws://{}", listener.local_addr()?);
     let server = tokio::spawn(async move {
@@ -19,15 +19,20 @@ async fn follow_on_prompts_reuse_the_session_socket_and_context() -> Result<()> 
         let mut socket = accept_async(stream).await?;
         let warmup = next_json(&mut socket).await?;
         assert_warmup(&warmup);
+        assert_eq!(warmup["reasoning"]["effort"], "low");
         assert_eq!(warmup["input"][1]["content"][0]["text"], "custom prompt");
         send_warmup(&mut socket, "resp-warmup").await?;
 
         let first = next_json(&mut socket).await?;
         assert_eq!(first["previous_response_id"], "resp-warmup");
+        assert_eq!(first["reasoning"]["effort"], "low");
+        let prompt_cache_key = first["prompt_cache_key"].clone();
         send_final(&mut socket, "resp-first").await?;
 
         let follow_on = next_json(&mut socket).await?;
         assert_eq!(follow_on["previous_response_id"], "resp-first");
+        assert_eq!(follow_on["reasoning"]["effort"], "high");
+        assert_eq!(follow_on["prompt_cache_key"], prompt_cache_key);
         assert_eq!(follow_on["input"].as_array().map(Vec::len), Some(1));
         assert_eq!(follow_on["input"][0]["role"], "user");
         assert_eq!(follow_on["input"][0]["content"][0]["text"], "second prompt");
@@ -46,6 +51,7 @@ async fn follow_on_prompts_reuse_the_session_socket_and_context() -> Result<()> 
 
     let first = agent.prompt(Prompt::new("first prompt")).await?;
     assert_eq!(first.result().await?.final_message, "done");
+    agent.set_thinking(Thinking::High).await?;
     let second = agent.prompt(Prompt::new("second prompt")).await?;
     assert_eq!(second.result().await?.final_message, "done");
     drop(agent);
@@ -59,9 +65,92 @@ async fn follow_on_prompts_reuse_the_session_socket_and_context() -> Result<()> 
     assert_eq!(completed.len(), 2);
     assert_eq!(completed[0]["connection_attempts"], 1);
     assert_eq!(completed[0]["response_attempts"], 2);
+    assert_eq!(completed[0]["effort"], "low");
     assert_eq!(completed[1]["connection_attempts"], 0);
     assert_eq!(completed[1]["response_attempts"], 1);
+    assert_eq!(completed[1]["effort"], "high");
 
+    timeout(std::time::Duration::from_secs(5), server)
+        .await
+        .map_err(|_| eyre!("mock Responses server did not finish"))???;
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn queued_prompts_retain_the_thinking_captured_when_accepted() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("ws://{}", listener.local_addr()?);
+    let (first_started, first_started_rx) = tokio::sync::oneshot::channel();
+    let (release_first, release_first_rx) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await?;
+        let mut socket = accept_async(stream).await?;
+        let warmup = next_json(&mut socket).await?;
+        assert_eq!(warmup["reasoning"]["effort"], "low");
+        send_warmup(&mut socket, "resp-warmup").await?;
+
+        let first = next_json(&mut socket).await?;
+        assert_eq!(first["reasoning"]["effort"], "low");
+        first_started
+            .send(())
+            .map_err(|()| eyre!("first request signal receiver dropped"))?;
+        release_first_rx
+            .await
+            .map_err(|_| eyre!("first request release sender dropped"))?;
+        send_json(
+            &mut socket,
+            completed_response(
+                "resp-first-tool",
+                &[json!({
+                    "type": "custom_tool_call",
+                    "call_id": "call-exec",
+                    "name": "exec",
+                    "input": "text(\"continued\")"
+                })],
+            ),
+        )
+        .await?;
+
+        let continuation = next_json(&mut socket).await?;
+        assert_eq!(continuation["previous_response_id"], "resp-first-tool");
+        assert_eq!(continuation["reasoning"]["effort"], "low");
+        send_final(&mut socket, "resp-first").await?;
+
+        let queued = next_json(&mut socket).await?;
+        assert_eq!(queued["previous_response_id"], "resp-first");
+        assert_eq!(queued["reasoning"]["effort"], "low");
+        send_final(&mut socket, "resp-queued").await?;
+
+        let updated = next_json(&mut socket).await?;
+        assert_eq!(updated["previous_response_id"], "resp-queued");
+        assert_eq!(updated["reasoning"]["effort"], "high");
+        send_final(&mut socket, "resp-updated").await
+    });
+
+    let workspace = temporary_workspace("queued-thinking")?;
+    let responses = Responses::builder().websocket_url(endpoint).build();
+    let (agent, events) = Nanocodex::builder("test-key")
+        .thinking(Thinking::Low)
+        .workspace(&workspace)
+        .responses(responses)
+        .session_id("model-test")
+        .build()?;
+
+    let first = agent.prompt("first prompt").await?;
+    first_started_rx
+        .await
+        .map_err(|_| eyre!("first request was not observed"))?;
+    let queued = agent.prompt("queued prompt").await?;
+    agent.set_thinking(Thinking::High).await?;
+    release_first
+        .send(())
+        .map_err(|()| eyre!("first request release receiver dropped"))?;
+    first.result().await?;
+    queued.result().await?;
+    agent.prompt("updated prompt").await?.result().await?;
+
+    drop((agent, events));
     timeout(std::time::Duration::from_secs(5), server)
         .await
         .map_err(|_| eyre!("mock Responses server did not finish"))???;
@@ -1432,6 +1521,7 @@ async fn latest_fork_during_streaming_inherits_the_active_prompt_delta() -> Resu
 
         let active = next_json(&mut root).await?;
         assert_eq!(active["previous_response_id"], "resp-warmup");
+        assert_eq!(active["reasoning"]["effort"], "low");
         assert!(active.to_string().contains("active root prompt"));
         root_started
             .send(())
@@ -1441,6 +1531,7 @@ async fn latest_fork_during_streaming_inherits_the_active_prompt_delta() -> Resu
         let mut branch = accept_async(stream).await?;
         let fork = next_json(&mut branch).await?;
         assert_eq!(fork["previous_response_id"], "resp-warmup");
+        assert_eq!(fork["reasoning"]["effort"], "high");
         let fork_text = fork.to_string();
         assert!(fork_text.contains("active root prompt"));
         assert!(fork_text.contains("BTW question"));
@@ -1464,6 +1555,7 @@ async fn latest_fork_during_streaming_inherits_the_active_prompt_delta() -> Resu
     root_started_rx
         .await
         .map_err(|_| eyre!("root request was not observed"))?;
+    agent.set_thinking(Thinking::High).await?;
     let (fork, fork_events) = agent.fork().await?;
     let branch = fork.prompt("BTW question").await?;
     assert_eq!(branch.result().await?.final_message, "done");
@@ -1924,6 +2016,7 @@ async fn clean_spawn_reuses_an_explicit_cache_key_without_history_or_lineage() -
         let (stream, _) = listener.accept().await?;
         let mut child = accept_async(stream).await?;
         let child_warmup = next_json(&mut child).await?;
+        assert_eq!(child_warmup["reasoning"]["effort"], "high");
         let child_session = child_warmup["client_metadata"]["session_id"]
             .as_str()
             .ok_or_else(|| eyre!("clean child warmup omitted its session id"))?;
@@ -1963,6 +2056,7 @@ async fn clean_spawn_reuses_an_explicit_cache_key_without_history_or_lineage() -
         .await
         .ok_or_else(|| eyre!("root tool factory did not receive an agent handle"))?;
     root.prompt("root turn").await?.result().await?;
+    root.set_thinking(Thinking::High).await?;
 
     let (child, child_events) = root_handle.spawn().await?;
     received_handles

--- a/crates/nanocodex/src/model/telemetry.rs
+++ b/crates/nanocodex/src/model/telemetry.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 #[cfg(not(target_family = "wasm"))]
 use std::path::PathBuf;
 
-use nanocodex_core::{ModelConfig, Usage};
+use nanocodex_core::{ModelConfig, Thinking, Usage};
 use serde::Serialize;
 use serde_json::value::RawValue;
 use web_time::Instant;
@@ -223,13 +223,14 @@ pub(super) fn terminal_payload<'a>(
     terminal_status: &'static str,
     elapsed: Duration,
     config: &'a ModelConfig,
+    thinking: Thinking,
     stats: &'a RunStats,
 ) -> TerminalPayload<'a> {
     TerminalPayload {
         status: terminal_status,
         model: nanocodex_core::MODEL,
         reasoning_mode: config.reasoning_mode.as_str(),
-        effort: config.thinking.as_str(),
+        effort: thinking.as_str(),
         transport: TRANSPORT,
         orchestration: ModelConfig::orchestration(),
         duration_ms: duration_ms(elapsed),

--- a/crates/nanocodex/src/wasm.rs
+++ b/crates/nanocodex/src/wasm.rs
@@ -77,6 +77,7 @@ enum Command {
     Prompt {
         key: TurnKey,
         prompt: Prompt,
+        thinking: Option<Thinking>,
         result: oneshot::Sender<Result<CompletedWasmTurn, String>>,
     },
     Steer {
@@ -95,16 +96,22 @@ enum Command {
     Spawn {
         result: oneshot::Sender<Result<WasmNanocodex, String>>,
     },
+    SetThinking {
+        thinking: Thinking,
+        result: oneshot::Sender<Result<(), String>>,
+    },
 }
 
 enum QueuedTurn {
     Pending {
         key: TurnKey,
         prompt: Prompt,
+        thinking: Thinking,
         result: oneshot::Sender<Result<CompletedWasmTurn, String>>,
     },
     Cancelled {
         prompt: Prompt,
+        thinking: Thinking,
         result: oneshot::Sender<Result<CompletedWasmTurn, String>>,
     },
 }
@@ -199,6 +206,7 @@ impl WasmNanocodex {
             .send(Command::Prompt {
                 key,
                 prompt,
+                thinking: None,
                 result,
             })
             .map_err(|_| js_error("the Nanocodex driver stopped"))?;
@@ -253,6 +261,22 @@ impl WasmNanocodex {
         request_command(&self.commands, |result| Command::Spawn { result })
             .await
             .map_err(js_error)
+    }
+
+    /// Change the reasoning effort for subsequently accepted turns.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an unsupported effort or a stopped agent driver.
+    #[wasm_bindgen(js_name = setThinking)]
+    pub async fn set_thinking(&self, thinking: &str) -> Result<(), JsValue> {
+        let thinking = thinking.parse::<Thinking>().map_err(js_error)?;
+        request_command(&self.commands, |result| Command::SetThinking {
+            thinking,
+            result,
+        })
+        .await
+        .map_err(js_error)
     }
 }
 
@@ -455,6 +479,7 @@ async fn run_driver(
     events: EventSink,
     transport_stats: Arc<TransportStats>,
 ) {
+    let mut default_thinking = factory.config.thinking;
     let mut latest_checkpoint: Option<Arc<CommittedWasmCheckpoint>> = None;
     let mut queued_turns = VecDeque::new();
     let mut commands_open = true;
@@ -466,17 +491,27 @@ async fn run_driver(
                     QueuedTurn::Pending {
                         key,
                         prompt,
+                        thinking,
                         result,
                     } => {
                         break Command::Prompt {
                             key,
                             prompt,
+                            thinking: Some(thinking),
                             result,
                         };
                     }
-                    QueuedTurn::Cancelled { prompt, result } => {
+                    QueuedTurn::Cancelled {
+                        prompt,
+                        thinking,
+                        result,
+                    } => {
                         let outcome = model
-                            .emit_cancelled_before_start(&prompt, factory.workspace.as_deref())
+                            .emit_cancelled_before_start(
+                                &prompt,
+                                factory.workspace.as_deref(),
+                                thinking,
+                            )
                             .map_or_else(
                                 |error| Err(error.to_string()),
                                 |()| Err(NanocodexError::TurnCancelled.to_string()),
@@ -499,12 +534,24 @@ async fn run_driver(
         let Command::Prompt {
             key,
             prompt,
+            thinking,
             result,
         } = command
         else {
-            handle_idle_command(command, latest_checkpoint.as_ref(), &factory);
+            if let Command::SetThinking { thinking, result } = command {
+                default_thinking = thinking;
+                drop(result.send(Ok(())));
+                continue;
+            }
+            handle_idle_command(
+                command,
+                latest_checkpoint.as_ref(),
+                &factory,
+                default_thinking,
+            );
             continue;
         };
+        let thinking = thinking.unwrap_or(default_thinking);
 
         let (steers, steer_rx) = mpsc::channel(STEER_CAPACITY);
         let (cancel, cancel_rx) = oneshot::channel();
@@ -515,6 +562,7 @@ async fn run_driver(
         let mut execution = Box::pin(model.execute(
             prompt,
             factory.workspace.clone(),
+            thinking,
             steer_rx,
             cancel_rx,
             fork_snapshots,
@@ -540,8 +588,18 @@ async fn run_driver(
                 }
                 command = commands.recv() => {
                     match command {
-                        Some(Command::Prompt { key, prompt, result }) => {
-                            queued_turns.push_back(QueuedTurn::Pending { key, prompt, result });
+                        Some(Command::Prompt {
+                            key,
+                            prompt,
+                            thinking: _,
+                            result,
+                        }) => {
+                            queued_turns.push_back(QueuedTurn::Pending {
+                                key,
+                                prompt,
+                                thinking: default_thinking,
+                                result,
+                            });
                         }
                         Some(Command::Steer { key: target, prompt, result }) => {
                             if target != key {
@@ -572,7 +630,16 @@ async fn run_driver(
                             break execution.as_mut().await;
                         }
                         Some(command @ (Command::Fork { .. } | Command::Spawn { .. })) => {
-                            handle_idle_command(command, latest_checkpoint.as_ref(), &factory);
+                            handle_idle_command(
+                                command,
+                                latest_checkpoint.as_ref(),
+                                &factory,
+                                default_thinking,
+                            );
+                        }
+                        Some(Command::SetThinking { thinking, result }) => {
+                            default_thinking = thinking;
+                            drop(result.send(Ok(())));
                         }
                         None => commands_open = false,
                     }
@@ -634,19 +701,23 @@ fn handle_idle_command(
     command: Command,
     latest: Option<&Arc<CommittedWasmCheckpoint>>,
     factory: &WasmAgentFactory,
+    thinking: Thinking,
 ) {
     match command {
         Command::Fork { checkpoint, result } => {
             let checkpoint = checkpoint.or_else(|| latest.cloned());
             let outcome = checkpoint
                 .ok_or_else(|| NanocodexError::ForkBeforeCompletedTurn.to_string())
-                .and_then(|checkpoint| spawn_fork(factory, &checkpoint));
+                .and_then(|checkpoint| spawn_fork(factory, &checkpoint, thinking));
             drop(result.send(outcome));
         }
         Command::Spawn { result } => {
             let session_id = new_session_id();
             let lineage_id = Arc::<str>::from(session_id.as_str());
             let mut clean = factory.clone();
+            let mut config = (*clean.config).clone();
+            config.thinking = thinking;
+            clean.config = Arc::new(config);
             clean.lineage_id = lineage_id;
             clean.prompt_cache = ModelPromptCache::new(Arc::clone(&clean.lineage_id), None);
             drop(result.send(Ok(spawn_agent(clean, session_id, None))));
@@ -657,6 +728,9 @@ fn handle_idle_command(
         Command::Cancel { result, .. } => {
             drop(result.send(Err(NanocodexError::TurnNotCancellable.to_string())));
         }
+        Command::SetThinking { result, .. } => {
+            drop(result.send(Ok(())));
+        }
         Command::Prompt { .. } => {}
     }
 }
@@ -664,11 +738,15 @@ fn handle_idle_command(
 fn spawn_fork(
     factory: &WasmAgentFactory,
     checkpoint: &CommittedWasmCheckpoint,
+    thinking: Thinking,
 ) -> Result<WasmNanocodex, String> {
     if checkpoint.lineage_id != factory.lineage_id {
         return Err("checkpoint belongs to another conversation".to_owned());
     }
     let mut fork = factory.clone();
+    let mut config = (*fork.config).clone();
+    config.thinking = thinking;
+    fork.config = Arc::new(config);
     fork.workspace = Some(Arc::from(checkpoint.model.workspace()));
     Ok(spawn_agent(
         fork,
@@ -684,10 +762,23 @@ fn cancel_queued_turn(queued_turns: &mut VecDeque<QueuedTurn>, target: TurnKey) 
     else {
         return false;
     };
-    let Some(QueuedTurn::Pending { prompt, result, .. }) = queued_turns.remove(position) else {
+    let Some(QueuedTurn::Pending {
+        prompt,
+        thinking,
+        result,
+        ..
+    }) = queued_turns.remove(position)
+    else {
         return false;
     };
-    queued_turns.insert(position, QueuedTurn::Cancelled { prompt, result });
+    queued_turns.insert(
+        position,
+        QueuedTurn::Cancelled {
+            prompt,
+            thinking,
+            result,
+        },
+    );
     true
 }
 

--- a/examples/follow_on.rs
+++ b/examples/follow_on.rs
@@ -27,6 +27,7 @@ async fn main() -> Result<()> {
     let first = first.result().await?;
     println!("first result: {}", first.final_message);
 
+    agent.set_thinking(Thinking::High).await?;
     let second = agent
         .prompt(
             "What single word did you reply with in the previous turn? Reply with only that word in uppercase.",

--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -17,6 +17,8 @@ const agent = await Agent.create({
 const turn = agent.turn.prompt({ input: "Build the thing." });
 console.log(await turn.result());
 
+await agent.session.setThinking("high");
+
 const branch = await agent.session.fork({ at: turn });
 console.log(await branch.turn.prompt({ input: "Try another approach." }).result());
 
@@ -29,6 +31,7 @@ an owned client decorated with matching domain actions:
 
 - `agent.turn.prompt(...)` / `Actions.turn.prompt(agent, ...)`
 - `agent.session.fork(...)` / `Actions.session.fork(agent, ...)`
+- `agent.session.setThinking(...)` / `Actions.session.setThinking(agent, ...)`
 - `agent.session.spawn()` / `Actions.session.spawn(agent)`
 - `agent.events.watch(...)` / `Actions.events.watch(agent, ...)`
 

--- a/js/bindings/actions/index.mjs
+++ b/js/bindings/actions/index.mjs
@@ -11,6 +11,7 @@ export function agentActions() {
     },
     session: {
       fork: (options) => session.fork(agent, options),
+      setThinking: (thinking) => session.setThinking(agent, thinking),
       spawn: () => session.spawn(agent),
     },
     turn: {

--- a/js/bindings/actions/session.d.mts
+++ b/js/bindings/actions/session.d.mts
@@ -1,4 +1,4 @@
-import type { Agent, DefaultAgent, ForkOptions } from "../types.mjs";
+import type { Agent, DefaultAgent, ForkOptions, Thinking } from "../types.mjs";
 
 /** Forks the latest checkpoint, or the exact completed Turn supplied in `options.at`. */
 export function fork(agent: Agent<object>, options?: fork.Options): Promise<fork.ReturnType>;
@@ -12,3 +12,6 @@ export function spawn(agent: Agent<object>): Promise<spawn.ReturnType>;
 export declare namespace spawn {
   type ReturnType = DefaultAgent;
 }
+
+/** Changes the reasoning effort for subsequently accepted turns. */
+export function setThinking(agent: Agent<object>, thinking: Thinking): Promise<void>;

--- a/js/bindings/actions/session.mjs
+++ b/js/bindings/actions/session.mjs
@@ -1,4 +1,8 @@
-import { fork as forkAgent, spawn as spawnAgent } from "../internal.mjs";
+import {
+  fork as forkAgent,
+  setThinking as setAgentThinking,
+  spawn as spawnAgent,
+} from "../internal.mjs";
 
 export function fork(agent, options = {}) {
   return forkAgent(agent, options);
@@ -6,4 +10,8 @@ export function fork(agent, options = {}) {
 
 export function spawn(agent) {
   return spawnAgent(agent);
+}
+
+export function setThinking(agent, thinking) {
+  return setAgentThinking(agent, thinking);
 }

--- a/js/bindings/internal.mjs
+++ b/js/bindings/internal.mjs
@@ -71,6 +71,10 @@ export async function spawn(agent) {
   return createAgent(await state.raw.spawn(), state.runtime);
 }
 
+export function setThinking(agent, thinking) {
+  return agentState(agent).raw.setThinking(thinking);
+}
+
 export function subscribeAgentEvents(agent, listener, options = {}) {
   const state = agentState(agent);
   if (typeof state.runtime.subscribe !== "function") {

--- a/js/bindings/test/node.test.mjs
+++ b/js/bindings/test/node.test.mjs
@@ -45,6 +45,7 @@ test("Node-hosted WASM preserves follow-ons, cache identity, events, and custom 
 
     const generation = await reader.next();
     assert.equal(generation.previous_response_id, "resp-warmup");
+    assert.equal(generation.reasoning.effort, "none");
     sendCompleted(socket, "resp-tool", [{
       type: "custom_tool_call",
       call_id: "call-exec",
@@ -54,17 +55,20 @@ test("Node-hosted WASM preserves follow-ons, cache identity, events, and custom 
 
     const continuation = await reader.next();
     assert.equal(continuation.previous_response_id, "resp-tool");
+    assert.equal(continuation.reasoning.effort, "none");
     assert.match(JSON.stringify(continuation.input), /42/);
     sendFinal(socket, "resp-first", "42");
 
     const followOn = await reader.next();
     assert.equal(followOn.previous_response_id, "resp-first");
+    assert.equal(followOn.reasoning.effort, "high");
     assert.match(JSON.stringify(followOn.input), /Add one/);
     sendFinal(socket, "resp-second", "43");
   })();
 
   const first = agent.turn.prompt({ input: "Use multiply for 6 × 7." });
   assert.equal(await first.result(), "42");
+  await agent.session.setThinking("high");
   const second = Actions.turn.prompt(agent, { input: "Add one to that result." });
   assert.equal(await Actions.turn.getResult(second), "43");
   await scenario;

--- a/js/bindings/types.d.mts
+++ b/js/bindings/types.d.mts
@@ -38,6 +38,7 @@ export type AgentActions = {
   };
   session: {
     fork(options?: ForkOptions): Promise<DefaultAgent>;
+    setThinking(thinking: Thinking): Promise<void>;
     spawn(): Promise<DefaultAgent>;
   };
   turn: {

--- a/py/bindings/README.md
+++ b/py/bindings/README.md
@@ -14,6 +14,8 @@ py/bindings/.venv/bin/python examples/python/follow_on.py
 `prompt()` only accepts the turn and returns a `Turn`; `Turn.result()` does the
 blocking wait while releasing Python's GIL. `AgentEvents.recv_json()` likewise
 releases the GIL, so applications can consume it from a normal Python thread.
+`agent.set_thinking("high")` changes the effort for subsequently accepted turns
+without replacing the session.
 The Rust runtime, tools, transport, retries, history, and event ordering stay
 inside the extension; no app server or per-tool Python bridge is involved.
 

--- a/py/bindings/src/lib.rs
+++ b/py/bindings/src/lib.rs
@@ -84,6 +84,15 @@ impl Nanocodex {
         })
     }
 
+    /// Change the reasoning effort for subsequently accepted turns.
+    fn set_thinking(&self, py: Python<'_>, thinking: &str) -> PyResult<()> {
+        let thinking = parse_thinking(thinking)?;
+        let runtime = Arc::clone(&self.runtime);
+        let agent = self.agent.clone();
+        py.detach(move || runtime.block_on(agent.set_thinking(thinking)))
+            .map_err(runtime_error)
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "Nanocodex(runtime_references={})",

--- a/py/bindings/tests/test_binding.py
+++ b/py/bindings/tests/test_binding.py
@@ -12,6 +12,7 @@ class BindingTests(unittest.TestCase):
         )
         self.assertNotIn(secret, repr(agent))
         self.assertTrue(callable(agent.prompt))
+        agent.set_thinking("high")
         self.assertTrue(callable(events.recv_json))
 
     def test_configuration_errors_cross_the_boundary(self) -> None:
@@ -20,6 +21,10 @@ class BindingTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "expected standard or pro"):
             Nanocodex("test-key", reasoning_mode="impossible")
+
+        agent, _ = Nanocodex("test-key")
+        with self.assertRaisesRegex(ValueError, "expected none"):
+            agent.set_thinking("impossible")
 
         with self.assertRaisesRegex(RuntimeError, "OpenAI credentials are empty"):
             Nanocodex("")


### PR DESCRIPTION
## Overview

Adds the ability to change thinking/reasoning effort between turns.

Upstream Codex permits reasoning effort to be changed on an existing thread for subsequent turns:
- https://github.com/openai/codex/blob/35eaf3ffb0bf2001486c68c47a3d946b34d16634/codex-rs/app-server-protocol/src/protocol/v2/turn.rs#L134-L136
- https://github.com/openai/codex/blob/35eaf3ffb0bf2001486c68c47a3d946b34d16634/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L248-L250