### PR TITLE
build: bump mpp-rs autoswap diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=08b732305d6e442e4f06b6bf2fe69d77a4955255#08b732305d6e442e4f06b6bf2fe69d77a4955255"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=d4fd2b8bf842a498c93916bb7bc7698ed3f18a9f#d4fd2b8bf842a498c93916bb7bc7698ed3f18a9f"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -3905,7 +3905,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=08b732305d6e442e4f06b6bf2fe69d77a4955255#08b732305d6e442e4f06b6bf2fe69d77a4955255"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=d4fd2b8bf842a498c93916bb7bc7698ed3f18a9f#d4fd2b8bf842a498c93916bb7bc7698ed3f18a9f"
 dependencies = [
  "alloy",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ getrandom = "0.3.4"
 http = "1.3.1"
 http-body-util = "0.1.3"
 hudsucker = { version = "0.25.0", default-features = false, features = ["rcgen-ca", "rustls-client"] }
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "08b732305d6e442e4f06b6bf2fe69d77a4955255", default-features = false }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "d4fd2b8bf842a498c93916bb7bc7698ed3f18a9f", default-features = false }
 mpp-egress = { version = "0.1.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.1.1", path = "crates/nanocodex" }
 nanocodex-core = { version = "0.1.1", path = "crates/nanocodex-core" }

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 arboard.workspace = true
 base64.workspace = true
-alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "08b732305d6e442e4f06b6bf2fe69d77a4955255" }
+alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "d4fd2b8bf842a498c93916bb7bc7698ed3f18a9f" }
 clap.workspace = true
 crossterm.workspace = true
 dotenvy.workspace = true
@@ -24,7 +24,7 @@ image.workspace = true
 nanocodex.workspace = true
 nanocodex-observability.workspace = true
 pulldown-cmark.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "08b732305d6e442e4f06b6bf2fe69d77a4955255", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "d4fd2b8bf842a498c93916bb7bc7698ed3f18a9f", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
 mpp-egress.workspace = true
 ratatui.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }

--- a/crates/mpp-egress/Cargo.toml
+++ b/crates/mpp-egress/Cargo.toml
@@ -15,7 +15,7 @@ base64.workspace = true
 futures-util.workspace = true
 http-body-util.workspace = true
 hudsucker.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "08b732305d6e442e4f06b6bf2fe69d77a4955255", default-features = false, features = ["client"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "d4fd2b8bf842a498c93916bb7bc7698ed3f18a9f", default-features = false, features = ["client"] }
 rand.workspace = true
 reqwest = { package = "reqwest", version = "0.13", default-features = false, features = ["native-tls", "stream"] }
 tempfile.workspace = true


### PR DESCRIPTION
## Summary
- pin mpp-rs to merged [tempoxyz/mpp-rs#346](https://github.com/tempoxyz/mpp-rs/pull/346)
- report the actual autoswap input-token balance instead of `have ` when a session top-up cannot be funded

## Verification
- `cargo check -p nanocodex-bin` (dev-georgios)
- `cargo test -p mpp-egress pays_and_replays_ten_thousand_bounded_parallel_requests_exactly_once -- --nocapture` (10,000 requests, concurrency 100)
- live `nanocodex run --provider.tempo` with no `OPENAI_API_KEY` reached the deployed Responses WebSocket; the deployed OpenAI bridge currently terminates with an upstream `server_error`, tracked separately from this dependency-only diagnostic bump

The commit is SSH-signed.