### PR TITLE
feat: add turbo recursive task tooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -1639,6 +1640,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "borsh"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,6 +1723,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -2980,6 +2993,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3103,6 +3125,17 @@ name = "fancy-regex"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -3255,6 +3288,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3302,6 +3346,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -4372,6 +4426,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05a6cff806294a7699d48761d4ae2bdebab7fa2eef05e4a0b83320f0ff46901"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex 0.18.0",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex",
+ "jsonschema-value",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.28.0",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84708dd3f6c5327478a96f37378adb27deed6a626cf84d19de780d9e8ae84b17"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8c04ab4ce60e42c4e302d3bd9d184652bb56f212495d2eea23573bcbf72556"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4831,6 +4937,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5040,6 +5152,7 @@ dependencies = [
  "nanocodex-egress",
  "nanocodex-eval",
  "nanocodex-observability",
+ "nanocodex-rlm",
  "nanocodex-tools",
  "nanocodex-vm",
  "nanocodex-voice",
@@ -5269,6 +5382,21 @@ dependencies = [
  "reqwest",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "nanocodex-rlm"
+version = "0.3.0"
+dependencies = [
+ "eyre",
+ "futures-util",
+ "jsonschema",
+ "nanocodex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite 0.30.0",
+ "uuid",
 ]
 
 [[package]]
@@ -5557,6 +5685,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -7105,6 +7239,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "referencing"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980e77f5cfffc592c0e7dfb6d20770a0b96a6ab94d403de7454ed9799505e4ba"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -8657,6 +8808,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8674,6 +8834,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -9584,6 +9756,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-id-start"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9703,6 +9881,16 @@ dependencies = [
  "serde_core",
  "sha1_smol",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/experimental/nanocodex-vm",
     "crates/nanocodex-oai-api",
     "crates/nanocodex-observability",
+    "crates/nanocodex-rlm",
     "crates/nanocodex-tools",
     "crates/nanocodex-tools/macros",
     "examples",
@@ -77,6 +78,7 @@ nanocodex-eval = { version = "0.3.0", path = "crates/experimental/nanocodex-eval
 nanocodex-vm = { version = "0.3.0", path = "crates/experimental/nanocodex-vm" }
 nanocodex-oai-api = { version = "0.3.0", path = "crates/nanocodex-oai-api" }
 nanocodex-observability = { version = "0.3.0", path = "crates/nanocodex-observability" }
+nanocodex-rlm = { version = "0.3.0", path = "crates/nanocodex-rlm" }
 nanocodex-tools = { version = "0.3.0", path = "crates/nanocodex-tools" }
 nanocodex-tools-macros = { version = "0.3.0", path = "crates/nanocodex-tools/macros" }
 nanousd = { version = "0.3.0", path = "bin/nanousd" }
@@ -86,6 +88,7 @@ reflink-copy = "0.1.30"
 image = { version = "0.25.9", default-features = false, features = ["bmp", "gif", "jpeg", "png", "pnm", "webp"] }
 iana-time-zone = "0.1.64"
 js-sys = "0.3.82"
+jsonschema = { version = "0.48.5", default-features = false }
 nix = { version = "0.31.3", default-features = false, features = ["process", "resource", "signal", "user"] }
 portable-pty = "0.9.0"
 pulldown-cmark = { version = "0.10", default-features = false }

--- a/Justfile
+++ b/Justfile
@@ -252,7 +252,8 @@ run:
 build-agent:
     @mkdir -p "{{agent_artifact_dir}}"
     @echo "Building native Linux agent artifact (Cargo profile: {{build_profile}})..."
-    @docker build --quiet --build-arg CARGO_PROFILE="{{build_profile}}" --file harbor_adapter/nanocodex.Dockerfile --target artifact --output type=local,dest="{{agent_artifact_dir}}" .
+    @build_sha=$(git rev-parse HEAD); \
+        docker build --quiet --build-arg CARGO_PROFILE="{{build_profile}}" --build-arg VERGEN_GIT_SHA="$build_sha" --file harbor_adapter/nanocodex.Dockerfile --target artifact --output type=local,dest="{{agent_artifact_dir}}" .
     @test -x "{{agent_artifact}}"
 
 # Daytona sandboxes are AMD64 even when Harbor is orchestrated from Apple
@@ -260,7 +261,8 @@ build-agent:
 build-agent-hosted:
     @mkdir -p "{{hosted_agent_artifact_dir}}"
     @echo "Building AMD64 Linux agent artifact for Daytona (Cargo profile: {{build_profile}})..."
-    @docker build --quiet --platform linux/amd64 --build-arg CARGO_PROFILE="{{build_profile}}" --file harbor_adapter/nanocodex.Dockerfile --target artifact --output type=local,dest="{{hosted_agent_artifact_dir}}" .
+    @build_sha=$(git rev-parse HEAD); \
+        docker build --quiet --platform linux/amd64 --build-arg CARGO_PROFILE="{{build_profile}}" --build-arg VERGEN_GIT_SHA="$build_sha" --file harbor_adapter/nanocodex.Dockerfile --target artifact --output type=local,dest="{{hosted_agent_artifact_dir}}" .
     @test -f "{{hosted_agent_artifact}}" && test -x "{{hosted_agent_artifact}}"
 
 # Ask the CLI artifact workflow to build from the exact head of one open PR.

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -43,6 +43,7 @@ image.workspace = true
 nanocodex.workspace = true
 nanocodex-browser.workspace = true
 nanocodex-observability.workspace = true
+nanocodex-rlm.workspace = true
 nanocodex-voice.workspace = true
 nix.workspace = true
 nanousd = { workspace = true, optional = true }

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -159,6 +159,10 @@ pub(crate) struct AgentArgs {
     )]
     subagents: bool,
 
+    /// Enable recursive structured task tools for this session.
+    #[arg(long, env = "NANOCODEX_TURBO", action = ArgAction::SetTrue)]
+    pub(crate) turbo: bool,
+
     /// Write Codex-compatible resumable threads beneath `CODEX_HOME`.
     #[arg(
         long,
@@ -248,7 +252,8 @@ impl AgentArgs {
     }
 
     pub(crate) async fn build(self, vm: VmArgs) -> Result<ConfiguredAgent> {
-        self.build_inner(None, vm, false).await
+        let turbo = self.turbo;
+        self.build_inner(None, vm, turbo, turbo).await
     }
 
     pub(crate) async fn build_resumed(
@@ -256,11 +261,13 @@ impl AgentArgs {
         session: DurableSession,
         vm: VmArgs,
     ) -> Result<ConfiguredAgent> {
-        self.build_inner(Some(session), vm, true).await
+        let turbo = self.turbo;
+        self.build_inner(Some(session), vm, true, turbo).await
     }
 
     pub(crate) async fn build_for_tui(self, vm: VmArgs) -> Result<ConfiguredAgent> {
-        self.build_inner(None, vm, true).await
+        let turbo = self.turbo;
+        self.build_inner(None, vm, true, turbo).await
     }
 
     async fn build_inner(
@@ -268,6 +275,7 @@ impl AgentArgs {
         durable: Option<DurableSession>,
         vm: VmArgs,
         with_task_tools: bool,
+        task_tools_enabled: bool,
     ) -> Result<ConfiguredAgent> {
         let thinking = self.thinking();
         let web_search = self.web_search();
@@ -345,7 +353,7 @@ impl AgentArgs {
         let tools = tools.build()?;
         let task_runtime = with_task_tools.then(|| {
             let runtime = TaskRuntime::new();
-            runtime.set_enabled(false);
+            runtime.set_enabled(task_tools_enabled);
             runtime
         });
         let child_agents = self.subagents.then(|| Arc::new(ChildAgents::default()));

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -23,6 +23,7 @@ use nanocodex::{
     },
     tools::mcp::McpHandle,
 };
+use nanocodex_rlm::TaskRuntime;
 
 use crate::browser::{BrowserArgs, ConfiguredBrowser};
 use crate::mcp::{ConfiguredMcp, McpArgs};
@@ -35,6 +36,7 @@ pub(crate) struct ConfiguredAgent {
     pub(crate) events: AgentEvents,
     pub(crate) realtime: Option<OpenAi>,
     pub(crate) child_agents: Option<Arc<ChildAgents>>,
+    pub(crate) task_runtime: Option<TaskRuntime>,
     pub(crate) mpp_adapter: Option<MppAdapter>,
     pub(crate) mcp: Option<McpHandle>,
     pub(crate) browser: Option<ConfiguredBrowser>,
@@ -246,7 +248,7 @@ impl AgentArgs {
     }
 
     pub(crate) async fn build(self, vm: VmArgs) -> Result<ConfiguredAgent> {
-        self.build_inner(None, vm).await
+        self.build_inner(None, vm, false).await
     }
 
     pub(crate) async fn build_resumed(
@@ -254,13 +256,18 @@ impl AgentArgs {
         session: DurableSession,
         vm: VmArgs,
     ) -> Result<ConfiguredAgent> {
-        self.build_inner(Some(session), vm).await
+        self.build_inner(Some(session), vm, true).await
+    }
+
+    pub(crate) async fn build_for_tui(self, vm: VmArgs) -> Result<ConfiguredAgent> {
+        self.build_inner(None, vm, true).await
     }
 
     async fn build_inner(
         self,
         durable: Option<DurableSession>,
         vm: VmArgs,
+        with_task_tools: bool,
     ) -> Result<ConfiguredAgent> {
         let thinking = self.thinking();
         let web_search = self.web_search();
@@ -336,6 +343,11 @@ impl AgentArgs {
             tools = tools.provider(browser.tool());
         }
         let tools = tools.build()?;
+        let task_runtime = with_task_tools.then(|| {
+            let runtime = TaskRuntime::new();
+            runtime.set_enabled(false);
+            runtime
+        });
         let child_agents = self.subagents.then(|| Arc::new(ChildAgents::default()));
         let mut builder = Nanocodex::builder(openai)
             .model(self.model)
@@ -353,11 +365,20 @@ impl AgentArgs {
         if let Some(rollout) = session.rollout {
             builder = builder.rollout(rollout);
         }
-        let builder = if let Some(child_agents) = &child_agents {
+        let builder = if child_agents.is_some() || task_runtime.is_some() {
             let tools = tools;
-            let child_agents = Arc::downgrade(child_agents);
+            let child_agents = child_agents.as_ref().map(Arc::downgrade);
+            let task_tools = task_runtime.as_ref().map(TaskRuntime::tools);
             builder.tools_factory(move |agent| {
-                subagents::with_subagents(tools.clone(), agent, child_agents.clone())
+                let mut installed = tools.clone();
+                if let Some(child_agents) = &child_agents {
+                    installed =
+                        subagents::with_subagents(installed, agent.clone(), child_agents.clone())?;
+                }
+                if let Some(task_tools) = &task_tools {
+                    installed = task_tools.install(installed, agent)?;
+                }
+                Ok(installed)
             })
         } else {
             builder.tools(tools)
@@ -373,6 +394,7 @@ impl AgentArgs {
             events,
             realtime,
             child_agents,
+            task_runtime,
             mpp_adapter,
             mcp: mcp_handle,
             browser: configured_browser,

--- a/bin/nanocodex/src/main.rs
+++ b/bin/nanocodex/src/main.rs
@@ -335,6 +335,16 @@ mod tests {
         );
     }
 
+    #[test]
+    fn turbo_is_explicitly_selectable_for_one_shot_runs() {
+        let cli = Cli::try_parse_from(["nanocodex", "run", "--turbo", "reply with ok"]).unwrap();
+
+        let Some(Command::Run(command)) = cli.command else {
+            panic!("expected one-shot run command");
+        };
+        assert!(command.agent.turbo);
+    }
+
     #[cfg(feature = "tempo")]
     #[test]
     fn provider_selection_is_exclusive() {

--- a/bin/nanocodex/src/run.rs
+++ b/bin/nanocodex/src/run.rs
@@ -6,6 +6,11 @@ use tokio::io::{AsyncWrite, AsyncWriteExt};
 use crate::config::AgentArgs;
 use crate::vm::VmArgs;
 
+const TURBO_ENABLED_MARKER: &str = r#"<nanocodex_turbo enabled="true" parallel_agents="4">
+Recursive structured task tools are available. Use four parallel child workstreams when useful,
+then synthesize and verify their results before completing the task.
+</nanocodex_turbo>"#;
+
 #[derive(Args)]
 pub(crate) struct Run {
     /// Prompt submitted to the agent.
@@ -20,12 +25,21 @@ pub(crate) struct Run {
 impl Run {
     pub(crate) async fn run(self, config: AgentArgs, vm: VmArgs) -> Result<()> {
         let configured = config.build(vm).await?;
+        let turbo = configured
+            .task_runtime
+            .as_ref()
+            .is_some_and(nanocodex_rlm::TaskRuntime::is_enabled);
         let handle = configured.handle;
         let mut events = configured.events;
         let mut stdout = tokio::io::stdout();
         let run_result: Result<()> = async {
             for _ in 0..self.repeat {
-                let turn = handle.prompt(self.prompt.clone()).await?;
+                let prompt = if turbo {
+                    format!("{TURBO_ENABLED_MARKER}\n\n{}", self.prompt)
+                } else {
+                    self.prompt.clone()
+                };
+                let turn = handle.prompt(prompt).await?;
                 let control = turn.control();
                 let completion = async {
                     write_turn_jsonl(&mut events, &mut stdout).await?;

--- a/bin/nanocodex/src/run.rs
+++ b/bin/nanocodex/src/run.rs
@@ -56,6 +56,9 @@ impl Run {
         if let Some(child_agents) = configured.child_agents {
             child_agents.shutdown().await;
         }
+        if let Some(task_runtime) = configured.task_runtime {
+            task_runtime.shutdown().await;
+        }
         let browser_shutdown_result = if let Some(browser) = configured.browser {
             browser.shutdown().await
         } else {

--- a/bin/nanocodex/src/tui/app.rs
+++ b/bin/nanocodex/src/tui/app.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
+    fmt::Write as _,
     path::PathBuf,
     sync::Arc,
     time::{Duration, Instant},
@@ -91,6 +92,7 @@ struct PendingPaste {
 pub(super) struct SubmittedPrompt {
     display: String,
     local_images: Vec<PathBuf>,
+    model_prefix: Option<String>,
 }
 
 impl SubmittedPrompt {
@@ -98,6 +100,7 @@ impl SubmittedPrompt {
         Self {
             display,
             local_images,
+            model_prefix: None,
         }
     }
 
@@ -117,7 +120,14 @@ impl SubmittedPrompt {
         self.display.insert_str(0, prefix);
     }
 
+    pub(super) fn set_model_prefix(&mut self, prefix: String) {
+        self.model_prefix = Some(prefix);
+    }
+
     fn append(&mut self, mut other: Self) {
+        if self.model_prefix.is_none() {
+            self.model_prefix = other.model_prefix.take();
+        }
         let image_offset = self.local_images.len();
         for index in (1..=other.local_images.len()).rev() {
             other.display = other.display.replace(
@@ -133,8 +143,11 @@ impl SubmittedPrompt {
     }
 
     pub(super) fn into_prompt(self) -> Prompt {
+        let display = self.model_prefix.map_or(self.display.clone(), |prefix| {
+            format!("{prefix}\n\n{}", self.display)
+        });
         if self.local_images.is_empty() {
-            return Prompt::new(self.display);
+            return Prompt::new(display);
         }
 
         let mut content = self
@@ -142,8 +155,8 @@ impl SubmittedPrompt {
             .into_iter()
             .map(|path| UserInput::LocalImage { path, detail: None })
             .collect::<Vec<_>>();
-        if !self.display.is_empty() {
-            content.push(UserInput::Text { text: self.display });
+        if !display.is_empty() {
+            content.push(UserInput::Text { text: display });
         }
         Prompt::content(content)
     }
@@ -1165,6 +1178,7 @@ pub(super) struct App {
     tool_details_expanded: bool,
     fast_mode: bool,
     model: Model,
+    turbo_mode: bool,
     thinking: Thinking,
     reasoning_picker: Option<ReasoningPicker>,
 }
@@ -1217,6 +1231,7 @@ impl App {
             tool_details_expanded: true,
             fast_mode: false,
             model: Model::default(),
+            turbo_mode: false,
             thinking: Thinking::default(),
             reasoning_picker: None,
         }
@@ -1285,6 +1300,11 @@ impl App {
             btw.conversation.note_tail_will_change();
             btw.conversation.transcript.invalidate_math_layouts();
         }
+    }
+
+    pub(super) const fn with_turbo_mode(mut self, enabled: bool) -> Self {
+        self.turbo_mode = enabled;
+        self
     }
 
     pub(super) fn insert_char(&mut self, character: char) {
@@ -2591,6 +2611,32 @@ impl App {
         self.set_active_status("Fast mode unchanged");
     }
 
+    pub(super) const fn turbo_mode(&self) -> bool {
+        self.turbo_mode
+    }
+
+    pub(super) fn turbo_mode_changed(&mut self, enabled: bool) {
+        self.turbo_mode = enabled;
+        self.set_active_status(if enabled {
+            "Turbo enabled"
+        } else {
+            "Turbo disabled"
+        });
+    }
+
+    pub(super) fn has_pending_agent_work(&self) -> bool {
+        self.main.running
+            || self.main.pending_turns > 0
+            || self
+                .main_branches
+                .iter()
+                .any(|branch| branch.conversation.running || branch.conversation.pending_turns > 0)
+            || self
+                .btw
+                .as_ref()
+                .is_some_and(|btw| btw.conversation.running || btw.conversation.pending_turns > 0)
+    }
+
     pub(super) const fn thinking(&self) -> Thinking {
         self.thinking
     }
@@ -2970,6 +3016,9 @@ fn summarize_tool_arguments(tool: &str, arguments: &Value) -> String {
         if let Some(summary) = summarize_mcp_arguments(tool, object) {
             return summary;
         }
+        if let Some(summary) = summarize_task_arguments(tool, object) {
+            return summary;
+        }
         let preferred = match tool {
             "view_image" => object.get("path").and_then(Value::as_str),
             "read_file" => object
@@ -2992,6 +3041,13 @@ fn summarize_tool_arguments(tool: &str, arguments: &Value) -> String {
 }
 
 fn present_tool_name(tool: &str, arguments: &Value) -> String {
+    match tool {
+        "task" => return "Task".to_owned(),
+        "task_batch" => return "Task batch".to_owned(),
+        "task_continue" => return "Task follow-up".to_owned(),
+        "submit_result" => return "Submit result".to_owned(),
+        _ => {}
+    }
     if tool == "browser" {
         return arguments.get("action").and_then(Value::as_str).map_or_else(
             || "Browser".to_owned(),
@@ -3126,6 +3182,53 @@ fn present_mcp_operation(operation: &str) -> &str {
     }
 }
 
+fn summarize_task_arguments(tool: &str, object: &serde_json::Map<String, Value>) -> Option<String> {
+    match tool {
+        "task" => object
+            .get("instruction")
+            .and_then(Value::as_str)
+            .map(compact_tool_text),
+        "task_continue" => {
+            let instruction = object.get("instruction").and_then(Value::as_str)?;
+            let task_id = object.get("task_id").and_then(Value::as_str);
+            Some(task_id.map_or_else(
+                || compact_tool_text(instruction),
+                |task_id| {
+                    format!(
+                        "{} · {}",
+                        compact_task_id(task_id),
+                        compact_tool_text(instruction)
+                    )
+                },
+            ))
+        }
+        "task_batch" => {
+            let tasks = object.get("tasks").and_then(Value::as_array)?;
+            let preview = tasks
+                .iter()
+                .filter_map(|task| task.get("instruction").and_then(Value::as_str))
+                .take(3)
+                .map(compact_tool_text)
+                .collect::<Vec<_>>()
+                .join(" · ");
+            let count = tasks.len();
+            Some(if preview.is_empty() {
+                format!("{count} task{}", if count == 1 { "" } else { "s" })
+            } else {
+                format!(
+                    "{count} task{} · {preview}",
+                    if count == 1 { "" } else { "s" }
+                )
+            })
+        }
+        "submit_result" => object
+            .get("output")
+            .map(compact_arguments)
+            .or_else(|| Some("structured result".to_owned())),
+        _ => None,
+    }
+}
+
 fn summarize_web_arguments(object: &serde_json::Map<String, Value>) -> Option<String> {
     for (operation, field) in [
         ("search_query", "q"),
@@ -3186,6 +3289,9 @@ fn running_cell_id(result: &Value) -> Option<String> {
 }
 
 fn summarize_tool_result(tool: Option<&str>, result: &Value, status: ToolStatus) -> String {
+    if let Some(summary) = summarize_task_result(tool, result, status) {
+        return summary;
+    }
     if tool == Some("exec_command") {
         let decoded = result
             .as_str()
@@ -3218,6 +3324,87 @@ fn summarize_tool_result(tool: Option<&str>, result: &Value, status: ToolStatus)
         return compact_arguments(result);
     }
     String::new()
+}
+
+fn summarize_task_result(tool: Option<&str>, result: &Value, status: ToolStatus) -> Option<String> {
+    let tool = tool?;
+    if !matches!(
+        tool,
+        "task" | "task_batch" | "task_continue" | "submit_result"
+    ) {
+        return None;
+    }
+    if matches!(status, ToolStatus::Failed | ToolStatus::Cancelled) {
+        return Some(compact_arguments(result));
+    }
+    let decoded = result
+        .as_str()
+        .and_then(|value| serde_json::from_str::<Value>(value).ok())
+        .unwrap_or_else(|| result.clone());
+    match tool {
+        "task" | "task_continue" => {
+            let object = decoded.as_object()?;
+            let task_id = object
+                .get("task_id")
+                .and_then(Value::as_str)
+                .map(compact_task_id);
+            let output = object.get("output").map(compact_arguments);
+            Some(
+                [task_id, output]
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>()
+                    .join(" · "),
+            )
+        }
+        "task_batch" => {
+            let outcomes = decoded.as_array()?;
+            let completed = outcomes
+                .iter()
+                .filter(|outcome| {
+                    outcome.get("status").and_then(Value::as_str) == Some("completed")
+                })
+                .count();
+            let failed = outcomes.len().saturating_sub(completed);
+            let mut summary = format!("{completed} completed");
+            if failed > 0 {
+                let _ = write!(summary, " · {failed} failed");
+            }
+            let outputs = outcomes
+                .iter()
+                .filter_map(|outcome| outcome.get("output"))
+                .map(compact_arguments)
+                .take(3)
+                .collect::<Vec<_>>();
+            if !outputs.is_empty() {
+                summary.push_str(" · ");
+                summary.push_str(&outputs.join(" · "));
+            }
+            let errors = outcomes
+                .iter()
+                .filter_map(|outcome| outcome.get("error").and_then(Value::as_str))
+                .map(compact_tool_text)
+                .take(2)
+                .collect::<Vec<_>>();
+            if !errors.is_empty() {
+                summary.push_str(" · error: ");
+                summary.push_str(&errors.join(" · "));
+            }
+            Some(compact_tool_text(&summary))
+        }
+        "submit_result" => Some("accepted".to_owned()),
+        _ => None,
+    }
+}
+
+fn compact_task_id(task_id: &str) -> String {
+    const PREFIX: usize = 13;
+    if task_id.chars().count() <= PREFIX {
+        return task_id.to_owned();
+    }
+    let mut compact = task_id.chars().take(PREFIX).collect::<String>();
+    compact.push('…');
+    compact
 }
 
 fn compact_arguments(arguments: &Value) -> String {
@@ -3287,7 +3474,7 @@ mod tests {
 
     use super::{
         App, EscapeAction, PaneId, SubmittedPrompt, present_tool_name, smooth_scroll_drain,
-        summarize_tool_arguments,
+        summarize_task_result, summarize_tool_arguments,
     };
     use crate::tui::transcript::TranscriptItem;
 
@@ -3512,6 +3699,68 @@ mod tests {
         assert!(!rendered.contains("call_read_tool"));
         assert!(!rendered.contains("_search_tools"));
         assert!(!rendered.contains("{\"query\""));
+    }
+
+    #[test]
+    fn recursive_tasks_present_instructions_and_structured_outcomes() {
+        let task = json!({
+            "instruction": "Check the proof independently.",
+            "context": { "claim": "P" },
+            "output_schema": { "type": "object" }
+        });
+        assert_eq!(present_tool_name("task", &task), "Task");
+        assert_eq!(
+            summarize_tool_arguments("task", &task),
+            "Check the proof independently."
+        );
+
+        let follow_up = json!({
+            "task_id": "task_019f9727-38c0-7d73-9db4",
+            "instruction": "Revise using the verifier feedback.",
+            "output_schema": { "type": "object" }
+        });
+        assert_eq!(
+            summarize_tool_arguments("task_continue", &follow_up),
+            "task_019f9727… · Revise using the verifier feedback."
+        );
+
+        let batch = json!({
+            "tasks": [
+                { "instruction": "Try algebra." },
+                { "instruction": "Try geometry." },
+                { "instruction": "Look for a counterexample." }
+            ],
+            "output_schema": { "type": "object" }
+        });
+        assert_eq!(present_tool_name("task_batch", &batch), "Task batch");
+        assert_eq!(
+            summarize_tool_arguments("task_batch", &batch),
+            "3 tasks · Try algebra. · Try geometry. · Look for a counterexample."
+        );
+
+        let outcomes = json!([
+            {
+                "status": "completed",
+                "task_id": "task_a",
+                "output": { "verdict": "valid" }
+            },
+            {
+                "status": "failed",
+                "task_id": "task_b",
+                "error": "missing submit_result"
+            }
+        ]);
+        assert_eq!(
+            summarize_task_result(
+                Some("task_batch"),
+                &outcomes,
+                crate::tui::transcript::ToolStatus::Completed
+            ),
+            Some(
+                "1 completed · 1 failed · {\"verdict\":\"valid\"} · error: missing submit_result"
+                    .to_owned()
+            )
+        );
     }
 
     #[test]

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -34,6 +34,7 @@ use nanocodex::{
     },
     tools::mcp::McpHandle,
 };
+use nanocodex_rlm::TaskRuntime;
 use nanocodex_voice::{
     CHATGPT_REALTIME_VOICES, PLATFORM_REALTIME_VOICES, RealtimeVoice, VoiceAgentControl,
     VoiceEvent, VoiceEvents, VoiceSession, VoiceSessionBuilder, VoiceSpeaker,
@@ -68,6 +69,10 @@ const DEFAULT_JAEGER_UI_URL: &str = "http://127.0.0.1:16686";
 const JAEGER_UI_URL_ENV: &str = "NANOCODEX_JAEGER_UI_URL";
 const MOUSE_SCROLL_ROWS: usize = 3;
 const MAX_AGENT_EVENTS_PER_BATCH: usize = 256;
+const TURBO_ENABLED_MARKER: &str =
+    "<nanocodex_turbo enabled=\"true\">Recursive task tools are available.</nanocodex_turbo>";
+const TURBO_DISABLED_MARKER: &str =
+    "<nanocodex_turbo enabled=\"false\">Recursive task tools are unavailable.</nanocodex_turbo>";
 
 enum WorkerCommand {
     Prompt {
@@ -106,6 +111,9 @@ enum WorkerCommand {
         id: u64,
     },
     SetFastMode {
+        enabled: bool,
+    },
+    SetTurboMode {
         enabled: bool,
     },
     SetThinking {
@@ -540,6 +548,7 @@ enum Submission {
     Cancel,
     Trace,
     Fast(Option<bool>),
+    Turbo(Option<bool>),
     ReasoningPicker,
     Voice(VoiceControl),
     McpLogin(String),
@@ -581,13 +590,17 @@ pub(crate) async fn run(
     let configured = if let Some(session) = resume {
         config.build_resumed(session, vm).await?
     } else {
-        config.build(vm).await?
+        config.build_for_tui(vm).await?
     };
     let agent = configured.handle;
     let mut agent_events = configured.events;
     let realtime = configured.realtime;
-    let root_session_id = Arc::<str>::from(agent_events.request_id());
     let child_agents = configured.child_agents;
+    let root_session_id = Arc::<str>::from(agent_events.request_id());
+    let task_runtime = configured
+        .task_runtime
+        .ok_or_else(|| eyre::eyre!("TUI task runtime was not configured"))?;
+    let initial_turbo_mode = task_runtime.is_enabled();
     let mpp_adapter = configured.mpp_adapter;
     let mcp = configured.mcp;
     let browser = configured.browser;
@@ -599,6 +612,7 @@ pub(crate) async fn run(
         Arc::clone(&root_session_id),
         realtime,
         mcp,
+        task_runtime.clone(),
         worker_rx,
         update_tx,
     );
@@ -624,7 +638,8 @@ pub(crate) async fn run(
     let mut app = App::new(cwd)
         .with_model(initial_model)
         .with_thinking(initial_thinking)
-        .with_fast_mode(initial_fast_mode);
+        .with_fast_mode(initial_fast_mode)
+        .with_turbo_mode(initial_turbo_mode);
     app.set_math_renderer(math_renderer.clone());
     app.restore_transcript(restored_transcript);
     let mut ui = UiModel::new(app, Arc::clone(&root_session_id));
@@ -723,7 +738,8 @@ pub(crate) async fn run(
     // Restore the terminal before disconnecting the paid WebSocket session.
     drop((terminal, worker_tx, agent_events));
     math_renderer.shutdown();
-    let shutdown_result = shutdown_runtime(worker, child_agents, mpp_adapter, browser, vm).await;
+    let shutdown_result =
+        shutdown_runtime(worker, child_agents, task_runtime, mpp_adapter, browser, vm).await;
     loop_result?;
     shutdown_result
 }
@@ -737,7 +753,8 @@ fn resolve_cwd(config: &AgentArgs) -> Result<PathBuf> {
 
 async fn shutdown_runtime(
     worker: tokio::task::JoinHandle<()>,
-    child_agents: Option<std::sync::Arc<crate::subagents::ChildAgents>>,
+    child_agents: Option<Arc<crate::subagents::ChildAgents>>,
+    task_runtime: TaskRuntime,
     mpp_adapter: Option<crate::mpp::MppAdapter>,
     browser: Option<crate::browser::ConfiguredBrowser>,
     vm: Option<crate::vm::ConfiguredVm>,
@@ -757,6 +774,7 @@ async fn shutdown_runtime(
     } else {
         Ok(())
     };
+    task_runtime.shutdown().await;
     let shutdown_result = if let Some(adapter) = mpp_adapter {
         adapter.shutdown().await
     } else {
@@ -992,7 +1010,8 @@ fn handle_worker_update(
             request_id,
         } => {
             if let Some(prompt) = app.main_branch_opened(id, parent_id, prompt_id, request_id) {
-                let prompt = SubmittedPrompt::text(prompt);
+                let mut prompt = SubmittedPrompt::text(prompt);
+                mark_turbo_mode(&mut prompt, app.turbo_mode());
                 let prompt_id = app
                     .queue_prompt(PaneId::Main, prompt.display().to_owned())
                     .ok_or_else(|| {
@@ -1077,6 +1096,7 @@ fn spawn_agent_worker(
     root_session_id: Arc<str>,
     realtime: Option<OpenAi>,
     mcp: Option<McpHandle>,
+    task_runtime: TaskRuntime,
     mut commands: mpsc::UnboundedReceiver<WorkerCommand>,
     updates: mpsc::UnboundedSender<WorkerEvent>,
 ) -> tokio::task::JoinHandle<()> {
@@ -1094,6 +1114,7 @@ fn spawn_agent_worker(
             archived_main: Vec::new(),
             next_turn_id: 1,
             btw: None,
+            task_runtime,
             finished: finished_tx,
             updates,
             mcp,
@@ -1152,6 +1173,7 @@ struct AgentWorker {
     archived_main: Vec<MainWorkerBranch>,
     next_turn_id: u64,
     btw: Option<BtwWorker>,
+    task_runtime: TaskRuntime,
     finished: mpsc::UnboundedSender<FinishedTurn>,
     updates: mpsc::UnboundedSender<WorkerEvent>,
     mcp: Option<McpHandle>,
@@ -1199,6 +1221,7 @@ impl AgentWorker {
             }
             WorkerCommand::SwitchMainBranch { id } => self.switch_main_branch(id),
             WorkerCommand::SetFastMode { enabled } => self.set_fast_mode(enabled).await,
+            WorkerCommand::SetTurboMode { enabled } => self.task_runtime.set_enabled(enabled),
             WorkerCommand::SetThinking { thinking } => self.set_thinking(thinking).await,
             WorkerCommand::McpLogin { name } => self.mcp_login(name),
             WorkerCommand::McpReload { name } => self.mcp_reload(name),
@@ -2613,6 +2636,8 @@ fn submit(
     };
     match classify_submission(input) {
         Submission::Prompt(prompt) => {
+            let mut prompt = prompt;
+            mark_turbo_mode(&mut prompt, app.turbo_mode());
             let target = app.focus;
             if matches!(intent, SubmitIntent::Immediate) && app.is_running(target) {
                 if let Some(id) = app.queue_steer(target, prompt.clone()) {
@@ -2630,6 +2655,10 @@ fn submit(
             }
         }
         Submission::Btw(prompt) => {
+            let prompt = prompt.map(|mut prompt| {
+                mark_turbo_mode(&mut prompt, app.turbo_mode());
+                prompt
+            });
             if let Some(id) = app.btw_id() {
                 app.focus_btw();
                 if let Some(prompt) = prompt {
@@ -2688,6 +2717,15 @@ fn submit(
         Submission::Fast(enabled) => {
             let enabled = enabled.unwrap_or(!app.fast_mode());
             send_command(commands, WorkerCommand::SetFastMode { enabled })?;
+        }
+        Submission::Turbo(enabled) => {
+            if app.has_pending_agent_work() {
+                app.push_active_error("Finish active and queued turns before changing turbo mode");
+            } else {
+                let enabled = enabled.unwrap_or(!app.turbo_mode());
+                app.turbo_mode_changed(enabled);
+                send_command(commands, WorkerCommand::SetTurboMode { enabled })?;
+            }
         }
         Submission::ReasoningPicker => app.open_reasoning_picker(),
         Submission::Voice(control) => {
@@ -2757,6 +2795,16 @@ fn classify_submission(input: impl Into<SubmittedPrompt>) -> Submission {
     if trimmed == "/fast" {
         return Submission::Fast(None);
     }
+    if trimmed == "/turbo" {
+        return Submission::Turbo(None);
+    }
+    if let Some(argument) = trimmed.strip_prefix("/turbo ") {
+        return match argument.trim() {
+            "on" => Submission::Turbo(Some(true)),
+            "off" => Submission::Turbo(Some(false)),
+            _ => Submission::InvalidCommand("Usage: /turbo [on|off]".to_owned()),
+        };
+    }
     if let Some(argument) = trimmed.strip_prefix("/fast ") {
         return match argument.trim() {
             "on" => Submission::Fast(Some(true)),
@@ -2792,6 +2840,17 @@ fn classify_submission(input: impl Into<SubmittedPrompt>) -> Submission {
         );
     }
     Submission::Prompt(input)
+}
+
+fn mark_turbo_mode(prompt: &mut SubmittedPrompt, enabled: bool) {
+    prompt.set_model_prefix(
+        if enabled {
+            TURBO_ENABLED_MARKER
+        } else {
+            TURBO_DISABLED_MARKER
+        }
+        .to_owned(),
+    );
 }
 
 fn active_session_id<'a>(app: &'a App, root_session_id: &'a str) -> Option<&'a str> {
@@ -2867,8 +2926,11 @@ mod tests {
     use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent, MouseEventKind};
     use futures_util::{SinkExt, StreamExt};
     use nanocodex::{
-        Nanocodex, OpenAi, Thinking, agent::events::AgentEventKind, oai::__private::EventSink,
+        Nanocodex, OpenAi, Thinking,
+        agent::{events::AgentEventKind, input::PromptInput},
+        oai::__private::EventSink,
     };
+    use nanocodex_rlm::TaskRuntime;
     use nanocodex_voice::RealtimeVoice;
     use serde_json::{Value, json};
     use tokio::{net::TcpListener, sync::mpsc, time::timeout};
@@ -2878,8 +2940,8 @@ mod tests {
         BTW_BOUNDARY, PaneId, RedrawPriority, Submission, TerminalAction, UiAction, UiModel,
         UiUpdate, VoiceControl, WorkerCommand, WorkerEvent, active_session_id,
         apply_main_agent_event_batch, classify_submission, handle_key, handle_worker_update,
-        paste_clipboard_image, prepare_btw_prompt, report_cancel_outcome, session_trace_url,
-        spawn_agent_worker,
+        mark_turbo_mode, paste_clipboard_image, prepare_btw_prompt, report_cancel_outcome,
+        session_trace_url, spawn_agent_worker,
     };
     use crate::tui::{
         app::App,
@@ -2953,6 +3015,19 @@ mod tests {
             classify_submission("/fast turbo"),
             Submission::InvalidCommand("Usage: /fast [on|off]".to_owned())
         );
+        assert_eq!(classify_submission("/turbo"), Submission::Turbo(None));
+        assert_eq!(
+            classify_submission(" /turbo on "),
+            Submission::Turbo(Some(true))
+        );
+        assert_eq!(
+            classify_submission("/turbo off"),
+            Submission::Turbo(Some(false))
+        );
+        assert_eq!(
+            classify_submission("/turbo maybe"),
+            Submission::InvalidCommand("Usage: /turbo [on|off]".to_owned())
+        );
         assert_eq!(classify_submission("/model"), Submission::ReasoningPicker);
         assert_eq!(
             classify_submission(" /thinking "),
@@ -2992,6 +3067,19 @@ mod tests {
             classify_submission("/modeling"),
             Submission::Prompt("/modeling".into())
         );
+    }
+
+    #[test]
+    fn turbo_mode_marker_is_model_visible_but_not_displayed() {
+        let mut prompt = crate::tui::app::SubmittedPrompt::text("inspect the crate".to_owned());
+        mark_turbo_mode(&mut prompt, true);
+        assert_eq!(prompt.display(), "inspect the crate");
+        let prompt = prompt.into_prompt();
+        let PromptInput::Text(input) = prompt.instruction else {
+            panic!("text-only submission should remain a text prompt");
+        };
+        assert!(input.contains("<nanocodex_turbo enabled=\"true\">"));
+        assert!(input.ends_with("inspect the crate"));
     }
 
     #[test]
@@ -3371,6 +3459,7 @@ mod tests {
             Arc::from(session_id.to_string()),
             None,
             None,
+            TaskRuntime::new(),
             worker_rx,
             updates,
         );
@@ -3467,6 +3556,7 @@ mod tests {
             std::sync::Arc::from(session_id.to_string()),
             None,
             None,
+            TaskRuntime::new(),
             worker_rx,
             updates,
         );
@@ -3586,6 +3676,7 @@ mod tests {
             std::sync::Arc::from(session_id.to_string()),
             None,
             None,
+            TaskRuntime::new(),
             worker_rx,
             updates,
         );

--- a/bin/nanocodex/src/tui/transcript.rs
+++ b/bin/nanocodex/src/tui/transcript.rs
@@ -1589,17 +1589,23 @@ fn child_lines(
 ) -> Vec<Line<'static>> {
     let (icon, color) = tool_style(child.status);
     let argument_lines = child.arguments.lines().collect::<Vec<_>>();
+    let structured_task = matches!(
+        child.name.as_str(),
+        "Task" | "Task batch" | "Task follow-up" | "Submit result"
+    );
     let detail_style = Style::default().fg(Color::DarkGray);
     let mut detail = Vec::new();
     if let Some(patch) = &child.patch {
         push_styled_detail(&mut detail, patch.summary.clone(), detail_style);
-    } else if argument_lines.len() <= 1 {
+    } else if !structured_task && argument_lines.len() <= 1 {
         push_styled_detail(&mut detail, child.arguments.clone(), detail_style);
     }
     if let Some(duration_ns) = child.duration_ns {
         push_styled_detail(&mut detail, format_duration(duration_ns), detail_style);
     }
-    if let Some(result) = child.result.as_deref().filter(|result| !result.is_empty()) {
+    if !structured_task
+        && let Some(result) = child.result.as_deref().filter(|result| !result.is_empty())
+    {
         push_styled_detail(&mut detail, result.to_owned(), detail_style);
     }
     let child_name = match (child.name.as_str(), child.status) {
@@ -1616,7 +1622,24 @@ fn child_lines(
         header.extend(detail);
     }
     let mut lines = vec![Line::from(header)];
-    if let Some(patch) = &child.patch {
+    if structured_task {
+        lines.extend(prefixed_activity_detail(
+            &child.arguments,
+            continuation,
+            "  ",
+            width,
+            Style::default().fg(Color::Gray),
+        ));
+        if let Some(result) = child.result.as_deref().filter(|result| !result.is_empty()) {
+            lines.extend(prefixed_activity_detail(
+                result,
+                continuation,
+                "  → ",
+                width,
+                Style::default().fg(color),
+            ));
+        }
+    } else if let Some(patch) = &child.patch {
         let prefix_width = u16::try_from(continuation.len()).unwrap_or(u16::MAX);
         let patch_lines = patch.lines(width.saturating_sub(prefix_width));
         lines.extend(prefixed_patch_lines(&patch_lines[1..], continuation));
@@ -1629,6 +1652,43 @@ fn child_lines(
         }
     }
     lines
+}
+
+fn prefixed_activity_detail(
+    detail: &str,
+    prefix: &'static str,
+    marker: &'static str,
+    width: u16,
+    style: Style,
+) -> Vec<Line<'static>> {
+    if detail.is_empty() {
+        return Vec::new();
+    }
+    let prefix_width = UnicodeWidthStr::width(prefix);
+    let marker_width = UnicodeWidthStr::width(marker);
+    let content_width = width
+        .saturating_sub(
+            u16::try_from(prefix_width.saturating_add(marker_width)).unwrap_or(u16::MAX),
+        )
+        .max(1);
+    wrap_line(detail, content_width)
+        .into_iter()
+        .enumerate()
+        .map(|(index, row)| {
+            Line::from(vec![
+                Span::styled(prefix, Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    if index == 0 {
+                        marker.to_owned()
+                    } else {
+                        " ".repeat(marker_width)
+                    },
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(row, style),
+            ])
+        })
+        .collect()
 }
 
 fn child_activity_groups(children: &[ToolActivity]) -> Vec<std::ops::Range<usize>> {
@@ -3486,6 +3546,66 @@ R_{\mu\nu}-\frac12R\,g_{\mu\nu}+\Lambda g_{\mu\nu}
         assert!(rendered.contains("--workspace"));
         assert!(rendered.contains("│ └ ✓ apply_patch  src/main.rs · 80ms · applied"));
         assert!(rendered.contains("└── ✓ Ran  jq -s add /tmp/parts/*.json"));
+    }
+
+    #[test]
+    fn turbo_tasks_render_as_first_class_code_mode_activity() {
+        let mut transcript = Transcript::default();
+        transcript.push(TranscriptItem::Tool {
+            call_id: "exec-turbo".to_owned(),
+            name: "exec".to_owned(),
+            arguments: "delegate and verify".to_owned(),
+            status: ToolStatus::Running,
+        });
+        assert!(transcript.push_tool_child(
+            "exec-turbo/code-1".to_owned(),
+            "Task".to_owned(),
+            "Check the proof independently.".to_owned(),
+            ToolStatus::Running,
+        ));
+        assert!(transcript.push_tool_child(
+            "exec-turbo/code-2".to_owned(),
+            "Task batch".to_owned(),
+            "3 tasks · Try algebra. · Try geometry. · Try a counterexample.".to_owned(),
+            ToolStatus::Running,
+        ));
+        assert!(transcript.set_tool_result_timing(
+            "exec-turbo/code-1",
+            ToolStatus::Completed,
+            Some(1_000_000),
+            Some(80_000_000),
+            Some("task_019f972… · {\"verdict\":\"valid\"}".to_owned()),
+        ));
+        assert!(transcript.set_tool_result_timing(
+            "exec-turbo/code-2",
+            ToolStatus::Completed,
+            Some(2_000_000),
+            Some(100_000_000),
+            Some(
+                "2 completed · 1 failed · {\"idea\":\"algebra\"} · error: no submission".to_owned(),
+            ),
+        ));
+
+        let mut terminal = Terminal::new(TestBackend::new(110, 10)).unwrap();
+        terminal
+            .draw(|frame| {
+                frame.render_widget(transcript.widget(0, None, None, "empty"), frame.area());
+            })
+            .unwrap();
+        let rendered = terminal.backend().to_string();
+        assert!(rendered.contains("✓ Task  80ms"));
+        assert!(rendered.contains("Check the proof independently."));
+        assert!(rendered.contains("task_019f972… · {\"verdict\":\"valid\"}"));
+        assert!(rendered.contains("✓ Task batch  100ms"));
+        assert!(rendered.contains("3 tasks · Try algebra."));
+        assert!(
+            rendered.contains("2 completed · 1 failed"),
+            "batch outcome was not visible:\n{rendered}"
+        );
+        assert!(
+            rendered.contains("error: no submission"),
+            "batch failure was not visible:\n{rendered}"
+        );
     }
 
     #[test]

--- a/bin/nanocodex/src/tui/view.rs
+++ b/bin/nanocodex/src/tui/view.rs
@@ -561,10 +561,15 @@ fn render_footer(frame: &mut Frame<'_>, app: &App, area: Rect) {
         )
     } else {
         format!(
-            "  /btw <question> side fork · /voice [voice] · {tool_help} · Ctrl+V image · Enter send/steer · Tab queue · {escape_help} · Ctrl+C quit"
+            "  /turbo · /btw <question> side fork · /voice [voice] · {tool_help} · Ctrl+V image · Enter send/steer · Tab queue · {escape_help} · Ctrl+C quit"
         )
     };
-    let model_width = app.model().as_str().len() + 3 + "default".len() + 7 + 1;
+    let model_width = app.model().as_str().len()
+        + 3
+        + "default".len()
+        + 7
+        + usize::from(app.turbo_mode()) * " · turbo".len()
+        + 1;
     let model_width = saturating_u16(model_width).min(area.width);
     let [left, right] =
         Layout::horizontal([Constraint::Min(0), Constraint::Length(model_width)]).areas(area);
@@ -578,6 +583,14 @@ fn render_footer(frame: &mut Frame<'_>, app: &App, area: Rect) {
         ])),
         left,
     );
+    let model = footer_model(app);
+    frame.render_widget(
+        Paragraph::new(Line::from(model)).alignment(Alignment::Right),
+        right,
+    );
+}
+
+fn footer_model(app: &App) -> Vec<Span<'static>> {
     let mut model = vec![Span::styled(
         app.model().as_str(),
         Style::default().fg(Color::Cyan),
@@ -597,11 +610,14 @@ fn render_footer(frame: &mut Frame<'_>, app: &App, area: Rect) {
             Style::default().fg(Color::LightYellow),
         ));
     }
+    if app.turbo_mode() {
+        model.push(Span::styled(
+            " · turbo",
+            Style::default().fg(Color::LightMagenta),
+        ));
+    }
     model.push(Span::raw(" "));
-    frame.render_widget(
-        Paragraph::new(Line::from(model)).alignment(Alignment::Right),
-        right,
-    );
+    model
 }
 
 fn footer_queue(steers: usize, queued: usize) -> String {
@@ -840,17 +856,18 @@ mod tests {
     }
 
     #[test]
-    fn footer_keeps_model_on_the_bottom_right_and_marks_fast_mode() {
+    fn footer_keeps_model_on_the_bottom_right_and_marks_runtime_modes() {
         let mut terminal = Terminal::new(TestBackend::new(80, 16)).unwrap();
         let mut app = App::new("/workspace".into());
         app.fast_mode_changed(true);
+        app.turbo_mode_changed(true);
 
         terminal.draw(|frame| render(frame, &mut app)).unwrap();
         let footer = terminal.backend().buffer().content[15 * 80..16 * 80]
             .iter()
             .map(ratatui::buffer::Cell::symbol)
             .collect::<String>();
-        assert!(footer.ends_with("gpt-5.6-sol · high · fast "));
+        assert!(footer.ends_with("gpt-5.6-sol · high · fast · turbo "));
     }
 
     #[test]
@@ -1379,7 +1396,7 @@ mod tests {
                 "\"┌ Message → Main ──────────────────────────────┐\"\n",
                 "\"│                                              │\"\n",
                 "\"└──────────────────────────────────────────────┘\"\n",
-                "\" Ready  /btw <quest          gpt-5.6-sol · high \"\n",
+                "\" Ready  /turbo · /           gpt-5.6-sol · high \"\n",
             )
         );
     }

--- a/crates/nanocodex-rlm/Cargo.toml
+++ b/crates/nanocodex-rlm/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "nanocodex-rlm"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Recursive structured task tools for Nanocodex Code Mode"
+
+[dependencies]
+futures-util.workspace = true
+jsonschema.workspace = true
+nanocodex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "rt", "sync"] }
+uuid.workspace = true
+
+[dev-dependencies]
+eyre.workspace = true
+tokio = { workspace = true, features = ["net", "time"] }
+tokio-tungstenite.workspace = true
+
+[lints]
+workspace = true

--- a/crates/nanocodex-rlm/src/lib.rs
+++ b/crates/nanocodex-rlm/src/lib.rs
@@ -1,0 +1,905 @@
+//! Recursive, structured child-task tools for Nanocodex Code Mode.
+//!
+//! The crate is intentionally a thin consumer of Nanocodex's public agent and
+//! tool APIs. Retain a [`TaskRuntime`] for as long as installed tools should
+//! remain usable, and capture the weak [`TaskTools`] value in the agent's tools
+//! factory so clean children receive fresh agent-relative handlers.
+
+use std::{
+    collections::HashMap,
+    io,
+    sync::{
+        Arc, Mutex as StdMutex, Weak,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+
+use futures_util::future::join_all;
+use jsonschema::Validator;
+use nanocodex::{
+    AgentEvents, Nanocodex, Tool, Tools,
+    agent::{AgentHandle, TurnControl},
+    tools::{
+        ToolContext, ToolDefinition, ToolInput, ToolOutput, ToolResult, ToolsBuildError,
+        contract::{ToolError, async_trait},
+    },
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio::{
+    sync::{Mutex, Semaphore},
+    task::JoinHandle,
+};
+use uuid::Uuid;
+
+const MAX_DEPTH: usize = 4;
+const MAX_BATCH_SIZE: usize = 16;
+const MAX_ACTIVE_TASKS: usize = 64;
+
+/// Owning lifecycle for one family of retained recursive task tools.
+#[derive(Clone)]
+pub struct TaskRuntime {
+    state: Arc<TaskState>,
+}
+
+impl Default for TaskRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TaskRuntime {
+    /// Creates an enabled task runtime with conservative fixed bounds.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(TaskState {
+                enabled: AtomicBool::new(true),
+                active: Arc::new(Semaphore::new(MAX_ACTIVE_TASKS)),
+                registry: Mutex::new(Registry::default()),
+            }),
+        }
+    }
+
+    /// Returns weak, cycle-free tool installation state for a tools factory.
+    #[must_use]
+    pub fn tools(&self) -> TaskTools {
+        TaskTools {
+            state: Arc::downgrade(&self.state),
+        }
+    }
+
+    /// Enables or disables new task, batch, and continuation calls.
+    ///
+    /// A task already accepted continues to completion so it can submit its
+    /// structured result and commit a safe child transcript boundary.
+    pub fn set_enabled(&self, enabled: bool) {
+        self.state.enabled.store(enabled, Ordering::Release);
+    }
+
+    /// Reports whether new recursive task calls are enabled.
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        self.state.enabled.load(Ordering::Acquire)
+    }
+
+    /// Drops all retained children and waits for their event drains to stop.
+    pub async fn shutdown(&self) {
+        self.set_enabled(false);
+        let sessions = {
+            let mut registry = self.state.registry.lock().await;
+            registry.depths.clear();
+            registry.pending.clear();
+            std::mem::take(&mut registry.tasks)
+        };
+        let mut event_tasks = Vec::with_capacity(sessions.len());
+        for session in sessions.values() {
+            if let Ok(mut event_task) = session.event_task.lock()
+                && let Some(event_task) = event_task.take()
+            {
+                event_tasks.push(event_task);
+            }
+        }
+        drop(sessions);
+        for event_task in event_tasks {
+            let _ = event_task.await;
+        }
+    }
+}
+
+/// Weak task-tool installer intended to be captured by `tools_factory`.
+#[derive(Clone)]
+pub struct TaskTools {
+    state: Weak<TaskState>,
+}
+
+impl TaskTools {
+    /// Adds `task`, `task_batch`, `task_continue`, and `submit_result` to a
+    /// per-agent tool collection.
+    ///
+    /// # Errors
+    ///
+    /// Returns the normal tool-registry validation errors.
+    pub fn install(&self, tools: Tools, agent: AgentHandle) -> Result<Tools, ToolsBuildError> {
+        tools
+            .into_builder()
+            .tool(TaskTool {
+                agent: agent.clone(),
+                state: self.state.clone(),
+            })
+            .tool(TaskBatchTool {
+                agent,
+                state: self.state.clone(),
+            })
+            .tool(TaskContinueTool {
+                state: self.state.clone(),
+            })
+            .tool(SubmitResultTool {
+                state: self.state.clone(),
+            })
+            .build()
+    }
+}
+
+struct TaskState {
+    enabled: AtomicBool,
+    active: Arc<Semaphore>,
+    registry: Mutex<Registry>,
+}
+
+#[derive(Default)]
+struct Registry {
+    tasks: HashMap<Box<str>, Arc<ChildSession>>,
+    depths: HashMap<Box<str>, usize>,
+    pending: HashMap<Box<str>, PendingSubmission>,
+}
+
+struct ChildSession {
+    agent: Nanocodex,
+    turn: Mutex<()>,
+    event_task: StdMutex<Option<JoinHandle<()>>>,
+}
+
+struct PendingSubmission {
+    token: Uuid,
+    validator: Validator,
+    output: Option<Value>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TaskArgs {
+    instruction: String,
+    #[serde(default)]
+    context: Option<Value>,
+    output_schema: Value,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BatchTaskArgs {
+    instruction: String,
+    #[serde(default)]
+    context: Option<Value>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TaskBatchArgs {
+    tasks: Vec<BatchTaskArgs>,
+    output_schema: Value,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TaskContinueArgs {
+    task_id: Box<str>,
+    instruction: String,
+    #[serde(default)]
+    context: Option<Value>,
+    output_schema: Value,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SubmitResultArgs {
+    output: Value,
+}
+
+#[derive(Serialize)]
+struct TaskSuccess {
+    task_id: Box<str>,
+    output: Value,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum BatchTaskResult {
+    Completed { task_id: Box<str>, output: Value },
+    Failed { task_id: Box<str>, error: String },
+}
+
+#[derive(Clone, Copy)]
+enum FailureRetention {
+    Drop,
+    Retain,
+}
+
+struct TaskTool {
+    agent: AgentHandle,
+    state: Weak<TaskState>,
+}
+
+struct TaskBatchTool {
+    agent: AgentHandle,
+    state: Weak<TaskState>,
+}
+
+struct TaskContinueTool {
+    state: Weak<TaskState>,
+}
+
+struct SubmitResultTool {
+    state: Weak<TaskState>,
+}
+
+#[async_trait]
+impl Tool for TaskTool {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::function(
+            "task",
+            "Runs one isolated clean-room child task and returns exactly one runtime-schema-validated result. The child receives only the instruction and explicitly supplied context.",
+            task_parameters(),
+        )
+        .with_output_schema(task_success_schema())
+    }
+
+    async fn execute(&self, input: ToolInput, context: ToolContext<'_>) -> ToolResult {
+        let args: TaskArgs = input.decode_json()?;
+        let state = upgrade(&self.state)?;
+        ensure_enabled(&state)?;
+        validate_instruction(&args.instruction)?;
+        let task_id = new_task_id();
+        let result = run_new_task(
+            Arc::clone(&state),
+            &self.agent,
+            context.session_id(),
+            task_id.clone(),
+            args,
+            None,
+            FailureRetention::Drop,
+        )
+        .await?;
+        Ok(ToolOutput::json(&TaskSuccess {
+            task_id,
+            output: result,
+        }))
+    }
+}
+
+#[async_trait]
+impl Tool for TaskBatchTool {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::function(
+            "task_batch",
+            "Runs a bounded batch of isolated clean-room child tasks concurrently. All tasks share the runtime output schema; results stay in input order and individual failures do not discard successful siblings.",
+            task_batch_parameters(),
+        )
+        .with_output_schema(task_batch_output_schema())
+    }
+
+    async fn execute(&self, input: ToolInput, context: ToolContext<'_>) -> ToolResult {
+        let args: TaskBatchArgs = input.decode_json()?;
+        let state = upgrade(&self.state)?;
+        ensure_enabled(&state)?;
+        if args.tasks.is_empty() {
+            return Err(tool_error("task_batch requires at least one task"));
+        }
+        if args.tasks.len() > MAX_BATCH_SIZE {
+            return Err(tool_error(format!(
+                "task_batch accepts at most {MAX_BATCH_SIZE} tasks"
+            )));
+        }
+        for task in &args.tasks {
+            validate_instruction(&task.instruction)?;
+        }
+        let validator = Arc::new(compile_schema(&args.output_schema)?);
+
+        let schema = Arc::new(args.output_schema);
+        let parent_session_id = Arc::<str>::from(context.session_id());
+        let futures = args.tasks.into_iter().map(|task| {
+            let state = Arc::clone(&state);
+            let agent = self.agent.clone();
+            let schema = Arc::clone(&schema);
+            let validator = Arc::clone(&validator);
+            let parent_session_id = Arc::clone(&parent_session_id);
+            async move {
+                let task_id = new_task_id();
+                let args = TaskArgs {
+                    instruction: task.instruction,
+                    context: task.context,
+                    output_schema: (*schema).clone(),
+                };
+                match run_new_task(
+                    state,
+                    &agent,
+                    &parent_session_id,
+                    task_id.clone(),
+                    args,
+                    Some((*validator).clone()),
+                    FailureRetention::Retain,
+                )
+                .await
+                {
+                    Ok(output) => BatchTaskResult::Completed { task_id, output },
+                    Err(error) => BatchTaskResult::Failed {
+                        task_id,
+                        error: error.to_string(),
+                    },
+                }
+            }
+        });
+        let results = join_all(futures).await;
+        Ok(ToolOutput::json(&results))
+    }
+}
+
+#[async_trait]
+impl Tool for TaskContinueTool {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::function(
+            "task_continue",
+            "Runs a follow-up turn on one retained child task. Only that child's prior conversation is preserved; optional new context remains explicit.",
+            task_continue_parameters(),
+        )
+        .with_output_schema(task_success_schema())
+    }
+
+    async fn execute(&self, input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
+        let args: TaskContinueArgs = input.decode_json()?;
+        let state = upgrade(&self.state)?;
+        ensure_enabled(&state)?;
+        validate_instruction(&args.instruction)?;
+        let validator = compile_schema(&args.output_schema)?;
+        let _active = Arc::clone(&state.active)
+            .try_acquire_owned()
+            .map_err(|_| tool_error("task concurrency limit reached"))?;
+        let child = {
+            let registry = state.registry.lock().await;
+            registry.tasks.get(&args.task_id).cloned()
+        }
+        .ok_or_else(|| tool_error(format!("unknown task_id {}", args.task_id)))?;
+        let _turn = child.turn.lock().await;
+        let output = run_child_turn(
+            &state,
+            &child.agent,
+            &args.instruction,
+            args.context.as_ref(),
+            &args.output_schema,
+            validator,
+        )
+        .await?;
+        Ok(ToolOutput::json(&TaskSuccess {
+            task_id: args.task_id,
+            output,
+        }))
+    }
+}
+
+#[async_trait]
+impl Tool for SubmitResultTool {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::function(
+            "submit_result",
+            "Returns the current child task's final structured output. This is task-internal plumbing: call it exactly once with an output matching the runtime schema in the task prompt.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "output": {
+                        "description": "The final JSON value required by the current task's runtime output schema."
+                    }
+                },
+                "required": ["output"],
+                "additionalProperties": false
+            }),
+        )
+        .with_output_schema(json!({
+            "type": "object",
+            "properties": {
+                "accepted": { "type": "boolean", "const": true }
+            },
+            "required": ["accepted"],
+            "additionalProperties": false
+        }))
+    }
+
+    async fn execute(&self, input: ToolInput, context: ToolContext<'_>) -> ToolResult {
+        let SubmitResultArgs { output } = input.decode_json()?;
+        let state = upgrade(&self.state)?;
+        state.submit(context.session_id(), output).await?;
+        Ok(ToolOutput::from_json(json!({ "accepted": true }), true))
+    }
+}
+
+async fn run_new_task(
+    state: Arc<TaskState>,
+    agent: &AgentHandle,
+    parent_session_id: &str,
+    task_id: Box<str>,
+    args: TaskArgs,
+    validator: Option<Validator>,
+    failure_retention: FailureRetention,
+) -> Result<Value, ToolError> {
+    ensure_enabled(&state)?;
+    let validator = match validator {
+        Some(validator) => validator,
+        None => compile_schema(&args.output_schema)?,
+    };
+    let depth = {
+        let registry = state.registry.lock().await;
+        registry.depths.get(parent_session_id).copied().unwrap_or(0)
+    };
+    if depth >= MAX_DEPTH {
+        return Err(tool_error(format!(
+            "task recursion depth limit {MAX_DEPTH} reached"
+        )));
+    }
+    let _active = Arc::clone(&state.active)
+        .try_acquire_owned()
+        .map_err(|_| tool_error("task concurrency limit reached"))?;
+    let (child, events) = agent.spawn().await?;
+    let child_session_id = child.session_id().to_string().into_boxed_str();
+    let event_task = drain_events(events);
+    let session = Arc::new(ChildSession {
+        agent: child,
+        turn: Mutex::new(()),
+        event_task: StdMutex::new(Some(event_task)),
+    });
+    {
+        let mut registry = state.registry.lock().await;
+        registry
+            .depths
+            .insert(child_session_id.clone(), depth.saturating_add(1));
+        registry.tasks.insert(task_id.clone(), Arc::clone(&session));
+    }
+    let mut task_guard = NewTaskGuard::new(Arc::downgrade(&state), task_id, child_session_id);
+    let _turn = session.turn.lock().await;
+    let result = run_child_turn(
+        &state,
+        &session.agent,
+        &args.instruction,
+        args.context.as_ref(),
+        &args.output_schema,
+        validator,
+    )
+    .await;
+    if result.is_ok() || matches!(failure_retention, FailureRetention::Retain) {
+        task_guard.disarm();
+    }
+    result
+}
+
+async fn run_child_turn(
+    state: &Arc<TaskState>,
+    child: &Nanocodex,
+    instruction: &str,
+    context: Option<&Value>,
+    output_schema: &Value,
+    validator: Validator,
+) -> Result<Value, ToolError> {
+    let session_id = child.session_id().to_string().into_boxed_str();
+    let token = Uuid::now_v7();
+    {
+        let mut registry = state.registry.lock().await;
+        if registry.pending.contains_key(&session_id) {
+            return Err(tool_error("child already has a pending structured task"));
+        }
+        registry.pending.insert(
+            session_id.clone(),
+            PendingSubmission {
+                token,
+                validator,
+                output: None,
+            },
+        );
+    }
+    let mut guard = TaskTurnGuard::new(Arc::downgrade(state), session_id.clone(), token);
+    let prompt = task_prompt(instruction, context, output_schema)?;
+    let turn = child.prompt(prompt).await?;
+    guard.control = Some(turn.control());
+    let result = turn.result().await;
+    guard.disarm();
+    let submitted = state.take_submission(&session_id, token).await;
+    result?;
+    submitted.ok_or_else(|| {
+        tool_error("child task ended without one valid submit_result({ output }) call")
+    })
+}
+
+impl TaskState {
+    async fn submit(&self, session_id: &str, output: Value) -> Result<(), ToolError> {
+        let mut registry = self.registry.lock().await;
+        let pending = registry
+            .pending
+            .get_mut(session_id)
+            .ok_or_else(|| tool_error("submit_result is only available during a child task"))?;
+        if pending.output.is_some() {
+            return Err(tool_error(
+                "submit_result already accepted one result for this task",
+            ));
+        }
+        let errors = pending
+            .validator
+            .iter_errors(&output)
+            .take(4)
+            .map(|error| error.to_string())
+            .collect::<Vec<_>>();
+        if !errors.is_empty() {
+            return Err(tool_error(format!(
+                "submitted output does not match the required schema: {}",
+                errors.join("; ")
+            )));
+        }
+        pending.output = Some(output);
+        Ok(())
+    }
+
+    async fn take_submission(&self, session_id: &str, token: Uuid) -> Option<Value> {
+        let mut registry = self.registry.lock().await;
+        let matches = registry
+            .pending
+            .get(session_id)
+            .is_some_and(|pending| pending.token == token);
+        if !matches {
+            return None;
+        }
+        registry
+            .pending
+            .remove(session_id)
+            .and_then(|pending| pending.output)
+    }
+
+    async fn clear_submission(&self, session_id: &str, token: Uuid) {
+        let mut registry = self.registry.lock().await;
+        if registry
+            .pending
+            .get(session_id)
+            .is_some_and(|pending| pending.token == token)
+        {
+            registry.pending.remove(session_id);
+        }
+    }
+
+    async fn remove_task(&self, task_id: &str, session_id: &str) {
+        let mut registry = self.registry.lock().await;
+        registry.tasks.remove(task_id);
+        registry.depths.remove(session_id);
+        registry.pending.remove(session_id);
+    }
+}
+
+struct NewTaskGuard {
+    state: Weak<TaskState>,
+    task_id: Box<str>,
+    session_id: Box<str>,
+    armed: bool,
+}
+
+impl NewTaskGuard {
+    const fn new(state: Weak<TaskState>, task_id: Box<str>, session_id: Box<str>) -> Self {
+        Self {
+            state,
+            task_id,
+            session_id,
+            armed: true,
+        }
+    }
+
+    const fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for NewTaskGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let state = self.state.clone();
+        let task_id = self.task_id.clone();
+        let session_id = self.session_id.clone();
+        tokio::spawn(async move {
+            if let Some(state) = state.upgrade() {
+                state.remove_task(&task_id, &session_id).await;
+            }
+        });
+    }
+}
+
+struct TaskTurnGuard {
+    state: Weak<TaskState>,
+    session_id: Box<str>,
+    token: Uuid,
+    control: Option<TurnControl>,
+    armed: bool,
+}
+
+impl TaskTurnGuard {
+    const fn new(state: Weak<TaskState>, session_id: Box<str>, token: Uuid) -> Self {
+        Self {
+            state,
+            session_id,
+            token,
+            control: None,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+        self.control = None;
+    }
+}
+
+impl Drop for TaskTurnGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let state = self.state.clone();
+        let session_id = self.session_id.clone();
+        let token = self.token;
+        let control = self.control.take();
+        tokio::spawn(async move {
+            if let Some(control) = control {
+                let _ = control.cancel().await;
+            }
+            if let Some(state) = state.upgrade() {
+                state.clear_submission(&session_id, token).await;
+            }
+        });
+    }
+}
+
+fn drain_events(mut events: AgentEvents) -> JoinHandle<()> {
+    tokio::spawn(async move { while events.recv().await.is_some() {} })
+}
+
+fn compile_schema(schema: &Value) -> Result<Validator, ToolError> {
+    jsonschema::validator_for(schema)
+        .map_err(|error| tool_error(format!("invalid output_schema: {error}")))
+}
+
+fn task_prompt(
+    instruction: &str,
+    context: Option<&Value>,
+    output_schema: &Value,
+) -> Result<String, ToolError> {
+    let context = serde_json::to_string_pretty(&context.unwrap_or(&Value::Null))?;
+    let schema = serde_json::to_string_pretty(output_schema)?;
+    Ok(format!(
+        "Work as an isolated child agent. You have no inherited parent transcript. Use only the \
+         task instruction, the explicit context below, your own conversation, and normally \
+         available workspace/tools.\n\nYour contractual result is not prose. Before finishing, \
+         use Code Mode to call `await tools.submit_result({{ output: ... }})` exactly once with a \
+         JSON value matching the output schema. If validation rejects it, correct the value and \
+         retry. After a result is accepted, finish the turn concisely.\n\n\
+         <task_instruction>\n{instruction}\n</task_instruction>\n\n\
+         <explicit_context>\n{context}\n</explicit_context>\n\n\
+         <output_schema>\n{schema}\n</output_schema>"
+    ))
+}
+
+fn validate_instruction(instruction: &str) -> Result<(), ToolError> {
+    if instruction.trim().is_empty() {
+        return Err(tool_error("task instruction must not be empty"));
+    }
+    Ok(())
+}
+
+fn ensure_enabled(state: &TaskState) -> Result<(), ToolError> {
+    if !state.enabled.load(Ordering::Acquire) {
+        return Err(tool_error(
+            "recursive task tools are disabled; enable the application task mode first",
+        ));
+    }
+    Ok(())
+}
+
+fn upgrade(state: &Weak<TaskState>) -> Result<Arc<TaskState>, ToolError> {
+    state
+        .upgrade()
+        .ok_or_else(|| tool_error("task runtime stopped"))
+}
+
+fn new_task_id() -> Box<str> {
+    format!("task_{}", Uuid::now_v7()).into_boxed_str()
+}
+
+fn tool_error(error: impl Into<String>) -> ToolError {
+    Box::new(io::Error::other(error.into()))
+}
+
+fn task_parameters() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "instruction": {
+                "type": "string",
+                "description": "A complete focused instruction for the clean child."
+            },
+            "context": {
+                "description": "Optional explicit JSON context selected by the parent, commonly from context()."
+            },
+            "output_schema": {
+                "description": "The runtime JSON Schema that the child's submitted output must satisfy."
+            }
+        },
+        "required": ["instruction", "output_schema"],
+        "additionalProperties": false
+    })
+}
+
+fn task_batch_parameters() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "tasks": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": MAX_BATCH_SIZE,
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "instruction": { "type": "string" },
+                        "context": {
+                            "description": "Optional explicit JSON context for only this child."
+                        }
+                    },
+                    "required": ["instruction"],
+                    "additionalProperties": false
+                }
+            },
+            "output_schema": {
+                "description": "One runtime JSON Schema shared by every child output in this batch."
+            }
+        },
+        "required": ["tasks", "output_schema"],
+        "additionalProperties": false
+    })
+}
+
+fn task_continue_parameters() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": "The opaque task_id returned by task or task_batch."
+            },
+            "instruction": {
+                "type": "string",
+                "description": "A complete focused follow-up instruction for the retained child."
+            },
+            "context": {
+                "description": "Optional new explicit JSON context for this child turn."
+            },
+            "output_schema": {
+                "description": "The runtime JSON Schema that this follow-up output must satisfy."
+            }
+        },
+        "required": ["task_id", "instruction", "output_schema"],
+        "additionalProperties": false
+    })
+}
+
+fn task_success_schema() -> Value {
+    json!({
+        "type": "object",
+        "properties": {
+            "task_id": { "type": "string" },
+            "output": {}
+        },
+        "required": ["task_id", "output"],
+        "additionalProperties": false
+    })
+}
+
+fn task_batch_output_schema() -> Value {
+    json!({
+        "type": "array",
+        "items": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "status": { "type": "string", "const": "completed" },
+                        "task_id": { "type": "string" },
+                        "output": {}
+                    },
+                    "required": ["status", "task_id", "output"],
+                    "additionalProperties": false
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "status": { "type": "string", "const": "failed" },
+                        "task_id": { "type": "string" },
+                        "error": { "type": "string" }
+                    },
+                    "required": ["status", "task_id", "error"],
+                    "additionalProperties": false
+                }
+            ]
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use nanocodex::{
+        Tool,
+        tools::{ToolContext, ToolInput},
+    };
+    use serde_json::{Value, json, value::to_raw_value};
+
+    use super::{SubmitResultArgs, SubmitResultTool, TaskRuntime, compile_schema};
+
+    #[test]
+    fn compiles_runtime_output_schema() {
+        let validator = compile_schema(&json!({
+            "type": "object",
+            "properties": { "answer": { "type": "integer" } },
+            "required": ["answer"],
+            "additionalProperties": false
+        }))
+        .expect("schema should compile");
+        assert!(validator.is_valid(&json!({ "answer": 42 })));
+        assert!(!validator.is_valid(&json!({ "answer": "42" })));
+    }
+
+    #[tokio::test]
+    async fn submit_result_rejects_invalid_and_duplicate_values() {
+        let runtime = TaskRuntime::new();
+        let token = uuid::Uuid::now_v7();
+        runtime.state.registry.lock().await.pending.insert(
+            "child".into(),
+            super::PendingSubmission {
+                token,
+                validator: compile_schema(&json!({
+                    "type": "object",
+                    "properties": { "answer": { "type": "integer" } },
+                    "required": ["answer"],
+                    "additionalProperties": false
+                }))
+                .expect("schema should compile"),
+                output: None,
+            },
+        );
+        let tool = SubmitResultTool {
+            state: std::sync::Arc::downgrade(&runtime.state),
+        };
+        let history = Vec::new();
+        let context = ToolContext::new("test", "child", "call", &history, 100);
+
+        let invalid = input(&json!({ "output": { "answer": "nope" } }));
+        assert!(tool.execute(invalid, context).await.is_err());
+
+        let valid = input(&json!({ "output": { "answer": 42 } }));
+        assert!(tool.execute(valid, context).await.is_ok());
+
+        let duplicate = input(&json!({ "output": { "answer": 43 } }));
+        assert!(tool.execute(duplicate, context).await.is_err());
+        assert_eq!(
+            runtime.state.take_submission("child", token).await,
+            Some(json!({ "answer": 42 }))
+        );
+    }
+
+    fn input(value: &Value) -> ToolInput {
+        let args: SubmitResultArgs =
+            serde_json::from_value(value.clone()).expect("test input should decode");
+        drop(args);
+        ToolInput::Function(to_raw_value(value).expect("test input should encode"))
+    }
+}

--- a/crates/nanocodex-rlm/tests/task_e2e.rs
+++ b/crates/nanocodex-rlm/tests/task_e2e.rs
@@ -1,0 +1,524 @@
+use std::path::PathBuf;
+
+use eyre::{Result, eyre};
+use futures_util::{SinkExt, StreamExt};
+use nanocodex::{Nanocodex, NanocodexError, OpenAi, Thinking, Tools};
+use nanocodex_rlm::TaskRuntime;
+use serde_json::{Value, json};
+use tokio::{net::TcpListener, time::timeout};
+use tokio_tungstenite::{WebSocketStream, accept_async, tungstenite::Message};
+
+const CHILD_SUBMIT_SOURCE: &str = "
+const accepted = await tools.submit_result({ output: { answer: 42 } });
+text(JSON.stringify(accepted));
+";
+const CHILD_CONTINUE_SOURCE: &str = "
+const accepted = await tools.submit_result({ output: { answer: 43 } });
+text(JSON.stringify(accepted));
+";
+const BATCH_SUBMIT_SOURCE: &str = "
+const accepted = await tools.submit_result({ output: { value: 11 } });
+text(JSON.stringify(accepted));
+";
+
+#[tokio::test]
+async fn parent_task_runs_a_clean_child_and_returns_its_submitted_result() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("ws://{}", listener.local_addr()?);
+    let server = tokio::spawn(serve_responses(listener));
+    let workspace = temporary_workspace();
+    std::fs::create_dir_all(&workspace)?;
+
+    let runtime = TaskRuntime::new();
+    let task_tools = runtime.tools();
+    let openai = OpenAi::builder("test-key")
+        .websocket_url(endpoint)
+        .build()?;
+    let (agent, events) = Nanocodex::builder(openai)
+        .thinking(Thinking::Low)
+        .workspace(&workspace)
+        .tools_factory(move |agent| {
+            let tools = Tools::builder()
+                .web_search(false)
+                .image_generation(false)
+                .build()?;
+            task_tools.install(tools, agent)
+        })
+        .build()?;
+
+    let turn = agent
+        .prompt("PARENT_SECRET: delegate the arithmetic task")
+        .await?;
+    let result = timeout(std::time::Duration::from_secs(10), turn.result())
+        .await
+        .map_err(|_| eyre!("root task turn timed out"))??;
+    assert_eq!(result.final_message(), "root received 42");
+
+    timeout(std::time::Duration::from_secs(5), server)
+        .await
+        .map_err(|_| eyre!("mock Responses server did not finish"))???;
+    runtime.shutdown().await;
+    drop((agent, events));
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn task_batch_preserves_input_order_and_returns_partial_failures() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("ws://{}", listener.local_addr()?);
+    let server = tokio::spawn(serve_batch_responses(listener));
+    let workspace = temporary_workspace();
+    std::fs::create_dir_all(&workspace)?;
+
+    let runtime = TaskRuntime::new();
+    let task_tools = runtime.tools();
+    let openai = OpenAi::builder("test-key")
+        .websocket_url(endpoint)
+        .build()?;
+    let (agent, events) = Nanocodex::builder(openai)
+        .thinking(Thinking::Low)
+        .workspace(&workspace)
+        .tools_factory(move |agent| {
+            let tools = Tools::builder()
+                .web_search(false)
+                .image_generation(false)
+                .build()?;
+            task_tools.install(tools, agent)
+        })
+        .build()?;
+
+    let result = timeout(
+        std::time::Duration::from_secs(10),
+        agent.prompt("Run the ordered batch.").await?.result(),
+    )
+    .await
+    .map_err(|_| eyre!("root batch turn timed out"))??;
+    assert_eq!(result.final_message(), "batch reduced");
+
+    timeout(std::time::Duration::from_secs(5), server)
+        .await
+        .map_err(|_| eyre!("batch mock Responses server did not finish"))???;
+    runtime.shutdown().await;
+    drop((agent, events));
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn cancelling_the_parent_cell_stops_its_clean_child() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("ws://{}", listener.local_addr()?);
+    let (child_started, child_started_rx) = tokio::sync::oneshot::channel();
+    let server = tokio::spawn(serve_cancel_responses(listener, child_started));
+    let workspace = temporary_workspace();
+    std::fs::create_dir_all(&workspace)?;
+
+    let runtime = TaskRuntime::new();
+    let task_tools = runtime.tools();
+    let openai = OpenAi::builder("test-key")
+        .websocket_url(endpoint)
+        .build()?;
+    let (agent, events) = Nanocodex::builder(openai)
+        .thinking(Thinking::Low)
+        .workspace(&workspace)
+        .tools_factory(move |agent| {
+            let tools = Tools::builder()
+                .web_search(false)
+                .image_generation(false)
+                .build()?;
+            task_tools.install(tools, agent)
+        })
+        .build()?;
+
+    let turn = agent.prompt("Start a cancellable child task.").await?;
+    timeout(std::time::Duration::from_secs(5), child_started_rx)
+        .await
+        .map_err(|_| eyre!("child task did not start"))??;
+    turn.cancel().await?;
+    assert!(matches!(
+        turn.result().await,
+        Err(NanocodexError::TurnCancelled)
+    ));
+    timeout(std::time::Duration::from_secs(5), server)
+        .await
+        .map_err(|_| eyre!("cancel mock Responses server did not finish"))???;
+
+    runtime.shutdown().await;
+    drop((agent, events));
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+async fn serve_responses(listener: TcpListener) -> Result<()> {
+    let (root_stream, _) = listener.accept().await?;
+    let mut root = accept_async(root_stream).await?;
+    let root_warmup = next_json(&mut root).await?;
+    assert!(
+        root_warmup.to_string().contains("task_batch"),
+        "root warmup omitted recursive task tools: {root_warmup}"
+    );
+    send_completed(&mut root, "root-warmup", &[]).await?;
+
+    let root_generation = next_json(&mut root).await?;
+    assert!(root_generation.to_string().contains("PARENT_SECRET"));
+    send_completed(
+        &mut root,
+        "root-task-call",
+        &[json!({
+            "type": "custom_tool_call",
+            "call_id": "root-exec",
+            "name": "exec",
+            "input": r#"
+const delegated = await tools.task({
+  instruction: "Compute six times seven.",
+  context: { operands: [6, 7] },
+  output_schema: {
+    type: "object",
+    properties: { answer: { type: "integer" } },
+    required: ["answer"],
+    additionalProperties: false
+  }
+});
+const refined = await tools.task_continue({
+  task_id: delegated.task_id,
+  instruction: "Add one to the prior answer.",
+  context: { prior: delegated.output },
+  output_schema: {
+    type: "object",
+    properties: { answer: { type: "integer" } },
+    required: ["answer"],
+    additionalProperties: false
+  }
+});
+text(JSON.stringify({ delegated, refined }));
+"#
+        })],
+    )
+    .await?;
+
+    let (child_stream, _) = listener.accept().await?;
+    let mut child = accept_async(child_stream).await?;
+    serve_child(&mut child).await?;
+
+    let root_continuation = next_json(&mut root).await?;
+    assert_eq!(
+        root_continuation["input"][0]["type"],
+        "custom_tool_call_output"
+    );
+    let root_output = root_continuation.to_string();
+    assert!(root_output.contains("\\\"answer\\\":42"));
+    assert!(root_output.contains("\\\"answer\\\":43"));
+    send_completed(
+        &mut root,
+        "root-final",
+        &[json!({
+            "type": "message",
+            "role": "assistant",
+            "content": [{ "type": "output_text", "text": "root received 42" }]
+        })],
+    )
+    .await
+}
+
+async fn serve_cancel_responses(
+    listener: TcpListener,
+    child_started: tokio::sync::oneshot::Sender<()>,
+) -> Result<()> {
+    let (root_stream, _) = listener.accept().await?;
+    let mut root = accept_async(root_stream).await?;
+    let root_warmup = next_json(&mut root).await?;
+    assert!(root_warmup.to_string().contains("task"));
+    send_completed(&mut root, "cancel-root-warmup", &[]).await?;
+
+    let root_generation = next_json(&mut root).await?;
+    assert!(root_generation.to_string().contains("cancellable"));
+    send_completed(
+        &mut root,
+        "cancel-root-call",
+        &[json!({
+            "type": "custom_tool_call",
+            "call_id": "cancel-root-exec",
+            "name": "exec",
+            "input": r#"
+const result = await tools.task({
+  instruction: "Wait for further input without submitting.",
+  output_schema: { type: "object" }
+});
+text(JSON.stringify(result));
+"#
+        })],
+    )
+    .await?;
+
+    let (child_stream, _) = listener.accept().await?;
+    let mut child = accept_async(child_stream).await?;
+    let child_warmup = next_json(&mut child).await?;
+    assert!(child_warmup.to_string().contains("submit_result"));
+    send_completed(&mut child, "cancel-child-warmup", &[]).await?;
+    let child_generation = next_json(&mut child).await?;
+    assert!(
+        child_generation
+            .to_string()
+            .contains("Wait for further input")
+    );
+    child_started
+        .send(())
+        .map_err(|()| eyre!("cancellation test receiver dropped"))?;
+
+    loop {
+        match child.next().await {
+            Some(Ok(Message::Close(_)) | Err(_)) | None => break,
+            Some(Ok(_)) => {}
+        }
+    }
+    drop(root);
+    Ok(())
+}
+
+async fn serve_batch_responses(listener: TcpListener) -> Result<()> {
+    let (root_stream, _) = listener.accept().await?;
+    let mut root = accept_async(root_stream).await?;
+    let root_warmup = next_json(&mut root).await?;
+    assert!(root_warmup.to_string().contains("task_batch"));
+    send_completed(&mut root, "batch-root-warmup", &[]).await?;
+
+    let root_generation = next_json(&mut root).await?;
+    assert!(root_generation.to_string().contains("ordered batch"));
+    send_completed(
+        &mut root,
+        "batch-root-call",
+        &[json!({
+            "type": "custom_tool_call",
+            "call_id": "batch-root-exec",
+            "name": "exec",
+            "input": r#"
+const outcomes = await tools.task_batch({
+  tasks: [
+    { instruction: "Return the first value.", context: { ordinal: 1 } },
+    { instruction: "Finish without submitting.", context: { ordinal: 2 } }
+  ],
+  output_schema: {
+    type: "object",
+    properties: { value: { type: "integer" } },
+    required: ["value"],
+    additionalProperties: false
+  }
+});
+text(JSON.stringify(outcomes));
+"#
+        })],
+    )
+    .await?;
+
+    let (first_stream, _) = listener.accept().await?;
+    let first = tokio::spawn(serve_batch_child(first_stream, "batch-child-a"));
+    let (second_stream, _) = listener.accept().await?;
+    let second = tokio::spawn(serve_batch_child(second_stream, "batch-child-b"));
+    let (first, second) = tokio::join!(first, second);
+    first??;
+    second??;
+
+    let root_continuation = next_json(&mut root).await?;
+    let output = root_continuation.to_string();
+    let completed = output
+        .find("completed")
+        .ok_or_else(|| eyre!("batch output omitted completed outcome: {output}"))?;
+    let failed = output
+        .find("failed")
+        .ok_or_else(|| eyre!("batch output omitted failed outcome: {output}"))?;
+    assert!(
+        completed < failed,
+        "batch output lost input order: {output}"
+    );
+    assert!(output.contains("11"));
+    assert!(output.contains("without one valid submit_result"));
+    send_completed(
+        &mut root,
+        "batch-root-final",
+        &[json!({
+            "type": "message",
+            "role": "assistant",
+            "content": [{ "type": "output_text", "text": "batch reduced" }]
+        })],
+    )
+    .await
+}
+
+async fn serve_batch_child(stream: tokio::net::TcpStream, response_prefix: &str) -> Result<()> {
+    let mut child = accept_async(stream).await?;
+    let warmup = next_json(&mut child).await?;
+    assert!(warmup.to_string().contains("submit_result"));
+    send_completed(&mut child, &format!("{response_prefix}-warmup"), &[]).await?;
+
+    let generation = next_json(&mut child).await?;
+    let request = generation.to_string();
+    if request.contains("Return the first value.") {
+        send_completed(
+            &mut child,
+            &format!("{response_prefix}-submit-call"),
+            &[json!({
+                "type": "custom_tool_call",
+                "call_id": format!("{response_prefix}-exec"),
+                "name": "exec",
+                "input": BATCH_SUBMIT_SOURCE
+            })],
+        )
+        .await?;
+        let continuation = next_json(&mut child).await?;
+        assert!(continuation.to_string().contains("accepted"));
+    } else {
+        assert!(request.contains("Finish without submitting."));
+    }
+    send_completed(
+        &mut child,
+        &format!("{response_prefix}-final"),
+        &[json!({
+            "type": "message",
+            "role": "assistant",
+            "content": [{ "type": "output_text", "text": "child finished" }]
+        })],
+    )
+    .await
+}
+
+async fn serve_child(child: &mut WebSocketStream<tokio::net::TcpStream>) -> Result<()> {
+    let child_warmup = next_json(child).await?;
+    assert!(
+        child_warmup.to_string().contains("submit_result"),
+        "child warmup omitted submit_result: {child_warmup}"
+    );
+    assert!(
+        !child_warmup.to_string().contains("PARENT_SECRET"),
+        "clean child inherited the parent prompt: {child_warmup}"
+    );
+    send_completed(child, "child-warmup", &[]).await?;
+
+    let child_generation = next_json(child).await?;
+    let child_request = child_generation.to_string();
+    assert!(child_request.contains("Compute six times seven."));
+    assert!(child_request.contains("operands"));
+    assert!(!child_request.contains("PARENT_SECRET"));
+    send_completed(
+        child,
+        "child-submit-call",
+        &[json!({
+            "type": "custom_tool_call",
+            "call_id": "child-exec",
+            "name": "exec",
+            "input": CHILD_SUBMIT_SOURCE
+        })],
+    )
+    .await?;
+
+    let child_continuation = next_json(child).await?;
+    assert_eq!(
+        child_continuation["input"][0]["type"],
+        "custom_tool_call_output"
+    );
+    assert!(
+        child_continuation.to_string().contains("accepted"),
+        "child continuation omitted submit_result acceptance: {child_continuation}"
+    );
+    send_completed(
+        child,
+        "child-final",
+        &[json!({
+            "type": "message",
+            "role": "assistant",
+            "content": [{ "type": "output_text", "text": "submitted" }]
+        })],
+    )
+    .await?;
+
+    let continued_generation = next_json(child).await?;
+    assert_eq!(continued_generation["previous_response_id"], "child-final");
+    let continued_request = continued_generation.to_string();
+    assert!(continued_request.contains("Add one to the prior answer."));
+    assert!(continued_request.contains("prior"));
+    assert!(continued_request.contains("42"));
+    assert!(!continued_request.contains("PARENT_SECRET"));
+    send_completed(
+        child,
+        "child-continue-submit-call",
+        &[json!({
+            "type": "custom_tool_call",
+            "call_id": "child-continue-exec",
+            "name": "exec",
+            "input": CHILD_CONTINUE_SOURCE
+        })],
+    )
+    .await?;
+
+    let continued_submission = next_json(child).await?;
+    assert_eq!(
+        continued_submission["input"][0]["type"],
+        "custom_tool_call_output"
+    );
+    assert!(continued_submission.to_string().contains("accepted"));
+    send_completed(
+        child,
+        "child-continue-final",
+        &[json!({
+            "type": "message",
+            "role": "assistant",
+            "content": [{ "type": "output_text", "text": "continued result submitted" }]
+        })],
+    )
+    .await
+}
+
+async fn next_json<S>(socket: &mut WebSocketStream<S>) -> Result<Value>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    loop {
+        let message = socket
+            .next()
+            .await
+            .ok_or_else(|| eyre!("client closed before sending a request"))??;
+        if let Message::Text(text) = message {
+            return Ok(serde_json::from_str(text.as_str())?);
+        }
+    }
+}
+
+async fn send_completed<S>(
+    socket: &mut WebSocketStream<S>,
+    response_id: &str,
+    output: &[Value],
+) -> Result<()>
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    socket
+        .send(Message::Text(
+            json!({
+                "type": "response.completed",
+                "response": {
+                    "id": response_id,
+                    "status": "completed",
+                    "output": output,
+                    "usage": {
+                        "input_tokens": 10,
+                        "input_tokens_details": { "cached_tokens": 5 },
+                        "output_tokens": 2,
+                        "output_tokens_details": { "reasoning_tokens": 1 },
+                        "total_tokens": 12
+                    }
+                }
+            })
+            .to_string()
+            .into(),
+        ))
+        .await?;
+    Ok(())
+}
+
+fn temporary_workspace() -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "nanocodex-rlm-e2e-{}-{}",
+        std::process::id(),
+        uuid::Uuid::now_v7()
+    ))
+}

--- a/crates/nanocodex-tools/src/code_mode/bootstrap.js
+++ b/crates/nanocodex-tools/src/code_mode/bootstrap.js
@@ -25,6 +25,14 @@
       ? undefined
       : jsonParse(jsonStringify(value));
 
+  function deepFreeze(value) {
+    if (value === null || typeof value !== "object" || Object.isFrozen(value)) {
+      return value;
+    }
+    for (const item of Object.values(value)) deepFreeze(item);
+    return Object.freeze(value);
+  }
+
   function stringify(value) {
     if (
       value === undefined ||
@@ -71,9 +79,10 @@
     return jsonParse(encoded);
   }
 
-  return async function runCell(source, definitionsJson, initialStoredJson) {
+  return async function runCell(source, definitionsJson, initialStoredJson, contextJson) {
     const definitions = jsonParse(definitionsJson);
     const initialStored = jsonParse(initialStoredJson);
+    const contextItems = deepFreeze(jsonParse(contextJson));
     const stored = new Map(Object.entries(initialStored));
     const storedWrites = new Map();
     const declaredTools = Object.create(null);
@@ -241,6 +250,10 @@
       return stored.has(normalizedKey) ? cloneValue(stored.get(normalizedKey)) : undefined;
     }
 
+    function context() {
+      return contextItems;
+    }
+
     function yield_control() {
       nativeYield();
     }
@@ -279,6 +292,7 @@
         "notify",
         "store",
         "load",
+        "context",
         "yield_control",
         "exit",
         "setTimeout",
@@ -297,6 +311,7 @@
           notify,
           store,
           load,
+          context,
           yield_control,
           exit,
           nativeSetTimeout,

--- a/crates/nanocodex-tools/src/code_mode/context.rs
+++ b/crates/nanocodex-tools/src/code_mode/context.rs
@@ -1,0 +1,311 @@
+use nanocodex_core::{
+    AgentMessageContent, ContentItem, FunctionOutputBody, FunctionOutputContent, MessagePhase,
+    MessageRole, ReasoningContent, ReasoningSummary, ResponseItem,
+};
+use serde::{Deserialize, Serialize};
+
+/// A stable, semantic projection of one item in the invoking agent's transcript.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContextItem {
+    Message {
+        role: MessageRole,
+        content: Vec<ContextContent>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        phase: Option<MessagePhase>,
+    },
+    AgentMessage {
+        author: Box<str>,
+        recipient: Box<str>,
+        content: Vec<ContextContent>,
+    },
+    Reasoning {
+        summary: Vec<Box<str>>,
+        content: Vec<Box<str>>,
+    },
+    ToolCall {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        call_id: Option<Box<str>>,
+        name: Box<str>,
+        input: Box<str>,
+    },
+    ToolResult {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        call_id: Option<Box<str>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<Box<str>>,
+        output: Vec<ContextContent>,
+    },
+    Compaction,
+}
+
+/// Content exposed by [`ContextItem`] inside Code Mode.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContextContent {
+    Text { text: Box<str> },
+    Image { image_url: Box<str> },
+    Audio { audio_url: Box<str> },
+}
+
+pub(super) fn project(history: &[ResponseItem]) -> Vec<ContextItem> {
+    history.iter().filter_map(project_item).collect()
+}
+
+fn project_item(item: &ResponseItem) -> Option<ContextItem> {
+    match item {
+        ResponseItem::Message {
+            role,
+            content,
+            phase,
+            ..
+        } => Some(ContextItem::Message {
+            role: *role,
+            content: content.iter().map(project_content).collect(),
+            phase: *phase,
+        }),
+        ResponseItem::AgentMessage {
+            author,
+            recipient,
+            content,
+            ..
+        } => Some(ContextItem::AgentMessage {
+            author: author.clone(),
+            recipient: recipient.clone(),
+            content: content.iter().filter_map(project_agent_content).collect(),
+        }),
+        ResponseItem::Reasoning {
+            summary, content, ..
+        } => Some(ContextItem::Reasoning {
+            summary: summary.iter().map(project_summary).collect(),
+            content: content
+                .iter()
+                .flatten()
+                .map(project_reasoning_content)
+                .collect(),
+        }),
+        item => project_tool_item(item),
+    }
+}
+
+fn project_tool_item(item: &ResponseItem) -> Option<ContextItem> {
+    match item {
+        ResponseItem::LocalShellCall {
+            call_id, action, ..
+        } => Some(ContextItem::ToolCall {
+            call_id: call_id.clone(),
+            name: "local_shell".into(),
+            input: serialize_typed(action),
+        }),
+        ResponseItem::FunctionCall {
+            name,
+            arguments,
+            call_id,
+            ..
+        } => Some(ContextItem::ToolCall {
+            call_id: Some(call_id.clone()),
+            name: name.clone(),
+            input: arguments.clone(),
+        }),
+        ResponseItem::FunctionCallOutput {
+            call_id, output, ..
+        } => Some(ContextItem::ToolResult {
+            call_id: Some(call_id.clone()),
+            name: None,
+            output: project_output(output),
+        }),
+        ResponseItem::ToolSearchCall {
+            call_id, arguments, ..
+        } => Some(ContextItem::ToolCall {
+            call_id: call_id.clone(),
+            name: "tool_search".into(),
+            input: serialize_typed(arguments),
+        }),
+        ResponseItem::CustomToolCall {
+            call_id,
+            name,
+            input,
+            ..
+        } => Some(ContextItem::ToolCall {
+            call_id: Some(call_id.clone()),
+            name: name.clone(),
+            input: input.clone(),
+        }),
+        ResponseItem::CustomToolCallOutput {
+            call_id,
+            name,
+            output,
+            ..
+        } => Some(ContextItem::ToolResult {
+            call_id: Some(call_id.clone()),
+            name: name.clone(),
+            output: project_output(output),
+        }),
+        ResponseItem::ToolSearchOutput { call_id, tools, .. } => Some(ContextItem::ToolResult {
+            call_id: call_id.clone(),
+            name: Some("tool_search".into()),
+            output: vec![ContextContent::Text {
+                text: serialize_typed(tools),
+            }],
+        }),
+        ResponseItem::WebSearchCall { action, .. } => Some(ContextItem::ToolCall {
+            call_id: None,
+            name: "web_search".into(),
+            input: action.as_ref().map_or_else(|| "{}".into(), serialize_typed),
+        }),
+        ResponseItem::ImageGenerationCall {
+            revised_prompt,
+            result,
+            ..
+        } => Some(ContextItem::ToolResult {
+            call_id: None,
+            name: Some("image_generation".into()),
+            output: [
+                revised_prompt.as_ref().map(|prompt| ContextContent::Text {
+                    text: prompt.clone(),
+                }),
+                Some(ContextContent::Image {
+                    image_url: result.clone(),
+                }),
+            ]
+            .into_iter()
+            .flatten()
+            .collect(),
+        }),
+        ResponseItem::Compaction { .. }
+        | ResponseItem::CompactionTrigger {}
+        | ResponseItem::ContextCompaction { .. } => Some(ContextItem::Compaction),
+        ResponseItem::AdditionalTools { .. }
+        | ResponseItem::Other(_)
+        | ResponseItem::Message { .. }
+        | ResponseItem::AgentMessage { .. }
+        | ResponseItem::Reasoning { .. } => None,
+    }
+}
+
+fn project_content(content: &ContentItem) -> ContextContent {
+    match content {
+        ContentItem::InputText { text } | ContentItem::OutputText { text, .. } => {
+            ContextContent::Text { text: text.clone() }
+        }
+        ContentItem::InputImage { image_url, .. } => ContextContent::Image {
+            image_url: image_url.clone(),
+        },
+        ContentItem::InputAudio { audio_url } => ContextContent::Audio {
+            audio_url: audio_url.clone(),
+        },
+    }
+}
+
+fn project_agent_content(content: &AgentMessageContent) -> Option<ContextContent> {
+    match content {
+        AgentMessageContent::InputText { text } => {
+            Some(ContextContent::Text { text: text.clone() })
+        }
+        AgentMessageContent::EncryptedContent { .. } => None,
+    }
+}
+
+fn project_summary(summary: &ReasoningSummary) -> Box<str> {
+    match summary {
+        ReasoningSummary::SummaryText { text } => text.clone(),
+    }
+}
+
+fn project_reasoning_content(content: &ReasoningContent) -> Box<str> {
+    match content {
+        ReasoningContent::ReasoningText { text } | ReasoningContent::Text { text } => text.clone(),
+    }
+}
+
+fn project_output(output: &FunctionOutputBody) -> Vec<ContextContent> {
+    match output {
+        FunctionOutputBody::Text(text) => vec![ContextContent::Text { text: text.clone() }],
+        FunctionOutputBody::Content(content) => {
+            content.iter().filter_map(project_output_content).collect()
+        }
+    }
+}
+
+fn project_output_content(content: &FunctionOutputContent) -> Option<ContextContent> {
+    match content {
+        FunctionOutputContent::InputText { text } => {
+            Some(ContextContent::Text { text: text.clone() })
+        }
+        FunctionOutputContent::InputImage { image_url, .. } => Some(ContextContent::Image {
+            image_url: image_url.clone(),
+        }),
+        FunctionOutputContent::InputAudio { audio_url } => Some(ContextContent::Audio {
+            audio_url: audio_url.clone(),
+        }),
+        FunctionOutputContent::EncryptedContent { .. } => None,
+    }
+}
+
+fn serialize_typed(value: &impl Serialize) -> Box<str> {
+    serde_json::to_string(value)
+        .unwrap_or_else(|error| format!("failed to serialize context item: {error}"))
+        .into_boxed_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use nanocodex_core::{ContentItem, FunctionOutputBody, MessageRole, ResponseItem};
+
+    use super::{ContextContent, ContextItem, project};
+
+    #[test]
+    fn projects_semantic_history_without_provider_ids() {
+        let history = vec![
+            ResponseItem::message(
+                MessageRole::User,
+                [ContentItem::InputText {
+                    text: "question".into(),
+                }],
+            ),
+            ResponseItem::FunctionCall {
+                id: Some("fc_provider".into()),
+                name: "lookup".into(),
+                namespace: None,
+                arguments: r#"{"key":"value"}"#.into(),
+                call_id: "call_1".into(),
+                caller: None,
+                status: None,
+                created_by: None,
+                internal_chat_message_metadata_passthrough: None,
+                encrypted_function_args: None,
+            },
+            ResponseItem::function_call_output(
+                "call_1".to_owned(),
+                FunctionOutputBody::Text("result".into()),
+            ),
+            ResponseItem::compaction_trigger(),
+        ];
+
+        assert_eq!(
+            project(&history),
+            vec![
+                ContextItem::Message {
+                    role: MessageRole::User,
+                    content: vec![ContextContent::Text {
+                        text: "question".into(),
+                    }],
+                    phase: None,
+                },
+                ContextItem::ToolCall {
+                    call_id: Some("call_1".into()),
+                    name: "lookup".into(),
+                    input: r#"{"key":"value"}"#.into(),
+                },
+                ContextItem::ToolResult {
+                    call_id: Some("call_1".into()),
+                    name: None,
+                    output: vec![ContextContent::Text {
+                        text: "result".into(),
+                    }],
+                },
+                ContextItem::Compaction,
+            ]
+        );
+    }
+}

--- a/crates/nanocodex-tools/src/code_mode/context.rs
+++ b/crates/nanocodex-tools/src/code_mode/context.rs
@@ -1,4 +1,4 @@
-use nanocodex_core::{
+use nanocodex_oai_api::responses::{
     AgentMessageContent, ContentItem, FunctionOutputBody, FunctionOutputContent, MessagePhase,
     MessageRole, ReasoningContent, ReasoningSummary, ResponseItem,
 };
@@ -8,34 +8,54 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ContextItem {
+    /// One developer, user, or assistant message.
     Message {
+        /// Message author role.
         role: MessageRole,
+        /// Ordered message content.
         content: Vec<ContextContent>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        /// Optional assistant presentation phase.
         phase: Option<MessagePhase>,
     },
+    /// One agent-to-agent message.
     AgentMessage {
+        /// Sending agent identity.
         author: Box<str>,
+        /// Receiving agent identity.
         recipient: Box<str>,
+        /// Ordered visible content.
         content: Vec<ContextContent>,
     },
+    /// API-visible reasoning summaries and content.
     Reasoning {
+        /// Ordered reasoning summaries.
         summary: Vec<Box<str>>,
+        /// Ordered API-visible reasoning content.
         content: Vec<Box<str>>,
     },
+    /// One model-issued tool call.
     ToolCall {
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        /// Tool-call identity when available.
         call_id: Option<Box<str>>,
+        /// Model-visible tool name.
         name: Box<str>,
+        /// Serialized tool input.
         input: Box<str>,
     },
+    /// One tool result.
     ToolResult {
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        /// Tool-call identity when available.
         call_id: Option<Box<str>>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
+        /// Tool name when available.
         name: Option<Box<str>>,
+        /// Ordered result content.
         output: Vec<ContextContent>,
     },
+    /// One transcript compaction boundary.
     Compaction,
 }
 
@@ -43,9 +63,21 @@ pub enum ContextItem {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ContextContent {
-    Text { text: Box<str> },
-    Image { image_url: Box<str> },
-    Audio { audio_url: Box<str> },
+    /// Plain text content.
+    Text {
+        /// Complete text.
+        text: Box<str>,
+    },
+    /// Image content.
+    Image {
+        /// Data URL or remote image URL.
+        image_url: Box<str>,
+    },
+    /// Audio content.
+    Audio {
+        /// Data URL or remote audio URL.
+        audio_url: Box<str>,
+    },
 }
 
 pub(super) fn project(history: &[ResponseItem]) -> Vec<ContextItem> {
@@ -250,7 +282,9 @@ fn serialize_typed(value: &impl Serialize) -> Box<str> {
 
 #[cfg(test)]
 mod tests {
-    use nanocodex_core::{ContentItem, FunctionOutputBody, MessageRole, ResponseItem};
+    use nanocodex_oai_api::responses::{
+        ContentItem, FunctionOutputBody, MessageRole, ResponseItem,
+    };
 
     use super::{ContextContent, ContextItem, project};
 

--- a/crates/nanocodex-tools/src/code_mode/description.rs
+++ b/crates/nanocodex-tools/src/code_mode/description.rs
@@ -5,6 +5,41 @@ use serde_json::Value;
 
 const DEFERRED_NESTED_TOOLS_GUIDANCE: &str = r"Some deferred nested tools may be omitted from this description. They are still available on the global `tools` object and listed in `ALL_TOOLS`.
 To find one, filter `ALL_TOOLS` by `name` and `description`.";
+const CONTEXT_TYPESCRIPT: &str = r#"type ContextContent =
+  | { type: "text"; text: string }
+  | { type: "image"; image_url: string }
+  | { type: "audio"; audio_url: string };
+type ContextItem =
+  | {
+      type: "message";
+      role: "developer" | "user" | "assistant";
+      content: readonly ContextContent[];
+      phase?: "commentary" | "final_answer";
+    }
+  | {
+      type: "agent_message";
+      author: string;
+      recipient: string;
+      content: readonly ContextContent[];
+    }
+  | {
+      type: "reasoning";
+      summary: readonly string[];
+      content: readonly string[];
+    }
+  | {
+      type: "tool_call";
+      call_id?: string;
+      name: string;
+      input: string;
+    }
+  | {
+      type: "tool_result";
+      call_id?: string;
+      name?: string;
+      output: readonly ContextContent[];
+    }
+  | { type: "compaction" };"#;
 // Based on https://modelcontextprotocol.io/specification/draft/schema#calltoolresult.
 const MCP_TYPESCRIPT_PREAMBLE: &str = r#"type Role = "user" | "assistant";
 type MetaObject = Record<string, unknown>;
@@ -83,11 +118,11 @@ type CallToolResult<TStructured = { [key: string]: unknown }> = {
   [key: string]: unknown;
 };"#;
 const EXEC_DESCRIPTION: &str = r#"Run JavaScript code to orchestrate/compose tool calls
-- Evaluates the provided JavaScript code in a fresh V8 isolate as an async module.
+- Evaluates the provided JavaScript code in a fresh embedded runtime as an async function.
 - All nested tools are available on the global `tools` object, for example `await tools.exec_command(...)`. Tool names are exposed as normalized JavaScript identifiers, for example `await tools.mcp__ologs__get_profile(...)`.
 - Nested tool methods take either a string or an object as their input argument.
 - Nested tools return either an object or a string, based on the description.
-- Runs raw JavaScript -- no Node, no file system, no network access, no console.
+- Runs the runtime's supported JavaScript subset -- no Node, no file system, no network access, no console.
 - Accepts raw JavaScript source text, not JSON, quoted strings, or markdown code fences.
 - You may optionally start the tool input with a first-line pragma like `// @exec: {"yield_time_ms": 10000, "max_output_tokens": 1000}`.
 - `yield_time_ms` asks `exec` to yield early if the script is still running. Defaults to 10000 ms.
@@ -102,6 +137,7 @@ const EXEC_DESCRIPTION: &str = r#"Run JavaScript code to orchestrate/compose too
 - `generatedImage(result: { image_url: string; output_hint?: string })`: Appends an image-generation result and its optional output hint. HTTP(S) URLs are not supported.
 - `store(key: string, value: any)`: stores a serializable value under a string key for later `exec` calls in the same session.
 - `load(key: string)`: returns the stored value for a string key, or `undefined` if it is missing.
+- `context(): readonly ContextItem[]`: returns an immutable snapshot of the invoking agent's current transcript for this cell.
 - `notify(value: string | number | boolean | undefined | null)`: immediately injects an extra `custom_tool_call_output` for the current `exec` call. Values are stringified like `text(...)`.
 - `setTimeout(callback: () => void, delayMs?: number)`: schedules a callback to run later and returns a timeout id. Pending timeouts do not keep `exec` alive by themselves; await an explicit promise if you need to wait for one.
 - `clearTimeout(timeoutId?: number)`: cancels a timeout created by `setTimeout`.
@@ -125,6 +161,10 @@ pub(super) fn exec_description(
             "\nInspect the matching `ALL_TOOLS` entry for complete guidance before using an unfamiliar runtime-provided tool.",
         );
     }
+    let _ = write!(
+        description,
+        "\n\nContext Types:\n```ts\n{CONTEXT_TYPESCRIPT}\n```"
+    );
     if has_deferred_tools {
         let _ = write!(description, "\n\n{DEFERRED_NESTED_TOOLS_GUIDANCE}");
     }

--- a/crates/nanocodex-tools/src/code_mode/embedded.rs
+++ b/crates/nanocodex-tools/src/code_mode/embedded.rs
@@ -19,7 +19,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use tokio::sync::mpsc;
 
-use super::RuntimeEvent;
+use super::{ContextItem, RuntimeEvent};
 
 const BOOTSTRAP: &str = include_str!("bootstrap.js");
 
@@ -48,6 +48,7 @@ struct StartExecution {
     source: String,
     tools: Vec<Value>,
     stored: HashMap<String, Value>,
+    context: Vec<ContextItem>,
 }
 
 struct ExecutionState {
@@ -114,6 +115,7 @@ impl EmbeddedHost {
         source: &str,
         stored: HashMap<String, Value>,
         tools: Vec<Value>,
+        context: Vec<ContextItem>,
     ) -> Result<(), String> {
         self.command_tx
             .send(HostCommand::Start(StartExecution {
@@ -121,6 +123,7 @@ impl EmbeddedHost {
                 source: source.to_owned(),
                 tools,
                 stored,
+                context,
             }))
             .map_err(|_| "embedded QuickJS code-mode host is unavailable".to_owned())
     }
@@ -264,8 +267,10 @@ fn run_execution_in_context<'js>(
         .map_err(|error| format!("failed to encode QuickJS tool metadata: {error}"))?;
     let stored = serde_json::to_string(&start.stored)
         .map_err(|error| format!("failed to encode QuickJS stored values: {error}"))?;
+    let context_items = serde_json::to_string(&start.context)
+        .map_err(|error| format!("failed to encode QuickJS context items: {error}"))?;
     let promise = run_cell
-        .call::<_, Promise<'js>>((start.source, tools, stored))
+        .call::<_, Promise<'js>>((start.source, tools, stored, context_items))
         .catch(ctx)
         .map_err(|error| format!("embedded QuickJS execution failed to start: {error}"))?;
     drain_jobs(ctx);

--- a/crates/nanocodex-tools/src/code_mode/mod.rs
+++ b/crates/nanocodex-tools/src/code_mode/mod.rs
@@ -1,5 +1,6 @@
 //! Code Mode execution results, notifications, and nested-tool observation.
 
+mod context;
 pub(crate) mod description;
 mod embedded;
 mod output;
@@ -30,6 +31,7 @@ pub use crate::hosted::{
     CodeModeExecution, CodeModeNotification, CodeModeObserver, CodeModeUpdate, NestedToolCall,
 };
 use crate::runtime::{OwnedToolContext, ToolRegistry};
+pub use context::{ContextContent, ContextItem};
 use embedded::EmbeddedHost;
 pub(crate) use spec::{exec_spec, wait_spec};
 
@@ -1217,8 +1219,14 @@ async fn run_cell_actor(
     record_elapsed("host.wait_ns", host_wait_started_at);
     tracing::Span::current().record("host.reused", reused);
     let run = async {
-        host.start_cell(cell_id, &source, stored, tools.nested_tool_metadata())
-            .map_err(HostFailure::new)?;
+        host.start_cell(
+            cell_id,
+            &source,
+            stored,
+            tools.nested_tool_metadata(),
+            context::project(&context.history),
+        )
+        .map_err(HostFailure::new)?;
         host.drive_cell(
             cell_id,
             &context.call_id,

--- a/crates/nanocodex-tools/src/code_mode/tests.rs
+++ b/crates/nanocodex-tools/src/code_mode/tests.rs
@@ -233,6 +233,55 @@ text({ previous: previous ?? null, current: globalThis.__nanocodexContextGenerat
 }
 
 #[tokio::test]
+async fn context_builtin_is_a_deep_frozen_per_execution_snapshot() -> Result<()> {
+    let workspace = temporary_workspace("context-snapshot")?;
+    let tools = test_tools(&workspace);
+    let first_history = vec![ResponseItem::message(
+        nanocodex_oai_api::responses::MessageRole::User,
+        [nanocodex_oai_api::responses::ContentItem::InputText {
+            text: "first".into(),
+        }],
+    )];
+    let first = tools
+        .execute_code(
+            r"
+const items = context();
+text({
+  items,
+  frozen: Object.isFrozen(items),
+  itemFrozen: Object.isFrozen(items[0]),
+  contentFrozen: Object.isFrozen(items[0].content),
+});
+",
+            test_context(&first_history),
+        )
+        .await;
+
+    let second_history = vec![ResponseItem::message(
+        nanocodex_oai_api::responses::MessageRole::Assistant,
+        [nanocodex_oai_api::responses::ContentItem::output_text(
+            "second",
+        )],
+    )];
+    let second = tools
+        .execute_code("text(context());", test_context(&second_history))
+        .await;
+
+    assert!(first.success, "{}", execution_output(&first));
+    assert!(second.success, "{}", execution_output(&second));
+    assert_eq!(
+        emitted_text(&first)?,
+        r#"{"items":[{"type":"message","role":"user","content":[{"type":"text","text":"first"}]}],"frozen":true,"itemFrozen":true,"contentFrozen":true}"#
+    );
+    assert_eq!(
+        emitted_text(&second)?,
+        r#"[{"type":"message","role":"assistant","content":[{"type":"text","text":"second"}]}]"#
+    );
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn execution_prototype_mutations_do_not_leak_across_quickjs_contexts() -> Result<()> {
     let workspace = temporary_workspace("isolated-quickjs-prototypes")?;
     let tools = test_tools(&workspace);

--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,7 @@ allow = [
     "CDLA-Permissive-2.0",
     "ISC",
     "MIT",
+    "MIT-0",
     "MPL-2.0",
     "LicenseRef-ring",
     "Unicode-3.0",

--- a/harbor_adapter/agent.py
+++ b/harbor_adapter/agent.py
@@ -162,6 +162,7 @@ class NanocodexAgent(BaseInstalledAgent):
         fast_mode: bool = False,
         web_search: bool = True,
         subagents: bool = False,
+        turbo: bool = False,
         install_node: bool = False,
         system_prompt_path: str | Path | None = None,
         agents_md_path: str | Path | None = None,
@@ -199,6 +200,7 @@ class NanocodexAgent(BaseInstalledAgent):
         self._fast_mode = fast_mode
         self._web_search = web_search
         self._subagents = subagents
+        self._turbo = turbo
         self._install_node = install_node
         self._system_prompt_path = self._resolve_context_file(
             system_prompt_path, "system prompt"
@@ -343,7 +345,7 @@ class NanocodexAgent(BaseInstalledAgent):
         self._publish_events(result.stdout)
 
     def _run_arguments(self, prompt: str) -> list[str]:
-        return [
+        arguments = [
             self._BINARY,
             "run",
             "--model",
@@ -358,9 +360,11 @@ class NanocodexAgent(BaseInstalledAgent):
             str(self._web_search).lower(),
             "--subagents",
             str(getattr(self, "_subagents", False)).lower(),
-            "--",
-            prompt,
         ]
+        if getattr(self, "_turbo", False):
+            arguments.append("--turbo")
+        arguments.extend(["--", prompt])
+        return arguments
 
     def _classify_exec_error(self, command: str, result: Any) -> Exception:
         # BaseInstalledAgent classifies and raises before returning a nonzero

--- a/harbor_adapter/test_agent.py
+++ b/harbor_adapter/test_agent.py
@@ -397,6 +397,18 @@ class WebSearchContractTests(unittest.TestCase):
             ["--", "- benchmark instruction"],
         )
 
+    def test_run_arguments_enable_turbo_explicitly(self) -> None:
+        agent = object.__new__(NanocodexAgent)
+        agent._model = "test-model"
+        agent._effort = "max"
+        agent._web_search = False
+        agent._turbo = True
+
+        self.assertEqual(
+            agent._run_arguments("test prompt")[-3:],
+            ["--turbo", "--", "test prompt"],
+        )
+
     def test_terminal_bench_disables_web_search(self) -> None:
         repository = Path(__file__).resolve().parents[1]
         config = yaml.safe_load(


### PR DESCRIPTION
## Summary

- add typed, immutable `context()` transcript snapshots to Code Mode
- add schema-constrained `task`, `task_batch`, `task_continue`, and `submit_result` through a new `nanocodex-rlm` crate
- expose the runtime through the TUI `/turbo` toggle and headless `--turbo`, with recursive activity rendered as first-class Code Mode work
- preserve the current subagent, browser, VM, MCP, voice, resume, and model-policy paths while layering Turbo tools per agent

## Rebase

Rebased onto `master@b7c4cd79`. The old NanoUSD signer fix, retired Harbor nightly, stale FrontierBench/MCP-SSE changes, and superseded planning commit were dropped. Existing benchmark policy files were preserved.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p nanocodex-rlm -p nanocodex-tools -p nanocodex-bin --all-targets -- -D warnings`
- `cargo test --locked -p nanocodex-rlm` (2 unit + 3 deterministic WebSocket integration tests)
- `cargo test --locked -p nanocodex-tools code_mode::tests` (56 tests)
- `cargo test --locked -p nanocodex-bin turbo` (3 tests)
- `cargo check --locked --workspace --examples`

## Architecture decision still required

This remains a draft. The current crate-boundary policy intentionally does not list `nanocodex-rlm` as a public SDK crate, and current `PLAN.md` asks whether PR #32 solves a demonstrated problem or should become a smaller application-owned experiment. Do not update that policy snapshot or merge this PR without resolving that decision from differential evidence.
