### PR TITLE
feat(wasm): expose reusable host-managed transport

### DIFF
--- a/crates/nanocodex-agent/src/model/run/responses.rs
+++ b/crates/nanocodex-agent/src/model/run/responses.rs
@@ -135,6 +135,9 @@ pub(super) fn unsupported_tool_message(tools: &ToolRuntime, call: &CodeCall) -> 
     if call.namespace.is_none() && matches!(call.name.as_str(), "exec" | "wait") {
         return None;
     }
+    if matches!(call.kind, CodeCallKind::Function) && tools.contains(&qualified_tool_name(call)) {
+        return None;
+    }
     if call.namespace.is_some() && matches!(call.kind, CodeCallKind::Function) {
         let qualified_name = qualified_tool_name(call);
         return (!tools.contains(&qualified_name))

--- a/crates/nanocodex-agent/src/model/run/tool_calls.rs
+++ b/crates/nanocodex-agent/src/model/run/tool_calls.rs
@@ -432,7 +432,7 @@ where
                 response_items: vec![response_item],
             });
         }
-        if matches!(call.kind, CodeCallKind::Function) && call.namespace.is_some() {
+        if matches!(call.kind, CodeCallKind::Function) && tools.contains(&qualified_name) {
             let context = ToolContext::new(
                 MODEL,
                 session_id,

--- a/crates/nanocodex-tools/src/hosted/mod.rs
+++ b/crates/nanocodex-tools/src/hosted/mod.rs
@@ -50,7 +50,7 @@ mod types;
 
 use std::{error::Error, fmt, future::Future, pin::Pin};
 
-use crate::{ToolContext, ToolDefinition};
+use crate::{ToolContext, ToolDefinition, ToolInput, ToolOutput};
 
 pub use input::{prepare_output_images, prepare_user_input};
 pub use runtime::{HostedToolRuntime, HostedToolRuntimeControl, HostedTools};
@@ -103,6 +103,16 @@ impl fmt::Display for CodeModeHostError {
 
 impl Error for CodeModeHostError {}
 
+/// Model-visible dispatch policy selected by an embedding host.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum HostedToolMode {
+    /// Expose one Code Mode `exec` tool and nest application tools below it.
+    #[default]
+    Code,
+    /// Expose application tools directly without dynamic code evaluation.
+    Direct,
+}
+
 /// Application-owned Code Mode and nested-tool execution boundary.
 ///
 /// The host receives a read-only [`ToolContext`] for every cell and returns the
@@ -111,6 +121,11 @@ impl Error for CodeModeHostError {}
 /// [`CodeModeExecution`] for model-visible script failures. Reserve
 /// [`CodeModeHostError`] for failures in the host bridge itself.
 pub trait CodeModeHost: Send + Sync + 'static {
+    /// Selects Code Mode or CSP-safe direct function dispatch.
+    fn tool_mode(&self) -> HostedToolMode {
+        HostedToolMode::Code
+    }
+
     /// Returns the tools available to Code Mode for this session.
     ///
     /// The runtime calls this synchronously while building the model-visible
@@ -123,4 +138,18 @@ pub trait CodeModeHost: Send + Sync + 'static {
         source: &'a str,
         context: ToolContext<'a>,
     ) -> HostFuture<'a, Result<CodeModeExecution, CodeModeHostError>>;
+
+    /// Executes one directly exposed application tool.
+    fn execute_tool<'a>(
+        &'a self,
+        name: &'a str,
+        _input: ToolInput,
+        _context: ToolContext<'a>,
+    ) -> HostFuture<'a, Result<ToolOutput, CodeModeHostError>> {
+        Box::pin(async move {
+            Err(CodeModeHostError::new(format!(
+                "direct hosted tool `{name}` is unavailable"
+            )))
+        })
+    }
 }

