### PR TITLE
feat(tui): render display math with Ratatex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,22 @@
 version = 4
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,6 +1360,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1922,6 +1948,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2386,6 +2421,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,13 +2440,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -2577,7 +2633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2628,6 +2684,17 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fancy-regex"
@@ -2792,6 +2859,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2937,7 +3027,7 @@ dependencies = [
  "log",
  "rustversion",
  "windows-link",
- "windows-result",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -3360,7 +3450,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3455,6 +3545,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "icy_sixel"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc0a9c4770bc47b0a933256a496cfb8b6531f753ea9bccb19c6dff0ff7273fc"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3510,7 +3606,7 @@ dependencies = [
  "image-webp",
  "moxcms",
  "num-traits",
- "png",
+ "png 0.18.1",
  "tiff",
  "zune-core 0.5.1",
  "zune-jpeg 0.5.15",
@@ -4195,6 +4291,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4208,6 +4313,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -4403,6 +4518,7 @@ dependencies = [
  "nix 0.31.3",
  "pulldown-cmark",
  "rand 0.9.5",
+ "ratatex",
  "ratatui",
  "reqwest",
  "self-replace",
@@ -5099,6 +5215,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5221,11 +5358,21 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.13.1",
  "phf_shared 0.13.1",
  "serde",
 ]
@@ -5241,6 +5388,16 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.7",
+]
+
+[[package]]
+name = "phf_generator"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
@@ -5251,15 +5408,37 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_macros"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.13.1",
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -5327,6 +5506,19 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "png"
@@ -5654,7 +5846,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5801,6 +5993,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatex"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d61493e25a18254d630c12b1ed370302b1318fa2348c572b7fc2677b9e27f2c"
+dependencies = [
+ "base64",
+ "crossbeam-channel",
+ "directories",
+ "hex",
+ "image",
+ "ratatui",
+ "ratatui-image",
+ "ratex-layout",
+ "ratex-parser",
+ "ratex-render",
+ "ratex-types",
+ "sha2 0.10.9",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "ratatui"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5819,6 +6034,135 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "ratatui-image"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dbebe428e366c230b2251c7091f2a56ec2bf818d96cdc807f6474428ee09040"
+dependencies = [
+ "base64-simd",
+ "icy_sixel",
+ "image",
+ "rand 0.8.7",
+ "ratatui",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "windows 0.58.0",
+]
+
+[[package]]
+name = "ratex-font"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a7b73531dabe934a3e725ed5c90d18dacf43778b7a208381390943a9a8c24db"
+dependencies = [
+ "phf 0.11.3",
+ "ratex-types",
+]
+
+[[package]]
+name = "ratex-font-loader"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6542b55c6273b2ca3eb66021da061dfc84bc8303b434e1332218b63728742b7e"
+dependencies = [
+ "ab_glyph",
+ "ratex-font",
+ "ratex-katex-fonts",
+ "ratex-types",
+ "ratex-unicode-font",
+]
+
+[[package]]
+name = "ratex-katex-fonts"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c915a17fd71c41374d1ec19651a26ca352e757e1342391c2cbc5b825dacaa64b"
+dependencies = [
+ "rust-embed",
+]
+
+[[package]]
+name = "ratex-layout"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1792738e2e36683cd20de742296a5233759565efc8cd03831064a0ccfb1fe0f7"
+dependencies = [
+ "ratex-font",
+ "ratex-parser",
+ "ratex-types",
+ "serde_json",
+]
+
+[[package]]
+name = "ratex-lexer"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f704add86d7bf4c4ecc7767f45ab38a44f1bbfa4b49725b2ae53c32e83b8a61e"
+dependencies = [
+ "ratex-types",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ratex-parser"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "079ec2e7ac6bc76137a6de093a173d1f901139a51318589ab9ce17139c21a6f0"
+dependencies = [
+ "fancy-regex 0.14.0",
+ "ratex-font",
+ "ratex-lexer",
+ "ratex-types",
+ "regex",
+ "regex-lite",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "ratex-render"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55c423b56c30c5da2efccf080b960cd1df7918443dc5ce81db056ce6c9fffc67"
+dependencies = [
+ "ab_glyph",
+ "png 0.17.16",
+ "ratex-font",
+ "ratex-font-loader",
+ "ratex-katex-fonts",
+ "ratex-layout",
+ "ratex-parser",
+ "ratex-types",
+ "ratex-unicode-font",
+ "serde_json",
+ "tiny-skia",
+ "ttf-parser",
+]
+
+[[package]]
+name = "ratex-types"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cf0be3d050525f0f7d37af55a443d7648c222ccc617639950e3de1f8e6f9900"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "ratex-unicode-font"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c460464b7fba27343b2b391179ac6c86fcffac5116455158e2b08ce80866fd8"
+dependencies = [
+ "fontdb",
+ "system-fonts",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -5856,6 +6200,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5884,7 +6239,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rustix 1.1.4",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -5909,6 +6264,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
@@ -6338,6 +6699,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
 name = "rquickjs"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6427,6 +6794,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
+dependencies = [
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.119",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
+dependencies = [
+ "sha2 0.11.0",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6491,7 +6893,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6549,7 +6951,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7125,6 +7527,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7228,6 +7639,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "strsim"
@@ -7354,7 +7771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
 dependencies = [
  "bincode 1.3.3",
- "fancy-regex",
+ "fancy-regex 0.16.2",
  "flate2",
  "fnv",
  "once_cell",
@@ -7363,6 +7780,26 @@ dependencies = [
  "serde_derive",
  "thiserror 2.0.18",
  "walkdir",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "system-fonts"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46ba78ea149d4bb0626dacad10aa789eedc83395889890a0e6e7ec69a4577442"
+dependencies = [
+ "fontdb",
+ "sys-locale",
+ "web-sys",
 ]
 
 [[package]]
@@ -7404,7 +7841,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7613,6 +8050,32 @@ checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.17.16",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -7949,6 +8412,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8211,6 +8683,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8401,7 +8879,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8412,12 +8890,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.62.2",
  "windows-future",
  "windows-numerics",
 ]
@@ -8428,7 +8916,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets",
 ]
 
 [[package]]
@@ -8437,11 +8938,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -8450,9 +8951,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
  "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8460,6 +8972,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8489,8 +9012,17 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
  "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
@@ -8500,6 +9032,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ proc-macro-crate = "3"
 proc-macro2 = "1.0.106"
 quote = "1.0.46"
 ratatui = { version = "0.29.0", features = ["unstable-rendered-line-info"] }
+ratatex = "0.1.0"
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls"] }
 rusqlite = { version = "0.38", features = ["bundled"] }
 rquickjs = "0.12.1"
@@ -144,6 +145,44 @@ result-large-err = "allow"
 [profile.dev]
 debug = "line-tables-only"
 split-debuginfo = "unpacked"
+
+# Display math runs during interactive debug builds. Keep the small native
+# parser/layout/raster stack optimized so a cold formula is ready in one frame.
+[profile.dev.package.ratatex]
+opt-level = 1
+
+[profile.dev.package.ratex-font]
+opt-level = 3
+
+[profile.dev.package.ratex-font-loader]
+opt-level = 3
+
+[profile.dev.package.ratex-katex-fonts]
+opt-level = 3
+
+[profile.dev.package.ratex-layout]
+opt-level = 3
+
+[profile.dev.package.ratex-lexer]
+opt-level = 3
+
+[profile.dev.package.ratex-parser]
+opt-level = 3
+
+[profile.dev.package.ratex-render]
+opt-level = 3
+
+[profile.dev.package.ratex-types]
+opt-level = 3
+
+[profile.dev.package.ratex-unicode-font]
+opt-level = 3
+
+[profile.dev.package.tiny-skia]
+opt-level = 3
+
+[profile.dev.package.tiny-skia-path]
+opt-level = 3
 
 [profile.release]
 opt-level = 3

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -53,6 +53,7 @@ pulldown-cmark.workspace = true
 mpp = { workspace = true, optional = true, features = ["client", "tempo", "reqwest-rustls-tls"] }
 rand = { workspace = true, optional = true }
 ratatui.workspace = true
+ratatex.workspace = true
 reqwest = { workspace = true, features = ["blocking", "stream"] }
 self-replace.workspace = true
 semver.workspace = true

--- a/bin/nanocodex/benches/tui_render.rs
+++ b/bin/nanocodex/benches/tui_render.rs
@@ -12,6 +12,7 @@ mod tui {
 
     use criterion::{BatchSize, BenchmarkId, Criterion, Throughput};
     use nanocodex::agent::events::{AgentEvent, AgentEventKind, AgentEventTiming, TimedAgentEvent};
+    use ratatex::{PixelSize, Ratatex, TerminalProfile};
     use ratatui::{
         Terminal, TerminalOptions, Viewport,
         backend::{CrosstermBackend, TestBackend},
@@ -1421,6 +1422,25 @@ mod tui {
         criterion.bench_function("tui_markdown/image_placeholder_100k", |bencher| {
             bencher.iter(|| markdown::render_agent_markdown(black_box(&image), 120));
         });
+
+        let display_math = (0..32)
+            .map(|index| {
+                format!(
+                    "Result {index}\n\n$$\\sum_{{k=0}}^n k^2 = \
+                     \\frac{{n(n+1)(2n+1)}}{{6}}$$"
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let renderer = Ratatex::builder(TerminalProfile::unsupported(PixelSize::new(10, 20)))
+            .build()
+            .expect("display-math benchmark renderer should initialize");
+        criterion.bench_function("tui_markdown/display_math_fallback_32/120", |bencher| {
+            bencher.iter(|| {
+                markdown::render_agent_markdown_with_math(black_box(&display_math), 120, &renderer)
+            });
+        });
+        renderer.shutdown();
 
         let oversized_rust_line = format!("let value = \"{}\";", "x".repeat(1024 * 1024));
         criterion.bench_function(

--- a/bin/nanocodex/src/tui/app.rs
+++ b/bin/nanocodex/src/tui/app.rs
@@ -16,6 +16,7 @@ use nanocodex::{
         rollout::RolloutTranscriptItem,
     },
 };
+use ratatex::Ratatex;
 use ratatui::{
     buffer::Buffer,
     layout::{Position, Rect},
@@ -1248,6 +1249,32 @@ impl App {
         self
     }
 
+    pub(super) fn set_math_renderer(&mut self, renderer: Ratatex) {
+        self.main.transcript.set_math_renderer(renderer.clone());
+        for branch in &mut self.main_branches {
+            branch
+                .conversation
+                .transcript
+                .set_math_renderer(renderer.clone());
+        }
+        if let Some(btw) = &mut self.btw {
+            btw.conversation.transcript.set_math_renderer(renderer);
+        }
+    }
+
+    pub(super) fn invalidate_math_layouts(&mut self) {
+        self.main.note_tail_will_change();
+        self.main.transcript.invalidate_math_layouts();
+        for branch in &mut self.main_branches {
+            branch.conversation.note_tail_will_change();
+            branch.conversation.transcript.invalidate_math_layouts();
+        }
+        if let Some(btw) = &mut self.btw {
+            btw.conversation.note_tail_will_change();
+            btw.conversation.transcript.invalidate_math_layouts();
+        }
+    }
+
     pub(super) fn insert_char(&mut self, character: char) {
         self.prepare_composer_edit();
         self.snap_cursor_out_of_pending_paste();
@@ -2033,10 +2060,14 @@ impl App {
     pub(super) fn begin_btw(&mut self) -> u64 {
         let id = self.next_btw_id;
         self.next_btw_id = self.next_btw_id.saturating_add(1);
+        let mut conversation = Conversation::new("Forking latest checkpoint");
+        if let Some(renderer) = self.main.transcript.math_renderer() {
+            conversation.transcript.set_math_renderer(renderer);
+        }
         self.btw = Some(BtwPane {
             id,
             request_id: None,
-            conversation: Conversation::new("Forking latest checkpoint"),
+            conversation,
         });
         if !self.tool_details_expanded
             && let Some(btw) = &mut self.btw
@@ -3159,7 +3190,7 @@ fn bounded_multiline_text(value: &str, max_chars: usize, max_lines: usize) -> St
 #[cfg(test)]
 mod tests {
     use std::{
-        sync::Arc,
+        sync::{Arc, mpsc},
         time::{Duration, Instant},
     };
 
@@ -3168,6 +3199,7 @@ mod tests {
         input::{PromptInput, UserInput},
         rollout::RolloutTranscriptItem,
     };
+    use ratatex::{PixelSize, Ratatex, TerminalProfile};
     use ratatui::{buffer::Buffer, layout::Rect, widgets::Widget};
     use serde_json::{Value, json};
 
@@ -3601,6 +3633,52 @@ mod tests {
         assert!(app.main.scroll_from_bottom > old_offset);
         assert!(app.main.has_unseen_output);
         assert_eq!(after, before);
+    }
+
+    #[test]
+    fn completed_math_relayout_preserves_a_scrolled_view() {
+        let (wake_tx, wake_rx) = mpsc::sync_channel(1);
+        let cache = tempfile::tempdir().unwrap();
+        let renderer = Ratatex::builder(TerminalProfile::kitty(PixelSize::new(10, 20), false))
+            .cache_dir(cache.path())
+            .on_update(move || {
+                let _ = wake_tx.try_send(());
+            })
+            .build()
+            .unwrap();
+        let mut app = App::new(".".into());
+        app.set_math_renderer(renderer.clone());
+        app.main.settle_viewport(40, 6);
+        for index in 0..8 {
+            app.main
+                .push_output(TranscriptItem::User(format!("earlier message {index}")));
+        }
+        app.main
+            .push_assistant_delta("formula incoming\n\n\\[\n\\frac{a}{b}+\\frac{c}{d}");
+        app.main.settle_viewport(40, 6);
+        app.main.scroll_from_bottom = 5;
+        app.main.smooth_scroll_from_bottom = 0;
+
+        let area = Rect::new(0, 0, 40, 6);
+        let mut before = Buffer::empty(area);
+        app.main
+            .transcript
+            .widget(app.main.scroll_from_bottom, None, None, "empty")
+            .render(area, &mut before);
+        let old_offset = app.main.scroll_from_bottom;
+
+        wake_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        app.invalidate_math_layouts();
+        app.main.settle_viewport(40, 6);
+
+        let mut after = Buffer::empty(area);
+        app.main
+            .transcript
+            .widget(app.main.scroll_from_bottom, None, None, "empty")
+            .render(area, &mut after);
+        assert!(app.main.scroll_from_bottom > old_offset);
+        assert_eq!(after, before);
+        renderer.shutdown();
     }
 
     #[test]

--- a/bin/nanocodex/src/tui/markdown.rs
+++ b/bin/nanocodex/src/tui/markdown.rs
@@ -1,9 +1,14 @@
 use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
+use ratatex::{Formula, FormulaState, Ratatex};
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span, Text},
 };
-use std::{borrow::Cow, fmt::Write as _, sync::OnceLock};
+use std::{
+    borrow::Cow,
+    fmt::Write as _,
+    sync::{Arc, OnceLock},
+};
 use syntect::{
     easy::HighlightLines,
     highlighting::{FontStyle, Theme, ThemeSet},
@@ -16,15 +21,143 @@ use unicode_width::UnicodeWidthStr;
 const MAX_HIGHLIGHT_LINE_BYTES: usize = 4 * 1024;
 
 pub(super) fn render_agent_markdown(source: &str, width: u16) -> Text<'static> {
-    let mut writer = MarkdownWriter::new(width);
+    render_agent_markdown_inner(source, width, None, &[], MathFallback::Source).text
+}
+
+#[cfg(test)]
+pub(super) fn render_agent_markdown_with_math(
+    source: &str,
+    width: u16,
+    renderer: &Ratatex,
+) -> RenderedAgentMarkdown {
+    render_agent_markdown_inner(source, width, Some(renderer), &[], MathFallback::Pending)
+}
+
+pub(super) fn render_finalized_agent_markdown_with_math(
+    source: &str,
+    width: u16,
+    renderer: &Ratatex,
+    previous: &[StreamingFormulaFrame],
+) -> RenderedAgentMarkdown {
+    render_agent_markdown_inner(
+        source,
+        width,
+        Some(renderer),
+        previous,
+        MathFallback::Pending,
+    )
+}
+
+pub(super) fn render_streaming_agent_markdown_with_math(
+    source: &str,
+    width: u16,
+    renderer: &Ratatex,
+    previous: &[StreamingFormulaFrame],
+) -> RenderedAgentMarkdown {
+    render_agent_markdown_inner(
+        source,
+        width,
+        Some(renderer),
+        previous,
+        MathFallback::PendingOrFailed,
+    )
+}
+
+fn render_agent_markdown_inner(
+    source: &str,
+    width: u16,
+    renderer: Option<&Ratatex>,
+    previous: &[StreamingFormulaFrame],
+    math_fallback: MathFallback,
+) -> RenderedAgentMarkdown {
+    let (prepared, formulas) = renderer.map_or_else(
+        || (Cow::Borrowed(source), Vec::new()),
+        |_| prepare_display_math(source),
+    );
+    let mut writer = MarkdownWriter::new(width, &formulas, renderer, previous, math_fallback);
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
     options.insert(Options::ENABLE_TABLES);
     options.insert(Options::ENABLE_TASKLISTS);
-    for event in Parser::new_ext(source, options) {
+    for event in Parser::new_ext(&prepared, options) {
         writer.event(event);
     }
     writer.finish()
+}
+
+#[derive(Clone, Copy)]
+enum MathFallback {
+    Source,
+    Pending,
+    PendingOrFailed,
+}
+
+impl MathFallback {
+    const fn hides_pending(self) -> bool {
+        !matches!(self, Self::Source)
+    }
+
+    const fn hides_failed(self) -> bool {
+        matches!(self, Self::PendingOrFailed)
+    }
+}
+
+pub(super) struct RenderedAgentMarkdown {
+    pub(super) text: Text<'static>,
+    pub(super) formulas: Vec<MarkdownFormula>,
+    pub(super) formula_sources: Vec<Arc<str>>,
+    pub(super) math_generation: Option<u64>,
+}
+
+#[derive(Clone, Default)]
+pub(super) struct StreamingFormulaFrame {
+    pub(super) sources: Vec<Arc<str>>,
+    pub(super) formula: Option<Arc<Formula>>,
+}
+
+#[derive(Clone)]
+pub(super) struct MarkdownFormula {
+    pub(super) index: usize,
+    pub(super) formula: Arc<Formula>,
+    pub(super) full_source: Arc<str>,
+    pub(super) line: usize,
+    pub(super) column: u16,
+}
+
+struct DisplayFormula {
+    source: String,
+    full_source: String,
+}
+
+fn prepare_display_math(source: &str) -> (Cow<'_, str>, Vec<DisplayFormula>) {
+    let regions = ratatex::display_math(source);
+    if regions.is_empty() {
+        return (Cow::Borrowed(source), Vec::new());
+    }
+    let mut prepared = String::with_capacity(source.len());
+    let mut formulas = Vec::with_capacity(regions.len());
+    let mut cursor = 0;
+    for region in regions {
+        let range = region.range();
+        prepared.push_str(&source[cursor..range.start]);
+        let index = formulas.len();
+        let _ = write!(prepared, "\n\n<!--ratatex-display:{index}-->\n\n");
+        formulas.push(DisplayFormula {
+            source: region.source().to_owned(),
+            full_source: region.full_source().to_owned(),
+        });
+        cursor = range.end;
+    }
+    prepared.push_str(&source[cursor..]);
+    (Cow::Owned(prepared), formulas)
+}
+
+fn display_math_marker(html: &str) -> Option<usize> {
+    html.trim()
+        .strip_prefix("<!--ratatex-display:")?
+        .strip_suffix("-->")?
+        .parse()
+        .ok()
 }
 
 #[cfg(test)]
@@ -276,18 +409,19 @@ fn markdown_code_blocks(source: &str) -> Vec<CodeBlock> {
 }
 
 pub(super) fn heal_streaming_markdown(source: &str) -> Cow<'_, str> {
+    let source = ratatex::heal_streaming_display_math(source);
     let mut suffix = String::new();
-    if let Some(fence) = open_fence(source) {
+    if let Some(fence) = open_fence(&source) {
         if !source.ends_with('\n') {
             suffix.push('\n');
         }
         suffix.extend(std::iter::repeat_n(fence.marker, fence.length));
     } else {
-        heal_inline_markers(source, &mut suffix);
-        heal_link(source, &mut suffix);
+        heal_inline_markers(&source, &mut suffix);
+        heal_link(&source, &mut suffix);
     }
     if suffix.is_empty() {
-        Cow::Borrowed(source)
+        source
     } else {
         Cow::Owned(format!("{source}{suffix}"))
     }
@@ -604,7 +738,7 @@ fn marker_is_delimiter(bytes: &[u8], index: usize, run: usize) -> bool {
     before_flanking || after_flanking
 }
 
-struct MarkdownWriter {
+struct MarkdownWriter<'a> {
     width: u16,
     lines: Vec<Line<'static>>,
     current: Vec<Span<'static>>,
@@ -615,6 +749,11 @@ struct MarkdownWriter {
     code_block: Option<CodeBlock>,
     table: Option<TableState>,
     image: Option<MarkdownImage>,
+    formulas: &'a [DisplayFormula],
+    renderer: Option<&'a Ratatex>,
+    previous_formulas: &'a [StreamingFormulaFrame],
+    math_fallback: MathFallback,
+    rendered_formulas: Vec<MarkdownFormula>,
 }
 
 struct ListState {
@@ -640,8 +779,14 @@ struct TableState {
     in_header: bool,
 }
 
-impl MarkdownWriter {
-    fn new(width: u16) -> Self {
+impl<'a> MarkdownWriter<'a> {
+    fn new(
+        width: u16,
+        formulas: &'a [DisplayFormula],
+        renderer: Option<&'a Ratatex>,
+        previous_formulas: &'a [StreamingFormulaFrame],
+        math_fallback: MathFallback,
+    ) -> Self {
         Self {
             width,
             lines: vec![Line::styled(
@@ -658,6 +803,11 @@ impl MarkdownWriter {
             code_block: None,
             table: None,
             image: None,
+            formulas,
+            renderer,
+            previous_formulas,
+            math_fallback,
+            rendered_formulas: Vec::new(),
         }
     }
 
@@ -797,9 +947,13 @@ impl MarkdownWriter {
                 self.append_text(if checked { "[✓] " } else { "[ ] " });
             }
             Event::Html(html) | Event::InlineHtml(html) => {
-                let plain = strip_html(&html);
-                if !plain.is_empty() {
-                    self.append_text(&plain);
+                if let Some(index) = display_math_marker(&html) {
+                    self.append_display_math(index);
+                } else {
+                    let plain = strip_html(&html);
+                    if !plain.is_empty() {
+                        self.append_text(&plain);
+                    }
                 }
             }
             Event::FootnoteReference(label) => self.append_text(&format!("[{label}]")),
@@ -868,6 +1022,105 @@ impl MarkdownWriter {
                 self.flush_current();
             }
         }
+    }
+
+    fn append_display_math(&mut self, index: usize) {
+        let Some(formula) = self.formulas.get(index) else {
+            return;
+        };
+        let source = formula.source.clone();
+        let full_source = formula.full_source.clone();
+        self.flush_current();
+        self.ensure_prefix();
+        let column = self
+            .current
+            .iter()
+            .map(|span| UnicodeWidthStr::width(span.content.as_ref()))
+            .sum::<usize>()
+            .min(usize::from(u16::MAX)) as u16;
+        let max_columns = self.width.saturating_sub(column).max(1);
+        let state = self.renderer.map_or(FormulaState::Unsupported, |renderer| {
+            renderer.request(&source, max_columns)
+        });
+        match state {
+            FormulaState::Ready(formula) => {
+                self.append_ready_formula(index, formula, full_source, column);
+            }
+            FormulaState::Pending => {
+                if let Some(previous) = self.previous_formula(index, &source, max_columns) {
+                    self.append_ready_formula(index, previous, full_source, column);
+                } else if self.math_fallback.hides_pending() {
+                    self.append_hidden_formula();
+                } else {
+                    self.append_formula_source(&full_source);
+                }
+            }
+            FormulaState::Failed(_) if self.math_fallback.hides_failed() => {
+                if let Some(previous) = self.previous_formula(index, &source, max_columns) {
+                    self.append_ready_formula(index, previous, full_source, column);
+                } else {
+                    self.append_hidden_formula();
+                }
+            }
+            FormulaState::Failed(_) | FormulaState::Unsupported => {
+                self.append_formula_source(&full_source);
+            }
+        }
+    }
+
+    fn previous_formula(
+        &self,
+        index: usize,
+        current_source: &str,
+        max_columns: u16,
+    ) -> Option<Arc<Formula>> {
+        let previous = self.previous_formulas.get(index)?;
+        if let Some(renderer) = self.renderer {
+            for source in previous.sources.iter().rev() {
+                if source.as_ref() == current_source {
+                    continue;
+                }
+                if let FormulaState::Ready(formula) = renderer.request(source, max_columns) {
+                    return Some(formula);
+                }
+            }
+        }
+        previous
+            .formula
+            .as_ref()
+            .filter(|formula| formula.columns() <= max_columns)
+            .cloned()
+    }
+
+    fn append_ready_formula(
+        &mut self,
+        index: usize,
+        formula: Arc<Formula>,
+        full_source: String,
+        column: u16,
+    ) {
+        self.current.clear();
+        let line = self.lines.len();
+        self.lines
+            .extend((0..formula.rows()).map(|_| Line::raw(" ")));
+        self.rendered_formulas.push(MarkdownFormula {
+            index,
+            formula,
+            full_source: full_source.into(),
+            line,
+            column,
+        });
+    }
+
+    fn append_hidden_formula(&mut self) {
+        self.current.clear();
+        self.lines.push(Line::raw(" "));
+    }
+
+    fn append_formula_source(&mut self, full_source: &str) {
+        self.append_text(full_source);
+        self.flush_current();
+        self.blank_line();
     }
 
     fn ensure_prefix(&mut self) {
@@ -1059,7 +1312,7 @@ impl MarkdownWriter {
         }
     }
 
-    fn finish(mut self) -> Text<'static> {
+    fn finish(mut self) -> RenderedAgentMarkdown {
         self.flush_current();
         while self
             .lines
@@ -1069,7 +1322,18 @@ impl MarkdownWriter {
             let _ = self.lines.pop();
         }
         self.lines.push(Line::raw(""));
-        Text::from(self.lines)
+        RenderedAgentMarkdown {
+            text: Text::from(self.lines),
+            formulas: self.rendered_formulas,
+            formula_sources: self
+                .formulas
+                .iter()
+                .map(|formula| Arc::from(formula.source.as_str()))
+                .collect(),
+            math_generation: (!self.formulas.is_empty())
+                .then(|| self.renderer.map(Ratatex::generation))
+                .flatten(),
+        }
     }
 }
 
@@ -1152,13 +1416,14 @@ fn strip_html(html: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::{collections::HashSet, sync::mpsc, time::Duration};
 
+    use ratatex::{PixelSize, Ratatex, TerminalProfile};
     use ratatui::{Terminal, backend::TestBackend, widgets::Paragraph};
 
     use super::{
         code_line_count, heal_streaming_markdown, highlighted_code_lines, render_agent_markdown,
-        restore_markdown_links,
+        render_agent_markdown_with_math, restore_markdown_links,
     };
 
     fn render(markdown: &str, width: u16, height: u16) -> String {
@@ -1188,6 +1453,109 @@ mod tests {
         assert!(!rendered.contains("LOC"));
         assert!(!rendered.contains("┌─"));
         assert!(rendered.contains("fn main() {}"));
+    }
+
+    #[test]
+    fn unsupported_graphics_preserves_display_math_as_text() {
+        let renderer = Ratatex::builder(TerminalProfile::unsupported(PixelSize::default()))
+            .build()
+            .unwrap();
+        let rendered = render_agent_markdown_with_math(
+            "Before\n\n$$\\nabla\\cdot\\mathbf{u}=0$$\n\nAfter",
+            60,
+            &renderer,
+        );
+        let text = rendered
+            .text
+            .lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+
+        assert!(text.contains(r"$$\nabla\cdot\mathbf{u}=0$$"));
+        assert!(rendered.formulas.is_empty());
+        assert!(rendered.math_generation.is_some());
+        renderer.shutdown();
+    }
+
+    #[test]
+    fn display_math_becomes_placeholder_rows() {
+        let (wake_tx, wake_rx) = mpsc::sync_channel(1);
+        let cache = tempfile::tempdir().unwrap();
+        let renderer = Ratatex::builder(TerminalProfile::kitty(PixelSize::new(10, 20), false))
+            .cache_dir(cache.path())
+            .on_update(move || {
+                let _ = wake_tx.try_send(());
+            })
+            .build()
+            .unwrap();
+        let source = r"Before
+
+$$
+\rho\left(\frac{\partial \mathbf{u}}{\partial t}
++(\mathbf{u}\cdot\nabla)\mathbf{u}\right)
+=-\nabla p+\mu\nabla^2\mathbf{u}+\rho\mathbf{f}
+$$
+
+After";
+
+        let pending = render_agent_markdown_with_math(source, 100, &renderer);
+        assert!(pending.formulas.is_empty());
+        assert!(
+            pending
+                .text
+                .lines
+                .iter()
+                .flat_map(|line| line.spans.iter())
+                .all(|span| !span.content.contains(r"\rho"))
+        );
+        wake_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        let rendered = render_agent_markdown_with_math(source, 100, &renderer);
+        assert_eq!(rendered.formulas.len(), 1);
+        assert!(rendered.formulas[0].formula.columns() > 10);
+        assert!(rendered.formulas[0].formula.rows() > 1);
+        assert_eq!(renderer.drain_terminal_commands().len(), 1);
+        renderer.shutdown();
+    }
+
+    #[test]
+    fn display_math_uses_only_one_surrounding_markdown_gap() {
+        let (wake_tx, wake_rx) = mpsc::sync_channel(1);
+        let cache = tempfile::tempdir().unwrap();
+        let renderer = Ratatex::builder(TerminalProfile::kitty(PixelSize::new(10, 20), false))
+            .cache_dir(cache.path())
+            .on_update(move || {
+                let _ = wake_tx.try_send(());
+            })
+            .build()
+            .unwrap();
+        let source = "### Maxwell\n\n\\[\\nabla\\cdot\\mathbf{E}=0\\]\n\n### Next";
+
+        let _ = render_agent_markdown_with_math(source, 80, &renderer);
+        wake_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        let rendered = render_agent_markdown_with_math(source, 80, &renderer);
+        let formula = &rendered.formulas[0];
+        let lines = rendered
+            .text
+            .lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>();
+        let maxwell = lines
+            .iter()
+            .position(|line| line.contains("Maxwell"))
+            .unwrap();
+        let next = lines.iter().position(|line| line.contains("Next")).unwrap();
+
+        assert_eq!(formula.line, maxwell + 2);
+        assert_eq!(next, formula.line + usize::from(formula.formula.rows()));
+        renderer.shutdown();
     }
 
     #[test]

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -17,7 +17,7 @@ use std::{
     path::PathBuf,
     process::{Command, Stdio},
     sync::Arc,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use crossterm::event::{
@@ -33,6 +33,7 @@ use nanocodex::{
     },
     tools::mcp::McpHandle,
 };
+use ratatex::{Ratatex, TerminalProfile};
 use tokio::{
     sync::mpsc,
     time::{MissedTickBehavior, interval, sleep_until},
@@ -300,6 +301,7 @@ enum RedrawPriority {
 enum UiUpdate {
     Redraw(RedrawPriority),
     RedrawAnimation,
+    RestoreTerminalGraphics,
     Ignore,
     Quit,
     ExternalEditor,
@@ -411,8 +413,10 @@ impl UiModel {
                         self.pending_notification = None;
                         // tmux can resize this pane before returning focus to it. The resize
                         // frame may be presented while tmux is still repainting its layout, so
-                        // redraw once more after focus has settled on this pane.
-                        return Ok(UiUpdate::Redraw(RedrawPriority::Immediate));
+                        // redraw once more after focus has settled on this pane. Graphics
+                        // passthrough emitted while a tmux window is invisible is discarded, so
+                        // the caller must also restore Ratatex's terminal-side image state.
+                        return Ok(UiUpdate::RestoreTerminalGraphics);
                     }
                     Event::FocusLost => {
                         self.terminal_focused = false;
@@ -543,9 +547,25 @@ pub(crate) async fn run(
     );
 
     let mut terminal = TerminalSession::enter().wrap_err("failed to initialize the terminal")?;
+    let terminal_profile = TerminalProfile::query(Duration::from_millis(750));
+    let (math_update_tx, mut math_update_rx) = mpsc::channel(1);
+    let math_renderer = Ratatex::builder(terminal_profile)
+        .on_update(move || {
+            let _ = math_update_tx.try_send(());
+        })
+        .build()
+        .wrap_err("failed to initialize the display-math renderer")?;
+    let availability = math_renderer.availability();
+    tracing::debug!(
+        graphics = availability.graphics,
+        cell_width = terminal_profile.cell.width,
+        cell_height = terminal_profile.cell.height,
+        "initialized Ratatex"
+    );
     let mut input_events = EventStream::new();
     let mut ticker = ui_ticker();
     let mut app = App::new(cwd).with_thinking(initial_thinking);
+    app.set_math_renderer(math_renderer.clone());
     app.restore_transcript(restored_transcript);
     let mut ui = UiModel::new(app, Arc::clone(&root_session_id));
     let mut scheduler = RenderScheduler::new(STREAM_FRAME_INTERVAL, Instant::now());
@@ -564,6 +584,7 @@ pub(crate) async fn run(
                 &mut scheduler,
                 &mut stream_telemetry,
                 &mut notifier,
+                &math_renderer,
             )?;
 
             let render_deadline = scheduler.deadline();
@@ -578,8 +599,13 @@ pub(crate) async fn run(
                     std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "terminal input closed")
                 })?;
                 let update = ui.update(UiAction::Terminal(event), &worker_tx)?;
-                if update == UiUpdate::ExternalEditor {
+                if update == UiUpdate::RestoreTerminalGraphics {
+                    math_renderer.reupload_all();
+                    ui.app.invalidate_math_layouts();
+                } else if update == UiUpdate::ExternalEditor {
                     input_events = run_external_editor(input_events, &mut terminal, &mut ui.app).await?;
+                    math_renderer.reupload_all();
+                    ui.app.invalidate_math_layouts();
                     scheduler.request_immediate(Instant::now());
                 } else if apply_update(update, &mut scheduler) {
                     break Ok(());
@@ -625,6 +651,10 @@ pub(crate) async fn run(
                     break Ok(());
                 }
             }
+            _ = math_update_rx.recv() => {
+                ui.app.invalidate_math_layouts();
+                scheduler.request_immediate(Instant::now());
+            }
             }
         }
     }
@@ -632,6 +662,7 @@ pub(crate) async fn run(
 
     // Restore the terminal before disconnecting the paid WebSocket session.
     drop((terminal, worker_tx, agent_events));
+    math_renderer.shutdown();
     let shutdown_result = shutdown_runtime(worker, child_agents, mpp_adapter, vm).await;
     loop_result?;
     shutdown_result
@@ -728,6 +759,7 @@ fn render_due_frame(
     scheduler: &mut RenderScheduler,
     stream_telemetry: &mut StreamTelemetry,
     notifier: &mut Notifier,
+    math_renderer: &Ratatex,
 ) -> Result<()> {
     if !scheduler.is_due(Instant::now()) {
         return Ok(());
@@ -735,7 +767,8 @@ fn render_due_frame(
     ui.apply_pending_mouse_scroll();
     ui.app.advance_smooth_scroll();
     let render_started = Instant::now();
-    let draw_metrics = match scheduler.scope().unwrap_or(RenderScope::Full) {
+    let math_output_bytes = flush_math_commands(terminal, math_renderer)?;
+    let mut draw_metrics = match scheduler.scope().unwrap_or(RenderScope::Full) {
         RenderScope::Full => terminal.draw(|frame| view::render(frame, &mut ui.app))?,
         RenderScope::Animation => terminal.draw_reusing_last_frame(|frame, reused| {
             if reused {
@@ -745,6 +778,7 @@ fn render_due_frame(
             }
         })?,
     };
+    draw_metrics.output_bytes = draw_metrics.output_bytes.saturating_add(math_output_bytes);
     if let Some(text) = ui.app.take_pending_copy() {
         match clipboard::copy_to_clipboard(&text) {
             Ok(()) => {
@@ -768,6 +802,16 @@ fn render_due_frame(
         scheduler.request_streaming(presented_at);
     }
     Ok(())
+}
+
+fn flush_math_commands(terminal: &mut TerminalSession, math_renderer: &Ratatex) -> Result<u64> {
+    let mut output_bytes = 0_u64;
+    for command in math_renderer.drain_terminal_commands() {
+        terminal.write_control_sequence(command.as_bytes())?;
+        output_bytes =
+            output_bytes.saturating_add(u64::try_from(command.len()).unwrap_or(u64::MAX));
+    }
+    Ok(output_bytes)
 }
 
 fn worker_event_received(
@@ -823,6 +867,7 @@ fn apply_update(update: UiUpdate, scheduler: &mut RenderScheduler) -> bool {
     let now = Instant::now();
     match update {
         UiUpdate::Redraw(RedrawPriority::Immediate) => scheduler.request_immediate(now),
+        UiUpdate::RestoreTerminalGraphics => scheduler.request_immediate(now),
         UiUpdate::Redraw(RedrawPriority::Streaming) => scheduler.request_streaming(now),
         UiUpdate::Redraw(RedrawPriority::InputBurst) => scheduler.request_input_burst(now),
         UiUpdate::RedrawAnimation => scheduler.request_animation(now),
@@ -3002,7 +3047,7 @@ mod tests {
         assert_eq!(
             ui.update(UiAction::Terminal(Event::FocusGained), &commands)
                 .unwrap(),
-            UiUpdate::Redraw(RedrawPriority::Immediate)
+            UiUpdate::RestoreTerminalGraphics
         );
         assert!(ui.pending_notification.is_none());
         assert_eq!(ui.app.input, "unfinished draft");

--- a/bin/nanocodex/src/tui/selection.rs
+++ b/bin/nanocodex/src/tui/selection.rs
@@ -1,5 +1,6 @@
 use std::time::{Duration, Instant};
 
+use ratatex::is_formula_placeholder;
 use ratatui::{
     buffer::Buffer,
     layout::{Position, Rect},
@@ -76,6 +77,8 @@ pub(super) struct ScreenSelection {
     copied_before: Vec<String>,
     copied_after: Vec<String>,
     pending_click: Option<SelectionClick>,
+    formula_cells: Vec<Position>,
+    anchor_was_formula: bool,
 }
 
 impl ScreenSelection {
@@ -84,6 +87,7 @@ impl ScreenSelection {
     }
 
     fn begin_at(&mut self, position: Position, now: Instant) -> bool {
+        let anchor_was_formula = self.formula_cells.contains(&position);
         self.pending_copy = None;
         self.copy_after_render = false;
         self.highlight_mode = HighlightMode::Selection;
@@ -94,6 +98,7 @@ impl ScreenSelection {
         self.copied_before.clear();
         self.copied_after.clear();
         self.pending_click = None;
+        self.anchor_was_formula = anchor_was_formula;
         if !self.is_selectable(position) {
             return self.clear();
         }
@@ -164,6 +169,11 @@ impl ScreenSelection {
             });
         }
         if self.anchor == self.head && self.mode == SelectionMode::Character {
+            if self.anchor_was_formula {
+                self.completed_click = None;
+                self.click_count = 0;
+                return true;
+            }
             if let (Some(surface_index), Some(surface)) = (self.surface_index, self.surface) {
                 self.pending_click = Some(SelectionClick {
                     surface_index,
@@ -204,6 +214,7 @@ impl ScreenSelection {
         self.scroll_snapshot = None;
         self.copied_before.clear();
         self.copied_after.clear();
+        self.anchor_was_formula = false;
         changed
     }
 
@@ -231,6 +242,20 @@ impl ScreenSelection {
         self.selectable_area_count = selectable_areas.len().min(self.selectable_areas.len());
         self.selectable_areas[..self.selectable_area_count]
             .copy_from_slice(&selectable_areas[..self.selectable_area_count]);
+        self.formula_cells.clear();
+        for area in &self.selectable_areas[..self.selectable_area_count] {
+            let left = area.x.max(buffer.area.x);
+            let right = area.right().min(buffer.area.right());
+            let top = area.y.max(buffer.area.y);
+            let bottom = area.bottom().min(buffer.area.bottom());
+            for y in top..bottom {
+                for x in left..right {
+                    if is_formula_placeholder(buffer[(x, y)].symbol()) {
+                        self.formula_cells.push(Position::new(x, y));
+                    }
+                }
+            }
+        }
         let Some((raw_start, raw_end)) = self.ordered() else {
             return;
         };
@@ -839,6 +864,22 @@ mod tests {
         assert_eq!(click.surface_index, 0);
         assert_eq!(click.surface, area);
         assert_eq!(click.position, (7, 5).into());
+    }
+
+    #[test]
+    fn clicking_a_formula_placeholder_pins_selection_for_the_source_redraw() {
+        let area = Rect::new(0, 0, 12, 2);
+        let mut buffer = Buffer::empty(area);
+        buffer[(2, 1)].set_symbol("\u{10eeee}\u{0305}\u{0305}");
+        let mut selection = ScreenSelection::default();
+        selection.render(&mut buffer, &[area]);
+
+        assert!(selection.begin((2, 1).into()));
+        assert!(selection.finish((2, 1).into()));
+
+        assert!(selection.is_active());
+        assert!(selection.take_pending_click().is_none());
+        assert!(selection.take_pending_copy().is_none());
     }
 
     #[test]

--- a/bin/nanocodex/src/tui/transcript.rs
+++ b/bin/nanocodex/src/tui/transcript.rs
@@ -8,6 +8,7 @@ use std::{
     },
 };
 
+use ratatex::{Formula, FormulaWidget, Ratatex, SignedPosition};
 use ratatui::{
     buffer::Buffer,
     layout::{Alignment, Position, Rect},
@@ -22,8 +23,9 @@ use super::app::PlanStepStatus;
 use super::composer::ComposerLayout;
 use super::diff::{PatchPresentation, present_apply_patch};
 use super::markdown::{
-    LogicalMarkdown, heal_streaming_markdown, render_agent_markdown,
-    restore_markdown_links_from_sources,
+    LogicalMarkdown, MarkdownFormula, RenderedAgentMarkdown, StreamingFormulaFrame,
+    heal_streaming_markdown, render_agent_markdown, render_finalized_agent_markdown_with_math,
+    render_streaming_agent_markdown_with_math, restore_markdown_links_from_sources,
 };
 
 #[derive(Clone, Copy)]
@@ -63,6 +65,7 @@ pub(super) struct Transcript {
     editable_users: Vec<usize>,
     cached_total_height: AtomicU64,
     tool_details_expanded: Arc<AtomicBool>,
+    math_renderer: Option<Ratatex>,
 }
 
 impl Default for Transcript {
@@ -72,6 +75,7 @@ impl Default for Transcript {
             editable_users: Vec::new(),
             cached_total_height: AtomicU64::new(0),
             tool_details_expanded: Arc::new(AtomicBool::new(true)),
+            math_renderer: None,
         }
     }
 }
@@ -83,6 +87,7 @@ impl Clone for Transcript {
             editable_users: self.editable_users.clone(),
             cached_total_height: AtomicU64::new(self.cached_total_height.load(Ordering::Relaxed)),
             tool_details_expanded: Arc::clone(&self.tool_details_expanded),
+            math_renderer: self.math_renderer.clone(),
         }
     }
 }
@@ -122,7 +127,27 @@ impl Transcript {
         self.entries.push(Arc::new(TranscriptEntry::new(
             item,
             Arc::clone(&self.tool_details_expanded),
+            self.math_renderer.clone(),
         )));
+        self.invalidate_total_height();
+    }
+
+    pub(super) fn set_math_renderer(&mut self, renderer: Ratatex) {
+        for entry in &mut self.entries {
+            Arc::make_mut(entry).set_math_renderer(renderer.clone());
+        }
+        self.math_renderer = Some(renderer);
+        self.invalidate_total_height();
+    }
+
+    pub(super) fn math_renderer(&self) -> Option<Ratatex> {
+        self.math_renderer.clone()
+    }
+
+    pub(super) fn invalidate_math_layouts(&self) {
+        for entry in &self.entries {
+            entry.invalidate_math_layout();
+        }
         self.invalidate_total_height();
     }
 
@@ -169,6 +194,7 @@ impl Transcript {
         let mut entry = TranscriptEntry::new(
             TranscriptItem::User(message),
             Arc::clone(&self.tool_details_expanded),
+            self.math_renderer.clone(),
         );
         entry.prompt_id = Some(prompt_id);
         self.editable_users.push(self.entries.len());
@@ -341,6 +367,7 @@ impl Transcript {
                 .to_vec(),
             cached_total_height: AtomicU64::new(0),
             tool_details_expanded: Arc::clone(&self.tool_details_expanded),
+            math_renderer: self.math_renderer.clone(),
         }
     }
 
@@ -416,6 +443,7 @@ impl Transcript {
             selected,
             inline_edit,
             empty_message,
+            math_fallback: false,
         }
     }
 
@@ -475,6 +503,14 @@ pub(super) struct TranscriptWidget<'a> {
     selected: Option<usize>,
     inline_edit: Option<InlineEdit<'a>>,
     empty_message: &'static str,
+    math_fallback: bool,
+}
+
+impl TranscriptWidget<'_> {
+    pub(super) const fn math_fallback(mut self, enabled: bool) -> Self {
+        self.math_fallback = enabled;
+        self
+    }
 }
 
 impl Widget for TranscriptWidget<'_> {
@@ -513,6 +549,7 @@ impl Widget for TranscriptWidget<'_> {
                 viewport,
                 Some(selected),
                 self.inline_edit,
+                self.math_fallback,
             );
             return;
         }
@@ -553,6 +590,7 @@ impl Widget for TranscriptWidget<'_> {
                 },
                 self.selected,
                 self.inline_edit,
+                self.math_fallback,
             );
             return;
         }
@@ -575,6 +613,7 @@ impl Widget for TranscriptWidget<'_> {
             },
             self.selected,
             self.inline_edit,
+            self.math_fallback,
         );
     }
 }
@@ -694,6 +733,7 @@ fn render_entries(
     viewport: Viewport,
     selected: Option<usize>,
     inline_edit: Option<InlineEdit<'_>>,
+    math_fallback: bool,
 ) {
     let mut local_scroll = viewport.local_scroll;
     let mut screen_y = viewport.screen_y;
@@ -724,6 +764,7 @@ fn render_entries(
                     local_scroll,
                     entry_height,
                     selected == Some(index),
+                    math_fallback,
                 );
             }
             screen_y = screen_y.saturating_add(visible_height);
@@ -822,6 +863,14 @@ struct MarkdownContent {
     show_header: bool,
     cached: Mutex<Option<RenderedText>>,
     logical_copy: Mutex<Option<LogicalMarkdown>>,
+    math_frames: Mutex<Option<MathFrames>>,
+    math_renderer: Option<Ratatex>,
+}
+
+#[derive(Clone)]
+struct MathFrames {
+    width: u16,
+    formulas: Vec<StreamingFormulaFrame>,
 }
 
 #[derive(Clone)]
@@ -830,7 +879,16 @@ struct RenderedText {
     text: Text<'static>,
     line_heights: Vec<usize>,
     prewrapped_lines: Vec<Option<Vec<Line<'static>>>>,
+    formulas: Vec<RenderedFormula>,
     height: usize,
+}
+
+#[derive(Clone)]
+struct RenderedFormula {
+    formula: Arc<Formula>,
+    full_source: Arc<str>,
+    visual_top: usize,
+    column: u16,
 }
 
 #[derive(Clone)]
@@ -924,6 +982,13 @@ impl Clone for MarkdownContent {
                     .unwrap_or_else(PoisonError::into_inner)
                     .clone(),
             ),
+            math_frames: Mutex::new(
+                self.math_frames
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner)
+                    .clone(),
+            ),
+            math_renderer: self.math_renderer.clone(),
         }
     }
 }
@@ -941,7 +1006,11 @@ impl Clone for TranscriptEntry {
 }
 
 impl TranscriptEntry {
-    fn new(item: TranscriptItem, tool_details_expanded: Arc<AtomicBool>) -> Self {
+    fn new(
+        item: TranscriptItem,
+        tool_details_expanded: Arc<AtomicBool>,
+        math_renderer: Option<Ratatex>,
+    ) -> Self {
         let (kind, user_message, content) = match item {
             TranscriptItem::User(message) => {
                 let text = message_text(
@@ -956,12 +1025,12 @@ impl TranscriptEntry {
             TranscriptItem::Assistant(message) => (
                 EntryKind::Assistant,
                 None,
-                EntryContent::Markdown(MarkdownContent::streaming(&message)),
+                EntryContent::Markdown(MarkdownContent::streaming(&message, math_renderer)),
             ),
             TranscriptItem::Reasoning(message) => (
                 EntryKind::Reasoning,
                 None,
-                EntryContent::Markdown(MarkdownContent::reasoning(&message)),
+                EntryContent::Markdown(MarkdownContent::reasoning(&message, math_renderer)),
             ),
             TranscriptItem::Tool {
                 call_id,
@@ -1004,6 +1073,13 @@ impl TranscriptEntry {
         }
     }
 
+    fn set_math_renderer(&mut self, renderer: Ratatex) {
+        if let EntryContent::Markdown(markdown) = &mut self.content {
+            markdown.set_math_renderer(renderer);
+        }
+        self.cached_height.store(0, Ordering::Relaxed);
+    }
+
     #[cfg(test)]
     fn paragraph(&self) -> Paragraph<'static> {
         Paragraph::new(match &self.content {
@@ -1032,6 +1108,12 @@ impl TranscriptEntry {
         {
             let _ = text.lines.pop();
             self.cached_height.store(0, Ordering::Relaxed);
+        }
+    }
+
+    fn invalidate_math_layout(&self) {
+        if let EntryContent::Markdown(markdown) = &self.content {
+            markdown.invalidate_math_layout();
         }
     }
 
@@ -1079,6 +1161,7 @@ impl TranscriptEntry {
         scroll: usize,
         total_height: usize,
         selected: bool,
+        math_fallback: bool,
     ) {
         match &self.content {
             EntryContent::Static(text) => {
@@ -1098,7 +1181,14 @@ impl TranscriptEntry {
                 }
             }
             EntryContent::Markdown(markdown) => {
-                markdown.render(area, buffer, scroll, total_height, selected);
+                markdown.render_with_math_fallback(
+                    area,
+                    buffer,
+                    scroll,
+                    total_height,
+                    selected,
+                    math_fallback,
+                );
             }
             EntryContent::Tool(tool) => {
                 tool.render(area, buffer, scroll, total_height, selected);
@@ -1136,10 +1226,10 @@ impl TranscriptEntry {
         if !matches!(self.kind, EntryKind::Assistant) {
             return false;
         }
-        match &mut self.content {
-            EntryContent::Markdown(markdown) => markdown.finalize(message),
-            _ => self.content = EntryContent::Markdown(MarkdownContent::new(message)),
-        }
+        let EntryContent::Markdown(markdown) = &mut self.content else {
+            return false;
+        };
+        markdown.finalize(message);
         self.cached_height.store(0, Ordering::Relaxed);
         true
     }
@@ -1765,7 +1855,8 @@ fn format_duration(duration_ns: u64) -> String {
 }
 
 impl MarkdownContent {
-    fn new(source: &str) -> Self {
+    #[cfg(test)]
+    fn new(source: &str, math_renderer: Option<Ratatex>) -> Self {
         Self {
             source: source.to_owned(),
             streaming: false,
@@ -1774,10 +1865,12 @@ impl MarkdownContent {
             show_header: true,
             cached: Mutex::new(None),
             logical_copy: Mutex::new(None),
+            math_frames: Mutex::new(None),
+            math_renderer,
         }
     }
 
-    fn streaming(source: &str) -> Self {
+    fn streaming(source: &str, math_renderer: Option<Ratatex>) -> Self {
         Self {
             source: source.to_owned(),
             streaming: true,
@@ -1786,10 +1879,12 @@ impl MarkdownContent {
             show_header: true,
             cached: Mutex::new(None),
             logical_copy: Mutex::new(None),
+            math_frames: Mutex::new(None),
+            math_renderer,
         }
     }
 
-    fn reasoning(source: &str) -> Self {
+    fn reasoning(source: &str, math_renderer: Option<Ratatex>) -> Self {
         let source = format!("• {}", indent_reasoning(source));
         Self {
             plain_streaming: is_plain_streaming_markdown(&source),
@@ -1799,7 +1894,22 @@ impl MarkdownContent {
             show_header: false,
             cached: Mutex::new(None),
             logical_copy: Mutex::new(None),
+            math_frames: Mutex::new(None),
+            math_renderer,
         }
+    }
+
+    fn set_math_renderer(&mut self, renderer: Ratatex) {
+        self.math_renderer = Some(renderer);
+        *self.cached.lock().unwrap_or_else(PoisonError::into_inner) = None;
+        *self
+            .math_frames
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = None;
+    }
+
+    fn invalidate_math_layout(&self) {
+        *self.cached.lock().unwrap_or_else(PoisonError::into_inner) = None;
     }
 
     fn append(&mut self, delta: &str) {
@@ -1905,6 +2015,7 @@ impl MarkdownContent {
         self.with_rendered(width, |rendered| rendered.height)
     }
 
+    #[cfg(test)]
     fn render(
         &self,
         area: Rect,
@@ -1913,11 +2024,23 @@ impl MarkdownContent {
         total_height: usize,
         selected: bool,
     ) {
+        self.render_with_math_fallback(area, buffer, scroll, total_height, selected, false);
+    }
+
+    fn render_with_math_fallback(
+        &self,
+        area: Rect,
+        buffer: &mut Buffer,
+        scroll: usize,
+        total_height: usize,
+        selected: bool,
+        math_fallback: bool,
+    ) {
         if area.is_empty() {
             return;
         }
         self.with_rendered(area.width, |rendered| {
-            rendered.render(area, buffer, scroll, total_height, selected);
+            rendered.render_markdown(area, buffer, scroll, total_height, selected, math_fallback);
         });
     }
 
@@ -1935,10 +2058,38 @@ impl MarkdownContent {
             } else {
                 Cow::Borrowed(self.source.as_str())
             };
-            let mut text = render_agent_markdown(&source, width);
-            if !self.show_header && !text.lines.is_empty() {
-                let _ = text.lines.remove(0);
-                for (index, line) in text.lines.iter_mut().enumerate() {
+            let previous = self
+                .math_frames
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .as_ref()
+                .filter(|frames| frames.width == width)
+                .map_or_else(Vec::new, |frames| frames.formulas.clone());
+            let mut rendered = self.math_renderer.as_ref().map_or_else(
+                || RenderedAgentMarkdown {
+                    text: render_agent_markdown(&source, width),
+                    formulas: Vec::new(),
+                    formula_sources: Vec::new(),
+                    math_generation: None,
+                },
+                |renderer| {
+                    if self.streaming {
+                        render_streaming_agent_markdown_with_math(
+                            &source, width, renderer, &previous,
+                        )
+                    } else {
+                        render_finalized_agent_markdown_with_math(
+                            &source, width, renderer, &previous,
+                        )
+                    }
+                },
+            );
+            if !self.show_header && !rendered.text.lines.is_empty() {
+                let _ = rendered.text.lines.remove(0);
+                for formula in &mut rendered.formulas {
+                    formula.line = formula.line.saturating_sub(1);
+                }
+                for (index, line) in rendered.text.lines.iter_mut().enumerate() {
                     if line
                         .spans
                         .first()
@@ -1951,8 +2102,45 @@ impl MarkdownContent {
                     }
                 }
             }
-            text.style = self.base_style;
-            RenderedText::new(text, width)
+            rendered.text.style = self.base_style;
+            let next_math_frames = rendered.math_generation.is_some().then(|| {
+                let mut formulas = previous;
+                if formulas.len() < rendered.formula_sources.len() {
+                    formulas.resize_with(
+                        rendered.formula_sources.len(),
+                        StreamingFormulaFrame::default,
+                    );
+                }
+                for (index, source) in rendered.formula_sources.iter().enumerate() {
+                    let frame = &mut formulas[index];
+                    if frame
+                        .sources
+                        .last()
+                        .is_none_or(|previous| previous != source)
+                    {
+                        frame.sources.push(Arc::clone(source));
+                        if frame.sources.len() > 8 {
+                            let excess = frame.sources.len().saturating_sub(8);
+                            frame.sources.drain(..excess);
+                        }
+                    }
+                }
+                for formula in &rendered.formulas {
+                    if formulas.len() <= formula.index {
+                        formulas.resize_with(
+                            formula.index.saturating_add(1),
+                            StreamingFormulaFrame::default,
+                        );
+                    }
+                    formulas[formula.index].formula = Some(Arc::clone(&formula.formula));
+                }
+                MathFrames { width, formulas }
+            });
+            *self
+                .math_frames
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner) = next_math_frames;
+            RenderedText::with_formulas(rendered.text, width, rendered.formulas)
         });
         read(rendered)
     }
@@ -1960,19 +2148,47 @@ impl MarkdownContent {
 
 impl RenderedText {
     fn new(text: Text<'static>, width: u16) -> Self {
+        Self::with_formulas(text, width, Vec::new())
+    }
+
+    fn with_formulas(text: Text<'static>, width: u16, formulas: Vec<MarkdownFormula>) -> Self {
+        let mut formula_rows = vec![false; text.lines.len()];
+        for formula in &formulas {
+            let end = formula
+                .line
+                .saturating_add(usize::from(formula.formula.rows()))
+                .min(formula_rows.len());
+            if let Some(rows) = formula_rows.get_mut(formula.line..end) {
+                rows.fill(true);
+            }
+        }
         let mut line_heights = Vec::with_capacity(text.lines.len());
         let mut prewrapped_lines = Vec::with_capacity(text.lines.len());
-        for line in &text.lines {
-            let (height, rows) = rendered_line_layout(line, &text, width);
+        for (index, line) in text.lines.iter().enumerate() {
+            let (height, rows) = if formula_rows[index] {
+                (1, None)
+            } else {
+                rendered_line_layout(line, &text, width)
+            };
             line_heights.push(height);
             prewrapped_lines.push(rows);
         }
         let height = line_heights.iter().copied().sum();
+        let formulas = formulas
+            .into_iter()
+            .map(|formula| RenderedFormula {
+                visual_top: line_heights.iter().take(formula.line).copied().sum(),
+                formula: formula.formula,
+                full_source: formula.full_source,
+                column: formula.column,
+            })
+            .collect();
         Self {
             width,
             text,
             line_heights,
             prewrapped_lines,
+            formulas,
             height,
         }
     }
@@ -2050,6 +2266,30 @@ impl RenderedText {
         total_height: usize,
         selected: bool,
     ) {
+        self.render_inner(area, buffer, scroll, total_height, selected, false);
+    }
+
+    fn render_markdown(
+        &self,
+        area: Rect,
+        buffer: &mut Buffer,
+        scroll: usize,
+        total_height: usize,
+        selected: bool,
+        math_fallback: bool,
+    ) {
+        self.render_inner(area, buffer, scroll, total_height, selected, math_fallback);
+    }
+
+    fn render_inner(
+        &self,
+        area: Rect,
+        buffer: &mut Buffer,
+        scroll: usize,
+        total_height: usize,
+        selected: bool,
+        math_fallback: bool,
+    ) {
         if area.is_empty() {
             return;
         }
@@ -2102,6 +2342,27 @@ impl RenderedText {
             }
             line_top = line_bottom;
             index = index.saturating_add(1);
+        }
+        for formula in &self.formulas {
+            let formula_bottom = formula
+                .visual_top
+                .saturating_add(usize::from(formula.formula.rows()));
+            if formula_bottom <= scroll || formula.visual_top >= viewport_bottom {
+                continue;
+            }
+            let x = i32::from(formula.column);
+            let y = i32::try_from(formula.visual_top)
+                .unwrap_or(i32::MAX)
+                .saturating_sub(i32::try_from(scroll).unwrap_or(i32::MAX));
+            let widget = FormulaWidget::new(&formula.formula).position(SignedPosition::new(x, y));
+            if math_fallback || selected {
+                widget
+                    .compact_source_fallback(formula.full_source.as_ref())
+                    .source_fallback_style(Style::default().fg(Color::White))
+                    .render(area, buffer);
+            } else {
+                widget.render(area, buffer);
+            }
         }
         if selected {
             buffer.set_style(area, Style::default().add_modifier(Modifier::REVERSED));
@@ -2556,8 +2817,12 @@ fn saturating_u16(value: usize) -> u16 {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, atomic::AtomicBool};
+    use std::{
+        sync::{Arc, atomic::AtomicBool, mpsc},
+        time::Duration,
+    };
 
+    use ratatex::{PixelSize, Ratatex, TerminalProfile};
     use ratatui::{
         Terminal,
         backend::TestBackend,
@@ -2604,9 +2869,288 @@ mod tests {
     }
 
     #[test]
+    fn formula_flows_through_the_transcript_buffer() {
+        let (wake_tx, wake_rx) = mpsc::sync_channel(1);
+        let cache = tempfile::tempdir().unwrap();
+        let renderer = Ratatex::builder(TerminalProfile::kitty(PixelSize::new(10, 20), false))
+            .cache_dir(cache.path())
+            .on_update(move || {
+                let _ = wake_tx.try_send(());
+            })
+            .build()
+            .unwrap();
+        let mut transcript = Transcript::default();
+        transcript.set_math_renderer(renderer.clone());
+        transcript.push(TranscriptItem::Assistant(
+            r"For an incompressible fluid:
+
+$$
+\rho\left(\frac{\partial \mathbf{u}}{\partial t}
++(\mathbf{u}\cdot\nabla)\mathbf{u}\right)
+=-\nabla p+\mu\nabla^2\mathbf{u}+\rho\mathbf{f}
+$$
+
+with $\mathbf{u}$ denoting velocity."
+                .to_owned(),
+        ));
+
+        let _ = transcript.height_from(0, 120);
+        wake_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        transcript.invalidate_math_layouts();
+        assert_eq!(renderer.drain_terminal_commands().len(), 1);
+
+        let mut terminal = Terminal::new(TestBackend::new(120, 20)).unwrap();
+        terminal
+            .draw(|frame| {
+                frame.render_widget(transcript.widget(0, None, None, "empty"), frame.area());
+            })
+            .unwrap();
+        let placeholders = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .filter(|cell| cell.symbol().starts_with('\u{10eeee}'))
+            .count();
+        assert!(placeholders > 10);
+
+        terminal
+            .draw(|frame| {
+                frame.render_widget(
+                    transcript
+                        .widget(0, None, None, "empty")
+                        .math_fallback(true),
+                    frame.area(),
+                );
+            })
+            .unwrap();
+        assert!(terminal.backend().to_string().contains(r"\rho"));
+        assert!(
+            terminal
+                .backend()
+                .buffer()
+                .content
+                .iter()
+                .all(|cell| !cell.symbol().starts_with('\u{10eeee}'))
+        );
+        renderer.shutdown();
+    }
+
+    #[test]
+    fn streaming_formula_keeps_the_last_ready_frame_without_exposing_tex() {
+        let (wake_tx, wake_rx) = mpsc::sync_channel(4);
+        let cache = tempfile::tempdir().unwrap();
+        let renderer = Ratatex::builder(TerminalProfile::kitty(PixelSize::new(10, 20), false))
+            .cache_dir(cache.path())
+            .on_update(move || {
+                let _ = wake_tx.try_send(());
+            })
+            .build()
+            .unwrap();
+        let mut markdown = MarkdownContent::streaming("Before\n\n\\[\nx", Some(renderer.clone()));
+
+        let (pending_lines, pending_formulas) = markdown.with_rendered(80, |rendered| {
+            (
+                rendered
+                    .text
+                    .lines
+                    .iter()
+                    .map(|line| {
+                        line.spans
+                            .iter()
+                            .map(|span| span.content.as_ref())
+                            .collect::<String>()
+                    })
+                    .collect::<Vec<_>>(),
+                rendered.formulas.len(),
+            )
+        });
+        assert!(pending_lines.iter().any(|line| line.contains("Before")));
+        assert!(pending_lines.iter().all(|line| !line.contains(r"\[")));
+        assert!(pending_lines.iter().all(|line| line.trim() != "x"));
+        assert_eq!(pending_formulas, 0);
+
+        wake_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        markdown.invalidate_math_layout();
+        markdown.append("+y");
+        let (fallback, fallback_text) = markdown.with_rendered(80, |rendered| {
+            assert_eq!(rendered.formulas.len(), 1);
+            (
+                Arc::clone(&rendered.formulas[0].formula),
+                rendered
+                    .text
+                    .lines
+                    .iter()
+                    .flat_map(|line| line.spans.iter())
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>(),
+            )
+        });
+        assert!(!fallback_text.contains(r"\["));
+        assert!(!fallback_text.contains("x+y"));
+
+        wake_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        markdown.invalidate_math_layout();
+        let replacement = markdown.with_rendered(80, |rendered| {
+            assert_eq!(rendered.formulas.len(), 1);
+            Arc::clone(&rendered.formulas[0].formula)
+        });
+        assert!(!Arc::ptr_eq(&fallback, &replacement));
+
+        markdown.append("+z");
+        let stored_fallback = markdown.with_rendered(80, |rendered| {
+            assert_eq!(rendered.formulas.len(), 1);
+            Arc::clone(&rendered.formulas[0].formula)
+        });
+        assert!(Arc::ptr_eq(&replacement, &stored_fallback));
+        wake_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        markdown.invalidate_math_layout();
+        let final_prefix = markdown.with_rendered(80, |rendered| {
+            assert_eq!(rendered.formulas.len(), 1);
+            Arc::clone(&rendered.formulas[0].formula)
+        });
+
+        markdown.append("\n\\]");
+        let closed = markdown.with_rendered(80, |rendered| {
+            assert_eq!(rendered.formulas.len(), 1);
+            Arc::clone(&rendered.formulas[0].formula)
+        });
+        assert!(Arc::ptr_eq(&final_prefix, &closed));
+
+        let finalized_source = "Before\n\n\\[\nx+y+z+w\n\\]";
+        markdown.finalize(finalized_source);
+        let (finalizing, finalizing_text) = markdown.with_rendered(80, |rendered| {
+            assert_eq!(rendered.formulas.len(), 1);
+            (
+                Arc::clone(&rendered.formulas[0].formula),
+                rendered
+                    .text
+                    .lines
+                    .iter()
+                    .flat_map(|line| line.spans.iter())
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>(),
+            )
+        });
+        assert!(Arc::ptr_eq(&closed, &finalizing));
+        assert!(!finalizing_text.contains(r"\["));
+        assert!(!finalizing_text.contains("x+y+z+w"));
+
+        wake_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        markdown.invalidate_math_layout();
+        let finalized = markdown.with_rendered(80, |rendered| {
+            assert_eq!(rendered.formulas.len(), 1);
+            Arc::clone(&rendered.formulas[0].formula)
+        });
+        assert!(!Arc::ptr_eq(&finalizing, &finalized));
+        renderer.shutdown();
+    }
+
+    #[test]
+    fn scrolling_through_a_formula_preserves_its_placeholder_tiles() {
+        let (wake_tx, wake_rx) = mpsc::sync_channel(1);
+        let cache = tempfile::tempdir().unwrap();
+        let renderer = Ratatex::builder(TerminalProfile::kitty(PixelSize::new(10, 20), false))
+            .cache_dir(cache.path())
+            .on_update(move || {
+                let _ = wake_tx.try_send(());
+            })
+            .build()
+            .unwrap();
+        let source = "Before\n\n\\[\\frac{a}{b}+\\frac{c}{d}\\]\n\nAfter";
+        let markdown = MarkdownContent::new(source, Some(renderer.clone()));
+        let _ = markdown.height(60);
+        wake_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        markdown.invalidate_math_layout();
+
+        let (formula_top, formula_rows, formula_column, height) =
+            markdown.with_rendered(60, |rendered| {
+                let formula = &rendered.formulas[0];
+                (
+                    formula.visual_top,
+                    usize::from(formula.formula.rows()),
+                    formula.column,
+                    rendered.height,
+                )
+            });
+        assert!(formula_rows > 1);
+
+        let full_area = Rect::new(0, 0, 60, saturating_u16(height));
+        let mut full = Buffer::empty(full_area);
+        markdown.render(full_area, &mut full, 0, height, false);
+        let expected = full[(
+            formula_column,
+            saturating_u16(formula_top.saturating_add(1)),
+        )]
+            .symbol()
+            .to_owned();
+
+        let clipped_area = Rect::new(0, 0, 60, 2);
+        let mut clipped = Buffer::empty(clipped_area);
+        markdown.render(
+            clipped_area,
+            &mut clipped,
+            formula_top.saturating_add(1),
+            height,
+            false,
+        );
+        assert_eq!(clipped[(formula_column, 0)].symbol(), expected);
+        assert!(ratatex::is_formula_placeholder(&expected));
+        renderer.shutdown();
+    }
+
+    #[test]
+    fn formula_only_markdown_reserves_exactly_the_image_rows() {
+        let (wake_tx, wake_rx) = mpsc::sync_channel(1);
+        let cache = tempfile::tempdir().unwrap();
+        let renderer = Ratatex::builder(TerminalProfile::kitty(PixelSize::new(14, 27), false))
+            .cache_dir(cache.path())
+            .on_update(move || {
+                let _ = wake_tx.try_send(());
+            })
+            .build()
+            .unwrap();
+        let source = r"\[
+\begin{aligned}
+R^\rho{}_{\sigma\mu\nu}
+&=\partial_\mu\Gamma^\rho_{\nu\sigma}
+-\partial_\nu\Gamma^\rho_{\mu\sigma}
++\Gamma^\rho_{\mu\lambda}\Gamma^\lambda_{\nu\sigma}
+-\Gamma^\rho_{\nu\lambda}\Gamma^\lambda_{\mu\sigma},\\
+\Gamma^\rho_{\mu\nu}
+&=\frac12g^{\rho\kappa}
+\left(\partial_\mu g_{\kappa\nu}
++\partial_\nu g_{\kappa\mu}
+-\partial_\kappa g_{\mu\nu}\right),\\
+R_{\mu\nu}-\frac12R\,g_{\mu\nu}+\Lambda g_{\mu\nu}
+&=\frac{8\pi G}{c^4}T_{\mu\nu},
+\qquad
+\nabla_\mu T^{\mu\nu}=0.
+\end{aligned}
+\]";
+        let markdown = MarkdownContent::new(source, Some(renderer.clone()));
+        let _ = markdown.height(54);
+        wake_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        markdown.invalidate_math_layout();
+
+        markdown.with_rendered(54, |rendered| {
+            let formula = &rendered.formulas[0];
+            assert_eq!(
+                rendered.height,
+                formula
+                    .visual_top
+                    .saturating_add(usize::from(formula.formula.rows()))
+                    .saturating_add(1)
+            );
+        });
+        renderer.shutdown();
+    }
+
+    #[test]
     fn markdown_viewport_render_matches_full_paragraph_scrolling() {
         let markdown = MarkdownContent::new(
             "# Heading\n\nA **styled** paragraph with `code`, unicode λ, and a long line that wraps across several visual rows without losing its formatting.\n\n- first\n  - nested\n\n| A | B |\n| - | - |\n| one | two |",
+            None,
         );
         for width in [20, 43] {
             let height = markdown.height(width);
@@ -2628,7 +3172,7 @@ mod tests {
     #[test]
     fn long_styled_markdown_line_uses_parity_checked_cached_rows() {
         let source = format!("**{}**", "styled λ text ".repeat(600));
-        let markdown = MarkdownContent::new(&source);
+        let markdown = MarkdownContent::new(&source, None);
         let width = 20;
         let height = markdown.height(width);
         assert!(height > 256);
@@ -2660,11 +3204,11 @@ mod tests {
             ("plain", "\n\n# heading"),
         ] {
             for width in [20, 80] {
-                let mut incremental = MarkdownContent::streaming(source);
+                let mut incremental = MarkdownContent::streaming(source, None);
                 let _ = incremental.height(width);
                 incremental.append(delta);
 
-                let fresh = MarkdownContent::streaming(&format!("{source}{delta}"));
+                let fresh = MarkdownContent::streaming(&format!("{source}{delta}"), None);
                 assert_eq!(
                     incremental.materialized_text(width),
                     fresh.materialized_text(width),
@@ -2685,11 +3229,11 @@ mod tests {
             ("plain", "\n\nnext paragraph"),
         ] {
             for width in [20, 80] {
-                let mut incremental = MarkdownContent::reasoning(source);
+                let mut incremental = MarkdownContent::reasoning(source, None);
                 let _ = incremental.height(width);
                 incremental.append_reasoning(delta);
 
-                let fresh = MarkdownContent::reasoning(&format!("{source}{delta}"));
+                let fresh = MarkdownContent::reasoning(&format!("{source}{delta}"), None);
                 assert_eq!(
                     incremental.materialized_text(width),
                     fresh.materialized_text(width),

--- a/bin/nanocodex/src/tui/view.rs
+++ b/bin/nanocodex/src/tui/view.rs
@@ -422,12 +422,15 @@ fn render_transcript(
     frame.render_widget(block, area);
 
     frame.render_widget(
-        conversation.transcript.widget(
-            scroll_from_bottom,
-            conversation.selected_user,
-            inline_edit,
-            empty_message,
-        ),
+        conversation
+            .transcript
+            .widget(
+                scroll_from_bottom,
+                conversation.selected_user,
+                inline_edit,
+                empty_message,
+            )
+            .math_fallback(preserve_view),
         inner,
     );
     if let Some(edit) = inline_edit
@@ -732,9 +735,13 @@ fn saturating_u16(value: usize) -> u16 {
 
 #[cfg(test)]
 mod tests {
-    use std::io;
-    use std::time::Instant;
+    use std::{
+        io,
+        sync::mpsc,
+        time::{Duration, Instant},
+    };
 
+    use ratatex::{PixelSize, Ratatex, TerminalProfile};
     use ratatui::{
         Terminal,
         backend::{Backend, ClearType, TestBackend, WindowSize},
@@ -997,6 +1004,183 @@ mod tests {
         let selected = terminal.backend().buffer().cell((start_x, row)).unwrap();
         assert_eq!(selected.bg, Color::Indexed(8));
         assert!(selected.modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn clicking_then_selecting_a_rendered_formula_copies_its_latex() {
+        let (wake_tx, wake_rx) = mpsc::sync_channel(1);
+        let cache = tempfile::tempdir().unwrap();
+        let renderer = Ratatex::builder(TerminalProfile::kitty(PixelSize::new(10, 20), false))
+            .cache_dir(cache.path())
+            .on_update(move || {
+                let _ = wake_tx.try_send(());
+            })
+            .build()
+            .unwrap();
+        let source = "$$\n\\frac{a}{b}=c\n$$";
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
+        let mut app = App::new("/workspace".into());
+        app.set_math_renderer(renderer.clone());
+        app.main
+            .transcript
+            .push(TranscriptItem::Assistant(source.to_owned()));
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        wake_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        app.invalidate_math_layouts();
+        let _ = renderer.drain_terminal_commands();
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+
+        let width = usize::from(terminal.backend().buffer().area.width);
+        let formula_cells = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .enumerate()
+            .filter_map(|(index, cell)| {
+                ratatex::is_formula_placeholder(cell.symbol()).then_some(Position::new(
+                    u16::try_from(index % width).unwrap(),
+                    u16::try_from(index / width).unwrap(),
+                ))
+            })
+            .collect::<Vec<_>>();
+        assert!(!formula_cells.is_empty());
+        let start = Position::new(
+            formula_cells.iter().map(|cell| cell.x).min().unwrap(),
+            formula_cells.iter().map(|cell| cell.y).min().unwrap(),
+        );
+        let end = Position::new(
+            formula_cells.iter().map(|cell| cell.x).max().unwrap(),
+            formula_cells.iter().map(|cell| cell.y).max().unwrap(),
+        );
+
+        assert!(app.begin_mouse_selection(start));
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        assert!(app.finish_mouse_selection(start));
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+
+        assert!(app.take_pending_copy().is_none());
+        assert!(
+            terminal
+                .backend()
+                .buffer()
+                .content
+                .iter()
+                .all(|cell| !ratatex::is_formula_placeholder(cell.symbol()))
+        );
+        let fallback_text = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert_eq!(fallback_text.matches("$$").count(), 2);
+
+        assert!(app.begin_mouse_selection(start));
+        assert!(app.finish_mouse_selection(end));
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+
+        assert_eq!(app.take_pending_copy().as_deref(), Some(source));
+        assert_eq!(
+            terminal.backend().buffer().cell(start).unwrap().bg,
+            Color::Indexed(8)
+        );
+        assert!(
+            terminal
+                .backend()
+                .buffer()
+                .content
+                .iter()
+                .all(|cell| !ratatex::is_formula_placeholder(cell.symbol()))
+        );
+        renderer.shutdown();
+    }
+
+    #[test]
+    fn source_mode_copies_multiple_formulas_with_surrounding_text() {
+        let (wake_tx, wake_rx) = mpsc::channel();
+        let cache = tempfile::tempdir().unwrap();
+        let renderer = Ratatex::builder(TerminalProfile::kitty(PixelSize::new(10, 20), false))
+            .cache_dir(cache.path())
+            .on_update(move || {
+                let _ = wake_tx.send(());
+            })
+            .build()
+            .unwrap();
+        let source = "Before\n\n$$\na=b\n$$\n\nBetween\n\n$$\nc=d\n$$\n\nAfter";
+        let mut terminal = Terminal::new(TestBackend::new(80, 30)).unwrap();
+        let mut app = App::new("/workspace".into());
+        app.set_math_renderer(renderer.clone());
+        app.main
+            .transcript
+            .push(TranscriptItem::Assistant(source.to_owned()));
+
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        for _ in 0..2 {
+            wake_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        }
+        app.invalidate_math_layouts();
+        let _ = renderer.drain_terminal_commands();
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+
+        let width = usize::from(terminal.backend().buffer().area.width);
+        let first_formula = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .enumerate()
+            .find_map(|(index, cell)| {
+                ratatex::is_formula_placeholder(cell.symbol()).then_some(Position::new(
+                    u16::try_from(index % width).unwrap(),
+                    u16::try_from(index / width).unwrap(),
+                ))
+            })
+            .unwrap();
+        assert!(app.begin_mouse_selection(first_formula));
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        assert!(app.finish_mouse_selection(first_formula));
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+        assert!(
+            terminal
+                .backend()
+                .buffer()
+                .content
+                .iter()
+                .all(|cell| !ratatex::is_formula_placeholder(cell.symbol()))
+        );
+
+        let find_text = |needle: &str| {
+            let buffer = terminal.backend().buffer();
+            (0..buffer.area.height).find_map(|row| {
+                (0..buffer.area.width).find_map(|column| {
+                    let end = column.saturating_add(u16::try_from(needle.len()).ok()?);
+                    (end <= buffer.area.width
+                        && (column..end)
+                            .map(|x| buffer[(x, row)].symbol())
+                            .collect::<String>()
+                            == needle)
+                        .then_some((
+                            Position::new(column, row),
+                            Position::new(end.saturating_sub(1), row),
+                        ))
+                })
+            })
+        };
+        let (start, _) = find_text("Before").unwrap();
+        let (_, end) = find_text("After").unwrap();
+
+        assert!(app.begin_mouse_selection(start));
+        assert!(app.finish_mouse_selection(end));
+        terminal.draw(|frame| render(frame, &mut app)).unwrap();
+
+        assert_eq!(
+            app.take_pending_copy().as_deref(),
+            Some("Before\n$$\na=b\n$$\nBetween\n$$\nc=d\n$$\nAfter")
+        );
+        renderer.shutdown();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- integrate the released `ratatex` renderer with Nanocodex's terminal lifecycle, redraw wakeups, graphics re-upload, and shutdown
- detect and heal streaming display math, retain the last ready formula while newer prefixes render, and preserve formula geometry while scrolling and clipping
- make rendered formulas selectable by switching them back to their original LaTeX on click/drag, including selections spanning multiple formulas and surrounding text
- preserve the scoped animation redraw path while flushing pending Ratatex graphics before frame presentation
- add focused rendering, streaming, scrolling, selection, and benchmark coverage

## Why

Nanocodex previously treated display math as ordinary Markdown text. That exposed incomplete TeX while a response streamed and offered no way to render equations without cursor-positioned graphics that break transcript scrolling and selection.

Ratatex renders in-process into Kitty Unicode-placeholder cells that participate in the normal Ratatui buffer. The integration keeps the transcript's row model authoritative while allowing formulas to refine asynchronously and remain copyable as source.

## User impact

Display equations render as TeX-quality graphics during streaming, remain aligned while the transcript scrolls or resizes, survive terminal/tmux focus changes, and return to exact LaTeX when selected for copying.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p nanocodex-bin --bin nanocodex --locked`
- `cargo test -p nanocodex-bin --bin nanocodex --locked` — 233 passed, 2 ignored
- `cargo clippy -p nanocodex-bin --all-targets --locked -- -D warnings`
- live Nanocodex TUI smoke with streaming equations, scrolling, click-to-source, and multi-formula clipboard copy