### PR TITLE
ci: publish Harbor-compatible nightlies

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,11 +29,9 @@ jobs:
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             artifact: nanocodex-x86_64-unknown-linux-gnu
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             artifact: nanocodex-aarch64-unknown-linux-gnu
-            apt: gcc-aarch64-linux-gnu
-            linker: aarch64-linux-gnu-gcc
           - os: macos-14
             target: aarch64-apple-darwin
             artifact: nanocodex-aarch64-apple-darwin
@@ -54,16 +52,9 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         with:
           cache-on-failure: true
-      - name: Install cross-linker
-        if: matrix.apt != ''
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes ${{ matrix.apt }}
       - name: Build nightly binary
         shell: bash
         env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.linker }}
           TAG_NAME: nightly
           VERGEN_GIT_SHA: ${{ github.sha }}
         run: cargo build --locked --profile maxperf --package nanocodex-bin --target ${{ matrix.target }}
@@ -86,10 +77,57 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  build-harbor:
+    if: github.repository == 'gakonst/nanocodex'
+    name: build Harbor static x86_64 Linux
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - name: Build static Harbor agent
+        shell: bash
+        env:
+          TAG_NAME: nightly
+          VERGEN_GIT_SHA: ${{ github.sha }}
+        run: |
+          mkdir dist
+          docker build \
+            --platform linux/amd64 \
+            --build-arg CARGO_PROFILE=maxperf \
+            --build-arg TAG_NAME="$TAG_NAME" \
+            --build-arg VERGEN_GIT_SHA="$VERGEN_GIT_SHA" \
+            --file harbor_adapter/nanocodex.Dockerfile \
+            --target artifact \
+            --output type=local,dest=dist \
+            .
+          mv dist/nanocodex dist/nanocodex-x86_64-unknown-linux-musl
+      - name: Verify the Harbor artifact is portable
+        shell: bash
+        run: |
+          file dist/nanocodex-x86_64-unknown-linux-musl
+          docker run --rm \
+            --volume "$PWD/dist:/dist:ro" \
+            alpine:3.21 \
+            /dist/nanocodex-x86_64-unknown-linux-musl --version
+          docker run --rm \
+            --volume "$PWD/dist:/dist:ro" \
+            ubuntu:22.04 \
+            /dist/nanocodex-x86_64-unknown-linux-musl --version
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: nanocodex-x86_64-unknown-linux-musl
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 1
+
   publish:
     if: github.repository == 'gakonst/nanocodex'
     name: publish immutable and rolling nightlies
-    needs: build
+    needs: [build, build-harbor]
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     permissions:

--- a/Justfile
+++ b/Justfile
@@ -8,7 +8,9 @@ agent_artifact_dir := ".nanocodex/installed"
 agent_artifact := agent_artifact_dir + "/nanocodex"
 hosted_agent_artifact_dir := agent_artifact_dir + "/daytona-amd64"
 hosted_agent_artifact := hosted_agent_artifact_dir + "/nanocodex"
+hosted_agent_checksum := hosted_agent_artifact + ".sha256"
 hosted_agent_release_tag := env_var_or_default("NANOCODEX_HOSTED_AGENT_RELEASE_TAG", "nightly")
+hosted_agent_url := "https://github.com/gakonst/nanocodex/releases/download/" + hosted_agent_release_tag + "/nanocodex-x86_64-unknown-linux-musl"
 default_eval := "evals/terminal-bench-2.yaml"
 default_jobs := ".nanocodex/harbor/jobs"
 setup_jobs := ".nanocodex/harbor/setup"
@@ -190,7 +192,7 @@ build-agent-hosted:
 # Harbor environments. The release checksum manifest is always verified.
 download-agent-hosted:
     ./scripts/download-harbor-agent.sh "{{hosted_agent_release_tag}}" "{{hosted_agent_artifact}}"
-    @test -f "{{hosted_agent_artifact}}" && test -x "{{hosted_agent_artifact}}"
+    @test -f "{{hosted_agent_artifact}}" && test -x "{{hosted_agent_artifact}}" && test -s "{{hosted_agent_checksum}}"
 
 check-hosted-auth:
     @test -n "${DAYTONA_API_KEY:-}" || { test -n "${DAYTONA_JWT_TOKEN:-}" && test -n "${DAYTONA_ORGANIZATION_ID:-}"; } || { echo "set DAYTONA_API_KEY (or DAYTONA_JWT_TOKEN and DAYTONA_ORGANIZATION_ID) in .env" >&2; exit 2; }
