### PR TITLE
ci: run website worker tests in the web job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,8 @@ jobs:
           name: nanocodex-web-wasm
           path: js/bindings/pkg-web
       - run: npm ci --prefix web
+      - name: Run website worker and transcript tests
+        run: npm test --prefix web
       - name: Type-check and build the website
         working-directory: web
         run: npm run typecheck && npx --no-install vite build

--- a/Justfile
+++ b/Justfile
@@ -74,6 +74,10 @@ test-wasm: build-wasm
     npm test --prefix js/bindings
     npm test --prefix js/react
 
+# Run website worker tests and the shared JS transcript reducer suite (Node >=22.13).
+test-web:
+    npm test --prefix web
+
 # Run custom JavaScript tooling and a follow-on through Node-hosted WASM.
 smoke-wasm-node: build-wasm
     npm ci --prefix examples/node


### PR DESCRIPTION
## Summary
- Run `npm test --prefix web` in the CI `web` job so `web/worker/index.test.ts` (and the package's transcript suite) cannot regress unnoticed.
- Add `just test-web` for local parity.

Closes #54

## Why
`web/package.json` already defines `"test": "npm --prefix ../js/tui test && node --test worker/index.test.ts"`, but CI only typechecked and built the site. This is separate from any TUI-only bindings CI work: the gap is the website worker job.

## Verification
- Local `npm test --prefix web` on Node 22.22.3: **15 transcript + 4 worker tests passed**

## Test plan
- [x] CI `web` job runs `npm test --prefix web`
- [x] Worker tests stay green without OpenAI credentials