### PR TITLE
fix(cli): surface terminal MPP payment failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=2c861ba4632d485785ad41fefc0fdfbcd50b0f18#2c861ba4632d485785ad41fefc0fdfbcd50b0f18"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=cdaef22ecc0f8c1ab7c48d7e52c04725a694b820#cdaef22ecc0f8c1ab7c48d7e52c04725a694b820"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=2c861ba4632d485785ad41fefc0fdfbcd50b0f18#2c861ba4632d485785ad41fefc0fdfbcd50b0f18"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=cdaef22ecc0f8c1ab7c48d7e52c04725a694b820#cdaef22ecc0f8c1ab7c48d7e52c04725a694b820"
 dependencies = [
  "alloy",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ getrandom = "0.3.4"
 http = "1.3.1"
 http-body-util = "0.1.3"
 hudsucker = { version = "0.25.0", default-features = false, features = ["rcgen-ca", "rustls-client"] }
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "2c861ba4632d485785ad41fefc0fdfbcd50b0f18", default-features = false }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "cdaef22ecc0f8c1ab7c48d7e52c04725a694b820", default-features = false }
 mpp-egress = { version = "0.1.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.1.1", path = "crates/nanocodex" }
 nanocodex-core = { version = "0.1.1", path = "crates/nanocodex-core" }

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 arboard.workspace = true
 base64.workspace = true
-alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "2c861ba4632d485785ad41fefc0fdfbcd50b0f18" }
+alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "cdaef22ecc0f8c1ab7c48d7e52c04725a694b820" }
 clap.workspace = true
 crossterm.workspace = true
 dotenvy.workspace = true
@@ -24,7 +24,7 @@ image.workspace = true
 nanocodex.workspace = true
 nanocodex-observability.workspace = true
 pulldown-cmark.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "2c861ba4632d485785ad41fefc0fdfbcd50b0f18", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "cdaef22ecc0f8c1ab7c48d7e52c04725a694b820", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
 mpp-egress.workspace = true
 ratatui.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }

--- a/bin/nanocodex/src/mpp.rs
+++ b/bin/nanocodex/src/mpp.rs
@@ -1,4 +1,5 @@
 use std::{
+    error::Error as StdError,
     net::TcpListener as StdTcpListener,
     path::PathBuf,
     sync::{Arc, Mutex},
@@ -6,8 +7,8 @@ use std::{
 };
 
 use alloy_transport_mpp::{
-    CloseProvider, CloseRequest, MppApplicationWs, MppApplicationWsConnect, VoucherProvider,
-    VoucherRequest,
+    CloseProvider, CloseRequest, MppApplicationWs, MppApplicationWsConnect, MppWsError,
+    VoucherProvider, VoucherRequest,
 };
 use clap::{ArgAction, Args, builder::NonEmptyStringValueParser};
 use eyre::{Context, Result, eyre};
@@ -574,7 +575,9 @@ async fn serve(
                 };
                 let config = Arc::clone(&config);
                 let bridge_shutdown = bridge_shutdown_tx.subscribe();
-                bridges.spawn(async move { bridge(stream, &config, bridge_shutdown).await });
+                bridges.spawn(async move {
+                    Box::pin(bridge(stream, &config, bridge_shutdown)).await
+                });
             }
             completed = bridges.join_next(), if !bridges.is_empty() => {
                 record_bridge_result(completed);
@@ -613,7 +616,7 @@ async fn bridge(
 ) -> Result<()> {
     let downstream_headers = Arc::new(Mutex::new(None));
     let captured = Arc::clone(&downstream_headers);
-    let downstream = accept_hdr_async(stream, move |request: &Request, response: Response| {
+    let mut downstream = accept_hdr_async(stream, move |request: &Request, response: Response| {
         if let Ok(mut headers) = captured.lock() {
             *headers = Some(request.headers().clone());
         }
@@ -654,10 +657,16 @@ async fn bridge(
             HeaderValue::from_str(api_key)?,
         );
     }
-    let upstream = connector
-        .connect()
-        .await
-        .wrap_err("failed to open the paid MPP WebSocket")?;
+    let upstream = match connector.connect().await {
+        Ok(upstream) => upstream,
+        Err(error) if is_terminal_mpp_error(&error) => {
+            send_terminal_mpp_error(&mut downstream, &error).await?;
+            return Ok(());
+        }
+        Err(error) => {
+            return Err(error).wrap_err("failed to open the paid MPP WebSocket");
+        }
+    };
     relay(downstream, upstream, shutdown).await
 }
 
@@ -696,7 +705,16 @@ async fn relay(
                 }
             },
             outbound = upstream.next() => {
-                let text = outbound.wrap_err("paid MPP WebSocket receive failed")?;
+                let text = match outbound {
+                    Ok(text) => text,
+                    Err(error) if is_terminal_mpp_error(&error) => {
+                        send_terminal_mpp_error(&mut downstream, &error).await?;
+                        break Ok(());
+                    }
+                    Err(error) => {
+                        break Err(error).wrap_err("paid MPP WebSocket receive failed");
+                    }
+                };
                 if let Err(error) = downstream.send(Message::Text(text.into())).await {
                     if *shutdown.borrow() {
                         break Ok(());
@@ -711,6 +729,55 @@ async fn relay(
         .await
         .wrap_err("failed to disconnect the paid MPP WebSocket")?;
     relay_result
+}
+
+fn is_terminal_mpp_error(error: &MppWsError) -> bool {
+    matches!(
+        error,
+        MppWsError::ProbeStatus { .. }
+            | MppWsError::UnsupportedChallenge
+            | MppWsError::Payment(_)
+            | MppWsError::InvalidHeader(_)
+            | MppWsError::MalformedFrame(_)
+            | MppWsError::PaymentError { .. }
+    )
+}
+
+async fn send_terminal_mpp_error(
+    downstream: &mut WebSocketStream<TcpStream>,
+    error: &MppWsError,
+) -> Result<()> {
+    let event = terminal_mpp_error_event(error);
+    downstream
+        .send(Message::Text(event.into()))
+        .await
+        .wrap_err("failed to send the MPP error to the Responses client")?;
+    downstream
+        .close(None)
+        .await
+        .wrap_err("failed to close the Responses WebSocket after an MPP error")
+}
+
+fn terminal_mpp_error_event(error: &MppWsError) -> String {
+    serde_json::json!({
+        "type": "error",
+        "error": {
+            "code": "mpp_payment_failed",
+            "message": error_chain(error),
+        }
+    })
+    .to_string()
+}
+
+fn error_chain(error: &(dyn StdError + 'static)) -> String {
+    let mut message = error.to_string();
+    let mut source = error.source();
+    while let Some(cause) = source {
+        message.push_str(": ");
+        message.push_str(&cause.to_string());
+        source = cause.source();
+    }
+    message
 }
 
 #[cfg(test)]
@@ -820,5 +887,27 @@ mod tests {
     fn preserves_mppx_websocket_namespace() {
         let namespace = websocket_origin("wss://openai.mpp.tempo.xyz/v1/responses").unwrap();
         assert_eq!(namespace, "wss://openai.mpp.tempo.xyz");
+    }
+
+    #[test]
+    fn deterministic_mpp_failures_become_terminal_api_errors() {
+        let error = MppWsError::Payment(MppError::InvalidConfig(
+            "insufficient balance for session top-up".to_owned(),
+        ));
+
+        assert!(is_terminal_mpp_error(&error));
+        let event: serde_json::Value =
+            serde_json::from_str(&terminal_mpp_error_event(&error)).unwrap();
+        assert_eq!(event["type"], "error");
+        assert_eq!(event["error"]["code"], "mpp_payment_failed");
+        assert_eq!(
+            event["error"]["message"],
+            "MPP payment failed: Invalid configuration: insufficient balance for session top-up"
+        );
+    }
+
+    #[test]
+    fn transport_closures_remain_retryable() {
+        assert!(!is_terminal_mpp_error(&MppWsError::Closed));
     }
 }

--- a/crates/mpp-egress/Cargo.toml
+++ b/crates/mpp-egress/Cargo.toml
@@ -15,7 +15,7 @@ base64.workspace = true
 futures-util.workspace = true
 http-body-util.workspace = true
 hudsucker.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "2c861ba4632d485785ad41fefc0fdfbcd50b0f18", default-features = false, features = ["client"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "cdaef22ecc0f8c1ab7c48d7e52c04725a694b820", default-features = false, features = ["client"] }
 rand.workspace = true
 reqwest = { package = "reqwest", version = "0.13", default-features = false, features = ["native-tls", "stream"] }
 tempfile.workspace = true


### PR DESCRIPTION
## Summary
- upgrade to mpp-rs with unsponsored session top-up preflight
- forward deterministic MPP failures through the local Responses bridge as terminal API error events
- preserve existing retries for genuine WebSocket transport closures

## Why
An underfunded session top-up was correctly rejected by mpp-rs, but the local bridge dropped the semantic error and reset the socket. Nanocodex retried the whole model attempt five times, consuming five streamed session vouchers for a request that could never complete.

## Validation
- `cargo test -p nanocodex-bin mpp::tests::`
- `cargo clippy -p nanocodex-bin --all-targets -- -D warnings`
- live mainnet validation follows in the PR comments