### PR TITLE
feat(tools): expose the ambient sensitive environment

### DIFF
--- a/crates/nanocodex-tools/README.md
+++ b/crates/nanocodex-tools/README.md
@@ -135,7 +135,9 @@ tool implementation or an alternate mode for normal native applications.
 
 The crate root intentionally contains only the normal registry path:
 [`Tools`], `ToolsBuilder`, `ToolsBuildError`, [`Tool`], `tool`, and the
-types required by the `Tool` methods.
+types required by the `Tool` methods, plus
+[`ambient_sensitive_environment`](crate::ambient_sensitive_environment) for
+deliberately restoring proxy-safe credential markers to tool subprocesses.
 
 - [`contract`] contains complete model-visible inputs, outputs, errors, and
   retained wire forms.

--- a/crates/nanocodex-tools/src/lib.rs
+++ b/crates/nanocodex-tools/src/lib.rs
@@ -102,6 +102,9 @@ pub(crate) use runtime::{DynamicToolProvider, ImageGenerationConfig, WebSearchCo
 #[cfg(all(not(target_family = "wasm"), feature = "native"))]
 #[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
 pub use runtime::{ToolsBuildError, ToolsBuilder};
+#[cfg(all(not(target_family = "wasm"), feature = "native"))]
+#[cfg_attr(docsrs, doc(cfg(all(not(target_family = "wasm"), feature = "native"))))]
+pub use shell::ambient_sensitive_environment;
 #[cfg(all(not(target_family = "wasm"), feature = "workspace-runtime"))]
 pub(crate) use standard::StandardTool;
 

--- a/crates/nanocodex-tools/src/shell/mod.rs
+++ b/crates/nanocodex-tools/src/shell/mod.rs
@@ -5,6 +5,8 @@ mod tool;
 
 #[cfg(feature = "native")]
 pub(crate) use process::ProcessGroupGuard;
+#[cfg(feature = "native")]
+pub use process::ambient_sensitive_environment;
 pub(crate) use tool::{ExecCommandHandler, WriteStdinHandler};
 
 use std::{

--- a/crates/nanocodex-tools/src/shell/process.rs
+++ b/crates/nanocodex-tools/src/shell/process.rs
@@ -373,6 +373,36 @@ fn normalize_environment(environment: &mut Vec<(OsString, OsString)>) {
     }
 }
 
+/// Returns the ambient environment variables the shell tool withholds from tool
+/// subprocesses because their names look sensitive.
+///
+/// Pass the result to
+/// [`ToolsBuilder::process_environment`](crate::ToolsBuilder::process_environment)
+/// when the embedder's tools legitimately need them. That is the case behind a
+/// credential-injecting proxy, where the variable holds a marker the proxy
+/// substitutes at the network boundary rather than a secret — a tool that cannot
+/// send the marker cannot authenticate at all, so withholding it only breaks the
+/// tool. Forwarded UTF-8 values of at least eight bytes still join the existing
+/// redaction list, so they stay masked in tool output.
+///
+/// Selecting by name is deliberate: forwarding the whole ambient environment
+/// would also override the shell normalization (`TERM`, `PAGER`, `NO_COLOR`, ...)
+/// that keeps tool output machine-readable.
+///
+/// # Security
+///
+/// This function selects variables by name and cannot distinguish proxy-safe
+/// markers from real secrets. Passing its result to a tool runtime grants every
+/// tool subprocess access to every returned value. Only use it when the embedding
+/// boundary deliberately permits that access.
+#[cfg(feature = "native")]
+#[must_use]
+pub fn ambient_sensitive_environment() -> Vec<(OsString, OsString)> {
+    env::vars_os()
+        .filter(|(name, _)| is_sensitive_name(name))
+        .collect()
+}
+
 fn is_sensitive_name(name: &OsStr) -> bool {
     name.to_string_lossy()
         .to_ascii_uppercase()
@@ -384,7 +414,42 @@ fn is_sensitive_name(name: &OsStr) -> bool {
 mod tests {
     use std::ffi::OsString;
 
+    #[cfg(feature = "native")]
+    use std::collections::BTreeSet;
+
+    #[cfg(feature = "native")]
+    use super::ambient_sensitive_environment;
     use super::{NORMALIZED_ENVIRONMENT, normalize_environment, sanitized_environment};
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn ambient_sensitive_environment_partitions_the_ambient_environment() {
+        let forwarded: BTreeSet<_> = ambient_sensitive_environment()
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+        let (kept, _) = sanitized_environment(&[]);
+        let kept: BTreeSet<_> = kept.into_iter().map(|(name, _)| name).collect();
+
+        // The contract an embedder relies on: forwarding this set restores what
+        // the child lost and nothing else, so the two sets partition the ambient
+        // environment.
+        assert!(kept.is_disjoint(&forwarded));
+        for name in std::env::vars_os().map(|(name, _)| name) {
+            assert!(
+                kept.contains(&name) || forwarded.contains(&name),
+                "{name:?} is neither kept nor forwarded"
+            );
+        }
+        for name in &forwarded {
+            assert!(
+                !NORMALIZED_ENVIRONMENT
+                    .iter()
+                    .any(|(normalized, _)| name == normalized),
+                "{name:?} would override the shell normalization"
+            );
+        }
+    }
 
     #[test]
     fn normalized_environment_overrides_terminal_and_pager_values() {


### PR DESCRIPTION
Per Slack with @gakonst. Consumer: paradigmxyz/centaur#1192.

## Problem

The shell tool withholds ambient variables whose names look sensitive from tool subprocesses. Behind a credential-injecting proxy that assumption inverts: the variable holds a marker the proxy substitutes at the network boundary, not a secret, so a tool that cannot send it cannot authenticate at all and withholding it only breaks the tool. Ours is `GITHUB_TOKEN` — `git push` gets a 401 challenge it can never answer.

`ToolsBuilder::process_environment` is already the answer, and the CLI uses it for exactly this shape with the mpp-egress proxy password. The gap is that an embedder cannot *name* the set to forward: `SENSITIVE_ENV_PARTS` and `is_sensitive_name` are both private, so it ends up copying the parts list — a copy that drifts in the dangerous direction, since a part added here and missed there stops forwarding that variable again.

## Change

Expose `ambient_sensitive_environment()` beside the predicate, so forwarding is:

```rust
Tools::builder()
    .process_environment(ambient_sensitive_environment())
    .build()?
```

Returning a named set rather than the whole environment is deliberate: overrides are applied *after* `normalize_environment`, so forwarding everything would clobber `TERM=dumb`, `PAGER=cat`, `NO_COLOR=1` and the rest.

The test pins the contract an embedder actually relies on — that this set and what `sanitized_environment` keeps *partition* the ambient environment: every ambient variable is one or the other, never both, and nothing returned would override `NORMALIZED_ENVIRONMENT`.

## One thing I left alone

A forwarded value equal to its own variable name (our marker, 12 bytes, over the 8-byte floor) joins the redaction list, so every harmless literal mention of `GITHUB_TOKEN` in tool output becomes `[REDACTED]` — including in `env` and error messages, exactly when someone is debugging why GitHub is failing. Skipping redaction when `value == name`, or a per-override opt-out, would both work; I didn't want to presume which. Happy to add it here or separately.

## Validated

`cargo test -p nanocodex-tools shell::process` — 3 pass, including the new one. `cargo fmt --check` and `cargo clippy -p nanocodex-tools -p nanocodex --all-targets` clean.
