### PR TITLE
feat: resume Codex rollouts in Nanocodex

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,12 @@ Recording appends Codex's model-context response items and its legacy turn and
 message events after each completed or cancelled turn, so both resumed model
 context and the visible Codex transcript are restored. Compaction uses explicit
 replacement-history records, and failed partial output is excluded.
+`nanocodex resume <thread-id>` discovers the same rollout beneath
+`$CODEX_HOME/sessions` (or `archived_sessions`) that `codex resume` uses and
+materializes its latest replacement-history boundary plus subsequent response
+items. No Nanocodex-specific sidecar is required, so Codex-created threads can
+be continued directly. Pass `--prompt "..."` to submit a follow-on prompt as
+soon as the TUI opens.
 The rollout writer projects the same committed session boundary exposed by
 `TurnResult::snapshot()` rather than maintaining a second conversation state.
 `flush_rollout()` retries pending writes and provides a durability barrier.

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -6,8 +6,8 @@ use std::{
 use clap::{ArgAction, Args, builder::NonEmptyStringValueParser};
 use eyre::{Result, WrapErr, eyre};
 use nanocodex::{
-    AgentEvents, Nanocodex, OpenAiAuth, OpenAiAuthMode, ReasoningMode, Responses, ResponsesHistory,
-    ResponsesTransport, RolloutConfig, Thinking, Tools,
+    AgentEvents, DurableSession, Nanocodex, OpenAiAuth, OpenAiAuthMode, ReasoningMode, Responses,
+    ResponsesHistory, ResponsesTransport, RolloutConfig, SessionSnapshot, Thinking, Tools,
 };
 
 use crate::mcp::McpArgs;
@@ -19,6 +19,13 @@ pub(crate) struct ConfiguredAgent {
     pub(crate) events: AgentEvents,
     pub(crate) child_agents: Option<Arc<ChildAgents>>,
     pub(crate) mpp_adapter: Option<MppAdapter>,
+}
+
+struct SessionBuild {
+    workspace: PathBuf,
+    session_id: Option<String>,
+    snapshot: Option<SessionSnapshot>,
+    rollout: Option<RolloutConfig>,
 }
 
 #[derive(Args)]
@@ -36,8 +43,8 @@ pub(crate) struct AgentArgs {
     auth_file: Option<PathBuf>,
 
     /// Working directory exposed to the coding tools.
-    #[arg(long, default_value = ".")]
-    cwd: PathBuf,
+    #[arg(long)]
+    cwd: Option<PathBuf>,
 
     /// Reasoning effort: none, low, medium, high, xhigh, or max.
     #[arg(long, env = "OPENAI_REASONING_EFFORT", default_value_t)]
@@ -120,7 +127,7 @@ pub(crate) struct AgentArgs {
 
 impl AgentArgs {
     pub(crate) fn cwd(&self) -> &Path {
-        &self.cwd
+        self.cwd.as_deref().unwrap_or_else(|| Path::new("."))
     }
 
     pub(crate) const fn uses_tempo(&self) -> bool {
@@ -132,8 +139,16 @@ impl AgentArgs {
     }
 
     pub(crate) async fn build(self) -> Result<ConfiguredAgent> {
+        self.build_inner(None).await
+    }
+
+    pub(crate) async fn build_resumed(self, session: DurableSession) -> Result<ConfiguredAgent> {
+        self.build_inner(Some(session)).await
+    }
+
+    async fn build_inner(self, durable: Option<DurableSession>) -> Result<ConfiguredAgent> {
         let codex_home = default_codex_home()?;
-        let rollout = self.rollouts.then(|| codex_home.clone());
+        let session = prepare_session_build(self.cwd, self.rollouts, &codex_home, durable)?;
         let mpp_enabled = self.mpp.is_enabled();
         let auth = if mpp_enabled {
             OpenAiAuth::api_key("tempo-proxy")
@@ -173,17 +188,21 @@ impl AgentArgs {
         }
         let tools = tools.build()?;
         let child_agents = self.subagents.then(|| Arc::new(ChildAgents::default()));
-        let builder = Nanocodex::builder(auth)
+        let mut builder = Nanocodex::builder(auth)
             .reasoning_mode(self.reasoning_mode)
             .thinking(self.thinking)
-            .workspace(self.cwd)
+            .workspace(session.workspace)
             .codex_home(codex_home)
             .responses(responses);
-        let builder = if let Some(codex_home) = rollout {
-            builder.rollout(RolloutConfig::new(codex_home))
-        } else {
-            builder
-        };
+        if let Some(session_id) = session.session_id {
+            builder = builder.session_id(session_id);
+        }
+        if let Some(snapshot) = session.snapshot {
+            builder = builder.resume(snapshot);
+        }
+        if let Some(rollout) = session.rollout {
+            builder = builder.rollout(rollout);
+        }
         let builder = if let Some(child_agents) = &child_agents {
             let tools = tools.clone();
             let child_agents = Arc::downgrade(child_agents);
@@ -206,6 +225,44 @@ impl AgentArgs {
             mpp_adapter,
         })
     }
+}
+
+fn prepare_session_build(
+    requested_workspace: Option<PathBuf>,
+    rollouts: bool,
+    codex_home: &Path,
+    durable: Option<DurableSession>,
+) -> Result<SessionBuild> {
+    let Some(session) = durable else {
+        return Ok(SessionBuild {
+            workspace: requested_workspace.unwrap_or_else(|| PathBuf::from(".")),
+            session_id: None,
+            snapshot: None,
+            rollout: rollouts.then(|| RolloutConfig::new(codex_home)),
+        });
+    };
+    let restored = Path::new(session.workspace())
+        .canonicalize()
+        .wrap_err("failed to resolve the resumed workspace")?;
+    if let Some(requested) = requested_workspace {
+        let requested = requested
+            .canonicalize()
+            .wrap_err("failed to resolve the requested workspace")?;
+        if requested != restored {
+            return Err(eyre!(
+                "resumed thread workspace is {}; --cwd requested {}",
+                restored.display(),
+                requested.display()
+            ));
+        }
+    }
+    let (session_id, snapshot, rollout) = session.into_parts();
+    Ok(SessionBuild {
+        workspace: restored,
+        session_id: Some(session_id),
+        snapshot: Some(snapshot),
+        rollout: rollouts.then_some(rollout),
+    })
 }
 
 fn direct_websocket_url(explicit: Option<String>, auth_mode: OpenAiAuthMode) -> String {

--- a/bin/nanocodex/src/main.rs
+++ b/bin/nanocodex/src/main.rs
@@ -11,8 +11,11 @@ mod tui;
 mod update;
 mod version;
 
+use std::path::PathBuf;
+
 use clap::{Args, Parser, Subcommand, builder::NonEmptyStringValueParser};
-use eyre::Result;
+use eyre::{Result, WrapErr};
+use nanocodex::RolloutConfig;
 
 use config::AgentArgs;
 use observability::ObservabilityArgs;
@@ -48,6 +51,8 @@ enum Command {
     Credits(credits::Credits),
     /// Run one prompt and stream JSONL events to stdout.
     Run(Box<RunCommand>),
+    /// Resume a Codex or Nanocodex thread in the interactive TUI.
+    Resume(Box<ResumeCommand>),
     /// Update this executable from a GitHub release channel.
     Update(update::Update),
 }
@@ -64,6 +69,23 @@ struct RunCommand {
     observability: ObservabilityArgs,
 }
 
+#[derive(Args)]
+struct ResumeCommand {
+    /// Codex thread UUID to resume.
+    #[arg(value_parser = NonEmptyStringValueParser::new())]
+    thread_id: String,
+
+    #[command(flatten)]
+    agent: AgentArgs,
+
+    #[command(flatten)]
+    observability: ObservabilityArgs,
+
+    /// Submit an initial follow-on prompt immediately after the TUI opens.
+    #[arg(long, value_parser = NonEmptyStringValueParser::new())]
+    prompt: Option<String>,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Keep direct `cargo run` behavior consistent with the Justfile without
@@ -73,6 +95,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
     let uses_tempo = match &cli.command {
         Some(Command::Run(command)) => command.agent.uses_tempo(),
+        Some(Command::Resume(command)) => command.agent.uses_tempo(),
         None => cli.agent.uses_tempo(),
         Some(Command::Auth(_) | Command::Credits(_) | Command::Update(_)) => false,
     };
@@ -86,10 +109,19 @@ async fn main() -> Result<()> {
             let _observability = command.observability.install(false, command.agent.cwd())?;
             command.run.run(command.agent).await
         }
+        Some(Command::Resume(command)) => {
+            let codex_home = config::default_codex_home()?;
+            let session = RolloutConfig::new(&codex_home)
+                .load_session(&command.thread_id)
+                .wrap_err_with(|| format!("failed to load Codex thread {}", command.thread_id))?;
+            let workspace = PathBuf::from(session.workspace());
+            let _observability = command.observability.install(true, &workspace)?;
+            tui::run(command.agent, command.prompt, Some(session)).await
+        }
         Some(Command::Update(command)) => command.run().await,
         None => {
             let _observability = cli.observability.install(true, cli.agent.cwd())?;
-            tui::run(cli.agent, cli.prompt).await
+            tui::run(cli.agent, cli.prompt, None).await
         }
     }
 }
@@ -143,5 +175,27 @@ mod tests {
             .unwrap();
 
         assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn resume_accepts_a_thread_id_and_agent_configuration() {
+        let cli = Cli::try_parse_from([
+            "nanocodex",
+            "resume",
+            "019c0d31-c308-7d91-bff4-5dca82d15ac6",
+            "--provider.openai",
+            "--api-key",
+            "test-key",
+            "--prompt",
+            "continue",
+        ])
+        .unwrap();
+
+        let Some(Command::Resume(command)) = cli.command else {
+            panic!("resume command was not parsed");
+        };
+        assert_eq!(command.thread_id, "019c0d31-c308-7d91-bff4-5dca82d15ac6");
+        assert_eq!(command.prompt.as_deref(), Some("continue"));
+        assert!(!command.agent.uses_tempo());
     }
 }

--- a/bin/nanocodex/src/tui/app.rs
+++ b/bin/nanocodex/src/tui/app.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use nanocodex::{AgentEvent, AgentEventKind, Prompt, RolloutMessage, Thinking, UserInput};
+use nanocodex::{AgentEvent, AgentEventKind, Prompt, RolloutTranscriptItem, Thinking, UserInput};
 use ratatui::{
     buffer::Buffer,
     layout::{Position, Rect},
@@ -1183,11 +1183,25 @@ impl App {
         }
     }
 
-    pub(super) fn restore_messages(&mut self, messages: impl IntoIterator<Item = RolloutMessage>) {
-        for message in messages {
-            let item = match message {
-                RolloutMessage::User(message) => TranscriptItem::User(message),
-                RolloutMessage::Assistant(message) => TranscriptItem::Assistant(message),
+    pub(super) fn restore_transcript(
+        &mut self,
+        transcript: impl IntoIterator<Item = RolloutTranscriptItem>,
+    ) {
+        for activity in transcript {
+            let item = match activity {
+                RolloutTranscriptItem::User(message) => TranscriptItem::User(message),
+                RolloutTranscriptItem::Reasoning(message) => TranscriptItem::Reasoning(message),
+                RolloutTranscriptItem::Assistant(message) => TranscriptItem::Assistant(message),
+                RolloutTranscriptItem::Tool {
+                    call_id,
+                    name,
+                    arguments,
+                } => TranscriptItem::Tool {
+                    call_id,
+                    name,
+                    arguments,
+                    status: ToolStatus::Completed,
+                },
             };
             self.main.push_output(item);
         }
@@ -3062,7 +3076,7 @@ mod tests {
         time::{Duration, Instant},
     };
 
-    use nanocodex::{AgentEvent, AgentEventKind, PromptInput, RolloutMessage, UserInput};
+    use nanocodex::{AgentEvent, AgentEventKind, PromptInput, RolloutTranscriptItem, UserInput};
     use ratatui::{buffer::Buffer, layout::Rect, widgets::Widget};
     use serde_json::{Value, json};
 
@@ -3084,14 +3098,20 @@ mod tests {
     }
 
     #[test]
-    fn restored_rollout_messages_seed_the_visible_transcript() {
+    fn restored_rollout_activity_seeds_the_visible_transcript() {
         let mut app = App::new(std::path::PathBuf::from("/worktree"));
-        app.restore_messages([
-            RolloutMessage::User("visible prompt".to_owned()),
-            RolloutMessage::Assistant("visible answer".to_owned()),
+        app.restore_transcript([
+            RolloutTranscriptItem::User("visible prompt".to_owned()),
+            RolloutTranscriptItem::Reasoning("thinking".to_owned()),
+            RolloutTranscriptItem::Tool {
+                call_id: "call-1".to_owned(),
+                name: "exec".to_owned(),
+                arguments: "pwd".to_owned(),
+            },
+            RolloutTranscriptItem::Assistant("visible answer".to_owned()),
         ]);
 
-        assert_eq!(app.main.transcript.len(), 2);
+        assert_eq!(app.main.transcript.len(), 4);
         assert_eq!(
             app.main.transcript.latest_user_message(),
             Some("visible prompt")

--- a/bin/nanocodex/src/tui/app.rs
+++ b/bin/nanocodex/src/tui/app.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use nanocodex::{AgentEvent, AgentEventKind, Prompt, Thinking, UserInput};
+use nanocodex::{AgentEvent, AgentEventKind, Prompt, RolloutMessage, Thinking, UserInput};
 use ratatui::{
     buffer::Buffer,
     layout::{Position, Rect},
@@ -1180,6 +1180,16 @@ impl App {
             fast_mode: false,
             thinking: Thinking::default(),
             reasoning_picker: None,
+        }
+    }
+
+    pub(super) fn restore_messages(&mut self, messages: impl IntoIterator<Item = RolloutMessage>) {
+        for message in messages {
+            let item = match message {
+                RolloutMessage::User(message) => TranscriptItem::User(message),
+                RolloutMessage::Assistant(message) => TranscriptItem::Assistant(message),
+            };
+            self.main.push_output(item);
         }
     }
 
@@ -3052,7 +3062,7 @@ mod tests {
         time::{Duration, Instant},
     };
 
-    use nanocodex::{AgentEvent, AgentEventKind, PromptInput, UserInput};
+    use nanocodex::{AgentEvent, AgentEventKind, PromptInput, RolloutMessage, UserInput};
     use ratatui::{buffer::Buffer, layout::Rect, widgets::Widget};
     use serde_json::{Value, json};
 
@@ -3071,6 +3081,21 @@ mod tests {
             "payload": payload,
         }))
         .unwrap()
+    }
+
+    #[test]
+    fn restored_rollout_messages_seed_the_visible_transcript() {
+        let mut app = App::new(std::path::PathBuf::from("/worktree"));
+        app.restore_messages([
+            RolloutMessage::User("visible prompt".to_owned()),
+            RolloutMessage::Assistant("visible answer".to_owned()),
+        ]);
+
+        assert_eq!(app.main.transcript.len(), 2);
+        assert_eq!(
+            app.main.transcript.latest_user_message(),
+            Some("visible prompt")
+        );
     }
 
     #[test]

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -26,8 +26,8 @@ use crossterm::event::{
 use eyre::{Result, WrapErr};
 use futures_util::StreamExt;
 use nanocodex::{
-    AgentEvent, AgentEvents, Nanocodex, NanocodexError, Thinking, TimedAgentEvent, TurnControl,
-    TurnResult,
+    AgentEvent, AgentEvents, DurableSession, Nanocodex, NanocodexError, Thinking, TimedAgentEvent,
+    TurnControl, TurnResult,
 };
 use tokio::{
     sync::mpsc,
@@ -471,10 +471,21 @@ enum Submission {
     clippy::too_many_lines,
     reason = "the ordered terminal, agent, worker, and render event loop is intentionally cohesive"
 )]
-pub(crate) async fn run(config: AgentArgs, initial_prompt: Option<String>) -> Result<()> {
+pub(crate) async fn run(
+    config: AgentArgs,
+    initial_prompt: Option<String>,
+    resume: Option<DurableSession>,
+) -> Result<()> {
     let initial_thinking = config.thinking();
-    let cwd = resolve_cwd(&config)?;
-    let configured = config.build().await?;
+    let cwd = resume
+        .as_ref()
+        .map(|session| PathBuf::from(session.workspace()))
+        .unwrap_or(resolve_cwd(&config)?);
+    let configured = if let Some(session) = resume {
+        config.build_resumed(session).await?
+    } else {
+        config.build().await?
+    };
     let agent = configured.handle;
     let mut agent_events = configured.events;
     let root_session_id = Arc::<str>::from(agent_events.request_id());

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -477,9 +477,9 @@ pub(crate) async fn run(
     resume: Option<DurableSession>,
 ) -> Result<()> {
     let initial_thinking = config.thinking();
-    let restored_messages = resume
+    let restored_transcript = resume
         .as_ref()
-        .map(|session| session.messages().to_vec())
+        .map(|session| session.transcript().to_vec())
         .unwrap_or_default();
     let cwd = resume
         .as_ref()
@@ -503,7 +503,7 @@ pub(crate) async fn run(
     let mut input_events = EventStream::new();
     let mut ticker = ui_ticker();
     let mut app = App::new(cwd).with_thinking(initial_thinking);
-    app.restore_messages(restored_messages);
+    app.restore_transcript(restored_transcript);
     let mut ui = UiModel::new(app, Arc::clone(&root_session_id));
     let mut scheduler = RenderScheduler::new(STREAM_FRAME_INTERVAL, Instant::now());
     let mut stream_telemetry = StreamTelemetry::default();

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -477,6 +477,10 @@ pub(crate) async fn run(
     resume: Option<DurableSession>,
 ) -> Result<()> {
     let initial_thinking = config.thinking();
+    let restored_messages = resume
+        .as_ref()
+        .map(|session| session.messages().to_vec())
+        .unwrap_or_default();
     let cwd = resume
         .as_ref()
         .map(|session| PathBuf::from(session.workspace()))
@@ -498,10 +502,9 @@ pub(crate) async fn run(
     let mut terminal = TerminalSession::enter().wrap_err("failed to initialize the terminal")?;
     let mut input_events = EventStream::new();
     let mut ticker = ui_ticker();
-    let mut ui = UiModel::new(
-        App::new(cwd).with_thinking(initial_thinking),
-        Arc::clone(&root_session_id),
-    );
+    let mut app = App::new(cwd).with_thinking(initial_thinking);
+    app.restore_messages(restored_messages);
+    let mut ui = UiModel::new(app, Arc::clone(&root_session_id));
     let mut scheduler = RenderScheduler::new(STREAM_FRAME_INTERVAL, Instant::now());
     let mut stream_telemetry = StreamTelemetry::default();
     let mut view_telemetry = ViewTelemetry::new(Arc::clone(&root_session_id));

--- a/crates/nanocodex/src/agent.rs
+++ b/crates/nanocodex/src/agent.rs
@@ -27,21 +27,50 @@ use crate::{
     model::{
         agent::{
             CompletedModelTurn, ModelCheckpoint, ModelRun, ModelTurnOutcome, PreparedCheckpoint,
-            prepare_checkpoint, prepare_resumed_checkpoint,
+            prepare_checkpoint, prepare_resumed_checkpoint, prepare_rollout_checkpoint,
         },
         load_global_instructions,
     },
     responses::{FactoryResponses, LayeredResponses, Responses, StandardResponses},
     rollout::{RolloutConfig, RolloutInfo, RolloutOrigin, RolloutRecorder, RolloutTurn},
-    session::{CommittedSession, SessionSnapshot},
+    session::{CommittedSession, SessionResume, SessionSnapshot},
 };
 
 const COMMAND_CAPACITY: usize = 8;
 const STEER_CAPACITY: usize = 8;
+const CODEX_THREAD_ID_ENV_VAR: &str = "CODEX_THREAD_ID";
 
 type ServiceFactory<S> = Arc<dyn Fn() -> S + Send + Sync>;
 type ToolsFactory =
     Arc<dyn Fn(AgentHandle) -> std::result::Result<Tools, ToolsBuildError> + Send + Sync>;
+
+enum InitialResume {
+    Exact(Box<ModelCheckpoint>),
+    Rollout(Box<RolloutResume>),
+}
+
+struct RolloutResume {
+    workspace: String,
+    canonical_context: nanocodex_core::ResponseItem,
+    history: Vec<nanocodex_core::ResponseItem>,
+    prompt_cache_key: Arc<str>,
+}
+
+impl InitialResume {
+    fn workspace(&self) -> &str {
+        match self {
+            Self::Exact(checkpoint) => checkpoint.workspace(),
+            Self::Rollout(resume) => &resume.workspace,
+        }
+    }
+
+    fn history_len(&self) -> usize {
+        match self {
+            Self::Exact(checkpoint) => checkpoint.history().len(),
+            Self::Rollout(resume) => resume.history.len(),
+        }
+    }
+}
 
 #[derive(Clone)]
 enum ToolsConfiguration {
@@ -56,6 +85,14 @@ impl ToolsConfiguration {
             Self::PerAgent(factory) => factory(agent_handle).map_err(Into::into),
         }
     }
+}
+
+fn bind_agent_environment(tools: Tools, session_id: &str) -> Result<Tools> {
+    tools
+        .into_builder()
+        .process_environment([(CODEX_THREAD_ID_ENV_VAR, session_id)])
+        .build()
+        .map_err(Into::into)
 }
 
 /// Completion handle for an accepted turn.
@@ -1385,7 +1422,7 @@ where
             session_id,
             workspace,
             (self.service_factory)(),
-            Some(checkpoint.model().clone()),
+            Some(InitialResume::Exact(Box::new(checkpoint.model().clone()))),
             None,
             AgentOrigin {
                 kind: "fork",
@@ -1455,8 +1492,15 @@ where
     let session_id = session_id.unwrap_or_else(new_session_id);
     let PromptCacheConfig { key, shared } = prompt_cache;
     let is_resume = resume.is_some();
-    let (lineage_id, prompt_cache_key, initial_checkpoint) = if let Some(snapshot) = resume {
-        let (lineage_id, restored_cache_key, checkpoint) = snapshot.into_checkpoint()?;
+    let (lineage_id, prompt_cache_key, initial_resume) = if let Some(snapshot) = resume {
+        let SessionResume {
+            lineage_id,
+            prompt_cache_key: restored_cache_key,
+            workspace,
+            canonical_context,
+            history,
+            checkpoint,
+        } = snapshot.into_resume()?;
         if key
             .as_deref()
             .is_some_and(|key| key != restored_cache_key.as_ref())
@@ -1465,7 +1509,18 @@ where
                 "configured prompt cache key does not match the resumed session".to_owned(),
             ));
         }
-        (lineage_id, Some(restored_cache_key), Some(checkpoint))
+        let initial = checkpoint.map_or_else(
+            || {
+                InitialResume::Rollout(Box::new(RolloutResume {
+                    workspace,
+                    canonical_context,
+                    history,
+                    prompt_cache_key: Arc::clone(&restored_cache_key),
+                }))
+            },
+            |checkpoint| InitialResume::Exact(Box::new(checkpoint)),
+        );
+        (lineage_id, Some(restored_cache_key), Some(initial))
     } else {
         (
             Arc::<str>::from(session_id.as_str()),
@@ -1483,9 +1538,9 @@ where
                 })
         })
         .transpose()?;
-    let workspace = if let Some(checkpoint) = initial_checkpoint.as_ref() {
-        let restored = crate::model::resolve_workspace(Some(checkpoint.workspace()))?;
-        if restored != checkpoint.workspace() {
+    let workspace = if let Some(initial) = initial_resume.as_ref() {
+        let restored = crate::model::resolve_workspace(Some(initial.workspace()))?;
+        if restored != initial.workspace() {
             return Err(NanocodexError::InvalidSessionSnapshot(
                 "workspace no longer resolves to the stored location".to_owned(),
             ));
@@ -1520,7 +1575,7 @@ where
         session_id,
         workspace,
         service,
-        initial_checkpoint,
+        initial_resume,
         global_instructions,
         AgentOrigin {
             kind: if is_resume { "resume" } else { "root" },
@@ -1535,7 +1590,7 @@ fn spawn_agent_driver<S>(
     session_id: String,
     workspace: Option<Arc<str>>,
     service: S,
-    initial_checkpoint: Option<ModelCheckpoint>,
+    initial_resume: Option<InitialResume>,
     global_instructions: Option<Arc<str>>,
     origin: AgentOrigin,
 ) -> Result<(Nanocodex, AgentEvents)>
@@ -1547,9 +1602,12 @@ where
     let runtime = tokio::runtime::Handle::try_current()
         .map_err(|_| NanocodexError::TokioRuntimeUnavailable)?;
     let (commands, receiver) = mpsc::channel(COMMAND_CAPACITY);
-    let tools = spawner.tools.materialize(AgentHandle {
-        commands: commands.downgrade(),
-    })?;
+    let tools = bind_agent_environment(
+        spawner.tools.materialize(AgentHandle {
+            commands: commands.downgrade(),
+        })?,
+        &session_id,
+    )?;
     let rollout = spawner
         .rollout
         .as_ref()
@@ -1570,6 +1628,7 @@ where
                     kind: origin.kind,
                     parent_thread_id: origin.parent_session_id.as_deref(),
                 },
+                initial_resume.as_ref().map(InitialResume::history_len),
             )
             .map_err(|source| NanocodexError::InitializeRollout {
                 codex_home: config.codex_home().to_path_buf(),
@@ -1580,9 +1639,28 @@ where
     let rollout_info = rollout.as_ref().map(|recorder| recorder.info().clone());
     let session_id: Arc<str> = Arc::from(session_id);
     let (events, event_stream) = EventSink::channel(session_id.to_string());
-    let initial_model = initial_checkpoint
-        .map(|checkpoint| {
-            prepare_resumed_checkpoint(checkpoint, &spawner.config, &tools, &session_id)
+    let initial_model = initial_resume
+        .map(|initial| match initial {
+            InitialResume::Exact(checkpoint) => {
+                prepare_resumed_checkpoint(*checkpoint, &spawner.config, &tools, &session_id)
+            }
+            InitialResume::Rollout(resume) => {
+                let RolloutResume {
+                    workspace,
+                    canonical_context,
+                    history,
+                    prompt_cache_key,
+                } = *resume;
+                prepare_rollout_checkpoint(
+                    workspace,
+                    canonical_context,
+                    history,
+                    prompt_cache_key,
+                    &spawner.config,
+                    &tools,
+                    &session_id,
+                )
+            }
         })
         .transpose()?;
     let transport_stats = Arc::new(TransportStats::default());
@@ -1725,7 +1803,10 @@ mod tests {
 
     use super::*;
     use async_trait::async_trait;
-    use nanocodex_tools::{DynamicToolProvider, ToolContext, ToolDefinition, ToolExecution};
+    use nanocodex_tools::{
+        DynamicToolProvider, ToolContext, ToolDefinition, ToolExecution, ToolInput, ToolOutputBody,
+        ToolRuntime,
+    };
     use serde_json::Value;
     use tempfile::tempdir;
     use tower::{ServiceBuilder, limit::ConcurrencyLimitLayer, timeout::TimeoutLayer};
@@ -1904,6 +1985,43 @@ mod tests {
         assert!(rollout.path().is_file());
         agent.flush_rollout().await.unwrap();
         drop((agent, events));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn agent_session_id_is_authoritative_in_shell_environment() {
+        let workspace = tempdir().unwrap();
+        let tools = Tools::builder()
+            .process_environment([(CODEX_THREAD_ID_ENV_VAR, "caller-spoof")])
+            .build()
+            .unwrap();
+        let tools = bind_agent_environment(tools, "agent-thread").unwrap();
+        let runtime = ToolRuntime::new_with_tools(workspace.path(), None, None, &tools);
+        let input = serde_json::value::RawValue::from_string(
+            r#"{"cmd":"printf '%s' \"$CODEX_THREAD_ID\"","login":false}"#.to_owned(),
+        )
+        .unwrap();
+
+        let execution = runtime
+            .execute_tool(
+                "exec_command",
+                ToolInput::Function(input),
+                ToolContext {
+                    model: "test",
+                    session_id: "agent-thread",
+                    call_id: "call-1",
+                    history: &[],
+                    output_token_budget: 1_000,
+                },
+            )
+            .await;
+
+        assert!(execution.success);
+        let ToolOutputBody::Text(output) = execution.output else {
+            panic!("shell returned non-text output");
+        };
+        let output: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(output["output"], "agent-thread");
     }
 
     #[test]

--- a/crates/nanocodex/src/lib.rs
+++ b/crates/nanocodex/src/lib.rs
@@ -56,7 +56,7 @@ pub use responses::{FactoryResponses, LayeredResponses, StandardResponses};
 #[cfg(not(target_family = "wasm"))]
 pub use responses::{Responses, ResponsesBuilder};
 #[cfg(not(target_family = "wasm"))]
-pub use rollout::{DurableSession, RolloutConfig, RolloutInfo};
+pub use rollout::{DurableSession, RolloutConfig, RolloutInfo, RolloutMessage};
 #[cfg(not(target_family = "wasm"))]
 pub use schemars::JsonSchema as ToolSchema;
 pub use session::SessionSnapshot;

--- a/crates/nanocodex/src/lib.rs
+++ b/crates/nanocodex/src/lib.rs
@@ -56,7 +56,7 @@ pub use responses::{FactoryResponses, LayeredResponses, StandardResponses};
 #[cfg(not(target_family = "wasm"))]
 pub use responses::{Responses, ResponsesBuilder};
 #[cfg(not(target_family = "wasm"))]
-pub use rollout::{DurableSession, RolloutConfig, RolloutInfo, RolloutMessage};
+pub use rollout::{DurableSession, RolloutConfig, RolloutInfo, RolloutTranscriptItem};
 #[cfg(not(target_family = "wasm"))]
 pub use schemars::JsonSchema as ToolSchema;
 pub use session::SessionSnapshot;

--- a/crates/nanocodex/src/lib.rs
+++ b/crates/nanocodex/src/lib.rs
@@ -56,7 +56,7 @@ pub use responses::{FactoryResponses, LayeredResponses, StandardResponses};
 #[cfg(not(target_family = "wasm"))]
 pub use responses::{Responses, ResponsesBuilder};
 #[cfg(not(target_family = "wasm"))]
-pub use rollout::{RolloutConfig, RolloutInfo};
+pub use rollout::{DurableSession, RolloutConfig, RolloutInfo};
 #[cfg(not(target_family = "wasm"))]
 pub use schemars::JsonSchema as ToolSchema;
 pub use session::SessionSnapshot;

--- a/crates/nanocodex/src/model/agent.rs
+++ b/crates/nanocodex/src/model/agent.rs
@@ -585,6 +585,44 @@ pub(crate) fn prepare_resumed_checkpoint(
     Ok(prepared)
 }
 
+pub(crate) fn prepare_rollout_checkpoint(
+    workspace: String,
+    canonical_context: ResponseItem,
+    history: Vec<ResponseItem>,
+    prompt_cache_key: Arc<str>,
+    config: &ModelConfig,
+    tools: &Tools,
+    session_id: &str,
+) -> Result<PreparedCheckpoint> {
+    let runtime = tool_runtime(&workspace, config, tools);
+    #[cfg(not(target_family = "wasm"))]
+    let tool_specs = {
+        let _ = session_id;
+        runtime.model_specs()
+    };
+    #[cfg(target_family = "wasm")]
+    let tool_specs = runtime.model_specs(session_id);
+    let request_prefix = request_profile(
+        "rollout-resume",
+        "rollout-resume",
+        tool_specs,
+        config.system_prompt(),
+    )
+    .prefix()
+    .to_vec();
+    let checkpoint = ModelCheckpoint::resume(
+        workspace,
+        request_prefix,
+        prompt_cache_key,
+        canonical_context,
+        history,
+    )?;
+    Ok(PreparedCheckpoint {
+        checkpoint,
+        runtime,
+    })
+}
+
 fn without_response_item_ids(items: &[ResponseItem]) -> Vec<ResponseItem> {
     items
         .iter()

--- a/crates/nanocodex/src/rollout.rs
+++ b/crates/nanocodex/src/rollout.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::File,
-    io::{self, Write},
+    io::{self, BufRead, BufReader, Write},
     path::{Path, PathBuf},
     time::Instant,
 };
@@ -17,7 +17,7 @@ use tokio::{
 };
 use tracing::error;
 
-use crate::session::CommittedSession;
+use crate::session::{CommittedSession, SessionSnapshot};
 
 const COMMAND_CAPACITY: usize = 8;
 
@@ -25,6 +25,7 @@ const COMMAND_CAPACITY: usize = 8;
 #[derive(Clone, Debug)]
 pub struct RolloutConfig {
     codex_home: PathBuf,
+    resume_path: Option<PathBuf>,
 }
 
 impl RolloutConfig {
@@ -33,6 +34,7 @@ impl RolloutConfig {
     pub fn new(codex_home: impl Into<PathBuf>) -> Self {
         Self {
             codex_home: codex_home.into(),
+            resume_path: None,
         }
     }
 
@@ -41,6 +43,221 @@ impl RolloutConfig {
     pub fn codex_home(&self) -> &Path {
         &self.codex_home
     }
+
+    /// Loads a Codex or Nanocodex session recorded beneath this Codex home.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the thread ID is not a UUID, the session does not
+    /// exist, or its rollout is malformed or incompatible.
+    pub fn load_session(&self, thread_id: &str) -> io::Result<DurableSession> {
+        DurableSession::load(&self.codex_home, thread_id)
+    }
+
+    pub(crate) fn resumed(mut self, rollout_path: PathBuf) -> Self {
+        self.resume_path = Some(rollout_path);
+        self
+    }
+}
+
+/// A completed model boundary materialized from a Codex-compatible rollout.
+#[derive(Clone, Debug)]
+pub struct DurableSession {
+    codex_home: PathBuf,
+    thread_id: String,
+    rollout_path: PathBuf,
+    snapshot: SessionSnapshot,
+}
+
+impl DurableSession {
+    fn load(codex_home: &Path, thread_id: &str) -> io::Result<Self> {
+        uuid::Uuid::parse_str(thread_id).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid Codex thread ID `{thread_id}`: {error}"),
+            )
+        })?;
+        let rollout_path = find_rollout_path(codex_home, thread_id)?.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("no Codex rollout found for thread {thread_id}"),
+            )
+        })?;
+        let (workspace, history) = materialize_rollout(&rollout_path, thread_id)?;
+        let snapshot = SessionSnapshot::from_rollout(thread_id.to_owned(), workspace, history)
+            .map_err(io::Error::other)?;
+        Ok(Self {
+            codex_home: codex_home.to_path_buf(),
+            thread_id: thread_id.to_owned(),
+            rollout_path,
+            snapshot,
+        })
+    }
+
+    /// Returns the stable thread UUID retained across process restarts.
+    #[must_use]
+    pub fn thread_id(&self) -> &str {
+        &self.thread_id
+    }
+
+    /// Returns the original workspace restored by this session.
+    #[must_use]
+    pub fn workspace(&self) -> &str {
+        self.snapshot.workspace()
+    }
+
+    /// Returns the restored model boundary.
+    #[must_use]
+    pub fn snapshot(&self) -> &SessionSnapshot {
+        &self.snapshot
+    }
+
+    /// Returns the Codex-compatible rollout reopened by this session.
+    #[must_use]
+    pub fn rollout_path(&self) -> &Path {
+        &self.rollout_path
+    }
+
+    /// Splits this loaded boundary into the builder inputs needed to continue it.
+    #[must_use]
+    pub fn into_parts(self) -> (String, SessionSnapshot, RolloutConfig) {
+        (
+            self.thread_id,
+            self.snapshot,
+            RolloutConfig::new(self.codex_home).resumed(self.rollout_path),
+        )
+    }
+}
+
+fn find_rollout_path(codex_home: &Path, thread_id: &str) -> io::Result<Option<PathBuf>> {
+    let suffix = format!("-{thread_id}.jsonl");
+    let compressed_suffix = format!("-{thread_id}.jsonl.zst");
+    for root in [
+        codex_home.join("sessions"),
+        codex_home.join("archived_sessions"),
+    ] {
+        let mut directories = vec![root];
+        while let Some(directory) = directories.pop() {
+            let entries = match std::fs::read_dir(&directory) {
+                Ok(entries) => entries,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error),
+            };
+            for entry in entries {
+                let entry = entry?;
+                let file_type = entry.file_type()?;
+                if file_type.is_dir() {
+                    directories.push(entry.path());
+                    continue;
+                }
+                if !file_type.is_file() {
+                    continue;
+                }
+                let file_name = entry.file_name();
+                let Some(file_name) = file_name.to_str() else {
+                    continue;
+                };
+                if file_name.ends_with(&suffix) {
+                    return entry.path().canonicalize().map(Some);
+                }
+                if file_name.ends_with(&compressed_suffix) {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Unsupported,
+                        format!(
+                            "compressed Codex rollout {} is not supported yet",
+                            entry.path().display()
+                        ),
+                    ));
+                }
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn materialize_rollout(path: &Path, thread_id: &str) -> io::Result<(String, Vec<ResponseItem>)> {
+    let mut workspace = None;
+    let mut history = Vec::new();
+    for (index, line) in BufReader::new(File::open(path)?).lines().enumerate() {
+        let line = line?;
+        let value: serde_json::Value = serde_json::from_str(&line).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "failed to decode {} line {}: {error}",
+                    path.display(),
+                    index + 1
+                ),
+            )
+        })?;
+        match value.get("type").and_then(serde_json::Value::as_str) {
+            Some("session_meta") if workspace.is_none() => {
+                let payload = &value["payload"];
+                if payload.get("id").and_then(serde_json::Value::as_str) != Some(thread_id) {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "Codex rollout thread ID does not match its filename",
+                    ));
+                }
+                workspace = Some(
+                    payload
+                        .get("cwd")
+                        .and_then(serde_json::Value::as_str)
+                        .ok_or_else(|| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "Codex rollout session metadata is missing its workspace",
+                            )
+                        })?
+                        .to_owned(),
+                );
+            }
+            Some("response_item") => {
+                let item = serde_json::from_value(value["payload"].clone()).map_err(|error| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "failed to decode response item at {} line {}: {error}",
+                            path.display(),
+                            index + 1
+                        ),
+                    )
+                })?;
+                history.push(item);
+            }
+            Some("compacted") => {
+                history = serde_json::from_value(value["payload"]["replacement_history"].clone())
+                    .map_err(|error| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "failed to decode replacement history at {} line {}: {error}",
+                            path.display(),
+                            index + 1
+                        ),
+                    )
+                })?;
+            }
+            _ => {}
+        }
+    }
+    let workspace = workspace.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Codex rollout is missing session metadata",
+        )
+    })?;
+    let workspace = Path::new(&workspace).canonicalize()?;
+    let workspace = workspace.into_os_string().into_string().map_err(|path| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "Codex rollout workspace is not valid UTF-8: {}",
+                Path::new(&path).display()
+            ),
+        )
+    })?;
+    Ok((workspace, history))
 }
 
 /// Stable identity and file location of a recorded Nanocodex thread.
