### PR TITLE
ci: compile public examples and run JS TUI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
           cache-on-failure: true
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - run: cargo check -p nanocodex-examples --bins --locked
       - run: cargo doc --workspace --all-features --no-deps --locked
         env:
           RUSTDOCFLAGS: -D warnings
@@ -119,6 +120,7 @@ jobs:
           ./scripts/build-js-package.sh
           npm test --prefix js/bindings
           npm test --prefix js/react
+          npm test --prefix js/tui
           npm run build --prefix examples/react-vite
       - name: Build and test Python bindings
         shell: bash

--- a/Justfile
+++ b/Justfile
@@ -66,6 +66,10 @@ test-wasm: build-wasm
     npm test --prefix js/bindings
     npm test --prefix js/react
 
+# Run the framework-independent JS transcript reducer tests (requires Node >=22.13).
+test-tui:
+    npm test --prefix js/tui
+
 # Run custom JavaScript tooling and a follow-on through Node-hosted WASM.
 smoke-wasm-node: build-wasm
     npm ci --prefix examples/node
@@ -272,6 +276,7 @@ view jobs=default_jobs:
 check:
     cargo fmt --all -- --check
     cargo clippy --workspace --all-targets --all-features -- -D warnings
+    cargo check -p nanocodex-examples --bins --locked
     cargo test --workspace
     .venv/bin/python -m unittest discover -s harbor_adapter -p 'test_*.py'
     .venv/bin/python -m compileall -q harbor_adapter


### PR DESCRIPTION
## Summary
- Enforce `cargo check -p nanocodex-examples --bins --locked` in the CI quality job and `just check`, matching the validation rule already stated in `AGENTS.md`.
- Run the existing `js/tui` behavioral reducer tests in the bindings CI job (Node 22), and add `just test-tui`.

## Why
Public example bins and the shared JS transcript tests existed, but CI never executed them. This closes that hole without changing product APIs.

## Verification
- `cargo +1.97 check -p nanocodex-examples --bins --locked` passed locally
- `npm test --prefix js/tui` with Node 22.22.3: **15/15 passed**

## Test plan
- [x] CI quality job runs example bin check
- [x] CI bindings job runs `npm test --prefix js/tui`
- [x] Confirm no collision with open TUI feature PRs (#33/#34); this only runs existing tests