### PR TITLE
perf(tui): bound redraw CPU while streaming

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -155,6 +155,7 @@ bench-stream:
     cargo bench -p nanocodex-bin --bench tui_render -- tui_stream_telemetry
     cargo bench -p nanocodex-bin --bench tui_render -- tui_transcript_delta
     cargo bench -p nanocodex-bin --bench tui_render -- tui_trace_render
+    cargo bench -p nanocodex-bin --bench tui_render -- '^(tui_redraw_scope|tui_streaming_frame_budget)'
 
 # Rebuild every PR #50 hot-path estimate, then enforce the checked-in median
 # latency thresholds. TUI frame-count, changed-cell, and output-byte limits are

--- a/bin/nanocodex/benches/tui_render.rs
+++ b/bin/nanocodex/benches/tui_render.rs
@@ -1,13 +1,21 @@
 use criterion::{criterion_group, criterion_main};
 
 mod tui {
-    use std::{cell::Cell, fmt::Write as _, hint::black_box, rc::Rc, sync::Arc, time::Instant};
+    use std::{
+        cell::Cell,
+        fmt::Write as _,
+        hint::black_box,
+        rc::Rc,
+        sync::Arc,
+        time::{Duration, Instant},
+    };
 
     use criterion::{BatchSize, BenchmarkId, Criterion, Throughput};
     use nanocodex::agent::events::{AgentEvent, AgentEventKind, AgentEventTiming, TimedAgentEvent};
     use ratatui::{
         Terminal, TerminalOptions, Viewport,
         backend::{CrosstermBackend, TestBackend},
+        buffer::Buffer,
         layout::Rect,
     };
 
@@ -45,6 +53,11 @@ mod tui {
     }
 
     #[allow(dead_code, unused_imports)]
+    mod scheduler {
+        include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/tui/scheduler.rs"));
+    }
+
+    #[allow(dead_code, unused_imports)]
     mod view {
         include!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/tui/view.rs"));
     }
@@ -60,8 +73,9 @@ mod tui {
     }
 
     use app::App;
+    use scheduler::{ANIMATION_TICK_INTERVAL, STREAM_FRAME_INTERVAL};
     use telemetry::StreamTelemetry;
-    use terminal::{ByteCountingWriter, DrawMetrics, MeasuredBackend};
+    use terminal::{ByteCountingWriter, DrawMetrics, MeasuredBackend, seed_from_cached_frame};
     use transcript::{ToolStatus, Transcript, TranscriptItem};
 
     #[derive(Clone, Copy)]
@@ -237,10 +251,7 @@ mod tui {
             inner: Vec::new(),
             bytes: Rc::clone(&output_bytes),
         };
-        let backend = MeasuredBackend {
-            inner: CrosstermBackend::new(writer),
-            changed_cells: 0,
-        };
+        let backend = MeasuredBackend::new(CrosstermBackend::new(writer));
         let terminal = Terminal::with_options(
             backend,
             TerminalOptions {
@@ -335,6 +346,220 @@ mod tui {
                 }
             }
         }
+        group.finish();
+    }
+
+    type RedrawTerminal = Terminal<MeasuredBackend<TestBackend>>;
+
+    #[derive(Clone, Copy)]
+    enum RedrawCacheKind {
+        None,
+        LegacySnapshot,
+        Diff,
+    }
+
+    impl RedrawCacheKind {
+        const ALL: [Self; 3] = [Self::None, Self::LegacySnapshot, Self::Diff];
+
+        const fn full_name(self) -> &'static str {
+            match self {
+                Self::None => "full_without_snapshot",
+                Self::LegacySnapshot => "full_with_legacy_snapshot",
+                Self::Diff => "full_with_diff_cache",
+            }
+        }
+
+        const fn animation_name(self) -> &'static str {
+            match self {
+                Self::None => "animation_with_full_render",
+                Self::LegacySnapshot => "animation_with_legacy_snapshot",
+                Self::Diff => "animation_with_diff_cache",
+            }
+        }
+    }
+
+    struct RedrawHarness {
+        app: App,
+        terminal: RedrawTerminal,
+        cache_kind: RedrawCacheKind,
+        legacy_snapshot: Option<Buffer>,
+    }
+
+    impl RedrawHarness {
+        fn new(shape: TraceShape, width: u16, height: u16, cache_kind: RedrawCacheKind) -> Self {
+            let mut app = trace_app(shape);
+            app.main.running = true;
+            let test_backend = TestBackend::new(width, height);
+            let backend = match cache_kind {
+                RedrawCacheKind::Diff => MeasuredBackend::with_frame_cache(test_backend),
+                RedrawCacheKind::None | RedrawCacheKind::LegacySnapshot => {
+                    MeasuredBackend::new(test_backend)
+                }
+            };
+            let mut terminal =
+                Terminal::new(backend).expect("redraw benchmark terminal should initialize");
+            let legacy_snapshot = {
+                let completed = terminal
+                    .draw(|frame| view::render(frame, &mut app))
+                    .expect("initial redraw benchmark frame should render");
+                matches!(cache_kind, RedrawCacheKind::LegacySnapshot)
+                    .then(|| completed.buffer.clone())
+            };
+            Self {
+                app,
+                terminal,
+                cache_kind,
+                legacy_snapshot,
+            }
+        }
+
+        fn draw_full(&mut self) {
+            // Invalidate the streaming tail's layout without growing the
+            // fixture, and advance one visible cell to exercise the diff.
+            self.app.on_tick();
+            assert!(self.app.main.transcript.append_assistant_delta(""));
+            let next_snapshot = {
+                let completed = self
+                    .terminal
+                    .draw(|frame| view::render(frame, &mut self.app))
+                    .expect("full redraw benchmark frame should render");
+                matches!(self.cache_kind, RedrawCacheKind::LegacySnapshot)
+                    .then(|| completed.buffer.clone())
+            };
+            if let Some(snapshot) = next_snapshot {
+                self.legacy_snapshot = Some(snapshot);
+            }
+            black_box(&self.legacy_snapshot);
+        }
+
+        fn draw_animation(&mut self) {
+            self.app.on_tick();
+            match self.cache_kind {
+                RedrawCacheKind::None => {
+                    self.terminal
+                        .draw(|frame| view::render(frame, &mut self.app))
+                        .expect("full animation benchmark frame should render");
+                }
+                RedrawCacheKind::LegacySnapshot => {
+                    let cached = self
+                        .legacy_snapshot
+                        .as_ref()
+                        .expect("legacy redraw benchmark should have a snapshot");
+                    self.terminal.current_buffer_mut().clone_from(cached);
+                    let next_snapshot = self
+                        .terminal
+                        .draw(|frame| view::render_animation(frame, &mut self.app))
+                        .expect("legacy animation benchmark frame should render")
+                        .buffer
+                        .clone();
+                    self.legacy_snapshot = Some(next_snapshot);
+                }
+                RedrawCacheKind::Diff => {
+                    assert!(seed_from_cached_frame(&mut self.terminal));
+                    self.terminal
+                        .draw(|frame| view::render_animation(frame, &mut self.app))
+                        .expect("diff-cached animation benchmark frame should render");
+                }
+            }
+            black_box(&self.legacy_snapshot);
+        }
+    }
+
+    pub(super) fn redraw_scope_benchmark(criterion: &mut Criterion) {
+        let mut group = criterion.benchmark_group("tui_redraw_scope");
+        for shape in TRACE_SHAPES {
+            for (width, height) in TERMINAL_SIZES {
+                for cache_kind in RedrawCacheKind::ALL {
+                    let mut harness = RedrawHarness::new(shape, width, height, cache_kind);
+                    group.bench_function(
+                        BenchmarkId::new(
+                            shape.name,
+                            format!("{}/{width}x{height}", cache_kind.full_name()),
+                        ),
+                        |bencher| bencher.iter(|| harness.draw_full()),
+                    );
+                }
+
+                for cache_kind in RedrawCacheKind::ALL {
+                    let mut harness = RedrawHarness::new(shape, width, height, cache_kind);
+                    group.bench_function(
+                        BenchmarkId::new(
+                            shape.name,
+                            format!("{}/{width}x{height}", cache_kind.animation_name()),
+                        ),
+                        |bencher| bencher.iter(|| harness.draw_animation()),
+                    );
+                }
+            }
+        }
+        group.finish();
+    }
+
+    pub(super) fn streaming_frame_budget_benchmark(criterion: &mut Criterion) {
+        const LEGACY_FRAMES: u64 = 120;
+
+        let mut group = criterion.benchmark_group("tui_streaming_frame_budget");
+        group.sample_size(10);
+        group.throughput(Throughput::Elements(LEGACY_FRAMES));
+
+        let shape = TRACE_SHAPES[0];
+        for cache_kind in RedrawCacheKind::ALL {
+            let mut harness = RedrawHarness::new(shape, 120, 40, cache_kind);
+            group.bench_function(
+                format!("codex_long/{}/120_frames_120x40", cache_kind.full_name()),
+                |bencher| {
+                    bencher.iter(|| {
+                        for _ in 0..LEGACY_FRAMES {
+                            harness.draw_full();
+                        }
+                    });
+                },
+            );
+        }
+
+        let scheduled_frames = u64::try_from(
+            Duration::from_secs(1)
+                .as_nanos()
+                .div_ceil(STREAM_FRAME_INTERVAL.as_nanos()),
+        )
+        .expect("scheduled frame count should fit in u64");
+        group.throughput(Throughput::Elements(scheduled_frames));
+        let mut harness = RedrawHarness::new(shape, 120, 40, RedrawCacheKind::Diff);
+        group.bench_function(
+            format!(
+                "codex_long/{}/{scheduled_frames}_scheduled_frames_120x40",
+                RedrawCacheKind::Diff.full_name()
+            ),
+            |bencher| {
+                bencher.iter(|| {
+                    for _ in 0..scheduled_frames {
+                        harness.draw_full();
+                    }
+                });
+            },
+        );
+
+        let animation_frames = u64::try_from(
+            Duration::from_secs(1)
+                .as_nanos()
+                .div_ceil(ANIMATION_TICK_INTERVAL.as_nanos()),
+        )
+        .expect("animation frame count should fit in u64");
+        group.throughput(Throughput::Elements(animation_frames));
+        let mut harness = RedrawHarness::new(shape, 120, 40, RedrawCacheKind::Diff);
+        group.bench_function(
+            format!(
+                "codex_long/{}/{animation_frames}_scheduled_animation_frames_120x40",
+                RedrawCacheKind::Diff.animation_name()
+            ),
+            |bencher| {
+                bencher.iter(|| {
+                    for _ in 0..animation_frames {
+                        harness.draw_animation();
+                    }
+                });
+            },
+        );
         group.finish();
     }
 
