### PR TITLE
perf(tui,tempo): trim reasoning updates and payment graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2780,21 +2780,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3268,22 +3253,6 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots 1.0.8",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -3974,7 +3943,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=75fe974d9fcf7e09b18f12f255db8e16df379cda#75fe974d9fcf7e09b18f12f255db8e16df379cda"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=dce520a10519308a7262c898a731deb03d98dc0c#dce520a10519308a7262c898a731deb03d98dc0c"
 dependencies = [
  "alloy",
  "async-trait",
@@ -4322,23 +4291,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nix"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4665,47 +4617,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -5690,11 +5605,9 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -5706,7 +5619,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -7462,7 +7374,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=2048aab43e64743d298f27173476e0e5274a9448#2048aab43e64743d298f27173476e0e5274a9448"
+source = "git+https://github.com/tempoxyz/tempo?rev=187e419a80472bdce5bdc7289088c6de0686a488#187e419a80472bdce5bdc7289088c6de0686a488"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -7502,7 +7414,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=2048aab43e64743d298f27173476e0e5274a9448#2048aab43e64743d298f27173476e0e5274a9448"
+source = "git+https://github.com/tempoxyz/tempo?rev=187e419a80472bdce5bdc7289088c6de0686a488#187e419a80472bdce5bdc7289088c6de0686a488"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -7518,7 +7430,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=2048aab43e64743d298f27173476e0e5274a9448#2048aab43e64743d298f27173476e0e5274a9448"
+source = "git+https://github.com/tempoxyz/tempo?rev=187e419a80472bdce5bdc7289088c6de0686a488#187e419a80472bdce5bdc7289088c6de0686a488"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -7530,7 +7442,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=2048aab43e64743d298f27173476e0e5274a9448#2048aab43e64743d298f27173476e0e5274a9448"
+source = "git+https://github.com/tempoxyz/tempo?rev=187e419a80472bdce5bdc7289088c6de0686a488#187e419a80472bdce5bdc7289088c6de0686a488"
 dependencies = [
  "alloy-eips",
  "alloy-evm",
@@ -7542,7 +7454,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=2048aab43e64743d298f27173476e0e5274a9448#2048aab43e64743d298f27173476e0e5274a9448"
+source = "git+https://github.com/tempoxyz/tempo?rev=187e419a80472bdce5bdc7289088c6de0686a488#187e419a80472bdce5bdc7289088c6de0686a488"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7748,16 +7660,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3827,7 +3827,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=bb4655d1c0fcb0410e5f00013f03f8d847807344#bb4655d1c0fcb0410e5f00013f03f8d847807344"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=5caad442edeab796821b7f3bb009ab6945106e35#5caad442edeab796821b7f3bb009ab6945106e35"
 dependencies = [
  "alloy",
  "async-trait",
@@ -6921,7 +6921,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=19915e655c2679f8c0f02400f88c10bb222d3912#19915e655c2679f8c0f02400f88c10bb222d3912"
+source = "git+https://github.com/tempoxyz/tempo?rev=9081cc65940c419ab60ebd1fd8170483ee49cfe1#9081cc65940c419ab60ebd1fd8170483ee49cfe1"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -6961,7 +6961,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=19915e655c2679f8c0f02400f88c10bb222d3912#19915e655c2679f8c0f02400f88c10bb222d3912"
+source = "git+https://github.com/tempoxyz/tempo?rev=9081cc65940c419ab60ebd1fd8170483ee49cfe1#9081cc65940c419ab60ebd1fd8170483ee49cfe1"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -6977,7 +6977,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=19915e655c2679f8c0f02400f88c10bb222d3912#19915e655c2679f8c0f02400f88c10bb222d3912"
+source = "git+https://github.com/tempoxyz/tempo?rev=9081cc65940c419ab60ebd1fd8170483ee49cfe1#9081cc65940c419ab60ebd1fd8170483ee49cfe1"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -6989,7 +6989,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=19915e655c2679f8c0f02400f88c10bb222d3912#19915e655c2679f8c0f02400f88c10bb222d3912"
+source = "git+https://github.com/tempoxyz/tempo?rev=9081cc65940c419ab60ebd1fd8170483ee49cfe1#9081cc65940c419ab60ebd1fd8170483ee49cfe1"
 dependencies = [
  "alloy-eips",
  "alloy-hardforks",
@@ -7000,7 +7000,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=19915e655c2679f8c0f02400f88c10bb222d3912#19915e655c2679f8c0f02400f88c10bb222d3912"
+source = "git+https://github.com/tempoxyz/tempo?rev=9081cc65940c419ab60ebd1fd8170483ee49cfe1#9081cc65940c419ab60ebd1fd8170483ee49cfe1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,10 +67,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c36ddb69f5e41407e7a93aead3480f7c8ff076e73d01a951ae8f7ea4542c1ca0"
 dependencies = [
  "alloy-primitives",
- "alloy-rlp",
  "num_enum",
  "phf 0.14.0",
- "serde",
 ]
 
 [[package]]
@@ -202,7 +200,6 @@ dependencies = [
  "borsh",
  "k256",
  "serde",
- "serde_with",
  "thiserror 2.0.18",
 ]
 
@@ -255,26 +252,6 @@ dependencies = [
  "alloy-sol-types",
  "async-trait",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "alloy-evm"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acde665074b478c97047dc2a461b4916cac77922d690e5b7415d1941ae7ff7bf"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-hardforks",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
- "alloy-sol-types",
- "auto_impl",
- "derive_more",
- "revm",
- "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -511,22 +488,6 @@ dependencies = [
  "alloy-serde",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "alloy-rpc-types-engine"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d30ff2e8f7d05433c1d36cf0f1ba045bf071a3d139f63923742fbdfb171dfe44"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-serde",
- "derive_more",
- "serde",
- "strum 0.27.2",
 ]
 
 [[package]]
@@ -843,7 +804,6 @@ checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
  "ark-ec",
  "ark-ff 0.5.0",
- "ark-r1cs-std",
  "ark-std 0.5.0",
 ]
 
@@ -1050,35 +1010,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-r1cs-std"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
-dependencies = [
- "ark-ec",
- "ark-ff 0.5.0",
- "ark-relations",
- "ark-std 0.5.0",
- "educe",
- "num-bigint",
- "num-integer",
- "num-traits",
- "tracing",
-]
-
-[[package]]
-name = "ark-relations"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
-dependencies = [
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
- "tracing",
- "tracing-subscriber 0.2.25",
-]
-
-[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,9 +1129,6 @@ name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "asn1-rs"
@@ -1325,7 +1253,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
- "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -2476,7 +2403,6 @@ dependencies = [
  "hex",
  "rand_core 0.6.4",
  "sha2 0.9.9",
- "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -2720,26 +2646,6 @@ dependencies = [
  "rand 0.8.7",
  "rustc-hex",
  "static_assertions",
-]
-
-[[package]]
-name = "fixed-map"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ed19add84e8cb9e8cc5f7074de0324247149ffef0b851e215fb0edc50c229b"
-dependencies = [
- "fixed-map-derive",
-]
-
-[[package]]
-name = "fixed-map-derive"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dc7a9cb3326bafb80642c5ce99b39a2c0702d4bfa8ee8a3e773791a6cbe2407"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -3642,18 +3548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-types"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
-dependencies = [
- "http",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3786,7 +3680,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3844,16 +3738,6 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "metrics"
-version = "0.24.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
-dependencies = [
- "portable-atomic",
- "rapidhash",
-]
 
 [[package]]
 name = "mime"
@@ -3943,7 +3827,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/tempoxyz/mpp-rs?rev=dce520a10519308a7262c898a731deb03d98dc0c#dce520a10519308a7262c898a731deb03d98dc0c"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=bb4655d1c0fcb0410e5f00013f03f8d847807344#bb4655d1c0fcb0410e5f00013f03f8d847807344"
 dependencies = [
  "alloy",
  "async-trait",
@@ -3959,8 +3843,6 @@ dependencies = [
  "sha2 0.11.0",
  "subtle",
  "tempo-alloy",
- "tempo-contracts",
- "tempo-primitives",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -3985,7 +3867,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4038,7 +3920,7 @@ dependencies = [
  "tokio-tungstenite",
  "tower",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "url",
  "uuid",
  "wasm-bindgen",
@@ -4169,7 +4051,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-opentelemetry",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4233,7 +4115,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -4280,12 +4162,11 @@ dependencies = [
  "sha2 0.11.0",
  "tempfile",
  "tempo-alloy",
- "tempo-primitives",
  "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "url",
  "uuid",
 ]
@@ -4722,7 +4603,6 @@ dependencies = [
  "arrayvec",
  "bitvec",
  "byte-slice-cast",
- "bytes",
  "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
@@ -5221,21 +5101,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quanta"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "once_cell",
- "raw-cpuid",
- "wasi",
- "web-sys",
- "winapi",
-]
-
-[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5456,19 +5321,10 @@ dependencies = [
  "itertools 0.13.0",
  "lru 0.12.5",
  "paste",
- "strum 0.26.3",
+ "strum",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "11.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
-dependencies = [
- "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -5632,26 +5488,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-chainspec"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
-dependencies = [
- "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-genesis",
- "alloy-primitives",
- "alloy-trie",
- "auto_impl",
- "derive_more",
- "reth-ethereum-forks",
- "reth-network-peers",
- "reth-primitives-traits",
- "serde_json",
-]
-
-[[package]]
 name = "reth-codecs"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5664,7 +5500,6 @@ dependencies = [
  "alloy-trie",
  "bytes",
  "modular-bitfield",
- "parity-scale-codec",
  "reth-codecs-derive",
  "reth-zstd-compressors",
  "serde",
@@ -5682,56 +5517,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-db-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
-dependencies = [
- "alloy-consensus",
- "alloy-primitives",
- "arrayvec",
- "bytes",
- "derive_more",
- "metrics",
- "modular-bitfield",
- "reth-codecs",
- "reth-db-models",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-trie-common",
- "roaring",
- "serde",
-]
-
-[[package]]
-name = "reth-db-models"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "bytes",
- "modular-bitfield",
- "reth-codecs",
- "reth-primitives-traits",
- "serde",
-]
-
-[[package]]
-name = "reth-ethereum-forks"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
-dependencies = [
- "alloy-eip2124",
- "alloy-hardforks",
- "alloy-primitives",
- "auto_impl",
- "once_cell",
-]
-
-[[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
 source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
@@ -5743,69 +5528,6 @@ dependencies = [
  "reth-codecs",
  "reth-primitives-traits",
  "serde",
-]
-
-[[package]]
-name = "reth-evm"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
-dependencies = [
- "alloy-consensus",
- "alloy-eip7928",
- "alloy-eips",
- "alloy-evm",
- "alloy-primitives",
- "auto_impl",
- "derive_more",
- "futures-util",
- "reth-execution-errors",
- "reth-execution-types",
- "reth-primitives-traits",
- "reth-storage-api",
- "reth-storage-errors",
- "reth-trie-common",
- "revm",
-]
-
-[[package]]
-name = "reth-execution-errors"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
-dependencies = [
- "alloy-evm",
- "alloy-primitives",
- "alloy-rlp",
- "nybbles",
- "reth-storage-errors",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-execution-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-evm",
- "alloy-primitives",
- "derive_more",
- "reth-ethereum-primitives",
- "reth-primitives-traits",
- "reth-trie-common",
- "revm",
-]
-
-[[package]]
-name = "reth-network-peers"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
-dependencies = [
- "alloy-primitives",
- "alloy-rlp",
- "serde_with",
- "thiserror 2.0.18",
- "url",
 ]
 
 [[package]]
@@ -5821,13 +5543,10 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-trie",
- "byteorder",
  "bytes",
  "dashmap",
  "derive_more",
- "modular-bitfield",
  "once_cell",
- "quanta",
  "reth-codecs",
  "revm-bytecode",
  "revm-primitives",
@@ -5835,143 +5554,6 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-prune-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
-dependencies = [
- "alloy-primitives",
- "derive_more",
- "modular-bitfield",
- "reth-codecs",
- "serde",
- "strum 0.27.2",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "reth-rpc-convert"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
-dependencies = [
- "alloy-consensus",
- "alloy-evm",
- "alloy-json-rpc",
- "alloy-network",
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "auto_impl",
- "dyn-clone",
- "jsonrpsee-types",
- "reth-evm",
- "reth-primitives-traits",
- "reth-rpc-traits",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-rpc-traits"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace77dbcdd59c014fda4565ebfec76cd1fe6f5d98584b4655e8d22a947b9eee3"
-dependencies = [
- "alloy-consensus",
- "alloy-network",
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-signer",
- "reth-primitives-traits",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-stages-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
-dependencies = [
- "alloy-primitives",
- "bytes",
- "modular-bitfield",
- "reth-codecs",
- "reth-trie-common",
- "serde",
-]
-
-[[package]]
-name = "reth-static-file-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
-dependencies = [
- "alloy-primitives",
- "derive_more",
- "fixed-map",
- "reth-stages-types",
- "serde",
- "strum 0.27.2",
-]
-
-[[package]]
-name = "reth-storage-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
-dependencies = [
- "alloy-consensus",
- "alloy-eip7928",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rpc-types-engine",
- "auto_impl",
- "reth-chainspec",
- "reth-db-models",
- "reth-ethereum-primitives",
- "reth-execution-types",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-errors",
- "reth-trie-common",
- "revm",
-]
-
-[[package]]
-name = "reth-storage-errors"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "derive_more",
- "reth-codecs",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-static-file-types",
- "revm",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "reth-trie-common"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
-dependencies = [
- "alloy-consensus",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types-eth",
- "alloy-trie",
- "arrayvec",
- "bytes",
- "derive_more",
- "itertools 0.14.0",
- "nybbles",
- "reth-codecs",
- "reth-primitives-traits",
- "revm",
- "serde",
 ]
 
 [[package]]
@@ -6111,7 +5693,6 @@ dependencies = [
  "revm-primitives",
  "revm-state",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -6140,15 +5721,12 @@ dependencies = [
  "ark-serialize 0.5.0",
  "arrayref",
  "aurora-engine-modexp",
- "blst",
- "c-kzg",
  "cfg-if",
  "k256",
  "p256",
  "revm-context-interface",
  "revm-primitives",
  "ripemd",
- "secp256k1 0.31.1",
  "sha2 0.10.9",
 ]
 
@@ -6197,7 +5775,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -6272,16 +5850,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "roaring"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
-dependencies = [
- "bytemuck",
- "byteorder",
 ]
 
 [[package]]
@@ -6525,7 +6093,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -7202,16 +6770,7 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
+ "strum_macros",
 ]
 
 [[package]]
@@ -7224,18 +6783,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
  "syn 2.0.119",
 ]
 
@@ -7374,7 +6921,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=187e419a80472bdce5bdc7289088c6de0686a488#187e419a80472bdce5bdc7289088c6de0686a488"
+source = "git+https://github.com/tempoxyz/tempo?rev=19915e655c2679f8c0f02400f88c10bb222d3912#19915e655c2679f8c0f02400f88c10bb222d3912"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -7414,7 +6961,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=187e419a80472bdce5bdc7289088c6de0686a488#187e419a80472bdce5bdc7289088c6de0686a488"
+source = "git+https://github.com/tempoxyz/tempo?rev=19915e655c2679f8c0f02400f88c10bb222d3912#19915e655c2679f8c0f02400f88c10bb222d3912"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -7430,7 +6977,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=187e419a80472bdce5bdc7289088c6de0686a488#187e419a80472bdce5bdc7289088c6de0686a488"
+source = "git+https://github.com/tempoxyz/tempo?rev=19915e655c2679f8c0f02400f88c10bb222d3912#19915e655c2679f8c0f02400f88c10bb222d3912"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -7442,10 +6989,9 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=187e419a80472bdce5bdc7289088c6de0686a488#187e419a80472bdce5bdc7289088c6de0686a488"
+source = "git+https://github.com/tempoxyz/tempo?rev=19915e655c2679f8c0f02400f88c10bb222d3912#19915e655c2679f8c0f02400f88c10bb222d3912"
 dependencies = [
  "alloy-eips",
- "alloy-evm",
  "alloy-hardforks",
  "paste",
  "serde",
@@ -7454,28 +7000,21 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/tempoxyz/tempo?rev=187e419a80472bdce5bdc7289088c6de0686a488#187e419a80472bdce5bdc7289088c6de0686a488"
+source = "git+https://github.com/tempoxyz/tempo?rev=19915e655c2679f8c0f02400f88c10bb222d3912#19915e655c2679f8c0f02400f88c10bb222d3912"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-evm",
- "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-rpc-types-eth",
  "alloy-serde",
- "aws-lc-rs",
  "base64",
  "derive_more",
  "ed25519-consensus",
- "modular-bitfield",
  "once_cell",
  "p256",
  "reth-codecs",
- "reth-db-api",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
- "reth-rpc-convert",
  "revm",
  "serde",
  "serde_json",
@@ -7834,7 +7373,7 @@ dependencies = [
  "symlink",
  "thiserror 2.0.18",
  "time",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -7881,7 +7420,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "web-time",
 ]
 
@@ -7892,15 +7431,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
  "tracing-core",
 ]
 
@@ -8036,12 +7566,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ http = "1.3.1"
 http-body-util = "0.1.3"
 hmac = "0.13.0"
 hudsucker = { version = "0.25.0", git = "https://github.com/gakonst/hudsucker", rev = "0c7da328e446518036b9420db3e75451fca522e9", default-features = false, features = ["rcgen-ca", "rustls-client"] }
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "bb4655d1c0fcb0410e5f00013f03f8d847807344", default-features = false }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "5caad442edeab796821b7f3bb009ab6945106e35", default-features = false }
 mpp-egress = { version = "0.1.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.1.1", path = "crates/nanocodex" }
 nanocodex-core = { version = "0.1.1", path = "crates/nanocodex-core" }
@@ -87,7 +87,7 @@ tempfile = "3.27.0"
 toml = "1.1.3"
 tokio = "1.48.0"
 tokio-tungstenite = { version = "0.30.0", default-features = false, features = ["connect", "rustls-tls-native-roots"] }
-tempo-alloy = { version = "=1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "19915e655c2679f8c0f02400f88c10bb222d3912" }
+tempo-alloy = { version = "=1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "9081cc65940c419ab60ebd1fd8170483ee49cfe1" }
 tower = { version = "0.5.2", features = ["limit", "load-shed", "retry", "timeout", "util"] }
 tracing = "0.1.44"
 tracing-appender = "0.2.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ http = "1.3.1"
 http-body-util = "0.1.3"
 hmac = "0.13.0"
 hudsucker = { version = "0.25.0", git = "https://github.com/gakonst/hudsucker", rev = "0c7da328e446518036b9420db3e75451fca522e9", default-features = false, features = ["rcgen-ca", "rustls-client"] }
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "75fe974d9fcf7e09b18f12f255db8e16df379cda", default-features = false }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "dce520a10519308a7262c898a731deb03d98dc0c", default-features = false }
 mpp-egress = { version = "0.1.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.1.1", path = "crates/nanocodex" }
 nanocodex-core = { version = "0.1.1", path = "crates/nanocodex-core" }
@@ -87,8 +87,8 @@ tempfile = "3.27.0"
 toml = "1.1.3"
 tokio = "1.48.0"
 tokio-tungstenite = { version = "0.30.0", default-features = false, features = ["connect", "rustls-tls-native-roots"] }
-tempo-alloy = { version = "=1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "2048aab43e64743d298f27173476e0e5274a9448" }
-tempo-primitives = { version = "=1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "2048aab43e64743d298f27173476e0e5274a9448" }
+tempo-alloy = { version = "=1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "187e419a80472bdce5bdc7289088c6de0686a488" }
+tempo-primitives = { version = "=1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "187e419a80472bdce5bdc7289088c6de0686a488" }
 tower = { version = "0.5.2", features = ["limit", "load-shed", "retry", "timeout", "util"] }
 tracing = "0.1.44"
 tracing-appender = "0.2.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ http = "1.3.1"
 http-body-util = "0.1.3"
 hmac = "0.13.0"
 hudsucker = { version = "0.25.0", git = "https://github.com/gakonst/hudsucker", rev = "0c7da328e446518036b9420db3e75451fca522e9", default-features = false, features = ["rcgen-ca", "rustls-client"] }
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "dce520a10519308a7262c898a731deb03d98dc0c", default-features = false }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "bb4655d1c0fcb0410e5f00013f03f8d847807344", default-features = false }
 mpp-egress = { version = "0.1.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.1.1", path = "crates/nanocodex" }
 nanocodex-core = { version = "0.1.1", path = "crates/nanocodex-core" }
@@ -87,8 +87,7 @@ tempfile = "3.27.0"
 toml = "1.1.3"
 tokio = "1.48.0"
 tokio-tungstenite = { version = "0.30.0", default-features = false, features = ["connect", "rustls-tls-native-roots"] }
-tempo-alloy = { version = "=1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "187e419a80472bdce5bdc7289088c6de0686a488" }
-tempo-primitives = { version = "=1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "187e419a80472bdce5bdc7289088c6de0686a488" }
+tempo-alloy = { version = "=1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "19915e655c2679f8c0f02400f88c10bb222d3912" }
 tower = { version = "0.5.2", features = ["limit", "load-shed", "retry", "timeout", "util"] }
 tracing = "0.1.44"
 tracing-appender = "0.2.4"

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -27,7 +27,7 @@ nanocodex-observability.workspace = true
 nix.workspace = true
 nanousd.workspace = true
 pulldown-cmark.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "75fe974d9fcf7e09b18f12f255db8e16df379cda", default-features = false, features = ["client", "tempo", "reqwest-rustls-tls"] }
+mpp = { workspace = true, features = ["client", "tempo", "reqwest-rustls-tls"] }
 mpp-egress.workspace = true
 ratatui.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }

--- a/bin/nanocodex/benches/tui_render.rs
+++ b/bin/nanocodex/benches/tui_render.rs
@@ -1515,28 +1515,35 @@ mod tui {
     }
 
     pub(super) fn folded_tool_benchmarks(criterion: &mut Criterion) {
-        criterion.bench_function("tui_tool_tree/fold_3471_activities", |bencher| {
-            bencher.iter_batched_ref(
-                || {
-                    let mut transcript = Transcript::default();
-                    for index in 0..3_471 {
-                        transcript.push(TranscriptItem::Tool {
-                            call_id: format!("call-{index}"),
-                            name: "exec_command".to_owned(),
-                            arguments: format!("cargo test package-{index}"),
-                            status: ToolStatus::Completed,
-                        });
-                    }
-                    let shared = transcript.clone();
-                    (transcript, shared)
-                },
-                |(transcript, shared)| {
-                    transcript.set_tool_details_expanded(false);
-                    black_box((transcript.len(), shared.len()));
-                },
-                BatchSize::LargeInput,
-            );
-        });
+        const TOGGLES: usize = 1_024;
+        criterion.bench_function(
+            "tui_tool_tree/fold_expand_3471_activities_x1024",
+            |bencher| {
+                bencher.iter_batched_ref(
+                    || {
+                        let mut transcript = Transcript::default();
+                        for index in 0..3_471 {
+                            transcript.push(TranscriptItem::Tool {
+                                call_id: format!("call-{index}"),
+                                name: "exec_command".to_owned(),
+                                arguments: format!("cargo test package-{index}"),
+                                status: ToolStatus::Completed,
+                            });
+                        }
+                        let shared = transcript.clone();
+                        (transcript, shared)
+                    },
+                    |state| {
+                        for _ in 0..TOGGLES {
+                            state.0.set_tool_details_expanded(false);
+                            state.0.set_tool_details_expanded(true);
+                        }
+                        black_box((state.0.len(), state.1.len()));
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
 
         criterion.bench_function("tui_tool_tree/folded_tail_frame/120x40", |bencher| {
             let mut transcript = Transcript::default();

--- a/bin/nanocodex/src/credits.rs
+++ b/bin/nanocodex/src/credits.rs
@@ -1,12 +1,12 @@
 use std::{path::PathBuf, process::Command, time::Duration};
 
 use clap::{Args, Subcommand};
-use eyre::{Context, Result, eyre};
+use eyre::{Result, eyre};
 use nanousd::{
     CreateOrderRequest, CreateOrderResponse, CreditsClient, DEFAULT_API_URL, NANOUSD_DECIMALS,
     Order, OrderStatus,
 };
-use tempo_alloy::accounts::{TempoAccountsWallet, default_accounts_store_path};
+use tempo_alloy::accounts::TempoAccountsStore;
 
 #[derive(Args)]
 pub(crate) struct Credits {
@@ -85,13 +85,10 @@ struct WaitArgs {
 
 impl Credits {
     pub(crate) async fn run(self) -> Result<()> {
-        let wallet_path = self
+        let store = self
             .wallet_store
-            .map_or_else(default_accounts_store_path, Ok)?;
-        let wallet = TempoAccountsWallet::from_store(&wallet_path).wrap_err_with(|| {
-            format!("failed to load Tempo Accounts at {}", wallet_path.display())
-        })?;
-        let account = wallet.account();
+            .map_or_else(TempoAccountsStore::open_default, TempoAccountsStore::open)?;
+        let account = store.active_account()?;
         let client = CreditsClient::new(&self.api_url)?;
         match self.command {
             CreditsCommand::Status(args) => status(&client, account, args.json).await,

--- a/bin/nanocodex/src/mcp.rs
+++ b/bin/nanocodex/src/mcp.rs
@@ -24,7 +24,7 @@ const DEFAULT_MCP_SERVERS: [(&str, &str, &str); 3] = [
     ),
     (
         "tempo",
-        "https://api.tempo.xyz/mcp",
+        "https://mcp.tempo.xyz",
         "Tempo network and protocol tools.",
     ),
     (

--- a/bin/nanocodex/src/mpp.rs
+++ b/bin/nanocodex/src/mpp.rs
@@ -5,16 +5,18 @@ use eyre::{Context, Result, eyre};
 use mpp::{
     MppError, PaymentChallenge, PaymentCredential,
     client::{PaymentProvider, TempoAccountsProvider, tempo::AutoswapConfig},
-    protocol::intents::ChargeRequest,
+    protocol::{
+        core::accept_payment::{ACCEPT_PAYMENT_HEADER, from_methods},
+        intents::ChargeRequest,
+        methods::tempo::{INTENT_CHARGE, METHOD_NAME},
+    },
 };
 use mpp_egress::{EgressPolicy, MppEgress};
 use nanousd::{NANOUSD_ADDRESS, TEMPO_MAINNET_CHAIN_ID};
-use tempo_alloy::accounts::{TempoAccountsWallet, default_accounts_store_path};
 
 const DEFAULT_MPP_API_BASE_URL: &str = "https://openai.mpp.tempo.xyz/v1";
 const DEFAULT_TEMPO_SWAP_SLIPPAGE_BPS: u16 = 100;
 const DEFAULT_MAX_EGRESS_CHARGE: u128 = 100_000;
-const RESPONSES_ACCEPT_PAYMENT: &str = "tempo/charge";
 
 #[derive(Args, Clone)]
 pub(crate) struct MppArgs {
@@ -98,14 +100,11 @@ impl MppArgs {
             return Ok(None);
         }
 
-        let wallet_path = self
-            .wallet_store
-            .map_or_else(default_accounts_store_path, Ok)
-            .map_err(|error| eyre!(error))?;
-        let wallet = TempoAccountsWallet::from_store(&wallet_path).wrap_err_with(|| {
-            format!("failed to load Tempo Accounts at {}", wallet_path.display())
-        })?;
-        let provider = TempoAccountsProvider::new(wallet)
+        let provider = self.wallet_store.map_or_else(
+            TempoAccountsProvider::from_default_store,
+            TempoAccountsProvider::from_store,
+        )?;
+        let provider = provider
             .with_expected_chain_id(TEMPO_MAINNET_CHAIN_ID)
             .with_autoswap(AutoswapConfig::new(NANOUSD_ADDRESS, self.swap_slippage_bps));
         let provider = CappedChargeProvider {
@@ -260,8 +259,9 @@ impl MppAdapter {
 fn responses_payment_headers(api_key: Option<&str>) -> Result<reqwest::header::HeaderMap> {
     let mut headers = reqwest::header::HeaderMap::new();
     headers.insert(
-        reqwest::header::HeaderName::from_static("accept-payment"),
-        reqwest::header::HeaderValue::from_static(RESPONSES_ACCEPT_PAYMENT),
+        ACCEPT_PAYMENT_HEADER,
+        reqwest::header::HeaderValue::from_str(&from_methods(&[(METHOD_NAME, INTENT_CHARGE)]))
+            .wrap_err("failed to encode the Tempo Charge payment preference")?,
     );
     if let Some(api_key) = api_key {
         headers.insert(

--- a/bin/nanocodex/src/tui/transcript.rs
+++ b/bin/nanocodex/src/tui/transcript.rs
@@ -1774,10 +1774,11 @@ impl MarkdownContent {
     }
 
     fn reasoning(source: &str) -> Self {
+        let source = format!("• {}", indent_reasoning(source));
         Self {
-            source: format!("• {}", indent_reasoning(source)),
+            plain_streaming: is_plain_streaming_markdown(&source),
+            source,
             streaming: true,
-            plain_streaming: false,
             base_style: Style::default().add_modifier(Modifier::DIM),
             show_header: false,
             cached: Mutex::new(None),
@@ -1819,6 +1820,7 @@ impl MarkdownContent {
                     replace_tail,
                     &self.source[tail_start..],
                     self.base_style,
+                    self.show_header,
                 );
             }
         } else {
@@ -1827,15 +1829,34 @@ impl MarkdownContent {
     }
 
     fn append_reasoning(&mut self, delta: &str) {
+        let delta = indent_reasoning(delta);
         if self.source.ends_with("**") && delta.starts_with("**") {
             self.source.push_str("\n• ");
         }
-        self.source.push_str(&indent_reasoning(delta));
+        let incremental =
+            self.plain_streaming && plain_markdown_extension_is_safe(&self.source, &delta);
+        let tail_start = self
+            .source
+            .rfind('\n')
+            .map_or(0, |index| index.saturating_add(1));
+        let replace_tail = !self.source.is_empty() && !self.source.ends_with('\n');
+        self.source.push_str(&delta);
         *self
             .logical_copy
             .lock()
             .unwrap_or_else(PoisonError::into_inner) = None;
-        *self.cached.lock().unwrap_or_else(PoisonError::into_inner) = None;
+        self.plain_streaming = incremental;
+        let mut cached = self.cached.lock().unwrap_or_else(PoisonError::into_inner);
+        if incremental && let Some(rendered) = cached.as_mut() {
+            rendered.replace_plain_tail(
+                replace_tail,
+                &self.source[tail_start..],
+                self.base_style,
+                self.show_header,
+            );
+        } else {
+            *cached = None;
+        }
     }
 
     fn finalize(&mut self, source: &str) {
@@ -1940,16 +1961,37 @@ impl RenderedText {
         }
     }
 
-    fn replace_plain_tail(&mut self, replace_tail: bool, tail: &str, base_style: Style) {
+    fn replace_plain_tail(
+        &mut self,
+        replace_tail: bool,
+        tail: &str,
+        base_style: Style,
+        show_header: bool,
+    ) {
         self.pop_line();
         if replace_tail {
             self.pop_line();
         }
+        let mut first_line = !show_header && self.text.lines.is_empty();
         for line in tail.split_terminator('\n') {
-            self.push_line(Line::from(vec![
-                Span::raw("  "),
-                Span::styled(line.to_owned(), Style::default().fg(Color::White)),
-            ]));
+            let line = if first_line {
+                Line::from(Span::styled(
+                    line.to_owned(),
+                    Style::default().fg(Color::White),
+                ))
+            } else {
+                let line = if show_header {
+                    line
+                } else {
+                    line.strip_prefix("  ").unwrap_or(line)
+                };
+                Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled(line.to_owned(), Style::default().fg(Color::White)),
+                ])
+            };
+            self.push_line(line);
+            first_line = false;
         }
         self.text.style = base_style;
         self.push_line(Line::raw(""));
@@ -2607,6 +2649,31 @@ mod tests {
                 incremental.append(delta);
 
                 let fresh = MarkdownContent::streaming(&format!("{source}{delta}"));
+                assert_eq!(
+                    incremental.materialized_text(width),
+                    fresh.materialized_text(width),
+                    "source={source:?} delta={delta:?} width={width}",
+                );
+                assert_eq!(incremental.height(width), fresh.height(width));
+            }
+        }
+    }
+
+    #[test]
+    fn streaming_plain_reasoning_append_matches_a_fresh_parse() {
+        for (source, delta) in [
+            ("plain words", " added words"),
+            ("first line\nsecond line", "\nthird λ line"),
+            ("first line", "\nsecond line"),
+            ("plain", " *styled*"),
+            ("plain", "\n\nnext paragraph"),
+        ] {
+            for width in [20, 80] {
+                let mut incremental = MarkdownContent::reasoning(source);
+                let _ = incremental.height(width);
+                incremental.append_reasoning(delta);
+
+                let fresh = MarkdownContent::reasoning(&format!("{source}{delta}"));
                 assert_eq!(
                     incremental.materialized_text(width),
                     fresh.materialized_text(width),

--- a/bin/nanousd-api/Cargo.toml
+++ b/bin/nanousd-api/Cargo.toml
@@ -30,7 +30,6 @@ sha2-11 = { package = "sha2", version = "0.11" }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tempo-alloy.workspace = true
-tempo-primitives.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true

--- a/bin/nanousd-api/src/config.rs
+++ b/bin/nanousd-api/src/config.rs
@@ -10,7 +10,7 @@ use clap::{Parser, ValueEnum};
 use eyre::{Result, eyre};
 use nanousd::{DEFAULT_API_URL, NANOUSD_ADDRESS};
 
-const DEFAULT_RPC_URL: &str = "https://rpc.mainnet.tempo.xyz";
+const DEFAULT_RPC_URL: &str = "https://rpc.tempo.xyz";
 // The issuer account is funded in PathUSD. Deployments may override this to
 // match their dedicated issuer account and access-key policy.
 const DEFAULT_FEE_TOKEN: &str = "0x20c0000000000000000000000000000000000000";

--- a/bin/nanousd-api/src/issuer.rs
+++ b/bin/nanousd-api/src/issuer.rs
@@ -17,9 +17,8 @@ use alloy::{
 use async_trait::async_trait;
 use tempo_alloy::{
     TempoNetwork, accounts::TempoAccountsWallet, contracts::precompiles::ITIP20,
-    provider::TempoProviderBuilderExt, rpc::TempoTransactionRequest,
+    primitives::TempoTxEnvelope, provider::TempoProviderBuilderExt, rpc::TempoTransactionRequest,
 };
-use tempo_primitives::TempoTxEnvelope;
 
 use crate::db::Fulfillment;
 

--- a/crates/mpp-egress/Cargo.toml
+++ b/crates/mpp-egress/Cargo.toml
@@ -15,9 +15,9 @@ base64.workspace = true
 futures-util.workspace = true
 http-body-util.workspace = true
 hudsucker.workspace = true
-mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "75fe974d9fcf7e09b18f12f255db8e16df379cda", default-features = false, features = ["client"] }
+mpp = { workspace = true, features = ["client"] }
 rand.workspace = true
-reqwest = { package = "reqwest", version = "0.13", default-features = false, features = ["native-tls", "stream"] }
+reqwest = { workspace = true, features = ["stream"] }
 rustls.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true

--- a/crates/mpp-egress/src/lib.rs
+++ b/crates/mpp-egress/src/lib.rs
@@ -39,7 +39,10 @@ use hudsucker::{
         pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
     },
 };
-use mpp::client::{AcceptPaymentPolicy, ClientEvent, ClientEvents, Fetch, PaymentProvider};
+use mpp::client::{
+    AcceptPaymentPolicy, ClientEvent, ClientEvents, DEFAULT_MAX_PAYMENT_RETRIES, Fetch,
+    PaymentProvider,
+};
 use tempfile::TempDir;
 use tokio::{
     net::TcpListener,
@@ -49,7 +52,6 @@ use tokio::{
 use tracing::Instrument as _;
 
 const DEFAULT_MAX_REQUEST_BYTES: usize = 16 * 1024 * 1024;
-const DEFAULT_MAX_PAYMENT_RETRIES: usize = 4;
 const DEFAULT_MAX_CONCURRENT_CONNECTIONS: usize = 128;
 const DEFAULT_MAX_CONCURRENT_REQUESTS: usize = 128;
 const MAX_IDLE_CONNECTIONS_PER_HOST: usize = 4;
@@ -428,7 +430,7 @@ where
             .request(parts.method, parts.uri.to_string())
             .headers(parts.headers)
             .body(body);
-        let events = payment_events();
+        let events = ClientEvents::default();
         let _subscription = events.on_any(|event| async move {
             record_payment_event(&event);
         });
@@ -451,10 +453,6 @@ where
         );
         Ok(convert_response(response, &tracing::Span::current()))
     }
-}
-
-fn payment_events() -> ClientEvents {
-    ClientEvents::default()
 }
 
 fn record_payment_event(event: &ClientEvent) {

--- a/docs/MPP.md
+++ b/docs/MPP.md
@@ -34,12 +34,12 @@ deployment access key.
 
 ## Accounts and signing
 
-The CLI opens the Tempo Accounts SDK store at
-`~/.tempo/wallet/store.json` by default. `tempo-alloy` owns the concrete
-`TempoAccountsWallet` and lazily selects an authorized access key when a
-payment transaction is prepared. The resulting `TempoAccessKey` pins that
-exact key through authorization resolution, gas filling, sponsorship, and
-signing.
+`mpp-rs` opens the Tempo Accounts SDK store at
+`~/.tempo/wallet/store.json` by default. Its `TempoAccountsProvider` uses the
+concrete `TempoAccountsWallet` from `tempo-alloy`, which lazily selects an
+authorized access key when a payment transaction is prepared. The resulting
+`TempoAccessKey` pins that exact key through authorization resolution, gas
+filling, sponsorship, and signing.
 
 There is no Nanocodex wallet wrapper, signer enum, or signing-mode flag.
 `tempo-alloy` implements Alloy's existing wallet and filler traits;

--- a/docs/NANOUSD_CREDITS.md
+++ b/docs/NANOUSD_CREDITS.md
@@ -50,15 +50,15 @@ cargo run -p nanousd-api -- \
   --issuer-mode alloy
 ```
 
-The Alloy issuer loads the active account and P-256 access key from Tempo
-Wallet. It adapts that key to Alloy's `NetworkWallet<TempoNetwork>`, then uses a
-typed `ITIP20::mint` call and Alloy's normal provider transaction lifecycle. It
-never invokes a shell or passes a private key on a command line. An explicit
-`NANOUSD_WALLET_STORE` selects a different Wallet store. The key must be
-authorized on-chain before the service starts, authorized to call NANOUSD, and
-have enough allowance for its configured gas fee token. The issuer never
-attaches a `key_authorization` payload. Use a dedicated, narrowly scoped issuer
-key for a deployed service.
+The Alloy issuer uses `tempo-alloy`'s `TempoAccountsWallet`, which directly
+implements Alloy's wallet and transaction-filler traits and lazily selects an
+authorized P-256 access key. It then uses a typed `ITIP20::mint` call and
+Alloy's normal provider transaction lifecycle. It never invokes a shell or
+passes a private key on a command line. An explicit `NANOUSD_WALLET_STORE`
+selects a different Wallet store. The key must be authorized on-chain before
+the service starts, authorized to call NANOUSD, and have enough allowance for
+its configured gas fee token. The issuer never attaches a `key_authorization`
+payload. Use a dedicated, narrowly scoped issuer key for a deployed service.
 
 The default fee token is PathUSD because that is the funded token in the issuer
 account. Set `NANOUSD_FEE_TOKEN` to match both the balance and fee-token


### PR DESCRIPTION
## Summary

- update Nanocodex to merged mpp-rs `5caad442` and Tempo Accounts head `9081cc659`
- delegate Accounts-store loading, Charge construction/signing, payment headers, retry defaults, and Tempo primitives to mpp-rs / tempo-alloy instead of duplicating them locally
- remove the accidental Reth/Revm node stack from normal Nanocodex builds while preserving node integrations behind tempo-alloy `reth`
- centralize the MPP dependency and use the workspace Rustls client, removing the native-TLS/OpenSSL dependency chain
- update the built-in Tempo MCP and mainnet RPC defaults to the current official endpoints
- incrementally update cached plain reasoning tails instead of reparsing the full retained reasoning transcript
- repair the tool fold benchmark so it measures 1,024 real fold/expand cycles

## Measured impact

- reasoning append after 100 KB: 3.896 ms to 5.85 µs (about 666x faster)
- normal `nanocodex-bin` package graph: 817 to 681 unique entries; all 54 named `reth-*`, `revm`, and `alloy-evm` entries removed
- release binary, controlled rebuild of the exact previous PR head versus this head: 34,389,456 to 33,299,776 bytes (1,089,680 bytes / 3.17% smaller)
- 1,024 tool fold/expand cycles: about 3.01 µs
- assistant streaming benchmarks showed no meaningful regression

## Validation

- `cargo fmt --all -- --check`
- locked workspace check and Clippy across all targets/features with warnings denied
- full locked workspace test suite and doctests
- MPP egress proxy tests, including 10,000 bounded parallel payments exactly once
- final locked release build and dependency-tree audit

No live API or model call is involved.
