### PR TITLE
fix: compact before follow-on sampling

### DIFF
--- a/crates/nanocodex-service/src/attempt.rs
+++ b/crates/nanocodex-service/src/attempt.rs
@@ -199,7 +199,7 @@ impl ResponsesAttempt {
         full_history: ResponseHistory,
         incremental_history: ResponseHistory,
         incremental_start: usize,
-        previous_response_id: &str,
+        previous_response_id: Option<&str>,
         trigger: ResponseItem,
         thinking: Thinking,
         fast_mode: bool,
@@ -213,14 +213,14 @@ impl ResponsesAttempt {
             incremental_history,
             incremental_start,
             tail: Some(trigger),
-            previous_response_id: Some(previous_response_id.to_owned()),
+            previous_response_id: previous_response_id.map(str::to_owned),
             thinking,
             fast_mode,
             profile,
             observer,
             attempt: 1,
             max_attempts: RESPONSE_MAX_ATTEMPTS,
-            full_replay: false,
+            full_replay: previous_response_id.is_none(),
         }
     }
 
@@ -411,7 +411,7 @@ impl ResponsesAttemptFactory {
         full_history: ResponseHistory,
         incremental_history: ResponseHistory,
         incremental_start: usize,
-        previous_response_id: &str,
+        previous_response_id: Option<&str>,
         trigger: ResponseItem,
         thinking: Thinking,
         fast_mode: bool,
@@ -434,7 +434,10 @@ impl ResponsesAttemptFactory {
 #[cfg(test)]
 mod tests {
     use super::{ResponseHistory, ResponsesAttemptFactory, TransportStats};
-    use nanocodex_core::{EventSink, Thinking, responses::RequestProfile};
+    use nanocodex_core::{
+        ContentItem, EventSink, MessageRole, ResponseItem, Thinking, responses::RequestProfile,
+    };
+    use serde_json::json;
     use std::sync::Arc;
 
     #[test]
@@ -460,5 +463,45 @@ mod tests {
         assert!(attempt.prepare_retry());
         assert_eq!(attempt.thinking(), Thinking::High);
         assert!(attempt.fast_mode());
+    }
+
+    #[test]
+    fn compaction_without_a_checkpoint_replays_authoritative_history() {
+        let (events, _receiver) = EventSink::channel("attempt-test".to_owned());
+        let factory = ResponsesAttemptFactory::new(
+            RequestProfile::new("attempt-test", "attempt-test", Arc::from([])),
+            events,
+            Arc::new(TransportStats::default()),
+        );
+        let history = ResponseHistory::new(vec![ResponseItem::message(
+            MessageRole::User,
+            [ContentItem::InputText {
+                text: "retained history".into(),
+            }],
+        )]);
+        let attempt = factory.compaction(
+            1,
+            history.clone(),
+            history,
+            1,
+            None,
+            ResponseItem::compaction_trigger(),
+            Thinking::Medium,
+            false,
+        );
+
+        assert!(attempt.is_full_replay());
+        assert_eq!(attempt.previous_response_id(), None);
+        assert_eq!(
+            serde_json::to_value(attempt.input_items().collect::<Vec<_>>()).unwrap(),
+            json!([
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{ "type": "input_text", "text": "retained history" }]
+                },
+                { "type": "compaction_trigger" }
+            ])
+        );
     }
 }

--- a/crates/nanocodex/src/model/agent.rs
+++ b/crates/nanocodex/src/model/agent.rs
@@ -904,6 +904,15 @@ where
                 self.drain_steers(&mut session.conversation, &mut steers)
                     .await?;
             }
+            self.maybe_compact(
+                self.stats.model_calls,
+                &mut session.conversation,
+                &session.factory,
+                &session.workspace,
+                session.tools.working_directory(),
+                session.tools.default_shell_name(),
+            )
+            .await?;
             Self::publish_fork_snapshot(session, fork_snapshots, self.global_instructions.as_ref());
             let call_index = self.stats.model_calls + 1;
             let response = self
@@ -924,15 +933,6 @@ where
             if code_calls.is_empty() {
                 if end_turn == Some(false) {
                     session.conversation.clear_delta();
-                    self.maybe_compact(
-                        call_index,
-                        &mut session.conversation,
-                        &session.factory,
-                        &session.workspace,
-                        session.tools.working_directory(),
-                        session.tools.default_shell_name(),
-                    )
-                    .await?;
                     continue;
                 }
                 if !steers.is_empty() {
@@ -962,15 +962,6 @@ where
                     .await?;
                 session.conversation.append(output);
             }
-            self.maybe_compact(
-                call_index,
-                &mut session.conversation,
-                &session.factory,
-                &session.workspace,
-                session.tools.working_directory(),
-                session.tools.default_shell_name(),
-            )
-            .await?;
         }
     }
 