@@ -173,7 +390,17 @@ impl RolloutRecorder {
         cwd: &Path,
         instructions: &str,
         origin: RolloutOrigin<'_>,
+        resume_history_len: Option<usize>,
     ) -> io::Result<Self> {
+        if let Some(path) = &config.resume_path {
+            let history_len = resume_history_len.ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "resumed rollout requires restored history",
+                )
+            })?;
+            return Self::resume(runtime, thread_id, path, history_len);
+        }
         let local = Local::now();
         let directory = config
             .codex_home
@@ -220,10 +447,32 @@ impl RolloutRecorder {
         file.flush()?;
         file.sync_all()?;
 
+        let writer = RolloutWriter::new(tokio::fs::File::from_std(file), initial_window_id);
+        Ok(Self::spawn(runtime, thread_id, path, writer))
+    }
+
+    fn resume(
+        runtime: &Handle,
+        thread_id: &str,
+        path: &Path,
+        history_len: usize,
+    ) -> io::Result<Self> {
+        let state = read_resume_writer_state(path, thread_id)?;
+        if state.written_len > history_len {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Codex rollout contains history newer than the durable Nanocodex boundary",
+            ));
+        }
+        let file = File::options().read(true).append(true).open(path)?;
+        let writer = RolloutWriter::resumed(tokio::fs::File::from_std(file), state);
+        Ok(Self::spawn(runtime, thread_id, path.to_path_buf(), writer))
+    }
+
+    fn spawn(runtime: &Handle, thread_id: &str, path: PathBuf, writer: RolloutWriter) -> Self {
         let (commands, receiver) = mpsc::channel(COMMAND_CAPACITY);
         let writer_path = path.clone();
         drop(runtime.spawn(async move {
-            let writer = RolloutWriter::new(tokio::fs::File::from_std(file), initial_window_id);
             if let Err(source) = writer.run(receiver).await {
                 error!(
                     target: "nanocodex",
@@ -233,13 +482,13 @@ impl RolloutRecorder {
                 );
             }
         }));
-        Ok(Self {
+        Self {
             info: RolloutInfo {
                 thread_id: thread_id.to_owned(),
                 path,
             },
             commands,
-        })
+        }
     }
 
     pub(crate) fn info(&self) -> &RolloutInfo {
@@ -319,6 +568,20 @@ impl RolloutWriter {
         }
     }
 
+    fn resumed(file: tokio::fs::File, state: ResumeWriterState) -> Self {
+        Self {
+            file,
+            pending: None,
+            written_revision: Some(0),
+            written_len: state.written_len,
+            window_number: state.window_number,
+            first_window_id: state.first_window_id,
+            current_window_id: state.current_window_id,
+            #[cfg(test)]
+            injected_write_failures: 0,
+        }
+    }
+
     async fn run(mut self, mut commands: mpsc::Receiver<RolloutCommand>) -> io::Result<()> {
         while let Some(command) = commands.recv().await {
             match command {
@@ -347,7 +610,8 @@ impl RolloutWriter {
         let Some(commit) = self.pending.take() else {
             return Ok(());
         };
-        match self.append_with_retry(&commit).await {
+        let persisted = self.append_with_retry(&commit).await;
+        match persisted {
             Ok(()) => Ok(()),
             Err(source) => {
                 self.pending = Some(commit);
@@ -574,6 +838,13 @@ struct WindowAdvance {
     id: String,
 }
 
+struct ResumeWriterState {
+    written_len: usize,
+    window_number: u64,
+    first_window_id: String,
+    current_window_id: String,
+}
+
 #[derive(Serialize)]
 struct RolloutLine<T> {
     timestamp: String,
@@ -721,6 +992,82 @@ struct CompactedItem {
     window_id: String,
 }
 
+fn read_resume_writer_state(path: &Path, thread_id: &str) -> io::Result<ResumeWriterState> {
+    let mut first_window_id = None;
+    let mut current_window_id = None;
+    let mut window_number = 0;
+    let mut written_len = 0;
+    for line in BufReader::new(File::open(path)?).lines() {
+        let line = line?;
+        let value: serde_json::Value = serde_json::from_str(&line).map_err(io::Error::other)?;
+        match value.get("type").and_then(serde_json::Value::as_str) {
+            Some("session_meta") if first_window_id.is_none() => {
+                let payload = &value["payload"];
+                if payload.get("id").and_then(serde_json::Value::as_str) != Some(thread_id) {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "Codex rollout thread ID does not match durable session",
+                    ));
+                }
+                let window = payload["context_window"]["window_id"]
+                    .as_str()
+                    .ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "Codex rollout is missing its initial context window",
+                        )
+                    })?
+                    .to_owned();
+                first_window_id = Some(window.clone());
+                current_window_id = Some(window);
+            }
+            Some("compacted") => {
+                let payload = &value["payload"];
+                written_len = payload["replacement_history"]
+                    .as_array()
+                    .ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "Codex compaction is missing replacement history",
+                        )
+                    })?
+                    .len();
+                window_number = payload["window_number"].as_u64().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "Codex compaction is missing its window number",
+                    )
+                })?;
+                current_window_id = Some(
+                    payload["window_id"]
+                        .as_str()
+                        .ok_or_else(|| {
+                            io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "Codex compaction is missing its window ID",
+                            )
+                        })?
+                        .to_owned(),
+                );
+            }
+            Some("response_item") => written_len = written_len.saturating_add(1),
+            _ => {}
+        }
+    }
+    let first_window_id = first_window_id.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Codex rollout is missing session metadata",
+        )
+    })?;
+    Ok(ResumeWriterState {
+        written_len,
+        window_number,
+        current_window_id: current_window_id.unwrap_or_else(|| first_window_id.clone()),
+        first_window_id,
+    })
+}
+
 fn timestamp() -> String {
     Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
 }
