### PR TITLE
feat: support HTTPS and Responses replay policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1843,6 +1843,7 @@ dependencies = [
  "http",
  "js-sys",
  "nanocodex-core",
+ "reqwest 0.12.28",
  "rustls",
  "serde",
  "serde_json",

--- a/PLAN.md
+++ b/PLAN.md
@@ -135,11 +135,11 @@ Socket tasks and mutable driver details stay private.
   localhost callback. The CLI owns browser UX and `login`, `status`, and
   `logout`; the library owns token parsing, redacted snapshots, persistence,
   refresh, and recovery.
-- The CLI prefers `OPENAI_API_KEY`, including the repository `.env` loaded by
-  direct runs. Without a key it falls back to Codex's `$CODEX_HOME/auth.json`
-  (normally `~/.codex/auth.json`), so an existing Codex login remains reusable.
-  An explicit auth-file path selects ChatGPT authorization even when a key is
-  available and remains available for isolated embedders.
+- The CLI prefers Codex's existing `$CODEX_HOME/auth.json` (normally
+  `~/.codex/auth.json`) for implicit authentication. If that file is absent it
+  falls back to `OPENAI_API_KEY`, including a repository `.env` loaded by
+  direct runs. Explicit `--api-key` and auth-file paths remain authoritative
+  for callers that need to select a different credential.
 - ChatGPT mode selects the Codex backend endpoints and sends the bearer,
   `ChatGPT-Account-ID`, and optional FedRAMP header. Refresh is proactive near
   expiry and reactive once after a 401. Rotating refresh tokens are serialized,

--- a/PLAN.md
+++ b/PLAN.md
@@ -8,7 +8,7 @@ server, TUI, notebook, test harness, or future language binding without making
 any of those application shapes part of the core SDK.
 
 The library owns model execution, conversation history, prompt caching,
-Responses WebSocket state, tools, retries, and cancellation. Applications own
+Responses transport state, tools, retries, and cancellation. Applications own
 their presentation, event selection, tracing subscriber, persistence policy,
 and transport to their users. Native callers may explicitly enable a
 Codex-compatible committed-history rollout; the CLI enables that policy by
@@ -27,8 +27,9 @@ default so its completed threads can be handed off to `codex resume`.
   Callers never pass previous final messages, response IDs, reasoning items, or
   tool results back into the session.
 - The default is one fixed model contract with medium thinking, the standard
-  instructions, built-in tools, persistent Responses WebSocket, and bounded typed
-  retry/reconnect policy.
+  instructions, built-in tools, a persistent Responses WebSocket, and bounded
+  typed retry/reconnect policy. Native callers may instead fix HTTPS/SSE,
+  response storage, and history replay policy when they build the agent.
 - `Tools::builder().tool(...)` accepts both `#[tool]` functions and complete
   `Tool` implementations in the same heterogeneous registry.
 - `Responses::builder()` lets callers layer or replace the concrete Tower
@@ -48,16 +49,16 @@ application
                                       └─ ResponsesClient<S>
                                            └─ caller Tower layers
                                                 └─ retry policy
-                                                     └─ persistent WebSocket
+                                                     └─ WebSocket or HTTPS/SSE
 ```
 
 Crate ownership is fixed:
 
 - `nanocodex-core`: dependency-light prompts, events, model configuration, and
   typed Responses request/event/item data.
-- `nanocodex-service`: persistent WebSocket behavior, complete streamed
-  attempts, Tower service/client, retry policy, typed errors, and transport
-  telemetry.
+- `nanocodex-service`: persistent WebSocket and HTTPS/SSE behavior, complete
+  streamed attempts, Tower service/client, retry policy, typed errors, and
+  transport telemetry.
 - `nanocodex-tools`: code mode, local tools, custom-tool registry, process
   lifecycle, and bounded tool output.
 - `nanocodex-mcp`: stdio/Streamable HTTP clients, background handshake and tool
@@ -82,7 +83,7 @@ Socket tasks and mutable driver details stay private.
   are gone.
 - Public crate boundaries follow ownership rather than historical file layout.
 
-### 2. Responses WebSocket and Tower service
+### 2. Responses transports and Tower service
 
 - One `Service<ResponsesAttempt>` call covers a complete streamed attempt, not
   merely a frame send.

--- a/README.md
+++ b/README.md
@@ -251,12 +251,27 @@ nanocodex auth status
 nanocodex
 ```
 
-Plain `nanocodex` and `nanocodex run` prefer `OPENAI_API_KEY`; direct binary runs
-load it from the nearest `.env` automatically. An explicit `--api-key` overrides
-both automatic sources. Without an API key, the CLI falls back to the stored
-subscription session. To select `ChatGPT` explicitly while a key is available,
-pass `NANOCODEX_AUTH_FILE` or `--auth-file`. `nanocodex auth logout` removes the
-shared file and therefore logs both Codex and Nanocodex out.
+Plain `nanocodex` and `nanocodex run` prefer an existing Codex subscription
+session in `$CODEX_HOME/auth.json` (normally `~/.codex/auth.json`). If that file
+is absent, the CLI falls back to `OPENAI_API_KEY`; direct binary runs load the
+key from the nearest `.env` automatically. An explicit `--api-key` overrides
+both automatic sources, while `NANOCODEX_AUTH_FILE` or `--auth-file` selects a
+specific subscription file. A present but invalid auth file fails visibly
+instead of silently incurring API-key charges. `nanocodex auth logout` removes
+the shared file and therefore logs both Codex and Nanocodex out.
+
+The default Responses policy depends on the selected authorization:
+
+| Authorization | Default transport | Default `store` | Default history |
+| --- | --- | ---: | --- |
+| ChatGPT subscription | WebSocket | `false` | connection-local incremental |
+| API key | WebSocket | `true` | stored incremental |
+
+Selecting HTTPS keeps API-key sessions stored and incremental. ChatGPT HTTPS
+remains `store: false` and automatically switches to complete client-history
+replay because it has no connection-local checkpoint. Explicit
+`--store-responses` and `--responses-history` values override these defaults
+when the combination is supported.
 
 Library consumers own their login UX and can reuse the same managed session:
 
@@ -538,10 +553,10 @@ edit:
 ```sh
 curl -fsSL https://nanocodex.paradigm.xyz | bash
 
-# OPENAI_API_KEY is loaded from the nearest .env by default.
+# Reuse an existing Codex login, or fall back to OPENAI_API_KEY when absent.
 nanocodex
 
-# Or explicitly use the same subscription store Codex uses.
+# Create or explicitly select the same subscription store Codex uses.
 nanocodex auth login
 nanocodex --auth-file "${CODEX_HOME:-$HOME/.codex}/auth.json"
 ```

--- a/README.md
+++ b/README.md
@@ -273,6 +273,17 @@ replay because it has no connection-local checkpoint. Explicit
 `--store-responses` and `--responses-history` values override these defaults
 when the combination is supported.
 
+These defaults optimize the normal long-lived interactive session, where the
+retained WebSocket delivered warm first events in 80-151 ms versus 277-369 ms
+over HTTPS. HTTPS is the better explicit choice for cold or fork-heavy
+one-shot work: cold first events were 374-405 ms versus 587-679 ms for
+WebSocket, and fresh HTTPS forks reached their first event in 373-436 ms versus
+about 1.0-1.1 seconds for a new WebSocket. With API-key authentication,
+`store: true` also reduced three historical-fork requests by roughly 97%.
+Completion latency was backend-noisy, and every policy had identical token,
+cache, and estimated-cost behavior in this workload. See the full
+[transport benchmark](docs/RESPONSE_TRANSPORT_BENCH.md).
+
 Library consumers own their login UX and can reuse the same managed session:
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@
 
 Nanocodex is a Code Mode-first Rust agents SDK. It provides typed turns, tools,
 events, steering, cancellation, queueing, and fast historical forks over the
-OpenAI Responses WebSocket API. It keeps the complete coding-agent conversation
-inside your process without requiring an app server or durable control plane.
+OpenAI Responses API. It supports persistent WebSocket and HTTPS/SSE transports
+while keeping the complete coding-agent conversation inside your process,
+without requiring an app server or durable control plane.
 
 ## Installation
 
@@ -276,13 +277,15 @@ already-authorized WebSocket from the host and never own refresh tokens.
 ## Lifecycle details
 
 `Nanocodex::new` installs the standard instructions, medium thinking, built-in
-tools, persistent WebSocket, and retry/reconnect policy. Dropping the event
-receiver is supported; events then become a no-op.
+tools, persistent WebSocket, and retry/reconnect policy. The builder can instead
+fix HTTPS/SSE, response storage, and full-replay policy for the agent and all of
+its forks. Dropping the event receiver is supported; events then become a no-op.
 
 Callers never pass transcripts, response IDs, tool outputs, or turn IDs back to
-the agent. On a healthy socket the driver sends only the new delta with
-`previous_response_id`. After reconnecting it drops that ID and transparently
-replays its authoritative typed history.
+the agent. An incremental transport sends only the new delta with
+`previous_response_id`; full-replay policy transparently sends the authoritative
+typed history. A replacement ephemeral socket and HTTPS with `store: false`
+also replay that history.
 
 The Responses path encodes each wire request once and rejects common
 non-metadata frames before attempting metadata decoding. Every streamed attempt
@@ -612,7 +615,7 @@ integrations, managed subagents, and a mature TUI and IDE ecosystem.
 | --- | --- | --- |
 | Product boundary | Rust library in your process | Application and durable agent runtime |
 | State | In-memory authority; optional Codex-compatible rollout | Persisted threads and rollouts |
-| Follow-on turns | New input delta on one persistent WebSocket | Full Codex session lifecycle |
+| Follow-on turns | Fixed WebSocket or HTTPS policy; automatic delta or full replay | Full Codex session lifecycle |
 | Historical forks | Exact completed checkpoint; parent keeps running | Durable thread reconstruction |
 | Tools | Code Mode over Rust tools and MCP | Broad built-in tool and integration surface |
 | Middleware | Your concrete Tower stack | Codex-owned runtime policy |

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -6,7 +6,8 @@ use std::{
 use clap::{ArgAction, Args, builder::NonEmptyStringValueParser};
 use eyre::{Result, WrapErr, eyre};
 use nanocodex::{
-    AgentEvents, Nanocodex, OpenAiAuth, ReasoningMode, Responses, RolloutConfig, Thinking, Tools,
+    AgentEvents, Nanocodex, OpenAiAuth, ReasoningMode, Responses, ResponsesHistory,
+    ResponsesTransport, RolloutConfig, Thinking, Tools,
 };
 
 use crate::mcp::McpArgs;
@@ -88,7 +89,23 @@ pub(crate) struct AgentArgs {
     #[arg(long, env = "OPENAI_RESPONSES_WEBSOCKET_URL")]
     websocket_url: Option<String>,
 
-    /// `OpenAI` HTTP API base used by standalone web search.
+    /// Responses transport fixed for the complete agent session.
+    #[arg(
+        long,
+        env = "NANOCODEX_RESPONSES_TRANSPORT",
+        default_value_t = ResponsesTransport::WebSocket
+    )]
+    responses_transport: ResponsesTransport,
+
+    /// Incremental response-ID chaining or complete history replay.
+    #[arg(long, env = "NANOCODEX_RESPONSES_HISTORY")]
+    responses_history: Option<ResponsesHistory>,
+
+    /// Whether the Responses API retains server-side checkpoints.
+    #[arg(long, env = "NANOCODEX_STORE_RESPONSES", action = ArgAction::Set)]
+    store_responses: Option<bool>,
+
+    /// `OpenAI` HTTP API base used by HTTPS Responses and standalone web search.
     #[arg(long, env = "OPENAI_API_BASE_URL")]
     api_base_url: Option<String>,
 
@@ -105,7 +122,13 @@ impl AgentArgs {
         let codex_home = default_codex_home()?;
         let rollout = self.rollouts.then(|| codex_home.clone());
         let auth = select_auth(self.api_key, self.auth_file, environment_api_key()?)?;
-        let mut responses = Responses::builder();
+        let mut responses = Responses::builder().transport(self.responses_transport);
+        if let Some(history) = self.responses_history {
+            responses = responses.history(history);
+        }
+        if let Some(store) = self.store_responses {
+            responses = responses.store(store);
+        }
         if let Some(websocket_url) = self.websocket_url {
             responses = responses.websocket_url(websocket_url);
         }
@@ -258,6 +281,28 @@ mod tests {
             .expect("the CLI should expose the rollouts argument");
 
         assert_eq!(rollouts.get_default_values(), ["true"]);
+    }
+
+    #[test]
+    fn responses_transport_is_selected_once_at_startup() {
+        let command = crate::Cli::command();
+        let transport = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "responses_transport")
+            .expect("the CLI should expose the Responses transport argument");
+        assert_eq!(transport.get_default_values(), ["websocket"]);
+
+        let history = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "responses_history")
+            .expect("the CLI should expose the Responses history argument");
+        assert!(history.get_default_values().is_empty());
+
+        let store = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "store_responses")
+            .expect("the CLI should expose the Responses storage argument");
+        assert!(store.get_default_values().is_empty());
     }
 
     #[test]

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -25,7 +25,7 @@ pub(crate) struct ConfiguredAgent {
     reason = "independent CLI feature toggles are not one state machine"
 )]
 pub(crate) struct AgentArgs {
-    /// Explicit `OpenAI` API key override. Otherwise `OPENAI_API_KEY` is preferred.
+    /// Explicit `OpenAI` API key override.
     #[arg(long, value_parser = NonEmptyStringValueParser::new())]
     api_key: Option<String>,
 
@@ -183,16 +183,40 @@ fn select_auth(
     auth_file: Option<PathBuf>,
     environment_api_key: Option<String>,
 ) -> Result<OpenAiAuth> {
+    select_auth_with_default(
+        explicit_api_key,
+        auth_file,
+        environment_api_key,
+        default_auth_file,
+    )
+}
+
+fn select_auth_with_default<F>(
+    explicit_api_key: Option<String>,
+    auth_file: Option<PathBuf>,
+    environment_api_key: Option<String>,
+    resolve_default_auth_file: F,
+) -> Result<OpenAiAuth>
+where
+    F: FnOnce() -> Result<PathBuf>,
+{
     if let Some(api_key) = explicit_api_key {
         return Ok(OpenAiAuth::api_key(api_key));
     }
     if let Some(auth_file) = auth_file {
         return load_subscription_auth(&auth_file);
     }
+    let auth_file = resolve_default_auth_file()?;
+    if auth_file
+        .try_exists()
+        .wrap_err_with(|| format!("failed to inspect {}", auth_file.display()))?
+    {
+        return load_subscription_auth(&auth_file);
+    }
     if let Some(api_key) = environment_api_key {
         return Ok(OpenAiAuth::api_key(api_key));
     }
-    load_subscription_auth(&default_auth_file()?)
+    load_subscription_auth(&auth_file)
 }
 
 fn environment_api_key() -> Result<Option<String>> {
@@ -249,7 +273,7 @@ mod tests {
     use clap::CommandFactory;
     use nanocodex::OpenAiAuthMode;
 
-    use super::select_auth;
+    use super::{select_auth, select_auth_with_default};
 
     static NEXT_PATH: AtomicU64 = AtomicU64::new(0);
 
@@ -259,6 +283,22 @@ mod tests {
             std::process::id(),
             NEXT_PATH.fetch_add(1, Ordering::Relaxed)
         ))
+    }
+
+    fn write_chatgpt_auth(path: &std::path::Path) {
+        std::fs::write(
+            path,
+            br#"{
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "id_token": "header.e30.signature",
+                    "access_token": "access-token",
+                    "refresh_token": "refresh-token",
+                    "account_id": "account-1"
+                }
+            }"#,
+        )
+        .unwrap();
     }
 
     #[test]
@@ -318,10 +358,41 @@ mod tests {
     }
 
     #[test]
-    fn environment_key_is_the_automatic_default() {
-        let auth = select_auth(None, None, Some("environment-key".into())).unwrap();
+    fn default_chatgpt_auth_precedes_the_environment_key() {
+        let auth_file = auth_file();
+        write_chatgpt_auth(&auth_file);
+
+        let auth = select_auth_with_default(None, None, Some("environment-key".into()), || {
+            Ok(auth_file.clone())
+        })
+        .unwrap();
+
+        assert_eq!(auth.mode(), OpenAiAuthMode::ChatGpt);
+        std::fs::remove_file(auth_file).unwrap();
+    }
+
+    #[test]
+    fn environment_key_is_used_when_the_default_auth_file_is_missing() {
+        let auth_file = auth_file();
+        let auth =
+            select_auth_with_default(None, None, Some("environment-key".into()), || Ok(auth_file))
+                .unwrap();
 
         assert_eq!(auth.mode(), OpenAiAuthMode::ApiKey);
+    }
+
+    #[test]
+    fn invalid_default_auth_does_not_silently_fall_back_to_a_key() {
+        let auth_file = auth_file();
+        std::fs::write(&auth_file, b"{}").unwrap();
+
+        let error = select_auth_with_default(None, None, Some("environment-key".into()), || {
+            Ok(auth_file.clone())
+        })
+        .unwrap_err();
+
+        assert!(error.to_string().contains("no ChatGPT tokens"));
+        std::fs::remove_file(auth_file).unwrap();
     }
 
     #[test]

--- a/crates/nanocodex-core/src/auth.rs
+++ b/crates/nanocodex-core/src/auth.rs
@@ -13,7 +13,10 @@ pub enum OpenAiAuthMode {
 }
 
 impl OpenAiAuthMode {
-    pub(crate) const fn stores_responses(self) -> bool {
+    /// Whether the default endpoint for this authorization mode supports
+    /// retained Responses checkpoints.
+    #[must_use]
+    pub const fn supports_stored_responses(self) -> bool {
         matches!(self, Self::ApiKey)
     }
 

--- a/crates/nanocodex-core/src/lib.rs
+++ b/crates/nanocodex-core/src/lib.rs
@@ -187,6 +187,9 @@ pub struct ModelConfig {
     pub auth: OpenAiAuth,
     pub reasoning_mode: ReasoningMode,
     pub thinking: Thinking,
+    pub responses_transport: ResponsesTransport,
+    pub responses_history: ResponsesHistory,
+    pub store_responses: bool,
     pub websocket_url: String,
     pub api_base_url: String,
     pub system_prompt: Arc<str>,
@@ -215,9 +218,87 @@ impl Default for ModelConfig {
             auth: OpenAiAuth::api_key(String::new()),
             reasoning_mode: ReasoningMode::default(),
             thinking: Thinking::default(),
+            responses_transport: ResponsesTransport::default(),
+            responses_history: ResponsesHistory::default(),
+            store_responses: true,
             websocket_url: "wss://api.openai.com/v1/responses".to_owned(),
             api_base_url: "https://api.openai.com/v1".to_owned(),
             system_prompt: SYSTEM_PROMPT.into(),
+        }
+    }
+}
+
+/// Responses transport selected once when an agent session is built.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ResponsesTransport {
+    #[default]
+    WebSocket,
+    Https,
+}
+
+impl ResponsesTransport {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::WebSocket => "responses_websocket_v2",
+            Self::Https => "responses_https_sse",
+        }
+    }
+}
+
+impl fmt::Display for ResponsesTransport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::WebSocket => formatter.write_str("websocket"),
+            Self::Https => formatter.write_str("https"),
+        }
+    }
+}
+
+impl FromStr for ResponsesTransport {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "websocket" | "ws" => Ok(Self::WebSocket),
+            "https" | "http" => Ok(Self::Https),
+            _ => Err(format!(
+                "invalid Responses transport {value:?}; expected websocket or https"
+            )),
+        }
+    }
+}
+
+/// How committed client history is represented in each Responses request.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ResponsesHistory {
+    /// Reuse a response ID when the selected transport and storage policy make
+    /// it valid, falling back to complete client-owned history as needed.
+    #[default]
+    Incremental,
+    /// Send complete committed client-owned history on every request.
+    FullReplay,
+}
+
+impl fmt::Display for ResponsesHistory {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Incremental => formatter.write_str("incremental"),
+            Self::FullReplay => formatter.write_str("full-replay"),
+        }
+    }
+}
+
+impl FromStr for ResponsesHistory {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "incremental" => Ok(Self::Incremental),
+            "full-replay" | "replay" => Ok(Self::FullReplay),
+            _ => Err(format!(
+                "invalid Responses history policy {value:?}; expected incremental or full-replay"
+            )),
         }
     }
 }

