### PR TITLE
feat(tui): add Tact-inspired interaction polish

### DIFF
--- a/bin/nanocodex/benches/tui_render.rs
+++ b/bin/nanocodex/benches/tui_render.rs
@@ -40,6 +40,16 @@ mod tui {
     }
 
     #[allow(dead_code, unused_imports)]
+    mod branding {
+        include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/tui/branding.rs"));
+    }
+
+    #[allow(dead_code, unused_imports)]
+    mod actions {
+        include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/tui/actions.rs"));
+    }
+
+    #[allow(dead_code, unused_imports)]
     mod app {
         include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/tui/app.rs"));
     }
@@ -862,6 +872,40 @@ mod tui {
         });
     }
 
+    pub(super) fn action_palette_benchmark(criterion: &mut Criterion) {
+        criterion.bench_function("tui_action_palette/cached_frame/80x24", |bencher| {
+            let mut app = App::new("/workspace/nanocodex".into());
+            app.open_action_menu();
+            let mut terminal = Terminal::new(TestBackend::new(80, 24))
+                .expect("action palette benchmark terminal should initialize");
+            terminal
+                .draw(|frame| view::render(frame, &mut app))
+                .expect("initial action palette frame should render");
+            bencher.iter(|| {
+                terminal
+                    .draw(|frame| view::render(frame, &mut app))
+                    .expect("action palette benchmark frame should render");
+            });
+        });
+    }
+
+    pub(super) fn branding_benchmark(criterion: &mut Criterion) {
+        criterion.bench_function("tui_branding/animated_empty_frame/120x40", |bencher| {
+            let mut app = App::new("/workspace/nanocodex".into());
+            let mut terminal = Terminal::new(TestBackend::new(120, 40))
+                .expect("branding benchmark terminal should initialize");
+            terminal
+                .draw(|frame| view::render(frame, &mut app))
+                .expect("initial branding frame should render");
+            bencher.iter(|| {
+                app.on_tick();
+                terminal
+                    .draw(|frame| view::render(frame, &mut app))
+                    .expect("animated branding frame should render");
+            });
+        });
+    }
+
     pub(super) fn large_paste_benchmarks(criterion: &mut Criterion) {
         let pasted = sized_text(100 * 1_024, 5);
         let mut group = criterion.benchmark_group("tui_large_paste");
@@ -1577,6 +1621,8 @@ criterion_group!(
     tui::stream_telemetry_benchmark,
     tui::first_frame_benchmarks,
     tui::composer_benchmarks,
+    tui::action_palette_benchmark,
+    tui::branding_benchmark,
     tui::large_paste_benchmarks,
     tui::history_navigation_benchmarks,
     tui::branch_state_benchmarks,

--- a/bin/nanocodex/src/tui/actions.rs
+++ b/bin/nanocodex/src/tui/actions.rs
@@ -1,0 +1,330 @@
+// Searchable action palette for the interactive TUI.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+
+const ACTIONS: [Action; 11] = [
+    Action::Reasoning,
+    Action::FastMode,
+    Action::Btw,
+    Action::Branches,
+    Action::ToolDetails,
+    Action::Cancel,
+    Action::Trace,
+    Action::CloseBtw,
+    Action::McpLogin,
+    Action::McpReload,
+    Action::Keybindings,
+];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum Action {
+    Reasoning,
+    FastMode,
+    Btw,
+    Branches,
+    ToolDetails,
+    Cancel,
+    Trace,
+    CloseBtw,
+    McpLogin,
+    McpReload,
+    Keybindings,
+}
+
+#[derive(Clone, Copy)]
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "independent action availability toggles are not one state machine"
+)]
+pub(super) struct ActionContext {
+    pub(super) fast_mode: bool,
+    pub(super) btw_open: bool,
+    pub(super) btw_busy: bool,
+    pub(super) can_browse_branches: bool,
+    pub(super) can_cancel: bool,
+    pub(super) trace_available: bool,
+    pub(super) tool_details_expanded: bool,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(super) enum ActionMenuResult {
+    Handled,
+    Dismiss,
+    Trigger(Action),
+    SubmitLiteral(String),
+}
+
+pub(super) struct ActionMenu {
+    query: String,
+    matches: Vec<usize>,
+    selected: usize,
+}
+
+impl Default for ActionMenu {
+    fn default() -> Self {
+        Self {
+            query: String::new(),
+            matches: (0..ACTIONS.len()).collect(),
+            selected: 0,
+        }
+    }
+}
+
+impl ActionMenu {
+    pub(super) fn query(&self) -> &str {
+        &self.query
+    }
+
+    pub(super) fn visible_actions(&self) -> impl Iterator<Item = Action> + '_ {
+        self.matches.iter().map(|index| ACTIONS[*index])
+    }
+
+    pub(super) fn selected(&self) -> Option<usize> {
+        (!self.matches.is_empty()).then_some(self.selected)
+    }
+
+    pub(super) fn handle_key(&mut self, key: KeyEvent, context: ActionContext) -> ActionMenuResult {
+        if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+            return ActionMenuResult::Handled;
+        }
+        if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Enter {
+            return ActionMenuResult::SubmitLiteral(format!("/{}", self.query));
+        }
+        if key
+            .modifiers
+            .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+        {
+            return ActionMenuResult::Handled;
+        }
+
+        match key.code {
+            KeyCode::Esc => ActionMenuResult::Dismiss,
+            KeyCode::Backspace if self.query.is_empty() => ActionMenuResult::Dismiss,
+            KeyCode::Backspace => {
+                if let Some((index, _)) = self.query.char_indices().next_back() {
+                    self.query.truncate(index);
+                    self.refresh_matches();
+                }
+                ActionMenuResult::Handled
+            }
+            KeyCode::Up => {
+                self.selected = self.selected.saturating_sub(1);
+                ActionMenuResult::Handled
+            }
+            KeyCode::Down => {
+                self.selected = self
+                    .selected
+                    .saturating_add(1)
+                    .min(self.matches.len().saturating_sub(1));
+                ActionMenuResult::Handled
+            }
+            KeyCode::Enter | KeyCode::Tab => self.trigger_selected(context),
+            KeyCode::Char(character) => {
+                self.query.push(character);
+                self.refresh_matches();
+                ActionMenuResult::Handled
+            }
+            _ => ActionMenuResult::Handled,
+        }
+    }
+
+    pub(super) fn handle_paste(&mut self, text: &str) {
+        self.query
+            .extend(text.chars().filter(|character| !character.is_control()));
+        self.refresh_matches();
+    }
+
+    fn trigger_selected(&self, context: ActionContext) -> ActionMenuResult {
+        let Some(index) = self.matches.get(self.selected) else {
+            return ActionMenuResult::SubmitLiteral(format!("/{}", self.query));
+        };
+        let action = ACTIONS[*index];
+        if action.enabled(context) {
+            ActionMenuResult::Trigger(action)
+        } else {
+            ActionMenuResult::Handled
+        }
+    }
+
+    fn refresh_matches(&mut self) {
+        self.matches.clear();
+        self.matches.extend(
+            ACTIONS
+                .iter()
+                .enumerate()
+                .filter(|(_, action)| action.matches(&self.query))
+                .map(|(index, _)| index),
+        );
+        self.selected = 0;
+    }
+}
+
+impl Action {
+    pub(super) const fn command(self) -> Option<&'static str> {
+        match self {
+            Self::Reasoning => Some("/model"),
+            Self::FastMode => Some("/fast"),
+            Self::Btw => Some("/btw"),
+            Self::Cancel => Some("/cancel"),
+            Self::Trace => Some("/trace"),
+            Self::CloseBtw => Some("/close"),
+            Self::McpLogin => Some("/mcp login "),
+            Self::McpReload => Some("/mcp reload "),
+            Self::Branches | Self::ToolDetails | Self::Keybindings => None,
+        }
+    }
+
+    pub(super) const fn label(self, context: ActionContext) -> &'static str {
+        match self {
+            Self::Reasoning => "Change reasoning",
+            Self::FastMode if context.fast_mode => "Disable fast mode",
+            Self::FastMode => "Enable fast mode",
+            Self::Btw if context.btw_open => "Focus side question",
+            Self::Btw => "Open side question",
+            Self::Branches if !context.can_browse_branches => {
+                "Browse branches · no alternate branches"
+            }
+            Self::Branches => "Browse branches",
+            Self::ToolDetails if context.tool_details_expanded => "Collapse tool details",
+            Self::ToolDetails => "Expand tool details",
+            Self::Cancel if !context.can_cancel => "Cancel focused turn · idle",
+            Self::Cancel => "Cancel focused turn",
+            Self::Trace if !context.trace_available => "Open session trace · fork not ready",
+            Self::Trace => "Open session trace",
+            Self::CloseBtw if !context.btw_open => "Close side pane · not open",
+            Self::CloseBtw if context.btw_busy => "Close side pane · finish active work first",
+            Self::CloseBtw => "Close side pane",
+            Self::McpLogin => "Log in to MCP server…",
+            Self::McpReload => "Reload MCP server…",
+            Self::Keybindings => "Keyboard shortcuts",
+        }
+    }
+
+    pub(super) const fn enabled(self, context: ActionContext) -> bool {
+        match self {
+            Self::Branches => context.can_browse_branches,
+            Self::Cancel => context.can_cancel,
+            Self::Trace => context.trace_available,
+            Self::CloseBtw => context.btw_open && !context.btw_busy,
+            Self::Reasoning
+            | Self::FastMode
+            | Self::Btw
+            | Self::ToolDetails
+            | Self::McpLogin
+            | Self::McpReload
+            | Self::Keybindings => true,
+        }
+    }
+
+    fn matches(self, query: &str) -> bool {
+        if query.is_empty() {
+            return true;
+        }
+        self.search_terms()
+            .iter()
+            .any(|term| contains_ignore_ascii_case(term, query))
+    }
+
+    const fn search_terms(self) -> &'static [&'static str] {
+        match self {
+            Self::Reasoning => &["change reasoning", "model", "thinking", "/model"],
+            Self::FastMode => &["fast mode", "priority", "/fast"],
+            Self::Btw => &["side question", "fork", "btw", "/btw"],
+            Self::Branches => &["browse branches", "history", "tree"],
+            Self::ToolDetails => &["tool details", "fold", "expand", "collapse"],
+            Self::Cancel => &["cancel focused turn", "stop", "interrupt", "/cancel"],
+            Self::Trace => &["open session trace", "jaeger", "telemetry", "/trace"],
+            Self::CloseBtw => &["close side pane", "dismiss", "/close"],
+            Self::McpLogin => &["mcp login", "authenticate", "/mcp login"],
+            Self::McpReload => &["mcp reload", "refresh", "/mcp reload"],
+            Self::Keybindings => &["keyboard shortcuts", "keys", "help"],
+        }
+    }
+}
+
+fn contains_ignore_ascii_case(value: &str, query: &str) -> bool {
+    if query.len() > value.len() {
+        return false;
+    }
+    value
+        .as_bytes()
+        .windows(query.len())
+        .any(|window| window.eq_ignore_ascii_case(query.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    use super::{Action, ActionContext, ActionMenu, ActionMenuResult};
+
+    fn context() -> ActionContext {
+        ActionContext {
+            fast_mode: false,
+            btw_open: false,
+            btw_busy: false,
+            can_browse_branches: false,
+            can_cancel: false,
+            trace_available: true,
+            tool_details_expanded: true,
+        }
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn search_matches_labels_commands_and_aliases() {
+        let mut menu = ActionMenu::default();
+        for character in "thinking".chars() {
+            assert_eq!(
+                menu.handle_key(key(KeyCode::Char(character)), context()),
+                ActionMenuResult::Handled
+            );
+        }
+        assert_eq!(
+            menu.handle_key(key(KeyCode::Enter), context()),
+            ActionMenuResult::Trigger(Action::Reasoning)
+        );
+    }
+
+    #[test]
+    fn unavailable_actions_are_visible_but_cannot_trigger() {
+        let mut menu = ActionMenu::default();
+        for character in "branches".chars() {
+            let _ = menu.handle_key(key(KeyCode::Char(character)), context());
+        }
+        assert_eq!(
+            menu.handle_key(key(KeyCode::Enter), context()),
+            ActionMenuResult::Handled
+        );
+    }
+
+    #[test]
+    fn unknown_slash_input_can_still_be_submitted_to_the_model() {
+        let mut menu = ActionMenu::default();
+        for character in "review-pr".chars() {
+            let _ = menu.handle_key(key(KeyCode::Char(character)), context());
+        }
+        assert_eq!(
+            menu.handle_key(key(KeyCode::Enter), context()),
+            ActionMenuResult::SubmitLiteral("/review-pr".to_owned())
+        );
+    }
+
+    #[test]
+    fn control_enter_forces_the_search_text_through_the_normal_submission_path() {
+        let mut menu = ActionMenu::default();
+        for character in "trace notes".chars() {
+            let _ = menu.handle_key(key(KeyCode::Char(character)), context());
+        }
+        assert_eq!(
+            menu.handle_key(
+                KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL),
+                context()
+            ),
+            ActionMenuResult::SubmitLiteral("/trace notes".to_owned())
+        );
+    }
+}

--- a/bin/nanocodex/src/tui/app.rs
+++ b/bin/nanocodex/src/tui/app.rs
@@ -13,6 +13,7 @@ use ratatui::{
 use serde::Deserialize;
 use serde_json::Value;
 
+use super::actions::{ActionContext, ActionMenu};
 use super::composer::ComposerLayout;
 use super::selection::{
     ScreenSelection, SelectionClick, SelectionScrollDirection, SelectionScrollRequest,
@@ -1129,6 +1130,8 @@ pub(super) struct App {
     fast_mode: bool,
     thinking: Thinking,
     reasoning_picker: Option<ReasoningPicker>,
+    action_menu: Option<ActionMenu>,
+    keybindings_visible: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -1180,6 +1183,8 @@ impl App {
             fast_mode: false,
             thinking: Thinking::default(),
             reasoning_picker: None,
+            action_menu: None,
+            keybindings_visible: false,
         }
     }
 
@@ -2215,6 +2220,56 @@ impl App {
         !self.input.chars().all(char::is_whitespace)
     }
 
+    pub(super) fn open_action_menu(&mut self) {
+        self.action_menu = Some(ActionMenu::default());
+    }
+
+    pub(super) fn action_menu(&self) -> Option<&ActionMenu> {
+        self.action_menu.as_ref()
+    }
+
+    pub(super) fn action_menu_mut(&mut self) -> Option<&mut ActionMenu> {
+        self.action_menu.as_mut()
+    }
+
+    pub(super) fn close_action_menu(&mut self) {
+        self.action_menu = None;
+    }
+
+    pub(super) fn action_context(&self) -> ActionContext {
+        let conversation = self.active_conversation();
+        ActionContext {
+            fast_mode: self.fast_mode,
+            btw_open: self.btw.is_some(),
+            btw_busy: self.btw_busy(),
+            can_browse_branches: self.focus == PaneId::Main
+                && self.btw.is_none()
+                && self.historical_editor.is_none()
+                && self.pending_historical_edit.is_none()
+                && !self.main_branches.is_empty(),
+            can_cancel: conversation.running || conversation.pending_turns > 0,
+            trace_available: matches!(self.focus, PaneId::Main)
+                || self
+                    .btw
+                    .as_ref()
+                    .is_some_and(|btw| btw.request_id.is_some()),
+            tool_details_expanded: self.tool_details_expanded(),
+        }
+    }
+
+    pub(super) fn open_keybindings(&mut self) {
+        self.action_menu = None;
+        self.keybindings_visible = true;
+    }
+
+    pub(super) const fn keybindings_visible(&self) -> bool {
+        self.keybindings_visible
+    }
+
+    pub(super) fn close_keybindings(&mut self) {
+        self.keybindings_visible = false;
+    }
+
     pub(super) fn turn_finished(
         &mut self,
         target: PaneId,
@@ -2374,6 +2429,15 @@ impl App {
 
     pub(super) fn mouse_selection_needs_redraw(&self) -> bool {
         self.screen_selection.needs_tick()
+    }
+
+    pub(super) fn brand_animation_active(&self) -> bool {
+        self.btw.is_none()
+            && self.main.transcript.is_empty()
+            && self.branch_navigator.is_none()
+            && self.action_menu.is_none()
+            && !self.keybindings_visible
+            && self.reasoning_picker.is_none()
     }
 
     fn place_composer_cursor(&mut self, click: SelectionClick) -> bool {
@@ -3177,6 +3241,22 @@ mod tests {
             app.main.transcript.latest_user_message(),
             Some("visible prompt")
         );
+    }
+
+    #[test]
+    fn brand_animation_runs_only_for_the_unobscured_empty_main_transcript() {
+        let mut app = App::new("/worktree".into());
+        assert!(app.brand_animation_active());
+
+        app.open_action_menu();
+        assert!(!app.brand_animation_active());
+        app.close_action_menu();
+        assert!(app.brand_animation_active());
+
+        app.main
+            .transcript
+            .push(TranscriptItem::User("start working".to_owned()));
+        assert!(!app.brand_animation_active());
     }
 
     #[test]

--- a/bin/nanocodex/src/tui/branding.rs
+++ b/bin/nanocodex/src/tui/branding.rs
@@ -1,0 +1,231 @@
+// Responsive animated Nanocodex branding for an empty transcript.
+
+use std::f64::consts::TAU;
+
+use ratatui::{
+    buffer::Buffer,
+    layout::{Alignment, Rect},
+    style::{Color, Modifier, Style},
+    text::Line,
+    widgets::{Paragraph, Widget},
+};
+
+const FRAME_COUNT: usize = 48;
+const MAX_WIDTH: u16 = 64;
+const MAX_HEIGHT: u16 = 11;
+const RAMP: [&str; 9] = ["·", ":", "-", "=", "+", "*", "#", "%", "@"];
+const LEVEL_THRESHOLDS: [f64; 8] = [0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5];
+const ASCII_WORDMARK: [&str; 4] = [
+    " _ __   __ _ _ __   ___   ___ ___   __| | _____  __",
+    "| '_ \\ / _` | '_ \\ / _ \\ / __/ _ \\ / _` |/ _ \\ \\/ /",
+    "| | | | (_| | | | | (_) | (_| (_) | (_| |  __/>  <",
+    "|_| |_|\\__,_|_| |_|\\___/ \\___\\___/ \\__,_|\\___/_/\\_\\",
+];
+const ASCII_WIDTH: u16 = 51;
+const COMPACT_WORDMARK: &str = "nanocodex";
+const TAGLINE: &str = "small agent · sharp tools";
+
+pub(super) fn render_empty(
+    area: Rect,
+    buffer: &mut Buffer,
+    animation_frame: usize,
+    accent: Color,
+    fallback: &str,
+) {
+    if area.width < 18 || area.height < 4 {
+        render_fallback(area, buffer, fallback);
+        return;
+    }
+
+    let mask = centered_mask(area);
+    render_signal(mask, buffer, animation_frame, accent);
+    if mask.width >= ASCII_WIDTH.saturating_add(4) && mask.height >= 8 {
+        render_ascii_wordmark(mask, buffer);
+    } else {
+        render_compact_wordmark(mask, buffer);
+    }
+}
+
+fn render_signal(area: Rect, buffer: &mut Buffer, animation_frame: usize, accent: Color) {
+    let Ok(phase_index) = u16::try_from(animation_frame % FRAME_COUNT) else {
+        unreachable!("branding frame index is bounded by FRAME_COUNT");
+    };
+    let phase = TAU * f64::from(phase_index) / 48.0;
+    let center_x = f64::from(area.width.saturating_sub(1)) / 2.0;
+    let center_y = f64::from(area.height.saturating_sub(1)) / 2.0;
+    for row in 0..area.height {
+        let inset = corner_inset(row, area.height).min(area.width.saturating_sub(1) / 2);
+        for column in inset..area.width.saturating_sub(inset) {
+            let x = f64::from(column) - center_x;
+            let y = (f64::from(row) - center_y) * 2.2;
+            let distance =
+                ((x - phase.cos() * 8.0).powi(2) + (y - phase.sin() * 3.0).powi(2)).sqrt();
+            let value = (x * 0.23 + phase).sin()
+                + (x * 0.11 + y * 0.41 - phase * 2.0).sin()
+                + (distance * 0.31 - phase).sin();
+            let scaled = ((value + 3.0) / 6.0 * 8.0).clamp(0.0, 8.0);
+            let level = LEVEL_THRESHOLDS.partition_point(|threshold| scaled >= *threshold);
+            buffer[(area.x + column, area.y + row)]
+                .set_symbol(RAMP[level])
+                .set_style(signal_style(level, accent));
+        }
+    }
+}
+
+fn render_ascii_wordmark(mask: Rect, buffer: &mut Buffer) {
+    let panel = Rect::new(
+        mask.x + mask.width.saturating_sub(ASCII_WIDTH.saturating_add(2)) / 2,
+        mask.y + mask.height.saturating_sub(6) / 2,
+        ASCII_WIDTH.saturating_add(2),
+        6,
+    );
+    clear(panel, buffer);
+    let logo_style = Style::default()
+        .fg(Color::Cyan)
+        .add_modifier(Modifier::BOLD);
+    for (row, line) in ASCII_WORDMARK.iter().enumerate() {
+        buffer.set_string(
+            panel.x.saturating_add(1),
+            panel
+                .y
+                .saturating_add(u16::try_from(row).unwrap_or(u16::MAX)),
+            *line,
+            logo_style,
+        );
+    }
+    Paragraph::new(Line::styled(TAGLINE, Style::default().fg(Color::DarkGray)))
+        .alignment(Alignment::Center)
+        .render(
+            Rect::new(panel.x, panel.bottom().saturating_sub(1), panel.width, 1),
+            buffer,
+        );
+}
+
+fn render_compact_wordmark(mask: Rect, buffer: &mut Buffer) {
+    let panel_width = mask.width.min(32);
+    let panel_height = mask.height.min(3);
+    let panel = Rect::new(
+        mask.x + mask.width.saturating_sub(panel_width) / 2,
+        mask.y + mask.height.saturating_sub(panel_height) / 2,
+        panel_width,
+        panel_height,
+    );
+    clear(panel, buffer);
+    let wordmark_y = panel.y + panel.height.saturating_sub(2) / 2;
+    Paragraph::new(Line::styled(
+        COMPACT_WORDMARK,
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    ))
+    .alignment(Alignment::Center)
+    .render(Rect::new(panel.x, wordmark_y, panel.width, 1), buffer);
+    if panel.height >= 2 {
+        Paragraph::new(Line::styled(TAGLINE, Style::default().fg(Color::DarkGray)))
+            .alignment(Alignment::Center)
+            .render(
+                Rect::new(panel.x, wordmark_y.saturating_add(1), panel.width, 1),
+                buffer,
+            );
+    }
+}
+
+fn render_fallback(area: Rect, buffer: &mut Buffer, message: &str) {
+    Paragraph::new(Line::styled(
+        format!("  {message}"),
+        Style::default().fg(Color::DarkGray),
+    ))
+    .render(area, buffer);
+}
+
+fn centered_mask(area: Rect) -> Rect {
+    let width = MAX_WIDTH.min(area.width.saturating_sub(4)).max(1);
+    let height = MAX_HEIGHT.min(area.height.saturating_sub(2)).max(1);
+    Rect::new(
+        area.x + area.width.saturating_sub(width) / 2,
+        area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    )
+}
+
+fn clear(area: Rect, buffer: &mut Buffer) {
+    for row in area.y..area.bottom() {
+        for column in area.x..area.right() {
+            buffer[(column, row)].reset();
+        }
+    }
+}
+
+fn corner_inset(row: u16, height: u16) -> u16 {
+    let edge_distance = row.min(height.saturating_sub(1).saturating_sub(row));
+    match edge_distance {
+        0 => 3,
+        1 => 1,
+        _ => 0,
+    }
+}
+
+fn signal_style(level: usize, accent: Color) -> Style {
+    let style = Style::default().fg(accent);
+    if level < 3 {
+        style.add_modifier(Modifier::DIM)
+    } else if level >= 6 {
+        style.add_modifier(Modifier::BOLD)
+    } else {
+        style
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::{buffer::Buffer, layout::Rect, style::Color};
+
+    use super::{ASCII_WORDMARK, render_empty};
+
+    fn rendered(width: u16, height: u16, frame: usize) -> Buffer {
+        let area = Rect::new(0, 0, width, height);
+        let mut buffer = Buffer::empty(area);
+        render_empty(area, &mut buffer, frame, Color::Yellow, "fallback");
+        buffer
+    }
+
+    fn text(buffer: &Buffer) -> String {
+        (0..buffer.area.height)
+            .map(|row| {
+                (0..buffer.area.width)
+                    .map(|column| buffer[(column, row)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn wide_empty_state_centers_the_full_ascii_wordmark() {
+        let buffer = rendered(80, 20, 0);
+        let rendered = text(&buffer);
+        for line in ASCII_WORDMARK {
+            assert!(rendered.contains(line));
+        }
+        assert!(rendered.contains("small agent · sharp tools"));
+    }
+
+    #[test]
+    fn compact_empty_state_keeps_branding_legible() {
+        let rendered = text(&rendered(40, 6, 0));
+        assert!(rendered.contains("nanocodex"));
+        assert!(rendered.contains("small agent · sharp tools"));
+        assert!(!rendered.contains(ASCII_WORDMARK[0]));
+    }
+
+    #[test]
+    fn signal_field_changes_across_animation_frames() {
+        assert_ne!(rendered(80, 20, 0), rendered(80, 20, 4));
+    }
+
+    #[test]
+    fn tiny_empty_state_uses_the_plain_fallback() {
+        assert!(text(&rendered(16, 2, 0)).contains("fallback"));
+    }
+}

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -1,4 +1,6 @@
+mod actions;
 mod app;
+mod branding;
 mod clipboard;
 mod composer;
 mod diff;
@@ -36,6 +38,7 @@ use tokio::{
 use tracing::{Instrument, info_span};
 
 use self::{
+    actions::{Action, ActionMenuResult},
     app::{App, EscapeAction, PaneId, ReasoningPickerAction, SubmittedPrompt},
     notification::Notifier,
     scheduler::{RenderScheduler, STREAM_FRAME_INTERVAL},
@@ -604,7 +607,8 @@ pub(crate) async fn run(
             }
             _ = ticker.tick(), if ui.app.main.running
                 || ui.app.btw.as_ref().is_some_and(|btw| btw.conversation.running)
-                || ui.app.mouse_selection_needs_redraw() => {
+                || ui.app.mouse_selection_needs_redraw()
+                || ui.app.brand_animation_active() => {
                 if apply_update(ui.update(UiAction::Tick, &worker_tx)?, &mut scheduler) {
                     break Ok(());
                 }
@@ -1842,7 +1846,11 @@ fn handle_terminal_event(
         }
         Event::Paste(text) => {
             let _ = app.clear_mouse_selection();
-            app.handle_paste(&text);
+            if let Some(menu) = app.action_menu_mut() {
+                menu.handle_paste(&text);
+            } else if !app.keybindings_visible() {
+                app.handle_paste(&text);
+            }
             Ok(TerminalAction::Redraw)
         }
         Event::Mouse(mouse) => match mouse.kind {
@@ -1896,6 +1904,10 @@ fn handle_key(
     root_session_id: &str,
     commands: &mpsc::UnboundedSender<WorkerCommand>,
 ) -> Result<TerminalAction> {
+    if let Some(action) = handle_overlay_key(key, app, root_session_id, commands)? {
+        return Ok(action);
+    }
+
     if matches!(key.code, KeyCode::Char('v' | 'V'))
         && key
             .modifiers
@@ -1903,10 +1915,6 @@ fn handle_key(
     {
         paste_clipboard_image(app, clipboard::paste_image_to_temp_png);
         return Ok(TerminalAction::Redraw);
-    }
-
-    if let Some(action) = handle_reasoning_picker_key(key, app, commands)? {
-        return Ok(action);
     }
 
     if let Some(action) = handle_inline_historical_editor_key(key, app, commands)? {
@@ -1971,6 +1979,7 @@ fn handle_key(
             app.insert_char('\n');
         }
         KeyCode::Enter => submit(app, root_session_id, commands, SubmitIntent::Immediate)?,
+        KeyCode::Char('/') if app.input.is_empty() => app.open_action_menu(),
         KeyCode::Char(character) => app.insert_char(character),
         KeyCode::Backspace => app.backspace(),
         KeyCode::Delete => app.delete(),
@@ -2002,6 +2011,93 @@ fn handle_key(
         | KeyCode::Modifier(_) => {}
     }
     Ok(TerminalAction::Redraw)
+}
+
+fn handle_overlay_key(
+    key: KeyEvent,
+    app: &mut App,
+    root_session_id: &str,
+    commands: &mpsc::UnboundedSender<WorkerCommand>,
+) -> Result<Option<TerminalAction>> {
+    if let Some(action) = handle_keybindings_key(key, app) {
+        return Ok(Some(action));
+    }
+    if let Some(action) = handle_action_menu_key(key, app, root_session_id, commands)? {
+        return Ok(Some(action));
+    }
+    handle_reasoning_picker_key(key, app, commands)
+}
+
+fn handle_keybindings_key(key: KeyEvent, app: &mut App) -> Option<TerminalAction> {
+    if !app.keybindings_visible() {
+        return None;
+    }
+    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+        return Some(TerminalAction::Quit);
+    }
+    if key.modifiers.is_empty() && matches!(key.code, KeyCode::Esc | KeyCode::Char('q' | '?')) {
+        app.close_keybindings();
+    }
+    Some(TerminalAction::Redraw)
+}
+
+fn handle_action_menu_key(
+    key: KeyEvent,
+    app: &mut App,
+    root_session_id: &str,
+    commands: &mpsc::UnboundedSender<WorkerCommand>,
+) -> Result<Option<TerminalAction>> {
+    if app.action_menu().is_none() {
+        return Ok(None);
+    }
+    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+        return Ok(Some(TerminalAction::Quit));
+    }
+    let context = app.action_context();
+    let Some(result) = app
+        .action_menu_mut()
+        .map(|menu| menu.handle_key(key, context))
+    else {
+        return Ok(None);
+    };
+    match result {
+        ActionMenuResult::Handled => {}
+        ActionMenuResult::Dismiss => app.close_action_menu(),
+        ActionMenuResult::SubmitLiteral(input) => {
+            app.close_action_menu();
+            app.replace_input(input);
+            submit(app, root_session_id, commands, SubmitIntent::Immediate)?;
+        }
+        ActionMenuResult::Trigger(action) => {
+            app.close_action_menu();
+            match action {
+                Action::Branches => {
+                    let _ = app.toggle_branch_navigator();
+                }
+                Action::ToolDetails => {
+                    let _ = app.toggle_tool_details();
+                }
+                Action::Keybindings => app.open_keybindings(),
+                Action::McpLogin | Action::McpReload => {
+                    if let Some(command) = action.command() {
+                        app.replace_input(command.to_owned());
+                    }
+                }
+                Action::Reasoning
+                | Action::FastMode
+                | Action::Btw
+                | Action::Cancel
+                | Action::Trace
+                | Action::CloseBtw => {
+                    if let Some(command) = action.command() {
+                        app.replace_input(command.to_owned());
+                        submit(app, root_session_id, commands, SubmitIntent::Immediate)?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(Some(TerminalAction::Redraw))
 }
 
 fn handle_reasoning_picker_key(
@@ -2614,6 +2710,72 @@ mod tests {
             classify_submission("/modeling"),
             Submission::Prompt("/modeling".into())
         );
+    }
+
+    #[test]
+    fn leading_slash_opens_searchable_actions_and_can_open_reasoning() {
+        let (commands, mut worker) = mpsc::unbounded_channel();
+        let mut app = App::new("/workspace".into());
+
+        handle_key(
+            KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE),
+            &mut app,
+            "main-session",
+            &commands,
+        )
+        .unwrap();
+        assert!(app.action_menu().is_some());
+        assert!(app.input.is_empty());
+
+        for character in "thinking".chars() {
+            handle_key(
+                KeyEvent::new(KeyCode::Char(character), KeyModifiers::NONE),
+                &mut app,
+                "main-session",
+                &commands,
+            )
+            .unwrap();
+        }
+        handle_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut app,
+            "main-session",
+            &commands,
+        )
+        .unwrap();
+
+        assert!(app.action_menu().is_none());
+        assert!(app.reasoning_picker().is_some());
+        assert!(worker.try_recv().is_err());
+    }
+
+    #[test]
+    fn unmatched_action_search_preserves_unknown_slash_prompt_behavior() {
+        let (commands, mut worker) = mpsc::unbounded_channel();
+        let mut app = App::new("/workspace".into());
+        app.open_action_menu();
+        for character in "review-pr".chars() {
+            handle_key(
+                KeyEvent::new(KeyCode::Char(character), KeyModifiers::NONE),
+                &mut app,
+                "main-session",
+                &commands,
+            )
+            .unwrap();
+        }
+
+        handle_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut app,
+            "main-session",
+            &commands,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            worker.try_recv(),
+            Ok(WorkerCommand::Prompt { prompt, .. }) if prompt == "/review-pr"
+        ));
     }
 
     #[test]

--- a/bin/nanocodex/src/tui/transcript.rs
+++ b/bin/nanocodex/src/tui/transcript.rs
@@ -19,6 +19,7 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 use super::app::PlanStepStatus;
+use super::branding;
 use super::composer::ComposerLayout;
 use super::diff::{PatchPresentation, present_apply_patch};
 use super::markdown::{
@@ -88,7 +89,6 @@ impl Clone for Transcript {
 }
 
 impl Transcript {
-    #[cfg(test)]
     pub(super) fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
@@ -400,6 +400,7 @@ impl Transcript {
             selected,
             inline_edit,
             empty_message,
+            branding: None,
         }
     }
 
@@ -459,6 +460,14 @@ pub(super) struct TranscriptWidget<'a> {
     selected: Option<usize>,
     inline_edit: Option<InlineEdit<'a>>,
     empty_message: &'static str,
+    branding: Option<(usize, Color)>,
+}
+
+impl TranscriptWidget<'_> {
+    pub(super) const fn branded_empty(mut self, frame: usize, accent: Color) -> Self {
+        self.branding = Some((frame, accent));
+        self
+    }
 }
 
 impl Widget for TranscriptWidget<'_> {
@@ -467,6 +476,10 @@ impl Widget for TranscriptWidget<'_> {
             return;
         }
         if self.transcript.entries.is_empty() {
+            if let Some((frame, accent)) = self.branding {
+                branding::render_empty(area, buffer, frame, accent, self.empty_message);
+                return;
+            }
             Paragraph::new(Text::from(vec![
                 Line::raw(""),
                 Line::styled(

--- a/bin/nanocodex/src/tui/view.rs
+++ b/bin/nanocodex/src/tui/view.rs
@@ -3,7 +3,7 @@ use ratatui::{
     layout::{Alignment, Constraint, Layout, Position, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span, Text},
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::{Block, BorderType, Borders, Clear, List, ListItem, ListState, Paragraph},
 };
 use std::time::Instant;
 
@@ -12,6 +12,22 @@ use super::{
     composer::ComposerLayout,
     transcript::InlineEdit,
 };
+
+const KEYBINDINGS: [(&str, &str); 13] = [
+    ("Enter", "send; steer while the focused turn is running"),
+    ("Tab", "queue input; switch pane when the draft is empty"),
+    ("Shift+Enter", "insert a newline"),
+    ("↑ / ↓", "move by visual row; then select prior prompts"),
+    ("PageUp / PageDown", "scroll the focused transcript"),
+    ("Ctrl+End", "jump to the newest output"),
+    ("Ctrl+O", "expand or collapse tool details"),
+    ("Ctrl+G", "edit the draft in $VISUAL or $EDITOR"),
+    ("Ctrl+Alt+B", "browse the branch tree"),
+    ("Ctrl+Alt+↑ / ↓", "cycle retained branches"),
+    ("Ctrl+V / Alt+V", "attach an image from the clipboard"),
+    ("Esc Esc", "stop the focused running turn"),
+    ("Ctrl+C", "quit"),
+];
 
 pub(super) fn render(frame: &mut Frame<'_>, app: &mut App) {
     let area = frame.area();
@@ -57,6 +73,130 @@ pub(super) fn render(frame: &mut Frame<'_>, app: &mut App) {
     render_footer(frame, app, footer_area);
     app.render_mouse_selection(frame.buffer_mut(), selectable_areas.as_slice());
     render_reasoning_picker(frame, app);
+    render_action_menu(frame, app);
+    render_keybindings(frame, app);
+}
+
+fn render_action_menu(frame: &mut Frame<'_>, app: &App) {
+    let Some(menu) = app.action_menu() else {
+        return;
+    };
+    let area = centered(frame.area(), 64, 16);
+    let inner = render_popup(frame, area, "Actions");
+    if inner.is_empty() {
+        return;
+    }
+    let [search_area, actions_area, help_area] = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Min(1),
+        Constraint::Length(1),
+    ])
+    .areas(inner);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("  Search: /", Style::default().fg(Color::DarkGray)),
+            Span::raw(menu.query()),
+        ])),
+        search_area,
+    );
+
+    let context = app.action_context();
+    let items = menu.visible_actions().map(|action| {
+        let enabled = action.enabled(context);
+        let label = action.label(context);
+        let color = if enabled {
+            Color::Reset
+        } else {
+            Color::DarkGray
+        };
+        let mut spans = vec![Span::styled(label, Style::default().fg(color))];
+        if let Some(command) = action.command() {
+            spans.push(Span::styled(
+                format!("  {command}"),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+        ListItem::new(Line::from(spans))
+    });
+    let mut state = ListState::default().with_selected(menu.selected());
+    frame.render_stateful_widget(
+        List::new(items).highlight_symbol("› ").highlight_style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        actions_area,
+        &mut state,
+    );
+    frame.render_widget(
+        Paragraph::new(Line::styled(
+            "↑↓ move · enter/tab open · ctrl+enter send literal · esc close",
+            Style::default().fg(Color::DarkGray),
+        ))
+        .alignment(Alignment::Center),
+        help_area,
+    );
+}
+
+fn render_keybindings(frame: &mut Frame<'_>, app: &App) {
+    if !app.keybindings_visible() {
+        return;
+    }
+    let area = centered(frame.area(), 74, 17);
+    let inner = render_popup(frame, area, "Keyboard shortcuts");
+    let [body, help] = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).areas(inner);
+    let lines = KEYBINDINGS
+        .map(|(key, description)| {
+            Line::from(vec![
+                Span::styled(
+                    format!("  {key:<18}"),
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(description),
+            ])
+        })
+        .into_iter()
+        .collect::<Vec<_>>();
+    frame.render_widget(Paragraph::new(lines), body);
+    frame.render_widget(
+        Paragraph::new(Line::styled(
+            "esc close",
+            Style::default().fg(Color::DarkGray),
+        ))
+        .alignment(Alignment::Center),
+        help,
+    );
+}
+
+fn render_popup(frame: &mut Frame<'_>, area: Rect, title: &str) -> Rect {
+    let block = Block::default()
+        .title(format!(" {title} "))
+        .title_alignment(Alignment::Center)
+        .title_style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(Color::DarkGray));
+    let inner = block.inner(area);
+    frame.render_widget(Clear, area);
+    frame.render_widget(block, area);
+    inner
+}
+
+fn centered(area: Rect, width: u16, height: u16) -> Rect {
+    let width = width.min(area.width);
+    let height = height.min(area.height);
+    Rect::new(
+        area.x + area.width.saturating_sub(width) / 2,
+        area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    )
 }
 
 fn render_reasoning_picker(frame: &mut Frame<'_>, app: &App) {
@@ -185,6 +325,7 @@ fn render_transcripts(
     selectable_areas: &mut SelectableAreas,
 ) {
     let historical_editor_index = app.historical_editor_index();
+    let branding = Some((app.frame, thinking_color(app.thinking())));
     let inline_edit = historical_editor_index.map(|index| InlineEdit {
         index,
         input: app.input.as_str(),
@@ -208,6 +349,7 @@ fn render_transcripts(
                     empty_message:
                         "Ask Nanocodex to inspect, edit, run, or explain this workspace.",
                     preserve_view: preserve_main,
+                    branding: None,
                 },
             ));
             selectable_areas.push(render_transcript(
@@ -220,6 +362,7 @@ fn render_transcripts(
                     inline_edit: None,
                     empty_message: "Ask a quick side question without interrupting the main thread.",
                     preserve_view: preserve_btw,
+                    branding: None,
                 },
             ));
         }
@@ -242,6 +385,7 @@ fn render_transcripts(
                     empty_message:
                         "Ask Nanocodex to inspect, edit, run, or explain this workspace.",
                     preserve_view: false,
+                    branding: None,
                 },
             ));
         }
@@ -258,6 +402,7 @@ fn render_transcripts(
                 inline_edit,
                 empty_message: "Ask Nanocodex to inspect, edit, run, or explain this workspace.",
                 preserve_view: preserve_main,
+                branding,
             },
         ));
     }
@@ -355,6 +500,7 @@ struct TranscriptRenderOptions<'a> {
     inline_edit: Option<InlineEdit<'a>>,
     empty_message: &'static str,
     preserve_view: bool,
+    branding: Option<(usize, Color)>,
 }
 
 fn render_transcript(
@@ -369,6 +515,7 @@ fn render_transcript(
         inline_edit,
         empty_message,
         preserve_view,
+        branding,
     } = options;
     let title = if conversation.has_unseen_output {
         format!("{title}↓ New output · Ctrl+End ")
@@ -388,15 +535,17 @@ fn render_transcript(
     let scroll_from_bottom = conversation.display_scroll_from_bottom();
     frame.render_widget(block, area);
 
-    frame.render_widget(
-        conversation.transcript.widget(
-            scroll_from_bottom,
-            conversation.selected_user,
-            inline_edit,
-            empty_message,
-        ),
-        inner,
+    let widget = conversation.transcript.widget(
+        scroll_from_bottom,
+        conversation.selected_user,
+        inline_edit,
+        empty_message,
     );
+    let widget = match branding {
+        Some((frame, accent)) => widget.branded_empty(frame, accent),
+        None => widget,
+    };
+    frame.render_widget(widget, inner);
     if let Some(edit) = inline_edit
         && let Some(position) = conversation.transcript.inline_edit_cursor(
             inner,
@@ -473,7 +622,6 @@ fn render_composer(frame: &mut Frame<'_>, app: &App, area: Rect, layout: &Compos
 
 fn render_footer(frame: &mut Frame<'_>, app: &App, area: Rect) {
     let conversation = app.active_conversation();
-    let spinner = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
     let state = if app.branch_navigator_active() {
         "Branches — ↑/↓ or j/k switch + preview · Esc close".to_owned()
     } else if app.historical_editor_active() {
@@ -493,8 +641,8 @@ fn render_footer(frame: &mut Frame<'_>, app: &App, area: Rect) {
         "Stop Agent Turn — Esc again to confirm".to_owned()
     } else if conversation.running {
         format!(
-            "{} Working ({})",
-            spinner[app.frame % spinner.len()],
+            "[{}] Working ({})",
+            loader_frame(app.frame),
             format_elapsed(conversation.run_elapsed(Instant::now()))
         )
     } else {
@@ -515,24 +663,17 @@ fn render_footer(frame: &mut Frame<'_>, app: &App, area: Rect) {
             (steers, queued) => format!(" · {steers} steers · {queued} queued"),
         }
     };
-    let escape_help = if steers == 0 {
-        "Esc Esc stop"
+    let help = if conversation.running {
+        let escape = if steers == 0 {
+            "Esc Esc stop"
+        } else {
+            "Esc interrupt/send"
+        };
+        format!("  / actions · Enter steer · Tab queue · {escape}")
+    } else if app.btw.is_some() {
+        "  / actions · BackTab switch · Enter send · Tab queue".to_owned()
     } else {
-        "Esc interrupt/send"
-    };
-    let tool_help = if app.tool_details_expanded() {
-        "Ctrl+O fold tools"
-    } else {
-        "Ctrl+O expand tools"
-    };
-    let help = if app.btw.is_some() {
-        format!(
-            "  BackTab switch · {tool_help} · Ctrl+V image · /close dismiss · Enter send/steer · Tab queue · {escape_help} · Ctrl+C quit"
-        )
-    } else {
-        format!(
-            "  /btw <question> side fork · {tool_help} · Ctrl+V image · Enter send/steer · Tab queue · {escape_help} · Ctrl+C quit"
-        )
+        "  / actions · Enter send · Tab queue".to_owned()
     };
     let model_width = nanocodex::MODEL.len() + 3 + "default".len() + 7 + 1;
     let model_width = saturating_u16(model_width).min(area.width);
@@ -572,6 +713,34 @@ fn render_footer(frame: &mut Frame<'_>, app: &App, area: Rect) {
         Paragraph::new(Line::from(model)).alignment(Alignment::Right),
         right,
     );
+}
+
+fn thinking_color(thinking: nanocodex::Thinking) -> Color {
+    match thinking {
+        nanocodex::Thinking::None | nanocodex::Thinking::Low => Color::Gray,
+        nanocodex::Thinking::Medium => Color::Cyan,
+        nanocodex::Thinking::High => Color::Yellow,
+        nanocodex::Thinking::Xhigh => Color::Red,
+        nanocodex::Thinking::Max => Color::Magenta,
+    }
+}
+
+fn loader_frame(frame: usize) -> String {
+    const WORDMARK: &str = "nanocodex";
+    let length = WORDMARK.len();
+    let phase = frame % (length * 2);
+    WORDMARK
+        .chars()
+        .enumerate()
+        .map(|(index, character)| {
+            let visible = if phase < length {
+                index <= phase
+            } else {
+                index > phase - length
+            };
+            if visible { character } else { '·' }
+        })
+        .collect()
 }
 
 fn format_elapsed(elapsed: std::time::Duration) -> String {
@@ -705,7 +874,7 @@ mod tests {
         style::{Color, Modifier},
     };
 
-    use super::render;
+    use super::{loader_frame, render};
     use crate::tui::{app::App, transcript::TranscriptItem};
 
     #[test]
@@ -770,6 +939,15 @@ mod tests {
     }
 
     #[test]
+    fn running_loader_types_and_erases_a_stable_width_wordmark() {
+        assert_eq!(loader_frame(0), "n········");
+        assert_eq!(loader_frame(8), "nanocodex");
+        assert_eq!(loader_frame(9), "·anocodex");
+        assert_eq!(loader_frame(17), "·········");
+        assert!((0..36).all(|frame| loader_frame(frame).chars().count() == 9));
+    }
+
+    #[test]
     fn footer_keeps_model_on_the_bottom_right_and_marks_fast_mode() {
         let mut terminal = Terminal::new(TestBackend::new(80, 16)).unwrap();
         let mut app = App::new("/workspace".into());
@@ -807,6 +985,36 @@ mod tests {
         let rendered = terminal.backend().to_string();
         assert!(rendered.contains("Advanced Reasoning"));
         assert!(rendered.contains("For difficult problems when quality"));
+    }
+
+    #[test]
+    fn slash_action_menu_is_searchable_and_keeps_unavailable_actions_visible() {
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        let mut app = App::new("/workspace".into());
+        app.open_action_menu();
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let rendered = terminal.backend().to_string();
+        assert!(rendered.contains("Actions"));
+        assert!(rendered.contains("Search: /"));
+        assert!(rendered.contains("Change reasoning"));
+        assert!(rendered.contains("Browse branches · no alternate branches"));
+        assert!(rendered.contains("ctrl+enter send literal"));
+        assert_eq!(terminal.backend().buffer()[(8, 4)].symbol(), "╭");
+    }
+
+    #[test]
+    fn shortcut_reference_keeps_the_daily_driver_bindings_in_one_overlay() {
+        let mut terminal = Terminal::new(TestBackend::new(80, 24)).unwrap();
+        let mut app = App::new("/workspace".into());
+        app.open_keybindings();
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        let rendered = terminal.backend().to_string();
+        assert!(rendered.contains("Keyboard shortcuts"));
+        assert!(rendered.contains("send; steer while the focused turn is running"));
+        assert!(rendered.contains("browse the branch tree"));
+        assert!(rendered.contains("edit the draft in $VISUAL or $EDITOR"));
     }
 
     #[test]
@@ -1109,15 +1317,15 @@ mod tests {
                 "\" nanocodex   /workspace                         \"\n",
                 "\"┌ Main ────────────────────────────────────────┐\"\n",
                 "\"│                                              │\"\n",
-                "\"│  Ask Nanocodex to inspect, edit, run, or     │\"\n",
-                "\"│explain this workspace.                       │\"\n",
-                "\"│                                              │\"\n",
+                "\"│     ##            nanocodex           *+     │\"\n",
+                "\"│   ****    small agent · sharp tools   *++=   │\"\n",
+                "\"│     **                                ++     │\"\n",
                 "\"│                                              │\"\n",
                 "\"└──────────────────────────────────────────────┘\"\n",
                 "\"┌ Message → Main ──────────────────────────────┐\"\n",
                 "\"│                                              │\"\n",
                 "\"└──────────────────────────────────────────────┘\"\n",
-                "\" Ready  /btw <quest          gpt-5.6-sol · high \"\n",
+                "\" Ready  / actions ·          gpt-5.6-sol · high \"\n",
             )
         );
     }
@@ -1209,6 +1417,21 @@ mod tests {
         app.cursor = app.input.len();
         terminal.draw(|frame| render(frame, &mut app)).unwrap();
         assert_eq!(terminal.backend().draw_counts[2], 1);
+    }
+
+    #[test]
+    fn animated_branding_limits_terminal_changes_to_its_signal_mask() {
+        let backend = CountingBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new("/workspace".into());
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        app.on_tick();
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+
+        let changed_cells = terminal.backend().draw_counts[1];
+        assert!(changed_cells > 0);
+        assert!(changed_cells <= 64 * 11);
     }
 
     struct CountingBackend {

--- a/docs/TUI_NOTES.md
+++ b/docs/TUI_NOTES.md
@@ -26,6 +26,7 @@ The implementation in `bin/nanocodex/src/tui/mod.rs` is the source of truth.
 | `Esc`, then `Esc` within one second while running | Cancel the focused turn. The first press arms target-scoped confirmation and preserves the draft. Repeated key events do not confirm cancellation. |
 | `Ctrl+C` | Quit. |
 | `Ctrl+D` with an empty draft | Quit. |
+| `/` with an empty draft | Open the searchable action palette without changing the draft. Type to filter, use `Enter` or `Tab` to open an action, or use `Ctrl+Enter` to send the search as a literal slash-prefixed prompt. |
 
 `Enter` and `Tab` deliberately differ while work is active: `Enter` is a steer
 that may affect the current run, while `Tab` creates a later queued turn.
@@ -68,6 +69,11 @@ that may affect the current run, while `Tab` creates a later queued turn.
 | `/trace` | Open Jaeger filtered to the focused session. A `/btw` trace becomes available after its fork has produced a session ID. |
 
 Unknown slash-prefixed input is sent to the model as an ordinary prompt.
+
+The action palette also exposes non-command presentation controls such as the
+branch browser, tool-detail density, and the keyboard-shortcut reference. Actions
+that are not valid in the current pane remain visible with a concise reason and
+cannot be triggered.
 
 ## Current design and retained practices
 
@@ -190,6 +196,7 @@ The Criterion suite in `bin/nanocodex/benches/tui_render.rs` measures:
 - a 128-row follow-bottom burst, one smooth viewport step, and draining the
   bounded animation backlog at `120x40`;
 - repeated rendering of a 100 KiB multiline composer draft at `120x40`; and
+- an animated empty-state branding frame at `120x40`;
 - 100 KiB large-paste ingestion, placeholder rendering, and submission expansion;
 - first-frame rendering of a 16-file patch activity; and
 - selection of every retained user prompt and the first selected-history frame
@@ -351,6 +358,28 @@ Do not import Codex's app server, approval flow, generic history manager, or
 multi-agent scheduler. Nanocodex should copy useful invariants and operational
 behavior while retaining its much smaller consumer surface.
 
+## Tact findings retained
+
+The Tact comparison used `clabby/tact@7291a4085e303b37b9f92406937a7cbbae47e5a7`
+on 2026-07-25. Its strongest compatible presentation ideas were opening a
+searchable action menu from `/` only when the composer draft is empty and giving
+the untouched transcript a restrained animated identity. Nanocodex adopts the
+discoverability pattern while routing selected commands through its existing
+submission classifier and worker boundary. The palette therefore does not
+create a second command implementation, and an unmatched search still preserves
+the existing literal slash-prompt behavior.
+
+Tact's centered rounded modal chrome, dynamic unavailable-action labels, and
+dedicated shortcut reference also informed this slice. Its empty-state plasma
+field was adapted into a responsive Nanocodex ASCII wordmark with compact and
+plain-text fallbacks; its status motion became a stable-width wordmark that
+types and erases during active work. Animation is scheduled only while work or
+the unobscured empty state needs it, and disappears as soon as transcript
+content exists. Tact's broader component tree, session management, subagent
+inspector, theme configuration, and file finder were not copied: those either
+duplicate Nanocodex's existing measured consumer or require separate product
+and performance evidence.
+
 ## Candidate backlog
 
 Candidate IDs are stable handles for later filtering. `Now` means the idea fits
@@ -369,6 +398,8 @@ choice; `Defer` is intentionally outside the next slice.
 | `TUI-RENDER-01` | Done | Render assistant Markdown and useful tables. | Streaming snapshots heal incomplete constructs before parsing; completed source is exact and width-cached. Wide tables align columns, narrow tables become lossless labeled row cards, and fenced blocks receive native syntax highlighting with a plain fallback. Deterministic healing/reflow/highlighting tests and finalized/streaming frame benchmarks cover the boundary without changing the transcript event contract. |
 | `TUI-TOOL-01` | Done | Improve tool-call presentation. | Code Mode parent and `/code-N` child events form one timed activity tree with multiline highlighted JavaScript, multiline child continuation rows, compact results, explicit status, failure detail, and evidence-based sequence/overlap labels. Patch calls add operation-aware paths, moves, `+/-` counts, and styled hunks. A 16-child update/frame benchmark and 16-file patch frame cover the cached representation. |
 | `TUI-NOTIFY-01` | Done | Notify on completion while unfocused. | Focus reporting gates exactly one terminal-safe completion notification per turn. Known terminals receive OSC 9, tmux receives an escaped passthrough sequence, unknown terminals use BEL, and a backend write failure disables later attempts. |
+| `TUI-ACTIONS-01` | Done | Make the TUI's existing command and control vocabulary discoverable. | An empty-draft `/` opens a searchable, rounded action palette with context-aware availability, direct access to the shortcut reference, and a literal-submit escape hatch. Selected commands reuse the normal submission path; a compact footer keeps only immediate send/queue/cancel guidance visible. Deterministic interaction and frame tests cover search, disabled actions, command dispatch, unknown slash prompts, and both overlays. Its cached `80x24` frame measured 81.04 µs in the release-profile quick gate on 2026-07-25. |
+| `TUI-BRAND-01` | Done | Give idle and active waiting states a distinctive Nanocodex identity. | The empty main transcript renders a reasoning-colored animated signal field behind responsive full/compact ASCII branding, with a plain fallback for tiny panes. Split views remain quiet, content removes the mark immediately, and obscuring overlays pause its demand-driven ticker. Active work uses a fixed-width typing/erasing `nanocodex` loader. Deterministic tests cover responsive rendering, motion, scheduling, snapshots, and a changed-cell ceiling; the changed `120x40` frame measured 143.00 µs in the release-profile quick gate on 2026-07-25. |
 | `TUI-SEARCH-01` | Evaluate | Add transcript search and copy-oriented navigation. | First define how matches interact with semantic entries, wrapped rows, two panes, and streaming updates. |
 | `TUI-BTW-01` | Defer | Support multiple named `/btw` panes. | Product candidate already recorded in `docs/ORCHESTRATION_DECISION_CONTEXT.md`; preserve fresh driver/tool runtime ownership and explicit cleanup. This is broader than a rendering slice. |
 | `TUI-BTW-02` | Evaluate | Make branch cancellation and close cleanup explicit. | Cancellation exists, but busy `/close` is rejected. Decide whether close should offer cancel-and-close while guaranteeing subprocess and driver cleanup. |
@@ -394,6 +425,7 @@ choice; `Defer` is intentionally outside the next slice.
 ## Source map
 
 - Current input behavior: `bin/nanocodex/src/tui/mod.rs`
+- Empty-state identity: `bin/nanocodex/src/tui/branding.rs`
 - Composer display rows: `bin/nanocodex/src/tui/composer.rs`
 - External editor round trip: `bin/nanocodex/src/tui/external_editor.rs`
 - TUI state and Amp Escape invariant: `bin/nanocodex/src/tui/app.rs`


### PR DESCRIPTION
## Summary

- add a searchable slash action palette and keyboard shortcut overlay
- add responsive animated Nanocodex empty-state branding and a stable-width working loader
- keep animation demand-driven and add render benchmarks/regression coverage

## Validation

- `cargo test -p nanocodex-bin --bin nanocodex` (234 passed, 2 ignored)
- `cargo clippy -p nanocodex-bin --all-targets --no-deps -- -A clippy::doc-markdown -A clippy::too-many-lines -D warnings` (passed on the source checkout; clean master-based rerun was interrupted during dependency rebuild)
- `cargo bench -p nanocodex-bin --bench tui_render -- tui_branding --quick` (143.00 µs changed frame at 120x40)
- `git diff master...HEAD --check`