@@ -768,6 +1115,7 @@ mod tests {
                 kind: "root",
                 parent_thread_id: None,
             },
+            None,
         )
         .expect("create rollout")
     }
@@ -777,6 +1125,81 @@ mod tests {
             .lines()
             .map(|line| serde_json::from_str(&line.expect("read line")).expect("parse line"))
             .collect()
+    }
+
+    #[test]
+    fn loads_codex_rollout_without_a_nanocodex_sidecar() {
+        let home = tempdir().expect("temporary Codex home");
+        let thread_id = "019c0d31-c308-7d91-bff4-5dca82d15ac6";
+        let directory = home.path().join("sessions/2026/07/24");
+        std::fs::create_dir_all(&directory).expect("create rollout directory");
+        let path = directory.join(format!("rollout-2026-07-24T12-00-00-{thread_id}.jsonl"));
+        let mut file = File::create(&path).expect("create Codex rollout");
+        for value in [
+            serde_json::json!({
+                "timestamp": "2026-07-24T12:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": thread_id,
+                    "cwd": home.path(),
+                    "originator": "codex-tui",
+                    "history_mode": "legacy",
+                    "context_window": {"window_id": "window-1"}
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-24T12:00:01Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "discarded"}]
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-24T12:00:02Z",
+                "type": "compacted",
+                "payload": {
+                    "replacement_history": [{
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "retained"}]
+                    }],
+                    "window_number": 1,
+                    "first_window_id": "window-1",
+                    "previous_window_id": "window-1",
+                    "window_id": "window-2"
+                }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-24T12:00:03Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "continued"}]
+                }
+            }),
+        ] {
+            write_line(&mut file, &value).expect("write rollout line");
+        }
+        file.flush().expect("flush rollout");
+
+        let session = RolloutConfig::new(home.path())
+            .load_session(thread_id)
+            .expect("load Codex rollout");
+        assert_eq!(
+            Path::new(session.workspace()).canonicalize().unwrap(),
+            home.path().canonicalize().unwrap()
+        );
+        assert_eq!(session.rollout_path(), path.canonicalize().unwrap());
+        let snapshot = serde_json::to_value(session.snapshot()).expect("encode snapshot");
+        assert!(snapshot.get("request_prefix").is_none());
+        assert_eq!(snapshot["history"].as_array().map(Vec::len), Some(2));
+        let history = snapshot["history"].to_string();
+        assert!(history.contains("retained"));
+        assert!(history.contains("continued"));
+        assert!(!history.contains("discarded"));
     }
 
     #[tokio::test]