@@ -229,25 +231,29 @@ eval-task task effort="low" config=default_eval: build-agent
 eval-hosted config=default_eval: check-hosted-auth download-agent-hosted
     @test -x "{{harbor}}" || { echo "run 'just bootstrap' first" >&2; exit 2; }
     @job_name="$(date +%Y-%m-%d__%H-%M-%S)-eval-daytona-$BASHPID"; \
-        HARBOR_TELEMETRY=off "{{harbor}}" run --config "{{config}}" --env daytona --verifier "{{canonical_verifier}}" --agent-kwarg "binary_path={{hosted_agent_artifact}}" --agent-kwarg "install_node=true" --job-name "$job_name" --n-concurrent "{{hosted_eval_concurrency}}"
+        agent_sha=$(<"{{hosted_agent_checksum}}"); \
+        HARBOR_TELEMETRY=off "{{harbor}}" run --config "{{config}}" --env daytona --verifier "{{canonical_verifier}}" --agent-kwarg "binary_url={{hosted_agent_url}}" --agent-kwarg "binary_sha256=$agent_sha" --agent-kwarg "install_node=true" --job-name "$job_name" --n-concurrent "{{hosted_eval_concurrency}}"
 
 eval-task-hosted task effort="low" config=default_eval: check-hosted-auth download-agent-hosted
     @test -x "{{harbor}}" || { echo "run 'just bootstrap' first" >&2; exit 2; }
     @task="{{task}}"; \
+        agent_sha=$(<"{{hosted_agent_checksum}}"); \
         dataset=$(HARBOR_TELEMETRY=off "{{harbor}}" run --config "{{config}}" --print-config | jq -er '.datasets | if length == 1 then .[0] | "\(.name)@\(.ref)" else error("expected exactly one dataset") end'); \
         job_name="$(date +%Y-%m-%d__%H-%M-%S)-${task##*/}-daytona-$BASHPID"; \
-        HARBOR_TELEMETRY=off "{{harbor}}" run --config "{{config}}" --env daytona --verifier "{{canonical_verifier}}" --dataset "$dataset" --include-task-name "$task" --job-name "$job_name" --agent-kwarg "binary_path={{hosted_agent_artifact}}" --agent-kwarg "install_node=true" --agent-kwarg "effort={{effort}}"
+        HARBOR_TELEMETRY=off "{{harbor}}" run --config "{{config}}" --env daytona --verifier "{{canonical_verifier}}" --dataset "$dataset" --include-task-name "$task" --job-name "$job_name" --agent-kwarg "binary_url={{hosted_agent_url}}" --agent-kwarg "binary_sha256=$agent_sha" --agent-kwarg "install_node=true" --agent-kwarg "effort={{effort}}"
 
 # Run the exact k=5, stock-timeout Terminal-Bench 2.1 leaderboard job in
 # hosted AMD64 sandboxes. Upload remains a separate post-validation step.
 eval-leaderboard-hosted: check-hosted-auth download-agent-hosted
     @test -x "{{harbor}}" || { echo "run 'just bootstrap' first" >&2; exit 2; }
     @job_name="$(date +%Y-%m-%d__%H-%M-%S)-terminal-bench-2-1-leaderboard-$BASHPID"; \
+        agent_sha=$(<"{{hosted_agent_checksum}}"); \
         HARBOR_TELEMETRY=off "{{harbor}}" run \
             --config "evals/terminal-bench-2-1-leaderboard-high.yaml" \
             --env daytona \
             --verifier "{{canonical_verifier}}" \
-            --agent-kwarg "binary_path={{hosted_agent_artifact}}" \
+            --agent-kwarg "binary_url={{hosted_agent_url}}" \
+            --agent-kwarg "binary_sha256=$agent_sha" \
             --agent-kwarg "install_node=true" \
             --job-name "$job_name" \
             --n-attempts 5 \

--- a/Justfile
+++ b/Justfile
@@ -8,6 +8,7 @@ agent_artifact_dir := ".nanocodex/installed"
 agent_artifact := agent_artifact_dir + "/nanocodex"
 hosted_agent_artifact_dir := agent_artifact_dir + "/daytona-amd64"
 hosted_agent_artifact := hosted_agent_artifact_dir + "/nanocodex"
