### PR TITLE
feat(mcp): add in-app OAuth login and hot reload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4019,6 +4019,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-transport-mpp",
  "arboard",
+ "async-trait",
  "base64",
  "chrono",
  "clap",
@@ -4048,6 +4049,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-tungstenite 0.30.0",
+ "toml",
  "tracing",
  "two-face",
  "unicode-segmentation",
@@ -4106,6 +4108,7 @@ dependencies = [
  "http",
  "nanocodex-core",
  "nanocodex-tools",
+ "oauth2",
  "reqwest",
  "rmcp",
  "rustls",
@@ -4465,6 +4468,25 @@ dependencies = [
  "ruint",
  "serde",
  "smallvec",
+]
+
+[[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.7",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
@@ -5877,6 +5899,7 @@ dependencies = [
  "chrono",
  "futures",
  "http",
+ "oauth2",
  "pin-project-lite",
  "process-wrap",
  "reqwest",
@@ -5888,6 +5911,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -6424,6 +6448,15 @@ checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
 dependencies = [
  "itoa",
  "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
  "serde_core",
 ]
 
@@ -7321,6 +7354,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7349,6 +7397,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,8 @@ ratatui = { version = "0.29.0", features = ["unstable-rendered-line-info"] }
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "query", "rustls"] }
 rusqlite = { version = "0.38", features = ["bundled"] }
 rquickjs = "0.12.1"
-rmcp = { version = "1.8.0", default-features = false, features = ["client", "reqwest-tls-no-provider", "transport-child-process", "transport-streamable-http-client-reqwest"] }
+rmcp = { version = "1.8.0", default-features = false, features = ["auth", "client", "reqwest-tls-no-provider", "transport-child-process", "transport-streamable-http-client-reqwest"] }
+oauth2 = { version = "5.0", default-features = false }
 rustls = { version = "0.23.42", default-features = false, features = ["ring", "std"] }
 schemars = "0.8.22"
 self-replace = "1.5.0"
@@ -83,6 +84,7 @@ sonic-rs = "0.5.8"
 syn = { version = "2.0.119", features = ["full"] }
 thiserror = "2.0.17"
 tempfile = "3.27.0"
+toml = "1.1.3"
 tokio = "1.48.0"
 tokio-tungstenite = { version = "0.30.0", default-features = false, features = ["connect", "rustls-tls-native-roots"] }
 tempo-alloy = "1.8.1"

--- a/README.md
+++ b/README.md
@@ -616,12 +616,19 @@ nanocodex auth login
 nanocodex --auth-file "${CODEX_HOME:-$HOME/.codex}/auth.json"
 ```
 
-The CLI starts the deferred `openaiDeveloperDocs`, `tempo`, and `cloudflare`
-Streamable HTTP MCP providers by default. Their catalogs stay out of the stable
-model prompt until Code Mode calls `tool_search`. Disable the set with
-`--mcp-defaults false`, or override and extend it with the existing `--mcp` and
-`--mcp-stdio` options. `NANOCODEX_MCP_DEFAULTS=false` is the environment
-equivalent.
+The CLI merges enabled MCP servers from
+`${CODEX_HOME:-$HOME/.codex}/config.toml` with its deferred
+`openaiDeveloperDocs`, `tempo`, and `cloudflare` defaults. Explicit `--mcp` and
+`--mcp-stdio` entries take precedence over Codex config, and Codex entries take
+precedence over same-named defaults. Their catalogs stay out of the stable
+model prompt until Code Mode calls `tool_search`. Disable the built-in set with
+`--mcp-defaults false` and Codex config loading with
+`--mcp-codex-config false`; the environment equivalents are
+`NANOCODEX_MCP_DEFAULTS=false` and `NANOCODEX_MCP_CODEX_CONFIG=false`.
+Streamable HTTP servers also reuse Codex's file-backed MCP OAuth credentials.
+Expired access tokens refresh through the server's OAuth metadata and rotated
+credentials are persisted back to `.credentials.json` under the same
+cross-process lock as Codex.
 
 Provider prewarming is scheduled before agent construction returns, so the TUI
 does not wait for HTTP client setup, DNS/TLS, MCP handshakes, `tools/list`, or
@@ -649,7 +656,10 @@ while the mainline continues. The fork inherits the last completed response ID
 plus complete tool results and applied steers after that response; partial model
 output and unmatched tool calls remain excluded. With local telemetry running,
 `/trace` opens Jaeger filtered to every turn in the focused main or `/btw`
-session. The complete keybinding reference, retained Amp and Codex research, and
+session. `/mcp login <server>` opens browser OAuth and hot-reloads that server's
+tools into the running session after the callback; `/mcp reload <server>` retries
+discovery without restarting the TUI. The complete keybinding reference,
+retained Amp and Codex research, and
 prioritized Ratatui backlog live in
 [`docs/TUI_NOTES.md`](docs/TUI_NOTES.md). The headless `nanocodex run` adapter
 emits flushed JSONL for scripts and Harbor.

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -13,6 +13,7 @@ build = "build.rs"
 
 [dependencies]
 arboard.workspace = true
+async-trait.workspace = true
 alloy-primitives.workspace = true
 base64.workspace = true
 alloy-transport-mpp = { version = "=0.2.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "dd7835124cd3e28f7e18a613a7f7e799538ed1ad" }
@@ -40,6 +41,7 @@ two-face.workspace = true
 sha2.workspace = true
 shlex.workspace = true
 tempfile.workspace = true
+toml.workspace = true
 tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-tungstenite.workspace = true
 tracing.workspace = true

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -6,11 +6,11 @@ use std::{
 use clap::{ArgAction, Args, builder::NonEmptyStringValueParser};
 use eyre::{Result, WrapErr, eyre};
 use nanocodex::{
-    AgentEvents, Nanocodex, OpenAiAuth, OpenAiAuthMode, ReasoningMode, Responses, ResponsesHistory,
-    ResponsesTransport, RolloutConfig, Thinking, Tools,
+    AgentEvents, McpHandle, Nanocodex, OpenAiAuth, OpenAiAuthMode, ReasoningMode, Responses,
+    ResponsesHistory, ResponsesTransport, RolloutConfig, Thinking, Tools,
 };
 
-use crate::mcp::McpArgs;
+use crate::mcp::{ConfiguredMcp, McpArgs};
 use crate::mpp::{MppAdapter, MppArgs};
 use crate::subagents::{self, ChildAgents};
 
@@ -19,6 +19,7 @@ pub(crate) struct ConfiguredAgent {
     pub(crate) events: AgentEvents,
     pub(crate) child_agents: Option<Arc<ChildAgents>>,
     pub(crate) mpp_adapter: Option<MppAdapter>,
+    pub(crate) mcp: Option<McpHandle>,
 }
 
 #[derive(Args)]
@@ -163,8 +164,10 @@ impl AgentArgs {
         let mut tools = Tools::builder()
             .web_search(self.web_search)
             .image_generation(self.image_generation);
-        if let Some(mcp) = self.mcp.build()? {
-            tools = tools.provider(mcp);
+        let mcp = self.mcp.build(&codex_home)?;
+        let mcp_handle = mcp.as_ref().map(|mcp| mcp.handle.clone());
+        if let Some(ConfiguredMcp { provider, .. }) = mcp {
+            tools = tools.provider(provider);
         }
         if let Some(mpp_adapter) = &mpp_adapter {
             tools = tools
@@ -204,6 +207,7 @@ impl AgentArgs {
             events,
             child_agents,
             mpp_adapter,
+            mcp: mcp_handle,
         })
     }
 }
@@ -377,7 +381,7 @@ mod tests {
     }
 
     #[test]
-    fn standard_mcp_servers_are_enabled_by_default() {
+    fn standard_and_codex_config_mcp_servers_are_enabled_by_default() {
         let command = crate::Cli::command();
         let mcp_defaults = command
             .get_arguments()
@@ -385,6 +389,12 @@ mod tests {
             .expect("the CLI should expose the MCP defaults argument");
 
         assert_eq!(mcp_defaults.get_default_values(), ["true"]);
+
+        let codex_config = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "mcp_codex_config")
+            .expect("the CLI should expose the Codex MCP config argument");
+        assert_eq!(codex_config.get_default_values(), ["true"]);
     }
 
     #[test]

--- a/bin/nanocodex/src/mcp.rs
+++ b/bin/nanocodex/src/mcp.rs
@@ -1,8 +1,20 @@
-use std::{collections::BTreeMap, str::FromStr, time::Duration};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs::{self, File, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
+    thread,
+    time::Duration,
+};
 
+use async_trait::async_trait;
 use clap::{ArgAction, Args};
-use eyre::{Result, bail};
-use nanocodex::{Mcp, McpServer};
+use eyre::{Result, WrapErr, bail, eyre};
+use nanocodex::{Mcp, McpHandle, McpOAuthCredentials, McpOAuthStore, McpServer};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 const DEFAULT_MCP_SERVERS: [(&str, &str, &str); 3] = [
     (
@@ -32,6 +44,15 @@ pub(crate) struct McpArgs {
         action = ArgAction::Set
     )]
     mcp_defaults: bool,
+
+    /// Load enabled MCP servers from `$CODEX_HOME/config.toml`.
+    #[arg(
+        long,
+        env = "NANOCODEX_MCP_CODEX_CONFIG",
+        default_value_t = true,
+        action = ArgAction::Set
+    )]
+    mcp_codex_config: bool,
 
     /// Add a named Streamable HTTP MCP server (`NAME=URL`). Repeatable.
     #[arg(long = "mcp", value_name = "NAME=URL")]
@@ -71,8 +92,71 @@ struct ServerConfig {
     transport: Transport,
     description: Option<String>,
     arguments: Vec<String>,
+    environment: BTreeMap<String, String>,
+    cwd: Option<PathBuf>,
     bearer_env: Option<String>,
+    headers: BTreeMap<String, String>,
     header_env: Vec<(String, String)>,
+    startup_timeout: Option<Duration>,
+    tool_timeout: Option<Duration>,
+    enabled_tools: Option<Vec<String>>,
+    disabled_tools: Vec<String>,
+}
+
+#[derive(Default, Deserialize)]
+struct CodexConfig {
+    #[serde(default)]
+    mcp_servers: BTreeMap<String, CodexMcpServer>,
+}
+
+pub(crate) struct ConfiguredMcp {
+    pub(crate) provider: Mcp,
+    pub(crate) handle: McpHandle,
+}
+
+#[derive(Clone)]
+struct CodexOAuthStore {
+    codex_home: PathBuf,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+struct CodexOAuthEntry {
+    server_name: String,
+    server_url: String,
+    client_id: String,
+    access_token: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    expires_at: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    refresh_token: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    scopes: Vec<String>,
+}
+
+type CodexOAuthFile = BTreeMap<String, CodexOAuthEntry>;
+
+#[derive(Deserialize)]
+struct CodexMcpServer {
+    command: Option<String>,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    cwd: Option<PathBuf>,
+    url: Option<String>,
+    bearer_token_env_var: Option<String>,
+    #[serde(default)]
+    http_headers: BTreeMap<String, String>,
+    #[serde(default)]
+    env_http_headers: BTreeMap<String, String>,
+    #[serde(default = "enabled_by_default")]
+    enabled: bool,
+    startup_timeout_sec: Option<f64>,
+    startup_timeout_ms: Option<u64>,
+    tool_timeout_sec: Option<f64>,
+    enabled_tools: Option<Vec<String>>,
+    #[serde(default)]
+    disabled_tools: Vec<String>,
 }
 
 #[derive(Clone)]
@@ -89,7 +173,7 @@ struct NamedHeaderValue {
 }
 
 impl McpArgs {
-    pub(crate) fn build(self) -> Result<Option<Mcp>> {
+    pub(crate) fn build(self, codex_home: &Path) -> Result<Option<ConfiguredMcp>> {
         if self.mcp_startup_timeout == 0 || self.mcp_tool_timeout == 0 {
             bail!("MCP timeouts must be greater than zero");
         }
@@ -101,16 +185,41 @@ impl McpArgs {
         for command in self.stdio {
             insert_server(&mut servers, command, Transport::Stdio)?;
         }
+        let mut codex_server_names = BTreeSet::new();
+        let oauth_store = self
+            .mcp_codex_config
+            .then(|| Arc::new(CodexOAuthStore::new(codex_home.to_path_buf())));
+        if self.mcp_codex_config {
+            for (name, server) in load_codex_mcp_servers(codex_home)? {
+                codex_server_names.insert(name.clone());
+                if servers.contains_key(&name) {
+                    continue;
+                }
+                if let Some(server) = server {
+                    servers.insert(name, server);
+                }
+            }
+        }
         if self.mcp_defaults {
             for (name, url, description) in DEFAULT_MCP_SERVERS {
+                if codex_server_names.contains(name) {
+                    continue;
+                }
                 servers
                     .entry(name.to_owned())
                     .or_insert_with(|| ServerConfig {
                         transport: Transport::Http(url.to_owned()),
                         description: Some(description.to_owned()),
                         arguments: Vec::new(),
+                        environment: BTreeMap::new(),
+                        cwd: None,
                         bearer_env: None,
+                        headers: BTreeMap::new(),
                         header_env: Vec::new(),
+                        startup_timeout: None,
+                        tool_timeout: None,
+                        enabled_tools: None,
+                        disabled_tools: Vec::new(),
                     });
             }
         }
@@ -150,28 +259,372 @@ impl McpArgs {
 
         let startup_timeout = Duration::from_secs(self.mcp_startup_timeout);
         let tool_timeout = Duration::from_secs(self.mcp_tool_timeout);
-        let mut builder = Mcp::builder();
-        for (name, server) in servers {
-            let description = server.description;
-            let mut configured = match server.transport {
-                Transport::Http(url) => McpServer::http(url),
-                Transport::Stdio(command) => McpServer::stdio(command).args(server.arguments),
-            }
-            .startup_timeout(startup_timeout)
-            .tool_timeout(tool_timeout);
-            if let Some(description) = description {
-                configured = configured.description(description);
-            }
-            if let Some(variable) = server.bearer_env {
-                configured = configured.bearer_token_env(variable);
-            }
-            for (header, variable) in server.header_env {
-                configured = configured.header_env(header, variable);
-            }
-            builder = builder.server(name, configured);
-        }
-        Ok(Some(builder.build()?))
+        Ok(Some(build_mcp(
+            servers,
+            startup_timeout,
+            tool_timeout,
+            oauth_store,
+        )?))
     }
+}
+
+fn build_mcp(
+    servers: BTreeMap<String, ServerConfig>,
+    startup_timeout: Duration,
+    tool_timeout: Duration,
+    oauth_store: Option<Arc<CodexOAuthStore>>,
+) -> Result<ConfiguredMcp> {
+    let mut builder = Mcp::builder();
+    if let Some(store) = oauth_store {
+        builder = builder.oauth_store(store);
+    }
+    for (name, server) in servers {
+        let description = server.description;
+        let mut configured = match server.transport {
+            Transport::Http(url) => McpServer::http(url),
+            Transport::Stdio(command) => {
+                let mut configured = McpServer::stdio(command).args(server.arguments);
+                for (name, value) in server.environment {
+                    configured = configured.env(name, value);
+                }
+                if let Some(cwd) = server.cwd {
+                    configured = configured.cwd(cwd);
+                }
+                configured
+            }
+        }
+        .startup_timeout(server.startup_timeout.unwrap_or(startup_timeout))
+        .tool_timeout(server.tool_timeout.unwrap_or(tool_timeout));
+        if let Some(description) = description {
+            configured = configured.description(description);
+        }
+        if let Some(variable) = server.bearer_env {
+            configured = configured.bearer_token_env(variable);
+        }
+        for (header, value) in server.headers {
+            configured = configured.header(header, value);
+        }
+        for (header, variable) in server.header_env {
+            configured = configured.header_env(header, variable);
+        }
+        if let Some(enabled_tools) = server.enabled_tools {
+            configured = configured.enabled_tools(enabled_tools);
+        }
+        configured = configured.disabled_tools(server.disabled_tools);
+        builder = builder.server(name, configured);
+    }
+    let provider = builder.build()?;
+    let handle = provider.handle();
+    Ok(ConfiguredMcp { provider, handle })
+}
+
+fn load_codex_mcp_servers(codex_home: &Path) -> Result<BTreeMap<String, Option<ServerConfig>>> {
+    let path = codex_home.join("config.toml");
+    let contents = match fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(BTreeMap::new()),
+        Err(error) => {
+            return Err(error).wrap_err_with(|| format!("failed to read {}", path.display()));
+        }
+    };
+    let config: CodexConfig = toml::from_str(&contents)
+        .wrap_err_with(|| format!("failed to parse {}", path.display()))?;
+    config
+        .mcp_servers
+        .into_iter()
+        .map(|(name, server)| {
+            let server = server.into_server_config(&name)?;
+            Ok((name, server))
+        })
+        .collect()
+}
+
+impl CodexOAuthStore {
+    fn new(codex_home: PathBuf) -> Self {
+        Self { codex_home }
+    }
+
+    fn credentials_path(&self) -> PathBuf {
+        self.codex_home.join(".credentials.json")
+    }
+
+    fn load_blocking(
+        &self,
+        server_name: &str,
+        server_url: &str,
+    ) -> Result<Option<McpOAuthCredentials>, String> {
+        let _lock = CodexOAuthFileLock::acquire(&self.codex_home)?;
+        let entries = read_oauth_file(&self.credentials_path())?;
+        let entry = entries
+            .values()
+            .filter(|entry| entry.server_name == server_name && entry.server_url == server_url)
+            .max_by_key(|entry| entry.expires_at)
+            .cloned();
+        let Some(entry) = entry else {
+            return Ok(None);
+        };
+        if entry.client_id.trim().is_empty() || entry.access_token.trim().is_empty() {
+            return Err(format!(
+                "stored OAuth credentials for `{server_name}` are incomplete"
+            ));
+        }
+        let mut credentials =
+            McpOAuthCredentials::new(entry.client_id, entry.access_token).scopes(entry.scopes);
+        if let Some(refresh_token) = entry.refresh_token.filter(|token| !token.trim().is_empty()) {
+            credentials = credentials.refresh_token(refresh_token);
+        }
+        if let Some(expires_at) = entry.expires_at {
+            credentials = credentials.expires_at_millis(expires_at);
+        }
+        Ok(Some(credentials))
+    }
+
+    fn save_blocking(
+        &self,
+        server_name: &str,
+        server_url: &str,
+        credentials: &McpOAuthCredentials,
+    ) -> Result<(), String> {
+        let _lock = CodexOAuthFileLock::acquire(&self.codex_home)?;
+        let path = self.credentials_path();
+        let mut entries = read_oauth_file(&path)?;
+        entries
+            .retain(|_, entry| entry.server_name != server_name || entry.server_url != server_url);
+        entries.insert(
+            codex_oauth_key(server_name, server_url)?,
+            CodexOAuthEntry {
+                server_name: server_name.to_owned(),
+                server_url: server_url.to_owned(),
+                client_id: credentials.client_id().to_owned(),
+                access_token: credentials.access_token().to_owned(),
+                expires_at: credentials.expires_at(),
+                refresh_token: credentials.refresh_token_value().map(ToOwned::to_owned),
+                scopes: credentials.granted_scopes().to_vec(),
+            },
+        );
+        write_oauth_file(&path, &entries)
+    }
+}
+
+#[async_trait]
+impl McpOAuthStore for CodexOAuthStore {
+    async fn load(
+        &self,
+        server_name: &str,
+        server_url: &str,
+    ) -> Result<Option<McpOAuthCredentials>, String> {
+        let store = self.clone();
+        let server_name = server_name.to_owned();
+        let server_url = server_url.to_owned();
+        tokio::task::spawn_blocking(move || store.load_blocking(&server_name, &server_url))
+            .await
+            .map_err(|error| format!("MCP OAuth credential reader stopped: {error}"))?
+    }
+
+    async fn save(
+        &self,
+        server_name: &str,
+        server_url: &str,
+        credentials: &McpOAuthCredentials,
+    ) -> Result<(), String> {
+        let store = self.clone();
+        let server_name = server_name.to_owned();
+        let server_url = server_url.to_owned();
+        let credentials = credentials.clone();
+        tokio::task::spawn_blocking(move || {
+            store.save_blocking(&server_name, &server_url, &credentials)
+        })
+        .await
+        .map_err(|error| format!("MCP OAuth credential writer stopped: {error}"))?
+    }
+}
+
+struct CodexOAuthFileLock {
+    _file: File,
+}
+
+impl CodexOAuthFileLock {
+    fn acquire(codex_home: &Path) -> Result<Self, String> {
+        let directory = codex_home.join("mcp-oauth-locks");
+        fs::create_dir_all(&directory).map_err(|error| {
+            format!(
+                "failed to create MCP OAuth lock directory {}: {error}",
+                directory.display()
+            )
+        })?;
+        let path = directory.join("file-store.lock");
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .map_err(|error| {
+                format!("failed to open MCP OAuth lock {}: {error}", path.display())
+            })?;
+        let started = std::time::Instant::now();
+        loop {
+            match file.try_lock() {
+                Ok(()) => return Ok(Self { _file: file }),
+                Err(std::fs::TryLockError::WouldBlock)
+                    if started.elapsed() >= Duration::from_mins(1) =>
+                {
+                    return Err(format!(
+                        "timed out waiting for MCP OAuth lock {}",
+                        path.display()
+                    ));
+                }
+                Err(std::fs::TryLockError::WouldBlock) => {
+                    thread::sleep(Duration::from_millis(50));
+                }
+                Err(error) => {
+                    return Err(format!(
+                        "failed to lock MCP OAuth store {}: {error}",
+                        path.display()
+                    ));
+                }
+            }
+        }
+    }
+}
+
+fn read_oauth_file(path: &Path) -> Result<CodexOAuthFile, String> {
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(BTreeMap::new());
+        }
+        Err(error) => {
+            return Err(format!(
+                "failed to read MCP OAuth credentials {}: {error}",
+                path.display()
+            ));
+        }
+    };
+    serde_json::from_str(&contents).map_err(|error| {
+        format!(
+            "failed to parse MCP OAuth credentials {}: {error}",
+            path.display()
+        )
+    })
+}
+
+fn write_oauth_file(path: &Path, entries: &CodexOAuthFile) -> Result<(), String> {
+    let parent = path.parent().ok_or_else(|| {
+        format!(
+            "MCP OAuth credential path has no parent: {}",
+            path.display()
+        )
+    })?;
+    fs::create_dir_all(parent).map_err(|error| {
+        format!(
+            "failed to create MCP OAuth credential directory {}: {error}",
+            parent.display()
+        )
+    })?;
+    let encoded = serde_json::to_vec(entries)
+        .map_err(|error| format!("failed to encode MCP OAuth credentials: {error}"))?;
+    let mut temporary = tempfile::NamedTempFile::new_in(parent).map_err(|error| {
+        format!(
+            "failed to create temporary MCP OAuth credential file in {}: {error}",
+            parent.display()
+        )
+    })?;
+    temporary
+        .write_all(&encoded)
+        .map_err(|error| format!("failed to write MCP OAuth credentials: {error}"))?;
+    temporary
+        .as_file()
+        .sync_all()
+        .map_err(|error| format!("failed to sync MCP OAuth credentials: {error}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        temporary
+            .as_file()
+            .set_permissions(fs::Permissions::from_mode(0o600))
+            .map_err(|error| format!("failed to protect MCP OAuth credentials: {error}"))?;
+    }
+    temporary.persist(path).map_err(|error| {
+        format!(
+            "failed to replace MCP OAuth credentials {}: {}",
+            path.display(),
+            error.error
+        )
+    })?;
+    Ok(())
+}
+
+fn codex_oauth_key(server_name: &str, server_url: &str) -> Result<String, String> {
+    #[derive(Serialize)]
+    struct KeyPayload<'a> {
+        #[serde(rename = "type")]
+        kind: &'static str,
+        url: &'a str,
+        headers: BTreeMap<String, String>,
+    }
+
+    let encoded = serde_json::to_vec(&KeyPayload {
+        kind: "http",
+        url: server_url,
+        headers: BTreeMap::new(),
+    })
+    .map_err(|error| format!("failed to encode MCP OAuth credential key: {error}"))?;
+    let digest = Sha256::digest(encoded);
+    let prefix = format!("{digest:x}");
+    Ok(format!("{server_name}|{}", &prefix[..16]))
+}
+
+impl CodexMcpServer {
+    fn into_server_config(self, name: &str) -> Result<Option<ServerConfig>> {
+        if !self.enabled {
+            return Ok(None);
+        }
+        let transport = match (self.command, self.url) {
+            (Some(command), None) => Transport::Stdio(command),
+            (None, Some(url)) => Transport::Http(url),
+            (Some(_), Some(_)) => {
+                bail!("Codex MCP server `{name}` configures both `command` and `url`");
+            }
+            (None, None) => {
+                bail!("Codex MCP server `{name}` configures neither `command` nor `url`");
+            }
+        };
+        let startup_timeout = match (self.startup_timeout_sec, self.startup_timeout_ms) {
+            (Some(seconds), _) => {
+                Some(duration_from_seconds(name, "startup_timeout_sec", seconds)?)
+            }
+            (None, Some(milliseconds)) => Some(Duration::from_millis(milliseconds)),
+            (None, None) => None,
+        };
+        let tool_timeout = self
+            .tool_timeout_sec
+            .map(|seconds| duration_from_seconds(name, "tool_timeout_sec", seconds))
+            .transpose()?;
+        Ok(Some(ServerConfig {
+            transport,
+            description: Some("Configured in Codex config.toml.".to_owned()),
+            arguments: self.args,
+            environment: self.env,
+            cwd: self.cwd,
+            bearer_env: self.bearer_token_env_var,
+            headers: self.http_headers,
+            header_env: self.env_http_headers.into_iter().collect(),
+            startup_timeout,
+            tool_timeout,
+            enabled_tools: self.enabled_tools,
+            disabled_tools: self.disabled_tools,
+        }))
+    }
+}
+
+fn duration_from_seconds(server: &str, field: &str, seconds: f64) -> Result<Duration> {
+    Duration::try_from_secs_f64(seconds)
+        .map_err(|error| eyre!("Codex MCP server `{server}` has invalid `{field}`: {error}"))
+}
+
+const fn enabled_by_default() -> bool {
+    true
 }
 
 fn insert_server(
@@ -187,8 +640,15 @@ fn insert_server(
                 transport: transport(named.value),
                 description: None,
                 arguments: Vec::new(),
+                environment: BTreeMap::new(),
+                cwd: None,
                 bearer_env: None,
+                headers: BTreeMap::new(),
                 header_env: Vec::new(),
+                startup_timeout: None,
+                tool_timeout: None,
+                enabled_tools: None,
+                disabled_tools: Vec::new(),
             },
         )
         .is_some()
@@ -249,11 +709,17 @@ impl FromStr for NamedHeaderValue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nanocodex_tools::{ToolRuntime, Tools};
+    use nanocodex::{MODEL, ToolContext};
+    use nanocodex_observability::{LogFormat, LogOutput, ObservabilityBuilder};
+    use nanocodex_tools::{
+        DEFAULT_TOOL_OUTPUT_TOKENS, DynamicToolProvider, ToolInput, ToolRuntime, Tools,
+    };
+    use serde_json::{Value, json, value::to_raw_value};
 
     fn args() -> McpArgs {
         McpArgs {
             mcp_defaults: true,
+            mcp_codex_config: false,
             http: Vec::new(),
             stdio: Vec::new(),
             arguments: Vec::new(),
@@ -266,7 +732,7 @@ mod tests {
 
     #[test]
     fn default_mcp_servers_build() {
-        assert!(args().build().unwrap().is_some());
+        assert!(args().build(Path::new("/missing")).unwrap().is_some());
     }
 
     #[test]
@@ -276,7 +742,7 @@ mod tests {
                 mcp_defaults: false,
                 ..args()
             }
-            .build()
+            .build(Path::new("/missing"))
             .unwrap()
             .is_none()
         );
@@ -290,7 +756,7 @@ mod tests {
             value: "https://example.test/mcp".to_owned(),
         });
 
-        assert!(args.build().unwrap().is_some());
+        assert!(args.build(Path::new("/missing")).unwrap().is_some());
     }
 
     #[test]
@@ -303,7 +769,343 @@ mod tests {
             });
         }
 
-        assert!(args.build().is_err());
+        assert!(args.build(Path::new("/missing")).is_err());
+    }
+
+    #[test]
+    fn codex_servers_merge_between_explicit_entries_and_defaults() {
+        let codex_home = tempfile::tempdir().unwrap();
+        fs::write(
+            codex_home.path().join("config.toml"),
+            r#"
+[mcp_servers.centaur-paradigm]
+url = "https://centaur.example.test/mcp"
+startup_timeout_sec = 12.5
+tool_timeout_sec = 45
+enabled_tools = ["search"]
+disabled_tools = ["write"]
+
+[mcp_servers.local]
+command = "node"
+args = ["server.mjs"]
+cwd = "/workspace"
+
+[mcp_servers.local.env]
+MODE = "read-only"
+
+[mcp_servers.tempo]
+url = "https://disabled.example.test/mcp"
+enabled = false
+"#,
+        )
+        .unwrap();
+        let mut args = args();
+        args.mcp_codex_config = true;
+        let mcp = args.build(codex_home.path()).unwrap().unwrap();
+        let tools = Tools::builder().provider(mcp.provider).build().unwrap();
+        let encoded = serde_json::to_string(
+            &ToolRuntime::new_with_tools(".", None, None, &tools).model_specs(),
+        )
+        .unwrap();
+
+        assert!(encoded.contains("centaur-paradigm"));
+        assert!(encoded.contains("local"));
+        assert!(encoded.contains("openaiDeveloperDocs"));
+        assert!(encoded.contains("cloudflare"));
+        assert!(!encoded.contains("\n- tempo:"));
+    }
+
+    #[test]
+    fn codex_transport_options_are_preserved() {
+        let codex_home = tempfile::tempdir().unwrap();
+        fs::write(
+            codex_home.path().join("config.toml"),
+            r#"
+[mcp_servers.remote]
+url = "https://remote.example.test/mcp"
+bearer_token_env_var = "REMOTE_TOKEN"
+http_headers = { "X-Fixed" = "fixed" }
+env_http_headers = { "X-Secret" = "SECRET_HEADER" }
+startup_timeout_ms = 2500
+tool_timeout_sec = 9.5
+"#,
+        )
+        .unwrap();
+
+        let mut loaded = load_codex_mcp_servers(codex_home.path()).unwrap();
+        let server = loaded.remove("remote").unwrap().unwrap();
+        assert!(
+            matches!(server.transport, Transport::Http(ref url) if url == "https://remote.example.test/mcp")
+        );
+        assert_eq!(server.bearer_env.as_deref(), Some("REMOTE_TOKEN"));
+        assert_eq!(
+            server.headers.get("X-Fixed").map(String::as_str),
+            Some("fixed")
+        );
+        assert_eq!(
+            server.header_env,
+            vec![("X-Secret".to_owned(), "SECRET_HEADER".to_owned())]
+        );
+        assert_eq!(server.startup_timeout, Some(Duration::from_millis(2500)));
+        assert_eq!(server.tool_timeout, Some(Duration::from_millis(9500)));
+    }
+
+    #[tokio::test]
+    async fn codex_oauth_store_reads_legacy_keys_and_replaces_duplicates() {
+        let codex_home = tempfile::tempdir().unwrap();
+        let path = codex_home.path().join(".credentials.json");
+        fs::write(
+            &path,
+            r#"{
+                "remote|legacy": {
+                    "server_name": "remote",
+                    "server_url": "https://remote.example/mcp",
+                    "client_id": "old-client",
+                    "access_token": "old-access",
+                    "expires_at": 100,
+                    "refresh_token": "old-refresh",
+                    "scopes": ["mcp:tools"]
+                },
+                "remote|newer": {
+                    "server_name": "remote",
+                    "server_url": "https://remote.example/mcp",
+                    "client_id": "new-client",
+                    "access_token": "new-access",
+                    "expires_at": 200,
+                    "refresh_token": "new-refresh",
+                    "scopes": ["mcp:tools"]
+                },
+                "other|entry": {
+                    "server_name": "other",
+                    "server_url": "https://other.example/mcp",
+                    "client_id": "other-client",
+                    "access_token": "other-access",
+                    "scopes": []
+                }
+            }"#,
+        )
+        .unwrap();
+        let store = CodexOAuthStore::new(codex_home.path().to_path_buf());
+        let loaded = store
+            .load("remote", "https://remote.example/mcp")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded.client_id(), "new-client");
+        assert_eq!(loaded.access_token(), "new-access");
+
+        let replacement = McpOAuthCredentials::new("current-client", "current-access")
+            .refresh_token("current-refresh")
+            .expires_at_millis(300)
+            .scopes(["mcp:tools"]);
+        store
+            .save("remote", "https://remote.example/mcp", &replacement)
+            .await
+            .unwrap();
+        let entries: CodexOAuthFile =
+            serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(entries.len(), 2);
+        let key = codex_oauth_key("remote", "https://remote.example/mcp").unwrap();
+        assert_eq!(entries[&key].access_token, "current-access");
+        assert!(entries.contains_key("other|entry"));
+    }
+
+    #[test]
+    fn codex_oauth_key_matches_current_insertion_order() {
+        assert_eq!(
+            codex_oauth_key(
+                "centaur-paradigm",
+                "https://centaur-mcp.tailea35.ts.net/mcp"
+            )
+            .unwrap(),
+            "centaur-paradigm|144c94893cdf13f9"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore = "manual live Codex-config OAuth MCP reload smoke"]
+    async fn smoke_codex_oauth_mcp_reload() {
+        let codex_home = std::env::var_os("NANOCODEX_MCP_SMOKE_CODEX_HOME")
+            .map(PathBuf::from)
+            .expect("set NANOCODEX_MCP_SMOKE_CODEX_HOME");
+        let mut servers = load_codex_mcp_servers(&codex_home).unwrap();
+        servers.retain(|name, _| name.starts_with("centaur-"));
+        let servers = servers
+            .into_iter()
+            .filter_map(|(name, server)| server.map(|server| (name, server)))
+            .collect();
+        let configured = build_mcp(
+            servers,
+            Duration::from_secs(30),
+            Duration::from_mins(5),
+            Some(Arc::new(CodexOAuthStore::new(codex_home))),
+        )
+        .unwrap();
+
+        for name in ["centaur-paradigm", "centaur-tempo"] {
+            let tools = configured.handle.reload(name).await.unwrap();
+            assert!(tools > 0, "{name} should expose tools");
+            eprintln!("{name}: {tools} tools");
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "manual live MCP lifecycle benchmark"]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "the benchmark keeps one lifecycle and one configured provider"
+    )]
+    async fn benchmark_codex_oauth_mcp_lifecycle() {
+        let trace_guard = std::env::var_os("NANOCODEX_MCP_BENCH_TRACE").map(|path| {
+            let mut builder =
+                ObservabilityBuilder::new("nanocodex-mcp-bench", env!("CARGO_PKG_VERSION"))
+                    .filter("warn,nanocodex_mcp=info")
+                    .format(LogFormat::Json)
+                    .output(LogOutput::File(PathBuf::from(path)));
+            if let Ok(endpoint) = std::env::var("NANOCODEX_MCP_BENCH_OTEL") {
+                builder = builder
+                    .otel_filter("warn,nanocodex_mcp=info")
+                    .otlp_endpoint(endpoint);
+            }
+            builder.install().unwrap()
+        });
+        let iterations = benchmark_iterations("NANOCODEX_MCP_BENCH_RELOADS", 10);
+        let search_iterations = benchmark_iterations("NANOCODEX_MCP_BENCH_SEARCHES", 10_000);
+        let codex_home = std::env::var_os("NANOCODEX_MCP_SMOKE_CODEX_HOME")
+            .map(PathBuf::from)
+            .expect("set NANOCODEX_MCP_SMOKE_CODEX_HOME");
+        let mut servers = load_codex_mcp_servers(&codex_home).unwrap();
+        servers.retain(|name, _| name.starts_with("centaur-"));
+        let servers = servers
+            .into_iter()
+            .filter_map(|(name, server)| server.map(|server| (name, server)))
+            .collect();
+        let configured = build_mcp(
+            servers,
+            Duration::from_secs(30),
+            Duration::from_mins(5),
+            Some(Arc::new(CodexOAuthStore::new(codex_home))),
+        )
+        .unwrap();
+
+        let search = configured
+            .provider
+            .direct_tools()
+            .into_iter()
+            .next()
+            .unwrap();
+        let context = ToolContext {
+            model: MODEL,
+            session_id: "mcp-lifecycle-benchmark",
+            call_id: "catalog-search",
+            history: &[],
+            output_token_budget: DEFAULT_TOOL_OUTPUT_TOKENS,
+        };
+        let input = to_raw_value(&json!({
+            "query": "search tools domain ownership documentation"
+        }))
+        .unwrap();
+        let start_return = std::time::Instant::now();
+        configured.provider.start();
+        let start_return = start_return.elapsed();
+        let prewarm = std::time::Instant::now();
+        let initial_search = search
+            .execute(ToolInput::Function(input.clone()), context)
+            .await
+            .unwrap();
+        let prewarm = prewarm.elapsed();
+        assert!(initial_search.success);
+        eprintln!(
+            "{}",
+            json!({
+                "benchmark": "mcp_background_startup",
+                "start_return_us": start_return.as_secs_f64() * 1_000_000.0,
+                "catalog_ready_ms": duration_millis(prewarm),
+                "activated_tools": configured.provider.available_definitions().len(),
+            })
+        );
+
+        let mut catalog_tools = 0;
+        for name in ["centaur-paradigm", "centaur-tempo"] {
+            let mut samples = Vec::with_capacity(iterations);
+            let mut tool_count = 0;
+            for _ in 0..iterations {
+                let started = std::time::Instant::now();
+                tool_count = configured.handle.reload(name).await.unwrap();
+                samples.push(started.elapsed());
+            }
+            assert!(tool_count > 0, "{name} should expose tools");
+            catalog_tools += tool_count;
+            eprintln!(
+                "{}",
+                json!({
+                    "benchmark": "mcp_reload",
+                    "server": name,
+                    "tools": tool_count,
+                    "iterations": iterations,
+                    "cold_ms": duration_millis(samples[0]),
+                    "warm": duration_summary(&samples[1..]),
+                })
+            );
+        }
+
+        let started = std::time::Instant::now();
+        for _ in 0..search_iterations {
+            let result = search
+                .execute(ToolInput::Function(input.clone()), context)
+                .await
+                .unwrap();
+            assert!(result.success);
+        }
+        let elapsed = started.elapsed();
+        let search_count = f64::from(u32::try_from(search_iterations).unwrap());
+        eprintln!(
+            "{}",
+            json!({
+                "benchmark": "mcp_catalog_search",
+                "catalog_tools": catalog_tools,
+                "activated_tools": configured.provider.available_definitions().len(),
+                "iterations": search_iterations,
+                "total_ms": duration_millis(elapsed),
+                "mean_us": elapsed.as_secs_f64() * 1_000_000.0 / search_count,
+                "throughput_per_second": search_count / elapsed.as_secs_f64(),
+            })
+        );
+        if let Some(mut trace_guard) = trace_guard {
+            trace_guard.shutdown().unwrap();
+        }
+    }
+
+    fn benchmark_iterations(variable: &str, default: usize) -> usize {
+        std::env::var(variable)
+            .ok()
+            .map_or(default, |value| value.parse::<usize>().unwrap())
+            .max(1)
+    }
+
+    fn duration_millis(duration: Duration) -> f64 {
+        duration.as_secs_f64() * 1_000.0
+    }
+
+    fn duration_summary(samples: &[Duration]) -> Value {
+        if samples.is_empty() {
+            return json!({});
+        }
+        let mut sorted = samples.to_vec();
+        sorted.sort_unstable();
+        let percentile = |numerator: usize| {
+            let index = (sorted.len() - 1) * numerator / 100;
+            duration_millis(sorted[index])
+        };
+        json!({
+            "samples": sorted.len(),
+            "min_ms": duration_millis(sorted[0]),
+            "p50_ms": percentile(50),
+            "p95_ms": percentile(95),
+            "max_ms": duration_millis(*sorted.last().unwrap()),
+            "mean_ms": sorted.iter().map(Duration::as_secs_f64).sum::<f64>()
+                * 1_000.0 / f64::from(u32::try_from(sorted.len()).unwrap()),
+        })
     }
 
     #[test]
@@ -314,8 +1116,8 @@ mod tests {
         )
         .unwrap();
 
-        let mcp = args().build().unwrap().unwrap();
-        let default_tools = Tools::builder().provider(mcp).build().unwrap();
+        let mcp = args().build(Path::new("/missing")).unwrap().unwrap();
+        let default_tools = Tools::builder().provider(mcp.provider).build().unwrap();
         let with_defaults = serde_json::to_vec(
             &ToolRuntime::new_with_tools(".", None, None, &default_tools).model_specs(),
         )

--- a/bin/nanocodex/src/tui/app.rs
+++ b/bin/nanocodex/src/tui/app.rs
@@ -485,9 +485,9 @@ impl Conversation {
         }
         self.materialize_code_parent(&payload.call_id);
         let arguments = summarize_tool_arguments(&payload.tool, &payload.arguments);
-        self.status = format!("Running {}", payload.tool);
+        let name = present_tool_name(&payload.tool, &payload.arguments);
+        self.status = format!("Running {name}");
         let call_id = payload.call_id;
-        let name = present_tool_name(&payload.tool, &payload.arguments).to_owned();
         let status = ToolStatus::Running;
         if self.transcript.has_tool_parent(&call_id) {
             self.note_tail_will_change();
@@ -2857,6 +2857,9 @@ fn summarize_tool_arguments(tool: &str, arguments: &Value) -> String {
         {
             return summary;
         }
+        if let Some(summary) = summarize_mcp_arguments(tool, object) {
+            return summary;
+        }
         let preferred = match tool {
             "view_image" => object.get("path").and_then(Value::as_str),
             "read_file" => object
@@ -2878,14 +2881,21 @@ fn summarize_tool_arguments(tool: &str, arguments: &Value) -> String {
     compact_arguments(arguments)
 }
 
-fn present_tool_name<'a>(tool: &'a str, arguments: &Value) -> &'a str {
+fn present_tool_name(tool: &str, arguments: &Value) -> String {
+    if tool == "tool_search" {
+        return "MCP discovery".to_owned();
+    }
+    if let Some((server, operation)) = mcp_tool_parts(tool) {
+        let operation = mcp_wrapper_target(operation, arguments).unwrap_or(operation);
+        return format!("{server} › {}", present_mcp_operation(operation));
+    }
     if tool != "web__run" {
-        return tool;
+        return tool.to_owned();
     }
     let Some(object) = arguments.as_object() else {
-        return "Web";
+        return "Web".to_owned();
     };
-    if object.contains_key("search_query") {
+    let name = if object.contains_key("search_query") {
         "Web search"
     } else if object.contains_key("image_query") {
         "Image search"
@@ -2899,6 +2909,57 @@ fn present_tool_name<'a>(tool: &'a str, arguments: &Value) -> &'a str {
         "Sports"
     } else {
         "Web"
+    };
+    name.to_owned()
+}
+
+fn summarize_mcp_arguments(tool: &str, object: &serde_json::Map<String, Value>) -> Option<String> {
+    if tool == "tool_search" {
+        return object
+            .get("query")
+            .and_then(Value::as_str)
+            .map(compact_tool_text);
+    }
+    let (_, operation) = mcp_tool_parts(tool)?;
+    if operation == "get_tool_details" {
+        return object
+            .get("name")
+            .and_then(Value::as_str)
+            .map(|name| compact_tool_text(name.trim_start_matches('_')));
+    }
+    let target = matches!(operation, "call_read_tool" | "call_write_tool")
+        .then(|| object.get("name").and_then(Value::as_str))
+        .flatten();
+    let effective = if matches!(operation, "call_read_tool" | "call_write_tool") {
+        object.get("arguments").and_then(Value::as_object)
+    } else {
+        Some(object)
+    };
+    if let Some(effective) = effective {
+        for field in ["query", "q", "name", "path", "url", "ref_id"] {
+            if let Some(value) = effective.get(field).and_then(Value::as_str) {
+                return Some(compact_tool_text(value));
+            }
+        }
+    }
+    target.map(|target| compact_tool_text(target.trim_start_matches('_')))
+}
+
+fn mcp_tool_parts(tool: &str) -> Option<(&str, &str)> {
+    tool.strip_prefix("mcp__")?.split_once("__")
+}
+
+fn mcp_wrapper_target<'a>(operation: &str, arguments: &'a Value) -> Option<&'a str> {
+    matches!(operation, "call_read_tool" | "call_write_tool")
+        .then(|| arguments.get("name").and_then(Value::as_str))
+        .flatten()
+}
+
+fn present_mcp_operation(operation: &str) -> &str {
+    match operation.trim_start_matches('_') {
+        "search_tools" => "Search tools",
+        "get_tool_details" => "Tool details",
+        operation => operation,
     }
 }
 
@@ -3110,6 +3171,115 @@ mod tests {
             summarize_tool_arguments("web__run", &arguments),
             "Rust async cancellation · Tokio process groups"
         );
+    }
+
+    #[test]
+    fn mcp_discovery_and_gateway_calls_present_the_semantic_operation() {
+        let discovery = json!({ "query": "centaur domain ownership" });
+        assert_eq!(
+            present_tool_name("tool_search", &discovery),
+            "MCP discovery"
+        );
+        assert_eq!(
+            summarize_tool_arguments("tool_search", &discovery),
+            "centaur domain ownership"
+        );
+
+        let search = json!({
+            "name": "_search_tools",
+            "arguments": { "query": "innovationreception.org" }
+        });
+        assert_eq!(
+            present_tool_name("mcp__centaur-paradigm__call_read_tool", &search),
+            "centaur-paradigm › Search tools"
+        );
+        assert_eq!(
+            summarize_tool_arguments("mcp__centaur-paradigm__call_read_tool", &search),
+            "innovationreception.org"
+        );
+
+        let details = json!({ "name": "_search_tools" });
+        assert_eq!(
+            present_tool_name("mcp__centaur-paradigm__get_tool_details", &details),
+            "centaur-paradigm › Tool details"
+        );
+        assert_eq!(
+            summarize_tool_arguments("mcp__centaur-paradigm__get_tool_details", &details),
+            "search_tools"
+        );
+    }
+
+    #[test]
+    fn mcp_activity_renders_without_gateway_plumbing() {
+        let mut app = App::new(".".into());
+        app.main.on_agent_event(&event(
+            AgentEventKind::ToolCall,
+            &json!({
+                "call_id": "call-exec",
+                "tool": "exec",
+                "arguments": "await discover();"
+            }),
+        ));
+        app.main.on_agent_event(&event(
+            AgentEventKind::ToolCall,
+            &json!({
+                "call_id": "call-exec/code-1",
+                "tool": "tool_search",
+                "arguments": { "query": "centaur domain ownership" }
+            }),
+        ));
+        app.main.on_agent_event(&event(
+            AgentEventKind::ToolResult,
+            &json!({
+                "call_id": "call-exec/code-1",
+                "tool": "tool_search",
+                "status": "completed",
+                "result": { "tools": [{ "name": "mcp__centaur-paradigm__call_read_tool" }] }
+            }),
+        ));
+        app.main.on_agent_event(&event(
+            AgentEventKind::ToolCall,
+            &json!({
+                "call_id": "call-exec/code-2",
+                "tool": "mcp__centaur-paradigm__call_read_tool",
+                "arguments": {
+                    "name": "_search_tools",
+                    "arguments": { "query": "innovationreception.org" }
+                }
+            }),
+        ));
+        app.main.on_agent_event(&event(
+            AgentEventKind::ToolResult,
+            &json!({
+                "call_id": "call-exec/code-2",
+                "tool": "mcp__centaur-paradigm__call_read_tool",
+                "status": "completed",
+                "result": { "content": [] }
+            }),
+        ));
+
+        let area = Rect::new(0, 0, 100, 12);
+        let mut buffer = Buffer::empty(area);
+        app.main
+            .transcript
+            .widget(0, None, None, "empty")
+            .render(area, &mut buffer);
+        let rendered = buffer
+            .content
+            .chunks(usize::from(area.width))
+            .map(|row| {
+                row.iter()
+                    .map(ratatui::buffer::Cell::symbol)
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(rendered.contains("MCP discovery  centaur domain ownership"));
+        assert!(rendered.contains("centaur-paradigm › Search tools  innovationreception.org"));
+        assert!(!rendered.contains("call_read_tool"));
+        assert!(!rendered.contains("_search_tools"));
+        assert!(!rendered.contains("{\"query\""));
     }
 
     #[test]

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -870,7 +870,7 @@ fn handle_worker_update(
         WorkerEvent::ThinkingChanged { thinking } => app.thinking_changed(thinking),
         WorkerEvent::ThinkingChangeFailed { error } => app.thinking_change_failed(&error),
         WorkerEvent::McpLoginStarted { name } => {
-            app.set_active_status(format!("Waiting for MCP authentication: {name}"));
+            app.set_active_status(format!("Authorizing MCP server {name} in browser"));
         }
         WorkerEvent::McpReady {
             name,

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -26,8 +26,8 @@ use crossterm::event::{
 use eyre::{Result, WrapErr};
 use futures_util::StreamExt;
 use nanocodex::{
-    AgentEvent, AgentEvents, Nanocodex, NanocodexError, Thinking, TimedAgentEvent, TurnControl,
-    TurnResult,
+    AgentEvent, AgentEvents, McpHandle, Nanocodex, NanocodexError, Thinking, TimedAgentEvent,
+    TurnControl, TurnResult,
 };
 use tokio::{
     sync::mpsc,
@@ -98,6 +98,12 @@ enum WorkerCommand {
     },
     SetThinking {
         thinking: Thinking,
+    },
+    McpLogin {
+        name: String,
+    },
+    McpReload {
+        name: String,
     },
 }
 
@@ -196,6 +202,18 @@ enum WorkerEvent {
         thinking: Thinking,
     },
     ThinkingChangeFailed {
+        error: String,
+    },
+    McpLoginStarted {
+        name: String,
+    },
+    McpReady {
+        name: String,
+        tool_count: usize,
+        authenticated: bool,
+    },
+    McpFailed {
+        name: String,
         error: String,
     },
 }
@@ -464,6 +482,8 @@ enum Submission {
     Trace,
     Fast(Option<bool>),
     ReasoningPicker,
+    McpLogin(String),
+    McpReload(String),
     InvalidCommand(String),
 }
 
@@ -480,9 +500,16 @@ pub(crate) async fn run(config: AgentArgs, initial_prompt: Option<String>) -> Re
     let root_session_id = Arc::<str>::from(agent_events.request_id());
     let child_agents = configured.child_agents;
     let mpp_adapter = configured.mpp_adapter;
+    let mcp = configured.mcp;
     let (worker_tx, worker_rx) = mpsc::unbounded_channel();
     let (update_tx, mut update_rx) = mpsc::unbounded_channel();
-    let worker = spawn_agent_worker(agent, Arc::clone(&root_session_id), worker_rx, update_tx);
+    let worker = spawn_agent_worker(
+        agent,
+        Arc::clone(&root_session_id),
+        mcp,
+        worker_rx,
+        update_tx,
+    );
 
     let mut terminal = TerminalSession::enter().wrap_err("failed to initialize the terminal")?;
     let mut input_events = EventStream::new();
@@ -842,6 +869,24 @@ fn handle_worker_update(
         WorkerEvent::FastModeChangeFailed { error } => app.fast_mode_change_failed(&error),
         WorkerEvent::ThinkingChanged { thinking } => app.thinking_changed(thinking),
         WorkerEvent::ThinkingChangeFailed { error } => app.thinking_change_failed(&error),
+        WorkerEvent::McpLoginStarted { name } => {
+            app.set_active_status(format!("Waiting for MCP authentication: {name}"));
+        }
+        WorkerEvent::McpReady {
+            name,
+            tool_count,
+            authenticated,
+        } => {
+            let action = if authenticated {
+                "Authenticated and reloaded"
+            } else {
+                "Reloaded"
+            };
+            app.set_active_status(format!("{action} MCP server {name} ({tool_count} tools)"));
+        }
+        WorkerEvent::McpFailed { name, error } => {
+            app.push_active_error(format!("MCP server {name}: {error}"));
+        }
     }
     Ok(())
 }
@@ -849,6 +894,7 @@ fn handle_worker_update(
 fn spawn_agent_worker(
     root: Nanocodex,
     root_session_id: Arc<str>,
+    mcp: Option<McpHandle>,
     mut commands: mpsc::UnboundedReceiver<WorkerCommand>,
     updates: mpsc::UnboundedSender<WorkerEvent>,
 ) -> tokio::task::JoinHandle<()> {
@@ -868,6 +914,7 @@ fn spawn_agent_worker(
             btw: None,
             finished: finished_tx,
             updates,
+            mcp,
         };
         loop {
             tokio::select! {
@@ -892,6 +939,7 @@ struct AgentWorker {
     btw: Option<BtwWorker>,
     finished: mpsc::UnboundedSender<FinishedTurn>,
     updates: mpsc::UnboundedSender<WorkerEvent>,
+    mcp: Option<McpHandle>,
 }
 
 impl AgentWorker {
@@ -934,7 +982,86 @@ impl AgentWorker {
             WorkerCommand::SwitchMainBranch { id } => self.switch_main_branch(id),
             WorkerCommand::SetFastMode { enabled } => self.set_fast_mode(enabled).await,
             WorkerCommand::SetThinking { thinking } => self.set_thinking(thinking).await,
+            WorkerCommand::McpLogin { name } => self.mcp_login(name),
+            WorkerCommand::McpReload { name } => self.mcp_reload(name),
         }
+    }
+
+    fn mcp_login(&self, name: String) {
+        let Some(mcp) = self.mcp.clone() else {
+            drop(self.updates.send(WorkerEvent::McpFailed {
+                name,
+                error: "MCP is not configured".to_owned(),
+            }));
+            return;
+        };
+        let updates = self.updates.clone();
+        drop(tokio::spawn(async move {
+            let login = match mcp.login(&name).await {
+                Ok(login) => login,
+                Err(error) => {
+                    drop(updates.send(WorkerEvent::McpFailed {
+                        name,
+                        error: error.to_string(),
+                    }));
+                    return;
+                }
+            };
+            let authorization_url = login.authorization_url().to_owned();
+            if let Err(error) = open_browser(&authorization_url) {
+                drop(updates.send(WorkerEvent::McpFailed {
+                    name,
+                    error: format!(
+                        "failed to open OAuth page: {error}; open {authorization_url} manually"
+                    ),
+                }));
+                return;
+            }
+            drop(updates.send(WorkerEvent::McpLoginStarted { name: name.clone() }));
+            match login.wait().await {
+                Ok(tool_count) => {
+                    drop(updates.send(WorkerEvent::McpReady {
+                        name,
+                        tool_count,
+                        authenticated: true,
+                    }));
+                }
+                Err(error) => {
+                    drop(updates.send(WorkerEvent::McpFailed {
+                        name,
+                        error: error.to_string(),
+                    }));
+                }
+            }
+        }));
+    }
+
+    fn mcp_reload(&self, name: String) {
+        let Some(mcp) = self.mcp.clone() else {
+            drop(self.updates.send(WorkerEvent::McpFailed {
+                name,
+                error: "MCP is not configured".to_owned(),
+            }));
+            return;
+        };
+        let updates = self.updates.clone();
+        drop(tokio::spawn(async move {
+            match mcp.reload(&name).await {
+                Ok(tool_count) => {
+                    drop(updates.send(WorkerEvent::McpReady {
+                        name,
+                        tool_count,
+                        authenticated: false,
+                    }));
+                }
+                Err(error) => {
+                    drop(updates.send(WorkerEvent::McpFailed {
+                        name,
+                        error: error.to_string(),
+                    }));
+                }
+            }
+        }));
     }
 
     async fn set_fast_mode(&mut self, enabled: bool) {
@@ -2226,6 +2353,12 @@ fn submit(
             send_command(commands, WorkerCommand::SetFastMode { enabled })?;
         }
         Submission::ReasoningPicker => app.open_reasoning_picker(),
+        Submission::McpLogin(name) => {
+            send_command(commands, WorkerCommand::McpLogin { name })?;
+        }
+        Submission::McpReload(name) => {
+            send_command(commands, WorkerCommand::McpReload { name })?;
+        }
         Submission::InvalidCommand(error) => app.push_active_error(error),
     }
     Ok(())
@@ -2279,6 +2412,27 @@ fn classify_submission(input: impl Into<SubmittedPrompt>) -> Submission {
     if trimmed.starts_with("/model ") || trimmed.starts_with("/thinking ") {
         return Submission::InvalidCommand("Usage: /model or /thinking".to_owned());
     }
+    if let Some(name) = trimmed.strip_prefix("/mcp login ") {
+        let name = name.trim();
+        return if name.is_empty() || name.split_whitespace().count() != 1 {
+            Submission::InvalidCommand("Usage: /mcp login <server>".to_owned())
+        } else {
+            Submission::McpLogin(name.to_owned())
+        };
+    }
+    if let Some(name) = trimmed.strip_prefix("/mcp reload ") {
+        let name = name.trim();
+        return if name.is_empty() || name.split_whitespace().count() != 1 {
+            Submission::InvalidCommand("Usage: /mcp reload <server>".to_owned())
+        } else {
+            Submission::McpReload(name.to_owned())
+        };
+    }
+    if trimmed == "/mcp" || trimmed.starts_with("/mcp ") {
+        return Submission::InvalidCommand(
+            "Usage: /mcp login <server> or /mcp reload <server>".to_owned(),
+        );
+    }
     Submission::Prompt(input)
 }
 
@@ -2309,7 +2463,11 @@ fn open_session_traces(session_id: &str) -> Result<()> {
     let base_url =
         std::env::var(JAEGER_UI_URL_ENV).unwrap_or_else(|_| DEFAULT_JAEGER_UI_URL.to_owned());
     let url = session_trace_url(&base_url, session_id)?;
-    let mut command = browser_command(url.as_str());
+    open_browser(url.as_str())
+}
+
+fn open_browser(url: &str) -> Result<()> {
+    let mut command = browser_command(url);
     command
         .stdin(Stdio::null())
         .stdout(Stdio::null())
@@ -2411,6 +2569,20 @@ mod tests {
         assert_eq!(
             classify_submission("/thinking high"),
             Submission::InvalidCommand("Usage: /model or /thinking".to_owned())
+        );
+        assert_eq!(
+            classify_submission(" /mcp login centaur-tempo "),
+            Submission::McpLogin("centaur-tempo".to_owned())
+        );
+        assert_eq!(
+            classify_submission("/mcp reload centaur-paradigm"),
+            Submission::McpReload("centaur-paradigm".to_owned())
+        );
+        assert_eq!(
+            classify_submission("/mcp login"),
+            Submission::InvalidCommand(
+                "Usage: /mcp login <server> or /mcp reload <server>".to_owned()
+            )
         );
         assert_eq!(
             classify_submission("/btw-not-a-command".to_owned()),
@@ -2729,6 +2901,7 @@ mod tests {
         spawn_agent_worker(
             agent,
             std::sync::Arc::from("tui-steer-test"),
+            None,
             worker_rx,
             updates,
         );
@@ -2842,6 +3015,7 @@ mod tests {
         spawn_agent_worker(
             agent,
             std::sync::Arc::from("tui-historical-edit-test"),
+            None,
             worker_rx,
             updates,
         );

--- a/crates/nanocodex-mcp/Cargo.toml
+++ b/crates/nanocodex-mcp/Cargo.toml
@@ -23,13 +23,14 @@ bm25.workspace = true
 http.workspace = true
 nanocodex-core.workspace = true
 nanocodex-tools.workspace = true
+oauth2.workspace = true
 reqwest.workspace = true
 rmcp.workspace = true
 rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["process", "rt", "sync", "time"] }
+tokio = { workspace = true, features = ["io-util", "net", "process", "rt", "sync", "time"] }
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/nanocodex-mcp/src/catalog.rs
+++ b/crates/nanocodex-mcp/src/catalog.rs
@@ -31,7 +31,8 @@ struct Catalog {
     active: BTreeSet<String>,
     failures: BTreeMap<String, String>,
     search_index: Option<Arc<SearchIndex>>,
-    pending_servers: usize,
+    pending_servers: BTreeSet<String>,
+    generations: BTreeMap<String, u64>,
 }
 
 struct SearchIndex {
@@ -52,6 +53,16 @@ pub(crate) struct SearchResponse {
     failed_servers: BTreeMap<String, String>,
 }
 
+impl SearchResponse {
+    pub(crate) fn tool_count(&self) -> usize {
+        self.tools.len()
+    }
+
+    pub(crate) const fn pending_server_count(&self) -> usize {
+        self.pending_servers
+    }
+}
+
 #[derive(Serialize)]
 struct SearchTool {
     name: String,
@@ -62,15 +73,25 @@ struct SearchTool {
 }
 
 impl ProviderState {
-    pub(crate) fn new(server_count: usize, discovery_timeout: Duration) -> Self {
-        let (remaining, _) = watch::channel(server_count);
+    pub(crate) fn new(
+        server_names: impl IntoIterator<Item = String>,
+        discovery_timeout: Duration,
+    ) -> Self {
+        let pending_servers = server_names.into_iter().collect::<BTreeSet<_>>();
+        let generations = pending_servers
+            .iter()
+            .cloned()
+            .map(|name| (name, 0))
+            .collect();
+        let (remaining, _) = watch::channel(pending_servers.len());
         Self {
             catalog: Mutex::new(Catalog {
                 entries: BTreeMap::new(),
                 active: BTreeSet::new(),
                 failures: BTreeMap::new(),
                 search_index: None,
-                pending_servers: server_count,
+                pending_servers,
+                generations,
             }),
             remaining,
             discovery_timeout,
@@ -80,11 +101,25 @@ impl ProviderState {
     pub(crate) fn complete_server(
         &self,
         server_name: &str,
+        generation: u64,
         result: Result<Vec<ToolEntry>, String>,
     ) {
         let mut catalog = self.catalog();
+        if catalog.generations.get(server_name).copied() != Some(generation) {
+            return;
+        }
         match result {
             Ok(entries) => {
+                let removed = catalog
+                    .entries
+                    .iter()
+                    .filter_map(|(name, entry)| {
+                        (entry.server_name == server_name).then_some(name.clone())
+                    })
+                    .collect::<Vec<_>>();
+                for name in removed {
+                    catalog.entries.remove(&name);
+                }
                 for entry in entries {
                     if catalog.entries.contains_key(&entry.canonical_name) {
                         catalog.failures.insert(
@@ -100,13 +135,15 @@ impl ProviderState {
                         .entries
                         .insert(entry.canonical_name.clone(), Arc::new(entry));
                 }
+                let available = catalog.entries.keys().cloned().collect::<BTreeSet<_>>();
+                catalog.active.retain(|name| available.contains(name));
             }
             Err(error) => {
                 catalog.failures.insert(server_name.to_owned(), error);
             }
         }
-        catalog.pending_servers = catalog.pending_servers.saturating_sub(1);
-        if catalog.pending_servers == 0 {
+        catalog.pending_servers.remove(server_name);
+        if catalog.pending_servers.is_empty() {
             tracing::info!(
                 target: "nanocodex_mcp",
                 tool_count = catalog.entries.len(),
@@ -118,9 +155,25 @@ impl ProviderState {
         } else {
             catalog.search_index = None;
         }
-        let pending_servers = catalog.pending_servers;
+        let pending_servers = catalog.pending_servers.len();
         drop(catalog);
         self.remaining.send_replace(pending_servers);
+    }
+
+    pub(crate) fn begin_server(&self, server_name: &str) -> u64 {
+        let mut catalog = self.catalog();
+        let generation = catalog
+            .generations
+            .entry(server_name.to_owned())
+            .and_modify(|generation| *generation = generation.saturating_add(1))
+            .or_insert(0);
+        let generation = *generation;
+        catalog.failures.remove(server_name);
+        catalog.pending_servers.insert(server_name.to_owned());
+        let pending_servers = catalog.pending_servers.len();
+        drop(catalog);
+        self.remaining.send_replace(pending_servers);
+        generation
     }
 
     pub(crate) async fn search(
@@ -152,7 +205,7 @@ impl ProviderState {
             .search_index
             .clone()
             .ok_or_else(|| "MCP search index was not initialized".to_owned())?;
-        let pending_servers = catalog.pending_servers;
+        let pending_servers = catalog.pending_servers.len();
         let failed_servers = catalog.failures.clone();
         drop(catalog);
 
@@ -195,6 +248,9 @@ impl ProviderState {
     }
 
     async fn wait_for_startup(&self) {
+        if self.catalog().search_index.is_some() {
+            return;
+        }
         let mut remaining = self.remaining.subscribe();
         if *remaining.borrow() == 0 {
             return;

--- a/crates/nanocodex-mcp/src/client.rs
+++ b/crates/nanocodex-mcp/src/client.rs
@@ -1,27 +1,89 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, process::Stdio, sync::Arc};
 
 use http::{HeaderName, HeaderValue};
 use rmcp::{
     ServiceExt,
-    model::Tool,
+    model::{CallToolRequestParams, CallToolResult, Tool},
     service::{RoleClient, RunningService},
     transport::{
         StreamableHttpClientTransport, TokioChildProcess,
         streamable_http_client::StreamableHttpClientTransportConfig,
     },
 };
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tracing::{Instrument, Span, info_span};
 
-use crate::config::{McpServer, McpTransport};
+use crate::config::{McpServer, McpTransport, SecretSource};
+use crate::oauth::{McpOAuthStore, OAuthRuntime, transport_from_credentials};
 
-pub(crate) type Client = Arc<RunningService<RoleClient, ()>>;
+pub(crate) type Client = Arc<ClientInner>;
+
+pub(crate) struct ClientInner {
+    service: Arc<RunningService<RoleClient, ()>>,
+    oauth: Option<Arc<OAuthRuntime>>,
+}
+
+impl ClientInner {
+    pub(crate) async fn call_tool(
+        &self,
+        params: CallToolRequestParams,
+    ) -> Result<CallToolResult, rmcp::service::ServiceError> {
+        let result = self.service.call_tool(params).await;
+        if let Some(oauth) = &self.oauth
+            && let Err(error) = oauth.persist_if_changed().await
+        {
+            tracing::warn!(%error, "failed to persist refreshed MCP OAuth credentials");
+        }
+        result
+    }
+
+    async fn list_all_tools(&self) -> Result<Vec<Tool>, rmcp::service::ServiceError> {
+        let tools = self.service.list_all_tools().await;
+        if let Some(oauth) = &self.oauth
+            && let Err(error) = oauth.persist_if_changed().await
+        {
+            tracing::warn!(%error, "failed to persist refreshed MCP OAuth credentials");
+        }
+        tools
+    }
+}
 
 pub(crate) struct ConnectedServer {
     pub client: Client,
     pub tools: Vec<Tool>,
 }
 
-pub(crate) async fn connect(server: &McpServer) -> Result<ConnectedServer, String> {
-    match &server.transport {
+pub(crate) async fn connect(
+    server_name: &str,
+    server: &McpServer,
+    oauth_store: Option<Arc<dyn McpOAuthStore>>,
+    parent: &Span,
+) -> Result<ConnectedServer, String> {
+    let (transport_name, auth_mode) = match &server.transport {
+        McpTransport::Stdio { .. } => ("stdio", "none"),
+        McpTransport::StreamableHttp { bearer, .. } if bearer.is_some() => {
+            ("streamable_http", "bearer")
+        }
+        McpTransport::StreamableHttp { .. } if oauth_store.is_some() => {
+            ("streamable_http", "oauth_store")
+        }
+        McpTransport::StreamableHttp { .. } => ("streamable_http", "none"),
+    };
+    let span = info_span!(
+        target: "nanocodex_mcp",
+        parent: parent,
+        "mcp.transport_connect",
+        otel.kind = "client",
+        otel.status_code = tracing::field::Empty,
+        mcp.server = server_name,
+        mcp.transport = transport_name,
+        mcp.auth = auth_mode,
+        status = tracing::field::Empty,
+    );
+    // Keep this operation span out of the current tracing context. RMCP's initialize call
+    // creates a long-lived transport task which inherits the current context; entering this
+    // span would therefore keep the complete startup/reload trace open until client shutdown.
+    let result = match &server.transport {
         McpTransport::Stdio {
             command,
             args,
@@ -36,76 +98,264 @@ pub(crate) async fn connect(server: &McpServer) -> Result<ConnectedServer, Strin
             if let Some(cwd) = cwd {
                 command.current_dir(cwd);
             }
-            let transport = TokioChildProcess::new(command)
+            let (transport, stderr) = TokioChildProcess::builder(command)
+                .stderr(Stdio::piped())
+                .spawn()
                 .map_err(|error| format!("failed to launch stdio transport: {error}"))?;
-            let client = tokio::time::timeout(server.startup_timeout, ().serve(transport))
-                .await
-                .map_err(|_| startup_timeout(server, "initialize"))?
-                .map_err(|error| format!("MCP initialize failed: {}", error_chain(&error)))?;
-            finish_startup(server, client).await
+            if let Some(stderr) = stderr {
+                drain_server_stderr(server_name.to_owned(), stderr);
+            }
+            let client = connect_transport(server, transport, &span).await?;
+            finish_startup(server, client, None, &span).await
         }
         McpTransport::StreamableHttp {
             url,
             bearer,
             headers,
         } => {
-            // rmcp deliberately leaves the rustls crypto provider to its host.
-            // Installing ring is idempotent and keeps this crate usable without
-            // requiring nanocodex-service to have opened a WebSocket first.
-            drop(rustls::crypto::ring::default_provider().install_default());
-            let http_client = reqwest::Client::builder()
-                // Match RMCP's default: its streamed handshake responses are not always fully
-                // consumed before the next request, so retaining them as idle connections causes
-                // stalls or failed sends with real peers.
-                .pool_max_idle_per_host(0)
-                .build()
-                .map_err(|error| format!("failed to build MCP HTTP client: {error}"))?;
-            if url.trim().is_empty() {
-                return Err("Streamable HTTP URL must not be empty".to_owned());
+            connect_http(
+                server_name,
+                server,
+                url,
+                bearer.as_ref(),
+                headers,
+                oauth_store,
+                &span,
+            )
+            .await
+        }
+    };
+    span.record(
+        "status",
+        if result.is_ok() {
+            "completed"
+        } else {
+            "failed"
+        },
+    );
+    span.record(
+        "otel.status_code",
+        if result.is_ok() { "OK" } else { "ERROR" },
+    );
+    result
+}
+
+async fn connect_http(
+    server_name: &str,
+    server: &McpServer,
+    url: &str,
+    bearer: Option<&SecretSource>,
+    headers: &std::collections::BTreeMap<String, SecretSource>,
+    oauth_store: Option<Arc<dyn McpOAuthStore>>,
+    parent: &Span,
+) -> Result<ConnectedServer, String> {
+    // rmcp deliberately leaves the rustls crypto provider to its host.
+    // Installing ring is idempotent and keeps this crate usable without
+    // requiring nanocodex-service to have opened a WebSocket first.
+    drop(rustls::crypto::ring::default_provider().install_default());
+    if url.trim().is_empty() {
+        return Err("Streamable HTTP URL must not be empty".to_owned());
+    }
+    let mut resolved_headers = HashMap::with_capacity(headers.len());
+    let mut default_headers = reqwest::header::HeaderMap::with_capacity(headers.len());
+    for (name, source) in headers {
+        let name = name
+            .parse::<HeaderName>()
+            .map_err(|error| format!("invalid HTTP header name `{name}`: {error}"))?;
+        let value = source.resolve()?;
+        let mut value = HeaderValue::from_str(&value)
+            .map_err(|error| format!("invalid value for HTTP header `{name}`: {error}"))?;
+        value.set_sensitive(true);
+        resolved_headers.insert(name.clone(), value.clone());
+        default_headers.insert(name, value);
+    }
+    let http_client = reqwest::Client::builder()
+        // Match RMCP's default: its streamed handshake responses are not always fully consumed
+        // before the next request, so retaining them as idle connections can stall real peers.
+        .pool_max_idle_per_host(0)
+        .default_headers(default_headers)
+        .build()
+        .map_err(|error| format!("failed to build MCP HTTP client: {error}"))?;
+    let mut config = StreamableHttpClientTransportConfig::with_uri(url.to_owned())
+        .custom_headers(resolved_headers)
+        .reinit_on_expired_session(true);
+    if let Some(bearer) = bearer {
+        let token = bearer.resolve()?;
+        if token.trim().is_empty() {
+            return Err("resolved bearer token must not be empty".to_owned());
+        }
+        config = config.auth_header(token);
+        let transport = StreamableHttpClientTransport::with_client(http_client, config);
+        let client = connect_transport(server, transport, parent).await?;
+        return finish_startup(server, client, None, parent).await;
+    }
+    if let Some(store) = oauth_store {
+        let load_span = info_span!(
+            target: "nanocodex_mcp",
+            parent: parent,
+            "mcp.oauth.credentials_load",
+            otel.kind = "internal",
+            otel.status_code = tracing::field::Empty,
+            status = tracing::field::Empty,
+            credential.found = tracing::field::Empty,
+        );
+        let credentials = store
+            .load(server_name, url)
+            .instrument(load_span.clone())
+            .await;
+        load_span.record(
+            "status",
+            if credentials.is_ok() {
+                "completed"
+            } else {
+                "failed"
+            },
+        );
+        load_span.record(
+            "otel.status_code",
+            if credentials.is_ok() { "OK" } else { "ERROR" },
+        );
+        if let Ok(credentials) = &credentials {
+            load_span.record("credential.found", credentials.is_some());
+        }
+        let credentials = credentials?;
+        if let Some(credentials) = credentials {
+            let restore_span = info_span!(
+                target: "nanocodex_mcp",
+                parent: parent,
+                "mcp.oauth.restore",
+                otel.kind = "internal",
+                otel.status_code = tracing::field::Empty,
+                status = tracing::field::Empty,
+            );
+            let oauth =
+                transport_from_credentials(server_name, url, http_client, store, credentials)
+                    .instrument(restore_span.clone())
+                    .await;
+            restore_span.record("status", if oauth.is_ok() { "completed" } else { "failed" });
+            restore_span.record(
+                "otel.status_code",
+                if oauth.is_ok() { "OK" } else { "ERROR" },
+            );
+            let oauth = oauth?;
+            let runtime = oauth.runtime;
+            let transport = StreamableHttpClientTransport::with_client(oauth.client, config);
+            let client = connect_transport(server, transport, parent).await;
+            if let Err(error) = runtime.persist_if_changed().await {
+                tracing::warn!(%error, "failed to persist refreshed MCP OAuth credentials");
             }
-            let mut resolved_headers = HashMap::with_capacity(headers.len());
-            for (name, source) in headers {
-                let name = name
-                    .parse::<HeaderName>()
-                    .map_err(|error| format!("invalid HTTP header name `{name}`: {error}"))?;
-                let value = source.resolve()?;
-                let mut value = HeaderValue::from_str(&value)
-                    .map_err(|error| format!("invalid value for HTTP header `{name}`: {error}"))?;
-                value.set_sensitive(true);
-                resolved_headers.insert(name, value);
-            }
-            let mut config = StreamableHttpClientTransportConfig::with_uri(url.clone())
-                .custom_headers(resolved_headers)
-                .reinit_on_expired_session(true);
-            if let Some(bearer) = bearer {
-                let token = bearer.resolve()?;
-                if token.trim().is_empty() {
-                    return Err("resolved bearer token must not be empty".to_owned());
-                }
-                config = config.auth_header(token);
-            }
-            let transport = StreamableHttpClientTransport::with_client(http_client, config);
-            let client = tokio::time::timeout(server.startup_timeout, ().serve(transport))
-                .await
-                .map_err(|_| startup_timeout(server, "initialize"))?
-                .map_err(|error| format!("MCP initialize failed: {}", error_chain(&error)))?;
-            finish_startup(server, client).await
+            let client = client?;
+            return finish_startup(server, client, Some(runtime), parent).await;
         }
     }
+    let transport = StreamableHttpClientTransport::with_client(http_client, config);
+    let client = connect_transport(server, transport, parent).await?;
+    finish_startup(server, client, None, parent).await
+}
+
+async fn connect_transport<T, E, A>(
+    server: &McpServer,
+    transport: T,
+    parent: &Span,
+) -> Result<RunningService<RoleClient, ()>, String>
+where
+    T: rmcp::transport::IntoTransport<RoleClient, E, A>,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    let span = info_span!(
+        target: "nanocodex_mcp",
+        parent: parent,
+        "mcp.initialize",
+        otel.kind = "client",
+        otel.status_code = tracing::field::Empty,
+        status = tracing::field::Empty,
+    );
+    // Do not instrument `serve` with this span. RMCP's returned service retains the transport
+    // task, which would retain this span and every parent until the client is dropped. The span's
+    // own lifetime still measures the awaited initialize handshake without leaking into the
+    // long-lived transport.
+    let result = match tokio::time::timeout(server.startup_timeout, ().serve(transport)).await {
+        Ok(Ok(client)) => Ok(client),
+        Ok(Err(error)) => Err(format!("MCP initialize failed: {}", error_chain(&error))),
+        Err(_) => Err(startup_timeout(server, "initialize")),
+    };
+    span.record(
+        "status",
+        if result.is_ok() {
+            "completed"
+        } else {
+            "failed"
+        },
+    );
+    span.record(
+        "otel.status_code",
+        if result.is_ok() { "OK" } else { "ERROR" },
+    );
+    result
+}
+
+fn drain_server_stderr(server_name: String, stderr: tokio::process::ChildStderr) {
+    drop(tokio::spawn(async move {
+        let mut lines = BufReader::new(stderr).lines();
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) => tracing::info!(
+                    target: "nanocodex_mcp",
+                    server = %server_name,
+                    message = %line,
+                    "MCP server stderr"
+                ),
+                Ok(None) => break,
+                Err(error) => {
+                    tracing::warn!(
+                        target: "nanocodex_mcp",
+                        server = %server_name,
+                        %error,
+                        "failed to read MCP server stderr"
+                    );
+                    break;
+                }
+            }
+        }
+    }));
 }
 
 async fn finish_startup(
     server: &McpServer,
     client: RunningService<RoleClient, ()>,
+    oauth: Option<Arc<OAuthRuntime>>,
+    parent: &Span,
 ) -> Result<ConnectedServer, String> {
-    let client = Arc::new(client);
-    let tools = tokio::time::timeout(server.startup_timeout, client.list_all_tools())
-        .await
-        .map_err(|_| startup_timeout(server, "tools/list"))?
-        .map_err(|error| format!("MCP tools/list failed: {}", error_chain(&error)))?
-        .into_iter()
-        .filter(|tool| server.includes_tool(tool.name.as_ref()))
-        .collect();
+    let client = Arc::new(ClientInner {
+        service: Arc::new(client),
+        oauth,
+    });
+    let span = info_span!(
+        target: "nanocodex_mcp",
+        parent: parent,
+        "mcp.tools_list",
+        otel.kind = "client",
+        otel.status_code = tracing::field::Empty,
+        status = tracing::field::Empty,
+        tool.count = tracing::field::Empty,
+    );
+    let tools = match tokio::time::timeout(server.startup_timeout, client.list_all_tools()).await {
+        Ok(Ok(tools)) => Ok(tools
+            .into_iter()
+            .filter(|tool| server.includes_tool(tool.name.as_ref()))
+            .collect::<Vec<_>>()),
+        Ok(Err(error)) => Err(format!("MCP tools/list failed: {}", error_chain(&error))),
+        Err(_) => Err(startup_timeout(server, "tools/list")),
+    };
+    span.record("status", if tools.is_ok() { "completed" } else { "failed" });
+    span.record(
+        "otel.status_code",
+        if tools.is_ok() { "OK" } else { "ERROR" },
+    );
+    if let Ok(tools) = &tools {
+        span.record("tool.count", tools.len());
+    }
+    let tools = tools?;
     Ok(ConnectedServer { client, tools })
 }
 

--- a/crates/nanocodex-mcp/src/client.rs
+++ b/crates/nanocodex-mcp/src/client.rs
@@ -14,7 +14,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 use tracing::{Instrument, Span, info_span};
 
 use crate::config::{McpServer, McpTransport, SecretSource};
-use crate::oauth::{McpOAuthStore, OAuthRuntime, transport_from_credentials};
+use crate::oauth::{McpOAuthStore, OAuthMetadataCache, OAuthRuntime, transport_from_credentials};
 
 pub(crate) type Client = Arc<ClientInner>;
 
@@ -53,10 +53,33 @@ pub(crate) struct ConnectedServer {
     pub tools: Vec<Tool>,
 }
 
+struct HttpConnect<'a> {
+    server_name: &'a str,
+    server: &'a McpServer,
+    url: &'a str,
+    bearer: Option<&'a SecretSource>,
+    headers: &'a std::collections::BTreeMap<String, SecretSource>,
+    oauth_store: Option<Arc<dyn McpOAuthStore>>,
+    oauth_metadata: Arc<OAuthMetadataCache>,
+    parent: &'a Span,
+}
+
+struct StoredOAuthConnect<'a> {
+    server_name: &'a str,
+    server: &'a McpServer,
+    url: &'a str,
+    http_client: reqwest::Client,
+    config: StreamableHttpClientTransportConfig,
+    store: Arc<dyn McpOAuthStore>,
+    metadata: Arc<OAuthMetadataCache>,
+    parent: &'a Span,
+}
+
 pub(crate) async fn connect(
     server_name: &str,
     server: &McpServer,
     oauth_store: Option<Arc<dyn McpOAuthStore>>,
+    oauth_metadata: Arc<OAuthMetadataCache>,
     parent: &Span,
 ) -> Result<ConnectedServer, String> {
     let (transport_name, auth_mode) = match &server.transport {
@@ -113,15 +136,16 @@ pub(crate) async fn connect(
             bearer,
             headers,
         } => {
-            connect_http(
+            connect_http(HttpConnect {
                 server_name,
                 server,
                 url,
-                bearer.as_ref(),
+                bearer: bearer.as_ref(),
                 headers,
                 oauth_store,
-                &span,
-            )
+                oauth_metadata,
+                parent: &span,
+            })
             .await
         }
     };
@@ -140,15 +164,17 @@ pub(crate) async fn connect(
     result
 }
 
-async fn connect_http(
-    server_name: &str,
-    server: &McpServer,
-    url: &str,
-    bearer: Option<&SecretSource>,
-    headers: &std::collections::BTreeMap<String, SecretSource>,
-    oauth_store: Option<Arc<dyn McpOAuthStore>>,
-    parent: &Span,
-) -> Result<ConnectedServer, String> {
+async fn connect_http(input: HttpConnect<'_>) -> Result<ConnectedServer, String> {
+    let HttpConnect {
+        server_name,
+        server,
+        url,
+        bearer,
+        headers,
+        oauth_store,
+        oauth_metadata,
+        parent,
+    } = input;
     // rmcp deliberately leaves the rustls crypto provider to its host.
     // Installing ring is idempotent and keeps this crate usable without
     // requiring nanocodex-service to have opened a WebSocket first.
@@ -190,67 +216,98 @@ async fn connect_http(
         return finish_startup(server, client, None, parent).await;
     }
     if let Some(store) = oauth_store {
-        let load_span = info_span!(
-            target: "nanocodex_mcp",
-            parent: parent,
-            "mcp.oauth.credentials_load",
-            otel.kind = "internal",
-            otel.status_code = tracing::field::Empty,
-            status = tracing::field::Empty,
-            credential.found = tracing::field::Empty,
-        );
-        let credentials = store
-            .load(server_name, url)
-            .instrument(load_span.clone())
-            .await;
-        load_span.record(
-            "status",
-            if credentials.is_ok() {
-                "completed"
-            } else {
-                "failed"
-            },
-        );
-        load_span.record(
-            "otel.status_code",
-            if credentials.is_ok() { "OK" } else { "ERROR" },
-        );
-        if let Ok(credentials) = &credentials {
-            load_span.record("credential.found", credentials.is_some());
-        }
-        let credentials = credentials?;
-        if let Some(credentials) = credentials {
-            let restore_span = info_span!(
-                target: "nanocodex_mcp",
-                parent: parent,
-                "mcp.oauth.restore",
-                otel.kind = "internal",
-                otel.status_code = tracing::field::Empty,
-                status = tracing::field::Empty,
-            );
-            let oauth =
-                transport_from_credentials(server_name, url, http_client, store, credentials)
-                    .instrument(restore_span.clone())
-                    .await;
-            restore_span.record("status", if oauth.is_ok() { "completed" } else { "failed" });
-            restore_span.record(
-                "otel.status_code",
-                if oauth.is_ok() { "OK" } else { "ERROR" },
-            );
-            let oauth = oauth?;
-            let runtime = oauth.runtime;
-            let transport = StreamableHttpClientTransport::with_client(oauth.client, config);
-            let client = connect_transport(server, transport, parent).await;
-            if let Err(error) = runtime.persist_if_changed().await {
-                tracing::warn!(%error, "failed to persist refreshed MCP OAuth credentials");
-            }
-            let client = client?;
-            return finish_startup(server, client, Some(runtime), parent).await;
-        }
+        return connect_stored_oauth(StoredOAuthConnect {
+            server_name,
+            server,
+            url,
+            http_client,
+            config,
+            store,
+            metadata: oauth_metadata,
+            parent,
+        })
+        .await;
     }
     let transport = StreamableHttpClientTransport::with_client(http_client, config);
     let client = connect_transport(server, transport, parent).await?;
     finish_startup(server, client, None, parent).await
+}
+
+async fn connect_stored_oauth(input: StoredOAuthConnect<'_>) -> Result<ConnectedServer, String> {
+    let StoredOAuthConnect {
+        server_name,
+        server,
+        url,
+        http_client,
+        config,
+        store,
+        metadata,
+        parent,
+    } = input;
+    let load_span = info_span!(
+        target: "nanocodex_mcp",
+        parent: parent,
+        "mcp.oauth.credentials_load",
+        otel.kind = "internal",
+        otel.status_code = tracing::field::Empty,
+        status = tracing::field::Empty,
+        credential.found = tracing::field::Empty,
+    );
+    let credentials = store
+        .load(server_name, url)
+        .instrument(load_span.clone())
+        .await;
+    load_span.record(
+        "status",
+        if credentials.is_ok() {
+            "completed"
+        } else {
+            "failed"
+        },
+    );
+    load_span.record(
+        "otel.status_code",
+        if credentials.is_ok() { "OK" } else { "ERROR" },
+    );
+    if let Ok(credentials) = &credentials {
+        load_span.record("credential.found", credentials.is_some());
+    }
+    let Some(credentials) = credentials? else {
+        let transport = StreamableHttpClientTransport::with_client(http_client, config);
+        let client = connect_transport(server, transport, parent).await?;
+        return finish_startup(server, client, None, parent).await;
+    };
+
+    let restore_span = info_span!(
+        target: "nanocodex_mcp",
+        parent: parent,
+        "mcp.oauth.restore",
+        otel.kind = "internal",
+        otel.status_code = tracing::field::Empty,
+        status = tracing::field::Empty,
+        metadata.cache_hit = tracing::field::Empty,
+    );
+    let oauth =
+        transport_from_credentials(server_name, url, http_client, store, credentials, &metadata)
+            .instrument(restore_span.clone())
+            .await;
+    restore_span.record("status", if oauth.is_ok() { "completed" } else { "failed" });
+    restore_span.record(
+        "otel.status_code",
+        if oauth.is_ok() { "OK" } else { "ERROR" },
+    );
+    if let Ok(oauth) = &oauth {
+        restore_span.record("metadata.cache_hit", oauth.metadata_cache_hit);
+    }
+    let oauth = oauth?;
+    let runtime = oauth.runtime;
+    let transport = StreamableHttpClientTransport::with_client(oauth.client, config);
+    let client = connect_transport(server, transport, parent).await;
+    if let Err(error) = runtime.persist_if_changed().await {
+        tracing::warn!(%error, "failed to persist refreshed MCP OAuth credentials");
+    }
+    let client = client?;
+    finish_startup(server, client, Some(runtime), parent).await
 }
 
 async fn connect_transport<T, E, A>(

--- a/crates/nanocodex-mcp/src/lib.rs
+++ b/crates/nanocodex-mcp/src/lib.rs
@@ -3,6 +3,7 @@
 mod catalog;
 mod client;
 mod config;
+mod oauth;
 
 use std::{
     collections::{BTreeMap, btree_map::Entry},
@@ -25,6 +26,7 @@ use serde_json::{Value, json};
 use tracing::{Instrument, info_span};
 
 pub use config::McpServer;
+pub use oauth::{McpOAuthCredentials, McpOAuthStore};
 
 const TOOL_SEARCH_NAME: &str = "tool_search";
 
@@ -33,6 +35,7 @@ pub struct Mcp {
     servers: Arc<[NamedServer]>,
     state: Arc<ProviderState>,
     search: Arc<McpSearch>,
+    oauth_store: Option<Arc<dyn McpOAuthStore>>,
     started: AtomicBool,
 }
 
@@ -45,7 +48,40 @@ struct NamedServer {
 #[derive(Default)]
 pub struct McpBuilder {
     servers: BTreeMap<String, McpServer>,
+    oauth_store: Option<Arc<dyn McpOAuthStore>>,
     duplicate: Option<String>,
+}
+
+/// Cheap control handle for reconnecting and authorizing a running MCP provider.
+#[derive(Clone)]
+pub struct McpHandle {
+    servers: Arc<[NamedServer]>,
+    state: Arc<ProviderState>,
+    oauth_store: Option<Arc<dyn McpOAuthStore>>,
+}
+
+/// An in-progress browser OAuth login.
+pub struct McpLogin {
+    authorization_url: String,
+    completion: tokio::task::JoinHandle<Result<usize, McpControlError>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum McpControlError {
+    #[error("unknown MCP server `{0}`")]
+    UnknownServer(String),
+    #[error("MCP server `{0}` does not use Streamable HTTP")]
+    NotHttp(String),
+    #[error("MCP server `{0}` has explicit bearer authentication")]
+    ExplicitBearer(String),
+    #[error("no MCP OAuth credential store is configured")]
+    NoOAuthStore,
+    #[error("MCP OAuth login failed: {0}")]
+    OAuth(String),
+    #[error("MCP server `{server}` failed to reload: {error}")]
+    Reload { server: String, error: String },
+    #[error("MCP OAuth login task stopped: {0}")]
+    LoginTask(String),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -72,9 +108,25 @@ impl Mcp {
     pub fn builder() -> McpBuilder {
         McpBuilder::default()
     }
+
+    #[must_use]
+    pub fn handle(&self) -> McpHandle {
+        McpHandle {
+            servers: Arc::clone(&self.servers),
+            state: Arc::clone(&self.state),
+            oauth_store: self.oauth_store.clone(),
+        }
+    }
 }
 
 impl McpBuilder {
+    /// Installs caller-owned persistence for OAuth-capable Streamable HTTP servers.
+    #[must_use]
+    pub fn oauth_store(mut self, store: Arc<dyn McpOAuthStore>) -> Self {
+        self.oauth_store = Some(store);
+        self
+    }
+
     /// Adds a named stdio or Streamable HTTP MCP server.
     #[must_use]
     pub fn server(mut self, name: impl Into<String>, server: McpServer) -> Self {
@@ -114,7 +166,10 @@ impl McpBuilder {
             });
         }
         let servers: Arc<[NamedServer]> = named.into();
-        let state = Arc::new(ProviderState::new(servers.len(), discovery_timeout));
+        let state = Arc::new(ProviderState::new(
+            servers.iter().map(|server| server.name.clone()),
+            discovery_timeout,
+        ));
         let search = Arc::new(McpSearch {
             state: Arc::clone(&state),
             description: search_description(&servers),
@@ -123,8 +178,212 @@ impl McpBuilder {
             servers,
             state,
             search,
+            oauth_store: self.oauth_store,
             started: AtomicBool::new(false),
         })
+    }
+}
+
+impl McpHandle {
+    /// Reconnects one configured server and atomically replaces its discovered tools.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the server name is unknown or the replacement connection cannot
+    /// initialize and list its tools.
+    pub async fn reload(&self, server_name: &str) -> Result<usize, McpControlError> {
+        let span = info_span!(
+            target: "nanocodex_mcp",
+            parent: None,
+            "mcp.server_reload",
+            otel.kind = "client",
+            otel.status_code = tracing::field::Empty,
+            mcp.server = server_name,
+            status = tracing::field::Empty,
+            tool.count = tracing::field::Empty,
+        );
+        // Do not enter this span while connecting. RMCP's transport task inherits the current
+        // tracing context and outlives the reload operation; children use explicit parents.
+        let result = self.reload_inner(server_name, &span).await;
+        span.record(
+            "status",
+            if result.is_ok() {
+                "completed"
+            } else {
+                "failed"
+            },
+        );
+        span.record(
+            "otel.status_code",
+            if result.is_ok() { "OK" } else { "ERROR" },
+        );
+        if let Ok(tool_count) = &result {
+            span.record("tool.count", tool_count);
+        }
+        result
+    }
+
+    async fn reload_inner(
+        &self,
+        server_name: &str,
+        parent: &tracing::Span,
+    ) -> Result<usize, McpControlError> {
+        let server = self
+            .servers
+            .iter()
+            .find(|server| server.name == server_name)
+            .ok_or_else(|| McpControlError::UnknownServer(server_name.to_owned()))?;
+        let generation = self.state.begin_server(server_name);
+        let result = client::connect(
+            server_name,
+            &server.config,
+            self.oauth_store.clone(),
+            parent,
+        )
+        .await;
+        match result {
+            Ok(connected) => {
+                let count = connected.tools.len();
+                let entries = connected
+                    .tools
+                    .into_iter()
+                    .map(|tool| {
+                        ToolEntry::new(
+                            server_name,
+                            &tool,
+                            Arc::clone(&connected.client),
+                            server.config.tool_timeout,
+                        )
+                    })
+                    .collect();
+                self.state
+                    .complete_server(server_name, generation, Ok(entries));
+                Ok(count)
+            }
+            Err(error) => {
+                self.state
+                    .complete_server(server_name, generation, Err(error.clone()));
+                Err(McpControlError::Reload {
+                    server: server_name.to_owned(),
+                    error,
+                })
+            }
+        }
+    }
+
+    /// Starts an OAuth browser login for one server.
+    ///
+    /// Await [`McpLogin::wait`] after opening [`McpLogin::authorization_url`]. A successful login
+    /// persists the credentials and hot-reloads the server before completing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an unknown or unsupported server, a missing OAuth store, or when the
+    /// authorization flow cannot be initialized.
+    pub async fn login(&self, server_name: &str) -> Result<McpLogin, McpControlError> {
+        let span = info_span!(
+            target: "nanocodex_mcp",
+            parent: None,
+            "mcp.oauth.login",
+            otel.kind = "client",
+            otel.status_code = tracing::field::Empty,
+            mcp.server = server_name,
+            status = tracing::field::Empty,
+            tool.count = tracing::field::Empty,
+        );
+        self.login_inner(server_name, span).await
+    }
+
+    async fn login_inner(
+        &self,
+        server_name: &str,
+        span: tracing::Span,
+    ) -> Result<McpLogin, McpControlError> {
+        let server = self
+            .servers
+            .iter()
+            .find(|server| server.name == server_name)
+            .ok_or_else(|| McpControlError::UnknownServer(server_name.to_owned()))?;
+        let store = self
+            .oauth_store
+            .clone()
+            .ok_or(McpControlError::NoOAuthStore)?;
+        let (url, bearer, headers) = match &server.config.transport {
+            config::McpTransport::StreamableHttp {
+                url,
+                bearer,
+                headers,
+            } => (url.clone(), bearer.is_some(), headers.clone()),
+            config::McpTransport::Stdio { .. } => {
+                return Err(McpControlError::NotHttp(server_name.to_owned()));
+            }
+        };
+        if bearer {
+            return Err(McpControlError::ExplicitBearer(server_name.to_owned()));
+        }
+        let flow = oauth::begin_login(server_name.to_owned(), url, headers, store)
+            .instrument(span.clone())
+            .await
+            .map_err(|error| {
+                span.record("status", "failed");
+                span.record("otel.status_code", "ERROR");
+                McpControlError::OAuth(error)
+            })?;
+        let handle = self.clone();
+        let name = server_name.to_owned();
+        let completion_span = span.clone();
+        let completion = tokio::spawn(
+            async move {
+                let result = async {
+                    flow.completion
+                        .await
+                        .map_err(|error| McpControlError::LoginTask(error.to_string()))?
+                        .map_err(McpControlError::OAuth)?;
+                    handle.reload(&name).await
+                }
+                .await;
+                completion_span.record(
+                    "status",
+                    if result.is_ok() {
+                        "completed"
+                    } else {
+                        "failed"
+                    },
+                );
+                completion_span.record(
+                    "otel.status_code",
+                    if result.is_ok() { "OK" } else { "ERROR" },
+                );
+                if let Ok(tool_count) = &result {
+                    completion_span.record("tool.count", tool_count);
+                }
+                result
+            }
+            .instrument(span),
+        );
+        Ok(McpLogin {
+            authorization_url: flow.authorization_url,
+            completion,
+        })
+    }
+}
+
+impl McpLogin {
+    #[must_use]
+    pub fn authorization_url(&self) -> &str {
+        &self.authorization_url
+    }
+
+    /// Waits for the browser callback and the automatic server reload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when authorization, credential persistence, or the subsequent hot reload
+    /// fails.
+    pub async fn wait(self) -> Result<usize, McpControlError> {
+        self.completion
+            .await
+            .map_err(|error| McpControlError::LoginTask(error.to_string()))?
     }
 }
 
@@ -138,6 +397,7 @@ impl DynamicToolProvider for Mcp {
             let name = server.name.clone();
             let config = server.config.clone();
             let state = Arc::clone(&self.state);
+            let oauth_store = self.oauth_store.clone();
             let span = info_span!(
                 target: "nanocodex_mcp",
                 parent: None,
@@ -148,9 +408,10 @@ impl DynamicToolProvider for Mcp {
                 status = tracing::field::Empty,
                 tool.count = tracing::field::Empty,
             );
-            drop(tokio::spawn(
-                async move {
-                    let result = client::connect(&config).await.map(|connected| {
+            drop(tokio::spawn(async move {
+                let result = client::connect(&name, &config, oauth_store, &span)
+                    .await
+                    .map(|connected| {
                         connected
                             .tools
                             .into_iter()
@@ -164,26 +425,23 @@ impl DynamicToolProvider for Mcp {
                             })
                             .collect::<Vec<_>>()
                     });
-                    let current = tracing::Span::current();
-                    current.record(
-                        "status",
-                        if result.is_ok() {
-                            "completed"
-                        } else {
-                            "failed"
-                        },
-                    );
-                    current.record(
-                        "otel.status_code",
-                        if result.is_ok() { "OK" } else { "ERROR" },
-                    );
-                    if let Ok(tools) = &result {
-                        current.record("tool.count", tools.len());
-                    }
-                    state.complete_server(&name, result);
+                span.record(
+                    "status",
+                    if result.is_ok() {
+                        "completed"
+                    } else {
+                        "failed"
+                    },
+                );
+                span.record(
+                    "otel.status_code",
+                    if result.is_ok() { "OK" } else { "ERROR" },
+                );
+                if let Ok(tools) = &result {
+                    span.record("tool.count", tools.len());
                 }
-                .instrument(span),
-            ));
+                state.complete_server(&name, 0, result);
+            }));
         }
     }
 
@@ -321,7 +579,39 @@ impl Tool for McpSearch {
 
     async fn execute(&self, input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
         let input = input.decode_json::<SearchInput>()?;
-        Ok(match self.state.search(&input.query, input.limit).await {
+        let span = info_span!(
+            target: "nanocodex_mcp",
+            "mcp.catalog_search",
+            otel.kind = "internal",
+            otel.status_code = tracing::field::Empty,
+            query.bytes = input.query.len(),
+            result.count = tracing::field::Empty,
+            pending_servers = tracing::field::Empty,
+            status = tracing::field::Empty,
+        );
+        tracing::info!(parent: &span, query = %input.query, limit = input.limit, "MCP catalog search");
+        let result = self
+            .state
+            .search(&input.query, input.limit)
+            .instrument(span.clone())
+            .await;
+        span.record(
+            "status",
+            if result.is_ok() {
+                "completed"
+            } else {
+                "failed"
+            },
+        );
+        span.record(
+            "otel.status_code",
+            if result.is_ok() { "OK" } else { "ERROR" },
+        );
+        if let Ok(result) = &result {
+            span.record("result.count", result.tool_count());
+            span.record("pending_servers", result.pending_server_count());
+        }
+        Ok(match result {
             Ok(result) => ToolExecution::json(&result),
             Err(error) => ToolExecution::error(error),
         })
@@ -479,6 +769,60 @@ mod tests {
         assert!(matches!(
             execution.output,
             ToolOutputBody::Text(output) if output.contains("fixture:hello")
+        ));
+    }
+
+    #[tokio::test]
+    async fn reload_replaces_a_live_server_without_restarting_or_deactivating_tools() {
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/stdio-server.mjs");
+        let mcp = Mcp::builder()
+            .server(
+                "fixture",
+                McpServer::stdio("node").arg(fixture.to_string_lossy()),
+            )
+            .build()
+            .unwrap();
+        let handle = mcp.handle();
+        mcp.start();
+        let context = ToolContext {
+            model: MODEL,
+            session_id: "reload-session",
+            call_id: "search-call",
+            history: &[],
+            output_token_budget: DEFAULT_TOOL_OUTPUT_TOKENS,
+        };
+        let search = mcp
+            .search
+            .execute(
+                ToolInput::Function(to_raw_value(&json!({ "query": "echo message" })).unwrap()),
+                context,
+            )
+            .await
+            .unwrap();
+        assert!(search.success);
+
+        assert_eq!(handle.reload("fixture").await.unwrap(), 1);
+        assert!(
+            mcp.available_definitions()
+                .iter()
+                .any(|definition| definition.name() == "mcp__fixture__echo")
+        );
+        let execution = mcp
+            .execute(
+                "mcp__fixture__echo",
+                json!({ "message": "after-reload" }),
+                ToolContext {
+                    call_id: "tool-call",
+                    ..context
+                },
+            )
+            .await
+            .unwrap();
+        assert!(execution.success);
+        assert!(matches!(
+            execution.output,
+            ToolOutputBody::Text(output) if output.contains("fixture:after-reload")
         ));
     }
 

--- a/crates/nanocodex-mcp/src/lib.rs
+++ b/crates/nanocodex-mcp/src/lib.rs
@@ -36,6 +36,7 @@ pub struct Mcp {
     state: Arc<ProviderState>,
     search: Arc<McpSearch>,
     oauth_store: Option<Arc<dyn McpOAuthStore>>,
+    oauth_metadata: Arc<oauth::OAuthMetadataCache>,
     started: AtomicBool,
 }
 
@@ -58,6 +59,7 @@ pub struct McpHandle {
     servers: Arc<[NamedServer]>,
     state: Arc<ProviderState>,
     oauth_store: Option<Arc<dyn McpOAuthStore>>,
+    oauth_metadata: Arc<oauth::OAuthMetadataCache>,
 }
 
 /// An in-progress browser OAuth login.
@@ -115,6 +117,7 @@ impl Mcp {
             servers: Arc::clone(&self.servers),
             state: Arc::clone(&self.state),
             oauth_store: self.oauth_store.clone(),
+            oauth_metadata: Arc::clone(&self.oauth_metadata),
         }
     }
 }
@@ -179,6 +182,7 @@ impl McpBuilder {
             state,
             search,
             oauth_store: self.oauth_store,
+            oauth_metadata: Arc::new(oauth::OAuthMetadataCache::default()),
             started: AtomicBool::new(false),
         })
     }
@@ -238,6 +242,7 @@ impl McpHandle {
             server_name,
             &server.config,
             self.oauth_store.clone(),
+            Arc::clone(&self.oauth_metadata),
             parent,
         )
         .await;
@@ -398,6 +403,7 @@ impl DynamicToolProvider for Mcp {
             let config = server.config.clone();
             let state = Arc::clone(&self.state);
             let oauth_store = self.oauth_store.clone();
+            let oauth_metadata = Arc::clone(&self.oauth_metadata);
             let span = info_span!(
                 target: "nanocodex_mcp",
                 parent: None,
@@ -409,7 +415,7 @@ impl DynamicToolProvider for Mcp {
                 tool.count = tracing::field::Empty,
             );
             drop(tokio::spawn(async move {
-                let result = client::connect(&name, &config, oauth_store, &span)
+                let result = client::connect(&name, &config, oauth_store, oauth_metadata, &span)
                     .await
                     .map(|connected| {
                         connected

--- a/crates/nanocodex-mcp/src/oauth.rs
+++ b/crates/nanocodex-mcp/src/oauth.rs
@@ -1,0 +1,522 @@
+use std::{
+    collections::BTreeMap,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use async_trait::async_trait;
+use http::{HeaderName, HeaderValue};
+use oauth2::{AccessToken, RefreshToken, Scope, TokenResponse, basic::BasicTokenType};
+use rmcp::transport::{
+    AuthorizationManager,
+    auth::{AuthClient, OAuthState, OAuthTokenResponse, VendorExtraTokenFields},
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+    sync::Mutex,
+    task::JoinHandle,
+};
+use tracing::{Instrument, info_span};
+
+use crate::config::SecretSource;
+
+const LOGIN_TIMEOUT: Duration = Duration::from_mins(5);
+const MAX_CALLBACK_BYTES: usize = 16 * 1024;
+
+/// OAuth credentials for one Streamable HTTP MCP server.
+///
+/// This value intentionally does not implement `Debug`: access and refresh tokens must not be
+/// emitted by diagnostics. Embedders normally provide these through an [`McpOAuthStore`].
+#[derive(Clone, PartialEq, Eq)]
+pub struct McpOAuthCredentials {
+    client_id: String,
+    access_token: String,
+    refresh_token: Option<String>,
+    expires_at_millis: Option<u64>,
+    scopes: Vec<String>,
+}
+
+impl McpOAuthCredentials {
+    #[must_use]
+    pub fn new(client_id: impl Into<String>, access_token: impl Into<String>) -> Self {
+        Self {
+            client_id: client_id.into(),
+            access_token: access_token.into(),
+            refresh_token: None,
+            expires_at_millis: None,
+            scopes: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn refresh_token(mut self, refresh_token: impl Into<String>) -> Self {
+        self.refresh_token = Some(refresh_token.into());
+        self
+    }
+
+    #[must_use]
+    pub fn expires_at_millis(mut self, expires_at_millis: u64) -> Self {
+        self.expires_at_millis = Some(expires_at_millis);
+        self
+    }
+
+    #[must_use]
+    pub fn scopes(mut self, scopes: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.scopes = scopes.into_iter().map(Into::into).collect();
+        self
+    }
+
+    #[must_use]
+    pub fn client_id(&self) -> &str {
+        &self.client_id
+    }
+
+    #[must_use]
+    pub fn access_token(&self) -> &str {
+        &self.access_token
+    }
+
+    #[must_use]
+    pub fn refresh_token_value(&self) -> Option<&str> {
+        self.refresh_token.as_deref()
+    }
+
+    #[must_use]
+    pub const fn expires_at(&self) -> Option<u64> {
+        self.expires_at_millis
+    }
+
+    #[must_use]
+    pub fn granted_scopes(&self) -> &[String] {
+        &self.scopes
+    }
+
+    fn to_token_response(&self) -> OAuthTokenResponse {
+        let mut response = OAuthTokenResponse::new(
+            AccessToken::new(self.access_token.clone()),
+            BasicTokenType::Bearer,
+            VendorExtraTokenFields::default(),
+        );
+        if let Some(refresh_token) = &self.refresh_token {
+            response.set_refresh_token(Some(RefreshToken::new(refresh_token.clone())));
+        }
+        if !self.scopes.is_empty() {
+            response.set_scopes(Some(self.scopes.iter().cloned().map(Scope::new).collect()));
+        }
+        if let Some(expires_at) = self.expires_at_millis {
+            response.set_expires_in(Some(&Duration::from_millis(
+                expires_at.saturating_sub(now_millis()),
+            )));
+        }
+        response
+    }
+
+    fn from_token_response(client_id: String, response: &OAuthTokenResponse) -> Self {
+        let expires_at_millis = response.expires_in().and_then(|expires_in| {
+            now_millis().checked_add(u64::try_from(expires_in.as_millis()).ok()?)
+        });
+        Self {
+            client_id,
+            access_token: response.access_token().secret().to_owned(),
+            refresh_token: response
+                .refresh_token()
+                .map(|token| token.secret().to_owned()),
+            expires_at_millis,
+            scopes: response
+                .scopes()
+                .map(|scopes| {
+                    scopes
+                        .iter()
+                        .map(|scope| scope.as_ref().to_owned())
+                        .collect()
+                })
+                .unwrap_or_default(),
+        }
+    }
+
+    fn same_token(&self, other: &Self) -> bool {
+        self.client_id == other.client_id
+            && self.access_token == other.access_token
+            && self.refresh_token == other.refresh_token
+            && self.scopes == other.scopes
+    }
+}
+
+/// Persistence selected by an embedding application for MCP OAuth credentials.
+#[async_trait]
+pub trait McpOAuthStore: Send + Sync {
+    async fn load(
+        &self,
+        server_name: &str,
+        server_url: &str,
+    ) -> Result<Option<McpOAuthCredentials>, String>;
+
+    async fn save(
+        &self,
+        server_name: &str,
+        server_url: &str,
+        credentials: &McpOAuthCredentials,
+    ) -> Result<(), String>;
+}
+
+pub(crate) struct OAuthRuntime {
+    server_name: String,
+    server_url: String,
+    manager: Arc<Mutex<AuthorizationManager>>,
+    store: Arc<dyn McpOAuthStore>,
+    last_credentials: Mutex<McpOAuthCredentials>,
+}
+
+impl OAuthRuntime {
+    pub(crate) fn new(
+        server_name: String,
+        server_url: String,
+        manager: Arc<Mutex<AuthorizationManager>>,
+        store: Arc<dyn McpOAuthStore>,
+        credentials: McpOAuthCredentials,
+    ) -> Self {
+        Self {
+            server_name,
+            server_url,
+            manager,
+            store,
+            last_credentials: Mutex::new(credentials),
+        }
+    }
+
+    pub(crate) async fn persist_if_changed(&self) -> Result<(), String> {
+        let (client_id, response) = self
+            .manager
+            .lock()
+            .await
+            .get_credentials()
+            .await
+            .map_err(|error| format!("failed to read refreshed OAuth credentials: {error}"))?;
+        let Some(response) = response else {
+            return Err("OAuth transport no longer has credentials".to_owned());
+        };
+        let mut credentials = McpOAuthCredentials::from_token_response(client_id, &response);
+        let mut previous = self.last_credentials.lock().await;
+        if credentials.same_token(&previous) {
+            credentials.expires_at_millis = previous.expires_at_millis;
+        }
+        if *previous == credentials {
+            return Ok(());
+        }
+        let span = info_span!(
+            target: "nanocodex_mcp",
+            "mcp.oauth.credentials_save",
+            otel.kind = "internal",
+            otel.status_code = tracing::field::Empty,
+            reason = "refresh",
+            status = tracing::field::Empty,
+        );
+        let result = self
+            .store
+            .save(&self.server_name, &self.server_url, &credentials)
+            .instrument(span.clone())
+            .await;
+        span.record(
+            "status",
+            if result.is_ok() {
+                "completed"
+            } else {
+                "failed"
+            },
+        );
+        span.record(
+            "otel.status_code",
+            if result.is_ok() { "OK" } else { "ERROR" },
+        );
+        result?;
+        *previous = credentials;
+        Ok(())
+    }
+}
+
+pub(crate) struct OAuthTransport {
+    pub(crate) client: AuthClient<reqwest::Client>,
+    pub(crate) runtime: Arc<OAuthRuntime>,
+}
+
+pub(crate) async fn transport_from_credentials(
+    server_name: &str,
+    server_url: &str,
+    http_client: reqwest::Client,
+    store: Arc<dyn McpOAuthStore>,
+    credentials: McpOAuthCredentials,
+) -> Result<OAuthTransport, String> {
+    let mut state = OAuthState::new(server_url, Some(http_client.clone()))
+        .await
+        .map_err(|error| format!("failed to discover MCP OAuth metadata: {error}"))?;
+    state
+        .set_credentials(&credentials.client_id, credentials.to_token_response())
+        .await
+        .map_err(|error| format!("failed to restore MCP OAuth credentials: {error}"))?;
+    let manager = state
+        .into_authorization_manager()
+        .ok_or_else(|| "restored MCP OAuth state was not authorized".to_owned())?;
+    let client = AuthClient::new(http_client, manager);
+    let runtime = Arc::new(OAuthRuntime::new(
+        server_name.to_owned(),
+        server_url.to_owned(),
+        Arc::clone(&client.auth_manager),
+        store,
+        credentials,
+    ));
+    Ok(OAuthTransport { client, runtime })
+}
+
+pub(crate) struct OAuthLoginFlow {
+    pub(crate) authorization_url: String,
+    pub(crate) completion: JoinHandle<Result<(), String>>,
+}
+
+pub(crate) async fn begin_login(
+    server_name: String,
+    server_url: String,
+    headers: BTreeMap<String, SecretSource>,
+    store: Arc<dyn McpOAuthStore>,
+) -> Result<OAuthLoginFlow, String> {
+    let client = oauth_http_client(headers)?;
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(|error| format!("failed to bind MCP OAuth callback: {error}"))?;
+    let address = listener
+        .local_addr()
+        .map_err(|error| format!("failed to inspect MCP OAuth callback: {error}"))?;
+    let redirect_uri = format!("http://{address}/callback");
+    let authorization_span = info_span!(
+        target: "nanocodex_mcp",
+        "mcp.oauth.authorization_start",
+        otel.kind = "client",
+        otel.status_code = tracing::field::Empty,
+        status = tracing::field::Empty,
+    );
+    let authorization = async {
+        let mut state = OAuthState::new(&server_url, Some(client))
+            .await
+            .map_err(|error| format!("failed to discover MCP OAuth metadata: {error}"))?;
+        state
+            .start_authorization(&[], &redirect_uri, Some("Nanocodex"))
+            .await
+            .map_err(|error| format!("failed to start MCP OAuth authorization: {error}"))?;
+        let authorization_url = state
+            .get_authorization_url()
+            .await
+            .map_err(|error| format!("failed to build MCP OAuth authorization URL: {error}"))?;
+        Ok::<_, String>((state, authorization_url))
+    }
+    .instrument(authorization_span.clone())
+    .await;
+    authorization_span.record(
+        "status",
+        if authorization.is_ok() {
+            "completed"
+        } else {
+            "failed"
+        },
+    );
+    authorization_span.record(
+        "otel.status_code",
+        if authorization.is_ok() { "OK" } else { "ERROR" },
+    );
+    let (state, authorization_url) = authorization?;
+
+    let parent = tracing::Span::current();
+    let completion = tokio::spawn(
+        complete_login(
+            listener,
+            redirect_uri,
+            state,
+            store,
+            server_name,
+            server_url,
+        )
+        .instrument(parent),
+    );
+    Ok(OAuthLoginFlow {
+        authorization_url,
+        completion,
+    })
+}
+
+async fn complete_login(
+    listener: TcpListener,
+    redirect_uri: String,
+    mut state: OAuthState,
+    store: Arc<dyn McpOAuthStore>,
+    server_name: String,
+    server_url: String,
+) -> Result<(), String> {
+    let callback_span = info_span!(
+        target: "nanocodex_mcp",
+        "mcp.oauth.callback_wait",
+        otel.kind = "server",
+        otel.status_code = tracing::field::Empty,
+        status = tracing::field::Empty,
+    );
+    let callback =
+        match tokio::time::timeout(LOGIN_TIMEOUT, receive_callback(listener, &redirect_uri))
+            .instrument(callback_span.clone())
+            .await
+        {
+            Ok(callback) => callback,
+            Err(_) => Err("timed out waiting for MCP OAuth callback".to_owned()),
+        };
+    callback_span.record(
+        "status",
+        if callback.is_ok() {
+            "completed"
+        } else {
+            "failed"
+        },
+    );
+    callback_span.record(
+        "otel.status_code",
+        if callback.is_ok() { "OK" } else { "ERROR" },
+    );
+    let callback = callback?;
+    let exchange_span = info_span!(
+        target: "nanocodex_mcp",
+        "mcp.oauth.code_exchange",
+        otel.kind = "client",
+        otel.status_code = tracing::field::Empty,
+        status = tracing::field::Empty,
+    );
+    let result = state
+        .handle_callback_url(&callback)
+        .instrument(exchange_span.clone())
+        .await
+        .map_err(|error| format!("failed to exchange MCP OAuth code: {error}"));
+    exchange_span.record(
+        "status",
+        if result.is_ok() {
+            "completed"
+        } else {
+            "failed"
+        },
+    );
+    exchange_span.record(
+        "otel.status_code",
+        if result.is_ok() { "OK" } else { "ERROR" },
+    );
+    result?;
+    let (client_id, response) = state
+        .get_credentials()
+        .await
+        .map_err(|error| format!("failed to read MCP OAuth credentials: {error}"))?;
+    let response =
+        response.ok_or_else(|| "MCP OAuth provider returned no credentials".to_owned())?;
+    let credentials = McpOAuthCredentials::from_token_response(client_id, &response);
+    let save_span = info_span!(
+        target: "nanocodex_mcp",
+        "mcp.oauth.credentials_save",
+        otel.kind = "internal",
+        otel.status_code = tracing::field::Empty,
+        reason = "login",
+        status = tracing::field::Empty,
+    );
+    let saved = store
+        .save(&server_name, &server_url, &credentials)
+        .instrument(save_span.clone())
+        .await;
+    save_span.record("status", if saved.is_ok() { "completed" } else { "failed" });
+    save_span.record(
+        "otel.status_code",
+        if saved.is_ok() { "OK" } else { "ERROR" },
+    );
+    saved
+}
+
+fn oauth_http_client(headers: BTreeMap<String, SecretSource>) -> Result<reqwest::Client, String> {
+    let mut resolved = reqwest::header::HeaderMap::with_capacity(headers.len());
+    for (name, source) in headers {
+        let name = name
+            .parse::<HeaderName>()
+            .map_err(|error| format!("invalid HTTP header name `{name}`: {error}"))?;
+        let value = source.resolve()?;
+        let mut value = HeaderValue::from_str(&value)
+            .map_err(|error| format!("invalid value for HTTP header `{name}`: {error}"))?;
+        value.set_sensitive(true);
+        resolved.insert(name, value);
+    }
+    reqwest::Client::builder()
+        .default_headers(resolved)
+        .pool_max_idle_per_host(0)
+        .build()
+        .map_err(|error| format!("failed to build MCP OAuth HTTP client: {error}"))
+}
+
+async fn receive_callback(listener: TcpListener, redirect_uri: &str) -> Result<String, String> {
+    let (mut stream, _) = listener
+        .accept()
+        .await
+        .map_err(|error| format!("failed to accept MCP OAuth callback: {error}"))?;
+    let mut bytes = Vec::with_capacity(2048);
+    loop {
+        let mut chunk = [0_u8; 1024];
+        let read = stream
+            .read(&mut chunk)
+            .await
+            .map_err(|error| format!("failed to read MCP OAuth callback: {error}"))?;
+        if read == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&chunk[..read]);
+        if bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+        if bytes.len() > MAX_CALLBACK_BYTES {
+            return Err("MCP OAuth callback headers were too large".to_owned());
+        }
+    }
+    let request = std::str::from_utf8(&bytes)
+        .map_err(|_| "MCP OAuth callback was not valid HTTP".to_owned())?;
+    let target = request
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .ok_or_else(|| "MCP OAuth callback did not contain a request target".to_owned())?;
+    let base = reqwest::Url::parse(redirect_uri)
+        .map_err(|error| format!("invalid MCP OAuth redirect URI: {error}"))?;
+    let callback = base
+        .join(target)
+        .map_err(|error| format!("invalid MCP OAuth callback target: {error}"))?;
+    if callback.path() != base.path() {
+        let _ = respond(&mut stream, 400, "Invalid OAuth callback path").await;
+        return Err("MCP OAuth callback used an unexpected path".to_owned());
+    }
+    respond(
+        &mut stream,
+        200,
+        "Authentication received. You may close this window.",
+    )
+    .await?;
+    Ok(callback.to_string())
+}
+
+async fn respond(
+    stream: &mut tokio::net::TcpStream,
+    status: u16,
+    body: &str,
+) -> Result<(), String> {
+    let reason = if status == 200 { "OK" } else { "Bad Request" };
+    let response = format!(
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream
+        .write_all(response.as_bytes())
+        .await
+        .map_err(|error| format!("failed to answer MCP OAuth callback: {error}"))
+}
+
+fn now_millis() -> u64 {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_millis();
+    u64::try_from(millis).unwrap_or(u64::MAX)
+}

--- a/crates/nanocodex-mcp/src/oauth.rs
+++ b/crates/nanocodex-mcp/src/oauth.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -9,12 +9,15 @@ use http::{HeaderName, HeaderValue};
 use oauth2::{AccessToken, RefreshToken, Scope, TokenResponse, basic::BasicTokenType};
 use rmcp::transport::{
     AuthorizationManager,
-    auth::{AuthClient, OAuthState, OAuthTokenResponse, VendorExtraTokenFields},
+    auth::{
+        AuthClient, AuthorizationMetadata, CredentialStore, InMemoryCredentialStore, OAuthState,
+        OAuthTokenResponse, StoredCredentials, VendorExtraTokenFields,
+    },
 };
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpListener,
-    sync::Mutex,
+    sync::{Mutex, RwLock},
     task::JoinHandle,
 };
 use tracing::{Instrument, info_span};
@@ -23,6 +26,28 @@ use crate::config::SecretSource;
 
 const LOGIN_TIMEOUT: Duration = Duration::from_mins(5);
 const MAX_CALLBACK_BYTES: usize = 16 * 1024;
+
+#[derive(Default)]
+pub(crate) struct OAuthMetadataCache {
+    entries: RwLock<HashMap<(String, String), AuthorizationMetadata>>,
+}
+
+impl OAuthMetadataCache {
+    async fn get(&self, server_name: &str, server_url: &str) -> Option<AuthorizationMetadata> {
+        self.entries
+            .read()
+            .await
+            .get(&(server_name.to_owned(), server_url.to_owned()))
+            .cloned()
+    }
+
+    async fn insert(&self, server_name: &str, server_url: &str, metadata: AuthorizationMetadata) {
+        self.entries
+            .write()
+            .await
+            .insert((server_name.to_owned(), server_url.to_owned()), metadata);
+    }
+}
 
 /// OAuth credentials for one Streamable HTTP MCP server.
 ///
@@ -238,6 +263,7 @@ impl OAuthRuntime {
 pub(crate) struct OAuthTransport {
     pub(crate) client: AuthClient<reqwest::Client>,
     pub(crate) runtime: Arc<OAuthRuntime>,
+    pub(crate) metadata_cache_hit: bool,
 }
 
 pub(crate) async fn transport_from_credentials(
@@ -246,17 +272,47 @@ pub(crate) async fn transport_from_credentials(
     http_client: reqwest::Client,
     store: Arc<dyn McpOAuthStore>,
     credentials: McpOAuthCredentials,
+    metadata_cache: &OAuthMetadataCache,
 ) -> Result<OAuthTransport, String> {
-    let mut state = OAuthState::new(server_url, Some(http_client.clone()))
+    let mut manager = AuthorizationManager::new(server_url)
         .await
-        .map_err(|error| format!("failed to discover MCP OAuth metadata: {error}"))?;
-    state
-        .set_credentials(&credentials.client_id, credentials.to_token_response())
+        .map_err(|error| format!("failed to initialize MCP OAuth state: {error}"))?;
+    manager
+        .with_client(http_client.clone())
+        .map_err(|error| format!("failed to configure MCP OAuth HTTP client: {error}"))?;
+    let (metadata, metadata_cache_hit) =
+        if let Some(metadata) = metadata_cache.get(server_name, server_url).await {
+            (metadata, true)
+        } else {
+            let metadata = manager
+                .discover_metadata()
+                .await
+                .map_err(|error| format!("failed to discover MCP OAuth metadata: {error}"))?;
+            metadata_cache
+                .insert(server_name, server_url, metadata.clone())
+                .await;
+            (metadata, false)
+        };
+    manager.set_metadata(metadata);
+
+    let credential_store = InMemoryCredentialStore::new();
+    credential_store
+        .save(StoredCredentials::new(
+            credentials.client_id.clone(),
+            Some(credentials.to_token_response()),
+            credentials.scopes.clone(),
+            Some(now_seconds()),
+        ))
+        .await
+        .map_err(|error| format!("failed to stage MCP OAuth credentials: {error}"))?;
+    manager.set_credential_store(credential_store);
+    let restored = manager
+        .initialize_from_store()
         .await
         .map_err(|error| format!("failed to restore MCP OAuth credentials: {error}"))?;
-    let manager = state
-        .into_authorization_manager()
-        .ok_or_else(|| "restored MCP OAuth state was not authorized".to_owned())?;
+    if !restored {
+        return Err("restored MCP OAuth state was not authorized".to_owned());
+    }
     let client = AuthClient::new(http_client, manager);
     let runtime = Arc::new(OAuthRuntime::new(
         server_name.to_owned(),
@@ -265,7 +321,11 @@ pub(crate) async fn transport_from_credentials(
         store,
         credentials,
     ));
-    Ok(OAuthTransport { client, runtime })
+    Ok(OAuthTransport {
+        client,
+        runtime,
+        metadata_cache_hit,
+    })
 }
 
 pub(crate) struct OAuthLoginFlow {
@@ -519,4 +579,101 @@ fn now_millis() -> u64 {
         .unwrap_or(Duration::ZERO)
         .as_millis();
     u64::try_from(millis).unwrap_or(u64::MAX)
+}
+
+fn now_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingStore {
+        saved: Mutex<Vec<McpOAuthCredentials>>,
+    }
+
+    #[async_trait]
+    impl McpOAuthStore for RecordingStore {
+        async fn load(
+            &self,
+            _server_name: &str,
+            _server_url: &str,
+        ) -> Result<Option<McpOAuthCredentials>, String> {
+            Ok(None)
+        }
+
+        async fn save(
+            &self,
+            _server_name: &str,
+            _server_url: &str,
+            credentials: &McpOAuthCredentials,
+        ) -> Result<(), String> {
+            self.saved.lock().await.push(credentials.clone());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn cached_metadata_preserves_refresh_and_rotated_token_persistence() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let token_endpoint = format!("http://{}/token", listener.local_addr().unwrap());
+        let responder = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = vec![0_u8; 4096];
+            let read = stream.read(&mut request).await.unwrap();
+            assert!(String::from_utf8_lossy(&request[..read]).contains("POST /token"));
+            let body = r#"{"access_token":"refreshed-access","token_type":"Bearer","expires_in":3600,"refresh_token":"rotated-refresh","scope":"mcp:tools"}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let server_name = "cached";
+        let server_url = "http://127.0.0.1:9/mcp";
+        let metadata: AuthorizationMetadata = serde_json::from_value(serde_json::json!({
+            "authorization_endpoint": "http://127.0.0.1:9/authorize",
+            "token_endpoint": token_endpoint,
+        }))
+        .unwrap();
+        let metadata_cache = OAuthMetadataCache::default();
+        metadata_cache
+            .insert(server_name, server_url, metadata)
+            .await;
+        let store = Arc::new(RecordingStore::default());
+        let credentials = McpOAuthCredentials::new("client", "expired-access")
+            .refresh_token("refresh-token")
+            .expires_at_millis(0)
+            .scopes(["mcp:tools"]);
+
+        let transport = transport_from_credentials(
+            server_name,
+            server_url,
+            reqwest::Client::new(),
+            store.clone(),
+            credentials,
+            &metadata_cache,
+        )
+        .await
+        .unwrap();
+        assert!(transport.metadata_cache_hit);
+        assert_eq!(
+            transport.client.get_access_token().await.unwrap(),
+            "refreshed-access"
+        );
+        transport.runtime.persist_if_changed().await.unwrap();
+        responder.await.unwrap();
+
+        let saved = store.saved.lock().await;
+        assert_eq!(saved.len(), 1);
+        assert_eq!(saved[0].access_token(), "refreshed-access");
+        assert_eq!(saved[0].refresh_token_value(), Some("rotated-refresh"));
+        assert_eq!(saved[0].granted_scopes(), ["mcp:tools"]);
+    }
 }

--- a/crates/nanocodex/src/lib.rs
+++ b/crates/nanocodex/src/lib.rs
@@ -39,7 +39,10 @@ pub use nanocodex_core::{
 #[cfg(not(target_family = "wasm"))]
 pub use nanocodex_macros::tool;
 #[cfg(not(target_family = "wasm"))]
-pub use nanocodex_mcp::{Mcp, McpBuildError, McpBuilder, McpServer};
+pub use nanocodex_mcp::{
+    Mcp, McpBuildError, McpBuilder, McpControlError, McpHandle, McpLogin, McpOAuthCredentials,
+    McpOAuthStore, McpServer,
+};
 pub use nanocodex_service::{
     DefaultResponsesService, ResponsesAttempt, ResponsesAttemptKind, ResponsesClient,
     ResponsesRetryPolicy, ResponsesService, ResponsesServiceError, ResponsesServiceResponse,


### PR DESCRIPTION
## Summary

- load enabled MCP servers and file-backed OAuth credentials from the Codex home
- add `/mcp login <server>` and `/mcp reload <server>` without restarting the running agent
- persist refreshed credentials atomically while sharing the Codex aggregate-store lock and recovering legacy duplicate keys by server name and URL
- hot-swap discovered tools generation-safely while retaining the previous working client during reload or failure
- cache OAuth authorization metadata across reconnects while preserving token expiry checks, refresh, rotation, and persistence
- trace MCP startup, transport connection, OAuth restore/login, initialize, tools/list, catalog search, reload, and remote calls
- add a repeatable ignored live lifecycle benchmark

## Responsiveness and benchmark

Measured in an optimized build against the two configured live Centaur servers, with 207 combined tools:

| Measurement | Result |
| --- | ---: |
| provider startup return | 87.6 us |
| both catalogs ready asynchronously | 3.25 s |
| Paradigm warm reload median | 1.42 s |
| Tempo warm reload median | 1.22 s |
| catalog search | 34.1 us |
| catalog search with local JSON tracing | 44.1 us |
| absolute trace overhead | 9.6 us/search |

MCP registration does not block app or agent readiness. An immediate first `tool_search` waits for background discovery and records that latency in `mcp.catalog_search`; subsequent searches are local BM25 operations.

Caching OAuth metadata reduced warm reload medians by about 58% for Paradigm and 61% for Tempo. Startup still performs initial metadata discovery. In the traced run, startup OAuth restore took 1.36–1.54 s with `metadata.cache_hit=false`; reload restore took 0.04–0.25 ms with `metadata.cache_hit=true`.

A fresh Jaeger run contained two startup roots and two reload roots with zero orphan parent references. Long-lived RMCP transport tasks no longer retain completed operation spans.

The live run reused the existing `~/.codex/.credentials.json` refresh credentials and required no browser login.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p nanocodex-mcp -p nanocodex-bin --all-targets -- -D warnings`
- `cargo test -p nanocodex-mcp` — 7 passed, 2 ignored live/stress tests
- `cargo test -p nanocodex-bin mcp --bins` — 12 passed, 2 ignored live/benchmark tests
- optimized live benchmark: 10 reloads per server and 10,000 catalog searches
- traced live lifecycle run through local Jaeger/OTLP