@@ -1631,6 +1856,8 @@ mod tui {
 criterion_group!(
     benches,
     tui::render_benchmarks,
+    tui::redraw_scope_benchmark,
+    tui::streaming_frame_budget_benchmark,
     tui::resize_benchmarks,
     tui::transcript_update_benchmark,
     tui::live_tail_render_benchmark,

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -17,7 +17,7 @@ use std::{
     path::PathBuf,
     process::{Command, Stdio},
     sync::Arc,
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 use crossterm::event::{
@@ -42,7 +42,7 @@ use tracing::{Instrument, info_span};
 use self::{
     app::{App, EscapeAction, PaneId, ReasoningPickerAction, SubmittedPrompt},
     notification::Notifier,
-    scheduler::{RenderScheduler, RenderScope, STREAM_FRAME_INTERVAL},
+    scheduler::{ANIMATION_TICK_INTERVAL, RenderScheduler, RenderScope, STREAM_FRAME_INTERVAL},
     telemetry::{StreamTelemetry, ViewTelemetry},
     terminal::TerminalSession,
     transcript::TranscriptItem,
@@ -786,7 +786,7 @@ fn worker_event_received(
 }
 
 fn ui_ticker() -> tokio::time::Interval {
-    let mut ticker = interval(Duration::from_millis(80));
+    let mut ticker = interval(ANIMATION_TICK_INTERVAL);
     ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
     ticker
 }

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -42,7 +42,7 @@ use tracing::{Instrument, info_span};
 use self::{
     app::{App, EscapeAction, PaneId, ReasoningPickerAction, SubmittedPrompt},
     notification::Notifier,
-    scheduler::{RenderScheduler, STREAM_FRAME_INTERVAL},
+    scheduler::{RenderScheduler, RenderScope, STREAM_FRAME_INTERVAL},
     telemetry::{StreamTelemetry, ViewTelemetry},
     terminal::TerminalSession,
     transcript::TranscriptItem,
@@ -299,6 +299,7 @@ enum RedrawPriority {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum UiUpdate {
     Redraw(RedrawPriority),
+    RedrawAnimation,
     Ignore,
     Quit,
     ExternalEditor,
@@ -467,8 +468,14 @@ impl UiModel {
                 Ok(UiUpdate::Redraw(RedrawPriority::Streaming))
             }
             UiAction::Tick => {
+                let requires_full_redraw =
+                    self.app.mouse_selection_needs_redraw() || self.app.historical_editor_active();
                 self.app.on_tick();
-                Ok(UiUpdate::Redraw(RedrawPriority::Streaming))
+                Ok(if requires_full_redraw {
+                    UiUpdate::Redraw(RedrawPriority::Streaming)
+                } else {
+                    UiUpdate::RedrawAnimation
+                })
             }
         }
     }
@@ -728,7 +735,16 @@ fn render_due_frame(
     ui.apply_pending_mouse_scroll();
     ui.app.advance_smooth_scroll();
     let render_started = Instant::now();
-    let draw_metrics = terminal.draw(|frame| view::render(frame, &mut ui.app))?;
+    let draw_metrics = match scheduler.scope().unwrap_or(RenderScope::Full) {
+        RenderScope::Full => terminal.draw(|frame| view::render(frame, &mut ui.app))?,
+        RenderScope::Animation => terminal.draw_reusing_last_frame(|frame, reused| {
+            if reused {
+                view::render_animation(frame, &mut ui.app);
+            } else {
+                view::render(frame, &mut ui.app);
+            }
+        })?,
+    };
     if let Some(text) = ui.app.take_pending_copy() {
         match clipboard::copy_to_clipboard(&text) {
             Ok(()) => {
@@ -809,6 +825,7 @@ fn apply_update(update: UiUpdate, scheduler: &mut RenderScheduler) -> bool {
         UiUpdate::Redraw(RedrawPriority::Immediate) => scheduler.request_immediate(now),
         UiUpdate::Redraw(RedrawPriority::Streaming) => scheduler.request_streaming(now),
         UiUpdate::Redraw(RedrawPriority::InputBurst) => scheduler.request_input_burst(now),
+        UiUpdate::RedrawAnimation => scheduler.request_animation(now),
         UiUpdate::Ignore | UiUpdate::ExternalEditor => {}
         UiUpdate::Quit => return true,
     }
@@ -2786,7 +2803,7 @@ mod tests {
         );
         assert_eq!(
             ui.update(UiAction::Tick, &commands).unwrap(),
-            UiUpdate::Redraw(RedrawPriority::Streaming)
+            UiUpdate::RedrawAnimation
         );
         assert_eq!(
             ui.update(UiAction::WorkerStopped, &commands).unwrap(),

--- a/bin/nanocodex/src/tui/scheduler.rs
+++ b/bin/nanocodex/src/tui/scheduler.rs
@@ -1,8 +1,11 @@
 use std::time::{Duration, Instant};
 
-/// Maximum demand-driven redraw rate. Fast terminals can present at 120 Hz,
-/// while Ratatui's buffer diff keeps unchanged cells off the wire.
-pub(super) const STREAM_FRAME_INTERVAL: Duration = Duration::from_nanos(8_333_334);
+pub(super) const ANIMATION_TICK_INTERVAL: Duration = Duration::from_millis(80);
+
+/// Maximum demand-driven redraw rate. Thirty frames per second keeps streamed
+/// terminal text responsive while bounding repeated full-frame layout work.
+/// Input and resize redraws bypass this limit.
+pub(super) const STREAM_FRAME_INTERVAL: Duration = Duration::from_nanos(33_333_334);
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub(super) enum RenderScope {
@@ -88,6 +91,24 @@ mod tests {
     use super::{RenderScheduler, RenderScope, STREAM_FRAME_INTERVAL};
 
     const FRAME: Duration = STREAM_FRAME_INTERVAL;
+
+    #[test]
+    fn streaming_frame_budget_is_thirty_per_second() {
+        assert_eq!(
+            Duration::from_secs(1).as_nanos().div_ceil(FRAME.as_nanos()),
+            30
+        );
+    }
+
+    #[test]
+    fn animation_tick_budget_is_thirteen_per_second() {
+        assert_eq!(
+            Duration::from_secs(1)
+                .as_nanos()
+                .div_ceil(super::ANIMATION_TICK_INTERVAL.as_nanos()),
+            13
+        );
+    }
 
     #[test]
     fn initial_frame_is_due_immediately() {

--- a/bin/nanocodex/src/tui/scheduler.rs
+++ b/bin/nanocodex/src/tui/scheduler.rs
@@ -4,11 +4,18 @@ use std::time::{Duration, Instant};
 /// while Ratatui's buffer diff keeps unchanged cells off the wire.
 pub(super) const STREAM_FRAME_INTERVAL: Duration = Duration::from_nanos(8_333_334);
 
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(super) enum RenderScope {
+    Animation,
+    Full,
+}
+
 #[derive(Debug)]
 pub(super) struct RenderScheduler {
     frame_interval: Duration,
     last_presented: Option<Instant>,
     deadline: Option<Instant>,
+    scope: Option<RenderScope>,
 }
 
 impl RenderScheduler {
@@ -17,10 +24,20 @@ impl RenderScheduler {
             frame_interval,
             last_presented: None,
             deadline: Some(now),
+            scope: Some(RenderScope::Full),
         }
     }
 
     pub(super) fn request_streaming(&mut self, now: Instant) {
+        self.request(now, RenderScope::Full);
+    }
+
+    pub(super) fn request_animation(&mut self, now: Instant) {
+        self.request(now, RenderScope::Animation);
+    }
+
+    fn request(&mut self, now: Instant, scope: RenderScope) {
+        self.scope = Some(self.scope.map_or(scope, |pending| pending.max(scope)));
         if self.deadline.is_some() {
             return;
         }
@@ -32,10 +49,12 @@ impl RenderScheduler {
     }
 
     pub(super) fn request_immediate(&mut self, now: Instant) {
+        self.scope = Some(RenderScope::Full);
         self.deadline = Some(self.deadline.map_or(now, |deadline| deadline.min(now)));
     }
 
     pub(super) fn request_input_burst(&mut self, now: Instant) {
+        self.scope = Some(RenderScope::Full);
         let burst_deadline = now + self.frame_interval;
         self.deadline = Some(
             self.deadline
@@ -47,12 +66,17 @@ impl RenderScheduler {
         self.deadline
     }
 
+    pub(super) const fn scope(&self) -> Option<RenderScope> {
+        self.scope
+    }
+
     pub(super) fn is_due(&self, now: Instant) -> bool {
         self.deadline.is_some_and(|deadline| deadline <= now)
     }
 
     pub(super) const fn presented(&mut self, now: Instant) {
         self.deadline = None;
+        self.scope = None;
         self.last_presented = Some(now);
     }
 }
@@ -61,7 +85,7 @@ impl RenderScheduler {
 mod tests {
     use std::time::{Duration, Instant};
 
-    use super::{RenderScheduler, STREAM_FRAME_INTERVAL};
+    use super::{RenderScheduler, RenderScope, STREAM_FRAME_INTERVAL};
 
     const FRAME: Duration = STREAM_FRAME_INTERVAL;
 
@@ -72,6 +96,7 @@ mod tests {
 
         assert!(scheduler.is_due(now));
         assert_eq!(scheduler.deadline(), Some(now));
+        assert_eq!(scheduler.scope(), Some(RenderScope::Full));
     }
 
     #[test]
@@ -85,6 +110,7 @@ mod tests {
         }
 
         assert_eq!(scheduler.deadline(), Some(start + FRAME));
+        assert_eq!(scheduler.scope(), Some(RenderScope::Full));
         assert!(!scheduler.is_due(start + Duration::from_millis(8)));
         assert!(scheduler.is_due(start + FRAME));
     }
@@ -142,6 +168,23 @@ mod tests {
         scheduler.presented(now);
 
         assert_eq!(scheduler.deadline(), None);
+        assert_eq!(scheduler.scope(), None);
         assert!(!scheduler.is_due(now + FRAME));
+    }
+
+    #[test]
+    fn animation_redraw_stays_scoped_until_full_content_changes() {
+        let start = Instant::now();
+        let mut scheduler = RenderScheduler::new(FRAME, start);
+        scheduler.presented(start);
+
+        scheduler.request_animation(start + Duration::from_millis(1));
+        assert_eq!(scheduler.scope(), Some(RenderScope::Animation));
+
+        scheduler.request_streaming(start + Duration::from_millis(2));
+        assert_eq!(scheduler.scope(), Some(RenderScope::Full));
+
+        scheduler.request_animation(start + Duration::from_millis(3));
+        assert_eq!(scheduler.scope(), Some(RenderScope::Full));
     }
 }

--- a/bin/nanocodex/src/tui/terminal.rs
+++ b/bin/nanocodex/src/tui/terminal.rs
@@ -26,7 +26,7 @@ use ratatui::{
     Frame, Terminal,
     backend::{Backend, ClearType, CrosstermBackend, WindowSize},
     buffer::{Buffer, Cell},
-    layout::{Position, Size},
+    layout::{Position, Rect, Size},
 };
 
 type TuiTerminal = Terminal<MeasuredBackend<CrosstermBackend<ByteCountingWriter<Stdout>>>>;
@@ -45,11 +45,17 @@ pub(super) struct ByteCountingWriter<W> {
 pub(super) struct MeasuredBackend<B> {
     pub(super) inner: B,
     pub(super) changed_cells: u64,
+    frame_cache: FrameCache,
+}
+
+enum FrameCache {
+    Disabled,
+    Invalid,
+    Ready(Buffer),
 }
 
 pub(super) struct TerminalSession {
     terminal: TuiTerminal,
-    last_frame: Option<Buffer>,
     output_bytes: Rc<CounterCell<u64>>,
     active: bool,
 }
@@ -84,22 +90,85 @@ impl<B: Write> Write for MeasuredBackend<B> {
     }
 }
 
+impl<B> MeasuredBackend<B> {
+    pub(super) const fn new(inner: B) -> Self {
+        Self {
+            inner,
+            changed_cells: 0,
+            frame_cache: FrameCache::Disabled,
+        }
+    }
+
+    pub(super) fn with_frame_cache(inner: B) -> Self {
+        let mut backend = Self::new(inner);
+        backend.frame_cache = FrameCache::Invalid;
+        backend
+    }
+
+    fn invalidate_frame_cache(&mut self) {
+        if !matches!(self.frame_cache, FrameCache::Disabled) {
+            self.frame_cache = FrameCache::Invalid;
+        }
+    }
+
+    fn take_frame_cache(&mut self) -> Option<Buffer> {
+        match std::mem::replace(&mut self.frame_cache, FrameCache::Invalid) {
+            FrameCache::Ready(buffer) => Some(buffer),
+            FrameCache::Disabled => {
+                self.frame_cache = FrameCache::Disabled;
+                None
+            }
+            FrameCache::Invalid => None,
+        }
+    }
+
+    fn restore_frame_cache(&mut self, buffer: Buffer) {
+        self.frame_cache = FrameCache::Ready(buffer);
+    }
+}
+
 impl<B: Backend> Backend for MeasuredBackend<B> {
     fn draw<'a, I>(&mut self, content: I) -> io::Result<()>
     where
         I: Iterator<Item = (u16, u16, &'a Cell)>,
     {
+        if matches!(self.frame_cache, FrameCache::Invalid) {
+            let size = self.inner.size()?;
+            self.frame_cache =
+                FrameCache::Ready(Buffer::empty(Rect::from((Position::ORIGIN, size))));
+        }
+
         let mut changed_cells = 0_u64;
-        let content = content.inspect(|_| {
+        let mut cache_valid = true;
+        let mut cached = match &mut self.frame_cache {
+            FrameCache::Ready(buffer) => Some(buffer),
+            FrameCache::Disabled | FrameCache::Invalid => None,
+        };
+        let content = content.inspect(|(x, y, cell)| {
             changed_cells = changed_cells.saturating_add(1);
+            if let Some(cached) = cached.as_deref_mut() {
+                let position = Position::new(*x, *y);
+                if cached.area.contains(position) {
+                    cached[(*x, *y)].clone_from(cell);
+                } else {
+                    cache_valid = false;
+                }
+            }
         });
         let result = self.inner.draw(content);
         self.changed_cells = self.changed_cells.saturating_add(changed_cells);
+        if !cache_valid {
+            self.invalidate_frame_cache();
+        }
         result
     }
 
     fn append_lines(&mut self, n: u16) -> io::Result<()> {
-        self.inner.append_lines(n)
+        let result = self.inner.append_lines(n);
+        if result.is_ok() {
+            self.invalidate_frame_cache();
+        }
+        result
     }
 
     fn hide_cursor(&mut self) -> io::Result<()> {
@@ -119,11 +188,19 @@ impl<B: Backend> Backend for MeasuredBackend<B> {
     }
 
     fn clear(&mut self) -> io::Result<()> {
-        self.inner.clear()
+        let result = self.inner.clear();
+        if result.is_ok() {
+            self.invalidate_frame_cache();
+        }
+        result
     }
 
     fn clear_region(&mut self, clear_type: ClearType) -> io::Result<()> {
-        self.inner.clear_region(clear_type)
+        let result = self.inner.clear_region(clear_type);
+        if result.is_ok() {
+            self.invalidate_frame_cache();
+        }
+        result
     }
 
     fn size(&self) -> io::Result<Size> {
@@ -157,14 +234,12 @@ impl TerminalSession {
             inner: output,
             bytes: Rc::clone(&output_bytes),
         };
-        let terminal = Terminal::new(MeasuredBackend {
-            inner: CrosstermBackend::new(writer),
-            changed_cells: 0,
-        })?;
+        let terminal = Terminal::new(MeasuredBackend::with_frame_cache(CrosstermBackend::new(
+            writer,
+        )))?;
         restore.armed = false;
         Ok(Self {
             terminal,
-            last_frame: None,
             output_bytes,
             active: true,
         })
@@ -179,28 +254,17 @@ impl TerminalSession {
         render: impl FnOnce(&mut Frame<'_>, bool),
     ) -> io::Result<DrawMetrics> {
         self.terminal.autoresize()?;
-        let cached_area = self
-            .last_frame
-            .as_ref()
-            .filter(|cached| seed_from_cached_frame(&mut self.terminal, cached))
-            .map(|cached| cached.area);
-        self.draw_inner(|frame| render(frame, cached_area == Some(frame.area())))
+        let reused = seed_from_cached_frame(&mut self.terminal);
+        self.draw_inner(|frame| render(frame, reused))
     }
 
     fn draw_inner(&mut self, render: impl FnOnce(&mut Frame<'_>)) -> io::Result<DrawMetrics> {
         let bytes_before = self.output_bytes.get();
         self.terminal.backend_mut().changed_cells = 0;
         begin_synchronized_update(self.terminal.backend_mut())?;
-        let draw_result = self
-            .terminal
-            .draw(render)
-            .map(|completed| completed.buffer.clone());
+        let draw_result = self.terminal.draw(render).map(|_| ());
         let end_result = end_synchronized_update(self.terminal.backend_mut());
-        let completed = match (draw_result, end_result) {
-            (Err(error), _) | (Ok(_), Err(error)) => return Err(error),
-            (Ok(completed), Ok(())) => completed,
-        };
-        self.last_frame = Some(completed);
+        draw_result.and(end_result)?;
         Ok(DrawMetrics {
             changed_cells: self.terminal.backend().changed_cells,
             output_bytes: self.output_bytes.get().saturating_sub(bytes_before),
@@ -232,19 +296,26 @@ impl TerminalSession {
         TERMINAL_ACTIVE.store(true, Ordering::Release);
         self.terminal.clear()?;
         self.terminal.autoresize()?;
-        self.last_frame = None;
         restore.armed = false;
         self.active = true;
         Ok(())
     }
 }
 
-fn seed_from_cached_frame<B: Backend>(terminal: &mut Terminal<B>, cached: &Buffer) -> bool {
-    let current = terminal.current_buffer_mut();
-    if current.area != cached.area {
+pub(super) fn seed_from_cached_frame<B: Backend>(
+    terminal: &mut Terminal<MeasuredBackend<B>>,
+) -> bool {
+    let Some(cached) = terminal.backend_mut().take_frame_cache() else {
         return false;
+    };
+    {
+        let current = terminal.current_buffer_mut();
+        if current.area != cached.area {
+            return false;
+        }
+        current.clone_from(&cached);
     }
-    current.clone_from(cached);
+    terminal.backend_mut().restore_frame_cache(cached);
     true
 }
 
@@ -371,10 +442,7 @@ mod tests {
 
     #[test]
     fn measured_backend_counts_ratatui_diff_cells() {
-        let backend = MeasuredBackend {
-            inner: TestBackend::new(20, 2),
-            changed_cells: 0,
-        };
+        let backend = MeasuredBackend::new(TestBackend::new(20, 2));
         let mut terminal = Terminal::new(backend).unwrap();
 
         terminal
@@ -391,24 +459,73 @@ mod tests {
 
     #[test]
     fn cached_frame_seeds_unchanged_cells_for_partial_redraws() {
-        let mut terminal = Terminal::new(TestBackend::new(20, 2)).unwrap();
-        let cached = terminal
+        let backend = MeasuredBackend::with_frame_cache(TestBackend::new(20, 2));
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
             .draw(|frame| {
                 frame.render_widget(Paragraph::new(Text::raw("static content")), frame.area());
             })
-            .unwrap()
-            .buffer
-            .clone();
+            .unwrap();
 
-        assert!(seed_from_cached_frame(&mut terminal, &cached));
+        assert!(seed_from_cached_frame(&mut terminal));
         terminal
             .draw(|frame| {
                 frame.buffer_mut()[(0, 1)].set_symbol("x");
             })
             .unwrap();
 
-        let rendered = terminal.backend().buffer();
+        let rendered = terminal.backend().inner.buffer();
         assert_eq!(rendered[(0, 0)].symbol(), "s");
         assert_eq!(rendered[(0, 1)].symbol(), "x");
+
+        assert!(seed_from_cached_frame(&mut terminal));
+        terminal
+            .draw(|frame| {
+                frame.buffer_mut()[(1, 1)].set_symbol("y");
+            })
+            .unwrap();
+        let rendered = terminal.backend().inner.buffer();
+        assert_eq!(rendered[(0, 0)].symbol(), "s");
+        assert_eq!(rendered[(0, 1)].symbol(), "x");
+        assert_eq!(rendered[(1, 1)].symbol(), "y");
+    }
+
+    #[test]
+    fn clearing_the_terminal_invalidates_the_frame_cache() {
+        let backend = MeasuredBackend::with_frame_cache(TestBackend::new(20, 2));
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                frame.render_widget(Paragraph::new(Text::raw("static content")), frame.area());
+            })
+            .unwrap();
+        assert!(seed_from_cached_frame(&mut terminal));
+
+        terminal.clear().unwrap();
+
+        assert!(!seed_from_cached_frame(&mut terminal));
+    }
+
+    #[test]
+    fn resizing_invalidates_then_rebuilds_the_frame_cache() {
+        let backend = MeasuredBackend::with_frame_cache(TestBackend::new(20, 2));
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                frame.render_widget(Paragraph::new(Text::raw("before resize")), frame.area());
+            })
+            .unwrap();
+        assert!(seed_from_cached_frame(&mut terminal));
+
+        terminal.backend_mut().inner.resize(30, 3);
+        terminal.autoresize().unwrap();
+        assert!(!seed_from_cached_frame(&mut terminal));
+
+        terminal
+            .draw(|frame| {
+                frame.render_widget(Paragraph::new(Text::raw("after resize")), frame.area());
+            })
+            .unwrap();
+        assert!(seed_from_cached_frame(&mut terminal));
     }
 }

--- a/bin/nanocodex/src/tui/terminal.rs
+++ b/bin/nanocodex/src/tui/terminal.rs
@@ -25,7 +25,7 @@ use crossterm::{
 use ratatui::{
     Frame, Terminal,
     backend::{Backend, ClearType, CrosstermBackend, WindowSize},
-    buffer::Cell,
+    buffer::{Buffer, Cell},
     layout::{Position, Size},
 };
 
@@ -49,6 +49,7 @@ pub(super) struct MeasuredBackend<B> {
 
 pub(super) struct TerminalSession {
     terminal: TuiTerminal,
+    last_frame: Option<Buffer>,
     output_bytes: Rc<CounterCell<u64>>,
     active: bool,
 }
@@ -163,18 +164,43 @@ impl TerminalSession {
         restore.armed = false;
         Ok(Self {
             terminal,
+            last_frame: None,
             output_bytes,
             active: true,
         })
     }
 
     pub(super) fn draw(&mut self, render: impl FnOnce(&mut Frame<'_>)) -> io::Result<DrawMetrics> {
+        self.draw_inner(render)
+    }
+
+    pub(super) fn draw_reusing_last_frame(
+        &mut self,
+        render: impl FnOnce(&mut Frame<'_>, bool),
+    ) -> io::Result<DrawMetrics> {
+        self.terminal.autoresize()?;
+        let cached_area = self
+            .last_frame
+            .as_ref()
+            .filter(|cached| seed_from_cached_frame(&mut self.terminal, cached))
+            .map(|cached| cached.area);
+        self.draw_inner(|frame| render(frame, cached_area == Some(frame.area())))
+    }
+
+    fn draw_inner(&mut self, render: impl FnOnce(&mut Frame<'_>)) -> io::Result<DrawMetrics> {
         let bytes_before = self.output_bytes.get();
         self.terminal.backend_mut().changed_cells = 0;
         begin_synchronized_update(self.terminal.backend_mut())?;
-        let draw_result = self.terminal.draw(render).map(|_| ());
+        let draw_result = self
+            .terminal
+            .draw(render)
+            .map(|completed| completed.buffer.clone());
         let end_result = end_synchronized_update(self.terminal.backend_mut());
-        draw_result.and(end_result)?;
+        let completed = match (draw_result, end_result) {
+            (Err(error), _) | (Ok(_), Err(error)) => return Err(error),
+            (Ok(completed), Ok(())) => completed,
+        };
+        self.last_frame = Some(completed);
         Ok(DrawMetrics {
             changed_cells: self.terminal.backend().changed_cells,
             output_bytes: self.output_bytes.get().saturating_sub(bytes_before),
@@ -206,10 +232,20 @@ impl TerminalSession {
         TERMINAL_ACTIVE.store(true, Ordering::Release);
         self.terminal.clear()?;
         self.terminal.autoresize()?;
+        self.last_frame = None;
         restore.armed = false;
         self.active = true;
         Ok(())
     }
+}
+
+fn seed_from_cached_frame<B: Backend>(terminal: &mut Terminal<B>, cached: &Buffer) -> bool {
+    let current = terminal.current_buffer_mut();
+    if current.area != cached.area {
+        return false;
+    }
+    current.clone_from(cached);
+    true
 }
 
 impl Drop for TerminalSession {
@@ -296,7 +332,7 @@ mod tests {
 
     use super::{
         ByteCountingWriter, MeasuredBackend, begin_synchronized_update, end_synchronized_update,
-        restore_commands,
+        restore_commands, seed_from_cached_frame,
     };
 
     #[test]
@@ -351,5 +387,28 @@ mod tests {
             .draw(|frame| frame.render_widget(Paragraph::new(Text::raw("hello")), frame.area()))
             .unwrap();
         assert_eq!(terminal.backend().changed_cells, 0);
+    }
+
+    #[test]
+    fn cached_frame_seeds_unchanged_cells_for_partial_redraws() {
+        let mut terminal = Terminal::new(TestBackend::new(20, 2)).unwrap();
+        let cached = terminal
+            .draw(|frame| {
+                frame.render_widget(Paragraph::new(Text::raw("static content")), frame.area());
+            })
+            .unwrap()
+            .buffer
+            .clone();
+
+        assert!(seed_from_cached_frame(&mut terminal, &cached));
+        terminal
+            .draw(|frame| {
+                frame.buffer_mut()[(0, 1)].set_symbol("x");
+            })
+            .unwrap();
+
+        let rendered = terminal.backend().buffer();
+        assert_eq!(rendered[(0, 0)].symbol(), "s");
+        assert_eq!(rendered[(0, 1)].symbol(), "x");
     }
 }

--- a/bin/nanocodex/src/tui/view.rs
+++ b/bin/nanocodex/src/tui/view.rs
@@ -14,7 +14,40 @@ use super::{
 };
 
 pub(super) fn render(frame: &mut Frame<'_>, app: &mut App) {
-    let area = frame.area();
+    let layout = view_layout(frame.area(), app);
+
+    render_header(frame, app, layout.header);
+    let mut selectable_areas = SelectableAreas::default();
+    render_transcripts(frame, app, layout.transcript, &mut selectable_areas);
+    render_pending(frame, app, layout.pending);
+    selectable_areas.push(render_composer(
+        frame,
+        app,
+        layout.composer,
+        &layout.composer_layout,
+    ));
+    render_footer(frame, app, layout.footer);
+    app.render_mouse_selection(frame.buffer_mut(), selectable_areas.as_slice());
+    render_reasoning_picker(frame, app);
+}
+
+pub(super) fn render_animation(frame: &mut Frame<'_>, app: &mut App) {
+    let layout = view_layout(frame.area(), app);
+    render_composer(frame, app, layout.composer, &layout.composer_layout);
+    render_footer(frame, app, layout.footer);
+    render_reasoning_picker(frame, app);
+}
+
+struct ViewLayout {
+    header: Rect,
+    transcript: Rect,
+    pending: Rect,
+    composer: Rect,
+    footer: Rect,
+    composer_layout: ComposerLayout,
+}
+
+fn view_layout(area: Rect, app: &mut App) -> ViewLayout {
     let composer_width = if app.historical_editor_active() {
         area.width.saturating_sub(4).max(1)
     } else {
@@ -49,14 +82,14 @@ pub(super) fn render(frame: &mut Frame<'_>, app: &mut App) {
     ])
     .areas(area);
 
-    render_header(frame, app, header_area);
-    let mut selectable_areas = SelectableAreas::default();
-    render_transcripts(frame, app, transcript_area, &mut selectable_areas);
-    render_pending(frame, app, pending_area);
-    selectable_areas.push(render_composer(frame, app, composer_area, &composer_layout));
-    render_footer(frame, app, footer_area);
-    app.render_mouse_selection(frame.buffer_mut(), selectable_areas.as_slice());
-    render_reasoning_picker(frame, app);
+    ViewLayout {
+        header: header_area,
+        transcript: transcript_area,
+        pending: pending_area,
+        composer: composer_area,
+        footer: footer_area,
+        composer_layout,
+    }
 }
 
 fn render_reasoning_picker(frame: &mut Frame<'_>, app: &App) {
@@ -710,7 +743,7 @@ mod tests {
         style::{Color, Modifier},
     };
 
-    use super::render;
+    use super::{render, render_animation};
     use crate::tui::{app::App, transcript::TranscriptItem};
 
     #[test]
@@ -772,6 +805,31 @@ mod tests {
         let rendered = terminal.backend().to_string();
         assert!(rendered.contains("Working (1m 05s)"));
         assert!(!rendered.contains("Running exec_command"));
+    }
+
+    #[test]
+    fn animation_render_matches_a_full_frame() {
+        let mut terminal = Terminal::new(TestBackend::new(80, 16)).unwrap();
+        let mut app = App::new("/workspace".into());
+        app.main.running = true;
+        app.main
+            .transcript
+            .push(TranscriptItem::Assistant("static transcript".to_owned()));
+        let cached = terminal
+            .draw(|frame| render(frame, &mut app))
+            .unwrap()
+            .buffer
+            .clone();
+
+        app.on_tick();
+        terminal.current_buffer_mut().clone_from(&cached);
+        terminal
+            .draw(|frame| render_animation(frame, &mut app))
+            .unwrap();
+        let animation_frame = terminal.backend().buffer().clone();
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        assert_eq!(animation_frame, *terminal.backend().buffer());
     }
 
     #[test]

--- a/docs/TUI_NOTES.md
+++ b/docs/TUI_NOTES.md
@@ -142,8 +142,9 @@ Unknown slash-prefixed input is sent to the model as an ordinary prompt.
 ### Scheduling
 
 - Rendering is demand-driven rather than a permanent full-speed loop.
-- Streaming events are coalesced behind an approximately 120 Hz maximum frame
-  rate (`8.333334 ms`).
+- Streaming events are coalesced behind an approximately 30 Hz maximum frame
+  rate (`33.333334 ms`). This bounds saturated full-layout CPU work while input
+  and resize redraws remain immediate.
 - Input and resize request an immediate frame and preempt a pending streaming
   deadline.
 - The retained Codex workload's densest 33 ms bucket contained 590
@@ -277,7 +278,18 @@ cargo bench -p nanocodex-bin --bench tui_render
 Use `just bench-stream` for the focused cross-layer gate. It also measures the
 timed agent-event envelope in `nanocodex-oai-api` and the TUI timing aggregator,
 so UI improvements are not credited for delays introduced before Ratatui
-receives an event or for unmeasured instrumentation overhead.
+receives an event or for unmeasured instrumentation overhead. The redraw-scope
+group retains the PR #64 whole-frame snapshot as a regression comparator, while
+the frame-budget group measures both the former 120-frame ceiling and the
+current scheduler's one-second CPU-work budget.
+
+On the 2026-07-29 `codex_long` `120x40` gate, one saturated second of the former
+120-frame path required 265.91 ms in the unoptimized profile. PR #64's complete
+frame snapshots required 282.87 ms. The 30-frame diff-maintained path required
+65.89 ms, a render-duty proxy of 6.6% of one core; its optimized-profile result
+was 6.62 ms. A waiting turn's 13 scoped animation frames required 15.56 ms
+unoptimized and 1.61 ms optimized. Input and resize latency are excluded because
+those redraws intentionally remain immediate.
 
 Every performance slice should select applicable gates before implementation:
 


### PR DESCRIPTION
## Summary

- retain the scoped animation redraw introduced by #64 while preserving its contributor-authored commit
- maintain the complete cached screen from Ratatui changed-cell diffs instead of cloning the full frame after every draw
- cap demand-driven streaming redraws at 30 Hz while keeping input and resize redraws immediate
- benchmark full, animation-only, legacy-snapshot, diff-cache, and one-second frame budgets across retained Codex and Amp workloads

## CPU evidence

On the retained `codex_long` workload at `120x40`, one saturated second measured:

| Path | Debug CPU work | Release CPU work |
|---|---:|---:|
| Former 120-frame path | 265.91 ms | 27.68 ms |
| PR #64 full-frame snapshots | 282.87 ms | 30.58 ms |
| Diff-maintained cache, 30 scheduled frames | 65.89 ms | 6.62 ms |
| Waiting turn, 13 scoped animation frames | 15.56 ms | 1.61 ms |

A live debug-build smoke during an active turn sampled Nanocodex at 0.0–2.6% CPU, averaging about 0.9%. That turn included mixed streaming and tool-wait periods; the retained saturated workload remains the deterministic regression gate.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p nanocodex-bin --bin nanocodex` (222 passed, 2 ignored)
- `cargo clippy -p nanocodex-bin --all-targets --all-features -- -D warnings`
- `cargo check -p nanocodex-examples --bins`
- `./scripts/check-crate-boundaries.sh`
- `./scripts/check-experimental-boundary.sh`
- debug and release `tui_streaming_frame_budget` benchmarks

Supersedes #64.
Closes #63.