--- a/crates/nanocodex-core/src/responses/request.rs
+++ b/crates/nanocodex-core/src/responses/request.rs
@@ -331,8 +331,8 @@ impl Serialize for ResponsesInput<'_> {
 
 #[derive(Serialize)]
 pub struct ResponseCreate<'a> {
-    #[serde(rename = "type")]
-    kind: &'static str,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    kind: Option<&'static str>,
     model: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     previous_response_id: Option<&'a str>,
@@ -393,8 +393,12 @@ impl<'a> ResponseCreate<'a> {
         profile: &'a RequestProfile,
         turn_state: Option<&'a str>,
     ) -> Self {
+        let websocket = matches!(
+            config.responses_transport,
+            crate::ResponsesTransport::WebSocket
+        );
         Self {
-            kind: "response.create",
+            kind: websocket.then_some("response.create"),
             model: crate::MODEL,
             previous_response_id,
             input,
@@ -406,7 +410,7 @@ impl<'a> ResponseCreate<'a> {
                 summary: "detailed",
                 context: "all_turns",
             },
-            store: config.auth.mode().stores_responses(),
+            store: config.store_responses,
             stream: true,
             include: ["reasoning.encrypted_content"],
             prompt_cache_key: profile.prompt_cache_key(),
@@ -415,8 +419,8 @@ impl<'a> ResponseCreate<'a> {
             client_metadata: ClientMetadata {
                 session_id: profile.session_id(),
                 thread_id: profile.session_id(),
-                responses_lite: "true",
-                turn_state,
+                responses_lite: websocket.then_some("true"),
+                turn_state: websocket.then_some(turn_state).flatten(),
             },
         }
     }
@@ -441,7 +445,8 @@ struct ClientMetadata<'a> {
     session_id: &'a str,
     thread_id: &'a str,
     #[serde(rename = "ws_request_header_x_openai_internal_codex_responses_lite")]
-    responses_lite: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    responses_lite: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "x-codex-turn-state")]
     turn_state: Option<&'a str>,
@@ -521,9 +526,9 @@ mod tests {
     }
 
     #[test]
