### PR TITLE
fix(cli): honor Tempo session deposit default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-mpp"
 version = "0.2.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=c5933597091230151368c426eb2061cca9192796#c5933597091230151368c426eb2061cca9192796"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=b02d4dae4e76843ef8affa58dda86f4844a13b8b#b02d4dae4e76843ef8affa58dda86f4844a13b8b"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -3904,7 +3904,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=c5933597091230151368c426eb2061cca9192796#c5933597091230151368c426eb2061cca9192796"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=b02d4dae4e76843ef8affa58dda86f4844a13b8b#b02d4dae4e76843ef8affa58dda86f4844a13b8b"
 dependencies = [
  "alloy",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ http = "1.3.1"
 http-body-util = "0.1.3"
 hmac = "0.13.0"
 hudsucker = { version = "0.25.0", git = "https://github.com/gakonst/hudsucker", rev = "0c7da328e446518036b9420db3e75451fca522e9", default-features = false, features = ["rcgen-ca", "rustls-client"] }
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "c5933597091230151368c426eb2061cca9192796", default-features = false }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "b02d4dae4e76843ef8affa58dda86f4844a13b8b", default-features = false }
 mpp-egress = { version = "0.1.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.1.1", path = "crates/nanocodex" }
 nanocodex-core = { version = "0.1.1", path = "crates/nanocodex-core" }

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -15,7 +15,7 @@ build = "build.rs"
 arboard.workspace = true
 alloy-primitives.workspace = true
 base64.workspace = true
-alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "c5933597091230151368c426eb2061cca9192796" }
+alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "b02d4dae4e76843ef8affa58dda86f4844a13b8b" }
 clap.workspace = true
 crossterm.workspace = true
 dotenvy.workspace = true
@@ -27,7 +27,7 @@ nanocodex-observability.workspace = true
 nix.workspace = true
 nanousd.workspace = true
 pulldown-cmark.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "c5933597091230151368c426eb2061cca9192796", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "b02d4dae4e76843ef8affa58dda86f4844a13b8b", default-features = false, features = ["tempo", "ws", "sqlite", "reqwest-rustls-tls"] }
 mpp-egress.workspace = true
 ratatui.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }

--- a/crates/mpp-egress/Cargo.toml
+++ b/crates/mpp-egress/Cargo.toml
@@ -15,7 +15,7 @@ base64.workspace = true
 futures-util.workspace = true
 http-body-util.workspace = true
 hudsucker.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "c5933597091230151368c426eb2061cca9192796", default-features = false, features = ["client"] }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "b02d4dae4e76843ef8affa58dda86f4844a13b8b", default-features = false, features = ["client"] }
 rand.workspace = true
 reqwest = { package = "reqwest", version = "0.13", default-features = false, features = ["native-tls", "stream"] }
 tempfile.workspace = true


### PR DESCRIPTION
## Summary
- bump `mpp-rs` to the merged session deposit fix
- keep the configured 5 USDC opening deposit distinct from the 25 USDC safety cap

## Live diagnosis
Before the fix, `--provider.tempo` built a 25,000,000-unit autoswap/open despite a 5,000,000-unit default. The selected Wallet access key then exceeded its PathUSD spending allowance. With this pin the opening transaction is 5,000,000 units; a separate existing wallet-key-capacity issue remains tracked independently.

## Testing
- `cargo build -p nanocodex-bin`
- focused mpp-rs deposit tests and full mpp-rs CI passed in tempoxyz/mpp-rs#348