+hosted_agent_release_tag := env_var_or_default("NANOCODEX_HOSTED_AGENT_RELEASE_TAG", "nightly")
 default_eval := "evals/terminal-bench-2.yaml"
 default_jobs := ".nanocodex/harbor/jobs"
 setup_jobs := ".nanocodex/harbor/setup"
@@ -185,6 +186,12 @@ build-agent-hosted:
     @docker build --quiet --platform linux/amd64 --build-arg CARGO_PROFILE="{{build_profile}}" --file harbor_adapter/nanocodex.Dockerfile --target artifact --output type=local,dest="{{hosted_agent_artifact_dir}}" .
     @test -f "{{hosted_agent_artifact}}" && test -x "{{hosted_agent_artifact}}"
 
+# Download the CI-built static AMD64 agent used by Daytona and other hosted
+# Harbor environments. The release checksum manifest is always verified.
+download-agent-hosted:
+    ./scripts/download-harbor-agent.sh "{{hosted_agent_release_tag}}" "{{hosted_agent_artifact}}"
+    @test -f "{{hosted_agent_artifact}}" && test -x "{{hosted_agent_artifact}}"
+
 check-hosted-auth:
     @test -n "${DAYTONA_API_KEY:-}" || { test -n "${DAYTONA_JWT_TOKEN:-}" && test -n "${DAYTONA_ORGANIZATION_ID:-}"; } || { echo "set DAYTONA_API_KEY (or DAYTONA_JWT_TOKEN and DAYTONA_ORGANIZATION_ID) in .env" >&2; exit 2; }
 
@@ -219,17 +226,33 @@ eval-task task effort="low" config=default_eval: build-agent
 
 # Run the same pinned task selection in hosted Daytona sandboxes. Harbor still
 # writes the job record locally; use `harbor upload` separately to share it.
-eval-hosted config=default_eval: check-hosted-auth build-agent-hosted
+eval-hosted config=default_eval: check-hosted-auth download-agent-hosted
     @test -x "{{harbor}}" || { echo "run 'just bootstrap' first" >&2; exit 2; }
     @job_name="$(date +%Y-%m-%d__%H-%M-%S)-eval-daytona-$BASHPID"; \
         HARBOR_TELEMETRY=off "{{harbor}}" run --config "{{config}}" --env daytona --verifier "{{canonical_verifier}}" --agent-kwarg "binary_path={{hosted_agent_artifact}}" --agent-kwarg "install_node=true" --job-name "$job_name" --n-concurrent "{{hosted_eval_concurrency}}"
 
-eval-task-hosted task effort="low" config=default_eval: check-hosted-auth build-agent-hosted
+eval-task-hosted task effort="low" config=default_eval: check-hosted-auth download-agent-hosted
     @test -x "{{harbor}}" || { echo "run 'just bootstrap' first" >&2; exit 2; }
     @task="{{task}}"; \
         dataset=$(HARBOR_TELEMETRY=off "{{harbor}}" run --config "{{config}}" --print-config | jq -er '.datasets | if length == 1 then .[0] | "\(.name)@\(.ref)" else error("expected exactly one dataset") end'); \
         job_name="$(date +%Y-%m-%d__%H-%M-%S)-${task##*/}-daytona-$BASHPID"; \
         HARBOR_TELEMETRY=off "{{harbor}}" run --config "{{config}}" --env daytona --verifier "{{canonical_verifier}}" --dataset "$dataset" --include-task-name "$task" --job-name "$job_name" --agent-kwarg "binary_path={{hosted_agent_artifact}}" --agent-kwarg "install_node=true" --agent-kwarg "effort={{effort}}"
