### PR TITLE
fix: harden Tempo Charge runtime safety

### DIFF
--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -1,4 +1,5 @@
 use std::{
+    num::NonZeroU32,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -176,17 +177,19 @@ impl AgentArgs {
         let mut responses = Responses::builder()
             .transport(responses_transport)
             .websocket_url(direct_websocket_url);
+        if mpp_enabled {
+            responses = responses.max_attempts(NonZeroU32::MIN);
+        }
         if let Some(history) = self.responses_history {
             responses = responses.history(history);
         }
         if let Some(store) = self.store_responses {
             responses = responses.store(store);
         }
-        let api_base_url = self.api_base_url.or_else(|| {
-            mpp_adapter
-                .as_ref()
-                .map(|adapter| adapter.api_base_url().to_owned())
-        });
+        let api_base_url = selected_api_base_url(
+            self.api_base_url,
+            mpp_adapter.as_ref().map(MppAdapter::api_base_url),
+        );
         if let Some(api_base_url) = api_base_url {
             responses = responses.api_base_url(api_base_url);
         }
@@ -293,6 +296,10 @@ fn direct_websocket_url(explicit: Option<String>, auth_mode: OpenAiAuthMode) -> 
     explicit.unwrap_or_else(|| auth_mode.default_websocket_url().to_owned())
 }
 
+fn selected_api_base_url(generic: Option<String>, tempo: Option<&str>) -> Option<String> {
+    tempo.map(str::to_owned).or(generic)
+}
+
 fn select_auth(
     explicit_api_key: Option<String>,
     auth_file: Option<PathBuf>,
@@ -388,7 +395,9 @@ mod tests {
     use clap::CommandFactory;
     use nanocodex::OpenAiAuthMode;
 
-    use super::{direct_websocket_url, select_auth, select_auth_with_default};
+    use super::{
+        direct_websocket_url, select_auth, select_auth_with_default, selected_api_base_url,
+    };
 
     #[test]
     fn default_websocket_url_follows_the_selected_auth_mode() {
@@ -406,6 +415,21 @@ mod tests {
                 OpenAiAuthMode::ChatGpt,
             ),
             "ws://127.0.0.1:1234/responses"
+        );
+    }
+
+    #[test]
+    fn tempo_api_base_overrides_the_generic_openai_base() {
+        assert_eq!(
+            selected_api_base_url(
+                Some("https://generic.example/v1".to_owned()),
+                Some("https://tempo.example/v1"),
+            ),
+            Some("https://tempo.example/v1".to_owned())
+        );
+        assert_eq!(
+            selected_api_base_url(Some("https://generic.example/v1".to_owned()), None),
+            Some("https://generic.example/v1".to_owned())
         );
     }
 

--- a/bin/nanousd-api/src/issuer.rs
+++ b/bin/nanousd-api/src/issuer.rs
@@ -7,7 +7,7 @@ use std::{
 
 use alloy::{
     eips::Encodable2718,
-    network::{IntoWallet, ReceiptResponse},
+    network::{ReceiptResponse, TransactionBuilder},
     primitives::{Address, B256, U256, keccak256},
     providers::{
         DynProvider, PendingTransactionBuilder, Provider, ProviderBuilder,
@@ -129,18 +129,13 @@ impl AlloyIssuer {
             TempoAccountsWallet::from_default_store,
             TempoAccountsWallet::from_store,
         )?;
-        let access_key = wallet.active_access_key()?;
-        if access_key.chain_id() != nanousd::TEMPO_MAINNET_CHAIN_ID {
-            return Err(IssuerError::WrongChain(access_key.chain_id()));
-        }
-        let account = access_key.account();
-        let access_key_address = access_key.address();
+        let account = wallet.account();
         let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
             .with_expiring_nonces()
-            .filler(access_key.into_wallet())
+            .filler(wallet)
             .connect_http(rpc_url.parse().map_err(alloy_error)?);
         let preparer = Arc::new(provider.clone());
-        tracing::info!(%account, access_key = %access_key_address, "loaded NanoUSD Alloy issuer");
+        tracing::info!(%account, "loaded NanoUSD Alloy issuer");
         Ok(Self {
             provider: provider.erased(),
             preparer,
@@ -188,6 +183,7 @@ impl Issuer for AlloyIssuer {
         let request = ITIP20::new(self.token, &self.provider)
             .mint(order.wallet, U256::from(order.amount))
             .into_transaction_request()
+            .with_chain_id(nanousd::TEMPO_MAINNET_CHAIN_ID)
             .with_fee_token(self.fee_token);
         self.preparer.prepare(request).await
     }
@@ -232,8 +228,6 @@ fn alloy_error(error: impl std::fmt::Display) -> IssuerError {
 pub(crate) enum IssuerError {
     #[error("failed to load the Tempo issuer wallet: {0}")]
     Wallet(#[from] tempo_alloy::accounts::TempoAccountsError),
-    #[error("issuer wallet is configured for chain {0}, expected Tempo mainnet")]
-    WrongChain(u64),
     #[error("Tempo Alloy operation failed: {0}")]
     Alloy(String),
     #[error("NanoUSD balance does not fit in the API representation")]
@@ -248,4 +242,58 @@ pub(crate) enum IssuerError {
     Clock,
     #[error("mock issuer balance lock was poisoned")]
     Poisoned,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use alloy::primitives::Address;
+    use serde_json::json;
+
+    use super::AlloyIssuer;
+
+    const ROOT: &str = "0x1111111111111111111111111111111111111111";
+    const TOKEN: &str = "0x2222222222222222222222222222222222222222";
+    const FEE_TOKEN: &str = "0x3333333333333333333333333333333333333333";
+
+    #[test]
+    fn construction_keeps_scoped_accounts_keys_lazy() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = directory.path().join("store.json");
+        fs::write(
+            &store,
+            serde_json::to_vec(&json!({
+                "tempo-cli.store": {
+                    "state": {
+                        "activeAccount": 0,
+                        "chainId": nanousd::TEMPO_MAINNET_CHAIN_ID,
+                        "accounts": [{ "address": ROOT }],
+                        "accessKeys": [{
+                            "access": ROOT,
+                            "address": "0x4444444444444444444444444444444444444444",
+                            "chainId": nanousd::TEMPO_MAINNET_CHAIN_ID,
+                            "keyType": "p256",
+                            "privateKey": format!("0x{}", "01".repeat(32)),
+                            "scopes": [{
+                                "address": TOKEN,
+                                "selector": "mint(address,uint256)",
+                            }],
+                        }],
+                    },
+                },
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let issuer = AlloyIssuer::new(
+            "http://127.0.0.1:1",
+            TOKEN.parse::<Address>().unwrap(),
+            FEE_TOKEN.parse::<Address>().unwrap(),
+            Some(&store),
+        );
+
+        assert!(issuer.is_ok());
+    }
 }

--- a/crates/nanocodex-service/src/attempt.rs
+++ b/crates/nanocodex-service/src/attempt.rs
@@ -1,6 +1,9 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicU32, AtomicU64, Ordering},
+use std::{
+    num::NonZeroU32,
+    sync::{
+        Arc,
+        atomic::{AtomicU32, AtomicU64, Ordering},
+    },
 };
 
 use nanocodex_core::{
@@ -11,7 +14,7 @@ use serde::Serialize;
 
 use crate::stream::{CompactionResult, TurnResult};
 
-const RESPONSE_MAX_ATTEMPTS: u32 = 5;
+const RESPONSE_MAX_ATTEMPTS: NonZeroU32 = NonZeroU32::new(5).unwrap();
 
 /// Kind of Responses operation passed through the Tower service stack.
 #[derive(Clone, Copy, Debug, Serialize)]
@@ -188,7 +191,7 @@ impl ResponsesAttempt {
             profile,
             observer,
             attempt: 1,
-            max_attempts: RESPONSE_MAX_ATTEMPTS,
+            max_attempts: RESPONSE_MAX_ATTEMPTS.get(),
             full_replay: previous_response_id.is_none(),
         }
     }
@@ -219,7 +222,7 @@ impl ResponsesAttempt {
             profile,
             observer,
             attempt: 1,
-            max_attempts: RESPONSE_MAX_ATTEMPTS,
+            max_attempts: RESPONSE_MAX_ATTEMPTS.get(),
             full_replay: previous_response_id.is_none(),
         }
     }
@@ -307,6 +310,10 @@ impl ResponsesAttempt {
         self.attempt += 1;
         self.full_replay = true;
         true
+    }
+
+    pub(crate) fn limit_attempts(&mut self, max_attempts: NonZeroU32) {
+        self.max_attempts = self.max_attempts.min(max_attempts.get());
     }
 
     pub(crate) fn force_full_replay(&mut self) {

--- a/crates/nanocodex-service/src/middleware/retry.rs
+++ b/crates/nanocodex-service/src/middleware/retry.rs
@@ -1,5 +1,6 @@
 use std::{
     future::Future,
+    num::NonZeroU32,
     pin::Pin,
     sync::{Arc, atomic::Ordering},
     time::Duration,
@@ -21,8 +22,28 @@ type RetryFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 #[cfg(target_family = "wasm")]
 type RetryFuture = Pin<Box<dyn Future<Output = ()>>>;
 
-#[derive(Clone, Copy, Default)]
-pub struct ResponsesRetryPolicy;
+/// Retry policy for the SDK-owned Responses transport stack.
+#[derive(Clone, Copy, Debug)]
+pub struct ResponsesRetryPolicy {
+    max_attempts: NonZeroU32,
+}
+
+impl ResponsesRetryPolicy {
+    /// Default number of total attempts, including the initial request.
+    pub const DEFAULT_MAX_ATTEMPTS: NonZeroU32 = NonZeroU32::new(5).unwrap();
+
+    /// Creates a retry policy with a fixed total-attempt limit.
+    #[must_use]
+    pub const fn new(max_attempts: NonZeroU32) -> Self {
+        Self { max_attempts }
+    }
+}
+
+impl Default for ResponsesRetryPolicy {
+    fn default() -> Self {
+        Self::new(Self::DEFAULT_MAX_ATTEMPTS)
+    }
+}
 
 impl Policy<ResponsesAttempt, ResponsesServiceResponse, ResponsesServiceError>
     for ResponsesRetryPolicy
@@ -34,6 +55,7 @@ impl Policy<ResponsesAttempt, ResponsesServiceResponse, ResponsesServiceError>
         request: &mut ResponsesAttempt,
         result: &mut Result<ResponsesServiceResponse, ResponsesServiceError>,
     ) -> Option<Self::Future> {
+        request.limit_attempts(self.max_attempts);
         let failure = result.as_ref().err()?;
         let checkpoint_missing =
             failure.is_checkpoint_missing() && request.previous_response_id().is_some();
@@ -112,7 +134,9 @@ impl Policy<ResponsesAttempt, ResponsesServiceResponse, ResponsesServiceError>
     }
 
     fn clone_request(&mut self, request: &ResponsesAttempt) -> Option<ResponsesAttempt> {
-        Some(request.clone())
+        let mut request = request.clone();
+        request.limit_attempts(self.max_attempts);
+        Some(request)
     }
 }
 

--- a/crates/nanocodex-service/src/service.rs
+++ b/crates/nanocodex-service/src/service.rs
@@ -1,5 +1,6 @@
 use std::{
     future::Future,
+    num::NonZeroU32,
     pin::Pin,
     sync::{Arc, atomic::Ordering},
     task::{Context, Poll},
@@ -82,6 +83,7 @@ impl ConnectionState {
 pub struct ResponsesService {
     config: Arc<ModelConfig>,
     connection: Arc<Mutex<ConnectionState>>,
+    max_attempts: NonZeroU32,
     #[cfg(not(target_family = "wasm"))]
     http: ResponsesHttp,
 }
@@ -98,6 +100,7 @@ impl ResponsesService {
             Self {
                 config,
                 connection: Arc::new(Mutex::new(ConnectionState::new())),
+                max_attempts: ResponsesRetryPolicy::DEFAULT_MAX_ATTEMPTS,
             }
         }
     }
@@ -110,14 +113,33 @@ impl ResponsesService {
         Self {
             config,
             connection: Arc::new(Mutex::new(ConnectionState::new())),
+            max_attempts: ResponsesRetryPolicy::DEFAULT_MAX_ATTEMPTS,
             http: ResponsesHttp::new(http_client),
         }
+    }
+
+    const fn with_max_attempts(mut self, max_attempts: NonZeroU32) -> Self {
+        self.max_attempts = max_attempts;
+        self
     }
 
     /// Builds the configured standard Responses service with retry policy.
     #[must_use]
     pub fn standard(config: Arc<ModelConfig>) -> DefaultResponsesService {
-        Retry::new(ResponsesRetryPolicy, Self::new(config))
+        Self::standard_with_max_attempts(config, ResponsesRetryPolicy::DEFAULT_MAX_ATTEMPTS)
+    }
+
+    /// Builds the configured standard Responses service with a fixed total
+    /// attempt limit.
+    #[must_use]
+    pub fn standard_with_max_attempts(
+        config: Arc<ModelConfig>,
+        max_attempts: NonZeroU32,
+    ) -> DefaultResponsesService {
+        Retry::new(
+            ResponsesRetryPolicy::new(max_attempts),
+            Self::new(config).with_max_attempts(max_attempts),
+        )
     }
 
     /// Builds the standard retry stack with a caller-configured HTTPS client.
@@ -127,9 +149,25 @@ impl ResponsesService {
         config: Arc<ModelConfig>,
         http_client: reqwest::Client,
     ) -> DefaultResponsesService {
+        Self::standard_with_http_client_and_max_attempts(
+            config,
+            http_client,
+            ResponsesRetryPolicy::DEFAULT_MAX_ATTEMPTS,
+        )
+    }
+
+    /// Builds the standard retry stack with a caller-configured HTTPS client
+    /// and fixed total-attempt limit.
+    #[cfg(not(target_family = "wasm"))]
+    #[must_use]
+    pub fn standard_with_http_client_and_max_attempts(
+        config: Arc<ModelConfig>,
+        http_client: reqwest::Client,
+        max_attempts: NonZeroU32,
+    ) -> DefaultResponsesService {
         Retry::new(
-            ResponsesRetryPolicy,
-            Self::new_with_http_client(config, http_client),
+            ResponsesRetryPolicy::new(max_attempts),
+            Self::new_with_http_client(config, http_client).with_max_attempts(max_attempts),
         )
     }
 
@@ -707,6 +745,7 @@ impl Service<ResponsesAttempt> for ResponsesService {
     }
 
     fn call(&mut self, mut request: ResponsesAttempt) -> Self::Future {
+        request.limit_attempts(self.max_attempts);
         let service = self.clone();
         Box::pin(async move {
             let mut connection = service.connection.lock().await;

--- a/crates/nanocodex/src/agent.rs
+++ b/crates/nanocodex/src/agent.rs
@@ -718,6 +718,7 @@ impl NanocodexBuilder<StandardResponses> {
             self.codex.rollout.as_ref(),
         )?;
         let config = Arc::new(self.config);
+        let max_attempts = self.responses.max_attempts;
         #[cfg(not(target_family = "wasm"))]
         let http_client = self.responses.http_client;
         let service_factory: ServiceFactory<DefaultResponsesService> = Arc::new({
@@ -726,17 +727,23 @@ impl NanocodexBuilder<StandardResponses> {
                 #[cfg(not(target_family = "wasm"))]
                 {
                     http_client.as_ref().map_or_else(
-                        || ResponsesService::standard(Arc::clone(&config)),
+                        || {
+                            ResponsesService::standard_with_max_attempts(
+                                Arc::clone(&config),
+                                max_attempts,
+                            )
+                        },
                         |client| {
-                            ResponsesService::standard_with_http_client(
+                            ResponsesService::standard_with_http_client_and_max_attempts(
                                 Arc::clone(&config),
                                 client.clone(),
+                                max_attempts,
                             )
                         },
                     )
                 }
                 #[cfg(target_family = "wasm")]
-                ResponsesService::standard(Arc::clone(&config))
+                ResponsesService::standard_with_max_attempts(Arc::clone(&config), max_attempts)
             }
         });
         build_agent(
@@ -777,6 +784,7 @@ where
         )?;
         let config = Arc::new(self.config);
         let layers = self.responses.service.0;
+        let max_attempts = self.responses.max_attempts;
         #[cfg(not(target_family = "wasm"))]
         let http_client = self.responses.http_client;
         let service_factory: ServiceFactory<L::Service> = Arc::new({
@@ -784,16 +792,23 @@ where
             move || {
                 #[cfg(not(target_family = "wasm"))]
                 let service = http_client.as_ref().map_or_else(
-                    || ResponsesService::standard(Arc::clone(&config)),
+                    || {
+                        ResponsesService::standard_with_max_attempts(
+                            Arc::clone(&config),
+                            max_attempts,
+                        )
+                    },
                     |client| {
-                        ResponsesService::standard_with_http_client(
+                        ResponsesService::standard_with_http_client_and_max_attempts(
                             Arc::clone(&config),
                             client.clone(),
+                            max_attempts,
                         )
                     },
                 );
                 #[cfg(target_family = "wasm")]
-                let service = ResponsesService::standard(Arc::clone(&config));
+                let service =
+                    ResponsesService::standard_with_max_attempts(Arc::clone(&config), max_attempts);
                 layers.clone().service(service)
             }
         });

--- a/crates/nanocodex/src/model/agent_tests.rs
+++ b/crates/nanocodex/src/model/agent_tests.rs
@@ -1,4 +1,5 @@
 use std::{
+    num::NonZeroU32,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -262,6 +263,66 @@ async fn https_uses_the_configured_http_client() -> Result<()> {
         "done"
     );
     drop((agent, events));
+    timeout(std::time::Duration::from_secs(5), server)
+        .await
+        .map_err(|_| eyre!("mock HTTPS Responses server did not finish"))???;
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn configured_attempt_limit_prevents_a_paid_request_replay() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("http://{}", listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        let request = next_http_json(&listener).await?;
+        send_http_unexpected_end(request.stream).await?;
+        if timeout(std::time::Duration::from_millis(100), listener.accept())
+            .await
+            .is_ok()
+        {
+            return Err(eyre!("Responses client replayed the failed paid request"));
+        }
+        Ok(())
+    });
+
+    let workspace = temporary_workspace("https-single-attempt")?;
+    let responses = Responses::builder()
+        .transport(ResponsesTransport::Https)
+        .api_base_url(endpoint)
+        .max_attempts(NonZeroU32::MIN)
+        .build();
+    let (agent, mut events) = Nanocodex::builder("test-key")
+        .thinking(Thinking::Low)
+        .workspace(&workspace)
+        .responses(responses)
+        .session_id("https-single-attempt")
+        .build()?;
+
+    let result = agent.prompt("paid request").await?.result().await;
+    assert!(result.is_err());
+    drop(agent);
+
+    let mut generation_attempts = 0;
+    let mut reported_max_attempts = None;
+    let mut observed_retry = false;
+    while let Some(event) = events.recv().await {
+        match event.kind {
+            nanocodex_core::AgentEventKind::ModelAttemptStarted => {
+                let payload = event.decode_payload::<Value>()?;
+                if payload["phase"] == "generation" {
+                    generation_attempts += 1;
+                    reported_max_attempts = payload["max_attempts"].as_u64();
+                }
+            }
+            nanocodex_core::AgentEventKind::ModelAttemptRetrying => observed_retry = true,
+            _ => {}
+        }
+    }
+    assert_eq!(generation_attempts, 1);
+    assert_eq!(reported_max_attempts, Some(1));
+    assert!(!observed_retry);
+
     timeout(std::time::Duration::from_secs(5), server)
         .await
         .map_err(|_| eyre!("mock HTTPS Responses server did not finish"))???;
@@ -3231,6 +3292,16 @@ async fn send_http_final(mut stream: TcpStream, response_id: &str) -> Result<()>
         body.len()
     );
     stream.write_all(response.as_bytes()).await?;
+    stream.shutdown().await?;
+    Ok(())
+}
+
+async fn send_http_unexpected_end(mut stream: TcpStream) -> Result<()> {
+    stream
+        .write_all(
+            b"HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+        )
+        .await?;
     stream.shutdown().await?;
     Ok(())
 }

--- a/crates/nanocodex/src/responses.rs
+++ b/crates/nanocodex/src/responses.rs
@@ -1,3 +1,6 @@
+use std::num::NonZeroU32;
+
+use nanocodex_service::ResponsesRetryPolicy;
 use tower::{
     ServiceBuilder,
     layer::util::{Identity, Stack},
@@ -33,6 +36,7 @@ pub struct Responses<S = StandardResponses> {
     pub(crate) transport: ResponsesTransport,
     pub(crate) history: Option<ResponsesHistory>,
     pub(crate) store: Option<bool>,
+    pub(crate) max_attempts: NonZeroU32,
     pub(crate) service: S,
 }
 
@@ -46,6 +50,7 @@ impl Default for Responses<StandardResponses> {
             transport: ResponsesTransport::WebSocket,
             history: None,
             store: None,
+            max_attempts: ResponsesRetryPolicy::DEFAULT_MAX_ATTEMPTS,
             service: StandardResponses,
         }
     }
@@ -75,6 +80,7 @@ impl ResponsesBuilder<StandardResponses> {
                 transport: self.responses.transport,
                 history: self.responses.history,
                 store: self.responses.store,
+                max_attempts: self.responses.max_attempts,
                 service: LayeredResponses(ServiceBuilder::new().layer(layer)),
             },
         }
@@ -96,6 +102,7 @@ impl ResponsesBuilder<StandardResponses> {
                 transport: self.responses.transport,
                 history: self.responses.history,
                 store: self.responses.store,
+                max_attempts: self.responses.max_attempts,
                 service: FactoryResponses(factory),
             },
         }
@@ -115,6 +122,7 @@ impl<L> ResponsesBuilder<LayeredResponses<L>> {
                 transport: self.responses.transport,
                 history: self.responses.history,
                 store: self.responses.store,
+                max_attempts: self.responses.max_attempts,
                 service: LayeredResponses(self.responses.service.0.layer(layer)),
             },
         }
@@ -152,6 +160,18 @@ impl<S> ResponsesBuilder<S> {
     #[must_use]
     pub const fn store(mut self, store: bool) -> Self {
         self.responses.store = Some(store);
+        self
+    }
+
+    /// Sets the maximum number of total attempts made by the SDK's standard
+    /// Responses retry stack, including the initial request.
+    ///
+    /// Set this to one when replaying a request could repeat an external side
+    /// effect, such as an up-front payment. Caller-supplied service factories
+    /// own their own retry policy.
+    #[must_use]
+    pub const fn max_attempts(mut self, max_attempts: NonZeroU32) -> Self {
+        self.responses.max_attempts = max_attempts;
         self
     }
 

--- a/docs/MPP.md
+++ b/docs/MPP.md
@@ -77,8 +77,16 @@ Tempo selects the HTTPS Responses transport. Explicitly selecting WebSocket
 with `--provider.tempo` is rejected during startup. Direct OpenAI continues to
 default to its persistent Responses WebSocket.
 
+Charge payment is accepted before the complete SSE response has arrived, so
+the CLI limits paid Responses calls to one SDK attempt. A premature close or
+other retryable stream failure is returned to the caller instead of replaying
+the request and risking a second charge. Retrying that prompt is an explicit
+caller action.
+
 The API base must use HTTPS. Plain HTTP is accepted only for loopback
-development endpoints, including an SSH-forwarded service.
+development endpoints, including an SSH-forwarded service. The
+Tempo-specific `--provider.tempo.api-base-url` takes precedence over the
+generic OpenAI API base setting while the Tempo provider is enabled.
 
 ## HTTP tool egress
 


### PR DESCRIPTION
Follow-up to #35.

## Summary

- cap Tempo Charge Responses calls at one SDK attempt so a stream failure cannot replay an up-front paid request
- make `--provider.tempo.api-base-url` take precedence over the generic OpenAI API base while Tempo is selected
- pass the lazy `TempoAccountsWallet` into the NanoUSD issuer filler so scoped keys and store rotation are selected per transaction
- pin mint requests to Tempo mainnet and document the explicit-retry behavior

## Root cause

The merged Charge path reused Nanocodex's standard five-attempt Responses retry stack even though payment is accepted before the SSE stream completes. A premature close could therefore enter MPP egress again as a new paid request. The CLI also selected the generic API base before the Tempo-specific endpoint, and the issuer eagerly converted the Accounts store's first unscoped key into a fixed wallet.

## Impact

Paid stream failures now surface to the caller after one attempt; retrying is explicit. Tempo endpoint selection is deterministic, and NanoUSD mint signing retains Tempo Accounts' lazy scoped-key and rotation behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` (includes public examples)
- `cargo test -p nanocodex-service -p nanocodex -p nanocodex-bin -p nanousd-api`
- focused no-replay, endpoint-precedence, and scoped-wallet regression tests

The later full-workspace test phase of local `just check` exhausted local disk after Clippy had passed; the generated 21 GiB worktree `target/` was cleaned. No paid live request was run.
