### PR TITLE
chore(mpp): bump RPC retry support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=3a689a1b1c194f54ad7a1afcbfa9be388706a94e#3a689a1b1c194f54ad7a1afcbfa9be388706a94e"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=2c861ba4632d485785ad41fefc0fdfbcd50b0f18#2c861ba4632d485785ad41fefc0fdfbcd50b0f18"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=3a689a1b1c194f54ad7a1afcbfa9be388706a94e#3a689a1b1c194f54ad7a1afcbfa9be388706a94e"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=2c861ba4632d485785ad41fefc0fdfbcd50b0f18#2c861ba4632d485785ad41fefc0fdfbcd50b0f18"
 dependencies = [
  "alloy",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ getrandom = "0.3.4"
 http = "1.3.1"
 http-body-util = "0.1.3"
 hudsucker = { version = "0.25.0", default-features = false, features = ["rcgen-ca", "rustls-client"] }
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "3a689a1b1c194f54ad7a1afcbfa9be388706a94e", default-features = false }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "2c861ba4632d485785ad41fefc0fdfbcd50b0f18", default-features = false }
 mpp-egress = { version = "0.1.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.1.1", path = "crates/nanocodex" }
 nanocodex-core = { version = "0.1.1", path = "crates/nanocodex-core" }

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 arboard.workspace = true
 base64.workspace = true
-alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "3a689a1b1c194f54ad7a1afcbfa9be388706a94e" }
+alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "2c861ba4632d485785ad41fefc0fdfbcd50b0f18" }
 clap.workspace = true
 crossterm.workspace = true
 dotenvy.workspace = true
@@ -24,7 +24,7 @@ image.workspace = true
 nanocodex.workspace = true
 nanocodex-observability.workspace = true
 pulldown-cmark.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "3a689a1b1c194f54ad7a1afcbfa9be388706a94e", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "2c861ba4632d485785ad41fefc0fdfbcd50b0f18", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
 mpp-egress.workspace = true
 ratatui.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }

--- a/bin/nanocodex/src/mcp.rs
+++ b/bin/nanocodex/src/mcp.rs
@@ -198,6 +198,54 @@ fn insert_server(
     Ok(())
 }
 
+fn server_mut<'a>(
+    servers: &'a mut BTreeMap<String, ServerConfig>,
+    name: &str,
+    option: &str,
+) -> Result<&'a mut ServerConfig> {
+    servers
+        .get_mut(name)
+        .ok_or_else(|| eyre::eyre!("{option} references unknown MCP server `{name}`"))
+}
+
+impl FromStr for NamedValue {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let (name, value) = value
+            .split_once('=')
+            .ok_or_else(|| "expected NAME=VALUE".to_owned())?;
+        if name.is_empty() || value.is_empty() {
+            return Err("name and value must not be empty".to_owned());
+        }
+        Ok(Self {
+            name: name.to_owned(),
+            value: value.to_owned(),
+        })
+    }
+}
+
+impl FromStr for NamedHeaderValue {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let (server_and_header, value) = value
+            .split_once('=')
+            .ok_or_else(|| "expected NAME:HEADER=ENV".to_owned())?;
+        let (name, header) = server_and_header
+            .split_once(':')
+            .ok_or_else(|| "expected NAME:HEADER=ENV".to_owned())?;
+        if name.is_empty() || header.is_empty() || value.is_empty() {
+            return Err("server, header, and environment variable must not be empty".to_owned());
+        }
+        Ok(Self {
+            name: name.to_owned(),
+            header: header.to_owned(),
+            value: value.to_owned(),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -289,53 +337,5 @@ mod tests {
             with_defaults.len(),
             with_defaults.len() - baseline.len()
         );
-    }
-}
-
-fn server_mut<'a>(
-    servers: &'a mut BTreeMap<String, ServerConfig>,
-    name: &str,
-    option: &str,
-) -> Result<&'a mut ServerConfig> {
-    servers
-        .get_mut(name)
-        .ok_or_else(|| eyre::eyre!("{option} references unknown MCP server `{name}`"))
-}
-
-impl FromStr for NamedValue {
-    type Err = String;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let (name, value) = value
-            .split_once('=')
-            .ok_or_else(|| "expected NAME=VALUE".to_owned())?;
-        if name.is_empty() || value.is_empty() {
-            return Err("name and value must not be empty".to_owned());
-        }
-        Ok(Self {
-            name: name.to_owned(),
-            value: value.to_owned(),
-        })
-    }
-}
-
-impl FromStr for NamedHeaderValue {
-    type Err = String;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        let (server_and_header, value) = value
-            .split_once('=')
-            .ok_or_else(|| "expected NAME:HEADER=ENV".to_owned())?;
-        let (name, header) = server_and_header
-            .split_once(':')
-            .ok_or_else(|| "expected NAME:HEADER=ENV".to_owned())?;
-        if name.is_empty() || header.is_empty() || value.is_empty() {
-            return Err("server, header, and environment variable must not be empty".to_owned());
-        }
-        Ok(Self {
-            name: name.to_owned(),
-            header: header.to_owned(),
-            value: value.to_owned(),
-        })
     }
 }

--- a/crates/mpp-egress/Cargo.toml
+++ b/crates/mpp-egress/Cargo.toml
@@ -15,7 +15,7 @@ base64.workspace = true
 futures-util.workspace = true
 http-body-util.workspace = true
 hudsucker.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "3a689a1b1c194f54ad7a1afcbfa9be388706a94e", default-features = false, features = ["client"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "2c861ba4632d485785ad41fefc0fdfbcd50b0f18", default-features = false, features = ["client"] }
 rand.workspace = true
 reqwest = { package = "reqwest", version = "0.13", default-features = false, features = ["native-tls", "stream"] }
 tempfile.workspace = true


### PR DESCRIPTION
Bumps `mpp` and `alloy-transport-mpp` to tempoxyz/mpp-rs@2c861ba, which adds a shared Alloy retry/backoff provider for Tempo RPC `-32005` throttling.

Upstream: https://github.com/tempoxyz/mpp-rs/pull/340

Validation:
- `cargo build -p nanocodex-bin`
- `cargo test -p mpp-egress` (6 passed, 1 ignored)
- CLI unit suite: 203 passed
- Live mpp-rs test: 400/400 concurrent credential preparations succeeded through real Tempo RPC; the prior provider exhausted retries on 283/400

The Ubuntu-only `mcp_cli` integration fixture cannot launch its subprocess (`No such file or directory`) and fails identically outside the changed MPP path.