### PR TITLE
feat(python): expose steer, cancel, spawn, and fork controls

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -56,6 +56,14 @@ test-python: build-python
 smoke-python: build-python
     "{{python_binding_bin}}" examples/python/follow_on.py
 
+# Run the Python events consumer against the live Responses API.
+smoke-python-events: build-python
+    "{{python_binding_bin}}" examples/python/events.py
+
+# Run the Python steer/spawn/fork lifecycle example against the live Responses API.
+smoke-python-lifecycle: build-python
+    "{{python_binding_bin}}" examples/python/lifecycle.py
+
 # Build one Rust/WASM artifact and generate both Node.js and browser bindings.
 build-wasm:
     @command -v wasm-bindgen >/dev/null || { echo "install wasm-bindgen-cli matching Cargo.lock" >&2; exit 2; }

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,8 @@ All language consumers live at this repository boundary:
 - Rust: `minimal.rs`, `follow_on.rs`, `lifecycle.rs`, `custom_tool.rs`, `subagents.rs`,
   `resume.rs`, `fork_conversations.rs`, `fork_checkpoint_bench.rs`, and `mcp.rs` are binaries
   in the `nanocodex-examples` package.
-- Python: `python/` uses the native PyO3 binding.
+- Python: `python/` uses the native PyO3 binding (`follow_on.py`, `events.py`,
+  `lifecycle.py`).
 - Node.js: `node/` uses the shared Rust/WASM package with a Node WebSocket host.
 - Browser: `react-vite/` runs that WASM agent in a module Worker and renders its
   ordered events in React.

--- a/examples/python/lifecycle.py
+++ b/examples/python/lifecycle.py
@@ -1,0 +1,37 @@
+"""Demonstrate Python steer, cancel, spawn, and fork controls."""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+
+from nanocodex import Nanocodex
+
+
+def main() -> None:
+    api_key = os.environ["OPENAI_API_KEY"]
+    agent, _ = Nanocodex(api_key, thinking="low")
+
+    turn = agent.prompt(
+        "Count slowly from 1 to 20 in words. Do not stop early unless steered."
+    )
+
+    def steer_later() -> None:
+        time.sleep(1.5)
+        turn.steer("Stop counting and reply with only the word STEERED.")
+
+    threading.Thread(target=steer_later, daemon=True).start()
+    print("steered:", turn.result())
+
+    sibling, _ = agent.spawn()
+    print("spawned:", sibling.prompt("Reply with only SPAWNED.").result())
+
+    parent = agent.prompt("Remember the token FORK_PY. Reply with OK.")
+    print("parent:", parent.result())
+    branch, _ = agent.fork_from(parent)
+    print("forked:", branch.prompt("What token did I ask you to remember?").result())
+
+
+if __name__ == "__main__":
+    main()

--- a/py/bindings/README.md
+++ b/py/bindings/README.md
@@ -17,6 +17,12 @@ releases the GIL, so applications can consume it from a normal Python thread.
 `agent.set_thinking("high")` changes the effort for subsequently accepted turns
 without replacing the session. `agent.set_fast_mode(True)` similarly enables
 priority service for subsequently accepted turns.
+
+Turn control matches the native SDK surface: `turn.steer(...)` injects input at
+the next safe model boundary, and `turn.cancel()` stops that exact unfinished
+turn. Session branching is also exposed: `agent.spawn()` starts a clean sibling,
+`agent.fork()` forks the latest safe boundary, and `agent.fork_from(turn)` forks
+from a completed turn's retained checkpoint.
 The Rust runtime, tools, transport, retries, history, and event ordering stay
 inside the extension; no app server or per-tool Python bridge is involved.
 
@@ -41,4 +47,5 @@ agent, events = Nanocodex(
 
 Runnable consumers live together at the repository boundary under
 [`examples/python`](../../examples/python): `follow_on.py` demonstrates retained
-conversation state and `events.py` consumes the ordered event receiver.
+conversation state, `events.py` consumes the ordered event receiver, and
+`lifecycle.py` exercises steer, spawn, and historical fork.

--- a/py/bindings/src/lib.rs
+++ b/py/bindings/src/lib.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 
 use nanocodex::{
     AgentEvents as RustAgentEvents, Nanocodex as RustNanocodex, OpenAiAuth, ReasoningMode,
-    Thinking, load_chatgpt_auth,
+    Thinking, TurnControl as RustTurnControl, TurnResult as RustTurnResult, load_chatgpt_auth,
 };
 use pyo3::{
     Bound, PyResult, Python,
@@ -61,16 +61,7 @@ impl Nanocodex {
                 builder.build()
             })
             .map_err(runtime_error)?;
-        Ok((
-            Self {
-                runtime: Arc::clone(&runtime),
-                agent,
-            },
-            AgentEvents {
-                runtime,
-                events: Arc::new(tokio::sync::Mutex::new(events)),
-            },
-        ))
+        Ok(wrap_agent(runtime, agent, events))
     }
 
     /// Accept a prompt and immediately return its independently awaitable turn.