--- a/crates/nanocodex/src/model/agent.rs
+++ b/crates/nanocodex/src/model/agent.rs
@@ -147,6 +147,22 @@ struct ModelSessionState {
     preserve_inherited_delta: bool,
 }
 
+impl ModelSessionState {
+    fn validate_workspace(&self, requested: Option<&str>) -> Result<()> {
+        let Some(requested) = requested else {
+            return Ok(());
+        };
+        let requested = resolve_workspace(Some(requested))?;
+        if requested != self.workspace {
+            return Err(NanocodexError::WorkspaceChanged {
+                current: self.workspace.clone(),
+                requested,
+            });
+        }
+        Ok(())
+    }
+}
+
 struct ActiveToolCall {
     call_id: String,
     name: String,
@@ -701,6 +717,41 @@ where
         }
     }
 
+    async fn prepare_follow_on_turn(
+        &mut self,
+        session: &mut ModelSessionState,
+        task: &Prompt,
+        cancel: &mut tokio::sync::oneshot::Receiver<()>,
+    ) -> Result<bool> {
+        let compacted = {
+            let compaction = self.maybe_compact(
+                self.stats.model_calls,
+                &mut session.conversation,
+                &session.factory,
+                &session.workspace,
+                session.tools.working_directory(),
+                session.tools.default_shell_name(),
+            );
+            tokio::pin!(compaction);
+            tokio::select! {
+                biased;
+                _ = &mut *cancel => return Ok(false),
+                outcome = &mut compaction => outcome?,
+            }
+        };
+        if compacted || session.preserve_inherited_delta {
+            session.preserve_inherited_delta = false;
+        } else {
+            session.conversation.clear_delta();
+        }
+        let user_content = prepare_user_input(&task.instruction).await;
+        session.conversation.append([ResponseItem::message(
+            nanocodex_core::MessageRole::User,
+            user_content,
+        )]);
+        Ok(true)
+    }
+
     async fn execute_task(
         &mut self,
         task: Prompt,
@@ -710,33 +761,24 @@ where
         fork_snapshots: &watch::Sender<Option<ModelCheckpoint>>,
     ) -> Result<ModelTaskOutcome> {
         let mut session = if let Some(mut session) = self.session.take() {
-            if let Some(requested) = requested_workspace.as_deref() {
-                let resolved = match resolve_workspace(Some(requested)) {
-                    Ok(resolved) => resolved,
-                    Err(error) => {
-                        self.session = Some(session);
-                        return Err(error);
-                    }
-                };
-                if resolved != session.workspace {
-                    let current = session.workspace.clone();
+            if let Err(error) = session.validate_workspace(requested_workspace.as_deref()) {
+                self.session = Some(session);
+                return Err(error);
+            }
+            match self
+                .prepare_follow_on_turn(&mut session, &task, cancel)
+                .await
+            {
+                Ok(true) => {}
+                Ok(false) => {
                     self.session = Some(session);
-                    return Err(NanocodexError::WorkspaceChanged {
-                        current,
-                        requested: resolved,
-                    });
+                    return Ok(ModelTaskOutcome::Cancelled);
+                }
+                Err(error) => {
+                    self.session = Some(session);
+                    return Err(error);
                 }
             }
-            let user_content = prepare_user_input(&task.instruction).await;
-            if session.preserve_inherited_delta {
-                session.preserve_inherited_delta = false;
-            } else {
-                session.conversation.clear_delta();
-            }
-            session.conversation.append([ResponseItem::message(
-                nanocodex_core::MessageRole::User,
-                user_content,
-            )]);
             session
         } else {
             let workspace = resolve_workspace(requested_workspace.as_deref())?;
@@ -904,15 +946,6 @@ where
                 self.drain_steers(&mut session.conversation, &mut steers)
                     .await?;
             }
-            self.maybe_compact(
-                self.stats.model_calls,
-                &mut session.conversation,
-                &session.factory,
-                &session.workspace,
-                session.tools.working_directory(),
-                session.tools.default_shell_name(),
-            )
-            .await?;
             Self::publish_fork_snapshot(session, fork_snapshots, self.global_instructions.as_ref());
             let call_index = self.stats.model_calls + 1;
             let response = self
@@ -933,12 +966,30 @@ where
             if code_calls.is_empty() {
                 if end_turn == Some(false) {
                     session.conversation.clear_delta();
+                    self.maybe_compact(
+                        call_index,
+                        &mut session.conversation,
+                        &session.factory,
+                        &session.workspace,
+                        session.tools.working_directory(),
+                        session.tools.default_shell_name(),
+                    )
+                    .await?;
                     continue;
                 }
                 if !steers.is_empty() {
                     // The completed response is retained by previous_response_id;
                     // the next delta contains only newly drained steer messages.
                     session.conversation.clear_delta();
+                    self.maybe_compact(
+                        call_index,
+                        &mut session.conversation,
+                        &session.factory,
+                        &session.workspace,
+                        session.tools.working_directory(),
+                        session.tools.default_shell_name(),
+                    )
+                    .await?;
                     continue;
                 }
                 if let Some(message) = final_message {
@@ -962,6 +1013,15 @@ where
                     .await?;
                 session.conversation.append(output);
             }
+            self.maybe_compact(
+                call_index,
+                &mut session.conversation,
+                &session.factory,
+                &session.workspace,
+                session.tools.working_directory(),
+                session.tools.default_shell_name(),
+            )
+            .await?;
         }
     }
 
@@ -1125,20 +1185,16 @@ where
         project_workspace: &str,
         working_directory: &str,
         shell: &str,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let Some(auto_compact_token_limit) = compaction::auto_compact_token_limit(MODEL) else {
-            return Ok(());
+            return Ok(false);
         };
         let active_context_tokens =
             conversation.active_context_tokens(self.server_reasoning_included);
         if active_context_tokens < auto_compact_token_limit {
-            return Ok(());
+            return Ok(false);
         }
-        let previous_response_id = conversation.previous_response_id.as_deref().ok_or(
-            NanocodexError::MalformedResponse {
-                detail: "compaction did not have a previous response ID",
-            },
-        )?;
+        let previous_response_id = conversation.previous_response_id.as_deref();
         let (item, _usage) = self
             .perform_compaction(
                 after_model_call_index,
@@ -1159,7 +1215,7 @@ where
             canonical_context,
             factory.profile().prefix(),
         );
-        Ok(())
+        Ok(true)
     }
 
     async fn perform_warmup(
@@ -1405,7 +1461,7 @@ where
         after_model_call_index: u32,
         history: nanocodex_core::responses::ResponseHistory,
         incremental_start: usize,
-        previous_response_id: &str,
+        previous_response_id: Option<&str>,
         active_context_tokens: u64,
         auto_compact_token_limit: u64,
         factory: &ResponsesAttemptFactory,

--- a/crates/nanocodex/src/model/agent_tests.rs
+++ b/crates/nanocodex/src/model/agent_tests.rs
@@ -1884,6 +1884,102 @@ async fn sol_compacts_with_a_trigger_and_installs_the_returned_context() -> Resu
 }
 
 #[tokio::test]
+async fn sol_compacts_before_sampling_a_follow_on_turn() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("ws://{}", listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await?;
+        let mut socket = accept_async(stream).await?;
+        assert_warmup(&next_json(&mut socket).await?);
+        send_warmup(&mut socket, "resp-warmup").await?;
+
+        let first = next_json(&mut socket).await?;
+        assert!(first.to_string().contains("first prompt"));
+        send_json(
+            &mut socket,
+            completed_response_with_usage(
+                "resp-first",
+                &[json!({
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{ "type": "output_text", "text": "done" }]
+                })],
+                244_800,
+            ),
+        )
+        .await?;
+
+        let compact = next_json(&mut socket).await?;
+        assert_eq!(compact["previous_response_id"], "resp-first");
+        assert_eq!(compact["input"].as_array().map(Vec::len), Some(2));
+        assert!(compact["input"][0].to_string().contains("second prompt"));
+        assert_eq!(compact["input"][1], json!({ "type": "compaction_trigger" }));
+        send_json(
+            &mut socket,
+            json!({
+                "type": "response.output_item.done",
+                "item": {
+                    "id": "cmp-server-id",
+                    "type": "compaction",
+                    "encrypted_content": "opaque-summary"
+                }
+            }),
+        )
+        .await?;
+        send_json(
+            &mut socket,
+            completed_response_with_usage("resp-compact", &[], 120),
+        )
+        .await?;
+
+        let second = next_json(&mut socket).await?;
+        assert!(second.get("previous_response_id").is_none());
+        assert!(second.to_string().contains("second prompt"));
+        assert_eq!(
+            second["input"].as_array().and_then(|items| items.last()),
+            Some(&json!({
+                "type": "compaction",
+                "encrypted_content": "opaque-summary"
+            }))
+        );
+        send_final(&mut socket, "resp-second").await
+    });
+
+    let workspace = temporary_workspace("pre-turn-compaction")?;
+    let responses = Responses::builder().websocket_url(endpoint).build();
+    let (agent, events) = Nanocodex::builder("test-key")
+        .thinking(Thinking::Low)
+        .workspace(&workspace)
+        .responses(responses)
+        .session_id("model-test")
+        .build()?;
+    assert_eq!(
+        agent
+            .prompt("first prompt")
+            .await?
+            .result()
+            .await?
+            .final_message,
+        "done"
+    );
+    assert_eq!(
+        agent
+            .prompt("second prompt")
+            .await?
+            .result()
+            .await?
+            .final_message,
+        "done"
+    );
+    drop((agent, events));
+    timeout(std::time::Duration::from_secs(5), server)
+        .await
+        .map_err(|_| eyre!("mock Responses server did not finish"))???;
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn latest_fork_during_streaming_inherits_the_active_prompt_delta() -> Result<()> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let endpoint = format!("ws://{}", listener.local_addr()?);