+
+# Run the exact k=5, stock-timeout Terminal-Bench 2.1 leaderboard job in
+# hosted AMD64 sandboxes. Upload remains a separate post-validation step.
+eval-leaderboard-hosted: check-hosted-auth download-agent-hosted
+    @test -x "{{harbor}}" || { echo "run 'just bootstrap' first" >&2; exit 2; }
+    @job_name="$(date +%Y-%m-%d__%H-%M-%S)-terminal-bench-2-1-leaderboard-$BASHPID"; \
+        HARBOR_TELEMETRY=off "{{harbor}}" run \
+            --config "evals/terminal-bench-2-1-leaderboard-high.yaml" \
+            --env daytona \
+            --verifier "{{canonical_verifier}}" \
+            --agent-kwarg "binary_path={{hosted_agent_artifact}}" \
+            --agent-kwarg "install_node=true" \
+            --job-name "$job_name" \
+            --n-attempts 5 \
+            --timeout-multiplier 1 \
+            --n-concurrent "{{hosted_eval_concurrency}}"
 
 # Open all locally retained Harbor jobs unless another jobs directory is supplied.
 view jobs=default_jobs:

--- a/Justfile
+++ b/Justfile
@@ -252,7 +252,9 @@ eval-leaderboard-hosted: check-hosted-auth download-agent-hosted
             --job-name "$job_name" \
             --n-attempts 5 \
             --timeout-multiplier 1 \
-            --n-concurrent "{{hosted_eval_concurrency}}"
+            --n-concurrent "{{hosted_eval_concurrency}}" \
+            --quiet \
+            --yes
 
 # Open all locally retained Harbor jobs unless another jobs directory is supplied.
 view jobs=default_jobs:

--- a/evals/terminal-bench-2-1-leaderboard-high.yaml
+++ b/evals/terminal-bench-2-1-leaderboard-high.yaml
@@ -4,6 +4,8 @@
 # leave environment, verifier, timeouts, and resources unset so Harbor uses the
 # canonical task definitions and default execution policy.
 jobs_dir: .nanocodex/harbor/jobs
+n_attempts: 5
+timeout_multiplier: 1.0
 
 agents:
   - import_path: harbor_adapter.agent:NanocodexAgent

--- a/harbor_adapter/agent.py
+++ b/harbor_adapter/agent.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import json
 import shlex
-import sys
 import tempfile
 import time
 from pathlib import Path
@@ -253,10 +252,6 @@ class NanocodexAgent(BaseInstalledAgent):
         finally:
             await self._remove_staged_api_key(environment)
         self._publish_events(result.stdout)
-        if result.stdout:
-            print(result.stdout, end="", flush=True)
-        if result.stderr:
-            print(result.stderr, end="", file=sys.stderr, flush=True)
 
     def _run_arguments(self, prompt: str) -> list[str]:
         return [
@@ -286,6 +281,7 @@ class NanocodexAgent(BaseInstalledAgent):
         temporary = events.with_name(f"{events.name}.host.tmp")
         temporary.write_text(stdout, encoding="utf-8")
         temporary.replace(events)
+        (self.logs_dir / Path(self._EVENTS_TMP).name).unlink(missing_ok=True)
 
     def populate_context_post_run(self, context: AgentContext) -> None:
         if getattr(self, "_post_run_validation_failed", False):

--- a/harbor_adapter/agent.py
+++ b/harbor_adapter/agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import shlex
 import tempfile
 import time
@@ -88,6 +89,26 @@ def _cli_tools_install_command(*, install_node: bool) -> str:
     )
 
 
+def _remote_binary_install_command(
+    *, binary_url: str, binary_sha256: str, destination: str
+) -> str:
+    """Download one immutable binary inside the Harbor environment."""
+    return (
+        "temporary=$(mktemp); "
+        'trap \'rm -f "$temporary"\' EXIT; '
+        "curl --fail --location --retry 5 --retry-all-errors "
+        f'--output "$temporary" {shlex.quote(binary_url)}; '
+        "if command -v sha256sum >/dev/null 2>&1; then "
+        'actual=$(sha256sum "$temporary" | awk \'{ print $1 }\'); '
+        "elif command -v shasum >/dev/null 2>&1; then "
+        'actual=$(shasum -a 256 "$temporary" | awk \'{ print $1 }\'); '
+        "else echo 'no SHA-256 implementation found' >&2; exit 1; fi; "
+        f"test \"$actual\" = {shlex.quote(binary_sha256)}; "
+        f'cp "$temporary" {shlex.quote(destination)}; '
+        f"chmod 0755 {shlex.quote(destination)}"
+    )
+
+
 class NanocodexAgent(BaseInstalledAgent):
     """Upload one Rust binary, run it once, and retain its JSONL."""
 