@@ -82,6 +73,7 @@ impl Nanocodex {
             .map_err(runtime_error)?;
         Ok(Turn {
             runtime: Arc::clone(&self.runtime),
+            control: turn.control(),
             state: Mutex::new(TurnState::Pending(turn)),
         })
     }
@@ -103,6 +95,39 @@ impl Nanocodex {
             .map_err(runtime_error)
     }
 
+    /// Start a clean sibling agent with the same private configuration.
+    ///
+    /// The sibling does not inherit conversation history.
+    fn spawn(&self, py: Python<'_>) -> PyResult<(Self, AgentEvents)> {
+        let runtime = Arc::clone(&self.runtime);
+        let agent = self.agent.clone();
+        let (child, events) = py
+            .detach(move || runtime.block_on(agent.spawn()))
+            .map_err(runtime_error)?;
+        Ok(wrap_agent(Arc::clone(&self.runtime), child, events))
+    }
+
+    /// Fork from the latest safe model boundary into an independently driven agent.
+    fn fork(&self, py: Python<'_>) -> PyResult<(Self, AgentEvents)> {
+        let runtime = Arc::clone(&self.runtime);
+        let agent = self.agent.clone();
+        let (child, events) = py
+            .detach(move || runtime.block_on(agent.fork()))
+            .map_err(runtime_error)?;
+        Ok(wrap_agent(Arc::clone(&self.runtime), child, events))
+    }
+
+    /// Fork from the exact checkpoint retained by a completed historical turn.
+    fn fork_from(&self, py: Python<'_>, turn: &Turn) -> PyResult<(Self, AgentEvents)> {
+        let completed = turn.completed_result()?;
+        let runtime = Arc::clone(&self.runtime);
+        let agent = self.agent.clone();
+        let (child, events) = py
+            .detach(move || runtime.block_on(agent.fork_from(&completed)))
+            .map_err(runtime_error)?;
+        Ok(wrap_agent(Arc::clone(&self.runtime), child, events))
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "Nanocodex(runtime_references={})",
@@ -114,24 +139,56 @@ impl Nanocodex {
 #[pyclass(module = "nanocodex._native")]
 struct Turn {
     runtime: Arc<Runtime>,
+    control: RustTurnControl,
     state: Mutex<TurnState>,
 }
 
 enum TurnState {
     Pending(nanocodex::Turn),
     Waiting,
-    Completed(String),
+    Completed(RustTurnResult),
     Failed(String),
+}
+
+impl Turn {
+    fn completed_result(&self) -> PyResult<RustTurnResult> {
+        let state = self.state.lock().map_err(lock_error)?;
+        match &*state {
+            TurnState::Completed(result) => Ok(result.clone()),
+            TurnState::Pending(_) | TurnState::Waiting => Err(PyRuntimeError::new_err(
+                "turn has not completed; await result() before fork_from",
+            )),
+            TurnState::Failed(error) => Err(PyRuntimeError::new_err(format!(
+                "turn failed and has no checkpoint: {error}"
+            ))),
+        }
+    }
 }
 
 #[pymethods]
 impl Turn {
+    /// Inject additional input into this turn at its next safe model boundary.
+    fn steer(&self, py: Python<'_>, instruction: String) -> PyResult<()> {
+        let runtime = Arc::clone(&self.runtime);
+        let control = self.control.clone();
+        py.detach(move || runtime.block_on(control.steer(instruction)))
+            .map_err(runtime_error)
+    }
+
+    /// Cancel this exact unfinished turn.
+    fn cancel(&self, py: Python<'_>) -> PyResult<()> {
+        let runtime = Arc::clone(&self.runtime);
+        let control = self.control.clone();
+        py.detach(move || runtime.block_on(control.cancel()))
+            .map_err(runtime_error)
+    }
+
     /// Block until the turn completes and return its final assistant message.
     fn result(&self, py: Python<'_>) -> PyResult<String> {
         let turn = {
             let mut state = self.state.lock().map_err(lock_error)?;
             match &*state {
-                TurnState::Completed(message) => return Ok(message.clone()),
+                TurnState::Completed(result) => return Ok(result.final_message.clone()),
                 TurnState::Failed(error) => return Err(PyRuntimeError::new_err(error.clone())),
                 TurnState::Waiting => {
                     return Err(PyRuntimeError::new_err(
@@ -149,8 +206,8 @@ impl Turn {
         let runtime = Arc::clone(&self.runtime);
         match py.detach(move || runtime.block_on(turn.result())) {
             Ok(result) => {
-                let message = result.final_message;
-                *self.state.lock().map_err(lock_error)? = TurnState::Completed(message.clone());
+                let message = result.final_message.clone();
+                *self.state.lock().map_err(lock_error)? = TurnState::Completed(result);
                 Ok(message)
             }
             Err(error) => {
@@ -180,6 +237,23 @@ impl AgentEvents {
             .map(|event| serde_json::to_string(&event).map_err(runtime_error))
             .transpose()
     }
+}
+
+fn wrap_agent(
+    runtime: Arc<Runtime>,
+    agent: RustNanocodex,
+    events: RustAgentEvents,
+) -> (Nanocodex, AgentEvents) {
+    (
+        Nanocodex {
+            runtime: Arc::clone(&runtime),
+            agent,
+        },
+        AgentEvents {
+            runtime,
+            events: Arc::new(tokio::sync::Mutex::new(events)),
+        },
+    )
 }
 
 fn build_runtime() -> PyResult<Arc<Runtime>> {

--- a/py/bindings/tests/test_binding.py
+++ b/py/bindings/tests/test_binding.py
@@ -12,6 +12,9 @@ class BindingTests(unittest.TestCase):
         )
         self.assertNotIn(secret, repr(agent))
         self.assertTrue(callable(agent.prompt))
+        self.assertTrue(callable(agent.spawn))
+        self.assertTrue(callable(agent.fork))
+        self.assertTrue(callable(agent.fork_from))
         agent.set_thinking("high")
         agent.set_fast_mode(True)
         self.assertTrue(callable(events.recv_json))
@@ -29,6 +32,32 @@ class BindingTests(unittest.TestCase):
 
         with self.assertRaisesRegex(RuntimeError, "OpenAI credentials are empty"):
             Nanocodex("")
+
+    def test_spawn_returns_independent_agent_without_network(self) -> None:
+        agent, _ = Nanocodex("test-key", thinking="none")
+        child, child_events = agent.spawn()
+        self.assertTrue(callable(child.prompt))
+        self.assertTrue(callable(child_events.recv_json))
+        self.assertIsNot(agent, child)
+
+    def test_fork_before_safe_boundary_is_typed(self) -> None:
+        agent, _ = Nanocodex("test-key", thinking="none")
+        with self.assertRaises(RuntimeError):
+            agent.fork()
+
+    def test_empty_steer_is_rejected(self) -> None:
+        agent, _ = Nanocodex("test-key", thinking="none")
+        turn = agent.prompt("queued for steer rejection")
+        with self.assertRaisesRegex(RuntimeError, "steer instruction must not be empty"):
+            turn.steer("")
+        turn.cancel()
+
+    def test_fork_from_before_result_is_rejected(self) -> None:
+        agent, _ = Nanocodex("test-key", thinking="none")
+        turn = agent.prompt("incomplete")
+        with self.assertRaisesRegex(RuntimeError, "turn has not completed"):
+            agent.fork_from(turn)
+        turn.cancel()
 
     @unittest.skipUnless(os.environ.get("OPENAI_API_KEY"), "live API key not configured")
     def test_live_follow_on_prompting(self) -> None:


### PR DESCRIPTION
## Summary
- Expose native turn lifecycle controls through PyO3: `turn.steer`, `turn.cancel`, `agent.spawn`, `agent.fork`, and `agent.fork_from(completed_turn)`.
- Retain completed `TurnResult` checkpoints so historical forks work like the JS/WASM bindings.
- Add deterministic binding tests, `examples/python/lifecycle.py`, and `just smoke-python-{events,lifecycle}` recipes.

## Why
Rust and JS already owned steer/cancel/fork/spawn. Python only had `prompt`/`result` plus thinking/fast mode, so embedders could not use the documented session contract from Python.

## Verification
- `cargo +1.97 check -p nanocodex-python --locked` passed
- `cargo +1.97 clippy -p nanocodex-python --all-targets -- -D warnings` passed
- `python -m unittest discover -s py/bindings/tests -v`: **6 passed, 1 skipped** (live API key absent)

## Test plan
- [x] CI bindings Python unittest job passes
- [x] Optional: `just smoke-python-lifecycle` with `OPENAI_API_KEY`
- [x] Confirm no overlap with open maintainer feature PRs