@@ -860,6 +1283,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resumed_writer_repairs_a_rollout_behind_the_durable_boundary() {
+        let home = tempdir().expect("temporary Codex home");
+        let original = recorder(home.path());
+        original
+            .persist_history(
+                ResponseHistory::new(vec![message("one")]),
+                0,
+                completed_turn("one", "first"),
+            )
+            .await
+            .expect("persist first turn");
+        original.flush().await.expect("flush first turn");
+        let path = original.info().path().to_path_buf();
+        drop(original);
+
+        let config = RolloutConfig::new(home.path()).resumed(path.clone());
+        let resumed = RolloutRecorder::create(
+            &Handle::current(),
+            &config,
+            "019c0d31-c308-7d91-bff4-5dca82d15ac6",
+            Path::new("/worktree"),
+            "base instructions",
+            RolloutOrigin {
+                kind: "resume",
+                parent_thread_id: None,
+            },
+            // The durable snapshot already contains `two`, but its rollout append failed.
+            Some(2),
+        )
+        .expect("resume rollout");
+        resumed
+            .persist_history(
+                ResponseHistory::new(vec![message("one"), message("two"), message("three")]),
+                0,
+                completed_turn("three", "resumed"),
+            )
+            .await
+            .expect("persist resumed turn");
+
+        let lines = lines(&resumed);
+        assert_eq!(
+            lines
+                .iter()
+                .filter(|line| line["type"] == "session_meta")
+                .count(),
+            1
+        );
+        let response_text = lines
+            .iter()
+            .filter(|line| line["type"] == "response_item")
+            .map(|line| line["payload"]["content"][0]["text"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(response_text, ["one", "two", "three"]);
+    }
+
+    #[tokio::test]
     async fn records_compaction_as_a_replacement_history_boundary() {
         let home = tempdir().expect("temporary Codex home");
         let recorder = recorder(home.path());
@@ -908,6 +1387,7 @@ mod tests {
                 kind: "fork",
                 parent_thread_id: Some(parent),
             },
+            None,
         )
         .expect("create fork rollout");
 

--- a/crates/nanocodex/src/rollout.rs
+++ b/crates/nanocodex/src/rollout.rs
@@ -1360,18 +1360,26 @@ mod tests {
                 arguments: "{\"code\":\"return true\"}".to_owned(),
             })
         );
