### PR TITLE
refactor(mpp): extract composable egress transport

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,10 @@
 - `nanocodex-tools/macros` contains the `nanocodex-tools-macros` package that
   implements `#[tool]`. Keep the executable under `bin/nanocodex`; do not move
   CLI behavior into the library.
-- Tempo payment, egress, and `NanoUSD` support stay under `bin/`; public
+- The unpublished experimental `nanocodex-egress` crate owns the authenticated
+  loopback HTTP(S) proxy, ephemeral CA, bounded forwarding, and ordered outbound
+  layer seam. Provider and payment behavior stays in the consuming application.
+- Tempo payment policy and `NanoUSD` support stay under `bin/`; public
   `nanocodex-*` library crates must not depend on them.
 - The unpublished experimental `nanocodex-vm` crate owns the complete VM
   boundary: the audited libkrun interface, VM/process configuration, gvproxy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4916,13 +4916,16 @@ version = "0.11.0"
 source = "git+https://github.com/gakonst/mpp-rs?rev=b1a7088bc05da933923220e29028ff75dbcb1ea4#b1a7088bc05da933923220e29028ff75dbcb1ea4"
 dependencies = [
  "alloy",
+ "anyhow",
  "async-trait",
  "base64",
  "hex",
  "hmac 0.13.0",
+ "http",
  "p256",
  "rand 0.10.2",
  "reqwest",
+ "reqwest-middleware",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",
@@ -5013,12 +5016,11 @@ dependencies = [
  "fs2",
  "futures-util",
  "hex",
- "http-body-util",
- "hudsucker",
  "image",
  "mpp",
  "nanocodex",
  "nanocodex-browser",
+ "nanocodex-egress",
  "nanocodex-observability",
  "nanocodex-tools",
  "nanocodex-vm",
@@ -5081,6 +5083,27 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "v8-heap-parser",
+]
+
+[[package]]
+name = "nanocodex-egress"
+version = "0.3.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "criterion",
+ "futures-util",
+ "http",
+ "http-body-util",
+ "hudsucker",
+ "rand 0.9.5",
+ "reqwest",
+ "reqwest-middleware",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -7087,6 +7110,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "thiserror 2.0.18",
+ "tower-service",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/nanocodex",
     "crates/nanocodex-agent",
     "crates/experimental/nanocodex-browser",
+    "crates/experimental/nanocodex-egress",
     "crates/experimental/nanocodex-voice",
     "crates/experimental/nanocodex-vm",
     "crates/nanocodex-oai-api",
@@ -67,6 +68,7 @@ mpp = { version = "=0.11.0", git = "https://github.com/gakonst/mpp-rs", rev = "b
 nanocodex = { version = "0.3.0", path = "crates/nanocodex" }
 nanocodex-agent = { version = "0.3.0", path = "crates/nanocodex-agent" }
 nanocodex-browser = { version = "0.3.0", path = "crates/experimental/nanocodex-browser" }
+nanocodex-egress = { version = "0.3.0", path = "crates/experimental/nanocodex-egress" }
 nanocodex-voice = { version = "0.3.0", path = "crates/experimental/nanocodex-voice" }
 nanocodex-vm = { version = "0.3.0", path = "crates/experimental/nanocodex-vm" }
 nanocodex-oai-api = { version = "0.3.0", path = "crates/nanocodex-oai-api" }
@@ -98,6 +100,7 @@ quote = "1.0.46"
 ratatui = { version = "0.29.0", features = ["unstable-rendered-line-info"] }
 ratatex = "0.1.0"
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls-ring"] }
+reqwest-middleware = "0.5.2"
 rustls = { version = "0.23.42", default-features = false, features = ["ring"] }
 rusqlite = { version = "0.38", features = ["bundled"] }
 rquickjs = "0.12.1"

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -20,9 +20,8 @@ default = []
 # Keep paid-provider composition out of the direct-agent development graph.
 tempo = [
     "dep:alloy-primitives",
-    "dep:http-body-util",
-    "dep:hudsucker",
     "dep:mpp",
+    "dep:nanocodex-egress",
     "dep:nanousd",
     "dep:nix",
     "dep:rand",
@@ -41,8 +40,6 @@ eyre.workspace = true
 fs2.workspace = true
 futures-util.workspace = true
 hex.workspace = true
-http-body-util = { workspace = true, optional = true }
-hudsucker = { workspace = true, optional = true }
 image.workspace = true
 nanocodex.workspace = true
 nanocodex-browser.workspace = true
@@ -51,7 +48,8 @@ nanocodex-voice.workspace = true
 nix = { workspace = true, optional = true }
 nanousd = { workspace = true, optional = true }
 pulldown-cmark.workspace = true
-mpp = { workspace = true, optional = true, features = ["client", "tempo", "reqwest-rustls-tls-no-provider"] }
+mpp = { workspace = true, optional = true, features = ["middleware", "tempo", "reqwest-rustls-tls-no-provider"] }
+nanocodex-egress = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 ratatui.workspace = true
 ratatex.workspace = true

--- a/bin/nanocodex/src/mpp.rs
+++ b/bin/nanocodex/src/mpp.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 mod egress;
 mod resource;
 
-use self::egress::{EgressPolicy, MppEgress};
+use self::egress::TempoEgress;
 use clap::{ArgAction, Args, builder::NonEmptyStringValueParser};
 use eyre::{Context, Result, eyre};
 use mpp::{
@@ -15,6 +15,7 @@ use mpp::{
         methods::tempo::{INTENT_CHARGE, METHOD_NAME},
     },
 };
+use nanocodex_egress::EgressProxy;
 use nanousd::{NANOUSD_ADDRESS, TEMPO_MAINNET_CHAIN_ID};
 
 const DEFAULT_MPP_API_BASE_URL: &str = "https://openai.mpp.tempo.xyz/v1";
@@ -115,7 +116,9 @@ impl MppArgs {
             provider,
             max_charge: self.egress_max_charge,
         };
-        let egress = MppEgress::start(provider, EgressPolicy::default())
+        let egress = EgressProxy::builder()
+            .layer(TempoEgress::new(provider))
+            .spawn()
             .await
             .wrap_err("failed to start the embedded MPP egress proxy")?;
 
@@ -206,7 +209,7 @@ fn normalize_api_base_url(value: &str) -> Result<String> {
 pub(crate) struct MppAdapter {
     api_base_url: String,
     mpp_api_key: Option<String>,
-    egress: Option<MppEgress>,
+    egress: Option<EgressProxy>,
 }
 
 impl MppAdapter {
@@ -215,9 +218,9 @@ impl MppAdapter {
     }
 
     pub(crate) fn tool_environment(&self) -> Vec<(std::ffi::OsString, std::ffi::OsString)> {
-        self.egress
-            .as_ref()
-            .map_or_else(Vec::new, MppEgress::environment)
+        self.egress.as_ref().map_or_else(Vec::new, |egress| {
+            egress.environment().into_iter().collect()
+        })
     }
 
     fn http_client_builder(&self) -> Result<reqwest::ClientBuilder> {
@@ -225,7 +228,7 @@ impl MppAdapter {
             .egress
             .as_ref()
             .ok_or_else(|| eyre!("MPP egress proxy is not running"))?;
-        let certificate = std::fs::read(egress.certificate_path())
+        let certificate = std::fs::read(egress.ca_certificate_path())
             .wrap_err("failed to read the MPP egress CA certificate")?;
         let certificate = reqwest::Certificate::from_pem(&certificate)
             .wrap_err("failed to parse the MPP egress CA certificate")?;

--- a/bin/nanocodex/src/mpp/egress.rs
+++ b/bin/nanocodex/src/mpp/egress.rs
@@ -1,458 +1,79 @@
-//! Private embedded HTTP egress proxy that handles MPP payment challenges.
-//!
-//! The proxy listens only on loopback. Callers pass [`MppEgress::environment`]
-//! to untrusted child processes; the payment provider and its signing material
-//! remain in the embedding process.
+//! Tempo-owned MPP behavior composed into the generic egress proxy.
 
-use std::{
-    collections::HashSet,
-    ffi::OsString,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-    num::NonZeroUsize,
-    sync::{
-        Arc, Mutex,
-        atomic::{AtomicU64, Ordering},
-    },
-};
+use std::sync::atomic::{AtomicU64, Ordering};
 
-use base64::{Engine as _, engine::general_purpose::STANDARD};
-use futures_util::TryStreamExt;
-use http_body_util::{BodyExt, Limited};
-use hudsucker::{
-    Body, HttpContext, HttpHandler, Proxy, RequestOrResponse,
-    certificate_authority::CertificateAuthority,
-    hyper::{
-        Method, Request, Response, StatusCode,
-        header::{
-            CONNECTION, HOST, HeaderValue, PROXY_AUTHENTICATE, PROXY_AUTHORIZATION,
-            TRANSFER_ENCODING, UPGRADE,
-        },
-        http::uri::Authority,
-    },
-    rcgen::{
-        BasicConstraints, CertificateParams, DistinguishedName, DnType, ExtendedKeyUsagePurpose,
-        IsCa, Issuer, KeyPair, KeyUsagePurpose, SanType, string::Ia5String,
-    },
-    rustls::{
-        ServerConfig,
-        crypto::ring,
-        pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
-    },
-};
 use mpp::client::{
-    AcceptPaymentPolicy, ClientEvent, ClientEvents, DEFAULT_MAX_PAYMENT_RETRIES, Fetch,
+    AcceptPaymentPolicy, ClientEvent, ClientEventSubscription, ClientEvents, PaymentMiddleware,
     PaymentProvider,
 };
-use tempfile::TempDir;
-use tokio::{
-    net::TcpListener,
-    sync::{Semaphore, oneshot},
-    task::JoinHandle,
+use nanocodex_egress::{
+    EgressLayer,
+    middleware::{
+        Error, Extensions, Middleware, Next, Request, Response, Result as MiddlewareResult,
+        async_trait,
+    },
 };
-use tracing::Instrument as _;
 
-const DEFAULT_MAX_REQUEST_BYTES: usize = 16 * 1024 * 1024;
-const DEFAULT_MAX_CONCURRENT_CONNECTIONS: usize = 128;
-const DEFAULT_MAX_CONCURRENT_REQUESTS: usize = 128;
-const MAX_IDLE_CONNECTIONS_PER_HOST: usize = 4;
-const CA_FILENAME: &str = "mpp-egress-ca.pem";
 const MPP_REQUEST_ID: &str = "mpp-request-id";
 
-/// Policy owned by one embedded proxy instance.
-#[derive(Clone, Debug)]
-pub struct EgressPolicy {
-    /// Maximum replayable request-body size accepted from a child process.
-    pub max_request_bytes: usize,
-    /// Maximum number of distinct payment challenges accepted for one request.
-    pub max_payment_retries: usize,
-    /// Maximum number of requests concurrently forwarded to origin services.
-    ///
-    /// Additional child requests wait locally before receiving a payment
-    /// challenge, so challenge lifetimes are not consumed behind payment-state
-    /// serialization.
-    pub max_concurrent_requests: usize,
-    /// Maximum number of concurrently accepted child proxy connections.
-    ///
-    /// Additional clients wait in the listener backlog before consuming a
-    /// process file descriptor.
-    pub max_concurrent_connections: usize,
-}
-
-impl Default for EgressPolicy {
-    fn default() -> Self {
-        Self {
-            max_request_bytes: DEFAULT_MAX_REQUEST_BYTES,
-            max_payment_retries: DEFAULT_MAX_PAYMENT_RETRIES,
-            max_concurrent_requests: DEFAULT_MAX_CONCURRENT_REQUESTS,
-            max_concurrent_connections: DEFAULT_MAX_CONCURRENT_CONNECTIONS,
-        }
-    }
-}
-
-/// A running loopback proxy and its ephemeral certificate authority.
-pub struct MppEgress {
-    proxy_url: String,
-    proxy_password: String,
-    proxy_authorization: String,
-    temp_dir: TempDir,
-    shutdown_tx: Option<oneshot::Sender<()>>,
-    task: Option<JoinHandle<Result<(), hudsucker::Error>>>,
-}
-
-impl MppEgress {
-    /// Starts an MPP-aware HTTP(S) proxy on an ephemeral loopback port.
-    ///
-    /// The provider is never shared with child processes. It should enforce
-    /// currency-specific spend/deposit limits before signing a credential.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the policy is invalid or the proxy listener, HTTP
-    /// client, temporary CA, or background proxy task cannot be initialized.
-    pub async fn start<P>(provider: P, policy: EgressPolicy) -> Result<Self, EgressError>
-    where
-        P: PaymentProvider + 'static,
-    {
-        if policy.max_request_bytes == 0 {
-            return Err(EgressError::InvalidPolicy(
-                "max_request_bytes must be greater than zero",
-            ));
-        }
-        if policy.max_payment_retries == 0 {
-            return Err(EgressError::InvalidPolicy(
-                "max_payment_retries must be greater than zero",
-            ));
-        }
-        if policy.max_concurrent_requests == 0 {
-            return Err(EgressError::InvalidPolicy(
-                "max_concurrent_requests must be greater than zero",
-            ));
-        }
-        let max_concurrent_connections = NonZeroUsize::new(policy.max_concurrent_connections)
-            .ok_or(EgressError::InvalidPolicy(
-                "max_concurrent_connections must be greater than zero",
-            ))?;
-
-        let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
-            .await
-            .map_err(EgressError::Bind)?;
-        let address = listener.local_addr().map_err(EgressError::LocalAddress)?;
-        let (authority, certificate_pem) = ephemeral_authority()?;
-        let temp_dir = tempfile::Builder::new()
-            .prefix("nanocodex-mpp-egress-")
-            .tempdir()
-            .map_err(EgressError::TempDir)?;
-        std::fs::write(temp_dir.path().join(CA_FILENAME), certificate_pem)
-            .map_err(EgressError::WriteCertificate)?;
-
-        let rustls_provider = ring::default_provider();
-        let client = reqwest::Client::builder()
-            .no_proxy()
-            .redirect(reqwest::redirect::Policy::none())
-            .pool_max_idle_per_host(MAX_IDLE_CONNECTIONS_PER_HOST)
-            .build()
-            .map_err(EgressError::Client)?;
-        let proxy_password = random_proxy_password();
-        let proxy_authorization = format!(
-            "Basic {}",
-            STANDARD.encode(format!("nanocodex:{proxy_password}"))
-        );
-        let proxy_url = format!("http://nanocodex:{proxy_password}@{address}");
-        let origin_permits = Arc::new(Semaphore::new(policy.max_concurrent_requests));
-        let handler = PaymentHandler {
-            provider,
-            client,
-            policy,
-            origin_permits,
-            proxy_authorization: proxy_authorization.clone(),
-            authenticated_clients: Arc::new(Mutex::new(HashSet::new())),
-            request_id_prefix: random_identifier(),
-            request_ids: Arc::new(AtomicU64::new(1)),
-        };
-        let (shutdown_tx, shutdown_rx) = oneshot::channel();
-        let proxy = Proxy::builder()
-            .with_listener(listener)
-            .with_ca(authority)
-            .with_rustls_connector(rustls_provider)
-            .with_max_concurrent_connections(max_concurrent_connections)
-            .with_http_handler(handler)
-            .with_graceful_shutdown(async move {
-                let _ = shutdown_rx.await;
-            })
-            .build()?;
-        let task = tokio::spawn(proxy.start());
-
-        Ok(Self {
-            proxy_url,
-            proxy_password,
-            proxy_authorization,
-            temp_dir,
-            shutdown_tx: Some(shutdown_tx),
-            task: Some(task),
-        })
-    }
-
-    /// Returns the HTTP proxy URL listened on by this instance.
-    #[must_use]
-    pub fn proxy_url(&self) -> String {
-        self.proxy_url.clone()
-    }
-
-    /// Returns environment overrides for curl and common HTTP runtimes.
-    ///
-    /// These values should be applied only to tool child processes, not to the
-    /// embedding process, so model/control-plane traffic is not intercepted.
-    #[must_use]
-    pub fn environment(&self) -> Vec<(OsString, OsString)> {
-        let proxy = OsString::from(self.proxy_url());
-        let certificate = self.temp_dir.path().join(CA_FILENAME).into_os_string();
-        [
-            ("http_proxy", proxy.clone()),
-            ("https_proxy", proxy.clone()),
-            ("HTTP_PROXY", proxy.clone()),
-            ("HTTPS_PROXY", proxy),
-            ("no_proxy", OsString::new()),
-            ("NO_PROXY", OsString::new()),
-            ("CURL_CA_BUNDLE", certificate.clone()),
-            ("SSL_CERT_FILE", certificate.clone()),
-            ("REQUESTS_CA_BUNDLE", certificate.clone()),
-            ("NODE_EXTRA_CA_CERTS", certificate),
-            (
-                "NANOCODEX_MPP_EGRESS_PASSWORD",
-                OsString::from(&self.proxy_password),
-            ),
-            (
-                "NANOCODEX_MPP_EGRESS_AUTHORIZATION",
-                OsString::from(&self.proxy_authorization),
-            ),
-        ]
-        .into_iter()
-        .map(|(name, value)| (OsString::from(name), value))
-        .collect()
-    }
-
-    /// Stops accepting traffic and waits for active proxy connections to drain.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the proxy task fails or cannot be joined.
-    pub async fn shutdown(mut self) -> Result<(), EgressError> {
-        if let Some(shutdown_tx) = self.shutdown_tx.take() {
-            let _ = shutdown_tx.send(());
-        }
-        if let Some(task) = self.task.take() {
-            task.await.map_err(EgressError::Join)??;
-        }
-        Ok(())
-    }
-
-    /// Path to the public ephemeral CA certificate.
-    #[must_use]
-    pub fn certificate_path(&self) -> std::path::PathBuf {
-        self.temp_dir.path().join(CA_FILENAME)
-    }
-}
-
-impl Drop for MppEgress {
-    fn drop(&mut self) {
-        if let Some(shutdown_tx) = self.shutdown_tx.take() {
-            let _ = shutdown_tx.send(());
-        }
-        if let Some(task) = self.task.take() {
-            task.abort();
-        }
-    }
-}
-
-#[derive(Clone)]
-struct PaymentHandler<P> {
-    provider: P,
-    client: reqwest::Client,
-    policy: EgressPolicy,
-    origin_permits: Arc<Semaphore>,
-    proxy_authorization: String,
-    authenticated_clients: Arc<Mutex<HashSet<SocketAddr>>>,
+/// MPP payment and replay as one Tempo-owned outbound egress layer.
+pub(super) struct TempoEgress<P> {
+    middleware: PaymentMiddleware<P>,
+    _events: ClientEventSubscription,
     request_id_prefix: String,
-    request_ids: Arc<AtomicU64>,
+    request_ids: AtomicU64,
 }
 
-impl<P> HttpHandler for PaymentHandler<P>
+impl<P> TempoEgress<P>
 where
     P: PaymentProvider + 'static,
 {
-    async fn handle_request(
-        &mut self,
-        context: &HttpContext,
-        mut request: Request<Body>,
-    ) -> RequestOrResponse {
-        let request_id = self.request_ids.fetch_add(1, Ordering::Relaxed);
-        let logical_request_id = format!("{}-{request_id}", self.request_id_prefix);
-        let span = tracing::info_span!(
-            target: "mpp_egress",
-            "mpp.egress.request",
-            request.id = request_id,
-            mpp.request.id = %logical_request_id,
-            client.address = %context.client_addr,
-            http.request.method = %request.method(),
-            url.full = %request.uri(),
-            request.upgrade = is_upgrade(&request),
-        );
-        async move {
-            tracing::info!(
-                target: "mpp_egress",
-                content_kind = "mpp.egress.request.headers",
-                content = ?request.headers(),
-                "trace content"
-            );
-            if !self.authorize(context, &request) {
-                tracing::warn!(
-                    target: "mpp_egress",
-                    stage = "mpp.egress.proxy_authentication.rejected",
-                    http.response.status_code = StatusCode::PROXY_AUTHENTICATION_REQUIRED.as_u16(),
-                    "MPP egress rejected an unauthenticated client"
-                );
-                return proxy_authentication_required().into();
-            }
-            tracing::info!(
-                target: "mpp_egress",
-                stage = "mpp.egress.proxy_authentication.accepted",
-                "MPP egress authenticated its child client"
-            );
-            request.headers_mut().remove(PROXY_AUTHORIZATION);
-            if request.method() == Method::CONNECT || is_upgrade(&request) {
-                tracing::info!(
-                    target: "mpp_egress",
-                    stage = "mpp.egress.tunnel.forwarded",
-                    "MPP egress forwarded a protocol tunnel without payment handling"
-                );
-                return request.into();
-            }
-
-            match self.forward(request, &logical_request_id).await {
-                Ok(response) => response.into(),
-                Err(ForwardError::RequestTooLarge) => {
-                    tracing::warn!(
-                        target: "mpp_egress",
-                        stage = "mpp.egress.request.failed",
-                        failure.kind = "request_too_large",
-                        http.response.status_code = StatusCode::PAYLOAD_TOO_LARGE.as_u16(),
-                        "MPP egress rejected an unreplayable request body"
-                    );
-                    error_response(
-                        StatusCode::PAYLOAD_TOO_LARGE,
-                        "request body exceeds the MPP egress replay limit",
-                    )
-                    .into()
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        target: "mpp_egress",
-                        stage = "mpp.egress.request.failed",
-                        failure.kind = "payment_or_forwarding",
-                        http.response.status_code = StatusCode::BAD_GATEWAY.as_u16(),
-                        error = %error,
-                        "MPP egress request failed"
-                    );
-                    error_response(StatusCode::BAD_GATEWAY, &error.to_string()).into()
-                }
-            }
+    /// Creates an MPP layer with the protocol library's retry default.
+    pub(super) fn new(provider: P) -> Self {
+        let events = ClientEvents::default();
+        let subscription = events.on_any(|event| async move {
+            record_payment_event(&event);
+        });
+        let middleware = PaymentMiddleware::new(provider)
+            .with_accept_payment_policy(AcceptPaymentPolicy::Never)
+            .with_events(events);
+        Self {
+            middleware,
+            _events: subscription,
+            request_id_prefix: random_identifier(),
+            request_ids: AtomicU64::new(1),
         }
-        .instrument(span)
-        .await
     }
 }
 
-impl<P> PaymentHandler<P>
+#[async_trait]
+impl<P> EgressLayer for TempoEgress<P>
 where
-    P: PaymentProvider,
+    P: PaymentProvider + 'static,
 {
-    fn authorize(&self, context: &HttpContext, request: &Request<Body>) -> bool {
-        if self
-            .authenticated_clients
-            .lock()
-            .is_ok_and(|clients| clients.contains(&context.client_addr))
-        {
-            return true;
-        }
-        let authorized = request
-            .headers()
-            .get(PROXY_AUTHORIZATION)
-            .and_then(|value| value.to_str().ok())
-            .is_some_and(|value| value == self.proxy_authorization);
-        if authorized && let Ok(mut clients) = self.authenticated_clients.lock() {
-            clients.insert(context.client_addr);
-        }
-        authorized
-    }
-
-    async fn forward(
+    async fn handle(
         &self,
-        request: Request<Body>,
-        logical_request_id: &str,
-    ) -> Result<Response<Body>, ForwardError> {
-        let (mut parts, body) = request.into_parts();
-        let body = Limited::new(body, self.policy.max_request_bytes)
-            .collect()
-            .await
-            .map_err(|_| ForwardError::RequestTooLarge)?
-            .to_bytes();
-        record_body_content("mpp.egress.request.body", &body);
-        remove_hop_by_hop_request_headers(&mut parts.headers);
-        parts.headers.insert(
-            MPP_REQUEST_ID,
-            HeaderValue::from_str(logical_request_id).map_err(ForwardError::RequestId)?,
-        );
-        let queued = self.origin_permits.available_permits() == 0;
-        if queued {
-            tracing::info!(
-                target: "mpp_egress",
-                stage = "mpp.egress.origin.request.queued",
-                origin.max_concurrent_requests = self.policy.max_concurrent_requests,
-                "MPP egress queued the request before contacting its origin"
-            );
-        }
-        let _origin_permit = self
-            .origin_permits
-            .acquire()
-            .await
-            .map_err(|_| ForwardError::Unavailable)?;
-        tracing::info!(
-            target: "mpp_egress",
-            stage = "mpp.egress.origin.request.started",
-            http.request.body.size = body.len(),
-            payment.max_retries = self.policy.max_payment_retries,
-            request.queued = queued,
-            "MPP egress sent the original request"
-        );
-
-        let builder = self
-            .client
-            .request(parts.method, parts.uri.to_string())
-            .headers(parts.headers)
-            .body(body);
-        let events = ClientEvents::default();
-        let _subscription = events.on_any(|event| async move {
-            record_payment_event(&event);
-        });
-        let response = builder
-            .send_with_payment_options_max_retries(
-                &self.provider,
-                &AcceptPaymentPolicy::Never,
-                events,
-                self.policy.max_payment_retries,
-            )
-            .await
-            .map_err(ForwardError::Payment)?;
-
-        let status = response.status();
-        tracing::info!(
-            target: "mpp_egress",
-            stage = "mpp.egress.request.completed",
-            http.response.status_code = status.as_u16(),
-            "MPP egress completed the request"
-        );
-        Ok(convert_response(response, &tracing::Span::current()))
+        mut request: Request,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> MiddlewareResult<Response> {
+        let request_id = self.request_ids.fetch_add(1, Ordering::Relaxed);
+        let logical_request_id = format!("{}-{request_id}", self.request_id_prefix);
+        tracing::Span::current().record("mpp.request.id", logical_request_id.as_str());
+        let value = logical_request_id.parse().map_err(Error::middleware)?;
+        request.headers_mut().insert(MPP_REQUEST_ID, value);
+        self.middleware.handle(request, extensions, next).await
     }
+}
+
+fn random_identifier() -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut identifier = String::with_capacity(64);
+    for byte in rand::random::<[u8; 32]>() {
+        identifier.push(char::from(HEX[usize::from(byte >> 4)]));
+        identifier.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    identifier
 }
 
 fn record_payment_event(event: &ClientEvent) {
@@ -531,327 +152,48 @@ fn record_payment_event(event: &ClientEvent) {
     }
 }
 
-fn record_body_content(kind: &'static str, body: &[u8]) {
-    if let Ok(content) = std::str::from_utf8(body) {
-        tracing::info!(
-            target: "mpp_egress",
-            content_kind = kind,
-            content,
-            "trace content"
-        );
-    } else {
-        tracing::info!(
-            target: "mpp_egress",
-            content_kind = kind,
-            content = ?body,
-            "trace content"
-        );
-    }
-}
-
-fn convert_response(response: reqwest::Response, span: &tracing::Span) -> Response<Body> {
-    let status = response.status();
-    let version = response.version();
-    let mut headers = response.headers().clone();
-    remove_hop_by_hop_response_headers(&mut headers);
-    span.in_scope(|| {
-        tracing::info!(
-            target: "mpp_egress",
-            content_kind = "mpp.egress.response.headers",
-            content = ?headers,
-            "trace content"
-        );
-    });
-    let content_span = span.clone();
-    let mut chunk_index = 0_u64;
-    let body = Body::from_stream(
-        response
-            .bytes_stream()
-            .map_ok(move |chunk| {
-                content_span.in_scope(|| {
-                    if let Ok(content) = std::str::from_utf8(&chunk) {
-                        tracing::info!(
-                            target: "mpp_egress",
-                            content_kind = "mpp.egress.response.body",
-                            response.chunk.index = chunk_index,
-                            response.chunk.size = chunk.len(),
-                            content,
-                            "trace content"
-                        );
-                    } else {
-                        tracing::info!(
-                            target: "mpp_egress",
-                            content_kind = "mpp.egress.response.body",
-                            response.chunk.index = chunk_index,
-                            response.chunk.size = chunk.len(),
-                            content = ?chunk.as_ref(),
-                            "trace content"
-                        );
-                    }
-                });
-                chunk_index = chunk_index.saturating_add(1);
-                chunk
-            })
-            .map_err(|_| hudsucker::Error::Unknown),
-    );
-    let mut response = Response::new(body);
-    *response.status_mut() = status;
-    *response.version_mut() = version;
-    *response.headers_mut() = headers;
-    response
-}
-
-fn is_upgrade(request: &Request<Body>) -> bool {
-    request.headers().contains_key(UPGRADE)
-        || request
-            .headers()
-            .get(CONNECTION)
-            .and_then(|value| value.to_str().ok())
-            .is_some_and(|value| {
-                value
-                    .split(',')
-                    .any(|token| token.trim().eq_ignore_ascii_case("upgrade"))
-            })
-}
-
-fn remove_hop_by_hop_request_headers(headers: &mut hudsucker::hyper::HeaderMap) {
-    remove_connection_named_headers(headers);
-    for name in [
-        CONNECTION,
-        HOST,
-        PROXY_AUTHORIZATION,
-        TRANSFER_ENCODING,
-        UPGRADE,
-    ] {
-        headers.remove(name);
-    }
-}
-
-fn remove_hop_by_hop_response_headers(headers: &mut hudsucker::hyper::HeaderMap) {
-    remove_connection_named_headers(headers);
-    for name in [CONNECTION, TRANSFER_ENCODING, UPGRADE] {
-        headers.remove(name);
-    }
-}
-
-fn remove_connection_named_headers(headers: &mut hudsucker::hyper::HeaderMap) {
-    let names = headers
-        .get_all(CONNECTION)
-        .iter()
-        .filter_map(|value| value.to_str().ok())
-        .flat_map(|value| value.split(','))
-        .filter_map(|name| {
-            name.trim()
-                .parse::<hudsucker::hyper::header::HeaderName>()
-                .ok()
-        })
-        .collect::<Vec<_>>();
-    for name in names {
-        headers.remove(name);
-    }
-}
-
-fn error_response(status: StatusCode, message: &str) -> Response<Body> {
-    let mut response = Response::new(Body::from(message.to_owned()));
-    *response.status_mut() = status;
-    response
-}
-
-fn proxy_authentication_required() -> Response<Body> {
-    let mut response = error_response(
-        StatusCode::PROXY_AUTHENTICATION_REQUIRED,
-        "proxy authentication required",
-    );
-    response.headers_mut().insert(
-        PROXY_AUTHENTICATE,
-        hudsucker::hyper::header::HeaderValue::from_static("Basic realm=\"nanocodex-mpp-egress\""),
-    );
-    response
-}
-
-fn random_proxy_password() -> String {
-    random_identifier()
-}
-
-fn random_identifier() -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut identifier = String::with_capacity(64);
-    for byte in rand::random::<[u8; 32]>() {
-        identifier.push(char::from(HEX[usize::from(byte >> 4)]));
-        identifier.push(char::from(HEX[usize::from(byte & 0x0f)]));
-    }
-    identifier
-}
-
-struct EphemeralAuthority {
-    issuer: Issuer<'static, KeyPair>,
-    private_key: PrivateKeyDer<'static>,
-    cache: Mutex<std::collections::HashMap<Authority, Arc<ServerConfig>>>,
-}
-
-impl CertificateAuthority for EphemeralAuthority {
-    async fn gen_server_config(&self, authority: &Authority) -> Arc<ServerConfig> {
-        if let Ok(cache) = self.cache.lock()
-            && let Some(config) = cache.get(authority)
-        {
-            return Arc::clone(config);
-        }
-
-        let mut params = CertificateParams::default();
-        params.serial_number = Some(rand::random::<u64>().into());
-        let mut distinguished_name = DistinguishedName::new();
-        distinguished_name.push(DnType::CommonName, authority.host());
-        params.distinguished_name = distinguished_name;
-        params
-            .subject_alt_names
-            .push(authority.host().parse::<IpAddr>().map_or_else(
-                |_| {
-                    SanType::DnsName(
-                        Ia5String::try_from(authority.host())
-                            .expect("HTTP authority host must be a valid DNS IA5 string"),
-                    )
-                },
-                SanType::IpAddress,
-            ));
-        params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
-        params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
-        params.use_authority_key_identifier_extension = true;
-        let certificate = params
-            .signed_by(self.issuer.key(), &self.issuer)
-            .expect("valid CA parameters must sign an ephemeral leaf certificate");
-        let mut config = ServerConfig::builder()
-            .with_no_client_auth()
-            .with_single_cert(
-                vec![CertificateDer::from(certificate)],
-                self.private_key.clone_key(),
-            )
-            .expect("generated leaf certificate and private key must match");
-        config.alpn_protocols = vec![b"http/1.1".to_vec()];
-        let config = Arc::new(config);
-
-        if let Ok(mut cache) = self.cache.lock()
-            && cache.len() < 1_024
-        {
-            cache.insert(authority.clone(), Arc::clone(&config));
-        }
-        config
-    }
-}
-
-fn ephemeral_authority() -> Result<(EphemeralAuthority, String), EgressError> {
-    let key_pair = KeyPair::generate().map_err(EgressError::Certificate)?;
-    let mut params = CertificateParams::default();
-    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-    let mut distinguished_name = DistinguishedName::new();
-    distinguished_name.push(DnType::CommonName, "Nanocodex ephemeral MPP egress");
-    params.distinguished_name = distinguished_name;
-    params.key_usages = vec![
-        KeyUsagePurpose::DigitalSignature,
-        KeyUsagePurpose::KeyCertSign,
-        KeyUsagePurpose::CrlSign,
-    ];
-    let certificate = params
-        .self_signed(&key_pair)
-        .map_err(EgressError::Certificate)?;
-    let certificate_pem = certificate.pem();
-    let private_key = PrivateKeyDer::from(PrivatePkcs8KeyDer::from(key_pair.serialize_der()));
-    let issuer =
-        Issuer::from_ca_cert_pem(&certificate_pem, key_pair).map_err(EgressError::Certificate)?;
-    Ok((
-        EphemeralAuthority {
-            issuer,
-            private_key,
-            cache: Mutex::new(std::collections::HashMap::new()),
-        },
-        certificate_pem,
-    ))
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum EgressError {
-    #[error("invalid MPP egress policy: {0}")]
-    InvalidPolicy(&'static str),
-    #[error("failed to bind the MPP egress listener")]
-    Bind(#[source] std::io::Error),
-    #[error("failed to read the MPP egress listener address")]
-    LocalAddress(#[source] std::io::Error),
-    #[error("failed to create the ephemeral MPP egress directory")]
-    TempDir(#[source] std::io::Error),
-    #[error("failed to write the ephemeral MPP egress CA certificate")]
-    WriteCertificate(#[source] std::io::Error),
-    #[error("failed to generate the ephemeral MPP egress CA")]
-    Certificate(#[source] hudsucker::rcgen::Error),
-    #[error("failed to build the MPP egress HTTP client")]
-    Client(#[source] reqwest::Error),
-    #[error("MPP egress proxy failed")]
-    Proxy(#[from] hudsucker::Error),
-    #[error("MPP egress proxy task failed")]
-    Join(#[source] tokio::task::JoinError),
-}
-
-#[derive(Debug, thiserror::Error)]
-enum ForwardError {
-    #[error("request body is too large to replay")]
-    RequestTooLarge,
-    #[error("failed to encode the MPP request ID")]
-    RequestId(#[source] hudsucker::hyper::header::InvalidHeaderValue),
-    #[error("MPP egress stopped while the request was queued")]
-    Unavailable,
-    #[error("MPP payment request failed: {0}")]
-    Payment(#[source] mpp::client::HttpError),
-}
-
 #[cfg(test)]
 mod tests {
-    use std::sync::{
-        Arc, Mutex as StdMutex,
-        atomic::{AtomicUsize, Ordering},
+    use std::{
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::Duration,
     };
 
     use axum::{
         Router,
-        body::Body as AxumBody,
+        body::Body,
         extract::Request,
         http::{StatusCode as AxumStatus, header::WWW_AUTHENTICATE},
         response::IntoResponse,
-        routing::{get, post},
+        routing::post,
     };
-    use futures_util::{StreamExt, future::join_all, stream};
+    use futures_util::{StreamExt, stream};
     use mpp::{
         Base64UrlJson, MppError, PaymentChallenge, PaymentCredential, PaymentPayload,
-        format_www_authenticate,
+        client::DEFAULT_MAX_PAYMENT_RETRIES, format_www_authenticate,
     };
+    use nanocodex_egress::{EgressProxy, EgressProxyBuilder};
 
     use super::*;
 
     #[derive(Clone, Default)]
-    struct LogBuffer(Arc<StdMutex<Vec<u8>>>);
-
-    struct LogWriter(Arc<StdMutex<Vec<u8>>>);
-
-    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for LogBuffer {
-        type Writer = LogWriter;
-
-        fn make_writer(&'a self) -> Self::Writer {
-            LogWriter(Arc::clone(&self.0))
-        }
-    }
-
-    impl std::io::Write for LogWriter {
-        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
-            self.0.lock().unwrap().write(bytes)
-        }
-
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-    }
-
-    #[derive(Clone, Default)]
     struct MockProvider {
-        payments: Arc<AtomicUsize>,
+        active: Arc<AtomicUsize>,
         commits: Arc<AtomicUsize>,
+        delay_payments: bool,
+        maximum: Arc<AtomicUsize>,
+        payments: Arc<AtomicUsize>,
         rollbacks: Arc<AtomicUsize>,
+    }
+
+    impl MockProvider {
+        fn with_payment_delay(mut self) -> Self {
+            self.delay_payments = true;
+            self
+        }
     }
 
     impl PaymentProvider for MockProvider {
@@ -860,7 +202,13 @@ mod tests {
         }
 
         async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
+            let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+            self.maximum.fetch_max(active, Ordering::SeqCst);
             self.payments.fetch_add(1, Ordering::SeqCst);
+            if self.delay_payments {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            self.active.fetch_sub(1, Ordering::SeqCst);
             Ok(PaymentCredential::new(
                 challenge.to_echo(),
                 PaymentPayload::hash("test-payment"),
@@ -887,7 +235,9 @@ mod tests {
     }
 
     async fn spawn_origin(app: Router) -> String {
-        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let listener = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+            .await
+            .unwrap();
         let address = listener.local_addr().unwrap();
         tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
@@ -895,14 +245,14 @@ mod tests {
         format!("http://{address}")
     }
 
-    fn challenge_header() -> String {
+    fn challenge_header(id: &str) -> String {
         let request = Base64UrlJson::from_value(&serde_json::json!({
             "amount": "1",
             "currency": "test"
         }))
         .unwrap();
         format_www_authenticate(&PaymentChallenge::new(
-            "challenge-1",
+            id,
             "test.local",
             "test",
             "charge",
@@ -911,7 +261,7 @@ mod tests {
         .unwrap()
     }
 
-    fn proxied_client(egress: &MppEgress) -> reqwest::Client {
+    fn proxied_client(egress: &EgressProxy) -> reqwest::Client {
         reqwest::Client::builder()
             .proxy(reqwest::Proxy::all(egress.proxy_url()).unwrap())
             .redirect(reqwest::redirect::Policy::none())
@@ -919,21 +269,28 @@ mod tests {
             .unwrap()
     }
 
-    type PaidObservation = (String, Vec<u8>, bool);
+    async fn mpp_proxy(
+        provider: MockProvider,
+        configure: impl FnOnce(EgressProxyBuilder) -> EgressProxyBuilder,
+    ) -> EgressProxy {
+        configure(EgressProxy::builder())
+            .layer(TempoEgress::new(provider))
+            .spawn()
+            .await
+            .unwrap()
+    }
 
-    async fn spawn_recording_paid_origin(
-        calls: Arc<AtomicUsize>,
-        observations: Arc<StdMutex<Vec<PaidObservation>>>,
-    ) -> String {
-        let challenge = challenge_header();
-        let app = Router::new().route(
+    #[tokio::test]
+    async fn pays_and_replays_the_exact_host_identified_request_once() {
+        let challenge = challenge_header("challenge-1");
+        let observations = Arc::new(Mutex::new(Vec::new()));
+        let route_observations = Arc::clone(&observations);
+        let origin = spawn_origin(Router::new().route(
             "/paid",
-            post(move |request: Request<AxumBody>| {
-                let calls = Arc::clone(&calls);
-                let observations = Arc::clone(&observations);
+            post(move |request: Request<Body>| {
                 let challenge = challenge.clone();
+                let observations = Arc::clone(&route_observations);
                 async move {
-                    calls.fetch_add(1, Ordering::SeqCst);
                     let request_id = request
                         .headers()
                         .get(MPP_REQUEST_ID)
@@ -942,13 +299,16 @@ mod tests {
                         .unwrap()
                         .to_owned();
                     let paid = request.headers().contains_key("authorization");
+                    let accepts_payment = request.headers().contains_key("accept-payment");
                     let body = axum::body::to_bytes(request.into_body(), 1024)
                         .await
                         .unwrap();
-                    observations
-                        .lock()
-                        .unwrap()
-                        .push((request_id, body.to_vec(), paid));
+                    observations.lock().unwrap().push((
+                        request_id,
+                        body.to_vec(),
+                        paid,
+                        accepts_payment,
+                    ));
                     if paid {
                         (AxumStatus::OK, "paid").into_response()
                     } else {
@@ -961,325 +321,223 @@ mod tests {
                     }
                 }
             }),
-        );
-        spawn_origin(app).await
-    }
-
-    #[tokio::test]
-    async fn rejects_clients_without_the_ephemeral_proxy_credential() {
-        let egress = MppEgress::start(MockProvider::default(), EgressPolicy::default())
-            .await
-            .unwrap();
-        let mut proxy: reqwest::Url = egress.proxy_url().parse().unwrap();
-        proxy.set_username("").unwrap();
-        proxy.set_password(None).unwrap();
-        let client = reqwest::Client::builder()
-            .proxy(reqwest::Proxy::all(proxy).unwrap())
-            .build()
-            .unwrap();
-
-        let response = client.get("http://example.invalid/").send().await.unwrap();
-
-        assert_eq!(response.status(), AxumStatus::PROXY_AUTHENTICATION_REQUIRED);
-        egress.shutdown().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn passes_unpaid_http_responses_through() {
-        let origin = spawn_origin(Router::new().route("/plain", get(|| async { "plain" }))).await;
-        let egress = MppEgress::start(MockProvider::default(), EgressPolicy::default())
-            .await
-            .unwrap();
-
-        let response = proxied_client(&egress)
-            .get(format!("{origin}/plain"))
-            .send()
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), AxumStatus::OK);
-        assert_eq!(response.text().await.unwrap(), "plain");
-        egress.shutdown().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn queues_excess_requests_before_contacting_the_origin() {
-        let active = Arc::new(AtomicUsize::new(0));
-        let maximum = Arc::new(AtomicUsize::new(0));
-        let started = Arc::new(tokio::sync::Notify::new());
-        let gate = Arc::new(Semaphore::new(0));
-        let app = Router::new().route(
-            "/bounded",
-            get({
-                let active = Arc::clone(&active);
-                let maximum = Arc::clone(&maximum);
-                let started = Arc::clone(&started);
-                let gate = Arc::clone(&gate);
-                move || {
-                    let active = Arc::clone(&active);
-                    let maximum = Arc::clone(&maximum);
-                    let started = Arc::clone(&started);
-                    let gate = Arc::clone(&gate);
-                    async move {
-                        let current = active.fetch_add(1, Ordering::SeqCst) + 1;
-                        maximum.fetch_max(current, Ordering::SeqCst);
-                        started.notify_one();
-                        let permit = gate.acquire().await.unwrap();
-                        permit.forget();
-                        active.fetch_sub(1, Ordering::SeqCst);
-                        "bounded"
-                    }
-                }
-            }),
-        );
-        let origin = spawn_origin(app).await;
-        let egress = MppEgress::start(
-            MockProvider::default(),
-            EgressPolicy {
-                max_concurrent_requests: 3,
-                ..EgressPolicy::default()
-            },
-        )
-        .await
-        .unwrap();
-        let client = proxied_client(&egress);
-        let requests = (0..12).map(|_| {
-            let client = client.clone();
-            let url = format!("{origin}/bounded");
-            tokio::spawn(async move { client.get(url).send().await.unwrap().status() })
-        });
-        let requests = requests.collect::<Vec<_>>();
-
-        while maximum.load(Ordering::SeqCst) < 3 {
-            started.notified().await;
-        }
-        assert_eq!(maximum.load(Ordering::SeqCst), 3);
-        assert_eq!(active.load(Ordering::SeqCst), 3);
-
-        gate.add_permits(12);
-        let statuses = join_all(requests)
-            .await
-            .into_iter()
-            .map(Result::unwrap)
-            .collect::<Vec<_>>();
-        assert!(statuses.iter().all(|status| *status == AxumStatus::OK));
-        assert_eq!(maximum.load(Ordering::SeqCst), 3);
-        egress.shutdown().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn queues_excess_connections_before_contacting_the_origin() {
-        const CONNECTIONS: usize = 3;
-        const REQUESTS: usize = 12;
-
-        let active = Arc::new(AtomicUsize::new(0));
-        let maximum = Arc::new(AtomicUsize::new(0));
-        let started = Arc::new(tokio::sync::Notify::new());
-        let gate = Arc::new(Semaphore::new(0));
-        let app = Router::new().route(
-            "/bounded-connections",
-            get({
-                let active = Arc::clone(&active);
-                let maximum = Arc::clone(&maximum);
-                let started = Arc::clone(&started);
-                let gate = Arc::clone(&gate);
-                move || {
-                    let active = Arc::clone(&active);
-                    let maximum = Arc::clone(&maximum);
-                    let started = Arc::clone(&started);
-                    let gate = Arc::clone(&gate);
-                    async move {
-                        let current = active.fetch_add(1, Ordering::SeqCst) + 1;
-                        maximum.fetch_max(current, Ordering::SeqCst);
-                        started.notify_one();
-                        let permit = gate.acquire().await.unwrap();
-                        permit.forget();
-                        active.fetch_sub(1, Ordering::SeqCst);
-                        "bounded"
-                    }
-                }
-            }),
-        );
-        let origin = spawn_origin(app).await;
-        let egress = MppEgress::start(
-            MockProvider::default(),
-            EgressPolicy {
-                max_concurrent_connections: CONNECTIONS,
-                max_concurrent_requests: REQUESTS,
-                ..EgressPolicy::default()
-            },
-        )
-        .await
-        .unwrap();
-        let clients = (0..REQUESTS)
-            .map(|_| proxied_client(&egress))
-            .collect::<Vec<_>>();
-        let requests = clients
-            .into_iter()
-            .map(|client| {
-                let url = format!("{origin}/bounded-connections");
-                tokio::spawn(async move { client.get(url).send().await.unwrap().status() })
-            })
-            .collect::<Vec<_>>();
-
-        while maximum.load(Ordering::SeqCst) < CONNECTIONS {
-            started.notified().await;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        assert_eq!(maximum.load(Ordering::SeqCst), CONNECTIONS);
-        assert_eq!(active.load(Ordering::SeqCst), CONNECTIONS);
-
-        gate.add_permits(REQUESTS);
-        let statuses = join_all(requests)
-            .await
-            .into_iter()
-            .map(Result::unwrap)
-            .collect::<Vec<_>>();
-        assert!(statuses.iter().all(|status| *status == AxumStatus::OK));
-        assert_eq!(maximum.load(Ordering::SeqCst), CONNECTIONS);
-        egress.shutdown().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn pays_and_replays_the_exact_request_body() {
-        let calls = Arc::new(AtomicUsize::new(0));
-        let request_ids = Arc::new(StdMutex::new(Vec::new()));
-        let calls_for_route = Arc::clone(&calls);
-        let request_ids_for_route = Arc::clone(&request_ids);
-        let challenge = challenge_header();
-        let app = Router::new().route(
-            "/paid",
-            post(move |request: Request<AxumBody>| {
-                let calls = Arc::clone(&calls_for_route);
-                let request_ids = Arc::clone(&request_ids_for_route);
-                let challenge = challenge.clone();
-                async move {
-                    calls.fetch_add(1, Ordering::SeqCst);
-                    request_ids.lock().unwrap().push(
-                        request
-                            .headers()
-                            .get(MPP_REQUEST_ID)
-                            .unwrap()
-                            .to_str()
-                            .unwrap()
-                            .to_owned(),
-                    );
-                    let paid = request.headers().contains_key("authorization");
-                    let body = axum::body::to_bytes(request.into_body(), 1024)
-                        .await
-                        .unwrap();
-                    if paid {
-                        assert_eq!(body.as_ref(), b"same-body");
-                        (AxumStatus::OK, "paid").into_response()
-                    } else {
-                        assert_eq!(body.as_ref(), b"same-body");
-                        (
-                            AxumStatus::PAYMENT_REQUIRED,
-                            [(WWW_AUTHENTICATE, challenge)],
-                            "payment required",
-                        )
-                            .into_response()
-                    }
-                }
-            }),
-        );
-        let origin = spawn_origin(app).await;
+        ))
+        .await;
         let provider = MockProvider::default();
         let payments = Arc::clone(&provider.payments);
-        let egress = MppEgress::start(provider, EgressPolicy::default())
-            .await
-            .unwrap();
+        let commits = Arc::clone(&provider.commits);
+        let egress = mpp_proxy(provider, |builder| builder).await;
 
         let response = proxied_client(&egress)
             .post(format!("{origin}/paid"))
+            .header(MPP_REQUEST_ID, "child-controlled")
             .body("same-body")
             .send()
             .await
             .unwrap();
 
         assert_eq!(response.status(), AxumStatus::OK);
-        assert_eq!(response.text().await.unwrap(), "paid");
-        assert_eq!(calls.load(Ordering::SeqCst), 2);
-        assert_eq!(payments.load(Ordering::SeqCst), 1);
         {
-            let request_ids = request_ids.lock().unwrap();
-            assert_eq!(request_ids.len(), 2);
-            assert_eq!(request_ids[0], request_ids[1]);
+            let observations = observations.lock().unwrap();
+            assert_eq!(observations.len(), 2);
+            assert_eq!(observations[0].0, observations[1].0);
+            assert_ne!(observations[0].0, "child-controlled");
+            assert_eq!(observations[0].1, b"same-body");
+            assert_eq!(observations[1].1, b"same-body");
+            assert!(!observations[0].2);
+            assert!(observations[1].2);
+            assert!(observations.iter().all(|observation| !observation.3));
         }
+        assert_eq!(payments.load(Ordering::SeqCst), 1);
+        assert_eq!(commits.load(Ordering::SeqCst), 1);
         egress.shutdown().await.unwrap();
     }
 
     #[tokio::test]
-    async fn pays_and_replays_ten_thousand_bounded_parallel_requests_exactly_once() {
+    async fn preserves_the_existing_default_payment_retry_policy() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let route_calls = Arc::clone(&calls);
+        let origin = spawn_origin(Router::new().route(
+            "/rotating-challenge",
+            post(move || {
+                let calls = Arc::clone(&route_calls);
+                async move {
+                    let call = calls.fetch_add(1, Ordering::SeqCst);
+                    let challenge = challenge_header(&format!("challenge-{call}"));
+                    (
+                        AxumStatus::PAYMENT_REQUIRED,
+                        [(WWW_AUTHENTICATE, challenge)],
+                        "payment required",
+                    )
+                }
+            }),
+        ))
+        .await;
+        let provider = MockProvider::default();
+        let payments = Arc::clone(&provider.payments);
+        let rollbacks = Arc::clone(&provider.rollbacks);
+        let egress = mpp_proxy(provider, |builder| builder).await;
+
+        let response = proxied_client(&egress)
+            .post(format!("{origin}/rotating-challenge"))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), AxumStatus::PAYMENT_REQUIRED);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            DEFAULT_MAX_PAYMENT_RETRIES + 1
+        );
+        assert_eq!(payments.load(Ordering::SeqCst), DEFAULT_MAX_PAYMENT_RETRIES);
+        assert_eq!(
+            rollbacks.load(Ordering::SeqCst),
+            DEFAULT_MAX_PAYMENT_RETRIES
+        );
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn promise_all_style_paid_requests_run_concurrently() {
+        const REQUESTS: usize = 141;
+        const CONCURRENCY: usize = 141;
+
+        super::super::resource::ensure_mpp_file_descriptor_capacity().unwrap();
+        let challenge = challenge_header("shared-challenge");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let route_calls = Arc::clone(&calls);
+        let origin = spawn_origin(Router::new().route(
+            "/paid",
+            post(move |request: Request| {
+                let challenge = challenge.clone();
+                let calls = Arc::clone(&route_calls);
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    if request.headers().contains_key("authorization") {
+                        (AxumStatus::OK, "paid").into_response()
+                    } else {
+                        (
+                            AxumStatus::PAYMENT_REQUIRED,
+                            [(WWW_AUTHENTICATE, challenge)],
+                            "payment required",
+                        )
+                            .into_response()
+                    }
+                }
+            }),
+        ))
+        .await;
+        let provider = MockProvider::default().with_payment_delay();
+        let payments = Arc::clone(&provider.payments);
+        let commits = Arc::clone(&provider.commits);
+        let maximum = Arc::clone(&provider.maximum);
+        let egress = mpp_proxy(provider, |builder| {
+            builder
+                .max_concurrent_requests(CONCURRENCY)
+                .max_concurrent_connections(CONCURRENCY * 2)
+        })
+        .await;
+        let client = proxied_client(&egress);
+
+        let statuses = stream::iter(0..REQUESTS)
+            .map(|_| {
+                let client = client.clone();
+                let url = format!("{origin}/paid");
+                async move { client.post(url).send().await.unwrap().status() }
+            })
+            .buffer_unordered(CONCURRENCY)
+            .collect::<Vec<_>>()
+            .await;
+
+        assert!(statuses.iter().all(AxumStatus::is_success));
+        assert_eq!(calls.load(Ordering::SeqCst), REQUESTS * 2);
+        assert_eq!(payments.load(Ordering::SeqCst), REQUESTS);
+        assert_eq!(commits.load(Ordering::SeqCst), REQUESTS);
+        assert!(
+            maximum.load(Ordering::SeqCst) > 1,
+            "payment handling was unexpectedly serialized"
+        );
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn pays_ten_thousand_bounded_parallel_requests_exactly_once() {
         const REQUESTS: usize = 10_000;
-        // Each in-process request owns client, proxy, and mock-origin sockets,
-        // while pooled keep-alive connections overlap request waves and the
-        // Rust test runner executes the other proxy tests concurrently. This
-        // test exercises exact-once behavior at volume; the dedicated bounds
-        // tests cover the production concurrency limits.
         const CONCURRENCY: usize = 8;
 
+        let challenge = challenge_header("shared-stress-challenge");
         let calls = Arc::new(AtomicUsize::new(0));
-        let observations = Arc::new(StdMutex::new(Vec::with_capacity(REQUESTS * 2)));
-        let origin =
-            spawn_recording_paid_origin(Arc::clone(&calls), Arc::clone(&observations)).await;
+        let observations = Arc::new(Mutex::new(Vec::with_capacity(REQUESTS * 2)));
+        let origin = spawn_origin(Router::new().route(
+            "/paid",
+            post({
+                let calls = Arc::clone(&calls);
+                let observations = Arc::clone(&observations);
+                move |request: Request<Body>| {
+                    let calls = Arc::clone(&calls);
+                    let challenge = challenge.clone();
+                    let observations = Arc::clone(&observations);
+                    async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        let request_id = request
+                            .headers()
+                            .get(MPP_REQUEST_ID)
+                            .unwrap()
+                            .to_str()
+                            .unwrap()
+                            .to_owned();
+                        let paid = request.headers().contains_key("authorization");
+                        let body = axum::body::to_bytes(request.into_body(), 1024)
+                            .await
+                            .unwrap();
+                        observations
+                            .lock()
+                            .unwrap()
+                            .push((request_id, body.to_vec(), paid));
+                        if paid {
+                            (AxumStatus::OK, "paid").into_response()
+                        } else {
+                            (
+                                AxumStatus::PAYMENT_REQUIRED,
+                                [(WWW_AUTHENTICATE, challenge)],
+                                "payment required",
+                            )
+                                .into_response()
+                        }
+                    }
+                }
+            }),
+        ))
+        .await;
         let provider = MockProvider::default();
         let payments = Arc::clone(&provider.payments);
         let commits = Arc::clone(&provider.commits);
         let rollbacks = Arc::clone(&provider.rollbacks);
-        let egress = MppEgress::start(
-            provider,
-            EgressPolicy {
-                max_concurrent_requests: CONCURRENCY,
-                ..EgressPolicy::default()
-            },
-        )
-        .await
-        .unwrap();
+        let egress = mpp_proxy(provider, |builder| {
+            builder.max_concurrent_requests(CONCURRENCY)
+        })
+        .await;
         let client = proxied_client(&egress);
 
-        let responses = stream::iter(0..REQUESTS)
+        let statuses = stream::iter(0..REQUESTS)
             .map(|index| {
                 let client = client.clone();
                 let url = format!("{origin}/paid");
                 async move {
-                    let response = client
+                    client
                         .post(url)
                         .body(format!("body-{index}"))
                         .send()
                         .await
-                        .unwrap();
-                    let status = response.status();
-                    let body = response.text().await.unwrap();
-                    (status, body)
+                        .unwrap()
+                        .status()
                 }
             })
             .buffer_unordered(CONCURRENCY)
             .collect::<Vec<_>>()
             .await;
 
-        let status_counts = responses.iter().fold(
-            std::collections::BTreeMap::new(),
-            |mut counts, (status, _)| {
-                *counts.entry(status.as_u16()).or_insert(0_usize) += 1;
-                counts
-            },
-        );
-        let error_counts = responses
-            .iter()
-            .filter(|(status, _)| !status.is_success())
-            .fold(
-                std::collections::BTreeMap::new(),
-                |mut counts, (_, body)| {
-                    *counts.entry(body).or_insert(0_usize) += 1;
-                    counts
-                },
-            );
-        assert_eq!(
-            status_counts,
-            std::collections::BTreeMap::from([(200, REQUESTS)]),
-            "error_counts={error_counts:?}"
-        );
+        assert!(statuses.iter().all(AxumStatus::is_success));
         assert_eq!(calls.load(Ordering::SeqCst), REQUESTS * 2);
         assert_eq!(payments.load(Ordering::SeqCst), REQUESTS);
         assert_eq!(commits.load(Ordering::SeqCst), REQUESTS);
@@ -1294,157 +552,6 @@ mod tests {
                 assert_ne!(pair[0].2, pair[1].2);
             }
         }
-        egress.shutdown().await.unwrap();
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn traces_the_complete_payment_retry_sequence() {
-        let logs = LogBuffer::default();
-        let subscriber = tracing_subscriber::fmt()
-            .json()
-            .with_writer(logs.clone())
-            .finish();
-        tracing::subscriber::set_global_default(subscriber).unwrap();
-        let challenge = challenge_header();
-        let app = Router::new().route(
-            "/paid",
-            post(move |request: Request<AxumBody>| {
-                let challenge = challenge.clone();
-                async move {
-                    if request.headers().contains_key("authorization") {
-                        (AxumStatus::OK, "paid").into_response()
-                    } else {
-                        (
-                            AxumStatus::PAYMENT_REQUIRED,
-                            [(WWW_AUTHENTICATE, challenge)],
-                            "payment required",
-                        )
-                            .into_response()
-                    }
-                }
-            }),
-        );
-        let origin = spawn_origin(app).await;
-        let egress = MppEgress::start(MockProvider::default(), EgressPolicy::default())
-            .await
-            .unwrap();
-
-        let response = proxied_client(&egress)
-            .post(format!("{origin}/paid"))
-            .body("audit-body")
-            .send()
-            .await
-            .unwrap();
-        assert_eq!(response.text().await.unwrap(), "paid");
-        egress.shutdown().await.unwrap();
-
-        let output = String::from_utf8(logs.0.lock().unwrap().clone()).unwrap();
-        let stages = [
-            "mpp.egress.origin.request.started",
-            "mpp.egress.challenge.received",
-            "mpp.egress.credential.created",
-            "mpp.egress.payment.response",
-            "mpp.egress.request.completed",
-        ];
-        let mut previous = 0;
-        for stage in stages {
-            let position = output[previous..].find(stage).unwrap() + previous;
-            previous = position;
-        }
-        assert!(output.contains("mpp.egress.request.body"));
-        assert!(output.contains("audit-body"));
-        assert!(output.contains("mpp.egress.response.body"));
-        assert!(output.contains("paid"));
-    }
-
-    #[tokio::test]
-    async fn rejects_request_bodies_above_the_replay_limit() {
-        let calls = Arc::new(AtomicUsize::new(0));
-        let calls_for_route = Arc::clone(&calls);
-        let origin = spawn_origin(Router::new().route(
-            "/upload",
-            post(move || {
-                let calls = Arc::clone(&calls_for_route);
-                async move {
-                    calls.fetch_add(1, Ordering::SeqCst);
-                    "unexpected"
-                }
-            }),
-        ))
-        .await;
-        let egress = MppEgress::start(
-            MockProvider::default(),
-            EgressPolicy {
-                max_request_bytes: 4,
-                ..EgressPolicy::default()
-            },
-        )
-        .await
-        .unwrap();
-
-        let response = proxied_client(&egress)
-            .post(format!("{origin}/upload"))
-            .body("too-large")
-            .send()
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), AxumStatus::PAYLOAD_TOO_LARGE);
-        assert_eq!(calls.load(Ordering::SeqCst), 0);
-        egress.shutdown().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn child_environment_points_at_the_ephemeral_proxy_and_ca() {
-        let egress = MppEgress::start(MockProvider::default(), EgressPolicy::default())
-            .await
-            .unwrap();
-        let environment = egress.environment();
-        let value = |name: &str| {
-            environment
-                .iter()
-                .find(|(candidate, _)| candidate == name)
-                .map(|(_, value)| value.clone())
-                .unwrap()
-        };
-
-        assert_eq!(value("https_proxy"), OsString::from(egress.proxy_url()));
-        assert!(value("NO_PROXY").is_empty());
-        assert_eq!(
-            std::path::PathBuf::from(value("CURL_CA_BUNDLE")),
-            egress.certificate_path()
-        );
-        assert!(egress.certificate_path().is_file());
-        assert_eq!(
-            value("NANOCODEX_MPP_EGRESS_PASSWORD"),
-            OsString::from(&egress.proxy_password)
-        );
-        assert_eq!(
-            value("NANOCODEX_MPP_EGRESS_AUTHORIZATION"),
-            OsString::from(&egress.proxy_authorization)
-        );
-        egress.shutdown().await.unwrap();
-    }
-
-    #[tokio::test]
-    #[ignore = "manual public-network HTTPS smoke"]
-    async fn live_https_mitm_smoke() {
-        let egress = MppEgress::start(MockProvider::default(), EgressPolicy::default())
-            .await
-            .unwrap();
-        let environment = egress.environment();
-        let output = tokio::task::spawn_blocking(move || {
-            std::process::Command::new("curl")
-                .args(["--fail", "--silent", "--show-error", "https://example.com/"])
-                .envs(environment)
-                .output()
-        })
-        .await
-        .unwrap()
-        .unwrap();
-
-        assert!(output.status.success());
-        assert!(String::from_utf8_lossy(&output.stdout).contains("Example Domain"));
         egress.shutdown().await.unwrap();
     }
 }

--- a/crates/experimental/README.md
+++ b/crates/experimental/README.md
@@ -9,6 +9,8 @@ being exercised and revised:
   plus retained guest-backed workspace tools.
 - [`nanocodex-browser`](nanocodex-browser/README.md): deterministic browser
   control, diagnostics, artifacts, and headed-browser VM composition.
+- [`nanocodex-egress`](nanocodex-egress/README.md): authenticated loopback
+  HTTP(S) forwarding and application-owned outbound middleware composition.
 
 Experimental means API stability, not reduced engineering standards. These
 packages remain workspace members and must pass the normal formatting, Clippy,

--- a/crates/experimental/nanocodex-egress/Cargo.toml
+++ b/crates/experimental/nanocodex-egress/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "nanocodex-egress"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Composable authenticated HTTP egress proxy"
+readme = "README.md"
+
+[dependencies]
+async-trait.workspace = true
+base64.workspace = true
+futures-util.workspace = true
+http-body-util.workspace = true
+http.workspace = true
+hudsucker.workspace = true
+rand.workspace = true
+reqwest = { workspace = true, features = ["stream"] }
+reqwest-middleware.workspace = true
+tempfile.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["fs", "net", "rt", "sync"] }
+tracing.workspace = true
+
+[dev-dependencies]
+axum.workspace = true
+criterion.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+
+[[bench]]
+name = "proxy_round_trip"
+harness = false
+
+[lints]
+workspace = true

--- a/crates/experimental/nanocodex-egress/README.md
+++ b/crates/experimental/nanocodex-egress/README.md
@@ -1,0 +1,54 @@
+# nanocodex-egress
+
+`nanocodex-egress` is Nanocodex's unpublished, experimental HTTP egress
+transport. It extracts the authenticated loopback proxy that previously lived
+inside the Tempo MPP adapter without changing the adapter's child-process
+contract.
+
+The crate owns proxy authentication, TLS interception, bounded replayable
+request bodies, forwarding concurrency, and lifecycle. Application protocols
+remain outside the crate and compose through `EgressLayer`; the Nanocodex
+binary implements its Tempo payment layer using MPP's request middleware.
+
+```rust,no_run
+use nanocodex_egress::{
+    EgressLayer, EgressProxy,
+    middleware::{
+        Extensions, Next, Request, Response, Result as MiddlewareResult,
+        async_trait,
+    },
+};
+
+struct ApplicationLayer;
+
+#[async_trait]
+impl EgressLayer for ApplicationLayer {
+    async fn handle(
+        &self,
+        request: Request,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> MiddlewareResult<Response> {
+        next.run(request, extensions).await
+    }
+}
+
+# async fn example() -> Result<(), Box<dyn std::error::Error>> {
+let proxy = EgressProxy::builder()
+    .layer(ApplicationLayer)
+    .spawn()
+    .await?;
+
+let child_environment = proxy.environment();
+assert!(!child_environment.is_empty());
+assert!(proxy.ca_certificate_path().is_file());
+proxy.shutdown().await?;
+# Ok(())
+# }
+```
+
+Layers run in builder order. The proxy keeps its random authentication
+credential and ephemeral CA in the host process, while `environment()`
+returns the same curl, Requests, Node, and MPP compatibility variables that the
+previous embedded MPP proxy exposed. Apply those variables only to tool child
+processes, not to Nanocodex's control-plane process.

--- a/crates/experimental/nanocodex-egress/benches/proxy_round_trip.rs
+++ b/crates/experimental/nanocodex-egress/benches/proxy_round_trip.rs
@@ -1,0 +1,91 @@
+use std::{hint::black_box, net::Ipv4Addr, time::Duration};
+
+use axum::{Router, extract::Request, routing::get};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use nanocodex_egress::{
+    EgressLayer, EgressProxy,
+    middleware::{Extensions, Next, Request as OutboundRequest, Response, async_trait},
+};
+
+struct MarkerLayer(&'static str);
+
+#[async_trait]
+impl EgressLayer for MarkerLayer {
+    async fn handle(
+        &self,
+        mut request: OutboundRequest,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> reqwest_middleware::Result<Response> {
+        request
+            .headers_mut()
+            .append("x-egress-benchmark", self.0.parse().unwrap());
+        next.run(request, extensions).await
+    }
+}
+
+fn benchmark_proxy_round_trip(criterion: &mut Criterion) {
+    let runtime = tokio::runtime::Runtime::new().expect("benchmark runtime");
+    let (origin, origin_task) = runtime.block_on(async {
+        let app = Router::new().route(
+            "/warm",
+            get(|request: Request| async move {
+                request
+                    .headers()
+                    .get_all("x-egress-benchmark")
+                    .iter()
+                    .count()
+                    .to_string()
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("benchmark origin listener");
+        let address = listener.local_addr().expect("benchmark origin address");
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("benchmark origin server");
+        });
+        (format!("http://{address}/warm"), task)
+    });
+
+    let mut group = criterion.benchmark_group("egress_proxy_round_trip");
+    group.sample_size(30);
+    group.measurement_time(Duration::from_secs(3));
+    group.throughput(Throughput::Elements(1));
+
+    for (name, layers) in [("direct", 0_usize), ("two_layers", 2_usize)] {
+        let proxy = runtime.block_on(async {
+            let mut builder = EgressProxy::builder();
+            if layers > 0 {
+                builder = builder.layer(MarkerLayer("one"));
+            }
+            if layers > 1 {
+                builder = builder.layer(MarkerLayer("two"));
+            }
+            builder.spawn().await.expect("benchmark proxy")
+        });
+        let client = reqwest::Client::builder()
+            .proxy(reqwest::Proxy::all(proxy.proxy_url()).expect("benchmark proxy URL"))
+            .build()
+            .expect("benchmark client");
+        let expected = layers.to_string();
+        group.bench_function(name, |bencher| {
+            bencher.to_async(&runtime).iter(|| async {
+                let response = client.get(&origin).send().await.expect("benchmark request");
+                let body = response.text().await.expect("benchmark response body");
+                assert_eq!(body, expected);
+                black_box(body);
+            });
+        });
+        runtime
+            .block_on(proxy.shutdown())
+            .expect("benchmark proxy shutdown");
+    }
+    group.finish();
+    origin_task.abort();
+}
+
+criterion_group!(benches, benchmark_proxy_round_trip);
+criterion_main!(benches);

--- a/crates/experimental/nanocodex-egress/examples/composable.rs
+++ b/crates/experimental/nanocodex-egress/examples/composable.rs
@@ -1,0 +1,41 @@
+use std::error::Error;
+
+use nanocodex_egress::{
+    EgressLayer, EgressProxy,
+    middleware::{Extensions, Next, Request, Response, Result as MiddlewareResult, async_trait},
+};
+
+struct ApplicationLayer;
+
+#[async_trait]
+impl EgressLayer for ApplicationLayer {
+    async fn handle(
+        &self,
+        request: Request,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> MiddlewareResult<Response> {
+        next.run(request, extensions).await
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?
+        .block_on(run())
+}
+
+async fn run() -> Result<(), Box<dyn Error>> {
+    let proxy = EgressProxy::builder()
+        .layer(ApplicationLayer)
+        .spawn()
+        .await?;
+
+    println!(
+        "composed application egress with {} child variables",
+        proxy.environment().len()
+    );
+    proxy.shutdown().await?;
+    Ok(())
+}

--- a/crates/experimental/nanocodex-egress/src/lib.rs
+++ b/crates/experimental/nanocodex-egress/src/lib.rs
@@ -1,0 +1,1205 @@
+//! Composable authenticated HTTP egress proxy.
+//!
+//! [`EgressProxy`] owns the loopback proxy, TLS interception, bounded request
+//! forwarding, and lifecycle. Applications compose protocol behavior through
+//! ordered [`EgressLayer`] implementations. Nanocodex uses that seam for MPP
+//! payment and replay while keeping wallet material in the host process.
+
+#![deny(missing_docs, rustdoc::broken_intra_doc_links)]
+
+/// The intentional extension seam for an application-defined [`EgressLayer`].
+///
+/// Reexports keep middleware versioning owned by this crate while allowing an
+/// application to adapt an existing middleware, as the Nanocodex binary does
+/// for Tempo MPP.
+pub mod middleware {
+    pub use async_trait::async_trait;
+    pub use http::Extensions;
+    pub use reqwest::{Request, Response};
+    pub use reqwest_middleware::{Error, Middleware, Next, Result};
+}
+
+use std::{
+    ffi::OsString,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    num::NonZeroUsize,
+    path::{Path, PathBuf},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use async_trait::async_trait;
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use futures_util::TryStreamExt;
+use http_body_util::{BodyExt, Limited};
+use hudsucker::{
+    Body, HttpContext, HttpHandler, Proxy, RequestOrResponse,
+    certificate_authority::CertificateAuthority,
+    hyper::{
+        Method, Request, Response, StatusCode,
+        header::{
+            CONNECTION, HOST, PROXY_AUTHENTICATE, PROXY_AUTHORIZATION, TRANSFER_ENCODING, UPGRADE,
+        },
+        http::uri::Authority,
+    },
+    rcgen::{
+        BasicConstraints, CertificateParams, DistinguishedName, DnType, ExtendedKeyUsagePurpose,
+        IsCa, Issuer, KeyPair, KeyUsagePurpose, SanType, string::Ia5String,
+    },
+    rustls::{
+        ServerConfig,
+        crypto::ring,
+        pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
+    },
+};
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, Middleware, Next};
+use tempfile::TempDir;
+use tokio::{
+    net::TcpListener,
+    sync::{Semaphore, oneshot},
+    task::JoinHandle,
+};
+use tracing::Instrument as _;
+
+const DEFAULT_MAX_REQUEST_BYTES: usize = 16 * 1024 * 1024;
+const DEFAULT_MAX_CONCURRENT_CONNECTIONS: usize = 128;
+const DEFAULT_MAX_CONCURRENT_REQUESTS: usize = 128;
+const MAX_IDLE_CONNECTIONS_PER_ORIGIN: usize = 4;
+const CA_FILENAME: &str = "mpp-egress-ca.pem";
+
+/// One independently composable outbound HTTP behavior.
+///
+/// Layers receive ordinary forwarded requests in attachment order.
+#[async_trait]
+pub trait EgressLayer: Send + Sync + 'static {
+    /// Handles one replayable outbound request and optionally invokes the rest
+    /// of the stack with [`Next::run`].
+    async fn handle(
+        &self,
+        request: reqwest::Request,
+        extensions: &mut ::http::Extensions,
+        next: Next<'_>,
+    ) -> reqwest_middleware::Result<reqwest::Response>;
+}
+
+/// Private transport policy owned by one embedded proxy instance.
+#[derive(Clone, Debug)]
+struct ProxyPolicy {
+    max_request_bytes: usize,
+    max_concurrent_requests: usize,
+    max_concurrent_connections: usize,
+}
+
+impl Default for ProxyPolicy {
+    fn default() -> Self {
+        Self {
+            max_request_bytes: DEFAULT_MAX_REQUEST_BYTES,
+            max_concurrent_requests: DEFAULT_MAX_CONCURRENT_REQUESTS,
+            max_concurrent_connections: DEFAULT_MAX_CONCURRENT_CONNECTIONS,
+        }
+    }
+}
+
+struct LayerMiddleware(Arc<dyn EgressLayer>);
+
+#[async_trait]
+impl Middleware for LayerMiddleware {
+    async fn handle(
+        &self,
+        request: reqwest::Request,
+        extensions: &mut ::http::Extensions,
+        next: Next<'_>,
+    ) -> reqwest_middleware::Result<reqwest::Response> {
+        self.0.handle(request, extensions, next).await
+    }
+}
+
+/// A running authenticated loopback proxy and its ephemeral certificate authority.
+pub struct EgressProxy {
+    proxy_url: String,
+    proxy_password: String,
+    proxy_authorization: String,
+    ca_certificate_path: PathBuf,
+    _temp_dir: TempDir,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    task: Option<JoinHandle<Result<(), hudsucker::Error>>>,
+    #[cfg(test)]
+    _test_permit: tokio::sync::OwnedSemaphorePermit,
+}
+
+impl EgressProxy {
+    /// Starts a composable proxy builder with no outbound layers.
+    #[must_use]
+    pub fn builder() -> EgressProxyBuilder {
+        EgressProxyBuilder::new()
+    }
+
+    async fn start(
+        policy: ProxyPolicy,
+        layers: Vec<Arc<dyn EgressLayer>>,
+    ) -> Result<Self, EgressError> {
+        #[cfg(test)]
+        let test_permit = test_proxy_permit().await;
+        if policy.max_request_bytes == 0 {
+            return Err(EgressError::ZeroMaxRequestBytes);
+        }
+        if policy.max_concurrent_requests == 0 {
+            return Err(EgressError::ZeroMaxConcurrentRequests);
+        }
+        let max_concurrent_connections = NonZeroUsize::new(policy.max_concurrent_connections)
+            .ok_or(EgressError::ZeroMaxConcurrentConnections)?;
+
+        let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
+            .await
+            .map_err(EgressError::Bind)?;
+        let address = listener.local_addr().map_err(EgressError::LocalAddress)?;
+        let (authority, certificate_pem) = ephemeral_authority()?;
+        let temp_dir = tempfile::Builder::new()
+            .prefix("nanocodex-mpp-egress-")
+            .tempdir()
+            .map_err(EgressError::TempDir)?;
+        let ca_certificate_path = temp_dir.path().join(CA_FILENAME);
+        std::fs::write(&ca_certificate_path, &certificate_pem)
+            .map_err(EgressError::WriteCertificate)?;
+
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .redirect(reqwest::redirect::Policy::none())
+            .pool_max_idle_per_host(MAX_IDLE_CONNECTIONS_PER_ORIGIN)
+            .build()
+            .map_err(EgressError::Client)?;
+        let mut client_builder = ClientBuilder::new(client);
+        for layer in &layers {
+            client_builder = client_builder.with(LayerMiddleware(Arc::clone(layer)));
+        }
+        let client = client_builder.build();
+        let proxy_password = random_proxy_password();
+        let proxy_authorization = format!(
+            "Basic {}",
+            STANDARD.encode(format!("nanocodex:{proxy_password}"))
+        );
+        let proxy_url = format!("http://nanocodex:{proxy_password}@{address}");
+        let origin_permits = Arc::new(Semaphore::new(policy.max_concurrent_requests));
+        let handler = ProxyHandler {
+            client,
+            policy,
+            origin_permits,
+            authentication: ProxyAuthentication {
+                authorization: proxy_authorization.clone().into(),
+                tunnel_authenticated: false,
+            },
+            request_ids: Arc::new(AtomicU64::new(1)),
+        };
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let proxy = Proxy::builder()
+            .with_listener(listener)
+            .with_ca(authority)
+            .with_rustls_connector(ring::default_provider())
+            .with_max_concurrent_connections(max_concurrent_connections)
+            .with_http_handler(handler)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .build()?;
+        let task = tokio::spawn(proxy.start());
+
+        Ok(Self {
+            proxy_url,
+            proxy_password,
+            proxy_authorization,
+            ca_certificate_path,
+            _temp_dir: temp_dir,
+            shutdown_tx: Some(shutdown_tx),
+            task: Some(task),
+            #[cfg(test)]
+            _test_permit: test_permit,
+        })
+    }
+
+    /// Returns the authenticated HTTP proxy URL.
+    ///
+    /// The URL contains a short-lived bearer credential and must not be logged.
+    #[must_use]
+    pub fn proxy_url(&self) -> String {
+        self.proxy_url.clone()
+    }
+
+    /// Returns environment overrides for curl and common HTTP runtimes.
+    ///
+    /// These values contain the proxy bearer capability. They should be applied
+    /// only to tool child processes, not logged or installed in the embedding
+    /// process, so model/control-plane traffic is not intercepted.
+    #[must_use]
+    pub fn environment(&self) -> Vec<(OsString, OsString)> {
+        let proxy = OsString::from(self.proxy_url());
+        let certificate = self.ca_certificate_path.clone().into_os_string();
+        [
+            ("http_proxy", proxy.clone()),
+            ("https_proxy", proxy.clone()),
+            ("HTTP_PROXY", proxy.clone()),
+            ("HTTPS_PROXY", proxy),
+            ("no_proxy", OsString::new()),
+            ("NO_PROXY", OsString::new()),
+            ("CURL_CA_BUNDLE", certificate.clone()),
+            ("SSL_CERT_FILE", certificate.clone()),
+            ("REQUESTS_CA_BUNDLE", certificate.clone()),
+            ("NODE_EXTRA_CA_CERTS", certificate),
+            (
+                "NANOCODEX_MPP_EGRESS_PASSWORD",
+                OsString::from(&self.proxy_password),
+            ),
+            (
+                "NANOCODEX_MPP_EGRESS_AUTHORIZATION",
+                OsString::from(&self.proxy_authorization),
+            ),
+        ]
+        .into_iter()
+        .map(|(name, value)| (OsString::from(name), value))
+        .collect()
+    }
+
+    /// Stops accepting traffic and waits for active proxy connections to drain.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the proxy task fails or cannot be joined.
+    pub async fn shutdown(mut self) -> Result<(), EgressError> {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
+        if let Some(task) = self.task.take() {
+            task.await.map_err(EgressError::Join)??;
+        }
+        Ok(())
+    }
+
+    /// Path to the public ephemeral CA certificate.
+    #[must_use]
+    pub fn ca_certificate_path(&self) -> &Path {
+        &self.ca_certificate_path
+    }
+}
+
+#[cfg(test)]
+async fn test_proxy_permit() -> tokio::sync::OwnedSemaphorePermit {
+    static PERMITS: std::sync::OnceLock<Arc<Semaphore>> = std::sync::OnceLock::new();
+    Arc::clone(PERMITS.get_or_init(|| Arc::new(Semaphore::new(4))))
+        .acquire_owned()
+        .await
+        .unwrap_or_else(|error| unreachable!("test proxy semaphore closed: {error}"))
+}
+
+/// Builder for one bounded proxy and its ordered outbound layers.
+pub struct EgressProxyBuilder {
+    policy: ProxyPolicy,
+    layers: Vec<Arc<dyn EgressLayer>>,
+}
+
+impl EgressProxyBuilder {
+    /// Creates a builder with bounded defaults and direct HTTP forwarding.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            policy: ProxyPolicy::default(),
+            layers: Vec::new(),
+        }
+    }
+
+    /// Sets the maximum replayable request-body size accepted from a child.
+    #[must_use]
+    pub const fn max_request_bytes(mut self, max_bytes: usize) -> Self {
+        self.policy.max_request_bytes = max_bytes;
+        self
+    }
+
+    /// Sets the maximum number of requests concurrently forwarded to origins.
+    ///
+    /// Additional child requests wait locally before entering outbound layers.
+    #[must_use]
+    pub const fn max_concurrent_requests(mut self, max_requests: usize) -> Self {
+        self.policy.max_concurrent_requests = max_requests;
+        self
+    }
+
+    /// Sets the maximum number of accepted child proxy connections.
+    ///
+    /// Additional clients remain in the listener backlog before consuming a
+    /// process file descriptor.
+    #[must_use]
+    pub const fn max_concurrent_connections(mut self, max_connections: usize) -> Self {
+        self.policy.max_concurrent_connections = max_connections;
+        self
+    }
+
+    /// Appends one independently owned outbound behavior.
+    ///
+    /// Layers run in attachment order on the initial request. A layer controls
+    /// whether and how the remaining stack runs through [`Next::run`].
+    #[must_use]
+    pub fn layer<L>(mut self, layer: L) -> Self
+    where
+        L: EgressLayer,
+    {
+        self.layers.push(Arc::new(layer));
+        self
+    }
+
+    /// Starts the proxy and its owned background task.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed initialization or proxy error.
+    pub async fn spawn(self) -> Result<EgressProxy, EgressError> {
+        EgressProxy::start(self.policy, self.layers).await
+    }
+}
+
+impl Default for EgressProxyBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for EgressProxy {
+    fn drop(&mut self) {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ProxyHandler {
+    client: ClientWithMiddleware,
+    policy: ProxyPolicy,
+    origin_permits: Arc<Semaphore>,
+    authentication: ProxyAuthentication,
+    request_ids: Arc<AtomicU64>,
+}
+
+#[derive(Clone)]
+struct ProxyAuthentication {
+    authorization: Arc<str>,
+    // The proxy backend carries the mutated CONNECT handler into only that
+    // intercepted stream; clones for unrelated client connections remain false.
+    tunnel_authenticated: bool,
+}
+
+impl ProxyAuthentication {
+    fn authorize(&mut self, request: &Request<Body>) -> bool {
+        let has_authorization = request
+            .headers()
+            .get(PROXY_AUTHORIZATION)
+            .is_some_and(|value| value.as_bytes() == self.authorization.as_bytes());
+        if has_authorization {
+            if request.method() == Method::CONNECT {
+                self.tunnel_authenticated = true;
+            }
+            return true;
+        }
+        self.tunnel_authenticated
+    }
+}
+
+impl HttpHandler for ProxyHandler {
+    async fn handle_request(
+        &mut self,
+        context: &HttpContext,
+        mut request: Request<Body>,
+    ) -> RequestOrResponse {
+        let request_id = self.request_ids.fetch_add(1, Ordering::Relaxed);
+        let span = tracing::info_span!(
+            target: "mpp_egress",
+            "mpp.egress.request",
+            request.id = request_id,
+            mpp.request.id = tracing::field::Empty,
+            client.address = %context.client_addr,
+            http.request.method = %request.method(),
+            url.full = %request.uri(),
+            request.upgrade = is_upgrade(&request),
+        );
+        async move {
+            tracing::info!(
+                target: "mpp_egress",
+                content_kind = "mpp.egress.request.headers",
+                content = ?request.headers(),
+                "trace content"
+            );
+            if !self.authentication.authorize(&request) {
+                tracing::warn!(
+                    target: "mpp_egress",
+                    stage = "mpp.egress.proxy_authentication.rejected",
+                    http.response.status_code = StatusCode::PROXY_AUTHENTICATION_REQUIRED.as_u16(),
+                    "MPP egress rejected an unauthenticated client"
+                );
+                return proxy_authentication_required().into();
+            }
+            tracing::info!(
+                target: "mpp_egress",
+                stage = "mpp.egress.proxy_authentication.accepted",
+                "MPP egress authenticated its child client"
+            );
+            request.headers_mut().remove(PROXY_AUTHORIZATION);
+            if request.method() == Method::CONNECT || is_upgrade(&request) {
+                tracing::info!(
+                    target: "mpp_egress",
+                    stage = "mpp.egress.tunnel.forwarded",
+                    "MPP egress forwarded a protocol tunnel without payment handling"
+                );
+                return request.into();
+            }
+
+            match self.forward(request).await {
+                Ok(response) => response.into(),
+                Err(ForwardError::RequestTooLarge) => {
+                    tracing::warn!(
+                        target: "mpp_egress",
+                        stage = "mpp.egress.request.failed",
+                        failure.kind = "request_too_large",
+                        http.response.status_code = StatusCode::PAYLOAD_TOO_LARGE.as_u16(),
+                        "MPP egress rejected an unreplayable request body"
+                    );
+                    error_response(
+                        StatusCode::PAYLOAD_TOO_LARGE,
+                        "request body exceeds the MPP egress replay limit",
+                    )
+                    .into()
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        target: "mpp_egress",
+                        stage = "mpp.egress.request.failed",
+                        failure.kind = "payment_or_forwarding",
+                        http.response.status_code = StatusCode::BAD_GATEWAY.as_u16(),
+                        error = %error,
+                        "MPP egress request failed"
+                    );
+                    error_response(StatusCode::BAD_GATEWAY, &error.to_string()).into()
+                }
+            }
+        }
+        .instrument(span)
+        .await
+    }
+}
+
+impl ProxyHandler {
+    async fn forward(&self, request: Request<Body>) -> Result<Response<Body>, ForwardError> {
+        let (mut parts, body) = request.into_parts();
+        let body = Limited::new(body, self.policy.max_request_bytes)
+            .collect()
+            .await
+            .map_err(|_| ForwardError::RequestTooLarge)?
+            .to_bytes();
+        record_body_content("mpp.egress.request.body", &body);
+        remove_hop_by_hop_request_headers(&mut parts.headers);
+        let queued = self.origin_permits.available_permits() == 0;
+        if queued {
+            tracing::info!(
+                target: "mpp_egress",
+                stage = "mpp.egress.origin.request.queued",
+                origin.max_concurrent_requests = self.policy.max_concurrent_requests,
+                "MPP egress queued the request before contacting its origin"
+            );
+        }
+        let _origin_permit = self
+            .origin_permits
+            .acquire()
+            .await
+            .map_err(|_| ForwardError::Unavailable)?;
+        tracing::info!(
+            target: "mpp_egress",
+            stage = "mpp.egress.origin.request.started",
+            http.request.body.size = body.len(),
+            request.queued = queued,
+            "MPP egress sent the original request"
+        );
+
+        let builder = self
+            .client
+            .request(parts.method, parts.uri.to_string())
+            .headers(parts.headers)
+            .body(body);
+        let response = builder.send().await.map_err(ForwardError::Layer)?;
+
+        let status = response.status();
+        tracing::info!(
+            target: "mpp_egress",
+            stage = "mpp.egress.request.completed",
+            http.response.status_code = status.as_u16(),
+            "MPP egress completed the request"
+        );
+        Ok(convert_response(response, &tracing::Span::current()))
+    }
+}
+
+fn record_body_content(kind: &'static str, body: &[u8]) {
+    if !tracing::enabled!(target: "mpp_egress", tracing::Level::INFO) {
+        return;
+    }
+    if let Ok(content) = std::str::from_utf8(body) {
+        tracing::info!(
+            target: "mpp_egress",
+            content_kind = kind,
+            content,
+            "trace content"
+        );
+    } else {
+        tracing::info!(
+            target: "mpp_egress",
+            content_kind = kind,
+            content = ?body,
+            "trace content"
+        );
+    }
+}
+
+fn convert_response(mut response: reqwest::Response, span: &tracing::Span) -> Response<Body> {
+    let status = response.status();
+    let version = response.version();
+    let mut headers = std::mem::take(response.headers_mut());
+    remove_hop_by_hop_response_headers(&mut headers);
+    let trace_content = tracing::enabled!(target: "mpp_egress", tracing::Level::INFO);
+    if trace_content {
+        span.in_scope(|| {
+            tracing::info!(
+                target: "mpp_egress",
+                content_kind = "mpp.egress.response.headers",
+                content = ?headers,
+                "trace content"
+            );
+        });
+    }
+    let stream = response.bytes_stream();
+    let body = if trace_content {
+        let content_span = span.clone();
+        let mut chunk_index = 0_u64;
+        Body::from_stream(
+            stream
+                .map_ok(move |chunk| {
+                    content_span.in_scope(|| {
+                        if let Ok(content) = std::str::from_utf8(&chunk) {
+                            tracing::info!(
+                                target: "mpp_egress",
+                                content_kind = "mpp.egress.response.body",
+                                response.chunk.index = chunk_index,
+                                response.chunk.size = chunk.len(),
+                                content,
+                                "trace content"
+                            );
+                        } else {
+                            tracing::info!(
+                                target: "mpp_egress",
+                                content_kind = "mpp.egress.response.body",
+                                response.chunk.index = chunk_index,
+                                response.chunk.size = chunk.len(),
+                                content = ?chunk.as_ref(),
+                                "trace content"
+                            );
+                        }
+                    });
+                    chunk_index = chunk_index.saturating_add(1);
+                    chunk
+                })
+                .map_err(|_| hudsucker::Error::Unknown),
+        )
+    } else {
+        Body::from_stream(stream.map_err(|_| hudsucker::Error::Unknown))
+    };
+    let mut response = Response::new(body);
+    *response.status_mut() = status;
+    *response.version_mut() = version;
+    *response.headers_mut() = headers;
+    response
+}
+
+fn is_upgrade(request: &Request<Body>) -> bool {
+    request.headers().contains_key(UPGRADE)
+        || request
+            .headers()
+            .get(CONNECTION)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| {
+                value
+                    .split(',')
+                    .any(|token| token.trim().eq_ignore_ascii_case("upgrade"))
+            })
+}
+
+fn remove_hop_by_hop_request_headers(headers: &mut hudsucker::hyper::HeaderMap) {
+    remove_connection_named_headers(headers);
+    for name in [
+        CONNECTION,
+        HOST,
+        PROXY_AUTHORIZATION,
+        TRANSFER_ENCODING,
+        UPGRADE,
+    ] {
+        headers.remove(name);
+    }
+}
+
+fn remove_hop_by_hop_response_headers(headers: &mut hudsucker::hyper::HeaderMap) {
+    remove_connection_named_headers(headers);
+    for name in [CONNECTION, TRANSFER_ENCODING, UPGRADE] {
+        headers.remove(name);
+    }
+}
+
+fn remove_connection_named_headers(headers: &mut hudsucker::hyper::HeaderMap) {
+    let names = headers
+        .get_all(CONNECTION)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(','))
+        .filter_map(|name| {
+            name.trim()
+                .parse::<hudsucker::hyper::header::HeaderName>()
+                .ok()
+        })
+        .collect::<Vec<_>>();
+    for name in names {
+        headers.remove(name);
+    }
+}
+
+fn error_response(status: StatusCode, message: &str) -> Response<Body> {
+    let mut response = Response::new(Body::from(message.to_owned()));
+    *response.status_mut() = status;
+    response
+}
+
+fn proxy_authentication_required() -> Response<Body> {
+    let mut response = error_response(
+        StatusCode::PROXY_AUTHENTICATION_REQUIRED,
+        "proxy authentication required",
+    );
+    response.headers_mut().insert(
+        PROXY_AUTHENTICATE,
+        hudsucker::hyper::header::HeaderValue::from_static("Basic realm=\"nanocodex-mpp-egress\""),
+    );
+    response
+}
+
+fn random_proxy_password() -> String {
+    random_identifier()
+}
+
+fn random_identifier() -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut identifier = String::with_capacity(64);
+    for byte in rand::random::<[u8; 32]>() {
+        identifier.push(char::from(HEX[usize::from(byte >> 4)]));
+        identifier.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    identifier
+}
+
+struct EphemeralAuthority {
+    issuer: Issuer<'static, KeyPair>,
+    private_key: PrivateKeyDer<'static>,
+    cache: Mutex<std::collections::HashMap<Authority, Arc<ServerConfig>>>,
+}
+
+impl CertificateAuthority for EphemeralAuthority {
+    async fn gen_server_config(&self, authority: &Authority) -> Arc<ServerConfig> {
+        if let Ok(cache) = self.cache.lock()
+            && let Some(config) = cache.get(authority)
+        {
+            return Arc::clone(config);
+        }
+
+        let mut params = CertificateParams::default();
+        params.serial_number = Some(rand::random::<u64>().into());
+        let mut distinguished_name = DistinguishedName::new();
+        distinguished_name.push(DnType::CommonName, authority.host());
+        params.distinguished_name = distinguished_name;
+        params
+            .subject_alt_names
+            .push(authority.host().parse::<IpAddr>().map_or_else(
+                |_| {
+                    SanType::DnsName(
+                        Ia5String::try_from(authority.host())
+                            .expect("HTTP authority host must be a valid DNS IA5 string"),
+                    )
+                },
+                SanType::IpAddress,
+            ));
+        params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+        params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+        params.use_authority_key_identifier_extension = true;
+        let certificate = params
+            .signed_by(self.issuer.key(), &self.issuer)
+            .expect("valid CA parameters must sign an ephemeral leaf certificate");
+        let mut config = ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(
+                vec![CertificateDer::from(certificate)],
+                self.private_key.clone_key(),
+            )
+            .expect("generated leaf certificate and private key must match");
+        config.alpn_protocols = vec![b"http/1.1".to_vec()];
+        let config = Arc::new(config);
+
+        if let Ok(mut cache) = self.cache.lock()
+            && cache.len() < 1_024
+        {
+            cache.insert(authority.clone(), Arc::clone(&config));
+        }
+        config
+    }
+}
+
+fn ephemeral_authority() -> Result<(EphemeralAuthority, String), EgressError> {
+    let key_pair = KeyPair::generate().map_err(EgressError::Certificate)?;
+    let mut params = CertificateParams::default();
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let mut distinguished_name = DistinguishedName::new();
+    distinguished_name.push(DnType::CommonName, "Nanocodex ephemeral egress");
+    params.distinguished_name = distinguished_name;
+    params.key_usages = vec![
+        KeyUsagePurpose::DigitalSignature,
+        KeyUsagePurpose::KeyCertSign,
+        KeyUsagePurpose::CrlSign,
+    ];
+    let certificate = params
+        .self_signed(&key_pair)
+        .map_err(EgressError::Certificate)?;
+    let certificate_pem = certificate.pem();
+    let private_key = PrivateKeyDer::from(PrivatePkcs8KeyDer::from(key_pair.serialize_der()));
+    let issuer =
+        Issuer::from_ca_cert_pem(&certificate_pem, key_pair).map_err(EgressError::Certificate)?;
+    Ok((
+        EphemeralAuthority {
+            issuer,
+            private_key,
+            cache: Mutex::new(std::collections::HashMap::new()),
+        },
+        certificate_pem,
+    ))
+}
+
+/// Failure to configure, start, run, or stop an egress proxy.
+#[derive(Debug, thiserror::Error)]
+pub enum EgressError {
+    /// The replayable request-body limit was zero.
+    #[error("egress max request bytes must be greater than zero")]
+    ZeroMaxRequestBytes,
+    /// The forwarded-request concurrency limit was zero.
+    #[error("egress max concurrent requests must be greater than zero")]
+    ZeroMaxConcurrentRequests,
+    /// The accepted-connection concurrency limit was zero.
+    #[error("egress max concurrent connections must be greater than zero")]
+    ZeroMaxConcurrentConnections,
+    /// The loopback listener could not be bound.
+    #[error("failed to bind the egress proxy listener")]
+    Bind(#[source] std::io::Error),
+    /// The bound listener address could not be read.
+    #[error("failed to read the egress proxy listener address")]
+    LocalAddress(#[source] std::io::Error),
+    /// The private ephemeral-CA directory could not be created.
+    #[error("failed to create the ephemeral egress directory")]
+    TempDir(#[source] std::io::Error),
+    /// The public CA certificate could not be persisted for child runtimes.
+    #[error("failed to write the ephemeral egress CA certificate")]
+    WriteCertificate(#[source] std::io::Error),
+    /// Ephemeral CA or leaf-certificate generation failed.
+    #[error("failed to generate the ephemeral egress CA")]
+    Certificate(#[source] hudsucker::rcgen::Error),
+    /// The origin-facing HTTP client could not be built.
+    #[error("failed to build the egress HTTP client")]
+    Client(#[source] reqwest::Error),
+    /// The proxy rejected its configuration or failed while serving.
+    #[error("egress proxy failed")]
+    Proxy(#[from] hudsucker::Error),
+    /// The background proxy task panicked or was cancelled unexpectedly.
+    #[error("egress proxy task failed")]
+    Join(#[source] tokio::task::JoinError),
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ForwardError {
+    #[error("request body is too large to replay")]
+    RequestTooLarge,
+    #[error("egress proxy stopped while the request was queued")]
+    Unavailable,
+    #[error("egress layer or origin request failed: {0}")]
+    Layer(#[source] reqwest_middleware::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use super::*;
+    use axum::{
+        Router,
+        extract::Request,
+        http::StatusCode as AxumStatus,
+        routing::{get, post},
+    };
+    use futures_util::future::join_all;
+
+    #[test]
+    fn proxy_authentication_only_retains_connect_tunnels() {
+        let mut authentication = ProxyAuthentication {
+            authorization: Arc::from("Basic test-credential"),
+            tunnel_authenticated: false,
+        };
+        let authorized_request = |method| {
+            Request::builder()
+                .method(method)
+                .header(PROXY_AUTHORIZATION, "Basic test-credential")
+                .body(Body::empty())
+                .unwrap()
+        };
+        let unauthenticated_request = || Request::new(Body::empty());
+
+        assert!(authentication.authorize(&authorized_request(Method::GET)));
+        assert!(!authentication.tunnel_authenticated);
+        assert!(!authentication.authorize(&unauthenticated_request()));
+
+        assert!(authentication.authorize(&authorized_request(Method::CONNECT)));
+        assert!(authentication.tunnel_authenticated);
+        assert!(authentication.clone().authorize(&unauthenticated_request()));
+
+        let mut fresh_connection = ProxyAuthentication {
+            authorization: Arc::clone(&authentication.authorization),
+            tunnel_authenticated: false,
+        };
+        assert!(!fresh_connection.authorize(&unauthenticated_request()));
+    }
+
+    struct HeaderLayer(&'static str);
+
+    #[async_trait]
+    impl EgressLayer for HeaderLayer {
+        async fn handle(
+            &self,
+            mut request: reqwest::Request,
+            extensions: &mut ::http::Extensions,
+            next: Next<'_>,
+        ) -> reqwest_middleware::Result<reqwest::Response> {
+            let previous = request
+                .headers()
+                .get("x-egress-layers")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or_default();
+            let value = if previous.is_empty() {
+                self.0.to_owned()
+            } else {
+                format!("{previous},{}", self.0)
+            };
+            request
+                .headers_mut()
+                .insert("x-egress-layers", value.parse().unwrap());
+            next.run(request, extensions).await
+        }
+    }
+
+    struct DenyLayer;
+
+    #[async_trait]
+    impl EgressLayer for DenyLayer {
+        async fn handle(
+            &self,
+            _request: reqwest::Request,
+            _extensions: &mut ::http::Extensions,
+            _next: Next<'_>,
+        ) -> reqwest_middleware::Result<reqwest::Response> {
+            let mut response = ::http::Response::new(reqwest::Body::from("denied"));
+            *response.status_mut() = reqwest::StatusCode::FORBIDDEN;
+            Ok(response.into())
+        }
+    }
+
+    #[tokio::test]
+    async fn builder_reports_each_zero_transport_limit_without_binding() {
+        assert!(matches!(
+            EgressProxy::builder().max_request_bytes(0).spawn().await,
+            Err(EgressError::ZeroMaxRequestBytes)
+        ));
+        assert!(matches!(
+            EgressProxy::builder()
+                .max_concurrent_requests(0)
+                .spawn()
+                .await,
+            Err(EgressError::ZeroMaxConcurrentRequests)
+        ));
+        assert!(matches!(
+            EgressProxy::builder()
+                .max_concurrent_connections(0)
+                .spawn()
+                .await,
+            Err(EgressError::ZeroMaxConcurrentConnections)
+        ));
+    }
+
+    async fn spawn_origin(app: Router) -> String {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{address}")
+    }
+
+    fn proxied_client(egress: &EgressProxy) -> reqwest::Client {
+        reqwest::Client::builder()
+            .proxy(reqwest::Proxy::all(egress.proxy_url()).unwrap())
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn rejects_clients_without_the_ephemeral_proxy_credential() {
+        let egress = EgressProxy::builder().spawn().await.unwrap();
+        let mut proxy: reqwest::Url = egress.proxy_url().parse().unwrap();
+        proxy.set_username("").unwrap();
+        proxy.set_password(None).unwrap();
+        let client = reqwest::Client::builder()
+            .proxy(reqwest::Proxy::all(proxy).unwrap())
+            .build()
+            .unwrap();
+
+        let response = client.get("http://example.invalid/").send().await.unwrap();
+
+        assert_eq!(response.status(), AxumStatus::PROXY_AUTHENTICATION_REQUIRED);
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn passes_ordinary_http_responses_through() {
+        let origin = spawn_origin(Router::new().route("/plain", get(|| async { "plain" }))).await;
+        let egress = EgressProxy::builder().spawn().await.unwrap();
+
+        let response = proxied_client(&egress)
+            .get(format!("{origin}/plain"))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), AxumStatus::OK);
+        assert_eq!(response.text().await.unwrap(), "plain");
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn layers_run_in_attachment_order() {
+        let origin = spawn_origin(Router::new().route(
+            "/layers",
+            get(|request: Request| async move {
+                request
+                    .headers()
+                    .get("x-egress-layers")
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default()
+                    .to_owned()
+            }),
+        ))
+        .await;
+        let egress = EgressProxy::builder()
+            .layer(HeaderLayer("first"))
+            .layer(HeaderLayer("second"))
+            .spawn()
+            .await
+            .unwrap();
+
+        let body = proxied_client(&egress)
+            .get(format!("{origin}/layers"))
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+
+        assert_eq!(body, "first,second");
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_layer_can_short_circuit_before_the_origin() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let route_calls = Arc::clone(&calls);
+        let origin = spawn_origin(Router::new().route(
+            "/denied",
+            get(move || {
+                let route_calls = Arc::clone(&route_calls);
+                async move {
+                    route_calls.fetch_add(1, Ordering::SeqCst);
+                    "unexpected"
+                }
+            }),
+        ))
+        .await;
+        let egress = EgressProxy::builder()
+            .layer(DenyLayer)
+            .spawn()
+            .await
+            .unwrap();
+
+        let response = proxied_client(&egress)
+            .get(format!("{origin}/denied"))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), AxumStatus::FORBIDDEN);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn queues_excess_requests_before_contacting_the_origin() {
+        let active = Arc::new(AtomicUsize::new(0));
+        let maximum = Arc::new(AtomicUsize::new(0));
+        let started = Arc::new(tokio::sync::Notify::new());
+        let gate = Arc::new(Semaphore::new(0));
+        let app = Router::new().route(
+            "/bounded",
+            get({
+                let active = Arc::clone(&active);
+                let maximum = Arc::clone(&maximum);
+                let started = Arc::clone(&started);
+                let gate = Arc::clone(&gate);
+                move || {
+                    let active = Arc::clone(&active);
+                    let maximum = Arc::clone(&maximum);
+                    let started = Arc::clone(&started);
+                    let gate = Arc::clone(&gate);
+                    async move {
+                        let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                        maximum.fetch_max(current, Ordering::SeqCst);
+                        started.notify_one();
+                        let permit = gate.acquire().await.unwrap();
+                        permit.forget();
+                        active.fetch_sub(1, Ordering::SeqCst);
+                        "bounded"
+                    }
+                }
+            }),
+        );
+        let origin = spawn_origin(app).await;
+        let egress = EgressProxy::builder()
+            .max_concurrent_requests(3)
+            .spawn()
+            .await
+            .unwrap();
+        let client = proxied_client(&egress);
+        let requests = (0..12)
+            .map(|_| {
+                let client = client.clone();
+                let url = format!("{origin}/bounded");
+                tokio::spawn(async move { client.get(url).send().await.unwrap().status() })
+            })
+            .collect::<Vec<_>>();
+
+        while maximum.load(Ordering::SeqCst) < 3 {
+            started.notified().await;
+        }
+        assert_eq!(active.load(Ordering::SeqCst), 3);
+
+        gate.add_permits(12);
+        let statuses = join_all(requests)
+            .await
+            .into_iter()
+            .map(Result::unwrap)
+            .collect::<Vec<_>>();
+        assert!(statuses.iter().all(|status| *status == AxumStatus::OK));
+        assert_eq!(maximum.load(Ordering::SeqCst), 3);
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn rejects_request_bodies_above_the_replay_limit() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_route = Arc::clone(&calls);
+        let origin = spawn_origin(Router::new().route(
+            "/upload",
+            post(move || {
+                let calls = Arc::clone(&calls_for_route);
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    "unexpected"
+                }
+            }),
+        ))
+        .await;
+        let egress = EgressProxy::builder()
+            .max_request_bytes(4)
+            .spawn()
+            .await
+            .unwrap();
+
+        let response = proxied_client(&egress)
+            .post(format!("{origin}/upload"))
+            .body("too-large")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), AxumStatus::PAYLOAD_TOO_LARGE);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn child_environment_matches_the_existing_mpp_proxy_contract() {
+        let egress = EgressProxy::builder().spawn().await.unwrap();
+        let environment = egress.environment();
+        let value = |name: &str| {
+            environment
+                .iter()
+                .find(|(candidate, _)| candidate == name)
+                .map(|(_, value)| value.clone())
+                .unwrap()
+        };
+
+        assert_eq!(value("https_proxy"), OsString::from(egress.proxy_url()));
+        assert!(value("NO_PROXY").is_empty());
+        assert_eq!(
+            PathBuf::from(value("CURL_CA_BUNDLE")),
+            egress.ca_certificate_path()
+        );
+        assert!(egress.ca_certificate_path().is_file());
+        assert_eq!(
+            value("NANOCODEX_MPP_EGRESS_PASSWORD"),
+            OsString::from(&egress.proxy_password)
+        );
+        assert_eq!(
+            value("NANOCODEX_MPP_EGRESS_AUTHORIZATION"),
+            OsString::from(&egress.proxy_authorization)
+        );
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore = "manual public-network HTTPS smoke"]
+    async fn live_https_mitm_smoke() {
+        let egress = EgressProxy::builder().spawn().await.unwrap();
+        let environment = egress.environment();
+        let output = tokio::task::spawn_blocking(move || {
+            std::process::Command::new("curl")
+                .args(["--fail", "--silent", "--show-error", "https://example.com/"])
+                .envs(environment)
+                .output()
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+        assert!(output.status.success());
+        assert!(String::from_utf8_lossy(&output.stdout).contains("Example Domain"));
+        egress.shutdown().await.unwrap();
+    }
+}


### PR DESCRIPTION
## Summary

- Extract the existing authenticated loopback egress proxy and ordered middleware composition into the unpublished experimental `nanocodex-egress` crate.
- Keep Tempo/MPP payment policy in `bin/nanocodex`; the binary now supplies it as an application-owned egress layer.
- Preserve native `--provider.tempo` behavior and defaults while making transport composition independently testable and benchmarkable.

## Compatibility boundary

This is intentionally a refactor with equivalent behavior:

- Charge payments only; NanoUSD autoswap and the existing charge cap and retry semantics are unchanged.
- Existing host proxy environment, authentication, CA filename, request/body/concurrency limits, and trace target remain unchanged.
- Existing Hudsucker, MPP, and Tempo dependency revisions remain pinned.
- No Sessions/PathUSD, secret replacement, VM route projection, or additional proxy hardening is included here. Those belong in stacked follow-ups.

## Validation

- `cargo fmt --all --check`
- `scripts/check-crate-boundaries.sh`
- warnings-denied Clippy for `nanocodex-egress` and the Tempo-enabled binary
- generic egress unit tests and public example compilation
- all 14 Tempo/MPP tests, including 141 concurrent Promise.all-style paid requests and a 10,000-request bounded-parallel exact-replay stress test
- Criterion comparison: direct median 75.751 µs; two composed layers median 76.119 µs

## Stacked follow-up

- #88 adds host-owned secret replacement on top. It is intentionally excluded from this equivalent-behavior refactor.