--- a/crates/nanocodex/src/model/agent_tests.rs
+++ b/crates/nanocodex/src/model/agent_tests.rs
@@ -1911,9 +1911,8 @@ async fn sol_compacts_before_sampling_a_follow_on_turn() -> Result<()> {
 
         let compact = next_json(&mut socket).await?;
         assert_eq!(compact["previous_response_id"], "resp-first");
-        assert_eq!(compact["input"].as_array().map(Vec::len), Some(2));
-        assert!(compact["input"][0].to_string().contains("second prompt"));
-        assert_eq!(compact["input"][1], json!({ "type": "compaction_trigger" }));
+        assert_eq!(compact["input"], json!([{ "type": "compaction_trigger" }]));
+        assert!(!compact.to_string().contains("second prompt"));
         send_json(
             &mut socket,
             json!({
@@ -1935,12 +1934,20 @@ async fn sol_compacts_before_sampling_a_follow_on_turn() -> Result<()> {
         let second = next_json(&mut socket).await?;
         assert!(second.get("previous_response_id").is_none());
         assert!(second.to_string().contains("second prompt"));
+        let second_input = second["input"]
+            .as_array()
+            .ok_or_else(|| eyre!("follow-on request input was not an array"))?;
         assert_eq!(
-            second["input"].as_array().and_then(|items| items.last()),
+            second_input.get(second_input.len().saturating_sub(2)),
             Some(&json!({
                 "type": "compaction",
                 "encrypted_content": "opaque-summary"
             }))
+        );
+        assert!(
+            second_input
+                .last()
+                .is_some_and(|item| item.to_string().contains("second prompt"))
         );
         send_final(&mut socket, "resp-second").await
     });

--- a/crates/nanocodex/src/model/telemetry.rs
+++ b/crates/nanocodex/src/model/telemetry.rs
@@ -79,7 +79,7 @@ pub(super) struct CompactionStarted<'a> {
     pub(super) after_model_call_index: u32,
     pub(super) active_context_tokens: u64,
     pub(super) auto_compact_token_limit: u64,
-    pub(super) previous_response_id: &'a str,
+    pub(super) previous_response_id: Option<&'a str>,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
Matches Codex's current compaction boundaries:

- Before a follow-on turn, check retained context and compact **before** recording or sending the new user input.
- Within a turn, check after a completed sample only when the model, a tool result, or queued steering requires another sampling step.
- Do not compact a terminal response until the next turn arrives.

The pre-turn path remains cancellation-aware. If a resumed or replayed session has no stored `previous_response_id`, compaction replays the authoritative typed history instead of failing.

The two-turn regression test proves the compaction request excludes the second prompt, then verifies that the next generation receives the compacted checkpoint immediately before that prompt. A service-level test covers compaction from full replay without a server checkpoint.

Closes #16.
