### PR TITLE
fix(cli): bound MPP egress concurrency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=d4fd2b8bf842a498c93916bb7bc7698ed3f18a9f#d4fd2b8bf842a498c93916bb7bc7698ed3f18a9f"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=c5933597091230151368c426eb2061cca9192796#c5933597091230151368c426eb2061cca9192796"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -3192,8 +3192,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 [[package]]
 name = "hudsucker"
 version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1d7c1c828ff6db12ddafb16768ecbac920df6301778d0eb78e95da0e44d94b"
+source = "git+https://github.com/gakonst/hudsucker?rev=0c7da328e446518036b9420db3e75451fca522e9#0c7da328e446518036b9420db3e75451fca522e9"
 dependencies = [
  "bstr",
  "futures",
@@ -3905,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=d4fd2b8bf842a498c93916bb7bc7698ed3f18a9f#d4fd2b8bf842a498c93916bb7bc7698ed3f18a9f"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=c5933597091230151368c426eb2061cca9192796#c5933597091230151368c426eb2061cca9192796"
 dependencies = [
  "alloy",
  "async-stream",
@@ -4033,6 +4032,7 @@ dependencies = [
  "nanocodex",
  "nanocodex-observability",
  "nanocodex-tools",
+ "nix 0.30.1",
  "pulldown-cmark",
  "ratatui",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ futures-util = "0.3.31"
 getrandom = "0.3.4"
 http = "1.3.1"
 http-body-util = "0.1.3"
-hudsucker = { version = "0.25.0", default-features = false, features = ["rcgen-ca", "rustls-client"] }
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "d4fd2b8bf842a498c93916bb7bc7698ed3f18a9f", default-features = false }
+hudsucker = { version = "0.25.0", git = "https://github.com/gakonst/hudsucker", rev = "0c7da328e446518036b9420db3e75451fca522e9", default-features = false, features = ["rcgen-ca", "rustls-client"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "c5933597091230151368c426eb2061cca9192796", default-features = false }
 mpp-egress = { version = "0.1.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.1.1", path = "crates/nanocodex" }
 nanocodex-core = { version = "0.1.1", path = "crates/nanocodex-core" }
@@ -45,7 +45,7 @@ rand = "0.9.2"
 image = { version = "0.25.9", default-features = false, features = ["gif", "jpeg", "png", "pnm", "webp"] }
 iana-time-zone = "0.1.64"
 js-sys = "0.3.82"
-nix = { version = "0.30.1", default-features = false, features = ["process", "signal", "user"] }
+nix = { version = "0.30.1", default-features = false, features = ["process", "resource", "signal", "user"] }
 portable-pty = "0.9.0"
 pulldown-cmark = { version = "0.10", default-features = false }
 syntect = { version = "5.3.0", default-features = false, features = ["default-syntaxes", "default-themes", "regex-fancy"] }

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 arboard.workspace = true
 base64.workspace = true
-alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "d4fd2b8bf842a498c93916bb7bc7698ed3f18a9f" }
+alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "c5933597091230151368c426eb2061cca9192796" }
 clap.workspace = true
 crossterm.workspace = true
 dotenvy.workspace = true
@@ -23,8 +23,9 @@ futures-util.workspace = true
 image.workspace = true
 nanocodex.workspace = true
 nanocodex-observability.workspace = true
+nix.workspace = true
 pulldown-cmark.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "d4fd2b8bf842a498c93916bb7bc7698ed3f18a9f", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "c5933597091230151368c426eb2061cca9192796", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
 mpp-egress.workspace = true
 ratatui.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -123,7 +123,6 @@ impl AgentArgs {
         &self.cwd
     }
 
-    #[cfg(test)]
     pub(crate) const fn uses_tempo(&self) -> bool {
         self.mpp.is_enabled()
     }

--- a/bin/nanocodex/src/main.rs
+++ b/bin/nanocodex/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod mcp;
 mod mpp;
 mod observability;
+mod resource;
 mod run;
 mod subagents;
 mod tui;
@@ -67,6 +68,14 @@ async fn main() -> Result<()> {
     let _ = dotenvy::dotenv();
 
     let cli = Cli::parse();
+    let uses_tempo = match &cli.command {
+        Some(Command::Run(command)) => command.agent.uses_tempo(),
+        None => cli.agent.uses_tempo(),
+        Some(Command::Auth(_) | Command::Update(_)) => false,
+    };
+    if uses_tempo {
+        resource::ensure_mpp_file_descriptor_capacity()?;
+    }
     match cli.command {
         Some(Command::Auth(command)) => command.run().await,
         Some(Command::Run(command)) => {

--- a/bin/nanocodex/src/resource.rs
+++ b/bin/nanocodex/src/resource.rs
@@ -1,0 +1,59 @@
+use eyre::{Result, WrapErr};
+
+#[cfg(unix)]
+const MPP_FILE_DESCRIPTOR_TARGET: nix::libc::rlim_t = 4_096;
+
+#[cfg(unix)]
+pub(crate) fn ensure_mpp_file_descriptor_capacity() -> Result<()> {
+    use nix::sys::resource::{RLIM_INFINITY, Resource, getrlimit, setrlimit};
+
+    let (soft_limit, hard_limit) = getrlimit(Resource::RLIMIT_NOFILE)
+        .wrap_err("failed to read the process file-descriptor limit")?;
+    let target = target_soft_limit(soft_limit, hard_limit, RLIM_INFINITY);
+    if target > soft_limit {
+        setrlimit(Resource::RLIMIT_NOFILE, target, hard_limit)
+            .wrap_err("failed to raise the process file-descriptor limit for MPP egress")?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+pub(crate) const fn ensure_mpp_file_descriptor_capacity() -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+const fn target_soft_limit(
+    soft_limit: nix::libc::rlim_t,
+    hard_limit: nix::libc::rlim_t,
+    infinity: nix::libc::rlim_t,
+) -> nix::libc::rlim_t {
+    if soft_limit >= MPP_FILE_DESCRIPTOR_TARGET {
+        soft_limit
+    } else if hard_limit == infinity || hard_limit >= MPP_FILE_DESCRIPTOR_TARGET {
+        MPP_FILE_DESCRIPTOR_TARGET
+    } else {
+        hard_limit
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preserves_an_existing_larger_soft_limit() {
+        assert_eq!(target_soft_limit(8_192, 16_384, u64::MAX), 8_192);
+    }
+
+    #[test]
+    fn raises_to_the_bounded_mpp_target() {
+        assert_eq!(target_soft_limit(256, 16_384, u64::MAX), 4_096);
+        assert_eq!(target_soft_limit(256, u64::MAX, u64::MAX), 4_096);
+    }
+
+    #[test]
+    fn respects_a_smaller_hard_limit() {
+        assert_eq!(target_soft_limit(256, 1_024, u64::MAX), 1_024);
+    }
+}

--- a/crates/mpp-egress/Cargo.toml
+++ b/crates/mpp-egress/Cargo.toml
@@ -15,7 +15,7 @@ base64.workspace = true
 futures-util.workspace = true
 http-body-util.workspace = true
 hudsucker.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "d4fd2b8bf842a498c93916bb7bc7698ed3f18a9f", default-features = false, features = ["client"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "c5933597091230151368c426eb2061cca9192796", default-features = false, features = ["client"] }
 rand.workspace = true
 reqwest = { package = "reqwest", version = "0.13", default-features = false, features = ["native-tls", "stream"] }
 tempfile.workspace = true

--- a/crates/mpp-egress/src/lib.rs
+++ b/crates/mpp-egress/src/lib.rs
@@ -8,6 +8,7 @@ use std::{
     collections::HashSet,
     ffi::OsString,
     net::{IpAddr, Ipv4Addr, SocketAddr},
+    num::NonZeroUsize,
     sync::{
         Arc, Mutex,
         atomic::{AtomicU64, Ordering},
@@ -49,7 +50,9 @@ use tracing::Instrument as _;
 
 const DEFAULT_MAX_REQUEST_BYTES: usize = 16 * 1024 * 1024;
 const DEFAULT_MAX_PAYMENT_RETRIES: usize = 4;
+const DEFAULT_MAX_CONCURRENT_CONNECTIONS: usize = 128;
 const DEFAULT_MAX_CONCURRENT_REQUESTS: usize = 32;
+const MAX_IDLE_CONNECTIONS_PER_HOST: usize = 4;
 const CA_FILENAME: &str = "mpp-egress-ca.pem";
 const MPP_REQUEST_ID: &str = "mpp-request-id";
 
@@ -66,6 +69,11 @@ pub struct EgressPolicy {
     /// challenge, so challenge lifetimes are not consumed behind payment-state
     /// serialization.
     pub max_concurrent_requests: usize,
+    /// Maximum number of concurrently accepted child proxy connections.
+    ///
+    /// Additional clients wait in the listener backlog before consuming a
+    /// process file descriptor.
+    pub max_concurrent_connections: usize,
 }
 
 impl Default for EgressPolicy {
@@ -74,6 +82,7 @@ impl Default for EgressPolicy {
             max_request_bytes: DEFAULT_MAX_REQUEST_BYTES,
             max_payment_retries: DEFAULT_MAX_PAYMENT_RETRIES,
             max_concurrent_requests: DEFAULT_MAX_CONCURRENT_REQUESTS,
+            max_concurrent_connections: DEFAULT_MAX_CONCURRENT_CONNECTIONS,
         }
     }
 }
@@ -117,6 +126,10 @@ impl MppEgress {
                 "max_concurrent_requests must be greater than zero",
             ));
         }
+        let max_concurrent_connections = NonZeroUsize::new(policy.max_concurrent_connections)
+            .ok_or(EgressError::InvalidPolicy(
+                "max_concurrent_connections must be greater than zero",
+            ))?;
 
         let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
             .await
@@ -133,6 +146,7 @@ impl MppEgress {
         let client = reqwest::Client::builder()
             .no_proxy()
             .redirect(reqwest::redirect::Policy::none())
+            .pool_max_idle_per_host(MAX_IDLE_CONNECTIONS_PER_HOST)
             .build()
             .map_err(EgressError::Client)?;
         let proxy_password = random_proxy_password();
@@ -157,6 +171,7 @@ impl MppEgress {
             .with_listener(listener)
             .with_ca(authority)
             .with_rustls_connector(aws_lc_rs::default_provider())
+            .with_max_concurrent_connections(max_concurrent_connections)
             .with_http_handler(handler)
             .with_graceful_shutdown(async move {
                 let _ = shutdown_rx.await;
@@ -1054,6 +1069,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn queues_excess_connections_before_contacting_the_origin() {
+        const CONNECTIONS: usize = 3;
+        const REQUESTS: usize = 12;
+
+        let active = Arc::new(AtomicUsize::new(0));
+        let maximum = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(tokio::sync::Notify::new());
+        let gate = Arc::new(Semaphore::new(0));
+        let app = Router::new().route(
+            "/bounded-connections",
+            get({
+                let active = Arc::clone(&active);
+                let maximum = Arc::clone(&maximum);
+                let started = Arc::clone(&started);
+                let gate = Arc::clone(&gate);
+                move || {
+                    let active = Arc::clone(&active);
+                    let maximum = Arc::clone(&maximum);
+                    let started = Arc::clone(&started);
+                    let gate = Arc::clone(&gate);
+                    async move {
+                        let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                        maximum.fetch_max(current, Ordering::SeqCst);
+                        started.notify_one();
+                        let permit = gate.acquire().await.unwrap();
+                        permit.forget();
+                        active.fetch_sub(1, Ordering::SeqCst);
+                        "bounded"
+                    }
+                }
+            }),
+        );
+        let origin = spawn_origin(app).await;
+        let egress = MppEgress::start(
+            MockProvider::default(),
+            EgressPolicy {
+                max_concurrent_connections: CONNECTIONS,
+                max_concurrent_requests: REQUESTS,
+                ..EgressPolicy::default()
+            },
+        )
+        .await
+        .unwrap();
+        let clients = (0..REQUESTS)
+            .map(|_| proxied_client(&egress))
+            .collect::<Vec<_>>();
+        let requests = clients
+            .into_iter()
+            .map(|client| {
+                let url = format!("{origin}/bounded-connections");
+                tokio::spawn(async move { client.get(url).send().await.unwrap().status() })
+            })
+            .collect::<Vec<_>>();
+
+        while maximum.load(Ordering::SeqCst) < CONNECTIONS {
+            started.notified().await;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(maximum.load(Ordering::SeqCst), CONNECTIONS);
+        assert_eq!(active.load(Ordering::SeqCst), CONNECTIONS);
+
+        gate.add_permits(REQUESTS);
+        let statuses = join_all(requests)
+            .await
+            .into_iter()
+            .map(Result::unwrap)
+            .collect::<Vec<_>>();
+        assert!(statuses.iter().all(|status| *status == AxumStatus::OK));
+        assert_eq!(maximum.load(Ordering::SeqCst), CONNECTIONS);
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn pays_and_replays_the_exact_request_body() {
         let calls = Arc::new(AtomicUsize::new(0));
         let request_ids = Arc::new(StdMutex::new(Vec::new()));
@@ -1125,7 +1213,12 @@ mod tests {
     #[tokio::test]
     async fn pays_and_replays_ten_thousand_bounded_parallel_requests_exactly_once() {
         const REQUESTS: usize = 10_000;
-        const CONCURRENCY: usize = 100;
+        // Each in-process request owns client, proxy, and mock-origin sockets,
+        // while pooled keep-alive connections overlap request waves and the
+        // Rust test runner executes the other proxy tests concurrently. This
+        // test exercises exact-once behavior at volume; the dedicated bounds
+        // tests cover the production concurrency limits.
+        const CONCURRENCY: usize = 8;
 
         let calls = Arc::new(AtomicUsize::new(0));
         let observations = Arc::new(StdMutex::new(Vec::with_capacity(REQUESTS * 2)));

--- a/crates/mpp-egress/src/lib.rs
+++ b/crates/mpp-egress/src/lib.rs
@@ -51,7 +51,7 @@ use tracing::Instrument as _;
 const DEFAULT_MAX_REQUEST_BYTES: usize = 16 * 1024 * 1024;
 const DEFAULT_MAX_PAYMENT_RETRIES: usize = 4;
 const DEFAULT_MAX_CONCURRENT_CONNECTIONS: usize = 128;
-const DEFAULT_MAX_CONCURRENT_REQUESTS: usize = 32;
+const DEFAULT_MAX_CONCURRENT_REQUESTS: usize = 128;
 const MAX_IDLE_CONNECTIONS_PER_HOST: usize = 4;
 const CA_FILENAME: &str = "mpp-egress-ca.pem";
 const MPP_REQUEST_ID: &str = "mpp-request-id";

--- a/crates/nanocodex-tools/src/code_mode/mod.rs
+++ b/crates/nanocodex-tools/src/code_mode/mod.rs
@@ -9,7 +9,7 @@ use futures_util::{FutureExt, StreamExt, future::BoxFuture, stream::FuturesUnord
 use serde::Deserialize;
 use serde_json::Value;
 use tokio::{
-    sync::{Mutex, mpsc, oneshot},
+    sync::{Mutex, Semaphore, mpsc, oneshot},
     task::JoinHandle,
     time::Duration,
 };
@@ -31,6 +31,7 @@ const DEFAULT_WAIT_YIELD: Duration = Duration::from_secs(10);
 const OBSERVER_YIELD_GRACE: Duration = Duration::from_secs(1);
 const MIN_YIELD_FOR_OBSERVER_GRACE: Duration = Duration::from_secs(10);
 const NESTED_YIELD_GRACE: Duration = Duration::from_secs(5);
+const MAX_CONCURRENT_NESTED_CALLS: usize = 128;
 const MAX_JS_SAFE_INTEGER: u64 = (1_u64 << 53) - 1;
 const EXEC_PRAGMA_PREFIX: &str = "// @exec:";
 pub(crate) struct CodeModeRuntime {
@@ -957,6 +958,7 @@ impl EmbeddedHost {
     ) -> Result<CellTerminal, HostFailure> {
         let mut pending_calls: FuturesUnordered<BoxFuture<'_, CompletedNestedCall>> =
             FuturesUnordered::new();
+        let nested_call_permits = Arc::new(Semaphore::new(MAX_CONCURRENT_NESTED_CALLS));
         let mut event_count = 0_u64;
         loop {
             tokio::select! {
@@ -996,7 +998,9 @@ impl EmbeddedHost {
                                 input: input.clone(),
                                 yield_after,
                             });
-                            pending_calls.push(
+                            let permit = Arc::clone(&nested_call_permits);
+                            let nested_call = async move {
+                                let _permit = permit.acquire_owned().await;
                                 execute_nested_call(
                                     tools,
                                     id,
@@ -1005,8 +1009,9 @@ impl EmbeddedHost {
                                     context,
                                     actor_started_at,
                                 )
-                                .boxed(),
-                            );
+                                .await
+                            };
+                            pending_calls.push(nested_call.boxed());
                         }
                         RuntimeEvent::Notify { text, .. } => {
                             let _ = updates.send(CellUpdate::Notification(

--- a/crates/nanocodex-tools/src/code_mode/tests.rs
+++ b/crates/nanocodex-tools/src/code_mode/tests.rs
@@ -1,15 +1,128 @@
-use std::{path::PathBuf, time::Duration};
+use std::{
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
 
 use eyre::{Result, eyre};
-use nanocodex_core::ResponseItem;
+use nanocodex_core::{ResponseItem, ToolDefinition};
 use serde_json::Value;
+use tokio::sync::Semaphore;
 
 use super::{
     CellUpdate, CodeModeExecution, CodeModeObserver, CodeModeUpdate, LiveCell, NestedToolCall,
     ObservationMode, nested_tool_yield_after, observe_cell, observer_yield_timeout,
     parse_exec_source,
 };
-use crate::{ToolContext, ToolOutputBody, ToolOutputContent, ToolRuntime, WebSearchConfig};
+use crate::{
+    Tool, ToolContext, ToolExecution, ToolInput, ToolOutputBody, ToolOutputContent, ToolResult,
+    ToolRuntime, Tools, WebSearchConfig,
+};
+
+struct ConcurrencyProbe {
+    state: Arc<ConcurrencyProbeState>,
+}
+
+struct ConcurrencyProbeState {
+    active: AtomicUsize,
+    maximum: AtomicUsize,
+    release: Semaphore,
+}
+
+#[async_trait::async_trait]
+impl Tool for ConcurrencyProbe {
+    fn name(&self) -> &'static str {
+        "concurrency_probe"
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::function(
+            self.name(),
+            "Waits until released by the test.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        )
+    }
+
+    async fn execute(&self, _input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
+        let active = self.state.active.fetch_add(1, Ordering::SeqCst) + 1;
+        self.state.maximum.fetch_max(active, Ordering::SeqCst);
+        let permit = self
+            .state
+            .release
+            .acquire()
+            .await
+            .map_err(|error| std::io::Error::other(error.to_string()))?;
+        permit.forget();
+        self.state.active.fetch_sub(1, Ordering::SeqCst);
+        Ok(ToolExecution::text("released"))
+    }
+}
+
+#[tokio::test]
+async fn nested_tool_calls_are_bounded_at_128() -> Result<()> {
+    const CALLS: usize = super::MAX_CONCURRENT_NESTED_CALLS + 1;
+
+    let workspace = temporary_workspace("bounded-nested-tools")?;
+    let state = Arc::new(ConcurrencyProbeState {
+        active: AtomicUsize::new(0),
+        maximum: AtomicUsize::new(0),
+        release: Semaphore::new(0),
+    });
+    let tools = Tools::builder()
+        .without_defaults()
+        .tool(ConcurrencyProbe {
+            state: Arc::clone(&state),
+        })
+        .build()?;
+    let runtime = ToolRuntime::new_with_tools(&workspace, None, None, &tools);
+    let execution = tokio::spawn(async move {
+        let history = Vec::new();
+        runtime
+            .execute_code(
+                &format!(
+                    "await Promise.all(Array.from({{ length: {CALLS} }}, () => \
+                     tools.concurrency_probe({{}})));"
+                ),
+                test_context(&history),
+            )
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while state.active.load(Ordering::SeqCst) < super::MAX_CONCURRENT_NESTED_CALLS {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await?;
+    tokio::time::sleep(Duration::from_millis(25)).await;
+    assert_eq!(
+        state.active.load(Ordering::SeqCst),
+        super::MAX_CONCURRENT_NESTED_CALLS
+    );
+    assert_eq!(
+        state.maximum.load(Ordering::SeqCst),
+        super::MAX_CONCURRENT_NESTED_CALLS
+    );
+
+    state.release.add_permits(CALLS);
+    let execution = execution.await?;
+    assert!(execution.success, "{}", execution_output(&execution));
+    assert_eq!(execution.nested_calls.len(), CALLS);
+    assert_eq!(
+        state.maximum.load(Ordering::SeqCst),
+        super::MAX_CONCURRENT_NESTED_CALLS
+    );
+
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
 
 #[test]
 fn long_observer_yields_include_completion_grace() {

--- a/deny.toml
+++ b/deny.toml
@@ -47,6 +47,7 @@ unknown-registry = "deny"
 unknown-git = "deny"
 required-git-spec = "rev"
 allow-git = [
+    "https://github.com/gakonst/hudsucker",
     "https://github.com/openai-oss-forks/tokio-tungstenite",
     "https://github.com/openai-oss-forks/tungstenite-rs",
     "https://github.com/tempoxyz/mpp-rs",


### PR DESCRIPTION
## Summary

- bound Code Mode nested tool execution, accepted MPP proxy connections, and paid-origin requests at 128
- cap idle origin connections and raise the Tempo CLI process soft file-descriptor limit to 4,096 where the OS hard limit permits
- consume the merged mpp-rs session RPC retry fix and the bounded Hudsucker connection API

## Validation

- `cargo test -p mpp-egress -p nanocodex-tools -p nanocodex-bin`
- `cargo clippy -p nanocodex-bin -p mpp-egress -p nanocodex-tools --all-targets -- -D warnings`
- deterministic 129-call Code Mode test proves call 129 queues behind the 128-call gate
- deterministic 10,000-request egress test preserves exact-once paid replay
- mainnet Nanocodex Code Mode benchmark: 10 sequential rounds × 128-way `Promise.all`, 1,280 curl workers, 1,280 completions, zero curl failures, zero local 502s, zero queued origin requests, zero `EMFILE`; peak parent FDs 672
- 48.957s Code Mode wall time, 4.896s average round, 5.167s maximum round

## Dependencies

- mpp-rs session RPC retry: https://github.com/tempoxyz/mpp-rs/pull/347 (merged)
- Hudsucker accepted-connection bound: https://github.com/omjadas/hudsucker/pull/191