### PR TITLE
Add VM-backed tools with composable egress

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,12 +1,3 @@
-[env]
-CARGO_NET_GIT_FETCH_WITH_CLI = "true"
-CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER = { value = "scripts/aarch64-unknown-linux-musl-linker", relative = true, force = true }
-CC_aarch64_unknown_linux_musl = { value = "scripts/aarch64-unknown-linux-musl-linker", relative = true, force = true }
-AR_aarch64_unknown_linux_musl = { value = "scripts/aarch64-unknown-linux-musl-ar", relative = true, force = true }
-
-[net]
-git-fetch-with-cli = true
-
 [target.aarch64-apple-darwin]
 linker = "/usr/bin/clang"
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,17 @@
+[env]
+CARGO_NET_GIT_FETCH_WITH_CLI = "true"
+CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER = { value = "scripts/aarch64-unknown-linux-musl-linker", relative = true, force = true }
+CC_aarch64_unknown_linux_musl = { value = "scripts/aarch64-unknown-linux-musl-linker", relative = true, force = true }
+AR_aarch64_unknown_linux_musl = { value = "scripts/aarch64-unknown-linux-musl-ar", relative = true, force = true }
+
+[net]
+git-fetch-with-cli = true
+
 [target.aarch64-apple-darwin]
 linker = "/usr/bin/clang"
+
+[target.aarch64-unknown-linux-musl]
+linker = "scripts/aarch64-unknown-linux-musl-linker"
 
 [target.x86_64-apple-darwin]
 linker = "/usr/bin/clang"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,8 @@
 - `nanovm` owns typed libkrun configuration, the audited FFI boundary,
   provider-neutral egress leases, and VMM process configuration.
 - `nanocodex-vm` owns the persistent host/guest tool protocol and the standard
-  workspace-tool adapters. Applications decide whether each agent driver uses
-  host tools or a fresh VM tool session.
+  workspace-tool adapters. Applications decide whether a root agent tree uses
+  host tools or one shared VM tool session.
 - `nanocodex-mcp` owns MCP transports, background handshake/discovery,
   authenticated connection inputs, deferred tool search, and remote dispatch.
 - `nanocodex` composes those crates into the owned agent lifecycle and exports

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,11 @@
   service/client.
 - `nanocodex-tools` owns code mode, built-in tools, the heterogeneous registry,
   and the public `Tool` trait.
+- `nanovm` owns typed libkrun configuration, the audited FFI boundary,
+  provider-neutral egress leases, and VMM process configuration.
+- `nanocodex-vm` owns the persistent host/guest tool protocol and the standard
+  workspace-tool adapters. Applications decide whether each agent driver uses
+  host tools or a fresh VM tool session.
 - `nanocodex-mcp` owns MCP transports, background handshake/discovery,
   authenticated connection inputs, deferred tool search, and remote dispatch.
 - `nanocodex` composes those crates into the owned agent lifecycle and exports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Features
+
+- [vm] Add persistent VM-backed workspace tools, composable egress leases, and
+  an MPP proxy layer.
+
 ## [0.2.0](https://github.com/gakonst/nanocodex/releases/tag/v0.2.0) - 2026-07-26
 
 ### Bug Fixes
@@ -140,7 +147,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add stock Codex parity differential
 - Stress parallel MPP egress replay ([#24](https://github.com/gakonst/nanocodex/issues/24))
 - Synchronize code cell termination output ([#23](https://github.com/gakonst/nanocodex/issues/23))
-
 ## [0.1.1](https://github.com/gakonst/nanocodex/releases/tag/v0.1.1) - 2026-07-23
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -131,7 +131,7 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -174,7 +174,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -200,7 +200,7 @@ dependencies = [
  "borsh",
  "k256",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -214,7 +214,7 @@ dependencies = [
  "borsh",
  "once_cell",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -251,7 +251,7 @@ dependencies = [
  "alloy-provider",
  "alloy-sol-types",
  "async-trait",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -306,7 +306,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -333,7 +333,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -411,7 +411,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -508,7 +508,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -534,7 +534,7 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -550,7 +550,7 @@ dependencies = [
  "async-trait",
  "k256",
  "rand 0.8.7",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -641,7 +641,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
@@ -677,7 +677,7 @@ dependencies = [
  "nybbles",
  "serde",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -760,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.104"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arboard"
@@ -780,7 +780,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
  "x11rb",
 ]
 
@@ -1142,7 +1142,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -1210,7 +1210,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.0",
 ]
 
 [[package]]
@@ -1484,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.17"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20659f9bbee16cbbd2f7393e40ab6309f5a98f76a2eb57a995ec508b72387fe"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
 dependencies = [
  "cc",
  "glob",
@@ -1516,7 +1516,7 @@ checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "borsh-derive",
  "bytes",
- "cfg_aliases 0.2.2",
+ "cfg_aliases 0.2.1",
 ]
 
 [[package]]
@@ -1566,9 +1566,9 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.2"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 
 [[package]]
 name = "byteorder"
@@ -1636,7 +1636,7 @@ dependencies = [
  "cached_proc_macro_types",
  "hashbrown 0.15.5",
  "once_cell",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "web-time",
 ]
 
@@ -1690,9 +1690,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1714,9 +1714,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -1772,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1794,14 +1794,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.4"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2111,9 +2111,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -2269,7 +2269,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2374,7 +2374,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid 0.9.6",
- "crypto-common 0.1.6",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -2498,9 +2498,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -2809,9 +2809,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2824,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2834,15 +2834,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2857,9 +2857,9 @@ checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2868,21 +2868,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2927,9 +2927,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -3206,7 +3206,7 @@ dependencies = [
  "moka",
  "rand 0.10.2",
  "rcgen",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-graceful",
@@ -3226,9 +3226,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3259,7 +3259,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.9",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -3425,9 +3425,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -3435,9 +3435,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.10"
+version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -3448,8 +3448,8 @@ dependencies = [
  "num-traits",
  "png",
  "tiff",
- "zune-core",
- "zune-jpeg",
+ "zune-core 0.5.1",
+ "zune-jpeg 0.5.15",
 ]
 
 [[package]]
@@ -3478,7 +3478,7 @@ dependencies = [
  "rustc_version 0.4.1",
  "tokio",
  "tracing",
- "vm-memory 0.18.0",
+ "vm-memory",
  "windows-sys 0.61.2",
 ]
 
@@ -3646,7 +3646,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -3766,7 +3766,7 @@ dependencies = [
  "kvm-ioctls",
  "libc",
  "linux-loader",
- "vm-memory 0.17.1",
+ "vm-memory",
  "vmm-sys-util 0.15.0",
  "windows-sys 0.61.2",
 ]
@@ -3805,12 +3805,12 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "lru 0.18.1",
+ "lru 0.16.4",
  "nix 0.30.1",
  "rand 0.9.5",
  "virtio-bindings",
  "vm-fdt",
- "vm-memory 0.17.1",
+ "vm-memory",
  "windows-sys 0.61.2",
 ]
 
@@ -3836,7 +3836,7 @@ version = "0.1.0-2.0.0-dev"
 source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
 dependencies = [
  "krun-utils",
- "vm-memory 0.17.1",
+ "vm-memory",
 ]
 
 [[package]]
@@ -3853,7 +3853,7 @@ name = "krun-smbios"
 version = "0.1.0-2.0.0-dev"
 source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
 dependencies = [
- "vm-memory 0.17.1",
+ "vm-memory",
 ]
 
 [[package]]
@@ -3893,7 +3893,7 @@ dependencies = [
  "linux-loader",
  "log",
  "nix 0.30.1",
- "vm-memory 0.17.1",
+ "vm-memory",
  "vmm-sys-util 0.14.0",
  "windows-sys 0.61.2",
  "zstd",
@@ -3937,9 +3937,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.189"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libkrun"
@@ -3960,7 +3960,7 @@ dependencies = [
  "libloading",
  "log",
  "once_cell",
- "vm-memory 0.17.1",
+ "vm-memory",
  "windows-sys 0.61.2",
 ]
 
@@ -4006,7 +4006,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de72cb02c55ecffcf75fe78295926f872eb6eb0a58d629c58a8c324dc26380f6"
 dependencies = [
- "vm-memory 0.17.1",
+ "vm-memory",
 ]
 
 [[package]]
@@ -4074,15 +4074,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "lru"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
-dependencies = [
- "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -4209,9 +4200,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.8.1"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -4236,7 +4227,7 @@ dependencies = [
  "sha2 0.11.0",
  "subtle",
  "tempo-alloy",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "uuid",
@@ -4257,7 +4248,7 @@ dependencies = [
  "rustls",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4308,7 +4299,7 @@ dependencies = [
  "sha1",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "tower",
@@ -4375,7 +4366,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "web-time",
 ]
@@ -4384,10 +4375,13 @@ dependencies = [
 name = "nanocodex-examples"
 version = "0.2.0"
 dependencies = [
+ "axum",
  "dotenvy",
  "eyre",
  "futures-util",
  "http",
+ "mpp",
+ "mpp-egress",
  "nanocodex",
  "nanocodex-vm",
  "nanovm",
@@ -4426,7 +4420,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -4441,7 +4435,7 @@ dependencies = [
  "opentelemetry_sdk",
  "reqwest",
  "rustls",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -4477,7 +4471,7 @@ dependencies = [
  "simd-json",
  "smallvec",
  "sonic-rs",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "tower",
@@ -4507,7 +4501,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4527,7 +4521,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4549,7 +4543,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "url",
 ]
 
@@ -4575,7 +4569,7 @@ dependencies = [
  "sha2 0.11.0",
  "tempfile",
  "tempo-alloy",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
@@ -4593,8 +4587,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.19",
- "vm-memory 0.17.1",
+ "thiserror 2.0.18",
+ "vm-memory",
 ]
 
 [[package]]
@@ -4617,7 +4611,7 @@ checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases 0.2.2",
+ "cfg_aliases 0.2.1",
  "libc",
  "memoffset",
 ]
@@ -4630,7 +4624,7 @@ checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases 0.2.2",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -4940,7 +4934,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -4970,7 +4964,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5003,7 +4997,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -5393,9 +5387,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.107"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -5559,14 +5553,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
- "cfg_aliases 0.2.2",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -5589,7 +5583,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5601,7 +5595,7 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
- "cfg_aliases 0.2.2",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2",
@@ -5611,9 +5605,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.47"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -5829,22 +5823,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5999,7 +5993,7 @@ dependencies = [
  "revm-state",
  "secp256k1 0.30.0",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6102,7 +6096,7 @@ dependencies = [
  "revm-primitives",
  "revm-state",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6290,7 +6284,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sse-stream",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -6334,7 +6328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6449,7 +6443,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6495,9 +6489,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -6754,9 +6748,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -6764,22 +6758,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6795,9 +6789,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.151"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -7064,9 +7058,9 @@ dependencies = [
 
 [[package]]
 name = "simd_cesu8"
-version = "1.2.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
 dependencies = [
  "rustc_version 0.4.1",
  "simdutf8",
@@ -7135,7 +7129,7 @@ dependencies = [
  "simdutf8",
  "sonic-number",
  "sonic-simd",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "zmij",
 ]
 
@@ -7172,9 +7166,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.5"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
+checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
 dependencies = [
  "bytes",
  "futures-util",
@@ -7274,9 +7268,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7329,7 +7323,7 @@ dependencies = [
  "regex-syntax",
  "serde",
  "serde_derive",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "walkdir",
 ]
 
@@ -7399,7 +7393,7 @@ dependencies = [
  "tempo-chainspec",
  "tempo-contracts",
  "tempo-primitives",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tower",
  "tracing",
 ]
@@ -7479,11 +7473,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -7499,13 +7493,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7528,23 +7522,23 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.11.3"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
 dependencies = [
  "fax",
  "flate2",
  "half",
  "quick-error",
  "weezl",
- "zune-jpeg",
+ "zune-jpeg 0.4.21",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "libc",
@@ -7564,9 +7558,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.32"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -7609,9 +7603,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -7638,9 +7632,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7659,9 +7653,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.19"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -7688,14 +7682,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.19"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -7818,7 +7811,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]
@@ -7923,7 +7916,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8129,17 +8122,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f39348a049689cabd3377cdd9182bf526ec76a6f823b79903896452e9d7a7380"
 dependencies = [
  "libc",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "winapi",
-]
-
-[[package]]
-name = "vm-memory"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b55e753c7725603745cb32b2287ef7ef3da05c03c7702cda3fa8abe25ae0465"
-dependencies = [
- "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -8300,9 +8284,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.9"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8313,14 +8297,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.9",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.9"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8469,25 +8453,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -8505,31 +8471,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -8548,22 +8497,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8572,22 +8509,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8596,22 +8521,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -8620,22 +8533,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -8707,7 +8608,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -8746,18 +8647,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8874,9 +8775,24 @@ dependencies = [
 
 [[package]]
 name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core 0.4.12",
+]
 
 [[package]]
 name = "zune-jpeg"
@@ -8884,5 +8800,5 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
- "zune-core",
+ "zune-core 0.5.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,6 +785,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcbox-ext4"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9dce000de67c1a27347fed86e9ce76199463fbb5a3d7f13cb0f3d1c16b6dae3"
+dependencies = [
+ "tar",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
 name = "ark-bls12-381"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2722,6 +2733,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4375,6 +4396,7 @@ dependencies = [
 name = "nanocodex-examples"
 version = "0.2.0"
 dependencies = [
+ "arcbox-ext4",
  "axum",
  "dotenvy",
  "eyre",
@@ -4385,10 +4407,12 @@ dependencies = [
  "nanocodex",
  "nanocodex-vm",
  "nanovm",
+ "reflink-copy",
  "reqwest",
  "rustls",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-tungstenite",
  "tower",
@@ -5839,6 +5863,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "reflink-copy"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustix 1.1.4",
+ "windows",
 ]
 
 [[package]]
@@ -7340,6 +7376,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8610,6 +8657,16 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -131,7 +131,7 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -174,7 +174,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -200,7 +200,7 @@ dependencies = [
  "borsh",
  "k256",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -214,7 +214,7 @@ dependencies = [
  "borsh",
  "once_cell",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -251,7 +251,7 @@ dependencies = [
  "alloy-provider",
  "alloy-sol-types",
  "async-trait",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -306,7 +306,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -333,7 +333,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -411,7 +411,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "url",
@@ -508,7 +508,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -534,7 +534,7 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -550,7 +550,7 @@ dependencies = [
  "async-trait",
  "k256",
  "rand 0.8.7",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -641,7 +641,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tower",
  "tracing",
@@ -677,7 +677,7 @@ dependencies = [
  "nybbles",
  "serde",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -760,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arboard"
@@ -780,7 +780,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -1142,7 +1142,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -1210,7 +1210,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1349,6 +1349,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+checksum = "c20659f9bbee16cbbd2f7393e40ab6309f5a98f76a2eb57a995ec508b72387fe"
 dependencies = [
  "cc",
  "glob",
@@ -1497,7 +1516,7 @@ checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "borsh-derive",
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
 ]
 
 [[package]]
@@ -1547,9 +1566,9 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.1"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -1570,6 +1589,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1598,7 +1636,7 @@ dependencies = [
  "cached_proc_macro_types",
  "hashbrown 0.15.5",
  "once_cell",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "web-time",
 ]
 
@@ -1619,6 +1657,15 @@ name = "cached_proc_macro_types"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
+
+[[package]]
+name = "caps"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1ddba47aba30b6a889298ad0109c3b8dcb0e8fc993b459daa7067d46f865e0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cassowary"
@@ -1643,9 +1690,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1667,9 +1714,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -1725,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.2"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1747,14 +1794,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2064,9 +2111,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -2195,6 +2242,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2296,7 +2374,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid 0.9.6",
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
@@ -2420,9 +2498,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
 ]
@@ -2466,6 +2544,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -2708,9 +2809,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2723,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2733,15 +2834,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2756,9 +2857,9 @@ checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2767,21 +2868,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2826,9 +2927,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -3105,7 +3206,7 @@ dependencies = [
  "moka",
  "rand 0.10.2",
  "rcgen",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tokio",
  "tokio-graceful",
@@ -3125,9 +3226,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3158,7 +3259,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -3324,9 +3425,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -3334,9 +3435,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.9"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -3347,8 +3448,8 @@ dependencies = [
  "num-traits",
  "png",
  "tiff",
- "zune-core 0.5.1",
- "zune-jpeg 0.5.15",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -3359,6 +3460,26 @@ checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
  "quick-error",
+]
+
+[[package]]
+name = "imago"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae7cfee876c698a1a2ed9c705ab18f21acbed82110f19b51cc458de73426fe2c"
+dependencies = [
+ "async-trait",
+ "bincode 2.0.1",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "nix 0.30.1",
+ "page_size",
+ "rustc_version 0.4.1",
+ "tokio",
+ "tracing",
+ "vm-memory 0.18.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3478,6 +3599,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3489,7 +3646,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link",
 ]
@@ -3597,6 +3754,182 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
+name = "krun-arch"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "krun-arch-gen",
+ "krun-smbios",
+ "krun-utils",
+ "krun-whp",
+ "kvm-bindings",
+ "kvm-ioctls",
+ "libc",
+ "linux-loader",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.15.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "krun-arch-gen"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+
+[[package]]
+name = "krun-cpuid"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "kvm-bindings",
+ "kvm-ioctls",
+ "vmm-sys-util 0.15.0",
+]
+
+[[package]]
+name = "krun-devices"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "bitflags 1.3.2",
+ "caps",
+ "crossbeam-channel",
+ "imago",
+ "krun-arch",
+ "krun-hvf",
+ "krun-polly",
+ "krun-utils",
+ "krun-whp",
+ "kvm-bindings",
+ "kvm-ioctls",
+ "libc",
+ "libloading",
+ "log",
+ "lru 0.18.1",
+ "nix 0.30.1",
+ "rand 0.9.5",
+ "virtio-bindings",
+ "vm-fdt",
+ "vm-memory 0.17.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "krun-hvf"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "crossbeam-channel",
+ "krun-arch",
+ "libloading",
+ "log",
+]
+
+[[package]]
+name = "krun-init-blob"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+
+[[package]]
+name = "krun-kernel"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "krun-utils",
+ "vm-memory 0.17.1",
+]
+
+[[package]]
+name = "krun-polly"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "krun-utils",
+ "libc",
+]
+
+[[package]]
+name = "krun-smbios"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "vm-memory 0.17.1",
+]
+
+[[package]]
+name = "krun-utils"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossbeam-channel",
+ "kvm-bindings",
+ "libc",
+ "log",
+ "nix 0.30.1",
+ "vmm-sys-util 0.15.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "krun-vmm"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "bzip2",
+ "crossbeam-channel",
+ "flate2",
+ "krun-arch",
+ "krun-arch-gen",
+ "krun-cpuid",
+ "krun-devices",
+ "krun-hvf",
+ "krun-kernel",
+ "krun-polly",
+ "krun-utils",
+ "kvm-bindings",
+ "kvm-ioctls",
+ "libc",
+ "linux-loader",
+ "log",
+ "nix 0.30.1",
+ "vm-memory 0.17.1",
+ "vmm-sys-util 0.14.0",
+ "windows-sys 0.61.2",
+ "zstd",
+]
+
+[[package]]
+name = "krun-whp"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "log",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "kvm-bindings"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11cf0ca75d59e9d298647c59cf6c5286fa048120caa77972a7a504a0824d234f"
+dependencies = [
+ "vmm-sys-util 0.15.0",
+]
+
+[[package]]
+name = "kvm-ioctls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333f77a20344a448f3f70664918135fddeb804e938f28a99d685bd92926e0b19"
+dependencies = [
+ "bitflags 2.13.1",
+ "kvm-bindings",
+ "libc",
+ "vmm-sys-util 0.15.0",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3604,9 +3937,42 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libkrun"
+version = "2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "crossbeam-channel",
+ "env_logger",
+ "krun-devices",
+ "krun-hvf",
+ "krun-init-blob",
+ "krun-polly",
+ "krun-utils",
+ "krun-vmm",
+ "kvm-bindings",
+ "kvm-ioctls",
+ "libc",
+ "libloading",
+ "log",
+ "once_cell",
+ "vm-memory 0.17.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"
@@ -3632,6 +3998,15 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linux-loader"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de72cb02c55ecffcf75fe78295926f872eb6eb0a58d629c58a8c324dc26380f6"
+dependencies = [
+ "vm-memory 0.17.1",
 ]
 
 [[package]]
@@ -3702,6 +4077,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3738,6 +4122,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -3816,9 +4209,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.11"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -3843,7 +4236,7 @@ dependencies = [
  "sha2 0.11.0",
  "subtle",
  "tempo-alloy",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tokio",
  "uuid",
@@ -3864,7 +4257,7 @@ dependencies = [
  "rustls",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3915,7 +4308,7 @@ dependencies = [
  "sha1",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-tungstenite",
  "tower",
@@ -3982,7 +4375,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "web-time",
 ]
@@ -3996,6 +4389,8 @@ dependencies = [
  "futures-util",
  "http",
  "nanocodex",
+ "nanocodex-vm",
+ "nanovm",
  "reqwest",
  "rustls",
  "serde",
@@ -4031,7 +4426,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
 ]
@@ -4046,7 +4441,7 @@ dependencies = [
  "opentelemetry_sdk",
  "reqwest",
  "rustls",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -4082,7 +4477,7 @@ dependencies = [
  "simd-json",
  "smallvec",
  "sonic-rs",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-tungstenite",
  "tower",
@@ -4112,12 +4507,30 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "nanocodex-vm"
+version = "0.1.1"
+dependencies = [
+ "async-trait",
+ "mpp-egress",
+ "nanocodex-tools",
+ "nanovm",
+ "nix 0.30.1",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4136,7 +4549,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "url",
 ]
 
@@ -4162,13 +4575,26 @@ dependencies = [
  "sha2 0.11.0",
  "tempfile",
  "tempo-alloy",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tower",
  "tracing",
  "tracing-subscriber",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "nanovm"
+version = "0.1.1"
+dependencies = [
+ "imago",
+ "libkrun",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.19",
+ "vm-memory 0.17.1",
 ]
 
 [[package]]
@@ -4191,8 +4617,9 @@ checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -4203,7 +4630,7 @@ checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
 ]
 
@@ -4513,7 +4940,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -4543,7 +4970,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4576,7 +5003,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.5",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
 ]
@@ -4592,6 +5019,16 @@ dependencies = [
  "primeorder",
  "serdect",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -4849,6 +5286,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "portable-pty"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4947,9 +5393,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -5113,14 +5559,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -5143,7 +5589,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5155,7 +5601,7 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
  "once_cell",
  "socket2",
@@ -5165,9 +5611,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -5383,22 +5829,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5553,7 +5999,7 @@ dependencies = [
  "revm-state",
  "secp256k1 0.30.0",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5656,7 +6102,7 @@ dependencies = [
  "revm-primitives",
  "revm-state",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5844,7 +6290,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sse-stream",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5888,7 +6334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -6003,7 +6449,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6049,9 +6495,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -6308,9 +6754,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -6318,22 +6764,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6349,9 +6795,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -6618,9 +7064,9 @@ dependencies = [
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version 0.4.1",
  "simdutf8",
@@ -6689,7 +7135,7 @@ dependencies = [
  "simdutf8",
  "sonic-number",
  "sonic-simd",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "zmij",
 ]
 
@@ -6726,9 +7172,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
 dependencies = [
  "bytes",
  "futures-util",
@@ -6828,9 +7274,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.0"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6875,7 +7321,7 @@ version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "fancy-regex",
  "flate2",
  "fnv",
@@ -6883,7 +7329,7 @@ dependencies = [
  "regex-syntax",
  "serde",
  "serde_derive",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
 ]
 
@@ -6953,7 +7399,7 @@ dependencies = [
  "tempo-chainspec",
  "tempo-contracts",
  "tempo-primitives",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tower",
  "tracing",
 ]
@@ -7033,11 +7479,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -7053,13 +7499,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7082,23 +7528,23 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
 dependencies = [
  "fax",
  "flate2",
  "half",
  "quick-error",
  "weezl",
- "zune-jpeg 0.4.21",
+ "zune-jpeg",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "libc",
@@ -7118,9 +7564,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -7163,9 +7609,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -7192,9 +7638,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7213,9 +7659,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -7242,13 +7688,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -7371,7 +7818,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tracing-subscriber",
 ]
@@ -7476,7 +7923,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -7574,6 +8021,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7650,6 +8103,64 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtio-bindings"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091f1f09cfbf2a78563b562e7a949465cce1aef63b6065645188d995162f8868"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "vm-fdt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e21282841a059bb62627ce8441c491f09603622cd5a21c43bfedc85a2952f23"
+
+[[package]]
+name = "vm-memory"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f39348a049689cabd3377cdd9182bf526ec76a6f823b79903896452e9d7a7380"
+dependencies = [
+ "libc",
+ "thiserror 2.0.19",
+ "winapi",
+]
+
+[[package]]
+name = "vm-memory"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b55e753c7725603745cb32b2287ef7ef3da05c03c7702cda3fa8abe25ae0465"
+dependencies = [
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d21f366bf22bfba3e868349978766a965cbe628c323d58e026be80b8357ab789"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "506c62fdf617a5176827c2f9afbcf1be155b03a9b4bf9617a60dbc07e3a1642f"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -7789,9 +8300,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7802,14 +8313,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7958,7 +8469,25 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -7976,14 +8505,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -8002,10 +8548,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8014,10 +8572,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8026,10 +8596,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -8038,10 +8620,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -8113,7 +8707,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -8152,18 +8746,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8280,24 +8874,9 @@ dependencies = [
 
 [[package]]
 name = "zune-core"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
-
-[[package]]
-name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
-
-[[package]]
-name = "zune-jpeg"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
-dependencies = [
- "zune-core 0.4.12",
-]
 
 [[package]]
 name = "zune-jpeg"
@@ -8305,5 +8884,5 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
- "zune-core 0.5.1",
+ "zune-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4535,7 +4535,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-vm"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "mpp-egress",
@@ -4604,7 +4604,7 @@ dependencies = [
 
 [[package]]
 name = "nanovm"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "imago",
  "libkrun",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4538,6 +4538,7 @@ name = "nanocodex-vm"
 version = "0.2.0"
 dependencies = [
  "async-trait",
+ "base64",
  "mpp-egress",
  "nanocodex-tools",
  "nanovm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["bin/nanocodex", "bin/nanousd-api", "crates/mpp-egress", "crates/nanocodex", "crates/nanocodex-core", "crates/nanocodex-macros", "crates/nanocodex-mcp", "crates/nanocodex-observability", "crates/nanocodex-service", "crates/nanocodex-tools", "crates/nanousd", "examples", "js/bindings", "py/bindings"]
+members = ["bin/nanocodex", "bin/nanousd-api", "crates/mpp-egress", "crates/nanocodex", "crates/nanocodex-core", "crates/nanocodex-macros", "crates/nanocodex-mcp", "crates/nanocodex-observability", "crates/nanocodex-service", "crates/nanocodex-tools", "crates/nanocodex-vm", "crates/nanousd", "crates/nanovm", "examples", "js/bindings", "py/bindings"]
 default-members = ["bin/nanocodex"]
 resolver = "2"
 
@@ -36,6 +36,8 @@ http = "1.3.1"
 http-body-util = "0.1.3"
 hmac = "0.13.0"
 hudsucker = { version = "0.25.0", git = "https://github.com/gakonst/hudsucker", rev = "0c7da328e446518036b9420db3e75451fca522e9", default-features = false, features = ["rcgen-ca", "rustls-client"] }
+imago = "=0.2.3"
+krun = { package = "libkrun", git = "https://github.com/containers/libkrun", rev = "df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0", features = ["blk", "net"] }
 mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "5caad442edeab796821b7f3bb009ab6945106e35", default-features = false }
 mpp-egress = { version = "0.2.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.2.0", path = "crates/nanocodex" }
@@ -45,7 +47,9 @@ nanocodex-mcp = { version = "0.2.0", path = "crates/nanocodex-mcp" }
 nanocodex-observability = { version = "0.2.0", path = "crates/nanocodex-observability" }
 nanocodex-service = { version = "0.2.0", path = "crates/nanocodex-service" }
 nanocodex-tools = { version = "0.2.0", path = "crates/nanocodex-tools" }
+nanocodex-vm = { version = "0.2.0", path = "crates/nanocodex-vm" }
 nanousd = { version = "0.2.0", path = "crates/nanousd" }
+nanovm = { version = "0.2.0", path = "crates/nanovm" }
 rand = "0.9.2"
 image = { version = "0.25.9", default-features = false, features = ["gif", "jpeg", "png", "pnm", "webp"] }
 iana-time-zone = "0.1.64"
@@ -98,12 +102,13 @@ unicode-width = "0.2"
 url = "2.5.7"
 uuid = { version = "1", features = ["v7"] }
 vergen = { version = "8", default-features = false }
+vm-memory = "=0.17.1"
 wasm-bindgen = "0.2.105"
 wasm-bindgen-futures = "0.4.55"
 web-time = "1.1.0"
 
 [workspace.lints.rust]
-unsafe_code = "forbid"
+unsafe_code = "deny"
 
 [workspace.lints.clippy]
 all = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ arboard = "3"
 base64 = "0.22.1"
 async-trait = "0.1.89"
 alloy-primitives = "1.6.1"
+arcbox-ext4 = "0.1.2"
 axum = "0.8.9"
 bm25 = "2.3.2"
 chrono = "0.4.43"
@@ -51,6 +52,7 @@ nanocodex-vm = { version = "0.2.0", path = "crates/nanocodex-vm" }
 nanousd = { version = "0.2.0", path = "crates/nanousd" }
 nanovm = { version = "0.2.0", path = "crates/nanovm" }
 rand = "0.9.2"
+reflink-copy = "0.1.30"
 image = { version = "0.25.9", default-features = false, features = ["gif", "jpeg", "png", "pnm", "webp"] }
 iana-time-zone = "0.1.64"
 js-sys = "0.3.82"
@@ -108,7 +110,7 @@ wasm-bindgen-futures = "0.4.55"
 web-time = "1.1.0"
 
 [workspace.lints.rust]
-unsafe_code = "deny"
+unsafe_code = "forbid"
 
 [workspace.lints.clippy]
 all = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ http-body-util = "0.1.3"
 hmac = "0.13.0"
 hudsucker = { version = "0.25.0", git = "https://github.com/gakonst/hudsucker", rev = "0c7da328e446518036b9420db3e75451fca522e9", default-features = false, features = ["rcgen-ca", "rustls-client"] }
 imago = "=0.2.3"
-krun = { package = "libkrun", git = "https://github.com/containers/libkrun", rev = "df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0", features = ["blk", "net"] }
+krun = { package = "libkrun", version = "=2.0.0-dev", git = "https://github.com/containers/libkrun", rev = "df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0", features = ["blk", "net"] }
 mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "5caad442edeab796821b7f3bb009ab6945106e35", default-features = false }
 mpp-egress = { version = "0.2.0", path = "crates/mpp-egress" }
 nanocodex = { version = "0.2.0", path = "crates/nanocodex" }

--- a/Justfile
+++ b/Justfile
@@ -93,6 +93,11 @@ smoke-mcp:
 
 # Build the end-to-end VM tool example. macOS VMM executables need the
 # Hypervisor entitlement; signing the built artifact keeps Cargo inputs clean.
+build-vm-guest:
+    CC_aarch64_unknown_linux_musl="{{justfile_directory()}}/scripts/aarch64-unknown-linux-musl-linker" \
+    AR_aarch64_unknown_linux_musl="{{justfile_directory()}}/scripts/aarch64-unknown-linux-musl-ar" \
+    cargo build -p nanocodex-vm --bin nanocodex-vm-guest --no-default-features --features guest --target aarch64-unknown-linux-musl
+
 build-vm-example:
     cargo build -p nanocodex-examples --bin vm-tools --all-features
     @if [ "$(uname -s)" = "Darwin" ]; then \

--- a/Justfile
+++ b/Justfile
@@ -94,11 +94,15 @@ smoke-mcp:
 # Build the end-to-end VM tool example. macOS VMM executables need the
 # Hypervisor entitlement; signing the built artifact keeps Cargo inputs clean.
 build-vm-guest:
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="{{justfile_directory()}}/scripts/aarch64-unknown-linux-musl-linker" \
     CC_aarch64_unknown_linux_musl="{{justfile_directory()}}/scripts/aarch64-unknown-linux-musl-linker" \
     AR_aarch64_unknown_linux_musl="{{justfile_directory()}}/scripts/aarch64-unknown-linux-musl-ar" \
     cargo build -p nanocodex-vm --bin nanocodex-vm-guest --no-default-features --features guest --target aarch64-unknown-linux-musl
 
 build-vm-example:
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="{{justfile_directory()}}/scripts/aarch64-unknown-linux-musl-linker" \
+    CC_aarch64_unknown_linux_musl="{{justfile_directory()}}/scripts/aarch64-unknown-linux-musl-linker" \
+    AR_aarch64_unknown_linux_musl="{{justfile_directory()}}/scripts/aarch64-unknown-linux-musl-ar" \
     cargo build -p nanocodex-examples --bin vm-tools --all-features
     @if [ "$(uname -s)" = "Darwin" ]; then \
         codesign --entitlements nanovm.entitlements --force --sign - target/debug/vm-tools; \

--- a/Justfile
+++ b/Justfile
@@ -91,6 +91,14 @@ dev-react-example:
 smoke-mcp:
     cargo run --quiet -p nanocodex-examples --bin mcp
 
+# Build the end-to-end VM tool example. macOS VMM executables need the
+# Hypervisor entitlement; signing the built artifact keeps Cargo inputs clean.
+build-vm-example:
+    cargo build -p nanocodex-examples --bin vm-tools --all-features
+    @if [ "$(uname -s)" = "Darwin" ]; then \
+        codesign --entitlements nanovm.entitlements --force --sign - target/debug/vm-tools; \
+    fi
+
 # Start the ephemeral localhost Jaeger backend used by the OTLP trace demo.
 otel-up:
     @docker compose -f docker-compose.otel.yml up --detach

--- a/PLAN.md
+++ b/PLAN.md
@@ -67,6 +67,10 @@ Crate ownership is fixed:
   transport telemetry.
 - `nanocodex-tools`: code mode, local tools, custom-tool registry, process
   lifecycle, and bounded tool output.
+- `nanovm`: typed libkrun configuration, the audited FFI boundary,
+  provider-neutral egress leases, and private VMM process configuration.
+- `nanocodex-vm`: persistent host/guest tool sessions and standard
+  workspace-tool adapters.
 - `nanocodex-mcp`: stdio/Streamable HTTP clients, background handshake and tool
   discovery, authenticated transports, BM25 search, and deferred Code Mode
   dispatch.

--- a/README.md
+++ b/README.md
@@ -611,7 +611,7 @@ cargo run -p nanocodex-examples --bin mcp
 cargo run -p nanocodex-examples --bin fork-conversations
 cargo run -p nanocodex-examples --bin subagents
 just build-vm-example
-target/debug/vm-tools ROOTFS [GUEST_RUNTIME_EXT4] [--prove-mpp]
+target/debug/vm-tools ROOTFS [GUEST_RUNTIME_BINARY_OR_EXT4] [--prove-mpp]
 ```
 
 ## CLI and repository

--- a/README.md
+++ b/README.md
@@ -583,6 +583,12 @@ extend the default outer-cell yield deadline while an explicit `@exec` deadline
 still wins. Live shell session IDs remain visible for later `write_stdin`
 calls, and stdout/stderr drains share one bounded completion deadline.
 
+Native applications can keep those workspace tools on the host or replace them
+with one persistent libkrun VM through `nanocodex-vm`. The model-visible
+contracts stay identical; MPP and secret gateways resolve into composable,
+conflict-checked `nanovm::EgressLease` layers. See
+[`docs/VM.md`](docs/VM.md) for the ownership boundary and end-to-end example.
+
 `AgentEvents` is an optional ordered stream independent of `TurnResult`. A TUI,
 server, notebook, or binding can consume all events, select a subset, or drop
 the receiver without changing prompt/result behavior. Libraries emit diagnostic
@@ -604,6 +610,7 @@ cargo run -p nanocodex-examples --bin custom-tool
 cargo run -p nanocodex-examples --bin mcp
 cargo run -p nanocodex-examples --bin fork-conversations
 cargo run -p nanocodex-examples --bin subagents
+cargo run -p nanocodex-examples --bin vm-tools -- ROOTFS
 ```
 
 ## CLI and repository
@@ -817,8 +824,9 @@ methodology, cache observations, raw trials, and reproduction commands.
 Nanocodex currently supports one model family (`gpt-5.6-sol`), one Responses
 WebSocket transport, and caller-defined tools. Sessions and branches live only
 as long as your process. Your application owns sandboxing, permissions,
-durability, and recursive cancellation policy for application-defined child
-agents. Code Mode requires Node.js 12.22 or newer on `PATH`.
+durability, selecting and provisioning optional VM-backed tools, and recursive
+cancellation policy for application-defined child agents. Code Mode requires
+Node.js 12.22 or newer on `PATH`.
 
 That is substantially less product than Codex. It is also much less machinery
 between your code and an agent turn.

--- a/README.md
+++ b/README.md
@@ -610,7 +610,8 @@ cargo run -p nanocodex-examples --bin custom-tool
 cargo run -p nanocodex-examples --bin mcp
 cargo run -p nanocodex-examples --bin fork-conversations
 cargo run -p nanocodex-examples --bin subagents
-cargo run -p nanocodex-examples --bin vm-tools -- ROOTFS
+just build-vm-example
+target/debug/vm-tools ROOTFS [GUEST_RUNTIME_EXT4] [--prove-mpp]
 ```
 
 ## CLI and repository

--- a/crates/nanocodex-tools/src/image/mod.rs
+++ b/crates/nanocodex-tools/src/image/mod.rs
@@ -421,6 +421,7 @@ fn load_for_prompt_bytes(
     Ok(image)
 }
 
+#[cfg(feature = "remote-tools")]
 pub(super) fn load_for_prompt_data_url(
     path: &Path,
     file_bytes: Vec<u8>,

--- a/crates/nanocodex-tools/src/lib.rs
+++ b/crates/nanocodex-tools/src/lib.rs
@@ -30,12 +30,14 @@ pub use image::{prepare_output_images, prepare_user_input};
 pub use nanocodex_core::{ImageDetail, ToolDefinition};
 #[cfg(not(target_family = "wasm"))]
 pub use plan::UpdatePlanTool;
+#[cfg(all(not(target_family = "wasm"), feature = "code-mode"))]
+pub use runtime::OwnedToolContext;
 #[cfg(not(target_family = "wasm"))]
 pub use runtime::{
-    DEFAULT_TOOL_OUTPUT_TOKENS, DynamicToolProvider, ImageGenerationConfig, OwnedToolContext,
-    ProcessTraceWire, Tool, ToolContext, ToolError, ToolExecution, ToolExecutionWire, ToolInput,
-    ToolInputError, ToolOutputBody, ToolOutputContent, ToolResult, ToolRuntime, ToolRuntimeControl,
-    Tools, ToolsBuildError, ToolsBuilder, WebSearchConfig, schema_for,
+    DEFAULT_TOOL_OUTPUT_TOKENS, DynamicToolProvider, ImageGenerationConfig, ProcessTraceWire, Tool,
+    ToolContext, ToolError, ToolExecution, ToolExecutionWire, ToolInput, ToolInputError,
+    ToolOutputBody, ToolOutputContent, ToolResult, ToolRuntime, ToolRuntimeControl, Tools,
+    ToolsBuildError, ToolsBuilder, WebSearchConfig, schema_for,
 };
 #[cfg(not(target_family = "wasm"))]
 pub use standard::StandardTool;

--- a/crates/nanocodex-tools/src/runtime.rs
+++ b/crates/nanocodex-tools/src/runtime.rs
@@ -4,8 +4,11 @@ use async_trait::async_trait;
 use nanocodex_core::{ImageDetail, OpenAiAuth, ResponseItem, ToolDefinition};
 use schemars::{JsonSchema, r#gen::SchemaSettings};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
+#[cfg(any(feature = "code-mode", test))]
+use serde_json::json;
 use serde_json::value::{RawValue, to_raw_value};
-use serde_json::{Map, Value, json};
+use serde_json::{Map, Value};
+#[cfg(feature = "code-mode")]
 use tracing::{Instrument, info, info_span};
 
 #[cfg(feature = "code-mode")]
@@ -78,6 +81,7 @@ pub struct ProcessTraceWire {
 /// Owned context used when a Code Mode cell may outlive the model tool call
 /// that started it.
 #[doc(hidden)]
+#[cfg(feature = "code-mode")]
 pub struct OwnedToolContext {
     pub(crate) model: String,
     pub(crate) session_id: String,
@@ -86,6 +90,7 @@ pub struct OwnedToolContext {
     pub(crate) output_token_budget: usize,
 }
 
+#[cfg(feature = "code-mode")]
 impl OwnedToolContext {
     #[must_use]
     pub fn new(
@@ -207,6 +212,7 @@ impl ToolExecution {
         }
     }
 
+    #[cfg(any(feature = "code-mode", feature = "remote-tools"))]
     pub(crate) fn value(&self) -> Value {
         if let Some(value) = &self.code_mode_value {
             return value.clone();
@@ -996,6 +1002,7 @@ impl ToolRegistry {
         }
     }
 
+    #[cfg(feature = "code-mode")]
     pub(crate) async fn execute_nested(
         &self,
         name: &str,
@@ -1099,6 +1106,7 @@ impl ToolRegistry {
         execution
     }
 
+    #[cfg(feature = "code-mode")]
     async fn execute_nested_inner(
         &self,
         name: &str,
@@ -1140,6 +1148,7 @@ impl ToolRegistry {
         }
     }
 
+    #[cfg(feature = "code-mode")]
     pub(crate) fn nested_tool_metadata(&self) -> Vec<Value> {
         let mut metadata = self
             .entries()
@@ -1183,15 +1192,18 @@ impl ToolRegistry {
         Some((self.ordered.get(index)?, self.definitions.get(index)?))
     }
 
+    #[cfg(feature = "code-mode")]
     pub(crate) fn definitions(&self) -> &[ToolDefinition] {
         &self.definitions
     }
 
+    #[cfg(feature = "code-mode")]
     fn entries(&self) -> impl Iterator<Item = (&Arc<dyn Tool>, &ToolDefinition)> {
         self.ordered.iter().zip(&self.definitions)
     }
 }
 
+#[cfg(feature = "code-mode")]
 fn record_tool_content(span: &tracing::Span, kind: &'static str, content: &str) {
     span.in_scope(|| {
         info!(
@@ -1203,6 +1215,7 @@ fn record_tool_content(span: &tracing::Span, kind: &'static str, content: &str) 
     });
 }
 
+#[cfg(feature = "code-mode")]
 fn definition_metadata(name: &str, definition: &ToolDefinition) -> Value {
     let kind = match definition {
         ToolDefinition::Function { .. } => "function",

--- a/crates/nanocodex-vm/Cargo.toml
+++ b/crates/nanocodex-vm/Cargo.toml
@@ -15,13 +15,13 @@ description = "VM-owned standard workspace tools for Nanocodex"
 
 [features]
 default = []
-mpp = ["dep:mpp-egress", "dep:nanovm"]
+mpp = ["dep:mpp-egress"]
 
 [dependencies]
 async-trait = "0.1.89"
 mpp-egress = { workspace = true, optional = true }
 nanocodex-tools.workspace = true
-nanovm = { workspace = true, optional = true }
+nanovm.workspace = true
 nix.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/nanocodex-vm/Cargo.toml
+++ b/crates/nanocodex-vm/Cargo.toml
@@ -22,7 +22,7 @@ mpp = ["host", "dep:mpp-egress"]
 [dependencies]
 async-trait = "0.1.89"
 mpp-egress = { workspace = true, optional = true }
-nanocodex-tools = { path = "../nanocodex-tools", default-features = false }
+nanocodex-tools = { path = "../nanocodex-tools", version = "0.2.0", default-features = false }
 nanovm = { workspace = true, optional = true }
 nix = { workspace = true, optional = true }
 serde.workspace = true

--- a/crates/nanocodex-vm/Cargo.toml
+++ b/crates/nanocodex-vm/Cargo.toml
@@ -21,6 +21,7 @@ mpp = ["host", "dep:mpp-egress"]
 
 [dependencies]
 async-trait = "0.1.89"
+base64.workspace = true
 mpp-egress = { workspace = true, optional = true }
 nanocodex-tools = { path = "../nanocodex-tools", version = "0.2.0", default-features = false }
 nanovm = { workspace = true, optional = true }

--- a/crates/nanocodex-vm/Cargo.toml
+++ b/crates/nanocodex-vm/Cargo.toml
@@ -14,20 +14,27 @@ categories.workspace = true
 description = "VM-owned standard workspace tools for Nanocodex"
 
 [features]
-default = []
-mpp = ["dep:mpp-egress"]
+default = ["host"]
+guest = ["dep:nix"]
+host = ["dep:nanovm"]
+mpp = ["host", "dep:mpp-egress"]
 
 [dependencies]
 async-trait = "0.1.89"
 mpp-egress = { workspace = true, optional = true }
-nanocodex-tools.workspace = true
-nanovm.workspace = true
-nix.workspace = true
+nanocodex-tools = { version = "0.1.1", path = "../nanocodex-tools", default-features = false }
+nanovm = { workspace = true, optional = true }
+nix = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tokio = { workspace = true, features = ["io-std", "io-util"] }
+tokio = { workspace = true, features = ["fs", "io-std", "io-util", "process", "rt", "sync", "time"] }
 tracing.workspace = true
+
+[[bin]]
+name = "nanocodex-vm-guest"
+path = "src/bin/nanocodex-vm-guest.rs"
+required-features = ["guest"]
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/nanocodex-vm/Cargo.toml
+++ b/crates/nanocodex-vm/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "nanocodex-vm"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "VM-owned standard workspace tools for Nanocodex"
+
+[features]
+default = []
+mpp = ["dep:mpp-egress", "dep:nanovm"]
+
+[dependencies]
+async-trait = "0.1.89"
+mpp-egress = { workspace = true, optional = true }
+nanocodex-tools.workspace = true
+nanovm = { workspace = true, optional = true }
+nix.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["io-std", "io-util"] }
+tracing.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+tracing-subscriber.workspace = true
+
+[lints]
+workspace = true

--- a/crates/nanocodex-vm/Cargo.toml
+++ b/crates/nanocodex-vm/Cargo.toml
@@ -22,7 +22,7 @@ mpp = ["host", "dep:mpp-egress"]
 [dependencies]
 async-trait = "0.1.89"
 mpp-egress = { workspace = true, optional = true }
-nanocodex-tools = { version = "0.1.1", path = "../nanocodex-tools", default-features = false }
+nanocodex-tools = { path = "../nanocodex-tools", default-features = false }
 nanovm = { workspace = true, optional = true }
 nix = { workspace = true, optional = true }
 serde.workspace = true

--- a/crates/nanocodex-vm/src/bin/nanocodex-vm-guest.rs
+++ b/crates/nanocodex-vm/src/bin/nanocodex-vm-guest.rs
@@ -1,0 +1,9 @@
+use std::path::PathBuf;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), nanocodex_vm::VmToolSessionError> {
+    let workspace = std::env::args_os()
+        .nth(1)
+        .map_or_else(|| PathBuf::from("/workspace"), PathBuf::from);
+    nanocodex_vm::serve_guest(workspace).await
+}

--- a/crates/nanocodex-vm/src/bin/nanocodex-vm-guest.rs
+++ b/crates/nanocodex-vm/src/bin/nanocodex-vm-guest.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), nanocodex_vm::VmToolSessionError> {
+async fn main() -> Result<(), nanocodex_vm::VmGuestError> {
     let workspace = std::env::args_os()
         .nth(1)
         .map_or_else(|| PathBuf::from("/workspace"), PathBuf::from);

--- a/crates/nanocodex-vm/src/guest.rs
+++ b/crates/nanocodex-vm/src/guest.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     path::{Path, PathBuf},
     process::{ExitStatus, Stdio},
     sync::{
@@ -26,12 +27,13 @@ use tokio::{
 };
 
 use crate::protocol::{
-    ControlResponse, ExecuteRequest, ExecuteResponse, ReadFileRequest, ReadFileResponse,
-    SessionRequest, SessionResponse, ShutdownRequest, ToolResponse, WriteFileRequest,
+    CancelRequest, ControlResponse, ExecuteRequest, ExecuteResponse, ReadFileRequest,
+    ReadFileResponse, SessionRequest, SessionResponse, ShutdownRequest, ToolResponse,
+    WriteFileRequest,
 };
 
 const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
-const MAX_CONTROL_FILE_BYTES: u64 = 32 * 1024 * 1024;
+const MAX_CONTROL_FILE_BYTES: usize = 32 * 1024 * 1024;
 const MAX_IN_FLIGHT_REQUESTS: usize = 64;
 
 /// Failure while serving VM tool requests inside the guest.
@@ -51,6 +53,9 @@ pub enum VmGuestError {
 
     #[error("VM tool protocol frame exceeded the {MAX_FRAME_BYTES}-byte limit")]
     FrameTooLarge,
+
+    #[error("VM tool protocol reused active request ID {0}")]
+    DuplicateRequestId(u64),
 }
 
 pub(crate) async fn serve(workspace: &Path) -> Result<(), VmGuestError> {
@@ -64,7 +69,8 @@ async fn serve_io(
 ) -> Result<(), VmGuestError> {
     let runtime = Arc::new(ToolRuntime::new(workspace, None, None));
     let mut input = BufReader::new(input);
-    let mut requests = JoinSet::new();
+    let mut requests = JoinSet::<SessionResponse>::new();
+    let mut active = HashMap::<u64, tokio::task::AbortHandle>::new();
     let mut accepting = true;
     let mut shutdown = None;
 
@@ -73,8 +79,11 @@ async fn serve_io(
             tokio::select! {
                 joined = requests.join_next(), if !requests.is_empty() => {
                     match joined.ok_or(VmGuestError::Closed)? {
-                        Ok(response) => write_response(&mut output, &response).await?,
-                        Err(error) if error.is_cancelled() && !accepting => {}
+                        Ok(response) => {
+                            active.remove(&response.id());
+                            write_response(&mut output, &response).await?;
+                        }
+                        Err(error) if error.is_cancelled() => {}
                         Err(error) => return Err(VmGuestError::Task(error.to_string())),
                     }
                 }
@@ -91,11 +100,28 @@ async fn serve_io(
                             shutdown = Some(request);
                             accepting = false;
                             runtime.control().cancel().await;
+                            active.clear();
                             requests.abort_all();
                         }
+                        SessionRequest::Cancel(request) => {
+                            if let Some(task) = active.remove(&request.target_id) {
+                                task.abort();
+                            }
+                            let response = SessionResponse::Cancel(ControlResponse {
+                                id: request.id,
+                                error: None,
+                            });
+                            write_response(&mut output, &response).await?;
+                        }
                         request => {
+                            let id = request.id();
+                            if active.contains_key(&id) {
+                                return Err(VmGuestError::DuplicateRequestId(id));
+                            }
                             let runtime = Arc::clone(&runtime);
-                            requests.spawn(async move { execute_request(runtime, request).await });
+                            let task =
+                                requests.spawn(async move { execute_request(runtime, request).await });
+                            active.insert(id, task);
                         }
                     }
                 }
@@ -135,6 +161,12 @@ async fn execute_request(runtime: Arc<ToolRuntime>, request: SessionRequest) -> 
         SessionRequest::ReadFile(request) => SessionResponse::ReadFile(read_file(request).await),
         SessionRequest::Execute(request) => {
             SessionResponse::Execute(execute_command(request).await)
+        }
+        SessionRequest::Cancel(CancelRequest { id, .. }) => {
+            SessionResponse::Cancel(ControlResponse {
+                id,
+                error: Some("cancel cannot be dispatched as a concurrent request".to_owned()),
+            })
         }
         SessionRequest::Shutdown(request) => SessionResponse::Shutdown(ControlResponse {
             id: request.id,
@@ -253,14 +285,34 @@ async fn atomic_write_file(
 
 async fn read_file(request: ReadFileRequest) -> ReadFileResponse {
     let contents = async {
-        let metadata = tokio::fs::metadata(&request.path).await?;
-        if metadata.len() > MAX_CONTROL_FILE_BYTES {
+        let file = tokio::fs::File::open(&request.path).await?;
+        let metadata = file.metadata().await?;
+        if !metadata.is_file() {
+            return Err(std::io::Error::other(
+                "control reads require a regular file",
+            ));
+        }
+        let maximum = u64::try_from(MAX_CONTROL_FILE_BYTES).unwrap_or(u64::MAX);
+        if metadata.len() > maximum {
             return Err(std::io::Error::other(format!(
                 "file is {} bytes, exceeding the {MAX_CONTROL_FILE_BYTES}-byte control limit",
                 metadata.len()
             )));
         }
-        tokio::fs::read(&request.path).await
+        let mut contents = Vec::with_capacity(
+            usize::try_from(metadata.len())
+                .unwrap_or(usize::MAX)
+                .min(MAX_CONTROL_FILE_BYTES),
+        );
+        file.take(maximum.saturating_add(1))
+            .read_to_end(&mut contents)
+            .await?;
+        if contents.len() > MAX_CONTROL_FILE_BYTES {
+            return Err(std::io::Error::other(format!(
+                "file grew beyond the {MAX_CONTROL_FILE_BYTES}-byte control limit while reading"
+            )));
+        }
+        Ok(contents)
     }
     .await;
     match contents {
@@ -478,8 +530,11 @@ mod tests {
 
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
-    use super::{execute_command, serve_io};
-    use crate::protocol::{ExecuteRequest, SessionRequest, SessionResponse, ShutdownRequest};
+    use super::{execute_command, read_file, serve_io};
+    use crate::protocol::{
+        CancelRequest, ExecuteRequest, ReadFileRequest, SessionRequest, SessionResponse,
+        ShutdownRequest,
+    };
 
     const DEFAULT_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
 
@@ -520,6 +575,26 @@ mod tests {
         assert!(response.error.is_none());
         assert!(response.stdout.is_none());
         assert!(response.stderr.is_none());
+    }
+
+    #[tokio::test]
+    async fn control_read_rejects_non_regular_files_without_blocking() {
+        let response = tokio::time::timeout(
+            Duration::from_secs(1),
+            read_file(ReadFileRequest {
+                id: 1,
+                path: "/dev/zero".to_owned(),
+            }),
+        )
+        .await
+        .expect("special-file rejection must not wait for EOF");
+
+        assert!(response.contents.is_none());
+        assert!(
+            response
+                .error
+                .is_some_and(|error| error.contains("regular file"))
+        );
     }
 
     #[tokio::test]
@@ -630,6 +705,83 @@ mod tests {
             SessionResponse::Shutdown(response) if response.id == 1 && response.error.is_none()
         ));
         drop(host_write);
+        guest_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn targeted_cancel_aborts_only_the_requested_guest_task() {
+        let workspace = tempfile::tempdir().unwrap();
+        let (host, guest) = tokio::io::duplex(64 * 1024);
+        let (host_read, mut host_write) = tokio::io::split(host);
+        let (guest_read, guest_write) = tokio::io::split(guest);
+        let guest_task = tokio::spawn({
+            let workspace = workspace.path().to_owned();
+            async move { serve_io(&workspace, guest_read, guest_write).await }
+        });
+        for request in [
+            SessionRequest::Execute(ExecuteRequest {
+                id: 0,
+                program: "/bin/sh".to_owned(),
+                arguments: vec!["-c".to_owned(), "sleep 30 & wait".to_owned()],
+                current_directory: workspace.path().to_string_lossy().into_owned(),
+                environment: Vec::new(),
+                timeout_millis: 60_000,
+                max_output_bytes: DEFAULT_OUTPUT_BYTES,
+            }),
+            SessionRequest::Cancel(CancelRequest {
+                id: 1,
+                target_id: 0,
+            }),
+            SessionRequest::Execute(ExecuteRequest {
+                id: 2,
+                program: "/usr/bin/true".to_owned(),
+                arguments: Vec::new(),
+                current_directory: workspace.path().to_string_lossy().into_owned(),
+                environment: Vec::new(),
+                timeout_millis: 5_000,
+                max_output_bytes: DEFAULT_OUTPUT_BYTES,
+            }),
+        ] {
+            host_write
+                .write_all(&serde_json::to_vec(&request).unwrap())
+                .await
+                .unwrap();
+            host_write.write_all(b"\n").await.unwrap();
+        }
+
+        let mut responses = BufReader::new(host_read).lines();
+        let mut cancelled = false;
+        let mut follow_up = false;
+        while !cancelled || !follow_up {
+            let line = tokio::time::timeout(Duration::from_secs(2), responses.next_line())
+                .await
+                .expect("cancellation and the independent follow-up must complete")
+                .unwrap()
+                .unwrap();
+            match serde_json::from_str::<SessionResponse>(&line).unwrap() {
+                SessionResponse::Cancel(response) if response.id == 1 => cancelled = true,
+                SessionResponse::Execute(response) if response.id == 2 => {
+                    assert!(response.error.is_none());
+                    assert!(!response.timed_out);
+                    follow_up = true;
+                }
+                response => panic!("unexpected response ID {}", response.id()),
+            }
+        }
+
+        host_write
+            .write_all(
+                &serde_json::to_vec(&SessionRequest::Shutdown(ShutdownRequest { id: 3 })).unwrap(),
+            )
+            .await
+            .unwrap();
+        host_write.write_all(b"\n").await.unwrap();
+        drop(host_write);
+        let shutdown = responses.next_line().await.unwrap().unwrap();
+        assert!(matches!(
+            serde_json::from_str::<SessionResponse>(&shutdown).unwrap(),
+            SessionResponse::Shutdown(response) if response.id == 3 && response.error.is_none()
+        ));
         guest_task.await.unwrap().unwrap();
     }
 }

--- a/crates/nanocodex-vm/src/guest.rs
+++ b/crates/nanocodex-vm/src/guest.rs
@@ -1,0 +1,635 @@
+use std::{
+    path::{Path, PathBuf},
+    process::{ExitStatus, Stdio},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use nanocodex_tools::{ToolContext, ToolRuntime};
+use nix::{
+    errno::Errno,
+    sys::signal::{Signal, killpg},
+    unistd::Pid,
+};
+use thiserror::Error;
+use tokio::{
+    io::{
+        AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt,
+        BufReader,
+    },
+    process::{Child, Command},
+    sync::mpsc,
+    task::JoinSet,
+};
+
+use crate::protocol::{
+    ControlResponse, ExecuteRequest, ExecuteResponse, ReadFileRequest, ReadFileResponse,
+    SessionRequest, SessionResponse, ShutdownRequest, ToolResponse, WriteFileRequest,
+};
+
+const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
+const MAX_CONTROL_FILE_BYTES: u64 = 32 * 1024 * 1024;
+const MAX_IN_FLIGHT_REQUESTS: usize = 64;
+
+/// Failure while serving VM tool requests inside the guest.
+#[derive(Debug, Error)]
+pub enum VmGuestError {
+    #[error("VM tool console I/O failed: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("VM tool protocol JSON failed: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("the VM tool console closed before a complete frame")]
+    Closed,
+
+    #[error("guest tool execution task failed: {0}")]
+    Task(String),
+
+    #[error("VM tool protocol frame exceeded the {MAX_FRAME_BYTES}-byte limit")]
+    FrameTooLarge,
+}
+
+pub(crate) async fn serve(workspace: &Path) -> Result<(), VmGuestError> {
+    serve_io(workspace, tokio::io::stdin(), tokio::io::stdout()).await
+}
+
+async fn serve_io(
+    workspace: &Path,
+    input: impl AsyncRead + Unpin,
+    mut output: impl AsyncWrite + Unpin,
+) -> Result<(), VmGuestError> {
+    let runtime = Arc::new(ToolRuntime::new(workspace, None, None));
+    let mut input = BufReader::new(input);
+    let mut requests = JoinSet::new();
+    let mut accepting = true;
+    let mut shutdown = None;
+
+    let result = async {
+        while accepting || !requests.is_empty() {
+            tokio::select! {
+                joined = requests.join_next(), if !requests.is_empty() => {
+                    match joined.ok_or(VmGuestError::Closed)? {
+                        Ok(response) => write_response(&mut output, &response).await?,
+                        Err(error) if error.is_cancelled() && !accepting => {}
+                        Err(error) => return Err(VmGuestError::Task(error.to_string())),
+                    }
+                }
+                frame = read_frame(&mut input),
+                    if accepting && requests.len() < MAX_IN_FLIGHT_REQUESTS =>
+                {
+                    let Some(frame) = frame? else {
+                        accepting = false;
+                        requests.abort_all();
+                        continue;
+                    };
+                    match serde_json::from_slice::<SessionRequest>(&frame)? {
+                        SessionRequest::Shutdown(request) => {
+                            shutdown = Some(request);
+                            accepting = false;
+                            runtime.control().cancel().await;
+                            requests.abort_all();
+                        }
+                        request => {
+                            let runtime = Arc::clone(&runtime);
+                            requests.spawn(async move { execute_request(runtime, request).await });
+                        }
+                    }
+                }
+            }
+        }
+        Ok::<_, VmGuestError>(shutdown)
+    }
+    .await;
+
+    runtime.control().cancel().await;
+    if let Some(request) = result? {
+        let response = SessionResponse::Shutdown(sync_filesystems(request).await);
+        write_response(&mut output, &response).await?;
+    }
+    Ok(())
+}
+
+async fn execute_request(runtime: Arc<ToolRuntime>, request: SessionRequest) -> SessionResponse {
+    match request {
+        SessionRequest::Tool(request) => {
+            let context = ToolContext {
+                model: &request.context.model,
+                session_id: &request.context.session_id,
+                call_id: &request.context.call_id,
+                history: &[],
+                output_token_budget: request.context.output_token_budget,
+            };
+            let execution = runtime
+                .execute_tool(request.tool.name(), request.input.into(), context)
+                .await;
+            SessionResponse::Tool(match execution.into_wire() {
+                Ok(execution) => ToolResponse::completed(request.id, execution),
+                Err(error) => ToolResponse::failed(request.id, error.to_string()),
+            })
+        }
+        SessionRequest::WriteFile(request) => SessionResponse::WriteFile(write_file(request).await),
+        SessionRequest::ReadFile(request) => SessionResponse::ReadFile(read_file(request).await),
+        SessionRequest::Execute(request) => {
+            SessionResponse::Execute(execute_command(request).await)
+        }
+        SessionRequest::Shutdown(request) => SessionResponse::Shutdown(ControlResponse {
+            id: request.id,
+            error: Some("shutdown cannot be dispatched as a concurrent request".to_owned()),
+        }),
+    }
+}
+
+async fn write_response(
+    output: &mut (impl AsyncWrite + Unpin),
+    response: &SessionResponse,
+) -> Result<(), VmGuestError> {
+    let mut encoded = serde_json::to_vec(response)?;
+    if encoded.len() > MAX_FRAME_BYTES {
+        return Err(VmGuestError::FrameTooLarge);
+    }
+    encoded.push(b'\n');
+    output.write_all(&encoded).await?;
+    output.flush().await?;
+    Ok(())
+}
+
+async fn read_frame(
+    reader: &mut (impl AsyncBufRead + Unpin),
+) -> Result<Option<Vec<u8>>, VmGuestError> {
+    let mut frame = Vec::new();
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            return if frame.is_empty() {
+                Ok(None)
+            } else {
+                Err(VmGuestError::Closed)
+            };
+        }
+        if let Some(newline) = available.iter().position(|byte| *byte == b'\n') {
+            if frame.len().saturating_add(newline) > MAX_FRAME_BYTES {
+                return Err(VmGuestError::FrameTooLarge);
+            }
+            frame.extend_from_slice(&available[..newline]);
+            reader.consume(newline + 1);
+            if frame.last() == Some(&b'\r') {
+                frame.pop();
+            }
+            return Ok(Some(frame));
+        }
+        if frame.len().saturating_add(available.len()) > MAX_FRAME_BYTES {
+            return Err(VmGuestError::FrameTooLarge);
+        }
+        let consumed = available.len();
+        frame.extend_from_slice(available);
+        reader.consume(consumed);
+    }
+}
+
+async fn sync_filesystems(request: ShutdownRequest) -> ControlResponse {
+    let error = match Command::new("/bin/sync").status().await {
+        Ok(status) if status.success() => None,
+        Ok(status) => Some(format!("sync exited with {status}")),
+        Err(error) => Some(error.to_string()),
+    };
+    ControlResponse {
+        id: request.id,
+        error,
+    }
+}
+
+async fn write_file(request: WriteFileRequest) -> ControlResponse {
+    let result =
+        atomic_write_file(&request.path, &request.contents, request.mode, request.id).await;
+    ControlResponse {
+        id: request.id,
+        error: result.err().map(|error| error.to_string()),
+    }
+}
+
+async fn atomic_write_file(
+    path: &str,
+    contents: &[u8],
+    mode: u32,
+    request_id: u64,
+) -> std::io::Result<()> {
+    let path = PathBuf::from(path);
+    let parent = path
+        .parent()
+        .ok_or_else(|| std::io::Error::other("file path has no parent"))?;
+    let name = path
+        .file_name()
+        .ok_or_else(|| std::io::Error::other("file path has no name"))?
+        .to_string_lossy();
+    tokio::fs::create_dir_all(parent).await?;
+    let temporary = parent.join(format!(".{name}.nanocodex-{request_id}.tmp"));
+    let result = async {
+        let mut file = tokio::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temporary)
+            .await?;
+        file.write_all(contents).await?;
+        file.flush().await?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            file.set_permissions(std::fs::Permissions::from_mode(mode))
+                .await?;
+        }
+        drop(file);
+        tokio::fs::rename(&temporary, &path).await
+    }
+    .await;
+    if result.is_err() {
+        let _ = tokio::fs::remove_file(&temporary).await;
+    }
+    result
+}
+
+async fn read_file(request: ReadFileRequest) -> ReadFileResponse {
+    let contents = async {
+        let metadata = tokio::fs::metadata(&request.path).await?;
+        if metadata.len() > MAX_CONTROL_FILE_BYTES {
+            return Err(std::io::Error::other(format!(
+                "file is {} bytes, exceeding the {MAX_CONTROL_FILE_BYTES}-byte control limit",
+                metadata.len()
+            )));
+        }
+        tokio::fs::read(&request.path).await
+    }
+    .await;
+    match contents {
+        Ok(contents) => ReadFileResponse {
+            id: request.id,
+            contents: Some(contents),
+            error: None,
+        },
+        Err(error) => ReadFileResponse {
+            id: request.id,
+            contents: None,
+            error: Some(error.to_string()),
+        },
+    }
+}
+
+async fn execute_command(request: ExecuteRequest) -> ExecuteResponse {
+    let mut command = Command::new(&request.program);
+    command
+        .args(&request.arguments)
+        .current_dir(&request.current_directory)
+        .env_clear()
+        .envs(request.environment.iter().cloned())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    command.process_group(0);
+
+    let timeout = Duration::from_millis(request.timeout_millis);
+    match command_output(&mut command, timeout, request.max_output_bytes).await {
+        Ok(CommandOutcome::Completed(output)) => ExecuteResponse {
+            id: request.id,
+            exit_code: Some(output.status.code().unwrap_or(1)),
+            stdout: Some(output.stdout),
+            stderr: Some(output.stderr),
+            error: None,
+            timed_out: false,
+            output_limit_exceeded: false,
+        },
+        Ok(CommandOutcome::TimedOut) => ExecuteResponse {
+            id: request.id,
+            exit_code: None,
+            stdout: None,
+            stderr: None,
+            error: None,
+            timed_out: true,
+            output_limit_exceeded: false,
+        },
+        Ok(CommandOutcome::OutputLimitExceeded) => ExecuteResponse {
+            id: request.id,
+            exit_code: None,
+            stdout: None,
+            stderr: None,
+            error: None,
+            timed_out: false,
+            output_limit_exceeded: true,
+        },
+        Err(error) => ExecuteResponse {
+            id: request.id,
+            exit_code: None,
+            stdout: None,
+            stderr: None,
+            error: Some(error.to_string()),
+            timed_out: false,
+            output_limit_exceeded: false,
+        },
+    }
+}
+
+enum CommandOutcome {
+    Completed(std::process::Output),
+    TimedOut,
+    OutputLimitExceeded,
+}
+
+enum WaitOutcome {
+    Exited(ExitStatus),
+    TimedOut,
+    OutputLimitExceeded,
+}
+
+async fn command_output(
+    command: &mut Command,
+    timeout: Duration,
+    max_output_bytes: usize,
+) -> std::io::Result<CommandOutcome> {
+    let mut child = command.spawn()?;
+    let process_group = child
+        .id()
+        .and_then(|id| i32::try_from(id).ok())
+        .map(Pid::from_raw);
+    let mut process_group_guard = ProcessGroupGuard(process_group);
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| std::io::Error::other("guest command stdout was not piped"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| std::io::Error::other("guest command stderr was not piped"))?;
+    let retained = Arc::new(AtomicUsize::new(0));
+    let (limit_sender, mut limit_receiver) = mpsc::channel(1);
+    let mut stdout = tokio::spawn(read_bounded(
+        stdout,
+        Arc::clone(&retained),
+        max_output_bytes,
+        limit_sender.clone(),
+    ));
+    let mut stderr = tokio::spawn(read_bounded(
+        stderr,
+        Arc::clone(&retained),
+        max_output_bytes,
+        limit_sender,
+    ));
+    let deadline = tokio::time::sleep(timeout);
+    tokio::pin!(deadline);
+
+    let mut outcome = tokio::select! {
+        status = child.wait() => WaitOutcome::Exited(status?),
+        () = &mut deadline => WaitOutcome::TimedOut,
+        Some(()) = limit_receiver.recv() => WaitOutcome::OutputLimitExceeded,
+    };
+    if !matches!(outcome, WaitOutcome::Exited(_)) {
+        if let Some(status) = child.try_wait()? {
+            outcome = WaitOutcome::Exited(status);
+        } else {
+            kill_process_group(&mut child, process_group)?;
+            child.wait().await?;
+        }
+    }
+    let (stdout, stderr) = tokio::time::timeout(Duration::from_secs(1), async {
+        let stdout = (&mut stdout).await.map_err(std::io::Error::other)??;
+        let stderr = (&mut stderr).await.map_err(std::io::Error::other)??;
+        Ok::<_, std::io::Error>((stdout, stderr))
+    })
+    .await
+    .unwrap_or_else(|_| {
+        let _ = kill_process_group(&mut child, process_group);
+        Err(std::io::Error::other(
+            "guest command descendants kept output pipes open",
+        ))
+    })?;
+    process_group_guard.disarm();
+    let output_limit_exceeded = retained.load(Ordering::Relaxed) > max_output_bytes;
+    match outcome {
+        WaitOutcome::Exited(_) if output_limit_exceeded => Ok(CommandOutcome::OutputLimitExceeded),
+        WaitOutcome::Exited(status) => Ok(CommandOutcome::Completed(std::process::Output {
+            status,
+            stdout,
+            stderr,
+        })),
+        WaitOutcome::TimedOut => Ok(CommandOutcome::TimedOut),
+        WaitOutcome::OutputLimitExceeded => Ok(CommandOutcome::OutputLimitExceeded),
+    }
+}
+
+fn kill_process_group(child: &mut Child, process_group: Option<Pid>) -> std::io::Result<()> {
+    if let Some(process_group) = process_group {
+        let child_kill = child.start_kill();
+        match killpg(process_group, Signal::SIGKILL) {
+            Ok(()) | Err(Errno::ESRCH) => Ok(()),
+            Err(Errno::EPERM) => child_kill.or(Ok(())),
+            Err(error) => Err(std::io::Error::other(error)),
+        }
+    } else {
+        child.start_kill()
+    }
+}
+
+struct ProcessGroupGuard(Option<Pid>);
+
+impl ProcessGroupGuard {
+    fn disarm(&mut self) {
+        self.0 = None;
+    }
+}
+
+impl Drop for ProcessGroupGuard {
+    fn drop(&mut self) {
+        if let Some(process_group) = self.0 {
+            let _ = killpg(process_group, Signal::SIGKILL);
+        }
+    }
+}
+
+async fn read_bounded(
+    mut reader: impl AsyncRead + Unpin,
+    retained: Arc<AtomicUsize>,
+    limit: usize,
+    limit_sender: mpsc::Sender<()>,
+) -> std::io::Result<Vec<u8>> {
+    let mut output = Vec::new();
+    let mut buffer = [0_u8; 8 * 1024];
+    let mut reported = false;
+    loop {
+        let read = reader.read(&mut buffer).await?;
+        if read == 0 {
+            break;
+        }
+        let offset = retained.fetch_add(read, Ordering::Relaxed);
+        let allowed = limit.saturating_sub(offset).min(read);
+        output.extend_from_slice(&buffer[..allowed]);
+        if allowed < read && !reported {
+            reported = true;
+            let _ = limit_sender.try_send(());
+        }
+    }
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    use super::{execute_command, serve_io};
+    use crate::protocol::{ExecuteRequest, SessionRequest, SessionResponse, ShutdownRequest};
+
+    const DEFAULT_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
+
+    #[tokio::test]
+    async fn timeout_kills_descendants_holding_output_pipes() {
+        let started_at = Instant::now();
+        let response = execute_command(ExecuteRequest {
+            id: 1,
+            program: "/bin/sh".to_owned(),
+            arguments: vec!["-c".to_owned(), "sleep 30 & wait".to_owned()],
+            current_directory: "/".to_owned(),
+            environment: Vec::new(),
+            timeout_millis: 25,
+            max_output_bytes: DEFAULT_OUTPUT_BYTES,
+        })
+        .await;
+
+        assert!(response.timed_out);
+        assert!(response.error.is_none());
+        assert!(started_at.elapsed() < Duration::from_secs(1));
+    }
+
+    #[tokio::test]
+    async fn command_output_is_bounded_while_it_is_produced() {
+        let response = execute_command(ExecuteRequest {
+            id: 1,
+            program: "/usr/bin/yes".to_owned(),
+            arguments: vec!["bounded".to_owned()],
+            current_directory: "/".to_owned(),
+            environment: Vec::new(),
+            timeout_millis: 5_000,
+            max_output_bytes: 8,
+        })
+        .await;
+
+        assert!(response.output_limit_exceeded);
+        assert!(!response.timed_out);
+        assert!(response.error.is_none());
+        assert!(response.stdout.is_none());
+        assert!(response.stderr.is_none());
+    }
+
+    #[tokio::test]
+    async fn independent_requests_execute_concurrently() {
+        let workspace = tempfile::tempdir().unwrap();
+        let marker = workspace.path().join("second-started");
+        let (host, guest) = tokio::io::duplex(64 * 1024);
+        let (host_read, mut host_write) = tokio::io::split(host);
+        let (guest_read, guest_write) = tokio::io::split(guest);
+        let guest_task = tokio::spawn({
+            let workspace = workspace.path().to_owned();
+            async move { serve_io(&workspace, guest_read, guest_write).await }
+        });
+
+        for request in [
+            SessionRequest::Execute(ExecuteRequest {
+                id: 0,
+                program: "/bin/sh".to_owned(),
+                arguments: vec![
+                    "-c".to_owned(),
+                    format!("while [ ! -f '{}' ]; do sleep 0.01; done", marker.display()),
+                ],
+                current_directory: workspace.path().to_string_lossy().into_owned(),
+                environment: Vec::new(),
+                timeout_millis: 5_000,
+                max_output_bytes: DEFAULT_OUTPUT_BYTES,
+            }),
+            SessionRequest::Execute(ExecuteRequest {
+                id: 1,
+                program: "/usr/bin/touch".to_owned(),
+                arguments: vec![marker.to_string_lossy().into_owned()],
+                current_directory: workspace.path().to_string_lossy().into_owned(),
+                environment: Vec::new(),
+                timeout_millis: 5_000,
+                max_output_bytes: DEFAULT_OUTPUT_BYTES,
+            }),
+        ] {
+            host_write
+                .write_all(&serde_json::to_vec(&request).unwrap())
+                .await
+                .unwrap();
+            host_write.write_all(b"\n").await.unwrap();
+        }
+
+        let mut responses = BufReader::new(host_read).lines();
+        for _ in 0..2 {
+            let line = responses.next_line().await.unwrap().unwrap();
+            assert!(matches!(
+                serde_json::from_str::<SessionResponse>(&line).unwrap(),
+                SessionResponse::Execute(response)
+                    if response.error.is_none() && !response.timed_out
+            ));
+        }
+        host_write
+            .write_all(
+                &serde_json::to_vec(&SessionRequest::Shutdown(ShutdownRequest { id: 2 })).unwrap(),
+            )
+            .await
+            .unwrap();
+        host_write.write_all(b"\n").await.unwrap();
+        drop(host_write);
+        let shutdown = responses.next_line().await.unwrap().unwrap();
+        assert!(matches!(
+            serde_json::from_str::<SessionResponse>(&shutdown).unwrap(),
+            SessionResponse::Shutdown(response) if response.id == 2 && response.error.is_none()
+        ));
+        guest_task.await.unwrap().unwrap();
+        assert!(marker.is_file());
+    }
+
+    #[tokio::test]
+    async fn shutdown_aborts_in_flight_work_before_syncing() {
+        let workspace = tempfile::tempdir().unwrap();
+        let (host, guest) = tokio::io::duplex(64 * 1024);
+        let (host_read, mut host_write) = tokio::io::split(host);
+        let (guest_read, guest_write) = tokio::io::split(guest);
+        let guest_task = tokio::spawn({
+            let workspace = workspace.path().to_owned();
+            async move { serve_io(&workspace, guest_read, guest_write).await }
+        });
+        for request in [
+            SessionRequest::Execute(ExecuteRequest {
+                id: 0,
+                program: "/bin/sh".to_owned(),
+                arguments: vec!["-c".to_owned(), "sleep 30 & wait".to_owned()],
+                current_directory: workspace.path().to_string_lossy().into_owned(),
+                environment: Vec::new(),
+                timeout_millis: 60_000,
+                max_output_bytes: DEFAULT_OUTPUT_BYTES,
+            }),
+            SessionRequest::Shutdown(ShutdownRequest { id: 1 }),
+        ] {
+            host_write
+                .write_all(&serde_json::to_vec(&request).unwrap())
+                .await
+                .unwrap();
+            host_write.write_all(b"\n").await.unwrap();
+        }
+
+        let mut responses = BufReader::new(host_read).lines();
+        let line = tokio::time::timeout(Duration::from_secs(2), responses.next_line())
+            .await
+            .expect("shutdown must not wait for the in-flight command")
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            serde_json::from_str::<SessionResponse>(&line).unwrap(),
+            SessionResponse::Shutdown(response) if response.id == 1 && response.error.is_none()
+        ));
+        drop(host_write);
+        guest_task.await.unwrap().unwrap();
+    }
+}

--- a/crates/nanocodex-vm/src/lib.rs
+++ b/crates/nanocodex-vm/src/lib.rs
@@ -12,7 +12,9 @@ use nanocodex_tools::{
 
 #[cfg(feature = "mpp")]
 pub use mpp::{MppVmEgressError, mpp_egress_layer};
-pub use session::{VmCommand, VmCommandOutput, VmToolSession, VmToolSessionError};
+pub use session::{
+    VmCommand, VmCommandOutput, VmToolSession, VmToolSessionError, VmToolSessionHandle,
+};
 
 /// One VM-aware execution capability shared by all proxied workspace tools.
 ///

--- a/crates/nanocodex-vm/src/lib.rs
+++ b/crates/nanocodex-vm/src/lib.rs
@@ -1,0 +1,189 @@
+#[cfg(feature = "mpp")]
+mod mpp;
+mod protocol;
+mod session;
+
+use std::{path::Path, sync::Arc};
+
+use nanocodex_tools::{
+    StandardTool, Tool, ToolContext, ToolDefinition, ToolInput, ToolResult, Tools, ToolsBuilder,
+    UpdatePlanTool,
+};
+
+#[cfg(feature = "mpp")]
+pub use mpp::{MppVmEgressError, mpp_egress_layer};
+pub use session::{VmCommand, VmCommandOutput, VmToolSession, VmToolSessionError};
+
+/// One VM-aware execution capability shared by all proxied workspace tools.
+///
+/// The concrete client owns transport, guest session routing, cancellation,
+/// and conversion of the guest's typed result into Nanocodex's `ToolResult`.
+#[async_trait::async_trait]
+pub trait VmToolClient: Send + Sync {
+    async fn execute(
+        &self,
+        tool: StandardTool,
+        input: ToolInput,
+        context: ToolContext<'_>,
+    ) -> ToolResult;
+}
+
+/// Clone-cheap factory for the standard tools whose effects belong in a VM.
+#[derive(Clone)]
+pub struct VmTools {
+    client: Arc<dyn VmToolClient>,
+}
+
+impl VmTools {
+    #[must_use]
+    pub fn new(client: impl VmToolClient + 'static) -> Self {
+        Self {
+            client: Arc::new(client),
+        }
+    }
+
+    #[must_use]
+    pub fn exec_command_tool(&self) -> VmTool {
+        self.tool(StandardTool::ExecCommand)
+    }
+
+    #[must_use]
+    pub fn write_stdin_tool(&self) -> VmTool {
+        self.tool(StandardTool::WriteStdin)
+    }
+
+    #[must_use]
+    pub fn apply_patch_tool(&self) -> VmTool {
+        self.tool(StandardTool::ApplyPatch)
+    }
+
+    #[must_use]
+    pub fn view_image_tool(&self) -> VmTool {
+        self.tool(StandardTool::ViewImage)
+    }
+
+    /// Starts a normal Nanocodex tool selection whose workspace effects are
+    /// forwarded to this VM.
+    ///
+    /// Web search and image generation retain their normal host-side
+    /// implementations. `update_plan` also stays host-side because it has no
+    /// workspace effect. Callers can keep configuring the returned builder,
+    /// including setting the guest-visible working directory and shell.
+    #[must_use]
+    pub fn tools_builder(&self) -> ToolsBuilder {
+        Tools::builder()
+            .workspace(false)
+            .tool(self.exec_command_tool())
+            .tool(self.write_stdin_tool())
+            .tool(self.apply_patch_tool())
+            .tool(self.view_image_tool())
+            .tool(UpdatePlanTool::new())
+    }
+
+    fn tool(&self, standard: StandardTool) -> VmTool {
+        VmTool {
+            standard,
+            client: Arc::clone(&self.client),
+        }
+    }
+}
+
+/// One standard Nanocodex tool whose execution is forwarded into a VM.
+#[derive(Clone)]
+pub struct VmTool {
+    standard: StandardTool,
+    client: Arc<dyn VmToolClient>,
+}
+
+impl VmTool {
+    #[must_use]
+    pub const fn standard(&self) -> StandardTool {
+        self.standard
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for VmTool {
+    fn name(&self) -> &'static str {
+        self.standard.name()
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        self.standard.definition()
+    }
+
+    async fn execute(&self, input: ToolInput, context: ToolContext<'_>) -> ToolResult {
+        self.client.execute(self.standard, input, context).await
+    }
+}
+
+/// Serves canonical workspace-tool requests over the guest's stdin/stdout.
+///
+/// A single invocation retains the native `ToolRuntime`, including interactive
+/// shell sessions, until the input stream closes.
+///
+/// # Errors
+///
+/// Returns an error for malformed protocol messages or guest console I/O.
+pub async fn serve_guest(workspace: impl AsRef<Path>) -> Result<(), VmToolSessionError> {
+    session::serve_guest(workspace.as_ref()).await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use nanocodex_tools::{StandardTool, Tool, ToolContext, ToolExecution, ToolInput};
+
+    use super::{VmToolClient, VmTools};
+
+    #[derive(Default)]
+    struct RecordingClient {
+        calls: Mutex<Vec<StandardTool>>,
+    }
+
+    #[async_trait::async_trait]
+    impl VmToolClient for RecordingClient {
+        async fn execute(
+            &self,
+            tool: StandardTool,
+            _input: ToolInput,
+            _context: ToolContext<'_>,
+        ) -> nanocodex_tools::ToolResult {
+            self.calls.lock().unwrap().push(tool);
+            Ok(ToolExecution::text(tool.name()))
+        }
+    }
+
+    #[test]
+    fn composes_vm_workspace_tools_with_the_host_plan_tool() {
+        let vm = VmTools::new(RecordingClient::default());
+        let tools = vm
+            .tools_builder()
+            .working_directory("/workspace")
+            .default_shell("sh")
+            .build()
+            .unwrap();
+
+        assert!(!tools.workspace_enabled());
+        assert!(tools.web_search_enabled());
+        assert!(tools.image_generation_enabled());
+    }
+
+    #[test]
+    fn definitions_are_the_upstream_standard_contracts() {
+        let vm = VmTools::new(RecordingClient::default());
+        for (tool, standard) in [
+            (vm.exec_command_tool(), StandardTool::ExecCommand),
+            (vm.write_stdin_tool(), StandardTool::WriteStdin),
+            (vm.apply_patch_tool(), StandardTool::ApplyPatch),
+            (vm.view_image_tool(), StandardTool::ViewImage),
+        ] {
+            assert_eq!(tool.name(), standard.name());
+            assert_eq!(
+                serde_json::to_value(tool.definition()).unwrap(),
+                serde_json::to_value(standard.definition()).unwrap()
+            );
+        }
+    }
+}

--- a/crates/nanocodex-vm/src/lib.rs
+++ b/crates/nanocodex-vm/src/lib.rs
@@ -1,17 +1,27 @@
+#[cfg(feature = "guest")]
+mod guest;
 #[cfg(feature = "mpp")]
 mod mpp;
 mod protocol;
+#[cfg(feature = "host")]
 mod session;
 
-use std::{path::Path, sync::Arc};
+#[cfg(feature = "guest")]
+use std::path::Path;
+#[cfg(feature = "host")]
+use std::sync::Arc;
 
+#[cfg(feature = "host")]
 use nanocodex_tools::{
     StandardTool, Tool, ToolContext, ToolDefinition, ToolInput, ToolResult, Tools, ToolsBuilder,
     UpdatePlanTool,
 };
 
+#[cfg(feature = "guest")]
+pub use guest::VmGuestError;
 #[cfg(feature = "mpp")]
 pub use mpp::{MppVmEgressError, mpp_egress_layer};
+#[cfg(feature = "host")]
 pub use session::{
     VmCommand, VmCommandOutput, VmToolSession, VmToolSessionError, VmToolSessionHandle,
 };
@@ -21,6 +31,7 @@ pub use session::{
 /// The concrete client owns transport, guest session routing, cancellation,
 /// and conversion of the guest's typed result into Nanocodex's `ToolResult`.
 #[async_trait::async_trait]
+#[cfg(feature = "host")]
 pub trait VmToolClient: Send + Sync {
     async fn execute(
         &self,
@@ -32,10 +43,12 @@ pub trait VmToolClient: Send + Sync {
 
 /// Clone-cheap factory for the standard tools whose effects belong in a VM.
 #[derive(Clone)]
+#[cfg(feature = "host")]
 pub struct VmTools {
     client: Arc<dyn VmToolClient>,
 }
 
+#[cfg(feature = "host")]
 impl VmTools {
     #[must_use]
     pub fn new(client: impl VmToolClient + 'static) -> Self {
@@ -92,11 +105,13 @@ impl VmTools {
 
 /// One standard Nanocodex tool whose execution is forwarded into a VM.
 #[derive(Clone)]
+#[cfg(feature = "host")]
 pub struct VmTool {
     standard: StandardTool,
     client: Arc<dyn VmToolClient>,
 }
 
+#[cfg(feature = "host")]
 impl VmTool {
     #[must_use]
     pub const fn standard(&self) -> StandardTool {
@@ -105,6 +120,7 @@ impl VmTool {
 }
 
 #[async_trait::async_trait]
+#[cfg(feature = "host")]
 impl Tool for VmTool {
     fn name(&self) -> &'static str {
         self.standard.name()
@@ -127,11 +143,12 @@ impl Tool for VmTool {
 /// # Errors
 ///
 /// Returns an error for malformed protocol messages or guest console I/O.
-pub async fn serve_guest(workspace: impl AsRef<Path>) -> Result<(), VmToolSessionError> {
-    session::serve_guest(workspace.as_ref()).await
+#[cfg(feature = "guest")]
+pub async fn serve_guest(workspace: impl AsRef<Path>) -> Result<(), VmGuestError> {
+    guest::serve(workspace.as_ref()).await
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "host"))]
 mod tests {
     use std::sync::Mutex;
 

--- a/crates/nanocodex-vm/src/mpp.rs
+++ b/crates/nanocodex-vm/src/mpp.rs
@@ -5,10 +5,10 @@ use std::{
 };
 
 use mpp_egress::MppEgress;
-use nanovm::{EgressError, EgressFile, EgressLease};
+use nanovm::{EgressError, EgressFile, EgressLease, GUEST_EGRESS_ROOT};
 use thiserror::Error;
 
-const GUEST_DIRECTORY: &str = "/tmp/nanocodex/egress/mpp";
+const GUEST_LAYER: &str = "mpp";
 const CA_FILENAME: &str = "mpp-egress-ca.pem";
 const CA_ENVIRONMENT: [&str; 4] = [
     "CURL_CA_BUNDLE",
@@ -45,7 +45,7 @@ where
             certificate.to_path_buf(),
         ));
     }
-    let guest_directory = PathBuf::from(GUEST_DIRECTORY);
+    let guest_directory = Path::new(GUEST_EGRESS_ROOT).join(GUEST_LAYER);
     let guest_certificate = guest_directory.join(CA_FILENAME);
     let guest_certificate = guest_certificate
         .to_str()
@@ -120,7 +120,7 @@ mod tests {
         );
         assert_eq!(
             lease.guest_environment().get("CURL_CA_BUNDLE"),
-            Some(&format!("{GUEST_DIRECTORY}/{CA_FILENAME}"))
+            Some(&format!("{GUEST_EGRESS_ROOT}/{GUEST_LAYER}/{CA_FILENAME}"))
         );
         assert_eq!(lease.guest_mounts().count(), 0);
         assert_eq!(lease.guest_files().count(), 1);

--- a/crates/nanocodex-vm/src/mpp.rs
+++ b/crates/nanocodex-vm/src/mpp.rs
@@ -1,0 +1,133 @@
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use mpp_egress::MppEgress;
+use nanovm::{EgressError, EgressLease, EgressMount};
+use thiserror::Error;
+
+const MPP_MOUNT_TAG: &str = "nanocodex-mpp-egress";
+const GUEST_DIRECTORY: &str = "/run/nanocodex/egress/mpp";
+const CA_FILENAME: &str = "mpp-egress-ca.pem";
+const CA_ENVIRONMENT: [&str; 4] = [
+    "CURL_CA_BUNDLE",
+    "SSL_CERT_FILE",
+    "REQUESTS_CA_BUNDLE",
+    "NODE_EXTRA_CA_CERTS",
+];
+
+/// Converts one running MPP proxy into a VM-facing egress layer.
+///
+/// The guest receives only the proxy lease credentials and public CA. The
+/// payment provider and wallet remain in the host proxy retained by the
+/// returned lease.
+///
+/// # Errors
+///
+/// Returns an error when the proxy's public CA is unavailable, generated
+/// environment is not UTF-8, or it conflicts with another value in the layer.
+pub fn mpp_egress_layer(egress: Arc<MppEgress>) -> Result<EgressLease, MppVmEgressError> {
+    let certificate = egress.certificate_path();
+    layer_from_parts(egress.environment(), &certificate, egress)
+}
+
+fn layer_from_parts<T>(
+    environment: Vec<(OsString, OsString)>,
+    certificate: &Path,
+    guard: Arc<T>,
+) -> Result<EgressLease, MppVmEgressError>
+where
+    T: Send + Sync + 'static,
+{
+    if !certificate.is_file() {
+        return Err(MppVmEgressError::CertificateNotFile(
+            certificate.to_path_buf(),
+        ));
+    }
+    let host_directory = certificate
+        .parent()
+        .ok_or_else(|| MppVmEgressError::CertificateWithoutParent(certificate.to_path_buf()))?;
+    let guest_directory = PathBuf::from(GUEST_DIRECTORY);
+    let guest_certificate = guest_directory.join(CA_FILENAME);
+    let guest_certificate = guest_certificate
+        .to_str()
+        .ok_or(MppVmEgressError::GuestCertificatePath)?
+        .to_owned();
+
+    let mut lease = EgressLease::internet();
+    lease.insert_mount(EgressMount {
+        tag: MPP_MOUNT_TAG.to_owned(),
+        host_path: host_directory.to_path_buf(),
+        guest_path: guest_directory,
+    })?;
+    for (name, value) in environment {
+        let name = name
+            .into_string()
+            .map_err(|_| MppVmEgressError::EnvironmentName)?;
+        let value = if CA_ENVIRONMENT.contains(&name.as_str()) {
+            guest_certificate.clone()
+        } else {
+            value
+                .into_string()
+                .map_err(|_| MppVmEgressError::EnvironmentValue(name.clone()))?
+        };
+        lease.insert_environment(name, value)?;
+    }
+    lease.retain(guard);
+    Ok(lease)
+}
+
+#[derive(Debug, Error)]
+pub enum MppVmEgressError {
+    #[error("MPP egress CA is not a regular file: {0}")]
+    CertificateNotFile(PathBuf),
+    #[error("MPP egress CA path has no parent directory: {0}")]
+    CertificateWithoutParent(PathBuf),
+    #[error("MPP guest CA path is not valid UTF-8")]
+    GuestCertificatePath,
+    #[error("MPP egress produced a non-UTF-8 environment name")]
+    EnvironmentName,
+    #[error("MPP egress produced a non-UTF-8 value for `{0}`")]
+    EnvironmentValue(String),
+    #[error(transparent)]
+    Egress(#[from] EgressError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mpp_layer_routes_curl_through_proxy_and_mounts_public_ca() {
+        let directory = tempfile::tempdir().unwrap();
+        let certificate = directory.path().join(CA_FILENAME);
+        std::fs::write(&certificate, "public ca").unwrap();
+        let guard = Arc::new(());
+        let environment = vec![
+            (
+                OsString::from("HTTPS_PROXY"),
+                OsString::from("http://lease:secret@127.0.0.1:1234"),
+            ),
+            (
+                OsString::from("CURL_CA_BUNDLE"),
+                certificate.as_os_str().to_owned(),
+            ),
+        ];
+
+        let lease = layer_from_parts(environment, &certificate, Arc::clone(&guard)).unwrap();
+
+        assert_eq!(
+            lease.guest_environment().get("HTTPS_PROXY"),
+            Some(&"http://lease:secret@127.0.0.1:1234".to_owned())
+        );
+        assert_eq!(
+            lease.guest_environment().get("CURL_CA_BUNDLE"),
+            Some(&format!("{GUEST_DIRECTORY}/{CA_FILENAME}"))
+        );
+        assert_eq!(lease.guest_mounts().count(), 1);
+        assert_eq!(Arc::strong_count(&guard), 2);
+        assert!(!format!("{lease:?}").contains("secret"));
+    }
+}

--- a/crates/nanocodex-vm/src/mpp.rs
+++ b/crates/nanocodex-vm/src/mpp.rs
@@ -5,11 +5,10 @@ use std::{
 };
 
 use mpp_egress::MppEgress;
-use nanovm::{EgressError, EgressLease, EgressMount};
+use nanovm::{EgressError, EgressFile, EgressLease};
 use thiserror::Error;
 
-const MPP_MOUNT_TAG: &str = "nanocodex-mpp-egress";
-const GUEST_DIRECTORY: &str = "/run/nanocodex/egress/mpp";
+const GUEST_DIRECTORY: &str = "/tmp/nanocodex/egress/mpp";
 const CA_FILENAME: &str = "mpp-egress-ca.pem";
 const CA_ENVIRONMENT: [&str; 4] = [
     "CURL_CA_BUNDLE",
@@ -46,9 +45,6 @@ where
             certificate.to_path_buf(),
         ));
     }
-    let host_directory = certificate
-        .parent()
-        .ok_or_else(|| MppVmEgressError::CertificateWithoutParent(certificate.to_path_buf()))?;
     let guest_directory = PathBuf::from(GUEST_DIRECTORY);
     let guest_certificate = guest_directory.join(CA_FILENAME);
     let guest_certificate = guest_certificate
@@ -57,11 +53,11 @@ where
         .to_owned();
 
     let mut lease = EgressLease::internet();
-    lease.insert_mount(EgressMount {
-        tag: MPP_MOUNT_TAG.to_owned(),
-        host_path: host_directory.to_path_buf(),
-        guest_path: guest_directory,
-    })?;
+    lease.insert_file(EgressFile::new(
+        &guest_certificate,
+        std::fs::read(certificate).map_err(MppVmEgressError::ReadCertificate)?,
+        0o444,
+    ))?;
     for (name, value) in environment {
         let name = name
             .into_string()
@@ -83,8 +79,8 @@ where
 pub enum MppVmEgressError {
     #[error("MPP egress CA is not a regular file: {0}")]
     CertificateNotFile(PathBuf),
-    #[error("MPP egress CA path has no parent directory: {0}")]
-    CertificateWithoutParent(PathBuf),
+    #[error("failed to read the MPP egress CA: {0}")]
+    ReadCertificate(#[source] std::io::Error),
     #[error("MPP guest CA path is not valid UTF-8")]
     GuestCertificatePath,
     #[error("MPP egress produced a non-UTF-8 environment name")]
@@ -100,7 +96,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn mpp_layer_routes_curl_through_proxy_and_mounts_public_ca() {
+    fn mpp_layer_routes_curl_through_proxy_and_provisions_public_ca() {
         let directory = tempfile::tempdir().unwrap();
         let certificate = directory.path().join(CA_FILENAME);
         std::fs::write(&certificate, "public ca").unwrap();
@@ -126,7 +122,8 @@ mod tests {
             lease.guest_environment().get("CURL_CA_BUNDLE"),
             Some(&format!("{GUEST_DIRECTORY}/{CA_FILENAME}"))
         );
-        assert_eq!(lease.guest_mounts().count(), 1);
+        assert_eq!(lease.guest_mounts().count(), 0);
+        assert_eq!(lease.guest_files().count(), 1);
         assert_eq!(Arc::strong_count(&guard), 2);
         assert!(!format!("{lease:?}").contains("secret"));
     }

--- a/crates/nanocodex-vm/src/protocol.rs
+++ b/crates/nanocodex-vm/src/protocol.rs
@@ -23,6 +23,7 @@ pub(crate) enum SessionResponse {
 }
 
 impl SessionResponse {
+    #[cfg(feature = "host")]
     pub const fn id(&self) -> u64 {
         match self {
             Self::Tool(response) => response.id,
@@ -64,6 +65,7 @@ pub(crate) struct ExecuteRequest {
     pub current_directory: String,
     pub environment: Vec<(String, String)>,
     pub timeout_millis: u64,
+    pub max_output_bytes: usize,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -90,6 +92,7 @@ pub(crate) struct ExecuteResponse {
     pub stderr: Option<Vec<u8>>,
     pub error: Option<String>,
     pub timed_out: bool,
+    pub output_limit_exceeded: bool,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -198,6 +201,7 @@ pub(crate) struct ToolResponse {
 }
 
 impl ToolResponse {
+    #[cfg(feature = "guest")]
     pub const fn completed(id: u64, execution: ToolExecutionWire) -> Self {
         Self {
             id,
@@ -206,6 +210,7 @@ impl ToolResponse {
         }
     }
 
+    #[cfg(feature = "guest")]
     pub const fn failed(id: u64, error: String) -> Self {
         Self {
             id,

--- a/crates/nanocodex-vm/src/protocol.rs
+++ b/crates/nanocodex-vm/src/protocol.rs
@@ -1,0 +1,216 @@
+use nanocodex_tools::{StandardTool, ToolExecutionWire, ToolInput};
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+
+#[derive(Deserialize, Serialize)]
+#[serde(tag = "kind", content = "payload", rename_all = "snake_case")]
+pub(crate) enum SessionRequest {
+    Tool(ToolRequest),
+    WriteFile(WriteFileRequest),
+    ReadFile(ReadFileRequest),
+    Execute(ExecuteRequest),
+    Shutdown(ShutdownRequest),
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(tag = "kind", content = "payload", rename_all = "snake_case")]
+pub(crate) enum SessionResponse {
+    Tool(ToolResponse),
+    WriteFile(ControlResponse),
+    ReadFile(ReadFileResponse),
+    Execute(ExecuteResponse),
+    Shutdown(ControlResponse),
+}
+
+impl SessionResponse {
+    pub const fn id(&self) -> u64 {
+        match self {
+            Self::Tool(response) => response.id,
+            Self::WriteFile(response) | Self::Shutdown(response) => response.id,
+            Self::ReadFile(response) => response.id,
+            Self::Execute(response) => response.id,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ShutdownRequest {
+    pub id: u64,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct WriteFileRequest {
+    pub id: u64,
+    pub path: String,
+    pub contents: Vec<u8>,
+    pub mode: u32,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ReadFileRequest {
+    pub id: u64,
+    pub path: String,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ExecuteRequest {
+    pub id: u64,
+    pub program: String,
+    pub arguments: Vec<String>,
+    pub current_directory: String,
+    pub environment: Vec<(String, String)>,
+    pub timeout_millis: u64,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ControlResponse {
+    pub id: u64,
+    pub error: Option<String>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ReadFileResponse {
+    pub id: u64,
+    pub contents: Option<Vec<u8>>,
+    pub error: Option<String>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ExecuteResponse {
+    pub id: u64,
+    pub exit_code: Option<i32>,
+    pub stdout: Option<Vec<u8>>,
+    pub stderr: Option<Vec<u8>>,
+    pub error: Option<String>,
+    pub timed_out: bool,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ToolRequest {
+    pub id: u64,
+    pub tool: StandardTool,
+    pub input: WireToolInput,
+    pub context: WireToolContext,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum WireToolInput {
+    Function { arguments: Box<RawValue> },
+    Freeform { input: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use nanocodex_tools::{ToolExecution, ToolInput};
+    use serde_json::{json, value::to_raw_value};
+
+    use super::{
+        SessionRequest, ShutdownRequest, ToolRequest, ToolResponse, WireToolContext, WireToolInput,
+    };
+
+    #[test]
+    fn shutdown_request_has_a_stable_typed_shape() {
+        let request = SessionRequest::Shutdown(ShutdownRequest { id: 9 });
+        let encoded = serde_json::to_string(&request).unwrap();
+
+        assert_eq!(encoded, r#"{"kind":"shutdown","payload":{"id":9}}"#);
+    }
+
+    #[test]
+    fn function_request_round_trips_opaque_arguments() {
+        let request = ToolRequest {
+            id: 7,
+            tool: nanocodex_tools::StandardTool::ExecCommand,
+            input: WireToolInput::from(ToolInput::Function(
+                to_raw_value(&json!({"cmd": "pwd"})).unwrap(),
+            )),
+            context: WireToolContext {
+                model: "model".to_owned(),
+                session_id: "session".to_owned(),
+                call_id: "call".to_owned(),
+                output_token_budget: 100,
+            },
+        };
+        let encoded = serde_json::to_string(&request).unwrap();
+        let decoded = serde_json::from_str::<ToolRequest>(&encoded).unwrap();
+        let ToolInput::Function(arguments) = ToolInput::from(decoded.input) else {
+            panic!("function input changed variants");
+        };
+        assert_eq!(arguments.get(), r#"{"cmd":"pwd"}"#);
+    }
+
+    #[test]
+    fn execution_response_round_trips_opaque_values() {
+        let response = ToolResponse::completed(
+            8,
+            ToolExecution::from_json(json!({"output": "ok"}), true)
+                .into_wire()
+                .unwrap(),
+        );
+        let encoded = serde_json::to_string(&response).unwrap();
+        let decoded = serde_json::from_str::<ToolResponse>(&encoded).unwrap();
+        assert_eq!(decoded.id, 8);
+    }
+}
+
+impl From<ToolInput> for WireToolInput {
+    fn from(input: ToolInput) -> Self {
+        match input {
+            ToolInput::Function(arguments) => Self::Function { arguments },
+            ToolInput::Freeform(input) => Self::Freeform { input },
+        }
+    }
+}
+
+impl From<WireToolInput> for ToolInput {
+    fn from(input: WireToolInput) -> Self {
+        match input {
+            WireToolInput::Function { arguments } => Self::Function(arguments),
+            WireToolInput::Freeform { input } => Self::Freeform(input),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct WireToolContext {
+    pub model: String,
+    pub session_id: String,
+    pub call_id: String,
+    pub output_token_budget: usize,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ToolResponse {
+    pub id: u64,
+    pub execution: Option<ToolExecutionWire>,
+    pub error: Option<String>,
+}
+
+impl ToolResponse {
+    pub const fn completed(id: u64, execution: ToolExecutionWire) -> Self {
+        Self {
+            id,
+            execution: Some(execution),
+            error: None,
+        }
+    }
+
+    pub const fn failed(id: u64, error: String) -> Self {
+        Self {
+            id,
+            execution: None,
+            error: Some(error),
+        }
+    }
+}

--- a/crates/nanocodex-vm/src/protocol.rs
+++ b/crates/nanocodex-vm/src/protocol.rs
@@ -153,12 +153,15 @@ mod tests {
 
     #[test]
     fn execution_response_round_trips_opaque_values() {
-        let response = ToolResponse::completed(
-            8,
-            ToolExecution::from_json(json!({"output": "ok"}), true)
-                .into_wire()
-                .unwrap(),
-        );
+        let response = ToolResponse {
+            id: 8,
+            execution: Some(
+                ToolExecution::from_json(json!({"output": "ok"}), true)
+                    .into_wire()
+                    .unwrap(),
+            ),
+            error: None,
+        };
         let encoded = serde_json::to_string(&response).unwrap();
         let decoded = serde_json::from_str::<ToolResponse>(&encoded).unwrap();
         assert_eq!(decoded.id, 8);

--- a/crates/nanocodex-vm/src/protocol.rs
+++ b/crates/nanocodex-vm/src/protocol.rs
@@ -9,7 +9,22 @@ pub(crate) enum SessionRequest {
     WriteFile(WriteFileRequest),
     ReadFile(ReadFileRequest),
     Execute(ExecuteRequest),
+    Cancel(CancelRequest),
     Shutdown(ShutdownRequest),
+}
+
+impl SessionRequest {
+    #[cfg(feature = "guest")]
+    pub const fn id(&self) -> u64 {
+        match self {
+            Self::Tool(request) => request.id,
+            Self::WriteFile(request) => request.id,
+            Self::ReadFile(request) => request.id,
+            Self::Execute(request) => request.id,
+            Self::Cancel(request) => request.id,
+            Self::Shutdown(request) => request.id,
+        }
+    }
 }
 
 #[derive(Deserialize, Serialize)]
@@ -19,15 +34,17 @@ pub(crate) enum SessionResponse {
     WriteFile(ControlResponse),
     ReadFile(ReadFileResponse),
     Execute(ExecuteResponse),
+    Cancel(ControlResponse),
     Shutdown(ControlResponse),
 }
 
 impl SessionResponse {
-    #[cfg(feature = "host")]
     pub const fn id(&self) -> u64 {
         match self {
             Self::Tool(response) => response.id,
-            Self::WriteFile(response) | Self::Shutdown(response) => response.id,
+            Self::WriteFile(response) | Self::Cancel(response) | Self::Shutdown(response) => {
+                response.id
+            }
             Self::ReadFile(response) => response.id,
             Self::Execute(response) => response.id,
         }
@@ -45,6 +62,7 @@ pub(crate) struct ShutdownRequest {
 pub(crate) struct WriteFileRequest {
     pub id: u64,
     pub path: String,
+    #[serde(with = "wire_bytes")]
     pub contents: Vec<u8>,
     pub mode: u32,
 }
@@ -70,6 +88,13 @@ pub(crate) struct ExecuteRequest {
 
 #[derive(Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub(crate) struct CancelRequest {
+    pub id: u64,
+    pub target_id: u64,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ControlResponse {
     pub id: u64,
     pub error: Option<String>,
@@ -79,6 +104,7 @@ pub(crate) struct ControlResponse {
 #[serde(deny_unknown_fields)]
 pub(crate) struct ReadFileResponse {
     pub id: u64,
+    #[serde(default, with = "optional_wire_bytes")]
     pub contents: Option<Vec<u8>>,
     pub error: Option<String>,
 }
@@ -88,11 +114,61 @@ pub(crate) struct ReadFileResponse {
 pub(crate) struct ExecuteResponse {
     pub id: u64,
     pub exit_code: Option<i32>,
+    #[serde(default, with = "optional_wire_bytes")]
     pub stdout: Option<Vec<u8>>,
+    #[serde(default, with = "optional_wire_bytes")]
     pub stderr: Option<Vec<u8>>,
     pub error: Option<String>,
     pub timed_out: bool,
     pub output_limit_exceeded: bool,
+}
+
+mod wire_bytes {
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+    use serde::{Deserialize, Deserializer, Serializer, de::Error as _};
+
+    pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&STANDARD.encode(bytes))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let encoded = String::deserialize(deserializer)?;
+        STANDARD.decode(encoded).map_err(D::Error::custom)
+    }
+}
+
+mod optional_wire_bytes {
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+    use serde::{Deserialize, Deserializer, Serializer, de::Error as _};
+
+    #[allow(
+        clippy::ref_option,
+        reason = "serde's `with` module contract passes the field by reference"
+    )]
+    pub fn serialize<S>(bytes: &Option<Vec<u8>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match bytes {
+            Some(bytes) => serializer.serialize_some(&STANDARD.encode(bytes)),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<u8>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<String>::deserialize(deserializer)?
+            .map(|encoded| STANDARD.decode(encoded).map_err(D::Error::custom))
+            .transpose()
+    }
 }
 
 #[derive(Deserialize, Serialize)]
@@ -118,6 +194,7 @@ mod tests {
 
     use super::{
         SessionRequest, ShutdownRequest, ToolRequest, ToolResponse, WireToolContext, WireToolInput,
+        WriteFileRequest,
     };
 
     #[test]
@@ -165,6 +242,25 @@ mod tests {
         let encoded = serde_json::to_string(&response).unwrap();
         let decoded = serde_json::from_str::<ToolResponse>(&encoded).unwrap();
         assert_eq!(decoded.id, 8);
+    }
+
+    #[test]
+    fn binary_control_payloads_use_bounded_base64_strings() {
+        let request = SessionRequest::WriteFile(WriteFileRequest {
+            id: 4,
+            path: "/tmp/output".to_owned(),
+            contents: vec![0, 127, 128, 255],
+            mode: 0o600,
+        });
+        let encoded = serde_json::to_string(&request).unwrap();
+
+        assert!(encoded.contains(r#""contents":"AH+A/w==""#));
+        assert!(!encoded.contains(r#""contents":[0,127,128,255]"#));
+        let decoded = serde_json::from_str::<SessionRequest>(&encoded).unwrap();
+        let SessionRequest::WriteFile(decoded) = decoded else {
+            panic!("write-file request changed variants");
+        };
+        assert_eq!(decoded.contents, [0, 127, 128, 255]);
     }
 }
 

--- a/crates/nanocodex-vm/src/session.rs
+++ b/crates/nanocodex-vm/src/session.rs
@@ -24,9 +24,9 @@ use tracing::{Instrument, Span, info, info_span};
 use crate::{
     VmToolClient,
     protocol::{
-        ControlResponse, ExecuteRequest, ExecuteResponse, ReadFileRequest, ReadFileResponse,
-        SessionRequest, SessionResponse, ShutdownRequest, ToolRequest, WireToolContext,
-        WireToolInput, WriteFileRequest,
+        CancelRequest, ControlResponse, ExecuteRequest, ExecuteResponse, ReadFileRequest,
+        ReadFileResponse, SessionRequest, SessionResponse, ShutdownRequest, ToolRequest,
+        WireToolContext, WireToolInput, WriteFileRequest,
     },
 };
 
@@ -759,6 +759,30 @@ impl Drop for PendingRequestGuard {
             && let Some(inner) = self.inner.upgrade()
         {
             lock_unpoisoned(&inner.pending).requests.remove(&self.id);
+            queue_cancel(&inner, self.id);
+        }
+    }
+}
+
+fn queue_cancel(inner: &Arc<VmToolSessionInner>, target_id: u64) {
+    if inner.closing.load(Ordering::Acquire) {
+        return;
+    }
+    let id = inner.next_id.fetch_add(1, Ordering::Relaxed);
+    let request = SessionRequest::Cancel(CancelRequest { id, target_id });
+    let Ok(mut frame) = serde_json::to_vec(&request) else {
+        return;
+    };
+    frame.push(b'\n');
+    match inner.input.try_send(frame) {
+        Ok(()) | Err(mpsc::error::TrySendError::Closed(_)) => {}
+        Err(mpsc::error::TrySendError::Full(frame)) => {
+            let input = inner.input.clone();
+            if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+                runtime.spawn(async move {
+                    let _ = input.send(frame).await;
+                });
+            }
         }
     }
 }
@@ -871,6 +895,7 @@ fn set_request_id(request: &mut SessionRequest, id: u64) {
         SessionRequest::WriteFile(request) => request.id = id,
         SessionRequest::ReadFile(request) => request.id = id,
         SessionRequest::Execute(request) => request.id = id,
+        SessionRequest::Cancel(request) => request.id = id,
         SessionRequest::Shutdown(request) => request.id = id,
     }
 }
@@ -1115,12 +1140,12 @@ mod tracing_tests {
     }
 
     #[test]
-    fn next_request_discards_a_cancelled_requests_late_response() {
+    fn cancelled_request_sends_targeted_guest_cancellation() {
         let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
-        let first = r#"{"kind":"write_file","payload":{"id":0,"error":null}}"#;
-        let second = r#"{"kind":"write_file","payload":{"id":1,"error":null}}"#;
+        let cancel = r#"{"kind":"cancel","payload":{"id":1,"error":null}}"#;
+        let second = r#"{"kind":"write_file","payload":{"id":2,"error":null}}"#;
         let script = format!(
-            "IFS= read -r first\nsleep 0.05\nprintf '%s\\n' '{first}'\nIFS= read -r second\nprintf '%s\\n' '{second}'"
+            "IFS= read -r first\nIFS= read -r cancel\nprintf '%s\\n' '{cancel}'\nIFS= read -r second\nprintf '%s\\n' '{second}'"
         );
         let mut command = tokio::process::Command::new("/bin/sh");
         command.arg("-c").arg(script);
@@ -1177,10 +1202,10 @@ mod tracing_tests {
     #[test]
     fn cancelled_partial_write_cannot_corrupt_the_next_request() {
         let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
-        let first = r#"{"kind":"write_file","payload":{"id":0,"error":null}}"#;
-        let second = r#"{"kind":"write_file","payload":{"id":1,"error":null}}"#;
+        let cancel = r#"{"kind":"cancel","payload":{"id":1,"error":null}}"#;
+        let second = r#"{"kind":"write_file","payload":{"id":2,"error":null}}"#;
         let script = format!(
-            "sleep 0.05\nIFS= read -r first\nprintf '%s\\n' '{first}'\nIFS= read -r second\nprintf '%s\\n' '{second}'"
+            "sleep 0.05\nIFS= read -r first\nIFS= read -r cancel\nprintf '%s\\n' '{cancel}'\nIFS= read -r second\nprintf '%s\\n' '{second}'"
         );
         let mut command = tokio::process::Command::new("/bin/sh");
         command.arg("-c").arg(script);

--- a/crates/nanocodex-vm/src/session.rs
+++ b/crates/nanocodex-vm/src/session.rs
@@ -1,13 +1,18 @@
 use std::{
+    collections::HashMap,
     path::{Path, PathBuf},
     process::{ExitStatus, Stdio},
-    sync::Arc,
+    sync::{
+        Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard, Weak,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
     time::{Duration, Instant},
 };
 
 use nanocodex_tools::{
     StandardTool, ToolContext, ToolExecution, ToolInput, ToolResult, ToolRuntime,
 };
+use nanovm::EgressLease;
 use nix::{
     errno::Errno,
     sys::signal::{Signal, killpg},
@@ -15,9 +20,10 @@ use nix::{
 };
 use thiserror::Error;
 use tokio::{
-    io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader, Lines},
+    io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader},
     process::{Child, ChildStdin, ChildStdout, Command},
-    sync::Mutex,
+    sync::{Mutex, oneshot},
+    task::JoinSet,
 };
 use tracing::{Instrument, Span, info, info_span};
 
@@ -104,8 +110,8 @@ pub enum VmToolSessionError {
     #[error("the VM tool console closed before replying")]
     Closed,
 
-    #[error("VM tool response {actual} did not match request {expected}")]
-    ResponseId { expected: u64, actual: u64 },
+    #[error("VM tool response router failed: {0}")]
+    Router(String),
 
     #[error("guest tool execution failed: {0}")]
     Guest(String),
@@ -121,24 +127,55 @@ pub enum VmToolSessionError {
 
     #[error("the VMM exited unsuccessfully after guest shutdown: {0}")]
     VmmExit(ExitStatus),
+
+    #[error("egress was already provisioned for this VM session")]
+    EgressAlreadyProvisioned,
+
+    #[error("egress guest file path is not valid UTF-8: {0}")]
+    EgressFilePath(PathBuf),
 }
 
-/// One persistent VMM child carrying workspace tool calls over its console.
-#[derive(Clone)]
+/// Owner of one persistent VMM child carrying workspace tool calls.
+///
+/// Keep this value alive for the complete root-agent tree. Clone
+/// [`VmToolSessionHandle`] or [`crate::VmTools`] into each driver's tool
+/// factory; all of those handles route to this one VM.
 pub struct VmToolSession {
+    handle: VmToolSessionHandle,
+    egress: Option<EgressLease>,
+}
+
+/// Clone-cheap capability for sending workspace tool calls to one owned VM.
+#[derive(Clone)]
+pub struct VmToolSessionHandle {
     inner: Arc<VmToolSessionInner>,
 }
 
 struct VmToolSessionInner {
     spawned_at: Instant,
-    state: Mutex<SessionState>,
+    next_id: AtomicU64,
+    closing: AtomicBool,
+    input: Mutex<Option<ChildStdin>>,
+    output: Mutex<Option<ChildStdout>>,
+    pending: StdMutex<PendingState>,
+    child: StdMutex<Option<Child>>,
 }
 
-struct SessionState {
-    child: Child,
-    input: ChildStdin,
-    output: Lines<BufReader<ChildStdout>>,
-    next_id: u64,
+#[derive(Default)]
+struct PendingState {
+    closed: Option<String>,
+    requests: HashMap<u64, PendingResponse>,
+}
+
+struct PendingResponse {
+    span: Span,
+    response: oneshot::Sender<Result<(SessionResponse, usize), String>>,
+}
+
+struct PendingRequestGuard {
+    inner: Weak<VmToolSessionInner>,
+    id: u64,
+    armed: bool,
 }
 
 impl VmToolSession {
@@ -193,21 +230,157 @@ impl VmToolSession {
                 .take()
                 .ok_or(VmToolSessionError::MissingPipe("stdout"))?;
             Ok(Self {
-                inner: Arc::new(VmToolSessionInner {
-                    spawned_at: Instant::now(),
-                    state: Mutex::new(SessionState {
-                        child,
-                        input,
-                        output: BufReader::new(output).lines(),
-                        next_id: 0,
+                handle: VmToolSessionHandle {
+                    inner: Arc::new(VmToolSessionInner {
+                        spawned_at: Instant::now(),
+                        next_id: AtomicU64::new(0),
+                        closing: AtomicBool::new(false),
+                        input: Mutex::new(Some(input)),
+                        output: Mutex::new(Some(output)),
+                        pending: StdMutex::new(PendingState::default()),
+                        child: StdMutex::new(Some(child)),
                     }),
-                }),
+                },
+                egress: None,
             })
         });
         record_vm_result(&span, started_at, &result);
         result
     }
 
+    /// Returns a clone-cheap capability for this session.
+    #[must_use]
+    pub fn handle(&self) -> VmToolSessionHandle {
+        self.handle.clone()
+    }
+
+    /// Returns the standard VM-backed workspace tool factory for this session.
+    #[must_use]
+    pub fn tools(&self) -> crate::VmTools {
+        crate::VmTools::new(self.handle())
+    }
+
+    /// Provisions provider-owned public files and retains the complete egress
+    /// lease for the lifetime of this VM session.
+    ///
+    /// Call this exactly once, after spawning the VMM and before exposing tool
+    /// handles to an agent. The same lease must already have been applied to
+    /// the VM configuration and guest command with [`EgressLease::configure`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when egress was already provisioned, a guest path is
+    /// not UTF-8, or the guest rejects a file write.
+    pub async fn provision_egress(
+        &mut self,
+        egress: EgressLease,
+    ) -> Result<(), VmToolSessionError> {
+        if self.egress.is_some() {
+            return Err(VmToolSessionError::EgressAlreadyProvisioned);
+        }
+        let files = egress.guest_files().cloned().collect::<Vec<_>>();
+        // Retain revocable provider state even when provisioning fails. The
+        // session remains deliberately non-retryable and dropping its owner
+        // tears down both the VMM and the incomplete lease.
+        self.egress = Some(egress);
+        for file in files {
+            let path = file
+                .guest_path()
+                .to_str()
+                .ok_or_else(|| VmToolSessionError::EgressFilePath(file.guest_path().to_owned()))?;
+            self.write_file(path, file.contents().to_vec(), file.mode())
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Writes one harness-owned file into the guest after the agent phase.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the console closes, file creation fails in the
+    /// guest, or the typed response is invalid.
+    pub async fn write_file(
+        &self,
+        path: impl Into<String>,
+        contents: Vec<u8>,
+        mode: u32,
+    ) -> Result<(), VmToolSessionError> {
+        self.handle.write_file(path, contents, mode).await
+    }
+
+    /// Reads one result artifact from the guest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the console closes, the file cannot be read, or
+    /// the typed response is invalid.
+    pub async fn read_file(&self, path: impl Into<String>) -> Result<Vec<u8>, VmToolSessionError> {
+        self.handle.read_file(path).await
+    }
+
+    /// Executes a trusted evaluation-harness command in the guest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the console closes, the command cannot run or
+    /// exceeds its deadline, or the typed response is invalid.
+    pub async fn command(&self, command: VmCommand) -> Result<VmCommandOutput, VmToolSessionError> {
+        self.handle.command(command).await
+    }
+
+    /// Flushes guest filesystems and waits for the VMM process to exit.
+    ///
+    /// Consuming the owner prevents a cloned tool capability from shutting
+    /// down the VM while another driver in the same agent tree is using it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the guest cannot acknowledge the request, the
+    /// VMM does not stop promptly, or it exits unsuccessfully.
+    pub async fn shutdown(self) -> Result<(), VmToolSessionError> {
+        self.handle.inner.closing.store(true, Ordering::Release);
+        let response = self
+            .handle
+            .control_request_inner(|id| SessionRequest::Shutdown(ShutdownRequest { id }), true)
+            .await?;
+        let SessionResponse::Shutdown(response) = response else {
+            return Err(VmToolSessionError::Protocol("expected a shutdown response"));
+        };
+        control_result(response)?;
+        self.handle.inner.input.lock().await.take();
+
+        let child = lock_unpoisoned(&self.handle.inner.child).take();
+        let Some(mut child) = child else {
+            return Err(VmToolSessionError::Closed);
+        };
+        let status = if let Ok(status) = tokio::time::timeout(SHUTDOWN_TIMEOUT, child.wait()).await
+        {
+            status?
+        } else {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            return Err(VmToolSessionError::ShutdownTimeout(SHUTDOWN_TIMEOUT));
+        };
+        close_pending(&self.handle.inner, "VM session shut down");
+        if !status.success() {
+            return Err(VmToolSessionError::VmmExit(status));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for VmToolSession {
+    fn drop(&mut self) {
+        self.handle.inner.closing.store(true, Ordering::Release);
+        close_pending(&self.handle.inner, "VM session owner was dropped");
+        if let Some(child) = lock_unpoisoned(&self.handle.inner.child).as_mut() {
+            let _ = child.start_kill();
+        }
+    }
+}
+
+impl VmToolSessionHandle {
     async fn request(
         &self,
         tool: StandardTool,
@@ -260,15 +433,8 @@ impl VmToolSession {
         context: ToolContext<'_>,
         span: &tracing::Span,
     ) -> Result<ToolExecution, VmToolSessionError> {
-        let queued_at = Instant::now();
-        let mut state = self.inner.state.lock().await;
-        span.record("rpc.queue.duration_ns", elapsed_ns(queued_at));
-        let id = state.next_id;
-        state.next_id = state.next_id.wrapping_add(1);
-        span.record("rpc.request.id", id);
-        span.record("vm.session.first_call", id == 0);
         let request = SessionRequest::Tool(ToolRequest {
-            id,
+            id: 0,
             tool,
             input: WireToolInput::from(input),
             context: WireToolContext {
@@ -278,14 +444,7 @@ impl VmToolSession {
                 output_token_budget: context.output_token_budget,
             },
         });
-        let encoded = serde_json::to_string(&request)?;
-        span.record("rpc.request.bytes", encoded.len());
-        record_vm_content(span, "tool.request", &encoded);
-        state.input.write_all(encoded.as_bytes()).await?;
-        state.input.write_all(b"\n").await?;
-        state.input.flush().await?;
-
-        let (response, response_bytes) = read_response(&mut state, id, span).await?;
+        let (response, response_bytes) = self.send_request(request, span, false).await?;
         span.record("rpc.response.bytes", response_bytes);
         span.record("vm.session.age_ns", elapsed_ns(self.inner.spawned_at));
         let SessionResponse::Tool(response) = response else {
@@ -300,12 +459,12 @@ impl VmToolSession {
         }
     }
 
-    /// Writes one harness-owned file into the guest after the agent phase.
+    /// Writes one harness-owned file into the guest.
     ///
     /// # Errors
     ///
-    /// Returns an error when the console closes, file creation fails in the
-    /// guest, or the typed response is invalid.
+    /// Returns an error when the session is closed, guest file creation fails,
+    /// or the response is invalid.
     pub async fn write_file(
         &self,
         path: impl Into<String>,
@@ -330,12 +489,12 @@ impl VmToolSession {
         control_result(response)
     }
 
-    /// Reads one result artifact from the guest.
+    /// Reads one harness-owned result artifact from the guest.
     ///
     /// # Errors
     ///
-    /// Returns an error when the console closes, the file cannot be read, or
-    /// the typed response is invalid.
+    /// Returns an error when the session is closed, the file cannot be read,
+    /// or the response is invalid.
     pub async fn read_file(&self, path: impl Into<String>) -> Result<Vec<u8>, VmToolSessionError> {
         let response = self
             .control_request(|id| {
@@ -362,12 +521,12 @@ impl VmToolSession {
         }
     }
 
-    /// Executes a trusted evaluation-harness command in the guest.
+    /// Executes one trusted harness command in the guest.
     ///
     /// # Errors
     ///
-    /// Returns an error when the console closes, the command cannot run or
-    /// exceeds its deadline, or the typed response is invalid.
+    /// Returns an error when the session is closed, the command fails to
+    /// start, exceeds its deadline, or returns an invalid response.
     pub async fn command(&self, command: VmCommand) -> Result<VmCommandOutput, VmToolSessionError> {
         let command_timeout = command.timeout;
         let timeout_millis = u64::try_from(command_timeout.as_millis()).unwrap_or(u64::MAX);
@@ -410,82 +569,178 @@ impl VmToolSession {
         }
     }
 
-    /// Flushes guest filesystems and waits for the VMM process to exit.
-    ///
-    /// No tool or control request may be sent through this session after a
-    /// successful shutdown.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error when the guest cannot acknowledge the request, the
-    /// VMM does not stop promptly, or it exits unsuccessfully.
-    pub async fn shutdown(&self) -> Result<(), VmToolSessionError> {
-        let response = self
-            .control_request(|id| SessionRequest::Shutdown(ShutdownRequest { id }))
-            .await?;
-        let SessionResponse::Shutdown(response) = response else {
-            return Err(VmToolSessionError::Protocol("expected a shutdown response"));
-        };
-        control_result(response)?;
-
-        let mut state = self.inner.state.lock().await;
-        let status = tokio::time::timeout(SHUTDOWN_TIMEOUT, state.child.wait())
-            .await
-            .map_err(|_| VmToolSessionError::ShutdownTimeout(SHUTDOWN_TIMEOUT))??;
-        if !status.success() {
-            return Err(VmToolSessionError::VmmExit(status));
-        }
-        Ok(())
-    }
-
     async fn control_request(
         &self,
         make_request: impl FnOnce(u64) -> SessionRequest,
     ) -> Result<SessionResponse, VmToolSessionError> {
-        let mut state = self.inner.state.lock().await;
-        let id = state.next_id;
-        state.next_id = state.next_id.wrapping_add(1);
-        let encoded = serde_json::to_string(&make_request(id))?;
-        state.input.write_all(encoded.as_bytes()).await?;
-        state.input.write_all(b"\n").await?;
-        state.input.flush().await?;
-        let (response, _) = read_response(&mut state, id, &Span::current()).await?;
+        self.control_request_inner(make_request, false).await
+    }
+
+    async fn control_request_inner(
+        &self,
+        make_request: impl FnOnce(u64) -> SessionRequest,
+        allow_closing: bool,
+    ) -> Result<SessionResponse, VmToolSessionError> {
+        let response = self
+            .send_request(make_request(0), &Span::current(), allow_closing)
+            .await?
+            .0;
         Ok(response)
+    }
+
+    async fn send_request(
+        &self,
+        mut request: SessionRequest,
+        span: &Span,
+        allow_closing: bool,
+    ) -> Result<(SessionResponse, usize), VmToolSessionError> {
+        if self.inner.closing.load(Ordering::Acquire) && !allow_closing {
+            return Err(VmToolSessionError::Closed);
+        }
+        self.ensure_reader().await?;
+        let id = self.inner.next_id.fetch_add(1, Ordering::Relaxed);
+        set_request_id(&mut request, id);
+        span.record("rpc.request.id", id);
+        span.record("vm.session.first_call", id == 0);
+        let encoded = serde_json::to_string(&request)?;
+        span.record("rpc.request.bytes", encoded.len());
+        record_vm_content(span, "tool.request", &encoded);
+
+        let (sender, receiver) = oneshot::channel();
+        {
+            let mut pending = lock_unpoisoned(&self.inner.pending);
+            if let Some(error) = &pending.closed {
+                return Err(VmToolSessionError::Router(error.clone()));
+            }
+            pending.requests.insert(
+                id,
+                PendingResponse {
+                    span: span.clone(),
+                    response: sender,
+                },
+            );
+        }
+        let mut guard = PendingRequestGuard {
+            inner: Arc::downgrade(&self.inner),
+            id,
+            armed: true,
+        };
+        let queued_at = Instant::now();
+        let write_result = async {
+            let mut input = self.inner.input.lock().await;
+            span.record("rpc.queue.duration_ns", elapsed_ns(queued_at));
+            let input = input.as_mut().ok_or(VmToolSessionError::Closed)?;
+            input.write_all(encoded.as_bytes()).await?;
+            input.write_all(b"\n").await?;
+            input.flush().await?;
+            Ok::<_, VmToolSessionError>(())
+        }
+        .await;
+        write_result?;
+        let response = receiver.await.map_err(|_| VmToolSessionError::Closed)?;
+        guard.armed = false;
+        response.map_err(VmToolSessionError::Router)
+    }
+
+    async fn ensure_reader(&self) -> Result<(), VmToolSessionError> {
+        let mut output = self.inner.output.lock().await;
+        if let Some(output) = output.take() {
+            let inner = Arc::downgrade(&self.inner);
+            tokio::spawn(async move {
+                route_responses(output, inner).await;
+            });
+            return Ok(());
+        }
+        let pending = lock_unpoisoned(&self.inner.pending);
+        match &pending.closed {
+            Some(error) => Err(VmToolSessionError::Router(error.clone())),
+            None => Ok(()),
+        }
     }
 }
 
-async fn read_response(
-    state: &mut SessionState,
-    expected_id: u64,
-    span: &Span,
-) -> Result<(SessionResponse, usize), VmToolSessionError> {
-    let mut response_bytes = 0_usize;
-    loop {
-        let line = state
-            .output
-            .next_line()
-            .await?
-            .ok_or(VmToolSessionError::Closed)?;
-        response_bytes = response_bytes.saturating_add(line.len());
-        record_vm_content(span, "tool.response", &line);
-        let response = serde_json::from_str::<SessionResponse>(&line)?;
-        let actual_id = response.id();
-        if actual_id == expected_id {
-            return Ok((response, response_bytes));
+impl Drop for PendingRequestGuard {
+    fn drop(&mut self) {
+        if self.armed
+            && let Some(inner) = self.inner.upgrade()
+        {
+            lock_unpoisoned(&inner.pending).requests.remove(&self.id);
         }
-        if actual_id < expected_id {
+    }
+}
+
+async fn route_responses(output: ChildStdout, inner: Weak<VmToolSessionInner>) {
+    let mut lines = BufReader::new(output).lines();
+    loop {
+        let line = match lines.next_line().await {
+            Ok(Some(line)) => line,
+            Ok(None) => {
+                if let Some(inner) = inner.upgrade() {
+                    close_pending(&inner, "VM tool console closed");
+                }
+                return;
+            }
+            Err(error) => {
+                if let Some(inner) = inner.upgrade() {
+                    close_pending(&inner, &format!("VM tool console read failed: {error}"));
+                }
+                return;
+            }
+        };
+        let response = match serde_json::from_str::<SessionResponse>(&line) {
+            Ok(response) => response,
+            Err(error) => {
+                if let Some(inner) = inner.upgrade() {
+                    close_pending(&inner, &format!("invalid VM tool response: {error}"));
+                }
+                return;
+            }
+        };
+        let Some(inner) = inner.upgrade() else {
+            return;
+        };
+        let id = response.id();
+        let pending = lock_unpoisoned(&inner.pending).requests.remove(&id);
+        if let Some(pending) = pending {
+            record_vm_content(&pending.span, "tool.response", &line);
+            let _ = pending.response.send(Ok((response, line.len())));
+        } else {
             info!(
                 target: "nanocodex_vm",
-                rpc_request_id = expected_id,
-                rpc_response_id = actual_id,
-                "discarded response for a cancelled VM tool request"
+                rpc_response_id = id,
+                "discarded response for a cancelled VM request"
             );
-            continue;
         }
-        return Err(VmToolSessionError::ResponseId {
-            expected: expected_id,
-            actual: actual_id,
-        });
+    }
+}
+
+fn set_request_id(request: &mut SessionRequest, id: u64) {
+    match request {
+        SessionRequest::Tool(request) => request.id = id,
+        SessionRequest::WriteFile(request) => request.id = id,
+        SessionRequest::ReadFile(request) => request.id = id,
+        SessionRequest::Execute(request) => request.id = id,
+        SessionRequest::Shutdown(request) => request.id = id,
+    }
+}
+
+fn close_pending(inner: &VmToolSessionInner, message: &str) {
+    let requests = {
+        let mut pending = lock_unpoisoned(&inner.pending);
+        if pending.closed.is_none() {
+            pending.closed = Some(message.to_owned());
+        }
+        std::mem::take(&mut pending.requests)
+    };
+    for (_, request) in requests {
+        let _ = request.response.send(Err(message.to_owned()));
+    }
+}
+
+fn lock_unpoisoned<T>(mutex: &StdMutex<T>) -> StdMutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
     }
 }
 
@@ -548,7 +803,7 @@ fn elapsed_ns(started_at: Instant) -> u64 {
 }
 
 #[async_trait::async_trait]
-impl VmToolClient for VmToolSession {
+impl VmToolClient for VmToolSessionHandle {
     async fn execute(
         &self,
         tool: StandardTool,
@@ -562,58 +817,110 @@ impl VmToolClient for VmToolSession {
 }
 
 pub(crate) async fn serve_guest(workspace: &Path) -> Result<(), VmToolSessionError> {
-    let runtime = ToolRuntime::new(workspace, None, None);
-    let input = tokio::io::stdin();
+    serve_guest_io(workspace, tokio::io::stdin(), tokio::io::stdout()).await
+}
+
+const MAX_IN_FLIGHT_GUEST_REQUESTS: usize = 64;
+
+async fn serve_guest_io(
+    workspace: &Path,
+    input: impl AsyncRead + Unpin,
+    mut output: impl tokio::io::AsyncWrite + Unpin,
+) -> Result<(), VmToolSessionError> {
+    let runtime = Arc::new(ToolRuntime::new(workspace, None, None));
     let mut lines = BufReader::new(input).lines();
-    let mut output = tokio::io::stdout();
-    while let Some(line) = lines.next_line().await? {
-        let request = serde_json::from_str::<SessionRequest>(&line)?;
-        let (response, shutdown) = match request {
-            SessionRequest::Tool(request) => {
-                let context = ToolContext {
-                    model: &request.context.model,
-                    session_id: &request.context.session_id,
-                    call_id: &request.context.call_id,
-                    history: &[],
-                    output_token_budget: request.context.output_token_budget,
-                };
-                let execution = runtime
-                    .execute_tool(request.tool.name(), request.input.into(), context)
-                    .await;
-                (
-                    SessionResponse::Tool(match execution.into_wire() {
-                        Ok(execution) => ToolResponse::completed(request.id, execution),
-                        Err(error) => ToolResponse::failed(request.id, error.to_string()),
-                    }),
-                    false,
-                )
+    let mut requests = JoinSet::new();
+    let mut accepting = true;
+    let mut shutdown = None;
+
+    let result = async {
+        while accepting || !requests.is_empty() {
+            tokio::select! {
+                joined = requests.join_next(), if !requests.is_empty() => {
+                    let response = joined
+                        .ok_or(VmToolSessionError::Closed)?
+                        .map_err(|error| VmToolSessionError::Guest(error.to_string()))?;
+                    write_guest_response(&mut output, &response).await?;
+                }
+                line = lines.next_line(),
+                    if accepting && requests.len() < MAX_IN_FLIGHT_GUEST_REQUESTS =>
+                {
+                    let Some(line) = line? else {
+                        accepting = false;
+                        continue;
+                    };
+                    match serde_json::from_str::<SessionRequest>(&line)? {
+                        SessionRequest::Shutdown(request) => {
+                            shutdown = Some(request);
+                            accepting = false;
+                        }
+                        request => {
+                            let runtime = Arc::clone(&runtime);
+                            requests.spawn(async move {
+                                execute_guest_request(runtime, request).await
+                            });
+                        }
+                    }
+                }
             }
-            SessionRequest::WriteFile(request) => (
-                SessionResponse::WriteFile(write_guest_file(request).await),
-                false,
-            ),
-            SessionRequest::ReadFile(request) => (
-                SessionResponse::ReadFile(read_guest_file(request).await),
-                false,
-            ),
-            SessionRequest::Execute(request) => (
-                SessionResponse::Execute(execute_guest_command(request).await),
-                false,
-            ),
-            SessionRequest::Shutdown(request) => {
-                let response = sync_guest_filesystems(request).await;
-                let shutdown = response.error.is_none();
-                (SessionResponse::Shutdown(response), shutdown)
-            }
-        };
-        let mut encoded = serde_json::to_vec(&response)?;
-        encoded.push(b'\n');
-        output.write_all(&encoded).await?;
-        output.flush().await?;
-        if shutdown {
-            return Ok(());
         }
+        Ok::<_, VmToolSessionError>(shutdown)
     }
+    .await;
+
+    runtime.control().cancel().await;
+    if let Some(request) = result? {
+        let response = SessionResponse::Shutdown(sync_guest_filesystems(request).await);
+        write_guest_response(&mut output, &response).await?;
+    }
+    Ok(())
+}
+
+async fn execute_guest_request(
+    runtime: Arc<ToolRuntime>,
+    request: SessionRequest,
+) -> SessionResponse {
+    match request {
+        SessionRequest::Tool(request) => {
+            let context = ToolContext {
+                model: &request.context.model,
+                session_id: &request.context.session_id,
+                call_id: &request.context.call_id,
+                history: &[],
+                output_token_budget: request.context.output_token_budget,
+            };
+            let execution = runtime
+                .execute_tool(request.tool.name(), request.input.into(), context)
+                .await;
+            SessionResponse::Tool(match execution.into_wire() {
+                Ok(execution) => ToolResponse::completed(request.id, execution),
+                Err(error) => ToolResponse::failed(request.id, error.to_string()),
+            })
+        }
+        SessionRequest::WriteFile(request) => {
+            SessionResponse::WriteFile(write_guest_file(request).await)
+        }
+        SessionRequest::ReadFile(request) => {
+            SessionResponse::ReadFile(read_guest_file(request).await)
+        }
+        SessionRequest::Execute(request) => {
+            SessionResponse::Execute(execute_guest_command(request).await)
+        }
+        SessionRequest::Shutdown(request) => SessionResponse::Shutdown(ControlResponse {
+            id: request.id,
+            error: Some("shutdown cannot be dispatched as a concurrent request".to_owned()),
+        }),
+    }
+}
+
+async fn write_guest_response(
+    output: &mut (impl tokio::io::AsyncWrite + Unpin),
+    response: &SessionResponse,
+) -> Result<(), VmToolSessionError> {
+    let mut encoded = serde_json::to_vec(response)?;
+    encoded.push(b'\n');
+    output.write_all(&encoded).await?;
+    output.flush().await?;
     Ok(())
 }
 
@@ -777,6 +1084,8 @@ mod tracing_tests {
 
     use super::VmToolSession;
 
+    static TRACE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
     #[derive(Clone, Default)]
     struct TraceCapture {
         spans: Arc<Mutex<HashMap<u64, CapturedSpan>>>,
@@ -845,6 +1154,7 @@ mod tracing_tests {
 
     #[test]
     fn vm_rpc_is_timed_and_parented_to_the_calling_tool() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
         let response = r#"{"kind":"tool","payload":{"id":0,"execution":{"output":"ok","success":true,"code_mode_value":null,"metadata":null,"process_trace":null},"error":null}}"#;
         let script = format!("IFS= read -r request\nprintf '%s\\n' '{response}'");
         let mut command = tokio::process::Command::new("/bin/sh");
@@ -868,6 +1178,7 @@ mod tracing_tests {
                     output_token_budget: 1_000,
                 };
                 let execution = session
+                    .handle()
                     .request(
                         StandardTool::ExecCommand,
                         ToolInput::Function(to_raw_value(&json!({"cmd": "true"})).unwrap()),
@@ -905,6 +1216,7 @@ mod tracing_tests {
 
     #[test]
     fn next_request_discards_a_cancelled_requests_late_response() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
         let first = r#"{"kind":"write_file","payload":{"id":0,"error":null}}"#;
         let second = r#"{"kind":"write_file","payload":{"id":1,"error":null}}"#;
         let script = format!(
@@ -932,14 +1244,45 @@ mod tracing_tests {
                 .unwrap();
         });
     }
+
+    #[test]
+    fn concurrent_handles_multiplex_out_of_order_responses() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let first = r#"{"kind":"write_file","payload":{"id":1,"error":null}}"#;
+        let second = r#"{"kind":"write_file","payload":{"id":0,"error":null}}"#;
+        let script =
+            format!("IFS= read -r first\nIFS= read -r second\nprintf '%s\\n' '{first}' '{second}'");
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg(script);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let session = VmToolSession::spawn(&mut command).unwrap();
+            let completed = tokio::time::timeout(Duration::from_secs(1), async {
+                tokio::join!(
+                    session.write_file("/first", Vec::new(), 0o600),
+                    session.write_file("/second", Vec::new(), 0o600),
+                )
+            })
+            .await
+            .expect("both requests should be written before either response");
+            completed.0.unwrap();
+            completed.1.unwrap();
+        });
+    }
 }
 
 #[cfg(test)]
 mod guest_command_tests {
     use std::time::{Duration, Instant};
 
-    use super::execute_guest_command;
-    use crate::protocol::ExecuteRequest;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    use super::{execute_guest_command, serve_guest_io};
+    use crate::protocol::{ExecuteRequest, SessionRequest, SessionResponse, ShutdownRequest};
 
     #[tokio::test]
     async fn timeout_kills_descendants_holding_output_pipes() {
@@ -957,5 +1300,64 @@ mod guest_command_tests {
         assert!(response.timed_out);
         assert!(response.error.is_none());
         assert!(started_at.elapsed() < Duration::from_secs(1));
+    }
+
+    #[tokio::test]
+    async fn guest_dispatches_independent_requests_concurrently() {
+        let workspace = tempfile::tempdir().unwrap();
+        let marker = workspace.path().join("second-started");
+        let (host, guest) = tokio::io::duplex(64 * 1024);
+        let (host_read, mut host_write) = tokio::io::split(host);
+        let (guest_read, guest_write) = tokio::io::split(guest);
+        let guest_task = tokio::spawn({
+            let workspace = workspace.path().to_owned();
+            async move { serve_guest_io(&workspace, guest_read, guest_write).await }
+        });
+
+        let requests = [
+            SessionRequest::Execute(ExecuteRequest {
+                id: 0,
+                program: "/bin/sh".to_owned(),
+                arguments: vec![
+                    "-c".to_owned(),
+                    format!("while [ ! -f '{}' ]; do sleep 0.01; done", marker.display()),
+                ],
+                current_directory: workspace.path().to_string_lossy().into_owned(),
+                environment: Vec::new(),
+                timeout_millis: 5_000,
+            }),
+            SessionRequest::Execute(ExecuteRequest {
+                id: 1,
+                program: "/usr/bin/touch".to_owned(),
+                arguments: vec![marker.to_string_lossy().into_owned()],
+                current_directory: workspace.path().to_string_lossy().into_owned(),
+                environment: Vec::new(),
+                timeout_millis: 5_000,
+            }),
+            SessionRequest::Shutdown(ShutdownRequest { id: 2 }),
+        ];
+        for request in requests {
+            host_write
+                .write_all(&serde_json::to_vec(&request).unwrap())
+                .await
+                .unwrap();
+            host_write.write_all(b"\n").await.unwrap();
+        }
+        drop(host_write);
+
+        let mut responses = BufReader::new(host_read).lines();
+        let mut first_succeeded = false;
+        for _ in 0..3 {
+            let line = responses.next_line().await.unwrap().unwrap();
+            if let SessionResponse::Execute(response) =
+                serde_json::from_str::<SessionResponse>(&line).unwrap()
+                && response.id == 0
+            {
+                first_succeeded = !response.timed_out && response.error.is_none();
+            }
+        }
+        guest_task.await.unwrap().unwrap();
+        assert!(first_succeeded);
+        assert!(marker.is_file());
     }
 }

--- a/crates/nanocodex-vm/src/session.rs
+++ b/crates/nanocodex-vm/src/session.rs
@@ -1,0 +1,961 @@
+use std::{
+    path::{Path, PathBuf},
+    process::{ExitStatus, Stdio},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use nanocodex_tools::{
+    StandardTool, ToolContext, ToolExecution, ToolInput, ToolResult, ToolRuntime,
+};
+use nix::{
+    errno::Errno,
+    sys::signal::{Signal, killpg},
+    unistd::Pid,
+};
+use thiserror::Error;
+use tokio::{
+    io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader, Lines},
+    process::{Child, ChildStdin, ChildStdout, Command},
+    sync::Mutex,
+};
+use tracing::{Instrument, Span, info, info_span};
+
+use crate::{
+    VmToolClient,
+    protocol::{
+        ControlResponse, ExecuteRequest, ExecuteResponse, ReadFileRequest, ReadFileResponse,
+        SessionRequest, SessionResponse, ShutdownRequest, ToolRequest, ToolResponse,
+        WireToolContext, WireToolInput, WriteFileRequest,
+    },
+};
+
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// One trusted command executed by the evaluation harness inside the guest.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VmCommand {
+    program: String,
+    arguments: Vec<String>,
+    current_directory: String,
+    environment: Vec<(String, String)>,
+    timeout: Duration,
+}
+
+impl VmCommand {
+    #[must_use]
+    pub fn new(program: impl Into<String>) -> Self {
+        Self {
+            program: program.into(),
+            arguments: Vec::new(),
+            current_directory: "/".to_owned(),
+            environment: Vec::new(),
+            timeout: Duration::from_mins(1),
+        }
+    }
+
+    #[must_use]
+    pub fn arg(mut self, argument: impl Into<String>) -> Self {
+        self.arguments.push(argument.into());
+        self
+    }
+
+    #[must_use]
+    pub fn current_directory(mut self, directory: impl Into<String>) -> Self {
+        self.current_directory = directory.into();
+        self
+    }
+
+    #[must_use]
+    pub fn environment(mut self, environment: impl IntoIterator<Item = (String, String)>) -> Self {
+        self.environment.extend(environment);
+        self
+    }
+
+    #[must_use]
+    pub const fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+}
+
+/// Complete output from one trusted harness command in the guest.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VmCommandOutput {
+    pub exit_code: i32,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}
+
+#[derive(Debug, Error)]
+pub enum VmToolSessionError {
+    #[error("failed to spawn the VMM process: {0}")]
+    Spawn(#[source] std::io::Error),
+
+    #[error("the VMM process did not expose piped {0}")]
+    MissingPipe(&'static str),
+
+    #[error("VM tool console I/O failed: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("VM tool protocol JSON failed: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("the VM tool console closed before replying")]
+    Closed,
+
+    #[error("VM tool response {actual} did not match request {expected}")]
+    ResponseId { expected: u64, actual: u64 },
+
+    #[error("guest tool execution failed: {0}")]
+    Guest(String),
+
+    #[error("guest command exceeded {0:?}")]
+    GuestTimeout(Duration),
+
+    #[error("invalid VM tool response: {0}")]
+    Protocol(&'static str),
+
+    #[error("the VMM did not exit within {0:?} after guest shutdown")]
+    ShutdownTimeout(Duration),
+
+    #[error("the VMM exited unsuccessfully after guest shutdown: {0}")]
+    VmmExit(ExitStatus),
+}
+
+/// One persistent VMM child carrying workspace tool calls over its console.
+#[derive(Clone)]
+pub struct VmToolSession {
+    inner: Arc<VmToolSessionInner>,
+}
+
+struct VmToolSessionInner {
+    spawned_at: Instant,
+    state: Mutex<SessionState>,
+}
+
+struct SessionState {
+    child: Child,
+    input: ChildStdin,
+    output: Lines<BufReader<ChildStdout>>,
+    next_id: u64,
+}
+
+impl VmToolSession {
+    /// Spawns a VMM command whose guest process runs [`crate::serve_guest`].
+    ///
+    /// The command's stdin and stdout are reserved for the typed protocol;
+    /// stderr remains available for VMM and guest diagnostics.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the child or either protocol pipe cannot be
+    /// created.
+    pub fn spawn(command: &mut Command) -> Result<Self, VmToolSessionError> {
+        let program = command
+            .as_std()
+            .get_program()
+            .to_string_lossy()
+            .into_owned();
+        let command_content = format!("{:?}", command.as_std());
+        let argument_count = command.as_std().get_args().count();
+        let span = info_span!(
+            target: "nanocodex_vm",
+            "vm.session.spawn",
+            otel.kind = "internal",
+            otel.status_code = tracing::field::Empty,
+            process.executable.name = program.as_str(),
+            process.command_args.count = argument_count,
+            process.id = tracing::field::Empty,
+            status = tracing::field::Empty,
+            error.message = tracing::field::Empty,
+            duration_ns = tracing::field::Empty,
+        );
+        record_vm_content(&span, "vm.command", &command_content);
+        let started_at = Instant::now();
+        let result = span.in_scope(|| {
+            let mut child = command
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .kill_on_drop(true)
+                .spawn()
+                .map_err(VmToolSessionError::Spawn)?;
+            if let Some(process_id) = child.id() {
+                span.record("process.id", process_id);
+            }
+            let input = child
+                .stdin
+                .take()
+                .ok_or(VmToolSessionError::MissingPipe("stdin"))?;
+            let output = child
+                .stdout
+                .take()
+                .ok_or(VmToolSessionError::MissingPipe("stdout"))?;
+            Ok(Self {
+                inner: Arc::new(VmToolSessionInner {
+                    spawned_at: Instant::now(),
+                    state: Mutex::new(SessionState {
+                        child,
+                        input,
+                        output: BufReader::new(output).lines(),
+                        next_id: 0,
+                    }),
+                }),
+            })
+        });
+        record_vm_result(&span, started_at, &result);
+        result
+    }
+
+    async fn request(
+        &self,
+        tool: StandardTool,
+        input: ToolInput,
+        context: ToolContext<'_>,
+    ) -> Result<ToolExecution, VmToolSessionError> {
+        let (input_kind, input_bytes) = match &input {
+            ToolInput::Function(arguments) => ("function", arguments.get().len()),
+            ToolInput::Freeform(input) => ("freeform", input.len()),
+        };
+        let span = info_span!(
+            target: "nanocodex_vm",
+            "vm.tool.rpc",
+            otel.kind = "client",
+            otel.status_code = tracing::field::Empty,
+            rpc.system = "libkrun.console",
+            rpc.method = tool.name(),
+            tool.name = tool.name(),
+            session.id = context.session_id,
+            tool.call_id = context.call_id,
+            tool.input.kind = input_kind,
+            tool.input.bytes = input_bytes,
+            rpc.request.id = tracing::field::Empty,
+            rpc.request.bytes = tracing::field::Empty,
+            rpc.response.bytes = tracing::field::Empty,
+            rpc.queue.duration_ns = tracing::field::Empty,
+            vm.session.first_call = tracing::field::Empty,
+            vm.session.age_ns = tracing::field::Empty,
+            tool.success = tracing::field::Empty,
+            status = tracing::field::Empty,
+            error.message = tracing::field::Empty,
+            duration_ns = tracing::field::Empty,
+        );
+        let started_at = Instant::now();
+        let result = self
+            .request_inner(tool, input, context, &span)
+            .instrument(span.clone())
+            .await;
+        if let Ok(execution) = &result {
+            span.record("tool.success", execution.success);
+        }
+        record_vm_result(&span, started_at, &result);
+        result
+    }
+
+    async fn request_inner(
+        &self,
+        tool: StandardTool,
+        input: ToolInput,
+        context: ToolContext<'_>,
+        span: &tracing::Span,
+    ) -> Result<ToolExecution, VmToolSessionError> {
+        let queued_at = Instant::now();
+        let mut state = self.inner.state.lock().await;
+        span.record("rpc.queue.duration_ns", elapsed_ns(queued_at));
+        let id = state.next_id;
+        state.next_id = state.next_id.wrapping_add(1);
+        span.record("rpc.request.id", id);
+        span.record("vm.session.first_call", id == 0);
+        let request = SessionRequest::Tool(ToolRequest {
+            id,
+            tool,
+            input: WireToolInput::from(input),
+            context: WireToolContext {
+                model: context.model.to_owned(),
+                session_id: context.session_id.to_owned(),
+                call_id: context.call_id.to_owned(),
+                output_token_budget: context.output_token_budget,
+            },
+        });
+        let encoded = serde_json::to_string(&request)?;
+        span.record("rpc.request.bytes", encoded.len());
+        record_vm_content(span, "tool.request", &encoded);
+        state.input.write_all(encoded.as_bytes()).await?;
+        state.input.write_all(b"\n").await?;
+        state.input.flush().await?;
+
+        let (response, response_bytes) = read_response(&mut state, id, span).await?;
+        span.record("rpc.response.bytes", response_bytes);
+        span.record("vm.session.age_ns", elapsed_ns(self.inner.spawned_at));
+        let SessionResponse::Tool(response) = response else {
+            return Err(VmToolSessionError::Protocol("expected a tool response"));
+        };
+        match (response.execution, response.error) {
+            (Some(execution), None) => ToolExecution::from_wire(execution).map_err(Into::into),
+            (None, Some(error)) => Err(VmToolSessionError::Guest(error)),
+            _ => Err(VmToolSessionError::Protocol(
+                "expected exactly one of execution or error",
+            )),
+        }
+    }
+
+    /// Writes one harness-owned file into the guest after the agent phase.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the console closes, file creation fails in the
+    /// guest, or the typed response is invalid.
+    pub async fn write_file(
+        &self,
+        path: impl Into<String>,
+        contents: Vec<u8>,
+        mode: u32,
+    ) -> Result<(), VmToolSessionError> {
+        let response = self
+            .control_request(|id| {
+                SessionRequest::WriteFile(WriteFileRequest {
+                    id,
+                    path: path.into(),
+                    contents,
+                    mode,
+                })
+            })
+            .await?;
+        let SessionResponse::WriteFile(response) = response else {
+            return Err(VmToolSessionError::Protocol(
+                "expected a write-file response",
+            ));
+        };
+        control_result(response)
+    }
+
+    /// Reads one result artifact from the guest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the console closes, the file cannot be read, or
+    /// the typed response is invalid.
+    pub async fn read_file(&self, path: impl Into<String>) -> Result<Vec<u8>, VmToolSessionError> {
+        let response = self
+            .control_request(|id| {
+                SessionRequest::ReadFile(ReadFileRequest {
+                    id,
+                    path: path.into(),
+                })
+            })
+            .await?;
+        let SessionResponse::ReadFile(ReadFileResponse {
+            contents, error, ..
+        }) = response
+        else {
+            return Err(VmToolSessionError::Protocol(
+                "expected a read-file response",
+            ));
+        };
+        match (contents, error) {
+            (Some(contents), None) => Ok(contents),
+            (None, Some(error)) => Err(VmToolSessionError::Guest(error)),
+            _ => Err(VmToolSessionError::Protocol(
+                "expected exactly one of contents or error",
+            )),
+        }
+    }
+
+    /// Executes a trusted evaluation-harness command in the guest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the console closes, the command cannot run or
+    /// exceeds its deadline, or the typed response is invalid.
+    pub async fn command(&self, command: VmCommand) -> Result<VmCommandOutput, VmToolSessionError> {
+        let command_timeout = command.timeout;
+        let timeout_millis = u64::try_from(command_timeout.as_millis()).unwrap_or(u64::MAX);
+        let response = self
+            .control_request(|id| {
+                SessionRequest::Execute(ExecuteRequest {
+                    id,
+                    program: command.program,
+                    arguments: command.arguments,
+                    current_directory: command.current_directory,
+                    environment: command.environment,
+                    timeout_millis,
+                })
+            })
+            .await?;
+        let SessionResponse::Execute(ExecuteResponse {
+            exit_code,
+            stdout,
+            stderr,
+            error,
+            timed_out,
+            ..
+        }) = response
+        else {
+            return Err(VmToolSessionError::Protocol("expected an execute response"));
+        };
+        match (exit_code, stdout, stderr, error, timed_out) {
+            (Some(exit_code), Some(stdout), Some(stderr), None, false) => Ok(VmCommandOutput {
+                exit_code,
+                stdout,
+                stderr,
+            }),
+            (None, None, None, None, true) => {
+                Err(VmToolSessionError::GuestTimeout(command_timeout))
+            }
+            (None, None, None, Some(error), false) => Err(VmToolSessionError::Guest(error)),
+            _ => Err(VmToolSessionError::Protocol(
+                "invalid execute response fields",
+            )),
+        }
+    }
+
+    /// Flushes guest filesystems and waits for the VMM process to exit.
+    ///
+    /// No tool or control request may be sent through this session after a
+    /// successful shutdown.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the guest cannot acknowledge the request, the
+    /// VMM does not stop promptly, or it exits unsuccessfully.
+    pub async fn shutdown(&self) -> Result<(), VmToolSessionError> {
+        let response = self
+            .control_request(|id| SessionRequest::Shutdown(ShutdownRequest { id }))
+            .await?;
+        let SessionResponse::Shutdown(response) = response else {
+            return Err(VmToolSessionError::Protocol("expected a shutdown response"));
+        };
+        control_result(response)?;
+
+        let mut state = self.inner.state.lock().await;
+        let status = tokio::time::timeout(SHUTDOWN_TIMEOUT, state.child.wait())
+            .await
+            .map_err(|_| VmToolSessionError::ShutdownTimeout(SHUTDOWN_TIMEOUT))??;
+        if !status.success() {
+            return Err(VmToolSessionError::VmmExit(status));
+        }
+        Ok(())
+    }
+
+    async fn control_request(
+        &self,
+        make_request: impl FnOnce(u64) -> SessionRequest,
+    ) -> Result<SessionResponse, VmToolSessionError> {
+        let mut state = self.inner.state.lock().await;
+        let id = state.next_id;
+        state.next_id = state.next_id.wrapping_add(1);
+        let encoded = serde_json::to_string(&make_request(id))?;
+        state.input.write_all(encoded.as_bytes()).await?;
+        state.input.write_all(b"\n").await?;
+        state.input.flush().await?;
+        let (response, _) = read_response(&mut state, id, &Span::current()).await?;
+        Ok(response)
+    }
+}
+
+async fn read_response(
+    state: &mut SessionState,
+    expected_id: u64,
+    span: &Span,
+) -> Result<(SessionResponse, usize), VmToolSessionError> {
+    let mut response_bytes = 0_usize;
+    loop {
+        let line = state
+            .output
+            .next_line()
+            .await?
+            .ok_or(VmToolSessionError::Closed)?;
+        response_bytes = response_bytes.saturating_add(line.len());
+        record_vm_content(span, "tool.response", &line);
+        let response = serde_json::from_str::<SessionResponse>(&line)?;
+        let actual_id = response.id();
+        if actual_id == expected_id {
+            return Ok((response, response_bytes));
+        }
+        if actual_id < expected_id {
+            info!(
+                target: "nanocodex_vm",
+                rpc_request_id = expected_id,
+                rpc_response_id = actual_id,
+                "discarded response for a cancelled VM tool request"
+            );
+            continue;
+        }
+        return Err(VmToolSessionError::ResponseId {
+            expected: expected_id,
+            actual: actual_id,
+        });
+    }
+}
+
+fn control_result(response: ControlResponse) -> Result<(), VmToolSessionError> {
+    match response.error {
+        None => Ok(()),
+        Some(error) => Err(VmToolSessionError::Guest(error)),
+    }
+}
+
+fn record_vm_result<T, E>(span: &tracing::Span, started_at: Instant, result: &Result<T, E>)
+where
+    E: std::fmt::Display,
+{
+    let duration_ns = elapsed_ns(started_at);
+    span.record("duration_ns", duration_ns);
+    match result {
+        Ok(_) => {
+            span.record("status", "completed");
+            span.record("otel.status_code", "OK");
+            span.in_scope(|| {
+                info!(
+                    target: "nanocodex_vm",
+                    duration_ns,
+                    status = "completed",
+                    "VM operation completed"
+                );
+            });
+        }
+        Err(error) => {
+            span.record("status", "failed");
+            span.record("otel.status_code", "ERROR");
+            span.record("error.message", tracing::field::display(error));
+            span.in_scope(|| {
+                info!(
+                    target: "nanocodex_vm",
+                    duration_ns,
+                    status = "failed",
+                    error = %error,
+                    "VM operation failed"
+                );
+            });
+        }
+    }
+}
+
+fn record_vm_content(span: &tracing::Span, kind: &'static str, content: &str) {
+    span.in_scope(|| {
+        info!(
+            target: "nanocodex_vm",
+            content_kind = kind,
+            content,
+            "VM tool content"
+        );
+    });
+}
+
+fn elapsed_ns(started_at: Instant) -> u64 {
+    u64::try_from(started_at.elapsed().as_nanos()).unwrap_or(u64::MAX)
+}
+
+#[async_trait::async_trait]
+impl VmToolClient for VmToolSession {
+    async fn execute(
+        &self,
+        tool: StandardTool,
+        input: ToolInput,
+        context: ToolContext<'_>,
+    ) -> ToolResult {
+        self.request(tool, input, context)
+            .await
+            .map_err(|error| Box::new(error) as _)
+    }
+}
+
+pub(crate) async fn serve_guest(workspace: &Path) -> Result<(), VmToolSessionError> {
+    let runtime = ToolRuntime::new(workspace, None, None);
+    let input = tokio::io::stdin();
+    let mut lines = BufReader::new(input).lines();
+    let mut output = tokio::io::stdout();
+    while let Some(line) = lines.next_line().await? {
+        let request = serde_json::from_str::<SessionRequest>(&line)?;
+        let (response, shutdown) = match request {
+            SessionRequest::Tool(request) => {
+                let context = ToolContext {
+                    model: &request.context.model,
+                    session_id: &request.context.session_id,
+                    call_id: &request.context.call_id,
+                    history: &[],
+                    output_token_budget: request.context.output_token_budget,
+                };
+                let execution = runtime
+                    .execute_tool(request.tool.name(), request.input.into(), context)
+                    .await;
+                (
+                    SessionResponse::Tool(match execution.into_wire() {
+                        Ok(execution) => ToolResponse::completed(request.id, execution),
+                        Err(error) => ToolResponse::failed(request.id, error.to_string()),
+                    }),
+                    false,
+                )
+            }
+            SessionRequest::WriteFile(request) => (
+                SessionResponse::WriteFile(write_guest_file(request).await),
+                false,
+            ),
+            SessionRequest::ReadFile(request) => (
+                SessionResponse::ReadFile(read_guest_file(request).await),
+                false,
+            ),
+            SessionRequest::Execute(request) => (
+                SessionResponse::Execute(execute_guest_command(request).await),
+                false,
+            ),
+            SessionRequest::Shutdown(request) => {
+                let response = sync_guest_filesystems(request).await;
+                let shutdown = response.error.is_none();
+                (SessionResponse::Shutdown(response), shutdown)
+            }
+        };
+        let mut encoded = serde_json::to_vec(&response)?;
+        encoded.push(b'\n');
+        output.write_all(&encoded).await?;
+        output.flush().await?;
+        if shutdown {
+            return Ok(());
+        }
+    }
+    Ok(())
+}
+
+async fn sync_guest_filesystems(request: ShutdownRequest) -> ControlResponse {
+    let error = match Command::new("/bin/sync").status().await {
+        Ok(status) if status.success() => None,
+        Ok(status) => Some(format!("sync exited with {status}")),
+        Err(error) => Some(error.to_string()),
+    };
+    ControlResponse {
+        id: request.id,
+        error,
+    }
+}
+
+async fn write_guest_file(request: WriteFileRequest) -> ControlResponse {
+    let result = async {
+        let path = PathBuf::from(&request.path);
+        let parent = path
+            .parent()
+            .ok_or_else(|| std::io::Error::other("file path has no parent"))?;
+        tokio::fs::create_dir_all(parent).await?;
+        tokio::fs::write(&path, request.contents).await?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(request.mode)).await?;
+        }
+        Ok::<_, std::io::Error>(())
+    }
+    .await;
+    ControlResponse {
+        id: request.id,
+        error: result.err().map(|error| error.to_string()),
+    }
+}
+
+async fn read_guest_file(request: ReadFileRequest) -> ReadFileResponse {
+    match tokio::fs::read(&request.path).await {
+        Ok(contents) => ReadFileResponse {
+            id: request.id,
+            contents: Some(contents),
+            error: None,
+        },
+        Err(error) => ReadFileResponse {
+            id: request.id,
+            contents: None,
+            error: Some(error.to_string()),
+        },
+    }
+}
+
+async fn execute_guest_command(request: ExecuteRequest) -> ExecuteResponse {
+    let mut command = Command::new(&request.program);
+    command
+        .args(&request.arguments)
+        .current_dir(&request.current_directory)
+        .env_clear()
+        .envs(request.environment.iter().cloned())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    #[cfg(unix)]
+    command.process_group(0);
+
+    let timeout = Duration::from_millis(request.timeout_millis);
+    match execute_command_to_output(&mut command, timeout).await {
+        Ok(Some(output)) => ExecuteResponse {
+            id: request.id,
+            exit_code: Some(output.status.code().unwrap_or(1)),
+            stdout: Some(output.stdout),
+            stderr: Some(output.stderr),
+            error: None,
+            timed_out: false,
+        },
+        Ok(None) => ExecuteResponse {
+            id: request.id,
+            exit_code: None,
+            stdout: None,
+            stderr: None,
+            error: None,
+            timed_out: true,
+        },
+        Err(error) => ExecuteResponse {
+            id: request.id,
+            exit_code: None,
+            stdout: None,
+            stderr: None,
+            error: Some(error.to_string()),
+            timed_out: false,
+        },
+    }
+}
+
+async fn execute_command_to_output(
+    command: &mut Command,
+    timeout: Duration,
+) -> std::io::Result<Option<std::process::Output>> {
+    let mut child = command.spawn()?;
+    let process_group = child
+        .id()
+        .and_then(|id| i32::try_from(id).ok())
+        .map(Pid::from_raw);
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| std::io::Error::other("guest command stdout was not piped"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| std::io::Error::other("guest command stderr was not piped"))?;
+    let stdout = tokio::spawn(read_to_end(stdout));
+    let stderr = tokio::spawn(read_to_end(stderr));
+
+    let status = if let Ok(status) = tokio::time::timeout(timeout, child.wait()).await {
+        status?
+    } else {
+        if let Some(process_group) = process_group {
+            match killpg(process_group, Signal::SIGKILL) {
+                Ok(()) | Err(Errno::ESRCH) => {}
+                Err(error) => return Err(std::io::Error::other(error)),
+            }
+        } else {
+            child.start_kill()?;
+        }
+        child.wait().await?;
+        stdout.await.map_err(std::io::Error::other)??;
+        stderr.await.map_err(std::io::Error::other)??;
+        return Ok(None);
+    };
+    let stdout = stdout.await.map_err(std::io::Error::other)??;
+    let stderr = stderr.await.map_err(std::io::Error::other)??;
+    Ok(Some(std::process::Output {
+        status,
+        stdout,
+        stderr,
+    }))
+}
+
+async fn read_to_end(mut reader: impl AsyncRead + Unpin) -> std::io::Result<Vec<u8>> {
+    let mut output = Vec::new();
+    reader.read_to_end(&mut output).await?;
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tracing_tests {
+    use std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use nanocodex_tools::{StandardTool, ToolContext, ToolInput};
+    use serde_json::{json, value::to_raw_value};
+    use tracing::{Id, Instrument, Subscriber, field::Visit, span::Attributes};
+    use tracing_subscriber::{
+        Layer, layer::Context as LayerContext, prelude::*, registry::LookupSpan,
+    };
+
+    use super::VmToolSession;
+
+    #[derive(Clone, Default)]
+    struct TraceCapture {
+        spans: Arc<Mutex<HashMap<u64, CapturedSpan>>>,
+        names: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    struct CapturedSpan {
+        name: &'static str,
+        parent: Option<u64>,
+        fields: HashMap<String, String>,
+    }
+
+    struct FieldCapture<'a>(&'a mut HashMap<String, String>);
+
+    impl Visit for FieldCapture<'_> {
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            self.0.insert(field.name().to_owned(), value.to_owned());
+        }
+
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            self.0.insert(field.name().to_owned(), format!("{value:?}"));
+        }
+    }
+
+    impl<S> Layer<S> for TraceCapture
+    where
+        S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    {
+        fn on_new_span(&self, attributes: &Attributes<'_>, id: &Id, context: LayerContext<'_, S>) {
+            self.names
+                .lock()
+                .unwrap()
+                .push(attributes.metadata().name());
+            let parent = attributes
+                .parent()
+                .map(|parent| parent.clone().into_u64())
+                .or_else(|| {
+                    attributes
+                        .is_contextual()
+                        .then(|| context.current_span().id().map(Id::into_u64))
+                        .flatten()
+                });
+            let mut fields = HashMap::new();
+            attributes.record(&mut FieldCapture(&mut fields));
+            self.spans.lock().unwrap().insert(
+                id.clone().into_u64(),
+                CapturedSpan {
+                    name: attributes.metadata().name(),
+                    parent,
+                    fields,
+                },
+            );
+        }
+
+        fn on_record(
+            &self,
+            id: &Id,
+            values: &tracing::span::Record<'_>,
+            _context: LayerContext<'_, S>,
+        ) {
+            if let Some(span) = self.spans.lock().unwrap().get_mut(&id.clone().into_u64()) {
+                values.record(&mut FieldCapture(&mut span.fields));
+            }
+        }
+    }
+
+    #[test]
+    fn vm_rpc_is_timed_and_parented_to_the_calling_tool() {
+        let response = r#"{"kind":"tool","payload":{"id":0,"execution":{"output":"ok","success":true,"code_mode_value":null,"metadata":null,"process_trace":null},"error":null}}"#;
+        let script = format!("IFS= read -r request\nprintf '%s\\n' '{response}'");
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg(script);
+        let capture = TraceCapture::default();
+        let dispatch = tracing::Dispatch::new(tracing_subscriber::registry().with(capture.clone()));
+        tracing::callsite::rebuild_interest_cache();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        tracing::dispatcher::with_default(&dispatch, || {
+            runtime.block_on(async {
+                let session = VmToolSession::spawn(&mut command).unwrap();
+                let context = ToolContext {
+                    model: "test-model",
+                    session_id: "test-session",
+                    call_id: "test-call",
+                    history: &[],
+                    output_token_budget: 1_000,
+                };
+                let execution = session
+                    .request(
+                        StandardTool::ExecCommand,
+                        ToolInput::Function(to_raw_value(&json!({"cmd": "true"})).unwrap()),
+                        context,
+                    )
+                    .instrument(tracing::info_span!("test.tool.execute"))
+                    .await
+                    .unwrap();
+                assert!(execution.success);
+            });
+        });
+
+        let spans = capture.spans.lock().unwrap();
+        let (tool_id, _) = spans
+            .iter()
+            .find(|(_, span)| span.name == "test.tool.execute")
+            .unwrap();
+        let rpc = spans
+            .values()
+            .find(|span| span.name == "vm.tool.rpc")
+            .unwrap();
+        assert_eq!(rpc.parent, Some(*tool_id));
+        assert_eq!(
+            rpc.fields.get("status").map(String::as_str),
+            Some("completed")
+        );
+        assert_eq!(
+            rpc.fields.get("vm.session.first_call").map(String::as_str),
+            Some("true")
+        );
+        assert!(rpc.fields.contains_key("rpc.queue.duration_ns"));
+        assert!(rpc.fields.contains_key("duration_ns"));
+        assert!(capture.names.lock().unwrap().contains(&"vm.session.spawn"));
+    }
+
+    #[test]
+    fn next_request_discards_a_cancelled_requests_late_response() {
+        let first = r#"{"kind":"write_file","payload":{"id":0,"error":null}}"#;
+        let second = r#"{"kind":"write_file","payload":{"id":1,"error":null}}"#;
+        let script = format!(
+            "IFS= read -r first\nsleep 0.05\nprintf '%s\\n' '{first}'\nIFS= read -r second\nprintf '%s\\n' '{second}'"
+        );
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg(script);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let session = VmToolSession::spawn(&mut command).unwrap();
+            let cancelled = tokio::time::timeout(
+                Duration::from_millis(10),
+                session.write_file("/first", Vec::new(), 0o600),
+            )
+            .await;
+            assert!(cancelled.is_err());
+
+            session
+                .write_file("/second", Vec::new(), 0o600)
+                .await
+                .unwrap();
+        });
+    }
+}
+
+#[cfg(test)]
+mod guest_command_tests {
+    use std::time::{Duration, Instant};
+
+    use super::execute_guest_command;
+    use crate::protocol::ExecuteRequest;
+
+    #[tokio::test]
+    async fn timeout_kills_descendants_holding_output_pipes() {
+        let started_at = Instant::now();
+        let response = execute_guest_command(ExecuteRequest {
+            id: 1,
+            program: "/bin/sh".to_owned(),
+            arguments: vec!["-c".to_owned(), "sleep 30 & wait".to_owned()],
+            current_directory: "/".to_owned(),
+            environment: Vec::new(),
+            timeout_millis: 25,
+        })
+        .await;
+
+        assert!(response.timed_out);
+        assert!(response.error.is_none());
+        assert!(started_at.elapsed() < Duration::from_secs(1));
+    }
+}

--- a/crates/nanocodex-vm/src/session.rs
+++ b/crates/nanocodex-vm/src/session.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    path::{Path, PathBuf},
+    path::PathBuf,
     process::{ExitStatus, Stdio},
     sync::{
         Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard, Weak,
@@ -9,21 +9,15 @@ use std::{
     time::{Duration, Instant},
 };
 
-use nanocodex_tools::{
-    StandardTool, ToolContext, ToolExecution, ToolInput, ToolResult, ToolRuntime,
-};
-use nanovm::EgressLease;
-use nix::{
-    errno::Errno,
-    sys::signal::{Signal, killpg},
-    unistd::Pid,
+use nanocodex_tools::{StandardTool, ToolContext, ToolExecution, ToolInput, ToolResult};
+use nanovm::{
+    EgressLease, GuestCommand, PrivateVmProcessConfig, VmConfig, VmProcessConfig, VmProcessError,
 };
 use thiserror::Error;
 use tokio::{
-    io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader},
+    io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader},
     process::{Child, ChildStdin, ChildStdout, Command},
-    sync::{Mutex, oneshot},
-    task::JoinSet,
+    sync::{Mutex, Semaphore, mpsc, oneshot},
 };
 use tracing::{Instrument, Span, info, info_span};
 
@@ -31,12 +25,17 @@ use crate::{
     VmToolClient,
     protocol::{
         ControlResponse, ExecuteRequest, ExecuteResponse, ReadFileRequest, ReadFileResponse,
-        SessionRequest, SessionResponse, ShutdownRequest, ToolRequest, ToolResponse,
-        WireToolContext, WireToolInput, WriteFileRequest,
+        SessionRequest, SessionResponse, ShutdownRequest, ToolRequest, WireToolContext,
+        WireToolInput, WriteFileRequest,
     },
 };
 
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
+const DEFAULT_COMMAND_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
+const MAX_GUEST_IN_FLIGHT_REQUESTS: usize = 64;
+const MAX_HOST_IN_FLIGHT_REQUESTS: usize = MAX_GUEST_IN_FLIGHT_REQUESTS - 1;
+const REQUEST_QUEUE_CAPACITY: usize = MAX_GUEST_IN_FLIGHT_REQUESTS;
 
 /// One trusted command executed by the evaluation harness inside the guest.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -46,6 +45,7 @@ pub struct VmCommand {
     current_directory: String,
     environment: Vec<(String, String)>,
     timeout: Duration,
+    max_output_bytes: usize,
 }
 
 impl VmCommand {
@@ -57,6 +57,7 @@ impl VmCommand {
             current_directory: "/".to_owned(),
             environment: Vec::new(),
             timeout: Duration::from_mins(1),
+            max_output_bytes: DEFAULT_COMMAND_OUTPUT_BYTES,
         }
     }
 
@@ -81,6 +82,13 @@ impl VmCommand {
     #[must_use]
     pub const fn timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
+        self
+    }
+
+    /// Bounds the combined stdout and stderr retained by this command.
+    #[must_use]
+    pub const fn max_output_bytes(mut self, max_output_bytes: usize) -> Self {
+        self.max_output_bytes = max_output_bytes;
         self
     }
 }
@@ -119,8 +127,14 @@ pub enum VmToolSessionError {
     #[error("guest command exceeded {0:?}")]
     GuestTimeout(Duration),
 
+    #[error("guest command output exceeded the {0}-byte limit")]
+    GuestOutputLimit(usize),
+
     #[error("invalid VM tool response: {0}")]
     Protocol(&'static str),
+
+    #[error("VM tool protocol frame exceeded the {MAX_FRAME_BYTES}-byte limit")]
+    FrameTooLarge,
 
     #[error("the VMM did not exit within {0:?} after guest shutdown")]
     ShutdownTimeout(Duration),
@@ -131,8 +145,14 @@ pub enum VmToolSessionError {
     #[error("egress was already provisioned for this VM session")]
     EgressAlreadyProvisioned,
 
+    #[error("cannot shut down the VM while {0} sibling capabilities are still alive")]
+    ActiveCapabilities(usize),
+
     #[error("egress guest file path is not valid UTF-8: {0}")]
     EgressFilePath(PathBuf),
+
+    #[error(transparent)]
+    VmProcess(#[from] VmProcessError),
 }
 
 /// Owner of one persistent VMM child carrying workspace tool calls.
@@ -142,7 +162,6 @@ pub enum VmToolSessionError {
 /// factory; all of those handles route to this one VM.
 pub struct VmToolSession {
     handle: VmToolSessionHandle,
-    egress: Option<EgressLease>,
 }
 
 /// Clone-cheap capability for sending workspace tool calls to one owned VM.
@@ -155,10 +174,13 @@ struct VmToolSessionInner {
     spawned_at: Instant,
     next_id: AtomicU64,
     closing: AtomicBool,
-    input: Mutex<Option<ChildStdin>>,
+    input: mpsc::Sender<Vec<u8>>,
+    request_slots: Semaphore,
     output: Mutex<Option<ChildStdout>>,
     pending: StdMutex<PendingState>,
     child: StdMutex<Option<Child>>,
+    egress: StdMutex<Option<EgressLease>>,
+    process_config: StdMutex<Option<PrivateVmProcessConfig>>,
 }
 
 #[derive(Default)]
@@ -179,7 +201,39 @@ struct PendingRequestGuard {
 }
 
 impl VmToolSession {
-    /// Spawns a VMM command whose guest process runs [`crate::serve_guest`].
+    /// Configures, spawns, and provisions one VM from the same egress lease.
+    ///
+    /// `command` must invoke a dedicated VMM process that accepts the private
+    /// [`VmProcessConfig`] path as its next argument. This method appends that
+    /// path, starts the process, waits for the guest tool server, provisions
+    /// public egress files, and retains provider guards with every returned
+    /// tool capability.
+    ///
+    /// Prefer this operation to separately calling [`EgressLease::configure`],
+    /// [`Self::spawn`], and [`Self::provision_egress`]: consuming the lease here
+    /// prevents launch-time environment and retained provider state from
+    /// diverging.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when private configuration cannot be written, the VMM
+    /// cannot start, or guest egress provisioning fails.
+    pub async fn spawn_configured(
+        mut command: Command,
+        vm: VmConfig,
+        guest: GuestCommand,
+        egress: EgressLease,
+    ) -> Result<Self, VmToolSessionError> {
+        let (vm, guest) = egress.configure(vm, &guest);
+        let process_config = VmProcessConfig::new(vm, guest).write_private()?;
+        command.arg(process_config.path());
+        let session = Self::spawn(&mut command)?;
+        *lock_unpoisoned(&session.handle.inner.process_config) = Some(process_config);
+        session.provision_egress(egress).await?;
+        Ok(session)
+    }
+
+    /// Spawns a VMM command whose guest process runs the companion guest server.
     ///
     /// The command's stdin and stdout are reserved for the typed protocol;
     /// stderr remains available for VMM and guest diagnostics.
@@ -229,19 +283,26 @@ impl VmToolSession {
                 .stdout
                 .take()
                 .ok_or(VmToolSessionError::MissingPipe("stdout"))?;
+            let (input_sender, input_receiver) = mpsc::channel(REQUEST_QUEUE_CAPACITY);
+            let inner = Arc::new(VmToolSessionInner {
+                spawned_at: Instant::now(),
+                next_id: AtomicU64::new(0),
+                closing: AtomicBool::new(false),
+                input: input_sender,
+                request_slots: Semaphore::new(MAX_HOST_IN_FLIGHT_REQUESTS),
+                output: Mutex::new(Some(output)),
+                pending: StdMutex::new(PendingState::default()),
+                child: StdMutex::new(Some(child)),
+                egress: StdMutex::new(None),
+                process_config: StdMutex::new(None),
+            });
+            tokio::spawn(write_requests(
+                input,
+                input_receiver,
+                Arc::downgrade(&inner),
+            ));
             Ok(Self {
-                handle: VmToolSessionHandle {
-                    inner: Arc::new(VmToolSessionInner {
-                        spawned_at: Instant::now(),
-                        next_id: AtomicU64::new(0),
-                        closing: AtomicBool::new(false),
-                        input: Mutex::new(Some(input)),
-                        output: Mutex::new(Some(output)),
-                        pending: StdMutex::new(PendingState::default()),
-                        child: StdMutex::new(Some(child)),
-                    }),
-                },
-                egress: None,
+                handle: VmToolSessionHandle { inner },
             })
         });
         record_vm_result(&span, started_at, &result);
@@ -271,18 +332,18 @@ impl VmToolSession {
     ///
     /// Returns an error when egress was already provisioned, a guest path is
     /// not UTF-8, or the guest rejects a file write.
-    pub async fn provision_egress(
-        &mut self,
-        egress: EgressLease,
-    ) -> Result<(), VmToolSessionError> {
-        if self.egress.is_some() {
-            return Err(VmToolSessionError::EgressAlreadyProvisioned);
-        }
+    pub async fn provision_egress(&self, egress: EgressLease) -> Result<(), VmToolSessionError> {
         let files = egress.guest_files().cloned().collect::<Vec<_>>();
-        // Retain revocable provider state even when provisioning fails. The
-        // session remains deliberately non-retryable and dropping its owner
-        // tears down both the VMM and the incomplete lease.
-        self.egress = Some(egress);
+        {
+            let mut provisioned = lock_unpoisoned(&self.handle.inner.egress);
+            if provisioned.is_some() {
+                return Err(VmToolSessionError::EgressAlreadyProvisioned);
+            }
+            // Retain revocable provider state even when provisioning fails.
+            // Tool handles keep the lease alive with the VMM, so dropping the
+            // launch owner cannot silently revoke an active agent tree.
+            *provisioned = Some(egress);
+        }
         for file in files {
             let path = file
                 .guest_path()
@@ -331,14 +392,19 @@ impl VmToolSession {
 
     /// Flushes guest filesystems and waits for the VMM process to exit.
     ///
-    /// Consuming the owner prevents a cloned tool capability from shutting
-    /// down the VM while another driver in the same agent tree is using it.
+    /// The operation rejects live sibling capabilities so it cannot stop the
+    /// VM while another driver in the same agent tree is using it. Because the
+    /// owner is borrowed, callers can drop those capabilities and retry.
     ///
     /// # Errors
     ///
     /// Returns an error when the guest cannot acknowledge the request, the
     /// VMM does not stop promptly, or it exits unsuccessfully.
-    pub async fn shutdown(self) -> Result<(), VmToolSessionError> {
+    pub async fn shutdown(&self) -> Result<(), VmToolSessionError> {
+        let sibling_capabilities = Arc::strong_count(&self.handle.inner).saturating_sub(1);
+        if sibling_capabilities != 0 {
+            return Err(VmToolSessionError::ActiveCapabilities(sibling_capabilities));
+        }
         self.handle.inner.closing.store(true, Ordering::Release);
         let response = self
             .handle
@@ -348,7 +414,6 @@ impl VmToolSession {
             return Err(VmToolSessionError::Protocol("expected a shutdown response"));
         };
         control_result(response)?;
-        self.handle.inner.input.lock().await.take();
 
         let child = lock_unpoisoned(&self.handle.inner.child).take();
         let Some(mut child) = child else {
@@ -370,11 +435,11 @@ impl VmToolSession {
     }
 }
 
-impl Drop for VmToolSession {
+impl Drop for VmToolSessionInner {
     fn drop(&mut self) {
-        self.handle.inner.closing.store(true, Ordering::Release);
-        close_pending(&self.handle.inner, "VM session owner was dropped");
-        if let Some(child) = lock_unpoisoned(&self.handle.inner.child).as_mut() {
+        self.closing.store(true, Ordering::Release);
+        close_pending(self, "last VM session capability was dropped");
+        if let Some(child) = lock_unpoisoned(&self.child).as_mut() {
             let _ = child.start_kill();
         }
     }
@@ -529,6 +594,7 @@ impl VmToolSessionHandle {
     /// start, exceeds its deadline, or returns an invalid response.
     pub async fn command(&self, command: VmCommand) -> Result<VmCommandOutput, VmToolSessionError> {
         let command_timeout = command.timeout;
+        let max_output_bytes = command.max_output_bytes;
         let timeout_millis = u64::try_from(command_timeout.as_millis()).unwrap_or(u64::MAX);
         let response = self
             .control_request(|id| {
@@ -539,6 +605,7 @@ impl VmToolSessionHandle {
                     current_directory: command.current_directory,
                     environment: command.environment,
                     timeout_millis,
+                    max_output_bytes,
                 })
             })
             .await?;
@@ -548,21 +615,34 @@ impl VmToolSessionHandle {
             stderr,
             error,
             timed_out,
+            output_limit_exceeded,
             ..
         }) = response
         else {
             return Err(VmToolSessionError::Protocol("expected an execute response"));
         };
-        match (exit_code, stdout, stderr, error, timed_out) {
-            (Some(exit_code), Some(stdout), Some(stderr), None, false) => Ok(VmCommandOutput {
-                exit_code,
-                stdout,
-                stderr,
-            }),
-            (None, None, None, None, true) => {
+        match (
+            exit_code,
+            stdout,
+            stderr,
+            error,
+            timed_out,
+            output_limit_exceeded,
+        ) {
+            (Some(exit_code), Some(stdout), Some(stderr), None, false, false) => {
+                Ok(VmCommandOutput {
+                    exit_code,
+                    stdout,
+                    stderr,
+                })
+            }
+            (None, None, None, None, true, false) => {
                 Err(VmToolSessionError::GuestTimeout(command_timeout))
             }
-            (None, None, None, Some(error), false) => Err(VmToolSessionError::Guest(error)),
+            (None, None, None, None, false, true) => {
+                Err(VmToolSessionError::GuestOutputLimit(max_output_bytes))
+            }
+            (None, None, None, Some(error), false, false) => Err(VmToolSessionError::Guest(error)),
             _ => Err(VmToolSessionError::Protocol(
                 "invalid execute response fields",
             )),
@@ -597,12 +677,29 @@ impl VmToolSessionHandle {
         if self.inner.closing.load(Ordering::Acquire) && !allow_closing {
             return Err(VmToolSessionError::Closed);
         }
+        let _request_slot = if allow_closing {
+            None
+        } else {
+            let permit = self
+                .inner
+                .request_slots
+                .acquire()
+                .await
+                .map_err(|_| VmToolSessionError::Closed)?;
+            if self.inner.closing.load(Ordering::Acquire) {
+                return Err(VmToolSessionError::Closed);
+            }
+            Some(permit)
+        };
         self.ensure_reader().await?;
         let id = self.inner.next_id.fetch_add(1, Ordering::Relaxed);
         set_request_id(&mut request, id);
         span.record("rpc.request.id", id);
         span.record("vm.session.first_call", id == 0);
         let encoded = serde_json::to_string(&request)?;
+        if encoded.len() > MAX_FRAME_BYTES {
+            return Err(VmToolSessionError::FrameTooLarge);
+        }
         span.record("rpc.request.bytes", encoded.len());
         record_vm_content(span, "tool.request", &encoded);
 
@@ -626,17 +723,14 @@ impl VmToolSessionHandle {
             armed: true,
         };
         let queued_at = Instant::now();
-        let write_result = async {
-            let mut input = self.inner.input.lock().await;
-            span.record("rpc.queue.duration_ns", elapsed_ns(queued_at));
-            let input = input.as_mut().ok_or(VmToolSessionError::Closed)?;
-            input.write_all(encoded.as_bytes()).await?;
-            input.write_all(b"\n").await?;
-            input.flush().await?;
-            Ok::<_, VmToolSessionError>(())
-        }
-        .await;
-        write_result?;
+        let mut frame = encoded.into_bytes();
+        frame.push(b'\n');
+        self.inner
+            .input
+            .send(frame)
+            .await
+            .map_err(|_| VmToolSessionError::Closed)?;
+        span.record("rpc.queue.duration_ns", elapsed_ns(queued_at));
         let response = receiver.await.map_err(|_| VmToolSessionError::Closed)?;
         guard.armed = false;
         response.map_err(VmToolSessionError::Router)
@@ -669,10 +763,30 @@ impl Drop for PendingRequestGuard {
     }
 }
 
+async fn write_requests(
+    mut input: ChildStdin,
+    mut requests: mpsc::Receiver<Vec<u8>>,
+    inner: Weak<VmToolSessionInner>,
+) {
+    while let Some(frame) = requests.recv().await {
+        let result = async {
+            input.write_all(&frame).await?;
+            input.flush().await
+        }
+        .await;
+        if let Err(error) = result {
+            if let Some(inner) = inner.upgrade() {
+                close_pending(&inner, &format!("VM tool console write failed: {error}"));
+            }
+            return;
+        }
+    }
+}
+
 async fn route_responses(output: ChildStdout, inner: Weak<VmToolSessionInner>) {
-    let mut lines = BufReader::new(output).lines();
+    let mut output = BufReader::new(output);
     loop {
-        let line = match lines.next_line().await {
+        let line = match read_frame(&mut output).await {
             Ok(Some(line)) => line,
             Ok(None) => {
                 if let Some(inner) = inner.upgrade() {
@@ -687,7 +801,7 @@ async fn route_responses(output: ChildStdout, inner: Weak<VmToolSessionInner>) {
                 return;
             }
         };
-        let response = match serde_json::from_str::<SessionResponse>(&line) {
+        let response = match serde_json::from_slice::<SessionResponse>(&line) {
             Ok(response) => response,
             Err(error) => {
                 if let Some(inner) = inner.upgrade() {
@@ -702,7 +816,11 @@ async fn route_responses(output: ChildStdout, inner: Weak<VmToolSessionInner>) {
         let id = response.id();
         let pending = lock_unpoisoned(&inner.pending).requests.remove(&id);
         if let Some(pending) = pending {
-            record_vm_content(&pending.span, "tool.response", &line);
+            record_vm_content(
+                &pending.span,
+                "tool.response",
+                &String::from_utf8_lossy(&line),
+            );
             let _ = pending.response.send(Ok((response, line.len())));
         } else {
             info!(
@@ -711,6 +829,39 @@ async fn route_responses(output: ChildStdout, inner: Weak<VmToolSessionInner>) {
                 "discarded response for a cancelled VM request"
             );
         }
+    }
+}
+
+async fn read_frame(
+    reader: &mut (impl AsyncBufRead + Unpin),
+) -> Result<Option<Vec<u8>>, VmToolSessionError> {
+    let mut frame = Vec::new();
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            return if frame.is_empty() {
+                Ok(None)
+            } else {
+                Err(VmToolSessionError::Closed)
+            };
+        }
+        if let Some(newline) = available.iter().position(|byte| *byte == b'\n') {
+            if frame.len().saturating_add(newline) > MAX_FRAME_BYTES {
+                return Err(VmToolSessionError::FrameTooLarge);
+            }
+            frame.extend_from_slice(&available[..newline]);
+            reader.consume(newline + 1);
+            if frame.last() == Some(&b'\r') {
+                frame.pop();
+            }
+            return Ok(Some(frame));
+        }
+        if frame.len().saturating_add(available.len()) > MAX_FRAME_BYTES {
+            return Err(VmToolSessionError::FrameTooLarge);
+        }
+        let consumed = available.len();
+        frame.extend_from_slice(available);
+        reader.consume(consumed);
     }
 }
 
@@ -816,257 +967,6 @@ impl VmToolClient for VmToolSessionHandle {
     }
 }
 
-pub(crate) async fn serve_guest(workspace: &Path) -> Result<(), VmToolSessionError> {
-    serve_guest_io(workspace, tokio::io::stdin(), tokio::io::stdout()).await
-}
-
-const MAX_IN_FLIGHT_GUEST_REQUESTS: usize = 64;
-
-async fn serve_guest_io(
-    workspace: &Path,
-    input: impl AsyncRead + Unpin,
-    mut output: impl tokio::io::AsyncWrite + Unpin,
-) -> Result<(), VmToolSessionError> {
-    let runtime = Arc::new(ToolRuntime::new(workspace, None, None));
-    let mut lines = BufReader::new(input).lines();
-    let mut requests = JoinSet::new();
-    let mut accepting = true;
-    let mut shutdown = None;
-
-    let result = async {
-        while accepting || !requests.is_empty() {
-            tokio::select! {
-                joined = requests.join_next(), if !requests.is_empty() => {
-                    let response = joined
-                        .ok_or(VmToolSessionError::Closed)?
-                        .map_err(|error| VmToolSessionError::Guest(error.to_string()))?;
-                    write_guest_response(&mut output, &response).await?;
-                }
-                line = lines.next_line(),
-                    if accepting && requests.len() < MAX_IN_FLIGHT_GUEST_REQUESTS =>
-                {
-                    let Some(line) = line? else {
-                        accepting = false;
-                        continue;
-                    };
-                    match serde_json::from_str::<SessionRequest>(&line)? {
-                        SessionRequest::Shutdown(request) => {
-                            shutdown = Some(request);
-                            accepting = false;
-                        }
-                        request => {
-                            let runtime = Arc::clone(&runtime);
-                            requests.spawn(async move {
-                                execute_guest_request(runtime, request).await
-                            });
-                        }
-                    }
-                }
-            }
-        }
-        Ok::<_, VmToolSessionError>(shutdown)
-    }
-    .await;
-
-    runtime.control().cancel().await;
-    if let Some(request) = result? {
-        let response = SessionResponse::Shutdown(sync_guest_filesystems(request).await);
-        write_guest_response(&mut output, &response).await?;
-    }
-    Ok(())
-}
-
-async fn execute_guest_request(
-    runtime: Arc<ToolRuntime>,
-    request: SessionRequest,
-) -> SessionResponse {
-    match request {
-        SessionRequest::Tool(request) => {
-            let context = ToolContext {
-                model: &request.context.model,
-                session_id: &request.context.session_id,
-                call_id: &request.context.call_id,
-                history: &[],
-                output_token_budget: request.context.output_token_budget,
-            };
-            let execution = runtime
-                .execute_tool(request.tool.name(), request.input.into(), context)
-                .await;
-            SessionResponse::Tool(match execution.into_wire() {
-                Ok(execution) => ToolResponse::completed(request.id, execution),
-                Err(error) => ToolResponse::failed(request.id, error.to_string()),
-            })
-        }
-        SessionRequest::WriteFile(request) => {
-            SessionResponse::WriteFile(write_guest_file(request).await)
-        }
-        SessionRequest::ReadFile(request) => {
-            SessionResponse::ReadFile(read_guest_file(request).await)
-        }
-        SessionRequest::Execute(request) => {
-            SessionResponse::Execute(execute_guest_command(request).await)
-        }
-        SessionRequest::Shutdown(request) => SessionResponse::Shutdown(ControlResponse {
-            id: request.id,
-            error: Some("shutdown cannot be dispatched as a concurrent request".to_owned()),
-        }),
-    }
-}
-
-async fn write_guest_response(
-    output: &mut (impl tokio::io::AsyncWrite + Unpin),
-    response: &SessionResponse,
-) -> Result<(), VmToolSessionError> {
-    let mut encoded = serde_json::to_vec(response)?;
-    encoded.push(b'\n');
-    output.write_all(&encoded).await?;
-    output.flush().await?;
-    Ok(())
-}
-
-async fn sync_guest_filesystems(request: ShutdownRequest) -> ControlResponse {
-    let error = match Command::new("/bin/sync").status().await {
-        Ok(status) if status.success() => None,
-        Ok(status) => Some(format!("sync exited with {status}")),
-        Err(error) => Some(error.to_string()),
-    };
-    ControlResponse {
-        id: request.id,
-        error,
-    }
-}
-
-async fn write_guest_file(request: WriteFileRequest) -> ControlResponse {
-    let result = async {
-        let path = PathBuf::from(&request.path);
-        let parent = path
-            .parent()
-            .ok_or_else(|| std::io::Error::other("file path has no parent"))?;
-        tokio::fs::create_dir_all(parent).await?;
-        tokio::fs::write(&path, request.contents).await?;
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(request.mode)).await?;
-        }
-        Ok::<_, std::io::Error>(())
-    }
-    .await;
-    ControlResponse {
-        id: request.id,
-        error: result.err().map(|error| error.to_string()),
-    }
-}
-
-async fn read_guest_file(request: ReadFileRequest) -> ReadFileResponse {
-    match tokio::fs::read(&request.path).await {
-        Ok(contents) => ReadFileResponse {
-            id: request.id,
-            contents: Some(contents),
-            error: None,
-        },
-        Err(error) => ReadFileResponse {
-            id: request.id,
-            contents: None,
-            error: Some(error.to_string()),
-        },
-    }
-}
-
-async fn execute_guest_command(request: ExecuteRequest) -> ExecuteResponse {
-    let mut command = Command::new(&request.program);
-    command
-        .args(&request.arguments)
-        .current_dir(&request.current_directory)
-        .env_clear()
-        .envs(request.environment.iter().cloned())
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .kill_on_drop(true);
-    #[cfg(unix)]
-    command.process_group(0);
-
-    let timeout = Duration::from_millis(request.timeout_millis);
-    match execute_command_to_output(&mut command, timeout).await {
-        Ok(Some(output)) => ExecuteResponse {
-            id: request.id,
-            exit_code: Some(output.status.code().unwrap_or(1)),
-            stdout: Some(output.stdout),
-            stderr: Some(output.stderr),
-            error: None,
-            timed_out: false,
-        },
-        Ok(None) => ExecuteResponse {
-            id: request.id,
-            exit_code: None,
-            stdout: None,
-            stderr: None,
-            error: None,
-            timed_out: true,
-        },
-        Err(error) => ExecuteResponse {
-            id: request.id,
-            exit_code: None,
-            stdout: None,
-            stderr: None,
-            error: Some(error.to_string()),
-            timed_out: false,
-        },
-    }
-}
-
-async fn execute_command_to_output(
-    command: &mut Command,
-    timeout: Duration,
-) -> std::io::Result<Option<std::process::Output>> {
-    let mut child = command.spawn()?;
-    let process_group = child
-        .id()
-        .and_then(|id| i32::try_from(id).ok())
-        .map(Pid::from_raw);
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| std::io::Error::other("guest command stdout was not piped"))?;
-    let stderr = child
-        .stderr
-        .take()
-        .ok_or_else(|| std::io::Error::other("guest command stderr was not piped"))?;
-    let stdout = tokio::spawn(read_to_end(stdout));
-    let stderr = tokio::spawn(read_to_end(stderr));
-
-    let status = if let Ok(status) = tokio::time::timeout(timeout, child.wait()).await {
-        status?
-    } else {
-        if let Some(process_group) = process_group {
-            match killpg(process_group, Signal::SIGKILL) {
-                Ok(()) | Err(Errno::ESRCH) => {}
-                Err(error) => return Err(std::io::Error::other(error)),
-            }
-        } else {
-            child.start_kill()?;
-        }
-        child.wait().await?;
-        stdout.await.map_err(std::io::Error::other)??;
-        stderr.await.map_err(std::io::Error::other)??;
-        return Ok(None);
-    };
-    let stdout = stdout.await.map_err(std::io::Error::other)??;
-    let stderr = stderr.await.map_err(std::io::Error::other)??;
-    Ok(Some(std::process::Output {
-        status,
-        stdout,
-        stderr,
-    }))
-}
-
-async fn read_to_end(mut reader: impl AsyncRead + Unpin) -> std::io::Result<Vec<u8>> {
-    let mut output = Vec::new();
-    reader.read_to_end(&mut output).await?;
-    Ok(output)
-}
-
 #[cfg(test)]
 mod tracing_tests {
     use std::{
@@ -1082,7 +982,7 @@ mod tracing_tests {
         Layer, layer::Context as LayerContext, prelude::*, registry::LookupSpan,
     };
 
-    use super::VmToolSession;
+    use super::{VmToolSession, VmToolSessionError};
 
     static TRACE_TEST_LOCK: Mutex<()> = Mutex::new(());
 
@@ -1273,91 +1173,119 @@ mod tracing_tests {
             completed.1.unwrap();
         });
     }
-}
 
-#[cfg(test)]
-mod guest_command_tests {
-    use std::time::{Duration, Instant};
+    #[test]
+    fn cancelled_partial_write_cannot_corrupt_the_next_request() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let first = r#"{"kind":"write_file","payload":{"id":0,"error":null}}"#;
+        let second = r#"{"kind":"write_file","payload":{"id":1,"error":null}}"#;
+        let script = format!(
+            "sleep 0.05\nIFS= read -r first\nprintf '%s\\n' '{first}'\nIFS= read -r second\nprintf '%s\\n' '{second}'"
+        );
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg(script);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
 
-    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+        runtime.block_on(async {
+            let session = VmToolSession::spawn(&mut command).unwrap();
+            let cancelled = tokio::time::timeout(
+                Duration::from_millis(10),
+                session.write_file("/large", vec![b'x'; 256 * 1024], 0o600),
+            )
+            .await;
+            assert!(cancelled.is_err());
 
-    use super::{execute_guest_command, serve_guest_io};
-    use crate::protocol::{ExecuteRequest, SessionRequest, SessionResponse, ShutdownRequest};
-
-    #[tokio::test]
-    async fn timeout_kills_descendants_holding_output_pipes() {
-        let started_at = Instant::now();
-        let response = execute_guest_command(ExecuteRequest {
-            id: 1,
-            program: "/bin/sh".to_owned(),
-            arguments: vec!["-c".to_owned(), "sleep 30 & wait".to_owned()],
-            current_directory: "/".to_owned(),
-            environment: Vec::new(),
-            timeout_millis: 25,
-        })
-        .await;
-
-        assert!(response.timed_out);
-        assert!(response.error.is_none());
-        assert!(started_at.elapsed() < Duration::from_secs(1));
-    }
-
-    #[tokio::test]
-    async fn guest_dispatches_independent_requests_concurrently() {
-        let workspace = tempfile::tempdir().unwrap();
-        let marker = workspace.path().join("second-started");
-        let (host, guest) = tokio::io::duplex(64 * 1024);
-        let (host_read, mut host_write) = tokio::io::split(host);
-        let (guest_read, guest_write) = tokio::io::split(guest);
-        let guest_task = tokio::spawn({
-            let workspace = workspace.path().to_owned();
-            async move { serve_guest_io(&workspace, guest_read, guest_write).await }
-        });
-
-        let requests = [
-            SessionRequest::Execute(ExecuteRequest {
-                id: 0,
-                program: "/bin/sh".to_owned(),
-                arguments: vec![
-                    "-c".to_owned(),
-                    format!("while [ ! -f '{}' ]; do sleep 0.01; done", marker.display()),
-                ],
-                current_directory: workspace.path().to_string_lossy().into_owned(),
-                environment: Vec::new(),
-                timeout_millis: 5_000,
-            }),
-            SessionRequest::Execute(ExecuteRequest {
-                id: 1,
-                program: "/usr/bin/touch".to_owned(),
-                arguments: vec![marker.to_string_lossy().into_owned()],
-                current_directory: workspace.path().to_string_lossy().into_owned(),
-                environment: Vec::new(),
-                timeout_millis: 5_000,
-            }),
-            SessionRequest::Shutdown(ShutdownRequest { id: 2 }),
-        ];
-        for request in requests {
-            host_write
-                .write_all(&serde_json::to_vec(&request).unwrap())
+            session
+                .write_file("/second", Vec::new(), 0o600)
                 .await
                 .unwrap();
-            host_write.write_all(b"\n").await.unwrap();
-        }
-        drop(host_write);
+        });
+    }
 
-        let mut responses = BufReader::new(host_read).lines();
-        let mut first_succeeded = false;
-        for _ in 0..3 {
-            let line = responses.next_line().await.unwrap().unwrap();
-            if let SessionResponse::Execute(response) =
-                serde_json::from_str::<SessionResponse>(&line).unwrap()
-                && response.id == 0
-            {
-                first_succeeded = !response.timed_out && response.error.is_none();
-            }
-        }
-        guest_task.await.unwrap().unwrap();
-        assert!(first_succeeded);
-        assert!(marker.is_file());
+    #[test]
+    fn tool_capabilities_own_the_vmm_and_egress_lifetime() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg("sleep 30");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let session = VmToolSession::spawn(&mut command).unwrap();
+            let guard = Arc::new(());
+            let weak_guard = Arc::downgrade(&guard);
+            let mut egress = nanovm::EgressLease::disabled();
+            egress.retain(guard);
+            session.provision_egress(egress).await.unwrap();
+            let tools = session.tools();
+
+            drop(session);
+            assert!(
+                weak_guard.upgrade().is_some(),
+                "dropping the launch owner must not revoke an active tool tree"
+            );
+
+            drop(tools);
+            assert!(
+                weak_guard.upgrade().is_none(),
+                "the last VM capability must release retained egress state"
+            );
+        });
+    }
+
+    #[test]
+    fn graceful_shutdown_rejects_live_sibling_capabilities() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let response = r#"{"kind":"shutdown","payload":{"id":0,"error":null}}"#;
+        let script = format!("IFS= read -r request\nprintf '%s\\n' '{response}'");
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg(script);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let session = VmToolSession::spawn(&mut command).unwrap();
+            let handle = session.handle();
+            assert!(matches!(
+                session.shutdown().await,
+                Err(VmToolSessionError::ActiveCapabilities(1))
+            ));
+            drop(handle);
+            session.shutdown().await.unwrap();
+        });
+    }
+
+    #[test]
+    fn configured_spawn_retains_private_input_until_the_vmm_has_loaded_it() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let response = r#"{"kind":"shutdown","payload":{"id":0,"error":null}}"#;
+        let script = format!(
+            "config=$1\nsleep 0.05\ntest -f \"$config\" || exit 9\nIFS= read -r request\nprintf '%s\\n' '{response}'"
+        );
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg(script).arg("vm-test");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let session = VmToolSession::spawn_configured(
+                command,
+                nanovm::VmConfig::ext4("/unused/root.ext4"),
+                nanovm::GuestCommand::new("/bin/true"),
+                nanovm::EgressLease::disabled(),
+            )
+            .await
+            .unwrap();
+            session.shutdown().await.unwrap();
+        });
     }
 }

--- a/crates/nanovm/Cargo.toml
+++ b/crates/nanovm/Cargo.toml
@@ -24,5 +24,6 @@ tempfile.workspace = true
 thiserror.workspace = true
 vm-memory.workspace = true
 
-[lints]
-workspace = true
+[lints.clippy]
+all = "warn"
+pedantic = "warn"

--- a/crates/nanovm/Cargo.toml
+++ b/crates/nanovm/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "nanovm"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+description = "Small, embedded libkrun microVM primitives for Rust"
+
+[dependencies]
+# libkrun's reviewed checkpoint accepts imago 0.2, but 0.2.4 selects an
+# incompatible vm-memory release. Keep consumers on the proven resolution.
+imago.workspace = true
+krun.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true
+thiserror.workspace = true
+vm-memory.workspace = true
+
+[lints]
+workspace = true

--- a/crates/nanovm/src/capabilities.rs
+++ b/crates/nanovm/src/capabilities.rs
@@ -1,0 +1,116 @@
+use std::collections::BTreeSet;
+
+use crate::VmError;
+
+/// Optional functionality compiled into the pinned libkrun build.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[repr(u64)]
+pub enum KrunFeature {
+    Network = 0,
+    Block = 1,
+    Gpu = 2,
+    Input = 4,
+    Tee = 6,
+    AmdSev = 7,
+    IntelTdx = 8,
+    AwsNitro = 9,
+    VirglResourceMap2 = 10,
+    InitBlob = 11,
+}
+
+const FEATURES: [KrunFeature; 10] = [
+    KrunFeature::Network,
+    KrunFeature::Block,
+    KrunFeature::Gpu,
+    KrunFeature::Input,
+    KrunFeature::Tee,
+    KrunFeature::AmdSev,
+    KrunFeature::IntelTdx,
+    KrunFeature::AwsNitro,
+    KrunFeature::VirglResourceMap2,
+    KrunFeature::InitBlob,
+];
+
+/// Host and build capabilities relevant when configuring a VM.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Capabilities {
+    max_vcpus: u32,
+    nested_virtualization: bool,
+    pause_resume: bool,
+    features: BTreeSet<KrunFeature>,
+}
+
+impl Capabilities {
+    /// Queries the active libkrun build and host hypervisor.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when libkrun cannot query a capability.
+    pub fn detect() -> Result<Self, VmError> {
+        let max_vcpus = positive(krun::krun_get_max_vcpus(), "query maximum vCPUs")?;
+        // SAFETY: this libkrun function has no pointer arguments or additional
+        // preconditions despite being declared unsafe in its Rust ABI.
+        let nested_virtualization = bool_status(
+            unsafe { krun::krun_check_nested_virt() },
+            "query nested virtualization",
+        )?;
+        let mut features = BTreeSet::new();
+        for feature in FEATURES {
+            if bool_status(
+                krun::krun_has_feature(feature as u64),
+                "query compiled feature",
+            )? {
+                features.insert(feature);
+            }
+        }
+
+        Ok(Self {
+            max_vcpus,
+            nested_virtualization,
+            pause_resume: cfg!(target_os = "macos"),
+            features,
+        })
+    }
+
+    #[must_use]
+    pub const fn max_vcpus(&self) -> u32 {
+        self.max_vcpus
+    }
+
+    #[must_use]
+    pub const fn nested_virtualization(&self) -> bool {
+        self.nested_virtualization
+    }
+
+    #[must_use]
+    pub const fn pause_resume(&self) -> bool {
+        self.pause_resume
+    }
+
+    #[must_use]
+    pub fn has(&self, feature: KrunFeature) -> bool {
+        self.features.contains(&feature)
+    }
+
+    pub fn features(&self) -> impl Iterator<Item = KrunFeature> + '_ {
+        self.features.iter().copied()
+    }
+}
+
+fn positive(status: i32, operation: &'static str) -> Result<u32, VmError> {
+    u32::try_from(status).map_err(|_| VmError::Libkrun {
+        operation,
+        errno: status.saturating_neg(),
+    })
+}
+
+fn bool_status(status: i32, operation: &'static str) -> Result<bool, VmError> {
+    match status {
+        0 => Ok(false),
+        1 => Ok(true),
+        _ => Err(VmError::Libkrun {
+            operation,
+            errno: status.saturating_neg(),
+        }),
+    }
+}

--- a/crates/nanovm/src/capabilities.rs
+++ b/crates/nanovm/src/capabilities.rs
@@ -1,3 +1,8 @@
+#![allow(
+    unsafe_code,
+    reason = "this module is one of the two audited libkrun FFI boundaries"
+)]
+
 use std::collections::BTreeSet;
 
 use crate::VmError;
@@ -36,7 +41,6 @@ const FEATURES: [KrunFeature; 10] = [
 pub struct Capabilities {
     max_vcpus: u32,
     nested_virtualization: bool,
-    pause_resume: bool,
     features: BTreeSet<KrunFeature>,
 }
 
@@ -67,7 +71,6 @@ impl Capabilities {
         Ok(Self {
             max_vcpus,
             nested_virtualization,
-            pause_resume: cfg!(target_os = "macos"),
             features,
         })
     }
@@ -80,11 +83,6 @@ impl Capabilities {
     #[must_use]
     pub const fn nested_virtualization(&self) -> bool {
         self.nested_virtualization
-    }
-
-    #[must_use]
-    pub const fn pause_resume(&self) -> bool {
-        self.pause_resume
     }
 
     #[must_use]

--- a/crates/nanovm/src/command.rs
+++ b/crates/nanovm/src/command.rs
@@ -1,0 +1,138 @@
+use std::{collections::BTreeMap, ffi::OsString, fmt, path::Path};
+
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
+/// A command to execute as the initial process inside a libkrun guest.
+#[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
+pub struct GuestCommand {
+    program: OsString,
+    arguments: Vec<OsString>,
+    #[serde(with = "environment_serde")]
+    environment: BTreeMap<OsString, OsString>,
+    current_dir: OsString,
+}
+
+impl fmt::Debug for GuestCommand {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GuestCommand")
+            .field("program", &self.program)
+            .field("arguments", &self.arguments)
+            .field(
+                "environment_keys",
+                &self.environment.keys().collect::<Vec<_>>(),
+            )
+            .field("current_dir", &self.current_dir)
+            .finish()
+    }
+}
+
+impl GuestCommand {
+    pub fn new(program: impl Into<OsString>) -> Self {
+        Self {
+            program: program.into(),
+            arguments: Vec::new(),
+            environment: BTreeMap::from([(OsString::from("PATH"), OsString::from(DEFAULT_PATH))]),
+            current_dir: OsString::from("/"),
+        }
+    }
+
+    #[must_use]
+    pub fn arg(mut self, argument: impl Into<OsString>) -> Self {
+        self.arguments.push(argument.into());
+        self
+    }
+
+    #[must_use]
+    pub fn args<I, A>(mut self, arguments: I) -> Self
+    where
+        I: IntoIterator<Item = A>,
+        A: Into<OsString>,
+    {
+        self.arguments.extend(arguments.into_iter().map(Into::into));
+        self
+    }
+
+    #[must_use]
+    pub fn env(mut self, name: impl Into<OsString>, value: impl Into<OsString>) -> Self {
+        self.environment.insert(name.into(), value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn current_dir(mut self, directory: impl Into<OsString>) -> Self {
+        self.current_dir = directory.into();
+        self
+    }
+
+    #[must_use]
+    pub fn program(&self) -> &Path {
+        Path::new(&self.program)
+    }
+
+    #[must_use]
+    pub fn arguments(&self) -> &[OsString] {
+        &self.arguments
+    }
+
+    #[must_use]
+    pub fn environment(&self) -> &BTreeMap<OsString, OsString> {
+        &self.environment
+    }
+
+    #[must_use]
+    pub fn current_directory(&self) -> &Path {
+        Path::new(&self.current_dir)
+    }
+}
+
+mod environment_serde {
+    use std::{collections::BTreeMap, ffi::OsString};
+
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S>(
+        environment: &BTreeMap<OsString, OsString>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        environment.iter().collect::<Vec<_>>().serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<BTreeMap<OsString, OsString>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Vec::<(OsString, OsString)>::deserialize(deserializer)?
+            .into_iter()
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_owns_guest_process_policy() {
+        let command = GuestCommand::new("/bin/sh")
+            .args(["-c", "pwd"])
+            .env("TERM", "dumb")
+            .current_dir("/workspace");
+
+        assert_eq!(command.program(), Path::new("/bin/sh"));
+        assert_eq!(
+            command.arguments(),
+            [OsString::from("-c"), OsString::from("pwd")]
+        );
+        assert_eq!(
+            command.environment().get(&OsString::from("TERM")),
+            Some(&OsString::from("dumb"))
+        );
+        assert_eq!(command.current_directory(), Path::new("/workspace"));
+    }
+}

--- a/crates/nanovm/src/config.rs
+++ b/crates/nanovm/src/config.rs
@@ -1,0 +1,334 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Root filesystem exposed to one guest.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum RootFilesystem {
+    /// A host directory shared through virtiofs.
+    Directory(PathBuf),
+    /// A raw ext4 image attached as the guest's writable root block device.
+    Ext4(PathBuf),
+}
+
+/// Network access supplied to the guest by libkrun.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub enum Network {
+    /// Do not attach a virtio-vsock device or proxy guest internet sockets.
+    Disabled,
+    /// Proxy guest internet sockets through libkrun TSI.
+    #[default]
+    Internet,
+    /// A private virtio-net interface connected to a gvproxy unixgram socket.
+    ///
+    /// Unlike TSI, this gives the guest its own loopback and port namespace.
+    Gvproxy {
+        socket: PathBuf,
+        mac_address: [u8; 6],
+    },
+}
+
+impl Network {
+    /// Creates a private virtio-net interface backed by gvproxy.
+    #[must_use]
+    pub fn gvproxy(socket: impl Into<PathBuf>) -> Self {
+        Self::Gvproxy {
+            socket: socket.into(),
+            mac_address: [0x5a, 0x94, 0xef, 0xe4, 0x0c, 0xee],
+        }
+    }
+}
+
+/// One additional block device attached after the root disk.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct BlockDevice {
+    id: String,
+    path: PathBuf,
+    read_only: bool,
+}
+
+impl BlockDevice {
+    /// Creates a writable block device.
+    pub fn read_write(id: impl Into<String>, path: impl Into<PathBuf>) -> Self {
+        Self {
+            id: id.into(),
+            path: path.into(),
+            read_only: false,
+        }
+    }
+
+    /// Creates an immutable block device.
+    pub fn read_only(id: impl Into<String>, path: impl Into<PathBuf>) -> Self {
+        Self {
+            id: id.into(),
+            path: path.into(),
+            read_only: true,
+        }
+    }
+
+    #[must_use]
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    #[must_use]
+    pub const fn is_read_only(&self) -> bool {
+        self.read_only
+    }
+}
+
+/// One narrowly scoped host directory exposed to the guest through virtiofs.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct SharedDirectory {
+    tag: String,
+    path: PathBuf,
+    read_only: bool,
+}
+
+impl SharedDirectory {
+    /// Creates a read-only share identified by `tag` inside the guest.
+    pub fn read_only(tag: impl Into<String>, path: impl Into<PathBuf>) -> Self {
+        Self {
+            tag: tag.into(),
+            path: path.into(),
+            read_only: true,
+        }
+    }
+
+    /// Creates a writable share identified by `tag` inside the guest.
+    pub fn read_write(tag: impl Into<String>, path: impl Into<PathBuf>) -> Self {
+        Self {
+            tag: tag.into(),
+            path: path.into(),
+            read_only: false,
+        }
+    }
+
+    #[must_use]
+    pub fn tag(&self) -> &str {
+        &self.tag
+    }
+
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    #[must_use]
+    pub const fn is_read_only(&self) -> bool {
+        self.read_only
+    }
+}
+
+/// Immutable configuration for one libkrun VM.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct VmConfig {
+    root: RootFilesystem,
+    cpus: u8,
+    memory_mib: u32,
+    network: Network,
+    block_devices: Vec<BlockDevice>,
+    shared_directories: Vec<SharedDirectory>,
+}
+
+impl VmConfig {
+    /// Creates a VM configuration with two vCPUs, 1 GiB RAM, and internet
+    /// socket proxying enabled.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: RootFilesystem::Directory(root.into()),
+            cpus: 2,
+            memory_mib: 1_024,
+            network: Network::Internet,
+            block_devices: Vec::new(),
+            shared_directories: Vec::new(),
+        }
+    }
+
+    /// Creates a VM backed by a raw ext4 root disk.
+    pub fn ext4(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: RootFilesystem::Ext4(root.into()),
+            cpus: 2,
+            memory_mib: 1_024,
+            network: Network::Internet,
+            block_devices: Vec::new(),
+            shared_directories: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn cpus(mut self, cpus: u8) -> Self {
+        self.cpus = cpus;
+        self
+    }
+
+    #[must_use]
+    pub fn memory_mib(mut self, memory_mib: u32) -> Self {
+        self.memory_mib = memory_mib;
+        self
+    }
+
+    #[must_use]
+    pub fn network(mut self, network: Network) -> Self {
+        self.network = network;
+        self
+    }
+
+    #[must_use]
+    pub fn shared_directory(mut self, directory: SharedDirectory) -> Self {
+        self.shared_directories.push(directory);
+        self
+    }
+
+    #[must_use]
+    pub fn block_device(mut self, device: BlockDevice) -> Self {
+        self.block_devices.push(device);
+        self
+    }
+
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        match &self.root {
+            RootFilesystem::Directory(path) | RootFilesystem::Ext4(path) => path,
+        }
+    }
+
+    #[must_use]
+    pub const fn root_filesystem(&self) -> &RootFilesystem {
+        &self.root
+    }
+
+    #[must_use]
+    pub const fn cpus_value(&self) -> u8 {
+        self.cpus
+    }
+
+    #[must_use]
+    pub const fn memory_mib_value(&self) -> u32 {
+        self.memory_mib
+    }
+
+    #[must_use]
+    pub const fn network_value(&self) -> &Network {
+        &self.network
+    }
+
+    #[must_use]
+    pub fn shared_directories(&self) -> &[SharedDirectory] {
+        &self.shared_directories
+    }
+
+    #[must_use]
+    pub fn block_devices(&self) -> &[BlockDevice] {
+        &self.block_devices
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_suitable_for_a_small_worker() {
+        let config = VmConfig::new("rootfs");
+
+        assert_eq!(config.root(), Path::new("rootfs"));
+        assert_eq!(
+            config.root_filesystem(),
+            &RootFilesystem::Directory(PathBuf::from("rootfs"))
+        );
+        assert_eq!(config.cpus_value(), 2);
+        assert_eq!(config.memory_mib_value(), 1_024);
+        assert_eq!(config.network_value(), &Network::Internet);
+    }
+
+    #[test]
+    fn policy_is_explicitly_overridable() {
+        let config = VmConfig::new("rootfs")
+            .cpus(8)
+            .memory_mib(4_096)
+            .network(Network::Disabled);
+
+        assert_eq!(config.cpus_value(), 8);
+        assert_eq!(config.memory_mib_value(), 4_096);
+        assert_eq!(config.network_value(), &Network::Disabled);
+    }
+
+    #[test]
+    fn gvproxy_network_has_an_isolated_default_identity() {
+        let network = Network::gvproxy("/tmp/network.sock");
+
+        assert_eq!(
+            network,
+            Network::Gvproxy {
+                socket: PathBuf::from("/tmp/network.sock"),
+                mac_address: [0x5a, 0x94, 0xef, 0xe4, 0x0c, 0xee],
+            }
+        );
+    }
+
+    #[test]
+    fn raw_ext4_is_an_explicit_root_kind() {
+        let config = VmConfig::ext4("rootfs.ext4");
+
+        assert_eq!(config.root(), Path::new("rootfs.ext4"));
+        assert_eq!(
+            config.root_filesystem(),
+            &RootFilesystem::Ext4(PathBuf::from("rootfs.ext4"))
+        );
+    }
+
+    #[test]
+    fn read_only_shares_are_explicit() {
+        let config = VmConfig::ext4("rootfs.ext4").shared_directory(SharedDirectory::read_only(
+            "nanocodex-tools",
+            "target/guest-tools",
+        ));
+
+        assert_eq!(
+            config.shared_directories(),
+            &[SharedDirectory::read_only(
+                "nanocodex-tools",
+                "target/guest-tools"
+            )]
+        );
+        assert!(config.shared_directories()[0].is_read_only());
+    }
+
+    #[test]
+    fn block_device_mutability_is_explicit() {
+        let config = VmConfig::ext4("rootfs.ext4")
+            .block_device(BlockDevice::read_write("cache", "cache.ext4"))
+            .block_device(BlockDevice::read_only("runtime", "runtime.ext4"));
+
+        assert!(!config.block_devices()[0].is_read_only());
+        assert!(config.block_devices()[1].is_read_only());
+    }
+
+    #[test]
+    fn writable_shares_are_explicit() {
+        let directory = SharedDirectory::read_write("nanocodex-cache", "cache");
+
+        assert_eq!(directory.tag(), "nanocodex-cache");
+        assert_eq!(directory.path(), Path::new("cache"));
+        assert!(!directory.is_read_only());
+    }
+
+    #[test]
+    fn read_only_block_devices_are_explicit() {
+        let config = VmConfig::ext4("rootfs.ext4")
+            .block_device(BlockDevice::read_only("runtime", "runtime.ext4"));
+
+        assert_eq!(
+            config.block_devices(),
+            &[BlockDevice::read_only("runtime", "runtime.ext4")]
+        );
+        assert!(config.block_devices()[0].is_read_only());
+    }
+}

--- a/crates/nanovm/src/egress.rs
+++ b/crates/nanovm/src/egress.rs
@@ -1,0 +1,346 @@
+use std::{any::Any, collections::BTreeMap, fmt, path::PathBuf, sync::Arc};
+
+use thiserror::Error;
+
+use crate::{GuestCommand, Network, SharedDirectory, VmConfig};
+
+const MOUNT_AND_EXEC: &str = concat!(
+    "set -eu; ",
+    "workdir=$1; shift; ",
+    "while [ \"$1\" != -- ]; do ",
+    "tag=$1; guest=$2; shift 2; ",
+    "mkdir -p -- \"$guest\"; ",
+    "mount -t virtiofs -o ro \"$tag\" \"$guest\"; ",
+    "done; ",
+    "shift; cd -- \"$workdir\"; exec \"$@\"",
+);
+
+/// VM-facing outbound-access configuration retained for one guest lifetime.
+///
+/// An application-specific provider can resolve MPP, secret, or capability
+/// policy into this type without exposing that policy to `nanovm`. Values are
+/// deliberately omitted from `Debug`: proxy URLs may contain short-lived
+/// credentials.
+#[derive(Clone)]
+pub struct EgressLease {
+    network: Network,
+    guest_environment: BTreeMap<String, String>,
+    guest_mounts: BTreeMap<String, EgressMount>,
+    guards: Vec<Arc<dyn Any + Send + Sync>>,
+}
+
+/// One provider-owned host directory mounted read-only into the guest.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EgressMount {
+    pub tag: String,
+    pub host_path: PathBuf,
+    pub guest_path: PathBuf,
+}
+
+impl EgressLease {
+    #[must_use]
+    pub fn new(network: Network) -> Self {
+        Self {
+            network,
+            guest_environment: BTreeMap::new(),
+            guest_mounts: BTreeMap::new(),
+            guards: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn internet() -> Self {
+        Self::new(Network::Internet)
+    }
+
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self::new(Network::Disabled)
+    }
+
+    /// Adds one guest environment value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the name is empty or was already assigned a
+    /// different value by another egress component.
+    pub fn insert_environment(
+        &mut self,
+        name: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Result<(), EgressError> {
+        let name = name.into();
+        if !valid_environment_name(&name) {
+            return Err(EgressError::InvalidEnvironmentName(name));
+        }
+        let value = value.into();
+        if self
+            .guest_environment
+            .get(&name)
+            .is_some_and(|current| current != &value)
+        {
+            return Err(EgressError::EnvironmentConflict(name));
+        }
+        self.guest_environment.insert(name, value);
+        Ok(())
+    }
+
+    /// Adds one read-only provider mount.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the tag or guest path collides with a different
+    /// mount.
+    pub fn insert_mount(&mut self, mount: EgressMount) -> Result<(), EgressError> {
+        if mount.tag.is_empty() {
+            return Err(EgressError::EmptyMountTag);
+        }
+        if self
+            .guest_mounts
+            .values()
+            .any(|current| current.guest_path == mount.guest_path && current != &mount)
+        {
+            return Err(EgressError::GuestMountConflict(mount.guest_path));
+        }
+        if self
+            .guest_mounts
+            .get(&mount.tag)
+            .is_some_and(|current| current != &mount)
+        {
+            return Err(EgressError::MountTagConflict(mount.tag));
+        }
+        self.guest_mounts.insert(mount.tag.clone(), mount);
+        Ok(())
+    }
+
+    /// Retains provider state, such as a revocable proxy lease, until the guest
+    /// is dropped.
+    pub fn retain<T>(&mut self, guard: Arc<T>)
+    where
+        T: Any + Send + Sync,
+    {
+        self.guards.push(guard);
+    }
+
+    /// Combines independently provisioned egress fragments.
+    ///
+    /// Identical network, environment, and mount configuration is idempotent.
+    /// Conflicting configuration fails closed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the fragments select different network modes or
+    /// assign incompatible environment or mount values.
+    pub fn merge(&mut self, other: Self) -> Result<(), EgressError> {
+        if self.network != other.network {
+            return Err(EgressError::NetworkConflict);
+        }
+        let mut merged = self.clone();
+        for (name, value) in other.guest_environment {
+            merged.insert_environment(name, value)?;
+        }
+        for mount in other.guest_mounts.into_values() {
+            merged.insert_mount(mount)?;
+        }
+        merged.guards.extend(other.guards);
+        *self = merged;
+        Ok(())
+    }
+
+    /// Returns this lease with one independently provisioned layer applied.
+    ///
+    /// This is the fluent form of [`Self::merge`]. It lets an application
+    /// assemble a VM route from concrete MPP, secret-gateway, and other
+    /// provider leases without teaching the VM package about those policies.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the new layer conflicts with an earlier layer.
+    pub fn with_layer(mut self, layer: Self) -> Result<Self, EgressError> {
+        self.merge(layer)?;
+        Ok(self)
+    }
+
+    /// Applies this lease to one VM configuration and guest command.
+    ///
+    /// Provider directories are attached read-only and mounted before the
+    /// requested program starts. Guest environment from the lease overrides
+    /// the command's value for the same name. The lease itself must remain
+    /// alive for at least as long as the resulting VM so its provider guards
+    /// continue to protect revocable proxy and secret routes.
+    #[must_use]
+    pub fn configure(&self, mut vm: VmConfig, command: &GuestCommand) -> (VmConfig, GuestCommand) {
+        vm = vm.network(self.network.clone());
+        let mut configured =
+            GuestCommand::new("/bin/sh").args(["-c", MOUNT_AND_EXEC, "nanovm-egress"]);
+        configured = configured.arg(command.current_directory().as_os_str());
+        for mount in self.guest_mounts() {
+            vm = vm.shared_directory(SharedDirectory::read_only(&mount.tag, &mount.host_path));
+            configured = configured.arg(&mount.tag).arg(mount.guest_path.as_os_str());
+        }
+        configured = configured.arg("--").arg(command.program().as_os_str());
+        configured = configured.args(command.arguments().iter().cloned());
+        for (name, value) in command.environment() {
+            configured = configured.env(name, value);
+        }
+        for (name, value) in self.guest_environment() {
+            configured = configured.env(name, value);
+        }
+        (vm, configured)
+    }
+
+    #[must_use]
+    pub const fn network(&self) -> &Network {
+        &self.network
+    }
+
+    #[must_use]
+    pub fn guest_environment(&self) -> &BTreeMap<String, String> {
+        &self.guest_environment
+    }
+
+    pub fn guest_mounts(&self) -> impl Iterator<Item = &EgressMount> {
+        self.guest_mounts.values()
+    }
+}
+
+impl fmt::Debug for EgressLease {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EgressLease")
+            .field("network", &self.network)
+            .field(
+                "guest_environment_keys",
+                &self.guest_environment.keys().collect::<Vec<_>>(),
+            )
+            .field(
+                "guest_mounts",
+                &self.guest_mounts.values().collect::<Vec<_>>(),
+            )
+            .field("guards", &self.guards.len())
+            .finish()
+    }
+}
+
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum EgressError {
+    #[error("egress fragments require conflicting VM network modes")]
+    NetworkConflict,
+    #[error("guest environment name `{0}` is not a shell identifier")]
+    InvalidEnvironmentName(String),
+    #[error("guest environment `{0}` has conflicting egress values")]
+    EnvironmentConflict(String),
+    #[error("egress mount tag must not be empty")]
+    EmptyMountTag,
+    #[error("egress mount tag `{0}` has conflicting host paths")]
+    MountTagConflict(String),
+    #[error("guest egress mount path `{0}` has conflicting providers")]
+    GuestMountConflict(PathBuf),
+}
+
+fn valid_environment_name(name: &str) -> bool {
+    let mut bytes = name.bytes();
+    bytes
+        .next()
+        .is_some_and(|byte| byte == b'_' || byte.is_ascii_alphabetic())
+        && bytes.all(|byte| byte == b'_' || byte.is_ascii_alphanumeric())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn independently_provisioned_egress_fragments_compose() {
+        let guard = Arc::new(());
+        let mut secrets = EgressLease::internet();
+        secrets
+            .insert_environment("NANOCENTAUR_SECRET_BASE_URL", "https://secret-gateway/v1")
+            .unwrap();
+        secrets
+            .insert_mount(EgressMount {
+                tag: "secret-ca".to_owned(),
+                host_path: PathBuf::from("/host/ca"),
+                guest_path: PathBuf::from("/run/egress/ca"),
+            })
+            .unwrap();
+        secrets.retain(Arc::clone(&guard));
+
+        let mut mpp = EgressLease::internet();
+        mpp.insert_environment(
+            "HTTPS_PROXY",
+            "http://mpp-lease:credential@host.internal:8080",
+        )
+        .unwrap();
+        let egress = EgressLease::internet()
+            .with_layer(mpp)
+            .unwrap()
+            .with_layer(secrets)
+            .unwrap();
+
+        assert_eq!(egress.guest_environment().len(), 2);
+        assert_eq!(egress.guest_mounts().count(), 1);
+        assert_eq!(Arc::strong_count(&guard), 2);
+        let debug = format!("{egress:?}");
+        assert!(!debug.contains("credential"));
+        assert!(!debug.contains("secret-gateway"));
+    }
+
+    #[test]
+    fn conflicting_provider_values_fail_closed() {
+        let mut secrets = EgressLease::internet();
+        secrets
+            .insert_environment("HTTPS_PROXY", "http://secret-gateway")
+            .unwrap();
+        let mut mpp = EgressLease::internet();
+        mpp.insert_environment("HTTPS_PROXY", "http://mpp-gateway")
+            .unwrap();
+
+        assert_eq!(
+            secrets.merge(mpp),
+            Err(EgressError::EnvironmentConflict("HTTPS_PROXY".to_owned()))
+        );
+    }
+
+    #[test]
+    fn lease_configures_network_mounts_and_proxy_environment() {
+        let mut lease = EgressLease::internet();
+        lease
+            .insert_environment("HTTPS_PROXY", "http://host.internal:8080")
+            .unwrap();
+        lease
+            .insert_mount(EgressMount {
+                tag: "mpp-ca".to_owned(),
+                host_path: PathBuf::from("/host/mpp"),
+                guest_path: PathBuf::from("/run/egress/mpp"),
+            })
+            .unwrap();
+        let command = GuestCommand::new("/usr/local/bin/nanocodex-vm-guest")
+            .arg("/workspace")
+            .env("HTTPS_PROXY", "http://untrusted")
+            .current_dir("/workspace");
+
+        let (vm, command) = lease.configure(
+            VmConfig::ext4("/tmp/rootfs").network(Network::Disabled),
+            &command,
+        );
+
+        assert_eq!(vm.network_value(), &Network::Internet);
+        assert_eq!(
+            vm.shared_directories(),
+            &[SharedDirectory::read_only("mpp-ca", "/host/mpp")]
+        );
+        assert_eq!(command.program(), std::path::Path::new("/bin/sh"));
+        assert_eq!(
+            command
+                .environment()
+                .get(&std::ffi::OsString::from("HTTPS_PROXY")),
+            Some(&std::ffi::OsString::from("http://host.internal:8080"))
+        );
+        assert!(
+            command
+                .arguments()
+                .contains(&std::ffi::OsString::from("/run/egress/mpp"))
+        );
+    }
+}

--- a/crates/nanovm/src/egress.rs
+++ b/crates/nanovm/src/egress.rs
@@ -1,8 +1,10 @@
 use std::{
     any::Any,
     collections::BTreeMap,
+    ffi::{OsStr, OsString},
     fmt,
-    path::{Path, PathBuf},
+    os::unix::ffi::{OsStrExt, OsStringExt},
+    path::{Component, Path, PathBuf},
     sync::Arc,
 };
 
@@ -10,16 +12,8 @@ use thiserror::Error;
 
 use crate::{GuestCommand, Network, SharedDirectory, VmConfig};
 
-const MOUNT_AND_EXEC: &str = concat!(
-    "set -eu; ",
-    "workdir=$1; shift; ",
-    "while [ \"$1\" != -- ]; do ",
-    "tag=$1; guest=$2; shift 2; ",
-    "mkdir -p -- \"$guest\"; ",
-    "mount -t virtiofs -o ro \"$tag\" \"$guest\"; ",
-    "done; ",
-    "shift; cd -- \"$workdir\"; exec \"$@\"",
-);
+pub const GUEST_EGRESS_ROOT: &str = "/tmp/nanocodex/egress";
+pub const MAX_EGRESS_FILE_BYTES: usize = 4 * 1024 * 1024;
 
 /// VM-facing outbound-access configuration retained for one guest lifetime.
 ///
@@ -116,6 +110,9 @@ impl EgressLease {
             return Err(EgressError::InvalidEnvironmentName(name));
         }
         let value = value.into();
+        if value.contains('\0') {
+            return Err(EgressError::EnvironmentValueContainsNul(name));
+        }
         if self
             .guest_environment
             .get(&name)
@@ -134,14 +131,18 @@ impl EgressLease {
     /// Returns an error when the tag or guest path collides with a different
     /// mount.
     pub fn insert_mount(&mut self, mount: EgressMount) -> Result<(), EgressError> {
-        if mount.tag.is_empty() {
-            return Err(EgressError::EmptyMountTag);
+        if !valid_mount_tag(&mount.tag) {
+            return Err(EgressError::InvalidMountTag(mount.tag));
         }
-        if self
-            .guest_mounts
-            .values()
-            .any(|current| current.guest_path == mount.guest_path && current != &mount)
-        {
+        if !mount.host_path.is_absolute() {
+            return Err(EgressError::HostMountPathNotAbsolute(mount.host_path));
+        }
+        if !valid_guest_egress_path(&mount.guest_path) {
+            return Err(EgressError::GuestMountPathOutsideRoot(mount.guest_path));
+        }
+        if self.guest_mounts.values().any(|current| {
+            paths_overlap(&current.guest_path, &mount.guest_path) && current != &mount
+        }) {
             return Err(EgressError::GuestMountConflict(mount.guest_path));
         }
         if self
@@ -150,6 +151,13 @@ impl EgressLease {
             .is_some_and(|current| current != &mount)
         {
             return Err(EgressError::MountTagConflict(mount.tag));
+        }
+        if self
+            .guest_files
+            .keys()
+            .any(|path| path.starts_with(&mount.guest_path))
+        {
+            return Err(EgressError::GuestMountFileOverlap(mount.guest_path));
         }
         self.guest_mounts.insert(mount.tag.clone(), mount);
         Ok(())
@@ -162,8 +170,28 @@ impl EgressLease {
     /// Returns an error when the guest path is not absolute or conflicts with
     /// a different provider file.
     pub fn insert_file(&mut self, file: EgressFile) -> Result<(), EgressError> {
-        if !file.guest_path.is_absolute() {
-            return Err(EgressError::GuestFilePathNotAbsolute(file.guest_path));
+        if !valid_guest_egress_path(&file.guest_path) {
+            return Err(EgressError::GuestFilePathOutsideRoot(file.guest_path));
+        }
+        if file.contents.len() > MAX_EGRESS_FILE_BYTES {
+            return Err(EgressError::GuestFileTooLarge {
+                path: file.guest_path,
+                size: file.contents.len(),
+                limit: MAX_EGRESS_FILE_BYTES,
+            });
+        }
+        if file.mode & !0o777 != 0 {
+            return Err(EgressError::InvalidGuestFileMode {
+                path: file.guest_path,
+                mode: file.mode,
+            });
+        }
+        if self
+            .guest_mounts
+            .values()
+            .any(|mount| file.guest_path.starts_with(&mount.guest_path))
+        {
+            return Err(EgressError::GuestMountFileOverlap(file.guest_path));
         }
         if self
             .guest_files
@@ -241,15 +269,28 @@ impl EgressLease {
         let mut configured = if self.guest_mounts.is_empty() {
             command.clone()
         } else {
-            let mut configured =
-                GuestCommand::new("/bin/sh").args(["-c", MOUNT_AND_EXEC, "nanovm-egress"]);
-            configured = configured.arg(command.current_directory().as_os_str());
+            let mut script = OsString::from("set -eu;");
             for mount in self.guest_mounts() {
                 vm = vm.shared_directory(SharedDirectory::read_only(&mount.tag, &mount.host_path));
-                configured = configured.arg(&mount.tag).arg(mount.guest_path.as_os_str());
+                append_shell_command(&mut script, " mkdir -p -- ", [mount.guest_path.as_os_str()]);
+                append_shell_command(
+                    &mut script,
+                    "; mount -t virtiofs -o ro ",
+                    [OsStr::new(&mount.tag), mount.guest_path.as_os_str()],
+                );
             }
-            configured = configured.arg("--").arg(command.program().as_os_str());
-            configured = configured.args(command.arguments().iter().cloned());
+            append_shell_command(
+                &mut script,
+                "; cd -- ",
+                [command.current_directory().as_os_str()],
+            );
+            append_shell_command(
+                &mut script,
+                "; exec ",
+                std::iter::once(command.program().as_os_str())
+                    .chain(command.arguments().iter().map(OsString::as_os_str)),
+            );
+            let mut configured = GuestCommand::new("/bin/sh").args(["-c"]).arg(script);
             for (name, value) in command.environment() {
                 configured = configured.env(name, value);
             }
@@ -310,14 +351,30 @@ pub enum EgressError {
     InvalidEnvironmentName(String),
     #[error("guest environment `{0}` has conflicting egress values")]
     EnvironmentConflict(String),
-    #[error("egress mount tag must not be empty")]
-    EmptyMountTag,
+    #[error("guest environment `{0}` contains a NUL byte")]
+    EnvironmentValueContainsNul(String),
+    #[error("egress mount tag `{0}` is not a portable identifier")]
+    InvalidMountTag(String),
+    #[error("host egress mount path must be absolute: {0}")]
+    HostMountPathNotAbsolute(PathBuf),
+    #[error("guest egress mount path must be a normalized child of {GUEST_EGRESS_ROOT}: {0}")]
+    GuestMountPathOutsideRoot(PathBuf),
     #[error("egress mount tag `{0}` has conflicting host paths")]
     MountTagConflict(String),
     #[error("guest egress mount path `{0}` has conflicting providers")]
     GuestMountConflict(PathBuf),
-    #[error("guest egress file path must be absolute: {0}")]
-    GuestFilePathNotAbsolute(PathBuf),
+    #[error("guest egress mount and file paths overlap at `{0}`")]
+    GuestMountFileOverlap(PathBuf),
+    #[error("guest egress file path must be a normalized child of {GUEST_EGRESS_ROOT}: {0}")]
+    GuestFilePathOutsideRoot(PathBuf),
+    #[error("guest egress file `{path}` is {size} bytes, exceeding the {limit}-byte limit")]
+    GuestFileTooLarge {
+        path: PathBuf,
+        size: usize,
+        limit: usize,
+    },
+    #[error("guest egress file `{path}` has invalid mode {mode:#o}")]
+    InvalidGuestFileMode { path: PathBuf, mode: u32 },
     #[error("guest egress file path `{0}` has conflicting providers")]
     GuestFileConflict(PathBuf),
 }
@@ -328,6 +385,60 @@ fn valid_environment_name(name: &str) -> bool {
         .next()
         .is_some_and(|byte| byte == b'_' || byte.is_ascii_alphabetic())
         && bytes.all(|byte| byte == b'_' || byte.is_ascii_alphanumeric())
+}
+
+fn valid_mount_tag(tag: &str) -> bool {
+    !tag.is_empty()
+        && tag.len() <= 64
+        && tag
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+}
+
+fn valid_guest_egress_path(path: &Path) -> bool {
+    path.is_absolute()
+        && path != Path::new(GUEST_EGRESS_ROOT)
+        && path.starts_with(GUEST_EGRESS_ROOT)
+        && path
+            .components()
+            .all(|component| !matches!(component, Component::CurDir | Component::ParentDir))
+}
+
+fn paths_overlap(first: &Path, second: &Path) -> bool {
+    first.starts_with(second) || second.starts_with(first)
+}
+
+fn append_shell_command<'a>(
+    script: &mut OsString,
+    prefix: &str,
+    arguments: impl IntoIterator<Item = &'a OsStr>,
+) {
+    script.push(prefix);
+    let mut first = true;
+    for argument in arguments {
+        if !first {
+            script.push(" ");
+        }
+        first = false;
+        script.push(shell_single_quote(argument));
+    }
+}
+
+fn shell_single_quote(value: &OsStr) -> OsString {
+    let bytes = value.as_bytes();
+    let mut quoted = Vec::with_capacity(bytes.len().saturating_add(2));
+    quoted.push(b'\'');
+    for byte in bytes {
+        match *byte {
+            b'\'' => quoted.extend_from_slice(b"'\\''"),
+            // libkrun cannot carry a literal double quote in an argv entry.
+            // Produce it at wrapper-shell evaluation time instead.
+            b'"' => quoted.extend_from_slice(b"'$(printf '\\042')'"),
+            byte => quoted.push(byte),
+        }
+    }
+    quoted.push(b'\'');
+    OsString::from_vec(quoted)
 }
 
 #[cfg(test)]
@@ -345,7 +456,7 @@ mod tests {
             .insert_mount(EgressMount {
                 tag: "secret-ca".to_owned(),
                 host_path: PathBuf::from("/host/ca"),
-                guest_path: PathBuf::from("/run/egress/ca"),
+                guest_path: PathBuf::from("/tmp/nanocodex/egress/secrets/ca"),
             })
             .unwrap();
         secrets.retain(Arc::clone(&guard));
@@ -388,7 +499,7 @@ mod tests {
 
     #[test]
     fn provider_files_compose_idempotently_and_conflicts_fail_closed() {
-        let path = "/tmp/nanovm/ca.pem";
+        let path = "/tmp/nanocodex/egress/mpp/ca.pem";
         let file = EgressFile::new(path, b"public ca".to_vec(), 0o444);
         let mut first = EgressLease::internet();
         first.insert_file(file.clone()).unwrap();
@@ -412,7 +523,7 @@ mod tests {
         let mut lease = EgressLease::internet();
         assert_eq!(
             lease.insert_file(EgressFile::new("relative/ca.pem", Vec::new(), 0o444)),
-            Err(EgressError::GuestFilePathNotAbsolute(PathBuf::from(
+            Err(EgressError::GuestFilePathOutsideRoot(PathBuf::from(
                 "relative/ca.pem"
             )))
         );
@@ -428,11 +539,12 @@ mod tests {
             .insert_mount(EgressMount {
                 tag: "mpp-ca".to_owned(),
                 host_path: PathBuf::from("/host/mpp"),
-                guest_path: PathBuf::from("/run/egress/mpp"),
+                guest_path: PathBuf::from("/tmp/nanocodex/egress/mpp"),
             })
             .unwrap();
         let command = GuestCommand::new("/usr/local/bin/nanocodex-vm-guest")
             .arg("/workspace")
+            .arg(r#"say "hello""#)
             .env("HTTPS_PROXY", "http://untrusted")
             .current_dir("/workspace");
 
@@ -447,17 +559,95 @@ mod tests {
             &[SharedDirectory::read_only("mpp-ca", "/host/mpp")]
         );
         assert_eq!(command.program(), std::path::Path::new("/bin/sh"));
+        assert_eq!(command.arguments()[0], "-c");
+        let script = command.arguments()[1].to_string_lossy();
+        assert!(script.contains("mount -t virtiofs -o ro 'mpp-ca'"));
+        assert!(script.contains("cd -- '/workspace'"));
+        assert!(script.contains("exec '/usr/local/bin/nanocodex-vm-guest' '/workspace'"));
+        assert!(script.contains("$(printf '\\042')"));
+        assert!(!script.contains('"'));
         assert_eq!(
             command
                 .environment()
                 .get(&std::ffi::OsString::from("HTTPS_PROXY")),
             Some(&std::ffi::OsString::from("http://host.internal:8080"))
         );
-        assert!(
-            command
-                .arguments()
-                .contains(&std::ffi::OsString::from("/run/egress/mpp"))
+    }
+
+    #[test]
+    fn mount_and_file_path_hierarchy_conflicts_fail_before_launch() {
+        let mut lease = EgressLease::internet();
+        lease
+            .insert_mount(EgressMount {
+                tag: "provider".to_owned(),
+                host_path: PathBuf::from("/host/provider"),
+                guest_path: PathBuf::from("/tmp/nanocodex/egress/provider"),
+            })
+            .unwrap();
+
+        assert_eq!(
+            lease.insert_file(EgressFile::new(
+                "/tmp/nanocodex/egress/provider/ca.pem",
+                Vec::new(),
+                0o444,
+            )),
+            Err(EgressError::GuestMountFileOverlap(PathBuf::from(
+                "/tmp/nanocodex/egress/provider/ca.pem"
+            )))
         );
+        assert_eq!(
+            lease.insert_mount(EgressMount {
+                tag: "nested".to_owned(),
+                host_path: PathBuf::from("/host/nested"),
+                guest_path: PathBuf::from("/tmp/nanocodex/egress/provider/nested"),
+            }),
+            Err(EgressError::GuestMountConflict(PathBuf::from(
+                "/tmp/nanocodex/egress/provider/nested"
+            )))
+        );
+    }
+
+    #[test]
+    fn egress_rejects_unsafe_values_before_vmm_configuration() {
+        let mut lease = EgressLease::internet();
+        assert_eq!(
+            lease.insert_environment("HTTPS_PROXY", "http://proxy\0hidden"),
+            Err(EgressError::EnvironmentValueContainsNul(
+                "HTTPS_PROXY".to_owned()
+            ))
+        );
+        assert!(matches!(
+            lease.insert_file(EgressFile::new(
+                "/tmp/nanocodex/egress/mpp/ca.pem",
+                vec![0; MAX_EGRESS_FILE_BYTES + 1],
+                0o444,
+            )),
+            Err(EgressError::GuestFileTooLarge { .. })
+        ));
+        assert!(matches!(
+            lease.insert_file(EgressFile::new(
+                "/tmp/nanocodex/egress/mpp/ca.pem",
+                Vec::new(),
+                0o4755,
+            )),
+            Err(EgressError::InvalidGuestFileMode { .. })
+        ));
+        assert!(matches!(
+            lease.insert_mount(EgressMount {
+                tag: "bad tag".to_owned(),
+                host_path: PathBuf::from("/host/provider"),
+                guest_path: PathBuf::from("/tmp/nanocodex/egress/provider"),
+            }),
+            Err(EgressError::InvalidMountTag(_))
+        ));
+        assert!(matches!(
+            lease.insert_mount(EgressMount {
+                tag: "provider".to_owned(),
+                host_path: PathBuf::from("relative"),
+                guest_path: PathBuf::from("/tmp/nanocodex/egress/provider"),
+            }),
+            Err(EgressError::HostMountPathNotAbsolute(_))
+        ));
     }
 
     #[test]

--- a/crates/nanovm/src/egress.rs
+++ b/crates/nanovm/src/egress.rs
@@ -1,4 +1,10 @@
-use std::{any::Any, collections::BTreeMap, fmt, path::PathBuf, sync::Arc};
+use std::{
+    any::Any,
+    collections::BTreeMap,
+    fmt,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use thiserror::Error;
 
@@ -26,6 +32,7 @@ pub struct EgressLease {
     network: Network,
     guest_environment: BTreeMap<String, String>,
     guest_mounts: BTreeMap<String, EgressMount>,
+    guest_files: BTreeMap<PathBuf, EgressFile>,
     guards: Vec<Arc<dyn Any + Send + Sync>>,
 }
 
@@ -37,6 +44,40 @@ pub struct EgressMount {
     pub guest_path: PathBuf,
 }
 
+/// One provider-owned public file provisioned before agent tools are exposed.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EgressFile {
+    guest_path: PathBuf,
+    contents: Vec<u8>,
+    mode: u32,
+}
+
+impl EgressFile {
+    #[must_use]
+    pub fn new(guest_path: impl Into<PathBuf>, contents: impl Into<Vec<u8>>, mode: u32) -> Self {
+        Self {
+            guest_path: guest_path.into(),
+            contents: contents.into(),
+            mode,
+        }
+    }
+
+    #[must_use]
+    pub fn guest_path(&self) -> &Path {
+        &self.guest_path
+    }
+
+    #[must_use]
+    pub fn contents(&self) -> &[u8] {
+        &self.contents
+    }
+
+    #[must_use]
+    pub const fn mode(&self) -> u32 {
+        self.mode
+    }
+}
+
 impl EgressLease {
     #[must_use]
     pub fn new(network: Network) -> Self {
@@ -44,6 +85,7 @@ impl EgressLease {
             network,
             guest_environment: BTreeMap::new(),
             guest_mounts: BTreeMap::new(),
+            guest_files: BTreeMap::new(),
             guards: Vec::new(),
         }
     }
@@ -113,6 +155,27 @@ impl EgressLease {
         Ok(())
     }
 
+    /// Adds one public CA or provider configuration file to provision in the guest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the guest path is not absolute or conflicts with
+    /// a different provider file.
+    pub fn insert_file(&mut self, file: EgressFile) -> Result<(), EgressError> {
+        if !file.guest_path.is_absolute() {
+            return Err(EgressError::GuestFilePathNotAbsolute(file.guest_path));
+        }
+        if self
+            .guest_files
+            .get(&file.guest_path)
+            .is_some_and(|current| current != &file)
+        {
+            return Err(EgressError::GuestFileConflict(file.guest_path));
+        }
+        self.guest_files.insert(file.guest_path.clone(), file);
+        Ok(())
+    }
+
     /// Retains provider state, such as a revocable proxy lease, until the guest
     /// is dropped.
     pub fn retain<T>(&mut self, guard: Arc<T>)
@@ -124,13 +187,14 @@ impl EgressLease {
 
     /// Combines independently provisioned egress fragments.
     ///
-    /// Identical network, environment, and mount configuration is idempotent.
+    /// Identical network, environment, mount, and guest-file configuration is
+    /// idempotent.
     /// Conflicting configuration fails closed.
     ///
     /// # Errors
     ///
     /// Returns an error when the fragments select different network modes or
-    /// assign incompatible environment or mount values.
+    /// assign incompatible environment, mount, or guest-file values.
     pub fn merge(&mut self, other: Self) -> Result<(), EgressError> {
         if self.network != other.network {
             return Err(EgressError::NetworkConflict);
@@ -141,6 +205,9 @@ impl EgressLease {
         }
         for mount in other.guest_mounts.into_values() {
             merged.insert_mount(mount)?;
+        }
+        for file in other.guest_files.into_values() {
+            merged.insert_file(file)?;
         }
         merged.guards.extend(other.guards);
         *self = merged;
@@ -171,18 +238,23 @@ impl EgressLease {
     #[must_use]
     pub fn configure(&self, mut vm: VmConfig, command: &GuestCommand) -> (VmConfig, GuestCommand) {
         vm = vm.network(self.network.clone());
-        let mut configured =
-            GuestCommand::new("/bin/sh").args(["-c", MOUNT_AND_EXEC, "nanovm-egress"]);
-        configured = configured.arg(command.current_directory().as_os_str());
-        for mount in self.guest_mounts() {
-            vm = vm.shared_directory(SharedDirectory::read_only(&mount.tag, &mount.host_path));
-            configured = configured.arg(&mount.tag).arg(mount.guest_path.as_os_str());
-        }
-        configured = configured.arg("--").arg(command.program().as_os_str());
-        configured = configured.args(command.arguments().iter().cloned());
-        for (name, value) in command.environment() {
-            configured = configured.env(name, value);
-        }
+        let mut configured = if self.guest_mounts.is_empty() {
+            command.clone()
+        } else {
+            let mut configured =
+                GuestCommand::new("/bin/sh").args(["-c", MOUNT_AND_EXEC, "nanovm-egress"]);
+            configured = configured.arg(command.current_directory().as_os_str());
+            for mount in self.guest_mounts() {
+                vm = vm.shared_directory(SharedDirectory::read_only(&mount.tag, &mount.host_path));
+                configured = configured.arg(&mount.tag).arg(mount.guest_path.as_os_str());
+            }
+            configured = configured.arg("--").arg(command.program().as_os_str());
+            configured = configured.args(command.arguments().iter().cloned());
+            for (name, value) in command.environment() {
+                configured = configured.env(name, value);
+            }
+            configured
+        };
         for (name, value) in self.guest_environment() {
             configured = configured.env(name, value);
         }
@@ -202,6 +274,10 @@ impl EgressLease {
     pub fn guest_mounts(&self) -> impl Iterator<Item = &EgressMount> {
         self.guest_mounts.values()
     }
+
+    pub fn guest_files(&self) -> impl Iterator<Item = &EgressFile> {
+        self.guest_files.values()
+    }
 }
 
 impl fmt::Debug for EgressLease {
@@ -216,6 +292,10 @@ impl fmt::Debug for EgressLease {
             .field(
                 "guest_mounts",
                 &self.guest_mounts.values().collect::<Vec<_>>(),
+            )
+            .field(
+                "guest_file_paths",
+                &self.guest_files.keys().collect::<Vec<_>>(),
             )
             .field("guards", &self.guards.len())
             .finish()
@@ -236,6 +316,10 @@ pub enum EgressError {
     MountTagConflict(String),
     #[error("guest egress mount path `{0}` has conflicting providers")]
     GuestMountConflict(PathBuf),
+    #[error("guest egress file path must be absolute: {0}")]
+    GuestFilePathNotAbsolute(PathBuf),
+    #[error("guest egress file path `{0}` has conflicting providers")]
+    GuestFileConflict(PathBuf),
 }
 
 fn valid_environment_name(name: &str) -> bool {
@@ -303,6 +387,38 @@ mod tests {
     }
 
     #[test]
+    fn provider_files_compose_idempotently_and_conflicts_fail_closed() {
+        let path = "/tmp/nanovm/ca.pem";
+        let file = EgressFile::new(path, b"public ca".to_vec(), 0o444);
+        let mut first = EgressLease::internet();
+        first.insert_file(file.clone()).unwrap();
+        let mut identical = EgressLease::internet();
+        identical.insert_file(file).unwrap();
+        first.merge(identical).unwrap();
+        assert_eq!(first.guest_files().count(), 1);
+
+        let mut conflicting = EgressLease::internet();
+        conflicting
+            .insert_file(EgressFile::new(path, b"different ca".to_vec(), 0o444))
+            .unwrap();
+        assert_eq!(
+            first.merge(conflicting),
+            Err(EgressError::GuestFileConflict(PathBuf::from(path)))
+        );
+    }
+
+    #[test]
+    fn provider_file_paths_must_be_absolute() {
+        let mut lease = EgressLease::internet();
+        assert_eq!(
+            lease.insert_file(EgressFile::new("relative/ca.pem", Vec::new(), 0o444)),
+            Err(EgressError::GuestFilePathNotAbsolute(PathBuf::from(
+                "relative/ca.pem"
+            )))
+        );
+    }
+
+    #[test]
     fn lease_configures_network_mounts_and_proxy_environment() {
         let mut lease = EgressLease::internet();
         lease
@@ -342,5 +458,18 @@ mod tests {
                 .arguments()
                 .contains(&std::ffi::OsString::from("/run/egress/mpp"))
         );
+    }
+
+    #[test]
+    fn mount_free_lease_preserves_the_direct_guest_command() {
+        let command = GuestCommand::new("/usr/local/bin/nanocodex-vm-guest")
+            .arg("/workspace")
+            .current_dir("/workspace");
+
+        let (vm, configured) =
+            EgressLease::disabled().configure(VmConfig::new("/rootfs"), &command);
+
+        assert_eq!(vm.network_value(), &Network::Disabled);
+        assert_eq!(configured, command);
     }
 }

--- a/crates/nanovm/src/gvproxy.rs
+++ b/crates/nanovm/src/gvproxy.rs
@@ -14,6 +14,7 @@ use thiserror::Error;
 
 const SOCKET_TIMEOUT: Duration = Duration::from_secs(5);
 const API_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_API_RESPONSE_BYTES: usize = 64 * 1024;
 
 #[derive(Debug, Error)]
 pub enum GvproxyError {
@@ -34,6 +35,9 @@ pub enum GvproxyError {
 
     #[error("gvproxy services API returned an invalid HTTP response")]
     InvalidApiResponse,
+
+    #[error("gvproxy services API response exceeded {MAX_API_RESPONSE_BYTES} bytes")]
+    ApiResponseTooLarge,
 
     #[error(transparent)]
     Json(#[from] serde_json::Error),
@@ -144,6 +148,12 @@ impl Gvproxy {
     /// Returns an error when the services socket cannot be reached or gvproxy
     /// rejects the request.
     pub fn unforward_tcp(&self, local: SocketAddr) -> Result<(), GvproxyError> {
+        if !local.ip().is_loopback() {
+            return Err(GvproxyError::NonLoopbackForward(local));
+        }
+        if local.port() == 0 {
+            return Err(GvproxyError::UnspecifiedHostPort);
+        }
         let body = serde_json::to_vec(&UnexposeRequest {
             local,
             protocol: "tcp",
@@ -193,7 +203,16 @@ fn services_request(socket: &Path, path: &str, body: &[u8]) -> Result<(), Gvprox
     stream.flush()?;
 
     let mut response = Vec::new();
-    stream.read_to_end(&mut response)?;
+    stream
+        .take(
+            u64::try_from(MAX_API_RESPONSE_BYTES)
+                .unwrap_or(u64::MAX)
+                .saturating_add(1),
+        )
+        .read_to_end(&mut response)?;
+    if response.len() > MAX_API_RESPONSE_BYTES {
+        return Err(GvproxyError::ApiResponseTooLarge);
+    }
     let response = String::from_utf8_lossy(&response);
     let (head, body) = response
         .split_once("\r\n\r\n")
@@ -213,7 +232,10 @@ fn services_request(socket: &Path, path: &str, body: &[u8]) -> Result<(), Gvprox
 
 #[cfg(test)]
 mod tests {
-    use std::net::{Ipv4Addr, SocketAddrV4};
+    use std::{
+        net::{Ipv4Addr, SocketAddrV4},
+        os::unix::net::UnixListener,
+    };
 
     use super::*;
 
@@ -231,5 +253,30 @@ mod tests {
             proxy.forward_tcp(local, remote),
             Err(GvproxyError::NonLoopbackForward(address)) if address == local
         ));
+        assert!(matches!(
+            proxy.unforward_tcp(local),
+            Err(GvproxyError::NonLoopbackForward(address)) if address == local
+        ));
+    }
+
+    #[test]
+    fn bounds_untrusted_services_api_responses() {
+        let directory = tempfile::tempdir().unwrap();
+        let socket = directory.path().join("services.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4 * 1024];
+            let _ = stream.read(&mut request).unwrap();
+            stream
+                .write_all(&vec![b'x'; MAX_API_RESPONSE_BYTES + 1])
+                .unwrap();
+        });
+
+        assert!(matches!(
+            services_request(&socket, "/services/test", b"{}"),
+            Err(GvproxyError::ApiResponseTooLarge)
+        ));
+        server.join().unwrap();
     }
 }

--- a/crates/nanovm/src/gvproxy.rs
+++ b/crates/nanovm/src/gvproxy.rs
@@ -1,0 +1,235 @@
+use std::{
+    fs,
+    io::{self, Read, Write},
+    net::SocketAddr,
+    os::unix::net::UnixStream,
+    path::{Path, PathBuf},
+    process::{Child, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+use serde::Serialize;
+use thiserror::Error;
+
+const SOCKET_TIMEOUT: Duration = Duration::from_secs(5);
+const API_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Error)]
+pub enum GvproxyError {
+    #[error("gvproxy exited before creating its sockets: {0}")]
+    EarlyExit(std::process::ExitStatus),
+
+    #[error("gvproxy did not create {path} within {timeout:?}")]
+    SocketTimeout { path: PathBuf, timeout: Duration },
+
+    #[error("refusing to expose a VM port on non-loopback host address {0}")]
+    NonLoopbackForward(SocketAddr),
+
+    #[error("host port zero cannot identify the resulting gvproxy listener")]
+    UnspecifiedHostPort,
+
+    #[error("gvproxy services API returned {status}: {body}")]
+    Api { status: String, body: String },
+
+    #[error("gvproxy services API returned an invalid HTTP response")]
+    InvalidApiResponse,
+
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+/// One owned gvproxy process supplying a private network stack to one VM.
+///
+/// The caller supplies an exclusive state directory. The process creates its
+/// vfkit-compatible unixgram socket and private services socket there. Dropping
+/// this value terminates and reaps gvproxy.
+pub struct Gvproxy {
+    child: Child,
+    network_socket: PathBuf,
+    services_socket: PathBuf,
+}
+
+impl Gvproxy {
+    /// Starts gvproxy and waits for both of its local sockets to become ready.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the state directory or log cannot be prepared,
+    /// gvproxy cannot start, or its network and services sockets do not become
+    /// ready before the startup deadline.
+    pub fn spawn(binary: &Path, state_directory: &Path, log: &Path) -> Result<Self, GvproxyError> {
+        fs::create_dir_all(state_directory)?;
+        if let Some(parent) = log.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let network_socket = state_directory.join("network.sock");
+        let services_socket = state_directory.join("services.sock");
+        remove_stale_socket(&network_socket)?;
+        remove_stale_socket(&services_socket)?;
+
+        let log = fs::File::create(log)?;
+        let mut child = std::process::Command::new(binary)
+            .arg("--listen-vfkit")
+            .arg(format!("unixgram:{}", network_socket.display()))
+            .arg("--services")
+            .arg(format!("unix://{}", services_socket.display()))
+            .arg("--ssh-port")
+            .arg("-1")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(log)
+            .spawn()?;
+
+        let started_at = Instant::now();
+        while !network_socket.exists() || !services_socket.exists() {
+            if let Some(status) = child.try_wait()? {
+                return Err(GvproxyError::EarlyExit(status));
+            }
+            if started_at.elapsed() >= SOCKET_TIMEOUT {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(GvproxyError::SocketTimeout {
+                    path: if network_socket.exists() {
+                        services_socket
+                    } else {
+                        network_socket
+                    },
+                    timeout: SOCKET_TIMEOUT,
+                });
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        Ok(Self {
+            child,
+            network_socket,
+            services_socket,
+        })
+    }
+
+    #[must_use]
+    pub fn network_socket(&self) -> &Path {
+        &self.network_socket
+    }
+
+    /// Forwards one loopback-only host TCP listener to a guest TCP listener.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for a non-loopback or unspecified host endpoint, a
+    /// services-socket failure, or a rejected gvproxy request.
+    pub fn forward_tcp(&self, local: SocketAddr, remote: SocketAddr) -> Result<(), GvproxyError> {
+        if !local.ip().is_loopback() {
+            return Err(GvproxyError::NonLoopbackForward(local));
+        }
+        if local.port() == 0 {
+            return Err(GvproxyError::UnspecifiedHostPort);
+        }
+        let body = serde_json::to_vec(&ExposeRequest {
+            local,
+            remote,
+            protocol: "tcp",
+        })?;
+        services_request(&self.services_socket, "/services/forwarder/expose", &body)
+    }
+
+    /// Removes a previously configured loopback TCP forward.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the services socket cannot be reached or gvproxy
+    /// rejects the request.
+    pub fn unforward_tcp(&self, local: SocketAddr) -> Result<(), GvproxyError> {
+        let body = serde_json::to_vec(&UnexposeRequest {
+            local,
+            protocol: "tcp",
+        })?;
+        services_request(&self.services_socket, "/services/forwarder/unexpose", &body)
+    }
+}
+
+impl Drop for Gvproxy {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[derive(Serialize)]
+struct ExposeRequest {
+    local: SocketAddr,
+    remote: SocketAddr,
+    protocol: &'static str,
+}
+
+#[derive(Serialize)]
+struct UnexposeRequest {
+    local: SocketAddr,
+    protocol: &'static str,
+}
+
+fn remove_stale_socket(path: &Path) -> Result<(), io::Error> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn services_request(socket: &Path, path: &str, body: &[u8]) -> Result<(), GvproxyError> {
+    let mut stream = UnixStream::connect(socket)?;
+    stream.set_read_timeout(Some(API_TIMEOUT))?;
+    stream.set_write_timeout(Some(API_TIMEOUT))?;
+    write!(
+        stream,
+        "POST {path} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    )?;
+    stream.write_all(body)?;
+    stream.flush()?;
+
+    let mut response = Vec::new();
+    stream.read_to_end(&mut response)?;
+    let response = String::from_utf8_lossy(&response);
+    let (head, body) = response
+        .split_once("\r\n\r\n")
+        .ok_or(GvproxyError::InvalidApiResponse)?;
+    let status = head
+        .lines()
+        .next()
+        .ok_or(GvproxyError::InvalidApiResponse)?;
+    if !status.starts_with("HTTP/1.1 200 ") && !status.starts_with("HTTP/1.0 200 ") {
+        return Err(GvproxyError::Api {
+            status: status.to_owned(),
+            body: body.trim().to_owned(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, SocketAddrV4};
+
+    use super::*;
+
+    #[test]
+    fn refuses_non_loopback_forwards_before_contacting_gvproxy() {
+        let proxy = Gvproxy {
+            child: std::process::Command::new("/usr/bin/true").spawn().unwrap(),
+            network_socket: PathBuf::new(),
+            services_socket: PathBuf::new(),
+        };
+        let local = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 9222));
+        let remote = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 127, 2), 9222));
+
+        assert!(matches!(
+            proxy.forward_tcp(local, remote),
+            Err(GvproxyError::NonLoopbackForward(address)) if address == local
+        ));
+    }
+}

--- a/crates/nanovm/src/krun.rs
+++ b/crates/nanovm/src/krun.rs
@@ -1,3 +1,8 @@
+#![allow(
+    unsafe_code,
+    reason = "this module is one of the two audited libkrun FFI boundaries"
+)]
+
 use std::{
     ffi::{CString, NulError, OsStr, c_char},
     io,
@@ -52,6 +57,9 @@ pub enum VmError {
         field: &'static str,
         source: NulError,
     },
+
+    #[error("{field} contains a double quote unsupported by libkrun's command-line transport")]
+    UnsupportedDoubleQuote { field: &'static str },
 
     #[error("libkrun {operation} failed with errno {errno}")]
     Libkrun { operation: &'static str, errno: i32 },
@@ -185,17 +193,6 @@ impl KrunVm {
         Ok(vm)
     }
 
-    /// Returns a thread-safe out-of-band pause/resume capability.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error after this context has entered the VMM loop.
-    pub fn control(&self) -> Result<KrunVmControl, VmError> {
-        self.context
-            .map(|context| KrunVmControl { context })
-            .ok_or(VmError::ContextConsumed)
-    }
-
     /// Configures the guest command and enters libkrun's blocking VMM loop.
     ///
     /// On successful boot this function does not return: libkrun exits the VMM
@@ -211,7 +208,7 @@ impl KrunVm {
         let arguments = command
             .arguments()
             .iter()
-            .map(|argument| c_string(argument, "guest argument"))
+            .map(|argument| array_string(argument, "guest argument"))
             .collect::<Result<Vec<_>, _>>()?;
         let mut argument_pointers = arguments
             .iter()
@@ -225,7 +222,7 @@ impl KrunVm {
                 let mut entry = name.clone();
                 entry.push("=");
                 entry.push(value);
-                c_string(&entry, "guest environment")
+                array_string(&entry, "guest environment")
             })
             .collect::<Result<Vec<_>, _>>()?;
         let mut environment_pointers = environment
@@ -260,8 +257,11 @@ impl KrunVm {
             "configure guest working directory",
         )?;
 
+        let status = krun::krun_start_enter(context);
+        if status < 0 {
+            return check(status, "start VM");
+        }
         self.context = None;
-        check(krun::krun_start_enter(context), "start VM")?;
         Err(VmError::UnexpectedReturn)
     }
 }
@@ -372,36 +372,6 @@ fn attach_shared_directories(context: u32, directories: &[SharedDirectory]) -> R
     Ok(())
 }
 
-/// Out-of-band control for a VM running in libkrun's event loop.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct KrunVmControl {
-    context: u32,
-}
-
-impl KrunVmControl {
-    /// Requests that every guest vCPU pause at an instruction boundary.
-    ///
-    /// libkrun currently implements this operation on macOS. The request is
-    /// idempotent and completes asynchronously in the VMM event loop.
-    ///
-    /// # Errors
-    ///
-    /// Returns an OS error reported by libkrun, including unsupported-platform
-    /// and not-yet-running errors.
-    pub fn pause(self) -> Result<(), VmError> {
-        check(krun::krun_vm_pause(self.context), "pause VM")
-    }
-
-    /// Resumes a VM previously paused with [`Self::pause`].
-    ///
-    /// # Errors
-    ///
-    /// Returns an OS error reported by libkrun.
-    pub fn resume(self) -> Result<(), VmError> {
-        check(krun::krun_vm_resume(self.context), "resume VM")
-    }
-}
-
 impl Drop for KrunVm {
     fn drop(&mut self) {
         if let Some(context) = self.context.take() {
@@ -412,6 +382,20 @@ impl Drop for KrunVm {
 
 fn c_string(value: &OsStr, field: &'static str) -> Result<CString, VmError> {
     CString::new(value.as_bytes()).map_err(|source| VmError::Nul { field, source })
+}
+
+/// Validates values for libkrun's quoted command-line array serialization.
+///
+/// `krun_set_exec` does not preserve the supplied C array directly: it wraps
+/// every entry in double quotes and forwards the resulting string through the
+/// guest kernel command line. Its parser cannot represent a literal double
+/// quote reliably, so fail closed instead of silently changing argv/envp.
+fn array_string(value: &OsStr, field: &'static str) -> Result<CString, VmError> {
+    let bytes = value.as_bytes();
+    if bytes.contains(&b'"') {
+        return Err(VmError::UnsupportedDoubleQuote { field });
+    }
+    CString::new(bytes).map_err(|source| VmError::Nul { field, source })
 }
 
 fn positive_context(status: i32, operation: &'static str) -> Result<u32, VmError> {
@@ -429,5 +413,26 @@ fn check(status: i32, operation: &'static str) -> Result<(), VmError> {
         })
     } else {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+
+    use super::{VmError, array_string};
+
+    #[test]
+    fn libkrun_array_values_reject_unrepresentable_quotes() {
+        assert!(matches!(
+            array_string(OsStr::new(r#"printf "%s""#), "test"),
+            Err(VmError::UnsupportedDoubleQuote { field: "test" })
+        ));
+        assert_eq!(
+            array_string(OsStr::new(r"backslash\path"), "test")
+                .unwrap()
+                .as_c_str(),
+            c"backslash\\path"
+        );
     }
 }

--- a/crates/nanovm/src/krun.rs
+++ b/crates/nanovm/src/krun.rs
@@ -1,0 +1,433 @@
+use std::{
+    ffi::{CString, NulError, OsStr, c_char},
+    io,
+    os::{fd::AsRawFd, unix::ffi::OsStrExt},
+    path::PathBuf,
+    ptr,
+};
+
+use thiserror::Error;
+
+use crate::{BlockDevice, GuestCommand, Network, RootFilesystem, SharedDirectory, VmConfig};
+
+const ROOT_TAG: &std::ffi::CStr = c"/dev/root";
+const ROOT_BLOCK_ID: &std::ffi::CStr = c"vda";
+const ROOT_BLOCK_DEVICE: &std::ffi::CStr = c"/dev/vda";
+const EXT4_FILESYSTEM: &std::ffi::CStr = c"ext4";
+const TSI_HIJACK_INET: u32 = 1;
+const NET_FLAG_VFKIT: u32 = 1 << 0;
+const NET_FLAG_DHCP_CLIENT: u32 = 1 << 1;
+const NET_FEATURE_CSUM: u32 = 1 << 0;
+const NET_FEATURE_GUEST_CSUM: u32 = 1 << 1;
+const NET_FEATURE_GUEST_TSO4: u32 = 1 << 7;
+const NET_FEATURE_GUEST_UFO: u32 = 1 << 10;
+const NET_FEATURE_HOST_TSO4: u32 = 1 << 11;
+const NET_FEATURE_HOST_UFO: u32 = 1 << 14;
+
+#[derive(Debug, Error)]
+pub enum VmError {
+    #[error("invalid VM configuration: {0}")]
+    InvalidConfig(&'static str),
+
+    #[error("failed to resolve root filesystem {path}: {source}")]
+    ResolveRoot { path: PathBuf, source: io::Error },
+
+    #[error("failed to resolve network socket {path}: {source}")]
+    ResolveNetworkSocket { path: PathBuf, source: io::Error },
+
+    #[error("root filesystem is not a directory: {0}")]
+    RootNotDirectory(PathBuf),
+
+    #[error("root disk is not a file: {0}")]
+    RootNotFile(PathBuf),
+
+    #[error("block device is not a file: {0}")]
+    BlockDeviceNotFile(PathBuf),
+
+    #[error("shared directory is not a directory: {0}")]
+    SharedDirectoryNotDirectory(PathBuf),
+
+    #[error("{field} contains a NUL byte")]
+    Nul {
+        field: &'static str,
+        source: NulError,
+    },
+
+    #[error("libkrun {operation} failed with errno {errno}")]
+    Libkrun { operation: &'static str, errno: i32 },
+
+    #[error("libkrun returned after starting the VM")]
+    UnexpectedReturn,
+
+    #[error("the libkrun context has already entered the VM")]
+    ContextConsumed,
+}
+
+/// A configured libkrun VM which has not entered its blocking event loop yet.
+///
+/// This is the low-level VMM primitive. [`Self::run`] does not return after a
+/// successful boot because libkrun owns the calling process until the guest
+/// exits. `NanoVM`'s durable process-backed handle will build on this primitive.
+pub struct KrunVm {
+    context: Option<u32>,
+}
+
+impl KrunVm {
+    /// Creates a libkrun configuration context.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the root filesystem or VM configuration is
+    /// invalid, or when libkrun rejects a requested device.
+    pub fn new(config: &VmConfig) -> Result<Self, VmError> {
+        if config.cpus_value() == 0 {
+            return Err(VmError::InvalidConfig("CPU count must be nonzero"));
+        }
+        if config.memory_mib_value() == 0 {
+            return Err(VmError::InvalidConfig("memory must be nonzero"));
+        }
+
+        let root = config
+            .root()
+            .canonicalize()
+            .map_err(|source| VmError::ResolveRoot {
+                path: config.root().to_path_buf(),
+                source,
+            })?;
+        match config.root_filesystem() {
+            RootFilesystem::Directory(_) if !root.is_dir() => {
+                return Err(VmError::RootNotDirectory(root));
+            }
+            RootFilesystem::Ext4(_) if !root.is_file() => {
+                return Err(VmError::RootNotFile(root));
+            }
+            RootFilesystem::Directory(_) | RootFilesystem::Ext4(_) => {}
+        }
+
+        let context = positive_context(krun::krun_create_ctx(), "create context")?;
+        let vm = Self {
+            context: Some(context),
+        };
+
+        check(
+            krun::krun_set_vm_config(context, config.cpus_value(), config.memory_mib_value()),
+            "configure VM",
+        )?;
+
+        let root = c_string(root.as_os_str(), "root filesystem path")?;
+        match config.root_filesystem() {
+            RootFilesystem::Directory(_) => {
+                // SAFETY: both C strings live through the call and libkrun copies their
+                // contents into the context before returning.
+                check(
+                    unsafe {
+                        krun::krun_add_virtiofs3(
+                            context,
+                            ROOT_TAG.as_ptr(),
+                            root.as_ptr(),
+                            0,
+                            false,
+                        )
+                    },
+                    "attach root filesystem",
+                )?;
+            }
+            RootFilesystem::Ext4(_) => {
+                // SAFETY: the path and block ID remain alive through each call;
+                // libkrun copies them into its context before returning.
+                check(
+                    unsafe {
+                        krun::krun_add_disk(context, ROOT_BLOCK_ID.as_ptr(), root.as_ptr(), false)
+                    },
+                    "attach root disk",
+                )?;
+                // SAFETY: all strings are static and NUL terminated.
+                check(
+                    unsafe {
+                        krun::krun_set_root_disk_remount(
+                            context,
+                            ROOT_BLOCK_DEVICE.as_ptr(),
+                            EXT4_FILESYSTEM.as_ptr(),
+                            ptr::null(),
+                        )
+                    },
+                    "select root disk",
+                )?;
+            }
+        }
+
+        attach_block_devices(context, config.block_devices())?;
+        attach_shared_directories(context, config.shared_directories())?;
+
+        let stdin = io::stdin();
+        let stdout = io::stdout();
+        let stderr = io::stderr();
+        // SAFETY: the standard descriptors remain owned by this process for
+        // the VM lifetime; libkrun duplicates the descriptors it needs.
+        check(
+            unsafe {
+                krun::krun_add_virtio_console_default(
+                    context,
+                    stdin.as_raw_fd(),
+                    stdout.as_raw_fd(),
+                    stderr.as_raw_fd(),
+                )
+            },
+            "attach console",
+        )?;
+
+        attach_network(context, config.network_value())?;
+        check(
+            krun::krun_split_irqchip(context, false),
+            "configure interrupt controller",
+        )?;
+
+        Ok(vm)
+    }
+
+    /// Returns a thread-safe out-of-band pause/resume capability.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error after this context has entered the VMM loop.
+    pub fn control(&self) -> Result<KrunVmControl, VmError> {
+        self.context
+            .map(|context| KrunVmControl { context })
+            .ok_or(VmError::ContextConsumed)
+    }
+
+    /// Configures the guest command and enters libkrun's blocking VMM loop.
+    ///
+    /// On successful boot this function does not return: libkrun exits the VMM
+    /// process when the guest shuts down. Call this only in a dedicated VMM
+    /// process.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a command value contains a NUL byte, libkrun
+    /// rejects the command, or the VMM loop unexpectedly returns.
+    pub fn run(mut self, command: &GuestCommand) -> Result<(), VmError> {
+        let executable = c_string(command.program().as_os_str(), "guest executable")?;
+        let arguments = command
+            .arguments()
+            .iter()
+            .map(|argument| c_string(argument, "guest argument"))
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut argument_pointers = arguments
+            .iter()
+            .map(|argument| argument.as_ptr())
+            .collect::<Vec<_>>();
+        argument_pointers.push(ptr::null());
+        let environment = command
+            .environment()
+            .iter()
+            .map(|(name, value)| {
+                let mut entry = name.clone();
+                entry.push("=");
+                entry.push(value);
+                c_string(&entry, "guest environment")
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut environment_pointers = environment
+            .iter()
+            .map(|entry| entry.as_ptr())
+            .collect::<Vec<_>>();
+        environment_pointers.push(ptr::null::<c_char>());
+        let context = self.context.ok_or(VmError::ContextConsumed)?;
+
+        // SAFETY: executable, argument, and environment storage remains alive
+        // through the call; each pointer list is NUL terminated. libkrun copies
+        // the values into its owned context.
+        check(
+            unsafe {
+                krun::krun_set_exec(
+                    context,
+                    executable.as_ptr(),
+                    argument_pointers.as_ptr(),
+                    environment_pointers.as_ptr(),
+                )
+            },
+            "configure guest command",
+        )?;
+        let current_dir = c_string(
+            command.current_directory().as_os_str(),
+            "guest working directory",
+        )?;
+        // SAFETY: the C string remains valid for the call and libkrun copies it
+        // into the context.
+        check(
+            unsafe { krun::krun_set_workdir(context, current_dir.as_ptr()) },
+            "configure guest working directory",
+        )?;
+
+        self.context = None;
+        check(krun::krun_start_enter(context), "start VM")?;
+        Err(VmError::UnexpectedReturn)
+    }
+}
+
+fn attach_network(context: u32, network: &Network) -> Result<(), VmError> {
+    match network {
+        Network::Disabled => {}
+        Network::Internet => {
+            check(
+                krun::krun_add_vsock(context, TSI_HIJACK_INET),
+                "enable TSI networking",
+            )?;
+        }
+        Network::Gvproxy {
+            socket,
+            mac_address,
+        } => {
+            let socket = socket
+                .canonicalize()
+                .map_err(|source| VmError::ResolveNetworkSocket {
+                    path: socket.clone(),
+                    source,
+                })?;
+            let socket = c_string(socket.as_os_str(), "gvproxy socket path")?;
+            let mut mac_address = *mac_address;
+            check(
+                // SAFETY: the socket string and MAC array remain alive for the
+                // call and libkrun copies both into its configuration.
+                unsafe {
+                    krun::krun_add_net_unixgram(
+                        context,
+                        socket.as_ptr(),
+                        -1,
+                        mac_address.as_mut_ptr(),
+                        COMPATIBLE_NETWORK_FEATURES,
+                        NET_FLAG_VFKIT | NET_FLAG_DHCP_CLIENT,
+                    )
+                },
+                "attach gvproxy network",
+            )?;
+        }
+    }
+    Ok(())
+}
+
+const COMPATIBLE_NETWORK_FEATURES: u32 = NET_FEATURE_CSUM
+    | NET_FEATURE_GUEST_CSUM
+    | NET_FEATURE_GUEST_TSO4
+    | NET_FEATURE_GUEST_UFO
+    | NET_FEATURE_HOST_TSO4
+    | NET_FEATURE_HOST_UFO;
+
+fn attach_block_devices(context: u32, devices: &[BlockDevice]) -> Result<(), VmError> {
+    for device in devices {
+        let path = device
+            .path()
+            .canonicalize()
+            .map_err(|source| VmError::ResolveRoot {
+                path: device.path().to_path_buf(),
+                source,
+            })?;
+        if !path.is_file() {
+            return Err(VmError::BlockDeviceNotFile(path));
+        }
+        let id = c_string(OsStr::new(device.id()), "block device ID")?;
+        let path = c_string(path.as_os_str(), "block device path")?;
+        // SAFETY: both strings remain valid through the call and libkrun
+        // copies their contents into the context before returning.
+        check(
+            unsafe {
+                krun::krun_add_disk(context, id.as_ptr(), path.as_ptr(), device.is_read_only())
+            },
+            "attach block device",
+        )?;
+    }
+    Ok(())
+}
+
+fn attach_shared_directories(context: u32, directories: &[SharedDirectory]) -> Result<(), VmError> {
+    for directory in directories {
+        let path = directory
+            .path()
+            .canonicalize()
+            .map_err(|source| VmError::ResolveRoot {
+                path: directory.path().to_path_buf(),
+                source,
+            })?;
+        if !path.is_dir() {
+            return Err(VmError::SharedDirectoryNotDirectory(path));
+        }
+        let tag = c_string(OsStr::new(directory.tag()), "shared directory tag")?;
+        let path = c_string(path.as_os_str(), "shared directory path")?;
+        // SAFETY: both C strings remain valid through the call and libkrun
+        // copies their contents into the context before returning.
+        check(
+            unsafe {
+                krun::krun_add_virtiofs3(
+                    context,
+                    tag.as_ptr(),
+                    path.as_ptr(),
+                    0,
+                    directory.is_read_only(),
+                )
+            },
+            "attach shared directory",
+        )?;
+    }
+    Ok(())
+}
+
+/// Out-of-band control for a VM running in libkrun's event loop.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct KrunVmControl {
+    context: u32,
+}
+
+impl KrunVmControl {
+    /// Requests that every guest vCPU pause at an instruction boundary.
+    ///
+    /// libkrun currently implements this operation on macOS. The request is
+    /// idempotent and completes asynchronously in the VMM event loop.
+    ///
+    /// # Errors
+    ///
+    /// Returns an OS error reported by libkrun, including unsupported-platform
+    /// and not-yet-running errors.
+    pub fn pause(self) -> Result<(), VmError> {
+        check(krun::krun_vm_pause(self.context), "pause VM")
+    }
+
+    /// Resumes a VM previously paused with [`Self::pause`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an OS error reported by libkrun.
+    pub fn resume(self) -> Result<(), VmError> {
+        check(krun::krun_vm_resume(self.context), "resume VM")
+    }
+}
+
+impl Drop for KrunVm {
+    fn drop(&mut self) {
+        if let Some(context) = self.context.take() {
+            let _ = krun::krun_free_ctx(context);
+        }
+    }
+}
+
+fn c_string(value: &OsStr, field: &'static str) -> Result<CString, VmError> {
+    CString::new(value.as_bytes()).map_err(|source| VmError::Nul { field, source })
+}
+
+fn positive_context(status: i32, operation: &'static str) -> Result<u32, VmError> {
+    u32::try_from(status).map_err(|_| VmError::Libkrun {
+        operation,
+        errno: status.saturating_neg(),
+    })
+}
+
+fn check(status: i32, operation: &'static str) -> Result<(), VmError> {
+    if status < 0 {
+        Err(VmError::Libkrun {
+            operation,
+            errno: status.saturating_neg(),
+        })
+    } else {
+        Ok(())
+    }
+}

--- a/crates/nanovm/src/lib.rs
+++ b/crates/nanovm/src/lib.rs
@@ -1,7 +1,4 @@
-#![allow(
-    unsafe_code,
-    reason = "the libkrun binding requires a small audited FFI boundary"
-)]
+#![deny(unsafe_code)]
 
 mod capabilities;
 mod command;
@@ -14,13 +11,9 @@ mod process;
 pub use capabilities::{Capabilities, KrunFeature};
 pub use command::GuestCommand;
 pub use config::{BlockDevice, Network, RootFilesystem, SharedDirectory, VmConfig};
-pub use egress::{EgressError, EgressFile, EgressLease, EgressMount};
+pub use egress::{
+    EgressError, EgressFile, EgressLease, EgressMount, GUEST_EGRESS_ROOT, MAX_EGRESS_FILE_BYTES,
+};
 pub use gvproxy::{Gvproxy, GvproxyError};
-pub use krun::{KrunVm, KrunVmControl, VmError};
+pub use krun::{KrunVm, VmError};
 pub use process::{PrivateVmProcessConfig, VmProcessConfig, VmProcessError};
-
-/// The complete upstream libkrun API pinned by this workspace's lockfile.
-///
-/// Prefer `NanoVM`'s typed API. This escape hatch makes new or specialized
-/// libkrun functionality available without waiting for a typed wrapper.
-pub use ::krun as raw;

--- a/crates/nanovm/src/lib.rs
+++ b/crates/nanovm/src/lib.rs
@@ -14,7 +14,7 @@ mod process;
 pub use capabilities::{Capabilities, KrunFeature};
 pub use command::GuestCommand;
 pub use config::{BlockDevice, Network, RootFilesystem, SharedDirectory, VmConfig};
-pub use egress::{EgressError, EgressLease, EgressMount};
+pub use egress::{EgressError, EgressFile, EgressLease, EgressMount};
 pub use gvproxy::{Gvproxy, GvproxyError};
 pub use krun::{KrunVm, KrunVmControl, VmError};
 pub use process::{PrivateVmProcessConfig, VmProcessConfig, VmProcessError};

--- a/crates/nanovm/src/lib.rs
+++ b/crates/nanovm/src/lib.rs
@@ -1,0 +1,26 @@
+#![allow(
+    unsafe_code,
+    reason = "the libkrun binding requires a small audited FFI boundary"
+)]
+
+mod capabilities;
+mod command;
+mod config;
+mod egress;
+mod gvproxy;
+mod krun;
+mod process;
+
+pub use capabilities::{Capabilities, KrunFeature};
+pub use command::GuestCommand;
+pub use config::{BlockDevice, Network, RootFilesystem, SharedDirectory, VmConfig};
+pub use egress::{EgressError, EgressLease, EgressMount};
+pub use gvproxy::{Gvproxy, GvproxyError};
+pub use krun::{KrunVm, KrunVmControl, VmError};
+pub use process::{PrivateVmProcessConfig, VmProcessConfig, VmProcessError};
+
+/// The complete upstream libkrun API pinned by this workspace's lockfile.
+///
+/// Prefer `NanoVM`'s typed API. This escape hatch makes new or specialized
+/// libkrun functionality available without waiting for a typed wrapper.
+pub use ::krun as raw;

--- a/crates/nanovm/src/process.rs
+++ b/crates/nanovm/src/process.rs
@@ -1,0 +1,128 @@
+use std::{
+    fs::File,
+    io::{self, BufReader, BufWriter, Write},
+    path::Path,
+};
+
+use serde::{Deserialize, Serialize};
+use tempfile::NamedTempFile;
+use thiserror::Error;
+
+use crate::{GuestCommand, KrunVm, VmConfig, VmError};
+
+const PROCESS_CONFIG_VERSION: u32 = 1;
+
+/// Complete owned input for one dedicated VMM process.
+///
+/// Keeping guest environment values in this file avoids exposing proxy
+/// credentials and secret placeholders through the VMM's process arguments.
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct VmProcessConfig {
+    version: u32,
+    vm: VmConfig,
+    command: GuestCommand,
+}
+
+impl VmProcessConfig {
+    #[must_use]
+    pub fn new(vm: VmConfig, command: GuestCommand) -> Self {
+        Self {
+            version: PROCESS_CONFIG_VERSION,
+            vm,
+            command,
+        }
+    }
+
+    /// Writes this configuration to a mode-0600 temporary file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the private file cannot be created or serialized.
+    pub fn write_private(&self) -> Result<PrivateVmProcessConfig, VmProcessError> {
+        let mut file = NamedTempFile::new()?;
+        let mut writer = BufWriter::new(file.as_file_mut());
+        serde_json::to_writer(&mut writer, self)?;
+        writer.flush()?;
+        drop(writer);
+        file.as_file_mut().flush()?;
+        Ok(PrivateVmProcessConfig { file })
+    }
+
+    /// Reads a process configuration created by [`Self::write_private`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the file cannot be read, has an unsupported
+    /// version, or contains an invalid configuration.
+    pub fn read(path: impl AsRef<Path>) -> Result<Self, VmProcessError> {
+        let config: Self = serde_json::from_reader(BufReader::new(File::open(path)?))?;
+        if config.version != PROCESS_CONFIG_VERSION {
+            return Err(VmProcessError::UnsupportedVersion(config.version));
+        }
+        Ok(config)
+    }
+
+    /// Enters the blocking libkrun loop described by this configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when VM construction or startup fails.
+    pub fn run(self) -> Result<(), VmError> {
+        KrunVm::new(&self.vm)?.run(&self.command)
+    }
+}
+
+/// Owned private file kept alive until its VMM child has loaded it.
+pub struct PrivateVmProcessConfig {
+    file: NamedTempFile,
+}
+
+impl PrivateVmProcessConfig {
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        self.file.path()
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum VmProcessError {
+    #[error("failed to access the private VM process configuration: {0}")]
+    Io(#[from] io::Error),
+    #[error("failed to encode the private VM process configuration: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("unsupported VM process configuration version {0}")]
+    UnsupportedVersion(u32),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{ffi::OsString, os::unix::fs::PermissionsExt};
+
+    use super::*;
+    use crate::Network;
+
+    #[test]
+    fn private_config_round_trips_without_argv_delivery() {
+        let command = GuestCommand::new("/bin/true")
+            .env("HTTPS_PROXY", "http://lease:credential@host.internal:8080");
+        let private = VmProcessConfig::new(
+            VmConfig::ext4("/tmp/rootfs.ext4").network(Network::Disabled),
+            command,
+        )
+        .write_private()
+        .unwrap();
+        let permissions = private.path().metadata().unwrap().permissions().mode();
+        assert_eq!(permissions & 0o077, 0);
+
+        let decoded = VmProcessConfig::read(private.path()).unwrap();
+        assert_eq!(
+            decoded
+                .command
+                .environment()
+                .get(&OsString::from("HTTPS_PROXY"))
+                .unwrap(),
+            &OsString::from("http://lease:credential@host.internal:8080")
+        );
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -47,6 +47,7 @@ unknown-registry = "deny"
 unknown-git = "deny"
 required-git-spec = "rev"
 allow-git = [
+    "https://github.com/containers/libkrun",
     "https://github.com/gakonst/hudsucker",
     "https://github.com/openai-oss-forks/tokio-tungstenite",
     "https://github.com/openai-oss-forks/tungstenite-rs",

--- a/docs/VM.md
+++ b/docs/VM.md
@@ -82,9 +82,12 @@ let (agent, events) = Nanocodex::builder(auth)
 # }
 ```
 
-The `VmToolSession` is the non-cloneable owner. Only it can shut the VM down.
-`VmTools` and `VmToolSessionHandle` are cloneable capabilities and cannot stop
-the shared VM out from under sibling drivers.
+The `VmToolSession` is the non-cloneable graceful-shutdown capability.
+`VmTools` and `VmToolSessionHandle` are cloneable capabilities. Every one of
+them keeps the VMM, private launch configuration, and egress guards alive, so
+capturing `VmTools` in a driver factory is sufficient for the complete agent
+tree. Graceful shutdown fails while sibling capabilities remain; drop the
+agents, tool registries, and cloned handles before calling it.
 
 ## Configurable egress
 
@@ -122,7 +125,7 @@ secrets.insert_environment(
 secrets.insert_mount(EgressMount {
     tag: "secret-ca".to_owned(),
     host_path: PathBuf::from("/host/secret-ca"),
-    guest_path: PathBuf::from("/run/egress/secret-ca"),
+    guest_path: PathBuf::from("/tmp/nanocodex/egress/secrets/ca"),
 })?;
 secrets.retain(Arc::new(())); // the real layer retains its proxy lease
 
@@ -132,30 +135,36 @@ EgressLease::internet()
 # }
 ```
 
-Applying the result to a `VmConfig` and `GuestCommand` selects the network,
+`VmToolSession::spawn_configured` consumes the complete lease and applies it to
+both launch configuration and retained session state. This selects the network,
 attaches provider directories read-only, mounts them before the guest runtime
-starts, and injects only the resolved guest environment. After spawning, give
-the same lease to the session so it provisions public files and retains all
-provider guards:
+starts, injects only the resolved guest environment, provisions public files,
+and retains every provider guard:
 
 ```rust,no_run
 # use nanocodex_vm::VmToolSession;
 # use nanovm::{EgressLease, GuestCommand, VmConfig};
-# async fn configure(egress: EgressLease, mut session: VmToolSession) -> Result<(), Box<dyn std::error::Error>> {
+# use tokio::process::Command;
+# async fn launch(egress: EgressLease) -> Result<VmToolSession, Box<dyn std::error::Error>> {
 let guest = GuestCommand::new("/usr/local/bin/nanocodex-vm-guest").arg("/workspace");
-let (vm, command) = egress.configure(
-    VmConfig::ext4("rootfs.ext4"),
-    &guest,
-);
-# drop((vm, command)); // spawn the configured VMM here
-session.provision_egress(egress).await?;
-# Ok(())
+let mut vmm = Command::new("dedicated-vmm-process");
+vmm.arg("--run-config");
+let session = VmToolSession::spawn_configured(
+    vmm,
+    VmConfig::ext4("private-session-rootfs.ext4"),
+    guest,
+    egress,
+).await?;
+# Ok(session)
 # }
 ```
 
-The complete configuration can be serialized to a mode-`0600` temporary file
-with `VmProcessConfig::write_private`. This keeps bearer proxy URLs and
-secret-route placeholders out of the VMM command line.
+The method serializes complete launch configuration to a mode-`0600` temporary
+file and retains it until the last VM capability is dropped. This keeps bearer
+proxy URLs and secret-route placeholders out of the VMM command line and avoids
+a process-start race. Lower-level `configure`, `write_private`, `spawn`, and
+`provision_egress` operations remain available for specialized launchers, but
+the application must then preserve the same ownership ordering itself.
 
 ### MPP and secret proxy layers
 
@@ -185,8 +194,19 @@ provider's credentials.
   interactive guest processes across sequential turns and subagent calls.
 - Concurrent drivers are multiplexed by request ID; one slow guest command
   does not block unrelated subagent calls.
-- Dropping the session kills its VMM child. Explicit shutdown asks the guest to
-  stop and bounds the wait for process exit.
+- The last session/tool capability kills its VMM child and releases egress.
+  Explicit shutdown first rejects live sibling capabilities, asks the guest to
+  cancel in-flight work and sync filesystems, then bounds the wait for exit.
+- Protocol frames are limited to 64 MiB, harness file reads to 32 MiB, and
+  trusted command output to 8 MiB by default. Command timeouts, output-limit
+  cancellation, guest shutdown, and capability drop terminate process groups,
+  including descendants.
+- Egress files are limited to 4 MiB. Mounts and files must be non-overlapping
+  descendants of `/tmp/nanocodex/egress`; mount tags and modes are validated
+  before launch.
+- A writable ext4 root is session-private. Reflink or sparse-copy an immutable
+  base image for each VM rather than attaching a shared benchmark image
+  directly.
 - On macOS, the dedicated VMM executable must carry the
   `com.apple.security.hypervisor` entitlement. `just build-vm-example` builds
   and ad-hoc signs the public proof binary with `nanovm.entitlements`.
@@ -200,4 +220,5 @@ provider's credentials.
 
 See `cargo run -p nanocodex-examples --bin vm-tools -- ROOTFS` for the
 end-to-end tool protocol example. The rootfs must contain
-`/usr/local/bin/nanocodex-vm-guest`.
+`/usr/local/bin/nanocodex-vm-guest`. Build the lean guest artifact with
+`just build-vm-guest`; its guest-only feature excludes `nanovm` and libkrun.

--- a/docs/VM.md
+++ b/docs/VM.md
@@ -36,9 +36,9 @@ through the normal tool-selection API:
 
 ```rust,no_run
 # use nanocodex::{Nanocodex, OpenAiAuth};
-# use nanocodex_vm::{VmToolSession, VmTools};
+# use nanocodex_vm::VmToolSession;
 # fn build(auth: OpenAiAuth, session: VmToolSession) -> nanocodex::Result<()> {
-let vm = VmTools::new(session);
+let vm = session.tools();
 let tools = vm
     .tools_builder()
     .working_directory("/workspace")
@@ -57,9 +57,34 @@ let (agent, events) = Nanocodex::builder(auth)
 image generation, and `update_plan` retain their existing host-side behavior.
 Callers can disable or replace those independently.
 
-Use `NanocodexBuilder::tools_factory` when an agent can spawn or fork. The
-factory must create a fresh root disk, VMM process, and `VmToolSession` for each
-driver; a child must not share its parent's mutable guest or shell sessions.
+Use `NanocodexBuilder::tools_factory` when an agent can spawn or fork. Start one
+`VmToolSession` for the root agent tree and capture its clone-cheap `VmTools` in
+the factory. Nanocodex invokes the factory once per driver, so agent-relative
+tools are freshly bound to that driver while every driver deliberately shares
+the same VM, filesystem, and retained guest shell sessions:
+
+```rust,no_run
+# use nanocodex::{Nanocodex, OpenAiAuth};
+# use nanocodex_vm::VmToolSession;
+# fn build(auth: OpenAiAuth, session: VmToolSession) -> nanocodex::Result<()> {
+let vm = session.tools();
+let (agent, events) = Nanocodex::builder(auth)
+    .workspace("/workspace")
+    .tools_factory(move |_agent| {
+        vm.tools_builder()
+            .working_directory("/workspace")
+            .default_shell("sh")
+            .build()
+    })
+    .build()?;
+# drop((agent, events));
+# Ok(())
+# }
+```
+
+The `VmToolSession` is the non-cloneable owner. Only it can shut the VM down.
+`VmTools` and `VmToolSessionHandle` are cloneable capabilities and cannot stop
+the shared VM out from under sibling drivers.
 
 ## Configurable egress
 
@@ -68,13 +93,13 @@ contribute:
 
 - a network mode;
 - guest environment such as an authenticated `HTTP_PROXY`/`HTTPS_PROXY`;
-- read-only CA or configuration mounts; and
+- read-only provider directories and public guest configuration files; and
 - lifecycle guards that keep revocable host services alive for the VM.
 
 Independent provider layers compose transactionally:
 
 ```rust,no_run
-use nanovm::{EgressLease, EgressMount};
+use nanovm::{EgressFile, EgressLease, EgressMount};
 use std::{path::PathBuf, sync::Arc};
 
 # fn configure() -> Result<EgressLease, nanovm::EgressError> {
@@ -83,6 +108,11 @@ mpp.insert_environment(
     "HTTPS_PROXY",
     "http://mpp-lease:credential@host.internal:8080",
 )?;
+mpp.insert_file(EgressFile::new(
+    "/tmp/nanocodex/egress/mpp/ca.pem",
+    b"public CA bytes".to_vec(),
+    0o444,
+))?;
 
 let mut secrets = EgressLease::internet();
 secrets.insert_environment(
@@ -104,17 +134,22 @@ EgressLease::internet()
 
 Applying the result to a `VmConfig` and `GuestCommand` selects the network,
 attaches provider directories read-only, mounts them before the guest runtime
-starts, and injects only the resolved guest environment:
+starts, and injects only the resolved guest environment. After spawning, give
+the same lease to the session so it provisions public files and retains all
+provider guards:
 
 ```rust,no_run
+# use nanocodex_vm::VmToolSession;
 # use nanovm::{EgressLease, GuestCommand, VmConfig};
-# fn configure(egress: EgressLease) {
+# async fn configure(egress: EgressLease, mut session: VmToolSession) -> Result<(), Box<dyn std::error::Error>> {
 let guest = GuestCommand::new("/usr/local/bin/nanocodex-vm-guest").arg("/workspace");
 let (vm, command) = egress.configure(
     VmConfig::ext4("rootfs.ext4"),
     &guest,
 );
-# drop((vm, command));
+# drop((vm, command)); // spawn the configured VMM here
+session.provision_egress(egress).await?;
+# Ok(())
 # }
 ```
 
@@ -125,15 +160,17 @@ secret-route placeholders out of the VMM command line.
 ### MPP and secret proxy layers
 
 The MPP provider remains a host-owned HTTP(S) proxy. Its layer points the guest
-at that proxy, mounts its public interception CA, and retains the wallet/proxy
-guard. Ordinary guest commands such as `curl` therefore receive a `402` through
-the proxy; the host pays and replays the exact bounded request without exposing
-the wallet to the VM. Enable `nanocodex-vm`'s `mpp` feature and pass an
-`Arc<MppEgress>` to `mpp_egress_layer` to produce that configuration.
+at that proxy, provisions its public interception CA, and retains the
+wallet/proxy guard. Ordinary guest commands such as `curl` therefore receive a
+`402` through the proxy; the host pays and replays the exact bounded request
+without exposing the wallet to the VM. Enable `nanocodex-vm`'s `mpp` feature
+and pass an `Arc<MppEgress>` to `mpp_egress_layer` to produce that
+configuration.
 
 NanoCentaur's Iron/secret egress follows the same contract: its layer carries
-the scoped proxy or gateway route, public CA mount, placeholders, and revocable
-lease guard. Resolved secrets remain host-side.
+the scoped proxy or gateway route, public CA/configuration files, placeholders,
+and revocable lease guard. Resolved secrets remain host-side and must never be
+placed in an `EgressFile`.
 
 A guest process can have only one value for `HTTPS_PROXY`. If two independently
 started providers both claim the front-proxy variables, lease composition
@@ -144,10 +181,15 @@ provider's credentials.
 
 ## Lifecycle and security
 
-- One VM tool session retains interactive guest processes across sequential
-  turns.
+- One VM tool session is shared by the complete root-agent tree and retains
+  interactive guest processes across sequential turns and subagent calls.
+- Concurrent drivers are multiplexed by request ID; one slow guest command
+  does not block unrelated subagent calls.
 - Dropping the session kills its VMM child. Explicit shutdown asks the guest to
   stop and bounds the wait for process exit.
+- On macOS, the dedicated VMM executable must carry the
+  `com.apple.security.hypervisor` entitlement. `just build-vm-example` builds
+  and ad-hoc signs the public proof binary with `nanovm.entitlements`.
 - Failed partial protocol responses are not converted into successful tool
   results.
 - Egress values are omitted from `Debug`; only environment names, mount

--- a/docs/VM.md
+++ b/docs/VM.md
@@ -193,12 +193,16 @@ provider's credentials.
 - One VM tool session is shared by the complete root-agent tree and retains
   interactive guest processes across sequential turns and subagent calls.
 - Concurrent drivers are multiplexed by request ID; one slow guest command
-  does not block unrelated subagent calls.
+  does not block unrelated subagent calls. Dropping an individual host request
+  sends a targeted cancellation frame, and the guest aborts that request's
+  process group without disturbing sibling work.
 - The last session/tool capability kills its VMM child and releases egress.
   Explicit shutdown first rejects live sibling capabilities, asks the guest to
   cancel in-flight work and sync filesystems, then bounds the wait for exit.
-- Protocol frames are limited to 64 MiB, harness file reads to 32 MiB, and
-  trusted command output to 8 MiB by default. Command timeouts, output-limit
+- Protocol frames are limited to 64 MiB and carry binary fields as base64
+  strings rather than allocation-heavy JSON byte arrays. Harness file reads
+  accept only regular files and are limited to 32 MiB; trusted command output
+  defaults to 8 MiB. Command timeouts, request cancellation, output-limit
   cancellation, guest shutdown, and capability drop terminate process groups,
   including descendants.
 - Egress files are limited to 4 MiB. Mounts and files must be non-overlapping

--- a/docs/VM.md
+++ b/docs/VM.md
@@ -1,0 +1,161 @@
+# VM-backed tools and egress
+
+Nanocodex keeps the agent lifecycle independent from where workspace tools
+execute. The default `Tools` selection runs `exec_command`, `write_stdin`,
+`apply_patch`, and `view_image` in the embedding process. Applications can
+replace those handlers with one persistent libkrun VM without changing their
+model-visible names or schemas.
+
+Two packages own the boundary:
+
+- `nanovm` owns typed libkrun configuration, the small audited FFI boundary,
+  private VMM process configuration, gvproxy lifecycle, and provider-neutral
+  egress leases.
+- `nanocodex-vm` owns the typed host/guest tool protocol, retained guest shell
+  sessions, bounded VMM process ownership, and adapters for
+  Nanocodex's standard workspace tools.
+
+Neither package owns application policy, agent identity, payment limits,
+secret resolution, rootfs preparation, or the choice to enable VM tools.
+
+## Selecting host or VM tools
+
+Host execution remains the default:
+
+```rust,no_run
+# use nanocodex::{Nanocodex, OpenAiAuth};
+# fn build(auth: OpenAiAuth) -> nanocodex::Result<()> {
+let (agent, events) = Nanocodex::builder(auth).build()?;
+# drop((agent, events));
+# Ok(())
+# }
+```
+
+A caller that has started one `VmToolSession` opts into VM workspace effects
+through the normal tool-selection API:
+
+```rust,no_run
+# use nanocodex::{Nanocodex, OpenAiAuth};
+# use nanocodex_vm::{VmToolSession, VmTools};
+# fn build(auth: OpenAiAuth, session: VmToolSession) -> nanocodex::Result<()> {
+let vm = VmTools::new(session);
+let tools = vm
+    .tools_builder()
+    .working_directory("/workspace")
+    .default_shell("sh")
+    .build()?;
+let (agent, events) = Nanocodex::builder(auth)
+    .workspace("/workspace")
+    .tools(tools)
+    .build()?;
+# drop((agent, events));
+# Ok(())
+# }
+```
+
+`VmTools::tools_builder` replaces only workspace-effecting tools. Web search,
+image generation, and `update_plan` retain their existing host-side behavior.
+Callers can disable or replace those independently.
+
+Use `NanocodexBuilder::tools_factory` when an agent can spawn or fork. The
+factory must create a fresh root disk, VMM process, and `VmToolSession` for each
+driver; a child must not share its parent's mutable guest or shell sessions.
+
+## Configurable egress
+
+`EgressLease` is the VM-facing output of application policy. A layer may
+contribute:
+
+- a network mode;
+- guest environment such as an authenticated `HTTP_PROXY`/`HTTPS_PROXY`;
+- read-only CA or configuration mounts; and
+- lifecycle guards that keep revocable host services alive for the VM.
+
+Independent provider layers compose transactionally:
+
+```rust,no_run
+use nanovm::{EgressLease, EgressMount};
+use std::{path::PathBuf, sync::Arc};
+
+# fn configure() -> Result<EgressLease, nanovm::EgressError> {
+let mut mpp = EgressLease::internet();
+mpp.insert_environment(
+    "HTTPS_PROXY",
+    "http://mpp-lease:credential@host.internal:8080",
+)?;
+
+let mut secrets = EgressLease::internet();
+secrets.insert_environment(
+    "NANOCENTAUR_SECRET_BASE_URL",
+    "https://secret-gateway.internal/v1",
+)?;
+secrets.insert_mount(EgressMount {
+    tag: "secret-ca".to_owned(),
+    host_path: PathBuf::from("/host/secret-ca"),
+    guest_path: PathBuf::from("/run/egress/secret-ca"),
+})?;
+secrets.retain(Arc::new(())); // the real layer retains its proxy lease
+
+EgressLease::internet()
+    .with_layer(mpp)?
+    .with_layer(secrets)
+# }
+```
+
+Applying the result to a `VmConfig` and `GuestCommand` selects the network,
+attaches provider directories read-only, mounts them before the guest runtime
+starts, and injects only the resolved guest environment:
+
+```rust,no_run
+# use nanovm::{EgressLease, GuestCommand, VmConfig};
+# fn configure(egress: EgressLease) {
+let guest = GuestCommand::new("/usr/local/bin/nanocodex-vm-guest").arg("/workspace");
+let (vm, command) = egress.configure(
+    VmConfig::ext4("rootfs.ext4"),
+    &guest,
+);
+# drop((vm, command));
+# }
+```
+
+The complete configuration can be serialized to a mode-`0600` temporary file
+with `VmProcessConfig::write_private`. This keeps bearer proxy URLs and
+secret-route placeholders out of the VMM command line.
+
+### MPP and secret proxy layers
+
+The MPP provider remains a host-owned HTTP(S) proxy. Its layer points the guest
+at that proxy, mounts its public interception CA, and retains the wallet/proxy
+guard. Ordinary guest commands such as `curl` therefore receive a `402` through
+the proxy; the host pays and replays the exact bounded request without exposing
+the wallet to the VM. Enable `nanocodex-vm`'s `mpp` feature and pass an
+`Arc<MppEgress>` to `mpp_egress_layer` to produce that configuration.
+
+NanoCentaur's Iron/secret egress follows the same contract: its layer carries
+the scoped proxy or gateway route, public CA mount, placeholders, and revocable
+lease guard. Resolved secrets remain host-side.
+
+A guest process can have only one value for `HTTPS_PROXY`. If two independently
+started providers both claim the front-proxy variables, lease composition
+fails closed. An application that needs both proxies on one request path must
+chain or route them host-side and expose one front proxy to the guest. The VM
+package deliberately does not guess proxy order or silently overwrite one
+provider's credentials.
+
+## Lifecycle and security
+
+- One VM tool session retains interactive guest processes across sequential
+  turns.
+- Dropping the session kills its VMM child. Explicit shutdown asks the guest to
+  stop and bounds the wait for process exit.
+- Failed partial protocol responses are not converted into successful tool
+  results.
+- Egress values are omitted from `Debug`; only environment names, mount
+  metadata, and guard counts are shown.
+- Read-only provider mounts and environment conflicts are explicit.
+- The libkrun unsafe surface stays inside `nanovm`; the rest of Nanocodex
+  remains safe Rust.
+
+See `cargo run -p nanocodex-examples --bin vm-tools -- ROOTFS` for the
+end-to-end tool protocol example. The rootfs must contain
+`/usr/local/bin/nanocodex-vm-guest`.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,16 +15,19 @@ dotenvy.workspace = true
 eyre.workspace = true
 futures-util.workspace = true
 http.workspace = true
+mpp.workspace = true
+mpp-egress.workspace = true
 nanocodex.workspace = true
-nanocodex-vm.workspace = true
+nanocodex-vm = { workspace = true, features = ["mpp"] }
 nanovm.workspace = true
 reqwest.workspace = true
 rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 tokio-tungstenite.workspace = true
 tower.workspace = true
+axum.workspace = true
 
 [[bin]]
 name = "minimal"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 description = "Public Nanocodex library examples"
 
 [dependencies]
+arcbox-ext4.workspace = true
 dotenvy.workspace = true
 eyre.workspace = true
 futures-util.workspace = true
@@ -21,6 +22,7 @@ nanocodex.workspace = true
 nanocodex-vm = { workspace = true, features = ["mpp"] }
 nanovm.workspace = true
 reqwest.workspace = true
+reflink-copy.workspace = true
 rustls.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -28,6 +30,7 @@ tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "syn
 tokio-tungstenite.workspace = true
 tower.workspace = true
 axum.workspace = true
+tempfile.workspace = true
 
 [[bin]]
 name = "minimal"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,6 +16,8 @@ eyre.workspace = true
 futures-util.workspace = true
 http.workspace = true
 nanocodex.workspace = true
+nanocodex-vm.workspace = true
+nanovm.workspace = true
 reqwest.workspace = true
 rustls.workspace = true
 serde.workspace = true
@@ -71,6 +73,10 @@ path = "codex_parity_bench.rs"
 [[bin]]
 name = "rollout-resume-bench"
 path = "rollout_resume_bench.rs"
+
+[[bin]]
+name = "vm-tools"
+path = "vm_tools.rs"
 
 [lints]
 workspace = true

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,8 @@ cargo run -p nanocodex-examples --bin subagents -- \
   "Review the retry policy using whatever clean or context-bearing workers you need"
 NANOCODEX_SUBAGENT_JSONL=1 cargo run -p nanocodex-examples --bin subagents
 cargo run -p nanocodex-examples --bin mcp
+just build-vm-example
+target/debug/vm-tools ROOTFS [GUEST_RUNTIME_EXT4] [--prove-mpp]
 just smoke-python
 just smoke-wasm-node
 just build-react-example
@@ -32,6 +34,14 @@ just build-react-example
 The live programs require `OPENAI_API_KEY`. The browser example instead asks
 the embedding application for an already-authorized Responses WebSocket URL;
 standard browser WebSockets cannot attach the upgrade authorization header.
+
+`vm-tools` does not call the model. It proves all VM-backed standard workspace
+tools against one retained guest and accepts either a directory root containing
+`/usr/local/bin/nanocodex-vm-guest` or an ext4 root plus a read-only guest
+runtime image. On macOS, `just build-vm-example` also applies the required
+Hypervisor entitlement.
+Pass `--prove-mpp` to additionally run a real guest `curl` through the
+host-owned MPP proxy and verify one payment and one exact replay.
 
 `subagents` exposes generic `spawn_agent`, `fork_agent`, and `prompt_agent` Code
 Mode tools; its Rust host contains no worker graph. The parent model decides the

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,7 +25,7 @@ cargo run -p nanocodex-examples --bin subagents -- \
 NANOCODEX_SUBAGENT_JSONL=1 cargo run -p nanocodex-examples --bin subagents
 cargo run -p nanocodex-examples --bin mcp
 just build-vm-example
-target/debug/vm-tools ROOTFS [GUEST_RUNTIME_EXT4] [--prove-mpp]
+target/debug/vm-tools ROOTFS [GUEST_RUNTIME_BINARY_OR_EXT4] [--prove-mpp]
 just smoke-python
 just smoke-wasm-node
 just build-react-example
@@ -37,8 +37,10 @@ standard browser WebSockets cannot attach the upgrade authorization header.
 
 `vm-tools` does not call the model. It proves all VM-backed standard workspace
 tools against one retained guest and accepts either a directory root containing
-`/usr/local/bin/nanocodex-vm-guest` or an ext4 root plus a read-only guest
-runtime image. On macOS, `just build-vm-example` also applies the required
+`/usr/local/bin/nanocodex-vm-guest` or an ext4 root plus a guest-runtime ELF or
+read-only runtime image. A runtime ELF is packed into a temporary ext4 image,
+and a supplied ext4 root is reflinked or sparse-copied into a private per-run
+disk before boot. On macOS, `just build-vm-example` also applies the required
 Hypervisor entitlement.
 Pass `--prove-mpp` to additionally run a real guest `curl` through the
 host-owned MPP proxy and verify one payment and one exact replay.

--- a/examples/vm_tools.rs
+++ b/examples/vm_tools.rs
@@ -1,13 +1,18 @@
 use std::{
     error::Error,
+    fs, io,
     net::Ipv4Addr,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     },
 };
 
+use arcbox_ext4::{
+    Formatter,
+    constants::{file_mode, make_mode},
+};
 use axum::{
     Router,
     extract::Request,
@@ -22,7 +27,10 @@ use mpp::{
 use mpp_egress::{EgressPolicy, MppEgress};
 use nanocodex::{Tool, ToolContext, ToolExecution, ToolInput, ToolOutputBody, ToolOutputContent};
 use nanocodex_vm::{VmToolSession, mpp_egress_layer};
-use nanovm::{BlockDevice, EgressLease, GuestCommand, VmConfig, VmProcessConfig};
+use nanovm::{
+    BlockDevice, EgressLease, EgressMount, GUEST_EGRESS_ROOT, GuestCommand, VmConfig,
+    VmProcessConfig,
+};
 use serde::Deserialize;
 use serde_json::value::to_raw_value;
 use tokio::process::Command;
@@ -30,6 +38,7 @@ use tokio::process::Command;
 const GUEST_RUNTIME: &str = "/usr/local/bin/nanocodex-vm-guest";
 const RUNTIME_BLOCK_DEVICE: &str = "/dev/vdb";
 const RUNTIME_MOUNT: &str = "/run/nanocodex";
+const RUNTIME_DISK_BYTES: u64 = 128 * 1024 * 1024;
 type AnyError = Box<dyn Error + Send + Sync>;
 
 #[derive(Deserialize)]
@@ -69,12 +78,33 @@ async fn run_host(arguments: Vec<std::ffi::OsString>, prove_mpp: bool) -> Result
         .first()
         .cloned()
         .map(PathBuf::from)
-        .ok_or("usage: vm-tools ROOTFS [GUEST_RUNTIME_EXT4] [--prove-mpp]")?;
+        .ok_or("usage: vm-tools ROOTFS [GUEST_RUNTIME_BINARY_OR_EXT4] [--prove-mpp]")?;
+    let (_private_root, root) = if root.is_file() {
+        let directory = tempfile::tempdir()?;
+        let private = directory.path().join("rootfs.ext4");
+        reflink_or_sparse_copy(&root, &private)?;
+        (Some(directory), private)
+    } else {
+        (None, root)
+    };
     let runtime = arguments.get(1).cloned().map(PathBuf::from);
+    let (_runtime_disk, runtime) = match runtime {
+        Some(runtime) => {
+            let (guard, runtime) = prepare_runtime_disk(&runtime)?;
+            (guard, Some(runtime))
+        }
+        None => (None, None),
+    };
     let (egress, mpp_proof) = if prove_mpp {
         let proof = MppProof::start().await?;
-        let layer = mpp_egress_layer(Arc::clone(&proof.egress))?;
-        (EgressLease::internet().with_layer(layer)?, Some(proof))
+        let mpp = mpp_egress_layer(Arc::clone(&proof.egress))?;
+        let secrets = secret_style_proof_layer()?;
+        (
+            EgressLease::internet()
+                .with_layer(mpp)?
+                .with_layer(secrets)?,
+            Some(proof),
+        )
     } else {
         (EgressLease::disabled(), None)
     };
@@ -100,8 +130,6 @@ async fn run_host(arguments: Vec<std::ffi::OsString>, prove_mpp: bool) -> Result
             GuestCommand::new(GUEST_RUNTIME).arg("/workspace"),
         )
     };
-    let (config, command) = egress.configure(config, &guest);
-    let process_config = VmProcessConfig::new(config, command).write_private()?;
     let executable = std::env::current_exe()?;
     let mut vmm = Command::new(executable);
     vmm.env_clear();
@@ -110,11 +138,10 @@ async fn run_host(arguments: Vec<std::ffi::OsString>, prove_mpp: bool) -> Result
             vmm.env(name, value);
         }
     }
-    vmm.arg("--vmm").arg(process_config.path());
-    let mut session = VmToolSession::spawn(&mut vmm)?;
-    session.provision_egress(egress).await?;
+    vmm.arg("--vmm");
+    let session = VmToolSession::spawn_configured(vmm, config, guest, egress).await?;
     let vm = session.tools();
-    let _agent_tools = vm
+    let agent_tools = vm
         .tools_builder()
         .working_directory("/workspace")
         .default_shell("sh")
@@ -247,6 +274,29 @@ async fn run_host(arguments: Vec<std::ffi::OsString>, prove_mpp: bool) -> Result
             .execute(
                 function_input(&serde_json::json!({
                     "cmd": format!(
+                        "test \"$NANOCENTAUR_SECRET_BASE_URL\" = \
+                         https://secret-gateway.invalid/v1; \
+                         if printf tamper 2>/dev/null >> {GUEST_EGRESS_ROOT}/secrets/route.txt; \
+                         then exit 9; fi; \
+                         cat {GUEST_EGRESS_ROOT}/secrets/route.txt"
+                    ),
+                    "workdir": "/workspace",
+                    "login": false
+                }))?,
+                context,
+            )
+            .await?;
+        let output = command_output(execution)?;
+        if output.exit_code != Some(0) || output.output.trim() != "public-route" {
+            return Err(format!("secret-style egress proof failed: {}", output.output).into());
+        }
+        println!("secret egress: independent environment and read-only mount composed");
+
+        let execution = vm
+            .exec_command_tool()
+            .execute(
+                function_input(&serde_json::json!({
+                    "cmd": format!(
                         "curl --fail --silent --show-error --request POST --data same-body {}",
                         proof.url
                     ),
@@ -266,8 +316,88 @@ async fn run_host(arguments: Vec<std::ffi::OsString>, prove_mpp: bool) -> Result
         println!("mpp egress: guest curl paid and replayed exactly once");
     }
     println!("all VM-owned tools executed through one retained libkrun VM");
+    drop(agent_tools);
+    drop(vm);
     session.shutdown().await?;
     Ok(())
+}
+
+fn reflink_or_sparse_copy(source: &Path, destination: &Path) -> io::Result<u64> {
+    match reflink_copy::reflink(source, destination) {
+        Ok(()) => return Ok(fs::metadata(destination)?.len()),
+        Err(_) => remove_partial_copy(destination)?,
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let status = std::process::Command::new("cp")
+            .args(["--reflink=never", "--sparse=always", "--"])
+            .arg(source)
+            .arg(destination)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()?;
+        if status.success() {
+            return Ok(fs::metadata(destination)?.len());
+        }
+        remove_partial_copy(destination)?;
+        Err(io::Error::other(format!(
+            "sparse disk copy failed with {status}"
+        )))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fs::copy(source, destination)
+}
+
+fn prepare_runtime_disk(runtime: &Path) -> Result<(Option<tempfile::TempDir>, PathBuf), AnyError> {
+    let contents = fs::read(runtime)?;
+    if !contents.starts_with(b"\x7fELF") {
+        return Ok((None, runtime.to_owned()));
+    }
+
+    let directory = tempfile::tempdir()?;
+    let image = directory.path().join("runtime.ext4");
+    let mut runtime_reader = contents.as_slice();
+    let mut formatter = Formatter::new(&image, 4_096, RUNTIME_DISK_BYTES)?;
+    formatter.create(
+        "/nanocodex-vm-guest",
+        make_mode(file_mode::S_IFREG, 0o755),
+        None,
+        None,
+        Some(&mut runtime_reader),
+        Some(0),
+        Some(0),
+        None,
+    )?;
+    formatter.close()?;
+    Ok((Some(directory), image))
+}
+
+fn secret_style_proof_layer() -> Result<EgressLease, AnyError> {
+    let directory = Arc::new(tempfile::tempdir()?);
+    fs::write(directory.path().join("route.txt"), "public-route\n")?;
+    let mut layer = EgressLease::internet();
+    layer.insert_environment(
+        "NANOCENTAUR_SECRET_BASE_URL",
+        "https://secret-gateway.invalid/v1",
+    )?;
+    layer.insert_mount(EgressMount {
+        tag: "secret-proof".to_owned(),
+        host_path: directory.path().to_owned(),
+        guest_path: Path::new(GUEST_EGRESS_ROOT).join("secrets"),
+    })?;
+    layer.retain(directory);
+    Ok(layer)
+}
+
+fn remove_partial_copy(path: &Path) -> io::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
 }
 
 struct MppProof {

--- a/examples/vm_tools.rs
+++ b/examples/vm_tools.rs
@@ -1,0 +1,197 @@
+use std::{error::Error, path::PathBuf};
+
+use nanocodex::{Tool, ToolContext, ToolExecution, ToolInput, ToolOutputBody, ToolOutputContent};
+use nanocodex_vm::{VmToolSession, VmTools};
+use nanovm::{EgressLease, GuestCommand, VmConfig, VmProcessConfig};
+use serde::Deserialize;
+use serde_json::value::to_raw_value;
+use tokio::process::Command;
+
+const GUEST_RUNTIME: &str = "/usr/local/bin/nanocodex-vm-guest";
+type AnyError = Box<dyn Error + Send + Sync>;
+
+#[derive(Deserialize)]
+struct CommandOutput {
+    output: String,
+    exit_code: Option<i32>,
+    session_id: Option<i64>,
+}
+
+#[tokio::main]
+#[allow(
+    clippy::too_many_lines,
+    reason = "the executable intentionally presents one linear end-to-end VM tool proof"
+)]
+async fn main() -> Result<(), AnyError> {
+    let mut arguments = std::env::args_os().skip(1);
+    if arguments.next().as_deref() == Some(std::ffi::OsStr::new("--vmm")) {
+        let config = arguments
+            .next()
+            .map(PathBuf::from)
+            .ok_or("VMM mode requires a private configuration path")?;
+        VmProcessConfig::read(config)?.run()?;
+        return Ok(());
+    }
+
+    let root = std::env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .ok_or("usage: vm-tools ROOTFS")?;
+    let egress = EgressLease::disabled();
+    let guest = GuestCommand::new(GUEST_RUNTIME).arg("/workspace");
+    let (config, command) = egress.configure(VmConfig::new(root).cpus(2).memory_mib(768), &guest);
+    let process_config = VmProcessConfig::new(config, command).write_private()?;
+    let executable = std::env::current_exe()?;
+    let mut vmm = Command::new(executable);
+    vmm.env_clear().arg("--vmm").arg(process_config.path());
+    let session = VmToolSession::spawn(&mut vmm)?;
+    let vm = VmTools::new(session);
+    let _agent_tools = vm
+        .tools_builder()
+        .working_directory("/workspace")
+        .default_shell("sh")
+        .build()?;
+    let context = ToolContext {
+        model: "vm-proof",
+        session_id: "session-1",
+        call_id: "call-1",
+        history: &[],
+        output_token_budget: 10_000,
+    };
+
+    let execution = vm
+        .exec_command_tool()
+        .execute(
+            function_input(&serde_json::json!({
+                "cmd": "printf 'kernel='; uname -srm; printf 'pid1='; cat /proc/1/comm",
+                "workdir": "/workspace",
+                "login": false
+            }))?,
+            context,
+        )
+        .await?;
+    let output = command_output(execution)?;
+    println!("exec_command: {}", output.output.trim());
+    if output.exit_code != Some(0) {
+        return Err("exec_command did not exit successfully".into());
+    }
+
+    let execution = vm
+        .exec_command_tool()
+        .execute(
+            function_input(&serde_json::json!({
+                "cmd": "cat",
+                "workdir": "/workspace",
+                "login": false,
+                "yield_time_ms": 250
+            }))?,
+            context,
+        )
+        .await?;
+    let output = command_output(execution)?;
+    let shell_session = output
+        .session_id
+        .ok_or("exec_command did not retain an interactive session")?;
+    println!("exec_command session: {shell_session}");
+
+    let execution = vm
+        .write_stdin_tool()
+        .execute(
+            function_input(&serde_json::json!({
+                "session_id": shell_session,
+                "chars": "from-host\n",
+                "yield_time_ms": 1_000
+            }))?,
+            context,
+        )
+        .await?;
+    let mut output = command_output(execution)?;
+    for _ in 0..3 {
+        if output.output.contains("from-host") {
+            break;
+        }
+        output = command_output(
+            vm.write_stdin_tool()
+                .execute(
+                    function_input(&serde_json::json!({
+                        "session_id": shell_session,
+                        "yield_time_ms": 1_000
+                    }))?,
+                    context,
+                )
+                .await?,
+        )?;
+    }
+    println!("write_stdin: {}", output.output.trim());
+    if !output.output.contains("from-host") {
+        return Err("write_stdin did not reach the retained guest process".into());
+    }
+
+    let proof_file = format!("vm-proof-{}.txt", std::process::id());
+    let patch = format!(
+        "*** Begin Patch\n*** Add File: {proof_file}\n+changed inside the guest\n*** End Patch"
+    );
+    let execution = vm
+        .apply_patch_tool()
+        .execute(ToolInput::Freeform(patch), context)
+        .await?;
+    println!("apply_patch: {}", text_output(execution)?.trim());
+
+    let execution = vm
+        .exec_command_tool()
+        .execute(
+            function_input(&serde_json::json!({
+                "cmd": "printf iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII= | base64 -d > pixel.png",
+                "workdir": "/workspace",
+                "login": false
+            }))?,
+            context,
+        )
+        .await?;
+    if command_output(execution)?.exit_code != Some(0) {
+        return Err("failed to prepare guest image fixture".into());
+    }
+
+    let execution = vm
+        .view_image_tool()
+        .execute(
+            function_input(&serde_json::json!({
+                "path": "pixel.png",
+                "detail": "original"
+            }))?,
+            context,
+        )
+        .await?;
+    let ToolOutputBody::Content(image_items) = execution.output else {
+        return Err("view_image did not return multimodal content".into());
+    };
+    let Some(ToolOutputContent::InputImage { image_url, detail }) = image_items.into_iter().next()
+    else {
+        return Err("view_image did not return an image".into());
+    };
+    println!(
+        "view_image: detail={detail:?}, data_url_bytes={}",
+        image_url.len()
+    );
+    println!("all VM-owned tools executed through one retained libkrun VM");
+    Ok(())
+}
+
+fn function_input(value: &serde_json::Value) -> Result<ToolInput, serde_json::Error> {
+    to_raw_value(value).map(ToolInput::Function)
+}
+
+fn command_output(execution: ToolExecution) -> Result<CommandOutput, AnyError> {
+    let text = text_output(execution)?;
+    serde_json::from_str(&text).map_err(Into::into)
+}
+
+fn text_output(execution: ToolExecution) -> Result<String, AnyError> {
+    if !execution.success {
+        return Err("tool execution reported failure".into());
+    }
+    match execution.output {
+        ToolOutputBody::Text(text) => Ok(text),
+        ToolOutputBody::Content(_) => Err("expected text tool output".into()),
+    }
+}

--- a/examples/vm_tools.rs
+++ b/examples/vm_tools.rs
@@ -1,13 +1,35 @@
-use std::{error::Error, path::PathBuf};
+use std::{
+    error::Error,
+    net::Ipv4Addr,
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
+use axum::{
+    Router,
+    extract::Request,
+    http::{StatusCode, header::WWW_AUTHENTICATE},
+    response::IntoResponse,
+    routing::post,
+};
+use mpp::{
+    Base64UrlJson, MppError, PaymentChallenge, PaymentCredential, PaymentPayload,
+    client::PaymentProvider, format_www_authenticate,
+};
+use mpp_egress::{EgressPolicy, MppEgress};
 use nanocodex::{Tool, ToolContext, ToolExecution, ToolInput, ToolOutputBody, ToolOutputContent};
-use nanocodex_vm::{VmToolSession, VmTools};
-use nanovm::{EgressLease, GuestCommand, VmConfig, VmProcessConfig};
+use nanocodex_vm::{VmToolSession, mpp_egress_layer};
+use nanovm::{BlockDevice, EgressLease, GuestCommand, VmConfig, VmProcessConfig};
 use serde::Deserialize;
 use serde_json::value::to_raw_value;
 use tokio::process::Command;
 
 const GUEST_RUNTIME: &str = "/usr/local/bin/nanocodex-vm-guest";
+const RUNTIME_BLOCK_DEVICE: &str = "/dev/vdb";
+const RUNTIME_MOUNT: &str = "/run/nanocodex";
 type AnyError = Box<dyn Error + Send + Sync>;
 
 #[derive(Deserialize)]
@@ -17,35 +39,81 @@ struct CommandOutput {
     session_id: Option<i64>,
 }
 
-#[tokio::main]
-#[allow(
-    clippy::too_many_lines,
-    reason = "the executable intentionally presents one linear end-to-end VM tool proof"
-)]
-async fn main() -> Result<(), AnyError> {
-    let mut arguments = std::env::args_os().skip(1);
-    if arguments.next().as_deref() == Some(std::ffi::OsStr::new("--vmm")) {
+fn main() -> Result<(), AnyError> {
+    let mut arguments = std::env::args_os().skip(1).collect::<Vec<_>>();
+    if arguments.first().is_some_and(|value| value == "--vmm") {
         let config = arguments
-            .next()
+            .get(1)
+            .cloned()
             .map(PathBuf::from)
             .ok_or("VMM mode requires a private configuration path")?;
         VmProcessConfig::read(config)?.run()?;
         return Ok(());
     }
+    let prove_mpp = arguments.last().is_some_and(|value| value == "--prove-mpp");
+    if prove_mpp {
+        arguments.pop();
+    }
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(run_host(arguments, prove_mpp))
+}
 
-    let root = std::env::args_os()
-        .nth(1)
+#[allow(
+    clippy::too_many_lines,
+    reason = "the executable intentionally presents one linear end-to-end VM tool proof"
+)]
+async fn run_host(arguments: Vec<std::ffi::OsString>, prove_mpp: bool) -> Result<(), AnyError> {
+    let root = arguments
+        .first()
+        .cloned()
         .map(PathBuf::from)
-        .ok_or("usage: vm-tools ROOTFS")?;
-    let egress = EgressLease::disabled();
-    let guest = GuestCommand::new(GUEST_RUNTIME).arg("/workspace");
-    let (config, command) = egress.configure(VmConfig::new(root).cpus(2).memory_mib(768), &guest);
+        .ok_or("usage: vm-tools ROOTFS [GUEST_RUNTIME_EXT4] [--prove-mpp]")?;
+    let runtime = arguments.get(1).cloned().map(PathBuf::from);
+    let (egress, mpp_proof) = if prove_mpp {
+        let proof = MppProof::start().await?;
+        let layer = mpp_egress_layer(Arc::clone(&proof.egress))?;
+        (EgressLease::internet().with_layer(layer)?, Some(proof))
+    } else {
+        (EgressLease::disabled(), None)
+    };
+    let (config, guest) = if let Some(runtime) = runtime {
+        let config = VmConfig::ext4(root)
+            .cpus(2)
+            .memory_mib(768)
+            .block_device(BlockDevice::read_only("nanocodex-runtime", runtime));
+        let init = format!(
+            "set -eu; mkdir -p \"$1\" {RUNTIME_MOUNT}; \
+             mount -t ext4 -o ro {RUNTIME_BLOCK_DEVICE} {RUNTIME_MOUNT}; \
+             exec {RUNTIME_MOUNT}/nanocodex-vm-guest \"$1\""
+        );
+        let guest = GuestCommand::new("/bin/sh")
+            .arg("-c")
+            .arg(init)
+            .arg("nanocodex-vm-init")
+            .arg("/workspace");
+        (config, guest)
+    } else {
+        (
+            VmConfig::new(root).cpus(2).memory_mib(768),
+            GuestCommand::new(GUEST_RUNTIME).arg("/workspace"),
+        )
+    };
+    let (config, command) = egress.configure(config, &guest);
     let process_config = VmProcessConfig::new(config, command).write_private()?;
     let executable = std::env::current_exe()?;
     let mut vmm = Command::new(executable);
-    vmm.env_clear().arg("--vmm").arg(process_config.path());
-    let session = VmToolSession::spawn(&mut vmm)?;
-    let vm = VmTools::new(session);
+    vmm.env_clear();
+    for name in ["DYLD_LIBRARY_PATH", "LD_LIBRARY_PATH"] {
+        if let Some(value) = std::env::var_os(name) {
+            vmm.env(name, value);
+        }
+    }
+    vmm.arg("--vmm").arg(process_config.path());
+    let mut session = VmToolSession::spawn(&mut vmm)?;
+    session.provision_egress(egress).await?;
+    let vm = session.tools();
     let _agent_tools = vm
         .tools_builder()
         .working_directory("/workspace")
@@ -173,8 +241,119 @@ async fn main() -> Result<(), AnyError> {
         "view_image: detail={detail:?}, data_url_bytes={}",
         image_url.len()
     );
+    if let Some(proof) = &mpp_proof {
+        let execution = vm
+            .exec_command_tool()
+            .execute(
+                function_input(&serde_json::json!({
+                    "cmd": format!(
+                        "curl --fail --silent --show-error --request POST --data same-body {}",
+                        proof.url
+                    ),
+                    "workdir": "/workspace",
+                    "login": false
+                }))?,
+                context,
+            )
+            .await?;
+        let output = command_output(execution)?;
+        if output.exit_code != Some(0) || output.output.trim() != "paid" {
+            return Err(format!("MPP curl proof failed: {}", output.output).into());
+        }
+        if proof.payments.load(Ordering::SeqCst) != 1 || proof.calls.load(Ordering::SeqCst) != 2 {
+            return Err("MPP curl was not paid and replayed exactly once".into());
+        }
+        println!("mpp egress: guest curl paid and replayed exactly once");
+    }
     println!("all VM-owned tools executed through one retained libkrun VM");
+    session.shutdown().await?;
     Ok(())
+}
+
+struct MppProof {
+    egress: Arc<MppEgress>,
+    url: String,
+    payments: Arc<AtomicUsize>,
+    calls: Arc<AtomicUsize>,
+}
+
+impl MppProof {
+    async fn start() -> Result<Self, AnyError> {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let challenge = payment_challenge()?;
+        let app = Router::new().route(
+            "/paid",
+            post({
+                let calls = Arc::clone(&calls);
+                move |request: Request| {
+                    let calls = Arc::clone(&calls);
+                    let challenge = challenge.clone();
+                    async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        if request.headers().contains_key("authorization") {
+                            (StatusCode::OK, "paid").into_response()
+                        } else {
+                            (
+                                StatusCode::PAYMENT_REQUIRED,
+                                [(WWW_AUTHENTICATE, challenge)],
+                                "payment required",
+                            )
+                                .into_response()
+                        }
+                    }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await?;
+        let address = listener.local_addr()?;
+        tokio::spawn(async move {
+            if let Err(error) = axum::serve(listener, app).await {
+                eprintln!("MPP proof origin failed: {error}");
+            }
+        });
+        let provider = ProofPaymentProvider::default();
+        let payments = Arc::clone(&provider.payments);
+        let egress = Arc::new(MppEgress::start(provider, EgressPolicy::default()).await?);
+        Ok(Self {
+            egress,
+            url: format!("http://{address}/paid"),
+            payments,
+            calls,
+        })
+    }
+}
+
+#[derive(Clone, Default)]
+struct ProofPaymentProvider {
+    payments: Arc<AtomicUsize>,
+}
+
+impl PaymentProvider for ProofPaymentProvider {
+    fn supports(&self, method: &str, intent: &str) -> bool {
+        method == "test" && intent == "charge"
+    }
+
+    async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+        self.payments.fetch_add(1, Ordering::SeqCst);
+        Ok(PaymentCredential::new(
+            challenge.to_echo(),
+            PaymentPayload::hash("vm-mpp-proof"),
+        ))
+    }
+}
+
+fn payment_challenge() -> Result<String, AnyError> {
+    let request = Base64UrlJson::from_value(&serde_json::json!({
+        "amount": "1",
+        "currency": "test"
+    }))?;
+    Ok(format_www_authenticate(&PaymentChallenge::new(
+        "vm-proof",
+        "test.local",
+        "test",
+        "charge",
+        request,
+    ))?)
 }
 
 fn function_input(value: &serde_json::Value) -> Result<ToolInput, serde_json::Error> {

--- a/nanovm.entitlements
+++ b/nanovm.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.hypervisor</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/aarch64-unknown-linux-musl-ar
+++ b/scripts/aarch64-unknown-linux-musl-ar
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    if command -v brew >/dev/null 2>&1; then
+        brew_bin="$(command -v brew)"
+    elif [ -x /opt/homebrew/bin/brew ]; then
+        brew_bin=/opt/homebrew/bin/brew
+    else
+        brew_bin=/usr/local/bin/brew
+    fi
+    exec "$("$brew_bin" --prefix llvm)/bin/llvm-ar" "$@"
+fi
+
+exec ar "$@"

--- a/scripts/aarch64-unknown-linux-musl-linker
+++ b/scripts/aarch64-unknown-linux-musl-linker
@@ -11,11 +11,22 @@ if [ "$(uname -s)" = "Darwin" ]; then
     fi
     PATH="$("$brew_bin" --prefix lld)/bin:$PATH"
     export PATH
-    exec /usr/bin/clang \
-        -target aarch64-linux-gnu \
-        -fuse-ld=lld \
-        -Wl,-strip-debug \
-        "$@"
+    case " $* " in
+        *" -c "*)
+            exec /usr/bin/clang \
+                -target aarch64-linux-gnu \
+                -Wno-unused-command-line-argument \
+                "$@"
+            ;;
+        *)
+            exec /usr/bin/clang \
+                -target aarch64-linux-gnu \
+                -fuse-ld=lld \
+                -Wno-unused-command-line-argument \
+                -Wl,-strip-debug \
+                "$@"
+            ;;
+    esac
 fi
 
 exec cc "$@"

--- a/scripts/aarch64-unknown-linux-musl-linker
+++ b/scripts/aarch64-unknown-linux-musl-linker
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    if command -v brew >/dev/null 2>&1; then
+        brew_bin="$(command -v brew)"
+    elif [ -x /opt/homebrew/bin/brew ]; then
+        brew_bin=/opt/homebrew/bin/brew
+    else
+        brew_bin=/usr/local/bin/brew
+    fi
+    PATH="$("$brew_bin" --prefix lld)/bin:$PATH"
+    export PATH
+    exec /usr/bin/clang \
+        -target aarch64-linux-gnu \
+        -fuse-ld=lld \
+        -Wl,-strip-debug \
+        "$@"
+fi
+
+exec cc "$@"


### PR DESCRIPTION
## What changed

- add `nanovm`, a typed libkrun package with explicit VM, block, share, network, and shutdown policy behind a small audited FFI boundary
- add `nanocodex-vm`, providing retained VM implementations of `exec_command`, `write_stdin`, `apply_patch`, and `view_image`
- expose clone-cheap `VmTools` handles so one root `VmToolSession` is captured by `tools_factory` and reused by the root agent, forks, and attached subagents
- multiplex concurrent host calls over one guest channel with request IDs, cancellation-safe response routing, bounded guest concurrency, retained shells, and owner-only shutdown
- add provider-neutral transactional egress composition for network mode, guest environment, read-only mounts, public provisioned files, and lifecycle guards
- package MPP as an optional egress layer: the wallet and payment replay remain host-side while ordinary guest `curl` receives only the front proxy and public CA
- document how NanoCentaur Iron secret egress composes as another provider layer without placing resolved secrets in the guest

## Ownership and egress

There is one VMM per root Nanocodex session tree, not one per tool call or subagent. Each driver still gets fresh agent-relative tool handlers bound to its own weak agent handle; only the VM workspace is shared. Dropping the owner closes pending RPCs and terminates the VMM, while explicit shutdown drains guest work and descendants.

Egress providers resolve into one neutral `EgressLease`. Duplicate identical fragments compose; conflicts fail closed. If MPP and Iron both need the single front `HTTPS_PROXY`, the application chains or routes those host-side layers and presents one front proxy to the VM.

## Validation

- full `cargo test --workspace --all-features`
- full `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- documentation build with warnings denied on the stacked browser branch
- repeated concurrent guest/RPC tests, including out-of-order completion and cancelled late responses
- live signed libkrun VM proof: Linux guest execution, retained shell plus `write_stdin`, `apply_patch`, `view_image`, and clean shutdown
- live MPP proof from guest `curl`: payment and exact request replay occurred once through the host-owned proxy