+        let web_search = visible_rollout_event(&serde_json::json!({
+            "type": "web_search_end",
+            "call_id": "search-1",
+            "query": "Nanocodex",
+            "action": {"type": "search", "queries": ["Nanocodex"]}
+        }))
+        .expect("web search activity");
+        let RolloutTranscriptItem::Tool {
+            call_id,
+            name,
+            arguments,
+        } = web_search
+        else {
+            panic!("web search must reconstruct as tool activity");
+        };
+        assert_eq!(call_id, "search-1");
+        assert_eq!(name, "web_search");
         assert_eq!(
-            visible_rollout_event(&serde_json::json!({
-                "type": "web_search_end",
-                "call_id": "search-1",
-                "query": "Nanocodex",
-                "action": {"type": "search", "queries": ["Nanocodex"]}
-            })),
-            Some(RolloutTranscriptItem::Tool {
-                call_id: "search-1".to_owned(),
-                name: "web_search".to_owned(),
-                arguments: "{\"queries\":[\"Nanocodex\"],\"type\":\"search\"}".to_owned(),
-            })
+            serde_json::from_str::<serde_json::Value>(&arguments).expect("web search arguments"),
+            serde_json::json!({"type": "search", "queries": ["Nanocodex"]})
         );
     }
 

--- a/crates/nanocodex/src/rollout.rs
+++ b/crates/nanocodex/src/rollout.rs
@@ -67,7 +67,7 @@ pub struct DurableSession {
     thread_id: String,
     rollout_path: PathBuf,
     snapshot: SessionSnapshot,
-    messages: Vec<RolloutMessage>,
+    transcript: Vec<RolloutTranscriptItem>,
 }
 
 impl DurableSession {
@@ -84,7 +84,7 @@ impl DurableSession {
                 format!("no Codex rollout found for thread {thread_id}"),
             )
         })?;