@@ -103,6 +124,8 @@ class NanocodexAgent(BaseInstalledAgent):
         self,
         logs_dir: Path,
         binary_path: str | Path = ".nanocodex/installed/nanocodex",
+        binary_url: str | None = None,
+        binary_sha256: str | None = None,
         model_name: str | None = None,
         effort: str = "low",
         web_search: bool = True,
@@ -124,6 +147,18 @@ class NanocodexAgent(BaseInstalledAgent):
             **kwargs,
         )
         self._binary_path = Path(binary_path).resolve()
+        if (binary_url is None) != (binary_sha256 is None):
+            raise ValueError("binary_url and binary_sha256 must be configured together")
+        if binary_url is not None and not binary_url.startswith("https://"):
+            raise ValueError("binary_url must use HTTPS")
+        if binary_sha256 is not None and not re.fullmatch(
+            r"[0-9a-fA-F]{64}", binary_sha256
+        ):
+            raise ValueError("binary_sha256 must contain 64 hexadecimal characters")
+        self._binary_url = binary_url
+        self._binary_sha256 = (
+            binary_sha256.lower() if binary_sha256 is not None else None
+        )
         self._model = self._api_model_name(model_name)
         if self._model != MODEL:
             raise ValueError(f"nanocodex supports only {MODEL}, got {self._model}")
@@ -147,7 +182,9 @@ class NanocodexAgent(BaseInstalledAgent):
         return f"{self._BINARY} --version"
 
     async def install(self, environment: BaseEnvironment) -> None:
-        if not self._binary_path.is_file():
+        binary_url = getattr(self, "_binary_url", None)
+        binary_sha256 = getattr(self, "_binary_sha256", None)
+        if binary_url is None and not self._binary_path.is_file():
             raise RuntimeError(
                 f"missing nanocodex binary at {self._binary_path}; run `just build-agent`"
             )
@@ -156,8 +193,18 @@ class NanocodexAgent(BaseInstalledAgent):
             _cli_tools_install_command(install_node=self._install_node),
             env={"DEBIAN_FRONTEND": "noninteractive"},
         )
-        await environment.upload_file(self._binary_path, self._BINARY)
-        await self.exec_as_root(environment, f"chmod 0755 {self._BINARY}")
+        if binary_url is not None and binary_sha256 is not None:
+            await self.exec_as_root(
+                environment,
+                _remote_binary_install_command(
+                    binary_url=binary_url,
+                    binary_sha256=binary_sha256,
+                    destination=self._BINARY,
+                ),
+            )
+        else:
+            await environment.upload_file(self._binary_path, self._BINARY)
+            await self.exec_as_root(environment, f"chmod 0755 {self._BINARY}")
 
     async def _stage_api_key(self, environment: BaseEnvironment) -> None:
         identity = await self.exec_as_agent(environment, "id -u")

--- a/harbor_adapter/nanocodex.Dockerfile
+++ b/harbor_adapter/nanocodex.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM rust:1.96-alpine3.21 AS build
+FROM rust:1.97-alpine3.22 AS build
 
 ARG TARGETARCH
 ARG CARGO_PROFILE=dev
@@ -98,7 +98,7 @@ RUN --mount=type=cache,id=nanocodex-cargo-registry,target=/usr/local/cargo/regis
 FROM scratch AS artifact
 COPY --from=build /out/nanocodex /nanocodex
 
-FROM alpine:3.21 AS runtime
+FROM alpine:3.22 AS runtime
 RUN apk add --no-cache ca-certificates git
 COPY --from=build /out/nanocodex /usr/local/bin/nanocodex
 ENTRYPOINT ["/usr/local/bin/nanocodex"]

--- a/harbor_adapter/test_agent.py
+++ b/harbor_adapter/test_agent.py
@@ -16,7 +16,11 @@ from unittest.mock import AsyncMock
 import yaml
 from harbor.models.agent.context import AgentContext
 
-from harbor_adapter.agent import NanocodexAgent, _cli_tools_install_command
+from harbor_adapter.agent import (
+    NanocodexAgent,
+    _cli_tools_install_command,
+    _remote_binary_install_command,
+)
 from harbor_adapter.codex import ParityCodexAgent
 from harbor_adapter.environment import _toolbox_mount_setup_command
 from harbor_adapter.verifier import (
@@ -82,6 +86,39 @@ class CliToolInstallContractTests(unittest.TestCase):
             agent.exec_as_root.await_args_list[1].args[1],
             "chmod 0755 /installed-agent/nanocodex",
         )
