### PR TITLE
chore: bump mpp-rs session fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=cdaef22ecc0f8c1ab7c48d7e52c04725a694b820#cdaef22ecc0f8c1ab7c48d7e52c04725a694b820"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=77330d1029c36859754430082b93e214cd2f2feb#77330d1029c36859754430082b93e214cd2f2feb"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -703,6 +703,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tracing",
@@ -3904,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=cdaef22ecc0f8c1ab7c48d7e52c04725a694b820#cdaef22ecc0f8c1ab7c48d7e52c04725a694b820"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=77330d1029c36859754430082b93e214cd2f2feb#77330d1029c36859754430082b93e214cd2f2feb"
 dependencies = [
  "alloy",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ getrandom = "0.3.4"
 http = "1.3.1"
 http-body-util = "0.1.3"
 hudsucker = { version = "0.25.0", default-features = false, features = ["rcgen-ca", "rustls-client"] }
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "cdaef22ecc0f8c1ab7c48d7e52c04725a694b820", default-features = false }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "77330d1029c36859754430082b93e214cd2f2feb", default-features = false }
 mpp-egress = { version = "0.1.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.1.1", path = "crates/nanocodex" }
 nanocodex-core = { version = "0.1.1", path = "crates/nanocodex-core" }

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 arboard.workspace = true
 base64.workspace = true
-alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "cdaef22ecc0f8c1ab7c48d7e52c04725a694b820" }
+alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "77330d1029c36859754430082b93e214cd2f2feb" }
 clap.workspace = true
 crossterm.workspace = true
 dotenvy.workspace = true
@@ -24,7 +24,7 @@ image.workspace = true
 nanocodex.workspace = true
 nanocodex-observability.workspace = true
 pulldown-cmark.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "cdaef22ecc0f8c1ab7c48d7e52c04725a694b820", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "77330d1029c36859754430082b93e214cd2f2feb", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
 mpp-egress.workspace = true
 ratatui.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }

--- a/crates/mpp-egress/Cargo.toml
+++ b/crates/mpp-egress/Cargo.toml
@@ -15,7 +15,7 @@ base64.workspace = true
 futures-util.workspace = true
 http-body-util.workspace = true
 hudsucker.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "cdaef22ecc0f8c1ab7c48d7e52c04725a694b820", default-features = false, features = ["client"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "77330d1029c36859754430082b93e214cd2f2feb", default-features = false, features = ["client"] }
 rand.workspace = true
 reqwest = { package = "reqwest", version = "0.13", default-features = false, features = ["native-tls", "stream"] }
 tempfile.workspace = true


### PR DESCRIPTION
## Summary

Bump the CLI and MPP egress to mpp-rs `77330d1`, bringing in the completed client-side session fixes:

- unsponsored TIP-1034 top-up preflight handling
- durable cold-session bootstrap
- WebSocket challenge refresh before five-minute expiry
- MPPx-compatible event semantics for paid application errors

This is intentionally independent from the terminal-error and egress-backpressure PRs.

## Validation

- `cargo test -p mpp-egress`
- `cargo check -p nanocodex-bin --all-targets`
- `cargo fmt --all --check`
- live mainnet WebSocket expiry validation on the included mpp-rs revision (same socket/channel accepted a paid turn after five minutes, zero reconnects/retries)