-        let (workspace, history, messages) = materialize_rollout(&rollout_path, thread_id)?;
+        let (workspace, history, transcript) = materialize_rollout(&rollout_path, thread_id)?;
         let snapshot = SessionSnapshot::from_rollout(thread_id.to_owned(), workspace, history)
             .map_err(io::Error::other)?;
         Ok(Self {
@@ -92,7 +92,7 @@ impl DurableSession {
             thread_id: thread_id.to_owned(),
             rollout_path,
             snapshot,
-            messages,
+            transcript,
         })
     }
 
@@ -120,10 +120,10 @@ impl DurableSession {
         &self.rollout_path
     }
 
-    /// Returns user and assistant messages used to restore a visible transcript.
+    /// Returns the visible activity used to restore the originating transcript.
     #[must_use]
-    pub fn messages(&self) -> &[RolloutMessage] {
-        &self.messages
+    pub fn transcript(&self) -> &[RolloutTranscriptItem] {
+        &self.transcript
     }
 
     /// Splits this loaded boundary into the builder inputs needed to continue it.
@@ -137,13 +137,24 @@ impl DurableSession {
     }
 }
 
-/// A user-visible message reconstructed from a Codex-compatible rollout.
+/// User-visible activity reconstructed from a Codex-compatible rollout.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum RolloutMessage {
+pub enum RolloutTranscriptItem {
     /// A submitted user prompt.
     User(String),
+    /// A reasoning summary displayed while the assistant was working.
+    Reasoning(String),
     /// An assistant message displayed by the originating client.
     Assistant(String),
+    /// A tool invocation displayed by the originating client.
+    Tool {
+        /// Stable call identifier from the rollout.
+        call_id: String,
+        /// Tool name sent by the model.
+        name: String,
+        /// Serialized tool arguments sent by the model.
+        arguments: String,
+    },
 }
 
 fn find_rollout_path(codex_home: &Path, thread_id: &str) -> io::Result<Option<PathBuf>> {
@@ -195,10 +206,10 @@ fn find_rollout_path(codex_home: &Path, thread_id: &str) -> io::Result<Option<Pa
 fn materialize_rollout(
     path: &Path,
     thread_id: &str,
-) -> io::Result<(String, Vec<ResponseItem>, Vec<RolloutMessage>)> {
+) -> io::Result<(String, Vec<ResponseItem>, Vec<RolloutTranscriptItem>)> {
     let mut workspace = None;
     let mut history = Vec::new();
-    let mut messages = Vec::new();
+    let mut transcript = Vec::new();
     for (index, line) in BufReader::new(File::open(path)?).lines().enumerate() {
         let line = line?;
         let value: serde_json::Value = serde_json::from_str(&line).map_err(|error| {
@@ -234,6 +245,9 @@ fn materialize_rollout(
                 );
             }
             Some("response_item") => {
+                if let Some(item) = visible_tool_call(&value["payload"]) {
+                    transcript.push(item);
+                }
                 let item = serde_json::from_value(value["payload"].clone()).map_err(|error| {
                     io::Error::new(
                         io::ErrorKind::InvalidData,
@@ -260,8 +274,8 @@ fn materialize_rollout(
                 })?;
             }
             Some("event_msg") => {
-                if let Some(message) = visible_rollout_message(&value["payload"]) {
-                    messages.push(message);
+                if let Some(item) = visible_rollout_event(&value["payload"]) {
+                    transcript.push(item);
                 }
             }
             _ => {}
@@ -283,20 +297,58 @@ fn materialize_rollout(
             ),
         )
     })?;
-    Ok((workspace, history, messages))
+    Ok((workspace, history, transcript))
 }
 
-fn visible_rollout_message(payload: &serde_json::Value) -> Option<RolloutMessage> {
-    let message = payload
-        .get("message")?
-        .as_str()
-        .filter(|message| !message.is_empty())?
-        .to_owned();
+fn visible_rollout_event(payload: &serde_json::Value) -> Option<RolloutTranscriptItem> {
     match payload.get("type")?.as_str()? {
-        "user_message" => Some(RolloutMessage::User(message)),
-        "agent_message" => Some(RolloutMessage::Assistant(message)),
+        "user_message" => visible_text(payload, "message").map(RolloutTranscriptItem::User),
+        "agent_reasoning" => visible_text(payload, "text").map(RolloutTranscriptItem::Reasoning),
+        "agent_message" => visible_text(payload, "message").map(RolloutTranscriptItem::Assistant),
+        "mcp_tool_call_end" => {
+            let invocation = payload.get("invocation")?;
+            let server = invocation.get("server")?.as_str()?;
+            let tool = invocation.get("tool")?.as_str()?;
+            Some(RolloutTranscriptItem::Tool {
+                call_id: payload.get("call_id")?.as_str()?.to_owned(),
+                name: format!("{server}.{tool}"),
+                arguments: serde_json::to_string(invocation.get("arguments")?).ok()?,
+            })
+        }
+        "web_search_end" => Some(RolloutTranscriptItem::Tool {
+            call_id: payload.get("call_id")?.as_str()?.to_owned(),
+            name: "web_search".to_owned(),
+            arguments: serde_json::to_string(payload.get("action")?).ok()?,
+        }),
         _ => None,
     }
+}
+
+fn visible_text(payload: &serde_json::Value, key: &str) -> Option<String> {
+    payload
+        .get(key)?
+        .as_str()
+        .filter(|text| !text.is_empty())
+        .map(str::to_owned)
+}
+
+fn visible_tool_call(payload: &serde_json::Value) -> Option<RolloutTranscriptItem> {
+    let (name, arguments) = match payload.get("type")?.as_str()? {
+        "custom_tool_call" => (
+            payload.get("name")?.as_str()?.to_owned(),
+            payload.get("input")?.as_str()?.to_owned(),
+        ),
+        "function_call" => (
+            payload.get("name")?.as_str()?.to_owned(),
+            payload.get("arguments")?.as_str()?.to_owned(),
+        ),
+        _ => return None,
+    };
+    Some(RolloutTranscriptItem::Tool {
+        call_id: payload.get("call_id")?.as_str()?.to_owned(),
+        name,
+        arguments,
+    })
 }
 
 /// Stable identity and file location of a recorded Nanocodex thread.
@@ -1218,6 +1270,11 @@ mod tests {
             serde_json::json!({
                 "timestamp": "2026-07-24T12:00:03Z",
                 "type": "event_msg",
+                "payload": {"type": "agent_reasoning", "text": "checking the workspace"}
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-24T12:00:03Z",
+                "type": "event_msg",
                 "payload": {"type": "agent_message", "message": "visible answer"}
             }),
             serde_json::json!({
@@ -1250,11 +1307,71 @@ mod tests {
         assert!(history.contains("continued"));
         assert!(!history.contains("discarded"));
         assert_eq!(
-            session.messages(),
+            session.transcript(),
             [
-                RolloutMessage::User("visible prompt".to_owned()),
-                RolloutMessage::Assistant("visible answer".to_owned()),
+                RolloutTranscriptItem::User("visible prompt".to_owned()),
+                RolloutTranscriptItem::Reasoning("checking the workspace".to_owned()),
+                RolloutTranscriptItem::Assistant("visible answer".to_owned()),
             ]
+        );
+    }
+
+    #[test]
+    fn reconstructs_custom_function_and_mcp_tool_activity() {
+        assert_eq!(
+            visible_tool_call(&serde_json::json!({
+                "type": "custom_tool_call",
+                "call_id": "custom-1",
+                "name": "exec",
+                "input": "text(true);"
+            })),
+            Some(RolloutTranscriptItem::Tool {
+                call_id: "custom-1".to_owned(),
+                name: "exec".to_owned(),
+                arguments: "text(true);".to_owned(),
+            })
+        );
+        assert_eq!(
+            visible_tool_call(&serde_json::json!({
+                "type": "function_call",
+                "call_id": "function-1",
+                "name": "wait",
+                "arguments": "{\"cell_id\":\"1\"}"
+            })),
+            Some(RolloutTranscriptItem::Tool {
+                call_id: "function-1".to_owned(),
+                name: "wait".to_owned(),
+                arguments: "{\"cell_id\":\"1\"}".to_owned(),
+            })
+        );
+        assert_eq!(
+            visible_rollout_event(&serde_json::json!({
+                "type": "mcp_tool_call_end",
+                "call_id": "mcp-1",
+                "invocation": {
+                    "server": "node_repl",
+                    "tool": "js",
+                    "arguments": {"code": "return true"}
+                }
+            })),
+            Some(RolloutTranscriptItem::Tool {
+                call_id: "mcp-1".to_owned(),
+                name: "node_repl.js".to_owned(),
+                arguments: "{\"code\":\"return true\"}".to_owned(),
+            })
+        );
+        assert_eq!(
+            visible_rollout_event(&serde_json::json!({
+                "type": "web_search_end",
+                "call_id": "search-1",
+                "query": "Nanocodex",
+                "action": {"type": "search", "queries": ["Nanocodex"]}
+            })),
+            Some(RolloutTranscriptItem::Tool {
+                call_id: "search-1".to_owned(),
+                name: "web_search".to_owned(),
+                arguments: "{\"queries\":[\"Nanocodex\"],\"type\":\"search\"}".to_owned(),
+            })
         );
     }
 

--- a/crates/nanocodex/src/rollout.rs
+++ b/crates/nanocodex/src/rollout.rs
@@ -67,6 +67,7 @@ pub struct DurableSession {
     thread_id: String,
     rollout_path: PathBuf,
     snapshot: SessionSnapshot,
+    messages: Vec<RolloutMessage>,
 }
 
 impl DurableSession {
@@ -83,7 +84,7 @@ impl DurableSession {
                 format!("no Codex rollout found for thread {thread_id}"),
             )
         })?;
-        let (workspace, history) = materialize_rollout(&rollout_path, thread_id)?;
+        let (workspace, history, messages) = materialize_rollout(&rollout_path, thread_id)?;
         let snapshot = SessionSnapshot::from_rollout(thread_id.to_owned(), workspace, history)
             .map_err(io::Error::other)?;
         Ok(Self {
@@ -91,6 +92,7 @@ impl DurableSession {
             thread_id: thread_id.to_owned(),
             rollout_path,
             snapshot,
+            messages,
         })
     }
 
@@ -118,6 +120,12 @@ impl DurableSession {
         &self.rollout_path
     }
 
+    /// Returns user and assistant messages used to restore a visible transcript.
+    #[must_use]
+    pub fn messages(&self) -> &[RolloutMessage] {
+        &self.messages
+    }
+
     /// Splits this loaded boundary into the builder inputs needed to continue it.
     #[must_use]
     pub fn into_parts(self) -> (String, SessionSnapshot, RolloutConfig) {
@@ -127,6 +135,15 @@ impl DurableSession {
             RolloutConfig::new(self.codex_home).resumed(self.rollout_path),
         )
     }
+}
+
+/// A user-visible message reconstructed from a Codex-compatible rollout.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RolloutMessage {
+    /// A submitted user prompt.
+    User(String),
+    /// An assistant message displayed by the originating client.
+    Assistant(String),
 }
 
 fn find_rollout_path(codex_home: &Path, thread_id: &str) -> io::Result<Option<PathBuf>> {
@@ -175,9 +192,13 @@ fn find_rollout_path(codex_home: &Path, thread_id: &str) -> io::Result<Option<Pa
     Ok(None)
 }
 
-fn materialize_rollout(path: &Path, thread_id: &str) -> io::Result<(String, Vec<ResponseItem>)> {
+fn materialize_rollout(
+    path: &Path,
+    thread_id: &str,
+) -> io::Result<(String, Vec<ResponseItem>, Vec<RolloutMessage>)> {
     let mut workspace = None;
     let mut history = Vec::new();
+    let mut messages = Vec::new();
     for (index, line) in BufReader::new(File::open(path)?).lines().enumerate() {
         let line = line?;
         let value: serde_json::Value = serde_json::from_str(&line).map_err(|error| {
@@ -238,6 +259,11 @@ fn materialize_rollout(path: &Path, thread_id: &str) -> io::Result<(String, Vec<
                     )
                 })?;
             }
+            Some("event_msg") => {
+                if let Some(message) = visible_rollout_message(&value["payload"]) {
+                    messages.push(message);
+                }
+            }
             _ => {}
         }
     }
@@ -257,7 +283,20 @@ fn materialize_rollout(path: &Path, thread_id: &str) -> io::Result<(String, Vec<
             ),
         )
     })?;
-    Ok((workspace, history))
+    Ok((workspace, history, messages))
+}
+
+fn visible_rollout_message(payload: &serde_json::Value) -> Option<RolloutMessage> {
+    let message = payload
+        .get("message")?
+        .as_str()
+        .filter(|message| !message.is_empty())?
+        .to_owned();
+    match payload.get("type")?.as_str()? {
+        "user_message" => Some(RolloutMessage::User(message)),
+        "agent_message" => Some(RolloutMessage::Assistant(message)),
+        _ => None,
+    }
 }
 
 /// Stable identity and file location of a recorded Nanocodex thread.