+
+    def test_remote_binary_install_downloads_and_verifies_before_installing(
+        self,
+    ) -> None:
+        checksum = "a" * 64
+        command = _remote_binary_install_command(
+            binary_url="https://example.test/nanocodex",
+            binary_sha256=checksum,
+            destination="/installed-agent/nanocodex",
+        )
+
+        self.assertIn("curl --fail --location --retry 5", command)
+        self.assertIn("https://example.test/nanocodex", command)
+        self.assertIn("sha256sum", command)
+        self.assertIn(checksum, command)
+        self.assertIn("chmod 0755 /installed-agent/nanocodex", command)
+
+    def test_remote_binary_install_skips_controller_upload(self) -> None:
+        agent = object.__new__(NanocodexAgent)
+        agent._binary_path = Path("/missing-on-controller")
+        agent._binary_url = "https://example.test/nanocodex"
+        agent._binary_sha256 = "b" * 64
+        agent._install_node = True
+        agent.exec_as_root = AsyncMock()
+        environment = SimpleNamespace(upload_file=AsyncMock())
+
+        asyncio.run(agent.install(environment))
+
+        environment.upload_file.assert_not_awaited()
+        self.assertEqual(agent.exec_as_root.await_count, 2)
+        download_command = agent.exec_as_root.await_args_list[1].args[1]
+        self.assertIn(agent._binary_url, download_command)
+        self.assertIn(agent._binary_sha256, download_command)
 
 
 class WebSearchContractTests(unittest.TestCase):

--- a/harbor_adapter/test_agent.py
+++ b/harbor_adapter/test_agent.py
@@ -858,6 +858,8 @@ class RunCancellationContractTests(unittest.IsolatedAsyncioTestCase):
                 return_value=SimpleNamespace(stdout=stream, stderr="")
             )
             environment = SimpleNamespace(capabilities=SimpleNamespace(mounted=True))
+            event_spool = agent.logs_dir / "events.jsonl.tmp"
+            event_spool.write_text(stream, encoding="utf-8")
 
             await agent.run("test", environment, AgentContext())
 
@@ -871,6 +873,7 @@ class RunCancellationContractTests(unittest.IsolatedAsyncioTestCase):
                 stream,
             )
             self.assertFalse((agent.logs_dir / "events.jsonl.host.tmp").exists())