-    fn response_storage_tracks_auth_mode() {
-        assert!(crate::OpenAiAuthMode::ApiKey.stores_responses());
-        assert!(!crate::OpenAiAuthMode::ChatGpt.stores_responses());
+    fn response_storage_support_tracks_auth_mode() {
+        assert!(crate::OpenAiAuthMode::ApiKey.supports_stored_responses());
+        assert!(!crate::OpenAiAuthMode::ChatGpt.supports_stored_responses());
     }
 
     #[test]

--- a/crates/nanocodex-service/Cargo.toml
+++ b/crates/nanocodex-service/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
-description = "Tower services and persistent Responses WebSocket transport for Nanocodex"
+description = "Tower services and Responses transports for Nanocodex"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -32,6 +32,7 @@ web-time.workspace = true
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 base64.workspace = true
 futures-util.workspace = true
+reqwest.workspace = true
 rustls.workspace = true
 tokio = { workspace = true, features = ["macros", "net", "rt", "sync", "time"] }
 tokio-tungstenite.workspace = true

--- a/crates/nanocodex-service/src/attempt.rs
+++ b/crates/nanocodex-service/src/attempt.rs
@@ -278,6 +278,10 @@ impl ResponsesAttempt {
         self.full_replay = true;
         true
     }
+
+    pub(crate) fn force_full_replay(&mut self) {
+        self.full_replay = true;
+    }
 }
 
 pub enum ResponsesOutput {

--- a/crates/nanocodex-service/src/error.rs
+++ b/crates/nanocodex-service/src/error.rs
@@ -55,6 +55,16 @@ pub enum ResponsesError {
     Api { event: String },
     #[error("Responses API rejected invalid image data: {event}")]
     InvalidImageRequest { event: String },
+    #[error("Responses HTTPS request failed")]
+    HttpRequest(#[source] reqwest::Error),
+    #[error("Responses HTTPS request was rejected with HTTP {status}: {body}")]
+    HttpRejected {
+        status: u16,
+        body: String,
+        retry_after: Option<Duration>,
+    },
+    #[error("Responses HTTPS stream contained invalid UTF-8")]
+    InvalidSseUtf8(#[source] std::string::FromUtf8Error),
 }
 
 impl ResponsesError {
@@ -81,6 +91,20 @@ impl ResponsesError {
             Self::UnexpectedEnd | Self::Closed { .. } => ("premature_close", None),
             Self::Receive(error) if is_transient_websocket(error) => ("receive_transport", None),
             Self::Api { event } => retryable_api_error(event)?,
+            Self::HttpRequest(error) if error.is_timeout() => ("https_timeout", None),
+            Self::HttpRequest(error) if error.is_connect() || error.is_body() => {
+                ("https_transport", None)
+            }
+            Self::HttpRejected {
+                status,
+                retry_after,
+                ..
+            } if *status == 429 => ("https_rate_limit", *retry_after),
+            Self::HttpRejected {
+                status,
+                retry_after,
+                ..
+            } if (500..=599).contains(status) => ("https_server", *retry_after),
             _ => return None,
         };
         Some(RetryAdvice {
@@ -114,6 +138,12 @@ impl ResponsesError {
             }
             Self::Api { .. } => "api",
             Self::InvalidImageRequest { .. } => "invalid_image_request",
+            Self::HttpRequest(error) if error.is_timeout() => "https_timeout",
+            Self::HttpRequest(_) => "https_transport",
+            Self::HttpRejected { status: 429, .. } => "https_rate_limit",
+            Self::HttpRejected { status, .. } if (500..=599).contains(status) => "https_server",
+            Self::HttpRejected { .. } => "https_rejected",
+            Self::InvalidSseUtf8(_) => "invalid_sse_utf8",
         }
     }
 

--- a/crates/nanocodex-service/src/http.rs
+++ b/crates/nanocodex-service/src/http.rs
@@ -1,0 +1,217 @@
+use std::time::Duration;
+
+use http::header;
+use nanocodex_core::{OpenAiAuthSnapshot, monotonic_now_ns};
+use tokio::time::timeout;
+use tokio_tungstenite::tungstenite::Utf8Bytes;
+
+use crate::{EncodedRequest, ResponsesError, socket::ReceivedText};
+
+const EVENT_IDLE_TIMEOUT: Duration = if cfg!(test) {
+    Duration::from_millis(100)
+} else {
+    Duration::from_secs(300)
+};
+const RESPONSES_LITE_HEADER: &str = "x-openai-internal-codex-responses-lite";
+
+#[derive(Clone)]
+pub(crate) struct ResponsesHttp {
+    client: reqwest::Client,
+}
+
+pub(crate) struct ResponsesHttpStream {
+    response: reqwest::Response,
+    decoder: SseDecoder,
+    ended: bool,
+}
+
+pub(crate) struct HttpMetadata {
+    pub(crate) reasoning_included: bool,
+}
+
+impl ResponsesHttp {
+    pub(crate) fn new() -> Self {
+        Self {
+            client: reqwest::Client::new(),
+        }
+    }
+
+    pub(crate) async fn send(
+        &self,
+        api_base_url: &str,
+        auth: &OpenAiAuthSnapshot,
+        session_id: &str,
+        request: &EncodedRequest,
+    ) -> Result<(ResponsesHttpStream, HttpMetadata), ResponsesError> {
+        let endpoint = format!("{}/responses", api_base_url.trim_end_matches('/'));
+        let mut builder = self
+            .client
+            .post(endpoint)
+            .bearer_auth(auth.bearer())
+            .header(header::CONTENT_TYPE, "application/json")
+            .header(header::ACCEPT, "text/event-stream")
+            .header(RESPONSES_LITE_HEADER, "true")
+            .header("session-id", session_id)
+            .header("thread-id", session_id)
+            .header("x-client-request-id", session_id)
+            .header(
+                header::USER_AGENT,
+                concat!("nanocodex/", env!("CARGO_PKG_VERSION")),
+            )
+            .body(request.raw().get().to_owned());
+        if let Some(account_id) = auth.account_id() {
+            builder = builder.header("ChatGPT-Account-ID", account_id);
+        }
+        if auth.is_fedramp() {
+            builder = builder.header("X-OpenAI-Fedramp", "true");
+        }
+        let response = builder.send().await.map_err(ResponsesError::HttpRequest)?;
+        let status = response.status();
+        if !status.is_success() {
+            let retry_after = retry_after(response.headers());
+            let body = response.text().await.unwrap_or_default();
+            return Err(ResponsesError::HttpRejected {
+                status: status.as_u16(),
+                body,
+                retry_after,
+            });
+        }
+        let metadata = HttpMetadata {
+            reasoning_included: response.headers().contains_key("x-reasoning-included"),
+        };
+        Ok((
+            ResponsesHttpStream {
+                response,
+                decoder: SseDecoder::default(),
+                ended: false,
+            },
+            metadata,
+        ))
+    }
+}
+
+impl ResponsesHttpStream {
+    pub(crate) async fn next_text_or_idle_timeout(
+        &mut self,
+    ) -> Result<ReceivedText, ResponsesError> {
+        timeout(EVENT_IDLE_TIMEOUT, self.next_text())
+            .await
+            .map_err(|_| ResponsesError::IdleTimeout {
+                seconds: EVENT_IDLE_TIMEOUT.as_secs(),
+            })?
+    }
+
+    async fn next_text(&mut self) -> Result<ReceivedText, ResponsesError> {
+        loop {
+            if let Some(text) = self.decoder.next()? {
+                return Ok(ReceivedText {
+                    text: Utf8Bytes::from(text),
+                    received_ns: monotonic_now_ns(),
+                });
+            }
+            if self.ended {
+                return Err(ResponsesError::UnexpectedEnd);
+            }
+            if let Some(chunk) = self
+                .response
+                .chunk()
+                .await
+                .map_err(ResponsesError::HttpRequest)?
+            {
+                self.decoder.push(&chunk);
+            } else {
+                self.ended = true;
+                self.decoder.finish();
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct SseDecoder {
+    bytes: Vec<u8>,
+    data: Vec<String>,
+    finished: bool,
+}
+
+impl SseDecoder {
+    fn push(&mut self, chunk: &[u8]) {
+        self.bytes.extend_from_slice(chunk);
+    }
+
+    fn finish(&mut self) {
+        self.finished = true;
+        if !self.bytes.is_empty() {
+            self.bytes.push(b'\n');
+        }
+        self.bytes.push(b'\n');
+    }
+
+    fn next(&mut self) -> Result<Option<String>, ResponsesError> {
+        loop {
+            let Some(newline) = self.bytes.iter().position(|byte| *byte == b'\n') else {
+                return Ok(None);
+            };
+            let mut line = self.bytes.drain(..=newline).collect::<Vec<_>>();
+            line.pop();
+            if line.last() == Some(&b'\r') {
+                line.pop();
+            }
+            let line = String::from_utf8(line).map_err(ResponsesError::InvalidSseUtf8)?;
+            if line.is_empty() {
+                if self.data.is_empty() {
+                    if self.finished && self.bytes.is_empty() {
+                        return Ok(None);
+                    }
+                    continue;
+                }
+                let event = self.data.join("\n");
+                self.data.clear();
+                if event == "[DONE]" {
+                    continue;
+                }
+                return Ok(Some(event));
+            }
+            if let Some(data) = line.strip_prefix("data:") {
+                self.data
+                    .push(data.strip_prefix(' ').unwrap_or(data).to_owned());
+            }
+        }
+    }
+}
+
+fn retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    headers
+        .get(header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_secs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SseDecoder;
+
+    #[test]
+    fn decodes_fragmented_and_multiline_sse_events() {
+        let mut decoder = SseDecoder::default();
+        decoder.push(b": keepalive\n\ndata: {\"type\":\"response.");
+        assert_eq!(decoder.next().unwrap(), None);
+        decoder.push(b"created\"}\r\n\r\ndata: first\ndata: second\n\n");
+        assert_eq!(
+            decoder.next().unwrap().as_deref(),
+            Some("{\"type\":\"response.created\"}")
+        );
+        assert_eq!(decoder.next().unwrap().as_deref(), Some("first\nsecond"));
+        assert_eq!(decoder.next().unwrap(), None);
+    }
+
+    #[test]
+    fn skips_done_and_flushes_an_unterminated_final_event() {
+        let mut decoder = SseDecoder::default();
+        decoder.push(b"data: [DONE]\n\ndata: final");
+        decoder.finish();
+        assert_eq!(decoder.next().unwrap().as_deref(), Some("final"));
+        assert_eq!(decoder.next().unwrap(), None);
+    }
+}

--- a/crates/nanocodex-service/src/lib.rs
+++ b/crates/nanocodex-service/src/lib.rs
@@ -7,6 +7,8 @@ mod error;
 #[cfg(target_family = "wasm")]
 #[path = "error_wasm.rs"]
 mod error;
+#[cfg(not(target_family = "wasm"))]
+mod http;
 mod middleware;
 mod service;
 mod service_error;

--- a/crates/nanocodex-service/src/service.rs
+++ b/crates/nanocodex-service/src/service.rs
@@ -8,7 +8,7 @@ use std::{
 #[cfg(not(target_family = "wasm"))]
 use nanocodex_core::OpenAiAuthMode;
 use nanocodex_core::{
-    AgentEventKind, ModelConfig, OpenAiAuthSnapshot,
+    AgentEventKind, ModelConfig, OpenAiAuthSnapshot, ResponsesHistory, ResponsesTransport,
     responses::{ResponseCreate, WarmupResponse, WarmupServerEvent},
 };
 use tokio::sync::Mutex;
@@ -16,6 +16,8 @@ use tower::{Service, retry::Retry};
 use tracing::{Instrument, info_span};
 use web_time::Instant;
 
+#[cfg(not(target_family = "wasm"))]
+use crate::http::{HttpMetadata, ResponsesHttp, ResponsesHttpStream};
 use crate::{
     EncodedRequest, ResponsesError,
     attempt::{ResponsesAttempt, ResponsesAttemptKind, ResponsesOutput, ResponsesServiceResponse},
@@ -75,11 +77,13 @@ impl ConnectionState {
     }
 }
 
-/// Stateful WebSocket attempt service at the base of a Responses Tower stack.
+/// Stateful transport attempt service at the base of a Responses Tower stack.
 #[derive(Clone)]
 pub struct ResponsesService {
     config: Arc<ModelConfig>,
     connection: Arc<Mutex<ConnectionState>>,
+    #[cfg(not(target_family = "wasm"))]
+    http: ResponsesHttp,
 }
 
 impl ResponsesService {
@@ -88,10 +92,12 @@ impl ResponsesService {
         Self {
             config,
             connection: Arc::new(Mutex::new(ConnectionState::new())),
+            #[cfg(not(target_family = "wasm"))]
+            http: ResponsesHttp::new(),
         }
     }
 
-    /// Builds the standard persistent-WebSocket service with retry policy.
+    /// Builds the configured standard Responses service with retry policy.
     #[must_use]
     pub fn standard(config: Arc<ModelConfig>) -> DefaultResponsesService {
         Retry::new(ResponsesRetryPolicy, Self::new(config))
@@ -108,6 +114,18 @@ impl ResponsesService {
             .response_attempts
             .fetch_add(1, Ordering::Relaxed);
         let started_at = Instant::now();
+        request.observer.emit(
+            AgentEventKind::ModelAttemptStarted,
+            AttemptStarted {
+                phase: request.kind,
+                model_call_index: request.call_index,
+                attempt: request.attempt,
+                max_attempts: request.max_attempts,
+                replay_mode: request.replay_mode(),
+                previous_response_id: request.previous_response_id(),
+                connection_generation: connection.generation,
+            },
+        )?;
         let result = self.run_inner(connection, request, started_at).await;
         tracing::Span::current().record(
             "status",
@@ -155,18 +173,33 @@ impl ResponsesService {
         request: &ResponsesAttempt,
         started_at: Instant,
     ) -> Result<ResponsesServiceResponse, ResponsesServiceError> {
-        request.observer.emit(
-            AgentEventKind::ModelAttemptStarted,
-            AttemptStarted {
-                phase: request.kind,
-                model_call_index: request.call_index,
-                attempt: request.attempt,
-                max_attempts: request.max_attempts,
-                replay_mode: request.replay_mode(),
-                previous_response_id: request.previous_response_id(),
-                connection_generation: connection.generation,
-            },
-        )?;
+        match self.config.responses_transport {
+            ResponsesTransport::WebSocket => {
+                self.run_websocket(connection, request, started_at).await
+            }
+            ResponsesTransport::Https => {
+                #[cfg(not(target_family = "wasm"))]
+                {
+                    self.run_https(request, started_at).await
+                }
+                #[cfg(target_family = "wasm")]
+                {
+                    Err(ResponsesServiceError::invalid_attempt_state(
+                        "HTTPS Responses transport is unavailable in browser WASM",
+                        FailurePhase::Connect,
+                        0,
+                    ))
+                }
+            }
+        }
+    }
+
+    async fn run_websocket(
+        &self,
+        connection: &mut ConnectionState,
+        request: &ResponsesAttempt,
+        started_at: Instant,
+    ) -> Result<ResponsesServiceResponse, ResponsesServiceError> {
         if connection.socket.is_none() {
             self.connect(connection, request).await?;
         }
@@ -209,7 +242,8 @@ impl ResponsesService {
             ),
             ResponsesAttemptKind::Generation => ResponsesOutput::Generation(
                 stream::receive(
-                    socket,
+                    &mut stream::ResponseEventSource::WebSocket(socket),
+                    ResponsesTransport::WebSocket.as_str(),
                     &request.observer.events,
                     required_call_index(request)?,
                     started_at,
@@ -219,7 +253,8 @@ impl ResponsesService {
             ),
             ResponsesAttemptKind::Compaction => ResponsesOutput::Compaction(
                 stream::receive_compaction(
-                    socket,
+                    &mut stream::ResponseEventSource::WebSocket(socket),
+                    ResponsesTransport::WebSocket.as_str(),
                     &request.observer.events,
                     required_call_index(request)?,
                     started_at,
@@ -247,6 +282,88 @@ impl ResponsesService {
             attempt: request.attempt,
             connection_generation: generation,
             server_reasoning_included: connection.server_reasoning_included,
+        })
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    async fn run_https(
+        &self,
+        request: &ResponsesAttempt,
+        started_at: Instant,
+    ) -> Result<ResponsesServiceResponse, ResponsesServiceError> {
+        if matches!(request.kind, ResponsesAttemptKind::Warmup) {
+            return Err(ResponsesServiceError::invalid_attempt_state(
+                "HTTPS Responses transport does not perform a warmup request",
+                FailurePhase::Protocol,
+                0,
+            ));
+        }
+        let encode_started_at = Instant::now();
+        let encoded = self.encode_request(&ConnectionState::new(), request)?;
+        let encode_duration_ns = elapsed_ns(encode_started_at);
+        let request_bytes = encoded.raw().get().len();
+        let transport = ResponsesTransport::Https.as_str();
+        let span = tracing::Span::current();
+        span.record("request.bytes", request_bytes);
+        span.record("request.encode.duration_ns", encode_duration_ns);
+        request.observer.emit(
+            AgentEventKind::ApiEvent,
+            ApiEvent {
+                direction: "outbound",
+                transport,
+                phase: request.kind.phase(),
+                model_call_index: request.call_index,
+                event: encoded.raw(),
+            },
+        )?;
+        let send_started_at = Instant::now();
+        let (mut response, metadata) = self
+            .send_https_with_auth_recovery(request.profile.session_id(), &encoded)
+            .await
+            .map_err(|error| ResponsesServiceError::responses(error, FailurePhase::Send, 0))?;
+        let send_duration_ns = elapsed_ns(send_started_at);
+        span.record("request.send.duration_ns", send_duration_ns);
+        let mut source = stream::ResponseEventSource::Https(&mut response);
+        let output = match request.kind {
+            ResponsesAttemptKind::Generation => ResponsesOutput::Generation(
+                stream::receive(
+                    &mut source,
+                    transport,
+                    &request.observer.events,
+                    required_call_index(request)?,
+                    started_at,
+                )
+                .await?,
+            ),
+            ResponsesAttemptKind::Compaction => ResponsesOutput::Compaction(
+                stream::receive_compaction(
+                    &mut source,
+                    transport,
+                    &request.observer.events,
+                    required_call_index(request)?,
+                    started_at,
+                )
+                .await?,
+            ),
+            ResponsesAttemptKind::Warmup => unreachable!("warmup rejected above"),
+        };
+        let pipeline_stats = match &output {
+            ResponsesOutput::Generation(result) => result.pipeline_stats,
+            ResponsesOutput::Compaction(result) => result.pipeline_stats,
+            ResponsesOutput::Warmup(_) => unreachable!("warmup rejected above"),
+        };
+        record_pipeline_stats(
+            &span,
+            request_bytes,
+            encode_duration_ns,
+            send_duration_ns,
+            pipeline_stats,
+        );
+        Ok(ResponsesServiceResponse {
+            output,
+            attempt: request.attempt,
+            connection_generation: 0,
+            server_reasoning_included: metadata.reasoning_included,
         })
     }
 
@@ -442,6 +559,37 @@ impl ResponsesService {
         ResponsesSocket::connect(&self.config.websocket_url, &auth, session_id).await
     }
 
+    #[cfg(not(target_family = "wasm"))]
+    async fn send_https_with_auth_recovery(
+        &self,
+        session_id: &str,
+        request: &EncodedRequest,
+    ) -> Result<(ResponsesHttpStream, HttpMetadata), ResponsesError> {
+        let auth = self.auth_snapshot().await?;
+        match self
+            .http
+            .send(&self.config.api_base_url, &auth, session_id, request)
+            .await
+        {
+            Err(ResponsesError::HttpRejected { status: 401, .. })
+                if auth.mode() == OpenAiAuthMode::ChatGpt =>
+            {
+                self.config
+                    .auth
+                    .recover_unauthorized(&auth)
+                    .await
+                    .map_err(|error| ResponsesError::Authorization {
+                        detail: error.to_string(),
+                    })?;
+                let refreshed = self.auth_snapshot().await?;
+                self.http
+                    .send(&self.config.api_base_url, &refreshed, session_id, request)
+                    .await
+            }
+            result => result,
+        }
+    }
+
     async fn auth_snapshot(&self) -> Result<OpenAiAuthSnapshot, ResponsesError> {
         self.config
             .auth
@@ -524,46 +672,62 @@ impl Service<ResponsesAttempt> for ResponsesService {
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, request: ResponsesAttempt) -> Self::Future {
+    fn call(&mut self, mut request: ResponsesAttempt) -> Self::Future {
         let service = self.clone();
-        let input_item_count = request.input_item_count();
-        let span = info_span!(
-            target: "nanocodex_service",
-            "responses.attempt",
-            otel.kind = "client",
-            otel.status_code = tracing::field::Empty,
-            phase = request.kind.phase(),
-            model.call_index = request.call_index,
-            attempt = request.attempt,
-            max_attempts = request.max_attempts,
-            replay.mode = request.replay_mode(),
-            model.input.item_count = input_item_count,
-            request.bytes = tracing::field::Empty,
-            request.encode.duration_ns = tracing::field::Empty,
-            request.send.duration_ns = tracing::field::Empty,
-            response.event.count = tracing::field::Empty,
-            response.bytes = tracing::field::Empty,
-            response.receive.wait_duration_ns = tracing::field::Empty,
-            response.parse.duration_ns = tracing::field::Empty,
-            response.emit.duration_ns = tracing::field::Empty,
-            response.decode.duration_ns = tracing::field::Empty,
-            response.socket_queue.duration_ns = tracing::field::Empty,
-            response.display_delta.count = tracing::field::Empty,
-            response.display_delta.bytes = tracing::field::Empty,
-            response.inter_delta_gap.max_ns = tracing::field::Empty,
-            response.inter_delta_stall_50ms.count = tracing::field::Empty,
-            response.inter_delta_stall_100ms.count = tracing::field::Empty,
-            response.inter_delta_stall_250ms.count = tracing::field::Empty,
-            status = tracing::field::Empty,
-            duration_ns = tracing::field::Empty,
-        );
-        Box::pin(
-            async move {
-                let mut connection = service.connection.lock().await;
-                service.run(&mut connection, &request).await
+        Box::pin(async move {
+            let mut connection = service.connection.lock().await;
+            if matches!(
+                service.config.responses_history,
+                ResponsesHistory::FullReplay
+            ) || (matches!(
+                service.config.responses_transport,
+                ResponsesTransport::Https
+            ) && !service.config.store_responses)
+                || (matches!(
+                    service.config.responses_transport,
+                    ResponsesTransport::WebSocket
+                ) && !service.config.store_responses
+                    && connection.socket.is_none()
+                    && request.previous_response_id().is_some())
+            {
+                request.force_full_replay();
             }
-            .instrument(span),
-        )
+            let input_item_count = request.input_item_count();
+            let span = info_span!(
+                target: "nanocodex_service",
+                "responses.attempt",
+                otel.kind = "client",
+                otel.status_code = tracing::field::Empty,
+                phase = request.kind.phase(),
+                model.call_index = request.call_index,
+                attempt = request.attempt,
+                max_attempts = request.max_attempts,
+                replay.mode = request.replay_mode(),
+                model.input.item_count = input_item_count,
+                request.bytes = tracing::field::Empty,
+                request.encode.duration_ns = tracing::field::Empty,
+                request.send.duration_ns = tracing::field::Empty,
+                response.event.count = tracing::field::Empty,
+                response.bytes = tracing::field::Empty,
+                response.receive.wait_duration_ns = tracing::field::Empty,
+                response.parse.duration_ns = tracing::field::Empty,
+                response.emit.duration_ns = tracing::field::Empty,
+                response.decode.duration_ns = tracing::field::Empty,
+                response.socket_queue.duration_ns = tracing::field::Empty,
+                response.display_delta.count = tracing::field::Empty,
+                response.display_delta.bytes = tracing::field::Empty,
+                response.inter_delta_gap.max_ns = tracing::field::Empty,
+                response.inter_delta_stall_50ms.count = tracing::field::Empty,
+                response.inter_delta_stall_100ms.count = tracing::field::Empty,
+                response.inter_delta_stall_250ms.count = tracing::field::Empty,
+                status = tracing::field::Empty,
+                duration_ns = tracing::field::Empty,
+            );
+            service
+                .run(&mut connection, &request)
+                .instrument(span)
+                .await
+        })
     }
 }
 

--- a/crates/nanocodex-service/src/service_error.rs
+++ b/crates/nanocodex-service/src/service_error.rs
@@ -141,7 +141,13 @@ impl From<ResponsesError> for ResponsesServiceError {
             ResponsesError::UnexpectedEnd
             | ResponsesError::Closed { .. }
             | ResponsesError::Receive(_) => FailurePhase::Receive,
+            #[cfg(not(target_family = "wasm"))]
+            ResponsesError::HttpRequest(_) | ResponsesError::InvalidSseUtf8(_) => {
+                FailurePhase::Receive
+            }
             ResponsesError::Api { .. } => FailurePhase::Api,
+            #[cfg(not(target_family = "wasm"))]
+            ResponsesError::HttpRejected { .. } => FailurePhase::Api,
             _ => FailurePhase::Protocol,
         };
         Self::responses(error, phase, 0)

--- a/crates/nanocodex-service/src/stream.rs
+++ b/crates/nanocodex-service/src/stream.rs
@@ -8,11 +8,13 @@ use nanocodex_core::{
 use serde::Serialize;
 use web_time::Instant;
 
+#[cfg(not(target_family = "wasm"))]
+use crate::http::ResponsesHttpStream;
 use crate::{
     ResponsesError,
     service_error::ResponsesServiceError,
     socket::{ResponsesSocket, decode_event, parse_raw_json},
-    telemetry::{ApiEvent, TRANSPORT, elapsed_ns},
+    telemetry::{ApiEvent, elapsed_ns},
 };
 
 const INVALID_IMAGE_ERROR: &str = "The image data you provided does not represent a valid image";
@@ -173,8 +175,27 @@ struct ReceivedServerEvent {
     api_event_seq: u64,
 }
 
+pub(crate) enum ResponseEventSource<'a> {
+    WebSocket(&'a mut ResponsesSocket),
+    #[cfg(not(target_family = "wasm"))]
+    Https(&'a mut ResponsesHttpStream),
+}
+
+impl ResponseEventSource<'_> {
+    async fn next_text_or_idle_timeout(
+        &mut self,
+    ) -> Result<crate::socket::ReceivedText, ResponsesError> {
+        match self {
+            Self::WebSocket(socket) => socket.next_text_or_idle_timeout().await,
+            #[cfg(not(target_family = "wasm"))]
+            Self::Https(stream) => stream.next_text_or_idle_timeout().await,
+        }
+    }
+}
+
 pub(crate) async fn receive(
-    socket: &mut ResponsesSocket,
+    source: &mut ResponseEventSource<'_>,
+    transport: &'static str,
     events: &EventSink,
     call_index: u32,
     started_at: Instant,
@@ -184,7 +205,15 @@ pub(crate) async fn receive(
     let mut timing = StreamTiming::new(started_at);
 
     loop {
-        let received = next_event(socket, events, "generation", call_index, &mut timing).await?;
+        let received = next_event(
+            source,
+            transport,
+            events,
+            "generation",
+            call_index,
+            &mut timing,
+        )
+        .await?;
         match received.event {
             ServerEvent::OutputItemAdded { output_index, item } => {
                 let Some(output_index) = output_index else {
@@ -319,7 +348,8 @@ fn emit_assistant_message(
 }
 
 pub(crate) async fn receive_compaction(
-    socket: &mut ResponsesSocket,
+    source: &mut ResponseEventSource<'_>,
+    transport: &'static str,
     events: &EventSink,
     call_index: u32,
     started_at: Instant,
@@ -328,7 +358,15 @@ pub(crate) async fn receive_compaction(
     let mut timing = StreamTiming::new(started_at);
 
     loop {
-        let received = next_event(socket, events, "compaction", call_index, &mut timing).await?;
+        let received = next_event(
+            source,
+            transport,
+            events,
+            "compaction",
+            call_index,
+            &mut timing,
+        )
+        .await?;
         match received.event {
             ServerEvent::OutputItemDone { item } => done_items.push(item),
             ServerEvent::Completed { mut response } => {
@@ -364,14 +402,15 @@ pub(crate) async fn receive_compaction(
 }
 
 async fn next_event(
-    socket: &mut ResponsesSocket,
+    source: &mut ResponseEventSource<'_>,
+    transport: &'static str,
     events: &EventSink,
     phase: &'static str,
     call_index: u32,
     timing: &mut StreamTiming,
 ) -> Result<ReceivedServerEvent, ResponsesServiceError> {
     let receive_started_at = Instant::now();
-    let received = socket.next_text_or_idle_timeout().await?;
+    let received = source.next_text_or_idle_timeout().await?;
     timing.pipeline.receive_wait_duration_ns = timing
         .pipeline
         .receive_wait_duration_ns
@@ -400,7 +439,7 @@ async fn next_event(
         AgentEventKind::ApiEvent,
         ApiEvent {
             direction: "inbound",
-            transport: TRANSPORT,
+            transport,
             phase,
             model_call_index: Some(call_index),
             event: raw_event,

--- a/crates/nanocodex/src/agent.rs
+++ b/crates/nanocodex/src/agent.rs
@@ -9,7 +9,8 @@ use std::{
 };
 
 use nanocodex_core::{
-    AgentEvents, EventSink, ModelConfig, OpenAiAuth, Prompt, ReasoningMode, Thinking,
+    AgentEvents, EventSink, ModelConfig, OpenAiAuth, OpenAiAuthMode, Prompt, ReasoningMode,
+    ResponsesHistory, ResponsesTransport, Thinking,
 };
 use nanocodex_service::{
     DefaultResponsesService, ResponsesAttempt, ResponsesClient, ResponsesService,
@@ -266,9 +267,9 @@ impl AgentHandle {
 }
 
 impl Nanocodex {
-    /// Builds a running agent with the standard instructions, tools, thinking level,
-    /// and Responses WebSocket stack, returning its prompt handle and ordered
-    /// event stream.
+    /// Builds a running agent with the standard instructions, tools, thinking
+    /// level, and Responses transport stack, returning its prompt handle and
+    /// ordered event stream.
     ///
     /// # Errors
     ///
@@ -1418,6 +1419,17 @@ where
 
 fn configure<S>(config: &mut ModelConfig, responses: &Responses<S>) {
     let mode = config.auth.mode();
+    config.responses_transport = responses.transport;
+    config.store_responses = responses
+        .store
+        .unwrap_or_else(|| mode.supports_stored_responses());
+    config.responses_history = responses.history.unwrap_or({
+        if matches!(responses.transport, ResponsesTransport::Https) && !config.store_responses {
+            ResponsesHistory::FullReplay
+        } else {
+            ResponsesHistory::Incremental
+        }
+    });
     config.websocket_url = responses
         .websocket_url
         .clone()
@@ -1438,14 +1450,31 @@ fn validate(
         .auth
         .validate()
         .map_err(|error| NanocodexError::InvalidRequest(error.to_string()))?;
-    if config.websocket_url.trim().is_empty() {
+    if matches!(config.responses_transport, ResponsesTransport::WebSocket)
+        && config.websocket_url.trim().is_empty()
+    {
         return Err(NanocodexError::InvalidRequest(
             "Responses WebSocket URL must not be empty".to_owned(),
         ));
     }
-    if config.api_base_url.trim().is_empty() {
+    if matches!(config.responses_transport, ResponsesTransport::Https)
+        && config.api_base_url.trim().is_empty()
+    {
         return Err(NanocodexError::InvalidRequest(
             "OpenAI API base URL must not be empty".to_owned(),
+        ));
+    }
+    if config.auth.mode() == OpenAiAuthMode::ChatGpt && config.store_responses {
+        return Err(NanocodexError::InvalidRequest(
+            "ChatGPT subscription authentication does not support store: true".to_owned(),
+        ));
+    }
+    if matches!(config.responses_transport, ResponsesTransport::Https)
+        && !config.store_responses
+        && matches!(config.responses_history, ResponsesHistory::Incremental)
+    {
+        return Err(NanocodexError::InvalidRequest(
+            "HTTPS with store: false requires full client-history replay".to_owned(),
         ));
     }
     if session_id.is_some_and(|session_id| session_id.trim().is_empty()) {

--- a/crates/nanocodex/src/lib.rs
+++ b/crates/nanocodex/src/lib.rs
@@ -31,9 +31,9 @@ pub use nanocodex_core::{
     InternalMessageMetadata, ItemStatus, JsonSchema, JsonValue, LocalShellAction,
     LocalShellExecAction, LocalShellStatus, MODEL, MessagePhase, MessageRole, OpenAiAuth,
     OpenAiAuthError, OpenAiAuthMode, OutputTextAnnotation, OutputTextLogprob, OutputTextTopLogprob,
-    Prompt, PromptInput, ReasoningContent, ReasoningMode, ReasoningSummary, ResponseItem, Thinking,
-    TimedAgentEvent, ToolCaller, ToolDefinition, Usage, UserInput, WebSearchAction,
-    monotonic_now_ns,
+    Prompt, PromptInput, ReasoningContent, ReasoningMode, ReasoningSummary, ResponseItem,
+    ResponsesHistory, ResponsesTransport, Thinking, TimedAgentEvent, ToolCaller, ToolDefinition,
+    Usage, UserInput, WebSearchAction, monotonic_now_ns,
 };
 #[cfg(not(target_family = "wasm"))]
 pub use nanocodex_macros::tool;

--- a/crates/nanocodex/src/model/agent.rs
+++ b/crates/nanocodex/src/model/agent.rs
@@ -1,12 +1,12 @@
 use std::{collections::HashMap, path::Path, sync::Arc};
 
 use nanocodex_core::{
-    AgentEventKind, EventSink, MODEL, ModelConfig, Prompt, ResponseItem, ToolDefinition, Usage,
-    responses::RequestProfile,
+    AgentEventKind, EventSink, MODEL, ModelConfig, Prompt, ResponseItem, ResponsesTransport,
+    ToolDefinition, Usage, responses::RequestProfile,
 };
 use nanocodex_service::{
     CodeCall, CodeCallKind, ResponsesAttempt, ResponsesAttemptFactory, ResponsesClient,
-    ResponsesOutput, ResponsesServiceResponse, TRANSPORT, TransportStats, TurnResult,
+    ResponsesOutput, ResponsesServiceResponse, TransportStats, TurnResult,
 };
 use serde::Serialize;
 use serde_json::value::RawValue;
@@ -298,6 +298,13 @@ impl<S> ModelRun<S> {
         )
     }
 
+    fn responses_endpoint(&self) -> &str {
+        match self.config.responses_transport {
+            ResponsesTransport::WebSocket => &self.config.websocket_url,
+            ResponsesTransport::Https => &self.config.api_base_url,
+        }
+    }
+
     fn load_agent_instructions(&self, workspace: &str) -> Result<Option<String>> {
         load_instructions(Path::new(workspace), self.global_instructions.as_deref())
     }
@@ -323,9 +330,9 @@ where
                 model: MODEL,
                 reasoning_mode: self.config.reasoning_mode.as_str(),
                 effort: self.config.thinking.as_str(),
-                transport: TRANSPORT,
+                transport: self.config.responses_transport.as_str(),
                 orchestration: ModelConfig::orchestration(),
-                websocket_url: display_endpoint(&self.config.websocket_url),
+                websocket_url: display_endpoint(self.responses_endpoint()),
                 workspace,
                 instruction_bytes: task.instruction.text_bytes(),
             },
@@ -364,9 +371,9 @@ where
                 model: MODEL,
                 reasoning_mode: self.config.reasoning_mode.as_str(),
                 effort: self.config.thinking.as_str(),
-                transport: TRANSPORT,
+                transport: self.config.responses_transport.as_str(),
                 orchestration: ModelConfig::orchestration(),
-                websocket_url: display_endpoint(&self.config.websocket_url),
+                websocket_url: display_endpoint(self.responses_endpoint()),
                 workspace: workspace.as_deref(),
                 instruction_bytes: task.instruction.text_bytes(),
             },
@@ -923,6 +930,9 @@ where
         &mut self,
         factory: &ResponsesAttemptFactory,
     ) -> Result<Option<String>> {
+        if matches!(self.config.responses_transport, ResponsesTransport::Https) {
+            return Ok(None);
+        }
         let started_at = Instant::now();
         self.events.emit(
             AgentEventKind::ModelWarmupStarted,

--- a/crates/nanocodex/src/model/agent_tests.rs
+++ b/crates/nanocodex/src/model/agent_tests.rs
@@ -1,14 +1,364 @@
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use eyre::{Result, eyre};
 use futures_util::{SinkExt, StreamExt};
 use serde_json::{Value, json};
-use tokio::{net::TcpListener, time::timeout};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    time::timeout,
+};
 use tokio_tungstenite::{WebSocketStream, accept_async, tungstenite::Message};
 
 use crate::{
-    AgentHandle, Nanocodex, NanocodexError, Prompt, Responses, ResponsesError, Thinking, Tools,
+    AgentHandle, Nanocodex, NanocodexError, OpenAiAuth, Prompt, Responses, ResponsesError,
+    ResponsesHistory, ResponsesTransport, Thinking, Tools,
 };
+
+#[derive(Clone)]
+struct StaticChatGptAuth;
+
+impl nanocodex_core::OpenAiAuthSource for StaticChatGptAuth {
+    fn validate(&self) -> std::result::Result<(), nanocodex_core::OpenAiAuthError> {
+        Ok(())
+    }
+
+    fn snapshot(
+        &self,
+    ) -> nanocodex_core::OpenAiAuthFuture<
+        '_,
+        std::result::Result<nanocodex_core::OpenAiAuthSnapshot, nanocodex_core::OpenAiAuthError>,
+    > {
+        Box::pin(async {
+            Ok(nanocodex_core::OpenAiAuthSnapshot::new(
+                nanocodex_core::OpenAiAuthMode::ChatGpt,
+                "subscription-token",
+                Some("account-123"),
+                false,
+                0,
+            ))
+        })
+    }
+
+    fn recover_unauthorized(
+        &self,
+        _rejected: &nanocodex_core::OpenAiAuthSnapshot,
+    ) -> nanocodex_core::OpenAiAuthFuture<
+        '_,
+        std::result::Result<(), nanocodex_core::OpenAiAuthError>,
+    > {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+fn chatgpt_auth() -> OpenAiAuth {
+    OpenAiAuth::managed_chatgpt(Arc::new(StaticChatGptAuth))
+}
+
+#[tokio::test]
+async fn https_ephemeral_replays_complete_follow_on_history() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("http://{}", listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        let first = next_http_json(&listener).await?;
+        assert_eq!(first.body["store"], false);
+        assert!(first.body.get("type").is_none());
+        assert!(first.body.get("previous_response_id").is_none());
+        assert!(first.body.to_string().contains("first prompt"));
+        send_http_final(first.stream, "resp-first").await?;
+
+        let second = next_http_json(&listener).await?;
+        assert_eq!(second.body["store"], false);
+        assert!(second.body.get("type").is_none());
+        assert!(second.body.get("previous_response_id").is_none());
+        let replay = second.body.to_string();
+        assert!(replay.contains("first prompt"));
+        assert!(replay.contains("done"));
+        assert!(replay.contains("second prompt"));
+        send_http_final(second.stream, "resp-second").await
+    });
+
+    let workspace = temporary_workspace("https-ephemeral-follow-on")?;
+    let responses = Responses::builder()
+        .transport(ResponsesTransport::Https)
+        .store(false)
+        .api_base_url(endpoint)
+        .build();
+    let (agent, events) = Nanocodex::builder("test-key")
+        .thinking(Thinking::Low)
+        .workspace(&workspace)
+        .responses(responses)
+        .session_id("https-ephemeral")
+        .build()?;
+    assert_eq!(
+        agent
+            .prompt("first prompt")
+            .await?
+            .result()
+            .await?
+            .final_message,
+        "done"
+    );
+    assert_eq!(
+        agent
+            .prompt("second prompt")
+            .await?
+            .result()
+            .await?
+            .final_message,
+        "done"
+    );
+    drop((agent, events));
+    timeout(std::time::Duration::from_secs(5), server)
+        .await
+        .map_err(|_| eyre!("mock HTTPS Responses server did not finish"))???;
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn https_stored_fork_uses_the_historical_response_checkpoint() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("http://{}", listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        let root = next_http_json(&listener).await?;
+        assert_eq!(root.body["store"], true);
+        assert!(root.body.get("previous_response_id").is_none());
+        send_http_final(root.stream, "resp-root").await?;
+
+        let branch = next_http_json(&listener).await?;
+        assert_eq!(branch.body["store"], true);
+        assert_eq!(branch.body["previous_response_id"], "resp-root");
+        assert!(branch.body.to_string().contains("branch prompt"));
+        send_http_final(branch.stream, "resp-branch").await
+    });
+
+    let workspace = temporary_workspace("https-stored-fork")?;
+    let responses = Responses::builder()
+        .transport(ResponsesTransport::Https)
+        .store(true)
+        .api_base_url(endpoint)
+        .build();
+    let (agent, root_events) = Nanocodex::builder("test-key")
+        .thinking(Thinking::Low)
+        .workspace(&workspace)
+        .responses(responses)
+        .session_id("https-stored")
+        .build()?;
+    let root = agent.prompt("root prompt").await?.result().await?;
+    let (fork, fork_events) = agent.fork_from(&root).await?;
+    assert_eq!(
+        fork.prompt("branch prompt")
+            .await?
+            .result()
+            .await?
+            .final_message,
+        "done"
+    );
+    drop((agent, fork, root_events, fork_events));
+    timeout(std::time::Duration::from_secs(5), server)
+        .await
+        .map_err(|_| eyre!("mock HTTPS Responses server did not finish"))???;
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn chatgpt_https_uses_subscription_headers_and_ephemeral_replay() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("http://{}", listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        let request = next_http_json(&listener).await?;
+        assert!(
+            request
+                .headers
+                .contains("authorization: bearer subscription-token")
+        );
+        assert!(request.headers.contains("chatgpt-account-id: account-123"));
+        assert_eq!(request.body["store"], false);
+        assert!(request.body.get("previous_response_id").is_none());
+        send_http_final(request.stream, "resp-chatgpt").await
+    });
+
+    let workspace = temporary_workspace("https-chatgpt")?;
+    let responses = Responses::builder()
+        .transport(ResponsesTransport::Https)
+        .api_base_url(endpoint)
+        .build();
+    let (agent, events) = Nanocodex::builder(chatgpt_auth())
+        .thinking(Thinking::Low)
+        .workspace(&workspace)
+        .responses(responses)
+        .session_id("https-chatgpt")
+        .build()?;
+    assert_eq!(
+        agent
+            .prompt("subscription prompt")
+            .await?
+            .result()
+            .await?
+            .final_message,
+        "done"
+    );
+    drop((agent, events));
+    timeout(std::time::Duration::from_secs(5), server)
+        .await
+        .map_err(|_| eyre!("mock HTTPS Responses server did not finish"))???;
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[test]
+fn rejects_invalid_auth_storage_and_https_history_policies() {
+    let stored_chatgpt = Responses::builder().store(true).build();
+    let error = Nanocodex::builder(chatgpt_auth())
+        .responses(stored_chatgpt)
+        .build()
+        .err()
+        .expect("ChatGPT store:true must fail");
+    assert!(
+        error
+            .to_string()
+            .contains("ChatGPT subscription authentication does not support store: true")
+    );
+
+    let incremental_ephemeral_https = Responses::builder()
+        .transport(ResponsesTransport::Https)
+        .store(false)
+        .history(ResponsesHistory::Incremental)
+        .build();
+    let error = Nanocodex::builder("test-key")
+        .responses(incremental_ephemeral_https)
+        .build()
+        .err()
+        .expect("ephemeral HTTPS incremental history must fail");
+    assert!(
+        error
+            .to_string()
+            .contains("HTTPS with store: false requires full client-history replay")
+    );
+}
+
+#[tokio::test]
+async fn websocket_ephemeral_chains_on_connection_and_replays_a_fresh_fork() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("ws://{}", listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await?;
+        let mut root = accept_async(stream).await?;
+        let warmup = next_json(&mut root).await?;
+        assert_eq!(warmup["store"], false);
+        assert_eq!(warmup["generate"], false);
+        send_warmup(&mut root, "resp-warmup").await?;
+
+        let first = next_json(&mut root).await?;
+        assert_eq!(first["store"], false);
+        assert_eq!(first["previous_response_id"], "resp-warmup");
+        send_final(&mut root, "resp-first").await?;
+
+        let second = next_json(&mut root).await?;
+        assert_eq!(second["previous_response_id"], "resp-first");
+        assert_eq!(second["input"].as_array().map(Vec::len), Some(1));
+        send_final(&mut root, "resp-second").await?;
+
+        let (stream, _) = listener.accept().await?;
+        let mut branch = accept_async(stream).await?;
+        let replay = next_json(&mut branch).await?;
+        assert_eq!(replay["store"], false);
+        assert!(replay.get("previous_response_id").is_none());
+        let replay = replay.to_string();
+        assert!(replay.contains("first prompt"));
+        assert!(replay.contains("branch prompt"));
+        send_final(&mut branch, "resp-branch").await
+    });
+
+    let workspace = temporary_workspace("websocket-ephemeral-fork")?;
+    let responses = Responses::builder()
+        .websocket_url(endpoint)
+        .store(false)
+        .build();
+    let (agent, root_events) = Nanocodex::builder("test-key")
+        .thinking(Thinking::Low)
+        .workspace(&workspace)
+        .responses(responses)
+        .session_id("websocket-ephemeral")
+        .build()?;
+    let first = agent.prompt("first prompt").await?.result().await?;
+    assert_eq!(
+        agent
+            .prompt("second prompt")
+            .await?
+            .result()
+            .await?
+            .final_message,
+        "done"
+    );
+    let (fork, fork_events) = agent.fork_from(&first).await?;
+    assert_eq!(
+        fork.prompt("branch prompt")
+            .await?
+            .result()
+            .await?
+            .final_message,
+        "done"
+    );
+    drop((agent, fork, root_events, fork_events));
+    timeout(std::time::Duration::from_secs(5), server)
+        .await
+        .map_err(|_| eyre!("mock Responses server did not finish"))???;
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn websocket_full_replay_never_sends_a_previous_response_id() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("ws://{}", listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await?;
+        let mut socket = accept_async(stream).await?;
+        let warmup = next_json(&mut socket).await?;
+        send_warmup(&mut socket, "resp-warmup").await?;
+
+        let first = next_json(&mut socket).await?;
+        assert!(first.get("previous_response_id").is_none());
+        assert!(first.to_string().contains("first prompt"));
+        send_final(&mut socket, "resp-first").await?;
+
+        let second = next_json(&mut socket).await?;
+        assert!(second.get("previous_response_id").is_none());
+        let replay = second.to_string();
+        assert!(replay.contains("first prompt"));
+        assert!(replay.contains("second prompt"));
+        send_final(&mut socket, "resp-second").await?;
+        drop(warmup);
+        Result::<()>::Ok(())
+    });
+
+    let workspace = temporary_workspace("websocket-full-replay")?;
+    let responses = Responses::builder()
+        .websocket_url(endpoint)
+        .store(false)
+        .history(ResponsesHistory::FullReplay)
+        .build();
+    let (agent, events) = Nanocodex::builder("test-key")
+        .thinking(Thinking::Low)
+        .workspace(&workspace)
+        .responses(responses)
+        .session_id("websocket-replay")
+        .build()?;
+    agent.prompt("first prompt").await?.result().await?;
+    agent.prompt("second prompt").await?.result().await?;
+    drop((agent, events));
+    timeout(std::time::Duration::from_secs(5), server)
+        .await
+        .map_err(|_| eyre!("mock Responses server did not finish"))???;
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
 
 #[tokio::test]
 async fn follow_on_prompts_reuse_the_session_socket_and_context() -> Result<()> {
@@ -2287,6 +2637,64 @@ fn completed_response_with_usage(response_id: &str, output: &[Value], total_toke
             }
         }
     })
+}
+
+struct CapturedHttpRequest {
+    stream: TcpStream,
+    headers: String,
+    body: Value,
+}
+
+async fn next_http_json(listener: &TcpListener) -> Result<CapturedHttpRequest> {
+    let (mut stream, _) = listener.accept().await?;
+    let mut bytes = Vec::with_capacity(4096);
+    let header_end = loop {
+        if let Some(position) = bytes.windows(4).position(|window| window == b"\r\n\r\n") {
+            break position + 4;
+        }
+        let read = stream.read_buf(&mut bytes).await?;
+        if read == 0 {
+            return Err(eyre!("HTTPS test client closed before request headers"));
+        }
+    };
+    let headers = String::from_utf8(bytes[..header_end].to_vec())?.to_ascii_lowercase();
+    let content_length = headers
+        .lines()
+        .find_map(|line| line.strip_prefix("content-length:"))
+        .map(str::trim)
+        .ok_or_else(|| eyre!("HTTPS test request omitted Content-Length"))?
+        .parse::<usize>()?;
+    while bytes.len() - header_end < content_length {
+        let read = stream.read_buf(&mut bytes).await?;
+        if read == 0 {
+            return Err(eyre!("HTTPS test client closed before request body"));
+        }
+    }
+    let body = serde_json::from_slice(&bytes[header_end..header_end + content_length])?;
+    Ok(CapturedHttpRequest {
+        stream,
+        headers,
+        body,
+    })
+}
+
+async fn send_http_final(mut stream: TcpStream, response_id: &str) -> Result<()> {
+    let event = completed_response(
+        response_id,
+        &[json!({
+            "type": "message",
+            "role": "assistant",
+            "content": [{ "type": "output_text", "text": "done" }]
+        })],
+    );
+    let body = format!("data: {event}\n\ndata: [DONE]\n\n");
+    let response = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream.write_all(response.as_bytes()).await?;
+    stream.shutdown().await?;
+    Ok(())
 }
 
 async fn next_json<S>(socket: &mut WebSocketStream<S>) -> Result<Value>

--- a/crates/nanocodex/src/model/telemetry.rs
+++ b/crates/nanocodex/src/model/telemetry.rs
@@ -11,7 +11,7 @@ use web_time::Instant;
 #[cfg(not(target_family = "wasm"))]
 use crate::NanocodexError;
 use crate::Result;
-use nanocodex_service::{TRANSPORT, TransportStatsDelta};
+use nanocodex_service::TransportStatsDelta;
 use nanocodex_tools::ToolOutputBody;
 
 const COST_STATUS: &str = "not_reported_by_responses_api";
@@ -230,7 +230,7 @@ pub(super) fn terminal_payload<'a>(
         model: nanocodex_core::MODEL,
         reasoning_mode: config.reasoning_mode.as_str(),
         effort: config.thinking.as_str(),
-        transport: TRANSPORT,
+        transport: config.responses_transport.as_str(),
         orchestration: ModelConfig::orchestration(),
         duration_ms: duration_ms(elapsed),
         duration_ns: duration_ns(elapsed),

--- a/crates/nanocodex/src/responses.rs
+++ b/crates/nanocodex/src/responses.rs
@@ -3,6 +3,8 @@ use tower::{
     layer::util::{Identity, Stack},
 };
 
+use nanocodex_core::{ResponsesHistory, ResponsesTransport};
+
 /// Marker used until the standard Responses service is constructed by the
 /// agent builder.
 #[derive(Clone, Copy, Debug, Default)]
@@ -26,6 +28,9 @@ pub struct FactoryResponses<F>(pub(crate) F);
 pub struct Responses<S = StandardResponses> {
     pub(crate) websocket_url: Option<String>,
     pub(crate) api_base_url: Option<String>,
+    pub(crate) transport: ResponsesTransport,
+    pub(crate) history: Option<ResponsesHistory>,
+    pub(crate) store: Option<bool>,
     pub(crate) service: S,
 }
 
@@ -34,6 +39,9 @@ impl Default for Responses<StandardResponses> {
         Self {
             websocket_url: None,
             api_base_url: None,
+            transport: ResponsesTransport::WebSocket,
+            history: None,
+            store: None,
             service: StandardResponses,
         }
     }
@@ -49,7 +57,7 @@ impl Responses<StandardResponses> {
 }
 
 impl ResponsesBuilder<StandardResponses> {
-    /// Adds a Tower layer around the SDK's standard persistent WebSocket and
+    /// Adds a Tower layer around the SDK's standard Responses transport and
     /// retry service. Layers are not materialized until
     /// [`crate::NanocodexBuilder::build`].
     #[must_use]
@@ -58,6 +66,9 @@ impl ResponsesBuilder<StandardResponses> {
             responses: Responses {
                 websocket_url: self.responses.websocket_url,
                 api_base_url: self.responses.api_base_url,
+                transport: self.responses.transport,
+                history: self.responses.history,
+                store: self.responses.store,
                 service: LayeredResponses(ServiceBuilder::new().layer(layer)),
             },
         }
@@ -74,6 +85,9 @@ impl ResponsesBuilder<StandardResponses> {
             responses: Responses {
                 websocket_url: self.responses.websocket_url,
                 api_base_url: self.responses.api_base_url,
+                transport: self.responses.transport,
+                history: self.responses.history,
+                store: self.responses.store,
                 service: FactoryResponses(factory),
             },
         }
@@ -88,6 +102,9 @@ impl<L> ResponsesBuilder<LayeredResponses<L>> {
             responses: Responses {
                 websocket_url: self.responses.websocket_url,
                 api_base_url: self.responses.api_base_url,
+                transport: self.responses.transport,
+                history: self.responses.history,
+                store: self.responses.store,
                 service: LayeredResponses(self.responses.service.0.layer(layer)),
             },
         }
@@ -100,6 +117,34 @@ pub struct ResponsesBuilder<S> {
 }
 
 impl<S> ResponsesBuilder<S> {
+    /// Selects the transport once for the complete lifetime of an agent and
+    /// every child or fork created from it.
+    #[must_use]
+    pub const fn transport(mut self, transport: ResponsesTransport) -> Self {
+        self.responses.transport = transport;
+        self
+    }
+
+    /// Selects incremental response-ID chaining or complete history replay.
+    ///
+    /// When omitted, HTTPS with `store: false` selects full replay and all
+    /// other combinations select incremental chaining.
+    #[must_use]
+    pub const fn history(mut self, history: ResponsesHistory) -> Self {
+        self.responses.history = Some(history);
+        self
+    }
+
+    /// Controls whether Responses checkpoints are retained by the API.
+    ///
+    /// The default is `true` for API-key authentication and `false` for
+    /// `ChatGPT` subscription authentication.
+    #[must_use]
+    pub const fn store(mut self, store: bool) -> Self {
+        self.responses.store = Some(store);
+        self
+    }
+
     #[must_use]
     pub fn websocket_url(mut self, url: impl Into<String>) -> Self {
         self.responses.websocket_url = Some(url.into());

--- a/crates/nanocodex/src/wasm.rs
+++ b/crates/nanocodex/src/wasm.rs
@@ -140,6 +140,9 @@ impl WasmNanocodex {
             auth: nanocodex_core::OpenAiAuth::api_key(config.api_key),
             reasoning_mode,
             thinking,
+            responses_transport: nanocodex_core::ResponsesTransport::WebSocket,
+            responses_history: nanocodex_core::ResponsesHistory::Incremental,
+            store_responses: true,
             websocket_url: config.websocket_url,
             api_base_url: config.api_base_url,
             system_prompt: config

--- a/docs/RESPONSES_TOWER.md
+++ b/docs/RESPONSES_TOWER.md
@@ -1,4 +1,4 @@
-# Responses WebSocket and Tower architecture
+# Responses transports and Tower architecture
 
 Status: implemented.
 
@@ -13,9 +13,10 @@ returns `(Nanocodex, AgentEvents)`. The driver owns mutable conversation,
 model, tool-runtime, and Tower service state. Each accepted prompt returns a
 `Turn`; `turn.result()` is independent from the optional event stream.
 
-One driver reuses its WebSocket, server response chain, typed history,
-code-mode runtime, shell sessions, and prompt-cache identity across follow-on
-turns. The caller does not replay earlier results.
+One driver reuses its selected transport policy, server response chain, typed
+history, code-mode runtime, shell sessions, and prompt-cache identity across
+follow-on turns. A WebSocket policy also reuses its connection. The caller does
+not replay earlier results.
 
 `ResponsesClient<S>` is generic over `Service<ResponsesAttempt>`. The common
 builder defers caller layers until it constructs the configured standard
@@ -58,21 +59,22 @@ retry, metrics, tracing, and error-mapping layers. Returning success after only
 sending a frame would make those policies incorrect.
 
 `ResponsesAttempt` is an owned replay snapshot. Large history is shared by
-`Arc`; cloning an attempt does not deep-clone the conversation. A healthy socket
-sends only the new delta with `previous_response_id`. A replacement socket
-invalidates that connection-local ID and serializes the full committed history.
+`Arc`; cloning an attempt does not deep-clone the conversation. Incremental
+history sends only the new delta with `previous_response_id`. Full-replay
+history serializes the complete committed conversation. A replacement
+ephemeral socket invalidates its connection-local ID and also replays history.
 
 Only completed responses enter history. Failed partial output cannot execute a
 tool or be replayed, so retry cannot duplicate a partial side effect.
 
 ## Standard resilience
 
-The default stack is one typed retry owner around one persistent socket:
+The default stack is one typed retry owner around one configured transport:
 
 ```text
 ResponsesRetryPolicy
   -> ResponsesService
-       -> ResponsesSocket
+       -> ResponsesSocket | HTTPS/SSE request
 ```
 
 Generation and compaction receive at most five attempts. Transient connection,
@@ -82,9 +84,10 @@ policy, quota, usage-limit, and context failures remain terminal. Server delay
 hints override bounded exponential backoff.
 
 Reconnect preserves the stable prompt-cache key and client-owned history,
-drops `previous_response_id`, and forces full-history replay. Requests retain
-`store: false`; prompt caching is an optimization, not the history source of
-truth.
+drops a connection-local `previous_response_id`, and forces full-history
+replay. HTTPS with `store: false` always replays because it has no
+connection-local checkpoint. Prompt caching is an optimization, not the
+history source of truth.
 
 ## Caller middleware
 

--- a/docs/RESPONSES_TOWER.md
+++ b/docs/RESPONSES_TOWER.md
@@ -146,6 +146,10 @@ cargo bench -p nanocodex-service --bench tower_responses
 Add `NANOCODEX_BENCH_EVENTS=/path/to/events.jsonl` to include a retained JSONL
 trace without checking private runtime data into the repository.
 
+The live [transport and storage benchmark](RESPONSE_TRANSPORT_BENCH.md) compares
+WebSocket and HTTPS/SSE, stored checkpoints and `store: false`, full history
+replay, and concurrent historical forks.
+
 ## Invariants
 
 - A partial response commits no history and executes no tool.

--- a/docs/RESPONSES_TOWER.md
+++ b/docs/RESPONSES_TOWER.md
@@ -18,6 +18,16 @@ history, code-mode runtime, shell sessions, and prompt-cache identity across
 follow-on turns. A WebSocket policy also reuses its connection. The caller does
 not replay earlier results.
 
+The standard policy is WebSocket plus incremental history. API-key
+authentication defaults to `store: true`; ChatGPT subscription authentication
+defaults to `store: false`. Selecting HTTPS with ChatGPT automatically selects
+full replay. WebSocket is the interactive default because its reused
+connection has the lowest measured warm first-event latency. Native callers
+can select HTTPS when cold start or fresh-fork startup matters more, but a
+session and every fork retain the one policy selected at build time. See
+[`RESPONSE_TRANSPORT_BENCH.md`](RESPONSE_TRANSPORT_BENCH.md) for the measured
+tradeoffs.
+
 `ResponsesClient<S>` is generic over `Service<ResponsesAttempt>`. The common
 builder defers caller layers until it constructs the configured standard
 service:

--- a/docs/RESPONSE_TRANSPORT_BENCH.md
+++ b/docs/RESPONSE_TRANSPORT_BENCH.md
@@ -1,0 +1,155 @@
+# Responses transport and storage benchmark
+
+`response-transport-bench` is a direct live-API experiment for separating the
+effects of transport, server storage, incremental response IDs, client-owned
+history replay, and historical forks. It is not a second Nanocodex runtime.
+
+## Matrix
+
+The benchmark holds the model, prompt prefix, prompt-cache key policy,
+reasoning effort, response validation, and concurrent fork workload constant.
+With OpenAI API-key authentication, it runs the seven supported combinations:
+
+| Variant | Transport | `store` | Mainline history | Fresh fork history |
+| --- | --- | ---: | --- | --- |
+| `ws-store-checkpoint` | WebSocket | `true` | response ID | response ID |
+| `ws-store-replay` | WebSocket | `true` | full replay | full replay |
+| `ws-ephemeral-connection` | WebSocket | `false` | connection-local response ID | full replay |
+| `ws-ephemeral-replay` | WebSocket | `false` | full replay | full replay |
+| `https-store-checkpoint` | HTTPS/SSE | `true` | response ID | response ID |
+| `https-store-replay` | HTTPS/SSE | `true` | full replay | full replay |
+| `https-ephemeral-replay` | HTTPS/SSE | `false` | full replay | full replay |
+
+HTTPS plus `store: false` cannot give a later request or a fresh fork a durable
+server checkpoint, so there is no `https-ephemeral-checkpoint` row. The
+WebSocket can reuse a response ID while that connection lives even with
+`store: false`; a fork opens an independent connection and therefore replays
+the complete committed history. This is the important Codex-like hybrid.
+The local Codex reference builds ordinary OpenAI requests with `store: false`
+in `codex-rs/core/src/client.rs`, sends the complete request through its HTTPS
+path, and derives a response-ID plus input-delta request only when its
+turn-scoped WebSocket sees a strict extension of the previous input.
+
+Each retained history checkpoint is an immutable linked segment. Cloning a
+checkpoint shares its entire prefix, while serialization walks the segments
+oldest-first. Fork setup therefore does not deep-clone response items even when
+the transport policy later requires a full replay.
+
+## Authentication compatibility
+
+The complete seven-row matrix requires `OPENAI_API_KEY`. ChatGPT subscription
+credentials from `~/.codex/auth.json` use the Codex backend endpoints, attach
+the ChatGPT account header, and deliberately send `store: false`. Consequently,
+the compatible transport policies are:
+
+| Policy | ChatGPT `auth.json` | Current Nanocodex runtime |
+| --- | --- | --- |
+| WebSocket, connection-local response ID, replay on a fresh fork | yes | yes |
+| WebSocket, full replay | yes | transport supports it |
+| HTTPS/SSE, full replay | yes | benchmark/reference path only |
+| Any `store: true` checkpoint policy | no | no |
+
+The benchmark executable itself currently exercises API-key authentication so
+that every row can be compared in one run. The compatibility claims above come
+from Nanocodex's auth-mode request construction and the reviewed local Codex
+HTTPS and WebSocket request paths, not from reusing a ChatGPT access token
+against `api.openai.com`.
+
+## Measurements
+
+For each request the JSON report records:
+
+- exact serialized request bytes and encoding time;
+- time to first streamed event and time through `response.completed`;
+- input, cached-input, cache-write, and output tokens;
+- WebSocket setup time where applicable.
+
+It also records chain wall time, local fork-snapshot clone time, and concurrent
+mainline-plus-forks wall time. Every assistant reply is checked against an
+exact expected token. Stored responses are deleted at the end unless
+`FORK_BENCH_RETAIN=1`.
+
+Run the complete default matrix with:
+
+```sh
+FORK_BENCH_OUTPUT=.nanocodex/benchmarks/response-transports.json \
+  cargo run --release -p nanocodex-examples --bin response-transport-bench
+```
+
+Useful controls are:
+
+```text
+FORK_BENCH_TURNS
+FORK_BENCH_FORK_TURNS             comma-separated, for example 2,4
+FORK_BENCH_MAINLINE_CONTINUATIONS
+FORK_BENCH_PREFIX_FACTS
+FORK_BENCH_REPEATS
+FORK_BENCH_VARIANTS               comma-separated names or all
+FORK_BENCH_OUTPUT
+FORK_BENCH_RETAIN
+OPENAI_API_KEY
+OPENAI_API_BASE_URL
+OPENAI_RESPONSES_WEBSOCKET_URL
+```
+
+Repeated runs rotate variant order to reduce a fixed ordering bias.
+
+## July 22, 2026 snapshot
+
+The retained local report is
+`.nanocodex/benchmarks/response-transport-repeated.json` and is intentionally
+outside Git. The release-build workload used two chain turns, forks from both
+turns, one simultaneous mainline continuation, 600 deterministic prefix facts,
+and three order-rotated repetitions. The table reports medians across the three
+trials; response and first-event medians include every request in that phase.
+
+| Variant | Chain request bytes | Chain response | Chain first event | Mean fork request bytes | Fork response | Mainline + forks wall |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `ws-store-checkpoint` | 26,907 | 1,116 ms | 124 ms | 785 | 1,290 ms | 1,759 ms |
+| `ws-store-replay` | 52,616 | 1,226 ms | 140 ms | 26,681 | 1,556 ms | 2,179 ms |
+| `ws-ephemeral-connection` | 26,933 | 1,089 ms | 122 ms | 26,706 | 2,180 ms | 2,935 ms |
+| `ws-ephemeral-replay` | 52,642 | 898 ms | 118 ms | 26,694 | 867 ms | 1,467 ms |
+| `https-store-checkpoint` | 26,743 | 1,073 ms | 342 ms | 703 | 1,385 ms | 1,712 ms |
+| `https-store-replay` | 52,452 | 936 ms | 350 ms | 26,599 | 1,608 ms | 1,728 ms |
+| `https-ephemeral-replay` | 52,478 | 946 ms | 308 ms | 26,612 | 1,387 ms | 1,671 ms |
+
+The stable findings from this small workload are:
+
+1. A stored response checkpoint reduced each fork request from about 26.6 KiB
+   to 0.7-0.8 KiB, a roughly 97% reduction. Incremental mainline chaining
+   roughly halved the two-turn request total because the initial request still
+   carried the complete prefix.
+2. `store: false` did not prevent delta requests on the persistent WebSocket,
+   but fresh forks had to rebroadcast their complete committed histories.
+3. Prompt caching was unchanged across the matrix: every chain reported 8,451
+   cached tokens out of 16,933 input tokens (49.9%). Storage and replay policy
+   did not improve this workload's cache-token ratio.
+4. WebSocket first-event latency was consistently lower: roughly 118-140 ms
+   on the chain versus 308-350 ms over HTTPS. A new WebSocket cost roughly
+   359-401 ms for the root and 468-499 ms for each fresh fork, so the benefit is
+   naturally strongest on a long-lived mainline and weaker for one-shot forks.
+5. Local checkpoint cloning took about 0.6-1.2 microseconds. Full-history JSON
+   encoding was about 18-20 microseconds at this size. These local costs were
+   negligible beside transport and inference, while request volume remained a
+   material scaling difference.
+
+End-to-end model completion and concurrent fork latency varied substantially
+between repetitions, including multi-second backend outliers. The snapshot is
+strong evidence for byte volume, cache behavior, connection setup, and
+first-event behavior; it is not enough evidence that `store` itself changes
+model generation latency. Larger histories and more repetitions should be used
+before making a release-level latency claim.
+
+## Design implication
+
+The TUI should select one transport and storage policy when it creates an agent
+session; forks should preserve that policy rather than switching transports.
+The persistent WebSocket optimization matters for interactive first-event
+latency and cheap mainline deltas. `store: true` matters independently when a
+branch must start from a historical checkpoint on a fresh connection: it
+avoids replaying that branch's retained history. If storage is unavailable,
+including with ChatGPT subscription authentication, the performant fallback is
+the current immutable segmented client-owned history, concurrent fork
+execution, stable cache key, and full replay on each fresh fork. HTTPS remains
+a viable single-session policy and can use stored checkpoints with API-key
+authentication when storage is enabled.

--- a/docs/RESPONSE_TRANSPORT_BENCH.md
+++ b/docs/RESPONSE_TRANSPORT_BENCH.md
@@ -90,9 +90,10 @@ For each request the JSON report records:
 - input, cached-input, cache-write, and output tokens;
 - WebSocket setup time where applicable.
 
-It also records chain wall time, local fork-snapshot clone time, and concurrent
-mainline-plus-forks wall time. Every assistant reply is checked against an
-exact expected token. Stored responses are deleted at the end unless
+It also normalizes cold start-to-first-event and completion, warm reused-client
+medians, local fork-snapshot clone time, fresh-fork setup and start timing, and
+concurrent mainline-plus-forks wall time. Every assistant reply is checked
+against an exact expected token. Stored responses are deleted at the end unless
 `FORK_BENCH_RETAIN=1`.
 
 Run the complete default matrix with:
@@ -120,51 +121,86 @@ OPENAI_RESPONSES_WEBSOCKET_URL
 
 Repeated runs rotate variant order to reduce a fixed ordering bias.
 
-## July 22, 2026 snapshot
+## July 23, 2026 ten-turn rerun
 
-The retained local report is
-`.nanocodex/benchmarks/response-transport-repeated.json` and is intentionally
-outside Git. The release-build workload used two chain turns, forks from both
-turns, one simultaneous mainline continuation, 600 deterministic prefix facts,
-and three order-rotated repetitions. The table reports medians across the three
-trials; response and first-event medians include every request in that phase.
+The retained raw reports are
+`.nanocodex/benchmarks/response-transport-10turn-rerun.json` and
+`.nanocodex/benchmarks/response-transport-10turn-ws-store-replay-replacement.json`;
+they are intentionally outside Git. The release-build workload used ten chain
+turns, historical forks from turns 3, 6, and 9, one simultaneous mainline
+continuation, 600 deterministic prefix facts, and three successful samples per
+variant. Variant order rotated between repetitions. One `ws-store-replay`
+sample was rejected after a transient peer TLS EOF and replaced with a clean
+targeted sample; it is not included in the medians.
 
-| Variant | Chain request bytes | Chain response | Chain first event | Mean fork request bytes | Fork response | Mainline + forks wall |
+Cold timing starts before fresh transport setup and includes the first request.
+For WebSocket this includes the handshake; for HTTPS the first request includes
+connection establishment. Warm medians cover chain turns 2 through 10 on the
+reused WebSocket or pooled HTTPS client. Compilation and process startup are
+excluded.
+
+| Variant | Cold first event | Cold complete | Warm first event | Warm complete | 10-turn request bytes |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `ws-store-checkpoint` | 679 ms | 1,847 ms | 80 ms | 1,047 ms | 32,974 |
+| `ws-store-replay` | 657 ms | 2,202 ms | 151 ms | 1,243 ms | 277,051 |
+| `ws-ephemeral-connection` | 587 ms | 1,380 ms | 99 ms | 955 ms | 33,104 |
+| `ws-ephemeral-replay` | 610 ms | 1,564 ms | 97 ms | 920 ms | 277,181 |
+| `https-store-checkpoint` | 400 ms | 1,211 ms | 369 ms | 1,241 ms | 32,154 |
+| `https-store-replay` | 374 ms | 1,944 ms | 361 ms | 1,315 ms | 276,231 |
+| `https-ephemeral-replay` | 405 ms | 1,260 ms | 277 ms | 1,051 ms | 276,361 |
+
+Fork snapshot cloning is the local cost before transport work. Fork
+start-to-first and start-to-complete include each branch's fresh transport
+setup and request. HTTPS setup rounds to zero because cloning the pooled client
+is local; any new network connection remains inside start-to-first. Race wall
+is the concurrent completion time for one mainline request and all three
+forks.
+
+| Variant | Clone per fork | Fork setup | Fork first event | Fork complete | Three-fork bytes | Mainline + forks wall |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| `ws-store-checkpoint` | 26,907 | 1,116 ms | 124 ms | 785 | 1,290 ms | 1,759 ms |
-| `ws-store-replay` | 52,616 | 1,226 ms | 140 ms | 26,681 | 1,556 ms | 2,179 ms |
-| `ws-ephemeral-connection` | 26,933 | 1,089 ms | 122 ms | 26,706 | 2,180 ms | 2,935 ms |
-| `ws-ephemeral-replay` | 52,642 | 898 ms | 118 ms | 26,694 | 867 ms | 1,467 ms |
-| `https-store-checkpoint` | 26,743 | 1,073 ms | 342 ms | 703 | 1,385 ms | 1,712 ms |
-| `https-store-replay` | 52,452 | 936 ms | 350 ms | 26,599 | 1,608 ms | 1,728 ms |
-| `https-ephemeral-replay` | 52,478 | 946 ms | 308 ms | 26,612 | 1,387 ms | 1,671 ms |
+| `ws-store-checkpoint` | 0.4 µs | 910 ms | 1,069 ms | 2,281 ms | 2,346 | 2,489 ms |
+| `ws-store-replay` | 0.4 µs | 971 ms | 1,135 ms | 2,040 ms | 84,759 | 2,217 ms |
+| `ws-ephemeral-connection` | 0.4 µs | 912 ms | 1,012 ms | 1,800 ms | 84,834 | 3,673 ms |
+| `ws-ephemeral-replay` | 0.4 µs | 832 ms | 999 ms | 2,047 ms | 84,798 | 2,376 ms |
+| `https-store-checkpoint` | 0.3 µs | <0.1 ms | 392 ms | 1,713 ms | 2,100 | 1,830 ms |
+| `https-store-replay` | 0.3 µs | <0.1 ms | 436 ms | 1,129 ms | 84,513 | 1,380 ms |
+| `https-ephemeral-replay` | 0.3 µs | <0.1 ms | 373 ms | 1,372 ms | 84,552 | 3,427 ms |
 
-The stable findings from this small workload are:
+Every policy reported the same median model usage for the complete 14-request
+workload: 120,201 input tokens, including 111,363 cache reads and 8,796 cache
+writes, plus 104 output tokens. Cache reads were therefore 92.6% of input.
+At the published standard GPT-5.6 Sol rates of $5 per million uncached input
+tokens and $30 per million output tokens, with cache reads at a 90% discount
+and cache writes at 1.25 times uncached input, the estimated cost is $0.114 per
+variant workload. The 21 successful samples cost an estimated $2.39, excluding
+the rejected partial request. Account-specific or priority pricing may differ.
+See [OpenAI's GPT-5.6 pricing](https://openai.com/index/gpt-5-6/#availability-and-pricing).
 
-1. A stored response checkpoint reduced each fork request from about 26.6 KiB
-   to 0.7-0.8 KiB, a roughly 97% reduction. Incremental mainline chaining
-   roughly halved the two-turn request total because the initial request still
-   carried the complete prefix.
-2. `store: false` did not prevent delta requests on the persistent WebSocket,
-   but fresh forks had to rebroadcast their complete committed histories.
-3. Prompt caching was unchanged across the matrix: every chain reported 8,451
-   cached tokens out of 16,933 input tokens (49.9%). Storage and replay policy
-   did not improve this workload's cache-token ratio.
-4. WebSocket first-event latency was consistently lower: roughly 118-140 ms
-   on the chain versus 308-350 ms over HTTPS. A new WebSocket cost roughly
-   359-401 ms for the root and 468-499 ms for each fresh fork, so the benefit is
-   naturally strongest on a long-lived mainline and weaker for one-shot forks.
-5. Local checkpoint cloning took about 0.6-1.2 microseconds. Full-history JSON
-   encoding was about 18-20 microseconds at this size. These local costs were
-   negligible beside transport and inference, while request volume remained a
-   material scaling difference.
+The stable findings are:
 
-End-to-end model completion and concurrent fork latency varied substantially
-between repetitions, including multi-second backend outliers. The snapshot is
-strong evidence for byte volume, cache behavior, connection setup, and
-first-event behavior; it is not enough evidence that `store` itself changes
-model generation latency. Larger histories and more repetitions should be used
-before making a release-level latency claim.
+1. A stored response checkpoint reduced three historical-fork requests from
+   about 84.5 KiB to 2.1-2.3 KiB, a roughly 97% reduction. Incremental chaining
+   reduced ten-turn mainline request volume by about 88%.
+2. `store: false` still permits connection-local delta requests on a persistent
+   WebSocket, but a fresh fork must replay complete committed history. HTTPS
+   with `store: false` must replay on every request.
+3. Transport, storage, and replay policy did not change model token usage,
+   cache reads, cache writes, or estimated API cost in this workload. Their
+   measurable effect was client wire volume and latency shape.
+4. Warm WebSocket first-event latency was 80-151 ms, materially lower than
+   HTTPS at 277-369 ms. Cold WebSocket first-event latency was slower because
+   its explicit handshake brought the total to 587-679 ms, versus 374-405 ms
+   for the first HTTPS event.
+5. Creating the local immutable fork snapshot remained effectively free at
+   0.3-0.4 microseconds per fork. A fresh WebSocket fork was dominated by an
+   0.8-1.0 second handshake; HTTPS forks reached their first event in
+   373-436 ms.
+
+End-to-end completion and concurrent race latency varied substantially between
+repetitions, including multi-second backend outliers. The rerun is strong
+evidence for byte volume, cache behavior, connection setup, and first-event
+behavior; it is not evidence that `store` itself changes model generation
+speed.
 
 ## Design implication
 

--- a/docs/RESPONSE_TRANSPORT_BENCH.md
+++ b/docs/RESPONSE_TRANSPORT_BENCH.md
@@ -206,12 +206,16 @@ speed.
 
 The TUI should select one transport and storage policy when it creates an agent
 session; forks should preserve that policy rather than switching transports.
-The persistent WebSocket optimization matters for interactive first-event
-latency and cheap mainline deltas. `store: true` matters independently when a
-branch must start from a historical checkpoint on a fresh connection: it
-avoids replaying that branch's retained history. If storage is unavailable,
-including with ChatGPT subscription authentication, the performant fallback is
-the current immutable segmented client-owned history, concurrent fork
-execution, stable cache key, and full replay on each fresh fork. HTTPS remains
-a viable single-session policy and can use stored checkpoints with API-key
+The persistent WebSocket is therefore the default for both authorization modes:
+it optimizes the common long-lived interactive mainline with the lowest warm
+first-event latency and cheap incremental turns. HTTPS is the explicit
+alternative for cold, one-shot, or fork-heavy sessions where avoiding a fresh
+WebSocket handshake matters more than warm mainline latency.
+
+`store: true` matters independently when a branch must start from a historical
+checkpoint on a fresh connection: it avoids replaying that branch's retained
+history. If storage is unavailable, including with ChatGPT subscription
+authentication, the performant fallback is the current immutable segmented
+client-owned history, concurrent fork execution, stable cache key, and full
+replay on each fresh fork. HTTPS can use stored checkpoints with API-key
 authentication when storage is enabled.

--- a/docs/RESPONSE_TRANSPORT_BENCH.md
+++ b/docs/RESPONSE_TRANSPORT_BENCH.md
@@ -45,8 +45,8 @@ the compatible transport policies are:
 | Policy | ChatGPT `auth.json` | Current Nanocodex runtime |
 | --- | --- | --- |
 | WebSocket, connection-local response ID, replay on a fresh fork | yes | yes |
-| WebSocket, full replay | yes | transport supports it |
-| HTTPS/SSE, full replay | yes | benchmark/reference path only |
+| WebSocket, full replay | yes | yes |
+| HTTPS/SSE, full replay | yes | yes |
 | Any `store: true` checkpoint policy | no | no |
 
 The benchmark executable itself currently exercises API-key authentication so
@@ -54,6 +54,32 @@ that every row can be compared in one run. The compatibility claims above come
 from Nanocodex's auth-mode request construction and the reviewed local Codex
 HTTPS and WebSocket request paths, not from reusing a ChatGPT access token
 against `api.openai.com`.
+
+## Library policy
+
+Transport, storage, and history policy are selected when the agent is built and
+are inherited unchanged by every clean child and historical fork:
+
+```rust
+use nanocodex::{Responses, ResponsesTransport};
+
+let responses = Responses::builder()
+    .transport(ResponsesTransport::Https)
+    .store(false)
+    .build();
+let (agent, events) = nanocodex::Nanocodex::builder(auth)
+    .responses(responses)
+    .build()?;
+```
+
+HTTPS with `store: false` automatically selects full client-history replay.
+Callers can explicitly select
+`ResponsesHistory::{Incremental, FullReplay}` for the other supported
+combinations. The builder rejects `store: true` with ChatGPT subscription
+authentication and incremental HTTPS history with `store: false`.
+
+The native CLI/TUI fixes the same policy at startup with
+`--responses-transport`, `--responses-history`, and `--store-responses`.
 
 ## Measurements
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -57,6 +57,10 @@ name = "fork-checkpoint-bench"
 path = "fork_checkpoint_bench.rs"
 
 [[bin]]
+name = "response-transport-bench"
+path = "response_transport_bench.rs"
+
+[[bin]]
 name = "codex-parity-bench"
 path = "codex_parity_bench.rs"
 

--- a/examples/fork_conversations.rs
+++ b/examples/fork_conversations.rs
@@ -1,7 +1,10 @@
 use std::{process, time::Duration};
 
 use eyre::{Result, WrapErr};
-use nanocodex::{AgentEventKind, AgentEvents, Nanocodex, Responses, Thinking, Tools, TurnResult};
+use nanocodex::{
+    AgentEventKind, AgentEvents, Nanocodex, Responses, ResponsesBuilder, ResponsesTransport,
+    StandardResponses, Thinking, Tools, TurnResult,
+};
 use tokio::task::JoinHandle;
 use tower::{limit::ConcurrencyLimitLayer, timeout::TimeoutLayer};
 
@@ -33,14 +36,9 @@ async fn main() -> Result<()> {
     let _ = dotenvy::dotenv();
     let api_key = std::env::var("OPENAI_API_KEY").wrap_err("OPENAI_API_KEY is required")?;
 
-    // These layers wrap Nanocodex's standard persistent-WebSocket/retry stack.
-    // They are deferred and cloned onto a fresh standard stack for every fork.
-    let responses = Responses::builder()
-        .websocket_url(env_or(
-            "OPENAI_RESPONSES_WEBSOCKET_URL",
-            DEFAULT_WEBSOCKET_URL,
-        ))
-        .api_base_url(env_or("OPENAI_API_BASE_URL", DEFAULT_API_BASE_URL))
+    // The fixed transport/storage policy and these layers are inherited by
+    // every fork, while each fork receives fresh mutable transport state.
+    let responses = configured_responses()?
         .layer(TimeoutLayer::new(Duration::from_secs(120)))
         .layer(ConcurrencyLimitLayer::new(1))
         .build();
@@ -205,4 +203,26 @@ const fn event_kind(kind: AgentEventKind) -> &'static str {
 
 fn env_or(name: &str, default: &str) -> String {
     std::env::var(name).unwrap_or_else(|_| default.to_owned())
+}
+
+fn configured_responses() -> Result<ResponsesBuilder<StandardResponses>> {
+    let transport = std::env::var("NANOCODEX_RESPONSES_TRANSPORT")
+        .unwrap_or_else(|_| ResponsesTransport::WebSocket.to_string())
+        .parse::<ResponsesTransport>()
+        .map_err(eyre::Report::msg)?;
+    let mut responses = Responses::builder()
+        .transport(transport)
+        .websocket_url(env_or(
+            "OPENAI_RESPONSES_WEBSOCKET_URL",
+            DEFAULT_WEBSOCKET_URL,
+        ))
+        .api_base_url(env_or("OPENAI_API_BASE_URL", DEFAULT_API_BASE_URL));
+    if let Ok(store) = std::env::var("NANOCODEX_STORE_RESPONSES") {
+        responses = responses.store(
+            store
+                .parse::<bool>()
+                .wrap_err("NANOCODEX_STORE_RESPONSES must be true or false")?,
+        );
+    }
+    Ok(responses)
 }

--- a/examples/response_transport_bench.rs
+++ b/examples/response_transport_bench.rs
@@ -1,0 +1,1424 @@
+//! Live Responses transport, storage, history-replay, and fork benchmark.
+//!
+//! This is deliberately a direct API benchmark rather than an alternate
+//! Nanocodex runtime. It holds the prompt and workload constant while varying
+//! only transport, `store`, and whether prior context is referenced by response
+//! ID or replayed by the client.
+
+use std::{
+    fmt::Write as _,
+    path::PathBuf,
+    process,
+    sync::Arc,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use eyre::{Context, Result, bail, eyre};
+use futures_util::{SinkExt, StreamExt, future::join_all};
+use http::{HeaderValue, header};
+use serde::Serialize;
+use serde_json::{Value, json};
+use tokio::{net::TcpStream, time::timeout};
+use tokio_tungstenite::{
+    MaybeTlsStream, WebSocketStream, connect_async,
+    tungstenite::{Message, client::IntoClientRequest},
+};
+
+const DEFAULT_WEBSOCKET_ENDPOINT: &str = "wss://api.openai.com/v1/responses";
+const DEFAULT_HTTP_BASE: &str = "https://api.openai.com/v1";
+const MODEL: &str = "gpt-5.6-sol";
+const WEBSOCKET_BETA: &str = "responses_websockets=2026-02-06";
+const DEFAULT_TURNS: usize = 4;
+const DEFAULT_PREFIX_FACTS: usize = 600;
+const DEFAULT_FORK_TURNS: &[usize] = &[2, 4];
+const DEFAULT_MAINLINE_CONTINUATIONS: usize = 1;
+const IO_TIMEOUT: Duration = Duration::from_secs(120);
+
+type Socket = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+const VARIANTS: &[Variant] = &[
+    Variant {
+        name: "ws-store-checkpoint",
+        transport: Transport::WebSocket,
+        store: true,
+        chain_history: HistoryPolicy::PreviousResponseId,
+        fork_history: HistoryPolicy::PreviousResponseId,
+    },
+    Variant {
+        name: "ws-store-replay",
+        transport: Transport::WebSocket,
+        store: true,
+        chain_history: HistoryPolicy::FullReplay,
+        fork_history: HistoryPolicy::FullReplay,
+    },
+    Variant {
+        name: "ws-ephemeral-connection",
+        transport: Transport::WebSocket,
+        store: false,
+        chain_history: HistoryPolicy::PreviousResponseId,
+        fork_history: HistoryPolicy::FullReplay,
+    },
+    Variant {
+        name: "ws-ephemeral-replay",
+        transport: Transport::WebSocket,
+        store: false,
+        chain_history: HistoryPolicy::FullReplay,
+        fork_history: HistoryPolicy::FullReplay,
+    },
+    Variant {
+        name: "https-store-checkpoint",
+        transport: Transport::Https,
+        store: true,
+        chain_history: HistoryPolicy::PreviousResponseId,
+        fork_history: HistoryPolicy::PreviousResponseId,
+    },
+    Variant {
+        name: "https-store-replay",
+        transport: Transport::Https,
+        store: true,
+        chain_history: HistoryPolicy::FullReplay,
+        fork_history: HistoryPolicy::FullReplay,
+    },
+    Variant {
+        name: "https-ephemeral-replay",
+        transport: Transport::Https,
+        store: false,
+        chain_history: HistoryPolicy::FullReplay,
+        fork_history: HistoryPolicy::FullReplay,
+    },
+];
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum Transport {
+    WebSocket,
+    Https,
+}
+
+impl Transport {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::WebSocket => "websocket",
+            Self::Https => "https",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum HistoryPolicy {
+    PreviousResponseId,
+    FullReplay,
+}
+
+impl HistoryPolicy {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::PreviousResponseId => "previous_response_id",
+            Self::FullReplay => "full_replay",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Variant {
+    name: &'static str,
+    transport: Transport,
+    store: bool,
+    chain_history: HistoryPolicy,
+    fork_history: HistoryPolicy,
+}
+
+#[derive(Clone, Default, Serialize)]
+struct Usage {
+    input: u64,
+    cached: u64,
+    cache_write: u64,
+    output: u64,
+}
+
+impl Usage {
+    fn add(&mut self, other: &Self) {
+        self.input += other.input;
+        self.cached += other.cached;
+        self.cache_write += other.cache_write;
+        self.output += other.output;
+    }
+}
+
+struct ResponseRun {
+    response_id: String,
+    output: Arc<[Arc<Value>]>,
+    reply: String,
+    usage: Usage,
+    request_bytes: usize,
+    encode_latency: Duration,
+    response_latency: Duration,
+    time_to_first_event: Duration,
+}
+
+impl ResponseRun {
+    fn measurement(&self) -> ResponseMeasurement {
+        ResponseMeasurement {
+            response_id: self.response_id.clone(),
+            reply: self.reply.clone(),
+            request_bytes: self.request_bytes,
+            encode_us: duration_us(self.encode_latency),
+            response_ms: duration_ms(self.response_latency),
+            time_to_first_event_ms: duration_ms(self.time_to_first_event),
+            usage: self.usage.clone(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ResponseMeasurement {
+    response_id: String,
+    reply: String,
+    request_bytes: usize,
+    encode_us: f64,
+    response_ms: f64,
+    time_to_first_event_ms: f64,
+    usage: Usage,
+}
+
+#[derive(Serialize)]
+struct BranchMeasurement {
+    from_turn: usize,
+    setup_ms: f64,
+    response: ResponseMeasurement,
+}
+
+#[derive(Serialize)]
+struct VariantMeasurement {
+    variant: &'static str,
+    transport: Transport,
+    store: bool,
+    chain_history: HistoryPolicy,
+    fork_history: HistoryPolicy,
+    root_setup_ms: f64,
+    chain_wall_ms: f64,
+    chain_median_response_ms: f64,
+    chain_request_bytes: usize,
+    chain_usage: Usage,
+    chain: Vec<ResponseMeasurement>,
+    fork_snapshot_clone_us: f64,
+    mainline_and_forks_wall_ms: f64,
+    mainline: Vec<ResponseMeasurement>,
+    branches: Vec<BranchMeasurement>,
+}
+
+#[derive(Serialize)]
+struct FailedVariant {
+    variant: &'static str,
+    error: String,
+}
+
+#[derive(Serialize)]
+struct BenchmarkReport {
+    schema_version: u32,
+    model: &'static str,
+    run_id: String,
+    turns: usize,
+    fork_turns: Vec<usize>,
+    mainline_continuations: usize,
+    prefix_facts: usize,
+    repeats: usize,
+    measurements: Vec<VariantMeasurement>,
+    failures: Vec<FailedVariant>,
+}
+
+struct BenchConfig {
+    websocket_endpoint: String,
+    http_endpoint: String,
+    api_key: String,
+    turns: usize,
+    prefix_facts: usize,
+    fork_turns: Vec<usize>,
+    mainline_continuations: usize,
+    repeats: usize,
+    variants: Vec<Variant>,
+    output: Option<PathBuf>,
+    retain: bool,
+}
+
+#[derive(Clone)]
+struct History {
+    head: Arc<HistorySegment>,
+}
+
+struct HistorySegment {
+    previous: Option<Arc<HistorySegment>>,
+    items: Arc<[Arc<Value>]>,
+    len: usize,
+}
+
+impl History {
+    fn new(item: Value) -> Self {
+        Self {
+            head: Arc::new(HistorySegment {
+                previous: None,
+                items: Arc::from([Arc::new(item)]),
+                len: 1,
+            }),
+        }
+    }
+
+    fn append(&self, user: Arc<Value>, output: &Arc<[Arc<Value>]>) -> Self {
+        let mut items = Vec::with_capacity(output.len() + 1);
+        items.push(user);
+        items.extend(output.iter().cloned());
+        Self {
+            head: Arc::new(HistorySegment {
+                previous: Some(Arc::clone(&self.head)),
+                len: self.head.len + items.len(),
+                items: items.into(),
+            }),
+        }
+    }
+
+    fn refs(&self) -> Vec<&Value> {
+        let mut segments = Vec::new();
+        let mut current = Some(self.head.as_ref());
+        while let Some(segment) = current {
+            segments.push(segment);
+            current = segment.previous.as_deref();
+        }
+        let mut items = Vec::with_capacity(self.head.len);
+        for segment in segments.into_iter().rev() {
+            items.extend(segment.items.iter().map(AsRef::as_ref));
+        }
+        items
+    }
+}
+
+#[derive(Clone)]
+struct TurnCheckpoint {
+    turn: usize,
+    response_id: String,
+    history: History,
+}
+
+enum TransportClient {
+    WebSocket(Box<Socket>),
+    Https(reqwest::Client),
+}
+
+struct ConnectedTransport {
+    client: TransportClient,
+    setup_latency: Duration,
+}
+
+struct LiveChain {
+    connection: ConnectedTransport,
+    root_session: String,
+    head_response_id: String,
+    history: History,
+    checkpoints: Vec<TurnCheckpoint>,
+    responses: Vec<ResponseRun>,
+}
+
+struct BranchRun {
+    from_turn: usize,
+    setup_latency: Duration,
+    response: ResponseRun,
+}
+
+struct MainlineRun {
+    responses: Vec<ResponseRun>,
+    stored_response_ids: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct RequestBody<'a> {
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    kind: Option<&'static str>,
+    model: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    previous_response_id: Option<&'a str>,
+    input: &'a [&'a Value],
+    tool_choice: &'static str,
+    parallel_tool_calls: bool,
+    reasoning: Reasoning,
+    store: bool,
+    stream: bool,
+    include: [&'static str; 1],
+    prompt_cache_key: &'a str,
+    text: TextControls,
+    client_metadata: ClientMetadata<'a>,
+}
+
+#[derive(Serialize)]
+struct Reasoning {
+    effort: &'static str,
+    context: &'static str,
+}
+
+#[derive(Serialize)]
+struct TextControls {
+    verbosity: &'static str,
+}
+
+#[derive(Serialize)]
+struct ClientMetadata<'a> {
+    session_id: &'a str,
+    thread_id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ws_request_header_x_openai_internal_codex_responses_lite: Option<&'static str>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _ = dotenvy::dotenv();
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let config = BenchConfig::from_env()?;
+    let run_id = run_id()?;
+    print_header(&config, &run_id);
+
+    let mut measurements = Vec::with_capacity(config.variants.len() * config.repeats);
+    let mut failures = Vec::new();
+    let mut stored_response_ids = Vec::new();
+    for repeat in 0..config.repeats {
+        for offset in 0..config.variants.len() {
+            let variant = config.variants[(offset + repeat) % config.variants.len()];
+            let trial_id = format!("{run_id}-r{}-{}", repeat + 1, variant.name);
+            match run_variant(&config, variant, &trial_id, &mut stored_response_ids).await {
+                Ok(measurement) => {
+                    print_variant_summary(&measurement);
+                    measurements.push(measurement);
+                }
+                Err(error) => {
+                    eprintln!("\n{} failed: {error:#}", variant.name);
+                    failures.push(FailedVariant {
+                        variant: variant.name,
+                        error: format!("{error:#}"),
+                    });
+                }
+            }
+        }
+    }
+
+    let report = BenchmarkReport {
+        schema_version: 1,
+        model: MODEL,
+        run_id,
+        turns: config.turns,
+        fork_turns: config.fork_turns.clone(),
+        mainline_continuations: config.mainline_continuations,
+        prefix_facts: config.prefix_facts,
+        repeats: config.repeats,
+        measurements,
+        failures,
+    };
+    if let Some(path) = &config.output {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .wrap_err_with(|| format!("failed to create {}", parent.display()))?;
+        }
+        std::fs::write(path, serde_json::to_vec_pretty(&report)?)
+            .wrap_err_with(|| format!("failed to write {}", path.display()))?;
+        println!("\nJSON report: {}", path.display());
+    }
+
+    if config.retain {
+        println!(
+            "retained {} stored responses because FORK_BENCH_RETAIN=1",
+            stored_response_ids.len()
+        );
+    } else {
+        cleanup_responses(&config, &stored_response_ids).await;
+    }
+
+    if report.failures.is_empty() {
+        Ok(())
+    } else {
+        bail!("{} benchmark variant(s) failed", report.failures.len())
+    }
+}
+
+impl BenchConfig {
+    fn from_env() -> Result<Self> {
+        let turns = env_usize("FORK_BENCH_TURNS", DEFAULT_TURNS)?;
+        let fork_turns = env_usize_list("FORK_BENCH_FORK_TURNS", DEFAULT_FORK_TURNS)?;
+        if let Some(turn) = fork_turns.iter().find(|turn| **turn > turns) {
+            bail!("fork turn {turn} exceeds FORK_BENCH_TURNS={turns}");
+        }
+        let variants = selected_variants()?;
+        Ok(Self {
+            websocket_endpoint: std::env::var("OPENAI_RESPONSES_WEBSOCKET_URL")
+                .unwrap_or_else(|_| DEFAULT_WEBSOCKET_ENDPOINT.to_owned()),
+            http_endpoint: format!(
+                "{}/responses",
+                std::env::var("OPENAI_API_BASE_URL")
+                    .unwrap_or_else(|_| DEFAULT_HTTP_BASE.to_owned())
+                    .trim_end_matches('/')
+            ),
+            api_key: std::env::var("OPENAI_API_KEY").wrap_err("OPENAI_API_KEY is required")?,
+            turns,
+            prefix_facts: env_usize("FORK_BENCH_PREFIX_FACTS", DEFAULT_PREFIX_FACTS)?,
+            fork_turns,
+            mainline_continuations: env_usize(
+                "FORK_BENCH_MAINLINE_CONTINUATIONS",
+                DEFAULT_MAINLINE_CONTINUATIONS,
+            )?,
+            repeats: env_usize("FORK_BENCH_REPEATS", 1)?,
+            variants,
+            output: std::env::var_os("FORK_BENCH_OUTPUT").map(PathBuf::from),
+            retain: std::env::var("FORK_BENCH_RETAIN").is_ok_and(|value| value == "1"),
+        })
+    }
+}
+
+async fn run_variant(
+    config: &BenchConfig,
+    variant: Variant,
+    trial_id: &str,
+    stored_response_ids: &mut Vec<String>,
+) -> Result<VariantMeasurement> {
+    println!(
+        "\n{}: transport={} store={} chain={} forks={}",
+        variant.name,
+        variant.transport.as_str(),
+        variant.store,
+        variant.chain_history.as_str(),
+        variant.fork_history.as_str()
+    );
+    let cache_key = format!("nc-transport-{trial_id}");
+    let root_session = format!("nc-root-{trial_id}");
+    let chain_started = Instant::now();
+    let mut chain = run_chain(
+        config,
+        variant,
+        &root_session,
+        &cache_key,
+        stored_response_ids,
+    )
+    .await?;
+    let chain_wall = chain_started.elapsed();
+
+    let snapshot_started = Instant::now();
+    let checkpoints = select_checkpoints(&chain.checkpoints, &config.fork_turns)?;
+    let snapshot_clone = snapshot_started.elapsed();
+
+    let root_http_client = match &chain.connection.client {
+        TransportClient::Https(client) => Some(client.clone()),
+        TransportClient::WebSocket(_) => None,
+    };
+    let race_started = Instant::now();
+    let branch_futures = checkpoints
+        .iter()
+        .map(|checkpoint| {
+            run_branch(
+                config,
+                variant,
+                trial_id,
+                &cache_key,
+                checkpoint,
+                root_http_client.clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let (mainline, branches) = tokio::join!(
+        continue_mainline(config, variant, &cache_key, &mut chain),
+        async {
+            join_all(branch_futures)
+                .await
+                .into_iter()
+                .collect::<Result<Vec<_>>>()
+        }
+    );
+    let race_wall = race_started.elapsed();
+    let mut mainline = mainline?;
+    let branches = branches?;
+    stored_response_ids.append(&mut mainline.stored_response_ids);
+    if variant.store {
+        stored_response_ids.extend(
+            branches
+                .iter()
+                .map(|branch| branch.response.response_id.clone()),
+        );
+    }
+
+    build_variant_measurement(
+        variant,
+        &chain,
+        chain_wall,
+        snapshot_clone,
+        race_wall,
+        &mainline,
+        &branches,
+    )
+}
+
+fn build_variant_measurement(
+    variant: Variant,
+    chain: &LiveChain,
+    chain_wall: Duration,
+    snapshot_clone: Duration,
+    race_wall: Duration,
+    mainline: &MainlineRun,
+    branches: &[BranchRun],
+) -> Result<VariantMeasurement> {
+    let chain_responses = chain_measurements(chain)?;
+    let mut chain_latencies = chain_responses
+        .iter()
+        .map(|response| response.response_ms)
+        .collect::<Vec<_>>();
+    chain_latencies.sort_by(f64::total_cmp);
+    let chain_request_bytes = chain_responses
+        .iter()
+        .map(|response| response.request_bytes)
+        .sum();
+    let mut chain_usage = Usage::default();
+    for response in &chain_responses {
+        chain_usage.add(&response.usage);
+    }
+    Ok(VariantMeasurement {
+        variant: variant.name,
+        transport: variant.transport,
+        store: variant.store,
+        chain_history: variant.chain_history,
+        fork_history: variant.fork_history,
+        root_setup_ms: duration_ms(chain.connection.setup_latency),
+        chain_wall_ms: duration_ms(chain_wall),
+        chain_median_response_ms: median(&chain_latencies),
+        chain_request_bytes,
+        chain_usage,
+        chain: chain_responses,
+        fork_snapshot_clone_us: duration_us(snapshot_clone),
+        mainline_and_forks_wall_ms: duration_ms(race_wall),
+        mainline: mainline
+            .responses
+            .iter()
+            .map(ResponseRun::measurement)
+            .collect(),
+        branches: branches
+            .iter()
+            .map(|branch| BranchMeasurement {
+                from_turn: branch.from_turn,
+                setup_ms: duration_ms(branch.setup_latency),
+                response: branch.response.measurement(),
+            })
+            .collect(),
+    })
+}
+
+async fn run_chain(
+    config: &BenchConfig,
+    variant: Variant,
+    root_session: &str,
+    cache_key: &str,
+    stored_response_ids: &mut Vec<String>,
+) -> Result<LiveChain> {
+    let developer = developer_message(config.prefix_facts);
+    let mut history = History::new(developer);
+    let mut previous_response_id = None;
+    let mut checkpoints = Vec::with_capacity(config.turns);
+    let mut connection = connect_transport(config, variant.transport, root_session, None).await?;
+    let mut responses = Vec::with_capacity(config.turns);
+
+    for turn in 1..=config.turns {
+        let user = Arc::new(user_message(&format!(
+            "Conversation turn {turn}. Reply with exactly ACK_{turn:02}."
+        )));
+        let input = request_input(
+            variant.chain_history,
+            &history,
+            &user,
+            previous_response_id.is_some(),
+        );
+        let prior = matches!(variant.chain_history, HistoryPolicy::PreviousResponseId)
+            .then_some(previous_response_id.as_deref())
+            .flatten();
+        let response = send_request(
+            config,
+            variant,
+            &mut connection.client,
+            cache_key,
+            root_session,
+            &input,
+            prior,
+        )
+        .await?;
+        require_reply(&response, &format!("ACK_{turn:02}"))?;
+        if variant.store {
+            stored_response_ids.push(response.response_id.clone());
+        }
+        previous_response_id = Some(response.response_id.clone());
+        history = history.append(user, &response.output);
+        checkpoints.push(TurnCheckpoint {
+            turn,
+            response_id: response.response_id.clone(),
+            history: history.clone(),
+        });
+        responses.push(response);
+    }
+
+    let head_response_id =
+        previous_response_id.ok_or_else(|| eyre!("the chain produced no response"))?;
+    Ok(LiveChain {
+        connection,
+        root_session: root_session.to_owned(),
+        head_response_id,
+        history,
+        checkpoints,
+        responses,
+    })
+}
+
+fn chain_measurements(chain: &LiveChain) -> Result<Vec<ResponseMeasurement>> {
+    if chain.responses.len() != chain.checkpoints.len() {
+        bail!(
+            "chain measurement count {} did not match checkpoint count {}",
+            chain.responses.len(),
+            chain.checkpoints.len()
+        );
+    }
+    Ok(chain
+        .responses
+        .iter()
+        .map(ResponseRun::measurement)
+        .collect())
+}
+
+async fn continue_mainline(
+    config: &BenchConfig,
+    variant: Variant,
+    cache_key: &str,
+    chain: &mut LiveChain,
+) -> Result<MainlineRun> {
+    let mut responses = Vec::with_capacity(config.mainline_continuations);
+    let mut stored_response_ids = Vec::with_capacity(config.mainline_continuations);
+    for continuation in 1..=config.mainline_continuations {
+        let turn = config.turns + continuation;
+        let user = Arc::new(user_message(&format!(
+            "Mainline conversation turn {turn}. Reply with exactly MAIN_{turn:02}."
+        )));
+        let input = request_input(variant.chain_history, &chain.history, &user, true);
+        let prior = matches!(variant.chain_history, HistoryPolicy::PreviousResponseId)
+            .then_some(chain.head_response_id.as_str());
+        let response = send_request(
+            config,
+            variant,
+            &mut chain.connection.client,
+            cache_key,
+            &chain.root_session,
+            &input,
+            prior,
+        )
+        .await?;
+        require_reply(&response, &format!("MAIN_{turn:02}"))?;
+        chain.head_response_id.clone_from(&response.response_id);
+        chain.history = chain.history.append(user, &response.output);
+        if variant.store {
+            stored_response_ids.push(response.response_id.clone());
+        }
+        responses.push(response);
+    }
+    Ok(MainlineRun {
+        responses,
+        stored_response_ids,
+    })
+}
+
+async fn run_branch(
+    config: &BenchConfig,
+    variant: Variant,
+    trial_id: &str,
+    cache_key: &str,
+    checkpoint: &TurnCheckpoint,
+    http_client: Option<reqwest::Client>,
+) -> Result<BranchRun> {
+    let session_id = format!("nc-fork-{}-{trial_id}", checkpoint.turn);
+    let user = Arc::new(user_message(&format!(
+        "You are a historical fork from turn {}. Reply exactly FORK_FROM_{:02}.",
+        checkpoint.turn, checkpoint.turn
+    )));
+    let input = request_input(variant.fork_history, &checkpoint.history, &user, true);
+    let prior = matches!(variant.fork_history, HistoryPolicy::PreviousResponseId)
+        .then_some(checkpoint.response_id.as_str());
+    let mut connection =
+        connect_transport(config, variant.transport, &session_id, http_client).await?;
+    let response = send_request(
+        config,
+        variant,
+        &mut connection.client,
+        cache_key,
+        &session_id,
+        &input,
+        prior,
+    )
+    .await?;
+    require_reply(&response, &format!("FORK_FROM_{:02}", checkpoint.turn))?;
+    Ok(BranchRun {
+        from_turn: checkpoint.turn,
+        setup_latency: connection.setup_latency,
+        response,
+    })
+}
+
+fn request_input<'a>(
+    policy: HistoryPolicy,
+    history: &'a History,
+    user: &'a Arc<Value>,
+    has_previous_response: bool,
+) -> Vec<&'a Value> {
+    if matches!(policy, HistoryPolicy::PreviousResponseId) && has_previous_response {
+        vec![user.as_ref()]
+    } else {
+        let mut input = history.refs();
+        input.push(user.as_ref());
+        input
+    }
+}
+
+async fn connect_transport(
+    config: &BenchConfig,
+    transport: Transport,
+    session_id: &str,
+    http_client: Option<reqwest::Client>,
+) -> Result<ConnectedTransport> {
+    let started = Instant::now();
+    let client = match transport {
+        Transport::WebSocket => {
+            TransportClient::WebSocket(Box::new(connect_websocket(config, session_id).await?))
+        }
+        Transport::Https => {
+            let client = match http_client {
+                Some(client) => client,
+                None => reqwest::Client::builder()
+                    .timeout(IO_TIMEOUT)
+                    .user_agent("nanocodex-response-transport-bench/0.1")
+                    .build()
+                    .wrap_err("failed to build HTTPS client")?,
+            };
+            TransportClient::Https(client)
+        }
+    };
+    Ok(ConnectedTransport {
+        client,
+        setup_latency: started.elapsed(),
+    })
+}
+
+async fn connect_websocket(config: &BenchConfig, session_id: &str) -> Result<Socket> {
+    let mut request = config
+        .websocket_endpoint
+        .as_str()
+        .into_client_request()
+        .wrap_err("invalid Responses WebSocket URL")?;
+    request.headers_mut().insert(
+        header::AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {}", config.api_key))?,
+    );
+    request
+        .headers_mut()
+        .insert("OpenAI-Beta", HeaderValue::from_static(WEBSOCKET_BETA));
+    request.headers_mut().insert(
+        "x-openai-internal-codex-responses-lite",
+        HeaderValue::from_static("true"),
+    );
+    for name in ["session-id", "thread-id", "x-client-request-id"] {
+        request
+            .headers_mut()
+            .insert(name, HeaderValue::from_str(session_id)?);
+    }
+    request.headers_mut().insert(
+        header::USER_AGENT,
+        HeaderValue::from_static("nanocodex-response-transport-bench/0.1"),
+    );
+    let (socket, _) = timeout(Duration::from_secs(20), connect_async(request))
+        .await
+        .wrap_err("Responses WebSocket handshake timed out")?
+        .wrap_err("Responses WebSocket handshake failed")?;
+    Ok(socket)
+}
+
+async fn send_request(
+    config: &BenchConfig,
+    variant: Variant,
+    transport: &mut TransportClient,
+    cache_key: &str,
+    session_id: &str,
+    input: &[&Value],
+    previous_response_id: Option<&str>,
+) -> Result<ResponseRun> {
+    let encode_started = Instant::now();
+    let body = RequestBody {
+        kind: matches!(variant.transport, Transport::WebSocket).then_some("response.create"),
+        model: MODEL,
+        previous_response_id,
+        input,
+        tool_choice: "auto",
+        parallel_tool_calls: false,
+        reasoning: Reasoning {
+            effort: "low",
+            context: "all_turns",
+        },
+        store: variant.store,
+        stream: true,
+        include: ["reasoning.encrypted_content"],
+        prompt_cache_key: cache_key,
+        text: TextControls { verbosity: "low" },
+        client_metadata: ClientMetadata {
+            session_id,
+            thread_id: session_id,
+            ws_request_header_x_openai_internal_codex_responses_lite: matches!(
+                variant.transport,
+                Transport::WebSocket
+            )
+            .then_some("true"),
+        },
+    };
+    let encoded = serde_json::to_string(&body)?;
+    let encode_latency = encode_started.elapsed();
+    let request_bytes = encoded.len();
+    match transport {
+        TransportClient::WebSocket(socket) => {
+            send_websocket(socket, encoded, request_bytes, encode_latency).await
+        }
+        TransportClient::Https(client) => {
+            send_https(
+                config,
+                client,
+                session_id,
+                encoded,
+                request_bytes,
+                encode_latency,
+            )
+            .await
+        }
+    }
+}
+
+async fn send_websocket(
+    socket: &mut Socket,
+    encoded: String,
+    request_bytes: usize,
+    encode_latency: Duration,
+) -> Result<ResponseRun> {
+    let started = Instant::now();
+    timeout(IO_TIMEOUT, socket.send(Message::Text(encoded.into())))
+        .await
+        .wrap_err("sending response.create timed out")?
+        .wrap_err("sending response.create failed")?;
+
+    let mut first_event = None;
+    let mut response_id = None;
+    loop {
+        let message = timeout(IO_TIMEOUT, socket.next())
+            .await
+            .wrap_err("waiting for a Responses event timed out")?
+            .ok_or_else(|| eyre!("Responses WebSocket ended before a terminal event"))?
+            .wrap_err("failed to receive a Responses event")?;
+        match message {
+            Message::Text(text) => {
+                let event: Value = serde_json::from_str(text.as_str())?;
+                first_event.get_or_insert_with(|| started.elapsed());
+                if let Some(completed) = process_event(&event, &mut response_id)? {
+                    return response_run(
+                        completed,
+                        response_id,
+                        request_bytes,
+                        encode_latency,
+                        started.elapsed(),
+                        first_event.unwrap_or_else(|| started.elapsed()),
+                    );
+                }
+            }
+            Message::Close(frame) => bail!("Responses WebSocket closed early: {frame:?}"),
+            Message::Binary(_) => bail!("Responses WebSocket returned binary data"),
+            Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {}
+        }
+    }
+}
+
+async fn send_https(
+    config: &BenchConfig,
+    client: &reqwest::Client,
+    session_id: &str,
+    encoded: String,
+    request_bytes: usize,
+    encode_latency: Duration,
+) -> Result<ResponseRun> {
+    let started = Instant::now();
+    let mut response = client
+        .post(&config.http_endpoint)
+        .bearer_auth(&config.api_key)
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::ACCEPT, "text/event-stream")
+        .header("x-openai-internal-codex-responses-lite", "true")
+        .header("session-id", session_id)
+        .header("thread-id", session_id)
+        .header("x-client-request-id", session_id)
+        .body(encoded)
+        .send()
+        .await
+        .wrap_err("HTTPS Responses request failed")?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        bail!("HTTPS Responses request returned {status}: {body}");
+    }
+
+    let mut buffered = Vec::new();
+    let mut first_event = None;
+    let mut response_id = None;
+    loop {
+        let chunk = timeout(IO_TIMEOUT, response.chunk())
+            .await
+            .wrap_err("waiting for an HTTPS Responses event timed out")?
+            .wrap_err("failed to read HTTPS Responses stream")?;
+        let Some(chunk) = chunk else {
+            bail!("HTTPS Responses stream ended before a terminal event");
+        };
+        buffered.extend_from_slice(&chunk);
+        while let Some(newline) = buffered.iter().position(|byte| *byte == b'\n') {
+            let mut line = buffered.drain(..=newline).collect::<Vec<_>>();
+            line.pop();
+            if line.last() == Some(&b'\r') {
+                line.pop();
+            }
+            let line = std::str::from_utf8(&line).wrap_err("SSE line was not UTF-8")?;
+            let Some(data) = line.strip_prefix("data:") else {
+                continue;
+            };
+            let data = data.trim_start();
+            if data.is_empty() || data == "[DONE]" {
+                continue;
+            }
+            let event: Value =
+                serde_json::from_str(data).wrap_err("failed to decode HTTPS SSE event")?;
+            first_event.get_or_insert_with(|| started.elapsed());
+            if let Some(completed) = process_event(&event, &mut response_id)? {
+                return response_run(
+                    completed,
+                    response_id,
+                    request_bytes,
+                    encode_latency,
+                    started.elapsed(),
+                    first_event.unwrap_or_else(|| started.elapsed()),
+                );
+            }
+        }
+    }
+}
+
+fn process_event<'a>(
+    event: &'a Value,
+    response_id: &mut Option<String>,
+) -> Result<Option<&'a Value>> {
+    if let Some(id) = event
+        .get("response")
+        .and_then(|response| response.get("id"))
+        .and_then(Value::as_str)
+    {
+        *response_id = Some(id.to_owned());
+    }
+    match event.get("type").and_then(Value::as_str).unwrap_or("") {
+        "response.completed" => event
+            .get("response")
+            .map(Some)
+            .ok_or_else(|| eyre!("response.completed omitted response")),
+        "response.failed" | "response.incomplete" | "error" => {
+            bail!("Responses terminal failure: {event}")
+        }
+        _ => Ok(None),
+    }
+}
+
+fn response_run(
+    completed: &Value,
+    observed_response_id: Option<String>,
+    request_bytes: usize,
+    encode_latency: Duration,
+    response_latency: Duration,
+    time_to_first_event: Duration,
+) -> Result<ResponseRun> {
+    let response_id = completed
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .or(observed_response_id)
+        .ok_or_else(|| eyre!("completed response omitted its ID"))?;
+    let output = completed
+        .get("output")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .map(Arc::new)
+        .collect::<Vec<_>>();
+    Ok(ResponseRun {
+        response_id,
+        reply: extract_reply(&output),
+        output: output.into(),
+        usage: parse_usage(completed.get("usage")),
+        request_bytes,
+        encode_latency,
+        response_latency,
+        time_to_first_event,
+    })
+}
+
+fn require_reply(response: &ResponseRun, expected: &str) -> Result<()> {
+    if response.reply.trim() == expected {
+        Ok(())
+    } else {
+        bail!(
+            "unexpected response: expected {expected:?}, got {:?}",
+            response.reply
+        )
+    }
+}
+
+fn select_checkpoints(
+    checkpoints: &[TurnCheckpoint],
+    fork_turns: &[usize],
+) -> Result<Vec<TurnCheckpoint>> {
+    fork_turns
+        .iter()
+        .map(|turn| {
+            checkpoints
+                .iter()
+                .find(|checkpoint| checkpoint.turn == *turn)
+                .cloned()
+                .ok_or_else(|| eyre!("missing checkpoint for turn {turn}"))
+        })
+        .collect()
+}
+
+fn developer_message(prefix_facts: usize) -> Value {
+    let mut text = String::from(
+        "You are a Responses transport benchmark. Follow the final sentence of each user message and reply with only the requested token. The remaining text is deterministic cache material.\n",
+    );
+    for fact in 0..prefix_facts {
+        let _ = write!(text, "cache_fact_{fact:04}=deterministic_value_{fact:04}; ");
+    }
+    json!({
+        "type": "message",
+        "role": "developer",
+        "content": [{"type": "input_text", "text": text}]
+    })
+}
+
+fn user_message(text: &str) -> Value {
+    json!({
+        "type": "message",
+        "role": "user",
+        "content": [{"type": "input_text", "text": text}]
+    })
+}
+
+fn parse_usage(usage: Option<&Value>) -> Usage {
+    let usage = usage.unwrap_or(&Value::Null);
+    Usage {
+        input: usage
+            .get("input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or_default(),
+        cached: usage
+            .pointer("/input_tokens_details/cached_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or_default(),
+        cache_write: usage
+            .pointer("/input_tokens_details/cache_write_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or_default(),
+        output: usage
+            .get("output_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or_default(),
+    }
+}
+
+fn extract_reply(output: &[Arc<Value>]) -> String {
+    output
+        .iter()
+        .filter_map(|item| item.as_object())
+        .filter(|item| item.get("type").and_then(Value::as_str) == Some("message"))
+        .filter_map(|item| item.get("content").and_then(Value::as_array))
+        .flatten()
+        .filter(|content| content.get("type").and_then(Value::as_str) == Some("output_text"))
+        .filter_map(|content| content.get("text").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+fn print_header(config: &BenchConfig, run_id: &str) {
+    println!("Responses transport benchmark");
+    println!("model: {MODEL}");
+    println!("run: {run_id}");
+    println!(
+        "turns: {}, forks: {:?}, mainline continuations: {}, prefix facts: {}, repeats: {}",
+        config.turns,
+        config.fork_turns,
+        config.mainline_continuations,
+        config.prefix_facts,
+        config.repeats
+    );
+}
+
+fn print_variant_summary(measurement: &VariantMeasurement) {
+    let fork_bytes: usize = measurement
+        .branches
+        .iter()
+        .map(|branch| branch.response.request_bytes)
+        .sum();
+    let fork_median = {
+        let mut values = measurement
+            .branches
+            .iter()
+            .map(|branch| branch.response.response_ms)
+            .collect::<Vec<_>>();
+        values.sort_by(f64::total_cmp);
+        median(&values)
+    };
+    println!(
+        "  chain: {:>8.1} ms wall, {:>7.1} ms median response, {:>8} request B, {:>5.1}% cached",
+        measurement.chain_wall_ms,
+        measurement.chain_median_response_ms,
+        measurement.chain_request_bytes,
+        percentage(
+            measurement.chain_usage.cached,
+            measurement.chain_usage.input
+        )
+    );
+    println!(
+        "  race:  {:>8.1} ms mainline + forks, {:>7.1} ms median fork response, {:>8} fork request B, snapshot clone {:.1} us",
+        measurement.mainline_and_forks_wall_ms,
+        fork_median,
+        fork_bytes,
+        measurement.fork_snapshot_clone_us
+    );
+}
+
+fn selected_variants() -> Result<Vec<Variant>> {
+    let Ok(value) = std::env::var("FORK_BENCH_VARIANTS") else {
+        return Ok(VARIANTS.to_vec());
+    };
+    if value.trim() == "all" {
+        return Ok(VARIANTS.to_vec());
+    }
+    let mut selected = Vec::new();
+    for name in value
+        .split(',')
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+    {
+        let variant = VARIANTS
+            .iter()
+            .find(|variant| variant.name == name)
+            .copied()
+            .ok_or_else(|| {
+                eyre!(
+                    "unknown variant {name:?}; expected one of {}",
+                    VARIANTS
+                        .iter()
+                        .map(|variant| variant.name)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )
+            })?;
+        if !selected
+            .iter()
+            .any(|existing: &Variant| existing.name == name)
+        {
+            selected.push(variant);
+        }
+    }
+    if selected.is_empty() {
+        bail!("FORK_BENCH_VARIANTS selected no variants");
+    }
+    Ok(selected)
+}
+
+fn env_usize(name: &str, default: usize) -> Result<usize> {
+    match std::env::var(name) {
+        Ok(value) => parse_positive_usize(name, &value),
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(error) => Err(error).wrap_err_with(|| format!("failed to read {name}")),
+    }
+}
+
+fn env_usize_list(name: &str, default: &[usize]) -> Result<Vec<usize>> {
+    let Ok(value) = std::env::var(name) else {
+        return Ok(default.to_vec());
+    };
+    let mut values = value
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| parse_positive_usize(name, value))
+        .collect::<Result<Vec<_>>>()?;
+    values.sort_unstable();
+    values.dedup();
+    if values.is_empty() {
+        bail!("{name} must contain at least one turn");
+    }
+    Ok(values)
+}
+
+fn parse_positive_usize(name: &str, value: &str) -> Result<usize> {
+    let parsed = value
+        .parse::<usize>()
+        .wrap_err_with(|| format!("{name} must contain positive integers"))?;
+    if parsed == 0 {
+        bail!("{name} values must be greater than zero");
+    }
+    Ok(parsed)
+}
+
+fn run_id() -> Result<String> {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .wrap_err("system clock is before the Unix epoch")?
+        .as_nanos();
+    Ok(format!("{nanos:x}-{:x}", process::id()))
+}
+
+async fn cleanup_responses(config: &BenchConfig, response_ids: &[String]) {
+    if response_ids.is_empty() {
+        return;
+    }
+    let endpoint = config
+        .http_endpoint
+        .strip_suffix("/responses")
+        .unwrap_or(&config.http_endpoint);
+    let client = reqwest::Client::new();
+    let mut deleted = 0;
+    for response_id in response_ids.iter().rev() {
+        let result = client
+            .delete(format!("{endpoint}/responses/{response_id}"))
+            .bearer_auth(&config.api_key)
+            .send()
+            .await;
+        match result {
+            Ok(response) if response.status().is_success() => deleted += 1,
+            Ok(response) => eprintln!(
+                "warning: failed to delete stored response {response_id}: HTTP {}",
+                response.status()
+            ),
+            Err(error) => {
+                eprintln!("warning: failed to delete stored response {response_id}: {error}");
+            }
+        }
+    }
+    println!(
+        "cleanup: deleted {deleted}/{} stored responses",
+        response_ids.len()
+    );
+}
+
+fn median(values: &[f64]) -> f64 {
+    match values.len() {
+        0 => 0.0,
+        len if len % 2 == 1 => values[len / 2],
+        len => f64::midpoint(values[len / 2 - 1], values[len / 2]),
+    }
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn percentage(part: u64, whole: u64) -> f64 {
+    if whole == 0 {
+        0.0
+    } else {
+        part as f64 * 100.0 / whole as f64
+    }
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn duration_ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn duration_us(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000_000.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn benchmark_matrix_covers_every_supported_policy_combination() {
+        assert_eq!(VARIANTS.len(), 7);
+        assert!(VARIANTS.iter().any(|variant| {
+            variant.name == "ws-ephemeral-connection"
+                && !variant.store
+                && matches!(variant.chain_history, HistoryPolicy::PreviousResponseId)
+                && matches!(variant.fork_history, HistoryPolicy::FullReplay)
+        }));
+        assert!(!VARIANTS.iter().any(|variant| {
+            matches!(variant.transport, Transport::Https)
+                && !variant.store
+                && matches!(variant.chain_history, HistoryPolicy::PreviousResponseId)
+        }));
+    }
+
+    #[test]
+    fn fork_history_snapshots_share_the_committed_prefix() {
+        let history = History::new(user_message("one"));
+        let snapshot = history.clone();
+        assert!(Arc::ptr_eq(&history.head, &snapshot.head));
+
+        let output: Arc<[Arc<Value>]> = Arc::from([Arc::new(user_message("output"))]);
+        let branch = snapshot.append(Arc::new(user_message("two")), &output);
+        assert!(Arc::ptr_eq(
+            branch.head.previous.as_ref().unwrap(),
+            &history.head
+        ));
+        assert_eq!(history.refs().len(), 1);
+        assert_eq!(branch.refs().len(), 3);
+    }
+
+    #[test]
+    fn websocket_and_https_requests_use_their_native_envelopes() {
+        let input_value = user_message("hello");
+        let input = [input_value];
+        let input = input.iter().collect::<Vec<_>>();
+        let request = |transport: Transport| RequestBody {
+            kind: matches!(transport, Transport::WebSocket).then_some("response.create"),
+            model: MODEL,
+            previous_response_id: None,
+            input: &input,
+            tool_choice: "auto",
+            parallel_tool_calls: false,
+            reasoning: Reasoning {
+                effort: "low",
+                context: "all_turns",
+            },
+            store: false,
+            stream: true,
+            include: ["reasoning.encrypted_content"],
+            prompt_cache_key: "cache",
+            text: TextControls { verbosity: "low" },
+            client_metadata: ClientMetadata {
+                session_id: "session",
+                thread_id: "session",
+                ws_request_header_x_openai_internal_codex_responses_lite: matches!(
+                    transport,
+                    Transport::WebSocket
+                )
+                .then_some("true"),
+            },
+        };
+        let websocket = serde_json::to_value(request(Transport::WebSocket)).unwrap();
+        let https = serde_json::to_value(request(Transport::Https)).unwrap();
+
+        assert_eq!(websocket["type"], "response.create");
+        assert_eq!(
+            websocket["client_metadata"]["ws_request_header_x_openai_internal_codex_responses_lite"],
+            "true"
+        );
+        assert!(https.get("type").is_none());
+        assert!(
+            https["client_metadata"]
+                .get("ws_request_header_x_openai_internal_codex_responses_lite")
+                .is_none()
+        );
+        assert_eq!(https["store"], false);
+    }
+}

--- a/examples/response_transport_bench.rs
+++ b/examples/response_transport_bench.rs
@@ -186,6 +186,8 @@ struct ResponseMeasurement {
 struct BranchMeasurement {
     from_turn: usize,
     setup_ms: f64,
+    start_to_first_event_ms: f64,
+    start_to_completion_ms: f64,
     response: ResponseMeasurement,
 }
 
@@ -197,12 +199,20 @@ struct VariantMeasurement {
     chain_history: HistoryPolicy,
     fork_history: HistoryPolicy,
     root_setup_ms: f64,
+    cold_start_to_first_event_ms: f64,
+    cold_start_to_completion_ms: f64,
+    warm_median_time_to_first_event_ms: f64,
+    warm_median_response_ms: f64,
     chain_wall_ms: f64,
     chain_median_response_ms: f64,
     chain_request_bytes: usize,
     chain_usage: Usage,
     chain: Vec<ResponseMeasurement>,
     fork_snapshot_clone_us: f64,
+    fork_snapshot_clone_per_fork_us: f64,
+    fork_median_setup_ms: f64,
+    fork_median_start_to_first_event_ms: f64,
+    fork_median_start_to_completion_ms: f64,
     mainline_and_forks_wall_ms: f64,
     mainline: Vec<ResponseMeasurement>,
     branches: Vec<BranchMeasurement>,
@@ -400,7 +410,7 @@ async fn main() -> Result<()> {
     }
 
     let report = BenchmarkReport {
-        schema_version: 1,
+        schema_version: 2,
         model: MODEL,
         run_id,
         turns: config.turns,
@@ -561,11 +571,29 @@ fn build_variant_measurement(
     branches: &[BranchRun],
 ) -> Result<VariantMeasurement> {
     let chain_responses = chain_measurements(chain)?;
+    let cold = chain_responses
+        .first()
+        .ok_or_else(|| eyre!("chain produced no cold response measurement"))?;
+    let warm = chain_responses.get(1..).unwrap_or_default();
     let mut chain_latencies = chain_responses
         .iter()
         .map(|response| response.response_ms)
         .collect::<Vec<_>>();
     chain_latencies.sort_by(f64::total_cmp);
+    let warm_median_response_ms = median_sorted(warm.iter().map(|response| response.response_ms));
+    let warm_median_time_to_first_event_ms =
+        median_sorted(warm.iter().map(|response| response.time_to_first_event_ms));
+    let fork_median_setup_ms = median_sorted(
+        branches
+            .iter()
+            .map(|branch| duration_ms(branch.setup_latency)),
+    );
+    let fork_median_start_to_first_event_ms = median_sorted(branches.iter().map(|branch| {
+        duration_ms(branch.setup_latency) + duration_ms(branch.response.time_to_first_event)
+    }));
+    let fork_median_start_to_completion_ms = median_sorted(branches.iter().map(|branch| {
+        duration_ms(branch.setup_latency) + duration_ms(branch.response.response_latency)
+    }));
     let chain_request_bytes = chain_responses
         .iter()
         .map(|response| response.request_bytes)
@@ -581,12 +609,21 @@ fn build_variant_measurement(
         chain_history: variant.chain_history,
         fork_history: variant.fork_history,
         root_setup_ms: duration_ms(chain.connection.setup_latency),
+        cold_start_to_first_event_ms: duration_ms(chain.connection.setup_latency)
+            + cold.time_to_first_event_ms,
+        cold_start_to_completion_ms: duration_ms(chain.connection.setup_latency) + cold.response_ms,
+        warm_median_time_to_first_event_ms,
+        warm_median_response_ms,
         chain_wall_ms: duration_ms(chain_wall),
         chain_median_response_ms: median(&chain_latencies),
         chain_request_bytes,
         chain_usage,
         chain: chain_responses,
         fork_snapshot_clone_us: duration_us(snapshot_clone),
+        fork_snapshot_clone_per_fork_us: duration_us(snapshot_clone) / usize_to_f64(branches.len()),
+        fork_median_setup_ms,
+        fork_median_start_to_first_event_ms,
+        fork_median_start_to_completion_ms,
         mainline_and_forks_wall_ms: duration_ms(race_wall),
         mainline: mainline
             .responses
@@ -598,6 +635,10 @@ fn build_variant_measurement(
             .map(|branch| BranchMeasurement {
                 from_turn: branch.from_turn,
                 setup_ms: duration_ms(branch.setup_latency),
+                start_to_first_event_ms: duration_ms(branch.setup_latency)
+                    + duration_ms(branch.response.time_to_first_event),
+                start_to_completion_ms: duration_ms(branch.setup_latency)
+                    + duration_ms(branch.response.response_latency),
                 response: branch.response.measurement(),
             })
             .collect(),
@@ -1166,19 +1207,16 @@ fn print_variant_summary(measurement: &VariantMeasurement) {
         .iter()
         .map(|branch| branch.response.request_bytes)
         .sum();
-    let fork_median = {
-        let mut values = measurement
-            .branches
-            .iter()
-            .map(|branch| branch.response.response_ms)
-            .collect::<Vec<_>>();
-        values.sort_by(f64::total_cmp);
-        median(&values)
-    };
     println!(
-        "  chain: {:>8.1} ms wall, {:>7.1} ms median response, {:>8} request B, {:>5.1}% cached",
+        "  cold: {:>7.1} ms first event, {:>7.1} ms complete; warm: {:>7.1} ms first event, {:>7.1} ms complete",
+        measurement.cold_start_to_first_event_ms,
+        measurement.cold_start_to_completion_ms,
+        measurement.warm_median_time_to_first_event_ms,
+        measurement.warm_median_response_ms,
+    );
+    println!(
+        "  chain: {:>8.1} ms wall, {:>8} request B, {:>5.1}% cached",
         measurement.chain_wall_ms,
-        measurement.chain_median_response_ms,
         measurement.chain_request_bytes,
         percentage(
             measurement.chain_usage.cached,
@@ -1186,11 +1224,15 @@ fn print_variant_summary(measurement: &VariantMeasurement) {
         )
     );
     println!(
-        "  race:  {:>8.1} ms mainline + forks, {:>7.1} ms median fork response, {:>8} fork request B, snapshot clone {:.1} us",
-        measurement.mainline_and_forks_wall_ms,
-        fork_median,
-        fork_bytes,
-        measurement.fork_snapshot_clone_us
+        "  forks: {:>7.1} ms start-to-first, {:>7.1} ms start-to-complete, {:>7.1} ms setup, {:.1} us local clone/fork",
+        measurement.fork_median_start_to_first_event_ms,
+        measurement.fork_median_start_to_completion_ms,
+        measurement.fork_median_setup_ms,
+        measurement.fork_snapshot_clone_per_fork_us,
+    );
+    println!(
+        "  race:  {:>8.1} ms mainline + forks, {:>8} fork request B",
+        measurement.mainline_and_forks_wall_ms, fork_bytes,
     );
 }
 
@@ -1319,6 +1361,12 @@ fn median(values: &[f64]) -> f64 {
     }
 }
 
+fn median_sorted(values: impl Iterator<Item = f64>) -> f64 {
+    let mut values = values.collect::<Vec<_>>();
+    values.sort_by(f64::total_cmp);
+    median(&values)
+}
+
 #[allow(clippy::cast_precision_loss)]
 fn percentage(part: u64, whole: u64) -> f64 {
     if whole == 0 {
@@ -1336,6 +1384,11 @@ fn duration_ms(duration: Duration) -> f64 {
 #[allow(clippy::cast_precision_loss)]
 fn duration_us(duration: Duration) -> f64 {
     duration.as_secs_f64() * 1_000_000.0
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn usize_to_f64(value: usize) -> f64 {
+    value as f64
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What changed

- add fixed per-agent ResponsesTransport, ResponsesHistory, and store policy to the public Rust builder
- implement native HTTPS/SSE through the same typed Tower attempt, retry, events, telemetry, and TurnResult path as WebSocket
- expose matching CLI/TUI startup flags; the policy is fixed for the session and inherited unchanged by children and historical forks
- keep typed client history authoritative across follow-on turns, retries, reconnects, and forks
- preserve connection-local WebSocket deltas with store:false, replay fresh ephemeral forks, and use durable response checkpoints where supported
- support ChatGPT ~/.codex/auth.json over both WebSocket and HTTPS with store:false; reject unsupported ChatGPT store:true and HTTPS ephemeral incremental combinations
- add a reproducible seven-policy live benchmark with cold, warm, fork-start, cache, byte, token, and cost reporting

## CLI defaults

Implicit authentication now prefers an existing Codex `$CODEX_HOME/auth.json` (normally `~/.codex/auth.json`) and falls back to `OPENAI_API_KEY` only when that file is absent. Explicit `--api-key` or `--auth-file` remains authoritative. A present but invalid auth file fails visibly instead of silently charging the API key.

| Selected auth | Default transport | Default store | Default history |
| --- | --- | ---: | --- |
| ChatGPT subscription | WebSocket | false | connection-local incremental |
| API key | WebSocket | true | stored incremental |

When HTTPS is selected, ChatGPT remains ephemeral and automatically uses full replay; API-key auth remains stored and incremental by default.

## Capability matrix

| Transport | store | Mainline | Fresh historical fork | ChatGPT auth.json |
| --- | ---: | --- | --- | --- |
| WebSocket | true | checkpoint or replay | checkpoint or replay | no |
| WebSocket | false | connection-local checkpoint or replay | replay | yes |
| HTTPS/SSE | true | checkpoint or replay | checkpoint or replay | no |
| HTTPS/SSE | false | replay | replay | yes |

API-key authentication supports every row. HTTPS plus store:false automatically selects full replay. Invalid explicit combinations fail during agent construction.

## Ten-turn benchmark

Release build, GPT-5.6 Sol at low effort, ten chain turns, forks from turns 3/6/9, one concurrent mainline continuation, 600 stable prefix facts, and three successful samples per policy. Cold includes fresh transport setup and the first request. Warm is the median of turns 2-10 on the reused transport.

| Variant | Cold first | Warm first | Cold complete | Warm complete | 10-turn bytes |
| --- | ---: | ---: | ---: | ---: | ---: |
| ws-store-checkpoint | 679 ms | 80 ms | 1,847 ms | 1,047 ms | 32,974 |
| ws-store-replay | 657 ms | 151 ms | 2,202 ms | 1,243 ms | 277,051 |
| ws-ephemeral-connection | 587 ms | 99 ms | 1,380 ms | 955 ms | 33,104 |
| ws-ephemeral-replay | 610 ms | 97 ms | 1,564 ms | 920 ms | 277,181 |
| https-store-checkpoint | 400 ms | 369 ms | 1,211 ms | 1,241 ms | 32,154 |
| https-store-replay | 374 ms | 361 ms | 1,944 ms | 1,315 ms | 276,231 |
| https-ephemeral-replay | 405 ms | 277 ms | 1,260 ms | 1,051 ms | 276,361 |

Warm WebSocket first-event latency was 80-151 ms versus 277-369 ms for HTTPS. Cold HTTPS reached the first event sooner because WebSocket paid an explicit handshake before its first request. Completion timing remained backend-noisy and is not evidence that store changes generation speed.

## Fork timing

Fork first/complete includes each branch fresh transport setup and request. Clone is immutable local checkpoint setup per fork. Race wall covers one mainline request plus three concurrent forks.

| Variant | Clone | Setup | Fork first | Fork complete | Three-fork bytes | Race wall |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| ws-store-checkpoint | 0.4 us | 910 ms | 1,069 ms | 2,281 ms | 2,346 | 2,489 ms |
| ws-store-replay | 0.4 us | 971 ms | 1,135 ms | 2,040 ms | 84,759 | 2,217 ms |
| ws-ephemeral-connection | 0.4 us | 912 ms | 1,012 ms | 1,800 ms | 84,834 | 3,673 ms |
| ws-ephemeral-replay | 0.4 us | 832 ms | 999 ms | 2,047 ms | 84,798 | 2,376 ms |
| https-store-checkpoint | 0.3 us | <0.1 ms | 392 ms | 1,713 ms | 2,100 | 1,830 ms |
| https-store-replay | 0.3 us | <0.1 ms | 436 ms | 1,129 ms | 84,513 | 1,380 ms |
| https-ephemeral-replay | 0.3 us | <0.1 ms | 373 ms | 1,372 ms | 84,552 | 3,427 ms |

Local fork creation is effectively free. Fresh WebSocket forks are handshake-bound; HTTPS forks start faster. Stored checkpoints reduce the three fork requests by about 97%. Without storage, fresh forks replay complete client-owned history.

## Cache and estimated cost

Every policy produced identical median usage across the complete 14-request workload: 120,201 input tokens, including 111,363 cache reads and 8,796 cache writes, plus 104 output tokens. Cache reads were 92.6% of input. Using published standard GPT-5.6 Sol rates, including discounted reads and 1.25x cache writes, each workload is estimated at $0.114. The 21 successful samples total about $2.39; account or priority pricing may differ. Pricing source: https://openai.com/index/gpt-5-6/#availability-and-pricing

Transport and storage policy therefore changed wire volume and latency shape, but not model tokens, cache behavior, or estimated cost in this workload.

## Verification

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --quiet
- cargo check -p nanocodex-wasm --target wasm32-unknown-unknown
- deterministic raw HTTP/SSE, fragmented SSE, auth-header, replay, checkpoint, reconnect, and fork tests
- live ChatGPT auth.json over HTTPS/store:false and WebSocket/store:false
- live API-key HTTPS/store:true checkpoint chaining
- live public-library ten-turn HTTPS/store:false run with concurrent historical forks and independent branch continuation
- repeated seven-policy direct API benchmark above

One ws-store-replay trial was rejected after a transient peer TLS EOF and replaced by a clean targeted sample; the failed partial sample is excluded from medians. Stored benchmark responses were deleted after each run. Full methodology and results are in docs/RESPONSE_TRANSPORT_BENCH.md.