@@ -1149,6 +1188,11 @@ mod tests {
             }),
             serde_json::json!({
                 "timestamp": "2026-07-24T12:00:01Z",
+                "type": "event_msg",
+                "payload": {"type": "user_message", "message": "visible prompt"}
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-24T12:00:01Z",
                 "type": "response_item",
                 "payload": {
                     "type": "message",
@@ -1170,6 +1214,11 @@ mod tests {
                     "previous_window_id": "window-1",
                     "window_id": "window-2"
                 }
+            }),
+            serde_json::json!({
+                "timestamp": "2026-07-24T12:00:03Z",
+                "type": "event_msg",
+                "payload": {"type": "agent_message", "message": "visible answer"}
             }),
             serde_json::json!({
                 "timestamp": "2026-07-24T12:00:03Z",
@@ -1200,6 +1249,13 @@ mod tests {
         assert!(history.contains("retained"));
         assert!(history.contains("continued"));
         assert!(!history.contains("discarded"));
+        assert_eq!(
+            session.messages(),
+            [
+                RolloutMessage::User("visible prompt".to_owned()),
+                RolloutMessage::Assistant("visible answer".to_owned()),
+            ]
+        );
     }
 
     #[tokio::test]

--- a/crates/nanocodex/src/session.rs
+++ b/crates/nanocodex/src/session.rs
@@ -43,7 +43,7 @@ impl CommittedSession {
             lineage_id: self.lineage_id.to_string(),
             prompt_cache_key: self.model.prompt_cache_key().to_owned(),
             workspace: self.model.workspace().to_owned(),
-            request_prefix: self.model.request_prefix().to_vec(),
+            request_prefix: Some(self.model.request_prefix().to_vec()),
             canonical_context: self.model.canonical_context().clone(),
             history: self.model.snapshot_history(),
         }
@@ -65,7 +65,8 @@ pub struct SessionSnapshot {
     lineage_id: String,
     prompt_cache_key: String,
     workspace: String,
-    request_prefix: Vec<ResponseItem>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    request_prefix: Option<Vec<ResponseItem>>,
     canonical_context: ResponseItem,
     history: Vec<ResponseItem>,
 }
@@ -82,13 +83,45 @@ impl fmt::Debug for SessionSnapshot {
 }
 
 impl SessionSnapshot {
+    pub(crate) fn from_rollout(
+        thread_id: String,
+        workspace: String,
+        history: Vec<ResponseItem>,
+    ) -> Result<Self> {
+        let canonical_context = history
+            .iter()
+            .find(|item| item.is_user_message())
+            .cloned()
+            .ok_or_else(|| {
+                NanocodexError::InvalidSessionSnapshot(
+                    "rollout does not contain a user message".to_owned(),
+                )
+            })?;
+        Ok(Self {
+            version: SESSION_SNAPSHOT_VERSION,
+            model: MODEL.to_owned(),
+            lineage_id: thread_id.clone(),
+            prompt_cache_key: thread_id,
+            workspace,
+            request_prefix: None,
+            canonical_context,
+            history,
+        })
+    }
+
     /// Snapshot format version understood by this Nanocodex release.
     #[must_use]
     pub const fn version(&self) -> u32 {
         self.version
     }
 
-    pub(crate) fn into_checkpoint(self) -> Result<(Arc<str>, Arc<str>, ModelCheckpoint)> {
+    /// Returns the absolute workspace retained by this session boundary.
+    #[must_use]
+    pub fn workspace(&self) -> &str {
+        &self.workspace
+    }
+
+    pub(crate) fn into_resume(self) -> Result<SessionResume> {
         if self.version != SESSION_SNAPSHOT_VERSION {
             return Err(NanocodexError::InvalidSessionSnapshot(format!(
                 "unsupported format version {}; expected {SESSION_SNAPSHOT_VERSION}",
@@ -116,37 +149,55 @@ impl SessionSnapshot {
                 "workspace must not be empty".to_owned(),
             ));
         }
-        if self.request_prefix.is_empty() {
-            return Err(NanocodexError::InvalidSessionSnapshot(
-                "request prefix must not be empty".to_owned(),
-            ));
-        }
-        if !matches!(
-            self.request_prefix.as_slice(),
-            [
-                ResponseItem::AdditionalTools {
-                    role: MessageRole::Developer,
-                    ..
-                },
-                ResponseItem::Message {
-                    role: MessageRole::Developer,
-                    ..
-                }
-            ]
-        ) {
+        if let Some(request_prefix) = self.request_prefix.as_ref()
+            && !matches!(
+                request_prefix.as_slice(),
+                [
+                    ResponseItem::AdditionalTools {
+                        role: MessageRole::Developer,
+                        ..
+                    },
+                    ResponseItem::Message {
+                        role: MessageRole::Developer,
+                        ..
+                    }
+                ]
+            )
+        {
             return Err(NanocodexError::InvalidSessionSnapshot(
                 "request prefix does not match the supported model contract".to_owned(),
             ));
         }
         let lineage_id = Arc::<str>::from(self.lineage_id);
         let prompt_cache_key = Arc::<str>::from(self.prompt_cache_key);
-        let checkpoint = ModelCheckpoint::resume(
-            self.workspace,
-            self.request_prefix,
-            Arc::clone(&prompt_cache_key),
-            self.canonical_context,
-            self.history,
-        )?;
-        Ok((lineage_id, prompt_cache_key, checkpoint))
+        let checkpoint = self
+            .request_prefix
+            .map(|request_prefix| {
+                ModelCheckpoint::resume(
+                    self.workspace.clone(),
+                    request_prefix,
+                    Arc::clone(&prompt_cache_key),
+                    self.canonical_context.clone(),
+                    self.history.clone(),
+                )
+            })
+            .transpose()?;
+        Ok(SessionResume {
+            lineage_id,
+            prompt_cache_key,
+            workspace: self.workspace,
+            canonical_context: self.canonical_context,
+            history: self.history,
+            checkpoint,
+        })
     }
+}
+
+pub(crate) struct SessionResume {
+    pub(crate) lineage_id: Arc<str>,
+    pub(crate) prompt_cache_key: Arc<str>,
+    pub(crate) workspace: String,
+    pub(crate) canonical_context: ResponseItem,
+    pub(crate) history: Vec<ResponseItem>,
+    pub(crate) checkpoint: Option<ModelCheckpoint>,
 }

--- a/crates/nanocodex/src/session.rs
+++ b/crates/nanocodex/src/session.rs
@@ -191,6 +191,22 @@ impl SessionSnapshot {
             checkpoint,
         })
     }
+
+    #[cfg(target_family = "wasm")]
+    pub(crate) fn into_checkpoint(self) -> Result<(Arc<str>, Arc<str>, ModelCheckpoint)> {
+        let SessionResume {
+            lineage_id,
+            prompt_cache_key,
+            checkpoint,
+            ..
+        } = self.into_resume()?;
+        let checkpoint = checkpoint.ok_or_else(|| {
+            NanocodexError::InvalidSessionSnapshot(
+                "serialized session is missing its request prefix".to_owned(),
+            )
+        })?;
+        Ok((lineage_id, prompt_cache_key, checkpoint))
+    }
 }
 
 pub(crate) struct SessionResume {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -68,5 +68,9 @@ path = "response_transport_bench.rs"
 name = "codex-parity-bench"
 path = "codex_parity_bench.rs"
 
+[[bin]]
+name = "rollout-resume-bench"
+path = "rollout_resume_bench.rs"
+
 [lints]
 workspace = true

--- a/examples/rollout_resume_bench.rs
+++ b/examples/rollout_resume_bench.rs
@@ -21,6 +21,7 @@ async fn main() -> Result<()> {
     for thread_id in thread_ids {
         let mut samples = Vec::with_capacity(iterations);
         let mut history_items = 0;
+        let mut visible_messages = 0;
         let mut rollout_bytes = 0;
         let mut loaded = None;
         for _ in 0..iterations {
@@ -33,6 +34,7 @@ async fn main() -> Result<()> {
             history_items = serde_json::to_value(session.snapshot())?["history"]
                 .as_array()
                 .map_or(0, Vec::len);
+            visible_messages = session.messages().len();
             loaded = Some(session);
         }
         let session = loaded.ok_or_else(|| eyre!("iteration count must be positive"))?;
@@ -46,7 +48,7 @@ async fn main() -> Result<()> {
         let sample_count = u32::try_from(samples.len()).wrap_err("too many benchmark samples")?;
         let mean = samples.iter().sum::<f64>() / f64::from(sample_count);
         println!(
-            "{thread_id}\tbytes={rollout_bytes}\thistory={history_items}\tvalidated=true\tmin_ms={:.3}\tp50_ms={median:.3}\tmean_ms={mean:.3}\tmax_ms={:.3}",
+            "{thread_id}\tbytes={rollout_bytes}\thistory={history_items}\tmessages={visible_messages}\tvalidated=true\tmin_ms={:.3}\tp50_ms={median:.3}\tmean_ms={mean:.3}\tmax_ms={:.3}",
             samples[0],
             samples[samples.len() - 1]
         );

--- a/examples/rollout_resume_bench.rs
+++ b/examples/rollout_resume_bench.rs
@@ -1,0 +1,55 @@
+use std::{env, path::PathBuf, time::Instant};
+
+use eyre::{Result, WrapErr, eyre};
+use nanocodex::{Nanocodex, RolloutConfig};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let mut args = env::args().skip(1);
+    let codex_home = PathBuf::from(args.next().ok_or_else(|| eyre!("missing CODEX_HOME"))?);
+    let iterations = args
+        .next()
+        .ok_or_else(|| eyre!("missing iteration count"))?
+        .parse::<usize>()
+        .wrap_err("iteration count must be an integer")?;
+    let thread_ids = args.collect::<Vec<_>>();
+    if thread_ids.is_empty() {
+        return Err(eyre!("provide at least one thread ID"));
+    }
+
+    let config = RolloutConfig::new(codex_home);
+    for thread_id in thread_ids {
+        let mut samples = Vec::with_capacity(iterations);
+        let mut history_items = 0;
+        let mut rollout_bytes = 0;
+        let mut loaded = None;
+        for _ in 0..iterations {
+            let started = Instant::now();
+            let session = config
+                .load_session(&thread_id)
+                .wrap_err_with(|| format!("failed to load {thread_id}"))?;
+            samples.push(started.elapsed().as_secs_f64() * 1_000.0);
+            rollout_bytes = session.rollout_path().metadata()?.len();
+            history_items = serde_json::to_value(session.snapshot())?["history"]
+                .as_array()
+                .map_or(0, Vec::len);
+            loaded = Some(session);
+        }
+        let session = loaded.ok_or_else(|| eyre!("iteration count must be positive"))?;
+        let (agent, events) = Nanocodex::builder("benchmark-only")
+            .resume(session.snapshot().clone())
+            .build()
+            .wrap_err_with(|| format!("failed to construct resumed driver for {thread_id}"))?;
+        drop((agent, events));
+        samples.sort_by(f64::total_cmp);
+        let median = samples[samples.len() / 2];
+        let sample_count = u32::try_from(samples.len()).wrap_err("too many benchmark samples")?;
+        let mean = samples.iter().sum::<f64>() / f64::from(sample_count);
+        println!(
+            "{thread_id}\tbytes={rollout_bytes}\thistory={history_items}\tvalidated=true\tmin_ms={:.3}\tp50_ms={median:.3}\tmean_ms={mean:.3}\tmax_ms={:.3}",
+            samples[0],
+            samples[samples.len() - 1]
+        );
+    }
+    Ok(())
+}

--- a/examples/rollout_resume_bench.rs
+++ b/examples/rollout_resume_bench.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
     for thread_id in thread_ids {
         let mut samples = Vec::with_capacity(iterations);
         let mut history_items = 0;
-        let mut visible_messages = 0;
+        let mut transcript_items = 0;
         let mut rollout_bytes = 0;
         let mut loaded = None;
         for _ in 0..iterations {
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
             history_items = serde_json::to_value(session.snapshot())?["history"]
                 .as_array()
                 .map_or(0, Vec::len);
-            visible_messages = session.messages().len();
+            transcript_items = session.transcript().len();
             loaded = Some(session);
         }
         let session = loaded.ok_or_else(|| eyre!("iteration count must be positive"))?;
@@ -48,7 +48,7 @@ async fn main() -> Result<()> {
         let sample_count = u32::try_from(samples.len()).wrap_err("too many benchmark samples")?;
         let mean = samples.iter().sum::<f64>() / f64::from(sample_count);
         println!(
-            "{thread_id}\tbytes={rollout_bytes}\thistory={history_items}\tmessages={visible_messages}\tvalidated=true\tmin_ms={:.3}\tp50_ms={median:.3}\tmean_ms={mean:.3}\tmax_ms={:.3}",
+            "{thread_id}\tbytes={rollout_bytes}\thistory={history_items}\ttranscript={transcript_items}\tvalidated=true\tmin_ms={:.3}\tp50_ms={median:.3}\tmean_ms={mean:.3}\tmax_ms={:.3}",
             samples[0],
             samples[samples.len() - 1]
         );


### PR DESCRIPTION
## Summary

- add `nanocodex resume <thread-id> [--prompt ...]` for Codex and Nanocodex sessions
- discover active or archived rollouts directly under `CODEX_HOME`, with no Nanocodex sidecar requirement
- materialize typed model history from response items and the latest compaction replacement boundary
- reconstruct prior prompts, replies, reasoning summaries, Code Mode/function/MCP calls, and web searches as native resumed-TUI activity
- rebuild the current Nanocodex request prefix while retaining restored history, workspace, thread identity, and append-to-the-same-rollout behavior
- add a release-mode rollout materialization benchmark

## Validation

- 93 Nanocodex library tests
- 211 Nanocodex CLI tests
- MCP CLI integration test
- focused rollout-materialization and resumed-transcript tests
- rustfmt
- focused Clippy with warnings denied
- resumed-driver construction against real Nanocodex and Codex rollouts

## Benchmark

20 release-mode iterations on local persisted rollouts:

| rollout | bytes | restored items | p50 |
| --- | ---: | ---: | ---: |
| Nanocodex | 16 KB | 3 | 0.26 ms |
| Codex compacted | 2.8 MB | 486 | 4.20 ms |
| Codex long/compacted | 83.3 MB | 375 | 66.35 ms |

The combined run, including resumed-driver validation, peaked around 40 MB RSS. A July 16 Codex coding rollout (386 KB, 70 model-history items) reconstructs 28 visible transcript items and loads at 1.8 ms p50 locally.

## Current limits

Compressed `.jsonl.zst` rollouts are rejected explicitly. Inherited paginated `history_base` rollouts are not yet materialized.

## CI note

The branch-local packages and bindings pass. The workspace CI jobs currently stop in pre-existing `nanousd-api` code because `tempo_wallet.rs` expects `TempoP256Signer` while the wallet now exposes `TempoPrimitiveSigner`; that file is outside this PR.