+            self.assertFalse(event_spool.exists())
 
     def test_nonzero_exit_publishes_captured_stdout_before_classification(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,7 @@ version = "0.1.0"
 description = "Harbor integration for the Rust nanocodex"
 requires-python = ">=3.13,<3.14"
 dependencies = [
-    # Pin an official nightly wheel instead of a raw Git checkout. Harbor's
-    # release pipeline embeds the viewer frontend; wheels built directly from
-    # Git contain only the API server because the frontend is a CI artifact.
-    "harbor[daytona]==0.18.1.dev202607150126",
+    "harbor[daytona]==0.20.0",
     # Harbor's own lock uses this universal wheel. Newer unconstrained releases
     # currently fall back to a slow, broken native build on macOS arm64.
     "litellm==1.86.2",

--- a/scripts/download-harbor-agent.sh
+++ b/scripts/download-harbor-agent.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+    echo "usage: $0 <release-tag> <destination>" >&2
+    exit 2
+fi
+
+release_tag=$1
+destination=$2
+artifact=nanocodex-x86_64-unknown-linux-musl
+release_base="https://github.com/gakonst/nanocodex/releases/download/${release_tag}"
+destination_dir=$(dirname "$destination")
+
+mkdir -p "$destination_dir"
+temporary_dir=$(mktemp -d "${destination_dir}/.nanocodex-download.XXXXXX")
+trap 'rm -rf "$temporary_dir"' EXIT
+
+curl --fail --location --retry 5 --retry-all-errors \
+    --output "$temporary_dir/SHA256SUMS" \
+    "${release_base}/SHA256SUMS"
+curl --fail --location --retry 5 --retry-all-errors \
+    --output "$temporary_dir/$artifact" \
+    "${release_base}/${artifact}"
+
+expected=$(
+    awk -v artifact="$artifact" '$2 == artifact { print $1 }' \
+        "$temporary_dir/SHA256SUMS"
+)
+if [[ ! "$expected" =~ ^[[:xdigit:]]{64}$ ]]; then
+    echo "release checksum manifest does not contain $artifact" >&2
+    exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    actual=$(sha256sum "$temporary_dir/$artifact" | awk '{ print $1 }')
+else
+    actual=$(shasum -a 256 "$temporary_dir/$artifact" | awk '{ print $1 }')
+fi
+if [[ "$actual" != "$expected" ]]; then
+    echo "checksum mismatch for $artifact: expected $expected, got $actual" >&2
+    exit 1
+fi
+
+chmod 0755 "$temporary_dir/$artifact"
+mv -f "$temporary_dir/$artifact" "$destination"
+printf 'Installed %s from %s (%s)\n' "$destination" "$release_tag" "$actual"

--- a/scripts/download-harbor-agent.sh
+++ b/scripts/download-harbor-agent.sh
@@ -43,5 +43,7 @@ if [[ "$actual" != "$expected" ]]; then
 fi
 
 chmod 0755 "$temporary_dir/$artifact"
+printf '%s\n' "$actual" > "$temporary_dir/$artifact.sha256"
 mv -f "$temporary_dir/$artifact" "$destination"
+mv -f "$temporary_dir/$artifact.sha256" "$destination.sha256"
 printf 'Installed %s from %s (%s)\n' "$destination" "$release_tag" "$actual"

--- a/uv.lock
+++ b/uv.lock
@@ -719,7 +719,7 @@ wheels = [
 
 [[package]]
 name = "harbor"
-version = "0.18.1.dev202607150126"
+version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dirhash" },
@@ -744,9 +744,9 @@ dependencies = [
     { name = "typer" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/0b/b0f5ccbfac0b3226c7bb1989b9abe4aef479052e28c447add9fcd819e784/harbor-0.18.1.dev202607150126.tar.gz", hash = "sha256:10d06af650a2c60637552bd978a17805ae89dd56983e1c593b0473320b5321f1", size = 1586969 }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/da/5a26998c6e7d9455321ab39bc8e9122993892ece13c3ad4f2b0de986aaf6/harbor-0.20.0.tar.gz", hash = "sha256:e2e5e88f772690fd121553ca34fd5d6dd6b4aaa51c8fae635abc84b112303112", size = 1590870 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/3d/7c1b146793c678f08a0d37c680307c3ae944fdd5db7d4bbbf33aad357ba8/harbor-0.18.1.dev202607150126-py3-none-any.whl", hash = "sha256:af4961086240097dcb48cb267f4b586b16455bfe552577c959244dca48cdf0fc", size = 1786778 },
+    { url = "https://files.pythonhosted.org/packages/76/03/b6617f32385295729f3af0ae0d512cf87ba4793b9ce462ea020d776a9025/harbor-0.20.0-py3-none-any.whl", hash = "sha256:4b7e48223aea2384cdb8c9eff35eaebd482fc9b1ec09f8193a121c47356ff19a", size = 1792416 },
 ]
 
 [package.optional-dependencies]
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "harbor", extras = ["daytona"], specifier = "==0.18.1.dev202607150126" },
+    { name = "harbor", extras = ["daytona"], specifier = "==0.20.0" },
     { name = "litellm", specifier = "==1.86.2" },
 ]
 


### PR DESCRIPTION
## Summary

- build and publish a static x86_64 Linux nightly specifically for Harbor/Daytona
- execute that artifact in both Alpine and Ubuntu during CI
- download it into the Harbor adapter with SHA-256 verification
- update the adapter to Harbor 0.20 and add the canonical Terminal-Bench 2.1 k=5/high hosted recipe
- move the aarch64 GNU nightly to a native ARM runner to avoid the cross-OpenSSL failure

## Validation

- `actionlint .github/workflows/nightly.yml`
- `bash -n scripts/download-harbor-agent.sh`
- `uv sync --frozen`
- `.venv/bin/python -m unittest discover -s harbor_adapter -p "test_*.py"` (38 passed)
- Harbor config parse/print with pinned Terminal-Bench 2.1 digest, k=5, canonical verifier, and Daytona
- `cargo fmt --all -- --check`
- `git diff --check`

The authoritative binary build and Alpine/Ubuntu execution checks run in the nightly workflow.