--- a/crates/nanocodex-tools/src/hosted/runtime.rs
+++ b/crates/nanocodex-tools/src/hosted/runtime.rs
@@ -1,4 +1,8 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    collections::HashSet,
+    path::PathBuf,
+    sync::{Arc, RwLock},
+};
 
 use nanocodex_oai_api::{
     responses::CustomToolFormat,
@@ -66,6 +70,7 @@ impl HostedTools {
 pub struct HostedToolRuntime {
     working_directory: Arc<str>,
     host: Option<Arc<dyn CodeModeHost>>,
+    direct_tool_names: RwLock<HashSet<String>>,
 }
 
 /// Cancellation handle for a hosted runtime.
@@ -91,6 +96,7 @@ impl HostedToolRuntime {
         Self {
             working_directory: Arc::from(workspace.to_string_lossy().into_owned()),
             host: None,
+            direct_tool_names: RwLock::new(HashSet::new()),
         }
     }
 
@@ -159,6 +165,19 @@ impl HostedToolRuntime {
         });
         definitions.sort_by(|left, right| left.name().cmp(right.name()));
         if mode == HostedToolMode::Direct {
+            if let Ok(mut names) = self.direct_tool_names.write() {
+                names.clear();
+                names.extend(
+                    definitions
+                        .iter()
+                        .map(|definition| definition.name().to_owned()),
+                );
+            } else {
+                tracing::warn!(
+                    target: "nanocodex_tools",
+                    "hosted direct-tool registry lock was poisoned"
+                );
+            }
             return (definitions, Vec::new());
         }
         let code_mode_tool_names = definitions
@@ -197,10 +216,14 @@ impl HostedToolRuntime {
 
     /// Returns `false`; hosted tools are callable only inside Code Mode.
     #[must_use]
-    pub fn contains(&self, _name: &str) -> bool {
-        self.host
-            .as_ref()
-            .is_some_and(|host| host.tool_mode() == HostedToolMode::Direct)
+    pub fn contains(&self, name: &str) -> bool {
+        self.host.as_ref().is_some_and(|host| {
+            host.tool_mode() == HostedToolMode::Direct
+                && self
+                    .direct_tool_names
+                    .read()
+                    .is_ok_and(|names| names.contains(name))
+        })
     }
 
     /// Returns a model-visible failure for unsupported direct hosted dispatch.

--- a/crates/nanocodex-tools/src/hosted/runtime.rs
+++ b/crates/nanocodex-tools/src/hosted/runtime.rs
@@ -7,7 +7,7 @@ use nanocodex_oai_api::{
 
 use super::{
     CodeModeExecution, CodeModeHost, CodeModeNotification, CodeModeObserver, CodeModeUpdate,
-    NestedToolCall, OwnedToolContext,
+    HostedToolMode, NestedToolCall, OwnedToolContext,
 };
 use crate::runtime_config::{ImageGenerationConfig, WebSearchConfig};
 
@@ -140,6 +140,10 @@ impl HostedToolRuntime {
         &self,
         session_id: &str,
     ) -> (Vec<ToolDefinition>, Vec<(String, String)>) {
+        let mode = self
+            .host
+            .as_ref()
+            .map_or(HostedToolMode::Code, |host| host.tool_mode());
         let mut definitions = self.host.as_ref().map_or_else(Vec::new, |host| {
             match host.tool_definitions(session_id) {
                 Ok(definitions) => definitions,
@@ -154,6 +158,9 @@ impl HostedToolRuntime {
             }
         });
         definitions.sort_by(|left, right| left.name().cmp(right.name()));
+        if mode == HostedToolMode::Direct {
+            return (definitions, Vec::new());
+        }
         let code_mode_tool_names = definitions
             .iter()
             .map(|definition| {
@@ -190,8 +197,10 @@ impl HostedToolRuntime {
 
     /// Returns `false`; hosted tools are callable only inside Code Mode.
     #[must_use]
-    pub const fn contains(&self, _name: &str) -> bool {
-        false
+    pub fn contains(&self, _name: &str) -> bool {
+        self.host
+            .as_ref()
+            .is_some_and(|host| host.tool_mode() == HostedToolMode::Direct)
     }
 
     /// Returns a model-visible failure for unsupported direct hosted dispatch.
@@ -205,12 +214,21 @@ impl HostedToolRuntime {
     pub async fn execute_tool(
         &self,
         name: &str,
-        _input: ToolInput,
-        _context: ToolContext<'_>,
+        input: ToolInput,
+        context: ToolContext<'_>,
     ) -> ToolOutput {
-        ToolOutput::error(format!(
-            "direct tool `{name}` is unavailable in a hosted runtime"
-        ))
+        let Some(host) = &self.host else {
+            return ToolOutput::error("no hosted tool adapter is configured");
+        };
+        if host.tool_mode() != HostedToolMode::Direct {
+            return ToolOutput::error(format!(
+                "direct tool `{name}` is unavailable in a Code Mode hosted runtime"
+            ));
+        }
+        match host.execute_tool(name, input, context).await {
+            Ok(output) => output,
+            Err(error) => ToolOutput::error(error.to_string()),
+        }
     }
 
     /// Executes one Code Mode cell through the embedding host.

--- a/crates/nanocodex-tools/src/lib.rs
+++ b/crates/nanocodex-tools/src/lib.rs
@@ -78,8 +78,8 @@ pub mod image {
 pub mod runtime {
     pub use crate::{
         hosted::{
-            HostedToolRuntime as ToolRuntime, HostedToolRuntimeControl as ToolRuntimeControl,
-            HostedTools as Tools, OwnedToolContext,
+            HostedToolMode, HostedToolRuntime as ToolRuntime,
+            HostedToolRuntimeControl as ToolRuntimeControl, HostedTools as Tools, OwnedToolContext,
         },
         runtime_config::{ImageGenerationConfig, WebSearchConfig},
     };

--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -242,6 +242,42 @@ const agent = await Agent.create({
 });
 ```
 
+Server-side Worker runtimes can await a `fetch()`-based WebSocket upgrade. The
+third callback argument is a discriminated authorization request plus connection
+metadata. With `apiKey`, `authorization` is `"bearer"` and `bearerToken` is
+present. With `hostAuth: true`, it is `"host_managed"`; the host must resolve
+credentials without exposing them to WASM. Do not retain or log bearer tokens.
+Return the socket alone or a descriptor containing response metadata:
+
+```js
+import { Agent } from "nanocodex/browser";
+import module from "nanocodex/wasm";
+
+const agent = await Agent.create({
+  apiKey,
+  module,
+  async createWebSocket(endpoint, sessionId, request) {
+    if (request.authorization !== "bearer") {
+      throw new Error("this host requires Nanocodex bearer authorization");
+    }
+    const response = await fetch(endpoint.replace("wss:", "https:"), {
+      headers: {
+        Authorization: `Bearer ${request.bearerToken}`,
+        Upgrade: "websocket",
+        "session-id": sessionId,
+      },
+    });
+    if (!response.webSocket) throw new Error(`upgrade failed: ${response.status}`);
+    response.webSocket.accept();
+    return { socket: response.webSocket, status: response.status };
+  },
+});
+```
+
+`hostAuth` is useful when the embedding runtime owns rotating credentials. The
+callback can acquire a fresh token, attempt the upgrade, and refresh-and-retry
+on 401. `apiKey`, `hostAuth`, and `mpp` are mutually exclusive.
+
 After publication, a browser can load the same entrypoint without a package
 manager or build step:
 

--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -276,7 +276,9 @@ const agent = await Agent.create({
 
 `hostAuth` is useful when the embedding runtime owns rotating credentials. The
 callback can acquire a fresh token, attempt the upgrade, and refresh-and-retry
-on 401. `apiKey`, `hostAuth`, and `mpp` are mutually exclusive.
+on 401. Bound and reject upgrade work in the callback: until it returns a
+socket, there is no connection handle for Nanocodex to close. `apiKey`,
+`hostAuth`, and `mpp` are mutually exclusive.
 
 After publication, a browser can load the same entrypoint without a package
 manager or build step:

--- a/js/bindings/browser/Agent.d.mts
+++ b/js/bindings/browser/Agent.d.mts
@@ -28,6 +28,8 @@ export declare namespace create {
     ): WebSocket | BrowserWebSocketConnection | Promise<WebSocket | BrowserWebSocketConnection>;
     module?: unknown;
     tools?: ToolMap | undefined;
+    /** Direct dispatch is CSP-safe; Code Mode requires dynamic JavaScript evaluation. */
+    toolMode?: "code" | "direct" | undefined;
     websocketUrl?: string | undefined;
   };
   type ReturnType = Agent;

--- a/js/bindings/browser/Agent.d.mts
+++ b/js/bindings/browser/Agent.d.mts
@@ -4,6 +4,10 @@ import type {
   MppSession,
   ToolMap,
 } from "../types.mjs";
+import type {
+  BrowserWebSocketConnection,
+  BrowserWebSocketRequest,
+} from "./host.mjs";
 
 export type Agent = DefaultAgent;
 
@@ -11,12 +15,17 @@ export type Agent = DefaultAgent;
 export function create(options?: create.Options): Promise<create.ReturnType>;
 export declare namespace create {
   type Options = AgentOptions & (
-    | { apiKey?: string | undefined; mpp?: never }
-    | { apiKey?: never; mpp: MppSession }
+    | { apiKey?: string | undefined; hostAuth?: never; mpp?: never }
+    | { apiKey?: never; hostAuth?: true; mpp?: never }
+    | { apiKey?: never; hostAuth?: never; mpp: MppSession }
   ) & {
     WebSocketImpl?: typeof WebSocket | undefined;
     apiBaseUrl?: string | undefined;
-    createWebSocket?(endpoint: string, sessionId: string): WebSocket;
+    createWebSocket?(
+      endpoint: string,
+      sessionId: string,
+      request: BrowserWebSocketRequest,
+    ): WebSocket | BrowserWebSocketConnection | Promise<WebSocket | BrowserWebSocketConnection>;
     module?: unknown;
     tools?: ToolMap | undefined;
     websocketUrl?: string | undefined;

--- a/js/bindings/browser/Agent.mjs
+++ b/js/bindings/browser/Agent.mjs
@@ -17,6 +17,7 @@ let initialized;
 export function create(options = {}) {
   const {
     apiKey,
+    hostAuth,
     mpp,
     websocketUrl,
     apiBaseUrl,
@@ -35,10 +36,14 @@ export function create(options = {}) {
   if (mpp !== undefined && apiKey !== undefined) {
     throw new TypeError("apiKey and mpp are mutually exclusive");
   }
+  if (hostAuth && (apiKey !== undefined || mpp !== undefined)) {
+    throw new TypeError("hostAuth is mutually exclusive with apiKey and mpp");
+  }
   const events = createEventChannel();
   const host = createBrowserHost({
     WebSocketImpl,
     createWebSocket,
+    hostAuth: hostAuth === true || (apiKey === undefined && mpp === undefined),
     mpp,
     onEvent: events.emit,
     tools,

--- a/js/bindings/browser/Agent.mjs
+++ b/js/bindings/browser/Agent.mjs
@@ -32,6 +32,7 @@ export function create(options = {}) {
     WebSocketImpl,
     createWebSocket,
     tools,
+    toolMode,
   } = options;
   if (mpp !== undefined && apiKey !== undefined) {
     throw new TypeError("apiKey and mpp are mutually exclusive");
@@ -47,6 +48,7 @@ export function create(options = {}) {
     mpp,
     onEvent: events.emit,
     tools,
+    toolMode,
   });
   activateHost(host);
   const runtime = defineRuntime({

--- a/js/bindings/browser/host.d.mts
+++ b/js/bindings/browser/host.d.mts
@@ -9,9 +9,41 @@ export type BrowserTool = {
 
 export type BrowserToolMap = Record<string, BrowserTool>;
 
+type BrowserWebSocketMetadata = {
+  accountId?: string | undefined;
+  fedramp?: boolean | undefined;
+  turnState?: string | undefined;
+};
+
+export type BrowserWebSocketRequest = BrowserWebSocketMetadata & (
+  | {
+    authorization: "bearer";
+    /** Resolved credential for this handshake. Do not retain or log it. */
+    bearerToken: string;
+  }
+  | {
+    authorization: "host_managed";
+    bearerToken?: never;
+  }
+);
+
+export type BrowserWebSocketConnection = {
+  socket: WebSocket;
+  status?: number | undefined;
+  requestId?: string | undefined;
+  serverModel?: string | undefined;
+  reasoningIncluded?: boolean | undefined;
+  turnState?: string | undefined;
+};
+
 export function createBrowserHost(options?: {
   WebSocketImpl?: typeof WebSocket;
-  createWebSocket?: (endpoint: string, sessionId: string) => WebSocket;
+  hostAuth?: boolean;
+  createWebSocket?: (
+    endpoint: string,
+    sessionId: string,
+    request: BrowserWebSocketRequest,
+  ) => WebSocket | BrowserWebSocketConnection | Promise<WebSocket | BrowserWebSocketConnection>;
   onEvent?: (eventJson: string) => void;
   tools?: BrowserToolMap;
   maxQueuedMessages?: number;

--- a/js/bindings/browser/host.mjs
+++ b/js/bindings/browser/host.mjs
@@ -26,11 +26,14 @@ export function createBrowserHost(options = {}) {
     const authorization = options.hostAuth
       ? { authorization: "host_managed" }
       : { authorization: "bearer", bearerToken: apiKey };
-    const opened = await createWebSocket(endpoint, sessionId, { ...metadata, ...authorization });
+    const request = { ...metadata };
+    delete request.authorization;
+    delete request.bearerToken;
+    Object.assign(request, authorization);
+    const opened = await createWebSocket(endpoint, sessionId, request);
     const { socket, ...handshake } = normalizeWebSocketConnection(opened);
     return new Promise((resolve, reject) => {
       let settled = false;
-      const handle = nextHandle++;
       const connection = {
         socket,
         queue: [],
@@ -42,6 +45,7 @@ export function createBrowserHost(options = {}) {
       const resolveOpen = () => {
         if (settled) return;
         settled = true;
+        const handle = nextHandle++;
         connections.set(handle, connection);
         resolve(JSON.stringify({
           handle,

--- a/js/bindings/browser/host.mjs
+++ b/js/bindings/browser/host.mjs
@@ -14,6 +14,10 @@ export function createBrowserHost(options = {}) {
   }
   const connections = new Map();
   const code = createCodeRuntime(options.tools);
+  const toolMode = options.toolMode ?? "code";
+  if (toolMode !== "code" && toolMode !== "direct") {
+    throw new TypeError("toolMode must be code or direct");
+  }
   const onEvent = options.onEvent || (() => {});
   const maxQueuedMessages = options.maxQueuedMessages ?? DEFAULT_MAX_QUEUED_MESSAGES;
   const maxQueuedBytes = options.maxQueuedBytes ?? DEFAULT_MAX_QUEUED_BYTES;
@@ -220,6 +224,8 @@ export function createBrowserHost(options = {}) {
     close,
     sleep: (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
     executeCode: code.executeCode,
+    executeTool: code.executeTool,
+    toolMode: () => toolMode,
     toolDefinitions: code.toolDefinitions,
     emitEvent: onEvent,
     reset: code.reset,

--- a/js/bindings/browser/host.mjs
+++ b/js/bindings/browser/host.mjs
@@ -21,12 +21,16 @@ export function createBrowserHost(options = {}) {
   const encoder = new TextEncoder();
   let nextHandle = 1;
 
-  function connect(endpoint, _apiKey, sessionId, metadata = {}) {
+  async function connect(endpoint, apiKey, sessionId, metadata = {}) {
     if (options.mpp) return connectMpp(endpoint);
+    const authorization = options.hostAuth
+      ? { authorization: "host_managed" }
+      : { authorization: "bearer", bearerToken: apiKey };
+    const opened = await createWebSocket(endpoint, sessionId, { ...metadata, ...authorization });
+    const { socket, ...handshake } = normalizeWebSocketConnection(opened);
     return new Promise((resolve, reject) => {
       let settled = false;
       const handle = nextHandle++;
-      const socket = createWebSocket(endpoint, sessionId, metadata);
       const connection = {
         socket,
         queue: [],
@@ -35,11 +39,20 @@ export function createBrowserHost(options = {}) {
         intentionallyClosed: false,
         overflowed: false,
       };
-      socket.addEventListener("open", () => {
+      const resolveOpen = () => {
+        if (settled) return;
         settled = true;
         connections.set(handle, connection);
-        resolve(JSON.stringify({ handle, status: 101, reasoning_included: false }));
-      }, { once: true });
+        resolve(JSON.stringify({
+          handle,
+          status: handshake.status ?? 101,
+          request_id: handshake.requestId,
+          server_model: handshake.serverModel,
+          reasoning_included: handshake.reasoningIncluded ?? false,
+          turn_state: handshake.turnState,
+        }));
+      };
+      socket.addEventListener("open", resolveOpen, { once: true });
       socket.addEventListener("message", (event) => {
         enqueue(connection, typeof event.data === "string"
           ? { kind: "text", text: event.data }
@@ -61,6 +74,11 @@ export function createBrowserHost(options = {}) {
           enqueue(connection, { kind: "error", detail: "WebSocket connection failed" });
         }
       });
+      if (socket.readyState === WEBSOCKET_OPEN) resolveOpen();
+      else if (socket.readyState > WEBSOCKET_OPEN) {
+        settled = true;
+        reject(new Error("WebSocket closed during connection"));
+      }
     });
   }
 
@@ -202,4 +220,14 @@ export function createBrowserHost(options = {}) {
     emitEvent: onEvent,
     reset: code.reset,
   });
+}
+
+function normalizeWebSocketConnection(opened) {
+  if (opened?.socket && typeof opened.socket.addEventListener === "function") {
+    return opened;
+  }
+  if (!opened || typeof opened.addEventListener !== "function") {
+    throw new TypeError("createWebSocket must return a WebSocket or a connection descriptor");
+  }
+  return { socket: opened };
 }

--- a/js/bindings/internal.mjs
+++ b/js/bindings/internal.mjs
@@ -235,6 +235,13 @@ const hostBridge = Object.freeze({
   executeCode(source, sessionId, callId) {
     return requiredSessionHost(sessionId).executeCode(source, sessionId, callId);
   },
+  executeTool(name, input, sessionId, callId) {
+    return requiredSessionHost(sessionId).executeTool(name, input, sessionId, callId);
+  },
+  toolMode(sessionId) {
+    // The WASM constructor asks before its session is adopted.
+    return (hostSessions.get(sessionId) ?? requiredActiveHost()).toolMode();
+  },
   toolDefinitions(sessionId) {
     // ModelRun builds its stable tool prefix inside the WASM constructor,
     // immediately before the returned session can be adopted. Runtime

--- a/js/bindings/node/Agent.d.mts
+++ b/js/bindings/node/Agent.d.mts
@@ -14,6 +14,7 @@ export declare namespace create {
     apiBaseUrl?: string | undefined;
     module?: unknown;
     tools?: ToolMap | undefined;
+    toolMode?: "code" | "direct" | undefined;
     websocketUrl?: string | undefined;
   };
   type ReturnType = Agent;

--- a/js/bindings/node/Agent.mjs
+++ b/js/bindings/node/Agent.mjs
@@ -31,6 +31,7 @@ export function create(options = {}) {
     apiBaseUrl,
     module,
     tools,
+    toolMode,
   } = options;
   const events = createEventChannel();
   if (mpp !== undefined && apiKey !== undefined) {
@@ -40,6 +41,7 @@ export function create(options = {}) {
     mpp,
     onEvent: events.emit,
     tools,
+    toolMode,
     workspace: workspace ?? resume?.workspace,
   });
   activateHost(host);

--- a/js/bindings/node/host.mjs
+++ b/js/bindings/node/host.mjs
@@ -18,6 +18,10 @@ export function createNodeHost(options = {}) {
     require: createRequire(resolve(options.workspace ?? process.cwd(), ".nanocodex-code-mode.cjs")),
     console: new Console({ stdout: process.stderr, stderr: process.stderr }),
   });
+  const toolMode = options.toolMode ?? "code";
+  if (toolMode !== "code" && toolMode !== "direct") {
+    throw new TypeError("toolMode must be code or direct");
+  }
   const onEvent = options.onEvent || (() => {});
   const connectTimeoutMs = options.connectTimeoutMs ?? 30_000;
   const sendTimeoutMs = options.sendTimeoutMs ?? 30_000;
@@ -237,6 +241,8 @@ export function createNodeHost(options = {}) {
     close,
     sleep: (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
     executeCode: code.executeCode,
+    executeTool: code.executeTool,
+    toolMode: () => toolMode,
     toolDefinitions: code.toolDefinitions,
     emitEvent: onEvent,
     reset: code.reset,

--- a/js/bindings/package.json
+++ b/js/bindings/package.json
@@ -16,6 +16,10 @@
     "./browser": {
       "types": "./browser/index.d.mts",
       "import": "./browser/index.mjs"
+    },
+    "./wasm": {
+      "types": "./wasm.d.mts",
+      "import": "./pkg-web/nanocodex_bg.wasm"
     }
   },
   "files": [
@@ -28,6 +32,7 @@
     "internal.mjs",
     "index.d.mts",
     "index.mjs",
+    "wasm.d.mts",
     "types.d.mts",
     "README.md"
   ],

--- a/js/bindings/runtime/code-runtime.mjs
+++ b/js/bindings/runtime/code-runtime.mjs
@@ -23,6 +23,24 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
   Object.freeze(configuredTools);
   Object.freeze(definitions);
   const encodedDefinitions = JSON.stringify(definitions);
+  const toolByName = new Map(configuredTools.map((tool) => [tool.name, tool]));
+
+  async function executeTool(name, encodedInput, sessionId = "default", callId = "tool") {
+    const tool = toolByName.get(name);
+    if (!tool) return encodeToolOutput(`unknown application tool: ${name}`, false, null);
+    let input;
+    try {
+      input = JSON.parse(encodedInput);
+    } catch (error) {
+      return encodeToolOutput(`invalid tool input: ${errorMessage(error)}`, false, null);
+    }
+    try {
+      const result = await tool.handler(input, { sessionId, parentCallId: "", callId });
+      return encodeToolOutput(outputBody(result), true, clone(result) ?? null);
+    } catch (error) {
+      return encodeToolOutput(errorMessage(error), false, null);
+    }
+  }
 
   async function executeCode(source, sessionId = "default", parentCallId = "exec") {
     const startedAt = performance.now();
@@ -151,10 +169,21 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
 
   return Object.freeze({
     executeCode,
+    executeTool,
     toolDefinitions: () => encodedDefinitions,
     reset() {
       stores.clear();
     },
+  });
+}
+
+function encodeToolOutput(output, success, codeModeValue) {
+  return JSON.stringify({
+    output,
+    success,
+    code_mode_value: codeModeValue,
+    metadata: null,
+    process_trace: null,
   });
 }
 

--- a/js/bindings/scripts/check-package.mjs
+++ b/js/bindings/scripts/check-package.mjs
@@ -24,6 +24,7 @@ const requiredFiles = [
   "browser/index.d.mts",
   "node/index.mjs",
   "node/index.d.mts",
+  "wasm.d.mts",
   "pkg-web/nanocodex.js",
   "pkg-web/nanocodex.d.ts",
   "pkg-web/nanocodex_bg.wasm",
@@ -44,6 +45,7 @@ export async function checkPackage(packageRoot = root) {
   assert.equal(packageJson.publishConfig?.access, "public");
   assert.equal(packageJson.exports?.["./browser"]?.import, "./browser/index.mjs");
   assert.equal(packageJson.exports?.["./node"]?.import, "./node/index.mjs");
+  assert.equal(packageJson.exports?.["./wasm"]?.import, "./pkg-web/nanocodex_bg.wasm");
   checkDocumentedBrowserVersion(readme, packageJson.version);
 
   for (const file of requiredFiles) {

--- a/js/bindings/src/wasm.rs
+++ b/js/bindings/src/wasm.rs
@@ -9,8 +9,12 @@ use nanocodex::{
         session::{SessionId, SessionSnapshot},
     },
     tools::{
-        ToolContext, ToolDefinition,
-        hosted::{CodeModeExecution, CodeModeHost, CodeModeHostError, HostFuture, HostedTools},
+        ToolContext, ToolDefinition, ToolInput, ToolOutput,
+        contract::ToolOutputWire,
+        hosted::{
+            CodeModeExecution, CodeModeHost, CodeModeHostError, HostFuture, HostedToolMode,
+            HostedTools,
+        },
     },
 };
 use serde::Deserialize;
@@ -31,13 +35,42 @@ extern "C" {
     fn host_execute_code(source: &str, session_id: &str, call_id: &str)
     -> Result<Promise, JsValue>;
 
+    #[wasm_bindgen(catch, js_namespace = ["globalThis", "nanocodexHost"], js_name = executeTool)]
+    fn host_execute_tool(
+        name: &str,
+        input: &str,
+        session_id: &str,
+        call_id: &str,
+    ) -> Result<Promise, JsValue>;
+
+    #[wasm_bindgen(js_namespace = ["globalThis", "nanocodexHost"], js_name = toolMode)]
+    fn host_tool_mode(session_id: &str) -> String;
+
     #[wasm_bindgen(catch, js_namespace = ["globalThis", "nanocodexHost"], js_name = toolDefinitions)]
     fn host_tool_definitions(session_id: &str) -> Result<String, JsValue>;
 }
 
-struct JavaScriptCodeModeHost;
+struct JavaScriptCodeModeHost {
+    mode: HostedToolMode,
+}
+
+impl JavaScriptCodeModeHost {
+    fn new() -> Self {
+        Self {
+            mode: if host_tool_mode("") == "direct" {
+                HostedToolMode::Direct
+            } else {
+                HostedToolMode::Code
+            },
+        }
+    }
+}
 
 impl CodeModeHost for JavaScriptCodeModeHost {
+    fn tool_mode(&self) -> HostedToolMode {
+        self.mode
+    }
+
     fn tool_definitions(&self, session_id: &str) -> Result<Vec<ToolDefinition>, CodeModeHostError> {
         let encoded = host_tool_definitions(session_id)
             .map_err(|error| CodeModeHostError::new(host_error_message(&error)))?;
@@ -66,6 +99,38 @@ impl CodeModeHost for JavaScriptCodeModeHost {
                 CodeModeHostError::new(format!(
                     "JavaScript Code Mode host returned invalid execution JSON: {error}"
                 ))
+            })
+        })
+    }
+
+    fn execute_tool<'a>(
+        &'a self,
+        name: &'a str,
+        input: ToolInput,
+        context: ToolContext<'a>,
+    ) -> HostFuture<'a, Result<ToolOutput, CodeModeHostError>> {
+        Box::pin(async move {
+            let input = match input {
+                ToolInput::Function(input) => input.get().to_owned(),
+                ToolInput::Freeform(input) => serde_json::to_string(&input).map_err(|error| {
+                    CodeModeHostError::new(format!("failed to encode hosted tool input: {error}"))
+                })?,
+            };
+            let promise = host_execute_tool(name, &input, context.session_id(), context.call_id())
+                .map_err(|error| CodeModeHostError::new(host_error_message(&error)))?;
+            let value = JsFuture::from(promise)
+                .await
+                .map_err(|error| CodeModeHostError::new(host_error_message(&error)))?;
+            let encoded = value.as_string().ok_or_else(|| {
+                CodeModeHostError::new("JavaScript tool host returned a non-string result")
+            })?;
+            let wire = serde_json::from_str::<ToolOutputWire>(&encoded).map_err(|error| {
+                CodeModeHostError::new(format!(
+                    "JavaScript tool host returned invalid execution JSON: {error}"
+                ))
+            })?;
+            ToolOutput::from_wire(wire).map_err(|error| {
+                CodeModeHostError::new(format!("JavaScript tool result was invalid: {error}"))
             })
         })
     }
@@ -129,7 +194,7 @@ impl WasmNanocodex {
             .build()
             .map_err(js_error)?;
         let mut builder =
-            RustNanocodex::builder(openai).tools(HostedTools::new(JavaScriptCodeModeHost));
+            RustNanocodex::builder(openai).tools(HostedTools::new(JavaScriptCodeModeHost::new()));
         if let Some(instructions) = config.instructions {
             builder = builder.instructions(instructions);
         }

--- a/js/bindings/test/browser-host.test.mjs
+++ b/js/bindings/test/browser-host.test.mjs
@@ -162,7 +162,10 @@ test("browser host never exposes its host-managed credential marker", async () =
     },
   });
 
-  await host.connect(socket.url, "host-managed", "session-1");
+  await host.connect(socket.url, "host-managed", "session-1", {
+    authorization: "bearer",
+    bearerToken: "metadata-must-not-override-auth",
+  });
   assert.deepEqual(request, { authorization: "host_managed" });
 });
 
@@ -177,11 +180,71 @@ test("an API key equal to the old host marker remains a bearer credential", asyn
     },
   });
 
-  await host.connect(socket.url, "host-managed", "session-1");
+  await host.connect(socket.url, "host-managed", "session-1", {
+    authorization: "host_managed",
+  });
   assert.deepEqual(request, {
     authorization: "bearer",
     bearerToken: "host-managed",
   });
+});
+
+test("browser host rejects failed upgrades without consuming handles", async () => {
+  const closed = new FakeWebSocket("wss://closed.test");
+  closed.readyState = 3;
+  const opened = new FakeWebSocket("wss://opened.test");
+  opened.readyState = FakeWebSocket.OPEN;
+  const results = [
+    Promise.reject(new Error("upgrade denied")),
+    {},
+    closed,
+    opened,
+  ];
+  const host = createBrowserHost({
+    createWebSocket() {
+      return results.shift();
+    },
+  });
+
+  await assert.rejects(
+    host.connect("wss://example.test", "secret", "session"),
+    /upgrade denied/,
+  );
+  await assert.rejects(
+    host.connect("wss://example.test", "secret", "session"),
+    /must return a WebSocket or a connection descriptor/,
+  );
+  await assert.rejects(
+    host.connect("wss://example.test", "secret", "session"),
+    /closed during connection/,
+  );
+  assert.equal(
+    JSON.parse(await host.connect("wss://example.test", "secret", "session")).handle,
+    1,
+  );
+});
+
+test("browser host settles a pre-opened socket exactly once", async () => {
+  const first = new FakeWebSocket("wss://first.test");
+  first.readyState = FakeWebSocket.OPEN;
+  const second = new FakeWebSocket("wss://second.test");
+  second.readyState = FakeWebSocket.OPEN;
+  const sockets = [first, second];
+  const host = createBrowserHost({
+    createWebSocket() {
+      return sockets.shift();
+    },
+  });
+
+  assert.equal(
+    JSON.parse(await host.connect(first.url, "secret", "session")).handle,
+    1,
+  );
+  first.open();
+  assert.equal(
+    JSON.parse(await host.connect(second.url, "secret", "session")).handle,
+    2,
+  );
 });
 
 test("browser host bounds queued receives and buffered sends", async () => {

--- a/js/bindings/test/browser-host.test.mjs
+++ b/js/bindings/test/browser-host.test.mjs
@@ -103,6 +103,87 @@ test("browser host does not require a global constructor for host-owned sockets"
   }
 });
 
+test("browser host awaits Worker upgrades and preserves handshake metadata", async () => {
+  const socket = new FakeWebSocket("wss://api.openai.test/v1/responses");
+  socket.readyState = FakeWebSocket.OPEN;
+  let request;
+  const host = createBrowserHost({
+    async createWebSocket(endpoint, sessionId, received) {
+      await Promise.resolve();
+      request = { endpoint, sessionId, received };
+      return {
+        socket,
+        status: 101,
+        requestId: "request-1",
+        serverModel: "gpt-test",
+        reasoningIncluded: true,
+        turnState: "turn-state-1",
+      };
+    },
+  });
+
+  const connected = JSON.parse(await host.connect(
+    "wss://api.openai.test/v1/responses",
+    "secret-token",
+    "session-1",
+    { accountId: "account-1", fedramp: true, turnState: "turn-state-0" },
+  ));
+
+  assert.deepEqual(request, {
+    endpoint: "wss://api.openai.test/v1/responses",
+    sessionId: "session-1",
+    received: {
+      accountId: "account-1",
+      authorization: "bearer",
+      bearerToken: "secret-token",
+      fedramp: true,
+      turnState: "turn-state-0",
+    },
+  });
+  assert.deepEqual(connected, {
+    handle: 1,
+    status: 101,
+    request_id: "request-1",
+    server_model: "gpt-test",
+    reasoning_included: true,
+    turn_state: "turn-state-1",
+  });
+});
+
+test("browser host never exposes its host-managed credential marker", async () => {
+  const socket = new FakeWebSocket("wss://chatgpt.test/backend-api/codex/responses");
+  socket.readyState = FakeWebSocket.OPEN;
+  let request;
+  const host = createBrowserHost({
+    hostAuth: true,
+    createWebSocket(_endpoint, _sessionId, received) {
+      request = received;
+      return socket;
+    },
+  });
+
+  await host.connect(socket.url, "host-managed", "session-1");
+  assert.deepEqual(request, { authorization: "host_managed" });
+});
+
+test("an API key equal to the old host marker remains a bearer credential", async () => {
+  const socket = new FakeWebSocket("wss://api.openai.test/v1/responses");
+  socket.readyState = FakeWebSocket.OPEN;
+  let request;
+  const host = createBrowserHost({
+    createWebSocket(_endpoint, _sessionId, received) {
+      request = received;
+      return socket;
+    },
+  });
+
+  await host.connect(socket.url, "host-managed", "session-1");
+  assert.deepEqual(request, {
+    authorization: "bearer",
+    bearerToken: "host-managed",
+  });
+});
+
 test("browser host bounds queued receives and buffered sends", async () => {
   const host = createBrowserHost({
     WebSocketImpl: FakeWebSocket,

--- a/js/bindings/test/browser-host.test.mjs
+++ b/js/bindings/test/browser-host.test.mjs
@@ -41,6 +41,27 @@ test("browser host carries ordered frames and application tools", async () => {
   assert.deepEqual(events, ["event"]);
 });
 
+test("browser host directly dispatches tools without dynamic code evaluation", async () => {
+  const host = createBrowserHost({
+    toolMode: "direct",
+    tools: {
+      runtimeInfo: {
+        parameters: { type: "object", additionalProperties: false },
+        handler: (_input, context) => ({ runtime: "worker", call_id: context.callId }),
+      },
+    },
+  });
+  assert.equal(host.toolMode(), "direct");
+  const result = JSON.parse(await host.executeTool(
+    "runtimeInfo",
+    "{}",
+    "session-1",
+    "call-1",
+  ));
+  assert.equal(result.success, true);
+  assert.deepEqual(JSON.parse(result.output), { runtime: "worker", call_id: "call-1" });
+});
+
 test("browser host opens application sockets through MPP", async () => {
   const socket = new FakeWebSocket("wss://paid.test");
   socket.readyState = FakeWebSocket.OPEN;

--- a/js/bindings/test/types.test-d.mts
+++ b/js/bindings/test/types.test-d.mts
@@ -65,6 +65,8 @@ async function check() {
   await BrowserAgent.create({ apiKey, mpp: { async ws() { return {} as WebSocket; } } });
   // @ts-expect-error API-key and host-managed authentication are mutually exclusive.
   await BrowserAgent.create({ apiKey, hostAuth: true });
+  // @ts-expect-error MPP and host-managed authentication are mutually exclusive.
+  await BrowserAgent.create({ hostAuth: true, mpp: { async ws() { return {} as WebSocket; } } });
   await Agent.create({
     mpp: {
       async ws() {

--- a/js/bindings/test/types.test-d.mts
+++ b/js/bindings/test/types.test-d.mts
@@ -58,10 +58,13 @@ async function check() {
   await Actions.session.shutdown(agent);
 
   await BrowserAgent.create({ websocketUrl: "wss://example.com" });
+  await BrowserAgent.create({ hostAuth: true, websocketUrl: "wss://example.com" });
   await BrowserAgent.create({ apiKey });
   await BrowserAgent.create({ mpp: { async ws() { return {} as WebSocket; } } });
   // @ts-expect-error API-key and MPP authentication are mutually exclusive.
   await BrowserAgent.create({ apiKey, mpp: { async ws() { return {} as WebSocket; } } });
+  // @ts-expect-error API-key and host-managed authentication are mutually exclusive.
+  await BrowserAgent.create({ apiKey, hostAuth: true });
   await Agent.create({
     mpp: {
       async ws() {

--- a/js/bindings/test/web-wasm.test.mjs
+++ b/js/bindings/test/web-wasm.test.mjs
@@ -106,6 +106,88 @@ test("web-target WASM runs the shared model loop through the browser host", asyn
   await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
 });
 
+test("web-target WASM directly dispatches a CSP-safe application tool", async () => {
+  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await new Promise((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const connection = new Promise((resolve) => server.once("connection", resolve));
+  const events = [];
+  const wasm = await readFile(new URL("../pkg-web/nanocodex_bg.wasm", import.meta.url));
+  const agent = await Agent.create({
+    apiKey: "test-key",
+    WebSocketImpl: WebSocket,
+    module: wasm,
+    sessionId: "018f1f9a-7b3c-7a07-8000-000000000008",
+    thinking: "low",
+    toolMode: "direct",
+    tools: {
+      runtimeInfo: {
+        description: "Return the runtime.",
+        parameters: { type: "object", additionalProperties: false },
+        handler: () => ({ runtime: "worker" }),
+      },
+    },
+    websocketUrl: `ws://127.0.0.1:${server.address().port}`,
+  });
+  const watch = agent.events.watch();
+  watch.onEvent((event) => events.push(event));
+  try {
+    const turn = agent.turn.prompt({ input: "Call runtimeInfo." });
+    const socket = await connection;
+    const reader = messageReader(socket);
+    const warmup = await reader.next();
+    const toolPrefix = warmup.input.find((item) => item.type === "additional_tools");
+    assert.deepEqual(toolPrefix.tools.map((tool) => tool.name), ["runtimeInfo"]);
+    send(socket, { type: "response.completed", response: { id: "direct-warmup", usage: null } });
+    const generation = await reader.next();
+    assert.equal(generation.previous_response_id, "direct-warmup");
+    send(socket, {
+      type: "response.completed",
+      response: {
+        id: "direct-tool",
+        status: "completed",
+        output: [{
+          type: "function_call",
+          call_id: "call-runtime",
+          namespace: "",
+          name: "runtimeInfo",
+          arguments: "{}",
+        }],
+        usage: null,
+      },
+    });
+    const continuation = await reader.next();
+    assert.equal(continuation.input[0].type, "function_call_output");
+    assert.equal(continuation.input[0].call_id, "call-runtime");
+    assert.deepEqual(JSON.parse(continuation.input[0].output), { runtime: "worker" });
+    send(socket, {
+      type: "response.completed",
+      response: {
+        id: "direct-final",
+        status: "completed",
+        output: [{
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "worker" }],
+        }],
+        usage: null,
+      },
+    });
+    assert.equal((await turn.result()).finalMessage, "worker");
+    assert.equal(events.some((event) =>
+      event.type === "tool.call" && event.payload.tool === "runtimeInfo"), true);
+    assert.equal(events.some((event) =>
+      event.type === "tool.result" && event.payload.status === "completed"), true);
+  } finally {
+    watch.off();
+    agent.dispose();
+    for (const socket of server.clients) socket.terminate();
+    await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+});
+
 function messageReader(socket) {
   const messages = [];
   let waiter;

--- a/js/bindings/test/web-wasm.test.mjs
+++ b/js/bindings/test/web-wasm.test.mjs
@@ -151,7 +151,6 @@ test("web-target WASM directly dispatches a CSP-safe application tool", async ()
         output: [{
           type: "function_call",
           call_id: "call-runtime",
-          namespace: "",
           name: "runtimeInfo",
           arguments: "{}",
         }],

--- a/js/bindings/wasm.d.mts
+++ b/js/bindings/wasm.d.mts
@@ -1,0 +1,4 @@
+/** Precompiled web WASM module for runtimes that import binary modules. */
+declare const module: WebAssembly.Module;
+
+export default module;


### PR DESCRIPTION
## Summary

- Export the precompiled web module as `nanocodex/wasm` for runtime-owned instantiation.
- Let hosts asynchronously open authorized Responses WebSockets without exposing subscription credentials to WASM.
- Add a CSP-safe direct hosted-tool bridge alongside code mode. It uses no `eval`/`Function` and dispatches unnamespaced names only when explicitly advertised.
- Preserve upgrade metadata, accept Worker-style sockets, and reject invalid/closed/duplicate upgrades without leaking handles.

This is the small reusable layer: no Cloudflare, Rivet, AgentOS, Pi, or serverless lifecycle code.

## Validation

- `cargo deny check`
- rustfmt and Clippy with warnings denied
- `just build-wasm`
- 37 JS binding/runtime/package tests
- web-WASM synthetic-model regression covering a direct hosted tool call
- auth isolation, package exports, declarations, packed install, and performance gates