### PR TITLE
docs(tools): document and lock Code Mode ICU locale gap

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -447,7 +447,10 @@ contract; do not import that app/session subsystem without a measured backend
 behavior that requires it. The known runtime-semantic difference is
 locale-aware `Date`/`Intl`: stock Code Mode's V8 build includes ICU, while the
 embedded QuickJS runtime does not. Exact parity for that surface requires an
-ICU-capable runtime rather than a partial locale shim. The local
+ICU-capable runtime rather than a partial locale shim. The measured QuickJS
+behavior and contributor guidance live in
+[`docs/CODE_MODE_LOCALE.md`](docs/CODE_MODE_LOCALE.md), with a regression in
+`embedded_quickjs_lacks_icu_locale_apis`. The local
 `benchmarks/codex_request_parity.py` differential now exercises basic tools,
 continued PTY shells, bounded shell output, tool failures, images, WebSocket
 reconnect/replay, automatic compaction, and process cancellation against a

--- a/crates/nanocodex-tools/src/code_mode/tests.rs
+++ b/crates/nanocodex-tools/src/code_mode/tests.rs
@@ -1502,6 +1502,49 @@ fn model_description_uses_codex_style_declarations() {
     std::fs::remove_dir_all(workspace).expect("temporary workspace should be removable");
 }
 
+#[tokio::test]
+async fn embedded_quickjs_lacks_icu_locale_apis() -> Result<()> {
+    // Stock Codex Code Mode uses an ICU-capable V8 build. Nanocodex embeds
+    // QuickJS without ICU, so locale-aware Date/Intl behavior is a deliberate
+    // documented difference rather than a silent shim. See docs/CODE_MODE_LOCALE.md.
+    let workspace = temporary_workspace("quickjs-locale-icu-gap")?;
+    let tools = test_tools(&workspace);
+    let history = Vec::new();
+    let source = r#"
+text({
+  typeofIntl: typeof Intl,
+  toLocaleDateString: (() => {
+    try {
+      return new Date(Date.UTC(2020, 0, 15)).toLocaleDateString("de-DE");
+    } catch (error) {
+      return `ERR:${String(error)}`;
+    }
+  })(),
+  numberFormat: (() => {
+    try {
+      return new Intl.NumberFormat("de-DE").format(1234.5);
+    } catch (error) {
+      return `ERR:${String(error)}`;
+    }
+  })(),
+});
+"#;
+    let execution = tools.execute_code(source, test_context(&history)).await;
+    assert!(execution.success, "{}", execution_output(&execution));
+    let payload: Value = serde_json::from_str(emitted_text(&execution)?)?;
+    assert_eq!(payload["typeofIntl"], "undefined");
+    assert_eq!(payload["toLocaleDateString"], "01/15/2020");
+    assert!(
+        payload["numberFormat"]
+            .as_str()
+            .is_some_and(|value| value.contains("Intl is not defined")),
+        "expected Intl.NumberFormat to fail without ICU, got {}",
+        payload["numberFormat"]
+    );
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
 fn emitted_text(execution: &CodeModeExecution) -> Result<&str> {
     let ToolOutputBody::Content(content) = &execution.output else {
         return Err(eyre!("code-mode execution did not emit content"));

--- a/docs/CODE_MODE_LOCALE.md
+++ b/docs/CODE_MODE_LOCALE.md
@@ -1,0 +1,37 @@
+# Code Mode locale / ICU gap
+
+Nanocodex Code Mode runs on embedded QuickJS. Stock Codex Code Mode runs on a
+V8 build that includes ICU. That difference is intentional and currently
+unshimmed: Nanocodex does not pretend to provide locale-aware `Date` / `Intl`
+parity.
+
+## Measured behavior
+
+Against the embedded QuickJS host used by `nanocodex-tools` (verified
+2026-07-26):
+
+| Expression | Embedded QuickJS result |
+| --- | --- |
+| `typeof Intl` | `"undefined"` |
+| `new Date(Date.UTC(2020, 0, 15)).toLocaleDateString("de-DE")` | `"01/15/2020"` (not German locale formatting) |
+| `new Intl.NumberFormat("de-DE").format(1234.5)` | throws `ReferenceError: Intl is not defined` |
+
+An ICU-capable Codex V8 build formats the same date and number with German
+locale conventions. Exact parity therefore requires an ICU-capable runtime, not
+a partial JavaScript shim.
+
+## Guidance for contributors
+
+- Do not add ad-hoc locale polyfills that only cover a subset of `Intl`.
+- Treat locale-sensitive Code Mode scripts as out of scope for request-parity
+  claims unless the differential explicitly records this deliberate difference.
+- Keep the regression locked by
+  `embedded_quickjs_lacks_icu_locale_apis` in
+  `crates/nanocodex-tools/src/code_mode/tests.rs`.
+- If a future product slice needs ICU, evaluate replacing or rebuilding the
+  embedded runtime rather than patching individual formatters.
+
+## Related
+
+- [`PLAN.md`](../PLAN.md) Codex parity checkpoint
+- [`benchmarks/codex_request_parity.py`](../benchmarks/codex_request_parity.py)


### PR DESCRIPTION
## Summary
- Add `docs/CODE_MODE_LOCALE.md` with measured embedded QuickJS locale/`Intl` behavior.
- Link it from the Codex parity section in `PLAN.md`.
- Add regression `embedded_quickjs_lacks_icu_locale_apis` so the deliberate ICU gap stays explicit.

## Why
`PLAN.md` already named this as the known runtime-semantic difference versus Codex V8+ICU, but there was no standalone doc or locked test. Contributors could otherwise “fix” it with a partial locale shim.

## Measured locally (2026-07-26)
| Expression | Embedded QuickJS |
| --- | --- |
| `typeof Intl` | `"undefined"` |
| `toLocaleDateString("de-DE")` for `2020-01-15` UTC | `"01/15/2020"` |
| `Intl.NumberFormat("de-DE")` | `ReferenceError: Intl is not defined` |

## Verification
- `cargo +1.97 test -p nanocodex-tools embedded_quickjs_lacks_icu_locale_apis` passed
- `cargo +1.97 clippy -p nanocodex-tools --all-targets --features code-mode -- -D warnings` passed

## Test plan
- [x] CI runs the new code-mode unit test
- [x] Docs render / link from `PLAN.md` looks correct