### PR TITLE
Support GPT-5.6 Pro reasoning mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,19 @@ let (historical, _events) = agent.fork_from(&checkpoint).await?;
 `prompt().await` means accepted, not completed. The agent retains conversation
 history, tools, cache identity, response chain, and its WebSocket automatically.
 
+GPT-5.6 Pro is selected independently from reasoning effort; it does not use a
+different model slug. All six effort levels are available in either mode:
+
+```rust
+let (agent, _events) = Nanocodex::builder(api_key)
+    .reasoning_mode(ReasoningMode::Pro)
+    .thinking(Thinking::Xhigh) // None, Low, Medium, High, Xhigh, or Max
+    .build()?;
+```
+
+The CLI equivalents are `--reasoning-mode pro --thinking xhigh`, with matching
+`OPENAI_REASONING_MODE` and `OPENAI_REASONING_EFFORT` environment variables.
+
 Independent agents that use the same immutable instructions and tool definitions
 may deliberately share only their provider-side prompt cache while retaining
 separate conversations, response chains, tools, and workspaces:

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -5,7 +5,9 @@ use std::{
 
 use clap::{ArgAction, Args, builder::NonEmptyStringValueParser};
 use eyre::{Result, WrapErr, eyre};
-use nanocodex::{AgentEvents, Nanocodex, OpenAiAuth, Responses, RolloutConfig, Thinking, Tools};
+use nanocodex::{
+    AgentEvents, Nanocodex, OpenAiAuth, ReasoningMode, Responses, RolloutConfig, Thinking, Tools,
+};
 
 use crate::mcp::McpArgs;
 use crate::subagents::{self, ChildAgents};
@@ -34,9 +36,13 @@ pub(crate) struct AgentArgs {
     #[arg(long, default_value = ".")]
     cwd: PathBuf,
 
-    /// Reasoning effort used by the model.
+    /// Reasoning effort: none, low, medium, high, xhigh, or max.
     #[arg(long, env = "OPENAI_REASONING_EFFORT", default_value_t)]
     thinking: Thinking,
+
+    /// Reasoning execution mode: standard or pro.
+    #[arg(long, env = "OPENAI_REASONING_MODE", default_value_t)]
+    reasoning_mode: ReasoningMode,
 
     /// Replace the standard system/developer instructions.
     #[arg(long, value_parser = NonEmptyStringValueParser::new())]
@@ -115,6 +121,7 @@ impl AgentArgs {
         let tools = tools.build()?;
         let child_agents = self.subagents.then(|| Arc::new(ChildAgents::default()));
         let builder = Nanocodex::builder(auth)
+            .reasoning_mode(self.reasoning_mode)
             .thinking(self.thinking)
             .workspace(self.cwd)
             .responses(responses);

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -24,6 +24,17 @@ Pass an API key positionally, or use native subscription credentials created by
 agent, events = Nanocodex(auth_file="/path/to/.codex/auth.json")
 ```
 
+GPT-5.6 Pro is a reasoning mode, not a different model slug. Select it
+independently from any supported effort level:
+
+```python
+agent, events = Nanocodex(
+    api_key,
+    reasoning_mode="pro",
+    thinking="xhigh",  # none, low, medium, high, xhigh, or max
+)
+```
+
 Runnable consumers live together at the repository boundary under
 [`examples/python`](../../examples/python): `follow_on.py` demonstrates retained
 conversation state and `events.py` consumes the ordered event receiver.

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -1,8 +1,8 @@
 use std::sync::{Arc, Mutex};
 
 use nanocodex::{
-    AgentEvents as RustAgentEvents, Nanocodex as RustNanocodex, OpenAiAuth, Thinking,
-    load_chatgpt_auth,
+    AgentEvents as RustAgentEvents, Nanocodex as RustNanocodex, OpenAiAuth, ReasoningMode,
+    Thinking, load_chatgpt_auth,
 };
 use pyo3::{
     Bound, PyResult, Python,
@@ -21,11 +21,12 @@ struct Nanocodex {
 #[pymethods]
 impl Nanocodex {
     #[new]
-    #[pyo3(signature = (api_key = None, *, auth_file = None, thinking = "medium", workspace = None, instructions = None))]
+    #[pyo3(signature = (api_key = None, *, auth_file = None, thinking = "medium", reasoning_mode = "standard", workspace = None, instructions = None))]
     fn new(
         api_key: Option<String>,
         auth_file: Option<String>,
         thinking: &str,
+        reasoning_mode: &str,
         workspace: Option<String>,
         instructions: Option<String>,
     ) -> PyResult<(Self, AgentEvents)> {
@@ -42,10 +43,13 @@ impl Nanocodex {
             }
         };
         let thinking = parse_thinking(thinking)?;
+        let reasoning_mode = parse_reasoning_mode(reasoning_mode)?;
         let runtime = build_runtime()?;
         let (agent, events) = runtime
             .block_on(async move {
-                let mut builder = RustNanocodex::builder(auth).thinking(thinking);
+                let mut builder = RustNanocodex::builder(auth)
+                    .reasoning_mode(reasoning_mode)
+                    .thinking(thinking);
                 if let Some(workspace) = workspace {
                     builder = builder.workspace(workspace);
                 }
@@ -168,6 +172,10 @@ fn build_runtime() -> PyResult<Arc<Runtime>> {
 }
 
 fn parse_thinking(value: &str) -> PyResult<Thinking> {
+    value.parse().map_err(PyValueError::new_err)
+}
+
+fn parse_reasoning_mode(value: &str) -> PyResult<ReasoningMode> {
     value.parse().map_err(PyValueError::new_err)
 }
 

--- a/bindings/python/tests/test_binding.py
+++ b/bindings/python/tests/test_binding.py
@@ -7,14 +7,19 @@ from nanocodex import Nanocodex
 class BindingTests(unittest.TestCase):
     def test_constructs_owned_handle_and_event_stream_without_exposing_secret(self) -> None:
         secret = "private-test-value"
-        agent, events = Nanocodex(secret, thinking="low")
+        agent, events = Nanocodex(
+            secret, thinking="none", reasoning_mode="pro"
+        )
         self.assertNotIn(secret, repr(agent))
         self.assertTrue(callable(agent.prompt))
         self.assertTrue(callable(events.recv_json))
 
     def test_configuration_errors_cross_the_boundary(self) -> None:
-        with self.assertRaisesRegex(ValueError, "expected low"):
+        with self.assertRaisesRegex(ValueError, "expected none"):
             Nanocodex("test-key", thinking="impossible")
+
+        with self.assertRaisesRegex(ValueError, "expected standard or pro"):
+            Nanocodex("test-key", reasoning_mode="impossible")
 
         with self.assertRaisesRegex(RuntimeError, "OpenAI credentials are empty"):
             Nanocodex("")

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -36,3 +36,6 @@ JavaScript tools are described with a name, description, JSON Schema, and
 handler. They are injected into code mode as `tools.<name>(input)`, and their
 calls/results are folded into the same ordered Rust `AgentEvent` stream as the
 parent `exec` call.
+
+Pass `reasoning_mode: "pro"` independently from `thinking`, which accepts
+`none`, `low`, `medium`, `high`, `xhigh`, or `max`.

--- a/bindings/wasm/test/node.test.mjs
+++ b/bindings/wasm/test/node.test.mjs
@@ -28,7 +28,8 @@ test("Node-hosted WASM preserves follow-ons, cache identity, events, and custom 
   const { Nanocodex } = require("../pkg-node/nanocodex.js");
   const agent = new Nanocodex(JSON.stringify({
     api_key: "test-key",
-    thinking: "low",
+    thinking: "none",
+    reasoning_mode: "pro",
     websocket_url: server.url,
     session_id: "wasm-session",
   }));
@@ -41,6 +42,8 @@ test("Node-hosted WASM preserves follow-ons, cache identity, events, and custom 
 
     const warmup = await reader.next();
     assert.equal(warmup.generate, false);
+    assert.equal(warmup.reasoning.mode, "pro");
+    assert.equal(warmup.reasoning.effort, "none");
     assert.equal(warmup.input[0].tools[0].name, "exec");
     assert.match(warmup.input[0].tools[0].description, /tools\.multiply/);
     sendWarmup(socket, "resp-warmup");

--- a/crates/nanocodex-core/src/lib.rs
+++ b/crates/nanocodex-core/src/lib.rs
@@ -185,6 +185,7 @@ impl UserInput {
 #[derive(Clone)]
 pub struct ModelConfig {
     pub auth: OpenAiAuth,
+    pub reasoning_mode: ReasoningMode,
     pub thinking: Thinking,
     pub websocket_url: String,
     pub api_base_url: String,
@@ -212,6 +213,7 @@ impl Default for ModelConfig {
     fn default() -> Self {
         Self {
             auth: OpenAiAuth::api_key(String::new()),
+            reasoning_mode: ReasoningMode::default(),
             thinking: Thinking::default(),
             websocket_url: "wss://api.openai.com/v1/responses".to_owned(),
             api_base_url: "https://api.openai.com/v1".to_owned(),
@@ -220,8 +222,58 @@ impl Default for ModelConfig {
     }
 }
 
+/// Responses reasoning execution mode for the supported GPT-5.6 model family.
+///
+/// Standard mode preserves the default request behavior. Pro mode performs
+/// additional model work before returning one final answer and can increase
+/// latency and token usage independently of [`Thinking`].
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ReasoningMode {
+    #[default]
+    Standard,
+    Pro,
+}
+
+impl ReasoningMode {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Standard => "standard",
+            Self::Pro => "pro",
+        }
+    }
+
+    pub(crate) const fn request_value(self) -> Option<&'static str> {
+        match self {
+            Self::Standard => None,
+            Self::Pro => Some("pro"),
+        }
+    }
+}
+
+impl fmt::Display for ReasoningMode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ReasoningMode {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "standard" => Ok(Self::Standard),
+            "pro" => Ok(Self::Pro),
+            _ => Err(format!(
+                "invalid reasoning mode {value:?}; expected standard or pro"
+            )),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum Thinking {
+    None,
     Low,
     #[default]
     Medium,
@@ -234,6 +286,7 @@ impl Thinking {
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
+            Self::None => "none",
             Self::Low => "low",
             Self::Medium => "medium",
             Self::High => "high",
@@ -254,13 +307,14 @@ impl FromStr for Thinking {
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
+            "none" => Ok(Self::None),
             "low" => Ok(Self::Low),
             "medium" => Ok(Self::Medium),
             "high" => Ok(Self::High),
             "xhigh" => Ok(Self::Xhigh),
             "max" => Ok(Self::Max),
             _ => Err(format!(
-                "invalid reasoning effort {value:?}; expected low, medium, high, xhigh, or max"
+                "invalid reasoning effort {value:?}; expected none, low, medium, high, xhigh, or max"
             )),
         }
     }
@@ -270,7 +324,24 @@ impl FromStr for Thinking {
 mod tests {
     use serde_json::json;
 
-    use super::Prompt;
+    use super::{Prompt, ReasoningMode, Thinking};
+
+    #[test]
+    fn reasoning_configuration_parses_every_public_value() {
+        assert_eq!("standard".parse(), Ok(ReasoningMode::Standard));
+        assert_eq!("pro".parse(), Ok(ReasoningMode::Pro));
+
+        for (value, expected) in [
+            ("none", Thinking::None),
+            ("low", Thinking::Low),
+            ("medium", Thinking::Medium),
+            ("high", Thinking::High),
+            ("xhigh", Thinking::Xhigh),
+            ("max", Thinking::Max),
+        ] {
+            assert_eq!(value.parse(), Ok(expected));
+        }
+    }
 
     #[test]
     fn prompt_serialization_contains_only_user_input() {

--- a/crates/nanocodex-core/src/responses/request.rs
+++ b/crates/nanocodex-core/src/responses/request.rs
@@ -401,6 +401,7 @@ impl<'a> ResponseCreate<'a> {
             tool_choice: "auto",
             parallel_tool_calls: false,
             reasoning: ReasoningControls {
+                mode: config.reasoning_mode.request_value(),
                 effort: config.thinking.as_str(),
                 summary: "detailed",
                 context: "all_turns",
@@ -423,6 +424,8 @@ impl<'a> ResponseCreate<'a> {
 
 #[derive(Clone, Copy, Serialize)]
 struct ReasoningControls {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mode: Option<&'static str>,
     effort: &'static str,
     summary: &'static str,
     context: &'static str,
@@ -447,7 +450,7 @@ struct ClientMetadata<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ContentItem, MessageRole, Thinking};
+    use crate::{ContentItem, MessageRole, ReasoningMode, Thinking};
     use serde_json::json;
 
     #[test]
@@ -482,6 +485,39 @@ mod tests {
     #[test]
     fn thinking_defaults_to_medium() {
         assert_eq!(ModelConfig::default().thinking, Thinking::Medium);
+    }
+
+    #[test]
+    fn pro_mode_and_every_effort_serialize_independently() {
+        let prefix: Arc<[ResponseItem]> = Arc::from([ResponseItem::message(
+            MessageRole::Developer,
+            [ContentItem::InputText {
+                text: "system prompt".into(),
+            }],
+        )]);
+        let profile = RequestProfile::new("pro-agent", "pro-lineage", prefix);
+
+        for (thinking, expected) in [
+            (Thinking::None, "none"),
+            (Thinking::Low, "low"),
+            (Thinking::Medium, "medium"),
+            (Thinking::High, "high"),
+            (Thinking::Xhigh, "xhigh"),
+            (Thinking::Max, "max"),
+        ] {
+            let config = ModelConfig {
+                auth: crate::OpenAiAuth::api_key("test-key"),
+                reasoning_mode: ReasoningMode::Pro,
+                thinking,
+                ..ModelConfig::default()
+            };
+            let request = serde_json::to_value(ResponseCreate::warmup(&config, &profile, None))
+                .expect("request should serialize");
+
+            assert_eq!(request["reasoning"]["mode"], json!("pro"));
+            assert_eq!(request["reasoning"]["effort"], json!(expected));
+            assert_eq!(request["reasoning"]["context"], json!("all_turns"));
+        }
     }
 
     #[test]

--- a/crates/nanocodex/src/agent.rs
+++ b/crates/nanocodex/src/agent.rs
@@ -8,7 +8,9 @@ use std::{
     },
 };
 
-use nanocodex_core::{AgentEvents, EventSink, ModelConfig, OpenAiAuth, Prompt, Thinking};
+use nanocodex_core::{
+    AgentEvents, EventSink, ModelConfig, OpenAiAuth, Prompt, ReasoningMode, Thinking,
+};
 use nanocodex_service::{
     DefaultResponsesService, ResponsesAttempt, ResponsesClient, ResponsesService,
     ResponsesServiceResponse, TransportStats,
@@ -468,6 +470,14 @@ impl<S> NanocodexBuilder<S> {
         self
     }
 
+    /// Sets the Responses reasoning execution mode. The default is
+    /// [`ReasoningMode::Standard`].
+    #[must_use]
+    pub const fn reasoning_mode(mut self, reasoning_mode: ReasoningMode) -> Self {
+        self.config.reasoning_mode = reasoning_mode;
+        self
+    }
+
     /// Replaces the standard built-in tool selection.
     #[must_use]
     pub fn tools(mut self, tools: Tools) -> Self {
@@ -730,7 +740,10 @@ where
         self.tools.start_providers();
         let session_id = self.events.request_id().to_owned();
         let rollout = self.rollout.take();
-        let thinking = self.spawner.config.thinking;
+        let reasoning = ReasoningSettings {
+            mode: self.spawner.config.reasoning_mode,
+            effort: self.spawner.config.thinking,
+        };
         let inherited_checkpoint = self.initial_checkpoint.as_ref().map(|checkpoint| {
             Arc::new(CommittedCheckpoint {
                 lineage_id: Arc::clone(&self.spawner.lineage_id),
@@ -797,7 +810,7 @@ where
                                 session_id.as_str(),
                                 self.spawner.lineage_id.as_ref(),
                                 &self.origin,
-                                thinking,
+                                reasoning,
                                 turn_index,
                                 prompt.instruction.text_bytes(),
                             );
@@ -854,7 +867,7 @@ where
                 session_id.as_str(),
                 self.spawner.lineage_id.as_ref(),
                 &self.origin,
-                thinking,
+                reasoning,
                 turn_index,
                 prompt.instruction.text_bytes(),
             );
@@ -1069,7 +1082,7 @@ fn agent_turn_span(
     session_id: &str,
     lineage_id: &str,
     origin: &AgentOrigin,
-    thinking: Thinking,
+    reasoning: ReasoningSettings,
     turn_index: u64,
     prompt_bytes: usize,
 ) -> tracing::Span {
@@ -1088,7 +1101,9 @@ fn agent_turn_span(
         agent.depth = origin.depth,
         trace.parented = parented,
         model = nanocodex_core::MODEL,
-        thinking = thinking.as_str(),
+        reasoning.mode = reasoning.mode.as_str(),
+        reasoning.effort = reasoning.effort.as_str(),
+        thinking = reasoning.effort.as_str(),
         turn.index = turn_index,
         prompt.bytes = prompt_bytes,
         status = tracing::field::Empty,
@@ -1097,6 +1112,12 @@ fn agent_turn_span(
         span.record("parent.session.id", parent_session_id.as_ref());
     }
     span
+}
+
+#[derive(Clone, Copy)]
+struct ReasoningSettings {
+    mode: ReasoningMode,
+    effort: Thinking,
 }
 
 fn cancel_queued_turn(queued_turns: &mut VecDeque<QueuedTurn>, target: TurnKey) -> bool {

--- a/crates/nanocodex/src/lib.rs
+++ b/crates/nanocodex/src/lib.rs
@@ -31,7 +31,7 @@ pub use nanocodex_core::{
     InternalMessageMetadata, ItemStatus, JsonSchema, JsonValue, LocalShellAction,
     LocalShellExecAction, LocalShellStatus, MODEL, MessagePhase, MessageRole, OpenAiAuth,
     OpenAiAuthError, OpenAiAuthMode, OutputTextAnnotation, OutputTextLogprob, OutputTextTopLogprob,
-    Prompt, PromptInput, ReasoningContent, ReasoningSummary, ResponseItem, Thinking,
+    Prompt, PromptInput, ReasoningContent, ReasoningMode, ReasoningSummary, ResponseItem, Thinking,
     TimedAgentEvent, ToolCaller, ToolDefinition, Usage, UserInput, WebSearchAction,
     monotonic_now_ns,
 };

--- a/crates/nanocodex/src/model/agent.rs
+++ b/crates/nanocodex/src/model/agent.rs
@@ -310,6 +310,7 @@ where
             RunStarted {
                 mode: "openai_model",
                 model: MODEL,
+                reasoning_mode: self.config.reasoning_mode.as_str(),
                 effort: self.config.thinking.as_str(),
                 transport: TRANSPORT,
                 orchestration: ModelConfig::orchestration(),
@@ -350,6 +351,7 @@ where
             RunStarted {
                 mode: "openai_model",
                 model: MODEL,
+                reasoning_mode: self.config.reasoning_mode.as_str(),
                 effort: self.config.thinking.as_str(),
                 transport: TRANSPORT,
                 orchestration: ModelConfig::orchestration(),
@@ -1045,6 +1047,7 @@ where
             ModelCallStarted {
                 call_index,
                 model: MODEL,
+                reasoning_mode: self.config.reasoning_mode.as_str(),
                 effort: self.config.thinking.as_str(),
                 previous_response_id,
             },
@@ -1059,6 +1062,8 @@ where
         let (input_item_count, input_bytes, input_content) = trace_model_input(&request);
         let span = model_call_span(
             call_index,
+            self.config.reasoning_mode.as_str(),
+            self.config.thinking.as_str(),
             previous_response_id.is_some(),
             input_item_count,
             input_bytes,
@@ -1350,6 +1355,8 @@ fn record_indexed_span_content(
 
 fn model_call_span(
     call_index: u32,
+    reasoning_mode: &str,
+    reasoning_effort: &str,
     previous_response: bool,
     input_item_count: usize,
     input_bytes: usize,
@@ -1360,6 +1367,8 @@ fn model_call_span(
         otel.kind = "internal",
         otel.status_code = tracing::field::Empty,
         model = MODEL,
+        reasoning.mode = reasoning_mode,
+        reasoning.effort = reasoning_effort,
         model.call_index = call_index,
         previous_response,
         model.input.item_count = input_item_count,

--- a/crates/nanocodex/src/model/telemetry.rs
+++ b/crates/nanocodex/src/model/telemetry.rs
@@ -20,6 +20,7 @@ const COST_STATUS: &str = "not_reported_by_responses_api";
 pub(super) struct ModelCallStarted<'a> {
     pub(super) call_index: u32,
     pub(super) model: &'a str,
+    pub(super) reasoning_mode: &'static str,
     pub(super) effort: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) previous_response_id: Option<&'a str>,
@@ -227,6 +228,7 @@ pub(super) fn terminal_payload<'a>(
     TerminalPayload {
         status: terminal_status,
         model: nanocodex_core::MODEL,
+        reasoning_mode: config.reasoning_mode.as_str(),
         effort: config.thinking.as_str(),
         transport: TRANSPORT,
         orchestration: ModelConfig::orchestration(),
@@ -242,6 +244,7 @@ pub(super) fn terminal_payload<'a>(
 pub(super) struct RunStarted<'a> {
     pub(super) mode: &'static str,
     pub(super) model: &'a str,
+    pub(super) reasoning_mode: &'static str,
     pub(super) effort: &'static str,
     pub(super) transport: &'static str,
     pub(super) orchestration: &'static str,
@@ -265,6 +268,7 @@ pub(super) struct RunError<'a> {
 pub(super) struct TerminalPayload<'a> {
     status: &'static str,
     model: &'a str,
+    reasoning_mode: &'static str,
     effort: &'static str,
     transport: &'static str,
     orchestration: &'static str,

--- a/crates/nanocodex/src/wasm.rs
+++ b/crates/nanocodex/src/wasm.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 
-use nanocodex_core::{EventSink, ModelConfig, Prompt, Thinking};
+use nanocodex_core::{EventSink, ModelConfig, Prompt, ReasoningMode, Thinking};
 use nanocodex_service::{ResponsesClient, ResponsesService, TransportStats};
 use nanocodex_tools::Tools;
 use serde::Deserialize;
@@ -25,6 +25,8 @@ struct WasmConfig {
     api_key: String,
     #[serde(default = "default_thinking")]
     thinking: String,
+    #[serde(default = "default_reasoning_mode")]
+    reasoning_mode: String,
     #[serde(default = "default_websocket_url")]
     websocket_url: String,
     #[serde(default = "default_api_base_url")]
@@ -61,9 +63,14 @@ impl WasmNanocodex {
             .map_err(|error| js_error(format!("invalid Nanocodex configuration: {error}")))?;
         validate(&config)?;
         let thinking = config.thinking.parse::<Thinking>().map_err(js_error)?;
+        let reasoning_mode = config
+            .reasoning_mode
+            .parse::<ReasoningMode>()
+            .map_err(js_error)?;
         let session_id = config.session_id.unwrap_or_else(new_session_id);
         let model_config = Arc::new(ModelConfig {
             auth: nanocodex_core::OpenAiAuth::api_key(config.api_key),
+            reasoning_mode,
             thinking,
             websocket_url: config.websocket_url,
             api_base_url: config.api_base_url,
@@ -214,6 +221,10 @@ fn new_session_id() -> String {
 
 fn default_thinking() -> String {
     "medium".to_owned()
+}
+
+fn default_reasoning_mode() -> String {
+    "standard".to_owned()
 }
 
 fn default_websocket_url() -> String {


### PR DESCRIPTION
## What changed

- add `standard` and `pro` reasoning modes for `gpt-5.6-sol`
- support all six reasoning effort levels from `none` through `max`
- expose the configuration through Rust, CLI, Python, and WASM
- include reasoning mode in lifecycle telemetry
- test every Pro/effort request combination

## Why

GPT-5.6 Pro is selected with `reasoning.mode: "pro"` rather than a separate model slug, while `reasoning.effort` remains independently configurable.

## Validation

- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- 66 `nanocodex` library tests
- 16 `nanocodex-core` tests
- live Responses WebSocket matrix for all six Pro effort levels

The current `origin/master` baseline has unrelated WASM-target compile failures in its existing tool-runtime and prompt-cache integration; those are outside this patch.
