### PR TITLE
chore: bump mpp-rs session rollback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=77330d1029c36859754430082b93e214cd2f2feb#77330d1029c36859754430082b93e214cd2f2feb"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=08b732305d6e442e4f06b6bf2fe69d77a4955255#08b732305d6e442e4f06b6bf2fe69d77a4955255"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -3905,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=77330d1029c36859754430082b93e214cd2f2feb#77330d1029c36859754430082b93e214cd2f2feb"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=08b732305d6e442e4f06b6bf2fe69d77a4955255#08b732305d6e442e4f06b6bf2fe69d77a4955255"
 dependencies = [
  "alloy",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ getrandom = "0.3.4"
 http = "1.3.1"
 http-body-util = "0.1.3"
 hudsucker = { version = "0.25.0", default-features = false, features = ["rcgen-ca", "rustls-client"] }
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "77330d1029c36859754430082b93e214cd2f2feb", default-features = false }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "08b732305d6e442e4f06b6bf2fe69d77a4955255", default-features = false }
 mpp-egress = { version = "0.1.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.1.1", path = "crates/nanocodex" }
 nanocodex-core = { version = "0.1.1", path = "crates/nanocodex-core" }

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 arboard.workspace = true
 base64.workspace = true
-alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "77330d1029c36859754430082b93e214cd2f2feb" }
+alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "08b732305d6e442e4f06b6bf2fe69d77a4955255" }
 clap.workspace = true
 crossterm.workspace = true
 dotenvy.workspace = true
@@ -24,7 +24,7 @@ image.workspace = true
 nanocodex.workspace = true
 nanocodex-observability.workspace = true
 pulldown-cmark.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "77330d1029c36859754430082b93e214cd2f2feb", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "08b732305d6e442e4f06b6bf2fe69d77a4955255", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
 mpp-egress.workspace = true
 ratatui.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }

--- a/bin/nanocodex/src/mpp.rs
+++ b/bin/nanocodex/src/mpp.rs
@@ -301,6 +301,22 @@ where
         self.provider.pay(challenge).await
     }
 
+    async fn commit_payment(
+        &self,
+        challenge: &PaymentChallenge,
+        credential: &PaymentCredential,
+    ) -> Result<(), MppError> {
+        self.provider.commit_payment(challenge, credential).await
+    }
+
+    async fn rollback_payment(
+        &self,
+        challenge: &PaymentChallenge,
+        credential: &PaymentCredential,
+    ) -> Result<(), MppError> {
+        self.provider.rollback_payment(challenge, credential).await
+    }
+
     fn accept_payment_header(&self) -> Option<String> {
         self.provider.accept_payment_header()
     }
@@ -470,6 +486,22 @@ impl PaymentProvider for NativeSession {
                 challenge,
             )
             .await
+    }
+
+    async fn commit_payment(
+        &self,
+        challenge: &PaymentChallenge,
+        credential: &PaymentCredential,
+    ) -> Result<(), MppError> {
+        self.session.commit_payment(challenge, credential).await
+    }
+
+    async fn rollback_payment(
+        &self,
+        challenge: &PaymentChallenge,
+        credential: &PaymentCredential,
+    ) -> Result<(), MppError> {
+        self.session.rollback_payment(challenge, credential).await
     }
 
     fn accept_payment_header(&self) -> Option<String> {
@@ -791,6 +823,8 @@ mod tests {
     #[derive(Clone, Default)]
     struct MockChargeProvider {
         payments: Arc<AtomicUsize>,
+        commits: Arc<AtomicUsize>,
+        rollbacks: Arc<AtomicUsize>,
     }
 
     impl PaymentProvider for MockChargeProvider {
@@ -804,6 +838,24 @@ mod tests {
                 challenge.to_echo(),
                 PaymentPayload::hash("paid"),
             ))
+        }
+
+        async fn commit_payment(
+            &self,
+            _: &PaymentChallenge,
+            _: &PaymentCredential,
+        ) -> Result<(), MppError> {
+            self.commits.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn rollback_payment(
+            &self,
+            _: &PaymentChallenge,
+            _: &PaymentCredential,
+        ) -> Result<(), MppError> {
+            self.rollbacks.fetch_add(1, Ordering::SeqCst);
+            Ok(())
         }
     }
 
@@ -862,6 +914,31 @@ mod tests {
 
         assert!(matches!(error, MppError::AmountExceedsMax { .. }));
         assert_eq!(payments.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn capped_charge_provider_forwards_payment_lifecycle() {
+        let inner = MockChargeProvider::default();
+        let commits = Arc::clone(&inner.commits);
+        let rollbacks = Arc::clone(&inner.rollbacks);
+        let provider = CappedChargeProvider {
+            provider: inner,
+            max_charge: 100,
+        };
+        let challenge = charge_challenge("100");
+        let credential = provider.pay(&challenge).await.unwrap();
+
+        provider
+            .commit_payment(&challenge, &credential)
+            .await
+            .unwrap();
+        provider
+            .rollback_payment(&challenge, &credential)
+            .await
+            .unwrap();
+
+        assert_eq!(commits.load(Ordering::SeqCst), 1);
+        assert_eq!(rollbacks.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/crates/mpp-egress/Cargo.toml
+++ b/crates/mpp-egress/Cargo.toml
@@ -15,7 +15,7 @@ base64.workspace = true
 futures-util.workspace = true
 http-body-util.workspace = true
 hudsucker.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "77330d1029c36859754430082b93e214cd2f2feb", default-features = false, features = ["client"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "08b732305d6e442e4f06b6bf2fe69d77a4955255", default-features = false, features = ["client"] }
 rand.workspace = true
 reqwest = { package = "reqwest", version = "0.13", default-features = false, features = ["native-tls", "stream"] }
 tempfile.workspace = true


### PR DESCRIPTION
Bumps mpp-rs to the merged session-open rollback fix from tempoxyz/mpp-rs#345.

The CLI wrappers now forward payment lifecycle hooks so both the Responses WebSocket transport and MPP egress commit accepted session opens and remove rejected optimistic opens from channels.db.

Validation:
- cargo check --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p nanocodex-bin mpp::tests
- cargo test -p mpp-egress
- upstream mpp-rs unit, integration, conformance, cross-SDK, and chain-backed tests