### PR TITLE
feat(vm): add retained VM-backed workspace tools

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,21 @@
+[env]
+CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER = { value = "scripts/aarch64-unknown-linux-musl-linker", relative = true, force = true }
+CC_aarch64_unknown_linux_musl = { value = "scripts/aarch64-unknown-linux-musl-linker", relative = true, force = true }
+AR_aarch64_unknown_linux_musl = { value = "scripts/aarch64-unknown-linux-musl-ar", relative = true, force = true }
+
 [target.aarch64-apple-darwin]
 linker = "/usr/bin/clang"
+runner = "scripts/codesign-runner"
+
+[target.aarch64-unknown-linux-musl]
+linker = "scripts/aarch64-unknown-linux-musl-linker"
+
+[target.x86_64-unknown-linux-musl]
+linker = "x86_64-linux-musl-gcc"
+# libc 0.2.189 requires an explicit ABI floor before exposing statx on musl.
+# Nanocodex's supported Linux VM host requires musl >= 1.2.3.
+rustflags = ["--cfg=libc_unstable_musl_v1_2_3"]
 
 [target.x86_64-apple-darwin]
 linker = "/usr/bin/clang"
+runner = "scripts/codesign-runner"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,35 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
 
+  vm-guest:
+    name: static Linux VM guest
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+        with:
+          toolchain: stable
+          targets: x86_64-unknown-linux-musl
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          cache-on-failure: true
+      - run: sudo apt-get update && sudo apt-get install --yes musl-tools
+      - name: Check the guest-only target matrix
+        run: >-
+          cargo check --locked --package nanocodex-vm --all-targets
+          --no-default-features --features guest-runtime
+      - name: Build the actual static guest artifact
+        run: >-
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
+          cargo build --locked --package nanocodex-vm
+          --bin nanocodex-vm-guest --no-default-features
+          --features guest-runtime --target x86_64-unknown-linux-musl
+
   policy:
     name: dependencies and spelling
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
       - uses: taiki-e/install-action@3522286d40783523f9c7880e33f785905b4c20d0 # v2
         with:
           tool: cargo-deny
+      - run: ./scripts/check-experimental-boundary.sh
       - run: cargo deny check
       - run: ./scripts/check-crate-boundaries.sh
       - uses: crate-ci/typos@96d9af6217dc2855210655af7e1ff19d23d4e593 # v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,11 @@
   CLI behavior into the library.
 - Tempo payment, egress, and `NanoUSD` support stay under `bin/`; public
   `nanocodex-*` library crates must not depend on them.
+- The unpublished experimental `nanocodex-vm` crate owns the complete VM
+  boundary: the audited libkrun interface, VM/process configuration, gvproxy
+  and provider-neutral egress, OCI/Dockerfile image preparation, and retained
+  host/guest workspace tools. Its guest reuses the canonical local
+  workspace-tool contracts rather than introducing a second tool runtime.
 - Each lower crate must remain useful without importing the higher orchestration
   crate. Avoid circular concepts and leaky socket/runtime types.
 - `scripts/check-crate-boundaries.sh` is the executable dependency policy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Features
+
+- [vm] Add persistent VM-backed workspace tools, immutable root-image
+  preparation, and provider-neutral composable egress leases.
+
 ## [0.3.0](https://github.com/gakonst/nanocodex/releases/tag/v0.3.0) - 2026-07-28
 
 ### Bug Fixes
@@ -145,7 +152,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [mcp] Verify read-only parallel dispatch
 - [tools] Serialize traced runtime integration tests
 - [tui] Preserve stored checkpoint branch coverage
-
 ## [0.2.0](https://github.com/gakonst/nanocodex/releases/tag/v0.2.0) - 2026-07-26
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e50185b84799c8b5f016a0c9da74309fe28d1c70fbe590a4e8d9cae6df3eebb0"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -782,6 +782,17 @@ dependencies = [
  "percent-encoding",
  "windows-sys 0.52.0",
  "x11rb",
+]
+
+[[package]]
+name = "arcbox-ext4"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9dce000de67c1a27347fed86e9ce76199463fbb5a3d7f13cb0f3d1c16b6dae3"
+dependencies = [
+ "tar",
+ "thiserror 2.0.18",
+ "uuid",
 ]
 
 [[package]]
@@ -1253,6 +1264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -1344,6 +1356,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -1566,6 +1597,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "c-kzg"
 version = "2.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,6 +1628,15 @@ dependencies = [
  "libc",
  "once_cell",
  "serde",
+]
+
+[[package]]
+name = "caps"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd1ddba47aba30b6a889298ad0109c3b8dcb0e8fc993b459daa7067d46f865e0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1952,6 +2011,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-epoch"
 version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2053,12 +2122,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2077,11 +2170,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.119",
 ]
@@ -2106,6 +2210,37 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "der"
@@ -2160,6 +2295,37 @@ checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn 2.0.119",
 ]
 
@@ -2376,6 +2542,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,7 +2577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2528,6 +2717,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,6 +2798,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2794,6 +3003,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "gif"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2808,6 +3028,19 @@ name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "group"
@@ -2959,6 +3192,15 @@ checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
+]
+
+[[package]]
+name = "http-auth"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3240,6 +3482,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "image"
 version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3266,6 +3524,26 @@ checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
  "quick-error",
+]
+
+[[package]]
+name = "imago"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae7cfee876c698a1a2ed9c705ab18f21acbed82110f19b51cc458de73426fe2c"
+dependencies = [
+ "async-trait",
+ "bincode 2.0.1",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "nix 0.30.1",
+ "page_size",
+ "rustc_version 0.4.1",
+ "tokio",
+ "tracing",
+ "vm-memory",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3332,7 +3610,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
@@ -3383,6 +3661,42 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "jni"
@@ -3455,6 +3769,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "aws-lc-rs",
+ "base64",
+ "getrandom 0.2.17",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3504,6 +3834,182 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
+name = "krun-arch"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "krun-arch-gen",
+ "krun-smbios",
+ "krun-utils",
+ "krun-whp",
+ "kvm-bindings",
+ "kvm-ioctls",
+ "libc",
+ "linux-loader",
+ "vm-memory",
+ "vmm-sys-util 0.15.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "krun-arch-gen"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+
+[[package]]
+name = "krun-cpuid"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "kvm-bindings",
+ "kvm-ioctls",
+ "vmm-sys-util 0.15.0",
+]
+
+[[package]]
+name = "krun-devices"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "bitflags 1.3.2",
+ "caps",
+ "crossbeam-channel",
+ "imago",
+ "krun-arch",
+ "krun-hvf",
+ "krun-polly",
+ "krun-utils",
+ "krun-whp",
+ "kvm-bindings",
+ "kvm-ioctls",
+ "libc",
+ "libloading",
+ "log",
+ "lru 0.16.4",
+ "nix 0.30.1",
+ "rand 0.9.5",
+ "virtio-bindings",
+ "vm-fdt",
+ "vm-memory",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "krun-hvf"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "crossbeam-channel",
+ "krun-arch",
+ "libloading",
+ "log",
+]
+
+[[package]]
+name = "krun-init-blob"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+
+[[package]]
+name = "krun-kernel"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "krun-utils",
+ "vm-memory",
+]
+
+[[package]]
+name = "krun-polly"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "krun-utils",
+ "libc",
+]
+
+[[package]]
+name = "krun-smbios"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "vm-memory",
+]
+
+[[package]]
+name = "krun-utils"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossbeam-channel",
+ "kvm-bindings",
+ "libc",
+ "log",
+ "nix 0.30.1",
+ "vmm-sys-util 0.15.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "krun-vmm"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "bzip2",
+ "crossbeam-channel",
+ "flate2",
+ "krun-arch",
+ "krun-arch-gen",
+ "krun-cpuid",
+ "krun-devices",
+ "krun-hvf",
+ "krun-kernel",
+ "krun-polly",
+ "krun-utils",
+ "kvm-bindings",
+ "kvm-ioctls",
+ "libc",
+ "linux-loader",
+ "log",
+ "nix 0.30.1",
+ "vm-memory",
+ "vmm-sys-util 0.14.0",
+ "windows-sys 0.61.2",
+ "zstd",
+]
+
+[[package]]
+name = "krun-whp"
+version = "0.1.0-2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "log",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "kvm-bindings"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11cf0ca75d59e9d298647c59cf6c5286fa048120caa77972a7a504a0824d234f"
+dependencies = [
+ "vmm-sys-util 0.15.0",
+]
+
+[[package]]
+name = "kvm-ioctls"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333f77a20344a448f3f70664918135fddeb804e938f28a99d685bd92926e0b19"
+dependencies = [
+ "bitflags 2.13.1",
+ "kvm-bindings",
+ "libc",
+ "vmm-sys-util 0.15.0",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3514,6 +4020,39 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libkrun"
+version = "2.0.0-dev"
+source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
+dependencies = [
+ "crossbeam-channel",
+ "env_logger",
+ "krun-devices",
+ "krun-hvf",
+ "krun-init-blob",
+ "krun-polly",
+ "krun-utils",
+ "krun-vmm",
+ "kvm-bindings",
+ "kvm-ioctls",
+ "libc",
+ "libloading",
+ "log",
+ "once_cell",
+ "vm-memory",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"
@@ -3539,6 +4078,15 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linux-loader"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de72cb02c55ecffcf75fe78295926f872eb6eb0a58d629c58a8c324dc26380f6"
+dependencies = [
+ "vm-memory",
 ]
 
 [[package]]
@@ -3645,6 +4193,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -3831,6 +4388,7 @@ dependencies = [
  "crossterm",
  "dotenvy",
  "eyre",
+ "fs2",
  "futures-util",
  "hex",
  "http-body-util",
@@ -3840,6 +4398,7 @@ dependencies = [
  "nanocodex",
  "nanocodex-observability",
  "nanocodex-tools",
+ "nanocodex-vm",
  "nanousd",
  "nix 0.31.3",
  "pulldown-cmark",
@@ -3876,9 +4435,12 @@ dependencies = [
  "futures-util",
  "http",
  "nanocodex",
+ "nanocodex-vm",
+ "reflink-copy",
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-tungstenite",
  "tower",
@@ -3965,6 +4527,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -3980,6 +4543,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "nanocodex-vm"
+version = "0.3.0"
+dependencies = [
+ "arcbox-ext4",
+ "async-trait",
+ "base64",
+ "criterion",
+ "filetime",
+ "flate2",
+ "fs2",
+ "futures-util",
+ "hex",
+ "ignore",
+ "libkrun",
+ "nanocodex-tools",
+ "nix 0.31.3",
+ "oci-client",
+ "reflink-copy",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "shlex",
+ "tar",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "zstd",
 ]
 
 [[package]]
@@ -4048,6 +4643,19 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -4316,12 +4924,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci-client"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5261a7fb43d9c53b8e63e6d5e86860719dad253d015d022066c72d585125aed8"
+dependencies = [
+ "bytes",
+ "chrono",
+ "futures-util",
+ "hex",
+ "http",
+ "http-auth",
+ "jsonwebtoken",
+ "lazy_static",
+ "oci-spec",
+ "olpc-cjson",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "unicase",
+]
+
+[[package]]
+name = "oci-spec"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8445a2631507cec628a15fdd6154b54a3ab3f20ed4fe9d73a3b8b7a4e1ba03a"
+dependencies = [
+ "const_format",
+ "derive_builder",
+ "getset",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
  "asn1-rs",
+]
+
+[[package]]
+name = "olpc-cjson"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696183c9b5fe81a7715d074fd632e8bd46f4ccc0231a3ed7fc580a80de5f7083"
+dependencies = [
+ "serde",
+ "serde_json",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -4446,6 +5109,16 @@ dependencies = [
  "primeorder",
  "serdect",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -4673,6 +5346,15 @@ name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "portable-pty"
@@ -4972,7 +5654,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5133,7 +5815,7 @@ dependencies = [
  "itertools 0.13.0",
  "lru 0.12.5",
  "paste",
- "strum",
+ "strum 0.26.3",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
@@ -5191,6 +5873,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "reflink-copy"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rustix 1.1.4",
+ "windows",
 ]
 
 [[package]]
@@ -5567,7 +6261,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -5797,7 +6491,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5855,7 +6549,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5873,7 +6567,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6210,7 +6904,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6547,8 +7241,14 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 
 [[package]]
 name = "strum_macros"
@@ -6560,6 +7260,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -6641,7 +7353,7 @@ version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "fancy-regex",
  "flate2",
  "fnv",
@@ -6666,6 +7378,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6681,7 +7404,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7297,6 +8020,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7333,9 +8065,21 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"
@@ -7416,6 +8160,55 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtio-bindings"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091f1f09cfbf2a78563b562e7a949465cce1aef63b6065645188d995162f8868"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "vm-fdt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e21282841a059bb62627ce8441c491f09603622cd5a21c43bfedc85a2952f23"
+
+[[package]]
+name = "vm-memory"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f39348a049689cabd3377cdd9182bf526ec76a6f823b79903896452e9d7a7380"
+dependencies = [
+ "libc",
+ "thiserror 2.0.18",
+ "winapi",
+]
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d21f366bf22bfba3e868349978766a965cbe628c323d58e026be80b8357ab789"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "506c62fdf617a5176827c2f9afbcf1be155b03a9b4bf9617a60dbc07e3a1642f"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -7608,7 +8401,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7616,6 +8409,27 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
 
 [[package]]
 name = "windows-core"
@@ -7628,6 +8442,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -7657,6 +8482,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -7708,6 +8543,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -7830,6 +8674,16 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "bin/nanousd-api",
     "crates/nanocodex",
     "crates/nanocodex-agent",
+    "crates/experimental/nanocodex-vm",
     "crates/nanocodex-oai-api",
     "crates/nanocodex-observability",
     "crates/nanocodex-tools",
@@ -37,6 +38,7 @@ arboard = "3"
 base64 = "0.22.1"
 async-trait = "=0.1.89"
 alloy-primitives = { version = "1.6.1", default-features = false, features = ["std"] }
+arcbox-ext4 = "0.1.2"
 axum = { version = "0.8.9", default-features = false, features = ["form", "http1", "json", "query", "tokio"] }
 bm25 = { version = "2.3.2", default-features = false }
 chrono = { version = "0.4.43", default-features = false, features = ["clock", "std", "wasmbind"] }
@@ -45,6 +47,9 @@ crossterm = { version = "0.28.1", features = ["bracketed-paste", "event-stream"]
 criterion = { version = "0.7.0", default-features = false, features = ["async_tokio", "cargo_bench_support"] }
 dotenvy = "0.15.7"
 eyre = "0.6.12"
+filetime = "0.2.26"
+flate2 = "1.1"
+fs2 = "0.4"
 futures-util = { version = "0.3.31", default-features = false, features = ["async-await", "sink", "std"] }
 getrandom = "0.4.3"
 hex = "0.4.3"
@@ -52,16 +57,21 @@ http = "1.3.1"
 http-body-util = "0.1.3"
 hmac = "0.13.0"
 hudsucker = { version = "0.25.0", git = "https://github.com/gakonst/hudsucker", rev = "0c7da328e446518036b9420db3e75451fca522e9", default-features = false, features = ["rcgen-ca", "rustls-client"] }
+ignore = "0.4.31"
+krun = { package = "libkrun", version = "=2.0.0-dev", git = "https://github.com/containers/libkrun", rev = "df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0", features = ["blk", "net"] }
 mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "5caad442edeab796821b7f3bb009ab6945106e35", default-features = false }
 nanocodex = { version = "0.3.0", path = "crates/nanocodex" }
 nanocodex-agent = { version = "0.3.0", path = "crates/nanocodex-agent" }
+nanocodex-vm = { version = "0.3.0", path = "crates/experimental/nanocodex-vm" }
 nanocodex-oai-api = { version = "0.3.0", path = "crates/nanocodex-oai-api" }
 nanocodex-observability = { version = "0.3.0", path = "crates/nanocodex-observability" }
 nanocodex-tools = { version = "0.3.0", path = "crates/nanocodex-tools" }
 nanocodex-tools-macros = { version = "0.3.0", path = "crates/nanocodex-tools/macros" }
 nanousd = { version = "0.3.0", path = "bin/nanousd" }
+oci-client = { version = "0.17.0", default-features = false, features = ["rustls-tls"] }
 rand = "0.9.2"
-image = { version = "0.25.9", default-features = false, features = ["gif", "jpeg", "png", "pnm", "webp"] }
+reflink-copy = "0.1.30"
+image = { version = "0.25.9", default-features = false, features = ["bmp", "gif", "jpeg", "png", "pnm", "webp"] }
 iana-time-zone = "0.1.64"
 js-sys = "0.3.82"
 nix = { version = "0.31.3", default-features = false, features = ["process", "resource", "signal", "user"] }
@@ -97,6 +107,7 @@ sonic-rs = "0.5.8"
 syn = { version = "2.0.119", features = ["full"] }
 thiserror = "2.0.17"
 tempfile = "3.27.0"
+tar = "0.4"
 toml = "1.1.3"
 tokio = "1.48.0"
 tokio-util = { version = "0.7", features = ["codec"] }
@@ -115,6 +126,7 @@ vergen = { version = "8", default-features = false }
 wasm-bindgen = "0.2.105"
 wasm-bindgen-futures = "0.4.55"
 web-time = "1.1.0"
+zstd = "0.13"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/Justfile
+++ b/Justfile
@@ -92,6 +92,33 @@ dev-react-example:
 smoke-mcp:
     cargo run --quiet -p nanocodex-examples --bin mcp
 
+# Build the end-to-end VM tool example. macOS VMM executables need the
+# Hypervisor entitlement; signing the built artifact keeps Cargo inputs clean.
+build-vm-guest:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    case "$(uname -m)" in
+      arm64|aarch64)
+        target=aarch64-unknown-linux-musl
+        export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="{{justfile_directory()}}/scripts/aarch64-unknown-linux-musl-linker"
+        export CC_aarch64_unknown_linux_musl="{{justfile_directory()}}/scripts/aarch64-unknown-linux-musl-linker"
+        export AR_aarch64_unknown_linux_musl="{{justfile_directory()}}/scripts/aarch64-unknown-linux-musl-ar"
+        ;;
+      x86_64|amd64) target=x86_64-unknown-linux-musl ;;
+      *) echo "unsupported VM guest architecture: $(uname -m)" >&2; exit 2 ;;
+    esac
+    cargo build -p nanocodex-vm --bin nanocodex-vm-guest \
+      --no-default-features --features guest-runtime --target "$target"
+
+build-vm-example:
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="{{justfile_directory()}}/scripts/aarch64-unknown-linux-musl-linker" \
+    CC_aarch64_unknown_linux_musl="{{justfile_directory()}}/scripts/aarch64-unknown-linux-musl-linker" \
+    AR_aarch64_unknown_linux_musl="{{justfile_directory()}}/scripts/aarch64-unknown-linux-musl-ar" \
+    cargo build -p nanocodex-examples --bin vm-tools --all-features
+    @if [ "$(uname -s)" = "Darwin" ]; then \
+        codesign --entitlements nanocodex-vm.entitlements --force --sign - target/debug/vm-tools; \
+    fi
+
 # Start the ephemeral localhost Jaeger backend used by the OTLP trace demo.
 otel-up:
     @docker compose -f docker-compose.otel.yml up --detach
@@ -141,6 +168,21 @@ bench-pr50:
     cargo bench -p nanocodex-tools --bench mcp_tool_search
     cargo bench -p nanocodex-bin --bench tui_render -- '^(tui_trace_render/codex_long/tail/(80x24|120x40|200x60)|tui_transcript_delta/assistant_100k|tui_stream_telemetry/apply_1024_and_present|tui_branch_state/codex_long/switch_branch|tui_markdown/syntax_fallback_oversized_line_1m|tui_tool_tree/result_269k_cached_frame/120x40|tui_code_mode_stream/apply_16_out_of_order_completions|tui_trace_resize/codex_long/80x24_to_200x60|tui_live_tail_first_frame/assistant_1m_single_line/120x40|tui_smooth_follow/drain_128_row_backlog/120x40|tui_terminal_output/(catch_up_frame|fast_mode_toggle)/120x40|tui_composer_render/multiline_100k/120x40|tui_large_paste/ingest_100k)$'
     ./scripts/check-benchmark-thresholds.sh
+
+# Deterministic warm-image and retained VM protocol latency gates.
+bench-vm:
+    cargo bench -p nanocodex-vm --bench image_cache
+    cargo bench -p nanocodex-vm --bench vm_session -- vm_session_protocol
+
+# Include actual libkrun boot, first RPC, and graceful shutdown. The root disk
+# is reflinked before each timed sample and is never mutated directly.
+bench-vm-live rootfs runtime firmware=".cache/libkrunfw/libkrunfw":
+    just build-vm-example
+    NANOCODEX_VM_VMM="{{justfile_directory()}}/target/debug/vm-tools" \
+    NANOCODEX_VM_ROOTFS="{{rootfs}}" \
+    NANOCODEX_VM_RUNTIME="{{runtime}}" \
+    NANOCODEX_VM_FIRMWARE="{{firmware}}" \
+    cargo bench -p nanocodex-vm --bench vm_session -- vm_session_live
 
 # Run a tool-using turn and retain events and diagnostic logs independently.
 otel-demo:
@@ -335,6 +377,7 @@ view jobs=default_jobs:
 # Checks stay small until the end-to-end agent path is real.
 check:
     ./scripts/check-crate-boundaries.sh
+    ./scripts/check-experimental-boundary.sh
     cargo fmt --all -- --check
     cargo clippy --workspace --all-targets --all-features -- -D warnings
     cargo test --workspace
@@ -366,6 +409,10 @@ release-check version:
         cargo package --locked --allow-dirty --no-verify --config .cargo/release.toml --package "$crate"; \
     done
     ./scripts/check-docs.sh
+
+# Enforce the one-way dependency and publication boundary for experimental crates.
+check-experimental:
+    ./scripts/check-experimental-boundary.sh
 
 # Regenerate the committed Alloy-style changelog for a release preparation PR.
 changelog version:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **[Install](#install)** · **[Agent API](#minimal-api-example)** ·
 **[Thesis](#thesis)** · **[Components](#components)** ·
-**[Documentation](#documentation)**
+**[VM-backed tools](#vm-backed-tools)** · **[Documentation](#documentation)**
 
 [ci]: https://github.com/gakonst/nanocodex/actions/workflows/ci.yml
 [crates]: https://crates.io/crates/nanocodex
@@ -192,6 +192,18 @@ directly.
 [Observability guide](crates/nanocodex-observability/README.md) ·
 [API documentation](https://docs.rs/nanocodex-observability)
 
+### Experimental systems components
+
+VM components live under [`crates/experimental/`](crates/experimental/README.md)
+while their public contracts mature:
+
+| Package | Responsibility |
+| --- | --- |
+| [`nanocodex-vm`](crates/experimental/nanocodex-vm/README.md) | VM lifecycle and images plus retained guest-backed workspace tools |
+
+The CLI is a consumer of this crate. VM-backed tools remain opt-in for normal
+agent sessions.
+
 ### CLI and language bindings
 
 The CLI/TUI, Python package, Node/browser package, React bindings, and examples
@@ -201,12 +213,36 @@ agent protocol.
 [Examples](examples/README.md) · [JavaScript](js/README.md) ·
 [Python](py/README.md) · [Web](web/README.md)
 
+## VM-backed tools
+
+Normal TUI and one-shot sessions keep host workspace tools by default. They can
+instead route `exec_command`, `write_stdin`, `apply_patch`, and `view_image`
+through one retained VM:
+
+```sh
+just build-vm-guest
+nanocodex \
+  --vm .nanocodex/vm/session-rootfs.ext4 \
+  --vm-guest-runtime target/aarch64-unknown-linux-musl/debug/nanocodex-vm-guest \
+  --vm-workspace /app
+nanocodex run "inspect the repository" \
+  --vm .nanocodex/vm/session-rootfs.ext4 \
+  --vm-guest-runtime target/aarch64-unknown-linux-musl/debug/nanocodex-vm-guest \
+  --vm-workspace /app
+```
+
+Directory roots may instead contain
+`/usr/local/bin/nanocodex-vm-guest`. See the
+[VM guide](docs/VM.md) for image preparation, lifecycle, egress, Linux
+requirements, and macOS signing.
+
 ## Documentation
 
 - [Facade API](https://docs.rs/nanocodex)
 - [Migration from 0.2.x](docs/MIGRATING.md)
 - [Examples](examples/README.md)
 - [Benchmarks and retained measurements](benchmarks/)
+- [VM-backed tools and egress](docs/VM.md)
 
 ## License
 

--- a/benchmarks/refactor_vm_baseline_2026-07-26.md
+++ b/benchmarks/refactor_vm_baseline_2026-07-26.md
@@ -1,0 +1,122 @@
+# VM and image baseline — 2026-07-26
+
+This is the first reproducible baseline for the refactor's VM slice. It keeps
+image-cache work, protocol overhead, and actual libkrun lifecycle time separate
+so cold compilation or image construction is never reported as agent latency.
+
+## Environment
+
+- MacBookPro18,2, Apple M1 Max, 32 GiB
+- macOS 26.3.1 (25D771280a)
+- rustc 1.97.1 (`8bab26f4f`, LLVM 22.1.6)
+- Cargo `bench` profile, optimized, debug information disabled
+- Criterion 0.7, 20 samples for deterministic benchmarks and 10 for live VM
+- arm64 Alpine 3.24 immutable root disk, 512 MiB logical size
+- current `aarch64-unknown-linux-musl` `nanocodex-vm-guest`
+- libkrun firmware 5
+
+The source worktree was based on `refactor/06-vm@5535935`; the measurements
+include the uncommitted VM/image slice subsequently recorded by this document.
+
+## Results
+
+Criterion's reported interval is shown verbatim. It is a confidence interval
+for the estimate, not a percentile claim.
+
+| Operation | Fixture | Estimate |
+| --- | --- | --- |
+| warm guest-runtime prepare | path-scoped source record and prepared 128 MiB ext4 disk | 32.662–38.613 µs |
+| warm image prepare | local immutable OCI reference and prepared 512 MiB ext4 disk | 62.020–63.628 µs |
+| attempt root reflink | prepared 512 MiB ext4 disk to a fresh APFS path | 114.22–119.44 µs |
+| retained protocol RPC | typed command over a retained local process protocol | 145.61–147.85 µs |
+| protocol spawn + first RPC + shutdown | local protocol process, no VM | 3.5824–3.8843 ms |
+| retained live-VM command RPC | `/bin/true` in one already-running libkrun guest | 320.93–352.97 µs |
+| live VM boot + first RPC + shutdown | private root reflink, current guest runtime, 2 vCPU/768 MiB | 162.63–165.22 ms |
+
+Reproduce the deterministic measurements with:
+
+```sh
+just bench-vm
+```
+
+Reproduce the live lifecycle measurement after building the signed VMM and
+guest:
+
+```sh
+just build-vm-guest
+just bench-vm-live \
+  .cache/vm/images/226b091c02ae88b383c42617e8508d4e72588b8cadaa8b75113548d2ee205336.ext4 \
+  target/aarch64-unknown-linux-musl/debug/nanocodex-vm-guest \
+  .cache/libkrunfw/libkrunfw
+```
+
+`NANOCODEX_VM_RUNTIME` accepts either the guest ELF or a prepared runtime ext4
+disk. The public `GuestRuntimeDisk::prepare` path stages an ELF once before
+Criterion starts timing and reuses the content-addressed runtime identity.
+
+## Regression gates
+
+The following machine-local budgets apply to this M1 Max baseline. CI keeps the
+structural gates deterministic; numeric comparisons run on a pinned benchmark
+host because filesystem and hypervisor timings are machine-sensitive.
+
+| Operation | Budget |
+| --- | --- |
+| warm guest-runtime prepare | ≤ 100 µs |
+| warm image prepare | ≤ 100 µs |
+| attempt root reflink | ≤ 200 µs |
+| retained protocol RPC | ≤ 250 µs |
+| retained live-VM command RPC | ≤ 600 µs |
+| live VM boot + first RPC + shutdown | ≤ 250 ms |
+
+Hard structural gates:
+
+- a healthy guest-runtime hit reads only its source/disk metadata and atomic
+  record; source or disk changes trigger complete byte/ext4 validation;
+- a valid warm prepared-disk hit does not decode OCI layer contents or launch a
+  VM;
+- two concurrent preparations of one cache key publish exactly one disk and
+  report one `created` plus one `hit`;
+- different image references and OCI layers resolve as sibling futures, with
+  each boundary capped at eight concurrent operations;
+- cache records and disks publish atomically under per-artifact process locks;
+- every attempt mutates a reflink/sparse copy, never the immutable cache disk;
+- one root-agent tree shares one retained VM and retained guest shell sessions;
+- request cancellation is targeted and does not stop sibling guest work;
+- output, protocol frames, file reads, and shutdown are bounded;
+- dropping the final capability kills the VMM and releases egress guards; and
+- one bounded `vm.image.prepare` root contains its resolve/format/build children
+  and preserves the complete Dockerfile as a span event.
+
+The normal agent path pays neither image construction nor VM boot per tool
+call. The measured retained live-VM boundary is sub-millisecond, leaving model,
+network, and actual tool work as the intended critical-path costs.
+
+The final warm rerun followed the public-API and cache-integrity audit. An
+intermediate implementation opened ext4 on every healthy hit and measured
+112.39–114.81 µs, breaching the 100 µs gate. The retained design validates the
+existing size/mtime cache record on healthy hits, opens ext4 when that record is
+missing or changed, and atomically rebuilds an invalid disk. That restored the
+warm path to 62.020–63.628 µs while preserving the new corruption-repair test.
+An earlier reflink sample taken with the filesystem nearly full measured
+151.99–157.01 µs; after removing only reproducible development artifacts and
+restoring free space, it returned to 112.28–131.16 µs and the final rerun above.
+
+## Feature-parity evidence
+
+- Existing host `exec_command`, `write_stdin`, `apply_patch`, and `view_image`
+  remain the default and retain their schemas.
+- VM-backed implementations are selected through the same `Tools` registry and
+  preserve retained shell behavior and multimodal output.
+- The real smoke booted libkrun and exercised all four tools through one current
+  guest before graceful shutdown.
+- The ignored live image integration test booted the same signed VMM through
+  `VmImageBuilder`, ran `RUN printf nanocodex-vm-image-live >
+  /nanocodex-vm-image-proof`, and read the exact bytes back from the published
+  ext4.
+- The guest-only build excludes OAI transport, TLS, Code Mode, and MCP
+  implementation dependencies; the normal native `nanocodex-tools` default
+  still includes MCP, `tool_search`, Code Mode, image processing, and remote
+  tools.
+- The VM OCI/Dockerfile cache identity is versioned independently from
+  higher-level consumers.

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -38,6 +38,7 @@ clap.workspace = true
 crossterm.workspace = true
 dotenvy.workspace = true
 eyre.workspace = true
+fs2.workspace = true
 futures-util.workspace = true
 hex.workspace = true
 http-body-util = { workspace = true, optional = true }
@@ -45,6 +46,7 @@ hudsucker = { workspace = true, optional = true }
 image.workspace = true
 nanocodex.workspace = true
 nanocodex-observability.workspace = true
+nanocodex-vm.workspace = true
 nix = { workspace = true, optional = true }
 nanousd = { workspace = true, optional = true }
 pulldown-cmark.workspace = true

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -22,6 +22,7 @@ use nanocodex::{
 use crate::mcp::{ConfiguredMcp, McpArgs};
 use crate::mpp::{MppAdapter, MppArgs};
 use crate::subagents::{self, ChildAgents};
+use crate::vm::{ConfiguredVm, VmArgs};
 
 pub(crate) struct ConfiguredAgent {
     pub(crate) handle: Nanocodex,
@@ -29,6 +30,7 @@ pub(crate) struct ConfiguredAgent {
     pub(crate) child_agents: Option<Arc<ChildAgents>>,
     pub(crate) mpp_adapter: Option<MppAdapter>,
     pub(crate) mcp: Option<McpHandle>,
+    pub(crate) vm: Option<ConfiguredVm>,
 }
 
 struct SessionBuild {
@@ -153,15 +155,23 @@ impl AgentArgs {
             })
     }
 
-    pub(crate) async fn build(self) -> Result<ConfiguredAgent> {
-        self.build_inner(None).await
+    pub(crate) async fn build(self, vm: VmArgs) -> Result<ConfiguredAgent> {
+        self.build_inner(None, vm).await
     }
 
-    pub(crate) async fn build_resumed(self, session: DurableSession) -> Result<ConfiguredAgent> {
-        self.build_inner(Some(session)).await
+    pub(crate) async fn build_resumed(
+        self,
+        session: DurableSession,
+        vm: VmArgs,
+    ) -> Result<ConfiguredAgent> {
+        self.build_inner(Some(session), vm).await
     }
 
-    async fn build_inner(self, durable: Option<DurableSession>) -> Result<ConfiguredAgent> {
+    async fn build_inner(
+        self,
+        durable: Option<DurableSession>,
+        vm: VmArgs,
+    ) -> Result<ConfiguredAgent> {
         let codex_home = default_codex_home()?;
         let responses_transport = self.responses_transport();
         let session = prepare_session_build(self.cwd, self.rollouts, &codex_home, durable)?;
@@ -200,7 +210,10 @@ impl AgentArgs {
             openai = openai.http_client(mpp_adapter.responses_http_client()?);
         }
         let openai = openai.build()?;
-        let mut tools = Tools::builder()
+        let configured_vm = vm.start().await?;
+        let mut tools = configured_vm
+            .as_ref()
+            .map_or_else(Tools::builder, ConfiguredVm::tools_builder)
             .web_search(self.web_search)
             .image_generation(self.image_generation);
         let mcp = self.mcp.build(&codex_home)?;
@@ -250,6 +263,7 @@ impl AgentArgs {
             child_agents,
             mpp_adapter,
             mcp: mcp_handle,
+            vm: configured_vm,
         })
     }
 }

--- a/bin/nanocodex/src/main.rs
+++ b/bin/nanocodex/src/main.rs
@@ -11,6 +11,7 @@ mod subagents;
 mod tui;
 mod update;
 mod version;
+mod vm;
 
 use std::path::PathBuf;
 
@@ -39,6 +40,9 @@ struct Cli {
     #[command(flatten)]
     observability: ObservabilityArgs,
 
+    #[command(flatten)]
+    vm: vm::VmArgs,
+
     /// Submit an initial prompt immediately after the TUI opens.
     #[arg(long, value_parser = NonEmptyStringValueParser::new())]
     prompt: Option<String>,
@@ -51,6 +55,9 @@ enum Command {
     /// Inspect or purchase Nanocodex NANOUSD credits.
     #[cfg(feature = "tempo")]
     Credits(credits::Credits),
+    /// Internal entrypoint for one dedicated libkrun VMM process.
+    #[command(hide = true)]
+    VmRunConfig(vm::VmRunConfig),
     /// Run one prompt and stream JSONL events to stdout.
     Run(Box<RunCommand>),
     /// Resume a Codex or Nanocodex thread in the interactive TUI.
@@ -69,6 +76,9 @@ struct RunCommand {
 
     #[command(flatten)]
     observability: ObservabilityArgs,
+
+    #[command(flatten)]
+    vm: vm::VmArgs,
 }
 
 #[derive(Args)]
@@ -83,25 +93,38 @@ struct ResumeCommand {
     #[command(flatten)]
     observability: ObservabilityArgs,
 
+    #[command(flatten)]
+    vm: vm::VmArgs,
+
     /// Submit an initial follow-on prompt immediately after the TUI opens.
     #[arg(long, value_parser = NonEmptyStringValueParser::new())]
     prompt: Option<String>,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     // Keep direct `cargo run` behavior consistent with the Justfile without
     // requiring shell-specific syntax to load the repository's `.env` file.
     let _ = dotenvy::dotenv();
 
     let cli = Cli::parse();
+    if let Some(Command::VmRunConfig(command)) = &cli.command {
+        return command.run();
+    }
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(run(cli))
+}
+
+async fn run(cli: Cli) -> Result<()> {
     match cli.command {
         Some(Command::Auth(command)) => command.run().await,
         #[cfg(feature = "tempo")]
         Some(Command::Credits(command)) => command.run().await,
+        Some(Command::VmRunConfig(_)) => unreachable!("VMM commands run before Tokio starts"),
         Some(Command::Run(command)) => {
             let _observability = command.observability.install(false, command.agent.cwd())?;
-            command.run.run(command.agent).await
+            command.run.run(command.agent, command.vm).await
         }
         Some(Command::Resume(command)) => {
             let codex_home = config::default_codex_home()?;
@@ -110,12 +133,12 @@ async fn main() -> Result<()> {
                 .wrap_err_with(|| format!("failed to load Codex thread {}", command.thread_id))?;
             let workspace = PathBuf::from(session.workspace());
             let _observability = command.observability.install(true, &workspace)?;
-            tui::run(command.agent, command.prompt, Some(session)).await
+            tui::run(command.agent, command.vm, command.prompt, Some(session)).await
         }
         Some(Command::Update(command)) => command.run().await,
         None => {
             let _observability = cli.observability.install(true, cli.agent.cwd())?;
-            tui::run(cli.agent, cli.prompt, None).await
+            tui::run(cli.agent, cli.vm, cli.prompt, None).await
         }
     }
 }
@@ -175,6 +198,41 @@ mod tests {
         assert_eq!(
             cli.agent.responses_transport(),
             nanocodex::oai::transport::ResponsesTransport::WebSocket
+        );
+    }
+
+    #[test]
+    fn vm_tools_are_opt_in_for_tui_and_one_shot_runs() {
+        let tui = Cli::try_parse_from(["nanocodex"]).unwrap();
+        assert!(!tui.vm.is_enabled());
+
+        let tui = Cli::try_parse_from([
+            "nanocodex",
+            "--vm",
+            "/tmp/rootfs",
+            "--vm-workspace",
+            "/workspace",
+        ])
+        .unwrap();
+        assert!(tui.vm.is_enabled());
+
+        let run = Cli::try_parse_from(["nanocodex", "run", "reply with ok", "--vm", "/tmp/rootfs"])
+            .unwrap();
+        let Some(Command::Run(run)) = run.command else {
+            panic!("run command was not parsed");
+        };
+        assert!(run.vm.is_enabled());
+    }
+
+    #[test]
+    fn vm_tuning_requires_an_opted_in_rootfs() {
+        let error = Cli::try_parse_from(["nanocodex", "--vm-cpus", "4"])
+            .err()
+            .unwrap();
+
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
         );
     }
 

--- a/bin/nanocodex/src/observability.rs
+++ b/bin/nanocodex/src/observability.rs
@@ -4,8 +4,7 @@ use clap::{Args, ValueEnum, builder::NonEmptyStringValueParser};
 use eyre::Result;
 use nanocodex_observability::{LogFormat, LogOutput, ObservabilityBuilder, ObservabilityGuard};
 
-const DEFAULT_FILTER: &str =
-    "warn,nanocodex=info,nanocodex_oai_api=info,nanocodex_tools=info,mpp_egress=info";
+const DEFAULT_FILTER: &str = "warn,nanocodex=info,nanocodex_oai_api=info,nanocodex_tools=info,nanocodex_vm=info,mpp_egress=info";
 
 #[derive(Args)]
 pub(crate) struct ObservabilityArgs {

--- a/bin/nanocodex/src/run.rs
+++ b/bin/nanocodex/src/run.rs
@@ -4,6 +4,7 @@ use nanocodex::AgentEvents;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 use crate::config::AgentArgs;
+use crate::vm::VmArgs;
 
 #[derive(Args)]
 pub(crate) struct Run {
@@ -17,8 +18,8 @@ pub(crate) struct Run {
 }
 
 impl Run {
-    pub(crate) async fn run(self, config: AgentArgs) -> Result<()> {
-        let configured = config.build().await?;
+    pub(crate) async fn run(self, config: AgentArgs, vm: VmArgs) -> Result<()> {
+        let configured = config.build(vm).await?;
         let handle = configured.handle;
         let mut events = configured.events;
         let mut stdout = tokio::io::stdout();
@@ -55,6 +56,11 @@ impl Run {
         if let Some(child_agents) = configured.child_agents {
             child_agents.shutdown().await;
         }
+        let vm_shutdown_result = if let Some(vm) = configured.vm {
+            vm.shutdown().await
+        } else {
+            Ok(())
+        };
         let shutdown_result = if let Some(adapter) = configured.mpp_adapter {
             adapter.shutdown().await
         } else {
@@ -62,6 +68,7 @@ impl Run {
         };
         run_result?;
         agent_shutdown?;
+        vm_shutdown_result?;
         shutdown_result
     }
 }

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -510,6 +510,7 @@ enum Submission {
 )]
 pub(crate) async fn run(
     config: AgentArgs,
+    vm: crate::vm::VmArgs,
     initial_prompt: Option<String>,
     resume: Option<DurableSession>,
 ) -> Result<()> {
@@ -523,9 +524,9 @@ pub(crate) async fn run(
         .map(|session| PathBuf::from(session.workspace()))
         .unwrap_or(resolve_cwd(&config)?);
     let configured = if let Some(session) = resume {
-        config.build_resumed(session).await?
+        config.build_resumed(session, vm).await?
     } else {
-        config.build().await?
+        config.build(vm).await?
     };
     let agent = configured.handle;
     let mut agent_events = configured.events;
@@ -533,6 +534,7 @@ pub(crate) async fn run(
     let child_agents = configured.child_agents;
     let mpp_adapter = configured.mpp_adapter;
     let mcp = configured.mcp;
+    let vm = configured.vm;
     let (worker_tx, worker_rx) = mpsc::unbounded_channel();
     let (update_tx, mut update_rx) = mpsc::unbounded_channel();
     let worker = spawn_agent_worker(
@@ -633,7 +635,7 @@ pub(crate) async fn run(
 
     // Restore the terminal before disconnecting the paid WebSocket session.
     drop((terminal, worker_tx, agent_events));
-    let shutdown_result = shutdown_runtime(worker, child_agents, mpp_adapter).await;
+    let shutdown_result = shutdown_runtime(worker, child_agents, mpp_adapter, vm).await;
     loop_result?;
     shutdown_result
 }
@@ -649,12 +651,18 @@ async fn shutdown_runtime(
     worker: tokio::task::JoinHandle<()>,
     child_agents: Option<std::sync::Arc<crate::subagents::ChildAgents>>,
     mpp_adapter: Option<crate::mpp::MppAdapter>,
+    vm: Option<crate::vm::ConfiguredVm>,
 ) -> Result<()> {
     worker.abort();
     let worker_result = worker.await;
     if let Some(child_agents) = child_agents {
         child_agents.shutdown().await;
     }
+    let vm_shutdown_result = if let Some(vm) = vm {
+        vm.shutdown().await
+    } else {
+        Ok(())
+    };
     let shutdown_result = if let Some(adapter) = mpp_adapter {
         adapter.shutdown().await
     } else {
@@ -665,6 +673,7 @@ async fn shutdown_runtime(
         Err(error) if error.is_cancelled() => {}
         Err(error) => return Err(error).wrap_err("TUI agent worker failed"),
     }
+    vm_shutdown_result?;
     shutdown_result
 }
 

--- a/bin/nanocodex/src/vm.rs
+++ b/bin/nanocodex/src/vm.rs
@@ -1,0 +1,233 @@
+use std::{
+    fs::{File, OpenOptions},
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
+
+use clap::{ArgAction, Args, builder::NonEmptyStringValueParser};
+use eyre::{Result, WrapErr, eyre};
+use fs2::FileExt as _;
+use nanocodex::tools::ToolsBuilder;
+use nanocodex_vm::{
+    VmWorkspace, VmWorkspaceError,
+    host::VmProcessConfig,
+    tools::{GuestRuntimeDisk, VmToolSessionError},
+};
+use tokio::time::sleep;
+use tracing::info;
+
+const DEFAULT_CPUS: u8 = 2;
+const DEFAULT_MEMORY_MIB: u32 = 1_024;
+const DEFAULT_EXT4_WORKSPACE: &str = "/app";
+const DEFAULT_DIRECTORY_WORKSPACE: &str = "/workspace";
+const DEFAULT_SHELL: &str = "bash";
+const DEFAULT_KRUNFW_DIRECTORY: &str = ".cache/libkrunfw/libkrunfw";
+const DEFAULT_VM_CACHE: &str = ".cache/vm";
+const CAPABILITY_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+const CAPABILITY_DRAIN_INTERVAL: Duration = Duration::from_millis(10);
+
+/// Opt-in VM workspace-tool configuration for normal agent sessions.
+#[derive(Args, Default)]
+pub(crate) struct VmArgs {
+    /// Run workspace-mutating tools in this writable VM root filesystem.
+    ///
+    /// The path may be a raw ext4 image or a directory rootfs. The selected
+    /// root is modified in place for the lifetime of the agent session.
+    #[arg(long = "vm", visible_alias = "vm-rootfs", value_name = "ROOTFS")]
+    rootfs: Option<PathBuf>,
+
+    /// Statically linked Linux guest executable used with a raw ext4 root.
+    #[arg(
+        long,
+        value_name = "ELF",
+        env = "NANOCODEX_VM_GUEST_RUNTIME",
+        requires = "rootfs"
+    )]
+    vm_guest_runtime: Option<PathBuf>,
+
+    /// Absolute working directory inside the VM.
+    #[arg(
+        long,
+        value_name = "PATH",
+        requires = "rootfs",
+        value_parser = NonEmptyStringValueParser::new()
+    )]
+    vm_workspace: Option<String>,
+
+    /// Number of virtual CPUs assigned to the VM.
+    #[arg(
+        long,
+        value_name = "COUNT",
+        requires = "rootfs",
+        value_parser = clap::value_parser!(u8).range(1..)
+    )]
+    vm_cpus: Option<u8>,
+
+    /// Guest memory in mebibytes.
+    #[arg(
+        long,
+        value_name = "MIB",
+        requires = "rootfs",
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    vm_memory_mib: Option<u32>,
+
+    /// Shell name described to the model for the VM environment.
+    #[arg(
+        long,
+        value_name = "SHELL",
+        requires = "rootfs",
+        value_parser = NonEmptyStringValueParser::new()
+    )]
+    vm_shell: Option<String>,
+
+    /// Disable guest internet socket proxying.
+    #[arg(long, requires = "rootfs", action = ArgAction::SetTrue)]
+    vm_no_network: bool,
+}
+
+pub(crate) struct ConfiguredVm {
+    session: VmWorkspace,
+    _root_lock: Option<File>,
+}
+
+/// Private synchronous entrypoint used by a spawned VMM child.
+#[derive(Args)]
+pub(crate) struct VmRunConfig {
+    /// Mode-0600 launch record prepared by `nanocodex-vm`.
+    #[arg(long)]
+    config: PathBuf,
+}
+
+impl VmRunConfig {
+    pub(crate) fn run(&self) -> Result<()> {
+        VmProcessConfig::read(&self.config)?.run()?;
+        Ok(())
+    }
+}
+
+impl VmArgs {
+    #[cfg(test)]
+    pub(crate) const fn is_enabled(&self) -> bool {
+        self.rootfs.is_some()
+    }
+
+    pub(crate) async fn start(self) -> Result<Option<ConfiguredVm>> {
+        let Some(rootfs) = self.rootfs else {
+            return Ok(None);
+        };
+        let rootfs = rootfs
+            .canonicalize()
+            .wrap_err_with(|| format!("failed to resolve VM rootfs {}", rootfs.display()))?;
+        let ext4 = rootfs.is_file();
+        if !ext4 && !rootfs.is_dir() {
+            return Err(eyre!(
+                "VM rootfs is neither a raw ext4 image nor a directory: {}",
+                rootfs.display()
+            ));
+        }
+        let workspace = self.vm_workspace.unwrap_or_else(|| {
+            if ext4 {
+                DEFAULT_EXT4_WORKSPACE.to_owned()
+            } else {
+                DEFAULT_DIRECTORY_WORKSPACE.to_owned()
+            }
+        });
+        if !Path::new(&workspace).is_absolute() {
+            return Err(eyre!(
+                "--vm-workspace must be an absolute guest path, got {workspace:?}"
+            ));
+        }
+        let root_lock = ext4.then(|| lock_writable_rootfs(&rootfs)).transpose()?;
+        let executable =
+            std::env::current_exe().wrap_err("failed to resolve the VMM executable")?;
+        let mut vm = VmWorkspace::builder(&rootfs, executable)
+            .vmm_argument("vm-run-config")
+            .vmm_argument("--config")
+            .guest_workspace(&workspace)
+            .shell(
+                self.vm_shell
+                    .clone()
+                    .unwrap_or_else(|| DEFAULT_SHELL.to_owned()),
+            )
+            .cpus(self.vm_cpus.unwrap_or(DEFAULT_CPUS))
+            .memory_mib(self.vm_memory_mib.unwrap_or(DEFAULT_MEMORY_MIB));
+        if ext4 {
+            let runtime = self.vm_guest_runtime.ok_or_else(|| {
+                eyre!(
+                    "raw ext4 VM roots require --vm-guest-runtime ELF; build it with \
+                     `just build-vm-guest` or set NANOCODEX_VM_GUEST_RUNTIME"
+                )
+            })?;
+            let runtime = GuestRuntimeDisk::prepare(runtime, DEFAULT_VM_CACHE)
+                .wrap_err("failed to prepare the read-only VM guest runtime disk")?;
+            vm = vm.guest_runtime_disk(runtime.path().to_path_buf());
+        } else if self.vm_guest_runtime.is_some() {
+            return Err(eyre!(
+                "--vm-guest-runtime is only used with raw ext4 roots; directory roots must \
+                 contain /usr/local/bin/nanocodex-vm-guest"
+            ));
+        }
+        if self.vm_no_network {
+            vm = vm.offline();
+        }
+        let firmware = Path::new(DEFAULT_KRUNFW_DIRECTORY);
+        let platform_firmware = if cfg!(target_os = "macos") {
+            firmware.join("libkrunfw.5.dylib")
+        } else {
+            firmware.join("libkrunfw.so.5")
+        };
+        if platform_firmware.is_file() {
+            vm = vm.firmware_directory(firmware);
+        }
+        let session = vm
+            .launch()
+            .await
+            .wrap_err("failed to start tool VM and reach guest readiness")?;
+        info!(
+            target: "nanocodex_vm",
+            vm_rootfs = %rootfs.display(),
+            vm_workspace = workspace,
+            vm_cpu_count = self.vm_cpus.unwrap_or(DEFAULT_CPUS),
+            vm_memory_mib = self.vm_memory_mib.unwrap_or(DEFAULT_MEMORY_MIB),
+            vm_network = if self.vm_no_network { "disabled" } else { "internet" },
+            "normal agent workspace tools are running in a VM"
+        );
+        Ok(Some(ConfiguredVm {
+            session,
+            _root_lock: root_lock,
+        }))
+    }
+}
+
+impl ConfiguredVm {
+    pub(crate) fn tools_builder(&self) -> ToolsBuilder {
+        self.session.tools_builder()
+    }
+
+    pub(crate) async fn shutdown(self) -> Result<()> {
+        let started_at = Instant::now();
+        loop {
+            match self.session.shutdown().await {
+                Ok(()) => return Ok(()),
+                Err(VmWorkspaceError::Session(VmToolSessionError::ActiveCapabilities(_)))
+                    if started_at.elapsed() < CAPABILITY_DRAIN_TIMEOUT =>
+                {
+                    sleep(CAPABILITY_DRAIN_INTERVAL).await;
+                }
+                Err(error) => return Err(error).wrap_err("failed to shut down the tool VM"),
+            }
+        }
+    }
+}
+
+fn lock_writable_rootfs(path: &Path) -> Result<File> {
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(path)
+        .wrap_err_with(|| format!("failed to open writable VM rootfs {}", path.display()))?;
+    file.try_lock_exclusive()
+        .wrap_err_with(|| format!("VM rootfs is already in use: {}", path.display()))?;
+    Ok(file)
+}

--- a/bin/nanocodex/src/vm.rs
+++ b/bin/nanocodex/src/vm.rs
@@ -20,7 +20,7 @@ const DEFAULT_CPUS: u8 = 2;
 const DEFAULT_MEMORY_MIB: u32 = 1_024;
 const DEFAULT_EXT4_WORKSPACE: &str = "/app";
 const DEFAULT_DIRECTORY_WORKSPACE: &str = "/workspace";
-const DEFAULT_SHELL: &str = "bash";
+const DEFAULT_SHELL: &str = "sh";
 const DEFAULT_KRUNFW_DIRECTORY: &str = ".cache/libkrunfw/libkrunfw";
 const DEFAULT_VM_CACHE: &str = ".cache/vm";
 const CAPABILITY_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
@@ -210,9 +210,10 @@ impl ConfiguredVm {
         loop {
             match self.session.shutdown().await {
                 Ok(()) => return Ok(()),
-                Err(VmWorkspaceError::Session(VmToolSessionError::ActiveCapabilities(_)))
-                    if started_at.elapsed() < CAPABILITY_DRAIN_TIMEOUT =>
-                {
+                Err(VmWorkspaceError::Session(
+                    VmToolSessionError::ActiveCapabilities(_)
+                    | VmToolSessionError::ActiveRequests(_),
+                )) if started_at.elapsed() < CAPABILITY_DRAIN_TIMEOUT => {
                     sleep(CAPABILITY_DRAIN_INTERVAL).await;
                 }
                 Err(error) => return Err(error).wrap_err("failed to shut down the tool VM"),

--- a/crates/experimental/README.md
+++ b/crates/experimental/README.md
@@ -1,0 +1,16 @@
+# Experimental crates
+
+This directory contains complete Nanocodex components whose APIs are still
+being exercised and revised:
+
+- [`nanocodex-vm`](nanocodex-vm/README.md): VM lifecycle and image preparation
+  plus retained guest-backed workspace tools.
+
+Experimental means API stability, not reduced engineering standards. These
+packages remain workspace members and must pass the normal formatting, Clippy,
+documentation, test, cancellation, tracing, and benchmark gates. They are not
+published as part of the stable crates.io release.
+
+Stable crates may not depend on experimental crates. Executables and examples
+may consume them so that the APIs can mature against real workloads before
+promotion into `crates/`.

--- a/crates/experimental/nanocodex-vm/Cargo.toml
+++ b/crates/experimental/nanocodex-vm/Cargo.toml
@@ -80,10 +80,17 @@ required-features = ["guest-runtime"]
 [[bench]]
 name = "image_cache"
 harness = false
+required-features = ["host"]
 
 [[bench]]
 name = "vm_session"
 harness = false
+required-features = ["host"]
+
+[[test]]
+name = "image_live_build"
+path = "tests/image_live_build.rs"
+required-features = ["host"]
 
 [lints.rust]
 unsafe_code = "deny"

--- a/crates/experimental/nanocodex-vm/Cargo.toml
+++ b/crates/experimental/nanocodex-vm/Cargo.toml
@@ -1,0 +1,97 @@
+[package]
+name = "nanocodex-vm"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
+description = "VM lifecycle, images, and retained workspace tools for Nanocodex"
+
+[features]
+default = ["host"]
+host = [
+    "dep:arcbox-ext4",
+    "dep:async-trait",
+    "dep:flate2",
+    "dep:fs2",
+    "dep:futures-util",
+    "dep:hex",
+    "dep:ignore",
+    "dep:krun",
+    "dep:oci-client",
+    "dep:reflink-copy",
+    "dep:sha2",
+    "dep:shlex",
+    "dep:tar",
+    "dep:tempfile",
+    "dep:tracing",
+    "dep:zstd",
+    "nanocodex-tools/native",
+]
+guest-runtime = ["dep:nix", "nanocodex-tools/workspace-runtime"]
+
+[dependencies]
+base64.workspace = true
+filetime.workspace = true
+nanocodex-tools = { path = "../../nanocodex-tools", version = "0.3.0", default-features = false }
+nix = { workspace = true, optional = true }
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["fs", "io-std", "io-util", "macros", "process", "rt", "rt-multi-thread", "sync", "time"] }
+
+[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+arcbox-ext4 = { workspace = true, optional = true }
+async-trait = { workspace = true, optional = true }
+flate2 = { workspace = true, optional = true }
+fs2 = { workspace = true, optional = true }
+futures-util = { workspace = true, optional = true }
+hex = { workspace = true, optional = true }
+ignore = { workspace = true, optional = true }
+krun = { workspace = true, optional = true }
+oci-client = { workspace = true, optional = true }
+reflink-copy = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
+shlex = { workspace = true, optional = true }
+tar = { workspace = true, optional = true }
+tempfile = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+zstd = { workspace = true, optional = true }
+
+[dev-dependencies]
+criterion.workspace = true
+nix.workspace = true
+reflink-copy.workspace = true
+tempfile.workspace = true
+tracing-subscriber.workspace = true
+
+[[bin]]
+name = "nanocodex-vm-guest"
+path = "src/bin/nanocodex-vm-guest.rs"
+doc = false
+required-features = ["guest-runtime"]
+
+[[bench]]
+name = "image_cache"
+harness = false
+
+[[bench]]
+name = "vm_session"
+harness = false
+
+[lints.rust]
+unsafe_code = "deny"
+
+[lints.clippy]
+all = { level = "warn", priority = -1 }
+missing-const-for-fn = "warn"
+use-self = "warn"
+redundant-clone = "warn"
+large-enum-variant = "allow"
+result-large-err = "allow"

--- a/crates/experimental/nanocodex-vm/GUEST_RUNTIME.md
+++ b/crates/experimental/nanocodex-vm/GUEST_RUNTIME.md
@@ -1,0 +1,17 @@
+# Nanocodex VM guest runtime
+
+Static Linux companion for the retained Nanocodex VM workspace.
+
+This is the crate documentation produced with `guest-runtime` and without the
+default `host` feature. [`tools::serve_guest`] keeps one canonical
+`nanocodex-tools` workspace runtime alive and serves `exec_command`,
+`write_stdin`, `apply_patch`, and `view_image` over the guest console.
+
+The artifact deliberately excludes libkrun host control, OCI/image
+preparation, OpenAI transport, Code Mode/QuickJS, MCP, and HTTP clients. It is
+an implementation companion built from the same revision as its host, not a
+second public execution model or a versioned remote service.
+
+The complete lockstep host/guest wire contract is documented in the package
+README. Applications should use the default `host` feature and its typed
+workspace API rather than calling [`tools::serve_guest`] directly.

--- a/crates/experimental/nanocodex-vm/README.md
+++ b/crates/experimental/nanocodex-vm/README.md
@@ -1,0 +1,276 @@
+# Nanocodex VM
+
+Retained libkrun workspaces and canonical workspace tools for Nanocodex.
+
+`nanocodex-vm` is an experimental, unpublished, library-first crate. An
+application owns one [`VmWorkspace`] for each isolation boundary, gives its
+[`tools::VmTools`] to one or more agents, and keeps the VM alive across
+sequential turns. The crate does not own agent scheduling, evaluation policy,
+payment providers, or secrets.
+
+The normal API is:
+
+- [`VmWorkspaceBuilder`] materializes and launches a retained private
+  workspace;
+- [`image`] prepares immutable root images;
+- [`tools`] stages the companion guest and exposes VM-backed Nanocodex tools;
+  and
+- [`host`] contains the lower-level libkrun, launch-record, networking, and
+  egress types used by specialized applications.
+
+The crate root intentionally re-exports only [`VmWorkspace`],
+[`VmWorkspaceBuilder`], and [`VmWorkspaceError`].
+
+## Use VM-backed workspace tools
+
+Build the static Linux companion with `just build-vm-guest`, prepare one
+read-only runtime disk, and launch a private copy of an immutable root:
+
+```no_run
+use nanocodex_vm::{
+    VmWorkspaceBuilder,
+    tools::GuestRuntimeDisk,
+};
+
+# async fn prepare() -> Result<(), Box<dyn std::error::Error>> {
+let runtime = GuestRuntimeDisk::prepare(
+    "target/aarch64-unknown-linux-musl/debug/nanocodex-vm-guest",
+    ".cache/nanocodex/vm",
+)?;
+let workspace = VmWorkspaceBuilder::private_from(
+    ".cache/nanocodex/images/project.ext4",
+    ".nanocodex/sessions/018f/root.ext4",
+    "nanocodex",
+)?
+.vmm_argument("vm-run-config")
+.guest_runtime_disk(runtime.path())
+.firmware_directory(".cache/libkrunfw/libkrunfw")
+.guest_workspace("/app")
+.launch()
+.await?;
+
+let tools = workspace.tools_builder().build()?;
+// Pass `tools` to `Nanocodex::builder(...).tools(tools)`.
+
+drop(tools);
+workspace.shutdown().await?;
+# Ok(())
+# }
+```
+
+[`VmWorkspace::tools`] returns a clone-cheap capability suitable for
+`NanocodexBuilder::tools_factory`. Every clone routes to the same retained
+guest runtime, filesystem, and interactive shell sessions. The non-cloneable
+workspace owner is the graceful-shutdown capability; drop agents, registries,
+and cloned tool handles before calling [`VmWorkspace::shutdown`].
+
+The default tool selection keeps web search, image generation, and
+`update_plan` on the host. It replaces only `exec_command`, `write_stdin`,
+`apply_patch`, and `view_image`, preserving their standard model-visible names
+and schemas.
+
+## Host, VMM, and guest ownership
+
+The retained path has three processes:
+
+```text
+embedding application
+  ├─ owns VmWorkspace, agent state, tools, policy, and egress leases
+  └─ spawns a dedicated VMM process from a mode-0600 launch record
+       └─ libkrun starts one Linux guest
+            └─ nanocodex-vm-guest serves workspace tools over the console
+```
+
+The application process does not call libkrun after starting an async runtime.
+Instead, [`host::VmProcessConfig::write_private`] writes a complete private
+launch record and the dedicated VMM entry point calls
+[`host::VmProcessConfig::run`] synchronously. This process boundary also keeps
+the macOS hypervisor entitlement on the smallest executable and prevents guest
+environment values from appearing in command-line arguments.
+
+The shipped `nanocodex` binary provides that entry point as the hidden
+`vm-run-config` command. A library consumer may provide the same small entry
+point in its own executable:
+
+```no_run
+use nanocodex_vm::host::VmProcessConfig;
+
+# fn vmm(config_path: std::path::PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+VmProcessConfig::read(config_path)?.run()?;
+# Ok(())
+# }
+```
+
+On macOS, the VMM executable must be signed with the
+`com.apple.security.hypervisor` entitlement. Ad-hoc signing is sufficient for
+local development; distribution uses the application's normal signing
+identity. `nanocodex-vm.entitlements` and `scripts/codesign-runner` provide the
+repository build path.
+
+Linux uses the same Rust API and needs no code signing. Running VMs requires
+`/dev/kvm` and `libkrunfw.so.5`. The supported x86_64 static guest build uses a
+musl 1.2.3 ABI floor because the pinned libkrun KVM path requires `statx`.
+
+## Root and runtime disks
+
+[`image::VmImageBuilder`] resolves a constrained Dockerfile/OCI build context
+into a content-addressed immutable ext4 root. A session should attach only a
+reflink or sparse copy made with
+[`image::PreparedRootDisk::reflink_to`]; writable roots are session-private.
+
+[`tools::GuestRuntimeDisk::prepare`] hashes the exact companion ELF and
+atomically publishes a reusable 128 MiB ext4 disk. The runtime disk is mounted
+read-only, independently from the writable project root. That keeps the guest
+implementation identical across a sweep without mutating every root image.
+
+Directory roots are a lower-level development escape hatch. They must already
+contain `/usr/local/bin/nanocodex-vm-guest`, and direct virtiofs access does
+not provide the same host mount-namespace isolation as a private ext4 root.
+
+## Host/guest RPC protocol
+
+This section is the complete current wire contract implemented by the host
+session and `nanocodex-vm-guest`. The protocol is private implementation
+detail: host and guest artifacts are built from the same Nanocodex revision,
+and there is currently no version negotiation or cross-version compatibility
+promise. Applications use the typed Rust API rather than constructing frames.
+
+### Transport and envelope
+
+The dedicated VMM's standard streams carry the guest's default virtio console:
+
+- host to guest: VMM stdin;
+- guest to host: VMM stdout; and
+- diagnostics only: VMM stderr.
+
+stdin and stdout are newline-delimited JSON. Each frame is one UTF-8 JSON
+object followed by `\n`; readers also accept `\r\n`. The newline is not part of
+the 64 MiB frame limit. Binary fields use standard padded base64. There is no
+authentication, checksum, compression, streaming sub-frame, or handshake
+beyond `ready`, because the transport is a private pipe to the owned VMM
+process.
+
+Every frame has the externally tagged envelope:
+
+```json
+{"kind":"ready","payload":{"id":0}}
+```
+
+`kind` is snake case. Every request carries a host-assigned `u64` `id`, and
+exactly one response carries the same ID unless the request is cancelled or
+the session fails. Responses may arrive in any order. The host allows at most
+63 ordinary requests to await responses; the guest executes at most 64
+requests concurrently, leaving capacity for control traffic.
+
+### Requests and responses
+
+`ready` establishes that the guest runtime is accepting work:
+
+```json
+{"kind":"ready","payload":{"id":0}}
+{"kind":"ready","payload":{"id":0,"error":null}}
+```
+
+`tool` executes one canonical workspace tool:
+
+```json
+{"kind":"tool","payload":{"id":1,"tool":"exec_command","input":{"function":{"arguments":{"cmd":"pwd"}}},"context":{"model":"gpt-5.6","session_id":"session-1","call_id":"call-1","output_token_budget":10000}}}
+{"kind":"tool","payload":{"id":1,"execution":{"output":"/app\n","success":true,"code_mode_value":null,"metadata":null,"process_trace":{"exit_code":0,"session_id":null,"original_token_count":null,"output_bytes":5,"wall_time_seconds":0.01}},"error":null}}
+```
+
+The normal adapter sends `exec_command`, `write_stdin`, `apply_patch`, or
+`view_image`. `input` is exactly one of:
+
+```json
+{"function":{"arguments":{"cmd":"pwd"}}}
+{"freeform":{"input":"*** Begin Patch\n...\n*** End Patch\n"}}
+```
+
+Function `arguments` remain opaque JSON. `context` contains `model`,
+`session_id`, `call_id`, and `output_token_budget`; conversation history is
+not copied into the guest context. `execution.output` is either a string or
+the canonical ordered multimodal array of `input_text`, `input_image`, and
+`input_audio` objects. `code_mode_value` and `metadata` are opaque JSON or
+`null`. `process_trace` is `null` or contains `exit_code`, `session_id`,
+`original_token_count`, `output_bytes`, and `wall_time_seconds`.
+
+An execution with `"success":false` is a model-visible tool failure. A failure
+of the RPC/tool runtime itself instead uses `"execution":null` and a non-null
+`"error"`. Exactly one of `execution` and `error` is present.
+
+The remaining control methods have these payloads:
+
+| `kind` | Request payload after `id` | Response payload after `id` |
+| --- | --- | --- |
+| `write_file` | `path`, base64 `contents`, Unix `mode`, optional `modified_unix_seconds` | `error` |
+| `create_directory` | `path`, Unix `mode`, optional `modified_unix_seconds` | `error` |
+| `read_file` | `path` | base64 `contents` or `error` |
+| `execute` | `program`, `arguments`, `current_directory`, `environment`, `timeout_millis`, `max_output_bytes` | `exit_code`, base64 `stdout`, base64 `stderr`, `error`, `timed_out`, `output_limit_exceeded` |
+| `cancel` | `target_id` | `error` |
+| `shutdown` | none | `error` |
+
+Concrete examples:
+
+```json
+{"kind":"write_file","payload":{"id":2,"path":"/tmp/input","contents":"aGVsbG8K","mode":420}}
+{"kind":"write_file","payload":{"id":2,"error":null}}
+{"kind":"create_directory","payload":{"id":3,"path":"/tmp/results","mode":493,"modified_unix_seconds":0}}
+{"kind":"create_directory","payload":{"id":3,"error":null}}
+{"kind":"read_file","payload":{"id":4,"path":"/tmp/results/out.txt"}}
+{"kind":"read_file","payload":{"id":4,"contents":"b2sK","error":null}}
+{"kind":"execute","payload":{"id":5,"program":"/bin/sh","arguments":["-lc","printf ok"],"current_directory":"/app","environment":[["PATH","/usr/bin:/bin"]],"timeout_millis":60000,"max_output_bytes":8388608}}
+{"kind":"execute","payload":{"id":5,"exit_code":0,"stdout":"b2s=","stderr":"","error":null,"timed_out":false,"output_limit_exceeded":false}}
+{"kind":"cancel","payload":{"id":6,"target_id":5}}
+{"kind":"cancel","payload":{"id":6,"error":null}}
+{"kind":"shutdown","payload":{"id":7}}
+{"kind":"shutdown","payload":{"id":7,"error":null}}
+```
+
+`write_file` creates parents and publishes through a sibling temporary file
+plus rename. `read_file` accepts only regular files and caps contents at
+32 MiB. `execute` clears the inherited environment, uses only the supplied
+pairs, captures combined output up to the requested bound, and kills the
+process group on timeout, output overflow, cancellation, or shutdown. It is a
+bounded one-response operation rather than a streaming terminal; retained
+interactive shells use the `exec_command`/`write_stdin` tool protocol.
+
+Dropping a host request removes its pending response and best-effort queues a
+`cancel` with a fresh ID. Cancelling an unknown or already completed target is
+successful. The host does not wait for this automatically generated cancel
+acknowledgement. `shutdown` stops acceptance, cancels active tool work and
+shell process groups, runs `/bin/sync`, replies, and exits.
+
+### Protocol failure
+
+The session fails closed on malformed JSON, an unknown request/response kind,
+an unknown field in a strict request payload, a frame larger than 64 MiB, a
+partial frame at EOF, or reuse of an ID that is still active. Clean host EOF
+cancels active work and exits the guest. A tool response that is too large is
+replaced with a scoped tool RPC error when that fallback fits; an oversized
+non-tool response terminates the session. A failed partial response is never
+turned into a successful tool result.
+
+## Egress and lifecycle
+
+[`host::EgressLease`] is the provider-neutral output of application policy. It
+combines network mode, guest environment, read-only mounts, public guest files,
+and host-side guards that must live as long as the VM. The VM crate never
+resolves secrets or chooses a payment provider. Conflicting environment or
+mount claims fail closed.
+
+The last workspace/tool capability kills the VMM child. Explicit shutdown
+first rejects live sibling capabilities, then requests guest cancellation and
+filesystem sync with a bounded exit wait. Timeouts and request cancellation
+terminate process groups and descendants.
+
+## Cargo features
+
+The default `host` feature contains image preparation, libkrun lifecycle, and
+VM-backed tool clients on Linux and macOS. `guest-runtime` contains only the
+companion server and the canonical `nanocodex-tools` workspace runtime. The
+split exists to produce a small static Linux guest ELF; it is not a second
+public execution model. Normal native `nanocodex-tools` and
+`nanocodex-oai-api` builds retain their complete default behavior.
+
+See `docs/VM.md` in the repository for CLI operation, egress composition, and
+build commands.

--- a/crates/experimental/nanocodex-vm/README.md
+++ b/crates/experimental/nanocodex-vm/README.md
@@ -28,7 +28,7 @@ read-only runtime disk, and launch a private copy of an immutable root:
 
 ```no_run
 use nanocodex_vm::{
-    VmWorkspaceBuilder,
+    image::{CachePolicy, VmImageBuilder},
     tools::GuestRuntimeDisk,
 };
 
@@ -37,15 +37,24 @@ let runtime = GuestRuntimeDisk::prepare(
     "target/aarch64-unknown-linux-musl/debug/nanocodex-vm-guest",
     ".cache/nanocodex/vm",
 )?;
-let workspace = VmWorkspaceBuilder::private_from(
-    ".cache/nanocodex/images/project.ext4",
+let image = VmImageBuilder::new("nanocodex", runtime.path())
+    .vmm_args(["vm-run-config", "--config"])
+    .firmware_directory(".cache/libkrunfw/libkrunfw")
+    .prepare(
+        "tasks/project/environment",
+        10 * 1024 * 1024 * 1024,
+        ".cache/nanocodex/vm",
+        CachePolicy::Reuse,
+    )
+    .await?;
+let workspace = image.private_workspace(
     ".nanocodex/sessions/018f/root.ext4",
     "nanocodex",
 )?
 .vmm_argument("vm-run-config")
+.vmm_argument("--config")
 .guest_runtime_disk(runtime.path())
 .firmware_directory(".cache/libkrunfw/libkrunfw")
-.guest_workspace("/app")
 .launch()
 .await?;
 
@@ -114,9 +123,32 @@ musl 1.2.3 ABI floor because the pinned libkrun KVM path requires `statx`.
 ## Root and runtime disks
 
 [`image::VmImageBuilder`] resolves a constrained Dockerfile/OCI build context
-into a content-addressed immutable ext4 root. A session should attach only a
-reflink or sparse copy made with
-[`image::PreparedRootDisk::reflink_to`]; writable roots are session-private.
+into a content-addressed immutable ext4 root. The final OCI/Dockerfile working
+directory, process environment, and detected shell are retained with
+[`image::PreparedRootDisk`]. Its
+[`image::PreparedRootDisk::private_workspace`] method is the normal bridge to
+the retained workspace API: it makes a no-clobber reflink or sparse copy and
+applies that runtime metadata. Writable roots are session-private.
+
+Build cache identity includes the Dockerfile and deterministic context, base
+manifest digests, architecture and disk size, VMM arguments and exact
+VMM/guest-runtime/configured-firmware file identities,
+CPU/memory/address-family policy, host resolver configuration, network mode,
+and the egress lease's non-secret cache scope. Set the firmware directory
+explicitly when firmware upgrades must invalidate cache entries; omitted
+system firmware is caller-managed stable runtime state. Cached
+OCI blobs are SHA-256 checked before their metadata fast path is established.
+Cached blobs and ext4 disks are published atomically and made read-only;
+changes to their inode, size, modification/change time, or permissions force
+validation or rebuilding. The caller-selected cache directory remains trusted
+application state rather than a security boundary against the same OS user.
+
+Dockerfile build VMs temporarily install the current usable host resolver and
+restore the image's original `/etc/resolv.conf` before a stage disk can be
+published. Retained private ext4 workspaces install resolver configuration at
+boot instead, so immutable images never retain host-specific DNS. Offline and
+gvproxy workspaces do not receive host resolver injection. Directory roots are
+host-backed development escape hatches and are not rewritten.
 
 [`tools::GuestRuntimeDisk::prepare`] hashes the exact companion ELF and
 atomically publishes a reusable 128 MiB ext4 disk. The runtime disk is mounted
@@ -161,6 +193,11 @@ exactly one response carries the same ID unless the request is cancelled or
 the session fails. Responses may arrive in any order. The host allows at most
 63 ordinary requests to await responses; the guest executes at most 64
 requests concurrently, leaving capacity for control traffic.
+
+Each ordinary request emits a `vm.tool.rpc` span. Its
+`rpc.admission.duration_ns` field measures time waiting for one of those 63
+host slots, while `rpc.queue.duration_ns` measures the later wait to enter the
+bounded writer channel. `duration_ns` covers the complete RPC.
 
 ### Requests and responses
 
@@ -234,11 +271,14 @@ process group on timeout, output overflow, cancellation, or shutdown. It is a
 bounded one-response operation rather than a streaming terminal; retained
 interactive shells use the `exec_command`/`write_stdin` tool protocol.
 
-Dropping a host request removes its pending response and best-effort queues a
-`cancel` with a fresh ID. Cancelling an unknown or already completed target is
-successful. The host does not wait for this automatically generated cancel
-acknowledgement. `shutdown` stops acceptance, cancels active tool work and
-shell process groups, runs `/bin/sync`, replies, and exits.
+Dropping a host request removes its pending response and queues a `cancel` with
+a fresh ID. The cancellation queue is bounded by the same 63 admission
+permits, and a permit is retained until the original request and its
+cancellation have both been written in that order. Cancelling an unknown or
+already completed target is successful. The host does not wait for this
+automatically generated cancel acknowledgement. `shutdown` stops acceptance,
+cancels active tool work and shell process groups, gives `/bin/sync` a
+five-second deadline, replies, and exits.
 
 ### Protocol failure
 
@@ -258,10 +298,21 @@ and host-side guards that must live as long as the VM. The VM crate never
 resolves secrets or chooses a payment provider. Conflicting environment or
 mount claims fail closed.
 
-The last workspace/tool capability kills the VMM child. Explicit shutdown
-first rejects live sibling capabilities, then requests guest cancellation and
-filesystem sync with a bounded exit wait. Timeouts and request cancellation
-terminate process groups and descendants.
+The built-in internet and disabled leases have stable build-cache scopes.
+Adding provider environment, mounts, or files clears that scope. An application
+using the resulting lease for Dockerfile builds must assign a non-secret
+identity with [`host::EgressLease::set_build_cache_scope`] after composition;
+otherwise image preparation fails rather than reusing output built through a
+different route or credential policy.
+
+The last workspace/tool capability kills the VMM child. Workspace startup has
+a 30-second default deadline covering readiness and egress provisioning;
+graceful shutdown has a 10-second default covering guest acknowledgement and
+VMM exit. Both are configurable on [`VmWorkspaceBuilder`]. Explicit shutdown
+atomically rejects live sibling capabilities and owner-borrowed requests.
+Cancelling the shutdown future force-terminates and reaps the child instead of
+leaving an unreachable VM. Timeouts and request cancellation terminate process
+groups and descendants.
 
 ## Cargo features
 
@@ -270,7 +321,9 @@ VM-backed tool clients on Linux and macOS. `guest-runtime` contains only the
 companion server and the canonical `nanocodex-tools` workspace runtime. The
 split exists to produce a small static Linux guest ELF; it is not a second
 public execution model. Normal native `nanocodex-tools` and
-`nanocodex-oai-api` builds retain their complete default behavior.
+`nanocodex-oai-api` builds retain their complete default behavior. CI checks
+the guest-only all-target matrix and builds the actual x86_64 musl guest
+artifact independently from the host feature.
 
 See `docs/VM.md` in the repository for CLI operation, egress composition, and
 build commands.

--- a/crates/experimental/nanocodex-vm/benches/image_cache.rs
+++ b/crates/experimental/nanocodex-vm/benches/image_cache.rs
@@ -1,0 +1,193 @@
+use std::{
+    fs::{self, File},
+    hint::black_box,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use flate2::{Compression, write::GzEncoder};
+use nanocodex_vm::image::{CachePolicy, VmImageBuilder};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+const FIXTURE_IMAGE: &str = "example.invalid/nanocodex-vm-benchmark:latest";
+const FIXTURE_MANIFEST: &str =
+    "sha256:2eeb0b07339f47ea087a4a9a3ece22c2fd80cc74a812870f163189812f9fc4df";
+const FIXTURE_LAYER: &str =
+    "sha256:018f4abf7d81ee0c83a4a0ef7fd0f2e3ea315714209860653c4af66a648824cb";
+const DISK_BYTES: u64 = 512 * 1024 * 1024;
+
+#[derive(Serialize)]
+struct ReferenceRecord<'a> {
+    version: u32,
+    image_reference: &'a str,
+    manifest_digest: &'a str,
+    layers: [LayerRecord<'a>; 1],
+    config: ImageConfig,
+}
+
+#[derive(Serialize)]
+struct LayerRecord<'a> {
+    digest: &'a str,
+    media_type: &'a str,
+}
+
+#[derive(Default, Serialize)]
+struct ImageConfig {
+    environment: std::collections::BTreeMap<String, String>,
+    working_directory: String,
+}
+
+struct Fixture {
+    _root: tempfile::TempDir,
+    context: PathBuf,
+    cache: PathBuf,
+    attempts: PathBuf,
+    builder: VmImageBuilder,
+}
+
+impl Fixture {
+    fn new(runtime: &tokio::runtime::Runtime) -> Self {
+        let root = tempfile::tempdir().expect("benchmark tempdir");
+        let context = root.path().join("context");
+        let cache = root.path().join("cache");
+        let attempts = root.path().join("attempts");
+        fs::create_dir_all(&context).expect("context directory");
+        fs::create_dir_all(&attempts).expect("attempt directory");
+        fs::write(
+            context.join("Dockerfile"),
+            format!("FROM {FIXTURE_IMAGE}\nWORKDIR /workspace\n"),
+        )
+        .expect("Dockerfile");
+
+        let blobs = cache.join("blobs");
+        fs::create_dir_all(&blobs).expect("blob cache");
+        write_shell_layer(&blobs.join(FIXTURE_LAYER.replace(':', "-")));
+        let reference = ReferenceRecord {
+            version: 2,
+            image_reference: FIXTURE_IMAGE,
+            manifest_digest: FIXTURE_MANIFEST,
+            layers: [LayerRecord {
+                digest: FIXTURE_LAYER,
+                media_type: "application/vnd.oci.image.layer.v1.tar+gzip",
+            }],
+            config: ImageConfig::default(),
+        };
+        let references = cache.join("references");
+        fs::create_dir_all(&references).expect("reference cache");
+        fs::write(
+            references.join(format!("{}.json", reference_key(FIXTURE_IMAGE))),
+            serde_json::to_vec(&reference).expect("reference JSON"),
+        )
+        .expect("reference record");
+
+        let builder = VmImageBuilder::new(
+            root.path().join("unused-vmm"),
+            root.path().join("unused-runtime.ext4"),
+        );
+        runtime
+            .block_on(builder.prepare(&context, DISK_BYTES, &cache, CachePolicy::Reuse))
+            .expect("prime immutable image cache");
+        Self {
+            _root: root,
+            context,
+            cache,
+            attempts,
+            builder,
+        }
+    }
+}
+
+fn write_shell_layer(path: &Path) {
+    let output = File::create(path).expect("layer");
+    let encoder = GzEncoder::new(output, Compression::fast());
+    let mut archive = tar::Builder::new(encoder);
+
+    let mut directory = tar::Header::new_gnu();
+    directory.set_entry_type(tar::EntryType::Directory);
+    directory.set_mode(0o755);
+    directory.set_size(0);
+    directory.set_cksum();
+    archive
+        .append_data(&mut directory, "bin/", std::io::empty())
+        .expect("bin directory");
+
+    let contents = b"#!/bin/sh\n";
+    let mut shell = tar::Header::new_gnu();
+    shell.set_entry_type(tar::EntryType::Regular);
+    shell.set_mode(0o755);
+    shell.set_size(contents.len() as u64);
+    shell.set_cksum();
+    archive
+        .append_data(&mut shell, "bin/sh", contents.as_slice())
+        .expect("shell");
+    let encoder = archive.into_inner().expect("finish tar");
+    drop(encoder.finish().expect("finish gzip"));
+}
+
+fn reference_key(image: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"nanocodex-vm-reference-v1\0linux\0");
+    #[cfg(target_arch = "aarch64")]
+    hasher.update(b"arm64");
+    #[cfg(target_arch = "x86_64")]
+    hasher.update(b"amd64");
+    hasher.update([0]);
+    hasher.update(image.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn benchmark_image_cache(criterion: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("benchmark runtime");
+    let fixture = Fixture::new(&runtime);
+    let counter = AtomicU64::new(0);
+
+    let mut group = criterion.benchmark_group("vm_image_cache");
+    group.sample_size(20);
+    group.measurement_time(Duration::from_secs(2));
+    group.bench_function("warm_prepare", |bencher| {
+        bencher.to_async(&runtime).iter(|| async {
+            let prepared = fixture
+                .builder
+                .prepare(
+                    &fixture.context,
+                    DISK_BYTES,
+                    &fixture.cache,
+                    CachePolicy::Reuse,
+                )
+                .await
+                .expect("warm preparation");
+            black_box((prepared.path(), prepared.workdir(), prepared.environment()));
+        });
+    });
+    group.bench_function("attempt_reflink", |bencher| {
+        let prepared = runtime
+            .block_on(fixture.builder.prepare(
+                &fixture.context,
+                DISK_BYTES,
+                &fixture.cache,
+                CachePolicy::Reuse,
+            ))
+            .expect("prepared image");
+        bencher.iter_batched(
+            || {
+                fixture.attempts.join(format!(
+                    "attempt-{}.ext4",
+                    counter.fetch_add(1, Ordering::Relaxed)
+                ))
+            },
+            |destination| {
+                let bytes = prepared.reflink_to(&destination).expect("attempt reflink");
+                fs::remove_file(destination).expect("remove attempt");
+                black_box(bytes);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_image_cache);
+criterion_main!(benches);

--- a/crates/experimental/nanocodex-vm/benches/vm_session.rs
+++ b/crates/experimental/nanocodex-vm/benches/vm_session.rs
@@ -1,0 +1,236 @@
+use std::{hint::black_box, path::PathBuf, time::Duration};
+
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use nanocodex_vm::{
+    host::{BlockDevice, EgressLease, GuestCommand, VmConfig},
+    tools::{GuestRuntimeDisk, GuestRuntimeDiskError, VmCommand, VmToolSession},
+};
+use tokio::process::Command;
+
+const RUNTIME_DEVICE: &str = "/dev/vdb";
+const RUNTIME_MOUNT: &str = "/run/nanocodex";
+#[cfg(target_os = "linux")]
+const FIRMWARE_LIBRARY_PATH_ENVIRONMENT: &str = "LD_LIBRARY_PATH";
+#[cfg(target_os = "macos")]
+const FIRMWARE_LIBRARY_PATH_ENVIRONMENT: &str = "DYLD_LIBRARY_PATH";
+
+fn protocol_server() -> Command {
+    let script = r#"
+while IFS= read -r request; do
+  id=${request#*\"id\":}
+  id=${id%%,*}
+  id=${id%%\}*}
+  case "$request" in
+    *'"kind":"ready"'*)
+      printf '{"kind":"ready","payload":{"id":%s,"error":null}}\n' "$id"
+      ;;
+    *'"kind":"execute"'*)
+      printf '{"kind":"execute","payload":{"id":%s,"exit_code":0,"stdout":"","stderr":"","error":null,"timed_out":false,"output_limit_exceeded":false}}\n' "$id"
+      ;;
+    *'"kind":"shutdown"'*)
+      printf '{"kind":"shutdown","payload":{"id":%s,"error":null}}\n' "$id"
+      exit 0
+      ;;
+    *)
+      exit 9
+      ;;
+  esac
+done
+"#;
+    let mut command = Command::new("/bin/sh");
+    command.arg("-c").arg(script);
+    command
+}
+
+fn benchmark_guest_runtime_cache(criterion: &mut Criterion) {
+    let directory = tempfile::tempdir().expect("runtime cache fixture");
+    let binary = directory.path().join("nanocodex-vm-guest");
+    let cache = directory.path().join("cache");
+    std::fs::write(&binary, b"\x7fELF benchmark guest runtime").expect("benchmark guest runtime");
+    GuestRuntimeDisk::prepare(&binary, &cache).expect("prime guest runtime cache");
+
+    let mut group = criterion.benchmark_group("vm_guest_runtime_cache");
+    group.measurement_time(Duration::from_secs(2));
+    group.bench_function("warm_prepare", |bencher| {
+        bencher.iter(|| {
+            black_box(
+                GuestRuntimeDisk::prepare(black_box(&binary), black_box(&cache))
+                    .expect("warm guest runtime cache"),
+            );
+        });
+    });
+    group.finish();
+}
+
+fn benchmark_protocol(criterion: &mut Criterion) {
+    let runtime = benchmark_runtime();
+    let session = {
+        let _runtime = runtime.enter();
+        VmToolSession::spawn(&mut protocol_server()).expect("protocol session")
+    };
+    let mut group = criterion.benchmark_group("vm_session_protocol");
+    group.sample_size(20);
+    group.measurement_time(Duration::from_secs(2));
+    group.bench_function("retained_command_rpc", |bencher| {
+        bencher.to_async(&runtime).iter(|| async {
+            let output = session
+                .command(VmCommand::new("/bin/true"))
+                .await
+                .expect("protocol command");
+            black_box(output);
+        });
+    });
+    group.bench_function("spawn_first_rpc_shutdown", |bencher| {
+        bencher.to_async(&runtime).iter_batched(
+            || VmToolSession::spawn(&mut protocol_server()).expect("protocol session"),
+            |session| async move {
+                let output = session
+                    .command(VmCommand::new("/bin/true"))
+                    .await
+                    .expect("protocol command");
+                session.shutdown().await.expect("protocol shutdown");
+                black_box(output);
+            },
+            BatchSize::PerIteration,
+        );
+    });
+    group.finish();
+    runtime
+        .block_on(session.shutdown())
+        .expect("protocol session shutdown");
+}
+
+struct LiveVm {
+    vmm: PathBuf,
+    rootfs: PathBuf,
+    runtime: PathBuf,
+    firmware: PathBuf,
+    _runtime_directory: Option<tempfile::TempDir>,
+    _runtime_disk: Option<GuestRuntimeDisk>,
+}
+
+impl LiveVm {
+    fn from_environment() -> Option<Self> {
+        let runtime = PathBuf::from(std::env::var_os("NANOCODEX_VM_RUNTIME")?);
+        let (runtime_directory, runtime_disk, runtime) = prepare_runtime_disk(runtime);
+        Some(Self {
+            vmm: std::env::var_os("NANOCODEX_VM_VMM")?.into(),
+            rootfs: std::env::var_os("NANOCODEX_VM_ROOTFS")?.into(),
+            runtime,
+            firmware: std::env::var_os("NANOCODEX_VM_FIRMWARE")?.into(),
+            _runtime_directory: runtime_directory,
+            _runtime_disk: runtime_disk,
+        })
+    }
+
+    fn private_root(&self) -> (tempfile::TempDir, PathBuf) {
+        let directory = tempfile::tempdir().expect("private VM directory");
+        let root = directory.path().join("rootfs.ext4");
+        reflink_copy::reflink(&self.rootfs, &root).expect("rootfs copy-on-write clone");
+        (directory, root)
+    }
+
+    async fn spawn(&self, root: PathBuf) -> VmToolSession {
+        let config = VmConfig::ext4(root)
+            .cpus(2)
+            .memory_mib(768)
+            .block_device(BlockDevice::read_only("nanocodex-runtime", &self.runtime));
+        let init = format!(
+            "set -eu; mkdir -p $1 {RUNTIME_MOUNT}; \
+             mount -t ext4 -o ro {RUNTIME_DEVICE} {RUNTIME_MOUNT}; \
+             exec {RUNTIME_MOUNT}/nanocodex-vm-guest $1"
+        );
+        let guest = GuestCommand::new("/bin/sh")
+            .arg("-c")
+            .arg(init)
+            .arg("nanocodex-vm-init")
+            .arg("/workspace");
+        let mut vmm = Command::new(&self.vmm);
+        vmm.arg("--vmm")
+            .env_clear()
+            .env(FIRMWARE_LIBRARY_PATH_ENVIRONMENT, &self.firmware);
+        VmToolSession::spawn_configured(vmm, config, guest, EgressLease::disabled())
+            .await
+            .expect("live VM session")
+    }
+
+    async fn run_once(&self, root: PathBuf) {
+        let session = self.spawn(root).await;
+        let output = session
+            .command(VmCommand::new("/bin/true"))
+            .await
+            .expect("live VM command");
+        assert_eq!(output.exit_code, 0);
+        session.shutdown().await.expect("live VM shutdown");
+    }
+}
+
+fn prepare_runtime_disk(
+    runtime: PathBuf,
+) -> (Option<tempfile::TempDir>, Option<GuestRuntimeDisk>, PathBuf) {
+    let directory = tempfile::tempdir().expect("runtime disk directory");
+    match GuestRuntimeDisk::prepare(&runtime, directory.path()) {
+        Ok(disk) => {
+            let path = disk.path().to_owned();
+            (Some(directory), Some(disk), path)
+        }
+        Err(GuestRuntimeDiskError::NotElf(_)) => (None, None, runtime),
+        Err(error) => panic!("guest runtime disk: {error}"),
+    }
+}
+
+fn benchmark_live_vm(criterion: &mut Criterion) {
+    let Some(vm) = LiveVm::from_environment() else {
+        eprintln!(
+            "live VM benchmark skipped; set NANOCODEX_VM_VMM, NANOCODEX_VM_ROOTFS, \
+             NANOCODEX_VM_RUNTIME, and NANOCODEX_VM_FIRMWARE"
+        );
+        return;
+    };
+    let runtime = benchmark_runtime();
+    let (retained_directory, retained_root) = vm.private_root();
+    let retained = runtime.block_on(vm.spawn(retained_root));
+    let mut group = criterion.benchmark_group("vm_session_live");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(10));
+    group.bench_function("retained_command_rpc", |bencher| {
+        bencher.to_async(&runtime).iter(|| async {
+            let output = retained
+                .command(VmCommand::new("/bin/true"))
+                .await
+                .expect("live VM command");
+            black_box(output);
+        });
+    });
+    let vm = &vm;
+    group.bench_function("boot_first_rpc_shutdown", |bencher| {
+        bencher.to_async(&runtime).iter_batched(
+            || vm.private_root(),
+            |(directory, root)| async move {
+                let _directory = directory;
+                vm.run_once(root).await;
+            },
+            BatchSize::PerIteration,
+        );
+    });
+    group.finish();
+    runtime
+        .block_on(retained.shutdown())
+        .expect("retained live VM shutdown");
+    drop(retained_directory);
+}
+
+fn benchmark_runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("benchmark runtime")
+}
+
+criterion_group!(
+    benches,
+    benchmark_guest_runtime_cache,
+    benchmark_protocol,
+    benchmark_live_vm
+);
+criterion_main!(benches);

--- a/crates/experimental/nanocodex-vm/src/bin/nanocodex-vm-guest.rs
+++ b/crates/experimental/nanocodex-vm/src/bin/nanocodex-vm-guest.rs
@@ -1,0 +1,16 @@
+#[cfg(target_os = "linux")]
+use std::path::PathBuf;
+
+#[cfg(target_os = "linux")]
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), nanocodex_vm::tools::VmGuestError> {
+    let workspace = std::env::args_os()
+        .nth(1)
+        .map_or_else(|| PathBuf::from("/workspace"), PathBuf::from);
+    nanocodex_vm::tools::serve_guest(workspace).await
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("nanocodex-vm-guest must be built for a Linux guest target");
+}

--- a/crates/experimental/nanocodex-vm/src/capabilities.rs
+++ b/crates/experimental/nanocodex-vm/src/capabilities.rs
@@ -1,0 +1,136 @@
+#![allow(
+    unsafe_code,
+    reason = "this module is one of the two audited libkrun FFI boundaries"
+)]
+
+use std::collections::BTreeSet;
+
+use crate::krun::VmError;
+
+/// Optional functionality compiled into the pinned libkrun build.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[repr(u64)]
+pub enum KrunFeature {
+    /// Virtio networking support.
+    Network = 0,
+    /// Virtio block-device support.
+    Block = 1,
+    /// GPU device support.
+    Gpu = 2,
+    /// Guest input-device support.
+    Input = 4,
+    /// Trusted-execution-environment support.
+    Tee = 6,
+    /// AMD SEV confidential-computing support.
+    AmdSev = 7,
+    /// Intel TDX confidential-computing support.
+    IntelTdx = 8,
+    /// AWS Nitro enclave support.
+    AwsNitro = 9,
+    /// `VirGL` resource-map version 2 support.
+    VirglResourceMap2 = 10,
+    /// Embedded guest init-blob support.
+    InitBlob = 11,
+}
+
+const FEATURES: [KrunFeature; 10] = [
+    KrunFeature::Network,
+    KrunFeature::Block,
+    KrunFeature::Gpu,
+    KrunFeature::Input,
+    KrunFeature::Tee,
+    KrunFeature::AmdSev,
+    KrunFeature::IntelTdx,
+    KrunFeature::AwsNitro,
+    KrunFeature::VirglResourceMap2,
+    KrunFeature::InitBlob,
+];
+
+/// Host and build capabilities relevant when configuring a VM.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Capabilities {
+    max_vcpus: u32,
+    nested_virtualization: bool,
+    pause_resume: bool,
+    features: BTreeSet<KrunFeature>,
+}
+
+impl Capabilities {
+    /// Queries the active libkrun build and host hypervisor.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when libkrun cannot query a capability.
+    pub fn detect() -> Result<Self, VmError> {
+        let max_vcpus = positive(krun::krun_get_max_vcpus(), "query maximum vCPUs")?;
+        // SAFETY: this libkrun function has no pointer arguments or additional
+        // preconditions despite being declared unsafe in its Rust ABI.
+        let nested_virtualization = bool_status(
+            unsafe { krun::krun_check_nested_virt() },
+            "query nested virtualization",
+        )?;
+        let mut features = BTreeSet::new();
+        for feature in FEATURES {
+            if bool_status(
+                krun::krun_has_feature(feature as u64),
+                "query compiled feature",
+            )? {
+                features.insert(feature);
+            }
+        }
+
+        Ok(Self {
+            max_vcpus,
+            nested_virtualization,
+            pause_resume: cfg!(target_os = "macos"),
+            features,
+        })
+    }
+
+    /// Returns the maximum number of virtual CPUs supported by the host.
+    #[must_use]
+    pub const fn max_vcpus(&self) -> u32 {
+        self.max_vcpus
+    }
+
+    /// Returns whether the host can expose nested virtualization.
+    #[must_use]
+    pub const fn nested_virtualization(&self) -> bool {
+        self.nested_virtualization
+    }
+
+    /// Whether the host supports out-of-band VM pause and resume.
+    #[must_use]
+    pub const fn pause_resume(&self) -> bool {
+        self.pause_resume
+    }
+
+    /// Returns whether the pinned libkrun build includes `feature`.
+    #[must_use]
+    pub fn has(&self, feature: KrunFeature) -> bool {
+        self.features.contains(&feature)
+    }
+
+    /// Iterates over optional features included in the pinned libkrun build.
+    pub fn features(&self) -> impl Iterator<Item = KrunFeature> + '_ {
+        self.features.iter().copied()
+    }
+}
+
+fn positive(status: i32, operation: &'static str) -> Result<u32, VmError> {
+    u32::try_from(status).map_err(|_| VmError::Libkrun {
+        operation,
+        errno: status.saturating_neg(),
+    })
+}
+
+const fn bool_status(status: i32, operation: &'static str) -> Result<bool, VmError> {
+    match status {
+        0 => Ok(false),
+        1 => Ok(true),
+        _ => Err(VmError::Libkrun {
+            operation,
+            errno: status.saturating_neg(),
+        }),
+    }
+}

--- a/crates/experimental/nanocodex-vm/src/command.rs
+++ b/crates/experimental/nanocodex-vm/src/command.rs
@@ -1,0 +1,148 @@
+use std::{collections::BTreeMap, ffi::OsString, fmt, path::Path};
+
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+
+/// A command to execute as the initial process inside a libkrun guest.
+#[derive(Clone, Deserialize, Eq, PartialEq, Serialize)]
+pub struct GuestCommand {
+    program: OsString,
+    arguments: Vec<OsString>,
+    #[serde(with = "environment_serde")]
+    environment: BTreeMap<OsString, OsString>,
+    current_dir: OsString,
+}
+
+impl fmt::Debug for GuestCommand {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GuestCommand")
+            .field("program", &self.program)
+            .field("arguments", &self.arguments)
+            .field(
+                "environment_keys",
+                &self.environment.keys().collect::<Vec<_>>(),
+            )
+            .field("current_dir", &self.current_dir)
+            .finish()
+    }
+}
+
+impl GuestCommand {
+    /// Creates a guest command with `/` as its working directory and a
+    /// conventional system `PATH`.
+    pub fn new(program: impl Into<OsString>) -> Self {
+        Self {
+            program: program.into(),
+            arguments: Vec::new(),
+            environment: BTreeMap::from([(OsString::from("PATH"), OsString::from(DEFAULT_PATH))]),
+            current_dir: OsString::from("/"),
+        }
+    }
+
+    /// Appends one argument.
+    #[must_use]
+    pub fn arg(mut self, argument: impl Into<OsString>) -> Self {
+        self.arguments.push(argument.into());
+        self
+    }
+
+    /// Appends arguments in order.
+    #[must_use]
+    pub fn args<I, A>(mut self, arguments: I) -> Self
+    where
+        I: IntoIterator<Item = A>,
+        A: Into<OsString>,
+    {
+        self.arguments.extend(arguments.into_iter().map(Into::into));
+        self
+    }
+
+    /// Sets or replaces one environment variable.
+    #[must_use]
+    pub fn env(mut self, name: impl Into<OsString>, value: impl Into<OsString>) -> Self {
+        self.environment.insert(name.into(), value.into());
+        self
+    }
+
+    /// Sets the absolute guest working directory.
+    #[must_use]
+    pub fn current_dir(mut self, directory: impl Into<OsString>) -> Self {
+        self.current_dir = directory.into();
+        self
+    }
+
+    /// Returns the guest executable.
+    #[must_use]
+    pub fn program(&self) -> &Path {
+        Path::new(&self.program)
+    }
+
+    /// Returns the ordered guest arguments.
+    #[must_use]
+    pub fn arguments(&self) -> &[OsString] {
+        &self.arguments
+    }
+
+    /// Returns the complete guest environment.
+    #[must_use]
+    pub const fn environment(&self) -> &BTreeMap<OsString, OsString> {
+        &self.environment
+    }
+
+    /// Returns the guest working directory.
+    #[must_use]
+    pub fn current_directory(&self) -> &Path {
+        Path::new(&self.current_dir)
+    }
+}
+
+mod environment_serde {
+    use std::{collections::BTreeMap, ffi::OsString};
+
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<S>(
+        environment: &BTreeMap<OsString, OsString>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        environment.iter().collect::<Vec<_>>().serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<BTreeMap<OsString, OsString>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Vec::<(OsString, OsString)>::deserialize(deserializer)?
+            .into_iter()
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_owns_guest_process_policy() {
+        let command = GuestCommand::new("/bin/sh")
+            .args(["-c", "pwd"])
+            .env("TERM", "dumb")
+            .current_dir("/workspace");
+
+        assert_eq!(command.program(), Path::new("/bin/sh"));
+        assert_eq!(
+            command.arguments(),
+            [OsString::from("-c"), OsString::from("pwd")]
+        );
+        assert_eq!(
+            command.environment().get(&OsString::from("TERM")),
+            Some(&OsString::from("dumb"))
+        );
+        assert_eq!(command.current_directory(), Path::new("/workspace"));
+    }
+}

--- a/crates/experimental/nanocodex-vm/src/config.rs
+++ b/crates/experimental/nanocodex-vm/src/config.rs
@@ -1,0 +1,354 @@
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Root filesystem exposed to one guest.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub enum RootFilesystem {
+    /// A host directory shared through virtiofs.
+    Directory(PathBuf),
+    /// A raw ext4 image attached as the guest's writable root block device.
+    Ext4(PathBuf),
+}
+
+/// Network access supplied to the guest by libkrun.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub enum Network {
+    /// Do not attach a virtio-vsock device or proxy guest internet sockets.
+    Disabled,
+    /// Proxy guest internet sockets through libkrun TSI.
+    #[default]
+    Internet,
+    /// A private virtio-net interface connected to a gvproxy unixgram socket.
+    ///
+    /// Unlike TSI, this gives the guest its own loopback and port namespace.
+    Gvproxy {
+        /// Host unixgram socket exposed by the owned gvproxy process.
+        socket: PathBuf,
+        /// Stable private MAC address assigned to the guest interface.
+        mac_address: [u8; 6],
+    },
+}
+
+impl Network {
+    /// Creates a private virtio-net interface backed by gvproxy.
+    #[must_use]
+    pub fn gvproxy(socket: impl Into<PathBuf>) -> Self {
+        Self::Gvproxy {
+            socket: socket.into(),
+            mac_address: [0x5a, 0x94, 0xef, 0xe4, 0x0c, 0xee],
+        }
+    }
+}
+
+/// One additional block device attached after the root disk.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct BlockDevice {
+    id: String,
+    path: PathBuf,
+    read_only: bool,
+}
+
+impl BlockDevice {
+    /// Creates a writable block device.
+    pub fn read_write(id: impl Into<String>, path: impl Into<PathBuf>) -> Self {
+        Self {
+            id: id.into(),
+            path: path.into(),
+            read_only: false,
+        }
+    }
+
+    /// Creates an immutable block device.
+    pub fn read_only(id: impl Into<String>, path: impl Into<PathBuf>) -> Self {
+        Self {
+            id: id.into(),
+            path: path.into(),
+            read_only: true,
+        }
+    }
+
+    /// Returns the libkrun block-device identifier.
+    #[must_use]
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Returns the host path of the block image.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Returns whether guest writes to the device are prohibited.
+    #[must_use]
+    pub const fn is_read_only(&self) -> bool {
+        self.read_only
+    }
+}
+
+/// One narrowly scoped host directory exposed to the guest through virtiofs.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct SharedDirectory {
+    tag: String,
+    path: PathBuf,
+    read_only: bool,
+}
+
+impl SharedDirectory {
+    /// Creates a read-only share identified by `tag` inside the guest.
+    pub fn read_only(tag: impl Into<String>, path: impl Into<PathBuf>) -> Self {
+        Self {
+            tag: tag.into(),
+            path: path.into(),
+            read_only: true,
+        }
+    }
+
+    /// Creates a writable share identified by `tag` inside the guest.
+    pub fn read_write(tag: impl Into<String>, path: impl Into<PathBuf>) -> Self {
+        Self {
+            tag: tag.into(),
+            path: path.into(),
+            read_only: false,
+        }
+    }
+
+    /// Returns the virtiofs mount tag.
+    #[must_use]
+    pub fn tag(&self) -> &str {
+        &self.tag
+    }
+
+    /// Returns the host directory shared through virtiofs.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Returns whether guest writes to the share are prohibited.
+    #[must_use]
+    pub const fn is_read_only(&self) -> bool {
+        self.read_only
+    }
+}
+
+/// Immutable configuration for one libkrun VM.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct VmConfig {
+    root: RootFilesystem,
+    cpus: u8,
+    memory_mib: u32,
+    network: Network,
+    block_devices: Vec<BlockDevice>,
+    shared_directories: Vec<SharedDirectory>,
+}
+
+impl VmConfig {
+    /// Creates a VM configuration with two vCPUs, 1 GiB RAM, and internet
+    /// socket proxying enabled.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: RootFilesystem::Directory(root.into()),
+            cpus: 2,
+            memory_mib: 1_024,
+            network: Network::Internet,
+            block_devices: Vec::new(),
+            shared_directories: Vec::new(),
+        }
+    }
+
+    /// Creates a VM backed by a raw ext4 root disk.
+    pub fn ext4(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: RootFilesystem::Ext4(root.into()),
+            cpus: 2,
+            memory_mib: 1_024,
+            network: Network::Internet,
+            block_devices: Vec::new(),
+            shared_directories: Vec::new(),
+        }
+    }
+
+    /// Sets the number of virtual CPUs.
+    #[must_use]
+    pub const fn cpus(mut self, cpus: u8) -> Self {
+        self.cpus = cpus;
+        self
+    }
+
+    /// Sets guest memory in mebibytes.
+    #[must_use]
+    pub const fn memory_mib(mut self, memory_mib: u32) -> Self {
+        self.memory_mib = memory_mib;
+        self
+    }
+
+    /// Selects the guest network mode.
+    #[must_use]
+    pub fn network(mut self, network: Network) -> Self {
+        self.network = network;
+        self
+    }
+
+    /// Adds one virtiofs directory.
+    #[must_use]
+    pub fn shared_directory(mut self, directory: SharedDirectory) -> Self {
+        self.shared_directories.push(directory);
+        self
+    }
+
+    /// Adds one block device after the root disk.
+    #[must_use]
+    pub fn block_device(mut self, device: BlockDevice) -> Self {
+        self.block_devices.push(device);
+        self
+    }
+
+    /// Returns the host root filesystem path.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        match &self.root {
+            RootFilesystem::Directory(path) | RootFilesystem::Ext4(path) => path,
+        }
+    }
+
+    /// Returns the selected root filesystem kind.
+    #[must_use]
+    pub const fn root_filesystem(&self) -> &RootFilesystem {
+        &self.root
+    }
+
+    /// Returns the configured virtual CPU count.
+    #[must_use]
+    pub const fn cpus_value(&self) -> u8 {
+        self.cpus
+    }
+
+    /// Returns configured guest memory in mebibytes.
+    #[must_use]
+    pub const fn memory_mib_value(&self) -> u32 {
+        self.memory_mib
+    }
+
+    /// Returns the selected guest network mode.
+    #[must_use]
+    pub const fn network_value(&self) -> &Network {
+        &self.network
+    }
+
+    /// Returns additional virtiofs directories in attachment order.
+    #[must_use]
+    pub fn shared_directories(&self) -> &[SharedDirectory] {
+        &self.shared_directories
+    }
+
+    /// Returns additional block devices in attachment order.
+    #[must_use]
+    pub fn block_devices(&self) -> &[BlockDevice] {
+        &self.block_devices
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_suitable_for_a_small_worker() {
+        let config = VmConfig::new("rootfs");
+
+        assert_eq!(config.root(), Path::new("rootfs"));
+        assert_eq!(
+            config.root_filesystem(),
+            &RootFilesystem::Directory(PathBuf::from("rootfs"))
+        );
+        assert_eq!(config.cpus_value(), 2);
+        assert_eq!(config.memory_mib_value(), 1_024);
+        assert_eq!(config.network_value(), &Network::Internet);
+    }
+
+    #[test]
+    fn policy_is_explicitly_overridable() {
+        let config = VmConfig::new("rootfs")
+            .cpus(8)
+            .memory_mib(4_096)
+            .network(Network::Disabled);
+
+        assert_eq!(config.cpus_value(), 8);
+        assert_eq!(config.memory_mib_value(), 4_096);
+        assert_eq!(config.network_value(), &Network::Disabled);
+    }
+
+    #[test]
+    fn gvproxy_network_has_an_isolated_default_identity() {
+        let network = Network::gvproxy("/tmp/network.sock");
+
+        assert_eq!(
+            network,
+            Network::Gvproxy {
+                socket: PathBuf::from("/tmp/network.sock"),
+                mac_address: [0x5a, 0x94, 0xef, 0xe4, 0x0c, 0xee],
+            }
+        );
+    }
+
+    #[test]
+    fn raw_ext4_is_an_explicit_root_kind() {
+        let config = VmConfig::ext4("rootfs.ext4");
+
+        assert_eq!(config.root(), Path::new("rootfs.ext4"));
+        assert_eq!(
+            config.root_filesystem(),
+            &RootFilesystem::Ext4(PathBuf::from("rootfs.ext4"))
+        );
+    }
+
+    #[test]
+    fn read_only_shares_are_explicit() {
+        let config = VmConfig::ext4("rootfs.ext4").shared_directory(SharedDirectory::read_only(
+            "nanocodex-tools",
+            "target/guest-tools",
+        ));
+
+        assert_eq!(
+            config.shared_directories(),
+            &[SharedDirectory::read_only(
+                "nanocodex-tools",
+                "target/guest-tools"
+            )]
+        );
+        assert!(config.shared_directories()[0].is_read_only());
+    }
+
+    #[test]
+    fn block_device_mutability_is_explicit() {
+        let config = VmConfig::ext4("rootfs.ext4")
+            .block_device(BlockDevice::read_write("cache", "cache.ext4"))
+            .block_device(BlockDevice::read_only("runtime", "runtime.ext4"));
+
+        assert!(!config.block_devices()[0].is_read_only());
+        assert!(config.block_devices()[1].is_read_only());
+    }
+
+    #[test]
+    fn writable_shares_are_explicit() {
+        let directory = SharedDirectory::read_write("nanocodex-cache", "cache");
+
+        assert_eq!(directory.tag(), "nanocodex-cache");
+        assert_eq!(directory.path(), Path::new("cache"));
+        assert!(!directory.is_read_only());
+    }
+
+    #[test]
+    fn read_only_block_devices_are_explicit() {
+        let config = VmConfig::ext4("rootfs.ext4")
+            .block_device(BlockDevice::read_only("runtime", "runtime.ext4"));
+
+        assert_eq!(
+            config.block_devices(),
+            &[BlockDevice::read_only("runtime", "runtime.ext4")]
+        );
+        assert!(config.block_devices()[0].is_read_only());
+    }
+}

--- a/crates/experimental/nanocodex-vm/src/egress.rs
+++ b/crates/experimental/nanocodex-vm/src/egress.rs
@@ -19,6 +19,9 @@ use crate::{
 pub const GUEST_EGRESS_ROOT: &str = "/tmp/nanocodex/egress";
 /// Maximum size of one public file provisioned through an egress lease.
 pub const MAX_EGRESS_FILE_BYTES: usize = 4 * 1024 * 1024;
+const MAX_BUILD_CACHE_SCOPE_BYTES: usize = 256;
+const INTERNET_BUILD_CACHE_SCOPE: &str = "network-internet-v1";
+const DISABLED_BUILD_CACHE_SCOPE: &str = "network-disabled-v1";
 
 /// VM-facing outbound-access configuration retained for one guest lifetime.
 ///
@@ -33,6 +36,7 @@ pub struct EgressLease {
     guest_mounts: BTreeMap<String, EgressMount>,
     guest_files: BTreeMap<PathBuf, EgressFile>,
     guards: Vec<Arc<dyn Any + Send + Sync>>,
+    build_cache_scope: Option<String>,
 }
 
 /// One provider-owned host directory mounted read-only into the guest.
@@ -119,12 +123,18 @@ impl EgressLease {
     /// Creates an empty lease for an explicit network mode.
     #[must_use]
     pub fn new(network: Network) -> Self {
+        let build_cache_scope = match &network {
+            Network::Disabled => Some(DISABLED_BUILD_CACHE_SCOPE.to_owned()),
+            Network::Internet => Some(INTERNET_BUILD_CACHE_SCOPE.to_owned()),
+            Network::Gvproxy { .. } => None,
+        };
         Self {
             network,
             guest_environment: BTreeMap::new(),
             guest_mounts: BTreeMap::new(),
             guest_files: BTreeMap::new(),
             guards: Vec::new(),
+            build_cache_scope,
         }
     }
 
@@ -166,7 +176,11 @@ impl EgressLease {
         {
             return Err(EgressError::EnvironmentConflict(name));
         }
+        if self.guest_environment.get(&name) == Some(&value) {
+            return Ok(());
+        }
         self.guest_environment.insert(name, value);
+        self.build_cache_scope = None;
         Ok(())
     }
 
@@ -198,6 +212,9 @@ impl EgressLease {
         {
             return Err(EgressError::MountTagConflict(mount.tag));
         }
+        if self.guest_mounts.get(&mount.tag) == Some(&mount) {
+            return Ok(());
+        }
         if self
             .guest_files
             .keys()
@@ -206,6 +223,7 @@ impl EgressLease {
             return Err(EgressError::GuestMountFileOverlap(mount.guest_path));
         }
         self.guest_mounts.insert(mount.tag.clone(), mount);
+        self.build_cache_scope = None;
         Ok(())
     }
 
@@ -246,8 +264,45 @@ impl EgressLease {
         {
             return Err(EgressError::GuestFileConflict(file.guest_path));
         }
+        if self.guest_files.get(&file.guest_path) == Some(&file) {
+            return Ok(());
+        }
         self.guest_files.insert(file.guest_path.clone(), file);
+        self.build_cache_scope = None;
         Ok(())
+    }
+
+    /// Assigns an opaque non-secret identity for outputs built through this
+    /// exact egress policy.
+    ///
+    /// Adding environment, mounts, or files clears the scope. Set it only after
+    /// composing the complete lease. The value becomes part of VM image cache
+    /// identity and must distinguish credential or provider state that can
+    /// change a Dockerfile `RUN` result, but it must never contain the
+    /// credential itself.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the scope is empty, too large, or contains a NUL
+    /// byte.
+    pub fn set_build_cache_scope(&mut self, scope: impl Into<String>) -> Result<(), EgressError> {
+        let scope = scope.into();
+        if scope.is_empty() || scope.len() > MAX_BUILD_CACHE_SCOPE_BYTES || scope.contains('\0') {
+            return Err(EgressError::InvalidBuildCacheScope);
+        }
+        self.build_cache_scope = Some(scope);
+        Ok(())
+    }
+
+    /// Returns this complete lease with an opaque non-secret build-cache
+    /// identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns the errors documented by [`Self::set_build_cache_scope`].
+    pub fn with_build_cache_scope(mut self, scope: impl Into<String>) -> Result<Self, EgressError> {
+        self.set_build_cache_scope(scope)?;
+        Ok(self)
     }
 
     /// Retains provider state, such as a revocable proxy lease, until the guest
@@ -273,6 +328,29 @@ impl EgressLease {
         if self.network != other.network {
             return Err(EgressError::NetworkConflict);
         }
+        let self_contributes_policy = !self.guest_environment.is_empty()
+            || !self.guest_mounts.is_empty()
+            || !self.guest_files.is_empty()
+            || !self.guards.is_empty();
+        let other_contributes_policy = !other.guest_environment.is_empty()
+            || !other.guest_mounts.is_empty()
+            || !other.guest_files.is_empty()
+            || !other.guards.is_empty();
+        let other_adds_policy = !other.guards.is_empty()
+            || other
+                .guest_environment
+                .iter()
+                .any(|(name, value)| self.guest_environment.get(name) != Some(value))
+            || other
+                .guest_mounts
+                .iter()
+                .any(|(tag, mount)| self.guest_mounts.get(tag) != Some(mount))
+            || other
+                .guest_files
+                .iter()
+                .any(|(path, file)| self.guest_files.get(path) != Some(file));
+        let self_build_cache_scope = self.build_cache_scope.clone();
+        let other_build_cache_scope = other.build_cache_scope.clone();
         let mut merged = self.clone();
         for (name, value) in other.guest_environment {
             merged.insert_environment(name, value)?;
@@ -284,6 +362,16 @@ impl EgressLease {
             merged.insert_file(file)?;
         }
         merged.guards.extend(other.guards);
+        merged.build_cache_scope = match (self_contributes_policy, other_contributes_policy) {
+            (false, false) | (true, false) => self_build_cache_scope,
+            (false, true) => other_build_cache_scope,
+            (true, true)
+                if !other_adds_policy && self_build_cache_scope == other_build_cache_scope =>
+            {
+                self_build_cache_scope
+            }
+            (true, true) => None,
+        };
         *self = merged;
         Ok(())
     }
@@ -362,6 +450,16 @@ impl EgressLease {
         &self.guest_environment
     }
 
+    /// Returns the non-secret identity under which Dockerfile build outputs may
+    /// be reused.
+    ///
+    /// `None` means guest-visible provider state was added after the last
+    /// explicit scope assignment, so a cached `RUN` output must not be reused.
+    #[must_use]
+    pub fn build_cache_scope(&self) -> Option<&str> {
+        self.build_cache_scope.as_deref()
+    }
+
     /// Iterates over read-only provider mounts.
     pub fn guest_mounts(&self) -> impl Iterator<Item = &EgressMount> {
         self.guest_mounts.values()
@@ -391,6 +489,7 @@ impl fmt::Debug for EgressLease {
                 &self.guest_files.keys().collect::<Vec<_>>(),
             )
             .field("guards", &self.guards.len())
+            .field("build_cache_scoped", &self.build_cache_scope.is_some())
             .finish()
     }
 }
@@ -398,6 +497,9 @@ impl fmt::Debug for EgressLease {
 /// Invalid or conflicting egress capability composition.
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
 pub enum EgressError {
+    /// A build-cache scope was empty, too large, or contained a NUL byte.
+    #[error("egress build-cache scope must be 1 to 256 non-NUL bytes")]
+    InvalidBuildCacheScope,
     /// Two layers require different guest network modes.
     #[error("egress fragments require conflicting VM network modes")]
     NetworkConflict,
@@ -519,6 +621,104 @@ fn shell_single_quote(value: &OsStr) -> OsString {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn build_cache_scope_tracks_the_complete_egress_policy() {
+        let mut internet = EgressLease::internet();
+        assert_eq!(
+            internet.build_cache_scope(),
+            Some(INTERNET_BUILD_CACHE_SCOPE)
+        );
+        assert_eq!(
+            EgressLease::disabled().build_cache_scope(),
+            Some(DISABLED_BUILD_CACHE_SCOPE)
+        );
+        assert!(
+            EgressLease::new(Network::gvproxy("/tmp/gvproxy.sock"))
+                .build_cache_scope()
+                .is_none()
+        );
+
+        internet
+            .insert_environment("HTTPS_PROXY", "http://proxy")
+            .unwrap();
+        assert!(internet.build_cache_scope().is_none());
+        internet.set_build_cache_scope("proxy-policy-v1").unwrap();
+        internet
+            .insert_environment("HTTPS_PROXY", "http://proxy")
+            .unwrap();
+        assert_eq!(internet.build_cache_scope(), Some("proxy-policy-v1"));
+        internet
+            .insert_file(EgressFile::new(
+                "/tmp/nanocodex/egress/ca.pem",
+                Vec::new(),
+                0o444,
+            ))
+            .unwrap();
+        assert!(internet.build_cache_scope().is_none());
+    }
+
+    #[test]
+    fn merged_egress_preserves_only_an_identical_cache_scope() {
+        let mut empty = EgressLease::internet();
+        let mut scoped = EgressLease::internet();
+        scoped
+            .insert_environment("HTTPS_PROXY", "http://proxy")
+            .unwrap();
+        scoped.set_build_cache_scope("scoped-policy").unwrap();
+        empty.merge(scoped).unwrap();
+        assert_eq!(empty.build_cache_scope(), Some("scoped-policy"));
+
+        let mut first = EgressLease::internet();
+        first
+            .insert_environment("HTTPS_PROXY", "http://proxy")
+            .unwrap();
+        first.set_build_cache_scope("same-policy").unwrap();
+        let mut identical = EgressLease::internet();
+        identical
+            .insert_environment("HTTPS_PROXY", "http://proxy")
+            .unwrap();
+        identical.set_build_cache_scope("same-policy").unwrap();
+        first.merge(identical).unwrap();
+        assert_eq!(first.build_cache_scope(), Some("same-policy"));
+
+        first.merge(EgressLease::internet()).unwrap();
+        assert_eq!(first.build_cache_scope(), Some("same-policy"));
+
+        let mut additional = EgressLease::internet();
+        additional
+            .insert_environment("NO_PROXY", "localhost")
+            .unwrap();
+        additional.set_build_cache_scope("same-policy").unwrap();
+        first.merge(additional).unwrap();
+        assert!(first.build_cache_scope().is_none());
+
+        first.set_build_cache_scope("same-policy").unwrap();
+        let mut different = EgressLease::internet();
+        different
+            .insert_environment("HTTPS_PROXY", "http://proxy")
+            .unwrap();
+        different.set_build_cache_scope("different-policy").unwrap();
+        first.merge(different).unwrap();
+        assert!(first.build_cache_scope().is_none());
+    }
+
+    #[test]
+    fn build_cache_scope_rejects_unsafe_identifiers() {
+        let mut lease = EgressLease::internet();
+        assert_eq!(
+            lease.set_build_cache_scope(""),
+            Err(EgressError::InvalidBuildCacheScope)
+        );
+        assert_eq!(
+            lease.set_build_cache_scope("contains\0nul"),
+            Err(EgressError::InvalidBuildCacheScope)
+        );
+        assert_eq!(
+            lease.set_build_cache_scope("x".repeat(MAX_BUILD_CACHE_SCOPE_BYTES + 1)),
+            Err(EgressError::InvalidBuildCacheScope)
+        );
+    }
 
     #[test]
     fn independently_provisioned_egress_fragments_compose() {

--- a/crates/experimental/nanocodex-vm/src/egress.rs
+++ b/crates/experimental/nanocodex-vm/src/egress.rs
@@ -1,0 +1,740 @@
+use std::{
+    any::Any,
+    collections::BTreeMap,
+    ffi::{OsStr, OsString},
+    fmt,
+    os::unix::ffi::{OsStrExt, OsStringExt},
+    path::{Component, Path, PathBuf},
+    sync::Arc,
+};
+
+use thiserror::Error;
+
+use crate::{
+    command::GuestCommand,
+    config::{Network, SharedDirectory, VmConfig},
+};
+
+/// Exclusive guest root under which provider egress assets may be exposed.
+pub const GUEST_EGRESS_ROOT: &str = "/tmp/nanocodex/egress";
+/// Maximum size of one public file provisioned through an egress lease.
+pub const MAX_EGRESS_FILE_BYTES: usize = 4 * 1024 * 1024;
+
+/// VM-facing outbound-access configuration retained for one guest lifetime.
+///
+/// An application-specific provider can resolve MPP, secret, or capability
+/// policy into this type without exposing that policy to the VM runtime.
+/// Values are deliberately omitted from `Debug`: proxy URLs may contain short-lived
+/// credentials.
+#[derive(Clone)]
+pub struct EgressLease {
+    network: Network,
+    guest_environment: BTreeMap<String, String>,
+    guest_mounts: BTreeMap<String, EgressMount>,
+    guest_files: BTreeMap<PathBuf, EgressFile>,
+    guards: Vec<Arc<dyn Any + Send + Sync>>,
+}
+
+/// One provider-owned host directory mounted read-only into the guest.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EgressMount {
+    tag: String,
+    host_path: PathBuf,
+    guest_path: PathBuf,
+}
+
+impl EgressMount {
+    /// Creates one provider directory that will be mounted read-only.
+    #[must_use]
+    pub fn read_only(
+        tag: impl Into<String>,
+        host_path: impl Into<PathBuf>,
+        guest_path: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            tag: tag.into(),
+            host_path: host_path.into(),
+            guest_path: guest_path.into(),
+        }
+    }
+
+    /// Returns the virtiofs mount tag.
+    #[must_use]
+    pub fn tag(&self) -> &str {
+        &self.tag
+    }
+
+    /// Returns the provider-owned host directory.
+    #[must_use]
+    pub fn host_path(&self) -> &Path {
+        &self.host_path
+    }
+
+    /// Returns the path at which the guest mounts the directory.
+    #[must_use]
+    pub fn guest_path(&self) -> &Path {
+        &self.guest_path
+    }
+}
+
+/// One provider-owned public file provisioned before agent tools are exposed.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EgressFile {
+    guest_path: PathBuf,
+    contents: Vec<u8>,
+    mode: u32,
+}
+
+impl EgressFile {
+    /// Creates one public file to provision before guest tools are exposed.
+    #[must_use]
+    pub fn new(guest_path: impl Into<PathBuf>, contents: impl Into<Vec<u8>>, mode: u32) -> Self {
+        Self {
+            guest_path: guest_path.into(),
+            contents: contents.into(),
+            mode,
+        }
+    }
+
+    /// Returns the normalized guest destination.
+    #[must_use]
+    pub fn guest_path(&self) -> &Path {
+        &self.guest_path
+    }
+
+    /// Returns the complete public file contents.
+    #[must_use]
+    pub fn contents(&self) -> &[u8] {
+        &self.contents
+    }
+
+    /// Returns Unix permission bits applied to the guest file.
+    #[must_use]
+    pub const fn mode(&self) -> u32 {
+        self.mode
+    }
+}
+
+impl EgressLease {
+    /// Creates an empty lease for an explicit network mode.
+    #[must_use]
+    pub fn new(network: Network) -> Self {
+        Self {
+            network,
+            guest_environment: BTreeMap::new(),
+            guest_mounts: BTreeMap::new(),
+            guest_files: BTreeMap::new(),
+            guards: Vec::new(),
+        }
+    }
+
+    /// Creates an empty lease with outbound internet access.
+    #[must_use]
+    pub fn internet() -> Self {
+        Self::new(Network::Internet)
+    }
+
+    /// Creates an empty lease with networking disabled.
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self::new(Network::Disabled)
+    }
+
+    /// Adds one guest environment value.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the name is empty or was already assigned a
+    /// different value by another egress component.
+    pub fn insert_environment(
+        &mut self,
+        name: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Result<(), EgressError> {
+        let name = name.into();
+        if !valid_environment_name(&name) {
+            return Err(EgressError::InvalidEnvironmentName(name));
+        }
+        let value = value.into();
+        if value.contains('\0') {
+            return Err(EgressError::EnvironmentValueContainsNul(name));
+        }
+        if self
+            .guest_environment
+            .get(&name)
+            .is_some_and(|current| current != &value)
+        {
+            return Err(EgressError::EnvironmentConflict(name));
+        }
+        self.guest_environment.insert(name, value);
+        Ok(())
+    }
+
+    /// Adds one read-only provider mount.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the tag or guest path collides with a different
+    /// mount.
+    pub fn insert_mount(&mut self, mount: EgressMount) -> Result<(), EgressError> {
+        if !valid_mount_tag(&mount.tag) {
+            return Err(EgressError::InvalidMountTag(mount.tag));
+        }
+        if !mount.host_path.is_absolute() {
+            return Err(EgressError::HostMountPathNotAbsolute(mount.host_path));
+        }
+        if !valid_guest_egress_path(&mount.guest_path) {
+            return Err(EgressError::GuestMountPathOutsideRoot(mount.guest_path));
+        }
+        if self.guest_mounts.values().any(|current| {
+            paths_overlap(&current.guest_path, &mount.guest_path) && current != &mount
+        }) {
+            return Err(EgressError::GuestMountConflict(mount.guest_path));
+        }
+        if self
+            .guest_mounts
+            .get(&mount.tag)
+            .is_some_and(|current| current != &mount)
+        {
+            return Err(EgressError::MountTagConflict(mount.tag));
+        }
+        if self
+            .guest_files
+            .keys()
+            .any(|path| path.starts_with(&mount.guest_path))
+        {
+            return Err(EgressError::GuestMountFileOverlap(mount.guest_path));
+        }
+        self.guest_mounts.insert(mount.tag.clone(), mount);
+        Ok(())
+    }
+
+    /// Adds one public CA or provider configuration file to provision in the guest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the guest path is not absolute or conflicts with
+    /// a different provider file.
+    pub fn insert_file(&mut self, file: EgressFile) -> Result<(), EgressError> {
+        if !valid_guest_egress_path(&file.guest_path) {
+            return Err(EgressError::GuestFilePathOutsideRoot(file.guest_path));
+        }
+        if file.contents.len() > MAX_EGRESS_FILE_BYTES {
+            return Err(EgressError::GuestFileTooLarge {
+                path: file.guest_path,
+                size: file.contents.len(),
+                limit: MAX_EGRESS_FILE_BYTES,
+            });
+        }
+        if file.mode & !0o777 != 0 {
+            return Err(EgressError::InvalidGuestFileMode {
+                path: file.guest_path,
+                mode: file.mode,
+            });
+        }
+        if self
+            .guest_mounts
+            .values()
+            .any(|mount| file.guest_path.starts_with(&mount.guest_path))
+        {
+            return Err(EgressError::GuestMountFileOverlap(file.guest_path));
+        }
+        if self
+            .guest_files
+            .get(&file.guest_path)
+            .is_some_and(|current| current != &file)
+        {
+            return Err(EgressError::GuestFileConflict(file.guest_path));
+        }
+        self.guest_files.insert(file.guest_path.clone(), file);
+        Ok(())
+    }
+
+    /// Retains provider state, such as a revocable proxy lease, until the guest
+    /// is dropped.
+    pub fn retain<T>(&mut self, guard: Arc<T>)
+    where
+        T: Any + Send + Sync,
+    {
+        self.guards.push(guard);
+    }
+
+    /// Combines independently provisioned egress fragments.
+    ///
+    /// Identical network, environment, mount, and guest-file configuration is
+    /// idempotent.
+    /// Conflicting configuration fails closed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the fragments select different network modes or
+    /// assign incompatible environment, mount, or guest-file values.
+    pub fn merge(&mut self, other: Self) -> Result<(), EgressError> {
+        if self.network != other.network {
+            return Err(EgressError::NetworkConflict);
+        }
+        let mut merged = self.clone();
+        for (name, value) in other.guest_environment {
+            merged.insert_environment(name, value)?;
+        }
+        for mount in other.guest_mounts.into_values() {
+            merged.insert_mount(mount)?;
+        }
+        for file in other.guest_files.into_values() {
+            merged.insert_file(file)?;
+        }
+        merged.guards.extend(other.guards);
+        *self = merged;
+        Ok(())
+    }
+
+    /// Returns this lease with one independently provisioned layer applied.
+    ///
+    /// This is the fluent form of [`Self::merge`]. It lets an application
+    /// assemble a VM route from concrete MPP, secret-gateway, and other
+    /// provider leases without teaching the VM package about those policies.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the new layer conflicts with an earlier layer.
+    pub fn with_layer(mut self, layer: Self) -> Result<Self, EgressError> {
+        self.merge(layer)?;
+        Ok(self)
+    }
+
+    /// Applies this lease to one VM configuration and guest command.
+    ///
+    /// Provider directories are attached read-only and mounted before the
+    /// requested program starts. Guest environment from the lease overrides
+    /// the command's value for the same name. The lease itself must remain
+    /// alive for at least as long as the resulting VM so its provider guards
+    /// continue to protect revocable proxy and secret routes.
+    #[must_use]
+    pub fn configure(&self, mut vm: VmConfig, command: &GuestCommand) -> (VmConfig, GuestCommand) {
+        vm = vm.network(self.network.clone());
+        let mut configured = if self.guest_mounts.is_empty() {
+            command.clone()
+        } else {
+            let mut script = OsString::from("set -eu;");
+            for mount in self.guest_mounts() {
+                vm = vm.shared_directory(SharedDirectory::read_only(&mount.tag, &mount.host_path));
+                append_shell_command(&mut script, " mkdir -p -- ", [mount.guest_path.as_os_str()]);
+                append_shell_command(
+                    &mut script,
+                    "; mount -t virtiofs -o ro ",
+                    [OsStr::new(&mount.tag), mount.guest_path.as_os_str()],
+                );
+            }
+            append_shell_command(
+                &mut script,
+                "; cd -- ",
+                [command.current_directory().as_os_str()],
+            );
+            append_shell_command(
+                &mut script,
+                "; exec ",
+                std::iter::once(command.program().as_os_str())
+                    .chain(command.arguments().iter().map(OsString::as_os_str)),
+            );
+            let mut configured = GuestCommand::new("/bin/sh").args(["-c"]).arg(script);
+            for (name, value) in command.environment() {
+                configured = configured.env(name, value);
+            }
+            configured
+        };
+        for (name, value) in self.guest_environment() {
+            configured = configured.env(name, value);
+        }
+        (vm, configured)
+    }
+
+    /// Returns the network mode required by the complete lease.
+    #[must_use]
+    pub const fn network(&self) -> &Network {
+        &self.network
+    }
+
+    /// Returns guest-visible environment entries.
+    ///
+    /// Values may contain short-lived capabilities and must not be logged.
+    #[must_use]
+    pub const fn guest_environment(&self) -> &BTreeMap<String, String> {
+        &self.guest_environment
+    }
+
+    /// Iterates over read-only provider mounts.
+    pub fn guest_mounts(&self) -> impl Iterator<Item = &EgressMount> {
+        self.guest_mounts.values()
+    }
+
+    /// Iterates over public files to provision before tool execution.
+    pub fn guest_files(&self) -> impl Iterator<Item = &EgressFile> {
+        self.guest_files.values()
+    }
+}
+
+impl fmt::Debug for EgressLease {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EgressLease")
+            .field("network", &self.network)
+            .field(
+                "guest_environment_keys",
+                &self.guest_environment.keys().collect::<Vec<_>>(),
+            )
+            .field(
+                "guest_mounts",
+                &self.guest_mounts.values().collect::<Vec<_>>(),
+            )
+            .field(
+                "guest_file_paths",
+                &self.guest_files.keys().collect::<Vec<_>>(),
+            )
+            .field("guards", &self.guards.len())
+            .finish()
+    }
+}
+
+/// Invalid or conflicting egress capability composition.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum EgressError {
+    /// Two layers require different guest network modes.
+    #[error("egress fragments require conflicting VM network modes")]
+    NetworkConflict,
+    /// A guest environment name is not a portable shell identifier.
+    #[error("guest environment name `{0}` is not a shell identifier")]
+    InvalidEnvironmentName(String),
+    /// Two layers assign different values to one guest environment name.
+    #[error("guest environment `{0}` has conflicting egress values")]
+    EnvironmentConflict(String),
+    /// A guest environment value cannot be represented as a process value.
+    #[error("guest environment `{0}` contains a NUL byte")]
+    EnvironmentValueContainsNul(String),
+    /// A virtiofs tag is empty, too long, or contains unsupported characters.
+    #[error("egress mount tag `{0}` is not a portable identifier")]
+    InvalidMountTag(String),
+    /// A provider mount refers to a relative host path.
+    #[error("host egress mount path must be absolute: {0}")]
+    HostMountPathNotAbsolute(PathBuf),
+    /// A mount destination escapes the exclusive guest egress root.
+    #[error("guest egress mount path must be a normalized child of {GUEST_EGRESS_ROOT}: {0}")]
+    GuestMountPathOutsideRoot(PathBuf),
+    /// Two different provider mounts claim the same virtiofs tag.
+    #[error("egress mount tag `{0}` has conflicting host paths")]
+    MountTagConflict(String),
+    /// Two different provider mounts overlap inside the guest.
+    #[error("guest egress mount path `{0}` has conflicting providers")]
+    GuestMountConflict(PathBuf),
+    /// A provisioned file overlaps a provider directory mount.
+    #[error("guest egress mount and file paths overlap at `{0}`")]
+    GuestMountFileOverlap(PathBuf),
+    /// A provisioned file escapes the exclusive guest egress root.
+    #[error("guest egress file path must be a normalized child of {GUEST_EGRESS_ROOT}: {0}")]
+    GuestFilePathOutsideRoot(PathBuf),
+    /// A provisioned file exceeds [`MAX_EGRESS_FILE_BYTES`].
+    #[error("guest egress file `{path}` is {size} bytes, exceeding the {limit}-byte limit")]
+    GuestFileTooLarge {
+        /// Guest destination.
+        path: PathBuf,
+        /// Requested file size.
+        size: usize,
+        /// Enforced maximum.
+        limit: usize,
+    },
+    /// A provisioned file contains mode bits outside Unix permissions.
+    #[error("guest egress file `{path}` has invalid mode {mode:#o}")]
+    InvalidGuestFileMode {
+        /// Guest destination.
+        path: PathBuf,
+        /// Rejected mode bits.
+        mode: u32,
+    },
+    /// Two layers assign different files to one guest destination.
+    #[error("guest egress file path `{0}` has conflicting providers")]
+    GuestFileConflict(PathBuf),
+}
+
+fn valid_environment_name(name: &str) -> bool {
+    let mut bytes = name.bytes();
+    bytes
+        .next()
+        .is_some_and(|byte| byte == b'_' || byte.is_ascii_alphabetic())
+        && bytes.all(|byte| byte == b'_' || byte.is_ascii_alphanumeric())
+}
+
+fn valid_mount_tag(tag: &str) -> bool {
+    !tag.is_empty()
+        && tag.len() <= 64
+        && tag
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+}
+
+fn valid_guest_egress_path(path: &Path) -> bool {
+    path.is_absolute()
+        && path != Path::new(GUEST_EGRESS_ROOT)
+        && path.starts_with(GUEST_EGRESS_ROOT)
+        && path
+            .components()
+            .all(|component| !matches!(component, Component::CurDir | Component::ParentDir))
+}
+
+fn paths_overlap(first: &Path, second: &Path) -> bool {
+    first.starts_with(second) || second.starts_with(first)
+}
+
+fn append_shell_command<'a>(
+    script: &mut OsString,
+    prefix: &str,
+    arguments: impl IntoIterator<Item = &'a OsStr>,
+) {
+    script.push(prefix);
+    let mut first = true;
+    for argument in arguments {
+        if !first {
+            script.push(" ");
+        }
+        first = false;
+        script.push(shell_single_quote(argument));
+    }
+}
+
+fn shell_single_quote(value: &OsStr) -> OsString {
+    let bytes = value.as_bytes();
+    let mut quoted = Vec::with_capacity(bytes.len().saturating_add(2));
+    quoted.push(b'\'');
+    for byte in bytes {
+        match *byte {
+            b'\'' => quoted.extend_from_slice(b"'\\''"),
+            // libkrun cannot carry a literal double quote in an argv entry.
+            // Produce it at wrapper-shell evaluation time instead.
+            b'"' => quoted.extend_from_slice(b"'$(printf '\\042')'"),
+            byte => quoted.push(byte),
+        }
+    }
+    quoted.push(b'\'');
+    OsString::from_vec(quoted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn independently_provisioned_egress_fragments_compose() {
+        let guard = Arc::new(());
+        let mut secrets = EgressLease::internet();
+        secrets
+            .insert_environment("NANOCENTAUR_SECRET_BASE_URL", "https://secret-gateway/v1")
+            .unwrap();
+        secrets
+            .insert_mount(EgressMount::read_only(
+                "secret-ca",
+                "/host/ca",
+                "/tmp/nanocodex/egress/secrets/ca",
+            ))
+            .unwrap();
+        secrets.retain(Arc::clone(&guard));
+
+        let mut mpp = EgressLease::internet();
+        mpp.insert_environment(
+            "HTTPS_PROXY",
+            "http://mpp-lease:credential@host.internal:8080",
+        )
+        .unwrap();
+        let egress = EgressLease::internet()
+            .with_layer(mpp)
+            .unwrap()
+            .with_layer(secrets)
+            .unwrap();
+
+        assert_eq!(egress.guest_environment().len(), 2);
+        assert_eq!(egress.guest_mounts().count(), 1);
+        assert_eq!(Arc::strong_count(&guard), 2);
+        let debug = format!("{egress:?}");
+        assert!(!debug.contains("credential"));
+        assert!(!debug.contains("secret-gateway"));
+    }
+
+    #[test]
+    fn conflicting_provider_values_fail_closed() {
+        let mut secrets = EgressLease::internet();
+        secrets
+            .insert_environment("HTTPS_PROXY", "http://secret-gateway")
+            .unwrap();
+        let mut mpp = EgressLease::internet();
+        mpp.insert_environment("HTTPS_PROXY", "http://mpp-gateway")
+            .unwrap();
+
+        assert_eq!(
+            secrets.merge(mpp),
+            Err(EgressError::EnvironmentConflict("HTTPS_PROXY".to_owned()))
+        );
+    }
+
+    #[test]
+    fn provider_files_compose_idempotently_and_conflicts_fail_closed() {
+        let path = "/tmp/nanocodex/egress/mpp/ca.pem";
+        let file = EgressFile::new(path, b"public ca".to_vec(), 0o444);
+        let mut first = EgressLease::internet();
+        first.insert_file(file.clone()).unwrap();
+        let mut identical = EgressLease::internet();
+        identical.insert_file(file).unwrap();
+        first.merge(identical).unwrap();
+        assert_eq!(first.guest_files().count(), 1);
+
+        let mut conflicting = EgressLease::internet();
+        conflicting
+            .insert_file(EgressFile::new(path, b"different ca".to_vec(), 0o444))
+            .unwrap();
+        assert_eq!(
+            first.merge(conflicting),
+            Err(EgressError::GuestFileConflict(PathBuf::from(path)))
+        );
+    }
+
+    #[test]
+    fn provider_file_paths_must_be_absolute() {
+        let mut lease = EgressLease::internet();
+        assert_eq!(
+            lease.insert_file(EgressFile::new("relative/ca.pem", Vec::new(), 0o444)),
+            Err(EgressError::GuestFilePathOutsideRoot(PathBuf::from(
+                "relative/ca.pem"
+            )))
+        );
+    }
+
+    #[test]
+    fn lease_configures_network_mounts_and_proxy_environment() {
+        let mut lease = EgressLease::internet();
+        lease
+            .insert_environment("HTTPS_PROXY", "http://host.internal:8080")
+            .unwrap();
+        lease
+            .insert_mount(EgressMount::read_only(
+                "mpp-ca",
+                "/host/mpp",
+                "/tmp/nanocodex/egress/mpp",
+            ))
+            .unwrap();
+        let command = GuestCommand::new("/usr/local/bin/nanocodex-vm-guest")
+            .arg("/workspace")
+            .arg(r#"say "hello""#)
+            .env("HTTPS_PROXY", "http://untrusted")
+            .current_dir("/workspace");
+
+        let (vm, command) = lease.configure(
+            VmConfig::ext4("/tmp/rootfs").network(Network::Disabled),
+            &command,
+        );
+
+        assert_eq!(vm.network_value(), &Network::Internet);
+        assert_eq!(
+            vm.shared_directories(),
+            &[SharedDirectory::read_only("mpp-ca", "/host/mpp")]
+        );
+        assert_eq!(command.program(), std::path::Path::new("/bin/sh"));
+        assert_eq!(command.arguments()[0], "-c");
+        let script = command.arguments()[1].to_string_lossy();
+        assert!(script.contains("mount -t virtiofs -o ro 'mpp-ca'"));
+        assert!(script.contains("cd -- '/workspace'"));
+        assert!(script.contains("exec '/usr/local/bin/nanocodex-vm-guest' '/workspace'"));
+        assert!(script.contains("$(printf '\\042')"));
+        assert!(!script.contains('"'));
+        assert_eq!(
+            command
+                .environment()
+                .get(&std::ffi::OsString::from("HTTPS_PROXY")),
+            Some(&std::ffi::OsString::from("http://host.internal:8080"))
+        );
+    }
+
+    #[test]
+    fn mount_and_file_path_hierarchy_conflicts_fail_before_launch() {
+        let mut lease = EgressLease::internet();
+        lease
+            .insert_mount(EgressMount::read_only(
+                "provider",
+                "/host/provider",
+                "/tmp/nanocodex/egress/provider",
+            ))
+            .unwrap();
+
+        assert_eq!(
+            lease.insert_file(EgressFile::new(
+                "/tmp/nanocodex/egress/provider/ca.pem",
+                Vec::new(),
+                0o444,
+            )),
+            Err(EgressError::GuestMountFileOverlap(PathBuf::from(
+                "/tmp/nanocodex/egress/provider/ca.pem"
+            )))
+        );
+        assert_eq!(
+            lease.insert_mount(EgressMount::read_only(
+                "nested",
+                "/host/nested",
+                "/tmp/nanocodex/egress/provider/nested",
+            )),
+            Err(EgressError::GuestMountConflict(PathBuf::from(
+                "/tmp/nanocodex/egress/provider/nested"
+            )))
+        );
+    }
+
+    #[test]
+    fn egress_rejects_unsafe_values_before_vmm_configuration() {
+        let mut lease = EgressLease::internet();
+        assert_eq!(
+            lease.insert_environment("HTTPS_PROXY", "http://proxy\0hidden"),
+            Err(EgressError::EnvironmentValueContainsNul(
+                "HTTPS_PROXY".to_owned()
+            ))
+        );
+        assert!(matches!(
+            lease.insert_file(EgressFile::new(
+                "/tmp/nanocodex/egress/mpp/ca.pem",
+                vec![0; MAX_EGRESS_FILE_BYTES + 1],
+                0o444,
+            )),
+            Err(EgressError::GuestFileTooLarge { .. })
+        ));
+        assert!(matches!(
+            lease.insert_file(EgressFile::new(
+                "/tmp/nanocodex/egress/mpp/ca.pem",
+                Vec::new(),
+                0o4755,
+            )),
+            Err(EgressError::InvalidGuestFileMode { .. })
+        ));
+        assert!(matches!(
+            lease.insert_mount(EgressMount::read_only(
+                "bad tag",
+                "/host/provider",
+                "/tmp/nanocodex/egress/provider",
+            )),
+            Err(EgressError::InvalidMountTag(_))
+        ));
+        assert!(matches!(
+            lease.insert_mount(EgressMount::read_only(
+                "provider",
+                "relative",
+                "/tmp/nanocodex/egress/provider",
+            )),
+            Err(EgressError::HostMountPathNotAbsolute(_))
+        ));
+    }
+
+    #[test]
+    fn mount_free_lease_preserves_the_direct_guest_command() {
+        let command = GuestCommand::new("/usr/local/bin/nanocodex-vm-guest")
+            .arg("/workspace")
+            .current_dir("/workspace");
+
+        let (vm, configured) =
+            EgressLease::disabled().configure(VmConfig::new("/rootfs"), &command);
+
+        assert_eq!(vm.network_value(), &Network::Disabled);
+        assert_eq!(configured, command);
+    }
+}

--- a/crates/experimental/nanocodex-vm/src/gvproxy.rs
+++ b/crates/experimental/nanocodex-vm/src/gvproxy.rs
@@ -1,0 +1,388 @@
+use std::{
+    fs,
+    io::{self, Read, Write},
+    net::SocketAddr,
+    os::unix::{net::UnixStream, process::CommandExt as _},
+    path::{Path, PathBuf},
+    process::{Child, Stdio},
+    thread,
+    time::{Duration, Instant},
+};
+
+use serde::Serialize;
+use thiserror::Error;
+
+const SOCKET_TIMEOUT: Duration = Duration::from_secs(5);
+const API_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_API_RESPONSE_BYTES: usize = 64 * 1024;
+
+/// Failure to launch, configure, or communicate with gvproxy.
+#[derive(Debug, Error)]
+pub enum GvproxyError {
+    /// The child exited before publishing its control sockets.
+    #[error("gvproxy exited before creating its sockets: {0}")]
+    EarlyExit(std::process::ExitStatus),
+
+    /// A required socket did not become ready before the startup deadline.
+    #[error("gvproxy did not create {path} within {timeout:?}")]
+    SocketTimeout {
+        /// Socket that remained unavailable.
+        path: PathBuf,
+        /// Enforced startup deadline.
+        timeout: Duration,
+    },
+
+    /// A caller attempted to expose a guest port beyond host loopback.
+    #[error("refusing to expose a VM port on non-loopback host address {0}")]
+    NonLoopbackForward(SocketAddr),
+
+    /// Port zero cannot identify a listener created outside gvproxy.
+    #[error("host port zero cannot identify the resulting gvproxy listener")]
+    UnspecifiedHostPort,
+
+    /// The gvproxy services API returned a non-success response.
+    #[error("gvproxy services API returned {status}: {body}")]
+    Api {
+        /// HTTP status line returned by gvproxy.
+        status: String,
+        /// Bounded response body returned by gvproxy.
+        body: String,
+    },
+
+    /// The gvproxy services response was not valid HTTP.
+    #[error("gvproxy services API returned an invalid HTTP response")]
+    InvalidApiResponse,
+
+    /// The gvproxy services response exceeded the fixed bound.
+    #[error("gvproxy services API response exceeded {MAX_API_RESPONSE_BYTES} bytes")]
+    ApiResponseTooLarge,
+
+    /// A gvproxy request or response could not be encoded.
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    /// Child-process, socket, or filesystem I/O failed.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+/// One owned gvproxy process supplying a private network stack to one VM.
+///
+/// The caller supplies an exclusive state directory. The process creates its
+/// vfkit-compatible unixgram socket and private services socket there. Dropping
+/// this value terminates and reaps gvproxy.
+pub struct Gvproxy {
+    child: Child,
+    network_socket: PathBuf,
+    services_socket: PathBuf,
+}
+
+impl Gvproxy {
+    /// Starts gvproxy and waits for both of its local sockets to become ready.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the state directory or log cannot be prepared,
+    /// gvproxy cannot start, or its network and services sockets do not become
+    /// ready before the startup deadline.
+    pub fn spawn(binary: &Path, state_directory: &Path, log: &Path) -> Result<Self, GvproxyError> {
+        Self::spawn_with_process_group(binary, state_directory, log, ProcessGroup::Inherited)
+    }
+
+    /// Starts gvproxy in a new process group and waits for its sockets.
+    ///
+    /// This is useful when an application handles terminal interrupts itself
+    /// and must keep owned VM work alive long enough to drain it. Dropping the
+    /// returned owner still terminates and reaps gvproxy.
+    ///
+    /// # Errors
+    ///
+    /// Returns the errors documented by [`Self::spawn`].
+    pub fn spawn_isolated(
+        binary: &Path,
+        state_directory: &Path,
+        log: &Path,
+    ) -> Result<Self, GvproxyError> {
+        Self::spawn_with_process_group(binary, state_directory, log, ProcessGroup::Isolated)
+    }
+
+    fn spawn_with_process_group(
+        binary: &Path,
+        state_directory: &Path,
+        log: &Path,
+        process_group: ProcessGroup,
+    ) -> Result<Self, GvproxyError> {
+        fs::create_dir_all(state_directory)?;
+        if let Some(parent) = log.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let network_socket = state_directory.join("network.sock");
+        let services_socket = state_directory.join("services.sock");
+        remove_stale_socket(&network_socket)?;
+        remove_stale_socket(&services_socket)?;
+
+        let log = fs::File::create(log)?;
+        let mut command = std::process::Command::new(binary);
+        command
+            .arg("--listen-vfkit")
+            .arg(format!("unixgram:{}", network_socket.display()))
+            .arg("--services")
+            .arg(format!("unix://{}", services_socket.display()))
+            .arg("--ssh-port")
+            .arg("-1")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(log);
+        if process_group == ProcessGroup::Isolated {
+            command.process_group(0);
+        }
+        let mut child = command.spawn()?;
+
+        let started_at = Instant::now();
+        while !network_socket.exists() || !services_socket.exists() {
+            if let Some(status) = child.try_wait()? {
+                return Err(GvproxyError::EarlyExit(status));
+            }
+            if started_at.elapsed() >= SOCKET_TIMEOUT {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(GvproxyError::SocketTimeout {
+                    path: if network_socket.exists() {
+                        services_socket
+                    } else {
+                        network_socket
+                    },
+                    timeout: SOCKET_TIMEOUT,
+                });
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        Ok(Self {
+            child,
+            network_socket,
+            services_socket,
+        })
+    }
+
+    /// Returns the vfkit-compatible unixgram network socket.
+    #[must_use]
+    pub fn network_socket(&self) -> &Path {
+        &self.network_socket
+    }
+
+    /// Forwards one loopback-only host TCP listener to a guest TCP listener.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for a non-loopback or unspecified host endpoint, a
+    /// services-socket failure, or a rejected gvproxy request.
+    pub fn forward_tcp(&self, local: SocketAddr, remote: SocketAddr) -> Result<(), GvproxyError> {
+        if !local.ip().is_loopback() {
+            return Err(GvproxyError::NonLoopbackForward(local));
+        }
+        if local.port() == 0 {
+            return Err(GvproxyError::UnspecifiedHostPort);
+        }
+        let body = serde_json::to_vec(&ExposeRequest {
+            local,
+            remote,
+            protocol: "tcp",
+        })?;
+        services_request(&self.services_socket, "/services/forwarder/expose", &body)
+    }
+
+    /// Removes a previously configured loopback TCP forward.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the services socket cannot be reached or gvproxy
+    /// rejects the request.
+    pub fn unforward_tcp(&self, local: SocketAddr) -> Result<(), GvproxyError> {
+        if !local.ip().is_loopback() {
+            return Err(GvproxyError::NonLoopbackForward(local));
+        }
+        if local.port() == 0 {
+            return Err(GvproxyError::UnspecifiedHostPort);
+        }
+        let body = serde_json::to_vec(&UnexposeRequest {
+            local,
+            protocol: "tcp",
+        })?;
+        services_request(&self.services_socket, "/services/forwarder/unexpose", &body)
+    }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum ProcessGroup {
+    Inherited,
+    Isolated,
+}
+
+impl Drop for Gvproxy {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[derive(Serialize)]
+struct ExposeRequest {
+    local: SocketAddr,
+    remote: SocketAddr,
+    protocol: &'static str,
+}
+
+#[derive(Serialize)]
+struct UnexposeRequest {
+    local: SocketAddr,
+    protocol: &'static str,
+}
+
+fn remove_stale_socket(path: &Path) -> Result<(), io::Error> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn services_request(socket: &Path, path: &str, body: &[u8]) -> Result<(), GvproxyError> {
+    let mut stream = UnixStream::connect(socket)?;
+    stream.set_read_timeout(Some(API_TIMEOUT))?;
+    stream.set_write_timeout(Some(API_TIMEOUT))?;
+    write!(
+        stream,
+        "POST {path} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    )?;
+    stream.write_all(body)?;
+    stream.flush()?;
+
+    let mut response = Vec::new();
+    stream
+        .take(
+            u64::try_from(MAX_API_RESPONSE_BYTES)
+                .unwrap_or(u64::MAX)
+                .saturating_add(1),
+        )
+        .read_to_end(&mut response)?;
+    if response.len() > MAX_API_RESPONSE_BYTES {
+        return Err(GvproxyError::ApiResponseTooLarge);
+    }
+    let response = String::from_utf8_lossy(&response);
+    let (head, body) = response
+        .split_once("\r\n\r\n")
+        .ok_or(GvproxyError::InvalidApiResponse)?;
+    let status = head
+        .lines()
+        .next()
+        .ok_or(GvproxyError::InvalidApiResponse)?;
+    if !status.starts_with("HTTP/1.1 200 ") && !status.starts_with("HTTP/1.0 200 ") {
+        return Err(GvproxyError::Api {
+            status: status.to_owned(),
+            body: body.trim().to_owned(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        net::{Ipv4Addr, SocketAddrV4},
+        os::unix::{fs::PermissionsExt as _, net::UnixListener},
+    };
+
+    use nix::unistd::getpgrp;
+
+    use super::*;
+
+    #[test]
+    fn caller_selects_inherited_or_isolated_process_group() {
+        let inherited = recorded_process_group(Gvproxy::spawn);
+        let isolated = recorded_process_group(Gvproxy::spawn_isolated);
+        let parent_group = getpgrp().as_raw();
+
+        assert_eq!(inherited.1, parent_group);
+        assert_ne!(inherited.0, inherited.1);
+        assert_eq!(isolated.0, isolated.1);
+        assert_ne!(isolated.1, parent_group);
+    }
+
+    fn recorded_process_group(
+        spawn: fn(&Path, &Path, &Path) -> Result<Gvproxy, GvproxyError>,
+    ) -> (i32, i32) {
+        let directory = tempfile::tempdir().unwrap();
+        let binary = directory.path().join("fake-gvproxy");
+        let record = directory.path().join("process-group");
+        fs::write(
+            &binary,
+            "#!/bin/sh\n\
+             directory=$(CDPATH= cd -- \"$(dirname -- \"$0\")\" && pwd)\n\
+             pid=$$\n\
+             pgid=$(ps -o pgid= -p \"$pid\" | tr -d ' ')\n\
+             printf '%s %s\\n' \"$pid\" \"$pgid\" > \"$directory/process-group\"\n\
+             exit 7\n",
+        )
+        .unwrap();
+        fs::set_permissions(&binary, fs::Permissions::from_mode(0o700)).unwrap();
+
+        let result = spawn(
+            &binary,
+            &directory.path().join("state"),
+            &directory.path().join("gvproxy.log"),
+        );
+        assert!(matches!(result, Err(GvproxyError::EarlyExit(_))));
+
+        let values = fs::read_to_string(record)
+            .unwrap()
+            .split_whitespace()
+            .map(|value| value.parse::<i32>().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(values.len(), 2);
+        (values[0], values[1])
+    }
+
+    #[test]
+    fn refuses_non_loopback_forwards_before_contacting_gvproxy() {
+        let proxy = Gvproxy {
+            child: std::process::Command::new("/usr/bin/true").spawn().unwrap(),
+            network_socket: PathBuf::new(),
+            services_socket: PathBuf::new(),
+        };
+        let local = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 9222));
+        let remote = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 168, 127, 2), 9222));
+
+        assert!(matches!(
+            proxy.forward_tcp(local, remote),
+            Err(GvproxyError::NonLoopbackForward(address)) if address == local
+        ));
+        assert!(matches!(
+            proxy.unforward_tcp(local),
+            Err(GvproxyError::NonLoopbackForward(address)) if address == local
+        ));
+    }
+
+    #[test]
+    fn bounds_untrusted_services_api_responses() {
+        let directory = tempfile::tempdir().unwrap();
+        let socket = directory.path().join("services.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 4 * 1024];
+            let _ = stream.read(&mut request).unwrap();
+            stream
+                .write_all(&vec![b'x'; MAX_API_RESPONSE_BYTES + 1])
+                .unwrap();
+        });
+
+        assert!(matches!(
+            services_request(&socket, "/services/test", b"{}"),
+            Err(GvproxyError::ApiResponseTooLarge)
+        ));
+        server.join().unwrap();
+    }
+}

--- a/crates/experimental/nanocodex-vm/src/image/disk.rs
+++ b/crates/experimental/nanocodex-vm/src/image/disk.rs
@@ -1,0 +1,79 @@
+use std::{fs, io, path::Path};
+
+#[cfg(target_os = "linux")]
+use std::process::{Command, Stdio};
+
+/// Copies a disk with reflink semantics when available and a sparse fallback.
+///
+/// The destination must not exist. A failed reflink attempt is cleaned before
+/// the fallback begins, and a failed fallback never leaves a partial disk.
+///
+/// # Errors
+///
+/// Returns an I/O error when the source cannot be read, the destination
+/// cannot be created, or neither reflink nor sparse copying succeeds.
+pub fn reflink_or_sparse_copy(source: &Path, destination: &Path) -> io::Result<u64> {
+    match reflink_copy::reflink(source, destination) {
+        Ok(()) => return Ok(fs::metadata(destination)?.len()),
+        Err(_) => remove_partial_copy(destination)?,
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let status = Command::new("cp")
+            .args(["--reflink=never", "--sparse=always", "--"])
+            .arg(source)
+            .arg(destination)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()?;
+        if status.success() {
+            return Ok(fs::metadata(destination)?.len());
+        }
+        remove_partial_copy(destination)?;
+        Err(io::Error::other(format!(
+            "sparse disk copy failed with {status}"
+        )))
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fs::copy(source, destination)
+}
+
+fn remove_partial_copy(path: &Path) -> io::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use std::{
+        fs::{self, File},
+        io::{Seek, SeekFrom, Write},
+        os::unix::fs::MetadataExt,
+    };
+
+    use super::reflink_or_sparse_copy;
+
+    #[test]
+    fn fallback_preserves_sparse_disk_allocation() {
+        let directory = tempfile::tempdir().unwrap();
+        let source = directory.path().join("source.ext4");
+        let destination = directory.path().join("destination.ext4");
+        let mut file = File::create(&source).unwrap();
+        file.seek(SeekFrom::Start(64 * 1024 * 1024)).unwrap();
+        file.write_all(b"disk-tail").unwrap();
+        drop(file);
+
+        reflink_or_sparse_copy(&source, &destination).unwrap();
+
+        let source_metadata = fs::metadata(&source).unwrap();
+        let destination_metadata = fs::metadata(&destination).unwrap();
+        assert_eq!(destination_metadata.len(), source_metadata.len());
+        assert!(destination_metadata.blocks().saturating_mul(512) < destination_metadata.len() / 4);
+    }
+}

--- a/crates/experimental/nanocodex-vm/src/image/disk.rs
+++ b/crates/experimental/nanocodex-vm/src/image/disk.rs
@@ -1,20 +1,40 @@
-use std::{fs, io, path::Path};
+use std::{fs, io, os::unix::fs::PermissionsExt as _, path::Path};
 
 #[cfg(target_os = "linux")]
 use std::process::{Command, Stdio};
 
 /// Copies a disk with reflink semantics when available and a sparse fallback.
 ///
-/// The destination must not exist. A failed reflink attempt is cleaned before
-/// the fallback begins, and a failed fallback never leaves a partial disk.
+/// The destination must not exist. The copy is materialized under a private
+/// temporary directory next to the destination and published without replacing
+/// any path that appeared concurrently. A failed attempt never modifies the
+/// destination or leaves a partial disk there.
 ///
 /// # Errors
 ///
 /// Returns an I/O error when the source cannot be read, the destination
 /// cannot be created, or neither reflink nor sparse copying succeeds.
 pub fn reflink_or_sparse_copy(source: &Path, destination: &Path) -> io::Result<u64> {
+    let parent = destination
+        .parent()
+        .ok_or_else(|| io::Error::other("disk copy destination has no parent directory"))?;
+    let temporary_directory = tempfile::Builder::new()
+        .prefix(".nanocodex-disk-copy.")
+        .tempdir_in(parent)?;
+    let temporary = temporary_directory.path().join("disk.ext4");
+    copy_into_owned_path(source, &temporary)?;
+    let metadata = fs::metadata(&temporary)?;
+    let bytes = metadata.len();
+    let mut permissions = metadata.permissions();
+    permissions.set_mode(0o600);
+    fs::set_permissions(&temporary, permissions)?;
+    fs::hard_link(&temporary, destination)?;
+    Ok(bytes)
+}
+
+fn copy_into_owned_path(source: &Path, destination: &Path) -> io::Result<()> {
     match reflink_copy::reflink(source, destination) {
-        Ok(()) => return Ok(fs::metadata(destination)?.len()),
+        Ok(()) => return Ok(()),
         Err(_) => remove_partial_copy(destination)?,
     }
 
@@ -29,7 +49,7 @@ pub fn reflink_or_sparse_copy(source: &Path, destination: &Path) -> io::Result<u
             .stderr(Stdio::null())
             .status()?;
         if status.success() {
-            return Ok(fs::metadata(destination)?.len());
+            return Ok(());
         }
         remove_partial_copy(destination)?;
         Err(io::Error::other(format!(
@@ -38,7 +58,7 @@ pub fn reflink_or_sparse_copy(source: &Path, destination: &Path) -> io::Result<u
     }
 
     #[cfg(not(target_os = "linux"))]
-    fs::copy(source, destination)
+    fs::copy(source, destination).map(|_| ())
 }
 
 fn remove_partial_copy(path: &Path) -> io::Result<()> {
@@ -49,16 +69,21 @@ fn remove_partial_copy(path: &Path) -> io::Result<()> {
     }
 }
 
-#[cfg(all(test, target_os = "linux"))]
+#[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt as _;
+
+    #[cfg(target_os = "linux")]
     use std::{
-        fs::{self, File},
+        fs::File,
         io::{Seek, SeekFrom, Write},
-        os::unix::fs::MetadataExt,
+        os::unix::fs::MetadataExt as _,
     };
 
     use super::reflink_or_sparse_copy;
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn fallback_preserves_sparse_disk_allocation() {
         let directory = tempfile::tempdir().unwrap();
@@ -75,5 +100,35 @@ mod tests {
         let destination_metadata = fs::metadata(&destination).unwrap();
         assert_eq!(destination_metadata.len(), source_metadata.len());
         assert!(destination_metadata.blocks().saturating_mul(512) < destination_metadata.len() / 4);
+    }
+
+    #[test]
+    fn existing_destination_is_never_replaced() {
+        let directory = tempfile::tempdir().unwrap();
+        let source = directory.path().join("source.ext4");
+        let destination = directory.path().join("destination.ext4");
+        fs::write(&source, b"new disk").unwrap();
+        fs::write(&destination, b"existing disk").unwrap();
+
+        let error = reflink_or_sparse_copy(&source, &destination).unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+        assert_eq!(fs::read(&destination).unwrap(), b"existing disk");
+    }
+
+    #[test]
+    fn published_disk_is_private_and_writable() {
+        let directory = tempfile::tempdir().unwrap();
+        let source = directory.path().join("source.ext4");
+        let destination = directory.path().join("destination.ext4");
+        fs::write(&source, b"disk").unwrap();
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o644)).unwrap();
+
+        reflink_or_sparse_copy(&source, &destination).unwrap();
+
+        assert_eq!(
+            fs::metadata(destination).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
     }
 }

--- a/crates/experimental/nanocodex-vm/src/image/mod.rs
+++ b/crates/experimental/nanocodex-vm/src/image/mod.rs
@@ -1,8 +1,8 @@
 //! Content-addressed OCI and Dockerfile root disks for Nanocodex VMs.
 //!
-//! The cache owns immutable prepared disks. Each VM attempt should take a
-//! cheap copy-on-write clone with [`PreparedRootDisk::reflink_to`] and mutate
-//! only that disposable copy.
+//! The cache owns immutable prepared disks. Each VM attempt should use
+//! [`PreparedRootDisk::private_workspace`] to take a cheap copy-on-write clone,
+//! inherit the image's runtime metadata, and mutate only that disposable copy.
 //!
 //! # Prepare and instantiate an image
 //!
@@ -31,8 +31,17 @@
 //!         CachePolicy::Reuse,
 //!     )
 //!     .await?;
-//! std::fs::create_dir_all(".nanocodex/attempts/018f")?;
-//! image.reflink_to(".nanocodex/attempts/018f/root.ext4")?;
+//! let workspace = image
+//!     .private_workspace(
+//!         ".nanocodex/attempts/018f/root.ext4",
+//!         "target/debug/vm-tools",
+//!     )?
+//!     .vmm_argument("--vmm")
+//!     .guest_runtime_disk(runtime.path())
+//!     .firmware_directory(".cache/libkrunfw/libkrunfw")
+//!     .launch()
+//!     .await?;
+//! # workspace.shutdown().await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -58,15 +67,21 @@ use std::{
     ffi::OsString,
     fs::{self, File},
     io::{self, BufReader, Read, Seek, SeekFrom, Write},
+    os::unix::{
+        ffi::OsStrExt as _,
+        fs::{MetadataExt as _, PermissionsExt as _},
+    },
     path::{Component, Path, PathBuf},
+    sync::Arc,
     time::Duration,
 };
 
 use crate::{
     command::GuestCommand,
-    config::{BlockDevice, VmConfig},
+    config::{BlockDevice, Network, VmConfig},
     egress::EgressLease,
     tools::{VmCommand, VmToolSession, VmToolSessionError},
+    workspace::{VmWorkspaceBuilder, VmWorkspaceError},
 };
 use arcbox_ext4::{Formatter, Reader};
 use flate2::read::GzDecoder;
@@ -78,14 +93,16 @@ use oci_client::{
 };
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use sha2::{Digest, Sha256};
-use tokio::process::Command;
+use tokio::{process::Command, sync::Mutex as AsyncMutex};
 use tracing::{Instrument, info, info_span};
 
 const BLOCK_SIZE: u32 = 4_096;
 const MINIMUM_DISK_BYTES: u64 = 512 * 1024 * 1024;
 const CACHE_RECORD_VERSION: u32 = 2;
-const IMAGE_BUILD_CACHE_VERSION: u32 = 1;
-const PREPARED_DISK_RECORD_VERSION: u32 = 1;
+const IMAGE_BUILD_CACHE_VERSION: u32 = 2;
+const PREPARED_DISK_RECORD_VERSION: u32 = 3;
+const CACHED_EXT4_RECORD_VERSION: u32 = 2;
+const BLOB_RECORD_VERSION: u32 = 2;
 const CONTEXT_DISK_BYTES: u64 = 128 * 1024 * 1024;
 const DEFAULT_RUN_TIMEOUT: Duration = Duration::from_mins(30);
 const DEFAULT_COPY_TIMEOUT: Duration = Duration::from_mins(10);
@@ -97,6 +114,13 @@ const BUILD_RUNTIME_DEVICE: &str = "/dev/vdb";
 const BUILD_CONTEXT_DEVICE: &str = "/dev/vdc";
 const BUILD_RUNTIME_MOUNT: &str = "/run/nanocodex";
 const BUILD_CONTEXT_MOUNT: &str = "/mnt/nanocodex-context";
+const BUILD_RESOLVER_STATE: &str = "/run/nanocodex-build-resolver";
+const RESTORE_BUILD_RESOLVER_SCRIPT: &str = r#"set -eu
+rm -f /etc/resolv.conf
+if [ -e /run/nanocodex-build-resolver/original ] || [ -L /run/nanocodex-build-resolver/original ]; then
+  mv /run/nanocodex-build-resolver/original /etc/resolv.conf
+fi
+rm -rf /run/nanocodex-build-resolver"#;
 const DEFAULT_GUEST_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 const DEFAULT_BUILD_VM_CPUS: u8 = 2;
 const DEFAULT_BUILD_VM_MEMORY_MIB: u32 = 4_096;
@@ -146,6 +170,9 @@ pub struct VmImageBuilder {
     run_timeout: Duration,
     copy_timeout: Duration,
     egress: EgressLease,
+    vmm_digest: Arc<AsyncMutex<Option<CachedFileDigest>>>,
+    runtime_digest: Arc<AsyncMutex<Option<CachedFileDigest>>>,
+    firmware_digest: Arc<AsyncMutex<Option<CachedFileDigest>>>,
 }
 
 impl VmImageBuilder {
@@ -169,6 +196,9 @@ impl VmImageBuilder {
             run_timeout: DEFAULT_RUN_TIMEOUT,
             copy_timeout: DEFAULT_COPY_TIMEOUT,
             egress: EgressLease::internet(),
+            vmm_digest: Arc::new(AsyncMutex::new(None)),
+            runtime_digest: Arc::new(AsyncMutex::new(None)),
+            firmware_digest: Arc::new(AsyncMutex::new(None)),
         }
     }
 
@@ -176,10 +206,14 @@ impl VmImageBuilder {
     ///
     /// A present `libkrunfw.5.dylib` on macOS or `libkrunfw.so.5` on Linux is
     /// added to the dedicated VMM's platform library search path. Builders and
-    /// VMMs with system-installed firmware can omit this setting.
+    /// VMMs with system-installed firmware can omit this setting. Set it
+    /// explicitly when reproducible build-cache invalidation across firmware
+    /// upgrades matters; system-installed firmware is treated as caller-owned
+    /// stable runtime state.
     #[must_use]
     pub fn firmware_directory(mut self, directory: impl Into<PathBuf>) -> Self {
         self.firmware_directory = Some(directory.into());
+        self.firmware_digest = Arc::new(AsyncMutex::new(None));
         self
     }
 
@@ -269,11 +303,53 @@ impl VmImageBuilder {
         self
     }
 
+    async fn build_cache_inputs(&self) -> Result<BuildCacheInputs, ImageError> {
+        let network = match self.egress.network() {
+            Network::Disabled => "disabled",
+            Network::Internet => "internet",
+            Network::Gvproxy { .. } => "gvproxy",
+        }
+        .to_owned();
+        let egress_scope = self
+            .egress
+            .build_cache_scope()
+            .ok_or(ImageError::UnscopedBuildEgress)?
+            .to_owned();
+        let (vmm_digest, runtime_digest, firmware_digest) =
+            if let Some(directory) = &self.firmware_directory {
+                let firmware = directory.join(FIRMWARE_LIBRARY_FILENAME);
+                let (vmm_digest, runtime_digest, firmware_digest) = tokio::try_join!(
+                    cached_file_digest(&self.vmm, &self.vmm_digest),
+                    cached_file_digest(&self.runtime_image, &self.runtime_digest),
+                    cached_file_digest(&firmware, &self.firmware_digest),
+                )?;
+                (vmm_digest, runtime_digest, firmware_digest)
+            } else {
+                let (vmm_digest, runtime_digest) = tokio::try_join!(
+                    cached_file_digest(&self.vmm, &self.vmm_digest),
+                    cached_file_digest(&self.runtime_image, &self.runtime_digest),
+                )?;
+                (vmm_digest, runtime_digest, "system-firmware".to_owned())
+            };
+        Ok(BuildCacheInputs {
+            vmm_digest,
+            runtime_digest,
+            firmware_digest,
+            resolver: match self.egress.network() {
+                Network::Internet => Some(host_resolver_configuration()?),
+                Network::Disabled | Network::Gvproxy { .. } => None,
+            },
+            network,
+            egress_scope,
+        })
+    }
+
     /// Prepares one immutable root disk from `directory/Dockerfile`.
     ///
     /// `disk_bytes` is rounded up to the minimum supported root-disk size.
-    /// Cache keys include the Dockerfile, ordered context archive, base
-    /// image manifests, target platform, and final disk size.
+    /// Cache keys include the Dockerfile, ordered context archive, base image
+    /// manifests, target platform and disk size, plus the complete build VM,
+    /// resolver, and non-secret egress execution identity.
     ///
     /// # Errors
     ///
@@ -438,6 +514,13 @@ pub enum ImageError {
     #[error("root disk formatting task failed: {0}")]
     Join(#[from] tokio::task::JoinError),
 
+    /// Guest-visible egress state can affect a build but has no safe cache
+    /// identity.
+    #[error(
+        "Dockerfile build output cannot be cached because the egress lease has no build-cache scope"
+    )]
+    UnscopedBuildEgress,
+
     /// The constrained Dockerfile parser rejected an instruction.
     #[error("unsupported Dockerfile instruction: {0}")]
     UnsupportedDockerfile(String),
@@ -512,6 +595,11 @@ impl PreparedRootDisk {
             .get(&final_stage.base_image)
             .ok_or_else(|| ImageError::UnknownCopySource(final_stage.base_image.clone()))?;
         let (path, disk_status, environment, shell) = if recipe.requires_build() {
+            let build_cache_inputs = builder.build_cache_inputs().await?;
+            let execution = BuildExecution {
+                builder,
+                cache_inputs: &build_cache_inputs,
+            };
             prepare_built_disk(
                 directory,
                 &dockerfile,
@@ -519,7 +607,7 @@ impl PreparedRootDisk {
                 &images,
                 cache,
                 disk_bytes,
-                builder,
+                &execution,
             )
             .await?
         } else {
@@ -528,14 +616,17 @@ impl PreparedRootDisk {
             (
                 path,
                 status,
-                docker_process_environment(&final_image.config.environment),
+                final_recipe_environment(&recipe, &images)?,
                 shell,
             )
         };
         Ok(Self {
             shell,
             path,
-            workdir: recipe.final_workdir().to_owned(),
+            workdir: recipe
+                .final_workdir()
+                .unwrap_or(&final_image.config.working_directory)
+                .to_owned(),
             environment,
             manifest_digest: final_image.manifest_digest.clone(),
             manifest_source: final_image.source,
@@ -608,6 +699,29 @@ impl PreparedRootDisk {
         }
         Ok(reflink_or_sparse_copy(&self.path, destination)?)
     }
+
+    /// Materializes a private writable root and applies this image's runtime
+    /// working directory, shell, and environment to its workspace builder.
+    ///
+    /// This is the normal library path from a prepared image to a retained VM.
+    /// The caller can continue configuring the returned builder with a guest
+    /// runtime disk, firmware, resources, and egress policy before launch.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the private root cannot be materialized.
+    pub fn private_workspace(
+        &self,
+        private_rootfs: impl Into<PathBuf>,
+        vmm_executable: impl Into<PathBuf>,
+    ) -> Result<VmWorkspaceBuilder, VmWorkspaceError> {
+        Ok(
+            VmWorkspaceBuilder::private_from(&self.path, private_rootfs, vmm_executable)?
+                .guest_workspace(self.workdir.clone())
+                .shell(self.shell.clone())
+                .environment(self.environment.clone()),
+        )
+    }
 }
 
 #[derive(Deserialize, Serialize)]
@@ -623,9 +737,37 @@ struct ReferenceRecord {
 #[derive(Deserialize, Serialize)]
 struct PreparedDiskRecord {
     version: u32,
-    file_bytes: u64,
-    modified_nanos: u128,
+    file: CacheFileIdentity,
     shell: String,
+}
+
+#[derive(Deserialize, Serialize)]
+struct BlobRecord {
+    version: u32,
+    digest: String,
+    file: CacheFileIdentity,
+}
+
+#[derive(Deserialize, Serialize)]
+struct CachedExt4Record {
+    version: u32,
+    file: CacheFileIdentity,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct CacheFileIdentity {
+    bytes: u64,
+    modified_nanos: u128,
+    changed_seconds: i64,
+    changed_nanos: i64,
+    device: u64,
+    inode: u64,
+}
+
+#[derive(Clone, Debug)]
+struct CachedFileDigest {
+    file: CacheFileIdentity,
+    digest: String,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -634,10 +776,34 @@ struct LayerRecord {
     media_type: String,
 }
 
-#[derive(Clone, Default, Deserialize, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
 struct ImageRuntimeConfig {
     environment: BTreeMap<String, String>,
     working_directory: String,
+}
+
+impl Default for ImageRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            environment: BTreeMap::new(),
+            working_directory: "/".to_owned(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct BuildCacheInputs {
+    vmm_digest: String,
+    runtime_digest: String,
+    firmware_digest: String,
+    resolver: Option<String>,
+    network: String,
+    egress_scope: String,
+}
+
+struct BuildExecution<'a> {
+    builder: &'a VmImageBuilder,
+    cache_inputs: &'a BuildCacheInputs,
 }
 
 fn read_cache_record<T: DeserializeOwned>(path: &Path) -> Result<Option<T>, ImageError> {
@@ -842,7 +1008,7 @@ impl DockerfileRecipe {
         self.stages.last()
     }
 
-    fn final_workdir(&self) -> &str {
+    fn final_workdir(&self) -> Option<&str> {
         self.final_stage()
             .into_iter()
             .flat_map(|stage| stage.instructions.iter().rev())
@@ -854,17 +1020,17 @@ impl DockerfileRecipe {
                 | DockerfileInstruction::Arg { .. }
                 | DockerfileInstruction::Cmd(_) => None,
             })
-            .unwrap_or("/")
     }
 
     fn requires_build(&self) -> bool {
-        self.stages.len() != 1
-            || self.stages.iter().any(|stage| {
-                stage
-                    .instructions
-                    .iter()
-                    .any(|instruction| !matches!(instruction, DockerfileInstruction::Workdir(_)))
+        self.stages.iter().any(|stage| {
+            stage.instructions.iter().any(|instruction| {
+                matches!(
+                    instruction,
+                    DockerfileInstruction::Run(_) | DockerfileInstruction::Copy(_)
+                )
             })
+        })
     }
 }
 
@@ -1091,7 +1257,7 @@ async fn prepare_flattened_disk(
     .await??;
     validate_root_disk(&temporary)?;
     publish(temporary, &path)?;
-    let shell = cached_prepared_shell(&path)?;
+    let shell = record_prepared_disk(&path)?;
     Ok((path, DiskStatus::Created, shell))
 }
 
@@ -1102,7 +1268,7 @@ async fn prepare_copy_source_disk(
 ) -> Result<PathBuf, ImageError> {
     let key = disk_cache_key(&image.manifest_digest, disk_bytes);
     let path = cache.join("images").join(format!("{key}.ext4"));
-    if valid_cached_ext4_disk(&path) {
+    if valid_cached_ext4_disk(&path)? {
         return Ok(path);
     }
     let parent = path
@@ -1110,7 +1276,7 @@ async fn prepare_copy_source_disk(
         .ok_or_else(|| io::Error::other("prepared copy source disk cache path has no parent"))?;
     fs::create_dir_all(parent)?;
     let _lock = acquire_cache_lock(cache, "images", &key).await?;
-    if valid_cached_ext4_disk(&path) {
+    if valid_cached_ext4_disk(&path)? {
         return Ok(path);
     }
     let temporary = temporary_path(parent, &format!(".{key}."))?;
@@ -1129,6 +1295,7 @@ async fn prepare_copy_source_disk(
     .await??;
     validate_ext4_disk(&temporary)?;
     publish(temporary, &path)?;
+    record_cached_ext4_disk(&path)?;
     Ok(path)
 }
 
@@ -1139,8 +1306,10 @@ async fn prepare_built_disk(
     images: &BTreeMap<String, PulledImage>,
     cache: &Path,
     disk_bytes: u64,
-    builder: &VmImageBuilder,
+    execution: &BuildExecution<'_>,
 ) -> Result<(PathBuf, DiskStatus, BTreeMap<String, String>, String), ImageError> {
+    let builder = execution.builder;
+    let build_cache_inputs = execution.cache_inputs;
     let context_directory = context_directory.to_path_buf();
     let context_cache = cache.to_path_buf();
     let span = info_span!(
@@ -1154,7 +1323,15 @@ async fn prepare_built_disk(
         span.in_scope(|| prepare_context_disk(&context_directory, &context_cache, disk_bytes))
     })
     .await??;
-    let key = build_cache_key(dockerfile, &context_digest, recipe, images, disk_bytes);
+    let key = build_cache_key(
+        dockerfile,
+        &context_digest,
+        recipe,
+        images,
+        disk_bytes,
+        builder,
+        build_cache_inputs,
+    );
     let builds = cache.join("builds");
     fs::create_dir_all(&builds)?;
     let path = builds.join(format!("{key}.ext4"));
@@ -1197,17 +1374,18 @@ async fn prepare_built_disk(
             &stage_disks,
             &stage_root,
             builder,
+            build_cache_inputs.resolver.as_deref(),
         )
         .instrument(span)
         .await?;
         stage_disks.push(stage_root);
     }
     let final_stage = stage_disks.last().ok_or(ImageError::InvalidFrom)?;
-    let published = temporary_path(&builds, &format!(".{key}.publish."))?;
+    let published = temporary.path().join("published.ext4");
     reflink_or_sparse_copy(final_stage, &published)?;
     validate_root_disk(&published)?;
-    publish(published, &path)?;
-    let shell = cached_prepared_shell(&path)?;
+    fs::rename(published, &path)?;
+    let shell = record_prepared_disk(&path)?;
     Ok((path, DiskStatus::Created, final_environment, shell))
 }
 
@@ -1268,7 +1446,7 @@ fn prepare_context_disk(
     let key = hex::encode(identity.finalize());
     let path = contexts.join(format!("{key}.ext4"));
     let _lock = CacheLock::acquire(cache, "contexts", &key)?;
-    if !valid_cached_ext4_disk(&path) {
+    if !valid_cached_ext4_disk(&path)? {
         archive_file.as_file_mut().seek(SeekFrom::Start(0))?;
         let temporary = temporary_path(&contexts, &format!(".{key}."))?;
         let mut formatter = Formatter::new(&temporary, BLOCK_SIZE, disk_bytes)?;
@@ -1276,6 +1454,7 @@ fn prepare_context_disk(
         formatter.close()?;
         validate_ext4_disk(&temporary)?;
         publish(temporary, &path)?;
+        record_cached_ext4_disk(&path)?;
     }
     validate_ext4_disk(&path)?;
     Ok((path, digest))
@@ -1358,6 +1537,7 @@ async fn execute_stage(
     stage_disks: &[PathBuf],
     stage_root: &Path,
     builder: &VmImageBuilder,
+    resolver: Option<&str>,
 ) -> Result<(), ImageError> {
     let mut mounts = Vec::<BuildMount>::new();
     let mut source_mounts = BTreeMap::<String, String>::new();
@@ -1404,7 +1584,8 @@ async fn execute_stage(
         });
     }
 
-    let (command, config, guest) = build_vmm_inputs(builder, stage_root, context_image, &mounts)?;
+    let (command, config, guest) =
+        build_vmm_inputs(builder, stage_root, context_image, &mounts, resolver)?;
     let session =
         VmToolSession::spawn_configured(command, config, guest, builder.egress.clone()).await?;
     let execution = execute_stage_inner(
@@ -1417,8 +1598,23 @@ async fn execute_stage(
         builder,
     )
     .await;
+    let resolver_cleanup = if resolver.is_some() {
+        run_build_command(
+            &session,
+            stage_index,
+            stage.instructions.len(),
+            VmCommand::new("/bin/sh")
+                .arg("-c")
+                .arg(RESTORE_BUILD_RESOLVER_SCRIPT)
+                .timeout(builder.copy_timeout),
+        )
+        .await
+    } else {
+        Ok(())
+    };
     let shutdown = session.shutdown().await;
     execution?;
+    resolver_cleanup?;
     shutdown?;
     Ok(())
 }
@@ -1428,6 +1624,7 @@ fn build_vmm_inputs(
     stage_root: &Path,
     context_image: &Path,
     mounts: &[BuildMount],
+    resolver: Option<&str>,
 ) -> Result<(Command, VmConfig, GuestCommand), ImageError> {
     let mut command = Command::new(&builder.vmm);
     command.args(&builder.vmm_arguments);
@@ -1445,15 +1642,14 @@ fn build_vmm_inputs(
     for mount in mounts {
         config = config.block_device(BlockDevice::read_only(&mount.key, &mount.disk));
     }
-    let resolver = host_resolver_configuration()?;
     let guest = GuestCommand::new("/bin/sh")
         .arg("-c")
-        .arg(build_guest_bootstrap_script(&resolver, builder.prefer_ipv4))
+        .arg(build_guest_bootstrap_script(resolver, builder.prefer_ipv4))
         .arg("nanocodex-vm-image-build");
     Ok((command, config, guest))
 }
 
-fn build_guest_bootstrap_script(resolver: &str, prefer_ipv4: bool) -> String {
+fn build_guest_bootstrap_script(resolver: Option<&str>, prefer_ipv4: bool) -> String {
     let address_preference = if prefer_ipv4 {
         concat!(
             "if ! printf 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6; then printf '%s\\n' 'nanocodex image build bootstrap: failed to write /proc/sys/net/ipv6/conf/all/disable_ipv6' >&2; exit 125; fi; ",
@@ -1462,8 +1658,13 @@ fn build_guest_bootstrap_script(resolver: &str, prefer_ipv4: bool) -> String {
     } else {
         ""
     };
+    let resolver = resolver.map_or_else(String::new, |resolver| {
+        format!(
+            "rm -rf {BUILD_RESOLVER_STATE} && mkdir -p {BUILD_RESOLVER_STATE} && if [ -e /etc/resolv.conf ] || [ -L /etc/resolv.conf ]; then mv /etc/resolv.conf {BUILD_RESOLVER_STATE}/original; fi && printf '{resolver}' > /etc/resolv.conf && "
+        )
+    });
     format!(
-        "{address_preference}printf '{resolver}' > /etc/resolv.conf && mkdir -p {BUILD_RUNTIME_MOUNT} && mount -t ext4 -o ro {BUILD_RUNTIME_DEVICE} {BUILD_RUNTIME_MOUNT} && exec {BUILD_RUNTIME_MOUNT}/nanocodex-vm-guest /"
+        "{address_preference}{resolver}mkdir -p {BUILD_RUNTIME_MOUNT} && mount -t ext4 -o ro {BUILD_RUNTIME_DEVICE} {BUILD_RUNTIME_MOUNT} && exec {BUILD_RUNTIME_MOUNT}/nanocodex-vm-guest /"
     )
 }
 
@@ -1785,8 +1986,11 @@ fn expand_variables(
     let mut index = 0;
     while index < bytes.len() {
         if bytes[index] != b'$' {
-            output.push(char::from(bytes[index]));
-            index += 1;
+            let Some(character) = input[index..].chars().next() else {
+                break;
+            };
+            output.push(character);
+            index += character.len_utf8();
             continue;
         }
         if bytes.get(index + 1) == Some(&b'{') {
@@ -1834,6 +2038,8 @@ fn build_cache_key(
     recipe: &DockerfileRecipe,
     images: &BTreeMap<String, PulledImage>,
     disk_bytes: u64,
+    builder: &VmImageBuilder,
+    inputs: &BuildCacheInputs,
 ) -> String {
     let mut hasher = Sha256::new();
     hasher.update(b"nanocodex-vm-image-build\0");
@@ -1842,6 +2048,32 @@ fn build_cache_key(
     hasher.update(GUEST_ARCHITECTURE.as_bytes());
     hasher.update([0]);
     hasher.update(disk_bytes.to_le_bytes());
+    hasher.update([builder.cpus]);
+    hasher.update(builder.memory_mib.to_le_bytes());
+    hasher.update([u8::from(builder.prefer_ipv4)]);
+    for argument in &builder.vmm_arguments {
+        hasher.update([0]);
+        hasher.update(argument.as_os_str().as_bytes());
+    }
+    for value in [
+        &inputs.vmm_digest,
+        &inputs.runtime_digest,
+        &inputs.firmware_digest,
+        &inputs.network,
+        &inputs.egress_scope,
+    ] {
+        hasher.update([0]);
+        hasher.update(value.as_bytes());
+    }
+    hasher.update([0]);
+    match &inputs.resolver {
+        Some(resolver) => {
+            hasher.update(b"resolver\0");
+            hasher.update(resolver.as_bytes());
+        }
+        None => hasher.update(b"no-resolver"),
+    }
+    hasher.update([0]);
     hasher.update(context_digest.as_bytes());
     hasher.update([0]);
     hasher.update(dockerfile.as_bytes());
@@ -1862,7 +2094,7 @@ fn build_cache_key(
     hex::encode(hasher.finalize())
 }
 
-fn host_resolver_configuration() -> io::Result<String> {
+pub(crate) fn host_resolver_configuration() -> io::Result<String> {
     for path in ["/run/systemd/resolve/resolv.conf", "/etc/resolv.conf"] {
         let Ok(contents) = fs::read_to_string(path) else {
             continue;
@@ -1924,14 +2156,14 @@ async fn resolve_image(
         .join(format!("{reference_key}.json"));
     if policy == CachePolicy::Reuse
         && let Some(record) = read_cache_record::<ReferenceRecord>(&reference_path)?
-        && let Some(image) = local_image(image_reference, cache, record)
+        && let Some(image) = local_image(image_reference, cache, record).await?
     {
         return Ok(image);
     }
     let _lock = acquire_cache_lock(cache, "references", &reference_key).await?;
     if policy == CachePolicy::Reuse
         && let Some(record) = read_cache_record::<ReferenceRecord>(&reference_path)?
-        && let Some(image) = local_image(image_reference, cache, record)
+        && let Some(image) = local_image(image_reference, cache, record).await?
     {
         return Ok(image);
     }
@@ -1955,7 +2187,11 @@ async fn resolve_image(
     Ok(image)
 }
 
-fn local_image(image: &str, cache: &Path, record: ReferenceRecord) -> Option<PulledImage> {
+async fn local_image(
+    image: &str,
+    cache: &Path,
+    record: ReferenceRecord,
+) -> Result<Option<PulledImage>, ImageError> {
     if record.version != CACHE_RECORD_VERSION
         || record.image_reference != image
         || !valid_digest(&record.manifest_digest)
@@ -1965,7 +2201,7 @@ fn local_image(image: &str, cache: &Path, record: ReferenceRecord) -> Option<Pul
             .iter()
             .any(|layer| !valid_digest(&layer.digest) || layer.media_type.is_empty())
     {
-        return None;
+        return Ok(None);
     }
     let layers = record
         .layers
@@ -1976,15 +2212,17 @@ fn local_image(image: &str, cache: &Path, record: ReferenceRecord) -> Option<Pul
             media_type: layer.media_type,
         })
         .collect::<Vec<_>>();
-    if layers.iter().any(|layer| !layer.path.is_file()) {
-        return None;
+    for layer in &layers {
+        if !valid_cached_blob(&layer.path, &layer.digest).await? {
+            return Ok(None);
+        }
     }
-    Some(PulledImage {
+    Ok(Some(PulledImage {
         manifest_digest: record.manifest_digest,
         layers,
         source: ManifestSource::Local,
         config: record.config,
-    })
+    }))
 }
 
 async fn pull_layers(image: &str, blobs: &Path) -> Result<PulledImage, ImageError> {
@@ -2015,10 +2253,10 @@ async fn pull_layers(image: &str, blobs: &Path) -> Result<PulledImage, ImageErro
         let reference = &reference;
         async move {
             let path = blob_path(blobs, &descriptor.digest);
-            if !path.is_file() {
+            if !valid_cached_blob(&path, &descriptor.digest).await? {
                 let lock_key = reference_cache_key(&descriptor.digest);
                 let _lock = acquire_cache_lock(blobs, "blobs", &lock_key).await?;
-                if !path.is_file() {
+                if !valid_cached_blob(&path, &descriptor.digest).await? {
                     let temporary = temporary_path(blobs, &format!(".{lock_key}."))?;
                     let mut output = tokio::fs::File::create(&temporary).await?;
                     client
@@ -2027,6 +2265,15 @@ async fn pull_layers(image: &str, blobs: &Path) -> Result<PulledImage, ImageErro
                     output.sync_all().await?;
                     drop(output);
                     publish(temporary, &path)?;
+                    if !valid_cached_blob(&path, &descriptor.digest).await? {
+                        return Err(ImageError::Io(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!(
+                                "downloaded OCI blob does not match digest {}",
+                                descriptor.digest
+                            ),
+                        )));
+                    }
                 }
             }
             Ok::<_, ImageError>(PulledLayer {
@@ -2073,6 +2320,47 @@ fn parse_image_config(config: &str) -> Result<ImageRuntimeConfig, ImageError> {
 
 fn blob_path(cache: &Path, digest: &str) -> PathBuf {
     cache.join(digest.replace(':', "-"))
+}
+
+async fn valid_cached_blob(path: &Path, digest: &str) -> Result<bool, ImageError> {
+    let Ok(metadata) = fs::symlink_metadata(path) else {
+        return Ok(false);
+    };
+    if !metadata.file_type().is_file() {
+        return Ok(false);
+    }
+    let record_path = path.with_extension("blob.json");
+    if let Some(record) = read_cache_record::<BlobRecord>(&record_path)?
+        && record.version == BLOB_RECORD_VERSION
+        && record.digest == digest
+        && record.file == cache_file_identity(&metadata)?
+        && metadata.permissions().mode() & 0o222 == 0
+    {
+        return Ok(true);
+    }
+
+    let Some(expected) = digest.strip_prefix("sha256:") else {
+        return Ok(false);
+    };
+    let before = cache_file_identity(&metadata)?;
+    let path_for_hash = path.to_path_buf();
+    let actual = tokio::task::spawn_blocking(move || sha256_file(&path_for_hash)).await??;
+    let after = fs::symlink_metadata(path)?;
+    if !after.file_type().is_file() || cache_file_identity(&after)? != before || actual != expected
+    {
+        return Ok(false);
+    }
+    mark_cache_file_read_only(path)?;
+    let metadata = fs::symlink_metadata(path)?;
+    write_cache_record(
+        &record_path,
+        &BlobRecord {
+            version: BLOB_RECORD_VERSION,
+            digest: digest.to_owned(),
+            file: cache_file_identity(&metadata)?,
+        },
+    )?;
+    Ok(true)
 }
 
 fn valid_digest(digest: &str) -> bool {
@@ -2131,10 +2419,7 @@ fn validate_root_disk(path: &Path) -> Result<(), ImageError> {
 }
 
 fn cached_root_disk(path: &Path) -> Option<String> {
-    if !path.is_file() {
-        return None;
-    }
-    match cached_prepared_shell(path) {
+    match validated_prepared_disk_record(path) {
         Ok(shell) => Some(shell),
         Err(error) => {
             info!(
@@ -2148,42 +2433,162 @@ fn cached_root_disk(path: &Path) -> Option<String> {
     }
 }
 
-fn valid_cached_ext4_disk(path: &Path) -> bool {
-    path.is_file() && validate_ext4_disk(path).is_ok()
+fn valid_cached_ext4_disk(path: &Path) -> Result<bool, ImageError> {
+    let Ok(metadata) = fs::symlink_metadata(path) else {
+        return Ok(false);
+    };
+    if !metadata.file_type().is_file() {
+        return Ok(false);
+    }
+    let record_path = path.with_extension("ext4.json");
+    let Some(record) = read_cache_record::<CachedExt4Record>(&record_path)? else {
+        return Ok(false);
+    };
+    Ok(record.version == CACHED_EXT4_RECORD_VERSION
+        && record.file == cache_file_identity(&metadata)?
+        && metadata.permissions().mode() & 0o222 == 0
+        && validate_ext4_disk(path).is_ok())
 }
 
-fn cached_prepared_shell(path: &Path) -> Result<String, ImageError> {
-    let metadata = fs::metadata(path)?;
-    let modified_nanos = modified_nanos(&metadata)?;
-    let record_path = path.with_extension("prepared.json");
-    if let Some(record) = read_cache_record::<PreparedDiskRecord>(&record_path)?
-        && record.version == PREPARED_DISK_RECORD_VERSION
-        && record.file_bytes == metadata.len()
-        && record.modified_nanos == modified_nanos
-        && matches!(record.shell.as_str(), "bash" | "sh")
-    {
-        return Ok(record.shell);
+fn validated_prepared_disk_record(path: &Path) -> Result<String, ImageError> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_file() {
+        return Err(ImageError::Io(io::Error::other(
+            "prepared disk cache path is not a regular file",
+        )));
     }
+    let record_path = path.with_extension("prepared.json");
+    let Some(record) = read_cache_record::<PreparedDiskRecord>(&record_path)? else {
+        return Err(ImageError::Io(io::Error::other(
+            "prepared disk cache record is missing",
+        )));
+    };
+    if record.version != PREPARED_DISK_RECORD_VERSION
+        || record.file != cache_file_identity(&metadata)?
+        || !matches!(record.shell.as_str(), "bash" | "sh")
+        || metadata.permissions().mode() & 0o222 != 0
+    {
+        return Err(ImageError::Io(io::Error::other(
+            "prepared disk cache record does not match the disk",
+        )));
+    }
+    validate_root_disk(path)?;
+    Ok(record.shell)
+}
 
+fn record_prepared_disk(path: &Path) -> Result<String, ImageError> {
+    validate_root_disk(path)?;
+    mark_cache_file_read_only(path)?;
+    let metadata = fs::symlink_metadata(path)?;
+    let file = cache_file_identity(&metadata)?;
+    let record_path = path.with_extension("prepared.json");
     let shell = prepared_shell(path)?.to_owned();
+    write_cache_record(
+        &path.with_extension("ext4.json"),
+        &CachedExt4Record {
+            version: CACHED_EXT4_RECORD_VERSION,
+            file: file.clone(),
+        },
+    )?;
     write_cache_record(
         &record_path,
         &PreparedDiskRecord {
             version: PREPARED_DISK_RECORD_VERSION,
-            file_bytes: metadata.len(),
-            modified_nanos,
+            file,
             shell: shell.clone(),
         },
     )?;
     Ok(shell)
 }
 
-fn modified_nanos(metadata: &fs::Metadata) -> io::Result<u128> {
-    metadata
+fn record_cached_ext4_disk(path: &Path) -> Result<(), ImageError> {
+    validate_ext4_disk(path)?;
+    mark_cache_file_read_only(path)?;
+    let metadata = fs::symlink_metadata(path)?;
+    write_cache_record(
+        &path.with_extension("ext4.json"),
+        &CachedExt4Record {
+            version: CACHED_EXT4_RECORD_VERSION,
+            file: cache_file_identity(&metadata)?,
+        },
+    )
+}
+
+fn mark_cache_file_read_only(path: &Path) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_file() {
+        return Err(io::Error::other("cache path is not a regular file"));
+    }
+    let mut permissions = metadata.permissions();
+    permissions.set_mode(permissions.mode() & !0o222);
+    fs::set_permissions(path, permissions)
+}
+
+fn cache_file_identity(metadata: &fs::Metadata) -> io::Result<CacheFileIdentity> {
+    let modified_nanos = metadata
         .modified()?
         .duration_since(std::time::UNIX_EPOCH)
         .map(|duration| duration.as_nanos())
-        .map_err(io::Error::other)
+        .map_err(io::Error::other)?;
+    Ok(CacheFileIdentity {
+        bytes: metadata.len(),
+        modified_nanos,
+        changed_seconds: metadata.ctime(),
+        changed_nanos: metadata.ctime_nsec(),
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    })
+}
+
+async fn cached_file_digest(
+    path: &Path,
+    cache: &Arc<AsyncMutex<Option<CachedFileDigest>>>,
+) -> Result<String, ImageError> {
+    let mut cached = cache.lock().await;
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_file() {
+        return Err(io::Error::other(format!(
+            "build runtime input is not a regular file: {}",
+            path.display()
+        ))
+        .into());
+    }
+    let before = cache_file_identity(&metadata)?;
+    if let Some(entry) = cached.as_ref()
+        && entry.file == before
+    {
+        return Ok(entry.digest.clone());
+    }
+    let path = path.to_path_buf();
+    let hash_path = path.clone();
+    let digest = tokio::task::spawn_blocking(move || sha256_file(&hash_path)).await??;
+    let after = cache_file_identity(&fs::symlink_metadata(&path)?)?;
+    if before != after {
+        return Err(io::Error::other(format!(
+            "build runtime input changed while it was being hashed: {}",
+            path.display()
+        ))
+        .into());
+    }
+    *cached = Some(CachedFileDigest {
+        file: after,
+        digest: digest.clone(),
+    });
+    Ok(digest)
+}
+
+fn sha256_file(path: &Path) -> io::Result<String> {
+    let mut file = File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; 1024 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hex::encode(hasher.finalize()))
 }
 
 fn prepared_shell(path: &Path) -> Result<&'static str, ImageError> {
@@ -2240,13 +2645,14 @@ mod tests {
     use crate::{config::Network, egress::EgressLease};
 
     use super::{
-        CACHE_RECORD_VERSION, CONTEXT_DISK_BYTES, COPY_SCRIPT, CachePolicy, DiskStatus,
-        DockerfileRecipe, FIRMWARE_LIBRARY_FILENAME, FIRMWARE_LIBRARY_PATH_ENVIRONMENT, ImageError,
-        ImageRuntimeConfig, LayerRecord, ManifestSource, PulledImage, PulledLayer, Reader,
-        ReferenceRecord, VmImageBuilder, append_normalized_context_entry, blob_path,
-        build_guest_bootstrap_script, configure_firmware_library_path, disk_cache_key,
-        docker_process_environment, output_tail, prepare_copy_source_disk, prepare_flattened_disk,
-        reference_cache_key, resolver_configuration, write_cache_record,
+        BuildCacheInputs, CACHE_RECORD_VERSION, CONTEXT_DISK_BYTES, COPY_SCRIPT, CachePolicy,
+        DiskStatus, DockerfileRecipe, FIRMWARE_LIBRARY_FILENAME, FIRMWARE_LIBRARY_PATH_ENVIRONMENT,
+        ImageError, ImageRuntimeConfig, LayerRecord, ManifestSource, PulledImage, PulledLayer,
+        Reader, ReferenceRecord, VmImageBuilder, append_normalized_context_entry, blob_path,
+        build_cache_key, build_guest_bootstrap_script, cached_file_digest,
+        configure_firmware_library_path, disk_cache_key, docker_process_environment, output_tail,
+        prepare_copy_source_disk, prepare_flattened_disk, reference_cache_key,
+        resolver_configuration, valid_cached_blob, valid_cached_ext4_disk, write_cache_record,
     };
     use flate2::{Compression, write::GzEncoder};
     use tracing::{
@@ -2261,8 +2667,6 @@ mod tests {
     const FIXTURE_IMAGE: &str = "example.invalid/nanocodex-vm-fixture:latest";
     const FIXTURE_MANIFEST: &str =
         "sha256:56249d7a2f93306106f6d8bcdf6423afb73c1b747d874febcc778beee25cb8bb";
-    const FIXTURE_LAYER: &str =
-        "sha256:bd89d118a7a5c5bcefe7129975d406284981f597340a222b5df50f7044157ff0";
     static IMAGE_PREPARE_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[cfg(unix)]
@@ -2396,19 +2800,24 @@ mod tests {
             fs::create_dir_all(&context).unwrap();
             fs::write(
                 context.join("Dockerfile"),
-                format!("FROM {FIXTURE_IMAGE}\nWORKDIR /workspace\n"),
+                format!(
+                    "FROM {FIXTURE_IMAGE}\nENV NANOCODEX_FIXTURE_MODE=flattened\nWORKDIR /workspace\n"
+                ),
             )
             .unwrap();
 
             let blobs = cache.join("blobs");
             fs::create_dir_all(&blobs).unwrap();
-            write_shell_layer(&blob_path(&blobs, FIXTURE_LAYER));
+            let temporary_layer = blobs.join("fixture-layer");
+            write_shell_layer(&temporary_layer);
+            let layer_digest = format!("sha256:{}", super::sha256_file(&temporary_layer).unwrap());
+            fs::rename(&temporary_layer, blob_path(&blobs, &layer_digest)).unwrap();
             let record = ReferenceRecord {
                 version: CACHE_RECORD_VERSION,
                 image_reference: FIXTURE_IMAGE.to_owned(),
                 manifest_digest: FIXTURE_MANIFEST.to_owned(),
                 layers: vec![LayerRecord {
-                    digest: FIXTURE_LAYER.to_owned(),
+                    digest: layer_digest,
                     media_type: "application/vnd.oci.image.layer.v1.tar+gzip".to_owned(),
                 }],
                 config: ImageRuntimeConfig::default(),
@@ -2489,7 +2898,7 @@ mod tests {
             recipe.final_stage().unwrap().base_image,
             "python:3.13-slim-bookworm"
         );
-        assert_eq!(recipe.final_workdir(), "/app");
+        assert_eq!(recipe.final_workdir(), Some("/app"));
         assert!(!recipe.requires_build());
     }
 
@@ -2526,10 +2935,10 @@ mod tests {
         assert!(builder.prefer_ipv4);
 
         let resolver = "nameserver 213.186.33.99\\n";
-        let dual_stack = build_guest_bootstrap_script(resolver, false);
+        let dual_stack = build_guest_bootstrap_script(Some(resolver), false);
         assert!(!dual_stack.contains("/proc/sys/net/ipv6"));
 
-        let prefer_ipv4 = build_guest_bootstrap_script(resolver, true);
+        let prefer_ipv4 = build_guest_bootstrap_script(Some(resolver), true);
         let all = prefer_ipv4
             .find("/proc/sys/net/ipv6/conf/all/disable_ipv6")
             .unwrap();
@@ -2550,6 +2959,13 @@ mod tests {
         assert!(prefer_ipv4.contains(
             "nanocodex image build bootstrap: failed to write /proc/sys/net/ipv6/conf/default/disable_ipv6"
         ));
+        assert!(prefer_ipv4.contains("mv /etc/resolv.conf /run/nanocodex-build-resolver/original"));
+        assert!(
+            super::RESTORE_BUILD_RESOLVER_SCRIPT
+                .contains("mv /run/nanocodex-build-resolver/original /etc/resolv.conf")
+        );
+        let offline = build_guest_bootstrap_script(None, false);
+        assert!(!offline.contains("resolv.conf"));
     }
 
     #[test]
@@ -2615,6 +3031,153 @@ ENV LEGACY value with spaces
     }
 
     #[test]
+    fn docker_variable_expansion_preserves_utf8() {
+        let environment = BTreeMap::from([("NAME".to_owned(), "世界".to_owned())]);
+        let arguments = BTreeMap::new();
+
+        assert_eq!(
+            super::expand_variables("café/$NAME/🦀", &environment, &arguments),
+            "café/世界/🦀"
+        );
+    }
+
+    #[test]
+    fn missing_oci_runtime_config_uses_the_container_root() {
+        let config = ImageRuntimeConfig::default();
+
+        assert_eq!(config.working_directory, "/");
+        assert!(config.environment.is_empty());
+    }
+
+    #[test]
+    fn build_cache_identity_covers_the_complete_execution_policy() {
+        let dockerfile = "FROM example.invalid/base:latest\nRUN printf ready > /proof\n";
+        let recipe = DockerfileRecipe::parse(dockerfile).unwrap();
+        let images = BTreeMap::from([(
+            "example.invalid/base:latest".to_owned(),
+            PulledImage {
+                manifest_digest: FIXTURE_MANIFEST.to_owned(),
+                layers: Vec::new(),
+                source: ManifestSource::Local,
+                config: ImageRuntimeConfig::default(),
+            },
+        )]);
+        let builder = VmImageBuilder::new("/vmm", "/runtime");
+        let inputs = BuildCacheInputs {
+            vmm_digest: "vmm-a".to_owned(),
+            runtime_digest: "runtime-a".to_owned(),
+            firmware_digest: "firmware-a".to_owned(),
+            resolver: Some("nameserver 192.0.2.1\\n".to_owned()),
+            network: "internet".to_owned(),
+            egress_scope: "internet-a".to_owned(),
+        };
+        let key = |builder: &VmImageBuilder, inputs: &BuildCacheInputs| {
+            build_cache_key(
+                dockerfile,
+                "context-a",
+                &recipe,
+                &images,
+                1024,
+                builder,
+                inputs,
+            )
+        };
+        let baseline = key(&builder, &inputs);
+
+        for changed in [
+            BuildCacheInputs {
+                vmm_digest: "vmm-b".to_owned(),
+                ..inputs.clone()
+            },
+            BuildCacheInputs {
+                runtime_digest: "runtime-b".to_owned(),
+                ..inputs.clone()
+            },
+            BuildCacheInputs {
+                firmware_digest: "firmware-b".to_owned(),
+                ..inputs.clone()
+            },
+            BuildCacheInputs {
+                resolver: Some("nameserver 192.0.2.2\\n".to_owned()),
+                ..inputs.clone()
+            },
+            BuildCacheInputs {
+                resolver: None,
+                ..inputs.clone()
+            },
+            BuildCacheInputs {
+                network: "gvproxy".to_owned(),
+                ..inputs.clone()
+            },
+            BuildCacheInputs {
+                egress_scope: "internet-b".to_owned(),
+                ..inputs.clone()
+            },
+        ] {
+            assert_ne!(key(&builder, &changed), baseline);
+        }
+        assert_ne!(key(&builder.clone().cpus(3), &inputs), baseline);
+        assert_ne!(key(&builder.clone().memory_mib(2048), &inputs), baseline);
+        assert_ne!(key(&builder.clone().prefer_ipv4(), &inputs), baseline);
+        assert_ne!(key(&builder.vmm_arg("--different"), &inputs), baseline);
+    }
+
+    #[test]
+    fn cached_runtime_digest_is_invalidated_by_file_changes() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("runtime.ext4");
+        fs::write(&path, b"first").unwrap();
+        let cache = Arc::new(tokio::sync::Mutex::new(None));
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let first = cached_file_digest(&path, &cache).await.unwrap();
+            assert_eq!(cached_file_digest(&path, &cache).await.unwrap(), first);
+            fs::write(&path, b"second-and-different").unwrap();
+            let second = cached_file_digest(&path, &cache).await.unwrap();
+            assert_ne!(second, first);
+        });
+    }
+
+    #[test]
+    fn cached_oci_blob_detects_same_size_content_corruption() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("sha256-fixture");
+        fs::write(&path, b"correct").unwrap();
+        let digest = format!("sha256:{}", super::sha256_file(&path).unwrap());
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            assert!(valid_cached_blob(&path, &digest).await.unwrap());
+            let pristine_metadata = fs::metadata(&path).unwrap();
+            assert_eq!(pristine_metadata.permissions().mode() & 0o222, 0);
+
+            let mut permissions = pristine_metadata.permissions();
+            permissions.set_mode(permissions.mode() | 0o200);
+            fs::set_permissions(&path, permissions).unwrap();
+            fs::write(&path, b"corrupt").unwrap();
+            filetime::set_file_mtime(
+                &path,
+                filetime::FileTime::from_last_modification_time(&pristine_metadata),
+            )
+            .unwrap();
+            assert!(!valid_cached_blob(&path, &digest).await.unwrap());
+
+            fs::write(&path, b"correct").unwrap();
+            assert!(valid_cached_blob(&path, &digest).await.unwrap());
+            assert_eq!(fs::metadata(&path).unwrap().permissions().mode() & 0o222, 0);
+        });
+    }
+
+    #[test]
     fn resolver_configuration_rejects_host_local_stubs() {
         assert_eq!(
             resolver_configuration(
@@ -2669,7 +3232,7 @@ CMD ["/bin/sh"]
         assert_eq!(recipe.stages.len(), 2);
         assert_eq!(recipe.stages[0].name.as_deref(), Some("build"));
         assert_eq!(recipe.stages[1].name.as_deref(), Some("target"));
-        assert_eq!(recipe.final_workdir(), "/app");
+        assert_eq!(recipe.final_workdir(), Some("/app"));
         assert!(recipe.requires_build());
         let super::DockerfileInstruction::Copy(copy) = &recipe.stages[1].instructions[0] else {
             panic!("expected the final-stage COPY instruction");
@@ -2792,6 +3355,7 @@ CMD ["/bin/sh"]
         assert_eq!(first.path(), second.path());
         assert_eq!(first.workdir(), "/workspace");
         assert_eq!(first.shell(), "sh");
+        assert_eq!(first.environment()["NANOCODEX_FIXTURE_MODE"], "flattened");
         assert_eq!(
             [first.disk_status(), second.disk_status()]
                 .into_iter()
@@ -2799,6 +3363,7 @@ CMD ["/bin/sh"]
                 .count(),
             1
         );
+        assert!(valid_cached_ext4_disk(first.path()).unwrap());
 
         let attempt = fixture.root.path().join("attempt.ext4");
         assert_eq!(
@@ -2828,6 +3393,13 @@ CMD ["/bin/sh"]
                 )
                 .await
                 .unwrap();
+            let mut permissions = fs::metadata(first.path()).unwrap().permissions();
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt as _;
+                permissions.set_mode(permissions.mode() | 0o200);
+            }
+            fs::set_permissions(first.path(), permissions).unwrap();
             fs::write(first.path(), b"corrupt").unwrap();
 
             let repaired = builder
@@ -2922,7 +3494,11 @@ CMD ["/bin/sh"]
         });
         assert_eq!(
             dockerfile_event.as_deref(),
-            Some("FROM example.invalid/nanocodex-vm-fixture:latest\nWORKDIR /workspace\n")
+            Some(
+                "FROM example.invalid/nanocodex-vm-fixture:latest\n\
+                 ENV NANOCODEX_FIXTURE_MODE=flattened\n\
+                 WORKDIR /workspace\n"
+            )
         );
     }
 }

--- a/crates/experimental/nanocodex-vm/src/image/mod.rs
+++ b/crates/experimental/nanocodex-vm/src/image/mod.rs
@@ -1,0 +1,2928 @@
+//! Content-addressed OCI and Dockerfile root disks for Nanocodex VMs.
+//!
+//! The cache owns immutable prepared disks. Each VM attempt should take a
+//! cheap copy-on-write clone with [`PreparedRootDisk::reflink_to`] and mutate
+//! only that disposable copy.
+//!
+//! # Prepare and instantiate an image
+//!
+//! ```no_run
+//! use nanocodex_vm::{
+//!     image::{CachePolicy, VmImageBuilder},
+//!     tools::GuestRuntimeDisk,
+//! };
+//!
+//! # async fn prepare() -> Result<(), Box<dyn std::error::Error>> {
+//! let runtime = GuestRuntimeDisk::prepare(
+//!     "target/aarch64-unknown-linux-musl/debug/nanocodex-vm-guest",
+//!     ".cache/vm",
+//! )?;
+//! let images = VmImageBuilder::new(
+//!     "target/debug/vm-tools",
+//!     runtime.path(),
+//! )
+//! .firmware_directory(".cache/libkrunfw/libkrunfw")
+//! .vmm_arg("--vmm");
+//! let image = images
+//!     .prepare(
+//!         "tasks/project/environment",
+//!         10 * 1024 * 1024 * 1024,
+//!         ".cache/vm",
+//!         CachePolicy::Reuse,
+//!     )
+//!     .await?;
+//! std::fs::create_dir_all(".nanocodex/attempts/018f")?;
+//! image.reflink_to(".nanocodex/attempts/018f/root.ext4")?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! The context contains an ordinary, deliberately constrained Dockerfile, for
+//! example:
+//!
+//! ```dockerfile
+//! FROM python:3.13-slim-bookworm
+//! WORKDIR /app
+//! COPY requirements.txt /app/
+//! RUN pip install -r requirements.txt
+//! ```
+
+#![deny(missing_docs, rustdoc::broken_intra_doc_links)]
+
+mod disk;
+
+pub use disk::reflink_or_sparse_copy;
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ffi::OsString,
+    fs::{self, File},
+    io::{self, BufReader, Read, Seek, SeekFrom, Write},
+    path::{Component, Path, PathBuf},
+    time::Duration,
+};
+
+use crate::{
+    command::GuestCommand,
+    config::{BlockDevice, VmConfig},
+    egress::EgressLease,
+    tools::{VmCommand, VmToolSession, VmToolSessionError},
+};
+use arcbox_ext4::{Formatter, Reader};
+use flate2::read::GzDecoder;
+use futures_util::{StreamExt, TryStreamExt, stream};
+use ignore::WalkBuilder;
+use oci_client::{
+    Client, Reference, client::ClientConfig, config::ConfigFile, manifest::ImageIndexEntry,
+    secrets::RegistryAuth,
+};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use sha2::{Digest, Sha256};
+use tokio::process::Command;
+use tracing::{Instrument, info, info_span};
+
+const BLOCK_SIZE: u32 = 4_096;
+const MINIMUM_DISK_BYTES: u64 = 512 * 1024 * 1024;
+const CACHE_RECORD_VERSION: u32 = 2;
+const IMAGE_BUILD_CACHE_VERSION: u32 = 1;
+const PREPARED_DISK_RECORD_VERSION: u32 = 1;
+const CONTEXT_DISK_BYTES: u64 = 128 * 1024 * 1024;
+const DEFAULT_RUN_TIMEOUT: Duration = Duration::from_mins(30);
+const DEFAULT_COPY_TIMEOUT: Duration = Duration::from_mins(10);
+const MAX_CONCURRENT_IMAGE_RESOLVES: usize = 8;
+const MAX_CONCURRENT_LAYER_DOWNLOADS: usize = 8;
+const BUILD_RUNTIME_ID: &str = "nanocodex-runtime";
+const BUILD_CONTEXT_ID: &str = "nanocodex-context";
+const BUILD_RUNTIME_DEVICE: &str = "/dev/vdb";
+const BUILD_CONTEXT_DEVICE: &str = "/dev/vdc";
+const BUILD_RUNTIME_MOUNT: &str = "/run/nanocodex";
+const BUILD_CONTEXT_MOUNT: &str = "/mnt/nanocodex-context";
+const DEFAULT_GUEST_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
+const DEFAULT_BUILD_VM_CPUS: u8 = 2;
+const DEFAULT_BUILD_VM_MEMORY_MIB: u32 = 4_096;
+#[cfg(target_os = "linux")]
+const FIRMWARE_LIBRARY_FILENAME: &str = "libkrunfw.so.5";
+#[cfg(target_os = "macos")]
+const FIRMWARE_LIBRARY_FILENAME: &str = "libkrunfw.5.dylib";
+#[cfg(target_os = "linux")]
+const FIRMWARE_LIBRARY_PATH_ENVIRONMENT: &str = "LD_LIBRARY_PATH";
+#[cfg(target_os = "macos")]
+const FIRMWARE_LIBRARY_PATH_ENVIRONMENT: &str = "DYLD_LIBRARY_PATH";
+#[cfg(target_arch = "aarch64")]
+const GUEST_ARCHITECTURE: &str = "arm64";
+#[cfg(target_arch = "x86_64")]
+const GUEST_ARCHITECTURE: &str = "amd64";
+const COPY_SCRIPT: &str = r#"set -eu
+dest=$1
+shift
+if [ "$#" -gt 1 ]; then
+  mkdir -p "$dest"
+  for src do cp -a "$src" "$dest/"; done
+elif [ -d "$1" ]; then
+  mkdir -p "$dest"
+  cp -a "$1/." "$dest/"
+elif [ "${dest%/}" != "$dest" ]; then
+  mkdir -p "$dest"
+  cp -a "$1" "$dest/"
+else
+  mkdir -p "$(dirname "$dest")"
+  cp -a "$1" "$dest"
+fi"#;
+
+/// Configuration used to prepare immutable VM root disks.
+///
+/// The VMM and runtime disk are used only for Dockerfiles that require build
+/// steps such as `RUN` or `COPY`. A single-stage `FROM` plus `WORKDIR` can be
+/// flattened directly from OCI layers.
+#[derive(Clone, Debug)]
+pub struct VmImageBuilder {
+    vmm: PathBuf,
+    vmm_arguments: Vec<OsString>,
+    runtime_image: PathBuf,
+    firmware_directory: Option<PathBuf>,
+    cpus: u8,
+    memory_mib: u32,
+    prefer_ipv4: bool,
+    run_timeout: Duration,
+    copy_timeout: Duration,
+    egress: EgressLease,
+}
+
+impl VmImageBuilder {
+    /// Creates an image builder backed by a dedicated VMM executable and guest
+    /// runtime disk.
+    ///
+    /// For Dockerfiles with `RUN` or `COPY`, the executable must accept a
+    /// private [`crate::host::VmProcessConfig`] path as its final argument. Use
+    /// [`Self::vmm_arg`] when that entry point requires a preceding flag or
+    /// subcommand. Flatten-only Dockerfiles do not launch it.
+    #[must_use]
+    pub fn new(vmm: impl Into<PathBuf>, runtime_image: impl Into<PathBuf>) -> Self {
+        Self {
+            vmm: vmm.into(),
+            vmm_arguments: Vec::new(),
+            runtime_image: runtime_image.into(),
+            firmware_directory: None,
+            cpus: DEFAULT_BUILD_VM_CPUS,
+            memory_mib: DEFAULT_BUILD_VM_MEMORY_MIB,
+            prefer_ipv4: false,
+            run_timeout: DEFAULT_RUN_TIMEOUT,
+            copy_timeout: DEFAULT_COPY_TIMEOUT,
+            egress: EgressLease::internet(),
+        }
+    }
+
+    /// Sets the directory containing the platform's libkrun firmware library.
+    ///
+    /// A present `libkrunfw.5.dylib` on macOS or `libkrunfw.so.5` on Linux is
+    /// added to the dedicated VMM's platform library search path. Builders and
+    /// VMMs with system-installed firmware can omit this setting.
+    #[must_use]
+    pub fn firmware_directory(mut self, directory: impl Into<PathBuf>) -> Self {
+        self.firmware_directory = Some(directory.into());
+        self
+    }
+
+    /// Appends one argument before the private VM process-config path.
+    ///
+    /// Use this when one executable exposes its dedicated VMM entry point
+    /// behind a subcommand or flag. For example, the end-to-end proof binary
+    /// uses `.vmm_arg("--vmm")`.
+    #[must_use]
+    pub fn vmm_arg(mut self, argument: impl Into<OsString>) -> Self {
+        self.vmm_arguments.push(argument.into());
+        self
+    }
+
+    /// Appends arguments before the private VM process-config path.
+    #[must_use]
+    pub fn vmm_args<I, A>(mut self, arguments: I) -> Self
+    where
+        I: IntoIterator<Item = A>,
+        A: Into<OsString>,
+    {
+        self.vmm_arguments
+            .extend(arguments.into_iter().map(Into::into));
+        self
+    }
+
+    /// Sets the virtual CPU count for Dockerfile build VMs.
+    ///
+    /// The default is 2. The underlying VMM returns a typed configuration
+    /// error when the value is unsupported.
+    #[must_use]
+    pub const fn cpus(mut self, cpus: u8) -> Self {
+        self.cpus = cpus;
+        self
+    }
+
+    /// Sets memory for Dockerfile build VMs in mebibytes.
+    ///
+    /// The default is 4096 MiB.
+    #[must_use]
+    pub const fn memory_mib(mut self, memory_mib: u32) -> Self {
+        self.memory_mib = memory_mib;
+        self
+    }
+
+    /// Prefers IPv4 inside each ephemeral Dockerfile build VM.
+    ///
+    /// The default leaves address selection unchanged. Under libkrun TSI this
+    /// policy makes normal/default address selection prefer IPv4; it does not
+    /// prevent a process from explicitly requesting `AF_INET6`. The policy
+    /// changes only the build guest's in-memory `/proc` network state, not the
+    /// prepared root filesystem or eventual task VM network policy.
+    #[must_use]
+    pub const fn prefer_ipv4(mut self) -> Self {
+        self.prefer_ipv4 = true;
+        self
+    }
+
+    /// Sets the timeout for each Dockerfile `RUN` instruction.
+    ///
+    /// The default is 30 minutes. Timeout cancellation terminates the guest
+    /// process group before the build returns an error.
+    #[must_use]
+    pub const fn run_timeout(mut self, timeout: Duration) -> Self {
+        self.run_timeout = timeout;
+        self
+    }
+
+    /// Sets the timeout for each build-context mount, `WORKDIR`, and `COPY`
+    /// operation.
+    ///
+    /// The default is 10 minutes.
+    #[must_use]
+    pub const fn copy_timeout(mut self, timeout: Duration) -> Self {
+        self.copy_timeout = timeout;
+        self
+    }
+
+    /// Sets the complete egress lease cloned into each Dockerfile build VM.
+    ///
+    /// The default permits ordinary internet access. Use
+    /// `EgressLease::disabled()` for an offline build, or supply a composed
+    /// host-owned MPP/secret lease. Lease values remain redacted from `Debug`.
+    #[must_use]
+    pub fn egress(mut self, egress: EgressLease) -> Self {
+        self.egress = egress;
+        self
+    }
+
+    /// Prepares one immutable root disk from `directory/Dockerfile`.
+    ///
+    /// `disk_bytes` is rounded up to the minimum supported root-disk size.
+    /// Cache keys include the Dockerfile, ordered context archive, base
+    /// image manifests, target platform, and final disk size.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the Dockerfile is unsupported, an OCI artifact
+    /// cannot be resolved, a build step fails, or the resulting ext4 disk is
+    /// invalid.
+    pub async fn prepare(
+        &self,
+        directory: impl AsRef<Path>,
+        disk_bytes: u64,
+        cache: impl AsRef<Path>,
+        policy: CachePolicy,
+    ) -> Result<PreparedRootDisk, ImageError> {
+        let directory = directory.as_ref();
+        let cache = cache.as_ref();
+        let span = info_span!(
+            target: "nanocodex_vm",
+            "vm.image.prepare",
+            otel.kind = "internal",
+            otel.status_code = tracing::field::Empty,
+            image.context.path = %directory.display(),
+            image.cache.path = %cache.display(),
+            image.disk.bytes = disk_bytes.max(MINIMUM_DISK_BYTES),
+            image.cache.policy = policy.as_str(),
+            image.build.prefer_ipv4 = self.prefer_ipv4,
+            image.cache.status = tracing::field::Empty,
+            image.manifest.source = tracing::field::Empty,
+            image.manifest.digest = tracing::field::Empty,
+            image.root.path = tracing::field::Empty,
+            status = tracing::field::Empty,
+            error.message = tracing::field::Empty,
+            duration_ns = tracing::field::Empty,
+        );
+        let started_at = std::time::Instant::now();
+        let result =
+            PreparedRootDisk::prepare_directory(directory, disk_bytes, cache, policy, self)
+                .instrument(span.clone())
+                .await;
+        span.record(
+            "duration_ns",
+            u64::try_from(started_at.elapsed().as_nanos()).unwrap_or(u64::MAX),
+        );
+        match &result {
+            Ok(image) => {
+                span.record("otel.status_code", "OK");
+                span.record("status", "completed");
+                span.record("image.cache.status", image.disk_status().as_str());
+                span.record("image.manifest.source", image.manifest_source().as_str());
+                span.record("image.manifest.digest", image.manifest_digest());
+                span.record("image.root.path", image.path().display().to_string());
+            }
+            Err(error) => {
+                span.record("otel.status_code", "ERROR");
+                span.record("status", "failed");
+                span.record("error.message", error.to_string());
+            }
+        }
+        result
+    }
+}
+
+/// An immutable, content-addressed root disk in the image cache.
+#[derive(Clone, Debug)]
+pub struct PreparedRootDisk {
+    path: PathBuf,
+    workdir: String,
+    shell: String,
+    environment: BTreeMap<String, String>,
+    manifest_digest: String,
+    manifest_source: ManifestSource,
+    disk_status: DiskStatus,
+}
+
+/// Whether mutable OCI references may use their validated local resolution.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CachePolicy {
+    /// Reuse a valid local manifest record and its cached blobs.
+    Reuse,
+    /// Resolve the mutable image reference from the registry again.
+    Refresh,
+}
+
+impl CachePolicy {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Reuse => "reuse",
+            Self::Refresh => "refresh",
+        }
+    }
+}
+
+/// Where the image manifest used for this preparation was resolved.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ManifestSource {
+    /// A validated local manifest record supplied the immutable digest.
+    Local,
+    /// The OCI registry supplied the immutable digest.
+    Registry,
+}
+
+impl ManifestSource {
+    /// Returns the stable telemetry spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Local => "local",
+            Self::Registry => "registry",
+        }
+    }
+}
+
+/// Whether the prepared disk was reused or materialized by this call.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DiskStatus {
+    /// The complete prepared disk was already present.
+    Hit,
+    /// This call materialized and atomically published the prepared disk.
+    Created,
+}
+
+impl DiskStatus {
+    /// Returns the stable telemetry spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Hit => "hit",
+            Self::Created => "created",
+        }
+    }
+}
+
+/// Failure to resolve, build, validate, or instantiate a VM root disk.
+#[derive(Debug, thiserror::Error)]
+pub enum ImageError {
+    /// A filesystem operation failed.
+    #[error("VM image filesystem operation failed: {0}")]
+    Io(#[from] io::Error),
+
+    /// An OCI image reference could not be parsed.
+    #[error("invalid OCI image reference {image}: {source}")]
+    Reference {
+        /// The caller-provided image reference.
+        image: String,
+        /// The OCI reference parser failure.
+        #[source]
+        source: oci_client::ParseError,
+    },
+
+    /// An OCI registry operation failed.
+    #[error("OCI registry operation failed: {0}")]
+    Registry(#[from] oci_client::errors::OciDistributionError),
+
+    /// Formatting an ext4 disk failed.
+    #[error("failed to format ext4 root disk: {0}")]
+    Ext4(#[from] arcbox_ext4::error::FormatError),
+
+    /// Inspecting an ext4 disk failed.
+    #[error("failed to inspect ext4 root disk: {0}")]
+    ReadExt4(#[from] arcbox_ext4::error::ReadError),
+
+    /// A blocking disk materialization task failed.
+    #[error("root disk formatting task failed: {0}")]
+    Join(#[from] tokio::task::JoinError),
+
+    /// The constrained Dockerfile parser rejected an instruction.
+    #[error("unsupported Dockerfile instruction: {0}")]
+    UnsupportedDockerfile(String),
+
+    /// A Dockerfile did not contain a valid base stage.
+    #[error("Dockerfile must contain exactly one FROM instruction")]
+    InvalidFrom,
+
+    /// An OCI layer uses a compression or media type that is not supported.
+    #[error("unsupported OCI layer media type: {0}")]
+    UnsupportedLayer(String),
+
+    /// A prepared root disk is missing a required path.
+    #[error("prepared image is missing required path {0}")]
+    MissingPreparedPath(&'static str),
+
+    /// OCI image configuration JSON was invalid.
+    #[error("invalid OCI image JSON: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// A build VM operation failed.
+    #[error("VM image build failed: {0}")]
+    Vm(#[from] VmToolSessionError),
+
+    /// A Dockerfile instruction returned a nonzero status.
+    #[error(
+        "Dockerfile stage {stage} instruction {instruction} exited with {exit_code}\nstdout (tail):\n{stdout}\nstderr (tail):\n{stderr}"
+    )]
+    BuildStep {
+        /// Zero-based Dockerfile stage index.
+        stage: usize,
+        /// Zero-based instruction index within the stage.
+        instruction: usize,
+        /// Guest process exit code.
+        exit_code: i32,
+        /// Bounded tail of standard output.
+        stdout: String,
+        /// Bounded tail of standard error.
+        stderr: String,
+    },
+
+    /// A context-relative `COPY` source did not exist.
+    #[error("COPY source does not exist in the build context: {0}")]
+    MissingCopySource(String),
+
+    /// `COPY --from` referred to neither an earlier stage nor an OCI image.
+    #[error("COPY --from refers to unknown stage or image: {0}")]
+    UnknownCopySource(String),
+}
+
+impl PreparedRootDisk {
+    async fn prepare_directory(
+        directory: &Path,
+        disk_bytes: u64,
+        cache: &Path,
+        policy: CachePolicy,
+        builder: &VmImageBuilder,
+    ) -> Result<Self, ImageError> {
+        let dockerfile_path = directory.join("Dockerfile");
+        let dockerfile = fs::read_to_string(&dockerfile_path)?;
+        info!(
+            target: "nanocodex_vm",
+            content_kind = "dockerfile",
+            content = dockerfile,
+            "VM image input"
+        );
+        let recipe = DockerfileRecipe::parse(&dockerfile)?;
+        let disk_bytes = disk_bytes.max(MINIMUM_DISK_BYTES);
+        let images = resolve_recipe_images(&recipe, cache, policy).await?;
+        let final_stage = recipe.final_stage().ok_or(ImageError::InvalidFrom)?;
+        let final_image = images
+            .get(&final_stage.base_image)
+            .ok_or_else(|| ImageError::UnknownCopySource(final_stage.base_image.clone()))?;
+        let (path, disk_status, environment, shell) = if recipe.requires_build() {
+            prepare_built_disk(
+                directory,
+                &dockerfile,
+                &recipe,
+                &images,
+                cache,
+                disk_bytes,
+                builder,
+            )
+            .await?
+        } else {
+            let (path, status, shell) =
+                prepare_flattened_disk(cache, final_image, disk_bytes).await?;
+            (
+                path,
+                status,
+                docker_process_environment(&final_image.config.environment),
+                shell,
+            )
+        };
+        Ok(Self {
+            shell,
+            path,
+            workdir: recipe.final_workdir().to_owned(),
+            environment,
+            manifest_digest: final_image.manifest_digest.clone(),
+            manifest_source: final_image.source,
+            disk_status,
+        })
+    }
+
+    /// Returns the immutable cached root-disk path.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Returns the final Dockerfile working directory.
+    #[must_use]
+    pub fn workdir(&self) -> &str {
+        &self.workdir
+    }
+
+    /// Returns the detected guest shell name, either `bash` or `sh`.
+    #[must_use]
+    pub fn shell(&self) -> &str {
+        &self.shell
+    }
+
+    /// Returns the final Docker process environment.
+    #[must_use]
+    pub const fn environment(&self) -> &BTreeMap<String, String> {
+        &self.environment
+    }
+
+    /// Returns the immutable digest of the final stage's base manifest.
+    #[must_use]
+    pub fn manifest_digest(&self) -> &str {
+        &self.manifest_digest
+    }
+
+    /// Returns how the final stage's base manifest was resolved.
+    #[must_use]
+    pub const fn manifest_source(&self) -> ManifestSource {
+        self.manifest_source
+    }
+
+    /// Returns whether this preparation reused or created the cached disk.
+    #[must_use]
+    pub const fn disk_status(&self) -> DiskStatus {
+        self.disk_status
+    }
+
+    /// Creates a disposable copy-on-write attempt disk.
+    ///
+    /// The destination must not exist and its parent directory must already
+    /// exist. Filesystems without reflink support use a sparse copy fallback.
+    /// The returned value is the logical disk size in bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error when the destination exists or cannot be cloned.
+    pub fn reflink_to(&self, destination: impl AsRef<Path>) -> Result<u64, ImageError> {
+        let destination = destination.as_ref();
+        if destination.exists() {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                format!(
+                    "attempt root disk already exists: {}",
+                    destination.display()
+                ),
+            )
+            .into());
+        }
+        Ok(reflink_or_sparse_copy(&self.path, destination)?)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct ReferenceRecord {
+    version: u32,
+    image_reference: String,
+    manifest_digest: String,
+    layers: Vec<LayerRecord>,
+    #[serde(default)]
+    config: ImageRuntimeConfig,
+}
+
+#[derive(Deserialize, Serialize)]
+struct PreparedDiskRecord {
+    version: u32,
+    file_bytes: u64,
+    modified_nanos: u128,
+    shell: String,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+struct LayerRecord {
+    digest: String,
+    media_type: String,
+}
+
+#[derive(Clone, Default, Deserialize, Serialize)]
+struct ImageRuntimeConfig {
+    environment: BTreeMap<String, String>,
+    working_directory: String,
+}
+
+fn read_cache_record<T: DeserializeOwned>(path: &Path) -> Result<Option<T>, ImageError> {
+    match fs::read(path) {
+        Ok(bytes) => match serde_json::from_slice(&bytes) {
+            Ok(record) => Ok(Some(record)),
+            Err(error) => {
+                info!(
+                    target: "nanocodex_vm",
+                    cache_record_path = %path.display(),
+                    error = %error,
+                    "ignoring invalid VM image cache record"
+                );
+                Ok(None)
+            }
+        },
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn write_cache_record(path: &Path, record: &impl Serialize) -> Result<(), ImageError> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::other("VM cache record path has no parent"))?;
+    fs::create_dir_all(parent)?;
+    let mut temporary = tempfile::Builder::new()
+        .prefix(".record.")
+        .tempfile_in(parent)?;
+    serde_json::to_writer(temporary.as_file_mut(), record)?;
+    publish(temporary.into_temp_path(), path)?;
+    Ok(())
+}
+
+struct CacheLock(File);
+
+impl CacheLock {
+    fn acquire(cache: &Path, namespace: &str, key: &str) -> io::Result<Self> {
+        let directory = cache.join("locks").join(namespace);
+        fs::create_dir_all(&directory)?;
+        let file = fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .truncate(false)
+            .write(true)
+            .open(directory.join(format!("{key}.lock")))?;
+        fs2::FileExt::lock_exclusive(&file)?;
+        Ok(Self(file))
+    }
+}
+
+impl Drop for CacheLock {
+    fn drop(&mut self) {
+        let _ = fs2::FileExt::unlock(&self.0);
+    }
+}
+
+async fn acquire_cache_lock(
+    cache: &Path,
+    namespace: &'static str,
+    key: &str,
+) -> Result<CacheLock, ImageError> {
+    let span = info_span!(
+        target: "nanocodex_vm",
+        "vm.image.cache_lock",
+        otel.kind = "internal",
+        image.cache.namespace = namespace,
+        image.cache.key = key,
+    );
+    let cache = cache.to_path_buf();
+    let key = key.to_owned();
+    tokio::task::spawn_blocking(move || {
+        span.in_scope(|| CacheLock::acquire(&cache, namespace, &key))
+    })
+    .await?
+    .map_err(Into::into)
+}
+
+fn temporary_path(directory: &Path, prefix: &str) -> io::Result<tempfile::TempPath> {
+    Ok(tempfile::Builder::new()
+        .prefix(prefix)
+        .tempfile_in(directory)?
+        .into_temp_path())
+}
+
+fn publish(temporary: tempfile::TempPath, destination: &Path) -> io::Result<()> {
+    temporary.persist(destination).map_err(|error| error.error)
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct DockerfileRecipe {
+    stages: Vec<DockerfileStage>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct DockerfileStage {
+    base_image: String,
+    name: Option<String>,
+    instructions: Vec<DockerfileInstruction>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum DockerfileInstruction {
+    Run(String),
+    Copy(DockerfileCopy),
+    Workdir(String),
+    Env {
+        name: String,
+        value: String,
+    },
+    Arg {
+        name: String,
+        default: Option<String>,
+    },
+    Cmd(String),
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct DockerfileCopy {
+    from: Option<String>,
+    sources: Vec<String>,
+    destination: String,
+}
+
+impl DockerfileRecipe {
+    fn parse(dockerfile: &str) -> Result<Self, ImageError> {
+        let mut stages = Vec::<DockerfileStage>::new();
+        for line in dockerfile_logical_lines(dockerfile)? {
+            let (instruction, arguments) = line
+                .split_once(char::is_whitespace)
+                .ok_or_else(|| ImageError::UnsupportedDockerfile(line.clone()))?;
+            match instruction.to_ascii_uppercase().as_str() {
+                "FROM" => {
+                    let fields = arguments.split_whitespace().collect::<Vec<_>>();
+                    let (base_image, name) = match fields.as_slice() {
+                        [base_image] => ((*base_image).to_owned(), None),
+                        [base_image, keyword, name] if keyword.eq_ignore_ascii_case("AS") => {
+                            ((*base_image).to_owned(), Some((*name).to_owned()))
+                        }
+                        _ => return Err(ImageError::InvalidFrom),
+                    };
+                    if base_image.is_empty() {
+                        return Err(ImageError::InvalidFrom);
+                    }
+                    stages.push(DockerfileStage {
+                        base_image,
+                        name,
+                        instructions: Vec::new(),
+                    });
+                }
+                "WORKDIR" => {
+                    if arguments.split_whitespace().count() != 1 || !valid_guest_workdir(arguments)
+                    {
+                        return Err(ImageError::UnsupportedDockerfile(line.clone()));
+                    }
+                    current_stage(&mut stages, &line)?
+                        .instructions
+                        .push(DockerfileInstruction::Workdir(arguments.to_owned()));
+                }
+                "RUN" if !arguments.trim().is_empty() => current_stage(&mut stages, &line)?
+                    .instructions
+                    .push(DockerfileInstruction::Run(arguments.to_owned())),
+                "COPY" => current_stage(&mut stages, &line)?
+                    .instructions
+                    .push(DockerfileInstruction::Copy(parse_copy(arguments, &line)?)),
+                "ENV" => {
+                    let assignments = parse_environment_assignments(arguments, &line)?;
+                    current_stage(&mut stages, &line)?.instructions.extend(
+                        assignments
+                            .into_iter()
+                            .map(|(name, value)| DockerfileInstruction::Env { name, value }),
+                    );
+                }
+                "ARG" => {
+                    let (name, default) = match arguments.split_once('=') {
+                        Some((name, value)) => (name, Some(value.to_owned())),
+                        None => (arguments, None),
+                    };
+                    if !valid_environment_name(name) {
+                        return Err(ImageError::UnsupportedDockerfile(line));
+                    }
+                    current_stage(&mut stages, &line)?.instructions.push(
+                        DockerfileInstruction::Arg {
+                            name: name.to_owned(),
+                            default,
+                        },
+                    );
+                }
+                "CMD" if !arguments.trim().is_empty() => current_stage(&mut stages, &line)?
+                    .instructions
+                    .push(DockerfileInstruction::Cmd(arguments.to_owned())),
+                _ => return Err(ImageError::UnsupportedDockerfile(line.clone())),
+            }
+        }
+        if stages.is_empty() {
+            return Err(ImageError::InvalidFrom);
+        }
+        Ok(Self { stages })
+    }
+
+    fn final_stage(&self) -> Option<&DockerfileStage> {
+        self.stages.last()
+    }
+
+    fn final_workdir(&self) -> &str {
+        self.final_stage()
+            .into_iter()
+            .flat_map(|stage| stage.instructions.iter().rev())
+            .find_map(|instruction| match instruction {
+                DockerfileInstruction::Workdir(workdir) => Some(workdir.as_str()),
+                DockerfileInstruction::Run(_)
+                | DockerfileInstruction::Copy(_)
+                | DockerfileInstruction::Env { .. }
+                | DockerfileInstruction::Arg { .. }
+                | DockerfileInstruction::Cmd(_) => None,
+            })
+            .unwrap_or("/")
+    }
+
+    fn requires_build(&self) -> bool {
+        self.stages.len() != 1
+            || self.stages.iter().any(|stage| {
+                stage
+                    .instructions
+                    .iter()
+                    .any(|instruction| !matches!(instruction, DockerfileInstruction::Workdir(_)))
+            })
+    }
+}
+
+fn dockerfile_logical_lines(dockerfile: &str) -> Result<Vec<String>, ImageError> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for raw_line in dockerfile.lines() {
+        let trimmed = raw_line.trim();
+        if current.is_empty() && (trimmed.is_empty() || trimmed.starts_with('#')) {
+            continue;
+        }
+        let continuation = raw_line.trim_end().ends_with('\\');
+        let fragment = if continuation {
+            raw_line.trim_end().strip_suffix('\\').unwrap_or(raw_line)
+        } else {
+            raw_line
+        };
+        if !current.is_empty() {
+            current.push(' ');
+        }
+        current.push_str(fragment.trim());
+        if !continuation {
+            let logical = std::mem::take(&mut current);
+            if !logical.is_empty() {
+                lines.push(logical);
+            }
+        }
+    }
+    if !current.is_empty() {
+        return Err(ImageError::UnsupportedDockerfile(current));
+    }
+    Ok(lines)
+}
+
+fn current_stage<'a>(
+    stages: &'a mut [DockerfileStage],
+    line: &str,
+) -> Result<&'a mut DockerfileStage, ImageError> {
+    stages
+        .last_mut()
+        .ok_or_else(|| ImageError::UnsupportedDockerfile(line.to_owned()))
+}
+
+fn parse_copy(arguments: &str, line: &str) -> Result<DockerfileCopy, ImageError> {
+    let mut fields = arguments.split_whitespace();
+    let first = fields
+        .next()
+        .ok_or_else(|| ImageError::UnsupportedDockerfile(line.to_owned()))?;
+    let (from, first_source) = match first.strip_prefix("--from=") {
+        Some(from) if !from.is_empty() => (Some(from.to_owned()), fields.next()),
+        Some(_) => return Err(ImageError::UnsupportedDockerfile(line.to_owned())),
+        None => (None, Some(first)),
+    };
+    let mut paths = first_source
+        .into_iter()
+        .chain(fields)
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    if paths.len() < 2 {
+        return Err(ImageError::UnsupportedDockerfile(line.to_owned()));
+    }
+    let destination = paths
+        .pop()
+        .ok_or_else(|| ImageError::UnsupportedDockerfile(line.to_owned()))?;
+    Ok(DockerfileCopy {
+        from,
+        sources: paths,
+        destination,
+    })
+}
+
+fn parse_environment_assignments(
+    arguments: &str,
+    line: &str,
+) -> Result<Vec<(String, String)>, ImageError> {
+    let mut fields = shlex::split(arguments)
+        .ok_or_else(|| ImageError::UnsupportedDockerfile(line.to_owned()))?;
+    let Some(first) = fields.first() else {
+        return Err(ImageError::UnsupportedDockerfile(line.to_owned()));
+    };
+    if !first.contains('=') {
+        if fields.len() < 2 || !valid_environment_name(first) {
+            return Err(ImageError::UnsupportedDockerfile(line.to_owned()));
+        }
+        let name = fields.remove(0);
+        return Ok(vec![(name, fields.join(" "))]);
+    }
+
+    fields
+        .into_iter()
+        .map(|assignment| {
+            let (name, value) = assignment
+                .split_once('=')
+                .ok_or_else(|| ImageError::UnsupportedDockerfile(line.to_owned()))?;
+            if !valid_environment_name(name) {
+                return Err(ImageError::UnsupportedDockerfile(line.to_owned()));
+            }
+            Ok((name.to_owned(), value.to_owned()))
+        })
+        .collect()
+}
+
+fn valid_environment_name(name: &str) -> bool {
+    let mut bytes = name.bytes();
+    bytes
+        .next()
+        .is_some_and(|byte| byte == b'_' || byte.is_ascii_alphabetic())
+        && bytes.all(|byte| byte == b'_' || byte.is_ascii_alphanumeric())
+}
+
+fn valid_guest_workdir(workdir: &str) -> bool {
+    let path = Path::new(workdir);
+    path.is_absolute()
+        && path
+            .components()
+            .all(|component| matches!(component, Component::RootDir | Component::Normal(_)))
+}
+
+async fn resolve_recipe_images(
+    recipe: &DockerfileRecipe,
+    cache: &Path,
+    policy: CachePolicy,
+) -> Result<BTreeMap<String, PulledImage>, ImageError> {
+    let stage_names = recipe
+        .stages
+        .iter()
+        .filter_map(|stage| stage.name.as_deref())
+        .collect::<BTreeSet<_>>();
+    let mut references = recipe
+        .stages
+        .iter()
+        .map(|stage| stage.base_image.clone())
+        .collect::<BTreeSet<_>>();
+    for copy in recipe.stages.iter().flat_map(|stage| {
+        stage
+            .instructions
+            .iter()
+            .filter_map(|instruction| match instruction {
+                DockerfileInstruction::Copy(copy) => Some(copy),
+                DockerfileInstruction::Run(_)
+                | DockerfileInstruction::Workdir(_)
+                | DockerfileInstruction::Env { .. }
+                | DockerfileInstruction::Arg { .. }
+                | DockerfileInstruction::Cmd(_) => None,
+            })
+    }) {
+        if let Some(from) = copy.from.as_deref()
+            && !stage_names.contains(from)
+            && from.parse::<usize>().is_err()
+        {
+            references.insert(from.to_owned());
+        }
+    }
+    let images = stream::iter(references.into_iter().map(|reference| {
+        let span = info_span!(
+            target: "nanocodex_vm",
+            "vm.image.resolve",
+            otel.kind = "client",
+            otel.status_code = tracing::field::Empty,
+            image.reference = reference.as_str(),
+            image.cache.policy = policy.as_str(),
+            image.manifest.source = tracing::field::Empty,
+            image.manifest.digest = tracing::field::Empty,
+            status = tracing::field::Empty,
+            error.message = tracing::field::Empty,
+        );
+        let operation_span = span.clone();
+        async move {
+            let result = resolve_image(&reference, cache, policy).await;
+            match &result {
+                Ok(image) => {
+                    operation_span.record("otel.status_code", "OK");
+                    operation_span.record("status", "completed");
+                    operation_span.record("image.manifest.source", image.source.as_str());
+                    operation_span.record("image.manifest.digest", image.manifest_digest.as_str());
+                }
+                Err(error) => {
+                    operation_span.record("otel.status_code", "ERROR");
+                    operation_span.record("status", "failed");
+                    operation_span.record("error.message", error.to_string());
+                }
+            }
+            result.map(|image| (reference, image))
+        }
+        .instrument(span)
+    }))
+    .buffered(MAX_CONCURRENT_IMAGE_RESOLVES)
+    .try_collect::<Vec<_>>()
+    .await?;
+    Ok(images.into_iter().collect())
+}
+
+async fn prepare_flattened_disk(
+    cache: &Path,
+    image: &PulledImage,
+    disk_bytes: u64,
+) -> Result<(PathBuf, DiskStatus, String), ImageError> {
+    let key = disk_cache_key(&image.manifest_digest, disk_bytes);
+    let path = cache.join("images").join(format!("{key}.ext4"));
+    if let Some(shell) = cached_root_disk(&path) {
+        return Ok((path, DiskStatus::Hit, shell));
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::other("prepared root disk cache path has no parent"))?;
+    fs::create_dir_all(parent)?;
+    let _lock = acquire_cache_lock(cache, "images", &key).await?;
+    if let Some(shell) = cached_root_disk(&path) {
+        return Ok((path, DiskStatus::Hit, shell));
+    }
+    let temporary = temporary_path(parent, &format!(".{key}."))?;
+    let temporary_for_task = temporary.to_path_buf();
+    let layers = image.layers.clone();
+    let span = info_span!(
+        target: "nanocodex_vm",
+        "vm.image.format",
+        otel.kind = "internal",
+        image.disk.bytes = disk_bytes,
+        image.layer.count = layers.len(),
+    );
+    tokio::task::spawn_blocking(move || {
+        span.in_scope(|| format_root_disk(&temporary_for_task, disk_bytes, &layers))
+    })
+    .await??;
+    validate_root_disk(&temporary)?;
+    publish(temporary, &path)?;
+    let shell = cached_prepared_shell(&path)?;
+    Ok((path, DiskStatus::Created, shell))
+}
+
+async fn prepare_copy_source_disk(
+    cache: &Path,
+    image: &PulledImage,
+    disk_bytes: u64,
+) -> Result<PathBuf, ImageError> {
+    let key = disk_cache_key(&image.manifest_digest, disk_bytes);
+    let path = cache.join("images").join(format!("{key}.ext4"));
+    if valid_cached_ext4_disk(&path) {
+        return Ok(path);
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::other("prepared copy source disk cache path has no parent"))?;
+    fs::create_dir_all(parent)?;
+    let _lock = acquire_cache_lock(cache, "images", &key).await?;
+    if valid_cached_ext4_disk(&path) {
+        return Ok(path);
+    }
+    let temporary = temporary_path(parent, &format!(".{key}."))?;
+    let temporary_for_task = temporary.to_path_buf();
+    let layers = image.layers.clone();
+    let span = info_span!(
+        target: "nanocodex_vm",
+        "vm.image.format",
+        otel.kind = "internal",
+        image.disk.bytes = disk_bytes,
+        image.layer.count = layers.len(),
+    );
+    tokio::task::spawn_blocking(move || {
+        span.in_scope(|| format_root_disk(&temporary_for_task, disk_bytes, &layers))
+    })
+    .await??;
+    validate_ext4_disk(&temporary)?;
+    publish(temporary, &path)?;
+    Ok(path)
+}
+
+async fn prepare_built_disk(
+    context_directory: &Path,
+    dockerfile: &str,
+    recipe: &DockerfileRecipe,
+    images: &BTreeMap<String, PulledImage>,
+    cache: &Path,
+    disk_bytes: u64,
+    builder: &VmImageBuilder,
+) -> Result<(PathBuf, DiskStatus, BTreeMap<String, String>, String), ImageError> {
+    let context_directory = context_directory.to_path_buf();
+    let context_cache = cache.to_path_buf();
+    let span = info_span!(
+        target: "nanocodex_vm",
+        "vm.image.context",
+        otel.kind = "internal",
+        image.context.path = %context_directory.display(),
+        image.disk.bytes = disk_bytes,
+    );
+    let (context_image, context_digest) = tokio::task::spawn_blocking(move || {
+        span.in_scope(|| prepare_context_disk(&context_directory, &context_cache, disk_bytes))
+    })
+    .await??;
+    let key = build_cache_key(dockerfile, &context_digest, recipe, images, disk_bytes);
+    let builds = cache.join("builds");
+    fs::create_dir_all(&builds)?;
+    let path = builds.join(format!("{key}.ext4"));
+    let final_environment = final_recipe_environment(recipe, images)?;
+    if let Some(shell) = cached_root_disk(&path) {
+        return Ok((path, DiskStatus::Hit, final_environment, shell));
+    }
+    let _lock = acquire_cache_lock(cache, "builds", &key).await?;
+    if let Some(shell) = cached_root_disk(&path) {
+        return Ok((path, DiskStatus::Hit, final_environment, shell));
+    }
+
+    let temporary = tempfile::Builder::new()
+        .prefix(&format!("{key}."))
+        .tempdir_in(&builds)?;
+    let mut stage_disks = Vec::with_capacity(recipe.stages.len());
+    for (stage_index, stage) in recipe.stages.iter().enumerate() {
+        let image = images
+            .get(&stage.base_image)
+            .ok_or_else(|| ImageError::UnknownCopySource(stage.base_image.clone()))?;
+        let (base, _, _) = prepare_flattened_disk(cache, image, disk_bytes).await?;
+        let stage_root = temporary.path().join(format!("stage-{stage_index}.ext4"));
+        reflink_or_sparse_copy(&base, &stage_root)?;
+        let span = info_span!(
+            target: "nanocodex_vm",
+            "vm.image.stage",
+            otel.kind = "internal",
+            image.stage.index = stage_index,
+            image.stage.base = stage.base_image.as_str(),
+            image.stage.instructions = stage.instructions.len(),
+        );
+        execute_stage(
+            stage_index,
+            stage,
+            recipe,
+            images,
+            cache,
+            disk_bytes,
+            &context_image,
+            &stage_disks,
+            &stage_root,
+            builder,
+        )
+        .instrument(span)
+        .await?;
+        stage_disks.push(stage_root);
+    }
+    let final_stage = stage_disks.last().ok_or(ImageError::InvalidFrom)?;
+    let published = temporary_path(&builds, &format!(".{key}.publish."))?;
+    reflink_or_sparse_copy(final_stage, &published)?;
+    validate_root_disk(&published)?;
+    publish(published, &path)?;
+    let shell = cached_prepared_shell(&path)?;
+    Ok((path, DiskStatus::Created, final_environment, shell))
+}
+
+fn prepare_context_disk(
+    environment: &Path,
+    cache: &Path,
+    task_disk_bytes: u64,
+) -> Result<(PathBuf, String), ImageError> {
+    let contexts = cache.join("contexts");
+    fs::create_dir_all(&contexts)?;
+    let mut archive_file = tempfile::NamedTempFile::new_in(&contexts)?;
+    {
+        let mut archive = tar::Builder::new(archive_file.as_file_mut());
+        append_normalized_context_entry(&mut archive, environment, Path::new("context"))?;
+        let mut walker = WalkBuilder::new(environment);
+        walker
+            .hidden(false)
+            .parents(false)
+            .ignore(false)
+            .git_ignore(false)
+            .git_global(false)
+            .git_exclude(false)
+            .follow_links(false)
+            .sort_by_file_path(std::cmp::Ord::cmp);
+        for entry in walker.build() {
+            let entry = entry.map_err(io::Error::other)?;
+            let relative = entry
+                .path()
+                .strip_prefix(environment)
+                .map_err(io::Error::other)?;
+            if relative.as_os_str().is_empty() {
+                continue;
+            }
+            append_normalized_context_entry(
+                &mut archive,
+                entry.path(),
+                &Path::new("context").join(relative),
+            )?;
+        }
+        archive.finish()?;
+    }
+    archive_file.as_file_mut().seek(SeekFrom::Start(0))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; 64 * 1024];
+    loop {
+        let read = archive_file.as_file_mut().read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    let digest = hex::encode(hasher.finalize());
+    let disk_bytes = task_disk_bytes.max(CONTEXT_DISK_BYTES);
+    let mut identity = Sha256::new();
+    identity.update(b"nanocodex-vm-context-ext4-v1\0");
+    identity.update(digest.as_bytes());
+    identity.update(disk_bytes.to_le_bytes());
+    let key = hex::encode(identity.finalize());
+    let path = contexts.join(format!("{key}.ext4"));
+    let _lock = CacheLock::acquire(cache, "contexts", &key)?;
+    if !valid_cached_ext4_disk(&path) {
+        archive_file.as_file_mut().seek(SeekFrom::Start(0))?;
+        let temporary = temporary_path(&contexts, &format!(".{key}."))?;
+        let mut formatter = Formatter::new(&temporary, BLOCK_SIZE, disk_bytes)?;
+        formatter.unpack_tar(BufReader::new(archive_file.as_file_mut()))?;
+        formatter.close()?;
+        validate_ext4_disk(&temporary)?;
+        publish(temporary, &path)?;
+    }
+    validate_ext4_disk(&path)?;
+    Ok((path, digest))
+}
+
+fn append_normalized_context_entry<W>(
+    archive: &mut tar::Builder<W>,
+    source: &Path,
+    archive_path: &Path,
+) -> Result<(), ImageError>
+where
+    W: Write,
+{
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let metadata = fs::symlink_metadata(source)?;
+    if metadata.file_type().is_symlink() {
+        return Err(ImageError::Io(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "VM build-context symlinks are unsupported: {}",
+                source.display()
+            ),
+        )));
+    }
+    let (entry_type, size) = if metadata.is_dir() {
+        (tar::EntryType::Directory, 0)
+    } else if metadata.is_file() {
+        (tar::EntryType::Regular, metadata.len())
+    } else {
+        return Err(ImageError::Io(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unsupported VM build-context entry: {}", source.display()),
+        )));
+    };
+    let mut header = tar::Header::new_gnu();
+    header.set_entry_type(entry_type);
+    header.set_size(size);
+    #[cfg(unix)]
+    header.set_mode(metadata.permissions().mode() & 0o7777);
+    #[cfg(not(unix))]
+    header.set_mode(if metadata.permissions().readonly() {
+        0o444
+    } else {
+        0o644
+    });
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_cksum();
+    if metadata.is_file() {
+        archive.append_data(
+            &mut header,
+            archive_path,
+            BufReader::new(File::open(source)?),
+        )?;
+    } else {
+        archive.append_data(&mut header, archive_path, io::empty())?;
+    }
+    Ok(())
+}
+
+struct BuildMount {
+    key: String,
+    disk: PathBuf,
+    device: String,
+    mount: String,
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn execute_stage(
+    stage_index: usize,
+    stage: &DockerfileStage,
+    recipe: &DockerfileRecipe,
+    images: &BTreeMap<String, PulledImage>,
+    cache: &Path,
+    disk_bytes: u64,
+    context_image: &Path,
+    stage_disks: &[PathBuf],
+    stage_root: &Path,
+    builder: &VmImageBuilder,
+) -> Result<(), ImageError> {
+    let mut mounts = Vec::<BuildMount>::new();
+    let mut source_mounts = BTreeMap::<String, String>::new();
+    for copy in stage
+        .instructions
+        .iter()
+        .filter_map(|instruction| match instruction {
+            DockerfileInstruction::Copy(copy) => Some(copy),
+            DockerfileInstruction::Run(_)
+            | DockerfileInstruction::Workdir(_)
+            | DockerfileInstruction::Env { .. }
+            | DockerfileInstruction::Arg { .. }
+            | DockerfileInstruction::Cmd(_) => None,
+        })
+    {
+        let Some(from) = copy.from.as_deref() else {
+            continue;
+        };
+        if source_mounts.contains_key(from) {
+            continue;
+        }
+        let disk = if let Some(source_stage) = resolve_stage_index(recipe, from) {
+            if source_stage >= stage_index {
+                return Err(ImageError::UnknownCopySource(from.to_owned()));
+            }
+            stage_disks
+                .get(source_stage)
+                .cloned()
+                .ok_or_else(|| ImageError::UnknownCopySource(from.to_owned()))?
+        } else {
+            let image = images
+                .get(from)
+                .ok_or_else(|| ImageError::UnknownCopySource(from.to_owned()))?;
+            prepare_copy_source_disk(cache, image, disk_bytes).await?
+        };
+        let source_number = mounts.len();
+        let mount = format!("/mnt/nanocodex-source-{source_number}");
+        source_mounts.insert(from.to_owned(), mount.clone());
+        mounts.push(BuildMount {
+            key: format!("source-{source_number}"),
+            disk,
+            device: guest_block_device(source_number + 3)?,
+            mount,
+        });
+    }
+
+    let (command, config, guest) = build_vmm_inputs(builder, stage_root, context_image, &mounts)?;
+    let session =
+        VmToolSession::spawn_configured(command, config, guest, builder.egress.clone()).await?;
+    let execution = execute_stage_inner(
+        &session,
+        stage_index,
+        stage,
+        images,
+        &source_mounts,
+        &mounts,
+        builder,
+    )
+    .await;
+    let shutdown = session.shutdown().await;
+    execution?;
+    shutdown?;
+    Ok(())
+}
+
+fn build_vmm_inputs(
+    builder: &VmImageBuilder,
+    stage_root: &Path,
+    context_image: &Path,
+    mounts: &[BuildMount],
+) -> Result<(Command, VmConfig, GuestCommand), ImageError> {
+    let mut command = Command::new(&builder.vmm);
+    command.args(&builder.vmm_arguments);
+    if let Some(directory) = &builder.firmware_directory {
+        configure_firmware_library_path(&mut command, directory)?;
+    }
+    let mut config = VmConfig::ext4(stage_root)
+        .cpus(builder.cpus)
+        .memory_mib(builder.memory_mib)
+        .block_device(BlockDevice::read_only(
+            BUILD_RUNTIME_ID,
+            &builder.runtime_image,
+        ))
+        .block_device(BlockDevice::read_only(BUILD_CONTEXT_ID, context_image));
+    for mount in mounts {
+        config = config.block_device(BlockDevice::read_only(&mount.key, &mount.disk));
+    }
+    let resolver = host_resolver_configuration()?;
+    let guest = GuestCommand::new("/bin/sh")
+        .arg("-c")
+        .arg(build_guest_bootstrap_script(&resolver, builder.prefer_ipv4))
+        .arg("nanocodex-vm-image-build");
+    Ok((command, config, guest))
+}
+
+fn build_guest_bootstrap_script(resolver: &str, prefer_ipv4: bool) -> String {
+    let address_preference = if prefer_ipv4 {
+        concat!(
+            "if ! printf 1 > /proc/sys/net/ipv6/conf/all/disable_ipv6; then printf '%s\\n' 'nanocodex image build bootstrap: failed to write /proc/sys/net/ipv6/conf/all/disable_ipv6' >&2; exit 125; fi; ",
+            "if ! printf 1 > /proc/sys/net/ipv6/conf/default/disable_ipv6; then printf '%s\\n' 'nanocodex image build bootstrap: failed to write /proc/sys/net/ipv6/conf/default/disable_ipv6' >&2; exit 125; fi; "
+        )
+    } else {
+        ""
+    };
+    format!(
+        "{address_preference}printf '{resolver}' > /etc/resolv.conf && mkdir -p {BUILD_RUNTIME_MOUNT} && mount -t ext4 -o ro {BUILD_RUNTIME_DEVICE} {BUILD_RUNTIME_MOUNT} && exec {BUILD_RUNTIME_MOUNT}/nanocodex-vm-guest /"
+    )
+}
+
+fn configure_firmware_library_path(command: &mut Command, directory: &Path) -> io::Result<()> {
+    if directory.join(FIRMWARE_LIBRARY_FILENAME).is_file() {
+        command.env(FIRMWARE_LIBRARY_PATH_ENVIRONMENT, directory.canonicalize()?);
+    }
+    Ok(())
+}
+
+async fn execute_stage_inner(
+    session: &VmToolSession,
+    stage_index: usize,
+    stage: &DockerfileStage,
+    images: &BTreeMap<String, PulledImage>,
+    source_mounts: &BTreeMap<String, String>,
+    mounts: &[BuildMount],
+    builder: &VmImageBuilder,
+) -> Result<(), ImageError> {
+    mount_build_disk(
+        session,
+        BUILD_CONTEXT_DEVICE,
+        BUILD_CONTEXT_MOUNT,
+        stage_index,
+        0,
+        builder.copy_timeout,
+    )
+    .await?;
+    for (index, mount) in mounts.iter().enumerate() {
+        mount_build_disk(
+            session,
+            &mount.device,
+            &mount.mount,
+            stage_index,
+            index + 1,
+            builder.copy_timeout,
+        )
+        .await?;
+    }
+
+    let image = images
+        .get(&stage.base_image)
+        .ok_or_else(|| ImageError::UnknownCopySource(stage.base_image.clone()))?;
+    let mut environment = docker_process_environment(&image.config.environment);
+    let mut arguments = BTreeMap::<String, String>::new();
+    let mut workdir = image.config.working_directory.clone();
+    if !valid_guest_workdir(&workdir) {
+        "/".clone_into(&mut workdir);
+    }
+
+    for (instruction_index, instruction) in stage.instructions.iter().enumerate() {
+        match instruction {
+            DockerfileInstruction::Workdir(directory) => {
+                workdir.clone_from(directory);
+                run_build_command(
+                    session,
+                    stage_index,
+                    instruction_index,
+                    VmCommand::new("/bin/mkdir")
+                        .arg("-p")
+                        .arg(directory)
+                        .timeout(builder.copy_timeout),
+                )
+                .await?;
+            }
+            DockerfileInstruction::Env { name, value } => {
+                let value = expand_variables(value, &environment, &arguments);
+                environment.insert(name.clone(), value);
+            }
+            DockerfileInstruction::Arg { name, default } => {
+                let value = default
+                    .as_deref()
+                    .map(|value| expand_variables(value, &environment, &arguments))
+                    .unwrap_or_default();
+                arguments.insert(name.clone(), value);
+            }
+            DockerfileInstruction::Run(script) => {
+                let mut command = VmCommand::new("/bin/sh")
+                    .arg("-c")
+                    .arg(script)
+                    .current_directory(&workdir)
+                    .timeout(builder.run_timeout);
+                command = command.environment(build_environment(&environment, &arguments));
+                run_build_command(session, stage_index, instruction_index, command).await?;
+            }
+            DockerfileInstruction::Copy(copy) => {
+                execute_copy(CopyExecution {
+                    session,
+                    stage_index,
+                    instruction_index,
+                    copy,
+                    workdir: &workdir,
+                    source_mounts,
+                    environment: &environment,
+                    arguments: &arguments,
+                    timeout: builder.copy_timeout,
+                })
+                .await?;
+            }
+            DockerfileInstruction::Cmd(_) => {}
+        }
+    }
+    Ok(())
+}
+
+async fn mount_build_disk(
+    session: &VmToolSession,
+    device: &str,
+    mount: &str,
+    stage: usize,
+    instruction: usize,
+    timeout: Duration,
+) -> Result<(), ImageError> {
+    run_build_command(
+        session,
+        stage,
+        instruction,
+        VmCommand::new("/bin/sh")
+            .arg("-c")
+            .arg("mkdir -p \"$1\" && mount -t ext4 -o ro \"$2\" \"$1\"")
+            .arg("nanocodex-vm-mount")
+            .arg(mount)
+            .arg(device)
+            .timeout(timeout),
+    )
+    .await
+}
+
+struct CopyExecution<'a> {
+    session: &'a VmToolSession,
+    stage_index: usize,
+    instruction_index: usize,
+    copy: &'a DockerfileCopy,
+    workdir: &'a str,
+    source_mounts: &'a BTreeMap<String, String>,
+    environment: &'a BTreeMap<String, String>,
+    arguments: &'a BTreeMap<String, String>,
+    timeout: Duration,
+}
+
+async fn execute_copy(input: CopyExecution<'_>) -> Result<(), ImageError> {
+    let source_root = match input.copy.from.as_deref() {
+        None => format!("{BUILD_CONTEXT_MOUNT}/context"),
+        Some(from) => input
+            .source_mounts
+            .get(from)
+            .cloned()
+            .ok_or_else(|| ImageError::UnknownCopySource(from.to_owned()))?,
+    };
+    let mut sources = Vec::with_capacity(input.copy.sources.len());
+    for source in &input.copy.sources {
+        let expanded = expand_variables(source, input.environment, input.arguments);
+        let relative = expanded.strip_prefix('/').unwrap_or(&expanded);
+        let relative = relative.strip_prefix("./").unwrap_or(relative);
+        let relative = Path::new(relative);
+        if relative.is_absolute()
+            || relative.components().any(|component| {
+                matches!(
+                    component,
+                    Component::ParentDir | Component::RootDir | Component::Prefix(_)
+                )
+            })
+        {
+            return Err(ImageError::MissingCopySource(expanded));
+        }
+        let source_path = Path::new(&source_root).join(relative);
+        sources.push(source_path.to_string_lossy().into_owned());
+    }
+    let destination = expand_variables(&input.copy.destination, input.environment, input.arguments);
+    let destination = if Path::new(&destination).is_absolute() {
+        destination
+    } else {
+        Path::new(input.workdir)
+            .join(destination)
+            .to_string_lossy()
+            .into_owned()
+    };
+    let mut command = VmCommand::new("/bin/sh")
+        .arg("-c")
+        .arg(COPY_SCRIPT)
+        .arg("nanocodex-vm-copy")
+        .arg(destination)
+        .timeout(input.timeout);
+    for source in sources {
+        command = command.arg(source);
+    }
+    run_build_command(
+        input.session,
+        input.stage_index,
+        input.instruction_index,
+        command,
+    )
+    .await
+}
+
+async fn run_build_command(
+    session: &VmToolSession,
+    stage: usize,
+    instruction: usize,
+    command: VmCommand,
+) -> Result<(), ImageError> {
+    let output = session.command(command).await?;
+    info!(
+        target: "nanocodex_vm",
+        build_stage = stage,
+        build_instruction = instruction,
+        process.exit_code = output.exit_code,
+        process.stdout.bytes = output.stdout.len(),
+        process.stderr.bytes = output.stderr.len(),
+        "VM image build instruction completed"
+    );
+    if output.exit_code == 0 {
+        return Ok(());
+    }
+    let stdout = output_tail(&output.stdout);
+    let stderr = output_tail(&output.stderr);
+    Err(ImageError::BuildStep {
+        stage,
+        instruction,
+        exit_code: output.exit_code,
+        stdout,
+        stderr,
+    })
+}
+
+fn output_tail(output: &[u8]) -> String {
+    const MAXIMUM_CHARS: usize = 8_192;
+
+    let output = String::from_utf8_lossy(output);
+    let skip = output.chars().count().saturating_sub(MAXIMUM_CHARS);
+    output.chars().skip(skip).collect()
+}
+
+fn build_environment(
+    environment: &BTreeMap<String, String>,
+    arguments: &BTreeMap<String, String>,
+) -> Vec<(String, String)> {
+    let mut result = environment.clone();
+    result.extend(arguments.clone());
+    result.into_iter().collect()
+}
+
+fn docker_process_environment(
+    image_environment: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    let mut environment = image_environment.clone();
+    environment
+        .entry("HOME".to_owned())
+        .or_insert_with(|| "/root".to_owned());
+    environment
+        .entry("PATH".to_owned())
+        .or_insert_with(|| DEFAULT_GUEST_PATH.to_owned());
+    environment
+}
+
+fn resolve_stage_index(recipe: &DockerfileRecipe, reference: &str) -> Option<usize> {
+    reference.parse::<usize>().ok().or_else(|| {
+        recipe
+            .stages
+            .iter()
+            .position(|stage| stage.name.as_deref() == Some(reference))
+    })
+}
+
+fn guest_block_device(index: usize) -> Result<String, ImageError> {
+    let suffix = u8::try_from(index)
+        .ok()
+        .and_then(|index| b'a'.checked_add(index))
+        .filter(u8::is_ascii_lowercase)
+        .ok_or_else(|| {
+            ImageError::UnsupportedDockerfile("too many build source disks".to_owned())
+        })?;
+    Ok(format!("/dev/vd{}", char::from(suffix)))
+}
+
+fn final_recipe_environment(
+    recipe: &DockerfileRecipe,
+    images: &BTreeMap<String, PulledImage>,
+) -> Result<BTreeMap<String, String>, ImageError> {
+    let stage = recipe.final_stage().ok_or(ImageError::InvalidFrom)?;
+    let image = images
+        .get(&stage.base_image)
+        .ok_or_else(|| ImageError::UnknownCopySource(stage.base_image.clone()))?;
+    let mut environment = docker_process_environment(&image.config.environment);
+    let mut arguments = BTreeMap::new();
+    for instruction in &stage.instructions {
+        match instruction {
+            DockerfileInstruction::Env { name, value } => {
+                environment.insert(
+                    name.clone(),
+                    expand_variables(value, &environment, &arguments),
+                );
+            }
+            DockerfileInstruction::Arg { name, default } => {
+                arguments.insert(
+                    name.clone(),
+                    default
+                        .as_deref()
+                        .map(|value| expand_variables(value, &environment, &arguments))
+                        .unwrap_or_default(),
+                );
+            }
+            DockerfileInstruction::Run(_)
+            | DockerfileInstruction::Copy(_)
+            | DockerfileInstruction::Workdir(_)
+            | DockerfileInstruction::Cmd(_) => {}
+        }
+    }
+    Ok(environment)
+}
+
+fn expand_variables(
+    input: &str,
+    environment: &BTreeMap<String, String>,
+    arguments: &BTreeMap<String, String>,
+) -> String {
+    let bytes = input.as_bytes();
+    let mut output = String::with_capacity(input.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'$' {
+            output.push(char::from(bytes[index]));
+            index += 1;
+            continue;
+        }
+        if bytes.get(index + 1) == Some(&b'{') {
+            let Some(end) = bytes[index + 2..].iter().position(|byte| *byte == b'}') else {
+                output.push('$');
+                index += 1;
+                continue;
+            };
+            let end = index + 2 + end;
+            let name = &input[index + 2..end];
+            output.push_str(
+                arguments
+                    .get(name)
+                    .or_else(|| environment.get(name))
+                    .map_or("", String::as_str),
+            );
+            index = end + 1;
+            continue;
+        }
+        let start = index + 1;
+        let mut end = start;
+        while end < bytes.len() && (bytes[end] == b'_' || bytes[end].is_ascii_alphanumeric()) {
+            end += 1;
+        }
+        if end == start {
+            output.push('$');
+            index += 1;
+            continue;
+        }
+        let name = &input[start..end];
+        output.push_str(
+            arguments
+                .get(name)
+                .or_else(|| environment.get(name))
+                .map_or("", String::as_str),
+        );
+        index = end;
+    }
+    output
+}
+
+fn build_cache_key(
+    dockerfile: &str,
+    context_digest: &str,
+    recipe: &DockerfileRecipe,
+    images: &BTreeMap<String, PulledImage>,
+    disk_bytes: u64,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"nanocodex-vm-image-build\0");
+    hasher.update(IMAGE_BUILD_CACHE_VERSION.to_le_bytes());
+    hasher.update(b"linux\0");
+    hasher.update(GUEST_ARCHITECTURE.as_bytes());
+    hasher.update([0]);
+    hasher.update(disk_bytes.to_le_bytes());
+    hasher.update(context_digest.as_bytes());
+    hasher.update([0]);
+    hasher.update(dockerfile.as_bytes());
+    for stage in &recipe.stages {
+        hasher.update([0]);
+        hasher.update(stage.base_image.as_bytes());
+        if let Some(image) = images.get(&stage.base_image) {
+            hasher.update([0]);
+            hasher.update(image.manifest_digest.as_bytes());
+        }
+    }
+    for (reference, image) in images {
+        hasher.update([0]);
+        hasher.update(reference.as_bytes());
+        hasher.update([0]);
+        hasher.update(image.manifest_digest.as_bytes());
+    }
+    hex::encode(hasher.finalize())
+}
+
+fn host_resolver_configuration() -> io::Result<String> {
+    for path in ["/run/systemd/resolve/resolv.conf", "/etc/resolv.conf"] {
+        let Ok(contents) = fs::read_to_string(path) else {
+            continue;
+        };
+        let configuration = resolver_configuration(&contents);
+        if !configuration.is_empty() {
+            return Ok(configuration);
+        }
+    }
+    Err(io::Error::other("host resolver has no usable nameserver"))
+}
+
+fn resolver_configuration(contents: &str) -> String {
+    let mut configuration = String::new();
+    for line in contents.lines() {
+        let mut fields = line.split_whitespace();
+        if fields.next() != Some("nameserver") {
+            continue;
+        }
+        let Some(address) = fields.next() else {
+            continue;
+        };
+        let Ok(address) = address.parse::<std::net::IpAddr>() else {
+            continue;
+        };
+        if fields.next().is_some() || address.is_loopback() || address.is_unspecified() {
+            continue;
+        }
+        configuration.push_str("nameserver ");
+        configuration.push_str(&address.to_string());
+        configuration.push_str("\\n");
+    }
+    configuration
+}
+
+#[derive(Clone)]
+struct PulledLayer {
+    digest: String,
+    path: PathBuf,
+    media_type: String,
+}
+
+#[derive(Clone)]
+struct PulledImage {
+    manifest_digest: String,
+    layers: Vec<PulledLayer>,
+    source: ManifestSource,
+    config: ImageRuntimeConfig,
+}
+
+async fn resolve_image(
+    image_reference: &str,
+    cache: &Path,
+    policy: CachePolicy,
+) -> Result<PulledImage, ImageError> {
+    let reference_key = reference_cache_key(image_reference);
+    let reference_path = cache
+        .join("references")
+        .join(format!("{reference_key}.json"));
+    if policy == CachePolicy::Reuse
+        && let Some(record) = read_cache_record::<ReferenceRecord>(&reference_path)?
+        && let Some(image) = local_image(image_reference, cache, record)
+    {
+        return Ok(image);
+    }
+    let _lock = acquire_cache_lock(cache, "references", &reference_key).await?;
+    if policy == CachePolicy::Reuse
+        && let Some(record) = read_cache_record::<ReferenceRecord>(&reference_path)?
+        && let Some(image) = local_image(image_reference, cache, record)
+    {
+        return Ok(image);
+    }
+
+    let image = pull_layers(image_reference, &cache.join("blobs")).await?;
+    let record = ReferenceRecord {
+        version: CACHE_RECORD_VERSION,
+        image_reference: image_reference.to_owned(),
+        manifest_digest: image.manifest_digest.clone(),
+        layers: image
+            .layers
+            .iter()
+            .map(|layer| LayerRecord {
+                digest: layer.digest.clone(),
+                media_type: layer.media_type.clone(),
+            })
+            .collect(),
+        config: image.config.clone(),
+    };
+    write_cache_record(&reference_path, &record)?;
+    Ok(image)
+}
+
+fn local_image(image: &str, cache: &Path, record: ReferenceRecord) -> Option<PulledImage> {
+    if record.version != CACHE_RECORD_VERSION
+        || record.image_reference != image
+        || !valid_digest(&record.manifest_digest)
+        || record.layers.is_empty()
+        || record
+            .layers
+            .iter()
+            .any(|layer| !valid_digest(&layer.digest) || layer.media_type.is_empty())
+    {
+        return None;
+    }
+    let layers = record
+        .layers
+        .into_iter()
+        .map(|layer| PulledLayer {
+            path: blob_path(&cache.join("blobs"), &layer.digest),
+            digest: layer.digest,
+            media_type: layer.media_type,
+        })
+        .collect::<Vec<_>>();
+    if layers.iter().any(|layer| !layer.path.is_file()) {
+        return None;
+    }
+    Some(PulledImage {
+        manifest_digest: record.manifest_digest,
+        layers,
+        source: ManifestSource::Local,
+        config: record.config,
+    })
+}
+
+async fn pull_layers(image: &str, blobs: &Path) -> Result<PulledImage, ImageError> {
+    fs::create_dir_all(blobs)?;
+    let reference = Reference::try_from(image).map_err(|source| ImageError::Reference {
+        image: image.to_owned(),
+        source,
+    })?;
+    let config = ClientConfig {
+        platform_resolver: Some(Box::new(linux_guest_manifest)),
+        ..ClientConfig::default()
+    };
+    let client = Client::new(config);
+    let (manifest, manifest_digest, config_json) = client
+        .pull_manifest_and_config(&reference, &RegistryAuth::Anonymous)
+        .await?;
+    let config = parse_image_config(&config_json)?;
+    let layers = stream::iter(manifest.layers.into_iter().map(|descriptor| {
+        let span = info_span!(
+            target: "nanocodex_vm",
+            "vm.image.blob",
+            otel.kind = "client",
+            image.reference = image,
+            image.layer.digest = descriptor.digest.as_str(),
+            image.layer.media_type = descriptor.media_type.as_str(),
+        );
+        let client = &client;
+        let reference = &reference;
+        async move {
+            let path = blob_path(blobs, &descriptor.digest);
+            if !path.is_file() {
+                let lock_key = reference_cache_key(&descriptor.digest);
+                let _lock = acquire_cache_lock(blobs, "blobs", &lock_key).await?;
+                if !path.is_file() {
+                    let temporary = temporary_path(blobs, &format!(".{lock_key}."))?;
+                    let mut output = tokio::fs::File::create(&temporary).await?;
+                    client
+                        .pull_blob(reference, &descriptor, &mut output)
+                        .await?;
+                    output.sync_all().await?;
+                    drop(output);
+                    publish(temporary, &path)?;
+                }
+            }
+            Ok::<_, ImageError>(PulledLayer {
+                digest: descriptor.digest,
+                path,
+                media_type: descriptor.media_type,
+            })
+        }
+        .instrument(span)
+    }))
+    .buffered(MAX_CONCURRENT_LAYER_DOWNLOADS)
+    .try_collect::<Vec<_>>()
+    .await?;
+    Ok(PulledImage {
+        manifest_digest,
+        layers,
+        source: ManifestSource::Registry,
+        config,
+    })
+}
+
+fn parse_image_config(config: &str) -> Result<ImageRuntimeConfig, ImageError> {
+    let config = serde_json::from_str::<ConfigFile>(config)?
+        .config
+        .unwrap_or_default();
+    let mut environment = BTreeMap::new();
+    for entry in config.env.unwrap_or_default() {
+        let Some((name, value)) = entry.split_once('=') else {
+            continue;
+        };
+        if valid_environment_name(name) {
+            environment.insert(name.to_owned(), value.to_owned());
+        }
+    }
+    let working_directory = config
+        .working_dir
+        .filter(|directory| valid_guest_workdir(directory))
+        .unwrap_or_else(|| "/".to_owned());
+    Ok(ImageRuntimeConfig {
+        environment,
+        working_directory,
+    })
+}
+
+fn blob_path(cache: &Path, digest: &str) -> PathBuf {
+    cache.join(digest.replace(':', "-"))
+}
+
+fn valid_digest(digest: &str) -> bool {
+    let Some(hash) = digest.strip_prefix("sha256:") else {
+        return false;
+    };
+    hash.len() == 64 && hash.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn linux_guest_manifest(manifests: &[ImageIndexEntry]) -> Option<String> {
+    manifests
+        .iter()
+        .find(|entry| {
+            entry.platform.as_ref().is_some_and(|platform| {
+                platform.os.to_string() == "linux"
+                    && platform.architecture.to_string() == GUEST_ARCHITECTURE
+            })
+        })
+        .map(|entry| entry.digest.clone())
+}
+
+fn format_root_disk(path: &Path, size: u64, layers: &[PulledLayer]) -> Result<(), ImageError> {
+    let mut formatter = Formatter::new(path, BLOCK_SIZE, size)?;
+    for layer in layers {
+        let file = File::open(&layer.path)?;
+        match layer.media_type.as_str() {
+            "application/vnd.docker.image.rootfs.diff.tar.gzip"
+            | "application/vnd.oci.image.layer.v1.tar+gzip"
+            | "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip" => {
+                formatter.unpack_tar(GzDecoder::new(BufReader::new(file)))?;
+            }
+            "application/vnd.oci.image.layer.v1.tar+zstd" => {
+                formatter.unpack_tar(zstd::stream::read::Decoder::new(BufReader::new(file))?)?;
+            }
+            "application/vnd.docker.image.rootfs.diff.tar"
+            | "application/vnd.oci.image.layer.v1.tar"
+            | "application/vnd.oci.image.layer.nondistributable.v1.tar" => {
+                formatter.unpack_tar(BufReader::new(file))?;
+            }
+            media_type => return Err(ImageError::UnsupportedLayer(media_type.to_owned())),
+        }
+    }
+    formatter.close()?;
+    Ok(())
+}
+
+fn validate_root_disk(path: &Path) -> Result<(), ImageError> {
+    validate_ext4_disk(path)?;
+    let mut reader = Reader::new(path)?;
+    for required in ["/bin/sh"] {
+        if !reader.exists(required) {
+            return Err(ImageError::MissingPreparedPath(required));
+        }
+    }
+    Ok(())
+}
+
+fn cached_root_disk(path: &Path) -> Option<String> {
+    if !path.is_file() {
+        return None;
+    }
+    match cached_prepared_shell(path) {
+        Ok(shell) => Some(shell),
+        Err(error) => {
+            info!(
+                target: "nanocodex_vm",
+                image_root_path = %path.display(),
+                error = %error,
+                "rebuilding invalid VM image cache disk"
+            );
+            None
+        }
+    }
+}
+
+fn valid_cached_ext4_disk(path: &Path) -> bool {
+    path.is_file() && validate_ext4_disk(path).is_ok()
+}
+
+fn cached_prepared_shell(path: &Path) -> Result<String, ImageError> {
+    let metadata = fs::metadata(path)?;
+    let modified_nanos = modified_nanos(&metadata)?;
+    let record_path = path.with_extension("prepared.json");
+    if let Some(record) = read_cache_record::<PreparedDiskRecord>(&record_path)?
+        && record.version == PREPARED_DISK_RECORD_VERSION
+        && record.file_bytes == metadata.len()
+        && record.modified_nanos == modified_nanos
+        && matches!(record.shell.as_str(), "bash" | "sh")
+    {
+        return Ok(record.shell);
+    }
+
+    let shell = prepared_shell(path)?.to_owned();
+    write_cache_record(
+        &record_path,
+        &PreparedDiskRecord {
+            version: PREPARED_DISK_RECORD_VERSION,
+            file_bytes: metadata.len(),
+            modified_nanos,
+            shell: shell.clone(),
+        },
+    )?;
+    Ok(shell)
+}
+
+fn modified_nanos(metadata: &fs::Metadata) -> io::Result<u128> {
+    metadata
+        .modified()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .map_err(io::Error::other)
+}
+
+fn prepared_shell(path: &Path) -> Result<&'static str, ImageError> {
+    let mut reader = Reader::new(path)?;
+    if reader.exists("/bin/bash") {
+        Ok("bash")
+    } else if reader.exists("/bin/sh") {
+        Ok("sh")
+    } else {
+        Err(ImageError::MissingPreparedPath("/bin/sh"))
+    }
+}
+
+fn validate_ext4_disk(path: &Path) -> Result<(), ImageError> {
+    let mut reader = Reader::new(path)?;
+    if !reader.exists("/") {
+        return Err(ImageError::MissingPreparedPath("/"));
+    }
+    Ok(())
+}
+
+fn disk_cache_key(manifest_digest: &str, disk_bytes: u64) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"nanocodex-vm-ext4-v3\0linux\0");
+    hasher.update(GUEST_ARCHITECTURE.as_bytes());
+    hasher.update([0]);
+    hasher.update(manifest_digest.as_bytes());
+    hasher.update([0]);
+    hasher.update(disk_bytes.to_le_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn reference_cache_key(image: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"nanocodex-vm-reference-v1\0linux\0");
+    hasher.update(GUEST_ARCHITECTURE.as_bytes());
+    hasher.update([0]);
+    hasher.update(image.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{BTreeMap, HashMap},
+        ffi::OsStr,
+        fs::{self, File},
+        path::{Path, PathBuf},
+        process::Command,
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use crate::{config::Network, egress::EgressLease};
+
+    use super::{
+        CACHE_RECORD_VERSION, CONTEXT_DISK_BYTES, COPY_SCRIPT, CachePolicy, DiskStatus,
+        DockerfileRecipe, FIRMWARE_LIBRARY_FILENAME, FIRMWARE_LIBRARY_PATH_ENVIRONMENT, ImageError,
+        ImageRuntimeConfig, LayerRecord, ManifestSource, PulledImage, PulledLayer, Reader,
+        ReferenceRecord, VmImageBuilder, append_normalized_context_entry, blob_path,
+        build_guest_bootstrap_script, configure_firmware_library_path, disk_cache_key,
+        docker_process_environment, output_tail, prepare_copy_source_disk, prepare_flattened_disk,
+        reference_cache_key, resolver_configuration, write_cache_record,
+    };
+    use flate2::{Compression, write::GzEncoder};
+    use tracing::{
+        Event, Id, Instrument, Subscriber,
+        field::Visit,
+        span::{Attributes, Record},
+    };
+    use tracing_subscriber::{
+        Layer, layer::Context as LayerContext, prelude::*, registry::LookupSpan,
+    };
+
+    const FIXTURE_IMAGE: &str = "example.invalid/nanocodex-vm-fixture:latest";
+    const FIXTURE_MANIFEST: &str =
+        "sha256:56249d7a2f93306106f6d8bcdf6423afb73c1b747d874febcc778beee25cb8bb";
+    const FIXTURE_LAYER: &str =
+        "sha256:bd89d118a7a5c5bcefe7129975d406284981f597340a222b5df50f7044157ff0";
+    static IMAGE_PREPARE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[cfg(unix)]
+    #[test]
+    fn build_context_headers_preserve_modes_and_normalize_host_metadata() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("run");
+        fs::write(&source, "#!/bin/sh\n").unwrap();
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o751)).unwrap();
+        let mut encoded = Vec::new();
+        {
+            let mut archive = tar::Builder::new(&mut encoded);
+            append_normalized_context_entry(&mut archive, &source, Path::new("context/run"))
+                .unwrap();
+            archive.finish().unwrap();
+        }
+
+        let mut archive = tar::Archive::new(std::io::Cursor::new(encoded));
+        let entry = archive.entries().unwrap().next().unwrap().unwrap();
+        let header = entry.header();
+        assert_eq!(header.mode().unwrap(), 0o751);
+        assert_eq!(header.uid().unwrap(), 0);
+        assert_eq!(header.gid().unwrap(), 0);
+        assert_eq!(header.mtime().unwrap(), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn build_context_rejects_symlinks() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("escape");
+        std::os::unix::fs::symlink("/etc/passwd", &source).unwrap();
+        let mut encoded = Vec::new();
+        let mut archive = tar::Builder::new(&mut encoded);
+
+        let error =
+            append_normalized_context_entry(&mut archive, &source, Path::new("context/escape"))
+                .unwrap_err();
+
+        assert!(error.to_string().contains("symlinks are unsupported"));
+    }
+
+    struct LocalImageFixture {
+        root: tempfile::TempDir,
+        context: PathBuf,
+        cache: PathBuf,
+    }
+
+    #[derive(Clone, Default)]
+    struct TraceCapture {
+        spans: Arc<Mutex<HashMap<u64, CapturedSpan>>>,
+        events: Arc<Mutex<Vec<CapturedEvent>>>,
+    }
+
+    struct CapturedSpan {
+        name: &'static str,
+        parent: Option<u64>,
+        fields: HashMap<String, String>,
+    }
+
+    struct CapturedEvent {
+        parent: Option<u64>,
+        fields: HashMap<String, String>,
+    }
+
+    struct FieldCapture<'a>(&'a mut HashMap<String, String>);
+
+    impl Visit for FieldCapture<'_> {
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            self.0.insert(field.name().to_owned(), value.to_owned());
+        }
+
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            self.0.insert(field.name().to_owned(), format!("{value:?}"));
+        }
+    }
+
+    impl<S> Layer<S> for TraceCapture
+    where
+        S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    {
+        fn on_new_span(&self, attributes: &Attributes<'_>, id: &Id, context: LayerContext<'_, S>) {
+            let parent = attributes
+                .parent()
+                .map(|parent| parent.clone().into_u64())
+                .or_else(|| {
+                    attributes
+                        .is_contextual()
+                        .then(|| context.current_span().id().map(Id::into_u64))
+                        .flatten()
+                });
+            let mut fields = HashMap::new();
+            attributes.record(&mut FieldCapture(&mut fields));
+            self.spans.lock().unwrap().insert(
+                id.clone().into_u64(),
+                CapturedSpan {
+                    name: attributes.metadata().name(),
+                    parent,
+                    fields,
+                },
+            );
+        }
+
+        fn on_record(&self, id: &Id, values: &Record<'_>, _context: LayerContext<'_, S>) {
+            if let Some(span) = self.spans.lock().unwrap().get_mut(&id.clone().into_u64()) {
+                values.record(&mut FieldCapture(&mut span.fields));
+            }
+        }
+
+        fn on_event(&self, event: &Event<'_>, context: LayerContext<'_, S>) {
+            let parent = event
+                .parent()
+                .map(|parent| parent.clone().into_u64())
+                .or_else(|| context.current_span().id().map(Id::into_u64));
+            let mut fields = HashMap::new();
+            event.record(&mut FieldCapture(&mut fields));
+            self.events
+                .lock()
+                .unwrap()
+                .push(CapturedEvent { parent, fields });
+        }
+    }
+
+    impl LocalImageFixture {
+        fn new() -> Self {
+            let root = tempfile::tempdir().unwrap();
+            let context = root.path().join("context");
+            let cache = root.path().join("cache");
+            fs::create_dir_all(&context).unwrap();
+            fs::write(
+                context.join("Dockerfile"),
+                format!("FROM {FIXTURE_IMAGE}\nWORKDIR /workspace\n"),
+            )
+            .unwrap();
+
+            let blobs = cache.join("blobs");
+            fs::create_dir_all(&blobs).unwrap();
+            write_shell_layer(&blob_path(&blobs, FIXTURE_LAYER));
+            let record = ReferenceRecord {
+                version: CACHE_RECORD_VERSION,
+                image_reference: FIXTURE_IMAGE.to_owned(),
+                manifest_digest: FIXTURE_MANIFEST.to_owned(),
+                layers: vec![LayerRecord {
+                    digest: FIXTURE_LAYER.to_owned(),
+                    media_type: "application/vnd.oci.image.layer.v1.tar+gzip".to_owned(),
+                }],
+                config: ImageRuntimeConfig::default(),
+            };
+            write_cache_record(
+                &cache
+                    .join("references")
+                    .join(format!("{}.json", reference_cache_key(FIXTURE_IMAGE))),
+                &record,
+            )
+            .unwrap();
+            Self {
+                root,
+                context,
+                cache,
+            }
+        }
+
+        fn builder(&self) -> VmImageBuilder {
+            VmImageBuilder::new(
+                self.root.path().join("unused-vmm"),
+                self.root.path().join("unused-runtime.ext4"),
+            )
+        }
+    }
+
+    fn write_shell_layer(path: &Path) {
+        let output = File::create(path).unwrap();
+        let encoder = GzEncoder::new(output, Compression::fast());
+        let mut archive = tar::Builder::new(encoder);
+
+        let mut directory = tar::Header::new_gnu();
+        directory.set_entry_type(tar::EntryType::Directory);
+        directory.set_mode(0o755);
+        directory.set_size(0);
+        directory.set_cksum();
+        archive
+            .append_data(&mut directory, "bin/", std::io::empty())
+            .unwrap();
+
+        let contents = b"#!/bin/sh\n";
+        let mut shell = tar::Header::new_gnu();
+        shell.set_entry_type(tar::EntryType::Regular);
+        shell.set_mode(0o755);
+        shell.set_size(contents.len() as u64);
+        shell.set_cksum();
+        archive
+            .append_data(&mut shell, "bin/sh", contents.as_slice())
+            .unwrap();
+        let encoder = archive.into_inner().unwrap();
+        drop(encoder.finish().unwrap());
+    }
+
+    fn write_copy_source_layer(path: &Path) {
+        let output = File::create(path).unwrap();
+        let encoder = GzEncoder::new(output, Compression::fast());
+        let mut archive = tar::Builder::new(encoder);
+
+        let contents = b"uv fixture\n";
+        let mut executable = tar::Header::new_gnu();
+        executable.set_entry_type(tar::EntryType::Regular);
+        executable.set_mode(0o755);
+        executable.set_size(contents.len() as u64);
+        executable.set_cksum();
+        archive
+            .append_data(&mut executable, "uv", contents.as_slice())
+            .unwrap();
+        let encoder = archive.into_inner().unwrap();
+        drop(encoder.finish().unwrap());
+    }
+
+    #[test]
+    fn accepts_the_first_proof_dockerfile() {
+        let recipe =
+            DockerfileRecipe::parse("FROM python:3.13-slim-bookworm\nWORKDIR /app\n").unwrap();
+
+        assert_eq!(
+            recipe.final_stage().unwrap().base_image,
+            "python:3.13-slim-bookworm"
+        );
+        assert_eq!(recipe.final_workdir(), "/app");
+        assert!(!recipe.requires_build());
+    }
+
+    #[test]
+    fn builder_retains_explicit_vm_execution_policy() {
+        let builder = VmImageBuilder::new("/opt/nanocodex-vmm", "/cache/runtime.ext4")
+            .firmware_directory("/opt/libkrunfw")
+            .vmm_args(["run", "--private-config"])
+            .cpus(6)
+            .memory_mib(8_192)
+            .run_timeout(Duration::from_mins(15))
+            .copy_timeout(Duration::from_mins(2))
+            .egress(EgressLease::disabled());
+
+        assert_eq!(builder.vmm, Path::new("/opt/nanocodex-vmm"));
+        assert_eq!(builder.runtime_image, Path::new("/cache/runtime.ext4"));
+        assert_eq!(
+            builder.firmware_directory.as_deref(),
+            Some(Path::new("/opt/libkrunfw"))
+        );
+        assert_eq!(builder.vmm_arguments, ["run", "--private-config"]);
+        assert_eq!(builder.cpus, 6);
+        assert_eq!(builder.memory_mib, 8_192);
+        assert_eq!(builder.run_timeout, Duration::from_mins(15));
+        assert_eq!(builder.copy_timeout, Duration::from_mins(2));
+        assert_eq!(builder.egress.network(), &Network::Disabled);
+    }
+
+    #[test]
+    fn build_address_family_preference_is_explicit_and_ephemeral() {
+        let builder = VmImageBuilder::new("/opt/nanocodex-vmm", "/cache/runtime.ext4");
+        assert!(!builder.prefer_ipv4);
+        let builder = builder.prefer_ipv4();
+        assert!(builder.prefer_ipv4);
+
+        let resolver = "nameserver 213.186.33.99\\n";
+        let dual_stack = build_guest_bootstrap_script(resolver, false);
+        assert!(!dual_stack.contains("/proc/sys/net/ipv6"));
+
+        let prefer_ipv4 = build_guest_bootstrap_script(resolver, true);
+        let all = prefer_ipv4
+            .find("/proc/sys/net/ipv6/conf/all/disable_ipv6")
+            .unwrap();
+        let default = prefer_ipv4
+            .find("/proc/sys/net/ipv6/conf/default/disable_ipv6")
+            .unwrap();
+        let resolver = prefer_ipv4.find("/etc/resolv.conf").unwrap();
+        let runtime = prefer_ipv4
+            .find("exec /run/nanocodex/nanocodex-vm-guest")
+            .unwrap();
+        assert!(all < default);
+        assert!(default < resolver);
+        assert!(resolver < runtime);
+        assert!(!prefer_ipv4.contains("/etc/sysctl"));
+        assert!(prefer_ipv4.contains(
+            "nanocodex image build bootstrap: failed to write /proc/sys/net/ipv6/conf/all/disable_ipv6"
+        ));
+        assert!(prefer_ipv4.contains(
+            "nanocodex image build bootstrap: failed to write /proc/sys/net/ipv6/conf/default/disable_ipv6"
+        ));
+    }
+
+    #[test]
+    fn firmware_directory_sets_the_platform_library_path() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::write(
+            directory.path().join(FIRMWARE_LIBRARY_FILENAME),
+            b"firmware",
+        )
+        .unwrap();
+        let mut command = tokio::process::Command::new("/opt/nanocodex-vmm");
+
+        configure_firmware_library_path(&mut command, directory.path()).unwrap();
+
+        let configured = command
+            .as_std()
+            .get_envs()
+            .find(|(name, _)| *name == OsStr::new(FIRMWARE_LIBRARY_PATH_ENVIRONMENT))
+            .and_then(|(_, value)| value)
+            .map(OsStr::to_owned);
+        assert_eq!(
+            configured.as_deref(),
+            Some(directory.path().canonicalize().unwrap().as_os_str())
+        );
+    }
+
+    #[test]
+    fn supplies_docker_root_process_defaults() {
+        let environment = docker_process_environment(&BTreeMap::new());
+
+        assert_eq!(environment.get("HOME").map(String::as_str), Some("/root"));
+        assert_eq!(
+            environment.get("PATH").map(String::as_str),
+            Some(super::DEFAULT_GUEST_PATH)
+        );
+    }
+
+    #[test]
+    fn docker_environment_removes_quotes_and_expands_in_order() {
+        let recipe = DockerfileRecipe::parse(
+            r#"FROM oven/bun:1.2.15-debian
+ENV PATH="/opt/venv/bin:${PATH}" MODE='frontier bench' EMPTY=
+ENV LEGACY value with spaces
+"#,
+        )
+        .unwrap();
+        let mut environment = BTreeMap::from([("PATH".to_owned(), "/bin".to_owned())]);
+        let arguments = BTreeMap::new();
+        for instruction in &recipe.stages[0].instructions {
+            let super::DockerfileInstruction::Env { name, value } = instruction else {
+                continue;
+            };
+            environment.insert(
+                name.clone(),
+                super::expand_variables(value, &environment, &arguments),
+            );
+        }
+
+        assert_eq!(environment["PATH"], "/opt/venv/bin:/bin");
+        assert_eq!(environment["MODE"], "frontier bench");
+        assert_eq!(environment["EMPTY"], "");
+        assert_eq!(environment["LEGACY"], "value with spaces");
+    }
+
+    #[test]
+    fn resolver_configuration_rejects_host_local_stubs() {
+        assert_eq!(
+            resolver_configuration(
+                "nameserver 127.0.0.53\nnameserver ::1\nnameserver 213.186.33.99\n"
+            ),
+            "nameserver 213.186.33.99\\n"
+        );
+    }
+
+    #[test]
+    fn copy_creates_a_missing_directory_for_a_trailing_slash_destination() {
+        let temporary = tempfile::tempdir().unwrap();
+        let source = temporary.path().join("client.conf");
+        let destination = format!("{}/", temporary.path().join("etc/pipewire").display());
+        fs::write(&source, "configured").unwrap();
+
+        let status = Command::new("/bin/sh")
+            .args([
+                "-c",
+                COPY_SCRIPT,
+                "nanocodex-vm-copy",
+                &destination,
+                source.to_str().unwrap(),
+            ])
+            .status()
+            .unwrap();
+
+        assert!(status.success());
+        assert_eq!(
+            fs::read_to_string(temporary.path().join("etc/pipewire/client.conf")).unwrap(),
+            "configured"
+        );
+    }
+
+    #[test]
+    fn parses_the_complete_terminal_bench_instruction_shape() {
+        let recipe = DockerfileRecipe::parse(
+            r#"FROM ubuntu:24.04 AS build
+ARG SOURCE=https://example.com/input
+ENV MODE=test
+RUN apt-get update && \
+    apt-get install -y curl
+COPY input.txt /root/
+FROM ubuntu:24.04 AS target
+COPY --from=build /root/input.txt /app/input.txt
+WORKDIR /app
+CMD ["/bin/sh"]
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(recipe.stages.len(), 2);
+        assert_eq!(recipe.stages[0].name.as_deref(), Some("build"));
+        assert_eq!(recipe.stages[1].name.as_deref(), Some("target"));
+        assert_eq!(recipe.final_workdir(), "/app");
+        assert!(recipe.requires_build());
+        let super::DockerfileInstruction::Copy(copy) = &recipe.stages[1].instructions[0] else {
+            panic!("expected the final-stage COPY instruction");
+        };
+        assert_eq!(copy.from.as_deref(), Some("build"));
+        assert_eq!(copy.sources, ["/root/input.txt"]);
+        assert_eq!(copy.destination, "/app/input.txt");
+    }
+
+    #[test]
+    fn rejects_workdir_parent_traversal() {
+        let error =
+            DockerfileRecipe::parse("FROM python:3.13-slim-bookworm\nWORKDIR /app/../root\n")
+                .err()
+                .unwrap();
+
+        assert!(error.to_string().contains("WORKDIR /app/../root"));
+    }
+
+    #[test]
+    fn flattened_disk_identity_is_task_recipe_independent() {
+        let digest = "sha256:56249d7a2f93306106f6d8bcdf6423afb73c1b747d874febcc778beee25cb8bb";
+        let first =
+            DockerfileRecipe::parse("FROM python:3.13-slim-bookworm\nWORKDIR /app\n").unwrap();
+        let second =
+            DockerfileRecipe::parse("FROM python:3.13-slim-bookworm\nWORKDIR /workspace\n")
+                .unwrap();
+
+        assert_ne!(first.final_workdir(), second.final_workdir());
+        assert_eq!(
+            first.final_stage().unwrap().base_image,
+            second.final_stage().unwrap().base_image
+        );
+        let first_key = disk_cache_key(digest, 1024);
+        let second_key = disk_cache_key(digest, 1024);
+        assert_eq!(first_key, second_key);
+        assert_ne!(disk_cache_key(digest, 1024), disk_cache_key(digest, 2048));
+        assert_ne!(
+            reference_cache_key("python:3.13-slim-bookworm"),
+            reference_cache_key("python:3.12-slim-bookworm")
+        );
+    }
+
+    #[test]
+    fn build_failure_diagnostics_keep_the_output_tail() {
+        let mut output = vec![b'a'; 8_192];
+        output.extend_from_slice(b"final compiler error");
+
+        let retained = output_tail(&output);
+
+        assert_eq!(retained.chars().count(), 8_192);
+        assert!(retained.ends_with("final compiler error"));
+    }
+
+    #[test]
+    fn copy_only_external_image_does_not_require_a_shell() {
+        let _test_guard = IMAGE_PREPARE_TEST_LOCK.lock().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let layer = root.path().join("copy-source.tar.gz");
+        write_copy_source_layer(&layer);
+        let image = PulledImage {
+            manifest_digest: "sha256:copy-source".to_owned(),
+            layers: vec![PulledLayer {
+                digest: "sha256:copy-source-layer".to_owned(),
+                path: layer,
+                media_type: "application/vnd.oci.image.layer.v1.tar+gzip".to_owned(),
+            }],
+            source: ManifestSource::Local,
+            config: ImageRuntimeConfig::default(),
+        };
+        let cache = root.path().join("cache");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let path = prepare_copy_source_disk(&cache, &image, CONTEXT_DISK_BYTES)
+                .await
+                .unwrap();
+            let mut reader = Reader::new(&path).unwrap();
+            assert!(reader.exists("/uv"));
+            assert!(!reader.exists("/bin/sh"));
+
+            let error = prepare_flattened_disk(&cache, &image, CONTEXT_DISK_BYTES)
+                .await
+                .unwrap_err();
+            assert!(matches!(error, ImageError::MissingPreparedPath("/bin/sh")));
+        });
+    }
+
+    #[test]
+    fn concurrent_preparation_singleflights_the_same_immutable_disk() {
+        let _test_guard = IMAGE_PREPARE_TEST_LOCK.lock().unwrap();
+        let fixture = LocalImageFixture::new();
+        let builder = fixture.builder();
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .unwrap();
+        let (first, second) = runtime.block_on(async {
+            tokio::join!(
+                builder.prepare(
+                    &fixture.context,
+                    super::MINIMUM_DISK_BYTES,
+                    &fixture.cache,
+                    CachePolicy::Reuse,
+                ),
+                builder.prepare(
+                    &fixture.context,
+                    super::MINIMUM_DISK_BYTES,
+                    &fixture.cache,
+                    CachePolicy::Reuse,
+                ),
+            )
+        });
+        let first = first.unwrap();
+        let second = second.unwrap();
+        assert_eq!(first.path(), second.path());
+        assert_eq!(first.workdir(), "/workspace");
+        assert_eq!(first.shell(), "sh");
+        assert_eq!(
+            [first.disk_status(), second.disk_status()]
+                .into_iter()
+                .filter(|status| *status == DiskStatus::Created)
+                .count(),
+            1
+        );
+
+        let attempt = fixture.root.path().join("attempt.ext4");
+        assert_eq!(
+            first.reflink_to(&attempt).unwrap(),
+            super::MINIMUM_DISK_BYTES
+        );
+        assert!(attempt.is_file());
+        assert!(first.reflink_to(&attempt).is_err());
+    }
+
+    #[test]
+    fn invalid_prepared_disk_is_rebuilt_under_the_same_cache_identity() {
+        let _test_guard = IMAGE_PREPARE_TEST_LOCK.lock().unwrap();
+        let fixture = LocalImageFixture::new();
+        let builder = fixture.builder();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        runtime.block_on(async {
+            let first = builder
+                .prepare(
+                    &fixture.context,
+                    super::MINIMUM_DISK_BYTES,
+                    &fixture.cache,
+                    CachePolicy::Reuse,
+                )
+                .await
+                .unwrap();
+            fs::write(first.path(), b"corrupt").unwrap();
+
+            let repaired = builder
+                .prepare(
+                    &fixture.context,
+                    super::MINIMUM_DISK_BYTES,
+                    &fixture.cache,
+                    CachePolicy::Reuse,
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(repaired.path(), first.path());
+            assert_eq!(repaired.disk_status(), DiskStatus::Created);
+            assert_eq!(repaired.shell(), "sh");
+        });
+    }
+
+    #[test]
+    fn preparation_has_one_bounded_root_with_parallel_work_below_it() {
+        let _test_guard = IMAGE_PREPARE_TEST_LOCK.lock().unwrap();
+        let fixture = LocalImageFixture::new();
+        let builder = fixture.builder().prefer_ipv4();
+        let capture = TraceCapture::default();
+        let dispatch = tracing::Dispatch::new(tracing_subscriber::registry().with(capture.clone()));
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        tracing::dispatcher::with_default(&dispatch, || {
+            tracing::callsite::rebuild_interest_cache();
+            runtime.block_on(
+                async {
+                    builder
+                        .prepare(
+                            &fixture.context,
+                            super::MINIMUM_DISK_BYTES,
+                            &fixture.cache,
+                            CachePolicy::Reuse,
+                        )
+                        .await
+                        .unwrap();
+                }
+                .instrument(tracing::info_span!("test.image.caller")),
+            );
+        });
+
+        let spans = capture.spans.lock().unwrap();
+        let (caller_id, _) = spans
+            .iter()
+            .find(|(_, span)| span.name == "test.image.caller")
+            .unwrap();
+        let (prepare_id, prepare) = spans
+            .iter()
+            .find(|(_, span)| span.name == "vm.image.prepare")
+            .unwrap();
+        assert_eq!(prepare.parent, Some(*caller_id));
+        assert_eq!(
+            prepare.fields.get("status").map(String::as_str),
+            Some("completed")
+        );
+        assert_eq!(
+            prepare.fields.get("image.cache.status").map(String::as_str),
+            Some("created")
+        );
+        assert!(prepare.fields.contains_key("duration_ns"));
+        assert_eq!(
+            prepare
+                .fields
+                .get("image.build.prefer_ipv4")
+                .map(String::as_str),
+            Some("true")
+        );
+
+        let resolve = spans
+            .values()
+            .find(|span| span.name == "vm.image.resolve")
+            .unwrap();
+        let format = spans
+            .values()
+            .find(|span| span.name == "vm.image.format")
+            .unwrap();
+        assert_eq!(resolve.parent, Some(*prepare_id));
+        assert_eq!(format.parent, Some(*prepare_id));
+
+        let dockerfile_event = capture.events.lock().unwrap().iter().find_map(|event| {
+            (event.parent == Some(*prepare_id)
+                && event.fields.get("content_kind").map(String::as_str) == Some("dockerfile"))
+            .then(|| event.fields.get("content").cloned())
+            .flatten()
+        });
+        assert_eq!(
+            dockerfile_event.as_deref(),
+            Some("FROM example.invalid/nanocodex-vm-fixture:latest\nWORKDIR /workspace\n")
+        );
+    }
+}

--- a/crates/experimental/nanocodex-vm/src/krun.rs
+++ b/crates/experimental/nanocodex-vm/src/krun.rs
@@ -1,0 +1,561 @@
+#![allow(
+    unsafe_code,
+    reason = "this module is one of the two audited libkrun FFI boundaries"
+)]
+
+use std::{
+    ffi::{CString, NulError, OsStr, c_char},
+    io,
+    os::{fd::AsRawFd, unix::ffi::OsStrExt},
+    path::PathBuf,
+    ptr,
+};
+
+use thiserror::Error;
+
+use crate::{
+    command::GuestCommand,
+    config::{BlockDevice, Network, RootFilesystem, SharedDirectory, VmConfig},
+};
+
+const ROOT_TAG: &std::ffi::CStr = c"/dev/root";
+const ROOT_BLOCK_ID: &std::ffi::CStr = c"vda";
+const ROOT_BLOCK_DEVICE: &std::ffi::CStr = c"/dev/vda";
+const EXT4_FILESYSTEM: &std::ffi::CStr = c"ext4";
+const TSI_HIJACK_INET: u32 = 1;
+const NET_FLAG_VFKIT: u32 = 1 << 0;
+const NET_FLAG_DHCP_CLIENT: u32 = 1 << 1;
+const NET_FEATURE_CSUM: u32 = 1 << 0;
+const NET_FEATURE_GUEST_CSUM: u32 = 1 << 1;
+const NET_FEATURE_GUEST_TSO4: u32 = 1 << 7;
+const NET_FEATURE_GUEST_UFO: u32 = 1 << 10;
+const NET_FEATURE_HOST_TSO4: u32 = 1 << 11;
+const NET_FEATURE_HOST_UFO: u32 = 1 << 14;
+
+/// Failure to validate, configure, control, or enter a libkrun VM.
+#[derive(Debug, Error)]
+pub enum VmError {
+    /// A typed VM policy value violates a libkrun precondition.
+    #[error("invalid VM configuration: {0}")]
+    InvalidConfig(&'static str),
+
+    /// The root filesystem could not be canonicalized.
+    #[error("failed to resolve root filesystem {path}: {source}")]
+    ResolveRoot {
+        /// Requested host path.
+        path: PathBuf,
+        /// Canonicalization failure.
+        source: io::Error,
+    },
+
+    /// An additional block-device path could not be canonicalized.
+    #[error("failed to resolve block device {path}: {source}")]
+    ResolveBlockDevice {
+        /// Requested host path.
+        path: PathBuf,
+        /// Canonicalization failure.
+        source: io::Error,
+    },
+
+    /// A virtiofs share path could not be canonicalized.
+    #[error("failed to resolve shared directory {path}: {source}")]
+    ResolveSharedDirectory {
+        /// Requested host path.
+        path: PathBuf,
+        /// Canonicalization failure.
+        source: io::Error,
+    },
+
+    /// A gvproxy network socket could not be canonicalized.
+    #[error("failed to resolve network socket {path}: {source}")]
+    ResolveNetworkSocket {
+        /// Requested socket path.
+        path: PathBuf,
+        /// Canonicalization failure.
+        source: io::Error,
+    },
+
+    /// A directory root policy resolved to a non-directory.
+    #[error("root filesystem is not a directory: {0}")]
+    RootNotDirectory(PathBuf),
+
+    /// An ext4 root policy resolved to a non-file.
+    #[error("root disk is not a file: {0}")]
+    RootNotFile(PathBuf),
+
+    /// An additional block-device path resolved to a non-file.
+    #[error("block device is not a file: {0}")]
+    BlockDeviceNotFile(PathBuf),
+
+    /// A virtiofs share resolved to a non-directory.
+    #[error("shared directory is not a directory: {0}")]
+    SharedDirectoryNotDirectory(PathBuf),
+
+    /// The guest working directory is not absolute.
+    #[error("guest working directory must be absolute: {0}")]
+    WorkingDirectoryNotAbsolute(PathBuf),
+
+    /// A path or command value contains a C-string terminator.
+    #[error("{field} contains a NUL byte")]
+    Nul {
+        /// Configuration field that could not be represented.
+        field: &'static str,
+        /// C-string construction failure.
+        source: NulError,
+    },
+
+    /// A command argument cannot survive libkrun's quoted kernel transport.
+    #[error("{field} contains a double quote unsupported by libkrun's command-line transport")]
+    UnsupportedDoubleQuote {
+        /// Command field that could not be represented.
+        field: &'static str,
+    },
+
+    /// A libkrun API operation returned a negative errno.
+    #[error("libkrun {operation} failed with errno {errno}")]
+    Libkrun {
+        /// Stable description of the failed operation.
+        operation: &'static str,
+        /// Positive errno reported by libkrun.
+        errno: i32,
+    },
+
+    /// The blocking VMM loop unexpectedly returned success.
+    #[error("libkrun returned after starting the VM")]
+    UnexpectedReturn,
+
+    /// A caller reused a context already handed to the VMM loop.
+    #[error("the libkrun context has already entered the VM")]
+    ContextConsumed,
+}
+
+/// A configured libkrun VM which has not entered its blocking event loop yet.
+///
+/// This is the low-level VMM primitive. [`Self::run`] does not return after a
+/// successful boot because libkrun owns the calling process until the guest
+/// exits. The retained process-backed session builds on this primitive.
+pub struct KrunVm {
+    context: Option<u32>,
+}
+
+impl KrunVm {
+    /// Creates a libkrun configuration context.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the root filesystem or VM configuration is
+    /// invalid, or when libkrun rejects a requested device.
+    pub fn new(config: &VmConfig) -> Result<Self, VmError> {
+        if config.cpus_value() == 0 {
+            return Err(VmError::InvalidConfig("CPU count must be nonzero"));
+        }
+        if config.memory_mib_value() == 0 {
+            return Err(VmError::InvalidConfig("memory must be nonzero"));
+        }
+
+        let root = config
+            .root()
+            .canonicalize()
+            .map_err(|source| VmError::ResolveRoot {
+                path: config.root().to_path_buf(),
+                source,
+            })?;
+        match config.root_filesystem() {
+            RootFilesystem::Directory(_) if !root.is_dir() => {
+                return Err(VmError::RootNotDirectory(root));
+            }
+            RootFilesystem::Ext4(_) if !root.is_file() => {
+                return Err(VmError::RootNotFile(root));
+            }
+            RootFilesystem::Directory(_) | RootFilesystem::Ext4(_) => {}
+        }
+
+        let context = positive_context(krun::krun_create_ctx(), "create context")?;
+        let vm = Self {
+            context: Some(context),
+        };
+
+        check(
+            krun::krun_set_vm_config(context, config.cpus_value(), config.memory_mib_value()),
+            "configure VM",
+        )?;
+
+        let root = c_string(root.as_os_str(), "root filesystem path")?;
+        match config.root_filesystem() {
+            RootFilesystem::Directory(_) => {
+                // SAFETY: both C strings live through the call and libkrun copies their
+                // contents into the context before returning.
+                check(
+                    unsafe {
+                        krun::krun_add_virtiofs3(
+                            context,
+                            ROOT_TAG.as_ptr(),
+                            root.as_ptr(),
+                            0,
+                            false,
+                        )
+                    },
+                    "attach root filesystem",
+                )?;
+            }
+            RootFilesystem::Ext4(_) => {
+                // SAFETY: the path and block ID remain alive through each call;
+                // libkrun copies them into its context before returning.
+                check(
+                    unsafe {
+                        krun::krun_add_disk(context, ROOT_BLOCK_ID.as_ptr(), root.as_ptr(), false)
+                    },
+                    "attach root disk",
+                )?;
+                // SAFETY: all strings are static and NUL terminated.
+                check(
+                    unsafe {
+                        krun::krun_set_root_disk_remount(
+                            context,
+                            ROOT_BLOCK_DEVICE.as_ptr(),
+                            EXT4_FILESYSTEM.as_ptr(),
+                            ptr::null(),
+                        )
+                    },
+                    "select root disk",
+                )?;
+            }
+        }
+
+        attach_block_devices(context, config.block_devices())?;
+        attach_shared_directories(context, config.shared_directories())?;
+
+        let stdin = io::stdin();
+        let stdout = io::stdout();
+        let stderr = io::stderr();
+        // SAFETY: the standard descriptors remain owned by this process for
+        // the VM lifetime; libkrun duplicates the descriptors it needs.
+        check(
+            unsafe {
+                krun::krun_add_virtio_console_default(
+                    context,
+                    stdin.as_raw_fd(),
+                    stdout.as_raw_fd(),
+                    stderr.as_raw_fd(),
+                )
+            },
+            "attach console",
+        )?;
+
+        attach_network(context, config.network_value())?;
+        check(
+            krun::krun_split_irqchip(context, false),
+            "configure interrupt controller",
+        )?;
+
+        Ok(vm)
+    }
+
+    /// Returns a thread-safe out-of-band pause/resume capability.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error after this context has entered the VMM loop.
+    pub fn control(&self) -> Result<KrunVmControl, VmError> {
+        self.context
+            .map(|context| KrunVmControl { context })
+            .ok_or(VmError::ContextConsumed)
+    }
+
+    /// Configures the guest command and enters libkrun's blocking VMM loop.
+    ///
+    /// On successful boot this function does not return: libkrun exits the VMM
+    /// process when the guest shuts down. Call this only in a dedicated VMM
+    /// process.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a command value contains a NUL byte, libkrun
+    /// rejects the command, or the VMM loop unexpectedly returns.
+    pub fn run(mut self, command: &GuestCommand) -> Result<(), VmError> {
+        validate_guest_command(command)?;
+        let executable = c_string(command.program().as_os_str(), "guest executable")?;
+        let arguments = command
+            .arguments()
+            .iter()
+            .map(|argument| array_string(argument, "guest argument"))
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut argument_pointers = arguments
+            .iter()
+            .map(|argument| argument.as_ptr())
+            .collect::<Vec<_>>();
+        argument_pointers.push(ptr::null());
+        let environment = command
+            .environment()
+            .iter()
+            .map(|(name, value)| {
+                let mut entry = name.clone();
+                entry.push("=");
+                entry.push(value);
+                array_string(&entry, "guest environment")
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut environment_pointers = environment
+            .iter()
+            .map(|entry| entry.as_ptr())
+            .collect::<Vec<_>>();
+        environment_pointers.push(ptr::null::<c_char>());
+        let context = self.context.ok_or(VmError::ContextConsumed)?;
+
+        // SAFETY: executable, argument, and environment storage remains alive
+        // through the call; each pointer list is NUL terminated. libkrun copies
+        // the values into its owned context.
+        check(
+            unsafe {
+                krun::krun_set_exec(
+                    context,
+                    executable.as_ptr(),
+                    argument_pointers.as_ptr(),
+                    environment_pointers.as_ptr(),
+                )
+            },
+            "configure guest command",
+        )?;
+        let current_dir = c_string(
+            command.current_directory().as_os_str(),
+            "guest working directory",
+        )?;
+        // SAFETY: the C string remains valid for the call and libkrun copies it
+        // into the context.
+        check(
+            unsafe { krun::krun_set_workdir(context, current_dir.as_ptr()) },
+            "configure guest working directory",
+        )?;
+
+        let status = krun::krun_start_enter(context);
+        if status < 0 {
+            return check(status, "start VM");
+        }
+        self.context = None;
+        Err(VmError::UnexpectedReturn)
+    }
+}
+
+fn attach_network(context: u32, network: &Network) -> Result<(), VmError> {
+    match network {
+        Network::Disabled => {}
+        Network::Internet => {
+            check(
+                krun::krun_add_vsock(context, TSI_HIJACK_INET),
+                "enable TSI networking",
+            )?;
+        }
+        Network::Gvproxy {
+            socket,
+            mac_address,
+        } => {
+            let socket = socket
+                .canonicalize()
+                .map_err(|source| VmError::ResolveNetworkSocket {
+                    path: socket.clone(),
+                    source,
+                })?;
+            let socket = c_string(socket.as_os_str(), "gvproxy socket path")?;
+            let mut mac_address = *mac_address;
+            check(
+                // SAFETY: the socket string and MAC array remain alive for the
+                // call and libkrun copies both into its configuration.
+                unsafe {
+                    krun::krun_add_net_unixgram(
+                        context,
+                        socket.as_ptr(),
+                        -1,
+                        mac_address.as_mut_ptr(),
+                        COMPATIBLE_NETWORK_FEATURES,
+                        NET_FLAG_VFKIT | NET_FLAG_DHCP_CLIENT,
+                    )
+                },
+                "attach gvproxy network",
+            )?;
+        }
+    }
+    Ok(())
+}
+
+const COMPATIBLE_NETWORK_FEATURES: u32 = NET_FEATURE_CSUM
+    | NET_FEATURE_GUEST_CSUM
+    | NET_FEATURE_GUEST_TSO4
+    | NET_FEATURE_GUEST_UFO
+    | NET_FEATURE_HOST_TSO4
+    | NET_FEATURE_HOST_UFO;
+
+fn attach_block_devices(context: u32, devices: &[BlockDevice]) -> Result<(), VmError> {
+    for device in devices {
+        let path = device
+            .path()
+            .canonicalize()
+            .map_err(|source| VmError::ResolveBlockDevice {
+                path: device.path().to_path_buf(),
+                source,
+            })?;
+        if !path.is_file() {
+            return Err(VmError::BlockDeviceNotFile(path));
+        }
+        let id = c_string(OsStr::new(device.id()), "block device ID")?;
+        let path = c_string(path.as_os_str(), "block device path")?;
+        // SAFETY: both strings remain valid through the call and libkrun
+        // copies their contents into the context before returning.
+        check(
+            unsafe {
+                krun::krun_add_disk(context, id.as_ptr(), path.as_ptr(), device.is_read_only())
+            },
+            "attach block device",
+        )?;
+    }
+    Ok(())
+}
+
+fn attach_shared_directories(context: u32, directories: &[SharedDirectory]) -> Result<(), VmError> {
+    for directory in directories {
+        let path =
+            directory
+                .path()
+                .canonicalize()
+                .map_err(|source| VmError::ResolveSharedDirectory {
+                    path: directory.path().to_path_buf(),
+                    source,
+                })?;
+        if !path.is_dir() {
+            return Err(VmError::SharedDirectoryNotDirectory(path));
+        }
+        let tag = c_string(OsStr::new(directory.tag()), "shared directory tag")?;
+        let path = c_string(path.as_os_str(), "shared directory path")?;
+        // SAFETY: both C strings remain valid through the call and libkrun
+        // copies their contents into the context before returning.
+        check(
+            unsafe {
+                krun::krun_add_virtiofs3(
+                    context,
+                    tag.as_ptr(),
+                    path.as_ptr(),
+                    0,
+                    directory.is_read_only(),
+                )
+            },
+            "attach shared directory",
+        )?;
+    }
+    Ok(())
+}
+
+/// Out-of-band control for a VM running in libkrun's event loop.
+///
+/// This capability is valid only while the [`KrunVm`] context is alive in its
+/// dedicated VMM process. Do not retain it after the VMM exits.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct KrunVmControl {
+    context: u32,
+}
+
+impl KrunVmControl {
+    /// Requests that every guest vCPU pause at an instruction boundary.
+    ///
+    /// libkrun currently implements this operation on macOS. The request is
+    /// idempotent and completes asynchronously in the VMM event loop.
+    ///
+    /// # Errors
+    ///
+    /// Returns an OS error reported by libkrun, including unsupported-platform
+    /// and not-yet-running errors.
+    pub fn pause(self) -> Result<(), VmError> {
+        check(krun::krun_vm_pause(self.context), "pause VM")
+    }
+
+    /// Resumes a VM previously paused with [`Self::pause`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an OS error reported by libkrun.
+    pub fn resume(self) -> Result<(), VmError> {
+        check(krun::krun_vm_resume(self.context), "resume VM")
+    }
+}
+
+impl Drop for KrunVm {
+    fn drop(&mut self) {
+        if let Some(context) = self.context.take() {
+            let _ = krun::krun_free_ctx(context);
+        }
+    }
+}
+
+fn c_string(value: &OsStr, field: &'static str) -> Result<CString, VmError> {
+    CString::new(value.as_bytes()).map_err(|source| VmError::Nul { field, source })
+}
+
+/// Validates values for libkrun's quoted command-line array serialization.
+///
+/// `krun_set_exec` does not preserve the supplied C array directly: it wraps
+/// every entry in double quotes and forwards the resulting string through the
+/// guest kernel command line. Its parser cannot represent a literal double
+/// quote reliably, so fail closed instead of silently changing argv/envp.
+fn array_string(value: &OsStr, field: &'static str) -> Result<CString, VmError> {
+    let bytes = value.as_bytes();
+    if bytes.contains(&b'"') {
+        return Err(VmError::UnsupportedDoubleQuote { field });
+    }
+    CString::new(bytes).map_err(|source| VmError::Nul { field, source })
+}
+
+fn validate_guest_command(command: &GuestCommand) -> Result<(), VmError> {
+    if !command.current_directory().is_absolute() {
+        return Err(VmError::WorkingDirectoryNotAbsolute(
+            command.current_directory().to_path_buf(),
+        ));
+    }
+    Ok(())
+}
+
+fn positive_context(status: i32, operation: &'static str) -> Result<u32, VmError> {
+    u32::try_from(status).map_err(|_| VmError::Libkrun {
+        operation,
+        errno: status.saturating_neg(),
+    })
+}
+
+const fn check(status: i32, operation: &'static str) -> Result<(), VmError> {
+    if status < 0 {
+        Err(VmError::Libkrun {
+            operation,
+            errno: status.saturating_neg(),
+        })
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{ffi::OsStr, path::Path};
+
+    use super::{GuestCommand, VmError, array_string, validate_guest_command};
+
+    #[test]
+    fn libkrun_array_values_reject_unrepresentable_quotes() {
+        assert!(matches!(
+            array_string(OsStr::new(r#"printf "%s""#), "test"),
+            Err(VmError::UnsupportedDoubleQuote { field: "test" })
+        ));
+        assert_eq!(
+            array_string(OsStr::new(r"backslash\path"), "test")
+                .unwrap()
+                .as_c_str(),
+            c"backslash\\path"
+        );
+    }
+
+    #[test]
+    fn guest_working_directory_must_be_absolute() {
+        assert!(matches!(
+            validate_guest_command(&GuestCommand::new("/bin/true").current_dir("workspace")),
+            Err(VmError::WorkingDirectoryNotAbsolute(path))
+                if path == Path::new("workspace")
+        ));
+        validate_guest_command(&GuestCommand::new("/bin/true").current_dir("/workspace")).unwrap();
+    }
+}

--- a/crates/experimental/nanocodex-vm/src/lib.rs
+++ b/crates/experimental/nanocodex-vm/src/lib.rs
@@ -1,0 +1,47 @@
+#![cfg_attr(feature = "host", doc = include_str!("../README.md"))]
+#![cfg_attr(not(feature = "host"), doc = include_str!("../GUEST_RUNTIME.md"))]
+#![deny(unsafe_code, missing_docs, rustdoc::broken_intra_doc_links)]
+
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+mod capabilities;
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+mod command;
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+mod config;
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+mod egress;
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+mod gvproxy;
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+pub mod image;
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+mod krun;
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+mod process;
+pub mod tools;
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+mod workspace;
+
+/// Low-level host-side VM configuration and lifecycle components.
+///
+/// Most applications should start with [`crate::VmWorkspaceBuilder`]. This
+/// module is for custom VMM entry points, network/egress policy, and direct
+/// libkrun lifecycle ownership.
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+pub mod host {
+    pub use crate::{
+        capabilities::{Capabilities, KrunFeature},
+        command::GuestCommand,
+        config::{BlockDevice, Network, RootFilesystem, SharedDirectory, VmConfig},
+        egress::{
+            EgressError, EgressFile, EgressLease, EgressMount, GUEST_EGRESS_ROOT,
+            MAX_EGRESS_FILE_BYTES,
+        },
+        gvproxy::{Gvproxy, GvproxyError},
+        krun::{KrunVm, KrunVmControl, VmError},
+        process::{PrivateVmProcessConfig, VmProcessConfig, VmProcessError},
+    };
+}
+
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+pub use workspace::{VmWorkspace, VmWorkspaceBuilder, VmWorkspaceError};

--- a/crates/experimental/nanocodex-vm/src/process.rs
+++ b/crates/experimental/nanocodex-vm/src/process.rs
@@ -1,0 +1,138 @@
+use std::{
+    fs::File,
+    io::{self, BufReader, BufWriter, Write},
+    path::Path,
+};
+
+use serde::{Deserialize, Serialize};
+use tempfile::NamedTempFile;
+use thiserror::Error;
+
+use crate::{
+    command::GuestCommand,
+    config::VmConfig,
+    krun::{KrunVm, VmError},
+};
+
+const PROCESS_CONFIG_VERSION: u32 = 1;
+
+/// Complete owned input for one dedicated VMM process.
+///
+/// Keeping guest environment values in this file avoids exposing proxy
+/// credentials and secret placeholders through the VMM's process arguments.
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct VmProcessConfig {
+    version: u32,
+    vm: VmConfig,
+    command: GuestCommand,
+}
+
+impl VmProcessConfig {
+    /// Creates a versioned launch record from complete owned VM inputs.
+    #[must_use]
+    pub const fn new(vm: VmConfig, command: GuestCommand) -> Self {
+        Self {
+            version: PROCESS_CONFIG_VERSION,
+            vm,
+            command,
+        }
+    }
+
+    /// Writes this configuration to a mode-0600 temporary file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the private file cannot be created or serialized.
+    pub fn write_private(&self) -> Result<PrivateVmProcessConfig, VmProcessError> {
+        let mut file = NamedTempFile::new()?;
+        let mut writer = BufWriter::new(file.as_file_mut());
+        serde_json::to_writer(&mut writer, self)?;
+        writer.flush()?;
+        drop(writer);
+        file.as_file_mut().flush()?;
+        Ok(PrivateVmProcessConfig { file })
+    }
+
+    /// Reads a process configuration created by [`Self::write_private`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the file cannot be read, has an unsupported
+    /// version, or contains an invalid configuration.
+    pub fn read(path: impl AsRef<Path>) -> Result<Self, VmProcessError> {
+        let config: Self = serde_json::from_reader(BufReader::new(File::open(path)?))?;
+        if config.version != PROCESS_CONFIG_VERSION {
+            return Err(VmProcessError::UnsupportedVersion(config.version));
+        }
+        Ok(config)
+    }
+
+    /// Enters the blocking libkrun loop described by this configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when VM construction or startup fails.
+    pub fn run(self) -> Result<(), VmError> {
+        KrunVm::new(&self.vm)?.run(&self.command)
+    }
+}
+
+/// Owned private file kept alive until its VMM child has loaded it.
+pub struct PrivateVmProcessConfig {
+    file: NamedTempFile,
+}
+
+impl PrivateVmProcessConfig {
+    /// Returns the mode-0600 temporary configuration path.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        self.file.path()
+    }
+}
+
+/// Failure to persist or load a private VMM launch record.
+#[derive(Debug, Error)]
+pub enum VmProcessError {
+    /// Private configuration file I/O failed.
+    #[error("failed to access the private VM process configuration: {0}")]
+    Io(#[from] io::Error),
+    /// Private configuration serialization failed.
+    #[error("failed to encode the private VM process configuration: {0}")]
+    Json(#[from] serde_json::Error),
+    /// The file uses a launch-record version this crate does not understand.
+    #[error("unsupported VM process configuration version {0}")]
+    UnsupportedVersion(u32),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{ffi::OsString, os::unix::fs::PermissionsExt};
+
+    use super::*;
+    use crate::config::Network;
+
+    #[test]
+    fn private_config_round_trips_without_argv_delivery() {
+        let command = GuestCommand::new("/bin/true")
+            .env("HTTPS_PROXY", "http://lease:credential@host.internal:8080");
+        let private = VmProcessConfig::new(
+            VmConfig::ext4("/tmp/rootfs.ext4").network(Network::Disabled),
+            command,
+        )
+        .write_private()
+        .unwrap();
+        let permissions = private.path().metadata().unwrap().permissions().mode();
+        assert_eq!(permissions & 0o077, 0);
+
+        let decoded = VmProcessConfig::read(private.path()).unwrap();
+        assert_eq!(
+            decoded
+                .command
+                .environment()
+                .get(&OsString::from("HTTPS_PROXY"))
+                .unwrap(),
+            &OsString::from("http://lease:credential@host.internal:8080")
+        );
+    }
+}

--- a/crates/experimental/nanocodex-vm/src/tools/guest.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/guest.rs
@@ -1,5 +1,6 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
+    ffi::OsString,
     path::{Path, PathBuf},
     process::{ExitStatus, Stdio},
     sync::{
@@ -34,6 +35,7 @@ use super::protocol::{
 
 const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 const MAX_CONTROL_FILE_BYTES: usize = 32 * 1024 * 1024;
+const FILESYSTEM_SYNC_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_IN_FLIGHT_REQUESTS: usize = 64;
 
 /// Failure while serving VM tool requests inside the guest.
@@ -83,10 +85,13 @@ async fn serve_io_with_frame_limit(
     mut output: impl AsyncWrite + Unpin,
     max_frame_bytes: usize,
 ) -> Result<(), VmGuestError> {
-    let runtime = Arc::new(WorkspaceToolRuntime::with_view_image_wire_limit(
-        workspace.to_path_buf(),
-        u64::try_from(max_frame_bytes).unwrap_or(u64::MAX),
-    ));
+    let runtime = Arc::new(
+        WorkspaceToolRuntime::with_environment_and_view_image_wire_limit(
+            workspace.to_path_buf(),
+            u64::try_from(max_frame_bytes).unwrap_or(u64::MAX),
+            std::env::vars_os().collect(),
+        ),
+    );
     let mut input = BufReader::new(input);
     let mut requests = JoinSet::<SessionResponse>::new();
     let mut active = HashMap::<u64, tokio::task::AbortHandle>::new();
@@ -321,10 +326,15 @@ async fn read_frame(
 }
 
 async fn sync_filesystems(request: ShutdownRequest) -> ControlResponse {
-    let error = match Command::new("/bin/sync").status().await {
-        Ok(status) if status.success() => None,
-        Ok(status) => Some(format!("sync exited with {status}")),
-        Err(error) => Some(error.to_string()),
+    let mut command = Command::new("/bin/sync");
+    command.kill_on_drop(true);
+    let error = match tokio::time::timeout(FILESYSTEM_SYNC_TIMEOUT, command.status()).await {
+        Ok(Ok(status)) if status.success() => None,
+        Ok(Ok(status)) => Some(format!("sync exited with {status}")),
+        Ok(Err(error)) => Some(error.to_string()),
+        Err(_) => Some(format!(
+            "sync exceeded the {FILESYSTEM_SYNC_TIMEOUT:?} shutdown deadline"
+        )),
     };
     ControlResponse {
         id: request.id,
@@ -470,12 +480,13 @@ async fn read_file(request: ReadFileRequest) -> ReadFileResponse {
 }
 
 async fn execute_command(request: ExecuteRequest) -> ExecuteResponse {
+    let environment = command_environment(std::env::vars_os(), &request.environment);
     let mut command = Command::new(&request.program);
     command
         .args(&request.arguments)
         .current_dir(&request.current_directory)
         .env_clear()
-        .envs(request.environment.iter().cloned())
+        .envs(environment)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -521,6 +532,20 @@ async fn execute_command(request: ExecuteRequest) -> ExecuteResponse {
             output_limit_exceeded: false,
         },
     }
+}
+
+fn command_environment(
+    inherited: impl IntoIterator<Item = (OsString, OsString)>,
+    overrides: &[(String, String)],
+) -> BTreeMap<OsString, OsString> {
+    let mut environment = inherited.into_iter().collect::<BTreeMap<_, _>>();
+    environment.extend(overrides.iter().map(|(name, value)| {
+        (
+            OsString::from(name.as_str()),
+            OsString::from(value.as_str()),
+        )
+    }));
+    environment
 }
 
 enum CommandOutcome {
@@ -667,6 +692,7 @@ async fn read_bounded(
 #[cfg(test)]
 mod tests {
     use std::{
+        ffi::OsString,
         fs::{self, File},
         time::{Duration, Instant, UNIX_EPOCH},
     };
@@ -680,12 +706,39 @@ mod tests {
         SessionResponse, ShutdownRequest, ToolRequest, WireToolContext, WireToolInput,
     };
     use super::{
-        atomic_write_file, create_directory_path, execute_command, read_file, serve_io,
-        serve_io_with_frame_limit,
+        atomic_write_file, command_environment, create_directory_path, execute_command, read_file,
+        serve_io, serve_io_with_frame_limit,
     };
 
     const DEFAULT_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
     const PATH_TRACING_IMAGE_BYTES: u64 = 48_262_737;
+
+    #[test]
+    fn trusted_commands_inherit_guest_environment_and_apply_explicit_overrides() {
+        let environment = command_environment(
+            [
+                (OsString::from("HTTPS_PROXY"), OsString::from("from-guest")),
+                (OsString::from("PATH"), OsString::from("/guest/bin")),
+            ],
+            &[
+                ("PATH".to_owned(), "/image/bin".to_owned()),
+                ("IMAGE_MODE".to_owned(), "release".to_owned()),
+            ],
+        );
+
+        assert_eq!(
+            environment.get(&OsString::from("HTTPS_PROXY")),
+            Some(&OsString::from("from-guest"))
+        );
+        assert_eq!(
+            environment.get(&OsString::from("PATH")),
+            Some(&OsString::from("/image/bin"))
+        );
+        assert_eq!(
+            environment.get(&OsString::from("IMAGE_MODE")),
+            Some(&OsString::from("release"))
+        );
+    }
 
     #[tokio::test]
     async fn filesystem_controls_apply_exact_modes_and_epoch_mtimes() {

--- a/crates/experimental/nanocodex-vm/src/tools/guest.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/guest.rs
@@ -1,0 +1,1170 @@
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    process::{ExitStatus, Stdio},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use nanocodex_tools::{ToolContext, workspace_runtime::WorkspaceToolRuntime};
+use nix::{
+    errno::Errno,
+    sys::signal::{Signal, killpg},
+    unistd::Pid,
+};
+use thiserror::Error;
+use tokio::{
+    io::{
+        AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt,
+        BufReader,
+    },
+    process::{Child, Command},
+    sync::mpsc,
+    task::JoinSet,
+};
+
+use super::protocol::{
+    CancelRequest, ControlResponse, CreateDirectoryRequest, ExecuteRequest, ExecuteResponse,
+    ReadFileRequest, ReadFileResponse, SessionRequest, SessionResponse, ShutdownRequest,
+    ToolResponse, WriteFileRequest,
+};
+
+const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
+const MAX_CONTROL_FILE_BYTES: usize = 32 * 1024 * 1024;
+const MAX_IN_FLIGHT_REQUESTS: usize = 64;
+
+/// Failure while serving VM tool requests inside the guest.
+#[derive(Debug, Error)]
+pub enum VmGuestError {
+    /// Guest console I/O failed.
+    #[error("VM tool console I/O failed: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// A protocol frame was not valid JSON.
+    #[error("VM tool protocol JSON failed: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// The host closed the console in the middle of a frame.
+    #[error("the VM tool console closed before a complete frame")]
+    Closed,
+
+    /// A concurrently executed guest request task failed.
+    #[error("guest tool execution task failed: {0}")]
+    Task(String),
+
+    /// An inbound or outbound protocol frame exceeded the fixed limit.
+    #[error("VM tool protocol frame exceeded the {MAX_FRAME_BYTES}-byte limit")]
+    FrameTooLarge,
+
+    /// The host reused an identifier while its earlier request was active.
+    #[error("VM tool protocol reused active request ID {0}")]
+    DuplicateRequestId(u64),
+}
+
+#[cfg(feature = "guest-runtime")]
+pub(crate) async fn serve(workspace: &Path) -> Result<(), VmGuestError> {
+    serve_io(workspace, tokio::io::stdin(), tokio::io::stdout()).await
+}
+
+async fn serve_io(
+    workspace: &Path,
+    input: impl AsyncRead + Unpin,
+    output: impl AsyncWrite + Unpin,
+) -> Result<(), VmGuestError> {
+    serve_io_with_frame_limit(workspace, input, output, MAX_FRAME_BYTES).await
+}
+
+async fn serve_io_with_frame_limit(
+    workspace: &Path,
+    input: impl AsyncRead + Unpin,
+    mut output: impl AsyncWrite + Unpin,
+    max_frame_bytes: usize,
+) -> Result<(), VmGuestError> {
+    let runtime = Arc::new(WorkspaceToolRuntime::with_view_image_wire_limit(
+        workspace.to_path_buf(),
+        u64::try_from(max_frame_bytes).unwrap_or(u64::MAX),
+    ));
+    let mut input = BufReader::new(input);
+    let mut requests = JoinSet::<SessionResponse>::new();
+    let mut active = HashMap::<u64, tokio::task::AbortHandle>::new();
+    let mut accepting = true;
+    let mut shutdown = None;
+
+    let result = async {
+        while accepting || !requests.is_empty() {
+            tokio::select! {
+                joined = requests.join_next(), if !requests.is_empty() => {
+                    match joined.ok_or(VmGuestError::Closed)? {
+                        Ok(response) => {
+                            active.remove(&response.id());
+                            write_response(&mut output, &response, max_frame_bytes).await?;
+                        }
+                        Err(error) if error.is_cancelled() => {}
+                        Err(error) => return Err(VmGuestError::Task(error.to_string())),
+                    }
+                }
+                frame = read_frame(&mut input),
+                    if accepting && requests.len() < MAX_IN_FLIGHT_REQUESTS =>
+                {
+                    let Some(frame) = frame? else {
+                        accepting = false;
+                        requests.abort_all();
+                        continue;
+                    };
+                    match serde_json::from_slice::<SessionRequest>(&frame)? {
+                        SessionRequest::Shutdown(request) => {
+                            shutdown = Some(request);
+                            accepting = false;
+                            runtime.control().cancel().await;
+                            active.clear();
+                            requests.abort_all();
+                        }
+                        SessionRequest::Cancel(request) => {
+                            if let Some(task) = active.remove(&request.target_id) {
+                                task.abort();
+                            }
+                            let response = SessionResponse::Cancel(ControlResponse {
+                                id: request.id,
+                                error: None,
+                            });
+                            write_response(&mut output, &response, max_frame_bytes).await?;
+                        }
+                        request => {
+                            let id = request.id();
+                            if active.contains_key(&id) {
+                                return Err(VmGuestError::DuplicateRequestId(id));
+                            }
+                            let runtime = Arc::clone(&runtime);
+                            let task =
+                                requests.spawn(async move { execute_request(runtime, request).await });
+                            active.insert(id, task);
+                        }
+                    }
+                }
+            }
+        }
+        Ok::<_, VmGuestError>(shutdown)
+    }
+    .await;
+
+    runtime.control().cancel().await;
+    if let Some(request) = result? {
+        let response = SessionResponse::Shutdown(sync_filesystems(request).await);
+        write_response(&mut output, &response, max_frame_bytes).await?;
+    }
+    Ok(())
+}
+
+async fn execute_request(
+    runtime: Arc<WorkspaceToolRuntime>,
+    request: SessionRequest,
+) -> SessionResponse {
+    match request {
+        SessionRequest::Ready(request) => SessionResponse::Ready(ControlResponse {
+            id: request.id,
+            error: None,
+        }),
+        SessionRequest::Tool(request) => {
+            let context = ToolContext::new(
+                &request.context.model,
+                &request.context.session_id,
+                &request.context.call_id,
+                &[],
+                request.context.output_token_budget,
+            );
+            let execution = runtime
+                .execute_tool(request.tool.name(), request.input.into(), context)
+                .await;
+            SessionResponse::Tool(match execution.into_wire() {
+                Ok(execution) => ToolResponse::completed(request.id, execution),
+                Err(error) => ToolResponse::failed(request.id, error.to_string()),
+            })
+        }
+        SessionRequest::WriteFile(request) => SessionResponse::WriteFile(write_file(request).await),
+        SessionRequest::CreateDirectory(request) => {
+            SessionResponse::CreateDirectory(create_directory(request).await)
+        }
+        SessionRequest::ReadFile(request) => SessionResponse::ReadFile(read_file(request).await),
+        SessionRequest::Execute(request) => {
+            SessionResponse::Execute(execute_command(request).await)
+        }
+        SessionRequest::Cancel(CancelRequest { id, .. }) => {
+            SessionResponse::Cancel(ControlResponse {
+                id,
+                error: Some("cancel cannot be dispatched as a concurrent request".to_owned()),
+            })
+        }
+        SessionRequest::Shutdown(request) => SessionResponse::Shutdown(ControlResponse {
+            id: request.id,
+            error: Some("shutdown cannot be dispatched as a concurrent request".to_owned()),
+        }),
+    }
+}
+
+async fn write_response(
+    output: &mut (impl AsyncWrite + Unpin),
+    response: &SessionResponse,
+    max_frame_bytes: usize,
+) -> Result<(), VmGuestError> {
+    let mut encoded = match encode_frame(response, max_frame_bytes)? {
+        EncodedFrame::Complete(encoded) => encoded,
+        EncodedFrame::TooLarge => {
+            let SessionResponse::Tool(response) = response else {
+                return Err(VmGuestError::FrameTooLarge);
+            };
+            let fallback = SessionResponse::Tool(ToolResponse::failed(
+                response.id,
+                format!(
+                    "VM tool response exceeded the {max_frame_bytes}-byte protocol frame limit"
+                ),
+            ));
+            match encode_frame(&fallback, max_frame_bytes)? {
+                EncodedFrame::Complete(encoded) => encoded,
+                EncodedFrame::TooLarge => return Err(VmGuestError::FrameTooLarge),
+            }
+        }
+    };
+    encoded.push(b'\n');
+    output.write_all(&encoded).await?;
+    output.flush().await?;
+    Ok(())
+}
+
+enum EncodedFrame {
+    Complete(Vec<u8>),
+    TooLarge,
+}
+
+fn encode_frame(
+    response: &SessionResponse,
+    max_frame_bytes: usize,
+) -> Result<EncodedFrame, serde_json::Error> {
+    let mut output = BoundedFrameWriter::new(max_frame_bytes);
+    match serde_json::to_writer(&mut output, response) {
+        Ok(()) => Ok(EncodedFrame::Complete(output.into_inner())),
+        Err(_) if output.limit_exceeded => Ok(EncodedFrame::TooLarge),
+        Err(error) => Err(error),
+    }
+}
+
+struct BoundedFrameWriter {
+    bytes: Vec<u8>,
+    max_bytes: usize,
+    limit_exceeded: bool,
+}
+
+impl BoundedFrameWriter {
+    fn new(max_bytes: usize) -> Self {
+        Self {
+            bytes: Vec::with_capacity(max_bytes.min(8 * 1024)),
+            max_bytes,
+            limit_exceeded: false,
+        }
+    }
+
+    fn into_inner(self) -> Vec<u8> {
+        self.bytes
+    }
+}
+
+impl std::io::Write for BoundedFrameWriter {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        if buffer.len() > self.max_bytes.saturating_sub(self.bytes.len()) {
+            self.limit_exceeded = true;
+            return Err(std::io::Error::other(
+                "VM tool protocol frame limit exceeded",
+            ));
+        }
+        self.bytes.extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+async fn read_frame(
+    reader: &mut (impl AsyncBufRead + Unpin),
+) -> Result<Option<Vec<u8>>, VmGuestError> {
+    let mut frame = Vec::new();
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            return if frame.is_empty() {
+                Ok(None)
+            } else {
+                Err(VmGuestError::Closed)
+            };
+        }
+        if let Some(newline) = available.iter().position(|byte| *byte == b'\n') {
+            if frame.len().saturating_add(newline) > MAX_FRAME_BYTES {
+                return Err(VmGuestError::FrameTooLarge);
+            }
+            frame.extend_from_slice(&available[..newline]);
+            reader.consume(newline + 1);
+            if frame.last() == Some(&b'\r') {
+                frame.pop();
+            }
+            return Ok(Some(frame));
+        }
+        if frame.len().saturating_add(available.len()) > MAX_FRAME_BYTES {
+            return Err(VmGuestError::FrameTooLarge);
+        }
+        let consumed = available.len();
+        frame.extend_from_slice(available);
+        reader.consume(consumed);
+    }
+}
+
+async fn sync_filesystems(request: ShutdownRequest) -> ControlResponse {
+    let error = match Command::new("/bin/sync").status().await {
+        Ok(status) if status.success() => None,
+        Ok(status) => Some(format!("sync exited with {status}")),
+        Err(error) => Some(error.to_string()),
+    };
+    ControlResponse {
+        id: request.id,
+        error,
+    }
+}
+
+async fn write_file(request: WriteFileRequest) -> ControlResponse {
+    let result = atomic_write_file(
+        &request.path,
+        &request.contents,
+        request.mode,
+        request.modified_unix_seconds,
+        request.id,
+    )
+    .await;
+    ControlResponse {
+        id: request.id,
+        error: result.err().map(|error| error.to_string()),
+    }
+}
+
+async fn atomic_write_file(
+    path: &str,
+    contents: &[u8],
+    mode: u32,
+    modified_unix_seconds: Option<i64>,
+    request_id: u64,
+) -> std::io::Result<()> {
+    let path = PathBuf::from(path);
+    let parent = path
+        .parent()
+        .ok_or_else(|| std::io::Error::other("file path has no parent"))?;
+    let name = path
+        .file_name()
+        .ok_or_else(|| std::io::Error::other("file path has no name"))?
+        .to_string_lossy();
+    tokio::fs::create_dir_all(parent).await?;
+    let temporary = parent.join(format!(".{name}.nanocodex-{request_id}.tmp"));
+    let result = async {
+        let mut file = tokio::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temporary)
+            .await?;
+        file.write_all(contents).await?;
+        file.flush().await?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            file.set_permissions(std::fs::Permissions::from_mode(mode))
+                .await?;
+        }
+        drop(file);
+        tokio::fs::rename(&temporary, &path).await?;
+        set_modified_time(&path, modified_unix_seconds)
+    }
+    .await;
+    if result.is_err() {
+        let _ = tokio::fs::remove_file(&temporary).await;
+    }
+    result
+}
+
+async fn create_directory(request: CreateDirectoryRequest) -> ControlResponse {
+    let result =
+        create_directory_path(&request.path, request.mode, request.modified_unix_seconds).await;
+    ControlResponse {
+        id: request.id,
+        error: result.err().map(|error| error.to_string()),
+    }
+}
+
+async fn create_directory_path(
+    path: &str,
+    mode: u32,
+    modified_unix_seconds: Option<i64>,
+) -> std::io::Result<()> {
+    let path = PathBuf::from(path);
+    tokio::fs::create_dir_all(&path).await?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(&path, std::fs::Permissions::from_mode(mode)).await?;
+    }
+    set_modified_time(&path, modified_unix_seconds)
+}
+
+fn set_modified_time(path: &Path, modified_unix_seconds: Option<i64>) -> std::io::Result<()> {
+    let Some(modified_unix_seconds) = modified_unix_seconds else {
+        return Ok(());
+    };
+    filetime::set_file_mtime(
+        path,
+        filetime::FileTime::from_unix_time(modified_unix_seconds, 0),
+    )
+}
+
+async fn read_file(request: ReadFileRequest) -> ReadFileResponse {
+    let contents = async {
+        let file = tokio::fs::File::open(&request.path).await?;
+        let metadata = file.metadata().await?;
+        if !metadata.is_file() {
+            return Err(std::io::Error::other(
+                "control reads require a regular file",
+            ));
+        }
+        let maximum = u64::try_from(MAX_CONTROL_FILE_BYTES).unwrap_or(u64::MAX);
+        if metadata.len() > maximum {
+            return Err(std::io::Error::other(format!(
+                "file is {} bytes, exceeding the {MAX_CONTROL_FILE_BYTES}-byte control limit",
+                metadata.len()
+            )));
+        }
+        let mut contents = Vec::with_capacity(
+            usize::try_from(metadata.len())
+                .unwrap_or(usize::MAX)
+                .min(MAX_CONTROL_FILE_BYTES),
+        );
+        file.take(maximum.saturating_add(1))
+            .read_to_end(&mut contents)
+            .await?;
+        if contents.len() > MAX_CONTROL_FILE_BYTES {
+            return Err(std::io::Error::other(format!(
+                "file grew beyond the {MAX_CONTROL_FILE_BYTES}-byte control limit while reading"
+            )));
+        }
+        Ok(contents)
+    }
+    .await;
+    match contents {
+        Ok(contents) => ReadFileResponse {
+            id: request.id,
+            contents: Some(contents),
+            error: None,
+        },
+        Err(error) => ReadFileResponse {
+            id: request.id,
+            contents: None,
+            error: Some(error.to_string()),
+        },
+    }
+}
+
+async fn execute_command(request: ExecuteRequest) -> ExecuteResponse {
+    let mut command = Command::new(&request.program);
+    command
+        .args(&request.arguments)
+        .current_dir(&request.current_directory)
+        .env_clear()
+        .envs(request.environment.iter().cloned())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    command.process_group(0);
+
+    let timeout = Duration::from_millis(request.timeout_millis);
+    match command_output(&mut command, timeout, request.max_output_bytes).await {
+        Ok(CommandOutcome::Completed(output)) => ExecuteResponse {
+            id: request.id,
+            exit_code: Some(output.status.code().unwrap_or(1)),
+            stdout: Some(output.stdout),
+            stderr: Some(output.stderr),
+            error: None,
+            timed_out: false,
+            output_limit_exceeded: false,
+        },
+        Ok(CommandOutcome::TimedOut { stdout, stderr }) => ExecuteResponse {
+            id: request.id,
+            exit_code: None,
+            stdout: Some(stdout),
+            stderr: Some(stderr),
+            error: None,
+            timed_out: true,
+            output_limit_exceeded: false,
+        },
+        Ok(CommandOutcome::OutputLimitExceeded) => ExecuteResponse {
+            id: request.id,
+            exit_code: None,
+            stdout: None,
+            stderr: None,
+            error: None,
+            timed_out: false,
+            output_limit_exceeded: true,
+        },
+        Err(error) => ExecuteResponse {
+            id: request.id,
+            exit_code: None,
+            stdout: None,
+            stderr: None,
+            error: Some(error.to_string()),
+            timed_out: false,
+            output_limit_exceeded: false,
+        },
+    }
+}
+
+enum CommandOutcome {
+    Completed(std::process::Output),
+    TimedOut { stdout: Vec<u8>, stderr: Vec<u8> },
+    OutputLimitExceeded,
+}
+
+enum WaitOutcome {
+    Exited(ExitStatus),
+    TimedOut,
+    OutputLimitExceeded,
+}
+
+async fn command_output(
+    command: &mut Command,
+    timeout: Duration,
+    max_output_bytes: usize,
+) -> std::io::Result<CommandOutcome> {
+    let mut child = command.spawn()?;
+    let process_group = child
+        .id()
+        .and_then(|id| i32::try_from(id).ok())
+        .map(Pid::from_raw);
+    let mut process_group_guard = ProcessGroupGuard(process_group);
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| std::io::Error::other("guest command stdout was not piped"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| std::io::Error::other("guest command stderr was not piped"))?;
+    let retained = Arc::new(AtomicUsize::new(0));
+    let (limit_sender, mut limit_receiver) = mpsc::channel(1);
+    let mut stdout = tokio::spawn(read_bounded(
+        stdout,
+        Arc::clone(&retained),
+        max_output_bytes,
+        limit_sender.clone(),
+    ));
+    let mut stderr = tokio::spawn(read_bounded(
+        stderr,
+        Arc::clone(&retained),
+        max_output_bytes,
+        limit_sender,
+    ));
+    let deadline = tokio::time::sleep(timeout);
+    tokio::pin!(deadline);
+
+    let mut outcome = tokio::select! {
+        status = child.wait() => WaitOutcome::Exited(status?),
+        () = &mut deadline => WaitOutcome::TimedOut,
+        Some(()) = limit_receiver.recv() => WaitOutcome::OutputLimitExceeded,
+    };
+    if !matches!(outcome, WaitOutcome::Exited(_)) {
+        if let Some(status) = child.try_wait()? {
+            outcome = WaitOutcome::Exited(status);
+        } else {
+            kill_process_group(&mut child, process_group)?;
+            child.wait().await?;
+        }
+    }
+    let (stdout, stderr) = tokio::time::timeout(Duration::from_secs(1), async {
+        let stdout = (&mut stdout).await.map_err(std::io::Error::other)??;
+        let stderr = (&mut stderr).await.map_err(std::io::Error::other)??;
+        Ok::<_, std::io::Error>((stdout, stderr))
+    })
+    .await
+    .unwrap_or_else(|_| {
+        let _ = kill_process_group(&mut child, process_group);
+        Err(std::io::Error::other(
+            "guest command descendants kept output pipes open",
+        ))
+    })?;
+    process_group_guard.disarm();
+    let output_limit_exceeded = retained.load(Ordering::Relaxed) > max_output_bytes;
+    match outcome {
+        WaitOutcome::Exited(_) if output_limit_exceeded => Ok(CommandOutcome::OutputLimitExceeded),
+        WaitOutcome::Exited(status) => Ok(CommandOutcome::Completed(std::process::Output {
+            status,
+            stdout,
+            stderr,
+        })),
+        WaitOutcome::TimedOut => Ok(CommandOutcome::TimedOut { stdout, stderr }),
+        WaitOutcome::OutputLimitExceeded => Ok(CommandOutcome::OutputLimitExceeded),
+    }
+}
+
+fn kill_process_group(child: &mut Child, process_group: Option<Pid>) -> std::io::Result<()> {
+    if let Some(process_group) = process_group {
+        let child_kill = child.start_kill();
+        match killpg(process_group, Signal::SIGKILL) {
+            Ok(()) | Err(Errno::ESRCH) => Ok(()),
+            Err(Errno::EPERM) => child_kill.or(Ok(())),
+            Err(error) => Err(std::io::Error::other(error)),
+        }
+    } else {
+        child.start_kill()
+    }
+}
+
+struct ProcessGroupGuard(Option<Pid>);
+
+impl ProcessGroupGuard {
+    const fn disarm(&mut self) {
+        self.0 = None;
+    }
+}
+
+impl Drop for ProcessGroupGuard {
+    fn drop(&mut self) {
+        if let Some(process_group) = self.0 {
+            let _ = killpg(process_group, Signal::SIGKILL);
+        }
+    }
+}
+
+async fn read_bounded(
+    mut reader: impl AsyncRead + Unpin,
+    retained: Arc<AtomicUsize>,
+    limit: usize,
+    limit_sender: mpsc::Sender<()>,
+) -> std::io::Result<Vec<u8>> {
+    let mut output = Vec::new();
+    let mut buffer = [0_u8; 8 * 1024];
+    let mut reported = false;
+    loop {
+        let read = reader.read(&mut buffer).await?;
+        if read == 0 {
+            break;
+        }
+        let offset = retained.fetch_add(read, Ordering::Relaxed);
+        let allowed = limit.saturating_sub(offset).min(read);
+        output.extend_from_slice(&buffer[..allowed]);
+        if allowed < read && !reported {
+            reported = true;
+            let _ = limit_sender.try_send(());
+        }
+    }
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs::{self, File},
+        time::{Duration, Instant, UNIX_EPOCH},
+    };
+
+    use nanocodex_tools::{ToolInput, contract::ToolOutputBody, standard::StandardTool};
+    use serde_json::{json, value::to_raw_value};
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    use super::super::protocol::{
+        CancelRequest, ExecuteRequest, ReadFileRequest, ReadyRequest, SessionRequest,
+        SessionResponse, ShutdownRequest, ToolRequest, WireToolContext, WireToolInput,
+    };
+    use super::{
+        atomic_write_file, create_directory_path, execute_command, read_file, serve_io,
+        serve_io_with_frame_limit,
+    };
+
+    const DEFAULT_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
+    const PATH_TRACING_IMAGE_BYTES: u64 = 48_262_737;
+
+    #[tokio::test]
+    async fn filesystem_controls_apply_exact_modes_and_epoch_mtimes() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let directory = root.path().join("tests");
+        let file = directory.join("test.sh");
+        let directory = directory.to_string_lossy();
+        let file = file.to_string_lossy();
+
+        create_directory_path(&directory, 0o700, None)
+            .await
+            .unwrap();
+        atomic_write_file(&file, b"#!/bin/sh\n", 0o640, Some(0), 7)
+            .await
+            .unwrap();
+        create_directory_path(&directory, 0o750, Some(0))
+            .await
+            .unwrap();
+
+        let file_metadata = fs::metadata(file.as_ref()).unwrap();
+        assert_eq!(file_metadata.permissions().mode() & 0o7777, 0o640);
+        assert_eq!(file_metadata.modified().unwrap(), UNIX_EPOCH);
+        let directory_metadata = fs::metadata(directory.as_ref()).unwrap();
+        assert_eq!(directory_metadata.permissions().mode() & 0o7777, 0o750);
+        assert_eq!(directory_metadata.modified().unwrap(), UNIX_EPOCH);
+    }
+
+    #[tokio::test]
+    async fn timeout_kills_descendants_holding_output_pipes() {
+        let started_at = Instant::now();
+        let response = execute_command(ExecuteRequest {
+            id: 1,
+            program: "/bin/sh".to_owned(),
+            arguments: vec![
+                "-c".to_owned(),
+                "printf 'partial stdout'; printf 'partial stderr' >&2; sleep 30 & wait".to_owned(),
+            ],
+            current_directory: "/".to_owned(),
+            environment: Vec::new(),
+            timeout_millis: 100,
+            max_output_bytes: DEFAULT_OUTPUT_BYTES,
+        })
+        .await;
+
+        assert!(response.timed_out);
+        assert!(response.error.is_none());
+        assert_eq!(
+            response.stdout.as_deref(),
+            Some(b"partial stdout".as_slice())
+        );
+        assert_eq!(
+            response.stderr.as_deref(),
+            Some(b"partial stderr".as_slice())
+        );
+        assert!(started_at.elapsed() < Duration::from_secs(1));
+    }
+
+    #[tokio::test]
+    async fn command_output_is_bounded_while_it_is_produced() {
+        let response = execute_command(ExecuteRequest {
+            id: 1,
+            program: "/usr/bin/yes".to_owned(),
+            arguments: vec!["bounded".to_owned()],
+            current_directory: "/".to_owned(),
+            environment: Vec::new(),
+            timeout_millis: 5_000,
+            max_output_bytes: 8,
+        })
+        .await;
+
+        assert!(response.output_limit_exceeded);
+        assert!(!response.timed_out);
+        assert!(response.error.is_none());
+        assert!(response.stdout.is_none());
+        assert!(response.stderr.is_none());
+    }
+
+    #[tokio::test]
+    async fn control_read_rejects_non_regular_files_without_blocking() {
+        let response = tokio::time::timeout(
+            Duration::from_secs(1),
+            read_file(ReadFileRequest {
+                id: 1,
+                path: "/dev/zero".to_owned(),
+            }),
+        )
+        .await
+        .expect("special-file rejection must not wait for EOF");
+
+        assert!(response.contents.is_none());
+        assert!(
+            response
+                .error
+                .is_some_and(|error| error.contains("regular file"))
+        );
+    }
+
+    #[tokio::test]
+    async fn independent_requests_execute_concurrently() {
+        let workspace = tempfile::tempdir().unwrap();
+        let marker = workspace.path().join("second-started");
+        let (host, guest) = tokio::io::duplex(64 * 1024);
+        let (host_read, mut host_write) = tokio::io::split(host);
+        let (guest_read, guest_write) = tokio::io::split(guest);
+        let guest_task = tokio::spawn({
+            let workspace = workspace.path().to_owned();
+            async move { serve_io(&workspace, guest_read, guest_write).await }
+        });
+
+        for request in [
+            SessionRequest::Execute(ExecuteRequest {
+                id: 0,
+                program: "/bin/sh".to_owned(),
+                arguments: vec![
+                    "-c".to_owned(),
+                    format!("while [ ! -f '{}' ]; do sleep 0.01; done", marker.display()),
+                ],
+                current_directory: workspace.path().to_string_lossy().into_owned(),
+                environment: Vec::new(),
+                timeout_millis: 5_000,
+                max_output_bytes: DEFAULT_OUTPUT_BYTES,
+            }),
+            SessionRequest::Execute(ExecuteRequest {
+                id: 1,
+                program: "/usr/bin/touch".to_owned(),
+                arguments: vec![marker.to_string_lossy().into_owned()],
+                current_directory: workspace.path().to_string_lossy().into_owned(),
+                environment: Vec::new(),
+                timeout_millis: 5_000,
+                max_output_bytes: DEFAULT_OUTPUT_BYTES,
+            }),
+        ] {
+            host_write
+                .write_all(&serde_json::to_vec(&request).unwrap())
+                .await
+                .unwrap();
+            host_write.write_all(b"\n").await.unwrap();
+        }
+
+        let mut responses = BufReader::new(host_read).lines();
+        for _ in 0..2 {
+            let line = responses.next_line().await.unwrap().unwrap();
+            assert!(matches!(
+                serde_json::from_str::<SessionResponse>(&line).unwrap(),
+                SessionResponse::Execute(response)
+                    if response.error.is_none() && !response.timed_out
+            ));
+        }
+        host_write
+            .write_all(
+                &serde_json::to_vec(&SessionRequest::Shutdown(ShutdownRequest { id: 2 })).unwrap(),
+            )
+            .await
+            .unwrap();
+        host_write.write_all(b"\n").await.unwrap();
+        drop(host_write);
+        let shutdown = responses.next_line().await.unwrap().unwrap();
+        assert!(matches!(
+            serde_json::from_str::<SessionResponse>(&shutdown).unwrap(),
+            SessionResponse::Shutdown(response) if response.id == 2 && response.error.is_none()
+        ));
+        guest_task.await.unwrap().unwrap();
+        assert!(marker.is_file());
+    }
+
+    #[tokio::test]
+    async fn shutdown_aborts_in_flight_work_before_syncing() {
+        let workspace = tempfile::tempdir().unwrap();
+        let (host, guest) = tokio::io::duplex(64 * 1024);
+        let (host_read, mut host_write) = tokio::io::split(host);
+        let (guest_read, guest_write) = tokio::io::split(guest);
+        let guest_task = tokio::spawn({
+            let workspace = workspace.path().to_owned();
+            async move { serve_io(&workspace, guest_read, guest_write).await }
+        });
+        for request in [
+            SessionRequest::Execute(ExecuteRequest {
+                id: 0,
+                program: "/bin/sh".to_owned(),
+                arguments: vec!["-c".to_owned(), "sleep 30 & wait".to_owned()],
+                current_directory: workspace.path().to_string_lossy().into_owned(),
+                environment: Vec::new(),
+                timeout_millis: 60_000,
+                max_output_bytes: DEFAULT_OUTPUT_BYTES,
+            }),
+            SessionRequest::Shutdown(ShutdownRequest { id: 1 }),
+        ] {
+            host_write
+                .write_all(&serde_json::to_vec(&request).unwrap())
+                .await
+                .unwrap();
+            host_write.write_all(b"\n").await.unwrap();
+        }
+
+        let mut responses = BufReader::new(host_read).lines();
+        let line = tokio::time::timeout(Duration::from_secs(2), responses.next_line())
+            .await
+            .expect("shutdown must not wait for the in-flight command")
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            serde_json::from_str::<SessionResponse>(&line).unwrap(),
+            SessionResponse::Shutdown(response) if response.id == 1 && response.error.is_none()
+        ));
+        drop(host_write);
+        guest_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn targeted_cancel_aborts_only_the_requested_guest_task() {
+        let workspace = tempfile::tempdir().unwrap();
+        let (host, guest) = tokio::io::duplex(64 * 1024);
+        let (host_read, mut host_write) = tokio::io::split(host);
+        let (guest_read, guest_write) = tokio::io::split(guest);
+        let guest_task = tokio::spawn({
+            let workspace = workspace.path().to_owned();
+            async move { serve_io(&workspace, guest_read, guest_write).await }
+        });
+        for request in [
+            SessionRequest::Execute(ExecuteRequest {
+                id: 0,
+                program: "/bin/sh".to_owned(),
+                arguments: vec!["-c".to_owned(), "sleep 30 & wait".to_owned()],
+                current_directory: workspace.path().to_string_lossy().into_owned(),
+                environment: Vec::new(),
+                timeout_millis: 60_000,
+                max_output_bytes: DEFAULT_OUTPUT_BYTES,
+            }),
+            SessionRequest::Cancel(CancelRequest {
+                id: 1,
+                target_id: 0,
+            }),
+            SessionRequest::Execute(ExecuteRequest {
+                id: 2,
+                program: "/usr/bin/true".to_owned(),
+                arguments: Vec::new(),
+                current_directory: workspace.path().to_string_lossy().into_owned(),
+                environment: Vec::new(),
+                timeout_millis: 5_000,
+                max_output_bytes: DEFAULT_OUTPUT_BYTES,
+            }),
+        ] {
+            host_write
+                .write_all(&serde_json::to_vec(&request).unwrap())
+                .await
+                .unwrap();
+            host_write.write_all(b"\n").await.unwrap();
+        }
+
+        let mut responses = BufReader::new(host_read).lines();
+        let mut cancelled = false;
+        let mut follow_up = false;
+        while !cancelled || !follow_up {
+            let line = tokio::time::timeout(Duration::from_secs(2), responses.next_line())
+                .await
+                .expect("cancellation and the independent follow-up must complete")
+                .unwrap()
+                .unwrap();
+            match serde_json::from_str::<SessionResponse>(&line).unwrap() {
+                SessionResponse::Cancel(response) if response.id == 1 => cancelled = true,
+                SessionResponse::Execute(response) if response.id == 2 => {
+                    assert!(response.error.is_none());
+                    assert!(!response.timed_out);
+                    follow_up = true;
+                }
+                response => panic!("unexpected response ID {}", response.id()),
+            }
+        }
+
+        host_write
+            .write_all(
+                &serde_json::to_vec(&SessionRequest::Shutdown(ShutdownRequest { id: 3 })).unwrap(),
+            )
+            .await
+            .unwrap();
+        host_write.write_all(b"\n").await.unwrap();
+        drop(host_write);
+        let shutdown = responses.next_line().await.unwrap().unwrap();
+        assert!(matches!(
+            serde_json::from_str::<SessionResponse>(&shutdown).unwrap(),
+            SessionResponse::Shutdown(response) if response.id == 3 && response.error.is_none()
+        ));
+        guest_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn oversized_tool_response_becomes_a_scoped_failure_and_guest_stays_ready() {
+        const TEST_FRAME_BYTES: usize = 1_024;
+
+        let workspace = tempfile::tempdir().unwrap();
+        let (host, guest) = tokio::io::duplex(64 * 1024);
+        let (host_read, mut host_write) = tokio::io::split(host);
+        let (guest_read, guest_write) = tokio::io::split(guest);
+        let guest_task = tokio::spawn({
+            let workspace = workspace.path().to_owned();
+            async move {
+                serve_io_with_frame_limit(&workspace, guest_read, guest_write, TEST_FRAME_BYTES)
+                    .await
+            }
+        });
+        let oversized = SessionRequest::Tool(ToolRequest {
+            id: 0,
+            tool: StandardTool::ExecCommand,
+            input: WireToolInput::from(ToolInput::Function(
+                to_raw_value(&json!({
+                    "cmd": "/usr/bin/yes x | /usr/bin/head -c 4096",
+                    "max_output_tokens": 10_000,
+                }))
+                .unwrap(),
+            )),
+            context: WireToolContext {
+                model: "model".to_owned(),
+                session_id: "session".to_owned(),
+                call_id: "oversized".to_owned(),
+                output_token_budget: 10_000,
+            },
+        });
+        host_write
+            .write_all(&serde_json::to_vec(&oversized).unwrap())
+            .await
+            .unwrap();
+        host_write.write_all(b"\n").await.unwrap();
+
+        let mut responses = BufReader::new(host_read).lines();
+        let line = responses.next_line().await.unwrap().unwrap();
+        let SessionResponse::Tool(response) =
+            serde_json::from_str::<SessionResponse>(&line).unwrap()
+        else {
+            panic!("expected a tool response");
+        };
+        assert_eq!(response.id, 0);
+        assert!(response.execution.is_none());
+        assert!(
+            response
+                .error
+                .is_some_and(|error| error.contains("1024-byte protocol frame limit"))
+        );
+
+        host_write
+            .write_all(&serde_json::to_vec(&SessionRequest::Ready(ReadyRequest { id: 1 })).unwrap())
+            .await
+            .unwrap();
+        host_write.write_all(b"\n").await.unwrap();
+        let line = responses.next_line().await.unwrap().unwrap();
+        assert!(matches!(
+            serde_json::from_str::<SessionResponse>(&line).unwrap(),
+            SessionResponse::Ready(response) if response.id == 1 && response.error.is_none()
+        ));
+
+        host_write
+            .write_all(
+                &serde_json::to_vec(&SessionRequest::Shutdown(ShutdownRequest { id: 2 })).unwrap(),
+            )
+            .await
+            .unwrap();
+        host_write.write_all(b"\n").await.unwrap();
+        drop(host_write);
+        let shutdown = responses.next_line().await.unwrap().unwrap();
+        assert!(matches!(
+            serde_json::from_str::<SessionResponse>(&shutdown).unwrap(),
+            SessionResponse::Shutdown(response) if response.id == 2 && response.error.is_none()
+        ));
+        guest_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn exact_path_tracing_image_is_rejected_before_encoding_and_session_remains_usable() {
+        let workspace = tempfile::tempdir().unwrap();
+        let image = workspace.path().join("image.ppm");
+        File::create(&image)
+            .unwrap()
+            .set_len(PATH_TRACING_IMAGE_BYTES)
+            .unwrap();
+        let (host, guest) = tokio::io::duplex(64 * 1024);
+        let (host_read, mut host_write) = tokio::io::split(host);
+        let (guest_read, guest_write) = tokio::io::split(guest);
+        let guest_task = tokio::spawn({
+            let workspace = workspace.path().to_owned();
+            async move { serve_io(&workspace, guest_read, guest_write).await }
+        });
+        let view_image = SessionRequest::Tool(ToolRequest {
+            id: 0,
+            tool: StandardTool::ViewImage,
+            input: WireToolInput::from(ToolInput::Function(
+                to_raw_value(&json!({
+                    "path": image,
+                    "detail": "original",
+                }))
+                .unwrap(),
+            )),
+            context: WireToolContext {
+                model: "model".to_owned(),
+                session_id: "session".to_owned(),
+                call_id: "view-image".to_owned(),
+                output_token_budget: 10_000,
+            },
+        });
+        host_write
+            .write_all(&serde_json::to_vec(&view_image).unwrap())
+            .await
+            .unwrap();
+        host_write.write_all(b"\n").await.unwrap();
+
+        let mut responses = BufReader::new(host_read).lines();
+        let line = responses.next_line().await.unwrap().unwrap();
+        let SessionResponse::Tool(response) =
+            serde_json::from_str::<SessionResponse>(&line).unwrap()
+        else {
+            panic!("expected a tool response");
+        };
+        assert_eq!(response.id, 0);
+        assert!(response.error.is_none());
+        let execution = response.execution.unwrap();
+        assert!(!execution.success);
+        let ToolOutputBody::Text(error) = execution.output else {
+            panic!("oversized image should return a bounded text error");
+        };
+        assert!(error.contains("48262737 bytes"));
+        assert!(error.contains("resize or convert"));
+
+        for request in [
+            SessionRequest::Cancel(CancelRequest {
+                id: 1,
+                target_id: 0,
+            }),
+            SessionRequest::Execute(ExecuteRequest {
+                id: 2,
+                program: "/usr/bin/true".to_owned(),
+                arguments: Vec::new(),
+                current_directory: workspace.path().to_string_lossy().into_owned(),
+                environment: Vec::new(),
+                timeout_millis: 5_000,
+                max_output_bytes: DEFAULT_OUTPUT_BYTES,
+            }),
+        ] {
+            host_write
+                .write_all(&serde_json::to_vec(&request).unwrap())
+                .await
+                .unwrap();
+            host_write.write_all(b"\n").await.unwrap();
+        }
+
+        let mut cancel_completed = false;
+        let mut command_completed = false;
+        while !cancel_completed || !command_completed {
+            let line = tokio::time::timeout(Duration::from_secs(2), responses.next_line())
+                .await
+                .expect("late cancellation and follow-up command must complete")
+                .unwrap()
+                .unwrap();
+            match serde_json::from_str::<SessionResponse>(&line).unwrap() {
+                SessionResponse::Cancel(response) if response.id == 1 => {
+                    assert!(response.error.is_none());
+                    cancel_completed = true;
+                }
+                SessionResponse::Execute(response) if response.id == 2 => {
+                    assert!(response.error.is_none());
+                    assert!(!response.timed_out);
+                    command_completed = true;
+                }
+                response => panic!("unexpected response ID {}", response.id()),
+            }
+        }
+
+        host_write
+            .write_all(
+                &serde_json::to_vec(&SessionRequest::Shutdown(ShutdownRequest { id: 3 })).unwrap(),
+            )
+            .await
+            .unwrap();
+        host_write.write_all(b"\n").await.unwrap();
+        drop(host_write);
+        let shutdown = responses.next_line().await.unwrap().unwrap();
+        assert!(matches!(
+            serde_json::from_str::<SessionResponse>(&shutdown).unwrap(),
+            SessionResponse::Shutdown(response) if response.id == 3 && response.error.is_none()
+        ));
+        guest_task.await.unwrap().unwrap();
+    }
+}

--- a/crates/experimental/nanocodex-vm/src/tools/mod.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/mod.rs
@@ -1,0 +1,279 @@
+//! Retained VM sessions for Nanocodex workspace tools.
+//!
+//! This module keeps the model-visible tool contract identical while forwarding
+//! `exec_command`, `write_stdin`, `apply_patch`, and `view_image` to one
+//! isolated guest. Native builds own the VMM child, cancellation, bounded
+//! protocol, and egress lease. The statically linked Linux guest target
+//! compiles the companion server over the canonical workspace-tool runtime.
+
+#![cfg_attr(
+    all(feature = "host", any(target_os = "linux", target_os = "macos")),
+    doc = r#"
+# Compose VM-backed tools
+
+```no_run
+use nanocodex_vm::{
+    host::{EgressLease, GuestCommand, VmConfig},
+    tools::VmToolSession,
+};
+use tokio::process::Command;
+
+# async fn build() -> Result<(), Box<dyn std::error::Error>> {
+let vmm = Command::new("dedicated-vmm-process");
+let session = VmToolSession::spawn_configured(
+    vmm,
+    VmConfig::ext4("attempts/018f/root.ext4")
+        .cpus(2)
+        .memory_mib(768),
+    GuestCommand::new("/usr/local/bin/nanocodex-vm-guest")
+        .arg("/workspace"),
+    EgressLease::disabled(),
+)
+.await?;
+let tools = session
+    .tools()
+    .tools_builder()
+    .working_directory("/workspace")
+    .build()?;
+# let _ = tools;
+# Ok(())
+# }
+```
+
+Dropping the last session capability kills the VMM. Call
+[`VmToolSession::shutdown`] when the application wants a graceful guest
+filesystem sync and bounded exit wait.
+"#
+)]
+#![cfg_attr(
+    feature = "guest-runtime",
+    doc = r#"
+# Run the companion guest server
+
+The dedicated guest process reserves stdin/stdout for the bounded typed
+protocol and keeps one native workspace-tool runtime alive:
+
+```no_run
+use nanocodex_vm::tools::serve_guest;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+serve_guest("/workspace").await?;
+# Ok(())
+# }
+```
+"#
+)]
+#![deny(missing_docs, rustdoc::broken_intra_doc_links)]
+
+#[cfg(any(feature = "guest-runtime", test))]
+mod guest;
+mod protocol;
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+mod runtime_disk;
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+mod session;
+
+#[cfg(feature = "guest-runtime")]
+use std::path::Path;
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+use std::sync::Arc;
+
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+use nanocodex_tools::{
+    Tool, ToolContext, ToolDefinition, ToolInput, ToolResult, Tools, ToolsBuilder,
+    standard::{StandardTool, UpdatePlanTool},
+};
+
+#[cfg(feature = "guest-runtime")]
+pub use guest::VmGuestError;
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+pub use runtime_disk::{GuestRuntimeDisk, GuestRuntimeDiskError, GuestRuntimeDiskStatus};
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+pub use session::{
+    VmCommand, VmCommandOutput, VmCommandPartialOutput, VmToolSession, VmToolSessionError,
+    VmToolSessionHandle,
+};
+
+/// One VM-aware execution capability shared by all proxied workspace tools.
+///
+/// The concrete client owns transport, guest session routing, cancellation,
+/// and conversion of the guest's typed result into Nanocodex's `ToolResult`.
+#[async_trait::async_trait]
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+pub trait VmToolClient: Send + Sync {
+    /// Executes one standard tool through the client-owned VM capability.
+    async fn execute(
+        &self,
+        tool: StandardTool,
+        input: ToolInput,
+        context: ToolContext<'_>,
+    ) -> ToolResult;
+}
+
+/// Clone-cheap factory for the standard tools whose effects belong in a VM.
+#[derive(Clone)]
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+pub struct VmTools {
+    client: Arc<dyn VmToolClient>,
+}
+
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+impl VmTools {
+    /// Creates a VM tool family over one clone-cheap execution capability.
+    #[must_use]
+    pub fn new(client: impl VmToolClient + 'static) -> Self {
+        Self {
+            client: Arc::new(client),
+        }
+    }
+
+    /// Returns the VM-backed `exec_command` tool.
+    #[must_use]
+    pub fn exec_command_tool(&self) -> VmTool {
+        self.tool(StandardTool::ExecCommand)
+    }
+
+    /// Returns the VM-backed `write_stdin` tool.
+    #[must_use]
+    pub fn write_stdin_tool(&self) -> VmTool {
+        self.tool(StandardTool::WriteStdin)
+    }
+
+    /// Returns the VM-backed `apply_patch` tool.
+    #[must_use]
+    pub fn apply_patch_tool(&self) -> VmTool {
+        self.tool(StandardTool::ApplyPatch)
+    }
+
+    /// Returns the VM-backed `view_image` tool.
+    #[must_use]
+    pub fn view_image_tool(&self) -> VmTool {
+        self.tool(StandardTool::ViewImage)
+    }
+
+    /// Starts a normal Nanocodex tool selection whose workspace effects are
+    /// forwarded to this VM.
+    ///
+    /// Web search and image generation retain their normal host-side
+    /// implementations. `update_plan` also stays host-side because it has no
+    /// workspace effect. Callers can keep configuring the returned builder,
+    /// including setting the guest-visible working directory and shell.
+    #[must_use]
+    pub fn tools_builder(&self) -> ToolsBuilder {
+        Tools::builder()
+            .workspace(false)
+            .tool(self.exec_command_tool())
+            .tool(self.write_stdin_tool())
+            .tool(self.apply_patch_tool())
+            .tool(self.view_image_tool())
+            .tool(UpdatePlanTool::new())
+    }
+
+    fn tool(&self, standard: StandardTool) -> VmTool {
+        VmTool {
+            standard,
+            client: Arc::clone(&self.client),
+        }
+    }
+}
+
+/// One standard Nanocodex tool whose execution is forwarded into a VM.
+#[derive(Clone)]
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+pub struct VmTool {
+    standard: StandardTool,
+    client: Arc<dyn VmToolClient>,
+}
+
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+impl VmTool {
+    /// Returns which canonical standard tool this adapter implements.
+    #[must_use]
+    pub const fn standard(&self) -> StandardTool {
+        self.standard
+    }
+}
+
+#[async_trait::async_trait]
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+impl Tool for VmTool {
+    fn definition(&self) -> ToolDefinition {
+        self.standard.definition()
+    }
+
+    async fn execute(&self, input: ToolInput, context: ToolContext<'_>) -> ToolResult {
+        self.client.execute(self.standard, input, context).await
+    }
+}
+
+/// Serves canonical workspace-tool requests over the guest's stdin/stdout.
+///
+/// A single invocation retains the native `ToolRuntime`, including interactive
+/// shell sessions, until the input stream closes.
+///
+/// # Errors
+///
+/// Returns an error for malformed protocol messages or guest console I/O.
+#[cfg(feature = "guest-runtime")]
+pub async fn serve_guest(workspace: impl AsRef<Path>) -> Result<(), VmGuestError> {
+    guest::serve(workspace.as_ref()).await
+}
+
+#[cfg(all(test, feature = "host", any(target_os = "linux", target_os = "macos")))]
+mod tests {
+    use std::sync::Mutex;
+
+    use nanocodex_tools::{Tool, ToolContext, ToolInput, ToolOutput, standard::StandardTool};
+
+    use super::{VmToolClient, VmTools};
+
+    #[derive(Default)]
+    struct RecordingClient {
+        calls: Mutex<Vec<StandardTool>>,
+    }
+
+    #[async_trait::async_trait]
+    impl VmToolClient for RecordingClient {
+        async fn execute(
+            &self,
+            tool: StandardTool,
+            _input: ToolInput,
+            _context: ToolContext<'_>,
+        ) -> nanocodex_tools::ToolResult {
+            self.calls.lock().unwrap().push(tool);
+            Ok(ToolOutput::text(tool.name()))
+        }
+    }
+
+    #[test]
+    fn composes_vm_workspace_tools_with_the_host_plan_tool() {
+        let vm = VmTools::new(RecordingClient::default());
+        let tools = vm
+            .tools_builder()
+            .working_directory("/workspace")
+            .default_shell("sh")
+            .build()
+            .unwrap();
+
+        assert!(!tools.workspace_enabled());
+        assert!(tools.web_search_enabled());
+        assert!(tools.image_generation_enabled());
+    }
+
+    #[test]
+    fn definitions_are_the_upstream_standard_contracts() {
+        let vm = VmTools::new(RecordingClient::default());
+        for (tool, standard) in [
+            (vm.exec_command_tool(), StandardTool::ExecCommand),
+            (vm.write_stdin_tool(), StandardTool::WriteStdin),
+            (vm.apply_patch_tool(), StandardTool::ApplyPatch),
+            (vm.view_image_tool(), StandardTool::ViewImage),
+        ] {
+            assert_eq!(tool.definition().name(), standard.name());
+            assert_eq!(
+                serde_json::to_value(tool.definition()).unwrap(),
+                serde_json::to_value(standard.definition()).unwrap()
+            );
+        }
+    }
+}

--- a/crates/experimental/nanocodex-vm/src/tools/mod.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/mod.rs
@@ -72,6 +72,8 @@ mod protocol;
 mod runtime_disk;
 #[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
 mod session;
+#[cfg(all(feature = "host", any(target_os = "linux", target_os = "macos")))]
+pub(crate) use session::{DEFAULT_SHUTDOWN_TIMEOUT, DEFAULT_STARTUP_TIMEOUT};
 
 #[cfg(feature = "guest-runtime")]
 use std::path::Path;

--- a/crates/experimental/nanocodex-vm/src/tools/mod.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/mod.rs
@@ -201,6 +201,13 @@ impl Tool for VmTool {
         self.standard.definition()
     }
 
+    fn supports_parallel_tool_calls(&self) -> bool {
+        matches!(
+            self.standard,
+            StandardTool::ExecCommand | StandardTool::WriteStdin | StandardTool::ViewImage
+        )
+    }
+
     async fn execute(&self, input: ToolInput, context: ToolContext<'_>) -> ToolResult {
         self.client.execute(self.standard, input, context).await
     }
@@ -275,5 +282,15 @@ mod tests {
                 serde_json::to_value(standard.definition()).unwrap()
             );
         }
+    }
+
+    #[test]
+    fn preserves_standard_workspace_tool_parallel_safety() {
+        let vm = VmTools::new(RecordingClient::default());
+
+        assert!(vm.exec_command_tool().supports_parallel_tool_calls());
+        assert!(vm.write_stdin_tool().supports_parallel_tool_calls());
+        assert!(vm.view_image_tool().supports_parallel_tool_calls());
+        assert!(!vm.apply_patch_tool().supports_parallel_tool_calls());
     }
 }

--- a/crates/experimental/nanocodex-vm/src/tools/protocol.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/protocol.rs
@@ -1,0 +1,487 @@
+use nanocodex_tools::{ToolInput, contract::ToolOutputWire, standard::StandardTool};
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+
+#[derive(Deserialize, Serialize)]
+#[serde(tag = "kind", content = "payload", rename_all = "snake_case")]
+pub(crate) enum SessionRequest {
+    Ready(ReadyRequest),
+    Tool(ToolRequest),
+    WriteFile(WriteFileRequest),
+    CreateDirectory(CreateDirectoryRequest),
+    ReadFile(ReadFileRequest),
+    Execute(ExecuteRequest),
+    Cancel(CancelRequest),
+    Shutdown(ShutdownRequest),
+}
+
+impl SessionRequest {
+    #[cfg(any(feature = "guest-runtime", test))]
+    pub const fn id(&self) -> u64 {
+        match self {
+            Self::Ready(request) => request.id,
+            Self::Tool(request) => request.id,
+            Self::WriteFile(request) => request.id,
+            Self::CreateDirectory(request) => request.id,
+            Self::ReadFile(request) => request.id,
+            Self::Execute(request) => request.id,
+            Self::Cancel(request) => request.id,
+            Self::Shutdown(request) => request.id,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(tag = "kind", content = "payload", rename_all = "snake_case")]
+pub(crate) enum SessionResponse {
+    Ready(ControlResponse),
+    Tool(ToolResponse),
+    WriteFile(ControlResponse),
+    CreateDirectory(ControlResponse),
+    ReadFile(ReadFileResponse),
+    Execute(ExecuteResponse),
+    Cancel(ControlResponse),
+    Shutdown(ControlResponse),
+}
+
+impl SessionResponse {
+    pub const fn id(&self) -> u64 {
+        match self {
+            Self::Ready(response) => response.id,
+            Self::Tool(response) => response.id,
+            Self::WriteFile(response)
+            | Self::CreateDirectory(response)
+            | Self::Cancel(response)
+            | Self::Shutdown(response) => response.id,
+            Self::ReadFile(response) => response.id,
+            Self::Execute(response) => response.id,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ReadyRequest {
+    pub id: u64,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ShutdownRequest {
+    pub id: u64,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct WriteFileRequest {
+    pub id: u64,
+    pub path: String,
+    #[serde(with = "wire_bytes")]
+    pub contents: Vec<u8>,
+    pub mode: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub modified_unix_seconds: Option<i64>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct CreateDirectoryRequest {
+    pub id: u64,
+    pub path: String,
+    pub mode: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub modified_unix_seconds: Option<i64>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ReadFileRequest {
+    pub id: u64,
+    pub path: String,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ExecuteRequest {
+    pub id: u64,
+    pub program: String,
+    pub arguments: Vec<String>,
+    pub current_directory: String,
+    pub environment: Vec<(String, String)>,
+    pub timeout_millis: u64,
+    pub max_output_bytes: usize,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct CancelRequest {
+    pub id: u64,
+    pub target_id: u64,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ControlResponse {
+    pub id: u64,
+    pub error: Option<String>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ReadFileResponse {
+    pub id: u64,
+    #[serde(default, with = "optional_wire_bytes")]
+    pub contents: Option<Vec<u8>>,
+    pub error: Option<String>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ExecuteResponse {
+    pub id: u64,
+    pub exit_code: Option<i32>,
+    #[serde(default, with = "optional_wire_bytes")]
+    pub stdout: Option<Vec<u8>>,
+    #[serde(default, with = "optional_wire_bytes")]
+    pub stderr: Option<Vec<u8>>,
+    pub error: Option<String>,
+    pub timed_out: bool,
+    pub output_limit_exceeded: bool,
+}
+
+mod wire_bytes {
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+    use serde::{Deserialize, Deserializer, Serializer, de::Error as _};
+
+    pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&STANDARD.encode(bytes))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let encoded = String::deserialize(deserializer)?;
+        STANDARD.decode(encoded).map_err(D::Error::custom)
+    }
+}
+
+mod optional_wire_bytes {
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+    use serde::{Deserialize, Deserializer, Serializer, de::Error as _};
+
+    #[allow(
+        clippy::ref_option,
+        reason = "serde's `with` module contract passes the field by reference"
+    )]
+    pub fn serialize<S>(bytes: &Option<Vec<u8>>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match bytes {
+            Some(bytes) => serializer.serialize_some(&STANDARD.encode(bytes)),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<u8>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<String>::deserialize(deserializer)?
+            .map(|encoded| STANDARD.decode(encoded).map_err(D::Error::custom))
+            .transpose()
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ToolRequest {
+    pub id: u64,
+    pub tool: StandardTool,
+    pub input: WireToolInput,
+    pub context: WireToolContext,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum WireToolInput {
+    Function { arguments: Box<RawValue> },
+    Freeform { input: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use nanocodex_tools::{ToolInput, ToolOutput, standard::StandardTool};
+    use serde_json::{json, value::to_raw_value};
+
+    use super::{
+        CancelRequest, ControlResponse, CreateDirectoryRequest, ExecuteRequest, ExecuteResponse,
+        ReadFileRequest, ReadFileResponse, ReadyRequest, SessionRequest, SessionResponse,
+        ShutdownRequest, ToolRequest, ToolResponse, WireToolContext, WireToolInput,
+        WriteFileRequest,
+    };
+
+    #[test]
+    fn readiness_request_has_a_stable_typed_shape() {
+        let request = SessionRequest::Ready(ReadyRequest { id: 4 });
+        let encoded = serde_json::to_string(&request).unwrap();
+
+        assert_eq!(encoded, r#"{"kind":"ready","payload":{"id":4}}"#);
+    }
+
+    #[test]
+    fn shutdown_request_has_a_stable_typed_shape() {
+        let request = SessionRequest::Shutdown(ShutdownRequest { id: 9 });
+        let encoded = serde_json::to_string(&request).unwrap();
+
+        assert_eq!(encoded, r#"{"kind":"shutdown","payload":{"id":9}}"#);
+    }
+
+    #[test]
+    fn function_request_round_trips_opaque_arguments() {
+        let request = ToolRequest {
+            id: 7,
+            tool: StandardTool::ExecCommand,
+            input: WireToolInput::from(ToolInput::Function(
+                to_raw_value(&json!({"cmd": "pwd"})).unwrap(),
+            )),
+            context: WireToolContext {
+                model: "model".to_owned(),
+                session_id: "session".to_owned(),
+                call_id: "call".to_owned(),
+                output_token_budget: 100,
+            },
+        };
+        let encoded = serde_json::to_string(&request).unwrap();
+        let decoded = serde_json::from_str::<ToolRequest>(&encoded).unwrap();
+        let ToolInput::Function(arguments) = ToolInput::from(decoded.input) else {
+            panic!("function input changed variants");
+        };
+        assert_eq!(arguments.get(), r#"{"cmd":"pwd"}"#);
+    }
+
+    #[test]
+    fn tool_request_and_response_have_stable_typed_shapes() {
+        let request = SessionRequest::Tool(ToolRequest {
+            id: 1,
+            tool: StandardTool::ExecCommand,
+            input: WireToolInput::from(ToolInput::Function(
+                to_raw_value(&json!({"cmd": "pwd"})).unwrap(),
+            )),
+            context: WireToolContext {
+                model: "gpt-5.6".to_owned(),
+                session_id: "session-1".to_owned(),
+                call_id: "call-1".to_owned(),
+                output_token_budget: 10_000,
+            },
+        });
+        assert_eq!(
+            serde_json::to_string(&request).unwrap(),
+            r#"{"kind":"tool","payload":{"id":1,"tool":"exec_command","input":{"function":{"arguments":{"cmd":"pwd"}}},"context":{"model":"gpt-5.6","session_id":"session-1","call_id":"call-1","output_token_budget":10000}}}"#
+        );
+
+        let response = SessionResponse::Tool(ToolResponse::completed(
+            1,
+            ToolOutput::text("/app\n")
+                .with_process_trace(Some(0), None, None, 5, 0.01)
+                .into_wire()
+                .unwrap(),
+        ));
+        assert_eq!(
+            serde_json::to_string(&response).unwrap(),
+            r#"{"kind":"tool","payload":{"id":1,"execution":{"output":"/app\n","success":true,"code_mode_value":null,"metadata":null,"process_trace":{"exit_code":0,"session_id":null,"original_token_count":null,"output_bytes":5,"wall_time_seconds":0.01}},"error":null}}"#
+        );
+    }
+
+    #[test]
+    fn execution_response_round_trips_opaque_values() {
+        let response = ToolResponse {
+            id: 8,
+            execution: Some(
+                ToolOutput::from_json(json!({"output": "ok"}), true)
+                    .into_wire()
+                    .unwrap(),
+            ),
+            error: None,
+        };
+        let encoded = serde_json::to_string(&response).unwrap();
+        let decoded = serde_json::from_str::<ToolResponse>(&encoded).unwrap();
+        assert_eq!(decoded.id, 8);
+    }
+
+    #[test]
+    fn binary_control_payloads_use_bounded_base64_strings() {
+        let request = SessionRequest::WriteFile(WriteFileRequest {
+            id: 4,
+            path: "/tmp/output".to_owned(),
+            contents: vec![0, 127, 128, 255],
+            mode: 0o600,
+            modified_unix_seconds: None,
+        });
+        let encoded = serde_json::to_string(&request).unwrap();
+
+        assert!(encoded.contains(r#""contents":"AH+A/w==""#));
+        assert!(!encoded.contains(r#""contents":[0,127,128,255]"#));
+        assert!(!encoded.contains("modified_unix_seconds"));
+        let decoded = serde_json::from_str::<SessionRequest>(&encoded).unwrap();
+        let SessionRequest::WriteFile(decoded) = decoded else {
+            panic!("write-file request changed variants");
+        };
+        assert_eq!(decoded.contents, [0, 127, 128, 255]);
+        assert_eq!(decoded.modified_unix_seconds, None);
+    }
+
+    #[test]
+    fn filesystem_metadata_requests_have_stable_typed_shapes() {
+        let write = SessionRequest::WriteFile(WriteFileRequest {
+            id: 4,
+            path: "/tmp/output".to_owned(),
+            contents: Vec::new(),
+            mode: 0o640,
+            modified_unix_seconds: Some(0),
+        });
+        assert_eq!(
+            serde_json::to_string(&write).unwrap(),
+            r#"{"kind":"write_file","payload":{"id":4,"path":"/tmp/output","contents":"","mode":416,"modified_unix_seconds":0}}"#
+        );
+
+        let directory = SessionRequest::CreateDirectory(CreateDirectoryRequest {
+            id: 5,
+            path: "/tmp/output-dir".to_owned(),
+            mode: 0o750,
+            modified_unix_seconds: Some(0),
+        });
+        let encoded = serde_json::to_string(&directory).unwrap();
+        assert_eq!(
+            encoded,
+            r#"{"kind":"create_directory","payload":{"id":5,"path":"/tmp/output-dir","mode":488,"modified_unix_seconds":0}}"#
+        );
+        let decoded = serde_json::from_str::<SessionRequest>(&encoded).unwrap();
+        let SessionRequest::CreateDirectory(decoded) = decoded else {
+            panic!("create-directory request changed variants");
+        };
+        assert_eq!(decoded.mode, 0o750);
+        assert_eq!(decoded.modified_unix_seconds, Some(0));
+    }
+
+    #[test]
+    fn host_control_envelopes_have_stable_typed_shapes() {
+        let read = SessionRequest::ReadFile(ReadFileRequest {
+            id: 4,
+            path: "/tmp/results/out.txt".to_owned(),
+        });
+        assert_eq!(
+            serde_json::to_string(&read).unwrap(),
+            r#"{"kind":"read_file","payload":{"id":4,"path":"/tmp/results/out.txt"}}"#
+        );
+        let read = SessionResponse::ReadFile(ReadFileResponse {
+            id: 4,
+            contents: Some(b"ok\n".to_vec()),
+            error: None,
+        });
+        assert_eq!(
+            serde_json::to_string(&read).unwrap(),
+            r#"{"kind":"read_file","payload":{"id":4,"contents":"b2sK","error":null}}"#
+        );
+
+        let execute = SessionRequest::Execute(ExecuteRequest {
+            id: 5,
+            program: "/bin/sh".to_owned(),
+            arguments: vec!["-lc".to_owned(), "printf ok".to_owned()],
+            current_directory: "/app".to_owned(),
+            environment: vec![("PATH".to_owned(), "/usr/bin:/bin".to_owned())],
+            timeout_millis: 60_000,
+            max_output_bytes: 8_388_608,
+        });
+        assert_eq!(
+            serde_json::to_string(&execute).unwrap(),
+            r#"{"kind":"execute","payload":{"id":5,"program":"/bin/sh","arguments":["-lc","printf ok"],"current_directory":"/app","environment":[["PATH","/usr/bin:/bin"]],"timeout_millis":60000,"max_output_bytes":8388608}}"#
+        );
+        let execute = SessionResponse::Execute(ExecuteResponse {
+            id: 5,
+            exit_code: Some(0),
+            stdout: Some(b"ok".to_vec()),
+            stderr: Some(Vec::new()),
+            error: None,
+            timed_out: false,
+            output_limit_exceeded: false,
+        });
+        assert_eq!(
+            serde_json::to_string(&execute).unwrap(),
+            r#"{"kind":"execute","payload":{"id":5,"exit_code":0,"stdout":"b2s=","stderr":"","error":null,"timed_out":false,"output_limit_exceeded":false}}"#
+        );
+
+        let cancel = SessionRequest::Cancel(CancelRequest {
+            id: 6,
+            target_id: 5,
+        });
+        assert_eq!(
+            serde_json::to_string(&cancel).unwrap(),
+            r#"{"kind":"cancel","payload":{"id":6,"target_id":5}}"#
+        );
+        let cancel = SessionResponse::Cancel(ControlResponse { id: 6, error: None });
+        assert_eq!(
+            serde_json::to_string(&cancel).unwrap(),
+            r#"{"kind":"cancel","payload":{"id":6,"error":null}}"#
+        );
+    }
+}
+
+impl From<ToolInput> for WireToolInput {
+    fn from(input: ToolInput) -> Self {
+        match input {
+            ToolInput::Function(arguments) => Self::Function { arguments },
+            ToolInput::Freeform(input) => Self::Freeform { input },
+        }
+    }
+}
+
+impl From<WireToolInput> for ToolInput {
+    fn from(input: WireToolInput) -> Self {
+        match input {
+            WireToolInput::Function { arguments } => Self::Function(arguments),
+            WireToolInput::Freeform { input } => Self::Freeform(input),
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct WireToolContext {
+    pub model: String,
+    pub session_id: String,
+    pub call_id: String,
+    pub output_token_budget: usize,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ToolResponse {
+    pub id: u64,
+    pub execution: Option<ToolOutputWire>,
+    pub error: Option<String>,
+}
+
+impl ToolResponse {
+    #[cfg(any(feature = "guest-runtime", test))]
+    pub const fn completed(id: u64, execution: ToolOutputWire) -> Self {
+        Self {
+            id,
+            execution: Some(execution),
+            error: None,
+        }
+    }
+
+    #[cfg(any(feature = "guest-runtime", test))]
+    pub const fn failed(id: u64, error: String) -> Self {
+        Self {
+            id,
+            execution: None,
+            error: Some(error),
+        }
+    }
+}

--- a/crates/experimental/nanocodex-vm/src/tools/runtime_disk.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/runtime_disk.rs
@@ -1,0 +1,806 @@
+use std::{
+    fs::{self, File},
+    io,
+    path::{Component, Path, PathBuf},
+    time::{Instant, UNIX_EPOCH},
+};
+
+use arcbox_ext4::{
+    Formatter, Reader,
+    constants::{file_mode, make_mode},
+    error::{FormatError, ReadError},
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tracing::{info, info_span};
+
+const BLOCK_SIZE: u32 = 4_096;
+const DISK_BYTES: u64 = 128 * 1024 * 1024;
+const GUEST_PATH: &str = "/nanocodex-vm-guest";
+const IDENTITY_VERSION: &[u8] = b"nanocodex-vm-guest-runtime-v1\0";
+const RECORD_VERSION: u32 = 1;
+
+/// Whether preparing a guest runtime disk reused or created its cache entry.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GuestRuntimeDiskStatus {
+    /// A validated content-addressed disk already existed.
+    Hit,
+    /// This call formatted and atomically published the disk.
+    Created,
+}
+
+impl GuestRuntimeDiskStatus {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Hit => "hit",
+            Self::Created => "created",
+        }
+    }
+}
+
+/// A content-addressed ext4 disk containing the Nanocodex VM guest runtime.
+///
+/// The disk remains in the caller-selected cache after this value is dropped,
+/// so it can be mounted read-only by many VM attempts. Clones only copy the
+/// path, digest, and preparation result.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GuestRuntimeDisk {
+    path: PathBuf,
+    digest: String,
+    status: GuestRuntimeDiskStatus,
+}
+
+impl GuestRuntimeDisk {
+    /// Stages a Linux guest ELF into a reusable ext4 disk.
+    ///
+    /// `cache` is the VM cache root, not its `runtimes` subdirectory. For
+    /// example:
+    ///
+    /// ```no_run
+    /// use nanocodex_vm::tools::{GuestRuntimeDisk, GuestRuntimeDiskStatus};
+    ///
+    /// # fn prepare() -> Result<(), Box<dyn std::error::Error>> {
+    /// let runtime = GuestRuntimeDisk::prepare(
+    ///     "target/aarch64-unknown-linux-musl/debug/nanocodex-vm-guest",
+    ///     ".cache/vm",
+    /// )?;
+    /// assert!(matches!(
+    ///     runtime.status(),
+    ///     GuestRuntimeDiskStatus::Hit | GuestRuntimeDiskStatus::Created
+    /// ));
+    /// let read_only_ext4 = runtime.path();
+    /// # let _ = read_only_ext4;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Equal binary bytes produce the same SHA-256 digest and cache path. A
+    /// healthy warm call validates an atomic size/mtime record rather than
+    /// rereading the binary or opening ext4. A changed source, disk, or record
+    /// falls back to a complete byte-for-byte validation. Concurrent callers
+    /// serialize on a per-digest filesystem lock and publish through unique
+    /// temporary files. The caller-selected cache root and every managed
+    /// descendant must be real directories or regular files; descendant
+    /// symlinks are rejected.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the binary cannot be read, is not an ELF, the cache
+    /// cannot be accessed, or a new ext4 disk cannot be formatted or validated.
+    pub fn prepare(
+        binary: impl AsRef<Path>,
+        cache: impl AsRef<Path>,
+    ) -> Result<Self, GuestRuntimeDiskError> {
+        let binary = binary.as_ref();
+        let cache = cache.as_ref();
+        let span = info_span!(
+            target: "nanocodex_vm",
+            "vm.guest_runtime.prepare",
+            otel.kind = "internal",
+            otel.status_code = tracing::field::Empty,
+            runtime.binary.path = %binary.display(),
+            runtime.binary.bytes = tracing::field::Empty,
+            runtime.cache.path = %cache.display(),
+            runtime.digest = tracing::field::Empty,
+            runtime.cache.status = tracing::field::Empty,
+            duration_ms = tracing::field::Empty,
+            status = tracing::field::Empty,
+            error.message = tracing::field::Empty,
+        );
+        let started = Instant::now();
+        let result = span.in_scope(|| Self::prepare_inner(binary, cache));
+        span.record("duration_ms", started.elapsed().as_secs_f64() * 1_000.0);
+        match &result {
+            Ok(runtime) => {
+                span.record("otel.status_code", "OK");
+                span.record("status", "completed");
+                span.record("runtime.digest", runtime.digest());
+                span.record("runtime.cache.status", runtime.status().as_str());
+                if let Ok(metadata) = fs::metadata(binary) {
+                    span.record("runtime.binary.bytes", metadata.len());
+                }
+            }
+            Err(error) => {
+                span.record("otel.status_code", "ERROR");
+                span.record("status", "failed");
+                span.record("error.message", error.to_string());
+            }
+        }
+        result
+    }
+
+    /// Returns the prepared ext4 disk path.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Returns the lowercase SHA-256 cache identity.
+    #[must_use]
+    pub fn digest(&self) -> &str {
+        &self.digest
+    }
+
+    /// Returns whether this call reused or created the disk.
+    #[must_use]
+    pub const fn status(&self) -> GuestRuntimeDiskStatus {
+        self.status
+    }
+
+    fn prepare_inner(binary: &Path, cache: &Path) -> Result<Self, GuestRuntimeDiskError> {
+        let binary =
+            fs::canonicalize(binary).map_err(|source| GuestRuntimeDiskError::ReadBinary {
+                path: binary.to_path_buf(),
+                source,
+            })?;
+        let cache = RuntimeCache::open(cache)?;
+        let source_snapshot = binary_snapshot(&binary)?;
+        let record_path = runtime_record_path(&cache, &binary)?;
+        if let Some((digest, path)) = recorded_runtime_disk(&record_path, source_snapshot, &cache)?
+        {
+            return Ok(Self {
+                path,
+                digest,
+                status: GuestRuntimeDiskStatus::Hit,
+            });
+        }
+
+        let bytes = fs::read(&binary).map_err(|source| GuestRuntimeDiskError::ReadBinary {
+            path: binary.clone(),
+            source,
+        })?;
+        if !bytes.starts_with(b"\x7fELF") {
+            return Err(GuestRuntimeDiskError::NotElf(binary));
+        }
+        if binary_snapshot(&binary)? != source_snapshot {
+            return Err(GuestRuntimeDiskError::BinaryChanged(binary));
+        }
+
+        let digest = runtime_digest(&bytes);
+        let directory = cache.directory(Path::new("runtimes").join(&digest))?;
+        let path = directory.join("runtime.ext4");
+        if valid_cached_disk(&path, &bytes)? {
+            write_runtime_record(&record_path, source_snapshot, &digest, &path)?;
+            return Ok(Self {
+                path,
+                digest,
+                status: GuestRuntimeDiskStatus::Hit,
+            });
+        }
+
+        let _lock = CacheLock::acquire(&cache, &digest)?;
+        if valid_cached_disk(&path, &bytes)? {
+            write_runtime_record(&record_path, source_snapshot, &digest, &path)?;
+            return Ok(Self {
+                path,
+                digest,
+                status: GuestRuntimeDiskStatus::Hit,
+            });
+        }
+
+        let temporary = tempfile::Builder::new()
+            .prefix(".runtime.")
+            .tempfile_in(&directory)
+            .map_err(|source| cache_error(directory.clone(), source))?
+            .into_temp_path();
+        let mut contents = bytes.as_slice();
+        let mut formatter = Formatter::new(&temporary, BLOCK_SIZE, DISK_BYTES)?;
+        formatter.create(
+            GUEST_PATH,
+            make_mode(file_mode::S_IFREG, 0o755),
+            None,
+            None,
+            Some(&mut contents),
+            Some(0),
+            Some(0),
+            None,
+        )?;
+        formatter.close()?;
+        validate_prepared_disk(&temporary, &bytes)?;
+        temporary
+            .persist(&path)
+            .map_err(|error| cache_error(path.clone(), error.error))?;
+        write_runtime_record(&record_path, source_snapshot, &digest, &path)?;
+
+        Ok(Self {
+            path,
+            digest,
+            status: GuestRuntimeDiskStatus::Created,
+        })
+    }
+}
+
+/// Failure while preparing a content-addressed VM guest runtime disk.
+#[derive(Debug, thiserror::Error)]
+pub enum GuestRuntimeDiskError {
+    /// The guest runtime binary could not be read.
+    #[error("failed to read VM guest runtime binary {}", path.display())]
+    ReadBinary {
+        /// Binary path supplied by the caller.
+        path: PathBuf,
+        /// Underlying filesystem error.
+        #[source]
+        source: io::Error,
+    },
+    /// The runtime binary changed while it was being indexed.
+    #[error("VM guest runtime binary {} changed while it was being indexed", .0.display())]
+    BinaryChanged(PathBuf),
+    /// The supplied runtime is not a Linux ELF executable.
+    #[error("VM guest runtime {} is not an ELF executable", .0.display())]
+    NotElf(PathBuf),
+    /// A cache directory, lock, temporary file, or publication failed.
+    #[error("failed to access VM guest runtime cache at {}", path.display())]
+    Cache {
+        /// Cache path being accessed.
+        path: PathBuf,
+        /// Underlying filesystem error.
+        #[source]
+        source: io::Error,
+    },
+    /// Formatting the ext4 disk failed.
+    #[error("failed to format VM guest runtime disk")]
+    Format(#[from] FormatError),
+    /// A newly formatted ext4 disk did not contain the expected runtime.
+    #[error("prepared VM guest runtime disk {} failed validation", path.display())]
+    InvalidPreparedDisk {
+        /// Temporary disk path that failed validation.
+        path: PathBuf,
+        /// Underlying ext4 read error, when one was available.
+        #[source]
+        source: Option<ReadError>,
+    },
+}
+
+struct RuntimeCache {
+    root: PathBuf,
+}
+
+impl RuntimeCache {
+    fn open(root: &Path) -> Result<Self, GuestRuntimeDiskError> {
+        fs::create_dir_all(root).map_err(|source| cache_error(root.to_path_buf(), source))?;
+        ensure_cache_directory(root)?;
+        Ok(Self {
+            root: root.to_path_buf(),
+        })
+    }
+
+    fn directory(&self, relative: impl AsRef<Path>) -> Result<PathBuf, GuestRuntimeDiskError> {
+        let relative = relative.as_ref();
+        let mut directory = self.root.clone();
+        for component in relative.components() {
+            let Component::Normal(component) = component else {
+                return Err(cache_error(
+                    self.root.join(relative),
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "runtime cache path contains a non-normal component",
+                    ),
+                ));
+            };
+            directory.push(component);
+            match fs::create_dir(&directory) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(source) => return Err(cache_error(directory, source)),
+            }
+            ensure_cache_directory(&directory)?;
+        }
+        Ok(directory)
+    }
+}
+
+fn ensure_cache_directory(path: &Path) -> Result<(), GuestRuntimeDiskError> {
+    let metadata =
+        fs::symlink_metadata(path).map_err(|source| cache_error(path.to_path_buf(), source))?;
+    if metadata.file_type().is_dir() {
+        Ok(())
+    } else {
+        Err(cache_error(
+            path.to_path_buf(),
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "runtime cache path component is not a directory",
+            ),
+        ))
+    }
+}
+
+fn cache_file_metadata(path: &Path) -> Result<Option<fs::Metadata>, GuestRuntimeDiskError> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_file() => Ok(Some(metadata)),
+        Ok(_) => Err(cache_error(
+            path.to_path_buf(),
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "runtime cache file is not a regular file",
+            ),
+        )),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(cache_error(path.to_path_buf(), source)),
+    }
+}
+
+fn ensure_cache_file(path: &Path) -> Result<(), GuestRuntimeDiskError> {
+    cache_file_metadata(path)?.map_or_else(
+        || {
+            Err(cache_error(
+                path.to_path_buf(),
+                io::Error::new(io::ErrorKind::NotFound, "runtime cache file does not exist"),
+            ))
+        },
+        |_| Ok(()),
+    )
+}
+
+struct CacheLock(File);
+
+impl CacheLock {
+    fn acquire(cache: &RuntimeCache, digest: &str) -> Result<Self, GuestRuntimeDiskError> {
+        let directory = cache.directory("locks/runtimes")?;
+        let path = directory.join(format!("{digest}.lock"));
+        let file = open_cache_lock(&path)?;
+        fs2::FileExt::lock_exclusive(&file).map_err(|source| cache_error(path.clone(), source))?;
+        Ok(Self(file))
+    }
+}
+
+fn open_cache_lock(path: &Path) -> Result<File, GuestRuntimeDiskError> {
+    match fs::OpenOptions::new()
+        .create_new(true)
+        .read(true)
+        .write(true)
+        .open(path)
+    {
+        Ok(file) => Ok(file),
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            ensure_cache_file(path)?;
+            fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(path)
+                .map_err(|source| cache_error(path.to_path_buf(), source))
+        }
+        Err(source) => Err(cache_error(path.to_path_buf(), source)),
+    }
+}
+
+impl Drop for CacheLock {
+    fn drop(&mut self) {
+        let _ = fs2::FileExt::unlock(&self.0);
+    }
+}
+
+fn runtime_digest(bytes: &[u8]) -> String {
+    let mut identity = Sha256::new();
+    identity.update(IDENTITY_VERSION);
+    identity.update(bytes);
+    hex::encode(identity.finalize())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct FileSnapshot {
+    bytes: u64,
+    modified_unix_ns: u64,
+}
+
+impl FileSnapshot {
+    fn from_metadata(metadata: &fs::Metadata) -> io::Result<Self> {
+        let modified = metadata
+            .modified()?
+            .duration_since(UNIX_EPOCH)
+            .map_err(io::Error::other)?;
+        Ok(Self {
+            bytes: metadata.len(),
+            modified_unix_ns: u64::try_from(modified.as_nanos()).map_err(io::Error::other)?,
+        })
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct GuestRuntimeRecord {
+    version: u32,
+    binary_bytes: u64,
+    binary_modified_unix_ns: u64,
+    digest: String,
+    disk_bytes: u64,
+    disk_modified_unix_ns: u64,
+}
+
+fn binary_snapshot(path: &Path) -> Result<FileSnapshot, GuestRuntimeDiskError> {
+    let metadata = fs::metadata(path).map_err(|source| GuestRuntimeDiskError::ReadBinary {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if !metadata.is_file() {
+        return Err(GuestRuntimeDiskError::ReadBinary {
+            path: path.to_path_buf(),
+            source: io::Error::new(io::ErrorKind::InvalidInput, "runtime binary is not a file"),
+        });
+    }
+    FileSnapshot::from_metadata(&metadata).map_err(|source| GuestRuntimeDiskError::ReadBinary {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn runtime_record_path(
+    cache: &RuntimeCache,
+    binary: &Path,
+) -> Result<PathBuf, GuestRuntimeDiskError> {
+    let mut identity = Sha256::new();
+    identity.update(b"nanocodex-vm-runtime-record-v1\0");
+    identity.update(binary.as_os_str().as_encoded_bytes());
+    Ok(cache
+        .directory("runtime-records")?
+        .join(format!("{}.json", hex::encode(identity.finalize()))))
+}
+
+fn recorded_runtime_disk(
+    record_path: &Path,
+    source: FileSnapshot,
+    cache: &RuntimeCache,
+) -> Result<Option<(String, PathBuf)>, GuestRuntimeDiskError> {
+    if cache_file_metadata(record_path)?.is_none() {
+        return Ok(None);
+    }
+    let contents = match fs::read(record_path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(cache_error(record_path.to_path_buf(), source)),
+    };
+    let record = match serde_json::from_slice::<GuestRuntimeRecord>(&contents) {
+        Ok(record) => record,
+        Err(error) => {
+            info!(
+                target: "nanocodex_vm",
+                cache_record_path = %record_path.display(),
+                error = %error,
+                "ignoring invalid VM guest runtime cache record"
+            );
+            return Ok(None);
+        }
+    };
+    if record.version != RECORD_VERSION
+        || record.binary_bytes != source.bytes
+        || record.binary_modified_unix_ns != source.modified_unix_ns
+        || !is_sha256_digest(&record.digest)
+        || record.disk_bytes != DISK_BYTES
+    {
+        return Ok(None);
+    }
+
+    let path = cache
+        .directory(Path::new("runtimes").join(&record.digest))?
+        .join("runtime.ext4");
+    let Some(metadata) = cache_file_metadata(&path)? else {
+        return Ok(None);
+    };
+    let disk = FileSnapshot::from_metadata(&metadata)
+        .map_err(|source| cache_error(path.clone(), source))?;
+    if disk.bytes != record.disk_bytes || disk.modified_unix_ns != record.disk_modified_unix_ns {
+        return Ok(None);
+    }
+    Ok(Some((record.digest, path)))
+}
+
+fn write_runtime_record(
+    record_path: &Path,
+    source: FileSnapshot,
+    digest: &str,
+    disk_path: &Path,
+) -> Result<(), GuestRuntimeDiskError> {
+    let metadata =
+        fs::metadata(disk_path).map_err(|source| cache_error(disk_path.to_path_buf(), source))?;
+    let disk = FileSnapshot::from_metadata(&metadata)
+        .map_err(|source| cache_error(disk_path.to_path_buf(), source))?;
+    let record = GuestRuntimeRecord {
+        version: RECORD_VERSION,
+        binary_bytes: source.bytes,
+        binary_modified_unix_ns: source.modified_unix_ns,
+        digest: digest.to_owned(),
+        disk_bytes: disk.bytes,
+        disk_modified_unix_ns: disk.modified_unix_ns,
+    };
+    let directory = record_path
+        .parent()
+        .ok_or_else(|| {
+            cache_error(
+                record_path.to_path_buf(),
+                io::Error::other("runtime cache record has no parent directory"),
+            )
+        })?
+        .to_path_buf();
+    ensure_cache_directory(&directory)?;
+    let _ = cache_file_metadata(record_path)?;
+    let mut temporary = tempfile::Builder::new()
+        .prefix(".runtime-record.")
+        .tempfile_in(&directory)
+        .map_err(|source| cache_error(directory, source))?;
+    serde_json::to_writer(temporary.as_file_mut(), &record)
+        .map_err(|source| cache_error(record_path.to_path_buf(), io::Error::other(source)))?;
+    temporary
+        .into_temp_path()
+        .persist(record_path)
+        .map_err(|error| cache_error(record_path.to_path_buf(), error.error))?;
+    Ok(())
+}
+
+fn is_sha256_digest(digest: &str) -> bool {
+    digest.len() == 64
+        && digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn valid_cached_disk(path: &Path, binary: &[u8]) -> Result<bool, GuestRuntimeDiskError> {
+    let Some(metadata) = cache_file_metadata(path)? else {
+        return Ok(false);
+    };
+    if metadata.len() != DISK_BYTES {
+        return Ok(false);
+    }
+    let Ok(mut reader) = Reader::new(path) else {
+        return Ok(false);
+    };
+    let Ok((_, inode)) = reader.stat(GUEST_PATH) else {
+        return Ok(false);
+    };
+    if !inode.is_reg() || inode.file_size() != binary.len() as u64 || inode.mode & 0o777 != 0o755 {
+        return Ok(false);
+    }
+    Ok(reader
+        .read_file(GUEST_PATH, 0, None)
+        .is_ok_and(|cached| cached == binary))
+}
+
+fn validate_prepared_disk(path: &Path, binary: &[u8]) -> Result<(), GuestRuntimeDiskError> {
+    let metadata = fs::metadata(path).map_err(|source| cache_error(path.to_path_buf(), source))?;
+    if !metadata.is_file() || metadata.len() != DISK_BYTES {
+        return Err(GuestRuntimeDiskError::InvalidPreparedDisk {
+            path: path.to_path_buf(),
+            source: None,
+        });
+    }
+    let mut reader =
+        Reader::new(path).map_err(|source| GuestRuntimeDiskError::InvalidPreparedDisk {
+            path: path.to_path_buf(),
+            source: Some(source),
+        })?;
+    let (_, inode) =
+        reader
+            .stat(GUEST_PATH)
+            .map_err(|source| GuestRuntimeDiskError::InvalidPreparedDisk {
+                path: path.to_path_buf(),
+                source: Some(source),
+            })?;
+    if !inode.is_reg() || inode.file_size() != binary.len() as u64 || inode.mode & 0o777 != 0o755 {
+        return Err(GuestRuntimeDiskError::InvalidPreparedDisk {
+            path: path.to_path_buf(),
+            source: None,
+        });
+    }
+    let contents = reader.read_file(GUEST_PATH, 0, None).map_err(|source| {
+        GuestRuntimeDiskError::InvalidPreparedDisk {
+            path: path.to_path_buf(),
+            source: Some(source),
+        }
+    })?;
+    if contents != binary {
+        return Err(GuestRuntimeDiskError::InvalidPreparedDisk {
+            path: path.to_path_buf(),
+            source: None,
+        });
+    }
+    Ok(())
+}
+
+const fn cache_error(path: PathBuf, source: io::Error) -> GuestRuntimeDiskError {
+    GuestRuntimeDiskError::Cache { path, source }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use arcbox_ext4::Reader;
+
+    use super::{GUEST_PATH, GuestRuntimeDisk, GuestRuntimeDiskStatus, runtime_digest};
+
+    #[test]
+    fn prepares_valid_content_addressed_disk_and_reuses_it() {
+        let directory = tempfile::tempdir().unwrap();
+        let binary = directory.path().join("nanocodex-vm-guest");
+        let bytes = b"\x7fELF deterministic guest runtime";
+        fs::write(&binary, bytes).unwrap();
+        let cache = directory.path().join("cache");
+
+        let created = GuestRuntimeDisk::prepare(&binary, &cache).unwrap();
+        assert_eq!(created.status(), GuestRuntimeDiskStatus::Created);
+        assert_eq!(created.digest(), runtime_digest(bytes));
+        assert_eq!(
+            created.path(),
+            cache
+                .join("runtimes")
+                .join(created.digest())
+                .join("runtime.ext4")
+        );
+
+        let mut reader = Reader::new(created.path()).unwrap();
+        let (_, inode) = reader.stat(GUEST_PATH).unwrap();
+        assert!(inode.is_reg());
+        assert_eq!(inode.file_size(), bytes.len() as u64);
+        assert_eq!(inode.mode & 0o777, 0o755);
+        assert_eq!(reader.read_file(GUEST_PATH, 0, None).unwrap(), bytes);
+
+        let reused = GuestRuntimeDisk::prepare(&binary, &cache).unwrap();
+        assert_eq!(reused.status(), GuestRuntimeDiskStatus::Hit);
+        assert_eq!(reused.path(), created.path());
+        assert_eq!(reused.digest(), created.digest());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_nested_runtime_directory_symlinks_without_external_writes() {
+        let bytes = b"\x7fELF nested runtime cache escape";
+        let digest = runtime_digest(bytes);
+        for relative in [
+            std::path::PathBuf::from("runtimes"),
+            std::path::PathBuf::from("runtimes").join(&digest),
+        ] {
+            let directory = tempfile::tempdir().unwrap();
+            let binary = directory.path().join("nanocodex-vm-guest");
+            let cache = directory.path().join("cache");
+            let outside = directory.path().join("outside");
+            fs::write(&binary, bytes).unwrap();
+            fs::create_dir(&cache).unwrap();
+            fs::create_dir(&outside).unwrap();
+            let link = cache.join(&relative);
+            fs::create_dir_all(link.parent().unwrap()).unwrap();
+            std::os::unix::fs::symlink(&outside, &link).unwrap();
+
+            let error = GuestRuntimeDisk::prepare(&binary, &cache).unwrap_err();
+
+            assert!(error.to_string().contains(&link.display().to_string()));
+            assert_eq!(fs::read_dir(&outside).unwrap().count(), 0);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_lock_and_record_directory_symlinks_without_external_writes() {
+        let bytes = b"\x7fELF nested lock and record escape";
+        for relative in ["runtime-records", "locks", "locks/runtimes"] {
+            let directory = tempfile::tempdir().unwrap();
+            let binary = directory.path().join("nanocodex-vm-guest");
+            let cache = directory.path().join("cache");
+            let outside = directory.path().join("outside");
+            fs::write(&binary, bytes).unwrap();
+            fs::create_dir(&cache).unwrap();
+            fs::create_dir(&outside).unwrap();
+            let link = cache.join(relative);
+            fs::create_dir_all(link.parent().unwrap()).unwrap();
+            std::os::unix::fs::symlink(&outside, &link).unwrap();
+
+            let error = GuestRuntimeDisk::prepare(&binary, &cache).unwrap_err();
+
+            assert!(error.to_string().contains(&link.display().to_string()));
+            assert_eq!(fs::read_dir(&outside).unwrap().count(), 0);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_managed_cache_file_symlinks_without_external_writes() {
+        let bytes = b"\x7fELF managed cache file escape";
+        let digest = runtime_digest(bytes);
+        for managed_file in ["record", "runtime", "lock"] {
+            let directory = tempfile::tempdir().unwrap();
+            let binary = directory.path().join("nanocodex-vm-guest");
+            let cache = directory.path().join("cache");
+            let outside = directory.path().join("outside-file");
+            fs::write(&binary, bytes).unwrap();
+            fs::write(&outside, b"outside sentinel").unwrap();
+            let path = match managed_file {
+                "record" => {
+                    let cache = super::RuntimeCache::open(&cache).unwrap();
+                    let binary = fs::canonicalize(&binary).unwrap();
+                    super::runtime_record_path(&cache, &binary).unwrap()
+                }
+                "runtime" => {
+                    let parent = cache.join("runtimes").join(&digest);
+                    fs::create_dir_all(&parent).unwrap();
+                    parent.join("runtime.ext4")
+                }
+                "lock" => {
+                    let parent = cache.join("locks/runtimes");
+                    fs::create_dir_all(&parent).unwrap();
+                    parent.join(format!("{digest}.lock"))
+                }
+                _ => unreachable!(),
+            };
+            std::os::unix::fs::symlink(&outside, &path).unwrap();
+
+            let error = GuestRuntimeDisk::prepare(&binary, &cache).unwrap_err();
+
+            assert!(error.to_string().contains(&path.display().to_string()));
+            assert_eq!(fs::read(&outside).unwrap(), b"outside sentinel");
+        }
+    }
+
+    #[test]
+    fn repairs_an_invalid_cache_entry_under_the_same_identity() {
+        let directory = tempfile::tempdir().unwrap();
+        let binary = directory.path().join("nanocodex-vm-guest");
+        let bytes = b"\x7fELF repaired guest runtime";
+        fs::write(&binary, bytes).unwrap();
+        let cache = directory.path().join("cache");
+        let first = GuestRuntimeDisk::prepare(&binary, &cache).unwrap();
+        fs::write(first.path(), b"corrupt").unwrap();
+
+        let repaired = GuestRuntimeDisk::prepare(&binary, &cache).unwrap();
+
+        assert_eq!(repaired.status(), GuestRuntimeDiskStatus::Created);
+        let mut reader = Reader::new(repaired.path()).unwrap();
+        assert_eq!(reader.read_file(GUEST_PATH, 0, None).unwrap(), bytes);
+    }
+
+    #[test]
+    fn repairs_same_sized_runtime_content_corruption() {
+        let directory = tempfile::tempdir().unwrap();
+        let binary = directory.path().join("nanocodex-vm-guest");
+        let bytes = b"\x7fELF original guest runtime";
+        fs::write(&binary, bytes).unwrap();
+        let cache = directory.path().join("cache");
+        let first = GuestRuntimeDisk::prepare(&binary, &cache).unwrap();
+
+        let mut replacement = bytes.to_vec();
+        let last = replacement.last_mut().unwrap();
+        *last ^= 1;
+        let mut formatter =
+            arcbox_ext4::Formatter::new(first.path(), 4_096, 128 * 1024 * 1024).unwrap();
+        let mut replacement = replacement.as_slice();
+        formatter
+            .create(
+                GUEST_PATH,
+                arcbox_ext4::constants::make_mode(
+                    arcbox_ext4::constants::file_mode::S_IFREG,
+                    0o755,
+                ),
+                None,
+                None,
+                Some(&mut replacement),
+                Some(0),
+                Some(0),
+                None,
+            )
+            .unwrap();
+        formatter.close().unwrap();
+
+        let repaired = GuestRuntimeDisk::prepare(&binary, &cache).unwrap();
+
+        assert_eq!(repaired.status(), GuestRuntimeDiskStatus::Created);
+        let mut reader = Reader::new(repaired.path()).unwrap();
+        assert_eq!(reader.read_file(GUEST_PATH, 0, None).unwrap(), bytes);
+    }
+}

--- a/crates/experimental/nanocodex-vm/src/tools/session.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/session.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    io,
     path::PathBuf,
     process::{ExitStatus, Stdio},
     sync::{
@@ -20,7 +21,7 @@ use thiserror::Error;
 use tokio::{
     io::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader},
     process::{Child, ChildStderr, ChildStdin, ChildStdout, Command},
-    sync::{Mutex, Notify, Semaphore, mpsc, oneshot},
+    sync::{Mutex, Notify, OwnedSemaphorePermit, Semaphore, mpsc, oneshot},
 };
 use tracing::{Instrument, Span, info, info_span};
 
@@ -33,7 +34,8 @@ use super::{
     },
 };
 
-const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+pub(crate) const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const DEFAULT_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 const DEFAULT_COMMAND_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
 const MAX_GUEST_IN_FLIGHT_REQUESTS: usize = 64;
@@ -151,6 +153,10 @@ pub enum VmToolSessionError {
     #[error("the VM tool console closed before replying")]
     Closed,
 
+    /// VM startup or egress provisioning did not complete before its deadline.
+    #[error("VM readiness and egress provisioning did not complete within {0:?}")]
+    StartupTimeout(Duration),
+
     /// The background response router failed.
     #[error("VM tool response router failed: {0}")]
     Router(String),
@@ -196,6 +202,10 @@ pub enum VmToolSessionError {
     #[error("cannot shut down the VM while {0} sibling capabilities are still alive")]
     ActiveCapabilities(usize),
 
+    /// Graceful shutdown was requested while owner-borrowed operations remained.
+    #[error("cannot shut down the VM while {0} requests are still in flight")]
+    ActiveRequests(usize),
+
     /// A public egress destination could not be represented by the guest protocol.
     #[error("egress guest file path is not valid UTF-8: {0}")]
     EgressFilePath(PathBuf),
@@ -222,17 +232,20 @@ pub struct VmToolSession {
 }
 
 /// Clone-cheap capability for sending workspace tool calls to one owned VM.
-#[derive(Clone)]
 pub struct VmToolSessionHandle {
     inner: Arc<VmToolSessionInner>,
+    counted_capability: bool,
 }
 
 struct VmToolSessionInner {
     spawned_at: Instant,
     next_id: AtomicU64,
     closing: AtomicBool,
-    input: mpsc::Sender<Vec<u8>>,
-    request_slots: Semaphore,
+    lifecycle: StdMutex<SessionLifecycle>,
+    input: mpsc::Sender<OutboundRequest>,
+    cancellations: mpsc::Sender<OutboundCancellation>,
+    request_slots: Arc<Semaphore>,
+    shutdown_timeout: Duration,
     output: Mutex<Option<ChildStdout>>,
     pending: StdMutex<PendingState>,
     terminal: StdMutex<TerminalDiagnostics>,
@@ -240,6 +253,26 @@ struct VmToolSessionInner {
     child: StdMutex<Option<Child>>,
     egress: StdMutex<Option<EgressLease>>,
     process_config: StdMutex<Option<PrivateVmProcessConfig>>,
+}
+
+#[derive(Default)]
+struct SessionLifecycle {
+    capabilities: usize,
+    in_flight_requests: usize,
+    closing: bool,
+}
+
+struct OutboundRequest {
+    id: u64,
+    frame: Vec<u8>,
+    written: Arc<AtomicBool>,
+}
+
+struct OutboundCancellation {
+    target_id: u64,
+    frame: Vec<u8>,
+    written: Arc<AtomicBool>,
+    _request_slot: OwnedSemaphorePermit,
 }
 
 #[derive(Default)]
@@ -264,6 +297,18 @@ struct PendingRequestGuard {
     inner: Weak<VmToolSessionInner>,
     id: u64,
     armed: bool,
+    queued: bool,
+    written: Arc<AtomicBool>,
+    request_slot: Option<OwnedSemaphorePermit>,
+}
+
+struct InFlightRequestGuard {
+    inner: Weak<VmToolSessionInner>,
+}
+
+struct ShutdownGuard {
+    inner: Arc<VmToolSessionInner>,
+    armed: bool,
 }
 
 impl VmToolSession {
@@ -282,13 +327,22 @@ impl VmToolSession {
     /// Returns an error when the private configuration cannot be written or
     /// the VMM process cannot start.
     pub fn spawn_vm(
-        mut command: Command,
+        command: Command,
         vm: VmConfig,
         guest: GuestCommand,
     ) -> Result<Self, VmToolSessionError> {
+        Self::spawn_vm_with_shutdown_timeout(command, vm, guest, DEFAULT_SHUTDOWN_TIMEOUT)
+    }
+
+    fn spawn_vm_with_shutdown_timeout(
+        mut command: Command,
+        vm: VmConfig,
+        guest: GuestCommand,
+        shutdown_timeout: Duration,
+    ) -> Result<Self, VmToolSessionError> {
         let process_config = VmProcessConfig::new(vm, guest).write_private()?;
         command.arg(process_config.path());
-        let session = Self::spawn(&mut command)?;
+        let session = Self::spawn_with_shutdown_timeout(&mut command, shutdown_timeout)?;
         *lock_unpoisoned(&session.handle.inner.process_config) = Some(process_config);
         Ok(session)
     }
@@ -309,18 +363,50 @@ impl VmToolSession {
     /// # Errors
     ///
     /// Returns an error when private configuration cannot be written, the VMM
-    /// cannot start, or guest egress provisioning fails.
+    /// cannot start, the guest is not ready within 30 seconds, or egress
+    /// provisioning fails or exceeds that same startup deadline.
     pub async fn spawn_configured(
         command: Command,
         vm: VmConfig,
         guest: GuestCommand,
         egress: EgressLease,
     ) -> Result<Self, VmToolSessionError> {
+        Self::spawn_configured_with_timeouts(
+            command,
+            vm,
+            guest,
+            egress,
+            DEFAULT_STARTUP_TIMEOUT,
+            DEFAULT_SHUTDOWN_TIMEOUT,
+        )
+        .await
+    }
+
+    pub(crate) async fn spawn_configured_with_timeouts(
+        command: Command,
+        vm: VmConfig,
+        guest: GuestCommand,
+        egress: EgressLease,
+        startup_timeout: Duration,
+        shutdown_timeout: Duration,
+    ) -> Result<Self, VmToolSessionError> {
         let (vm, guest) = egress.configure(vm, &guest);
-        let session = Self::spawn_vm(command, vm, guest)?;
-        session.ready().await?;
-        session.provision_egress(egress).await?;
-        Ok(session)
+        let session = Self::spawn_vm_with_shutdown_timeout(command, vm, guest, shutdown_timeout)?;
+        let startup = async {
+            session.ready().await?;
+            session.provision_egress(egress).await
+        };
+        match tokio::time::timeout(startup_timeout, startup).await {
+            Ok(Ok(())) => Ok(session),
+            Ok(Err(error)) => {
+                session.terminate().await;
+                Err(error)
+            }
+            Err(_) => {
+                session.terminate().await;
+                Err(VmToolSessionError::StartupTimeout(startup_timeout))
+            }
+        }
     }
 
     /// Spawns a VMM command whose guest process runs the companion guest server.
@@ -334,6 +420,13 @@ impl VmToolSession {
     /// Returns an error when the child or either protocol pipe cannot be
     /// created.
     pub fn spawn(command: &mut Command) -> Result<Self, VmToolSessionError> {
+        Self::spawn_with_shutdown_timeout(command, DEFAULT_SHUTDOWN_TIMEOUT)
+    }
+
+    fn spawn_with_shutdown_timeout(
+        command: &mut Command,
+        shutdown_timeout: Duration,
+    ) -> Result<Self, VmToolSessionError> {
         let runtime =
             tokio::runtime::Handle::try_current().map_err(|_| VmToolSessionError::NoRuntime)?;
         let program = command
@@ -381,12 +474,17 @@ impl VmToolSession {
                 .take()
                 .ok_or(VmToolSessionError::MissingPipe("stderr"))?;
             let (input_sender, input_receiver) = mpsc::channel(REQUEST_QUEUE_CAPACITY);
+            let (cancellation_sender, cancellation_receiver) =
+                mpsc::channel(MAX_HOST_IN_FLIGHT_REQUESTS);
             let inner = Arc::new(VmToolSessionInner {
                 spawned_at: Instant::now(),
                 next_id: AtomicU64::new(0),
                 closing: AtomicBool::new(false),
+                lifecycle: StdMutex::new(SessionLifecycle::default()),
                 input: input_sender,
-                request_slots: Semaphore::new(MAX_HOST_IN_FLIGHT_REQUESTS),
+                cancellations: cancellation_sender,
+                request_slots: Arc::new(Semaphore::new(MAX_HOST_IN_FLIGHT_REQUESTS)),
+                shutdown_timeout,
                 output: Mutex::new(Some(output)),
                 pending: StdMutex::new(PendingState::default()),
                 terminal: StdMutex::new(TerminalDiagnostics::default()),
@@ -398,11 +496,15 @@ impl VmToolSession {
             runtime.spawn(write_requests(
                 input,
                 input_receiver,
+                cancellation_receiver,
                 Arc::downgrade(&inner),
             ));
             runtime.spawn(capture_terminal_stderr(stderr, Arc::downgrade(&inner)));
             Ok(Self {
-                handle: VmToolSessionHandle { inner },
+                handle: VmToolSessionHandle {
+                    inner,
+                    counted_capability: false,
+                },
             })
         });
         record_vm_result(&span, started_at, &result);
@@ -543,44 +645,91 @@ impl VmToolSession {
         self.handle.command(command).await
     }
 
+    async fn terminate(&self) {
+        let child = begin_termination(&self.handle.inner);
+        if let Some(mut child) = child {
+            let _ = tokio::time::timeout(self.handle.inner.shutdown_timeout, child.wait()).await;
+        }
+    }
+
     /// Flushes guest filesystems and waits for the VMM process to exit.
     ///
-    /// The operation rejects live sibling capabilities so it cannot stop the
-    /// VM while another driver in the same agent tree is using it. Because the
-    /// owner is borrowed, callers can drop those capabilities and retry.
+    /// The operation rejects live sibling capabilities and owner-borrowed
+    /// requests so it cannot stop the VM while another driver in the same
+    /// agent tree is using it. Because the owner is borrowed, callers can drop
+    /// those capabilities or await those requests and retry.
     ///
     /// # Errors
     ///
     /// Returns an error when the guest cannot acknowledge the request, the
     /// VMM does not stop promptly, or it exits unsuccessfully.
     pub async fn shutdown(&self) -> Result<(), VmToolSessionError> {
-        let sibling_capabilities = Arc::strong_count(&self.handle.inner).saturating_sub(1);
-        if sibling_capabilities != 0 {
-            return Err(VmToolSessionError::ActiveCapabilities(sibling_capabilities));
+        {
+            let mut lifecycle = lock_unpoisoned(&self.handle.inner.lifecycle);
+            if lifecycle.closing {
+                return Err(VmToolSessionError::Closed);
+            }
+            if lifecycle.capabilities != 0 {
+                return Err(VmToolSessionError::ActiveCapabilities(
+                    lifecycle.capabilities,
+                ));
+            }
+            if lifecycle.in_flight_requests != 0 {
+                return Err(VmToolSessionError::ActiveRequests(
+                    lifecycle.in_flight_requests,
+                ));
+            }
+            lifecycle.closing = true;
         }
+        let mut shutdown_guard = ShutdownGuard {
+            inner: Arc::clone(&self.handle.inner),
+            armed: true,
+        };
         self.handle.inner.closing.store(true, Ordering::Release);
-        let response = self
-            .handle
-            .control_request_inner(|id| SessionRequest::Shutdown(ShutdownRequest { id }), true)
-            .await?;
+        self.handle.inner.request_slots.close();
+        let shutdown_timeout = self.handle.inner.shutdown_timeout;
+        let started_at = Instant::now();
+        let response = match tokio::time::timeout(
+            shutdown_timeout,
+            self.handle
+                .control_request_inner(|id| SessionRequest::Shutdown(ShutdownRequest { id }), true),
+        )
+        .await
+        {
+            Ok(Ok(response)) => response,
+            Ok(Err(error)) => {
+                self.terminate().await;
+                return Err(error);
+            }
+            Err(_) => {
+                self.terminate().await;
+                return Err(VmToolSessionError::ShutdownTimeout(shutdown_timeout));
+            }
+        };
         let SessionResponse::Shutdown(response) = response else {
+            self.terminate().await;
             return Err(VmToolSessionError::Protocol("expected a shutdown response"));
         };
-        control_result(response)?;
+        if let Err(error) = control_result(response) {
+            self.terminate().await;
+            return Err(error);
+        }
 
         let child = lock_unpoisoned(&self.handle.inner.child).take();
         let Some(mut child) = child else {
             return Err(VmToolSessionError::Closed);
         };
-        let status = if let Ok(status) = tokio::time::timeout(SHUTDOWN_TIMEOUT, child.wait()).await
-        {
-            status?
-        } else {
-            let _ = child.start_kill();
-            let _ = child.wait().await;
-            return Err(VmToolSessionError::ShutdownTimeout(SHUTDOWN_TIMEOUT));
+        let remaining = shutdown_timeout.saturating_sub(started_at.elapsed());
+        let status = match tokio::time::timeout(remaining, child.wait()).await {
+            Ok(status) => status?,
+            Err(_) => {
+                let _ = child.start_kill();
+                let _ = tokio::time::timeout(shutdown_timeout, child.wait()).await;
+                return Err(VmToolSessionError::ShutdownTimeout(shutdown_timeout));
+            }
         };
         close_pending(&self.handle.inner, "VM session shut down");
+        shutdown_guard.armed = false;
         if !status.success() {
             return Err(VmToolSessionError::VmmExit(status));
         }
@@ -592,9 +741,40 @@ impl Drop for VmToolSessionInner {
     fn drop(&mut self) {
         self.closing.store(true, Ordering::Release);
         close_pending(self, "last VM session capability was dropped");
-        if let Some(child) = lock_unpoisoned(&self.child).as_mut() {
+        let child = lock_unpoisoned(&self.child).take();
+        if let Some(mut child) = child {
             let _ = child.start_kill();
+            let egress = lock_unpoisoned(&self.egress).take();
+            let timeout = self.shutdown_timeout;
+            if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+                runtime.spawn(async move {
+                    let _egress = egress;
+                    let _ = tokio::time::timeout(timeout, child.wait()).await;
+                });
+            }
         }
+    }
+}
+
+impl Clone for VmToolSessionHandle {
+    fn clone(&self) -> Self {
+        let mut lifecycle = lock_unpoisoned(&self.inner.lifecycle);
+        lifecycle.capabilities = lifecycle.capabilities.saturating_add(1);
+        drop(lifecycle);
+        Self {
+            inner: Arc::clone(&self.inner),
+            counted_capability: true,
+        }
+    }
+}
+
+impl Drop for VmToolSessionHandle {
+    fn drop(&mut self) {
+        if !self.counted_capability {
+            return;
+        }
+        let mut lifecycle = lock_unpoisoned(&self.inner.lifecycle);
+        lifecycle.capabilities = lifecycle.capabilities.saturating_sub(1);
     }
 }
 
@@ -660,6 +840,7 @@ impl VmToolSessionHandle {
             rpc.request.id = tracing::field::Empty,
             rpc.request.bytes = tracing::field::Empty,
             rpc.response.bytes = tracing::field::Empty,
+            rpc.admission.duration_ns = tracing::field::Empty,
             rpc.queue.duration_ns = tracing::field::Empty,
             vm.session.first_call = tracing::field::Empty,
             vm.session.age_ns = tracing::field::Empty,
@@ -928,21 +1109,38 @@ impl VmToolSessionHandle {
         allow_closing: bool,
     ) -> Result<(SessionResponse, usize), VmToolSessionError> {
         if self.inner.closing.load(Ordering::Acquire) && !allow_closing {
-            return Err(VmToolSessionError::Closed);
+            return Err(self.closed_error());
         }
-        let _request_slot = if allow_closing {
+        let request_slot = if allow_closing {
             None
         } else {
-            let permit = self
-                .inner
-                .request_slots
-                .acquire()
+            let admission_started_at = Instant::now();
+            let permit = Arc::clone(&self.inner.request_slots)
+                .acquire_owned()
                 .await
-                .map_err(|_| VmToolSessionError::Closed)?;
+                .map_err(|_| self.closed_error())?;
+            span.record(
+                "rpc.admission.duration_ns",
+                elapsed_ns(admission_started_at),
+            );
             if self.inner.closing.load(Ordering::Acquire) {
-                return Err(VmToolSessionError::Closed);
+                return Err(self.closed_error());
             }
             Some(permit)
+        };
+        let _in_flight = if allow_closing {
+            None
+        } else {
+            let mut lifecycle = lock_unpoisoned(&self.inner.lifecycle);
+            if lifecycle.closing {
+                drop(lifecycle);
+                return Err(self.closed_error());
+            }
+            lifecycle.in_flight_requests = lifecycle.in_flight_requests.saturating_add(1);
+            drop(lifecycle);
+            Some(InFlightRequestGuard {
+                inner: Arc::downgrade(&self.inner),
+            })
         };
         self.ensure_reader().await?;
         let id = self.inner.next_id.fetch_add(1, Ordering::Relaxed);
@@ -970,21 +1168,26 @@ impl VmToolSessionHandle {
                 },
             );
         }
+        let written = Arc::new(AtomicBool::new(false));
         let mut guard = PendingRequestGuard {
             inner: Arc::downgrade(&self.inner),
             id,
             armed: true,
+            queued: false,
+            written: Arc::clone(&written),
+            request_slot,
         };
         let queued_at = Instant::now();
         let mut frame = encoded.into_bytes();
         frame.push(b'\n');
         self.inner
             .input
-            .send(frame)
+            .send(OutboundRequest { id, frame, written })
             .await
-            .map_err(|_| VmToolSessionError::Closed)?;
+            .map_err(|_| self.closed_error())?;
+        guard.queued = true;
         span.record("rpc.queue.duration_ns", elapsed_ns(queued_at));
-        let response = receiver.await.map_err(|_| VmToolSessionError::Closed)?;
+        let response = receiver.await.map_err(|_| self.closed_error())?;
         guard.armed = false;
         response.map_err(VmToolSessionError::Router)
     }
@@ -1004,6 +1207,13 @@ impl VmToolSessionHandle {
             None => Ok(()),
         }
     }
+
+    fn closed_error(&self) -> VmToolSessionError {
+        lock_unpoisoned(&self.inner.pending)
+            .closed
+            .clone()
+            .map_or(VmToolSessionError::Closed, VmToolSessionError::Router)
+    }
 }
 
 impl Drop for PendingRequestGuard {
@@ -1012,12 +1222,64 @@ impl Drop for PendingRequestGuard {
             && let Some(inner) = self.inner.upgrade()
         {
             lock_unpoisoned(&inner.pending).requests.remove(&self.id);
-            queue_cancel(&inner, self.id);
+            if self.queued
+                && let Some(request_slot) = self.request_slot.take()
+            {
+                queue_cancel(&inner, self.id, Arc::clone(&self.written), request_slot);
+            }
         }
     }
 }
 
-fn queue_cancel(inner: &Arc<VmToolSessionInner>, target_id: u64) {
+impl Drop for InFlightRequestGuard {
+    fn drop(&mut self) {
+        let Some(inner) = self.inner.upgrade() else {
+            return;
+        };
+        let mut lifecycle = lock_unpoisoned(&inner.lifecycle);
+        lifecycle.in_flight_requests = lifecycle.in_flight_requests.saturating_sub(1);
+    }
+}
+
+impl Drop for ShutdownGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let child = begin_termination(&self.inner);
+        let Some(mut child) = child else {
+            return;
+        };
+        let timeout = self.inner.shutdown_timeout;
+        let egress = lock_unpoisoned(&self.inner.egress).clone();
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                let _egress = egress;
+                let _ = tokio::time::timeout(timeout, child.wait()).await;
+            });
+        }
+    }
+}
+
+fn begin_termination(inner: &Arc<VmToolSessionInner>) -> Option<Child> {
+    {
+        let mut lifecycle = lock_unpoisoned(&inner.lifecycle);
+        lifecycle.closing = true;
+    }
+    inner.closing.store(true, Ordering::Release);
+    inner.request_slots.close();
+    close_pending(inner, "VM session terminated");
+    let mut child = lock_unpoisoned(&inner.child).take()?;
+    let _ = child.start_kill();
+    Some(child)
+}
+
+fn queue_cancel(
+    inner: &Arc<VmToolSessionInner>,
+    target_id: u64,
+    written: Arc<AtomicBool>,
+    request_slot: OwnedSemaphorePermit,
+) {
     if inner.closing.load(Ordering::Acquire) {
         return;
     }
@@ -1027,41 +1289,87 @@ fn queue_cancel(inner: &Arc<VmToolSessionInner>, target_id: u64) {
         return;
     };
     frame.push(b'\n');
-    match inner.input.try_send(frame) {
+    let cancellation = OutboundCancellation {
+        target_id,
+        frame,
+        written,
+        _request_slot: request_slot,
+    };
+    match inner.cancellations.try_send(cancellation) {
         Ok(()) | Err(mpsc::error::TrySendError::Closed(_)) => {}
-        Err(mpsc::error::TrySendError::Full(frame)) => {
-            let input = inner.input.clone();
-            if let Ok(runtime) = tokio::runtime::Handle::try_current() {
-                runtime.spawn(async move {
-                    let _ = input.send(frame).await;
-                });
-            }
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            inner.closing.store(true, Ordering::Release);
+            inner.request_slots.close();
+            close_pending(
+                inner,
+                "bounded VM cancellation queue exhausted unexpectedly",
+            );
         }
     }
 }
 
 async fn write_requests(
     mut input: ChildStdin,
-    mut requests: mpsc::Receiver<Vec<u8>>,
+    mut requests: mpsc::Receiver<OutboundRequest>,
+    mut cancellations: mpsc::Receiver<OutboundCancellation>,
     inner: Weak<VmToolSessionInner>,
 ) {
-    while let Some(frame) = requests.recv().await {
-        let result = async {
-            input.write_all(&frame).await?;
-            input.flush().await
+    let mut deferred_cancellations = HashMap::<u64, OutboundCancellation>::new();
+    loop {
+        enum Outbound {
+            Request(OutboundRequest),
+            Cancellation(OutboundCancellation),
         }
-        .await;
-        if let Err(error) = result {
-            if let Some(inner) = inner.upgrade() {
-                let message = terminal_router_message(
-                    &inner,
-                    &format!("VM tool console write failed: {error}"),
-                )
-                .await;
-                close_pending(&inner, &message);
+        let outbound = tokio::select! {
+            biased;
+            Some(cancellation) = cancellations.recv() => {
+                Outbound::Cancellation(cancellation)
             }
-            return;
+            Some(request) = requests.recv() => Outbound::Request(request),
+            else => break,
+        };
+        let result = match outbound {
+            Outbound::Cancellation(cancellation)
+                if !cancellation.written.load(Ordering::Acquire) =>
+            {
+                deferred_cancellations.insert(cancellation.target_id, cancellation);
+                continue;
+            }
+            Outbound::Cancellation(cancellation) => {
+                write_request_frame(&mut input, &cancellation.frame).await
+            }
+            Outbound::Request(request) => {
+                let result = write_request_frame(&mut input, &request.frame).await;
+                if result.is_ok() {
+                    request.written.store(true, Ordering::Release);
+                    if let Some(cancellation) = deferred_cancellations.remove(&request.id)
+                        && let Err(error) =
+                            write_request_frame(&mut input, &cancellation.frame).await
+                    {
+                        break close_writer_after_error(&inner, error).await;
+                    }
+                }
+                result
+            }
+        };
+        if let Err(error) = result {
+            close_writer_after_error(&inner, error).await;
+            break;
         }
+    }
+}
+
+async fn write_request_frame(input: &mut ChildStdin, frame: &[u8]) -> io::Result<()> {
+    input.write_all(frame).await?;
+    input.flush().await
+}
+
+async fn close_writer_after_error(inner: &Weak<VmToolSessionInner>, error: io::Error) {
+    if let Some(inner) = inner.upgrade() {
+        let message =
+            terminal_router_message(&inner, &format!("VM tool console write failed: {error}"))
+                .await;
+        close_pending(&inner, &message);
     }
 }
 
@@ -1246,6 +1554,7 @@ const fn set_request_id(request: &mut SessionRequest, id: u64) {
 }
 
 fn close_pending(inner: &VmToolSessionInner, message: &str) {
+    inner.request_slots.close();
     let requests = {
         let mut pending = lock_unpoisoned(&inner.pending);
         if pending.closed.is_none() {
@@ -1345,8 +1654,8 @@ impl VmToolClient for VmToolSessionHandle {
 mod tracing_tests {
     use std::{
         collections::HashMap,
-        sync::{Arc, Mutex},
-        time::Duration,
+        sync::{Arc, Mutex, atomic::Ordering},
+        time::{Duration, Instant},
     };
 
     use nanocodex_tools::{
@@ -1359,7 +1668,9 @@ mod tracing_tests {
         Layer, layer::Context as LayerContext, prelude::*, registry::LookupSpan,
     };
 
-    use super::{VmCommand, VmCommandPartialOutput, VmToolSession, VmToolSessionError};
+    use super::{
+        VmCommand, VmCommandPartialOutput, VmToolSession, VmToolSessionError, lock_unpoisoned,
+    };
 
     static TRACE_TEST_LOCK: Mutex<()> = Mutex::new(());
 
@@ -1440,7 +1751,7 @@ mod tracing_tests {
     }
 
     #[test]
-    fn vm_rpc_is_timed_and_parented_to_the_calling_tool() {
+    fn vm_rpc_is_timed_parented_and_records_admission_wait() {
         let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
         let response = r#"{"kind":"tool","payload":{"id":0,"execution":{"output":"ok","success":true,"code_mode_value":null,"metadata":null,"process_trace":null},"error":null}}"#;
         let script = format!("IFS= read -r request\nprintf '%s\\n' '{response}'");
@@ -1461,18 +1772,28 @@ mod tracing_tests {
             tracing::callsite::rebuild_interest_cache();
             runtime.block_on(async {
                 let session = VmToolSession::spawn(&mut command).unwrap();
+                let handle = session.handle();
+                let held_slots = handle
+                    .inner
+                    .request_slots
+                    .acquire_many(super::MAX_HOST_IN_FLIGHT_REQUESTS as u32)
+                    .await
+                    .unwrap();
                 let context =
                     ToolContext::new("test-model", "test-session", "test-call", &[], 1_000);
-                let execution = session
-                    .handle()
+                let request = handle
                     .request(
                         StandardTool::ExecCommand,
                         ToolInput::Function(to_raw_value(&json!({"cmd": "true"})).unwrap()),
                         context,
                     )
-                    .instrument(tracing::info_span!("test.tool.execute"))
-                    .await
-                    .unwrap();
+                    .instrument(tracing::info_span!("test.tool.execute"));
+                let release_slots = async move {
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                    drop(held_slots);
+                };
+                let (execution, ()) = tokio::join!(request, release_slots);
+                let execution = execution.unwrap();
                 assert!(execution.success);
             });
         });
@@ -1495,6 +1816,13 @@ mod tracing_tests {
             rpc.fields.get("vm.session.first_call").map(String::as_str),
             Some("true")
         );
+        let admission_duration_ns = rpc
+            .fields
+            .get("rpc.admission.duration_ns")
+            .unwrap()
+            .parse::<u64>()
+            .unwrap();
+        assert!(admission_duration_ns >= 15_000_000);
         assert!(rpc.fields.contains_key("rpc.queue.duration_ns"));
         assert!(rpc.fields.contains_key("duration_ns"));
         assert!(capture.names.lock().unwrap().contains(&"vm.session.spawn"));
@@ -1717,10 +2045,13 @@ mod tracing_tests {
             );
 
             drop(tools);
-            assert!(
-                weak_guard.upgrade().is_none(),
-                "the last VM capability must release retained egress state"
-            );
+            tokio::time::timeout(Duration::from_secs(1), async {
+                while weak_guard.upgrade().is_some() {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("egress must be released after the killed VMM is reaped");
         });
     }
 
@@ -1745,6 +2076,143 @@ mod tracing_tests {
             ));
             drop(handle);
             session.shutdown().await.unwrap();
+        });
+    }
+
+    #[test]
+    fn graceful_shutdown_rejects_owner_requests_already_in_flight() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg("IFS= read -r request\nsleep 30");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let session = VmToolSession::spawn(&mut command).unwrap();
+            {
+                let request = session.write_file("/pending", Vec::new(), 0o600);
+                tokio::pin!(request);
+                tokio::select! {
+                    result = &mut request => panic!("request unexpectedly completed: {result:?}"),
+                    () = tokio::time::sleep(Duration::from_millis(10)) => {}
+                }
+                assert!(matches!(
+                    session.shutdown().await,
+                    Err(VmToolSessionError::ActiveRequests(1))
+                ));
+            }
+            session.terminate().await;
+        });
+    }
+
+    #[test]
+    fn cancelling_graceful_shutdown_forcibly_terminates_the_vmm() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg("IFS= read -r request\nsleep 30");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let session =
+                VmToolSession::spawn_with_shutdown_timeout(&mut command, Duration::from_millis(50))
+                    .unwrap();
+            assert!(
+                tokio::time::timeout(Duration::from_millis(10), session.shutdown())
+                    .await
+                    .is_err()
+            );
+            assert!(session.handle.inner.closing.load(Ordering::Acquire));
+            assert!(lock_unpoisoned(&session.handle.inner.child).is_none());
+        });
+    }
+
+    #[test]
+    fn startup_and_shutdown_deadlines_are_enforced() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let mut startup_command = tokio::process::Command::new("/bin/sh");
+            startup_command.arg("-c").arg("sleep 30");
+            let started_at = Instant::now();
+            let startup = VmToolSession::spawn_configured_with_timeouts(
+                startup_command,
+                crate::config::VmConfig::ext4("/unused/root.ext4"),
+                crate::command::GuestCommand::new("/bin/true"),
+                crate::egress::EgressLease::disabled(),
+                Duration::from_millis(10),
+                Duration::from_millis(50),
+            )
+            .await;
+            assert!(matches!(
+                startup,
+                Err(VmToolSessionError::StartupTimeout(timeout))
+                    if timeout == Duration::from_millis(10)
+            ));
+            assert!(started_at.elapsed() < Duration::from_secs(1));
+
+            let mut shutdown_command = tokio::process::Command::new("/bin/sh");
+            shutdown_command
+                .arg("-c")
+                .arg("IFS= read -r request\nsleep 30");
+            let session = VmToolSession::spawn_with_shutdown_timeout(
+                &mut shutdown_command,
+                Duration::from_millis(10),
+            )
+            .unwrap();
+            let started_at = Instant::now();
+            assert!(matches!(
+                session.shutdown().await,
+                Err(VmToolSessionError::ShutdownTimeout(timeout))
+                    if timeout == Duration::from_millis(10)
+            ));
+            assert!(started_at.elapsed() < Duration::from_secs(1));
+        });
+    }
+
+    #[test]
+    fn cancellation_storm_releases_bounded_admission_slots() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg("sleep 30");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let session = VmToolSession::spawn(&mut command).unwrap();
+            for index in 0..(super::MAX_HOST_IN_FLIGHT_REQUESTS * 2) {
+                assert!(
+                    tokio::time::timeout(
+                        Duration::from_millis(1),
+                        session.write_file(format!("/cancelled-{index}"), Vec::new(), 0o600),
+                    )
+                    .await
+                    .is_err()
+                );
+            }
+            let permits = tokio::time::timeout(
+                Duration::from_secs(1),
+                session
+                    .handle
+                    .inner
+                    .request_slots
+                    .acquire_many(super::MAX_HOST_IN_FLIGHT_REQUESTS as u32),
+            )
+            .await
+            .expect("cancelled requests must release all admission slots")
+            .unwrap();
+            drop(permits);
+            session.terminate().await;
         });
     }
 

--- a/crates/experimental/nanocodex-vm/src/tools/session.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/session.rs
@@ -1,0 +1,1780 @@
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    process::{ExitStatus, Stdio},
+    sync::{
+        Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard, Weak,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use crate::{
+    command::GuestCommand,
+    config::VmConfig,
+    egress::EgressLease,
+    process::{PrivateVmProcessConfig, VmProcessConfig, VmProcessError},
+};
+use nanocodex_tools::{ToolContext, ToolInput, ToolOutput, ToolResult, standard::StandardTool};
+use thiserror::Error;
+use tokio::{
+    io::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader},
+    process::{Child, ChildStderr, ChildStdin, ChildStdout, Command},
+    sync::{Mutex, Notify, Semaphore, mpsc, oneshot},
+};
+use tracing::{Instrument, Span, info, info_span};
+
+use super::{
+    VmToolClient,
+    protocol::{
+        CancelRequest, ControlResponse, CreateDirectoryRequest, ExecuteRequest, ExecuteResponse,
+        ReadFileRequest, ReadFileResponse, ReadyRequest, SessionRequest, SessionResponse,
+        ShutdownRequest, ToolRequest, WireToolContext, WireToolInput, WriteFileRequest,
+    },
+};
+
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
+const DEFAULT_COMMAND_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
+const MAX_GUEST_IN_FLIGHT_REQUESTS: usize = 64;
+const MAX_HOST_IN_FLIGHT_REQUESTS: usize = MAX_GUEST_IN_FLIGHT_REQUESTS - 1;
+const REQUEST_QUEUE_CAPACITY: usize = MAX_GUEST_IN_FLIGHT_REQUESTS;
+const MAX_TERMINAL_STDERR_BYTES: usize = 64 * 1024;
+const TERMINAL_STDERR_DRAIN_GRACE: Duration = Duration::from_millis(250);
+
+/// One trusted host-control command executed inside the guest.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VmCommand {
+    program: String,
+    arguments: Vec<String>,
+    current_directory: String,
+    environment: Vec<(String, String)>,
+    timeout: Duration,
+    max_output_bytes: usize,
+}
+
+impl VmCommand {
+    /// Creates a trusted guest command with a one-minute deadline, `/` as its
+    /// working directory, and an 8 MiB combined output limit.
+    #[must_use]
+    pub fn new(program: impl Into<String>) -> Self {
+        Self {
+            program: program.into(),
+            arguments: Vec::new(),
+            current_directory: "/".to_owned(),
+            environment: Vec::new(),
+            timeout: Duration::from_mins(1),
+            max_output_bytes: DEFAULT_COMMAND_OUTPUT_BYTES,
+        }
+    }
+
+    /// Appends one argument.
+    #[must_use]
+    pub fn arg(mut self, argument: impl Into<String>) -> Self {
+        self.arguments.push(argument.into());
+        self
+    }
+
+    /// Sets the guest working directory.
+    #[must_use]
+    pub fn current_directory(mut self, directory: impl Into<String>) -> Self {
+        self.current_directory = directory.into();
+        self
+    }
+
+    /// Extends the guest environment.
+    #[must_use]
+    pub fn environment(mut self, environment: impl IntoIterator<Item = (String, String)>) -> Self {
+        self.environment.extend(environment);
+        self
+    }
+
+    /// Sets the execution deadline.
+    #[must_use]
+    pub const fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    /// Bounds the combined stdout and stderr retained by this command.
+    #[must_use]
+    pub const fn max_output_bytes(mut self, max_output_bytes: usize) -> Self {
+        self.max_output_bytes = max_output_bytes;
+        self
+    }
+}
+
+/// Complete output from one trusted host-control command in the guest.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VmCommandOutput {
+    /// Guest process exit code.
+    pub exit_code: i32,
+    /// Complete bounded standard output.
+    pub stdout: Vec<u8>,
+    /// Complete bounded standard error.
+    pub stderr: Vec<u8>,
+}
+
+/// Bounded output captured before a trusted guest command failed to complete.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VmCommandPartialOutput {
+    /// Standard output captured before the command stopped.
+    pub stdout: Vec<u8>,
+    /// Standard error captured before the command stopped.
+    pub stderr: Vec<u8>,
+}
+
+/// Failure to start, use, provision, or stop one retained VM tool session.
+#[derive(Debug, Error)]
+pub enum VmToolSessionError {
+    /// A session was started without an active Tokio runtime.
+    #[error("starting a VM tool session requires an active Tokio runtime")]
+    NoRuntime,
+
+    /// The VMM child could not be spawned.
+    #[error("failed to spawn the VMM process: {0}")]
+    Spawn(#[source] std::io::Error),
+
+    /// The VMM command did not expose a required protocol pipe.
+    #[error("the VMM process did not expose piped {0}")]
+    MissingPipe(&'static str),
+
+    /// Host-side process or protocol I/O failed.
+    #[error("VM tool console I/O failed: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// A host or guest protocol frame was not valid JSON.
+    #[error("VM tool protocol JSON failed: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// The VMM console closed before a pending response arrived.
+    #[error("the VM tool console closed before replying")]
+    Closed,
+
+    /// The background response router failed.
+    #[error("VM tool response router failed: {0}")]
+    Router(String),
+
+    /// The guest returned an application-level tool error.
+    #[error("guest tool execution failed: {0}")]
+    Guest(String),
+
+    /// A trusted host-control command exceeded its deadline.
+    #[error("guest command exceeded {timeout:?}")]
+    GuestTimeout {
+        /// Configured command deadline.
+        timeout: Duration,
+        /// Bounded output captured before the process group was terminated.
+        output: VmCommandPartialOutput,
+    },
+
+    /// A trusted host-control command exceeded its combined output limit.
+    #[error("guest command output exceeded the {0}-byte limit")]
+    GuestOutputLimit(usize),
+
+    /// The guest returned a response of the wrong typed shape.
+    #[error("invalid VM tool response: {0}")]
+    Protocol(&'static str),
+
+    /// An inbound or outbound protocol frame exceeded the fixed limit.
+    #[error("VM tool protocol frame exceeded the {MAX_FRAME_BYTES}-byte limit")]
+    FrameTooLarge,
+
+    /// Graceful guest shutdown did not stop the VMM before the deadline.
+    #[error("the VMM did not exit within {0:?} after guest shutdown")]
+    ShutdownTimeout(Duration),
+
+    /// The VMM returned an unsuccessful status after guest shutdown.
+    #[error("the VMM exited unsuccessfully after guest shutdown: {0}")]
+    VmmExit(ExitStatus),
+
+    /// Public egress assets were provisioned more than once.
+    #[error("egress was already provisioned for this VM session")]
+    EgressAlreadyProvisioned,
+
+    /// Graceful shutdown was requested while sibling capabilities remained.
+    #[error("cannot shut down the VM while {0} sibling capabilities are still alive")]
+    ActiveCapabilities(usize),
+
+    /// A public egress destination could not be represented by the guest protocol.
+    #[error("egress guest file path is not valid UTF-8: {0}")]
+    EgressFilePath(PathBuf),
+
+    /// Private VMM launch-record persistence failed.
+    #[error(transparent)]
+    VmProcess(#[from] VmProcessError),
+}
+
+#[derive(Debug, Error)]
+#[error("VM tool session ended before this request completed")]
+struct ModelSafeVmToolError {
+    #[source]
+    diagnostic: VmToolSessionError,
+}
+
+/// Owner of one persistent VMM child carrying workspace tool calls.
+///
+/// Keep this value alive for the complete root-agent tree. Clone
+/// [`VmToolSessionHandle`] or [`super::VmTools`] into each driver's tool
+/// factory; all of those handles route to this one VM.
+pub struct VmToolSession {
+    handle: VmToolSessionHandle,
+}
+
+/// Clone-cheap capability for sending workspace tool calls to one owned VM.
+#[derive(Clone)]
+pub struct VmToolSessionHandle {
+    inner: Arc<VmToolSessionInner>,
+}
+
+struct VmToolSessionInner {
+    spawned_at: Instant,
+    next_id: AtomicU64,
+    closing: AtomicBool,
+    input: mpsc::Sender<Vec<u8>>,
+    request_slots: Semaphore,
+    output: Mutex<Option<ChildStdout>>,
+    pending: StdMutex<PendingState>,
+    terminal: StdMutex<TerminalDiagnostics>,
+    terminal_closed: Notify,
+    child: StdMutex<Option<Child>>,
+    egress: StdMutex<Option<EgressLease>>,
+    process_config: StdMutex<Option<PrivateVmProcessConfig>>,
+}
+
+#[derive(Default)]
+struct PendingState {
+    closed: Option<String>,
+    requests: HashMap<u64, PendingResponse>,
+}
+
+struct PendingResponse {
+    span: Span,
+    response: oneshot::Sender<Result<(SessionResponse, usize), String>>,
+}
+
+#[derive(Default)]
+struct TerminalDiagnostics {
+    stderr_tail: Vec<u8>,
+    stderr_error: Option<String>,
+    closed: bool,
+}
+
+struct PendingRequestGuard {
+    inner: Weak<VmToolSessionInner>,
+    id: u64,
+    armed: bool,
+}
+
+impl VmToolSession {
+    /// Spawns one VM from complete typed inputs without an egress provider.
+    ///
+    /// `command` must invoke a dedicated VMM process that accepts the private
+    /// [`VmProcessConfig`] path as its next argument. The configuration remains
+    /// alive until the returned session stops, and keeps guest environment
+    /// values out of process arguments.
+    ///
+    /// Use [`Self::spawn_configured`] when a host-owned egress lease must also
+    /// configure and provision the guest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the private configuration cannot be written or
+    /// the VMM process cannot start.
+    pub fn spawn_vm(
+        mut command: Command,
+        vm: VmConfig,
+        guest: GuestCommand,
+    ) -> Result<Self, VmToolSessionError> {
+        let process_config = VmProcessConfig::new(vm, guest).write_private()?;
+        command.arg(process_config.path());
+        let session = Self::spawn(&mut command)?;
+        *lock_unpoisoned(&session.handle.inner.process_config) = Some(process_config);
+        Ok(session)
+    }
+
+    /// Configures, spawns, and provisions one VM from the same egress lease.
+    ///
+    /// `command` must invoke a dedicated VMM process that accepts the private
+    /// [`VmProcessConfig`] path as its next argument. This method appends that
+    /// path, starts the process, waits for the guest tool server, provisions
+    /// public egress files, and retains provider guards with every returned
+    /// tool capability.
+    ///
+    /// Prefer this operation to separately calling [`EgressLease::configure`],
+    /// [`Self::spawn`], and [`Self::provision_egress`]: consuming the lease here
+    /// prevents launch-time environment and retained provider state from
+    /// diverging.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when private configuration cannot be written, the VMM
+    /// cannot start, or guest egress provisioning fails.
+    pub async fn spawn_configured(
+        command: Command,
+        vm: VmConfig,
+        guest: GuestCommand,
+        egress: EgressLease,
+    ) -> Result<Self, VmToolSessionError> {
+        let (vm, guest) = egress.configure(vm, &guest);
+        let session = Self::spawn_vm(command, vm, guest)?;
+        session.ready().await?;
+        session.provision_egress(egress).await?;
+        Ok(session)
+    }
+
+    /// Spawns a VMM command whose guest process runs the companion guest server.
+    ///
+    /// The command's stdin and stdout are reserved for the typed protocol;
+    /// stderr is passed through while a bounded tail is retained for terminal
+    /// protocol failures.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the child or either protocol pipe cannot be
+    /// created.
+    pub fn spawn(command: &mut Command) -> Result<Self, VmToolSessionError> {
+        let runtime =
+            tokio::runtime::Handle::try_current().map_err(|_| VmToolSessionError::NoRuntime)?;
+        let program = command
+            .as_std()
+            .get_program()
+            .to_string_lossy()
+            .into_owned();
+        let command_content = format!("{:?}", command.as_std());
+        let argument_count = command.as_std().get_args().count();
+        let span = info_span!(
+            target: "nanocodex_vm",
+            "vm.session.spawn",
+            otel.kind = "internal",
+            otel.status_code = tracing::field::Empty,
+            process.executable.name = program.as_str(),
+            process.command_args.count = argument_count,
+            process.id = tracing::field::Empty,
+            status = tracing::field::Empty,
+            error.message = tracing::field::Empty,
+            duration_ns = tracing::field::Empty,
+        );
+        record_vm_content(&span, "vm.command", &command_content);
+        let started_at = Instant::now();
+        let result = span.in_scope(|| {
+            let mut child = command
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .kill_on_drop(true)
+                .spawn()
+                .map_err(VmToolSessionError::Spawn)?;
+            if let Some(process_id) = child.id() {
+                span.record("process.id", process_id);
+            }
+            let input = child
+                .stdin
+                .take()
+                .ok_or(VmToolSessionError::MissingPipe("stdin"))?;
+            let output = child
+                .stdout
+                .take()
+                .ok_or(VmToolSessionError::MissingPipe("stdout"))?;
+            let stderr = child
+                .stderr
+                .take()
+                .ok_or(VmToolSessionError::MissingPipe("stderr"))?;
+            let (input_sender, input_receiver) = mpsc::channel(REQUEST_QUEUE_CAPACITY);
+            let inner = Arc::new(VmToolSessionInner {
+                spawned_at: Instant::now(),
+                next_id: AtomicU64::new(0),
+                closing: AtomicBool::new(false),
+                input: input_sender,
+                request_slots: Semaphore::new(MAX_HOST_IN_FLIGHT_REQUESTS),
+                output: Mutex::new(Some(output)),
+                pending: StdMutex::new(PendingState::default()),
+                terminal: StdMutex::new(TerminalDiagnostics::default()),
+                terminal_closed: Notify::new(),
+                child: StdMutex::new(Some(child)),
+                egress: StdMutex::new(None),
+                process_config: StdMutex::new(None),
+            });
+            runtime.spawn(write_requests(
+                input,
+                input_receiver,
+                Arc::downgrade(&inner),
+            ));
+            runtime.spawn(capture_terminal_stderr(stderr, Arc::downgrade(&inner)));
+            Ok(Self {
+                handle: VmToolSessionHandle { inner },
+            })
+        });
+        record_vm_result(&span, started_at, &result);
+        result
+    }
+
+    /// Returns a clone-cheap capability for this session.
+    #[must_use]
+    pub fn handle(&self) -> VmToolSessionHandle {
+        self.handle.clone()
+    }
+
+    /// Returns the standard VM-backed workspace tool factory for this session.
+    #[must_use]
+    pub fn tools(&self) -> super::VmTools {
+        super::VmTools::new(self.handle())
+    }
+
+    /// Waits until the guest tool server has accepted and answered a typed
+    /// readiness request.
+    ///
+    /// Call this before exposing tools to model work when VM startup failure
+    /// should abort setup without spending a model request.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the VMM exits before the guest server is ready or
+    /// the readiness response is malformed.
+    pub async fn ready(&self) -> Result<(), VmToolSessionError> {
+        self.handle.ready().await
+    }
+
+    /// Provisions provider-owned public files and retains the complete egress
+    /// lease for the lifetime of this VM session.
+    ///
+    /// Call this exactly once, after spawning the VMM and before exposing tool
+    /// handles to an agent. The same lease must already have been applied to
+    /// the VM configuration and guest command with [`EgressLease::configure`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when egress was already provisioned, a guest path is
+    /// not UTF-8, or the guest rejects a file write.
+    pub async fn provision_egress(&self, egress: EgressLease) -> Result<(), VmToolSessionError> {
+        let files = egress.guest_files().cloned().collect::<Vec<_>>();
+        {
+            let mut provisioned = lock_unpoisoned(&self.handle.inner.egress);
+            if provisioned.is_some() {
+                return Err(VmToolSessionError::EgressAlreadyProvisioned);
+            }
+            // Retain revocable provider state even when provisioning fails.
+            // Tool handles keep the lease alive with the VMM, so dropping the
+            // launch owner cannot silently revoke an active agent tree.
+            *provisioned = Some(egress);
+        }
+        for file in files {
+            let path = file
+                .guest_path()
+                .to_str()
+                .ok_or_else(|| VmToolSessionError::EgressFilePath(file.guest_path().to_owned()))?;
+            self.write_file(path, file.contents().to_vec(), file.mode())
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Writes one host-owned file into the guest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the console closes, file creation fails in the
+    /// guest, or the typed response is invalid.
+    pub async fn write_file(
+        &self,
+        path: impl Into<String>,
+        contents: Vec<u8>,
+        mode: u32,
+    ) -> Result<(), VmToolSessionError> {
+        self.handle.write_file(path, contents, mode).await
+    }
+
+    /// Writes one host-owned file and applies an exact guest modification time.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the console closes, file creation or metadata
+    /// application fails in the guest, or the typed response is invalid.
+    pub async fn write_file_with_mtime(
+        &self,
+        path: impl Into<String>,
+        contents: Vec<u8>,
+        mode: u32,
+        modified_unix_seconds: i64,
+    ) -> Result<(), VmToolSessionError> {
+        self.handle
+            .write_file_with_mtime(path, contents, mode, modified_unix_seconds)
+            .await
+    }
+
+    /// Creates or updates one host-owned guest directory.
+    ///
+    /// `modified_unix_seconds` leaves the current modification time unchanged
+    /// when absent.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the console closes, directory creation or
+    /// metadata application fails in the guest, or the typed response is
+    /// invalid.
+    pub async fn create_directory(
+        &self,
+        path: impl Into<String>,
+        mode: u32,
+        modified_unix_seconds: Option<i64>,
+    ) -> Result<(), VmToolSessionError> {
+        self.handle
+            .create_directory(path, mode, modified_unix_seconds)
+            .await
+    }
+
+    /// Reads one result artifact from the guest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the console closes, the file cannot be read, or
+    /// the typed response is invalid.
+    pub async fn read_file(&self, path: impl Into<String>) -> Result<Vec<u8>, VmToolSessionError> {
+        self.handle.read_file(path).await
+    }
+
+    /// Executes a trusted host-control command in the guest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the console closes, the command cannot run or
+    /// exceeds its deadline, or the typed response is invalid.
+    pub async fn command(&self, command: VmCommand) -> Result<VmCommandOutput, VmToolSessionError> {
+        self.handle.command(command).await
+    }
+
+    /// Flushes guest filesystems and waits for the VMM process to exit.
+    ///
+    /// The operation rejects live sibling capabilities so it cannot stop the
+    /// VM while another driver in the same agent tree is using it. Because the
+    /// owner is borrowed, callers can drop those capabilities and retry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the guest cannot acknowledge the request, the
+    /// VMM does not stop promptly, or it exits unsuccessfully.
+    pub async fn shutdown(&self) -> Result<(), VmToolSessionError> {
+        let sibling_capabilities = Arc::strong_count(&self.handle.inner).saturating_sub(1);
+        if sibling_capabilities != 0 {
+            return Err(VmToolSessionError::ActiveCapabilities(sibling_capabilities));
+        }
+        self.handle.inner.closing.store(true, Ordering::Release);
+        let response = self
+            .handle
+            .control_request_inner(|id| SessionRequest::Shutdown(ShutdownRequest { id }), true)
+            .await?;
+        let SessionResponse::Shutdown(response) = response else {
+            return Err(VmToolSessionError::Protocol("expected a shutdown response"));
+        };
+        control_result(response)?;
+
+        let child = lock_unpoisoned(&self.handle.inner.child).take();
+        let Some(mut child) = child else {
+            return Err(VmToolSessionError::Closed);
+        };
+        let status = if let Ok(status) = tokio::time::timeout(SHUTDOWN_TIMEOUT, child.wait()).await
+        {
+            status?
+        } else {
+            let _ = child.start_kill();
+            let _ = child.wait().await;
+            return Err(VmToolSessionError::ShutdownTimeout(SHUTDOWN_TIMEOUT));
+        };
+        close_pending(&self.handle.inner, "VM session shut down");
+        if !status.success() {
+            return Err(VmToolSessionError::VmmExit(status));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for VmToolSessionInner {
+    fn drop(&mut self) {
+        self.closing.store(true, Ordering::Release);
+        close_pending(self, "last VM session capability was dropped");
+        if let Some(child) = lock_unpoisoned(&self.child).as_mut() {
+            let _ = child.start_kill();
+        }
+    }
+}
+
+impl VmToolSessionHandle {
+    /// Waits until the guest tool server answers a typed readiness request.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the VMM exits before the guest server is ready or
+    /// the readiness response is malformed.
+    pub async fn ready(&self) -> Result<(), VmToolSessionError> {
+        let span = info_span!(
+            target: "nanocodex_vm",
+            "vm.session.ready",
+            otel.kind = "internal",
+            otel.status_code = tracing::field::Empty,
+            vm.session.age_ns = tracing::field::Empty,
+            status = tracing::field::Empty,
+            error.message = tracing::field::Empty,
+            duration_ns = tracing::field::Empty,
+        );
+        let started_at = Instant::now();
+        let result = async {
+            let response = self
+                .control_request(|id| SessionRequest::Ready(ReadyRequest { id }))
+                .await?;
+            let SessionResponse::Ready(response) = response else {
+                return Err(VmToolSessionError::Protocol(
+                    "expected a readiness response",
+                ));
+            };
+            control_result(response)
+        }
+        .instrument(span.clone())
+        .await;
+        span.record("vm.session.age_ns", elapsed_ns(self.inner.spawned_at));
+        record_vm_result(&span, started_at, &result);
+        result
+    }
+
+    async fn request(
+        &self,
+        tool: StandardTool,
+        input: ToolInput,
+        context: ToolContext<'_>,
+    ) -> Result<ToolOutput, VmToolSessionError> {
+        let (input_kind, input_bytes) = match &input {
+            ToolInput::Function(arguments) => ("function", arguments.get().len()),
+            ToolInput::Freeform(input) => ("freeform", input.len()),
+        };
+        let span = info_span!(
+            target: "nanocodex_vm",
+            "vm.tool.rpc",
+            otel.kind = "client",
+            otel.status_code = tracing::field::Empty,
+            rpc.system = "libkrun.console",
+            rpc.method = tool.name(),
+            tool.name = tool.name(),
+            session.id = context.session_id(),
+            tool.call_id = context.call_id(),
+            tool.input.kind = input_kind,
+            tool.input.bytes = input_bytes,
+            rpc.request.id = tracing::field::Empty,
+            rpc.request.bytes = tracing::field::Empty,
+            rpc.response.bytes = tracing::field::Empty,
+            rpc.queue.duration_ns = tracing::field::Empty,
+            vm.session.first_call = tracing::field::Empty,
+            vm.session.age_ns = tracing::field::Empty,
+            tool.success = tracing::field::Empty,
+            status = tracing::field::Empty,
+            error.message = tracing::field::Empty,
+            duration_ns = tracing::field::Empty,
+        );
+        let started_at = Instant::now();
+        let result = self
+            .request_inner(tool, input, context, &span)
+            .instrument(span.clone())
+            .await;
+        if let Ok(execution) = &result {
+            span.record("tool.success", execution.success);
+        }
+        record_vm_result(&span, started_at, &result);
+        result
+    }
+
+    async fn request_inner(
+        &self,
+        tool: StandardTool,
+        input: ToolInput,
+        context: ToolContext<'_>,
+        span: &tracing::Span,
+    ) -> Result<ToolOutput, VmToolSessionError> {
+        let request = SessionRequest::Tool(ToolRequest {
+            id: 0,
+            tool,
+            input: WireToolInput::from(input),
+            context: WireToolContext {
+                model: context.model().to_owned(),
+                session_id: context.session_id().to_owned(),
+                call_id: context.call_id().to_owned(),
+                output_token_budget: context.output_token_budget(),
+            },
+        });
+        let (response, response_bytes) = self.send_request(request, span, false).await?;
+        span.record("rpc.response.bytes", response_bytes);
+        span.record("vm.session.age_ns", elapsed_ns(self.inner.spawned_at));
+        let SessionResponse::Tool(response) = response else {
+            return Err(VmToolSessionError::Protocol("expected a tool response"));
+        };
+        match (response.execution, response.error) {
+            (Some(execution), None) => ToolOutput::from_wire(execution).map_err(Into::into),
+            (None, Some(error)) => Err(VmToolSessionError::Guest(error)),
+            _ => Err(VmToolSessionError::Protocol(
+                "expected exactly one of execution or error",
+            )),
+        }
+    }
+
+    /// Writes one host-owned file into the guest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the session is closed, guest file creation fails,
+    /// or the response is invalid.
+    pub async fn write_file(
+        &self,
+        path: impl Into<String>,
+        contents: Vec<u8>,
+        mode: u32,
+    ) -> Result<(), VmToolSessionError> {
+        self.write_file_inner(path, contents, mode, None).await
+    }
+
+    /// Writes one host-owned file and applies an exact guest modification time.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the session is closed, guest file creation or
+    /// metadata application fails, or the response is invalid.
+    pub async fn write_file_with_mtime(
+        &self,
+        path: impl Into<String>,
+        contents: Vec<u8>,
+        mode: u32,
+        modified_unix_seconds: i64,
+    ) -> Result<(), VmToolSessionError> {
+        self.write_file_inner(path, contents, mode, Some(modified_unix_seconds))
+            .await
+    }
+
+    async fn write_file_inner(
+        &self,
+        path: impl Into<String>,
+        contents: Vec<u8>,
+        mode: u32,
+        modified_unix_seconds: Option<i64>,
+    ) -> Result<(), VmToolSessionError> {
+        let response = self
+            .control_request(|id| {
+                SessionRequest::WriteFile(WriteFileRequest {
+                    id,
+                    path: path.into(),
+                    contents,
+                    mode,
+                    modified_unix_seconds,
+                })
+            })
+            .await?;
+        let SessionResponse::WriteFile(response) = response else {
+            return Err(VmToolSessionError::Protocol(
+                "expected a write-file response",
+            ));
+        };
+        control_result(response)
+    }
+
+    /// Creates or updates one host-owned guest directory.
+    ///
+    /// `modified_unix_seconds` leaves the current modification time unchanged
+    /// when absent.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the session is closed, guest directory creation
+    /// or metadata application fails, or the response is invalid.
+    pub async fn create_directory(
+        &self,
+        path: impl Into<String>,
+        mode: u32,
+        modified_unix_seconds: Option<i64>,
+    ) -> Result<(), VmToolSessionError> {
+        let response = self
+            .control_request(|id| {
+                SessionRequest::CreateDirectory(CreateDirectoryRequest {
+                    id,
+                    path: path.into(),
+                    mode,
+                    modified_unix_seconds,
+                })
+            })
+            .await?;
+        let SessionResponse::CreateDirectory(response) = response else {
+            return Err(VmToolSessionError::Protocol(
+                "expected a create-directory response",
+            ));
+        };
+        control_result(response)
+    }
+
+    /// Reads one host-owned artifact from the guest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the session is closed, the file cannot be read,
+    /// or the response is invalid.
+    pub async fn read_file(&self, path: impl Into<String>) -> Result<Vec<u8>, VmToolSessionError> {
+        let response = self
+            .control_request(|id| {
+                SessionRequest::ReadFile(ReadFileRequest {
+                    id,
+                    path: path.into(),
+                })
+            })
+            .await?;
+        let SessionResponse::ReadFile(ReadFileResponse {
+            contents, error, ..
+        }) = response
+        else {
+            return Err(VmToolSessionError::Protocol(
+                "expected a read-file response",
+            ));
+        };
+        match (contents, error) {
+            (Some(contents), None) => Ok(contents),
+            (None, Some(error)) => Err(VmToolSessionError::Guest(error)),
+            _ => Err(VmToolSessionError::Protocol(
+                "expected exactly one of contents or error",
+            )),
+        }
+    }
+
+    /// Executes one trusted host-control command in the guest.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the session is closed, the command fails to
+    /// start, exceeds its deadline, or returns an invalid response.
+    pub async fn command(&self, command: VmCommand) -> Result<VmCommandOutput, VmToolSessionError> {
+        let command_timeout = command.timeout;
+        let max_output_bytes = command.max_output_bytes;
+        let timeout_millis = u64::try_from(command_timeout.as_millis()).unwrap_or(u64::MAX);
+        let response = self
+            .control_request(|id| {
+                SessionRequest::Execute(ExecuteRequest {
+                    id,
+                    program: command.program,
+                    arguments: command.arguments,
+                    current_directory: command.current_directory,
+                    environment: command.environment,
+                    timeout_millis,
+                    max_output_bytes,
+                })
+            })
+            .await?;
+        let SessionResponse::Execute(ExecuteResponse {
+            exit_code,
+            stdout,
+            stderr,
+            error,
+            timed_out,
+            output_limit_exceeded,
+            ..
+        }) = response
+        else {
+            return Err(VmToolSessionError::Protocol("expected an execute response"));
+        };
+        match (
+            exit_code,
+            stdout,
+            stderr,
+            error,
+            timed_out,
+            output_limit_exceeded,
+        ) {
+            (Some(exit_code), Some(stdout), Some(stderr), None, false, false) => {
+                Ok(VmCommandOutput {
+                    exit_code,
+                    stdout,
+                    stderr,
+                })
+            }
+            (None, Some(stdout), Some(stderr), None, true, false) => {
+                Err(VmToolSessionError::GuestTimeout {
+                    timeout: command_timeout,
+                    output: VmCommandPartialOutput { stdout, stderr },
+                })
+            }
+            (None, None, None, None, false, true) => {
+                Err(VmToolSessionError::GuestOutputLimit(max_output_bytes))
+            }
+            (None, None, None, Some(error), false, false) => Err(VmToolSessionError::Guest(error)),
+            _ => Err(VmToolSessionError::Protocol(
+                "invalid execute response fields",
+            )),
+        }
+    }
+
+    async fn control_request(
+        &self,
+        make_request: impl FnOnce(u64) -> SessionRequest,
+    ) -> Result<SessionResponse, VmToolSessionError> {
+        self.control_request_inner(make_request, false).await
+    }
+
+    async fn control_request_inner(
+        &self,
+        make_request: impl FnOnce(u64) -> SessionRequest,
+        allow_closing: bool,
+    ) -> Result<SessionResponse, VmToolSessionError> {
+        let response = self
+            .send_request(make_request(0), &Span::current(), allow_closing)
+            .await?
+            .0;
+        Ok(response)
+    }
+
+    async fn send_request(
+        &self,
+        mut request: SessionRequest,
+        span: &Span,
+        allow_closing: bool,
+    ) -> Result<(SessionResponse, usize), VmToolSessionError> {
+        if self.inner.closing.load(Ordering::Acquire) && !allow_closing {
+            return Err(VmToolSessionError::Closed);
+        }
+        let _request_slot = if allow_closing {
+            None
+        } else {
+            let permit = self
+                .inner
+                .request_slots
+                .acquire()
+                .await
+                .map_err(|_| VmToolSessionError::Closed)?;
+            if self.inner.closing.load(Ordering::Acquire) {
+                return Err(VmToolSessionError::Closed);
+            }
+            Some(permit)
+        };
+        self.ensure_reader().await?;
+        let id = self.inner.next_id.fetch_add(1, Ordering::Relaxed);
+        set_request_id(&mut request, id);
+        span.record("rpc.request.id", id);
+        span.record("vm.session.first_call", id == 0);
+        let encoded = serde_json::to_string(&request)?;
+        if encoded.len() > MAX_FRAME_BYTES {
+            return Err(VmToolSessionError::FrameTooLarge);
+        }
+        span.record("rpc.request.bytes", encoded.len());
+        record_vm_content(span, "tool.request", &encoded);
+
+        let (sender, receiver) = oneshot::channel();
+        {
+            let mut pending = lock_unpoisoned(&self.inner.pending);
+            if let Some(error) = &pending.closed {
+                return Err(VmToolSessionError::Router(error.clone()));
+            }
+            pending.requests.insert(
+                id,
+                PendingResponse {
+                    span: span.clone(),
+                    response: sender,
+                },
+            );
+        }
+        let mut guard = PendingRequestGuard {
+            inner: Arc::downgrade(&self.inner),
+            id,
+            armed: true,
+        };
+        let queued_at = Instant::now();
+        let mut frame = encoded.into_bytes();
+        frame.push(b'\n');
+        self.inner
+            .input
+            .send(frame)
+            .await
+            .map_err(|_| VmToolSessionError::Closed)?;
+        span.record("rpc.queue.duration_ns", elapsed_ns(queued_at));
+        let response = receiver.await.map_err(|_| VmToolSessionError::Closed)?;
+        guard.armed = false;
+        response.map_err(VmToolSessionError::Router)
+    }
+
+    async fn ensure_reader(&self) -> Result<(), VmToolSessionError> {
+        let mut output = self.inner.output.lock().await;
+        if let Some(output) = output.take() {
+            let inner = Arc::downgrade(&self.inner);
+            tokio::spawn(async move {
+                route_responses(output, inner).await;
+            });
+            return Ok(());
+        }
+        let pending = lock_unpoisoned(&self.inner.pending);
+        match &pending.closed {
+            Some(error) => Err(VmToolSessionError::Router(error.clone())),
+            None => Ok(()),
+        }
+    }
+}
+
+impl Drop for PendingRequestGuard {
+    fn drop(&mut self) {
+        if self.armed
+            && let Some(inner) = self.inner.upgrade()
+        {
+            lock_unpoisoned(&inner.pending).requests.remove(&self.id);
+            queue_cancel(&inner, self.id);
+        }
+    }
+}
+
+fn queue_cancel(inner: &Arc<VmToolSessionInner>, target_id: u64) {
+    if inner.closing.load(Ordering::Acquire) {
+        return;
+    }
+    let id = inner.next_id.fetch_add(1, Ordering::Relaxed);
+    let request = SessionRequest::Cancel(CancelRequest { id, target_id });
+    let Ok(mut frame) = serde_json::to_vec(&request) else {
+        return;
+    };
+    frame.push(b'\n');
+    match inner.input.try_send(frame) {
+        Ok(()) | Err(mpsc::error::TrySendError::Closed(_)) => {}
+        Err(mpsc::error::TrySendError::Full(frame)) => {
+            let input = inner.input.clone();
+            if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+                runtime.spawn(async move {
+                    let _ = input.send(frame).await;
+                });
+            }
+        }
+    }
+}
+
+async fn write_requests(
+    mut input: ChildStdin,
+    mut requests: mpsc::Receiver<Vec<u8>>,
+    inner: Weak<VmToolSessionInner>,
+) {
+    while let Some(frame) = requests.recv().await {
+        let result = async {
+            input.write_all(&frame).await?;
+            input.flush().await
+        }
+        .await;
+        if let Err(error) = result {
+            if let Some(inner) = inner.upgrade() {
+                let message = terminal_router_message(
+                    &inner,
+                    &format!("VM tool console write failed: {error}"),
+                )
+                .await;
+                close_pending(&inner, &message);
+            }
+            return;
+        }
+    }
+}
+
+async fn capture_terminal_stderr(mut stderr: ChildStderr, inner: Weak<VmToolSessionInner>) {
+    let mut passthrough = tokio::io::stderr();
+    let mut buffer = [0_u8; 8 * 1024];
+    let stderr_error = loop {
+        match stderr.read(&mut buffer).await {
+            Ok(0) => break None,
+            Ok(read) => {
+                let _ = passthrough.write_all(&buffer[..read]).await;
+                if let Some(inner) = inner.upgrade() {
+                    append_terminal_stderr(&mut lock_unpoisoned(&inner.terminal), &buffer[..read]);
+                }
+            }
+            Err(error) => break Some(error.to_string()),
+        }
+    };
+    let _ = passthrough.flush().await;
+    if let Some(inner) = inner.upgrade() {
+        let mut terminal = lock_unpoisoned(&inner.terminal);
+        terminal.stderr_error = stderr_error;
+        terminal.closed = true;
+        drop(terminal);
+        inner.terminal_closed.notify_waiters();
+    }
+}
+
+fn append_terminal_stderr(terminal: &mut TerminalDiagnostics, bytes: &[u8]) {
+    if bytes.len() >= MAX_TERMINAL_STDERR_BYTES {
+        terminal.stderr_tail.clear();
+        terminal
+            .stderr_tail
+            .extend_from_slice(&bytes[bytes.len() - MAX_TERMINAL_STDERR_BYTES..]);
+        return;
+    }
+    let overflow = terminal
+        .stderr_tail
+        .len()
+        .saturating_add(bytes.len())
+        .saturating_sub(MAX_TERMINAL_STDERR_BYTES);
+    if overflow != 0 {
+        terminal.stderr_tail.drain(..overflow);
+    }
+    terminal.stderr_tail.extend_from_slice(bytes);
+}
+
+async fn route_responses(output: ChildStdout, inner: Weak<VmToolSessionInner>) {
+    let mut output = BufReader::new(output);
+    loop {
+        let line = match read_frame(&mut output).await {
+            Ok(Some(line)) => line,
+            Ok(None) => {
+                if let Some(inner) = inner.upgrade() {
+                    let message = terminal_router_message(&inner, "VM tool console closed").await;
+                    close_pending(&inner, &message);
+                }
+                return;
+            }
+            Err(error) => {
+                if let Some(inner) = inner.upgrade() {
+                    let message = terminal_router_message(
+                        &inner,
+                        &format!("VM tool console read failed: {error}"),
+                    )
+                    .await;
+                    close_pending(&inner, &message);
+                }
+                return;
+            }
+        };
+        let response = match serde_json::from_slice::<SessionResponse>(&line) {
+            Ok(response) => response,
+            Err(error) => {
+                if let Some(inner) = inner.upgrade() {
+                    close_pending(&inner, &format!("invalid VM tool response: {error}"));
+                }
+                return;
+            }
+        };
+        let Some(inner) = inner.upgrade() else {
+            return;
+        };
+        let id = response.id();
+        let pending = lock_unpoisoned(&inner.pending).requests.remove(&id);
+        if let Some(pending) = pending {
+            record_vm_content(
+                &pending.span,
+                "tool.response",
+                &String::from_utf8_lossy(&line),
+            );
+            let _ = pending.response.send(Ok((response, line.len())));
+        } else {
+            info!(
+                target: "nanocodex_vm",
+                rpc_response_id = id,
+                "discarded response for a cancelled VM request"
+            );
+        }
+    }
+}
+
+async fn terminal_router_message(inner: &Arc<VmToolSessionInner>, base: &str) -> String {
+    let wait_for_stderr = async {
+        loop {
+            let closed = inner.terminal_closed.notified();
+            if lock_unpoisoned(&inner.terminal).closed {
+                return;
+            }
+            closed.await;
+        }
+    };
+    let _ = tokio::time::timeout(TERMINAL_STDERR_DRAIN_GRACE, wait_for_stderr).await;
+
+    let status = lock_unpoisoned(&inner.child)
+        .as_mut()
+        .and_then(|child| child.try_wait().ok().flatten());
+    let terminal = lock_unpoisoned(&inner.terminal);
+    let stderr = String::from_utf8_lossy(&terminal.stderr_tail);
+    let stderr = stderr.trim();
+    let mut details = Vec::new();
+    if let Some(status) = status {
+        details.push(format!("VMM exited with {status}"));
+    }
+    if !stderr.is_empty() {
+        details.push(format!("VMM stderr: {stderr}"));
+    }
+    if let Some(error) = &terminal.stderr_error {
+        details.push(format!("reading VMM stderr failed: {error}"));
+    }
+    if details.is_empty() {
+        base.to_owned()
+    } else {
+        format!("{base}; {}", details.join("; "))
+    }
+}
+
+async fn read_frame(
+    reader: &mut (impl AsyncBufRead + Unpin),
+) -> Result<Option<Vec<u8>>, VmToolSessionError> {
+    let mut frame = Vec::new();
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            return if frame.is_empty() {
+                Ok(None)
+            } else {
+                Err(VmToolSessionError::Closed)
+            };
+        }
+        if let Some(newline) = available.iter().position(|byte| *byte == b'\n') {
+            if frame.len().saturating_add(newline) > MAX_FRAME_BYTES {
+                return Err(VmToolSessionError::FrameTooLarge);
+            }
+            frame.extend_from_slice(&available[..newline]);
+            reader.consume(newline + 1);
+            if frame.last() == Some(&b'\r') {
+                frame.pop();
+            }
+            return Ok(Some(frame));
+        }
+        if frame.len().saturating_add(available.len()) > MAX_FRAME_BYTES {
+            return Err(VmToolSessionError::FrameTooLarge);
+        }
+        let consumed = available.len();
+        frame.extend_from_slice(available);
+        reader.consume(consumed);
+    }
+}
+
+const fn set_request_id(request: &mut SessionRequest, id: u64) {
+    match request {
+        SessionRequest::Ready(request) => request.id = id,
+        SessionRequest::Tool(request) => request.id = id,
+        SessionRequest::WriteFile(request) => request.id = id,
+        SessionRequest::CreateDirectory(request) => request.id = id,
+        SessionRequest::ReadFile(request) => request.id = id,
+        SessionRequest::Execute(request) => request.id = id,
+        SessionRequest::Cancel(request) => request.id = id,
+        SessionRequest::Shutdown(request) => request.id = id,
+    }
+}
+
+fn close_pending(inner: &VmToolSessionInner, message: &str) {
+    let requests = {
+        let mut pending = lock_unpoisoned(&inner.pending);
+        if pending.closed.is_none() {
+            pending.closed = Some(message.to_owned());
+        }
+        std::mem::take(&mut pending.requests)
+    };
+    for (_, request) in requests {
+        let _ = request.response.send(Err(message.to_owned()));
+    }
+}
+
+fn lock_unpoisoned<T>(mutex: &StdMutex<T>) -> StdMutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+fn control_result(response: ControlResponse) -> Result<(), VmToolSessionError> {
+    match response.error {
+        None => Ok(()),
+        Some(error) => Err(VmToolSessionError::Guest(error)),
+    }
+}
+
+fn record_vm_result<T, E>(span: &tracing::Span, started_at: Instant, result: &Result<T, E>)
+where
+    E: std::fmt::Display,
+{
+    let duration_ns = elapsed_ns(started_at);
+    span.record("duration_ns", duration_ns);
+    match result {
+        Ok(_) => {
+            span.record("status", "completed");
+            span.record("otel.status_code", "OK");
+            span.in_scope(|| {
+                info!(
+                    target: "nanocodex_vm",
+                    duration_ns,
+                    status = "completed",
+                    "VM operation completed"
+                );
+            });
+        }
+        Err(error) => {
+            span.record("status", "failed");
+            span.record("otel.status_code", "ERROR");
+            span.record("error.message", tracing::field::display(error));
+            span.in_scope(|| {
+                info!(
+                    target: "nanocodex_vm",
+                    duration_ns,
+                    status = "failed",
+                    error = %error,
+                    "VM operation failed"
+                );
+            });
+        }
+    }
+}
+
+fn record_vm_content(span: &tracing::Span, kind: &'static str, content: &str) {
+    span.in_scope(|| {
+        info!(
+            target: "nanocodex_vm",
+            content_kind = kind,
+            content,
+            "VM tool content"
+        );
+    });
+}
+
+fn elapsed_ns(started_at: Instant) -> u64 {
+    u64::try_from(started_at.elapsed().as_nanos()).unwrap_or(u64::MAX)
+}
+
+#[async_trait::async_trait]
+impl VmToolClient for VmToolSessionHandle {
+    async fn execute(
+        &self,
+        tool: StandardTool,
+        input: ToolInput,
+        context: ToolContext<'_>,
+    ) -> ToolResult {
+        match self.request(tool, input, context).await {
+            Ok(execution) => Ok(execution),
+            Err(diagnostic @ VmToolSessionError::Router(_)) => {
+                Err(Box::new(ModelSafeVmToolError { diagnostic }))
+            }
+            Err(error) => Err(Box::new(error)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tracing_tests {
+    use std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use nanocodex_tools::{
+        ToolContext, ToolInput, contract::ToolOutputBody, runtime::ToolRuntime,
+        standard::StandardTool,
+    };
+    use serde_json::{json, value::to_raw_value};
+    use tracing::{Id, Instrument, Subscriber, field::Visit, span::Attributes};
+    use tracing_subscriber::{
+        Layer, layer::Context as LayerContext, prelude::*, registry::LookupSpan,
+    };
+
+    use super::{VmCommand, VmCommandPartialOutput, VmToolSession, VmToolSessionError};
+
+    static TRACE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[derive(Clone, Default)]
+    struct TraceCapture {
+        spans: Arc<Mutex<HashMap<u64, CapturedSpan>>>,
+        names: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    struct CapturedSpan {
+        name: &'static str,
+        parent: Option<u64>,
+        fields: HashMap<String, String>,
+    }
+
+    struct FieldCapture<'a>(&'a mut HashMap<String, String>);
+
+    impl Visit for FieldCapture<'_> {
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            self.0.insert(field.name().to_owned(), value.to_owned());
+        }
+
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+            self.0.insert(field.name().to_owned(), format!("{value:?}"));
+        }
+    }
+
+    impl<S> Layer<S> for TraceCapture
+    where
+        S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    {
+        fn on_new_span(&self, attributes: &Attributes<'_>, id: &Id, context: LayerContext<'_, S>) {
+            self.names
+                .lock()
+                .unwrap()
+                .push(attributes.metadata().name());
+            let parent = attributes
+                .parent()
+                .map(|parent| parent.clone().into_u64())
+                .or_else(|| {
+                    attributes
+                        .is_contextual()
+                        .then(|| context.current_span().id().map(Id::into_u64))
+                        .flatten()
+                });
+            let mut fields = HashMap::new();
+            attributes.record(&mut FieldCapture(&mut fields));
+            self.spans.lock().unwrap().insert(
+                id.clone().into_u64(),
+                CapturedSpan {
+                    name: attributes.metadata().name(),
+                    parent,
+                    fields,
+                },
+            );
+        }
+
+        fn on_record(
+            &self,
+            id: &Id,
+            values: &tracing::span::Record<'_>,
+            _context: LayerContext<'_, S>,
+        ) {
+            if let Some(span) = self.spans.lock().unwrap().get_mut(&id.clone().into_u64()) {
+                values.record(&mut FieldCapture(&mut span.fields));
+            }
+        }
+    }
+
+    #[test]
+    fn spawning_without_a_tokio_runtime_returns_a_typed_error() {
+        let mut command = tokio::process::Command::new("/bin/true");
+
+        assert!(matches!(
+            VmToolSession::spawn(&mut command),
+            Err(VmToolSessionError::NoRuntime)
+        ));
+    }
+
+    #[test]
+    fn vm_rpc_is_timed_and_parented_to_the_calling_tool() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let response = r#"{"kind":"tool","payload":{"id":0,"execution":{"output":"ok","success":true,"code_mode_value":null,"metadata":null,"process_trace":null},"error":null}}"#;
+        let script = format!("IFS= read -r request\nprintf '%s\\n' '{response}'");
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg(script);
+        let capture = TraceCapture::default();
+        let dispatch = tracing::Dispatch::new(tracing_subscriber::registry().with(capture.clone()));
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        tracing::dispatcher::with_default(&dispatch, || {
+            // Earlier tests may have registered these static callsites while
+            // no subscriber was active. Rebuild only after installing this
+            // dispatch so cached `never` interest cannot make the assertion
+            // order-dependent.
+            tracing::callsite::rebuild_interest_cache();
+            runtime.block_on(async {
+                let session = VmToolSession::spawn(&mut command).unwrap();
+                let context =
+                    ToolContext::new("test-model", "test-session", "test-call", &[], 1_000);
+                let execution = session
+                    .handle()
+                    .request(
+                        StandardTool::ExecCommand,
+                        ToolInput::Function(to_raw_value(&json!({"cmd": "true"})).unwrap()),
+                        context,
+                    )
+                    .instrument(tracing::info_span!("test.tool.execute"))
+                    .await
+                    .unwrap();
+                assert!(execution.success);
+            });
+        });
+
+        let spans = capture.spans.lock().unwrap();
+        let (tool_id, _) = spans
+            .iter()
+            .find(|(_, span)| span.name == "test.tool.execute")
+            .unwrap();
+        let rpc = spans
+            .values()
+            .find(|span| span.name == "vm.tool.rpc")
+            .unwrap();
+        assert_eq!(rpc.parent, Some(*tool_id));
+        assert_eq!(
+            rpc.fields.get("status").map(String::as_str),
+            Some("completed")
+        );
+        assert_eq!(
+            rpc.fields.get("vm.session.first_call").map(String::as_str),
+            Some("true")
+        );
+        assert!(rpc.fields.contains_key("rpc.queue.duration_ns"));
+        assert!(rpc.fields.contains_key("duration_ns"));
+        assert!(capture.names.lock().unwrap().contains(&"vm.session.spawn"));
+    }
+
+    #[test]
+    fn readiness_waits_for_a_typed_guest_response() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let response = r#"{"kind":"ready","payload":{"id":0,"error":null}}"#;
+        let script = format!("IFS= read -r request\nprintf '%s\\n' '{response}'");
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg(script);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let session = VmToolSession::spawn(&mut command).unwrap();
+            session.ready().await.unwrap();
+        });
+    }
+
+    #[test]
+    fn model_tool_error_hides_terminal_stderr_while_operator_error_retains_it() {
+        const SENTINEL: &str = "SENTINEL_VM_SECRET_7f35ad";
+
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg(format!(
+            "IFS= read -r request\nprintf '%s\\n' 'guest runtime failed: {SENTINEL}' >&2\nexit 23"
+        ));
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let session = VmToolSession::spawn(&mut command).unwrap();
+            let tools = session
+                .tools()
+                .tools_builder()
+                .web_search(false)
+                .image_generation(false)
+                .build()
+                .unwrap();
+            let tool_runtime = ToolRuntime::new_with_tools("/", None, None, &tools);
+            let output = tool_runtime
+                .execute_tool(
+                    StandardTool::ExecCommand.name(),
+                    ToolInput::Function(to_raw_value(&json!({"cmd": "true"})).unwrap()),
+                    ToolContext::new("model", "session", "call", &[], 1_000),
+                )
+                .await;
+            assert!(!output.success);
+            let ToolOutputBody::Text(model_error) = output.output else {
+                panic!("tool registry should produce a model-visible text error");
+            };
+            assert_eq!(
+                model_error,
+                "VM tool session ended before this request completed"
+            );
+            assert!(!model_error.contains(SENTINEL));
+
+            let error = session.ready().await.unwrap_err();
+            let VmToolSessionError::Router(message) = error else {
+                panic!("expected a terminal router failure");
+            };
+            assert!(message.contains("VM tool console closed"));
+            assert!(message.contains(SENTINEL));
+        });
+    }
+
+    #[test]
+    fn cancelled_request_sends_targeted_guest_cancellation() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let cancel = r#"{"kind":"cancel","payload":{"id":1,"error":null}}"#;
+        let second = r#"{"kind":"write_file","payload":{"id":2,"error":null}}"#;
+        let script = format!(
+            "IFS= read -r first\nIFS= read -r cancel\nprintf '%s\\n' '{cancel}'\nIFS= read -r second\nprintf '%s\\n' '{second}'"
+        );
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg(script);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let session = VmToolSession::spawn(&mut command).unwrap();
+            let cancelled = tokio::time::timeout(
+                Duration::from_millis(10),
+                session.write_file("/first", Vec::new(), 0o600),
+            )
+            .await;
+            assert!(cancelled.is_err());
+
+            session
+                .write_file("/second", Vec::new(), 0o600)
+                .await
+                .unwrap();
+        });
+    }
+
+    #[test]
+    fn command_timeout_preserves_bounded_guest_output() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let response = r#"{"kind":"execute","payload":{"id":0,"exit_code":null,"stdout":"cGFydGlhbCBzdGRvdXQ=","stderr":"cGFydGlhbCBzdGRlcnI=","error":null,"timed_out":true,"output_limit_exceeded":false}}"#;
+        let script = format!("IFS= read -r request\nprintf '%s\\n' '{response}'");
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg(script);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let session = VmToolSession::spawn(&mut command).unwrap();
+            let error = session
+                .command(VmCommand::new("/bin/true").timeout(Duration::from_secs(17)))
+                .await
+                .unwrap_err();
+            let VmToolSessionError::GuestTimeout { timeout, output } = error else {
+                panic!("expected a typed guest timeout");
+            };
+            assert_eq!(timeout, Duration::from_secs(17));
+            assert_eq!(
+                output,
+                VmCommandPartialOutput {
+                    stdout: b"partial stdout".to_vec(),
+                    stderr: b"partial stderr".to_vec(),
+                }
+            );
+        });
+    }
+
+    #[test]
+    fn concurrent_handles_multiplex_out_of_order_responses() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let first = r#"{"kind":"write_file","payload":{"id":1,"error":null}}"#;
+        let second = r#"{"kind":"write_file","payload":{"id":0,"error":null}}"#;
+        let script =
+            format!("IFS= read -r first\nIFS= read -r second\nprintf '%s\\n' '{first}' '{second}'");
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg(script);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let session = VmToolSession::spawn(&mut command).unwrap();
+            let completed = tokio::time::timeout(Duration::from_secs(1), async {
+                tokio::join!(
+                    session.write_file("/first", Vec::new(), 0o600),
+                    session.write_file("/second", Vec::new(), 0o600),
+                )
+            })
+            .await
+            .expect("both requests should be written before either response");
+            completed.0.unwrap();
+            completed.1.unwrap();
+        });
+    }
+
+    #[test]
+    fn cancelled_partial_write_cannot_corrupt_the_next_request() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let cancel = r#"{"kind":"cancel","payload":{"id":1,"error":null}}"#;
+        let second = r#"{"kind":"write_file","payload":{"id":2,"error":null}}"#;
+        let script = format!(
+            "sleep 0.05\nIFS= read -r first\nIFS= read -r cancel\nprintf '%s\\n' '{cancel}'\nIFS= read -r second\nprintf '%s\\n' '{second}'"
+        );
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg(script);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let session = VmToolSession::spawn(&mut command).unwrap();
+            let cancelled = tokio::time::timeout(
+                Duration::from_millis(10),
+                session.write_file("/large", vec![b'x'; 256 * 1024], 0o600),
+            )
+            .await;
+            assert!(cancelled.is_err());
+
+            session
+                .write_file("/second", Vec::new(), 0o600)
+                .await
+                .unwrap();
+        });
+    }
+
+    #[test]
+    fn tool_capabilities_own_the_vmm_and_egress_lifetime() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg("sleep 30");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let session = VmToolSession::spawn(&mut command).unwrap();
+            let guard = Arc::new(());
+            let weak_guard = Arc::downgrade(&guard);
+            let mut egress = crate::egress::EgressLease::disabled();
+            egress.retain(guard);
+            session.provision_egress(egress).await.unwrap();
+            let tools = session.tools();
+
+            drop(session);
+            assert!(
+                weak_guard.upgrade().is_some(),
+                "dropping the launch owner must not revoke an active tool tree"
+            );
+
+            drop(tools);
+            assert!(
+                weak_guard.upgrade().is_none(),
+                "the last VM capability must release retained egress state"
+            );
+        });
+    }
+
+    #[test]
+    fn graceful_shutdown_rejects_live_sibling_capabilities() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let response = r#"{"kind":"shutdown","payload":{"id":0,"error":null}}"#;
+        let script = format!("IFS= read -r request\nprintf '%s\\n' '{response}'");
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg(script);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let session = VmToolSession::spawn(&mut command).unwrap();
+            let handle = session.handle();
+            assert!(matches!(
+                session.shutdown().await,
+                Err(VmToolSessionError::ActiveCapabilities(1))
+            ));
+            drop(handle);
+            session.shutdown().await.unwrap();
+        });
+    }
+
+    #[test]
+    fn configured_spawn_retains_private_input_until_the_vmm_has_loaded_it() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let ready = r#"{"kind":"ready","payload":{"id":0,"error":null}}"#;
+        let shutdown = r#"{"kind":"shutdown","payload":{"id":1,"error":null}}"#;
+        let script = format!(
+            "config=$1\nsleep 0.05\ntest -f \"$config\" || exit 9\n\
+             IFS= read -r request\nprintf '%s\\n' '{ready}'\n\
+             IFS= read -r request\nprintf '%s\\n' '{shutdown}'"
+        );
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg(script).arg("vm-test");
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let session = VmToolSession::spawn_configured(
+                command,
+                crate::config::VmConfig::ext4("/unused/root.ext4"),
+                crate::command::GuestCommand::new("/bin/true"),
+                crate::egress::EgressLease::disabled(),
+            )
+            .await
+            .unwrap();
+            session.shutdown().await.unwrap();
+        });
+    }
+}

--- a/crates/experimental/nanocodex-vm/src/workspace.rs
+++ b/crates/experimental/nanocodex-vm/src/workspace.rs
@@ -1,0 +1,435 @@
+use std::{
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use nanocodex_tools::ToolsBuilder;
+use tokio::process::Command;
+
+use crate::{
+    command::GuestCommand,
+    config::{BlockDevice, VmConfig},
+    egress::EgressLease,
+    image::reflink_or_sparse_copy,
+    tools::{VmToolSession, VmToolSessionError, VmTools},
+};
+
+const DEFAULT_CPUS: u8 = 2;
+const DEFAULT_MEMORY_MIB: u32 = 1_024;
+const DEFAULT_WORKSPACE: &str = "/app";
+const DEFAULT_SHELL: &str = "sh";
+const RUNTIME_BLOCK_ID: &str = "nanocodex-runtime";
+const RUNTIME_DEVICE: &str = "/dev/vdb";
+const RUNTIME_MOUNT: &str = "/run/nanocodex";
+const RUNTIME_EXECUTABLE: &str = "/run/nanocodex/nanocodex-vm-guest";
+
+/// High-level builder for one private retained VM workspace.
+///
+/// The normal portable path uses [`Self::private_from`] to materialize a
+/// writable raw-ext4 root from an immutable prepared image. The VMM executable
+/// is a small application-owned process that reads the private launch record
+/// appended by this crate and calls [`crate::host::VmProcessConfig::run`].
+pub struct VmWorkspaceBuilder {
+    rootfs: PathBuf,
+    vmm_executable: PathBuf,
+    vmm_arguments: Vec<OsString>,
+    guest_runtime_disk: Option<PathBuf>,
+    firmware_directory: Option<PathBuf>,
+    workspace: String,
+    shell: String,
+    cpus: u8,
+    memory_mib: u32,
+    egress: EgressLease,
+}
+
+/// One retained VM and the standard workspace tools routed into it.
+///
+/// Keep this owner alive for the complete Nanocodex session or root agent
+/// tree. Clone-cheap tool capabilities may be captured by a
+/// `NanocodexBuilder::tools_factory`; drop those agents and tools before
+/// calling [`Self::shutdown`].
+pub struct VmWorkspace {
+    session: VmToolSession,
+    rootfs: PathBuf,
+    workspace: String,
+    shell: String,
+}
+
+/// Failure to materialize, configure, start, or stop a high-level VM workspace.
+#[derive(Debug, thiserror::Error)]
+pub enum VmWorkspaceError {
+    /// A private root or loader path could not be prepared.
+    #[error("failed to prepare VM workspace files: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// The source root was not a raw ext4 image.
+    #[error("portable private VM workspaces require a raw ext4 source image: {0}")]
+    PrivateRootSource(PathBuf),
+
+    /// A required path was absent or had the wrong kind.
+    #[error("invalid VM workspace path {path}: {reason}")]
+    InvalidPath {
+        /// Rejected path.
+        path: PathBuf,
+        /// Stable reason for rejection.
+        reason: &'static str,
+    },
+
+    /// The guest working directory was not absolute.
+    #[error("guest workspace must be absolute: {0}")]
+    RelativeWorkspace(String),
+
+    /// A raw ext4 root was configured without the companion runtime disk.
+    #[error("raw ext4 VM workspace requires a prepared guest runtime disk")]
+    MissingGuestRuntime,
+
+    /// The retained guest session failed.
+    #[error(transparent)]
+    Session(#[from] VmToolSessionError),
+}
+
+impl VmWorkspace {
+    /// Starts a builder around an already-private VM root.
+    ///
+    /// Prefer [`VmWorkspaceBuilder::private_from`] for immutable prepared ext4
+    /// images. Passing a directory root is a low-level, non-confining escape
+    /// hatch because libkrun's direct virtiofs access does not isolate the host
+    /// mount namespace.
+    #[must_use]
+    pub fn builder(
+        private_rootfs: impl Into<PathBuf>,
+        vmm_executable: impl Into<PathBuf>,
+    ) -> VmWorkspaceBuilder {
+        VmWorkspaceBuilder::new(private_rootfs, vmm_executable)
+    }
+
+    /// Returns the private host root attached to this VM.
+    #[must_use]
+    pub fn rootfs(&self) -> &Path {
+        &self.rootfs
+    }
+
+    /// Returns the absolute guest working directory used by the tool builder.
+    #[must_use]
+    pub fn guest_workspace(&self) -> &str {
+        &self.workspace
+    }
+
+    /// Returns clone-cheap VM-backed standard workspace tools.
+    #[must_use]
+    pub fn tools(&self) -> VmTools {
+        self.session.tools()
+    }
+
+    /// Returns a normal Nanocodex tool builder with workspace effects routed
+    /// into this retained VM.
+    #[must_use]
+    pub fn tools_builder(&self) -> ToolsBuilder {
+        self.tools()
+            .tools_builder()
+            .working_directory(self.workspace.clone())
+            .default_shell(self.shell.clone())
+    }
+
+    /// Gracefully cancels guest work, syncs filesystems, and stops the VMM.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when clone-cheap sibling tool capabilities are still
+    /// alive or the guest/VMM does not complete its bounded shutdown.
+    pub async fn shutdown(&self) -> Result<(), VmWorkspaceError> {
+        self.session.shutdown().await?;
+        Ok(())
+    }
+}
+
+impl VmWorkspaceBuilder {
+    /// Configures an already-private root and application-owned VMM executable.
+    #[must_use]
+    pub fn new(private_rootfs: impl Into<PathBuf>, vmm_executable: impl Into<PathBuf>) -> Self {
+        Self {
+            rootfs: private_rootfs.into(),
+            vmm_executable: vmm_executable.into(),
+            vmm_arguments: Vec::new(),
+            guest_runtime_disk: None,
+            firmware_directory: None,
+            workspace: DEFAULT_WORKSPACE.to_owned(),
+            shell: DEFAULT_SHELL.to_owned(),
+            cpus: DEFAULT_CPUS,
+            memory_mib: DEFAULT_MEMORY_MIB,
+            egress: EgressLease::internet(),
+        }
+    }
+
+    /// Materializes one private writable ext4 root from an immutable image.
+    ///
+    /// The destination must not exist. Reflinks are used when available, with
+    /// a sparse-copy fallback.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the source is not a file, the destination exists,
+    /// or the private disk cannot be materialized.
+    pub fn private_from(
+        immutable_rootfs: impl AsRef<Path>,
+        private_rootfs: impl Into<PathBuf>,
+        vmm_executable: impl Into<PathBuf>,
+    ) -> Result<Self, VmWorkspaceError> {
+        let source = immutable_rootfs.as_ref();
+        if !source.is_file() {
+            return Err(VmWorkspaceError::PrivateRootSource(source.to_path_buf()));
+        }
+        let destination = private_rootfs.into();
+        if destination.exists() {
+            return Err(VmWorkspaceError::InvalidPath {
+                path: destination,
+                reason: "private destination already exists",
+            });
+        }
+        let parent = destination
+            .parent()
+            .ok_or_else(|| VmWorkspaceError::InvalidPath {
+                path: destination.clone(),
+                reason: "private destination has no parent",
+            })?;
+        fs::create_dir_all(parent)?;
+        reflink_or_sparse_copy(source, &destination)?;
+        Ok(Self::new(destination, vmm_executable))
+    }
+
+    /// Appends one argument understood by the application-owned VMM process.
+    #[must_use]
+    pub fn vmm_argument(mut self, argument: impl Into<OsString>) -> Self {
+        self.vmm_arguments.push(argument.into());
+        self
+    }
+
+    /// Selects the prepared read-only guest-runtime ext4 disk.
+    #[must_use]
+    pub fn guest_runtime_disk(mut self, disk: impl Into<PathBuf>) -> Self {
+        self.guest_runtime_disk = Some(disk.into());
+        self
+    }
+
+    /// Selects the directory containing platform libkrun firmware.
+    ///
+    /// Linux expects `libkrunfw.so.5`; macOS expects
+    /// `libkrunfw.5.dylib`. The directory is placed on the corresponding
+    /// loader path only for the VMM child.
+    #[must_use]
+    pub fn firmware_directory(mut self, directory: impl Into<PathBuf>) -> Self {
+        self.firmware_directory = Some(directory.into());
+        self
+    }
+
+    /// Sets the absolute guest working directory.
+    #[must_use]
+    pub fn guest_workspace(mut self, workspace: impl Into<String>) -> Self {
+        self.workspace = workspace.into();
+        self
+    }
+
+    /// Sets the shell description exposed to the model.
+    #[must_use]
+    pub fn shell(mut self, shell: impl Into<String>) -> Self {
+        self.shell = shell.into();
+        self
+    }
+
+    /// Sets the virtual CPU count.
+    #[must_use]
+    pub const fn cpus(mut self, cpus: u8) -> Self {
+        self.cpus = cpus;
+        self
+    }
+
+    /// Sets guest memory in mebibytes.
+    #[must_use]
+    pub const fn memory_mib(mut self, memory_mib: u32) -> Self {
+        self.memory_mib = memory_mib;
+        self
+    }
+
+    /// Disables guest networking.
+    #[must_use]
+    pub fn offline(mut self) -> Self {
+        self.egress = EgressLease::disabled();
+        self
+    }
+
+    /// Installs an application-owned provider-neutral egress lease.
+    #[must_use]
+    pub fn egress(mut self, egress: EgressLease) -> Self {
+        self.egress = egress;
+        self
+    }
+
+    /// Starts the VM, waits for typed guest readiness, and returns its owner.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid paths, missing platform firmware/runtime,
+    /// process startup, guest readiness, or egress provisioning.
+    pub async fn launch(self) -> Result<VmWorkspace, VmWorkspaceError> {
+        if !Path::new(&self.workspace).is_absolute() {
+            return Err(VmWorkspaceError::RelativeWorkspace(self.workspace));
+        }
+        if !self.rootfs.exists() {
+            return Err(VmWorkspaceError::InvalidPath {
+                path: self.rootfs,
+                reason: "private root does not exist",
+            });
+        }
+        if !self.vmm_executable.is_file() {
+            return Err(VmWorkspaceError::InvalidPath {
+                path: self.vmm_executable,
+                reason: "VMM executable is not a file",
+            });
+        }
+
+        let ext4 = self.rootfs.is_file();
+        let (config, guest) = if ext4 {
+            let runtime = self
+                .guest_runtime_disk
+                .ok_or(VmWorkspaceError::MissingGuestRuntime)?;
+            if !runtime.is_file() {
+                return Err(VmWorkspaceError::InvalidPath {
+                    path: runtime,
+                    reason: "guest runtime disk is not a file",
+                });
+            }
+            let config = VmConfig::ext4(&self.rootfs)
+                .cpus(self.cpus)
+                .memory_mib(self.memory_mib)
+                .block_device(BlockDevice::read_only(RUNTIME_BLOCK_ID, runtime));
+            let guest = GuestCommand::new("/bin/sh")
+                .arg("-c")
+                .arg(ext4_bootstrap(&self.workspace));
+            (config, guest)
+        } else if self.rootfs.is_dir() {
+            let runtime = self.rootfs.join("usr/local/bin/nanocodex-vm-guest");
+            if !runtime.is_file() {
+                return Err(VmWorkspaceError::InvalidPath {
+                    path: runtime,
+                    reason: "directory root is missing the guest runtime",
+                });
+            }
+            (
+                VmConfig::new(&self.rootfs)
+                    .cpus(self.cpus)
+                    .memory_mib(self.memory_mib),
+                GuestCommand::new("/usr/local/bin/nanocodex-vm-guest").arg(&self.workspace),
+            )
+        } else {
+            return Err(VmWorkspaceError::InvalidPath {
+                path: self.rootfs,
+                reason: "private root is neither a raw ext4 image nor a directory",
+            });
+        };
+
+        let mut command = Command::new(&self.vmm_executable);
+        command.args(self.vmm_arguments);
+        if let Some(firmware) = self.firmware_directory {
+            let firmware = firmware.canonicalize()?;
+            #[cfg(target_os = "linux")]
+            {
+                let library = firmware.join("libkrunfw.so.5");
+                if !library.is_file() {
+                    return Err(VmWorkspaceError::InvalidPath {
+                        path: library,
+                        reason: "Linux libkrun firmware is missing",
+                    });
+                }
+                command.env("LD_LIBRARY_PATH", firmware);
+            }
+            #[cfg(target_os = "macos")]
+            {
+                let library = firmware.join("libkrunfw.5.dylib");
+                if !library.is_file() {
+                    return Err(VmWorkspaceError::InvalidPath {
+                        path: library,
+                        reason: "macOS libkrun firmware is missing",
+                    });
+                }
+                command.env("DYLD_LIBRARY_PATH", firmware);
+            }
+        }
+
+        let session = VmToolSession::spawn_configured(command, config, guest, self.egress).await?;
+        Ok(VmWorkspace {
+            session,
+            rootfs: self.rootfs,
+            workspace: self.workspace,
+            shell: self.shell,
+        })
+    }
+}
+
+fn ext4_bootstrap(workspace: &str) -> String {
+    let workspace = shell_word(workspace);
+    format!(
+        "set -eu; mkdir -p -- {workspace} {RUNTIME_MOUNT}; \
+         mount -t ext4 -o ro {RUNTIME_DEVICE} {RUNTIME_MOUNT}; \
+         exec {RUNTIME_EXECUTABLE} {workspace}"
+    )
+}
+
+fn shell_word(value: &str) -> String {
+    let mut quoted = String::with_capacity(value.len().saturating_add(2));
+    quoted.push('\'');
+    for character in value.chars() {
+        if character == '\'' {
+            quoted.push_str("'\\''");
+        } else {
+            quoted.push(character);
+        }
+    }
+    quoted.push('\'');
+    quoted
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, os::unix::fs::PermissionsExt as _};
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn materializes_a_private_sparse_root_without_overwriting() {
+        let directory = tempdir().unwrap();
+        let source = directory.path().join("base.ext4");
+        let destination = directory.path().join("attempt/root.ext4");
+        let vmm = directory.path().join("vmm");
+        fs::write(&source, [0_u8; 4096]).unwrap();
+        fs::write(&vmm, b"vmm").unwrap();
+        fs::set_permissions(&vmm, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let builder = VmWorkspaceBuilder::private_from(&source, &destination, &vmm).unwrap();
+
+        assert_eq!(builder.rootfs, destination);
+        assert_eq!(fs::read(builder.rootfs).unwrap(), fs::read(source).unwrap());
+    }
+
+    #[tokio::test]
+    async fn rejects_relative_guest_workspace_before_process_start() {
+        let directory = tempdir().unwrap();
+        let root = directory.path().join("root");
+        let vmm = directory.path().join("vmm");
+        fs::create_dir(&root).unwrap();
+        fs::write(&vmm, b"vmm").unwrap();
+
+        let error = match VmWorkspace::builder(root, vmm)
+            .guest_workspace("relative")
+            .launch()
+            .await
+        {
+            Ok(_) => panic!("relative workspace unexpectedly launched"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(error, VmWorkspaceError::RelativeWorkspace(_)));
+    }
+}

--- a/crates/experimental/nanocodex-vm/src/workspace.rs
+++ b/crates/experimental/nanocodex-vm/src/workspace.rs
@@ -1,7 +1,9 @@
 use std::{
+    collections::BTreeMap,
     ffi::OsString,
     fs,
     path::{Path, PathBuf},
+    time::Duration,
 };
 
 use nanocodex_tools::ToolsBuilder;
@@ -9,10 +11,13 @@ use tokio::process::Command;
 
 use crate::{
     command::GuestCommand,
-    config::{BlockDevice, VmConfig},
+    config::{BlockDevice, Network, VmConfig},
     egress::EgressLease,
-    image::reflink_or_sparse_copy,
-    tools::{VmToolSession, VmToolSessionError, VmTools},
+    image::{host_resolver_configuration, reflink_or_sparse_copy},
+    tools::{
+        DEFAULT_SHUTDOWN_TIMEOUT, DEFAULT_STARTUP_TIMEOUT, VmToolSession, VmToolSessionError,
+        VmTools,
+    },
 };
 
 const DEFAULT_CPUS: u8 = 2;
@@ -38,9 +43,12 @@ pub struct VmWorkspaceBuilder {
     firmware_directory: Option<PathBuf>,
     workspace: String,
     shell: String,
+    environment: BTreeMap<String, String>,
     cpus: u8,
     memory_mib: u32,
     egress: EgressLease,
+    startup_timeout: Duration,
+    shutdown_timeout: Duration,
 }
 
 /// One retained VM and the standard workspace tools routed into it.
@@ -136,8 +144,9 @@ impl VmWorkspace {
     ///
     /// # Errors
     ///
-    /// Returns an error when clone-cheap sibling tool capabilities are still
-    /// alive or the guest/VMM does not complete its bounded shutdown.
+    /// Returns an error when clone-cheap sibling capabilities or owner-borrowed
+    /// requests are still alive, or the guest/VMM does not complete its
+    /// bounded shutdown.
     pub async fn shutdown(&self) -> Result<(), VmWorkspaceError> {
         self.session.shutdown().await?;
         Ok(())
@@ -156,9 +165,12 @@ impl VmWorkspaceBuilder {
             firmware_directory: None,
             workspace: DEFAULT_WORKSPACE.to_owned(),
             shell: DEFAULT_SHELL.to_owned(),
+            environment: BTreeMap::new(),
             cpus: DEFAULT_CPUS,
             memory_mib: DEFAULT_MEMORY_MIB,
             egress: EgressLease::internet(),
+            startup_timeout: DEFAULT_STARTUP_TIMEOUT,
+            shutdown_timeout: DEFAULT_SHUTDOWN_TIMEOUT,
         }
     }
 
@@ -237,6 +249,16 @@ impl VmWorkspaceBuilder {
         self
     }
 
+    /// Replaces the environment inherited by guest workspace commands.
+    ///
+    /// The egress lease is applied after this environment and therefore wins
+    /// when both provide the same name.
+    #[must_use]
+    pub fn environment(mut self, environment: impl IntoIterator<Item = (String, String)>) -> Self {
+        self.environment = environment.into_iter().collect();
+        self
+    }
+
     /// Sets the virtual CPU count.
     #[must_use]
     pub const fn cpus(mut self, cpus: u8) -> Self {
@@ -248,6 +270,20 @@ impl VmWorkspaceBuilder {
     #[must_use]
     pub const fn memory_mib(mut self, memory_mib: u32) -> Self {
         self.memory_mib = memory_mib;
+        self
+    }
+
+    /// Sets the complete deadline for guest readiness and egress provisioning.
+    #[must_use]
+    pub const fn startup_timeout(mut self, timeout: Duration) -> Self {
+        self.startup_timeout = timeout;
+        self
+    }
+
+    /// Sets the complete deadline for guest sync and VMM exit.
+    #[must_use]
+    pub const fn shutdown_timeout(mut self, timeout: Duration) -> Self {
+        self.shutdown_timeout = timeout;
         self
     }
 
@@ -289,7 +325,12 @@ impl VmWorkspaceBuilder {
         }
 
         let ext4 = self.rootfs.is_file();
-        let (config, guest) = if ext4 {
+        let resolver = if ext4 && matches!(self.egress.network(), Network::Internet) {
+            Some(host_resolver_configuration()?)
+        } else {
+            None
+        };
+        let (config, mut guest) = if ext4 {
             let runtime = self
                 .guest_runtime_disk
                 .ok_or(VmWorkspaceError::MissingGuestRuntime)?;
@@ -305,7 +346,7 @@ impl VmWorkspaceBuilder {
                 .block_device(BlockDevice::read_only(RUNTIME_BLOCK_ID, runtime));
             let guest = GuestCommand::new("/bin/sh")
                 .arg("-c")
-                .arg(ext4_bootstrap(&self.workspace));
+                .arg(ext4_bootstrap(&self.workspace, resolver.as_deref()));
             (config, guest)
         } else if self.rootfs.is_dir() {
             let runtime = self.rootfs.join("usr/local/bin/nanocodex-vm-guest");
@@ -327,6 +368,9 @@ impl VmWorkspaceBuilder {
                 reason: "private root is neither a raw ext4 image nor a directory",
             });
         };
+        for (name, value) in &self.environment {
+            guest = guest.env(name, value);
+        }
 
         let mut command = Command::new(&self.vmm_executable);
         command.args(self.vmm_arguments);
@@ -356,7 +400,15 @@ impl VmWorkspaceBuilder {
             }
         }
 
-        let session = VmToolSession::spawn_configured(command, config, guest, self.egress).await?;
+        let session = VmToolSession::spawn_configured_with_timeouts(
+            command,
+            config,
+            guest,
+            self.egress,
+            self.startup_timeout,
+            self.shutdown_timeout,
+        )
+        .await?;
         Ok(VmWorkspace {
             session,
             rootfs: self.rootfs,
@@ -366,13 +418,21 @@ impl VmWorkspaceBuilder {
     }
 }
 
-fn ext4_bootstrap(workspace: &str) -> String {
+fn ext4_bootstrap(workspace: &str, resolver: Option<&str>) -> String {
     let workspace = shell_word(workspace);
+    let resolver = resolver_bootstrap(resolver);
     format!(
-        "set -eu; mkdir -p -- {workspace} {RUNTIME_MOUNT}; \
+        "set -eu; {resolver}mkdir -p -- {workspace} {RUNTIME_MOUNT}; \
          mount -t ext4 -o ro {RUNTIME_DEVICE} {RUNTIME_MOUNT}; \
          exec {RUNTIME_EXECUTABLE} {workspace}"
     )
+}
+
+fn resolver_bootstrap(resolver: Option<&str>) -> String {
+    resolver.map_or_else(String::new, |resolver| {
+        let resolver = shell_word(&resolver.replace("\\n", "\n"));
+        format!("rm -f /etc/resolv.conf; printf '%s' {resolver} > /etc/resolv.conf; ")
+    })
 }
 
 fn shell_word(value: &str) -> String {
@@ -411,6 +471,28 @@ mod tests {
 
         assert_eq!(builder.rootfs, destination);
         assert_eq!(fs::read(builder.rootfs).unwrap(), fs::read(source).unwrap());
+    }
+
+    #[test]
+    fn resolver_injection_is_limited_to_private_ext4_roots() {
+        let resolver = "nameserver 192.0.2.1\\n";
+        let ext4 = ext4_bootstrap("/workspace", Some(resolver));
+        let offline = ext4_bootstrap("/workspace", None);
+
+        assert!(ext4.contains("192.0.2.1"));
+        assert!(ext4.contains("> /etc/resolv.conf"));
+        assert!(!offline.contains("resolv.conf"));
+    }
+
+    #[test]
+    fn builder_retains_explicit_image_environment() {
+        let builder = VmWorkspaceBuilder::new("/root.ext4", "/vmm").environment([
+            ("LANG".to_owned(), "C.UTF-8".to_owned()),
+            ("APP_MODE".to_owned(), "test".to_owned()),
+        ]);
+
+        assert_eq!(builder.environment["LANG"], "C.UTF-8");
+        assert_eq!(builder.environment["APP_MODE"], "test");
     }
 
     #[tokio::test]

--- a/crates/experimental/nanocodex-vm/tests/image_live_build.rs
+++ b/crates/experimental/nanocodex-vm/tests/image_live_build.rs
@@ -2,7 +2,8 @@ use std::{fs, path::PathBuf};
 
 use arcbox_ext4::Reader;
 use nanocodex_vm::{
-    image::{CachePolicy, VmImageBuilder},
+    host::EgressLease,
+    image::{CachePolicy, DiskStatus, VmImageBuilder},
     tools::GuestRuntimeDisk,
 };
 
@@ -20,14 +21,28 @@ async fn run_instruction_uses_the_public_private_config_vmm_contract() {
     let context = tempfile::tempdir().expect("build context");
     fs::write(
         context.path().join("Dockerfile"),
-        "FROM alpine:3.24\nRUN printf nanocodex-vm-image-live > /nanocodex-vm-image-proof\nWORKDIR /workspace\n",
+        concat!(
+            "FROM alpine:3.24\n",
+            "RUN printf nanocodex-vm-image-live > /nanocodex-vm-image-proof && ",
+            "printf %s \"$NANOCODEX_BUILD_EGRESS_PROOF\" > /nanocodex-vm-egress-proof\n",
+            "WORKDIR /workspace\n",
+        ),
     )
     .expect("Dockerfile");
 
-    let image = VmImageBuilder::new(vmm, runtime.path())
+    let mut egress = EgressLease::internet();
+    egress
+        .insert_environment("NANOCODEX_BUILD_EGRESS_PROOF", "inherited-by-run")
+        .expect("build egress environment");
+    egress
+        .set_build_cache_scope("image-live-build-egress-v1")
+        .expect("build egress cache scope");
+    let builder = VmImageBuilder::new(vmm, runtime.path())
         .firmware_directory(firmware)
-        .vmm_arg("--vmm")
-        .prepare(context.path(), DISK_BYTES, cache, CachePolicy::Reuse)
+        .egress(egress)
+        .vmm_arg("--vmm");
+    let image = builder
+        .prepare(context.path(), DISK_BYTES, &cache, CachePolicy::Reuse)
         .await
         .expect("prepared image");
 
@@ -37,7 +52,23 @@ async fn run_instruction_uses_the_public_private_config_vmm_contract() {
             .expect("proof file"),
         b"nanocodex-vm-image-live"
     );
+    assert_eq!(
+        disk.read_file("/nanocodex-vm-egress-proof", 0, Some(64))
+            .expect("egress proof file"),
+        b"inherited-by-run"
+    );
+    assert!(
+        !disk.exists("/run/nanocodex-build-resolver"),
+        "build-only resolver state must not persist in the prepared image"
+    );
     assert_eq!(image.workdir(), "/workspace");
+
+    let warm = builder
+        .prepare(context.path(), DISK_BYTES, &cache, CachePolicy::Reuse)
+        .await
+        .expect("warm prepared image");
+    assert_eq!(warm.disk_status(), DiskStatus::Hit);
+    assert_eq!(warm.path(), image.path());
 }
 
 fn required_path(name: &str) -> PathBuf {

--- a/crates/experimental/nanocodex-vm/tests/image_live_build.rs
+++ b/crates/experimental/nanocodex-vm/tests/image_live_build.rs
@@ -1,0 +1,48 @@
+use std::{fs, path::PathBuf};
+
+use arcbox_ext4::Reader;
+use nanocodex_vm::{
+    image::{CachePolicy, VmImageBuilder},
+    tools::GuestRuntimeDisk,
+};
+
+const DISK_BYTES: u64 = 512 * 1024 * 1024;
+
+#[tokio::test]
+#[ignore = "requires a signed libkrun VMM, firmware, current guest ELF, and OCI cache"]
+async fn run_instruction_uses_the_public_private_config_vmm_contract() {
+    let vmm = required_path("NANOCODEX_VM_IMAGE_VMM");
+    let guest = required_path("NANOCODEX_VM_IMAGE_RUNTIME");
+    let firmware = required_path("NANOCODEX_VM_IMAGE_FIRMWARE");
+    let cache = required_path("NANOCODEX_VM_IMAGE_CACHE");
+    let runtime =
+        GuestRuntimeDisk::prepare(guest, &cache).expect("content-addressed guest runtime disk");
+    let context = tempfile::tempdir().expect("build context");
+    fs::write(
+        context.path().join("Dockerfile"),
+        "FROM alpine:3.24\nRUN printf nanocodex-vm-image-live > /nanocodex-vm-image-proof\nWORKDIR /workspace\n",
+    )
+    .expect("Dockerfile");
+
+    let image = VmImageBuilder::new(vmm, runtime.path())
+        .firmware_directory(firmware)
+        .vmm_arg("--vmm")
+        .prepare(context.path(), DISK_BYTES, cache, CachePolicy::Reuse)
+        .await
+        .expect("prepared image");
+
+    let mut disk = Reader::new(image.path()).expect("prepared ext4");
+    assert_eq!(
+        disk.read_file("/nanocodex-vm-image-proof", 0, Some(64))
+            .expect("proof file"),
+        b"nanocodex-vm-image-live"
+    );
+    assert_eq!(image.workdir(), "/workspace");
+}
+
+fn required_path(name: &str) -> PathBuf {
+    std::env::var_os(name).map_or_else(
+        || panic!("{name} must name an existing live-test input"),
+        PathBuf::from,
+    )
+}

--- a/crates/nanocodex-oai-api/CONTRACTS.md
+++ b/crates/nanocodex-oai-api/CONTRACTS.md
@@ -1,0 +1,20 @@
+# Nanocodex OpenAI API contracts
+
+Dependency-light prompt, response-item, and tool contracts shared by
+Nanocodex process companions.
+
+This is the crate documentation produced when the default `client` feature is
+disabled. It contains no authentication, managed session, Tower service,
+network transport, telemetry, or pricing implementation. Normal applications
+should use the default features and the complete client API documented in the
+package README.
+
+[`Prompt`], [`Thinking`], [`ReasoningMode`], and [`ImageDetail`] define shared
+input policy. [`responses`] contains provider response events, items, content,
+and tool definitions. [`tools`] contains model-visible tool inputs, outputs,
+contexts, and the lossless process-boundary representation used by
+`nanocodex-tools`.
+
+The contract-only surface exists so a static companion such as
+`nanocodex-vm-guest` can reuse the exact same types without linking an unused
+OpenAI client. It is not an alternate provider or transport implementation.

--- a/crates/nanocodex-oai-api/Cargo.toml
+++ b/crates/nanocodex-oai-api/Cargo.toml
@@ -17,6 +17,17 @@ description = "Tower-native OpenAI Responses API and managed context for Nanocod
 all-features = true
 rustdoc-args = ["-D", "warnings"]
 
+[features]
+default = ["client"]
+client = [
+    "dep:base64",
+    "dep:getrandom",
+    "dep:reqwest",
+    "dep:sha2",
+    "dep:tokio-tungstenite",
+    "dep:url",
+]
+
 [dependencies]
 async-trait.workspace = true
 futures-util.workspace = true
@@ -32,13 +43,13 @@ uuid.workspace = true
 web-time.workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-base64.workspace = true
-getrandom.workspace = true
-reqwest.workspace = true
-sha2.workspace = true
+base64 = { workspace = true, optional = true }
+getrandom = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["io-util", "macros", "net", "rt", "sync", "time"] }
-tokio-tungstenite.workspace = true
-url.workspace = true
+tokio-tungstenite = { workspace = true, optional = true }
+url = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion.workspace = true
@@ -51,14 +62,22 @@ tracing-subscriber.workspace = true
 [[bench]]
 name = "fork_history"
 harness = false
+required-features = ["client"]
 
 [[bench]]
 name = "tower_responses"
 harness = false
+required-features = ["client"]
 
 [[bench]]
 name = "session_lifecycle"
 harness = false
+required-features = ["client"]
+
+[[test]]
+name = "it"
+path = "tests/it/main.rs"
+required-features = ["client"]
 
 [lints]
 workspace = true

--- a/crates/nanocodex-oai-api/README.md
+++ b/crates/nanocodex-oai-api/README.md
@@ -134,6 +134,15 @@ The higher-level `nanocodex-agent` crate decides *when* to compact and how to
 execute tools. This crate implements the provider operation and atomic history
 replacement without embedding agent policy.
 
+## Contract-only builds
+
+The default `client` feature remains the complete OpenAI boundary, including
+authentication, managed sessions, Tower services, transports, telemetry, and
+pricing. Process companions that only need the dependency-light prompt,
+response-item, and tool wire contracts may disable default features. This
+keeps one canonical contract without linking an unused network client; it does
+not create an alternate provider or transport implementation.
+
 ## Tools and managed sessions
 
 The [`tools`] module defines the model-visible tool contract shared with

--- a/crates/nanocodex-oai-api/src/lib.rs
+++ b/crates/nanocodex-oai-api/src/lib.rs
@@ -1,4 +1,5 @@
-#![doc = include_str!("../README.md")]
+#![cfg_attr(feature = "client", doc = include_str!("../README.md"))]
+#![cfg_attr(not(feature = "client"), doc = include_str!("../CONTRACTS.md"))]
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
@@ -8,60 +9,84 @@ compile_error!(
 );
 
 /// Authentication sources and managed credential snapshots.
+#[cfg(feature = "client")]
 pub mod auth;
 /// Complete typed lifecycle events emitted around Responses operations.
+#[cfg(feature = "client")]
 pub mod events;
+#[cfg(feature = "client")]
 mod openai;
 /// Automatic `gpt-5.6-sol` USD estimates from provider token usage.
+#[cfg(feature = "client")]
 pub mod pricing;
 /// Complete typed request, event, and item model for the Responses protocol.
 pub mod responses;
 /// Managed session identities, inputs, and compaction results.
+#[cfg(feature = "client")]
 pub mod session;
 /// Tool contracts shared by agent loops and concrete tool runtimes.
 pub mod tools;
 /// Generic Tower attempt, service, retry, and streamed-output contracts.
+#[cfg(feature = "client")]
 pub mod tower;
 /// Responses transport policy, errors, and connection statistics.
+#[cfg(feature = "client")]
 pub mod transport;
 
 use std::{fmt, path::PathBuf, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "client")]
 pub(crate) use auth::{OpenAiAuth, OpenAiAuthError, OpenAiAuthMode, OpenAiAuthSnapshot};
+#[cfg(feature = "client")]
 pub(crate) use events::stream::EventSink;
+#[cfg(feature = "client")]
 pub(crate) use events::{
     AgentEventData, AgentEventKind, AssistantEvent, ContextEvent, EventError, ModelEvent,
     ReasoningEvent, RunEvent, ToolEvent, TransportEvent, monotonic_now_ns,
 };
+#[cfg(feature = "client")]
 pub(crate) use openai::ModelConfig;
+#[cfg(feature = "client")]
 pub use openai::{OpenAi, OpenAiBuilder, OpenAiError};
+#[cfg(feature = "client")]
 pub(crate) use pricing::{CostStatus, EstimatedUsdCost};
 pub use responses::ResponseEvent;
+pub(crate) use responses::ResponseItem;
+#[cfg(feature = "client")]
 pub(crate) use responses::{
     ContentItem, FunctionOutputBody, FunctionOutputContent, MessagePhase, MessageRole,
-    ResponseItem, ResponseItemId, ToolDefinition, Usage,
+    ResponseItemId, ToolDefinition, Usage,
 };
+#[cfg(feature = "client")]
 pub use session::{
     CompletedResponse, Response, ResponseError, ResponseErrorKind, ResponseTurn, Session,
     SessionBuildError, SessionBuilder,
 };
+#[cfg(feature = "client")]
 pub(crate) use tools::ToolOutputBody;
+#[cfg(feature = "client")]
 pub(crate) use tower::attempt::{
     ResponsesAttempt, ResponsesAttemptFactory, ResponsesOutput, ResponsesServiceResponse,
     TransportStats,
 };
+#[cfg(feature = "client")]
 pub(crate) use tower::service::ResponsesService;
+#[cfg(feature = "client")]
 pub(crate) use tower::{
     DefaultResponsesService, ResponsesClient, ResponsesRetryPolicy, ResponsesServiceError,
 };
+#[cfg(feature = "client")]
 pub(crate) use transport::EncodedRequest;
+#[cfg(feature = "client")]
 pub(crate) use transport::{ResponsesError, ResponsesHistory, ResponsesTransport, RetryAdvice};
 
+#[cfg(feature = "client")]
 pub(crate) use tower::{attempt, middleware, service, service_error, stream};
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(feature = "client", not(target_family = "wasm")))]
 pub(crate) use transport::{connector, http};
+#[cfg(feature = "client")]
 pub(crate) use transport::{socket, telemetry};
 
 /// Internal bridge for the higher-level `nanocodex-agent` crate.
@@ -71,6 +96,7 @@ pub(crate) use transport::{socket, telemetry};
 /// the normal rustdoc surface while allowing the separately versioned agent
 /// crate to compose this crate without duplicating those mechanics.
 #[doc(hidden)]
+#[cfg(feature = "client")]
 pub mod __private {
     pub use crate::{
         events::stream::EventSink,
@@ -338,6 +364,7 @@ impl ReasoningMode {
         }
     }
 
+    #[cfg(feature = "client")]
     pub(crate) const fn request_value(self) -> Option<&'static str> {
         match self {
             Self::Standard => None,

--- a/crates/nanocodex-oai-api/src/responses/event.rs
+++ b/crates/nanocodex-oai-api/src/responses/event.rs
@@ -167,6 +167,7 @@ pub enum ResponseEvent {
 }
 
 impl ServerEvent {
+    #[cfg(feature = "client")]
     pub(crate) fn normalized(&self) -> Option<ResponseEvent> {
         match self {
             Self::Created { .. } => Some(ResponseEvent::Created),
@@ -281,7 +282,7 @@ fn completed_status() -> String {
     "completed".to_owned()
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "client"))]
 mod tests {
     use serde_json::json;
 

--- a/crates/nanocodex-oai-api/src/responses/mod.rs
+++ b/crates/nanocodex-oai-api/src/responses/mod.rs
@@ -3,6 +3,7 @@
 mod content;
 mod event;
 mod item;
+#[cfg(feature = "client")]
 mod request;
 mod tool;
 
@@ -17,6 +18,8 @@ pub use event::{
     WarmupResponse, WarmupServerEvent,
 };
 pub use item::{ResponseItem, ResponseItemId};
+#[cfg(feature = "client")]
 pub(crate) use request::{CreatePolicy, ResponseCreate};
+#[cfg(feature = "client")]
 pub use request::{RequestProfile, ResponseHistory, ResponsesInput};
 pub use tool::{CustomToolFormat, JsonSchema, JsonValue, ToolDefinition};

--- a/crates/nanocodex-tools/Cargo.toml
+++ b/crates/nanocodex-tools/Cargo.toml
@@ -17,48 +17,84 @@ description = "Code Mode and heterogeneous tool runtime for Nanocodex"
 all-features = true
 rustdoc-args = ["-D", "warnings"]
 
+[features]
+default = ["native"]
+workspace-runtime = [
+    "dep:async-trait",
+    "dep:base64",
+    "dep:getrandom",
+    "dep:portable-pty",
+    "dep:schemars",
+    "dep:thiserror",
+    "dep:tokio",
+    "dep:nix",
+]
+native = [
+    "workspace-runtime",
+    "nanocodex-oai-api/client",
+    "dep:bm25",
+    "dep:futures-util",
+    "dep:http",
+    "dep:image",
+    "dep:oauth2",
+    "dep:nanocodex-tools-macros",
+    "dep:reqwest",
+    "dep:rquickjs",
+    "dep:rmcp",
+    "dep:sha1",
+    "dep:tokio-util",
+]
+
 [dependencies]
-nanocodex-oai-api.workspace = true
+nanocodex-oai-api = { path = "../nanocodex-oai-api", version = "0.3.0", default-features = false }
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-async-trait.workspace = true
-base64.workspace = true
-bm25.workspace = true
-futures-util.workspace = true
-getrandom.workspace = true
-http.workspace = true
-image.workspace = true
-oauth2.workspace = true
-nanocodex-tools-macros.workspace = true
-portable-pty.workspace = true
-reqwest.workspace = true
-rquickjs.workspace = true
-rmcp.workspace = true
-schemars.workspace = true
-sha1.workspace = true
-thiserror.workspace = true
-tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "process", "rt", "sync", "time"] }
-tokio-util.workspace = true
+async-trait = { workspace = true, optional = true }
+base64 = { workspace = true, optional = true }
+bm25 = { workspace = true, optional = true }
+futures-util = { workspace = true, optional = true }
+getrandom = { workspace = true, optional = true }
+http = { workspace = true, optional = true }
+image = { workspace = true, optional = true }
+oauth2 = { workspace = true, optional = true }
+nanocodex-tools-macros = { workspace = true, optional = true }
+portable-pty = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true }
+rquickjs = { workspace = true, optional = true }
+rmcp = { workspace = true, optional = true }
+schemars = { workspace = true, optional = true }
+sha1 = { workspace = true, optional = true }
+thiserror = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "process", "rt", "sync", "time"], optional = true }
+tokio-util = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
-nix.workspace = true
+nix = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion.workspace = true
 eyre.workspace = true
 futures-util.workspace = true
+tempfile.workspace = true
 tracing-subscriber.workspace = true
 
 [[bench]]
 name = "mcp_tool_search"
 harness = false
+required-features = ["native"]
 
 [[bench]]
 name = "tool_process_output"
 harness = false
+required-features = ["native"]
+
+[[test]]
+name = "it"
+path = "tests/it/main.rs"
+required-features = ["native"]
 
 [lints]
 workspace = true

--- a/crates/nanocodex-tools/README.md
+++ b/crates/nanocodex-tools/README.md
@@ -119,6 +119,18 @@ the provider-native `tool_search` initially. Search results contain loadable MCP
 namespaces for direct model calls and also activate the matching definitions for
 Code Mode, keeping large catalogs out of the initial tool list.
 
+## Companion workspace runtimes
+
+The default `native` feature remains the complete tools crate: registry, Code
+Mode, MCP, web/image tools, macros, and standard workspace tools.
+
+The narrower `workspace-runtime` feature exists only for process companions
+such as `nanocodex-vm-guest`. With default features disabled, it exposes the
+canonical [`workspace_runtime::WorkspaceToolRuntime`], standard tool
+identities, and their shared contracts without linking OpenAI transports, Code
+Mode/QuickJS, MCP, or HTTP clients. This is artifact separation, not a second
+tool implementation or an alternate mode for normal native applications.
+
 ## Going lower level
 
 The crate root intentionally contains only the normal registry path:
@@ -135,4 +147,6 @@ types required by the `Tool` methods.
   and runtime control.
 - `standard` contains reusable standard-tool identities and the host-owned
   plan implementation.
+- [`workspace_runtime`] contains the retained canonical workspace-tool runtime
+  used by process companions.
 - [`image`] contains prompt-image preparation and tool-output normalization.

--- a/crates/nanocodex-tools/WORKSPACE_RUNTIME.md
+++ b/crates/nanocodex-tools/WORKSPACE_RUNTIME.md
@@ -1,0 +1,21 @@
+# Nanocodex workspace runtime
+
+Canonical retained workspace tools for constrained process companions.
+
+This is the crate documentation produced with `workspace-runtime` and without
+the default `native` feature. [`workspace_runtime::WorkspaceToolRuntime`]
+executes `exec_command`, `write_stdin`, `apply_patch`, and `view_image` through
+the same handlers used by the normal Nanocodex tools registry. Interactive
+shell sessions remain alive for the lifetime of the runtime, and
+[`workspace_runtime::WorkspaceToolRuntimeControl`] explicitly terminates their
+process groups and descendants.
+
+[`standard`] contains the stable tool identities and definitions. [`contract`]
+and the crate-root [`Tool`], [`ToolContext`], [`ToolInput`], [`ToolOutput`], and
+[`ToolResult`] types are the shared model-visible contract.
+
+This artifact deliberately excludes the agent-facing registry, Code Mode and
+QuickJS, MCP, macros, web/image generation clients, and OpenAI transport. It
+exists to build small static companions such as `nanocodex-vm-guest`; it is not
+a second tool implementation or an alternate mode for normal native
+applications.

--- a/crates/nanocodex-tools/src/apply_patch/mod.rs
+++ b/crates/nanocodex-tools/src/apply_patch/mod.rs
@@ -14,12 +14,12 @@ mod streaming_parser;
 
 use parser::{Hunk, UpdateFileChunk, parse_patch};
 
-pub(super) struct ApplyPatchHandler {
+pub(crate) struct ApplyPatchHandler {
     workspace: PathBuf,
 }
 
 impl ApplyPatchHandler {
-    pub(super) const fn new(workspace: PathBuf) -> Self {
+    pub(crate) const fn new(workspace: PathBuf) -> Self {
         Self { workspace }
     }
 }

--- a/crates/nanocodex-tools/src/image/mod.rs
+++ b/crates/nanocodex-tools/src/image/mod.rs
@@ -703,6 +703,25 @@ mod tests {
     }
 
     #[test]
+    fn converts_bitmap_to_supported_png() {
+        let image = RgbaImage::from_pixel(1, 1, Rgba([10, 20, 30, 255]));
+        let mut encoded = Cursor::new(Vec::new());
+        DynamicImage::ImageRgba8(image)
+            .write_to(&mut encoded, ImageFormat::Bmp)
+            .expect("encode bitmap fixture");
+
+        let image = load_for_prompt_bytes(
+            Path::new("tool-output.bmp"),
+            encoded.into_inner(),
+            HIGH_DETAIL_LIMITS,
+        )
+        .expect("decode bitmap");
+
+        assert_eq!(image.mime, "image/png");
+        assert!(image.bytes.starts_with(b"\x89PNG\r\n\x1a\n"));
+    }
+
+    #[test]
     fn data_url_input_guard_precedes_base64_decoding() {
         let error = decode_data_url("data:image/png;base64,AAAAA", 4)
             .expect_err("oversized representation should fail");

--- a/crates/nanocodex-tools/src/lib.rs
+++ b/crates/nanocodex-tools/src/lib.rs
@@ -1,41 +1,54 @@
-#![doc = include_str!("../README.md")]
+#![cfg_attr(feature = "native", doc = include_str!("../README.md"))]
+#![cfg_attr(
+    all(not(feature = "native"), feature = "workspace-runtime"),
+    doc = include_str!("../WORKSPACE_RUNTIME.md")
+)]
+#![cfg_attr(
+    not(any(feature = "native", feature = "workspace-runtime")),
+    doc = "Dependency-light model-visible tool contracts for Nanocodex."
+)]
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(target_family = "wasm", allow(clippy::module_name_repetitions))]
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "workspace-runtime"))]
 mod apply_patch;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "native"))]
 #[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
 pub mod code_mode;
+#[cfg(feature = "native")]
 pub mod hosted;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "native"))]
 #[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
 pub mod image;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "native"))]
 mod image_generation;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "native"))]
 #[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
 pub mod mcp;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "native"))]
 mod plan;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "native"))]
 #[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
 pub mod runtime;
+#[cfg(feature = "native")]
 mod runtime_config;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "workspace-runtime"))]
 mod shell;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "workspace-runtime"))]
 #[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
 pub mod standard;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "workspace-runtime"))]
 mod view_image;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "native"))]
 mod web_search;
+#[cfg(all(not(target_family = "wasm"), feature = "workspace-runtime"))]
+#[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
+pub mod workspace_runtime;
 
 /// Model-visible tool definitions, inputs, outputs, and execution contracts.
 pub mod contract {
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(all(not(target_family = "wasm"), feature = "workspace-runtime"))]
     #[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
     pub use async_trait::async_trait;
     pub use nanocodex_oai_api::tools::{
@@ -45,7 +58,7 @@ pub mod contract {
     };
 }
 
-#[cfg(target_family = "wasm")]
+#[cfg(all(target_family = "wasm", feature = "native"))]
 /// Code Mode results and observation contracts for the host-backed WASM runtime.
 pub mod code_mode {
     pub use crate::hosted::{
@@ -53,14 +66,14 @@ pub mod code_mode {
     };
 }
 
-#[cfg(target_family = "wasm")]
+#[cfg(all(target_family = "wasm", feature = "native"))]
 /// Image input and output preparation for the host-backed WASM runtime.
 pub mod image {
     pub use crate::hosted::{prepare_output_images, prepare_user_input};
     pub use nanocodex_oai_api::ImageDetail;
 }
 
-#[cfg(target_family = "wasm")]
+#[cfg(all(target_family = "wasm", feature = "native"))]
 /// Host-backed tool selection and execution runtime.
 pub mod runtime {
     pub use crate::{
@@ -72,38 +85,42 @@ pub mod runtime {
     };
 }
 
+#[cfg(all(not(target_family = "wasm"), feature = "native"))]
+pub(crate) use contract::ToolOutputBody;
+#[cfg(all(not(target_family = "wasm"), feature = "workspace-runtime"))]
+pub(crate) use contract::ToolOutputContent;
 pub use contract::{Tool, ToolContext, ToolDefinition, ToolInput, ToolOutput, ToolResult};
-#[cfg(not(target_family = "wasm"))]
-pub(crate) use contract::{ToolOutputBody, ToolOutputContent};
-#[cfg(not(target_family = "wasm"))]
-pub(crate) use image::ImageDetail;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "workspace-runtime"))]
+pub(crate) use nanocodex_oai_api::ImageDetail;
+#[cfg(all(not(target_family = "wasm"), feature = "native"))]
 #[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
 pub use nanocodex_tools_macros::tool;
+#[cfg(feature = "native")]
 pub use runtime::Tools;
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "native"))]
 pub(crate) use runtime::{DynamicToolProvider, ImageGenerationConfig, WebSearchConfig};
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "native"))]
 #[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
 pub use runtime::{ToolsBuildError, ToolsBuilder};
-#[cfg(not(target_family = "wasm"))]
+#[cfg(all(not(target_family = "wasm"), feature = "workspace-runtime"))]
 pub(crate) use standard::StandardTool;
 
 #[doc(hidden)]
 pub mod __private {
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(all(not(target_family = "wasm"), feature = "workspace-runtime"))]
     pub use async_trait::async_trait;
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(all(not(target_family = "wasm"), feature = "workspace-runtime"))]
     pub use schemars;
     #[cfg(not(target_family = "wasm"))]
     pub use serde;
 
+    #[cfg(all(not(target_family = "wasm"), feature = "native"))]
+    pub use crate::runtime::schema_for;
     #[cfg(not(target_family = "wasm"))]
-    pub use crate::{
-        Tool, ToolContext, ToolDefinition, ToolInput, ToolOutput, ToolResult, runtime::schema_for,
-    };
+    pub use crate::{Tool, ToolContext, ToolDefinition, ToolInput, ToolOutput, ToolResult};
 
     /// Builds the direct Responses tool prefix and the nested Code Mode name map together.
+    #[cfg(feature = "native")]
     pub fn model_contract(
         runtime: &crate::runtime::ToolRuntime,
         session_id: &str,

--- a/crates/nanocodex-tools/src/shell/mod.rs
+++ b/crates/nanocodex-tools/src/shell/mod.rs
@@ -3,6 +3,7 @@ mod process;
 mod selection;
 mod tool;
 
+#[cfg(feature = "native")]
 pub(crate) use process::ProcessGroupGuard;
 pub(crate) use tool::{ExecCommandHandler, WriteStdinHandler};
 
@@ -130,6 +131,7 @@ impl ShellSessions {
         }
     }
 
+    #[cfg(feature = "native")]
     pub(crate) const fn default_shell_name(&self) -> &'static str {
         self.default_shell.name()
     }
@@ -260,6 +262,7 @@ impl ShellSessions {
         }
     }
 
+    #[cfg(feature = "native")]
     pub(crate) async fn terminate_turn(&self, turn_id: u64) {
         let sessions = {
             let mut store = self.sessions.lock().await;

--- a/crates/nanocodex-tools/src/shell/selection.rs
+++ b/crates/nanocodex-tools/src/shell/selection.rs
@@ -29,6 +29,7 @@ impl Shell {
         &self.path
     }
 
+    #[cfg(feature = "native")]
     pub(super) const fn name(&self) -> &'static str {
         match self.shell_type {
             ShellType::Zsh => "zsh",

--- a/crates/nanocodex-tools/src/standard.rs
+++ b/crates/nanocodex-tools/src/standard.rs
@@ -4,6 +4,7 @@ use nanocodex_oai_api::{responses::CustomToolFormat, tools::ToolDefinition};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
+#[cfg(feature = "native")]
 pub use crate::plan::UpdatePlanTool;
 
 const APPLY_PATCH_GRAMMAR: &str = include_str!("apply_patch/apply_patch.lark");

--- a/crates/nanocodex-tools/src/view_image.rs
+++ b/crates/nanocodex-tools/src/view_image.rs
@@ -4,19 +4,31 @@ use base64::{Engine, engine::general_purpose::STANDARD};
 use nanocodex_oai_api::tools::ToolDefinition;
 use serde::Deserialize;
 use serde_json::json;
+use tokio::io::{AsyncRead, AsyncReadExt};
 
 use super::{
     ImageDetail, StandardTool, Tool, ToolContext, ToolInput, ToolOutput, ToolOutputContent,
     ToolResult,
 };
 
-pub(super) struct ViewImageHandler {
+pub(crate) struct ViewImageHandler {
     workspace: PathBuf,
+    max_wire_bytes: Option<u64>,
 }
 
 impl ViewImageHandler {
-    pub(super) const fn new(workspace: PathBuf) -> Self {
-        Self { workspace }
+    pub(crate) const fn new(workspace: PathBuf) -> Self {
+        Self {
+            workspace,
+            max_wire_bytes: None,
+        }
+    }
+
+    pub(crate) const fn with_wire_limit(workspace: PathBuf, max_wire_bytes: u64) -> Self {
+        Self {
+            workspace,
+            max_wire_bytes: Some(max_wire_bytes),
+        }
     }
 }
 
@@ -42,8 +54,17 @@ impl Tool for ViewImageHandler {
             }
         };
         let path = resolve(&self.workspace, Path::new(&arguments.path));
-        match tokio::fs::metadata(&path).await {
-            Ok(metadata) if metadata.is_file() => {}
+        let mut file = match tokio::fs::File::open(&path).await {
+            Ok(file) => file,
+            Err(error) => {
+                return Ok(ToolOutput::error(format!(
+                    "unable to locate image at `{}`: {error}",
+                    path.display()
+                )));
+            }
+        };
+        let metadata = match file.metadata().await {
+            Ok(metadata) if metadata.is_file() => metadata,
             Ok(_) => {
                 return Ok(ToolOutput::error(format!(
                     "image path `{}` is not a file",
@@ -56,14 +77,27 @@ impl Tool for ViewImageHandler {
                     path.display()
                 )));
             }
-        }
-        let bytes = match tokio::fs::read(&path).await {
-            Ok(bytes) => bytes,
-            Err(error) => {
-                return Ok(ToolOutput::error(format!(
-                    "unable to read image at `{}`: {error}",
-                    path.display()
-                )));
+        };
+        let bytes = match self.max_wire_bytes {
+            Some(max_wire_bytes) => {
+                let max_raw_bytes = max_raw_bytes(max_wire_bytes);
+                if metadata.len() > max_raw_bytes {
+                    return Ok(oversized_image_error(&path, metadata.len(), max_wire_bytes));
+                }
+                match read_bounded(&mut file, metadata.len(), max_raw_bytes).await {
+                    Ok(BoundedRead::Complete(bytes)) => bytes,
+                    Ok(BoundedRead::TooLarge) => {
+                        return Ok(growing_image_error(&path, max_raw_bytes, max_wire_bytes));
+                    }
+                    Err(error) => return Ok(read_error(&path, error)),
+                }
+            }
+            None => {
+                let mut bytes = Vec::new();
+                match file.read_to_end(&mut bytes).await {
+                    Ok(_) => bytes,
+                    Err(error) => return Ok(read_error(&path, error)),
+                }
             }
         };
         // The model-history boundary owns image validation, resizing, and caching.
@@ -82,6 +116,88 @@ impl Tool for ViewImageHandler {
     }
 }
 
+const DATA_URL_PREFIX_BYTES: u64 = 37;
+const VIEW_IMAGE_WIRE_COPIES: u64 = 2;
+const VIEW_IMAGE_WIRE_HEADROOM_BYTES: u64 = 4 * 1024;
+const INITIAL_IMAGE_READ_CAPACITY_BYTES: u64 = 64 * 1024;
+
+fn max_raw_bytes(max_wire_bytes: u64) -> u64 {
+    let fixed_bytes = DATA_URL_PREFIX_BYTES
+        .saturating_mul(VIEW_IMAGE_WIRE_COPIES)
+        .saturating_add(VIEW_IMAGE_WIRE_HEADROOM_BYTES);
+    max_wire_bytes
+        .saturating_sub(fixed_bytes)
+        .checked_div(VIEW_IMAGE_WIRE_COPIES)
+        .unwrap_or(0)
+        .checked_div(4)
+        .unwrap_or(0)
+        .saturating_mul(3)
+}
+
+fn estimated_wire_bytes(raw_bytes: u64) -> u64 {
+    raw_bytes
+        .div_ceil(3)
+        .checked_mul(4)
+        .and_then(|encoded| encoded.checked_add(DATA_URL_PREFIX_BYTES))
+        .and_then(|data_url| data_url.checked_mul(VIEW_IMAGE_WIRE_COPIES))
+        .and_then(|duplicated| duplicated.checked_add(VIEW_IMAGE_WIRE_HEADROOM_BYTES))
+        .unwrap_or(u64::MAX)
+}
+
+enum BoundedRead {
+    Complete(Vec<u8>),
+    TooLarge,
+}
+
+async fn read_bounded(
+    reader: &mut (impl AsyncRead + Unpin),
+    expected_bytes: u64,
+    max_raw_bytes: u64,
+) -> std::io::Result<BoundedRead> {
+    let read_limit = max_raw_bytes.saturating_add(1);
+    let initial_capacity = usize::try_from(
+        expected_bytes
+            .min(read_limit)
+            .min(INITIAL_IMAGE_READ_CAPACITY_BYTES),
+    )
+    .unwrap_or(0);
+    let mut bytes = Vec::with_capacity(initial_capacity);
+    reader.take(read_limit).read_to_end(&mut bytes).await?;
+    if u64::try_from(bytes.len()).unwrap_or(u64::MAX) > max_raw_bytes {
+        Ok(BoundedRead::TooLarge)
+    } else {
+        Ok(BoundedRead::Complete(bytes))
+    }
+}
+
+fn oversized_image_error(path: &Path, raw_bytes: u64, max_wire_bytes: u64) -> ToolOutput {
+    let estimated_wire_bytes = estimated_wire_bytes(raw_bytes);
+    ToolOutput::error(format!(
+        "image at `{}` is {raw_bytes} bytes and its VM transfer would require at least \
+         {estimated_wire_bytes} bytes, exceeding the {max_wire_bytes}-byte VM tool frame limit; \
+         resize or convert it to a compact PNG, JPEG, or WebP inside the VM (for example with \
+         ffmpeg or ImageMagick), then call view_image on the smaller file",
+        path.display(),
+    ))
+}
+
+fn growing_image_error(path: &Path, max_raw_bytes: u64, max_wire_bytes: u64) -> ToolOutput {
+    ToolOutput::error(format!(
+        "image at `{}` exceeded the {max_raw_bytes}-byte VM raw-image limit while it was read \
+         (the file may have grown), so its response cannot fit the {max_wire_bytes}-byte VM tool \
+         frame; resize or convert it to a compact PNG, JPEG, or WebP inside the VM (for example \
+         with ffmpeg or ImageMagick), then call view_image on the smaller file",
+        path.display(),
+    ))
+}
+
+fn read_error(path: &Path, error: std::io::Error) -> ToolOutput {
+    ToolOutput::error(format!(
+        "unable to read image at `{}`: {error}",
+        path.display()
+    ))
+}
+
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ViewImageArguments {
@@ -95,5 +211,112 @@ fn resolve(workspace: &Path, path: &Path) -> PathBuf {
         path.to_owned()
     } else {
         workspace.join(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs::{File, write},
+        io::Cursor,
+    };
+
+    use nanocodex_oai_api::tools::{ToolInput, ToolOutputBody};
+    use serde_json::{json, value::to_raw_value};
+    use tempfile::tempdir;
+
+    use super::*;
+
+    const VM_FRAME_BYTES: u64 = 64 * 1024 * 1024;
+    const PATH_TRACING_IMAGE_BYTES: u64 = 48_262_737;
+
+    #[tokio::test]
+    async fn vm_wire_limit_rejects_the_path_tracing_image_before_reading_it() {
+        let workspace = tempdir().unwrap();
+        let image = workspace.path().join("image.ppm");
+        File::create(&image)
+            .unwrap()
+            .set_len(PATH_TRACING_IMAGE_BYTES)
+            .unwrap();
+        let handler =
+            ViewImageHandler::with_wire_limit(workspace.path().to_owned(), VM_FRAME_BYTES);
+        let output = handler
+            .execute(
+                ToolInput::Function(
+                    to_raw_value(&json!({
+                        "path": image,
+                        "detail": "original",
+                    }))
+                    .unwrap(),
+                ),
+                ToolContext::new("model", "session", "call", &[], 10_000),
+            )
+            .await
+            .unwrap();
+
+        assert!(!output.success);
+        let ToolOutputBody::Text(error) = output.output else {
+            panic!("oversized VM image should return a bounded text error");
+        };
+        assert!(error.contains("48262737 bytes"));
+        assert!(error.contains("VM tool frame limit"));
+        assert!(error.contains("resize or convert"));
+        assert!(error.contains("PNG, JPEG, or WebP"));
+    }
+
+    #[tokio::test]
+    async fn bounded_reader_stops_at_raw_cap_plus_one_when_file_grows() {
+        const EXPECTED_BYTES: u64 = 3;
+        const MAX_RAW_BYTES: u64 = 1_024;
+
+        let mut grown_file = Cursor::new(vec![b'x'; 4_096]);
+        let result = read_bounded(&mut grown_file, EXPECTED_BYTES, MAX_RAW_BYTES)
+            .await
+            .unwrap();
+
+        assert!(matches!(result, BoundedRead::TooLarge));
+        assert_eq!(grown_file.position(), MAX_RAW_BYTES + 1);
+    }
+
+    #[tokio::test]
+    async fn bounded_vm_read_preserves_image_payload_and_detail() {
+        let workspace = tempdir().unwrap();
+        let image = workspace.path().join("small.png");
+        write(&image, [0, 1, 2]).unwrap();
+        let handler =
+            ViewImageHandler::with_wire_limit(workspace.path().to_owned(), VM_FRAME_BYTES);
+
+        let output = handler
+            .execute(
+                ToolInput::Function(
+                    to_raw_value(&json!({
+                        "path": image,
+                        "detail": "original",
+                    }))
+                    .unwrap(),
+                ),
+                ToolContext::new("model", "session", "call", &[], 10_000),
+            )
+            .await
+            .unwrap();
+
+        assert!(output.success);
+        let ToolOutputBody::Content(content) = output.output else {
+            panic!("view_image should preserve its multimodal output");
+        };
+        let [ToolOutputContent::InputImage { image_url, detail }] = content.as_slice() else {
+            panic!("view_image should return exactly one image");
+        };
+        assert_eq!(image_url, "data:application/octet-stream;base64,AAEC");
+        assert_eq!(*detail, ImageDetail::Original);
+    }
+
+    #[test]
+    fn wire_estimate_accounts_for_both_data_url_copies() {
+        assert_eq!(estimated_wire_bytes(PATH_TRACING_IMAGE_BYTES), 128_704_802);
+        assert!(estimated_wire_bytes(PATH_TRACING_IMAGE_BYTES) > VM_FRAME_BYTES);
+        let max_raw_bytes = max_raw_bytes(VM_FRAME_BYTES);
+        assert!(estimated_wire_bytes(max_raw_bytes) <= VM_FRAME_BYTES);
+        assert!(estimated_wire_bytes(max_raw_bytes + 1) > VM_FRAME_BYTES);
     }
 }

--- a/crates/nanocodex-tools/src/workspace_runtime.rs
+++ b/crates/nanocodex-tools/src/workspace_runtime.rs
@@ -1,0 +1,165 @@
+//! Focused retained runtime for the canonical local workspace tools.
+//!
+//! This runtime is intentionally smaller than the agent-facing
+//! `crate::runtime` module available in native builds. It lets constrained
+//! process boundaries, including the VM guest, reuse the exact workspace
+//! handlers without linking Code Mode, MCP, HTTP clients, or provider
+//! transports.
+
+use std::{
+    ffi::OsString,
+    path::PathBuf,
+    sync::{Arc, atomic::AtomicU64},
+};
+
+use crate::{
+    StandardTool, Tool, ToolContext, ToolInput, ToolOutput,
+    apply_patch::ApplyPatchHandler,
+    shell::{ExecCommandHandler, ShellSessions, WriteStdinHandler},
+    view_image::ViewImageHandler,
+};
+
+/// Retained canonical workspace-tool runtime.
+///
+/// Shell processes and interactive sessions live for the lifetime of this
+/// value, so a later `write_stdin` call can address a session created by
+/// `exec_command`.
+pub struct WorkspaceToolRuntime {
+    apply_patch: ApplyPatchHandler,
+    exec_command: ExecCommandHandler,
+    view_image: ViewImageHandler,
+    write_stdin: WriteStdinHandler,
+    sessions: Arc<ShellSessions>,
+}
+
+impl WorkspaceToolRuntime {
+    /// Creates a runtime rooted at `workspace` with a sanitized guest process
+    /// environment.
+    #[must_use]
+    pub fn new(workspace: PathBuf) -> Self {
+        Self::with_optional_view_image_wire_limit(workspace, None)
+    }
+
+    /// Creates a retained runtime whose `view_image` responses must fit one
+    /// bounded process-transport frame.
+    ///
+    /// This is an internal process-boundary policy. Normal in-process callers
+    /// should use [`Self::new`].
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_view_image_wire_limit(workspace: PathBuf, max_wire_bytes: u64) -> Self {
+        Self::with_optional_view_image_wire_limit(workspace, Some(max_wire_bytes))
+    }
+
+    fn with_optional_view_image_wire_limit(
+        workspace: PathBuf,
+        max_wire_bytes: Option<u64>,
+    ) -> Self {
+        let sessions = Arc::new(ShellSessions::with_environment_and_turn(
+            Arc::<Vec<(OsString, OsString)>>::default(),
+            Arc::new(AtomicU64::new(0)),
+        ));
+        Self {
+            apply_patch: ApplyPatchHandler::new(workspace.clone()),
+            exec_command: ExecCommandHandler::new(workspace.clone(), Arc::clone(&sessions)),
+            view_image: max_wire_bytes.map_or_else(
+                || ViewImageHandler::new(workspace.clone()),
+                |max_wire_bytes| {
+                    ViewImageHandler::with_wire_limit(workspace.clone(), max_wire_bytes)
+                },
+            ),
+            write_stdin: WriteStdinHandler::new(Arc::clone(&sessions)),
+            sessions,
+        }
+    }
+
+    /// Executes one canonical workspace tool through retained runtime state.
+    pub async fn execute_tool(
+        &self,
+        name: &str,
+        input: ToolInput,
+        context: ToolContext<'_>,
+    ) -> ToolOutput {
+        let result = match name {
+            name if name == StandardTool::ApplyPatch.name() => {
+                self.apply_patch.execute(input, context).await
+            }
+            name if name == StandardTool::ExecCommand.name() => {
+                self.exec_command.execute(input, context).await
+            }
+            name if name == StandardTool::ViewImage.name() => {
+                self.view_image.execute(input, context).await
+            }
+            name if name == StandardTool::WriteStdin.name() => {
+                self.write_stdin.execute(input, context).await
+            }
+            _ => return ToolOutput::error(format!("unknown workspace tool `{name}`")),
+        };
+        result.unwrap_or_else(|error| ToolOutput::error(error.to_string()))
+    }
+
+    /// Returns cancellation and shutdown control for retained subprocesses.
+    #[must_use]
+    pub fn control(&self) -> WorkspaceToolRuntimeControl {
+        WorkspaceToolRuntimeControl {
+            sessions: Arc::clone(&self.sessions),
+        }
+    }
+}
+
+/// Cancellation and shutdown control for a [`WorkspaceToolRuntime`].
+pub struct WorkspaceToolRuntimeControl {
+    sessions: Arc<ShellSessions>,
+}
+
+impl WorkspaceToolRuntimeControl {
+    /// Terminates every retained subprocess and its descendants.
+    pub async fn cancel(&self) {
+        self.sessions.terminate_all().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nanocodex_oai_api::tools::ToolInput;
+    use serde_json::value::to_raw_value;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn retains_shell_sessions_and_cancels_them() {
+        let workspace = tempdir().unwrap();
+        let runtime = WorkspaceToolRuntime::new(workspace.path().to_path_buf());
+        let input = ToolInput::Function(
+            to_raw_value(&serde_json::json!({
+                "cmd": "printf ready; sleep 30",
+                "yield_time_ms": 250
+            }))
+            .unwrap(),
+        );
+        let output = runtime
+            .execute_tool(
+                StandardTool::ExecCommand.name(),
+                input,
+                ToolContext::new("model", "session", "call", &[], 10_000),
+            )
+            .await;
+        assert!(output.success);
+        runtime.control().cancel().await;
+    }
+
+    #[tokio::test]
+    async fn rejects_non_workspace_tools() {
+        let workspace = tempdir().unwrap();
+        let runtime = WorkspaceToolRuntime::new(workspace.path().to_path_buf());
+        let output = runtime
+            .execute_tool(
+                "web_search",
+                ToolInput::Function(to_raw_value(&serde_json::json!({})).unwrap()),
+                ToolContext::new("model", "session", "call", &[], 10_000),
+            )
+            .await;
+        assert!(!output.success);
+    }
+}

--- a/crates/nanocodex-tools/src/workspace_runtime.rs
+++ b/crates/nanocodex-tools/src/workspace_runtime.rs
@@ -37,7 +37,11 @@ impl WorkspaceToolRuntime {
     /// environment.
     #[must_use]
     pub fn new(workspace: PathBuf) -> Self {
-        Self::with_optional_view_image_wire_limit(workspace, None)
+        Self::with_optional_view_image_wire_limit(
+            workspace,
+            None,
+            Arc::<Vec<(OsString, OsString)>>::default(),
+        )
     }
 
     /// Creates a retained runtime whose `view_image` responses must fit one
@@ -48,15 +52,40 @@ impl WorkspaceToolRuntime {
     #[doc(hidden)]
     #[must_use]
     pub fn with_view_image_wire_limit(workspace: PathBuf, max_wire_bytes: u64) -> Self {
-        Self::with_optional_view_image_wire_limit(workspace, Some(max_wire_bytes))
+        Self::with_optional_view_image_wire_limit(
+            workspace,
+            Some(max_wire_bytes),
+            Arc::<Vec<(OsString, OsString)>>::default(),
+        )
+    }
+
+    /// Creates a process-boundary runtime with an explicit environment that
+    /// should remain visible to guest shell commands.
+    ///
+    /// Values whose names look sensitive remain available to the isolated
+    /// process while also participating in normal subprocess-output
+    /// sanitization. Normal in-process callers should use [`Self::new`].
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_environment_and_view_image_wire_limit(
+        workspace: PathBuf,
+        max_wire_bytes: u64,
+        environment: Vec<(OsString, OsString)>,
+    ) -> Self {
+        Self::with_optional_view_image_wire_limit(
+            workspace,
+            Some(max_wire_bytes),
+            Arc::new(environment),
+        )
     }
 
     fn with_optional_view_image_wire_limit(
         workspace: PathBuf,
         max_wire_bytes: Option<u64>,
+        environment: Arc<Vec<(OsString, OsString)>>,
     ) -> Self {
         let sessions = Arc::new(ShellSessions::with_environment_and_turn(
-            Arc::<Vec<(OsString, OsString)>>::default(),
+            environment,
             Arc::new(AtomicU64::new(0)),
         ));
         Self {
@@ -121,7 +150,7 @@ impl WorkspaceToolRuntimeControl {
 
 #[cfg(test)]
 mod tests {
-    use nanocodex_oai_api::tools::ToolInput;
+    use nanocodex_oai_api::tools::{ToolInput, ToolOutputBody};
     use serde_json::value::to_raw_value;
     use tempfile::tempdir;
 
@@ -161,5 +190,40 @@ mod tests {
             )
             .await;
         assert!(!output.success);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn process_boundary_environment_reaches_guest_shell_commands() {
+        let workspace = tempdir().unwrap();
+        let runtime = WorkspaceToolRuntime::with_environment_and_view_image_wire_limit(
+            workspace.path().to_path_buf(),
+            1024 * 1024,
+            vec![(
+                OsString::from("NANOCODEX_IMAGE_ENV"),
+                OsString::from("from-image"),
+            )],
+        );
+        let input = ToolInput::Function(
+            to_raw_value(&serde_json::json!({
+                "cmd": "printf %s \"$NANOCODEX_IMAGE_ENV\""
+            }))
+            .unwrap(),
+        );
+
+        let output = runtime
+            .execute_tool(
+                StandardTool::ExecCommand.name(),
+                input,
+                ToolContext::new("model", "session", "call", &[], 10_000),
+            )
+            .await;
+
+        assert!(output.success);
+        let ToolOutputBody::Text(output) = output.output else {
+            panic!("shell command should return text");
+        };
+        let output = serde_json::from_str::<serde_json::Value>(&output).unwrap();
+        assert_eq!(output["output"], "from-image");
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -47,6 +47,7 @@ unknown-registry = "deny"
 unknown-git = "deny"
 required-git-spec = "rev"
 allow-git = [
+    "https://github.com/containers/libkrun",
     "https://github.com/gakonst/hudsucker",
     "https://github.com/openai-oss-forks/tokio-tungstenite",
     "https://github.com/openai-oss-forks/tungstenite-rs",

--- a/docs/VM.md
+++ b/docs/VM.md
@@ -1,0 +1,346 @@
+# VM-backed tools and egress
+
+Nanocodex keeps the agent lifecycle independent from where workspace tools
+execute. The default `Tools` selection runs `exec_command`, `write_stdin`,
+`apply_patch`, and `view_image` in the embedding process. Applications can
+replace those handlers with one persistent libkrun VM without changing their
+model-visible names or schemas.
+
+The unpublished `nanocodex-vm` package owns this boundary through its
+high-level retained workspace API and focused `host`, `image`, and `tools`
+modules: typed libkrun configuration and its small audited FFI surface, private
+VMM process configuration, gvproxy and neutral egress leases, OCI/Dockerfile
+image preparation and reflinks, and the retained host/guest tool protocol.
+
+The package does not own payment-provider policy, agent identity, secret
+resolution, or the caller's choice to enable VM tools.
+
+The crate's canonical public documentation is
+[`crates/experimental/nanocodex-vm/README.md`](../crates/experimental/nanocodex-vm/README.md).
+Its
+[host/guest RPC section](../crates/experimental/nanocodex-vm/README.md#hostguest-rpc-protocol)
+specifies every frame, limit, cancellation rule, and terminal failure in the
+private lockstep protocol.
+
+The Cargo split stays internal to this boundary. The default `host` feature
+retains image preparation, libkrun lifecycle, and VM-backed `Tools`;
+`guest-runtime` links only the canonical apply-patch, shell, write-stdin, and
+view-image handlers. The guest deliberately excludes the OpenAI transport,
+Code Mode/QuickJS, MCP, HTTP clients, and OCI preparation. Normal
+`nanocodex-tools` and `nanocodex-oai-api` builds retain their complete native
+behavior through default features.
+
+The checked-in x86_64 musl target configuration sets the supported ABI floor
+to musl 1.2.3 because the pinned libkrun KVM path requires `statx`. A Linux
+release host build therefore needs `musl-tools` and produces a static PIE with
+the same public host API; VM execution still requires `/dev/kvm` and
+`libkrunfw.so.5` at runtime.
+
+## Preparing immutable images
+
+`VmImageBuilder` turns a directory containing a concrete `Dockerfile` into one
+validated immutable disk. The cache key includes the Dockerfile, deterministic
+context archive, target architecture, base manifest digests, and disk size.
+Every mutable VM gets a reflink or sparse copy:
+
+```rust,no_run
+use nanocodex_vm::{
+    image::{CachePolicy, VmImageBuilder},
+    tools::GuestRuntimeDisk,
+};
+
+# async fn prepare() -> Result<(), Box<dyn std::error::Error>> {
+let runtime = GuestRuntimeDisk::prepare(
+    "target/aarch64-unknown-linux-musl/debug/nanocodex-vm-guest",
+    ".cache/vm",
+)?;
+let images = VmImageBuilder::new(
+    "target/debug/vm-tools",
+    runtime.path(),
+)
+.firmware_directory(".cache/libkrunfw/libkrunfw")
+.vmm_arg("--vmm");
+let image = images
+    .prepare(
+        "tasks/project/environment",
+        10 * 1024 * 1024 * 1024,
+        ".cache/vm",
+        CachePolicy::Reuse,
+    )
+    .await?;
+std::fs::create_dir_all(".nanocodex/attempts/018f")?;
+image.reflink_to(".nanocodex/attempts/018f/rootfs.ext4")?;
+# Ok(())
+# }
+```
+
+`GuestRuntimeDisk::prepare` hashes the exact guest ELF, validates an existing
+cache entry when present, and otherwise formats and atomically publishes one
+read-only 128 MiB ext4 runtime disk. Same-key processes
+single-flight on a filesystem lock. The returned path remains in the
+caller-selected cache after the value is dropped.
+
+Dockerfile build VMs default to 2 vCPUs, 4096 MiB, ordinary internet egress, a
+30-minute `RUN` timeout, and a 10-minute mount/`COPY` timeout.
+`VmImageBuilder::cpus`, `memory_mib`, `egress`, `run_timeout`, and
+`copy_timeout` make each policy explicit when those defaults are unsuitable.
+
+OCI references and layers resolve concurrently, with at most eight operations
+at either boundary. Same-key work single-flights across tasks and processes,
+while unrelated images remain parallel. Cache records and disks publish
+atomically; a valid warm disk hit never launches a VM or decodes layer
+contents.
+
+## Selecting host or VM tools
+
+Host execution remains the default:
+
+```rust,no_run
+# use nanocodex::{Nanocodex, OpenAiAuth};
+# fn build(auth: OpenAiAuth) -> nanocodex::Result<()> {
+let (agent, events) = Nanocodex::builder(auth).build()?;
+# drop((agent, events));
+# Ok(())
+# }
+```
+
+The shipped CLI exposes the same opt-in boundary in the normal TUI, one-shot
+runner, and resumed TUI:
+
+```sh
+nanocodex \
+  --vm .nanocodex/vm/session-rootfs.ext4 \
+  --vm-guest-runtime target/aarch64-unknown-linux-musl/debug/nanocodex-vm-guest \
+  --vm-workspace /app
+nanocodex run "make the requested change" \
+  --vm .nanocodex/vm/session-rootfs.ext4 \
+  --vm-guest-runtime target/aarch64-unknown-linux-musl/debug/nanocodex-vm-guest \
+  --vm-workspace /app
+nanocodex resume <thread-id> \
+  --vm .nanocodex/vm/session-rootfs.ext4 \
+  --vm-guest-runtime target/aarch64-unknown-linux-musl/debug/nanocodex-vm-guest \
+  --vm-workspace /app
+```
+
+`--vm` accepts either a raw ext4 root or a directory rootfs, retains one VM
+across sequential turns and the root agent tree, and modifies that root in
+place. Raw ext4 roots require the guest ELF through `--vm-guest-runtime` or
+`NANOCODEX_VM_GUEST_RUNTIME`; the CLI packs it into a content-addressed
+read-only block device. Directory roots must already contain
+`/usr/local/bin/nanocodex-vm-guest`. Use `--vm-no-network` for an offline guest.
+The provided root must be session-private; the CLI takes an exclusive advisory
+lock on raw disks to reject accidental concurrent attachment.
+
+A caller normally materializes one private raw-ext4 root and starts a retained
+workspace through the high-level API. Bootstrap shell, runtime block-device
+mounts, private process configuration, and guest readiness stay inside
+`nanocodex-vm`:
+
+```rust,no_run
+# use nanocodex::{Nanocodex, OpenAiAuth};
+# use nanocodex_vm::VmWorkspaceBuilder;
+# async fn build(auth: OpenAiAuth) -> Result<(), Box<dyn std::error::Error>> {
+let workspace = VmWorkspaceBuilder::private_from(
+    ".cache/nanocodex/images/task.ext4",
+    ".nanocodex/sessions/018f/root.ext4",
+    "nanocodex-vmm",
+)?
+.guest_runtime_disk(".cache/nanocodex/runtime.ext4")
+.firmware_directory(".cache/libkrunfw/libkrunfw")
+.guest_workspace("/app")
+.launch()
+.await?;
+let tools = workspace.tools_builder().build()?;
+let (agent, events) = Nanocodex::builder(auth)
+    .workspace(workspace.guest_workspace())
+    .tools(tools)
+    .build()?;
+# drop((agent, events));
+workspace.shutdown().await?;
+# Ok(())
+# }
+```
+
+`VmTools::tools_builder` replaces only workspace-effecting tools. Web search,
+image generation, and `update_plan` retain their existing host-side behavior.
+Callers can disable or replace those independently.
+
+Use `NanocodexBuilder::tools_factory` when an agent can spawn or fork. Start one
+`VmWorkspace` for the root agent tree and capture its clone-cheap `VmTools` in
+the factory. Nanocodex invokes the factory once per driver, so agent-relative
+tools are freshly bound to that driver while every driver deliberately shares
+the same VM, filesystem, and retained guest shell sessions:
+
+```rust,no_run
+# use nanocodex::{Nanocodex, OpenAiAuth};
+# use nanocodex_vm::tools::VmToolSession;
+# fn build(auth: OpenAiAuth, session: VmToolSession) -> nanocodex::Result<()> {
+let vm = session.tools();
+let (agent, events) = Nanocodex::builder(auth)
+    .workspace("/workspace")
+    .tools_factory(move |_agent| {
+        vm.tools_builder()
+            .working_directory("/workspace")
+            .default_shell("sh")
+            .build()
+    })
+    .build()?;
+# drop((agent, events));
+# Ok(())
+# }
+```
+
+The `VmToolSession` is the non-cloneable graceful-shutdown capability.
+`VmTools` and `VmToolSessionHandle` are cloneable capabilities. Every one of
+them keeps the VMM, private launch configuration, and egress guards alive, so
+capturing `VmTools` in a driver factory is sufficient for the complete agent
+tree. Graceful shutdown fails while sibling capabilities remain; drop the
+agents, tool registries, and cloned handles before calling it.
+
+## Configurable egress
+
+`EgressLease` is the VM-facing output of application policy. A layer may
+contribute:
+
+- a network mode;
+- guest environment such as an authenticated `HTTP_PROXY`/`HTTPS_PROXY`;
+- read-only provider directories and public guest configuration files; and
+- lifecycle guards that keep revocable host services alive for the VM.
+
+Independent provider layers compose transactionally:
+
+```rust,no_run
+use nanocodex_vm::host::{EgressFile, EgressLease, EgressMount};
+use std::sync::Arc;
+
+# fn configure() -> Result<EgressLease, nanocodex_vm::host::EgressError> {
+let mut payment_proxy = EgressLease::internet();
+payment_proxy.insert_environment(
+    "HTTPS_PROXY",
+    "http://mpp-lease:credential@host.internal:8080",
+)?;
+payment_proxy.insert_file(EgressFile::new(
+    "/tmp/nanocodex/egress/mpp/ca.pem",
+    b"public CA bytes".to_vec(),
+    0o444,
+))?;
+
+let mut secrets = EgressLease::internet();
+secrets.insert_environment(
+    "NANOCENTAUR_SECRET_BASE_URL",
+    "https://secret-gateway.internal/v1",
+)?;
+secrets.insert_mount(EgressMount::read_only(
+    "secret-ca",
+    "/host/secret-ca",
+    "/tmp/nanocodex/egress/secrets/ca",
+))?;
+secrets.retain(Arc::new(())); // the real layer retains its proxy lease
+
+EgressLease::internet()
+    .with_layer(payment_proxy)?
+    .with_layer(secrets)
+# }
+```
+
+`VmToolSession::spawn_configured` consumes the complete lease and applies it to
+both launch configuration and retained session state. This selects the network,
+attaches provider directories read-only, mounts them before the guest runtime
+starts, injects only the resolved guest environment, provisions public files,
+and retains every provider guard:
+
+```rust,no_run
+# use nanocodex_vm::{
+#     host::{EgressLease, GuestCommand, VmConfig},
+#     tools::VmToolSession,
+# };
+# use tokio::process::Command;
+# async fn launch(egress: EgressLease) -> Result<VmToolSession, Box<dyn std::error::Error>> {
+let guest = GuestCommand::new("/usr/local/bin/nanocodex-vm-guest").arg("/workspace");
+let mut vmm = Command::new("dedicated-vmm-process");
+vmm.arg("--run-config");
+let session = VmToolSession::spawn_configured(
+    vmm,
+    VmConfig::ext4("private-session-rootfs.ext4"),
+    guest,
+    egress,
+).await?;
+# Ok(session)
+# }
+```
+
+The method serializes complete launch configuration to a mode-`0600` temporary
+file and retains it until the last VM capability is dropped. This keeps bearer
+proxy URLs and secret-route placeholders out of the VMM command line and avoids
+a process-start race. Lower-level `configure`, `write_private`, `spawn`, and
+`provision_egress` operations remain available for specialized launchers, but
+the application must then preserve the same ownership ordering itself.
+
+### Application-owned payment and secret proxy layers
+
+Payment providers remain host-owned HTTP(S) proxies. An application-owned
+adapter can point the guest at a proxy, provision its public interception CA,
+and retain the wallet/proxy guard in a provider-neutral `EgressLease`.
+`nanocodex_vm` deliberately has no payment-provider integration;
+Tempo-specific payment policy stays under `bin/`.
+
+NanoCentaur's Iron/secret egress follows the same contract: its layer carries
+the scoped proxy or gateway route, public CA/configuration files, placeholders,
+and revocable lease guard. Resolved secrets remain host-side and must never be
+placed in an `EgressFile`.
+
+A guest process can have only one value for `HTTPS_PROXY`. If two independently
+started providers both claim the front-proxy variables, lease composition
+fails closed. An application that needs both proxies on one request path must
+chain or route them host-side and expose one front proxy to the guest. The VM
+package deliberately does not guess proxy order or silently overwrite one
+provider's credentials.
+
+## Lifecycle and security
+
+- One VM tool session is shared by the complete root-agent tree and retains
+  interactive guest processes across sequential turns and subagent calls.
+- Concurrent drivers are multiplexed by request ID; one slow guest command
+  does not block unrelated subagent calls. Dropping an individual host request
+  sends a targeted cancellation frame, and the guest aborts that request's
+  process group without disturbing sibling work.
+- The last session/tool capability kills its VMM child and releases egress.
+  Explicit shutdown first rejects live sibling capabilities, asks the guest to
+  cancel in-flight work and sync filesystems, then bounds the wait for exit.
+- Protocol frames are limited to 64 MiB and carry binary fields as base64
+  strings rather than allocation-heavy JSON byte arrays. Host-control file reads
+  accept only regular files and are limited to 32 MiB; trusted command output
+  defaults to 8 MiB. Command timeouts, request cancellation, output-limit
+  cancellation, guest shutdown, and capability drop terminate process groups,
+  including descendants.
+- Egress files are limited to 4 MiB. Mounts and files must be non-overlapping
+  descendants of `/tmp/nanocodex/egress`; mount tags and modes are validated
+  before launch.
+- A writable ext4 root is session-private. Reflink or sparse-copy an immutable
+  base image for each VM rather than attaching a shared benchmark image
+  directly.
+- On macOS, the dedicated VMM executable must carry the
+  `com.apple.security.hypervisor` entitlement. `just build-vm-example` builds
+  and ad-hoc signs the public proof binary with `nanocodex-vm.entitlements`.
+- Failed partial protocol responses are not converted into successful tool
+  results.
+- Egress values are omitted from `Debug`; only environment names, mount
+  metadata, and guard counts are shown.
+- Read-only provider mounts and environment conflicts are explicit.
+- The libkrun unsafe surface stays inside two audited
+  `nanocodex_vm` modules; the rest of Nanocodex remains safe Rust.
+- The companion guest reuses the canonical `nanocodex-tools` request/result
+  contracts and workspace-tool implementations. Cross-compiling the companion
+  guest target does not create an alternate tool runtime or change MCP
+  availability in normal native builds.
+
+See
+`cargo run -p nanocodex-examples --bin vm-tools -- ROOTFS GUEST_RUNTIME_BINARY`
+for the end-to-end tool protocol example. Build the lean guest artifact with
+`just build-vm-guest`; the example stages that ELF through
+`GuestRuntimeDisk::prepare` and mounts the resulting disk read-only.
+If the runtime argument is omitted, the rootfs must already contain
+`/usr/local/bin/nanocodex-vm-guest`.
+
+The retained baseline and regression budgets are recorded in
+[`benchmarks/refactor_vm_baseline_2026-07-26.md`](../benchmarks/refactor_vm_baseline_2026-07-26.md).

--- a/docs/VM.md
+++ b/docs/VM.md
@@ -28,20 +28,29 @@ retains image preparation, libkrun lifecycle, and VM-backed `Tools`;
 view-image handlers. The guest deliberately excludes the OpenAI transport,
 Code Mode/QuickJS, MCP, HTTP clients, and OCI preparation. Normal
 `nanocodex-tools` and `nanocodex-oai-api` builds retain their complete native
-behavior through default features.
+behavior through default features. CI checks the guest-only all-target matrix
+and separately builds the actual x86_64 musl companion.
 
 The checked-in x86_64 musl target configuration sets the supported ABI floor
-to musl 1.2.3 because the pinned libkrun KVM path requires `statx`. A Linux
-release host build therefore needs `musl-tools` and produces a static PIE with
-the same public host API; VM execution still requires `/dev/kvm` and
-`libkrunfw.so.5` at runtime.
+to musl 1.2.3 because the pinned libkrun KVM path requires `statx`. Building
+the companion on Linux therefore needs `musl-tools` and produces a static PIE.
+The host application remains a normal native build; VM execution still
+requires `/dev/kvm` and `libkrunfw.so.5` at runtime.
 
 ## Preparing immutable images
 
 `VmImageBuilder` turns a directory containing a concrete `Dockerfile` into one
-validated immutable disk. The cache key includes the Dockerfile, deterministic
-context archive, target architecture, base manifest digests, and disk size.
-Every mutable VM gets a reflink or sparse copy:
+validated immutable disk. The cache key covers the Dockerfile, deterministic
+context archive, target architecture, base manifest digests, disk size, VMM
+arguments and exact VMM/guest-runtime/configured-firmware files, VM resources
+and address-family policy, resolver configuration, network mode, and a
+non-secret egress-policy identity. Configure the firmware directory explicitly
+when firmware upgrades must invalidate cache entries; omitted system firmware
+is caller-managed stable runtime state. The caller-selected cache directory is
+trusted application state, not a security boundary against the same OS user.
+`PreparedRootDisk` retains the final container working directory, environment,
+and shell, then applies them while making each mutable VM's no-clobber reflink
+or sparse copy:
 
 ```rust,no_run
 use nanocodex_vm::{
@@ -68,8 +77,17 @@ let image = images
         CachePolicy::Reuse,
     )
     .await?;
-std::fs::create_dir_all(".nanocodex/attempts/018f")?;
-image.reflink_to(".nanocodex/attempts/018f/rootfs.ext4")?;
+let workspace = image
+    .private_workspace(
+        ".nanocodex/attempts/018f/rootfs.ext4",
+        "target/debug/vm-tools",
+    )?
+    .vmm_argument("--vmm")
+    .guest_runtime_disk(runtime.path())
+    .firmware_directory(".cache/libkrunfw/libkrunfw")
+    .launch()
+    .await?;
+# workspace.shutdown().await?;
 # Ok(())
 # }
 ```
@@ -88,8 +106,16 @@ Dockerfile build VMs default to 2 vCPUs, 4096 MiB, ordinary internet egress, a
 OCI references and layers resolve concurrently, with at most eight operations
 at either boundary. Same-key work single-flights across tasks and processes,
 while unrelated images remain parallel. Cache records and disks publish
-atomically; a valid warm disk hit never launches a VM or decodes layer
-contents.
+atomically and are made read-only. OCI blobs are SHA-256 checked before their
+metadata fast path is established; changes to cached file identity or
+permissions force validation or rebuilding. A valid warm disk hit never
+launches a VM or decodes layer contents.
+
+Build guests temporarily install the current usable host resolver and restore
+the image's original `/etc/resolv.conf` before publishing a stage. A retained
+private ext4 workspace installs resolver configuration only at boot, so an
+immutable image never captures host-specific DNS. Offline and gvproxy
+workspaces skip that injection; host-backed directory roots are left alone.
 
 ## Selecting host or VM tools
 
@@ -138,16 +164,17 @@ mounts, private process configuration, and guest readiness stay inside
 
 ```rust,no_run
 # use nanocodex::{Nanocodex, OpenAiAuth};
-# use nanocodex_vm::VmWorkspaceBuilder;
-# async fn build(auth: OpenAiAuth) -> Result<(), Box<dyn std::error::Error>> {
-let workspace = VmWorkspaceBuilder::private_from(
-    ".cache/nanocodex/images/task.ext4",
+# use nanocodex_vm::image::PreparedRootDisk;
+# async fn build(
+#     auth: OpenAiAuth,
+#     image: &PreparedRootDisk,
+# ) -> Result<(), Box<dyn std::error::Error>> {
+let workspace = image.private_workspace(
     ".nanocodex/sessions/018f/root.ext4",
     "nanocodex-vmm",
 )?
 .guest_runtime_disk(".cache/nanocodex/runtime.ext4")
 .firmware_directory(".cache/libkrunfw/libkrunfw")
-.guest_workspace("/app")
 .launch()
 .await?;
 let tools = workspace.tools_builder().build()?;
@@ -237,11 +264,20 @@ secrets.insert_mount(EgressMount::read_only(
 ))?;
 secrets.retain(Arc::new(())); // the real layer retains its proxy lease
 
-EgressLease::internet()
+let mut egress = EgressLease::internet()
     .with_layer(payment_proxy)?
-    .with_layer(secrets)
+    .with_layer(secrets)?;
+egress.set_build_cache_scope("mpp-and-secret-route-v1")?;
+Ok(egress)
 # }
 ```
+
+The built-in internet and disabled leases have stable cache scopes. Adding
+provider environment, mounts, or files clears the scope. Set a non-secret
+identity only after complete composition when the lease will be used by
+`VmImageBuilder`: Dockerfile build preparation rejects an unscoped provider
+lease rather than reusing output from a different route or credential policy.
+Runtime-only `VmWorkspaceBuilder::egress` does not require a cache scope.
 
 `VmToolSession::spawn_configured` consumes the complete lease and applies it to
 both launch configuration and retained session state. This selects the network,
@@ -302,11 +338,16 @@ provider's credentials.
   interactive guest processes across sequential turns and subagent calls.
 - Concurrent drivers are multiplexed by request ID; one slow guest command
   does not block unrelated subagent calls. Dropping an individual host request
-  sends a targeted cancellation frame, and the guest aborts that request's
-  process group without disturbing sibling work.
+  sends a targeted cancellation frame through a bounded queue while retaining
+  its admission permit until the request and cancellation are physically
+  written in order. The guest aborts that request's process group without
+  disturbing sibling work.
 - The last session/tool capability kills its VMM child and releases egress.
-  Explicit shutdown first rejects live sibling capabilities, asks the guest to
-  cancel in-flight work and sync filesystems, then bounds the wait for exit.
+  Startup defaults to a 30-second deadline for readiness plus provisioning.
+  Explicit shutdown atomically rejects live sibling capabilities and
+  owner-borrowed requests, gives guest sync and VMM exit a 10-second default
+  deadline, and forcibly terminates the child if the shutdown future itself is
+  cancelled. Both deadlines are configurable on `VmWorkspaceBuilder`.
 - Protocol frames are limited to 64 MiB and carry binary fields as base64
   strings rather than allocation-heavy JSON byte arrays. Host-control file reads
   accept only regular files and are limited to 32 MiB; trusted command output

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,12 +16,15 @@ eyre.workspace = true
 futures-util.workspace = true
 http.workspace = true
 nanocodex.workspace = true
+nanocodex-vm.workspace = true
 reqwest.workspace = true
+reflink-copy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
 tokio-tungstenite.workspace = true
 tower.workspace = true
+tempfile.workspace = true
 
 [[bin]]
 name = "minimal"
@@ -70,6 +73,10 @@ path = "codex_parity_bench.rs"
 [[bin]]
 name = "rollout-resume-bench"
 path = "rollout_resume_bench.rs"
+
+[[bin]]
+name = "vm-tools"
+path = "vm_tools.rs"
 
 [lints]
 workspace = true

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,8 @@ cargo run -p nanocodex-examples --bin subagents -- \
   "Review the retry policy using whatever clean or context-bearing workers you need"
 NANOCODEX_SUBAGENT_JSONL=1 cargo run -p nanocodex-examples --bin subagents
 cargo run -p nanocodex-examples --bin mcp
+just build-vm-example
+target/debug/vm-tools ROOTFS [GUEST_RUNTIME_BINARY_OR_EXT4]
 just smoke-python
 just smoke-wasm-node
 just build-react-example
@@ -32,6 +34,14 @@ just build-react-example
 The live programs require `OPENAI_API_KEY`. The browser example instead asks
 the embedding application for an already-authorized Responses WebSocket URL;
 standard browser WebSockets cannot attach the upgrade authorization header.
+
+`vm-tools` does not call the model. It proves all VM-backed standard workspace
+tools against one retained guest and accepts either a directory root containing
+`/usr/local/bin/nanocodex-vm-guest` or an ext4 root plus a guest-runtime ELF or
+read-only runtime image. A runtime ELF is packed into a temporary ext4 image,
+and a supplied ext4 root is reflinked or sparse-copied into a private per-run
+disk before boot. On macOS, `just build-vm-example` also applies the required
+Hypervisor entitlement.
 
 `subagents` exposes generic `spawn_agent`, `fork_agent`, and `prompt_agent` Code
 Mode tools; its Rust host contains no worker graph. The parent model decides the

--- a/examples/vm_tools.rs
+++ b/examples/vm_tools.rs
@@ -113,6 +113,7 @@ async fn run_host(arguments: Vec<std::ffi::OsString>) -> Result<(), AnyError> {
                 "cmd": "cat",
                 "workdir": "/workspace",
                 "login": false,
+                "tty": true,
                 "yield_time_ms": 250
             }))?,
             context,

--- a/examples/vm_tools.rs
+++ b/examples/vm_tools.rs
@@ -1,0 +1,241 @@
+use std::{
+    error::Error,
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use nanocodex::{
+    Tool,
+    tools::contract::{ToolContext, ToolInput, ToolOutput, ToolOutputBody, ToolOutputContent},
+};
+use nanocodex_vm::{
+    VmWorkspace, VmWorkspaceBuilder, host::VmProcessConfig, tools::GuestRuntimeDisk,
+};
+use serde::Deserialize;
+use serde_json::value::to_raw_value;
+
+type AnyError = Box<dyn Error + Send + Sync>;
+
+#[derive(Deserialize)]
+struct CommandOutput {
+    output: String,
+    exit_code: Option<i32>,
+    session_id: Option<i64>,
+}
+
+fn main() -> Result<(), AnyError> {
+    let arguments = std::env::args_os().skip(1).collect::<Vec<_>>();
+    if arguments.first().is_some_and(|value| value == "--vmm") {
+        let config = arguments
+            .get(1)
+            .cloned()
+            .map(PathBuf::from)
+            .ok_or("VMM mode requires a private configuration path")?;
+        VmProcessConfig::read(config)?.run()?;
+        return Ok(());
+    }
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(run_host(arguments))
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "the executable intentionally presents one linear end-to-end VM tool proof"
+)]
+async fn run_host(arguments: Vec<std::ffi::OsString>) -> Result<(), AnyError> {
+    let root = arguments
+        .first()
+        .cloned()
+        .map(PathBuf::from)
+        .ok_or("usage: vm-tools ROOTFS [GUEST_RUNTIME_BINARY_OR_EXT4]")?;
+    let executable = std::env::current_exe()?;
+    let (private_root, mut workspace) = if root.is_file() {
+        let directory = tempfile::tempdir()?;
+        let private = directory.path().join("rootfs.ext4");
+        let builder = VmWorkspaceBuilder::private_from(&root, &private, &executable)?;
+        (Some(directory), builder)
+    } else {
+        (None, VmWorkspace::builder(&root, &executable))
+    };
+    let runtime_input = arguments.get(1).cloned().map(PathBuf::from);
+    let prepared_runtime = match runtime_input.as_deref() {
+        Some(runtime) if is_elf(runtime)? => Some(GuestRuntimeDisk::prepare(runtime, ".cache/vm")?),
+        Some(_) | None => None,
+    };
+    let runtime = prepared_runtime
+        .as_ref()
+        .map(|runtime| runtime.path().to_owned())
+        .or(runtime_input);
+    if let Some(runtime) = runtime {
+        workspace = workspace.guest_runtime_disk(runtime);
+    }
+    workspace = workspace
+        .vmm_argument("--vmm")
+        .guest_workspace("/workspace")
+        .cpus(2)
+        .memory_mib(768)
+        .offline();
+    if let Some(loader_path) = std::env::var_os(if cfg!(target_os = "macos") {
+        "DYLD_LIBRARY_PATH"
+    } else {
+        "LD_LIBRARY_PATH"
+    }) {
+        workspace = workspace.firmware_directory(loader_path);
+    }
+    let workspace = workspace.launch().await?;
+    let vm = workspace.tools();
+    let agent_tools = workspace.tools_builder().build()?;
+    let context = ToolContext::new("vm-proof", "session-1", "call-1", &[], 10_000);
+
+    let execution = vm
+        .exec_command_tool()
+        .execute(
+            function_input(&serde_json::json!({
+                "cmd": "printf 'kernel='; uname -srm; printf 'pid1='; cat /proc/1/comm",
+                "workdir": "/workspace",
+                "login": false
+            }))?,
+            context,
+        )
+        .await?;
+    let output = command_output(execution)?;
+    println!("exec_command: {}", output.output.trim());
+    if output.exit_code != Some(0) {
+        return Err("exec_command did not exit successfully".into());
+    }
+
+    let execution = vm
+        .exec_command_tool()
+        .execute(
+            function_input(&serde_json::json!({
+                "cmd": "cat",
+                "workdir": "/workspace",
+                "login": false,
+                "yield_time_ms": 250
+            }))?,
+            context,
+        )
+        .await?;
+    let output = command_output(execution)?;
+    let shell_session = output
+        .session_id
+        .ok_or("exec_command did not retain an interactive session")?;
+    println!("exec_command session: {shell_session}");
+
+    let execution = vm
+        .write_stdin_tool()
+        .execute(
+            function_input(&serde_json::json!({
+                "session_id": shell_session,
+                "chars": "from-host\n",
+                "yield_time_ms": 1_000
+            }))?,
+            context,
+        )
+        .await?;
+    let mut output = command_output(execution)?;
+    for _ in 0..3 {
+        if output.output.contains("from-host") {
+            break;
+        }
+        output = command_output(
+            vm.write_stdin_tool()
+                .execute(
+                    function_input(&serde_json::json!({
+                        "session_id": shell_session,
+                        "yield_time_ms": 1_000
+                    }))?,
+                    context,
+                )
+                .await?,
+        )?;
+    }
+    println!("write_stdin: {}", output.output.trim());
+    if !output.output.contains("from-host") {
+        return Err("write_stdin did not reach the retained guest process".into());
+    }
+
+    let proof_file = format!("vm-proof-{}.txt", std::process::id());
+    let patch = format!(
+        "*** Begin Patch\n*** Add File: {proof_file}\n+changed inside the guest\n*** End Patch"
+    );
+    let execution = vm
+        .apply_patch_tool()
+        .execute(ToolInput::Freeform(patch), context)
+        .await?;
+    println!("apply_patch: {}", text_output(execution)?.trim());
+
+    let execution = vm
+        .exec_command_tool()
+        .execute(
+            function_input(&serde_json::json!({
+                "cmd": "printf iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII= | base64 -d > pixel.png",
+                "workdir": "/workspace",
+                "login": false
+            }))?,
+            context,
+        )
+        .await?;
+    if command_output(execution)?.exit_code != Some(0) {
+        return Err("failed to prepare guest image fixture".into());
+    }
+
+    let execution = vm
+        .view_image_tool()
+        .execute(
+            function_input(&serde_json::json!({
+                "path": "pixel.png",
+                "detail": "original"
+            }))?,
+            context,
+        )
+        .await?;
+    let ToolOutputBody::Content(image_items) = execution.output else {
+        return Err("view_image did not return multimodal content".into());
+    };
+    let Some(ToolOutputContent::InputImage { image_url, detail }) = image_items.into_iter().next()
+    else {
+        return Err("view_image did not return an image".into());
+    };
+    println!(
+        "view_image: detail={detail:?}, data_url_bytes={}",
+        image_url.len()
+    );
+    println!("all VM-owned tools executed through one retained libkrun VM");
+    drop(agent_tools);
+    drop(vm);
+    workspace.shutdown().await?;
+    drop(private_root);
+    Ok(())
+}
+
+fn is_elf(path: &Path) -> io::Result<bool> {
+    let mut file = fs::File::open(path)?;
+    let mut magic = [0_u8; 4];
+    match io::Read::read_exact(&mut file, &mut magic) {
+        Ok(()) => Ok(magic == *b"\x7fELF"),
+        Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
+fn function_input(value: &serde_json::Value) -> Result<ToolInput, serde_json::Error> {
+    to_raw_value(value).map(ToolInput::Function)
+}
+
+fn command_output(execution: ToolOutput) -> Result<CommandOutput, AnyError> {
+    let text = text_output(execution)?;
+    serde_json::from_str(&text).map_err(Into::into)
+}
+
+fn text_output(execution: ToolOutput) -> Result<String, AnyError> {
+    if !execution.success {
+        return Err("tool execution reported failure".into());
+    }
+    match execution.output {
+        ToolOutputBody::Text(text) => Ok(text),
+        ToolOutputBody::Content(_) => Err("expected text tool output".into()),
+    }
+}

--- a/nanocodex-vm.entitlements
+++ b/nanocodex-vm.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.hypervisor</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/aarch64-unknown-linux-musl-ar
+++ b/scripts/aarch64-unknown-linux-musl-ar
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    if command -v brew >/dev/null 2>&1; then
+        brew_bin="$(command -v brew)"
+    elif [ -x /opt/homebrew/bin/brew ]; then
+        brew_bin=/opt/homebrew/bin/brew
+    else
+        brew_bin=/usr/local/bin/brew
+    fi
+    exec "$("$brew_bin" --prefix llvm)/bin/llvm-ar" "$@"
+fi
+
+exec ar "$@"

--- a/scripts/aarch64-unknown-linux-musl-linker
+++ b/scripts/aarch64-unknown-linux-musl-linker
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -eu
+
+if [ "$(uname -s)" = "Darwin" ]; then
+    if command -v brew >/dev/null 2>&1; then
+        brew_bin="$(command -v brew)"
+    elif [ -x /opt/homebrew/bin/brew ]; then
+        brew_bin=/opt/homebrew/bin/brew
+    else
+        brew_bin=/usr/local/bin/brew
+    fi
+    PATH="$("$brew_bin" --prefix lld)/bin:$PATH"
+    export PATH
+    case " $* " in
+        *" -c "*)
+            exec /usr/bin/clang \
+                -target aarch64-linux-gnu \
+                -Wno-unused-command-line-argument \
+                "$@"
+            ;;
+        *)
+            exec /usr/bin/clang \
+                -target aarch64-linux-gnu \
+                -fuse-ld=lld \
+                -Wno-unused-command-line-argument \
+                -Wl,-strip-debug \
+                "$@"
+            ;;
+    esac
+fi
+
+exec cc "$@"

--- a/scripts/check-experimental-boundary.sh
+++ b/scripts/check-experimental-boundary.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repository_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+metadata_file="$(mktemp 2>/dev/null)" || {
+  echo "failed to create a Cargo metadata file" >&2
+  exit 1
+}
+trap 'rm -f -- "$metadata_file"' EXIT
+
+cd "$repository_root"
+cargo metadata --no-deps --format-version 1 > "$metadata_file"
+
+stable_prefix="$repository_root/crates/"
+experimental_prefix="$repository_root/crates/experimental/"
+
+published="$(
+  jq -r --arg experimental "$experimental_prefix" '
+    .packages[]
+    | select(.manifest_path | startswith($experimental))
+    | select(.publish != [])
+    | .name
+  ' "$metadata_file"
+)"
+if [[ -n "$published" ]]; then
+  echo "experimental packages must not be published:" >&2
+  printf '%s\n' "$published" >&2
+  exit 1
+fi
+
+violations="$(
+  jq -r \
+    --arg stable "$stable_prefix" \
+    --arg experimental "$experimental_prefix" '
+      [.packages[]
+        | select(.manifest_path | startswith($experimental))
+        | .name
+      ] as $experimental_names
+      | .packages[]
+      | select(
+          (.manifest_path | startswith($stable))
+          and (.manifest_path | startswith($experimental) | not)
+        )
+      | . as $package
+      | .dependencies[]
+      | select(.source == null)
+      | select(.name as $dependency | $experimental_names | index($dependency))
+      | "\($package.name) -> \(.name)"
+    ' "$metadata_file"
+)"
+if [[ -n "$violations" ]]; then
+  echo "stable crates must not depend on experimental crates:" >&2
+  printf '%s\n' "$violations" >&2
+  exit 1
+fi

--- a/scripts/codesign-runner
+++ b/scripts/codesign-runner
@@ -1,0 +1,66 @@
+#!/bin/sh
+set -eu
+
+binary=$1
+shift
+
+# VM-backed commands re-exec the current process as their VMM. Cargo can
+# replace its ordinary output on the next build, so run a content-addressed
+# entitled copy whose identity remains stable for every child spawned by this
+# process.
+requires_hypervisor=false
+for argument in "$@"; do
+    case "$argument" in
+        --vm|--vm=*|--vm-rootfs|--vm-rootfs=*)
+            requires_hypervisor=true
+            break
+            ;;
+    esac
+done
+
+if [ "$requires_hypervisor" = false ]; then
+    exec "$binary" "$@"
+fi
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repository_dir=$(dirname -- "$script_dir")
+entitlements="$repository_dir/nanocodex-vm.entitlements"
+binary_digest=$(shasum -a 256 "$binary" | cut -d ' ' -f 1)
+entitlements_digest=$(shasum -a 256 "$entitlements" | cut -d ' ' -f 1)
+signed_directory="$repository_dir/target/nanocodex-signed/$binary_digest-$entitlements_digest"
+signed_binary="$signed_directory/nanocodex"
+
+if [ ! -x "$signed_binary" ]; then
+    mkdir -p "$signed_directory"
+    temporary_binary="$signed_directory/nanocodex.$$.tmp"
+    codesign_log="$signed_directory/codesign.$$.log"
+    cp "$binary" "$temporary_binary"
+    if ! codesign \
+        --entitlements "$entitlements" \
+        --force \
+        --sign - \
+        "$temporary_binary" >"$codesign_log" 2>&1
+    then
+        cat "$codesign_log" >&2
+        rm -f "$codesign_log" "$temporary_binary"
+        exit 1
+    fi
+    rm -f "$codesign_log"
+    mv -f "$temporary_binary" "$signed_binary"
+fi
+
+firmware_dir="$repository_dir/.cache/libkrunfw/libkrunfw"
+legacy_firmware_dir="$repository_dir/.cache/libkrunfw/v5.5.0/libkrunfw"
+if [ ! -f "$firmware_dir/libkrunfw.5.dylib" ]; then
+    firmware_dir=$legacy_firmware_dir
+fi
+if [ -f "$firmware_dir/libkrunfw.5.dylib" ]; then
+    if [ -n "${DYLD_LIBRARY_PATH:-}" ]; then
+        DYLD_LIBRARY_PATH="$firmware_dir:$DYLD_LIBRARY_PATH"
+    else
+        DYLD_LIBRARY_PATH=$firmware_dir
+    fi
+    export DYLD_LIBRARY_PATH
+fi
+
+exec "$signed_binary" "$@"


### PR DESCRIPTION
## What this is

This is the VM + workspace-tools base of Part 2. It adds an actual retained Linux guest boundary to Nanocodex while keeping the agent and normal library API independent from where tools execute.

Evaluation is deliberately split into the next PR. This one owns the reusable primitive: one private VM workspace, canonical tools routed into it, immutable image preparation, explicit egress, and a lifecycle that an application can safely retain across turns and an agent tree.

The complete pre-split Part 2 head is preserved at `backup/pr58-full-before-vm-split-20260728@aa240f8b`.

## Why libkrun

`libkrun` is a good fit here because it gives us a small, embeddable VMM instead of making Nanocodex own a daemon or container control plane:

- KVM on Linux and Hypervisor.framework on macOS;
- a real private Linux guest kernel and root filesystem, not only host process filtering;
- raw ext4 roots, additional block devices, virtiofs shares, TSI internet proxying, and gvproxy when a private network namespace is required;
- direct process ownership, so cancellation and shutdown reduce to terminating one application-owned VMM child; and
- no provider, scheduler, or remote-service protocol forced into the public agent API.

The embedding process never enters libkrun's blocking loop. It writes a mode-`0600` launch record and spawns a dedicated VMM child—the shipped CLI re-enters itself through a hidden `vm-run-config` command—which loads the record and calls libkrun synchronously. This also keeps proxy credentials out of argv and gives the host an ordinary child-process lifecycle.

The unsafe libkrun surface is confined to two audited modules. Everything above it is typed safe Rust.

On macOS the VMM needs the Hypervisor entitlement; `just build-vm-example` builds and ad-hoc signs the proof executable. Linux uses the same Rust API with `/dev/kvm` and `libkrunfw.so.5` and has no signing step.

## Architecture

```text
embedding application
  ├─ owns OpenAI auth, agent state, policy, tracing, and egress leases
  ├─ owns one VmWorkspace for the desired isolation boundary
  └─ spawns one dedicated VMM child from a private launch record
       └─ libkrun guest
            ├─ private writable ext4 root
            ├─ read-only content-addressed guest-runtime disk
            └─ nanocodex-vm-guest
                 └─ canonical exec_command / write_stdin / apply_patch / view_image
```

The model-visible tool names and schemas do not change. `VmWorkspace::tools_builder()` replaces only `exec_command`, `write_stdin`, `apply_patch`, and `view_image`. OpenAI transport and credentials, Web Search, image generation, `update_plan`, MCP, Code Mode, and agent lifecycle remain host-owned.

The guest is a static Linux companion built from the same revision. It reuses the canonical `nanocodex-tools` handlers but excludes OpenAI transport, TLS, OCI code, MCP, Code Mode/QuickJS, and other host-only dependencies. The feature split in `nanocodex-tools` and `nanocodex-oai-api` exists only to produce this focused artifact; their default `native` and `client` builds preserve the existing complete behavior.

## Retained sessions and concurrency

The unit of ownership is one `VmWorkspace`, not one tool call. One workspace can be shared by the complete root-agent tree and across sequential turns, retaining the guest filesystem and interactive shell sessions. We therefore pay VM boot once and keep normal tool execution on the retained path.

Host and guest speak a private typed NDJSON protocol over the VMM console. Requests carry IDs and responses may arrive out of order, so slow commands do not serialize unrelated subagent work. The host admits 63 ordinary in-flight requests and the guest executes at most 64, reserving control capacity. Admission wait, writer-queue wait, and complete RPC duration are independently traced.

Cancellation is targeted: dropping one request queues a cancel for that request and kills its guest process group without disturbing siblings. Startup, output, frames, file reads, shutdown, and cancellation queues are bounded. Graceful shutdown syncs the guest, rejects live sibling capabilities or requests, and force-kills/reaps the VMM if its deadline or shutdown future is lost.

The complete wire contract—including framing, exact schemas, base64 fields, limits, cancellation ordering, shutdown, and fail-closed behavior—is documented in [`nanocodex-vm/README.md`](https://github.com/gakonst/nanocodex/blob/refactor/09-eval/crates/experimental/nanocodex-vm/README.md#hostguest-rpc-protocol).

## Images and cache identity

`VmImageBuilder` resolves a constrained Dockerfile/OCI build context into an immutable ext4 root. The cache identity covers the recipe and context, base manifest digests, architecture and disk size, exact VMM/guest-runtime/configured-firmware bytes, CPU/memory/address-family policy, resolver state, network mode, VMM arguments, and a non-secret egress-policy identity.

OCI references and layers resolve concurrently with bounded fanout. Same-key work single-flights across tasks and processes; unrelated images remain parallel. Blobs are SHA-256 checked, records and disks publish atomically, and healthy cache hits use metadata fast paths while identity or permission changes force complete validation or rebuilding.

A prepared image is never directly mutated. `PreparedRootDisk::private_workspace()` makes a no-clobber reflink when the filesystem supports it and falls back to a sparse copy. The separately cached 128 MiB guest-runtime ext4 disk is always attached read-only.

DNS injection is ephemeral: Dockerfile build guests restore the image's original resolver before publishing, while retained private roots install the current resolver only during boot. Offline and gvproxy modes skip it.

## Public API and CLI

The crate root intentionally exposes only `VmWorkspace`, `VmWorkspaceBuilder`, and `VmWorkspaceError`; detailed configuration lives under `host`, image preparation under `image`, and tool/RPC components under `tools`.

```rust
let workspace = image
    .private_workspace(".nanocodex/sessions/018f/root.ext4", "nanocodex-vmm")?
    .guest_runtime_disk(".cache/nanocodex/runtime.ext4")
    .firmware_directory(".cache/libkrunfw/libkrunfw")
    .launch()
    .await?;

let tools = workspace.tools_builder().build()?;
let (agent, events) = Nanocodex::builder(openai)
    .workspace(workspace.guest_workspace())
    .tools(tools)
    .build()?;
```

The normal TUI, one-shot runner, and resume path expose the same opt-in:

```sh
nanocodex run "make the requested change" \
  --vm .nanocodex/vm/session-rootfs.ext4 \
  --vm-guest-runtime target/aarch64-unknown-linux-musl/debug/nanocodex-vm-guest \
  --vm-workspace /app
```

Host execution remains the runtime default. With no `--vm`, VM construction returns before touching firmware, cache, rootfs, or VMM paths and the existing native `Tools::builder()` path is selected. The CLI currently links host VM support at build time; activation remains explicit.

Raw ext4 roots are the portable isolated path and are exclusively locked while attached. Directory roots are a development escape hatch backed directly by virtiofs; they must already be a complete Linux root containing `/usr/local/bin/nanocodex-vm-guest` and do not provide the same host mount-namespace isolation.

## Performance baseline

The important design choice is retention: image construction and VM boot are not paid per tool call. The checked-in M1 Max baseline keeps warm cache work, protocol overhead, and real libkrun lifecycle time separate:

| Operation | Measured estimate |
| --- | ---: |
| warm guest-runtime prepare | 32.7–38.6 µs |
| warm prepared-image lookup | 62.0–63.6 µs |
| private 512 MiB APFS reflink | 114–119 µs |
| retained local protocol RPC, no VM | 146–148 µs |
| retained live-VM `/bin/true` RPC | 321–353 µs |
| private-root reflink + VM boot + first RPC + shutdown | 163–165 ms |

The live benchmark used 2 vCPUs and 768 MiB. These are Criterion confidence intervals on one pinned machine, not cross-machine percentile claims. The current regression budgets are 600 µs for a retained live-VM command boundary and 250 ms for boot + first RPC + shutdown.

The normal retained path is therefore sub-millisecond before actual command work. Model latency, API latency, and the tool itself remain the critical path. Concurrent-VM RSS/density and end-to-end eval sweep throughput are intentionally not claimed here; those belong in the eval follow-up with representative tasks.

Full methodology and reproduction commands are in [`benchmarks/refactor_vm_baseline_2026-07-26.md`](https://github.com/gakonst/nanocodex/blob/refactor/09-eval/benchmarks/refactor_vm_baseline_2026-07-26.md).

## Egress and secrets

`EgressLease` is a provider-neutral capability assembled by the application. It may carry network mode, guest environment, read-only public mounts/files, and host-side guards that must remain alive for the VM. Conflicting environment or mount claims fail closed.

The VM crate does not resolve secrets or know about Tempo/NanoCentaur/provider policy. OpenAI auth remains host-side. Applications may expose one scoped host proxy or secret gateway and retain its revocable lease without placing raw secrets into the image or guest files. Build cache reuse additionally requires a non-secret identity for the fully composed egress policy.

## Validation

- `cargo test -p nanocodex-vm --all-features`: 97 unit tests, one ignored hardware test, and 6 doctests
- `cargo test -p nanocodex-oai-api -p nanocodex-tools --lib` with their default features: 255 passed, 2 ignored
- `cargo check -p nanocodex-bin` and focused no-flag/VM CLI-selection tests
- warnings-denied Clippy for `nanocodex-vm`, `nanocodex-tools`, and `nanocodex-bin`, all targets/features
- guest-only reduced-feature check and actual static musl guest build
- crate and experimental boundary checks, rustfmt, and `git diff --check`
- real libkrun image build exercising a Dockerfile `RUN`, egress environment, DNS cleanup, warm cache hit, and private root
- real retained VM smoke exercising Linux boot plus `exec_command`, retained `write_stdin`, `apply_patch`, and `view_image` through one VM before graceful shutdown

## Deferred

This PR contains no `nanocodex-eval` crate, Harbor adapter, eval CLI, sweep scheduler, benchmark result claim, or eval-specific agent/accounting change. Those belong in the next stack entry, built on this workspace boundary.