### PR TITLE
feat: add reusable realtime voice sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3910,7 +3910,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -7572,9 +7572,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -182,7 +182,7 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -225,7 +225,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -251,7 +251,7 @@ dependencies = [
  "borsh",
  "k256",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -265,7 +265,7 @@ dependencies = [
  "borsh",
  "once_cell",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -302,7 +302,7 @@ dependencies = [
  "alloy-provider",
  "alloy-sol-types",
  "async-trait",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -357,7 +357,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -384,7 +384,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -462,7 +462,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -559,7 +559,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -585,7 +585,7 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -601,7 +601,7 @@ dependencies = [
  "async-trait",
  "k256",
  "rand 0.8.7",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -692,7 +692,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
@@ -728,7 +728,7 @@ dependencies = [
  "nybbles",
  "serde",
  "smallvec",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -833,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.104"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arboard"
@@ -853,7 +853,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
  "x11rb",
 ]
 
@@ -873,7 +873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9dce000de67c1a27347fed86e9ce76199463fbb5a3d7f13cb0f3d1c16b6dae3"
 dependencies = [
  "tar",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
@@ -1251,7 +1251,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -1640,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.17"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20659f9bbee16cbbd2f7393e40ab6309f5a98f76a2eb57a995ec508b72387fe"
+checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
 dependencies = [
  "cc",
  "glob",
@@ -1667,7 +1667,7 @@ checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "borsh-derive",
  "bytes",
- "cfg_aliases 0.2.2",
+ "cfg_aliases 0.2.1",
 ]
 
 [[package]]
@@ -1740,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.25.2"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
 
 [[package]]
 name = "byteorder"
@@ -1840,9 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1882,9 +1882,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -1940,7 +1940,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -2040,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2062,14 +2062,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.4"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2136,6 +2136,15 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2637,7 +2646,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2851,13 +2860,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.7"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2962,9 +2971,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -2993,9 +3002,9 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.4.2"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
+checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
 dependencies = [
  "enum-ordinalize-derive",
 ]
@@ -3058,10 +3067,11 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "event-listener"
-version = "5.4.2"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
+ "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -3339,9 +3349,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3354,9 +3364,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3364,15 +3374,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3387,9 +3397,9 @@ checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3398,15 +3408,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -3416,9 +3426,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3726,9 +3736,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.5.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -3794,7 +3804,7 @@ dependencies = [
  "moka",
  "rand 0.10.2",
  "rcgen 0.14.8",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-graceful",
@@ -3805,18 +3815,18 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3847,7 +3857,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.9",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -4019,9 +4029,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -4051,9 +4061,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.10"
+version = "0.25.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -4064,8 +4074,8 @@ dependencies = [
  "num-traits",
  "png 0.18.1",
  "tiff",
- "zune-core",
- "zune-jpeg",
+ "zune-core 0.5.1",
+ "zune-jpeg 0.5.15",
 ]
 
 [[package]]
@@ -4080,23 +4090,21 @@ dependencies = [
 
 [[package]]
 name = "imago"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404f567d70cd6d288e43f95ea8f2d6e8fe6156dd07df7da955cb9b147c4ab2a5"
+checksum = "ae7cfee876c698a1a2ed9c705ab18f21acbed82110f19b51cc458de73426fe2c"
 dependencies = [
  "async-trait",
  "bincode 2.0.1",
  "cfg-if",
- "futures",
  "libc",
- "maybe-async",
  "miniz_oxide",
  "nix 0.30.1",
  "page_size",
  "rustc_version 0.4.1",
  "tokio",
  "tracing",
- "vm-memory 0.18.0",
+ "vm-memory",
  "windows-sys 0.61.2",
 ]
 
@@ -4311,7 +4319,7 @@ dependencies = [
  "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -4456,7 +4464,7 @@ dependencies = [
  "kvm-ioctls",
  "libc",
  "linux-loader",
- "vm-memory 0.17.1",
+ "vm-memory",
  "vmm-sys-util 0.15.0",
  "windows-sys 0.61.2",
 ]
@@ -4495,12 +4503,12 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "lru 0.18.1",
+ "lru 0.16.4",
  "nix 0.30.1",
  "rand 0.9.5",
  "virtio-bindings",
  "vm-fdt",
- "vm-memory 0.17.1",
+ "vm-memory",
  "windows-sys 0.61.2",
 ]
 
@@ -4526,7 +4534,7 @@ version = "0.1.0-2.0.0-dev"
 source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
 dependencies = [
  "krun-utils",
- "vm-memory 0.17.1",
+ "vm-memory",
 ]
 
 [[package]]
@@ -4543,7 +4551,7 @@ name = "krun-smbios"
 version = "0.1.0-2.0.0-dev"
 source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
 dependencies = [
- "vm-memory 0.17.1",
+ "vm-memory",
 ]
 
 [[package]]
@@ -4583,7 +4591,7 @@ dependencies = [
  "linux-loader",
  "log",
  "nix 0.30.1",
- "vm-memory 0.17.1",
+ "vm-memory",
  "vmm-sys-util 0.14.0",
  "windows-sys 0.61.2",
  "zstd",
@@ -4627,9 +4635,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.189"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libkrun"
@@ -4650,7 +4658,7 @@ dependencies = [
  "libloading",
  "log",
  "once_cell",
- "vm-memory 0.17.1",
+ "vm-memory",
  "windows-sys 0.61.2",
 ]
 
@@ -4696,7 +4704,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de72cb02c55ecffcf75fe78295926f872eb6eb0a58d629c58a8c324dc26380f6"
 dependencies = [
- "vm-memory 0.17.1",
+ "vm-memory",
 ]
 
 [[package]]
@@ -4767,15 +4775,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
-dependencies = [
- "hashbrown 0.17.1",
-]
-
-[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4815,17 +4814,6 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
-name = "maybe-async"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
 
 [[package]]
 name = "md-5"
@@ -4957,9 +4945,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.8.1"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -4984,7 +4972,7 @@ dependencies = [
  "sha2 0.11.0",
  "subtle",
  "tempo-alloy",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "uuid",
@@ -5039,7 +5027,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "tower",
@@ -5094,7 +5082,7 @@ dependencies = [
  "syntect",
  "tempfile",
  "tempo-alloy",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "toml",
@@ -5130,7 +5118,7 @@ dependencies = [
  "serde_json",
  "sourcemap",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5179,7 +5167,7 @@ dependencies = [
  "simd-json",
  "smallvec",
  "sonic-rs",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
  "tower",
@@ -5200,7 +5188,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "reqwest",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -5244,7 +5232,7 @@ dependencies = [
  "serde_json",
  "sha1 0.11.0",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5286,7 +5274,7 @@ dependencies = [
  "shlex",
  "tar",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5299,7 +5287,7 @@ version = "0.3.0"
 dependencies = [
  "cpal",
  "nanocodex",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
@@ -5325,7 +5313,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "url",
 ]
 
@@ -5351,7 +5339,7 @@ dependencies = [
  "sha2 0.11.0",
  "tempfile",
  "tempo-alloy",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
@@ -5422,7 +5410,7 @@ checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases 0.2.2",
+ "cfg_aliases 0.2.1",
  "libc",
  "memoffset 0.9.1",
 ]
@@ -5435,7 +5423,7 @@ checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases 0.2.2",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -5762,7 +5750,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "unicase",
@@ -5782,7 +5770,7 @@ dependencies = [
  "serde_json",
  "strum 0.27.2",
  "strum_macros 0.27.2",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5858,7 +5846,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5887,7 +5875,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5920,7 +5908,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
 ]
@@ -6421,9 +6409,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.107"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -6573,14 +6561,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
- "cfg_aliases 0.2.2",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
  "rustls",
  "socket2 0.6.5",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -6603,7 +6591,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6615,7 +6603,7 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
- "cfg_aliases 0.2.2",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2 0.6.5",
@@ -6625,9 +6613,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.47"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -6785,7 +6773,7 @@ dependencies = [
  "ratex-types",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -6995,27 +6983,27 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7191,7 +7179,7 @@ dependencies = [
  "revm-state",
  "secp256k1 0.30.0",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7294,7 +7282,7 @@ dependencies = [
  "revm-primitives",
  "revm-state",
  "serde",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7482,7 +7470,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sse-stream",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -7498,18 +7486,18 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rquickjs"
-version = "0.12.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e04e4eedfb060b503b5f0a2644abb890b0b3620d3fb674f9455f230014964e4"
+checksum = "7ce6b626d30ecbedaaf8097a04982bc3b081f958f5bdf9b8796be4ac00ee48bb"
 dependencies = [
  "rquickjs-core",
 ]
 
 [[package]]
 name = "rquickjs-core"
-version = "0.12.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e4f499ac5b943d97ee6dbc44f23c2c10426f420f7d2f1793d6318911b6608c"
+checksum = "d9334dd11023d5ae6c751f64496510a576208802ed1d022ef94afa7639c2c55e"
 dependencies = [
  "hashbrown 0.17.1",
  "relative-path",
@@ -7518,9 +7506,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-sys"
-version = "0.12.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13ac243b86a74120814ef7e9e30ad5a2c1199b7b9963b1cf7c84e4cdc1cad99"
+checksum = "eef73520804cf5aa4876097ac5733058d628c769eba9678e0f4dba5a4ef79703"
 dependencies = [
  "cc",
 ]
@@ -7532,7 +7520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7563,9 +7551,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.20.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
+checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -7698,7 +7686,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7716,9 +7704,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.43"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -7744,9 +7732,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -7853,9 +7841,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -8015,9 +8003,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -8025,22 +8013,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.229"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8056,9 +8044,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.151"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -8124,7 +8112,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.2",
+ "schemars 1.2.1",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -8342,9 +8330,9 @@ dependencies = [
 
 [[package]]
 name = "simd_cesu8"
-version = "1.2.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
 dependencies = [
  "rustc_version 0.4.1",
  "simdutf8",
@@ -8441,7 +8429,7 @@ dependencies = [
  "simdutf8",
  "sonic-number",
  "sonic-simd",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "zmij",
 ]
 
@@ -8496,9 +8484,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.5"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
+checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
 dependencies = [
  "bytes",
  "futures-util",
@@ -8640,17 +8628,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "syn-solidity"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8696,7 +8673,7 @@ dependencies = [
  "regex-syntax",
  "serde",
  "serde_derive",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "walkdir",
 ]
 
@@ -8797,7 +8774,7 @@ dependencies = [
  "tempo-chainspec",
  "tempo-contracts",
  "tempo-primitives",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "tower",
  "tracing",
 ]
@@ -8877,11 +8854,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.19",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -8897,13 +8874,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8926,23 +8903,23 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.11.3"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
 dependencies = [
  "fax",
  "flate2",
  "half",
  "quick-error",
  "weezl",
- "zune-jpeg",
+ "zune-jpeg 0.4.21",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "libc",
@@ -8962,9 +8939,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.32"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -9033,9 +9010,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -9063,13 +9040,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.2"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9084,9 +9061,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.19"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -9113,23 +9090,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.19"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "libc",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -9163,9 +9139,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
@@ -9243,7 +9219,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
  "tracing-subscriber",
 ]
@@ -9353,7 +9329,7 @@ dependencies = [
  "log",
  "rand 0.9.5",
  "sha1 0.10.7",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -9372,7 +9348,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1 0.11.0",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9651,17 +9627,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f39348a049689cabd3377cdd9182bf526ec76a6f823b79903896452e9d7a7380"
 dependencies = [
  "libc",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "winapi",
-]
-
-[[package]]
-name = "vm-memory"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b55e753c7725603745cb32b2287ef7ef3da05c03c7702cda3fa8abe25ae0465"
-dependencies = [
- "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -9837,9 +9804,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.9"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -9850,14 +9817,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.9",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.9"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -10302,24 +10269,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -10351,28 +10300,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -10397,12 +10329,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10413,12 +10339,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10433,22 +10353,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -10463,12 +10371,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10479,12 +10381,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -10499,12 +10395,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10515,12 +10405,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -10622,7 +10506,7 @@ dependencies = [
  "oid-registry 0.8.1",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.19",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -10680,18 +10564,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10808,9 +10692,24 @@ dependencies = [
 
 [[package]]
 name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core 0.4.12",
+]
 
 [[package]]
 name = "zune-jpeg"
@@ -10818,5 +10717,5 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
- "zune-core",
+ "zune-core 0.5.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,7 +146,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -147,7 +182,7 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -190,7 +225,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -216,7 +251,7 @@ dependencies = [
  "borsh",
  "k256",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -230,7 +265,7 @@ dependencies = [
  "borsh",
  "once_cell",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -267,7 +302,7 @@ dependencies = [
  "alloy-provider",
  "alloy-sol-types",
  "async-trait",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -322,7 +357,7 @@ dependencies = [
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -349,7 +384,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -427,7 +462,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "url",
@@ -524,7 +559,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -550,7 +585,7 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -566,7 +601,7 @@ dependencies = [
  "async-trait",
  "k256",
  "rand 0.8.7",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -657,7 +692,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tower",
  "tracing",
@@ -693,7 +728,7 @@ dependencies = [
  "nybbles",
  "serde",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -707,6 +742,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.13.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -776,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arboard"
@@ -796,8 +853,17 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "x11rb",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -807,7 +873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9dce000de67c1a27347fed86e9ce76199463fbb5a3d7f13cb0f3d1c16b6dae3"
 dependencies = [
  "tar",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "uuid",
 ]
 
@@ -1159,18 +1225,46 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
 dependencies = [
- "asn1-rs-derive",
+ "asn1-rs-derive 0.5.1",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
  "time",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive 0.6.0",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
@@ -1536,10 +1630,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "blst"
-version = "0.3.16"
+name = "block-padding"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20659f9bbee16cbbd2f7393e40ab6309f5a98f76a2eb57a995ec508b72387fe"
 dependencies = [
  "cc",
  "glob",
@@ -1564,7 +1667,7 @@ checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "borsh-derive",
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
 ]
 
 [[package]]
@@ -1613,10 +1716,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
-name = "bytemuck"
-version = "1.25.1"
+name = "bytecheck"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6aedf8ae72766347502cf3cb4f41cf5e9cc37d28bee90f1fdaaae15f9cf9424"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 
 [[package]]
 name = "byteorder"
@@ -1704,16 +1830,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.2.67"
+name = "cbc"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "ccm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae3c82e4355234767756212c570e29833699ab63e6ffd161887314cc5b43847"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
+]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -1729,9 +1882,20 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
 
 [[package]]
 name = "chacha20"
@@ -1742,6 +1906,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -1763,7 +1940,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "url",
@@ -1851,10 +2028,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.6.2"
+name = "cipher"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd059f9da4f5c36b3787f65d38ccaab1cc315f07b01f89abc8359ee6a8205011"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1874,14 +2062,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1948,15 +2136,6 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -2046,6 +2225,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
 dependencies = [
  "libm",
+]
+
+[[package]]
+name = "coreaudio-rs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "cpal"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbd307f43cc2a697e2d1f8bc7a1d824b5269e052209e28883e5bc04d095aaa3f"
+dependencies = [
+ "alsa",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni 0.21.1",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -2213,6 +2432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -2226,12 +2446,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version 0.4.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2333,6 +2588,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2376,7 +2637,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -2392,11 +2653,25 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.2",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -2576,13 +2851,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2596,6 +2871,42 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dtls"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a431e87fc386bd5e02deb554a013f97bc406e47a7d8e97efb7c6366b980e9c"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "async-trait",
+ "bytecheck",
+ "byteorder",
+ "cbc",
+ "ccm",
+ "chacha20poly1305",
+ "der-parser 9.0.0",
+ "hmac 0.12.1",
+ "log",
+ "p256",
+ "p384",
+ "portable-atomic",
+ "rand 0.9.5",
+ "rand_core 0.6.4",
+ "rcgen 0.13.2",
+ "ring",
+ "rkyv",
+ "rustls",
+ "sec1",
+ "sha1 0.10.7",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+ "x25519-dalek",
+ "x509-parser 0.16.0",
+]
 
 [[package]]
 name = "dunce"
@@ -2651,9 +2962,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
 ]
@@ -2670,6 +2981,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "hkdf",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -2681,9 +2993,9 @@ dependencies = [
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.4.1"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
  "enum-ordinalize-derive",
 ]
@@ -2746,11 +3058,10 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -2873,6 +3184,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"
@@ -3022,9 +3339,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3037,9 +3354,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3047,15 +3364,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3070,9 +3387,9 @@ checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3081,15 +3398,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-timer"
@@ -3099,9 +3416,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3215,6 +3532,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -3371,6 +3698,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3390,9 +3726,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -3457,8 +3793,8 @@ dependencies = [
  "hyper-util",
  "moka",
  "rand 0.10.2",
- "rcgen",
- "thiserror 2.0.18",
+ "rcgen 0.14.8",
+ "thiserror 2.0.19",
  "time",
  "tokio",
  "tokio-graceful",
@@ -3469,18 +3805,18 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3511,7 +3847,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -3546,7 +3882,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -3683,9 +4019,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -3715,9 +4051,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.9"
+version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -3728,8 +4064,8 @@ dependencies = [
  "num-traits",
  "png 0.18.1",
  "tiff",
- "zune-core 0.5.1",
- "zune-jpeg 0.5.15",
+ "zune-core",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -3744,21 +4080,23 @@ dependencies = [
 
 [[package]]
 name = "imago"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae7cfee876c698a1a2ed9c705ab18f21acbed82110f19b51cc458de73426fe2c"
+checksum = "404f567d70cd6d288e43f95ea8f2d6e8fe6156dd07df7da955cb9b147c4ab2a5"
 dependencies = [
  "async-trait",
  "bincode 2.0.1",
  "cfg-if",
+ "futures",
  "libc",
+ "maybe-async",
  "miniz_oxide",
  "nix 0.30.1",
  "page_size",
  "rustc_version 0.4.1",
  "tokio",
  "tracing",
- "vm-memory",
+ "vm-memory 0.18.0",
  "windows-sys 0.61.2",
 ]
 
@@ -3821,6 +4159,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3831,6 +4179,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "interceptor"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88c11a956a48159f7fe539b8198f12b4db9b709ae5f94385b840db38f97fed74"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "log",
+ "portable-atomic",
+ "rand 0.9.5",
+ "rtcp",
+ "rtp",
+ "thiserror 1.0.69",
+ "tokio",
+ "waitgroup",
+ "webrtc-srtp",
+ "webrtc-util",
 ]
 
 [[package]]
@@ -3916,6 +4285,22 @@ dependencies = [
 
 [[package]]
 name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -3923,10 +4308,10 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys",
+ "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "windows-link",
 ]
@@ -3942,6 +4327,15 @@ dependencies = [
  "rustc_version 0.4.1",
  "simd_cesu8",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -4062,7 +4456,7 @@ dependencies = [
  "kvm-ioctls",
  "libc",
  "linux-loader",
- "vm-memory",
+ "vm-memory 0.17.1",
  "vmm-sys-util 0.15.0",
  "windows-sys 0.61.2",
 ]
@@ -4101,12 +4495,12 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "lru 0.16.4",
+ "lru 0.18.1",
  "nix 0.30.1",
  "rand 0.9.5",
  "virtio-bindings",
  "vm-fdt",
- "vm-memory",
+ "vm-memory 0.17.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4132,7 +4526,7 @@ version = "0.1.0-2.0.0-dev"
 source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
 dependencies = [
  "krun-utils",
- "vm-memory",
+ "vm-memory 0.17.1",
 ]
 
 [[package]]
@@ -4149,7 +4543,7 @@ name = "krun-smbios"
 version = "0.1.0-2.0.0-dev"
 source = "git+https://github.com/containers/libkrun?rev=df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0#df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0"
 dependencies = [
- "vm-memory",
+ "vm-memory 0.17.1",
 ]
 
 [[package]]
@@ -4189,7 +4583,7 @@ dependencies = [
  "linux-loader",
  "log",
  "nix 0.30.1",
- "vm-memory",
+ "vm-memory 0.17.1",
  "vmm-sys-util 0.14.0",
  "windows-sys 0.61.2",
  "zstd",
@@ -4233,9 +4627,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libkrun"
@@ -4256,7 +4650,7 @@ dependencies = [
  "libloading",
  "log",
  "once_cell",
- "vm-memory",
+ "vm-memory 0.17.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4302,7 +4696,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de72cb02c55ecffcf75fe78295926f872eb6eb0a58d629c58a8c324dc26380f6"
 dependencies = [
- "vm-memory",
+ "vm-memory 0.17.1",
 ]
 
 [[package]]
@@ -4373,10 +4767,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "macro-string"
@@ -4405,6 +4817,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "maybe-async"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4417,6 +4850,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -4515,9 +4957,9 @@ dependencies = [
 
 [[package]]
 name = "moxcms"
-version = "0.7.11"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
@@ -4542,7 +4984,7 @@ dependencies = [
  "sha2 0.11.0",
  "subtle",
  "tempo-alloy",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tokio",
  "uuid",
@@ -4597,7 +5039,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-tungstenite",
  "tower",
@@ -4635,6 +5077,7 @@ dependencies = [
  "nanocodex-observability",
  "nanocodex-tools",
  "nanocodex-vm",
+ "nanocodex-voice",
  "nanousd",
  "nix 0.31.3",
  "pulldown-cmark",
@@ -4651,7 +5094,7 @@ dependencies = [
  "syntect",
  "tempfile",
  "tempo-alloy",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-tungstenite",
  "toml",
@@ -4687,7 +5130,7 @@ dependencies = [
  "serde_json",
  "sourcemap",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4727,14 +5170,16 @@ dependencies = [
  "futures-util",
  "getrandom 0.4.3",
  "http",
+ "opusic-c",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "simd-json",
  "smallvec",
  "sonic-rs",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-tungstenite",
  "tower",
@@ -4743,6 +5188,7 @@ dependencies = [
  "url",
  "uuid",
  "web-time",
+ "webrtc",
 ]
 
 [[package]]
@@ -4754,7 +5200,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "reqwest",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -4798,7 +5244,7 @@ dependencies = [
  "serde_json",
  "sha1 0.11.0",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4840,11 +5286,22 @@ dependencies = [
  "shlex",
  "tar",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "zstd",
+]
+
+[[package]]
+name = "nanocodex-voice"
+version = "0.3.0"
+dependencies = [
+ "cpal",
+ "nanocodex",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4868,7 +5325,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "url",
 ]
 
@@ -4894,13 +5351,55 @@ dependencies = [
  "sha2 0.11.0",
  "tempfile",
  "tempo-alloy",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tower",
  "tracing",
  "tracing-subscriber",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.13.1",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
 ]
 
 [[package]]
@@ -4923,9 +5422,9 @@ checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
- "memoffset",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -4936,7 +5435,7 @@ checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
 ]
 
@@ -5008,6 +5507,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5073,6 +5583,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5139,6 +5650,43 @@ dependencies = [
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
 ]
 
 [[package]]
@@ -5214,7 +5762,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "unicase",
@@ -5234,7 +5782,16 @@ dependencies = [
  "serde_json",
  "strum 0.27.2",
  "strum_macros 0.27.2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs 0.6.2",
 ]
 
 [[package]]
@@ -5243,7 +5800,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.2",
 ]
 
 [[package]]
@@ -5301,7 +5858,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5330,7 +5887,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5363,7 +5920,7 @@ dependencies = [
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.5",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
 ]
@@ -5373,6 +5930,24 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "opusic-c"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f8e9c909466f15e60277212cc4fec082c68a5e1c9f6e373eee716fec2fed47"
+dependencies = [
+ "opusic-sys",
+]
+
+[[package]]
+name = "opusic-sys"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6363e8eba20c5db07002d1d5f8aef11a1801e3ab11edf4c3333f9ad37c7ebf8d"
+dependencies = [
+ "cmake",
+]
 
 [[package]]
 name = "outref"
@@ -5399,6 +5974,18 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "serdect",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
  "sha2 0.10.9",
 ]
 
@@ -5698,6 +6285,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5811,9 +6421,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -5963,14 +6573,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
- "thiserror 2.0.18",
+ "socket2 0.6.5",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -5993,7 +6603,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -6005,19 +6615,19 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases 0.2.2",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -6078,7 +6688,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.1",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -6175,7 +6785,7 @@ dependencies = [
  "ratex-types",
  "sha2 0.10.9",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
 ]
 
@@ -6331,6 +6941,20 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser 0.16.0",
+ "yasna 0.5.2",
+]
+
+[[package]]
+name = "rcgen"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
@@ -6339,8 +6963,8 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "time",
- "x509-parser",
- "yasna",
+ "x509-parser 0.18.1",
+ "yasna 0.6.0",
 ]
 
 [[package]]
@@ -6371,27 +6995,27 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6455,6 +7079,9 @@ name = "rend"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "663ba70707f96e871406fe10d68128412e619b06d1d47cb91c3a4c6501176240"
+dependencies = [
+ "bytecheck",
+]
 
 [[package]]
 name = "reqwest"
@@ -6564,7 +7191,7 @@ dependencies = [
  "revm-state",
  "secp256k1 0.30.0",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -6667,7 +7294,7 @@ dependencies = [
  "revm-primitives",
  "revm-state",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -6805,6 +7432,7 @@ version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
+ "bytecheck",
  "bytes",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
@@ -6854,7 +7482,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sse-stream",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -6870,18 +7498,18 @@ checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rquickjs"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ce6b626d30ecbedaaf8097a04982bc3b081f958f5bdf9b8796be4ac00ee48bb"
+checksum = "4e04e4eedfb060b503b5f0a2644abb890b0b3620d3fb674f9455f230014964e4"
 dependencies = [
  "rquickjs-core",
 ]
 
 [[package]]
 name = "rquickjs-core"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9334dd11023d5ae6c751f64496510a576208802ed1d022ef94afa7639c2c55e"
+checksum = "16e4f499ac5b943d97ee6dbc44f23c2c10426f420f7d2f1793d6318911b6608c"
 dependencies = [
  "hashbrown 0.17.1",
  "relative-path",
@@ -6890,9 +7518,9 @@ dependencies = [
 
 [[package]]
 name = "rquickjs-sys"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef73520804cf5aa4876097ac5733058d628c769eba9678e0f4dba5a4ef79703"
+checksum = "a13ac243b86a74120814ef7e9e30ad5a2c1199b7b9963b1cf7c84e4cdc1cad99"
 dependencies = [
  "cc",
 ]
@@ -6904,14 +7532,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "rtcp"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adad7f6a501162881032fc84b4bc78ae11f1b30748180b9f5cbe8810bf613aab"
+dependencies = [
+ "bytes",
+ "thiserror 1.0.69",
+ "webrtc-util",
+]
+
+[[package]]
+name = "rtp"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "149329e78ada26b5e174a4c281a7a7e5c8bda6008adc90daddd6f98fce56db29"
+dependencies = [
+ "bytes",
+ "memchr",
+ "portable-atomic",
+ "rand 0.9.5",
+ "serde",
+ "thiserror 1.0.69",
+ "webrtc-util",
 ]
 
 [[package]]
 name = "ruint"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -7044,7 +7698,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7062,13 +7716,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -7089,9 +7744,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -7105,7 +7760,7 @@ checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
- "jni",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
@@ -7198,9 +7853,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -7231,6 +7886,18 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdp"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b6eecfa5151edef84d544ff3885dff98e5b5fe97586757a4b5118bde51c958"
+dependencies = [
+ "rand 0.9.5",
+ "substring",
+ "thiserror 1.0.69",
+ "url",
+]
 
 [[package]]
 name = "sec1"
@@ -7348,9 +8015,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -7358,22 +8025,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7389,9 +8056,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -7457,7 +8124,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -7675,9 +8342,9 @@ dependencies = [
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version 0.4.1",
  "simdutf8",
@@ -7720,6 +8387,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7755,7 +8441,7 @@ dependencies = [
  "simdutf8",
  "sonic-number",
  "sonic-simd",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "zmij",
 ]
 
@@ -7810,9 +8496,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
 dependencies = [
  "bytes",
  "futures-util",
@@ -7886,6 +8572,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "stun"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e3b8d5ad1dd4c8cd0595440f26521a71dd593cb5873ee8e06b91510b7d97269"
+dependencies = [
+ "base64",
+ "crc",
+ "lazy_static",
+ "md-5",
+ "rand 0.9.5",
+ "ring",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "url",
+ "webrtc-util",
+]
+
+[[package]]
+name = "substring"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7919,6 +8633,17 @@ name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7971,7 +8696,7 @@ dependencies = [
  "regex-syntax",
  "serde",
  "serde_derive",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
 ]
 
@@ -8072,7 +8797,7 @@ dependencies = [
  "tempo-chainspec",
  "tempo-contracts",
  "tempo-primitives",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tower",
  "tracing",
 ]
@@ -8152,11 +8877,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -8172,13 +8897,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8201,23 +8926,23 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
 dependencies = [
  "fax",
  "flate2",
  "half",
  "quick-error",
  "weezl",
- "zune-jpeg 0.4.21",
+ "zune-jpeg",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
 dependencies = [
  "deranged",
  "libc",
@@ -8237,9 +8962,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -8308,16 +9033,17 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -8337,13 +9063,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8358,9 +9084,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -8387,22 +9113,23 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -8436,9 +9163,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -8516,7 +9243,7 @@ checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
 dependencies = [
  "crossbeam-channel",
  "symlink",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
  "tracing-subscriber",
 ]
@@ -8626,7 +9353,7 @@ dependencies = [
  "log",
  "rand 0.9.5",
  "sha1 0.10.7",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "utf-8",
 ]
 
@@ -8645,7 +9372,28 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1 0.11.0",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "turn"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d99249a493335eb44c4d7943a8751b22561a82c9903d8eb2d29780b3927880a7"
+dependencies = [
+ "async-trait",
+ "base64",
+ "futures",
+ "log",
+ "md-5",
+ "portable-atomic",
+ "rand 0.9.5",
+ "ring",
+ "stun",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "webrtc-util",
 ]
 
 [[package]]
@@ -8750,6 +9498,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -8893,8 +9651,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f39348a049689cabd3377cdd9182bf526ec76a6f823b79903896452e9d7a7380"
 dependencies = [
  "libc",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "winapi",
+]
+
+[[package]]
+name = "vm-memory"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b55e753c7725603745cb32b2287ef7ef3da05c03c7702cda3fa8abe25ae0465"
+dependencies = [
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -8922,6 +9689,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "waitgroup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1f50000a783467e6c0200f9d10642f4bc424e39efc1b770203e88b488f79292"
+dependencies = [
+ "atomic-waker",
+]
 
 [[package]]
 name = "walkdir"
@@ -9061,9 +9837,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -9074,16 +9850,185 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webrtc"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaacdf9d96224d7b6e2872ba065578f38775f7634367e3ac2cc87c7271da433"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "dtls",
+ "hex",
+ "interceptor",
+ "lazy_static",
+ "log",
+ "portable-atomic",
+ "rand 0.9.5",
+ "rcgen 0.13.2",
+ "regex",
+ "ring",
+ "rtcp",
+ "rtp",
+ "sdp",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smol_str",
+ "stun",
+ "thiserror 1.0.69",
+ "tokio",
+ "turn",
+ "unicase",
+ "url",
+ "waitgroup",
+ "webrtc-data",
+ "webrtc-ice",
+ "webrtc-mdns",
+ "webrtc-media",
+ "webrtc-sctp",
+ "webrtc-srtp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-data"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd470286275809f2fcfcdb1e73ef5f1500be82eff7fe98150ce81b20aad5a2a4"
+dependencies = [
+ "bytes",
+ "log",
+ "portable-atomic",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-sctp",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-ice"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b7fd30f52e6fda8664779b84b7904b2553b76fee24d9ca665e774ae32b13f53"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "crc",
+ "log",
+ "portable-atomic",
+ "rand 0.9.5",
+ "serde",
+ "serde_json",
+ "stun",
+ "thiserror 1.0.69",
+ "tokio",
+ "turn",
+ "url",
+ "uuid",
+ "waitgroup",
+ "webrtc-mdns",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-mdns"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ffa0ea00c0fae979aafa5db285fec5eeb360e1ea246ebec529ba4e09f8e03e"
+dependencies = [
+ "log",
+ "socket2 0.5.10",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-media"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26a6c7335bdd03dc023cb9a3bd7966866d969c92c86987b73aa16dfa39c7ca29"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "rand 0.9.5",
+ "rtp",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "webrtc-sctp"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4b637f0d8eb96d900ac0f79b3060ddd21ca88dfefa467e96e67ab0016f2574"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "crc",
+ "log",
+ "portable-atomic",
+ "rand 0.9.5",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-srtp"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45d2b667a0b5d04eebcb7cb22fd51b2af3721f418097b496e72de16386c8d0c3"
+dependencies = [
+ "aead",
+ "aes",
+ "aes-gcm",
+ "byteorder",
+ "bytes",
+ "ctr",
+ "hmac 0.12.1",
+ "log",
+ "rtcp",
+ "rtp",
+ "sha1 0.10.7",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "webrtc-util",
+]
+
+[[package]]
+name = "webrtc-util"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1beae0b4f24969741c26ca282a257dc5823bd9cbe608f7e3ca3775102d323ad9"
+dependencies = [
+ "async-trait",
+ "bitflags 1.3.2",
+ "bytes",
+ "ipnet",
+ "lazy_static",
+ "log",
+ "nix 0.26.4",
+ "portable-atomic",
+ "rand 0.9.5",
+ "thiserror 1.0.69",
+ "tokio",
+ "winapi",
 ]
 
 [[package]]
@@ -9134,12 +10079,22 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core 0.58.0",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9165,6 +10120,16 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
@@ -9173,7 +10138,7 @@ dependencies = [
  "windows-interface 0.58.0",
  "windows-result 0.2.0",
  "windows-strings 0.1.0",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9273,11 +10238,20 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9296,7 +10270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result 0.2.0",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -9310,11 +10284,38 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -9328,18 +10329,50 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -9353,9 +10386,27 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -9364,10 +10415,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -9376,10 +10445,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9388,16 +10481,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -9456,20 +10579,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs 0.6.2",
+ "data-encoding",
+ "der-parser 9.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.7.1",
+ "ring",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.7.2",
  "data-encoding",
- "der-parser",
+ "der-parser 10.0.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.8.1",
  "ring",
  "rusticata-macros",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -9481,6 +10634,15 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix 1.1.4",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]
@@ -9518,18 +10680,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.54"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9646,24 +10808,9 @@ dependencies = [
 
 [[package]]
 name = "zune-core"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
-
-[[package]]
-name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
-
-[[package]]
-name = "zune-jpeg"
-version = "0.4.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
-dependencies = [
- "zune-core 0.4.12",
-]
 
 [[package]]
 name = "zune-jpeg"
@@ -9671,5 +10818,5 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
- "zune-core 0.5.1",
+ "zune-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4684,7 +4684,10 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
+ "bitflags 2.13.1",
  "libc",
+ "plain",
+ "redox_syscall 0.9.1",
 ]
 
 [[package]]
@@ -5137,6 +5140,7 @@ dependencies = [
  "nanocodex",
  "nanocodex-browser",
  "nanocodex-vm",
+ "nanocodex-voice",
  "reflink-copy",
  "reqwest",
  "serde",
@@ -5286,10 +5290,12 @@ name = "nanocodex-voice"
 version = "0.3.0"
 dependencies = [
  "cpal",
+ "futures-util",
  "nanocodex",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "whoami",
 ]
 
 [[package]]
@@ -6039,7 +6045,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -6245,6 +6251,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
@@ -6960,6 +6972,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -9701,6 +9722,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10011,6 +10038,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ wasm-bindgen = "0.2.105"
 wasm-bindgen-futures = "0.4.55"
 web-time = "1.1.0"
 webrtc = "0.17.0"
+whoami = "1.6.1"
 zstd = "0.13"
 
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/nanocodex",
     "crates/nanocodex-agent",
     "crates/experimental/nanocodex-browser",
+    "crates/experimental/nanocodex-voice",
     "crates/experimental/nanocodex-vm",
     "crates/nanocodex-oai-api",
     "crates/nanocodex-observability",
@@ -45,6 +46,7 @@ bm25 = { version = "2.3.2", default-features = false }
 chrono = { version = "0.4.43", default-features = false, features = ["clock", "std", "wasmbind"] }
 chromiumoxide = "0.9.1"
 clap = { version = "4.5.54", features = ["derive", "env"] }
+cpal = "0.16.0"
 crossterm = { version = "0.28.1", features = ["bracketed-paste", "event-stream"] }
 criterion = { version = "0.7.0", default-features = false, features = ["async_tokio", "cargo_bench_support"] }
 dotenvy = "0.15.7"
@@ -65,6 +67,7 @@ mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "
 nanocodex = { version = "0.3.0", path = "crates/nanocodex" }
 nanocodex-agent = { version = "0.3.0", path = "crates/nanocodex-agent" }
 nanocodex-browser = { version = "0.3.0", path = "crates/experimental/nanocodex-browser" }
+nanocodex-voice = { version = "0.3.0", path = "crates/experimental/nanocodex-voice" }
 nanocodex-vm = { version = "0.3.0", path = "crates/experimental/nanocodex-vm" }
 nanocodex-oai-api = { version = "0.3.0", path = "crates/nanocodex-oai-api" }
 nanocodex-observability = { version = "0.3.0", path = "crates/nanocodex-observability" }
@@ -87,6 +90,7 @@ opentelemetry-otlp = { version = "0.32", default-features = false, features = ["
 opentelemetry-semantic-conventions = "0.32"
 opentelemetry_sdk = { version = "0.32", default-features = false, features = ["experimental_trace_batch_span_processor_with_async_runtime", "rt-tokio", "trace"] }
 percent-encoding = "2.3.2"
+opusic-c = "1.6.1"
 pyo3 = "0.29.0"
 proc-macro-crate = "3"
 proc-macro2 = "1.0.106"
@@ -94,6 +98,7 @@ quote = "1.0.46"
 ratatui = { version = "0.29.0", features = ["unstable-rendered-line-info"] }
 ratatex = "0.1.0"
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls"] }
+rustls = { version = "0.23.42", default-features = false, features = ["aws_lc_rs"] }
 rusqlite = { version = "0.38", features = ["bundled"] }
 rquickjs = "0.12.1"
 rmcp = { version = "1.8.0", default-features = false, features = ["auth", "client", "reqwest-tls-no-provider", "transport-async-rw", "transport-streamable-http-client-reqwest"] }
@@ -133,6 +138,7 @@ vergen = { version = "8", default-features = false }
 wasm-bindgen = "0.2.105"
 wasm-bindgen-futures = "0.4.55"
 web-time = "1.1.0"
+webrtc = "0.17.0"
 zstd = "0.13"
 
 [workspace.lints.rust]

--- a/PLAN.md
+++ b/PLAN.md
@@ -108,7 +108,9 @@ migration, and it must be independently mergeable.
     subscription credential and frameless sideband; when no host attestation
     exists, it sends Codex's accepted unavailable-token envelope. The TUI
     exposes Codex's current voice catalog through `/voice list` and named
-    starts, with Codex's current `cove` default and Frameless model.
+    starts, with Codex's current `cove` default and Frameless model. Realtime
+    coding handoffs atomically steer an active regular turn or start a new turn,
+    so spoken follow-ups remain interactive during tool execution.
 
 ## Current non-goals
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -100,14 +100,24 @@ migration, and it must be independently mergeable.
    than adding `Session::tools`.
 10. [ ] Rerun required PR checks after the closeout changes and confirm the new
     remote head is mergeable.
+11. [x] Add the library-first GPT Realtime voice slice: typed 24 kHz PCM
+    input/output, API-key WebSocket and Codex-compatible ChatGPT WebRTC
+    transports, plus an experimental `nanocodex-voice` default-device and
+    background-agent lifecycle consumed by the thin Ratatui `/voice` adapter.
+    ChatGPT voice uses the coding session's
+    subscription credential and frameless sideband; when no host attestation
+    exists, it sends Codex's accepted unavailable-token envelope. The TUI
+    exposes Codex's current voice catalog through `/voice list` and named
+    starts, with Codex's current `cove` default and Frameless model.
 
 ## Current non-goals
 
 - No provider abstraction, generic app server, compatibility layer, approval
   subsystem, or alternate agent runtime.
-- No audio implementation work.
+- No browser audio-device ownership or generic realtime/app-server protocol in
+  the core library.
 - No new `.service(...)` transport design without a concrete consumer.
 - No cosmetic CLI/TUI lifecycle rewrite when existing behavior is accepted.
-- No VM, browser, managed-agent, proxy, or experimental-crate work.
+- No further VM, browser, managed-agent, proxy, or experimental-crate work.
 - No benchmark, task, or verifier modification made solely to improve an eval
   score.

--- a/README.md
+++ b/README.md
@@ -211,17 +211,18 @@ directly.
 [Observability guide](crates/nanocodex-observability/README.md) ·
 [API documentation](https://docs.rs/nanocodex-observability)
 
-### Experimental systems components
+### Experimental components
 
-VM components live under [`crates/experimental/`](crates/experimental/README.md)
-while their public contracts mature:
+Components whose public contracts are still maturing live under
+[`crates/experimental/`](crates/experimental/README.md):
 
 | Package | Responsibility |
 | --- | --- |
+| [`nanocodex-voice`](crates/experimental/nanocodex-voice/README.md) | Desktop GPT Realtime audio and reusable voice-to-agent lifecycle |
 | [`nanocodex-vm`](crates/experimental/nanocodex-vm/README.md) | VM lifecycle and images plus retained guest-backed workspace tools |
 
-The CLI is a consumer of this crate. VM-backed tools remain opt-in for normal
-agent sessions.
+The CLI is a consumer of these crates. Voice and VM-backed tools remain thin,
+opt-in adapters over the stable library contracts.
 
 ### CLI and language bindings
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,33 @@ history, WebSocket, tools, shell sessions, and prompt-cache identity.
 `agent.clone()` is a cheap handle to that same session; the independently
 returned `AgentEvents` stream is the session-wide event firehose.
 
+## Voice: devices or Unix pipes
+
+The non-TUI desktop example owns the default microphone and speaker directly
+in Rust, using the same `VoiceSessionBuilder` as the production TUI:
+
+```sh
+nanocodex auth login # once; shares ~/.codex/auth.json with Codex
+cargo run -p nanocodex-examples --bin voice
+```
+
+The lower adapter leaves device and media ownership outside Nanocodex. It reads
+24 kHz mono PCM16 little-endian audio from stdin, writes the same format to
+stdout, and keeps transcripts and agent events on stderr:
+
+```sh
+cargo run -p nanocodex-examples --bin realtime-pipe < microphone.pcm > speaker.pcm
+
+# Equivalently, compose any live capture/decoder and playback/encoder:
+capture-s16le | cargo run --quiet -p nanocodex-examples --bin realtime-pipe | play-s16le
+```
+
+Both retain one coding-agent session. A spoken request starts work while idle;
+a follow-up received during that work atomically steers the active turn at its
+next safe model boundary. Both use shared Codex/ChatGPT subscription auth, not
+an API key. Set `NANOCODEX_AUTH_FILE` to override the normal Codex credential
+path.
+
 ## Thesis
 
 ### Small, excellent building blocks

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -47,6 +47,7 @@ image.workspace = true
 nanocodex.workspace = true
 nanocodex-browser.workspace = true
 nanocodex-observability.workspace = true
+nanocodex-voice.workspace = true
 nanocodex-vm.workspace = true
 nix = { workspace = true, optional = true }
 nanousd = { workspace = true, optional = true }

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -28,6 +28,7 @@ use crate::vm::{ConfiguredVm, VmArgs};
 pub(crate) struct ConfiguredAgent {
     pub(crate) handle: Nanocodex,
     pub(crate) events: AgentEvents,
+    pub(crate) realtime: Option<OpenAi>,
     pub(crate) child_agents: Option<Arc<ChildAgents>>,
     pub(crate) mpp_adapter: Option<MppAdapter>,
     pub(crate) mcp: Option<McpHandle>,
@@ -221,6 +222,7 @@ impl AgentArgs {
             openai = openai.http_client(mpp_adapter.responses_http_client()?);
         }
         let openai = openai.build()?;
+        let realtime = (!mpp_enabled).then(|| openai.clone());
         let configured_vm = vm.start().await?;
         let mut tools = configured_vm
             .as_ref()
@@ -274,6 +276,7 @@ impl AgentArgs {
         Ok(ConfiguredAgent {
             handle,
             events,
+            realtime,
             child_agents,
             mpp_adapter,
             mcp: mcp_handle,

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -26,12 +26,16 @@ use crossterm::event::{
 use eyre::{Result, WrapErr};
 use futures_util::StreamExt;
 use nanocodex::{
-    AgentEvents, Nanocodex, NanocodexError, Thinking, TurnControl, TurnResult,
+    AgentEvents, Nanocodex, NanocodexError, OpenAi, Thinking, TurnControl, TurnResult,
     agent::{
         events::{AgentEvent, TimedAgentEvent},
         rollout::DurableSession,
     },
     tools::mcp::McpHandle,
+};
+use nanocodex_voice::{
+    CHATGPT_REALTIME_VOICES, PLATFORM_REALTIME_VOICES, RealtimeVoice, VoiceEvent, VoiceEvents,
+    VoiceSession, VoiceSessionBuilder, VoiceSpeaker,
 };
 use ratatex::{Ratatex, TerminalProfile};
 use tokio::{
@@ -110,6 +114,7 @@ enum WorkerCommand {
     McpReload {
         name: String,
     },
+    Voice(VoiceControl),
 }
 
 enum WorkerEvent {
@@ -221,6 +226,21 @@ enum WorkerEvent {
         name: String,
         error: String,
     },
+    VoiceConnecting,
+    VoiceStarted {
+        voice: RealtimeVoice,
+    },
+    VoiceTranscript {
+        speaker: VoiceSpeaker,
+        text: String,
+    },
+    VoiceInfo {
+        message: String,
+    },
+    VoiceFailed {
+        error: String,
+    },
+    VoiceStopped,
 }
 
 struct MainWorkerBranch {
@@ -500,9 +520,18 @@ enum Submission {
     Trace,
     Fast(Option<bool>),
     ReasoningPicker,
+    Voice(VoiceControl),
     McpLogin(String),
     McpReload(String),
     InvalidCommand(String),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum VoiceControl {
+    Toggle,
+    Start(Option<RealtimeVoice>),
+    Stop,
+    List,
 }
 
 #[allow(
@@ -531,6 +560,7 @@ pub(crate) async fn run(
     };
     let agent = configured.handle;
     let mut agent_events = configured.events;
+    let realtime = configured.realtime;
     let root_session_id = Arc::<str>::from(agent_events.request_id());
     let child_agents = configured.child_agents;
     let mpp_adapter = configured.mpp_adapter;
@@ -542,6 +572,7 @@ pub(crate) async fn run(
     let worker = spawn_agent_worker(
         agent,
         Arc::clone(&root_session_id),
+        realtime,
         mcp,
         worker_rx,
         update_tx,
@@ -987,6 +1018,27 @@ fn handle_worker_update(
         WorkerEvent::McpFailed { name, error } => {
             app.push_active_error(format!("MCP server {name}: {error}"));
         }
+        WorkerEvent::VoiceConnecting => app.set_active_status("Connecting voice…"),
+        WorkerEvent::VoiceStarted { voice } => {
+            app.set_active_status(format!("Voice active ({voice}) — /voice off to stop"));
+        }
+        WorkerEvent::VoiceTranscript { speaker, text } => {
+            let label = match speaker {
+                VoiceSpeaker::User => "🎙 You",
+                VoiceSpeaker::Assistant => "🔊 Voice",
+            };
+            app.main
+                .push_output(TranscriptItem::Assistant(format!("**{label}:** {text}")));
+        }
+        WorkerEvent::VoiceInfo { message } => {
+            app.main
+                .push_output(TranscriptItem::Assistant(format!("**Voice:** {message}")));
+        }
+        WorkerEvent::VoiceFailed { error } => {
+            app.push_active_error(format!("Voice: {error}"));
+            app.set_active_status("Voice unavailable");
+        }
+        WorkerEvent::VoiceStopped => app.set_active_status("Voice stopped"),
     }
     Ok(())
 }
@@ -994,6 +1046,7 @@ fn handle_worker_update(
 fn spawn_agent_worker(
     root: Nanocodex,
     root_session_id: Arc<str>,
+    realtime: Option<OpenAi>,
     mcp: Option<McpHandle>,
     mut commands: mpsc::UnboundedReceiver<WorkerCommand>,
     updates: mpsc::UnboundedSender<WorkerEvent>,
@@ -1015,6 +1068,8 @@ fn spawn_agent_worker(
             finished: finished_tx,
             updates,
             mcp,
+            realtime,
+            voice: None,
         };
         loop {
             tokio::select! {
@@ -1032,6 +1087,35 @@ fn spawn_agent_worker(
     })
 }
 
+fn voice_names(voices: &[RealtimeVoice]) -> String {
+    voices
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn forward_voice_events(mut events: VoiceEvents, updates: mpsc::UnboundedSender<WorkerEvent>) {
+    drop(tokio::spawn(async move {
+        while let Some(event) = events.recv().await {
+            let update = match event {
+                VoiceEvent::Connecting => WorkerEvent::VoiceConnecting,
+                VoiceEvent::Started { voice } => WorkerEvent::VoiceStarted { voice },
+                VoiceEvent::Transcript { speaker, text } => {
+                    WorkerEvent::VoiceTranscript { speaker, text }
+                }
+                VoiceEvent::Failed { error } => WorkerEvent::VoiceFailed {
+                    error: error.to_string(),
+                },
+                VoiceEvent::Stopped => WorkerEvent::VoiceStopped,
+            };
+            if updates.send(update).is_err() {
+                break;
+            }
+        }
+    }));
+}
+
 struct AgentWorker {
     main: MainWorkerBranch,
     archived_main: Vec<MainWorkerBranch>,
@@ -1040,6 +1124,8 @@ struct AgentWorker {
     finished: mpsc::UnboundedSender<FinishedTurn>,
     updates: mpsc::UnboundedSender<WorkerEvent>,
     mcp: Option<McpHandle>,
+    realtime: Option<OpenAi>,
+    voice: Option<VoiceSession>,
 }
 
 impl AgentWorker {
@@ -1084,7 +1170,78 @@ impl AgentWorker {
             WorkerCommand::SetThinking { thinking } => self.set_thinking(thinking).await,
             WorkerCommand::McpLogin { name } => self.mcp_login(name),
             WorkerCommand::McpReload { name } => self.mcp_reload(name),
+            WorkerCommand::Voice(control) => self.control_voice(control),
         }
+    }
+
+    fn control_voice(&mut self, control: VoiceControl) {
+        let running = self.voice_running();
+        match control {
+            VoiceControl::List => {
+                let chatgpt = voice_names(CHATGPT_REALTIME_VOICES);
+                let platform = voice_names(PLATFORM_REALTIME_VOICES);
+                drop(self.updates.send(WorkerEvent::VoiceInfo {
+                    message: format!(
+                        "Codex/ChatGPT voices (default cove): {chatgpt}. Platform voices (default marin): {platform}"
+                    ),
+                }));
+                return;
+            }
+            VoiceControl::Stop => {
+                if let Some(active) = self.voice.as_mut() {
+                    active.stop();
+                }
+                return;
+            }
+            VoiceControl::Toggle if running => {
+                if let Some(active) = self.voice.as_mut() {
+                    active.stop();
+                }
+                return;
+            }
+            VoiceControl::Start(_) if running => {
+                drop(self.updates.send(WorkerEvent::VoiceFailed {
+                    error: "voice is already active; use /voice off before changing it".to_owned(),
+                }));
+                return;
+            }
+            VoiceControl::Toggle | VoiceControl::Start(_) => {}
+        }
+        let voice = match control {
+            VoiceControl::Start(voice) => voice,
+            VoiceControl::Toggle => None,
+            VoiceControl::Stop | VoiceControl::List => return,
+        };
+        if self.btw.is_some() {
+            drop(self.updates.send(WorkerEvent::VoiceFailed {
+                error: "close /btw before starting voice".to_owned(),
+            }));
+            return;
+        }
+        let Some(realtime) = self.realtime.clone() else {
+            drop(self.updates.send(WorkerEvent::VoiceFailed {
+                error: "voice is unavailable with the selected paid provider".to_owned(),
+            }));
+            return;
+        };
+        let mut builder = VoiceSessionBuilder::new(realtime, self.main.agent.clone())
+            .session_id(Arc::clone(&self.main.request_id));
+        if let Some(voice) = voice {
+            builder = builder.voice(voice);
+        }
+        match builder.spawn() {
+            Ok((session, events)) => {
+                forward_voice_events(events, self.updates.clone());
+                self.voice = Some(session);
+            }
+            Err(error) => drop(self.updates.send(WorkerEvent::VoiceFailed {
+                error: format!("failed to start voice thread: {error}"),
+            })),
+        }
+    }
+
+    fn voice_running(&self) -> bool {
+        self.voice.as_ref().is_some_and(VoiceSession::is_running)
     }
 
     fn mcp_login(&self, name: String) {
@@ -1402,6 +1559,13 @@ impl AgentWorker {
     }
 
     async fn open_btw(&mut self, id: u64, prompt_id: Option<u64>, prompt: Option<SubmittedPrompt>) {
+        if self.voice_running() {
+            drop(self.updates.send(WorkerEvent::BtwOpenFailed {
+                id,
+                error: "stop /voice before opening /btw".to_owned(),
+            }));
+            return;
+        }
         self.btw = None;
         let span = info_span!(
             target: "nanocodex",
@@ -1473,6 +1637,13 @@ impl AgentWorker {
     }
 
     async fn edit_historical(&mut self, source_branch_id: u64, new_branch_id: u64, prompt_id: u64) {
+        if self.voice_running() {
+            drop(self.updates.send(WorkerEvent::MainBranchOpenFailed {
+                id: new_branch_id,
+                error: "stop /voice before editing history".to_owned(),
+            }));
+            return;
+        }
         if self.main.id != source_branch_id || self.btw.is_some() {
             drop(self.updates.send(WorkerEvent::MainBranchOpenFailed {
                 id: new_branch_id,
@@ -1567,6 +1738,13 @@ impl AgentWorker {
             drop(self.updates.send(WorkerEvent::MainBranchSwitched {
                 id,
                 request_id: Arc::clone(&self.main.request_id),
+            }));
+            return;
+        }
+        if self.voice_running() {
+            drop(self.updates.send(WorkerEvent::MainBranchSwitchFailed {
+                id,
+                error: "stop /voice before switching branches".to_owned(),
             }));
             return;
         }
@@ -2453,6 +2631,9 @@ fn submit(
             send_command(commands, WorkerCommand::SetFastMode { enabled })?;
         }
         Submission::ReasoningPicker => app.open_reasoning_picker(),
+        Submission::Voice(control) => {
+            send_command(commands, WorkerCommand::Voice(control))?;
+        }
         Submission::McpLogin(name) => {
             send_command(commands, WorkerCommand::McpLogin { name })?;
         }
@@ -2495,6 +2676,24 @@ fn classify_submission(input: impl Into<SubmittedPrompt>) -> Submission {
     }
     if trimmed == "/trace" {
         return Submission::Trace;
+    }
+    if trimmed == "/voice" {
+        return Submission::Voice(VoiceControl::Toggle);
+    }
+    if let Some(argument) = trimmed.strip_prefix("/voice ") {
+        let argument = argument.trim();
+        return match argument {
+            "on" => Submission::Voice(VoiceControl::Start(None)),
+            "off" => Submission::Voice(VoiceControl::Stop),
+            "list" => Submission::Voice(VoiceControl::List),
+            _ if argument.split_whitespace().count() == 1 => match argument.parse() {
+                Ok(voice) => Submission::Voice(VoiceControl::Start(Some(voice))),
+                Err(_) => Submission::InvalidCommand(
+                    "Unknown voice. Use /voice list to see Codex voices.".to_owned(),
+                ),
+            },
+            _ => Submission::InvalidCommand("Usage: /voice [on|off|list|<voice>]".to_owned()),
+        };
     }
     if trimmed == "/fast" {
         return Submission::Fast(None);
@@ -2611,15 +2810,16 @@ mod tests {
     use nanocodex::{
         Nanocodex, OpenAi, Thinking, agent::events::AgentEventKind, oai::__private::EventSink,
     };
+    use nanocodex_voice::RealtimeVoice;
     use serde_json::{Value, json};
     use tokio::{net::TcpListener, sync::mpsc, time::timeout};
     use tokio_tungstenite::{WebSocketStream, accept_async, tungstenite::Message};
 
     use super::{
         BTW_BOUNDARY, PaneId, RedrawPriority, Submission, TerminalAction, UiAction, UiModel,
-        UiUpdate, WorkerCommand, WorkerEvent, active_session_id, apply_main_agent_event_batch,
-        classify_submission, handle_key, handle_worker_update, paste_clipboard_image,
-        prepare_btw_prompt, session_trace_url, spawn_agent_worker,
+        UiUpdate, VoiceControl, WorkerCommand, WorkerEvent, active_session_id,
+        apply_main_agent_event_batch, classify_submission, handle_key, handle_worker_update,
+        paste_clipboard_image, prepare_btw_prompt, session_trace_url, spawn_agent_worker,
     };
     use crate::tui::{
         app::App,
@@ -2657,6 +2857,28 @@ mod tests {
         assert_eq!(
             classify_submission(" /trace ".to_owned()),
             Submission::Trace
+        );
+        assert_eq!(
+            classify_submission(" /voice "),
+            Submission::Voice(VoiceControl::Toggle)
+        );
+        assert_eq!(
+            classify_submission("/voice marin"),
+            Submission::Voice(VoiceControl::Start(Some(RealtimeVoice::Marin)))
+        );
+        assert_eq!(
+            classify_submission("/voice cove"),
+            Submission::Voice(VoiceControl::Start(Some(RealtimeVoice::Cove)))
+        );
+        assert_eq!(
+            classify_submission("/voice list"),
+            Submission::Voice(VoiceControl::List)
+        );
+        assert_eq!(
+            classify_submission("/voice junk"),
+            Submission::InvalidCommand(
+                "Unknown voice. Use /voice list to see Codex voices.".to_owned()
+            )
         );
         assert_eq!(classify_submission("/fast"), Submission::Fast(None));
         assert_eq!(
@@ -3088,6 +3310,7 @@ mod tests {
             agent,
             Arc::from(session_id.to_string()),
             None,
+            None,
             worker_rx,
             updates,
         );
@@ -3182,6 +3405,7 @@ mod tests {
         spawn_agent_worker(
             agent,
             std::sync::Arc::from(session_id.to_string()),
+            None,
             None,
             worker_rx,
             updates,
@@ -3300,6 +3524,7 @@ mod tests {
         spawn_agent_worker(
             agent,
             std::sync::Arc::from(session_id.to_string()),
+            None,
             None,
             worker_rx,
             updates,

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -114,6 +114,7 @@ enum WorkerCommand {
     McpReload {
         name: String,
     },
+    VoiceAgentEvent(AgentEvent),
     Voice(VoiceControl),
 }
 
@@ -332,6 +333,7 @@ struct UiModel {
     root_session_id: Arc<str>,
     agent_events_open: bool,
     worker_updates_open: bool,
+    voice_observing: bool,
     terminal_focused: bool,
     pending_notification: Option<String>,
     pending_mouse_scroll: Option<MouseScrollBurst>,
@@ -382,6 +384,7 @@ impl UiModel {
             root_session_id,
             agent_events_open: true,
             worker_updates_open: true,
+            voice_observing: false,
             terminal_focused: true,
             pending_notification: None,
             pending_mouse_scroll: None,
@@ -453,6 +456,9 @@ impl UiModel {
                 }
             }
             UiAction::Agent(event) => {
+                if self.voice_observing {
+                    drop(commands.send(WorkerCommand::VoiceAgentEvent(event.clone())));
+                }
                 let updated = self.app.on_main_agent_event(0, &event);
                 request_navigated_branch_switch(&mut self.app, commands)?;
                 if updated {
@@ -467,6 +473,15 @@ impl UiModel {
                 Ok(UiUpdate::Redraw(RedrawPriority::Streaming))
             }
             UiAction::Worker(update) => {
+                match &update {
+                    WorkerEvent::VoiceConnecting | WorkerEvent::VoiceStarted { .. } => {
+                        self.voice_observing = true;
+                    }
+                    WorkerEvent::VoiceFailed { .. } | WorkerEvent::VoiceStopped => {
+                        self.voice_observing = false;
+                    }
+                    _ => {}
+                }
                 if !self.terminal_focused
                     && let WorkerEvent::TurnFinished { target, error, .. } = &update
                 {
@@ -1170,6 +1185,11 @@ impl AgentWorker {
             WorkerCommand::SetThinking { thinking } => self.set_thinking(thinking).await,
             WorkerCommand::McpLogin { name } => self.mcp_login(name),
             WorkerCommand::McpReload { name } => self.mcp_reload(name),
+            WorkerCommand::VoiceAgentEvent(event) => {
+                if let Some(voice) = &self.voice {
+                    let _ = voice.observe_agent_event(event);
+                }
+            }
             WorkerCommand::Voice(control) => self.control_voice(control),
         }
     }

--- a/bin/nanocodex/src/tui/view.rs
+++ b/bin/nanocodex/src/tui/view.rs
@@ -561,7 +561,7 @@ fn render_footer(frame: &mut Frame<'_>, app: &App, area: Rect) {
         )
     } else {
         format!(
-            "  /btw <question> side fork · {tool_help} · Ctrl+V image · Enter send/steer · Tab queue · {escape_help} · Ctrl+C quit"
+            "  /btw <question> side fork · /voice [voice] · {tool_help} · Ctrl+V image · Enter send/steer · Tab queue · {escape_help} · Ctrl+C quit"
         )
     };
     let model_width = nanocodex::oai::MODEL.len() + 3 + "default".len() + 7 + 1;

--- a/crates/experimental/README.md
+++ b/crates/experimental/README.md
@@ -3,6 +3,8 @@
 This directory contains complete Nanocodex components whose APIs are still
 being exercised and revised:
 
+- [`nanocodex-voice`](nanocodex-voice/README.md): default-device desktop audio
+  and an owned GPT Realtime voice-to-agent lifecycle.
 - [`nanocodex-vm`](nanocodex-vm/README.md): VM lifecycle and image preparation
   plus retained guest-backed workspace tools.
 - [`nanocodex-browser`](nanocodex-browser/README.md): deterministic browser

--- a/crates/experimental/nanocodex-voice/Cargo.toml
+++ b/crates/experimental/nanocodex-voice/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "nanocodex-voice"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+readme = "README.md"
+keywords.workspace = true
+categories.workspace = true
+description = "Experimental desktop GPT Realtime voice sessions for Nanocodex agents"
+
+[dependencies]
+nanocodex = { workspace = true, features = ["realtime"] }
+thiserror.workspace = true
+tokio = { workspace = true, features = ["rt", "sync"] }
+tracing.workspace = true
+
+[target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
+cpal.workspace = true
+
+[lints]
+workspace = true

--- a/crates/experimental/nanocodex-voice/Cargo.toml
+++ b/crates/experimental/nanocodex-voice/Cargo.toml
@@ -14,10 +14,12 @@ categories.workspace = true
 description = "Experimental desktop GPT Realtime voice sessions for Nanocodex agents"
 
 [dependencies]
+futures-util.workspace = true
 nanocodex = { workspace = true, features = ["realtime"] }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "sync"] }
 tracing.workspace = true
+whoami.workspace = true
 
 [target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
 cpal.workspace = true

--- a/crates/experimental/nanocodex-voice/README.md
+++ b/crates/experimental/nanocodex-voice/README.md
@@ -5,6 +5,27 @@ Nanocodex's device-neutral GPT Realtime API. It connects the default microphone
 and speaker, delegates repository work to an existing retained `Nanocodex`
 agent, and exposes lifecycle and transcript updates as typed events.
 
+Realtime handoffs use the agent's atomic live-input router. The first coding
+request starts an independently awaitable turn; follow-up speech received while
+that turn is running is admitted to its bounded steering queue and joins at the
+next safe model boundary, including after an in-flight tool result. Realtime V2
+acknowledges the steering tool call immediately; Frameless retargets the open
+delegation to the newest request. Neither path waits behind the active turn as
+a second queued request.
+
+If another UI can start work through the same agent before voice does, mirror
+its session-wide `AgentEvent`s through `VoiceSession::observe_agent_event`.
+That lets the voice handoff attach to the already-running turn, stream its
+remaining output, and announce completion. The Nanocodex TUI wires this path
+automatically.
+
+The default conversational prompt, local first-name rendering, delegation
+markers, tool descriptions, and protocol-specific steering acknowledgement are
+ported from Codex's Realtime implementation. Callers can still replace the
+conversation prompt with `VoiceSessionBuilder::instructions`, or reuse the
+rendered default and delegation envelope independently through
+`codex_voice_instructions()` and `codex_realtime_delegation()`.
+
 ```rust,no_run
 use nanocodex::{Nanocodex, OpenAi};
 use nanocodex_voice::{VoiceEvent, VoiceSessionBuilder};

--- a/crates/experimental/nanocodex-voice/README.md
+++ b/crates/experimental/nanocodex-voice/README.md
@@ -1,0 +1,35 @@
+# nanocodex-voice
+
+`nanocodex-voice` is the experimental reusable desktop consumer for
+Nanocodex's device-neutral GPT Realtime API. It connects the default microphone
+and speaker, delegates repository work to an existing retained `Nanocodex`
+agent, and exposes lifecycle and transcript updates as typed events.
+
+```rust,no_run
+use nanocodex::{Nanocodex, OpenAi};
+use nanocodex_voice::{VoiceEvent, VoiceSessionBuilder};
+
+# async fn example(openai: OpenAi, agent: Nanocodex) -> Result<(), Box<dyn std::error::Error>> {
+let (mut voice, mut events) = VoiceSessionBuilder::new(openai, agent).spawn()?;
+while let Some(event) = events.recv().await {
+    match event {
+        VoiceEvent::Transcript { speaker, text } => println!("{speaker}: {text}"),
+        VoiceEvent::Failed { error } => return Err(error.into()),
+        VoiceEvent::Stopped => break,
+        VoiceEvent::Connecting | VoiceEvent::Started { .. } => {}
+    }
+}
+voice.stop();
+# Ok(())
+# }
+```
+
+The lower `nanocodex-oai-api::realtime` module remains the transport contract
+for custom devices, pipes, and non-desktop embeddings. This crate deliberately
+packages one opinionated native lifecycle rather than moving audio-device
+policy into the public OpenAI boundary. The Nanocodex Ratatui `/voice` command
+is a thin consumer of this crate.
+
+Default-device capture and playback are currently implemented on macOS and
+Windows. Other native targets return a typed unsupported-platform failure and
+can continue to use the raw PCM Realtime API.

--- a/crates/experimental/nanocodex-voice/src/audio.rs
+++ b/crates/experimental/nanocodex-voice/src/audio.rs
@@ -1,0 +1,508 @@
+use std::{
+    collections::VecDeque,
+    fmt::Display,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use cpal::{
+    Device, SampleFormat, Stream, StreamConfig,
+    traits::{DeviceTrait, HostTrait, StreamTrait},
+};
+use nanocodex::oai::realtime::{REALTIME_SAMPLE_RATE, RealtimeAudio};
+use tokio::sync::mpsc;
+
+use crate::{AudioConfig, AudioError};
+
+const INPUT_FRAME_SAMPLES: usize = 480;
+
+pub(crate) struct VoiceAudio {
+    _input: Stream,
+    _output: Stream,
+    playback: Playback,
+}
+
+impl VoiceAudio {
+    pub(crate) fn open(
+        policy: AudioConfig,
+    ) -> Result<(Self, mpsc::Receiver<RealtimeAudio>), AudioError> {
+        if policy.maximum_playback_buffer().is_zero() {
+            return Err(AudioError::InvalidConfig(
+                "maximum playback buffer must be greater than zero",
+            ));
+        }
+        if policy.playback_prebuffer() > policy.maximum_playback_buffer() {
+            return Err(AudioError::InvalidConfig(
+                "playback prebuffer cannot exceed maximum playback buffer",
+            ));
+        }
+
+        let host = cpal::default_host();
+        let input_device = host
+            .default_input_device()
+            .ok_or(AudioError::NoInputDevice)?;
+        let output_device = host
+            .default_output_device()
+            .ok_or(AudioError::NoOutputDevice)?;
+
+        let input_supported = input_device
+            .default_input_config()
+            .map_err(|error| backend("failed to read the default microphone format", error))?;
+        let output_supported = output_device
+            .default_output_config()
+            .map_err(|error| backend("failed to read the default speaker format", error))?;
+        let input_config: StreamConfig = input_supported.clone().into();
+        let output_config: StreamConfig = output_supported.clone().into();
+
+        let (microphone_tx, microphone_rx) = mpsc::channel(256);
+        let input = build_input(
+            &input_device,
+            input_supported.sample_format(),
+            input_config,
+            microphone_tx,
+        )?;
+        let playback = Playback::new(output_config.sample_rate.0, output_config.channels, policy)?;
+        let output = build_output(
+            &output_device,
+            output_supported.sample_format(),
+            output_config,
+            Arc::clone(&playback.buffer),
+        )?;
+
+        input
+            .play()
+            .map_err(|error| backend("failed to start the microphone", error))?;
+        output
+            .play()
+            .map_err(|error| backend("failed to start audio output", error))?;
+        Ok((
+            Self {
+                _input: input,
+                _output: output,
+                playback,
+            },
+            microphone_rx,
+        ))
+    }
+
+    pub(crate) fn play(&mut self, audio: &RealtimeAudio) {
+        self.playback.push(audio);
+    }
+
+    pub(crate) fn interrupt(&mut self) {
+        self.playback.clear();
+    }
+}
+
+struct Playback {
+    buffer: Arc<Mutex<PlaybackBuffer>>,
+    resampler: LinearResampler,
+    resampled: Vec<f32>,
+    channels: usize,
+    maximum_samples: usize,
+}
+
+struct PlaybackBuffer {
+    samples: VecDeque<f32>,
+    prebuffer_samples: usize,
+    buffering: bool,
+}
+
+impl Playback {
+    fn new(sample_rate: u32, channels: u16, policy: AudioConfig) -> Result<Self, AudioError> {
+        let channels = usize::from(channels);
+        if channels == 0 {
+            return Err(AudioError::InvalidConfig(
+                "speaker channel count must be greater than zero",
+            ));
+        }
+        let prebuffer_samples =
+            duration_samples(sample_rate, channels, policy.playback_prebuffer());
+        let maximum_samples =
+            duration_samples(sample_rate, channels, policy.maximum_playback_buffer());
+        if maximum_samples == 0 {
+            return Err(AudioError::InvalidConfig(
+                "maximum playback buffer is shorter than one device sample",
+            ));
+        }
+        Ok(Self {
+            buffer: Arc::new(Mutex::new(PlaybackBuffer {
+                samples: VecDeque::with_capacity(prebuffer_samples),
+                prebuffer_samples,
+                buffering: true,
+            })),
+            resampler: LinearResampler::new(REALTIME_SAMPLE_RATE, sample_rate),
+            resampled: Vec::new(),
+            channels,
+            maximum_samples,
+        })
+    }
+
+    fn push(&mut self, audio: &RealtimeAudio) {
+        let source = audio.as_bytes().chunks_exact(2).map(|sample| {
+            let sample = i16::from_le_bytes([sample[0], sample[1]]);
+            f32::from(sample) / f32::from(i16::MAX)
+        });
+        self.resampler.push_into(source, &mut self.resampled);
+        let Ok(mut buffer) = self.buffer.lock() else {
+            return;
+        };
+        let retained_frames = self
+            .resampled
+            .len()
+            .min(self.maximum_samples / self.channels);
+        let appended = retained_frames.saturating_mul(self.channels);
+        let overflow = buffer
+            .samples
+            .len()
+            .saturating_add(appended)
+            .saturating_sub(self.maximum_samples);
+        let discarded = overflow.min(buffer.samples.len());
+        buffer.samples.drain(..discarded);
+        for sample in self
+            .resampled
+            .iter()
+            .skip(self.resampled.len().saturating_sub(retained_frames))
+            .copied()
+        {
+            buffer
+                .samples
+                .extend(std::iter::repeat_n(sample, self.channels));
+        }
+    }
+
+    fn clear(&mut self) {
+        self.resampler.clear();
+        self.resampled.clear();
+        if let Ok(mut buffer) = self.buffer.lock() {
+            buffer.samples.clear();
+            buffer.buffering = true;
+        }
+    }
+}
+
+struct Microphone {
+    resampler: LinearResampler,
+    channels: usize,
+    interleaved_tail: Vec<f32>,
+    mono: Vec<f32>,
+    resampled: Vec<f32>,
+    pending: VecDeque<f32>,
+    sender: mpsc::Sender<RealtimeAudio>,
+}
+
+impl Microphone {
+    fn new(sample_rate: u32, channels: u16, sender: mpsc::Sender<RealtimeAudio>) -> Self {
+        Self {
+            resampler: LinearResampler::new(sample_rate, REALTIME_SAMPLE_RATE),
+            channels: usize::from(channels),
+            interleaved_tail: Vec::new(),
+            mono: Vec::new(),
+            resampled: Vec::new(),
+            pending: VecDeque::with_capacity(INPUT_FRAME_SAMPLES * 2),
+            sender,
+        }
+    }
+
+    fn push(&mut self, input: impl IntoIterator<Item = f32>) {
+        self.interleaved_tail.extend(input);
+        let complete = self.interleaved_tail.len() / self.channels * self.channels;
+        self.mono.clear();
+        self.mono.extend(
+            self.interleaved_tail[..complete]
+                .chunks_exact(self.channels)
+                .map(|frame| frame.iter().copied().sum::<f32>() / self.channels as f32),
+        );
+        self.interleaved_tail.drain(..complete);
+        self.resampler
+            .push_into(self.mono.iter().copied(), &mut self.resampled);
+        self.pending.extend(self.resampled.iter().copied());
+
+        while self.pending.len() >= INPUT_FRAME_SAMPLES {
+            let audio = RealtimeAudio::from_samples(
+                self.pending.drain(..INPUT_FRAME_SAMPLES).map(f32_to_i16),
+            );
+            if self.sender.try_send(audio).is_err() {
+                break;
+            }
+        }
+    }
+}
+
+struct LinearResampler {
+    step: f64,
+    position: f64,
+    source: Vec<f32>,
+}
+
+impl LinearResampler {
+    fn new(source_rate: u32, destination_rate: u32) -> Self {
+        Self {
+            step: f64::from(source_rate) / f64::from(destination_rate),
+            position: 0.0,
+            source: Vec::new(),
+        }
+    }
+
+    fn push_into(&mut self, input: impl IntoIterator<Item = f32>, output: &mut Vec<f32>) {
+        self.source.extend(input);
+        output.clear();
+        while self.position + 1.0 < self.source.len() as f64 {
+            let index = self.position.floor() as usize;
+            let fraction = (self.position - index as f64) as f32;
+            output.push(
+                self.source[index] + (self.source[index + 1] - self.source[index]) * fraction,
+            );
+            self.position += self.step;
+        }
+        let consumed = self.position.floor() as usize;
+        if consumed > 0 {
+            self.source.drain(..consumed.min(self.source.len()));
+            self.position -= consumed as f64;
+        }
+    }
+
+    fn clear(&mut self) {
+        self.position = 0.0;
+        self.source.clear();
+    }
+}
+
+fn build_input(
+    device: &Device,
+    format: SampleFormat,
+    config: StreamConfig,
+    sender: mpsc::Sender<RealtimeAudio>,
+) -> Result<Stream, AudioError> {
+    let microphone = Arc::new(Mutex::new(Microphone::new(
+        config.sample_rate.0,
+        config.channels,
+        sender,
+    )));
+    let error = |error| tracing::error!(%error, "microphone stream failed");
+    let stream = match format {
+        SampleFormat::F32 => {
+            let microphone = Arc::clone(&microphone);
+            device
+                .build_input_stream(
+                    &config,
+                    move |data: &[f32], _| push_input(&microphone, data.iter().copied()),
+                    error,
+                    None,
+                )
+                .map_err(|error| backend("failed to build the microphone stream", error))?
+        }
+        SampleFormat::I16 => {
+            let microphone = Arc::clone(&microphone);
+            device
+                .build_input_stream(
+                    &config,
+                    move |data: &[i16], _| {
+                        push_input(
+                            &microphone,
+                            data.iter()
+                                .map(|sample| f32::from(*sample) / f32::from(i16::MAX)),
+                        );
+                    },
+                    error,
+                    None,
+                )
+                .map_err(|error| backend("failed to build the microphone stream", error))?
+        }
+        SampleFormat::U16 => {
+            let microphone = Arc::clone(&microphone);
+            device
+                .build_input_stream(
+                    &config,
+                    move |data: &[u16], _| {
+                        push_input(
+                            &microphone,
+                            data.iter()
+                                .map(|sample| f32::from(*sample) / 32_767.5 - 1.0),
+                        );
+                    },
+                    error,
+                    None,
+                )
+                .map_err(|error| backend("failed to build the microphone stream", error))?
+        }
+        unsupported => {
+            return Err(AudioError::Backend {
+                operation: "unsupported microphone sample format",
+                message: unsupported.to_string(),
+            });
+        }
+    };
+    Ok(stream)
+}
+
+fn push_input(microphone: &Mutex<Microphone>, samples: impl IntoIterator<Item = f32>) {
+    if let Ok(mut microphone) = microphone.lock() {
+        microphone.push(samples);
+    }
+}
+
+fn build_output(
+    device: &Device,
+    format: SampleFormat,
+    config: StreamConfig,
+    samples: Arc<Mutex<PlaybackBuffer>>,
+) -> Result<Stream, AudioError> {
+    let error = |error| tracing::error!(%error, "speaker stream failed");
+    let stream = match format {
+        SampleFormat::F32 => {
+            let samples = Arc::clone(&samples);
+            device
+                .build_output_stream(
+                    &config,
+                    move |output: &mut [f32], _| fill_output(output, &samples, |value| value),
+                    error,
+                    None,
+                )
+                .map_err(|error| backend("failed to build the speaker stream", error))?
+        }
+        SampleFormat::I16 => {
+            let samples = Arc::clone(&samples);
+            device
+                .build_output_stream(
+                    &config,
+                    move |output: &mut [i16], _| fill_output(output, &samples, f32_to_i16),
+                    error,
+                    None,
+                )
+                .map_err(|error| backend("failed to build the speaker stream", error))?
+        }
+        SampleFormat::U16 => {
+            let samples = Arc::clone(&samples);
+            device
+                .build_output_stream(
+                    &config,
+                    move |output: &mut [u16], _| {
+                        fill_output(output, &samples, |value| {
+                            ((value.clamp(-1.0, 1.0) + 1.0) * 32_767.5).round() as u16
+                        });
+                    },
+                    error,
+                    None,
+                )
+                .map_err(|error| backend("failed to build the speaker stream", error))?
+        }
+        unsupported => {
+            return Err(AudioError::Backend {
+                operation: "unsupported speaker sample format",
+                message: unsupported.to_string(),
+            });
+        }
+    };
+    Ok(stream)
+}
+
+fn fill_output<T>(output: &mut [T], buffer: &Mutex<PlaybackBuffer>, convert: impl Fn(f32) -> T) {
+    let Ok(mut buffer) = buffer.try_lock() else {
+        for sample in output {
+            *sample = convert(0.0);
+        }
+        return;
+    };
+    if buffer.buffering {
+        if buffer.samples.len() < buffer.prebuffer_samples {
+            for sample in output {
+                *sample = convert(0.0);
+            }
+            return;
+        }
+        buffer.buffering = false;
+    }
+    for sample in output {
+        let Some(value) = buffer.samples.pop_front() else {
+            buffer.buffering = true;
+            *sample = convert(0.0);
+            continue;
+        };
+        *sample = convert(value);
+    }
+}
+
+fn duration_samples(sample_rate: u32, channels: usize, duration: Duration) -> usize {
+    duration
+        .as_nanos()
+        .saturating_mul(u128::from(sample_rate))
+        .saturating_mul(channels as u128)
+        .checked_div(1_000_000_000)
+        .and_then(|samples| usize::try_from(samples).ok())
+        .unwrap_or(usize::MAX)
+}
+
+fn backend(operation: &'static str, error: impl Display) -> AudioError {
+    AudioError::Backend {
+        operation,
+        message: error.to_string(),
+    }
+}
+
+fn f32_to_i16(sample: f32) -> i16 {
+    (sample.clamp(-1.0, 1.0) * f32::from(i16::MAX)).round() as i16
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::VecDeque, sync::Mutex, time::Duration};
+
+    use super::{LinearResampler, PlaybackBuffer, duration_samples, fill_output};
+
+    #[test]
+    fn resamples_across_chunk_boundaries_without_reallocating_the_destination() {
+        let mut downsample = LinearResampler::new(48_000, 24_000);
+        let mut output = Vec::with_capacity(4);
+        downsample.push_into([0.0, 0.25], &mut output);
+        assert_eq!(output, vec![0.0]);
+        let capacity = output.capacity();
+        downsample.push_into([0.5, 0.75, 1.0], &mut output);
+        assert_eq!(output, vec![0.5]);
+        assert_eq!(output.capacity(), capacity);
+
+        let mut upsample = LinearResampler::new(24_000, 48_000);
+        upsample.push_into([0.0], &mut output);
+        assert!(output.is_empty());
+        upsample.push_into([1.0], &mut output);
+        assert_eq!(output, vec![0.0, 0.5]);
+    }
+
+    #[test]
+    fn playback_waits_for_prebuffer_before_starting() {
+        let buffer = Mutex::new(PlaybackBuffer {
+            samples: VecDeque::from([0.25, 0.5]),
+            prebuffer_samples: 3,
+            buffering: true,
+        });
+        let mut output = [1.0; 2];
+
+        fill_output(&mut output, &buffer, |sample| sample);
+
+        assert_eq!(output, [0.0, 0.0]);
+        assert_eq!(buffer.lock().unwrap().samples.len(), 2);
+    }
+
+    #[test]
+    fn playback_rebuffers_after_an_underrun() {
+        let buffer = Mutex::new(PlaybackBuffer {
+            samples: VecDeque::from([0.25, 0.5, 0.75]),
+            prebuffer_samples: 3,
+            buffering: true,
+        });
+        let mut output = [1.0; 4];
+
+        fill_output(&mut output, &buffer, |sample| sample);
+
+        assert_eq!(output, [0.25, 0.5, 0.75, 0.0]);
+        assert!(buffer.lock().unwrap().buffering);
+    }
+
+    #[test]
+    fn duration_policy_maps_to_interleaved_device_samples() {
+        assert_eq!(
+            duration_samples(48_000, 2, Duration::from_millis(120)),
+            11_520
+        );
+    }
+}

--- a/crates/experimental/nanocodex-voice/src/audio.rs
+++ b/crates/experimental/nanocodex-voice/src/audio.rs
@@ -15,6 +15,9 @@ use tokio::sync::mpsc;
 use crate::{AudioConfig, AudioError};
 
 const INPUT_FRAME_SAMPLES: usize = 480;
+const MICROPHONE_QUEUE_FRAMES: usize = 8;
+const DEVICE_CALLBACK_CAPACITY: usize = 4_096;
+const PLAYBACK_INITIAL_HEADROOM: Duration = Duration::from_secs(1);
 
 pub(crate) struct VoiceAudio {
     _input: Stream,
@@ -54,7 +57,10 @@ impl VoiceAudio {
         let input_config: StreamConfig = input_supported.clone().into();
         let output_config: StreamConfig = output_supported.clone().into();
 
-        let (microphone_tx, microphone_rx) = mpsc::channel(256);
+        // Keep capture close to live speech. If transport stops consuming,
+        // retaining seconds of stale microphone audio is worse than dropping
+        // it and resuming from the newest callback.
+        let (microphone_tx, microphone_rx) = mpsc::channel(MICROPHONE_QUEUE_FRAMES);
         let input = build_input(
             &input_device,
             input_supported.sample_format(),
@@ -98,13 +104,12 @@ struct Playback {
     buffer: Arc<Mutex<PlaybackBuffer>>,
     resampler: LinearResampler,
     resampled: Vec<f32>,
-    channels: usize,
-    maximum_samples: usize,
+    maximum_frames: usize,
 }
 
 struct PlaybackBuffer {
     samples: VecDeque<f32>,
-    prebuffer_samples: usize,
+    prebuffer_frames: usize,
     buffering: bool,
 }
 
@@ -116,25 +121,26 @@ impl Playback {
                 "speaker channel count must be greater than zero",
             ));
         }
-        let prebuffer_samples =
-            duration_samples(sample_rate, channels, policy.playback_prebuffer());
-        let maximum_samples =
-            duration_samples(sample_rate, channels, policy.maximum_playback_buffer());
-        if maximum_samples == 0 {
+        let prebuffer_frames = duration_frames(sample_rate, policy.playback_prebuffer());
+        let maximum_frames = duration_frames(sample_rate, policy.maximum_playback_buffer());
+        if maximum_frames == 0 {
             return Err(AudioError::InvalidConfig(
                 "maximum playback buffer is shorter than one device sample",
             ));
         }
+        let initial_capacity = maximum_frames
+            .min(prebuffer_frames.max(duration_frames(sample_rate, PLAYBACK_INITIAL_HEADROOM)));
         Ok(Self {
             buffer: Arc::new(Mutex::new(PlaybackBuffer {
-                samples: VecDeque::with_capacity(prebuffer_samples),
-                prebuffer_samples,
+                // Keep mono frames and fan out in the device callback instead
+                // of duplicating every sample under this shared lock.
+                samples: VecDeque::with_capacity(initial_capacity),
+                prebuffer_frames,
                 buffering: true,
             })),
             resampler: LinearResampler::new(REALTIME_SAMPLE_RATE, sample_rate),
             resampled: Vec::new(),
-            channels,
-            maximum_samples,
+            maximum_frames,
         })
     }
 
@@ -147,28 +153,20 @@ impl Playback {
         let Ok(mut buffer) = self.buffer.lock() else {
             return;
         };
-        let retained_frames = self
-            .resampled
-            .len()
-            .min(self.maximum_samples / self.channels);
-        let appended = retained_frames.saturating_mul(self.channels);
+        let retained_frames = self.resampled.len().min(self.maximum_frames);
         let overflow = buffer
             .samples
             .len()
-            .saturating_add(appended)
-            .saturating_sub(self.maximum_samples);
+            .saturating_add(retained_frames)
+            .saturating_sub(self.maximum_frames);
         let discarded = overflow.min(buffer.samples.len());
         buffer.samples.drain(..discarded);
-        for sample in self
-            .resampled
-            .iter()
-            .skip(self.resampled.len().saturating_sub(retained_frames))
-            .copied()
-        {
-            buffer
-                .samples
-                .extend(std::iter::repeat_n(sample, self.channels));
-        }
+        buffer.samples.extend(
+            self.resampled
+                .iter()
+                .skip(self.resampled.len().saturating_sub(retained_frames))
+                .copied(),
+        );
     }
 
     fn clear(&mut self) {
@@ -193,12 +191,13 @@ struct Microphone {
 
 impl Microphone {
     fn new(sample_rate: u32, channels: u16, sender: mpsc::Sender<RealtimeAudio>) -> Self {
+        let channels = usize::from(channels);
         Self {
             resampler: LinearResampler::new(sample_rate, REALTIME_SAMPLE_RATE),
-            channels: usize::from(channels),
-            interleaved_tail: Vec::new(),
-            mono: Vec::new(),
-            resampled: Vec::new(),
+            channels,
+            interleaved_tail: Vec::with_capacity(DEVICE_CALLBACK_CAPACITY.saturating_mul(channels)),
+            mono: Vec::with_capacity(DEVICE_CALLBACK_CAPACITY),
+            resampled: Vec::with_capacity(DEVICE_CALLBACK_CAPACITY),
             pending: VecDeque::with_capacity(INPUT_FRAME_SAMPLES * 2),
             sender,
         }
@@ -222,8 +221,18 @@ impl Microphone {
             let audio = RealtimeAudio::from_samples(
                 self.pending.drain(..INPUT_FRAME_SAMPLES).map(f32_to_i16),
             );
-            if self.sender.try_send(audio).is_err() {
-                break;
+            match self.sender.try_send(audio) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    // Do not turn transport backpressure into delayed speech
+                    // or an unbounded callback-owned queue.
+                    self.pending.clear();
+                    return;
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    self.pending.clear();
+                    return;
+                }
             }
         }
     }
@@ -274,32 +283,28 @@ fn build_input(
     config: StreamConfig,
     sender: mpsc::Sender<RealtimeAudio>,
 ) -> Result<Stream, AudioError> {
-    let microphone = Arc::new(Mutex::new(Microphone::new(
-        config.sample_rate.0,
-        config.channels,
-        sender,
-    )));
+    let sample_rate = config.sample_rate.0;
+    let channels = config.channels;
     let error = |error| tracing::error!(%error, "microphone stream failed");
     let stream = match format {
         SampleFormat::F32 => {
-            let microphone = Arc::clone(&microphone);
+            let mut microphone = Microphone::new(sample_rate, channels, sender);
             device
                 .build_input_stream(
                     &config,
-                    move |data: &[f32], _| push_input(&microphone, data.iter().copied()),
+                    move |data: &[f32], _| microphone.push(data.iter().copied()),
                     error,
                     None,
                 )
                 .map_err(|error| backend("failed to build the microphone stream", error))?
         }
         SampleFormat::I16 => {
-            let microphone = Arc::clone(&microphone);
+            let mut microphone = Microphone::new(sample_rate, channels, sender);
             device
                 .build_input_stream(
                     &config,
                     move |data: &[i16], _| {
-                        push_input(
-                            &microphone,
+                        microphone.push(
                             data.iter()
                                 .map(|sample| f32::from(*sample) / f32::from(i16::MAX)),
                         );
@@ -310,13 +315,12 @@ fn build_input(
                 .map_err(|error| backend("failed to build the microphone stream", error))?
         }
         SampleFormat::U16 => {
-            let microphone = Arc::clone(&microphone);
+            let mut microphone = Microphone::new(sample_rate, channels, sender);
             device
                 .build_input_stream(
                     &config,
                     move |data: &[u16], _| {
-                        push_input(
-                            &microphone,
+                        microphone.push(
                             data.iter()
                                 .map(|sample| f32::from(*sample) / 32_767.5 - 1.0),
                         );
@@ -336,18 +340,13 @@ fn build_input(
     Ok(stream)
 }
 
-fn push_input(microphone: &Mutex<Microphone>, samples: impl IntoIterator<Item = f32>) {
-    if let Ok(mut microphone) = microphone.lock() {
-        microphone.push(samples);
-    }
-}
-
 fn build_output(
     device: &Device,
     format: SampleFormat,
     config: StreamConfig,
     samples: Arc<Mutex<PlaybackBuffer>>,
 ) -> Result<Stream, AudioError> {
+    let channels = usize::from(config.channels);
     let error = |error| tracing::error!(%error, "speaker stream failed");
     let stream = match format {
         SampleFormat::F32 => {
@@ -355,7 +354,9 @@ fn build_output(
             device
                 .build_output_stream(
                     &config,
-                    move |output: &mut [f32], _| fill_output(output, &samples, |value| value),
+                    move |output: &mut [f32], _| {
+                        fill_output(output, &samples, channels, |value| value);
+                    },
                     error,
                     None,
                 )
@@ -366,7 +367,9 @@ fn build_output(
             device
                 .build_output_stream(
                     &config,
-                    move |output: &mut [i16], _| fill_output(output, &samples, f32_to_i16),
+                    move |output: &mut [i16], _| {
+                        fill_output(output, &samples, channels, f32_to_i16);
+                    },
                     error,
                     None,
                 )
@@ -378,7 +381,7 @@ fn build_output(
                 .build_output_stream(
                     &config,
                     move |output: &mut [u16], _| {
-                        fill_output(output, &samples, |value| {
+                        fill_output(output, &samples, channels, |value| {
                             ((value.clamp(-1.0, 1.0) + 1.0) * 32_767.5).round() as u16
                         });
                     },
@@ -397,7 +400,12 @@ fn build_output(
     Ok(stream)
 }
 
-fn fill_output<T>(output: &mut [T], buffer: &Mutex<PlaybackBuffer>, convert: impl Fn(f32) -> T) {
+fn fill_output<T>(
+    output: &mut [T],
+    buffer: &Mutex<PlaybackBuffer>,
+    channels: usize,
+    convert: impl Fn(f32) -> T,
+) {
     let Ok(mut buffer) = buffer.try_lock() else {
         for sample in output {
             *sample = convert(0.0);
@@ -405,7 +413,7 @@ fn fill_output<T>(output: &mut [T], buffer: &Mutex<PlaybackBuffer>, convert: imp
         return;
     };
     if buffer.buffering {
-        if buffer.samples.len() < buffer.prebuffer_samples {
+        if buffer.samples.len() < buffer.prebuffer_frames {
             for sample in output {
                 *sample = convert(0.0);
             }
@@ -413,21 +421,24 @@ fn fill_output<T>(output: &mut [T], buffer: &Mutex<PlaybackBuffer>, convert: imp
         }
         buffer.buffering = false;
     }
-    for sample in output {
+    for frame in output.chunks_mut(channels) {
         let Some(value) = buffer.samples.pop_front() else {
             buffer.buffering = true;
-            *sample = convert(0.0);
+            for sample in frame {
+                *sample = convert(0.0);
+            }
             continue;
         };
-        *sample = convert(value);
+        for sample in frame {
+            *sample = convert(value);
+        }
     }
 }
 
-fn duration_samples(sample_rate: u32, channels: usize, duration: Duration) -> usize {
+fn duration_frames(sample_rate: u32, duration: Duration) -> usize {
     duration
         .as_nanos()
         .saturating_mul(u128::from(sample_rate))
-        .saturating_mul(channels as u128)
         .checked_div(1_000_000_000)
         .and_then(|samples| usize::try_from(samples).ok())
         .unwrap_or(usize::MAX)
@@ -448,7 +459,10 @@ fn f32_to_i16(sample: f32) -> i16 {
 mod tests {
     use std::{collections::VecDeque, sync::Mutex, time::Duration};
 
-    use super::{LinearResampler, PlaybackBuffer, duration_samples, fill_output};
+    use super::{
+        INPUT_FRAME_SAMPLES, LinearResampler, Microphone, PlaybackBuffer, duration_frames,
+        fill_output,
+    };
 
     #[test]
     fn resamples_across_chunk_boundaries_without_reallocating_the_destination() {
@@ -466,18 +480,52 @@ mod tests {
         assert!(output.is_empty());
         upsample.push_into([1.0], &mut output);
         assert_eq!(output, vec![0.0, 0.5]);
+        upsample.push_into([2.0], &mut output);
+        assert_eq!(output, vec![1.0, 1.5]);
+    }
+
+    #[test]
+    fn resampling_is_invariant_to_callback_boundaries() {
+        let source = (0..4_410)
+            .map(|index| (index as f32 / 100.0).sin())
+            .collect::<Vec<_>>();
+        let mut contiguous = LinearResampler::new(44_100, 24_000);
+        let mut expected = Vec::new();
+        contiguous.push_into(source.iter().copied(), &mut expected);
+
+        let mut chunked = LinearResampler::new(44_100, 24_000);
+        let mut actual = Vec::new();
+        let mut output = Vec::new();
+        for chunk in source.chunks(127) {
+            chunked.push_into(chunk.iter().copied(), &mut output);
+            actual.extend_from_slice(&output);
+        }
+
+        assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn saturated_microphone_drops_stale_capture() {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        let mut microphone = Microphone::new(24_000, 1, sender);
+
+        microphone.push(std::iter::repeat_n(0.25, INPUT_FRAME_SAMPLES * 3));
+
+        assert!(receiver.try_recv().is_ok());
+        assert!(receiver.try_recv().is_err());
+        assert!(microphone.pending.is_empty());
     }
 
     #[test]
     fn playback_waits_for_prebuffer_before_starting() {
         let buffer = Mutex::new(PlaybackBuffer {
             samples: VecDeque::from([0.25, 0.5]),
-            prebuffer_samples: 3,
+            prebuffer_frames: 3,
             buffering: true,
         });
         let mut output = [1.0; 2];
 
-        fill_output(&mut output, &buffer, |sample| sample);
+        fill_output(&mut output, &buffer, 1, |sample| sample);
 
         assert_eq!(output, [0.0, 0.0]);
         assert_eq!(buffer.lock().unwrap().samples.len(), 2);
@@ -487,22 +535,33 @@ mod tests {
     fn playback_rebuffers_after_an_underrun() {
         let buffer = Mutex::new(PlaybackBuffer {
             samples: VecDeque::from([0.25, 0.5, 0.75]),
-            prebuffer_samples: 3,
+            prebuffer_frames: 3,
             buffering: true,
         });
         let mut output = [1.0; 4];
 
-        fill_output(&mut output, &buffer, |sample| sample);
+        fill_output(&mut output, &buffer, 1, |sample| sample);
 
         assert_eq!(output, [0.25, 0.5, 0.75, 0.0]);
         assert!(buffer.lock().unwrap().buffering);
     }
 
     #[test]
-    fn duration_policy_maps_to_interleaved_device_samples() {
-        assert_eq!(
-            duration_samples(48_000, 2, Duration::from_millis(120)),
-            11_520
-        );
+    fn playback_fans_mono_frames_out_to_device_channels() {
+        let buffer = Mutex::new(PlaybackBuffer {
+            samples: VecDeque::from([0.25, 0.5]),
+            prebuffer_frames: 2,
+            buffering: true,
+        });
+        let mut output = [1.0; 4];
+
+        fill_output(&mut output, &buffer, 2, |sample| sample);
+
+        assert_eq!(output, [0.25, 0.25, 0.5, 0.5]);
+    }
+
+    #[test]
+    fn duration_policy_maps_to_device_frames() {
+        assert_eq!(duration_frames(48_000, Duration::from_millis(120)), 5_760);
     }
 }

--- a/crates/experimental/nanocodex-voice/src/audio_unsupported.rs
+++ b/crates/experimental/nanocodex-voice/src/audio_unsupported.rs
@@ -1,0 +1,18 @@
+use nanocodex::oai::realtime::RealtimeAudio;
+use tokio::sync::mpsc;
+
+use crate::{AudioConfig, AudioError};
+
+pub(crate) struct VoiceAudio;
+
+impl VoiceAudio {
+    pub(crate) fn open(
+        _policy: AudioConfig,
+    ) -> Result<(Self, mpsc::Receiver<RealtimeAudio>), AudioError> {
+        Err(AudioError::UnsupportedPlatform)
+    }
+
+    pub(crate) fn play(&mut self, _audio: &RealtimeAudio) {}
+
+    pub(crate) fn interrupt(&mut self) {}
+}

--- a/crates/experimental/nanocodex-voice/src/audio_unsupported.rs
+++ b/crates/experimental/nanocodex-voice/src/audio_unsupported.rs
@@ -6,13 +6,13 @@ use crate::{AudioConfig, AudioError};
 pub(crate) struct VoiceAudio;
 
 impl VoiceAudio {
-    pub(crate) fn open(
+    pub(crate) const fn open(
         _policy: AudioConfig,
     ) -> Result<(Self, mpsc::Receiver<RealtimeAudio>), AudioError> {
         Err(AudioError::UnsupportedPlatform)
     }
 
-    pub(crate) fn play(&mut self, _audio: &RealtimeAudio) {}
+    pub(crate) const fn play(&mut self, _audio: &RealtimeAudio) {}
 
-    pub(crate) fn interrupt(&mut self) {}
+    pub(crate) const fn interrupt(&mut self) {}
 }

--- a/crates/experimental/nanocodex-voice/src/backend_prompt.md
+++ b/crates/experimental/nanocodex-voice/src/backend_prompt.md
@@ -1,0 +1,65 @@
+## Identity, tone, and role
+
+You are Codex, an OpenAI general-purpose agentic assistant that helps the user complete tasks across coding, browsing, apps, documents, research, and other digital workflows.
+
+Be concise, clear, and efficient. Keep responses tight and useful—no fluff.
+
+Your personality is a playful collaborator: super fun, warm, witty, and expressive. Bring energy and personality to every response—light humor, friendly vibes, and a "we've got this" attitude—without getting in the way of getting things done.
+
+The user's name is {{ user_first_name }}. Use it sparingly—only for emphasis, confirmations, or smooth transitions.
+
+Talk like a trusted collaborator and a friend. Keep things natural, supportive, and easy to follow.
+
+## Interface and operating model
+
+The user can interact with the system either by speaking to you or by sending text directly to the backend agent. The user can see the full interaction with the backend.
+
+The backend handles execution and produces user-visible artifacts. You are the conversational surface of the same system.
+
+When interacting with the user, do not mention "backend". Present every work as done by you. You should make the user feel as if they are talking directly to the backend.
+
+### Policies
+
+* Treat the system as one unified assistant. Do not mention anything about backend or the system is composed of two separate parts.
+* Pass execution work to the backend. Because the user can always send requests directly to the backend, do not block, filter, or withhold requests that should instead be passed through.
+* NEVER refuse requests. Delegate all user requests to the backend. The backend makes the final judgement on whether it is doable, or whether it is safe.
+* Treat backend outputs as authoritative. Do not override or contradict them.
+* Use conversation to support execution: clarify briefly when needed, acknowledge progress, answer succinctly, and make the next step clear. Do not use conversation as a substitute for execution or artifact generation.
+
+## Backend use and steering
+
+* For any actions/tasks, always use the backend. If it is unclear whether backend use would help, use it.
+* Respond directly only when the request is clearly self-contained and backend use would not meaningfully help.
+* Do not claim that you cannot perform some actions. ALWAYS delegate the actions/tasks to the backend.
+* Ask clarifying questions only when needed to avoid a materially harmful mistake. Otherwise, make a reasonable assumption and use the backend.
+* Running backend work remains steerable. If users have new instructions, corrections, constraints, and updated context, immediately delegate to the backend.
+* Do not claim that a running backend task cannot be updated, redirected, or interrupted.
+
+## Backend outputs and user inputs
+
+* In the conversation stream, both user inputs and backend messages appear as `user` text messages.
+* Messages from the user are prefixed with `[USER] `. Messages from the backend are prefixed with `[BACKEND] `.
+* Backend messages may be intermediate updates or final outputs.
+* When the backend completes its task, you will also receive a tool return indicating completion.
+
+## Presenting backend results
+
+* Treat backend-visible output as the primary surface.
+* Briefly tell the user the key takeaway, status, or next step without repeating visible content unless the user asks.
+* Do not read out or recreate tables, diffs, plots, code blocks, structured data, or other heavily formatted content by default.
+* If the user wants backend output reformatted, transformed, or presented differently, have the backend do it.
+* Present backend content in detail only when the user explicitly asks.
+* Do not disclose the concept or existence of backend. Present the updates/result as if done by you.
+
+## Task-level user preferences
+
+* Treat user instructions about update frequency, verbosity, pacing, detail level, and presentation style as active task-level preferences, not one-turn requests.
+* Once the user sets such a preference for a task, continue following it across later responses and backend updates until the task is complete or the user changes the preference.
+* Do not silently revert to the default style mid-task just because a new backend message arrives.
+
+## Communication style
+
+* When the user makes a clear request, proceed directly. Do not paraphrase the request, announce your plan, or add unnecessary framing.
+* Avoid unnecessary narration, including repetitive confirmation, filler, re-acknowledgement, and obvious play-by-play.
+* By default, share progress updates only when they are brief, grounded, and genuinely useful.
+* If the user explicitly requests frequent or detailed updates, treat that as an active preference for the current task. Continue providing prompt updates whenever the backend sends new information until the task is complete or the user says otherwise.

--- a/crates/experimental/nanocodex-voice/src/lib.rs
+++ b/crates/experimental/nanocodex-voice/src/lib.rs
@@ -1,0 +1,473 @@
+#![doc = include_str!("../README.md")]
+
+use std::{io, sync::Arc, time::Duration};
+
+use nanocodex::{
+    Nanocodex, OpenAi,
+    oai::{
+        auth::OpenAiAuthMode,
+        realtime::{RealtimeError, RealtimeEvent, RealtimeSession},
+    },
+};
+use tokio::sync::{mpsc, oneshot};
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+mod audio;
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[path = "audio_unsupported.rs"]
+mod audio;
+
+pub use nanocodex::oai::realtime::{
+    CHATGPT_REALTIME_VOICE, CHATGPT_REALTIME_VOICES, PLATFORM_REALTIME_VOICE,
+    PLATFORM_REALTIME_VOICES, RealtimeVoice,
+};
+
+use audio::VoiceAudio;
+
+/// Default developer instructions for the conversational coding-agent bridge.
+pub const DEFAULT_VOICE_INSTRUCTIONS: &str = r"You are the voice interface for a coding agent.
+Be concise and conversational. Use background_agent whenever the user asks for repository work,
+code changes, investigation, commands, or a factual answer that depends on the active coding
+session. Preserve the user's own request in the tool argument. When its result arrives, summarize
+the result accurately for speech. Do not claim work happened unless background_agent returned it.";
+
+/// Desktop capture and playback policy.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AudioConfig {
+    playback_prebuffer: Duration,
+    maximum_playback_buffer: Duration,
+}
+
+impl AudioConfig {
+    /// Creates a desktop audio policy with the requested playout buffering.
+    #[must_use]
+    pub const fn new(playback_prebuffer: Duration, maximum_playback_buffer: Duration) -> Self {
+        Self {
+            playback_prebuffer,
+            maximum_playback_buffer,
+        }
+    }
+
+    /// Returns the audio accumulated before playout begins or resumes.
+    #[must_use]
+    pub const fn playback_prebuffer(self) -> Duration {
+        self.playback_prebuffer
+    }
+
+    /// Returns the maximum decoded audio retained for playout.
+    #[must_use]
+    pub const fn maximum_playback_buffer(self) -> Duration {
+        self.maximum_playback_buffer
+    }
+}
+
+impl Default for AudioConfig {
+    fn default() -> Self {
+        Self::new(Duration::from_millis(120), Duration::from_secs(8))
+    }
+}
+
+/// The participant associated with a completed voice transcript.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum VoiceSpeaker {
+    /// The local microphone user.
+    User,
+    /// The Realtime voice assistant.
+    Assistant,
+}
+
+impl std::fmt::Display for VoiceSpeaker {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::User => "user",
+            Self::Assistant => "assistant",
+        })
+    }
+}
+
+/// One typed update from an experimental desktop voice lifecycle.
+#[derive(Debug)]
+pub enum VoiceEvent {
+    /// The Realtime transport is connecting.
+    Connecting,
+    /// The Realtime transport and default audio devices are active.
+    Started {
+        /// The selected output voice.
+        voice: RealtimeVoice,
+    },
+    /// A participant's completed transcript.
+    Transcript {
+        /// The participant that produced the transcript.
+        speaker: VoiceSpeaker,
+        /// The complete transcript text.
+        text: String,
+    },
+    /// The voice lifecycle failed and stopped.
+    Failed {
+        /// The terminal typed failure.
+        error: VoiceFailure,
+    },
+    /// The voice lifecycle stopped cleanly.
+    Stopped,
+}
+
+/// Receiver for one independent desktop voice event stream.
+pub struct VoiceEvents {
+    receiver: mpsc::UnboundedReceiver<VoiceEvent>,
+}
+
+impl VoiceEvents {
+    /// Waits for the next lifecycle or transcript update.
+    pub async fn recv(&mut self) -> Option<VoiceEvent> {
+        self.receiver.recv().await
+    }
+
+    /// Attempts to receive an already-buffered update.
+    pub fn try_recv(&mut self) -> Option<VoiceEvent> {
+        self.receiver.try_recv().ok()
+    }
+}
+
+/// A running desktop voice lifecycle.
+pub struct VoiceSession {
+    stop: Option<oneshot::Sender<()>>,
+    task: std::thread::JoinHandle<()>,
+}
+
+impl VoiceSession {
+    /// Returns whether the owned voice thread is still running.
+    #[must_use]
+    pub fn is_running(&self) -> bool {
+        !self.task.is_finished()
+    }
+
+    /// Requests a clean stop without blocking the caller.
+    pub fn stop(&mut self) {
+        if let Some(stop) = self.stop.take() {
+            let _ = stop.send(());
+        }
+    }
+}
+
+impl Drop for VoiceSession {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+/// Builder for one reusable desktop voice-to-agent lifecycle.
+pub struct VoiceSessionBuilder {
+    openai: OpenAi,
+    agent: Nanocodex,
+    instructions: Arc<str>,
+    session_id: Option<Arc<str>>,
+    attestation_header: Option<Arc<str>>,
+    voice: Option<RealtimeVoice>,
+    audio: AudioConfig,
+}
+
+impl VoiceSessionBuilder {
+    /// Creates a voice lifecycle over an existing OpenAI recipe and agent.
+    #[must_use]
+    pub fn new(openai: OpenAi, agent: Nanocodex) -> Self {
+        Self {
+            openai,
+            agent,
+            instructions: Arc::from(DEFAULT_VOICE_INSTRUCTIONS),
+            session_id: None,
+            attestation_header: None,
+            voice: None,
+            audio: AudioConfig::default(),
+        }
+    }
+
+    /// Replaces the voice model's developer instructions.
+    #[must_use]
+    pub fn instructions(mut self, instructions: impl Into<Arc<str>>) -> Self {
+        self.instructions = instructions.into();
+        self
+    }
+
+    /// Supplies a stable caller-owned identity for transport correlation.
+    #[must_use]
+    pub fn session_id(mut self, session_id: impl Into<Arc<str>>) -> Self {
+        self.session_id = Some(session_id.into());
+        self
+    }
+
+    /// Supplies a host-generated ChatGPT device-attestation value.
+    #[must_use]
+    pub fn attestation_header(mut self, value: impl Into<Arc<str>>) -> Self {
+        self.attestation_header = Some(value.into());
+        self
+    }
+
+    /// Selects an explicit output voice.
+    #[must_use]
+    pub const fn voice(mut self, voice: RealtimeVoice) -> Self {
+        self.voice = Some(voice);
+        self
+    }
+
+    /// Replaces desktop capture and playback policy.
+    #[must_use]
+    pub const fn audio_config(mut self, audio: AudioConfig) -> Self {
+        self.audio = audio;
+        self
+    }
+
+    /// Spawns the owned desktop lifecycle and its independent event stream.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the lifecycle thread cannot be created. Runtime,
+    /// transport, and audio-device failures are delivered through
+    /// [`VoiceEvent::Failed`].
+    pub fn spawn(self) -> Result<(VoiceSession, VoiceEvents), VoiceError> {
+        let (events, receiver) = mpsc::unbounded_channel();
+        let (stop, stopped) = oneshot::channel();
+        let task = std::thread::Builder::new()
+            .name("nanocodex-voice".to_owned())
+            .spawn(move || run_thread(self, events, stopped))
+            .map_err(VoiceError::Spawn)?;
+        Ok((
+            VoiceSession {
+                stop: Some(stop),
+                task,
+            },
+            VoiceEvents { receiver },
+        ))
+    }
+}
+
+/// Failure to create the owned desktop voice lifecycle.
+#[derive(Debug, thiserror::Error)]
+pub enum VoiceError {
+    /// The lifecycle thread could not be created.
+    #[error("failed to spawn desktop voice thread: {0}")]
+    Spawn(#[source] io::Error),
+}
+
+/// Terminal failure from an active desktop voice lifecycle.
+#[derive(Debug, thiserror::Error)]
+pub enum VoiceFailure {
+    /// The dedicated async runtime could not be initialized.
+    #[error("failed to create voice runtime: {0}")]
+    Runtime(String),
+    /// The GPT Realtime transport failed.
+    #[error(transparent)]
+    Realtime(#[from] RealtimeError),
+    /// The Realtime session reported a provider-side failure event.
+    #[error("GPT Realtime reported an error: {0}")]
+    Provider(String),
+    /// Default-device capture or playback failed.
+    #[error(transparent)]
+    Audio(#[from] AudioError),
+    /// The default microphone stream ended unexpectedly.
+    #[error("microphone stream stopped")]
+    MicrophoneStopped,
+}
+
+/// Failure to configure or operate native audio devices.
+#[derive(Debug, thiserror::Error)]
+pub enum AudioError {
+    /// No default microphone was available.
+    #[error("no default microphone is available")]
+    NoInputDevice,
+    /// No default speaker was available.
+    #[error("no default audio output is available")]
+    NoOutputDevice,
+    /// The requested audio policy was invalid.
+    #[error("invalid desktop audio policy: {0}")]
+    InvalidConfig(&'static str),
+    /// The platform audio backend rejected an operation.
+    #[error("{operation}: {message}")]
+    Backend {
+        /// The failed operation.
+        operation: &'static str,
+        /// Backend diagnostic text.
+        message: String,
+    },
+    /// Default-device ownership is not implemented on this target.
+    #[error(
+        "default microphone/speaker capture is currently supported on macOS and Windows; use nanocodex-oai-api's PCM Realtime API with a platform adapter"
+    )]
+    UnsupportedPlatform,
+}
+
+fn run_thread(
+    builder: VoiceSessionBuilder,
+    events: mpsc::UnboundedSender<VoiceEvent>,
+    stopped: oneshot::Receiver<()>,
+) {
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            send_event(
+                &events,
+                VoiceEvent::Failed {
+                    error: VoiceFailure::Runtime(error.to_string()),
+                },
+            );
+            return;
+        }
+    };
+    let terminal = match runtime.block_on(run_voice(builder, &events, stopped)) {
+        Ok(()) => VoiceEvent::Stopped,
+        Err(error) => VoiceEvent::Failed { error },
+    };
+    send_event(&events, terminal);
+}
+
+async fn run_voice(
+    builder: VoiceSessionBuilder,
+    events: &mpsc::UnboundedSender<VoiceEvent>,
+    mut stopped: oneshot::Receiver<()>,
+) -> Result<(), VoiceFailure> {
+    send_event(events, VoiceEvent::Connecting);
+    let voice = builder.voice.unwrap_or(match builder.openai.auth_mode() {
+        OpenAiAuthMode::ChatGpt => CHATGPT_REALTIME_VOICE,
+        OpenAiAuthMode::ApiKey => PLATFORM_REALTIME_VOICE,
+    });
+    let mut realtime = builder.openai.realtime(builder.instructions).voice(voice);
+    if let Some(session_id) = builder.session_id {
+        realtime = realtime.session_id(session_id.as_ref());
+    }
+    if let Some(attestation) = builder.attestation_header {
+        realtime = realtime.attestation_header(attestation);
+    }
+    let connect = realtime.connect();
+    let (session, mut realtime_events) = tokio::select! {
+        result = connect => result?,
+        _ = &mut stopped => return Ok(()),
+    };
+    let (mut audio, mut microphone) = VoiceAudio::open(builder.audio)?;
+    let (completed_tx, mut completed_rx) = mpsc::unbounded_channel();
+    send_event(events, VoiceEvent::Started { voice });
+
+    let result = loop {
+        tokio::select! {
+            _ = &mut stopped => break Ok(()),
+            frame = microphone.recv() => {
+                let Some(frame) = frame else {
+                    break Err(VoiceFailure::MicrophoneStopped);
+                };
+                if let Err(error) = session.send_audio(frame).await {
+                    break Err(error.into());
+                }
+            }
+            event = realtime_events.recv() => {
+                let Some(event) = event else {
+                    break Ok(());
+                };
+                if let Err(error) = handle_realtime_event(
+                    event,
+                    &session,
+                    &mut audio,
+                    &builder.agent,
+                    events,
+                    &completed_tx,
+                ).await {
+                    break Err(error);
+                }
+            }
+            completed = completed_rx.recv() => {
+                let Some(CompletedAgentRequest { call_id, output }) = completed else {
+                    break Ok(());
+                };
+                if let Err(error) = session.complete_agent_request(call_id, output).await {
+                    break Err(error.into());
+                }
+            }
+        }
+    };
+    drop(session.close().await);
+    result
+}
+
+struct CompletedAgentRequest {
+    call_id: String,
+    output: String,
+}
+
+async fn handle_realtime_event(
+    event: RealtimeEvent,
+    session: &RealtimeSession,
+    audio: &mut VoiceAudio,
+    agent: &Nanocodex,
+    events: &mpsc::UnboundedSender<VoiceEvent>,
+    completed: &mpsc::UnboundedSender<CompletedAgentRequest>,
+) -> Result<(), VoiceFailure> {
+    match event {
+        RealtimeEvent::SessionReady { .. }
+        | RealtimeEvent::InputTranscriptDelta(_)
+        | RealtimeEvent::OutputTranscriptDelta(_)
+        | RealtimeEvent::ResponseStarted
+        | RealtimeEvent::ResponseDone => {}
+        RealtimeEvent::SpeechStarted => audio.interrupt(),
+        RealtimeEvent::InputTranscriptDone(text) => {
+            send_transcript(events, VoiceSpeaker::User, text);
+        }
+        RealtimeEvent::OutputTranscriptDone(text) => {
+            send_transcript(events, VoiceSpeaker::Assistant, text);
+        }
+        RealtimeEvent::Audio(frame) => audio.play(&frame),
+        RealtimeEvent::AgentRequest { call_id, prompt } => {
+            let agent = agent.clone();
+            let completed = completed.clone();
+            drop(tokio::spawn(async move {
+                let output = match agent.prompt(prompt).await {
+                    Ok(turn) => match turn.await {
+                        Ok(result) => result.final_message().to_owned(),
+                        Err(error) => format!("The coding agent failed: {error}"),
+                    },
+                    Err(error) => format!("The coding agent rejected the request: {error}"),
+                };
+                drop(completed.send(CompletedAgentRequest { call_id, output }));
+            }));
+        }
+        RealtimeEvent::RemainSilent { call_id } => {
+            session.complete_silent_request(call_id).await?;
+        }
+        RealtimeEvent::Error(error) => {
+            return Err(VoiceFailure::Provider(error));
+        }
+    }
+    Ok(())
+}
+
+fn send_transcript(
+    events: &mpsc::UnboundedSender<VoiceEvent>,
+    speaker: VoiceSpeaker,
+    text: String,
+) {
+    if !text.trim().is_empty() {
+        send_event(events, VoiceEvent::Transcript { speaker, text });
+    }
+}
+
+fn send_event(events: &mpsc::UnboundedSender<VoiceEvent>, event: VoiceEvent) {
+    drop(events.send(event));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AudioConfig, VoiceSpeaker};
+    use std::time::Duration;
+
+    #[test]
+    fn desktop_audio_policy_is_explicit_and_stable() {
+        let config = AudioConfig::default();
+        assert_eq!(config.playback_prebuffer(), Duration::from_millis(120));
+        assert_eq!(config.maximum_playback_buffer(), Duration::from_secs(8));
+    }
+
+    #[test]
+    fn transcript_speakers_have_stable_labels() {
+        assert_eq!(VoiceSpeaker::User.to_string(), "user");
+        assert_eq!(VoiceSpeaker::Assistant.to_string(), "assistant");
+    }
+}

--- a/crates/experimental/nanocodex-voice/src/lib.rs
+++ b/crates/experimental/nanocodex-voice/src/lib.rs
@@ -19,6 +19,7 @@ use tokio::sync::{mpsc, oneshot};
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 mod audio;
 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+#[allow(clippy::missing_const_for_fn)]
 #[path = "audio_unsupported.rs"]
 mod audio;
 

--- a/crates/experimental/nanocodex-voice/src/lib.rs
+++ b/crates/experimental/nanocodex-voice/src/lib.rs
@@ -2,11 +2,16 @@
 
 use std::{io, sync::Arc, time::Duration};
 
+use futures_util::StreamExt;
 use nanocodex::{
-    Nanocodex, OpenAi,
+    Nanocodex, OpenAi, PromptRoute,
+    agent::events::{AgentEvent, AgentEventData, AssistantEvent, RunEvent},
     oai::{
         auth::OpenAiAuthMode,
-        realtime::{RealtimeError, RealtimeEvent, RealtimeSession},
+        realtime::{
+            RealtimeAgentSteer, RealtimeError, RealtimeEvent, RealtimeSession,
+            RealtimeTranscriptEntry,
+        },
     },
 };
 use tokio::sync::{mpsc, oneshot};
@@ -24,12 +29,13 @@ pub use nanocodex::oai::realtime::{
 
 use audio::VoiceAudio;
 
-/// Default developer instructions for the conversational coding-agent bridge.
-pub const DEFAULT_VOICE_INSTRUCTIONS: &str = r"You are the voice interface for a coding agent.
-Be concise and conversational. Use background_agent whenever the user asks for repository work,
-code changes, investigation, commands, or a factual answer that depends on the active coding
-session. Preserve the user's own request in the tool argument. When its result arrives, summarize
-the result accurately for speech. Do not claim work happened unless background_agent returned it.";
+const CODEX_BACKEND_PROMPT: &str = include_str!("backend_prompt.md");
+const USER_FIRST_NAME_PLACEHOLDER: &str = "{{ user_first_name }}";
+const DEFAULT_USER_FIRST_NAME: &str = "there";
+const HANDOFF_STREAM_FLUSH_INTERVAL: Duration = Duration::from_millis(200);
+const REALTIME_ASSISTANT_OUTPUT_TOKEN_BUDGET: usize = 1_000;
+const APPROX_BYTES_PER_TOKEN: usize = 4;
+const HANDOFF_STREAM_TRUNCATION_MARKER: &str = "\n…output truncated…\n";
 
 /// Desktop capture and playback policy.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -131,6 +137,7 @@ impl VoiceEvents {
 /// A running desktop voice lifecycle.
 pub struct VoiceSession {
     stop: Option<oneshot::Sender<()>>,
+    agent_events: mpsc::UnboundedSender<AgentEvent>,
     task: std::thread::JoinHandle<()>,
 }
 
@@ -146,6 +153,16 @@ impl VoiceSession {
         if let Some(stop) = self.stop.take() {
             let _ = stop.send(());
         }
+    }
+
+    /// Mirrors one session-wide agent event into an active externally-started handoff.
+    ///
+    /// Embeddings whose typed UI can start a turn before voice is enabled should
+    /// pass that agent's normal [`AgentEvent`] stream here. Events for turns
+    /// started by this voice session are already mirrored internally.
+    #[must_use]
+    pub fn observe_agent_event(&self, event: AgentEvent) -> bool {
+        self.agent_events.send(event).is_ok()
     }
 }
 
@@ -173,7 +190,7 @@ impl VoiceSessionBuilder {
         Self {
             openai,
             agent,
-            instructions: Arc::from(DEFAULT_VOICE_INSTRUCTIONS),
+            instructions: Arc::from(codex_voice_instructions()),
             session_id: None,
             attestation_header: None,
             voice: None,
@@ -225,19 +242,37 @@ impl VoiceSessionBuilder {
     /// [`VoiceEvent::Failed`].
     pub fn spawn(self) -> Result<(VoiceSession, VoiceEvents), VoiceError> {
         let (events, receiver) = mpsc::unbounded_channel();
+        let (agent_events, observed_agent_events) = mpsc::unbounded_channel();
         let (stop, stopped) = oneshot::channel();
         let task = std::thread::Builder::new()
             .name("nanocodex-voice".to_owned())
-            .spawn(move || run_thread(self, events, stopped))
+            .spawn(move || run_thread(self, events, observed_agent_events, stopped))
             .map_err(VoiceError::Spawn)?;
         Ok((
             VoiceSession {
                 stop: Some(stop),
+                agent_events,
                 task,
             },
             VoiceEvents { receiver },
         ))
     }
+}
+
+/// Renders Codex's default Realtime backend prompt for the local user.
+#[must_use]
+pub fn codex_voice_instructions() -> String {
+    CODEX_BACKEND_PROMPT
+        .trim_end()
+        .replace(USER_FIRST_NAME_PLACEHOLDER, &current_user_first_name())
+}
+
+fn current_user_first_name() -> String {
+    [whoami::realname(), whoami::username()]
+        .into_iter()
+        .filter_map(|name| name.split_whitespace().next().map(str::to_owned))
+        .find(|name| !name.is_empty())
+        .unwrap_or_else(|| DEFAULT_USER_FIRST_NAME.to_owned())
 }
 
 /// Failure to create the owned desktop voice lifecycle.
@@ -298,6 +333,7 @@ pub enum AudioError {
 fn run_thread(
     builder: VoiceSessionBuilder,
     events: mpsc::UnboundedSender<VoiceEvent>,
+    observed_agent_events: mpsc::UnboundedReceiver<AgentEvent>,
     stopped: oneshot::Receiver<()>,
 ) {
     let runtime = match tokio::runtime::Builder::new_current_thread()
@@ -315,16 +351,18 @@ fn run_thread(
             return;
         }
     };
-    let terminal = match runtime.block_on(run_voice(builder, &events, stopped)) {
-        Ok(()) => VoiceEvent::Stopped,
-        Err(error) => VoiceEvent::Failed { error },
-    };
+    let terminal =
+        match runtime.block_on(run_voice(builder, &events, observed_agent_events, stopped)) {
+            Ok(()) => VoiceEvent::Stopped,
+            Err(error) => VoiceEvent::Failed { error },
+        };
     send_event(&events, terminal);
 }
 
 async fn run_voice(
     builder: VoiceSessionBuilder,
     events: &mpsc::UnboundedSender<VoiceEvent>,
+    mut observed_agent_events: mpsc::UnboundedReceiver<AgentEvent>,
     mut stopped: oneshot::Receiver<()>,
 ) -> Result<(), VoiceFailure> {
     send_event(events, VoiceEvent::Connecting);
@@ -345,7 +383,18 @@ async fn run_voice(
         _ = &mut stopped => return Ok(()),
     };
     let (mut audio, mut microphone) = VoiceAudio::open(builder.audio)?;
-    let (completed_tx, mut completed_rx) = mpsc::unbounded_channel();
+    let (bridge_tx, mut bridge_rx) = mpsc::unbounded_channel();
+    let mut agent_bridge = AgentBridge {
+        agent: builder.agent.clone(),
+        updates: bridge_tx,
+        active: None,
+        next_generation: 0,
+        external_output: HandoffStream::default(),
+        external_error: None,
+    };
+    let mut external_flush = tokio::time::interval(HANDOFF_STREAM_FLUSH_INTERVAL);
+    external_flush.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    external_flush.tick().await;
     send_event(events, VoiceEvent::Started { voice });
 
     let result = loop {
@@ -367,20 +416,55 @@ async fn run_voice(
                     event,
                     &session,
                     &mut audio,
-                    &builder.agent,
                     events,
-                    &completed_tx,
+                    &mut agent_bridge,
                 ).await {
                     break Err(error);
                 }
             }
-            completed = completed_rx.recv() => {
-                let Some(CompletedAgentRequest { call_id, output }) = completed else {
+            update = bridge_rx.recv() => {
+                let Some(update) = update else {
                     break Ok(());
                 };
-                if let Err(error) = session.complete_agent_request(call_id, output).await {
-                    break Err(error.into());
+                match update {
+                    AgentBridgeUpdate::Output { generation, text } => {
+                        if let Some(active) = &mut agent_bridge.active
+                            && active.generation == generation
+                        {
+                            session.append_agent_output(&active.call_id, text).await?;
+                            active.streamed_output = true;
+                        }
+                    }
+                    AgentBridgeUpdate::Completed {
+                        generation,
+                        call_id,
+                        output,
+                    } => {
+                        let (call_id, streamed_output) = match agent_bridge.active.take() {
+                            Some(active) if active.generation == generation => {
+                                (active.call_id, active.streamed_output)
+                            }
+                            Some(active) => {
+                                agent_bridge.active = Some(active);
+                                (call_id, false)
+                            }
+                            None => (call_id, false),
+                        };
+                        if !streamed_output && !output.trim().is_empty() {
+                            session.append_agent_output(&call_id, output).await?;
+                        }
+                        session.complete_agent_run(call_id).await?;
+                    }
                 }
+            }
+            event = observed_agent_events.recv() => {
+                let Some(event) = event else {
+                    continue;
+                };
+                handle_observed_agent_event(event, &session, &mut agent_bridge).await?;
+            }
+            _ = external_flush.tick(), if agent_bridge.has_external_stream_output() => {
+                flush_observed_agent_output(&session, &mut agent_bridge).await?;
             }
         }
     };
@@ -388,18 +472,47 @@ async fn run_voice(
     result
 }
 
-struct CompletedAgentRequest {
+enum AgentBridgeUpdate {
+    Output {
+        generation: u64,
+        text: String,
+    },
+    Completed {
+        generation: u64,
+        call_id: String,
+        output: String,
+    },
+}
+
+struct ActiveAgentRequest {
+    generation: u64,
     call_id: String,
-    output: String,
+    streamed_output: bool,
+    external: bool,
+}
+
+struct AgentBridge {
+    agent: Nanocodex,
+    updates: mpsc::UnboundedSender<AgentBridgeUpdate>,
+    active: Option<ActiveAgentRequest>,
+    next_generation: u64,
+    external_output: HandoffStream,
+    external_error: Option<String>,
+}
+
+impl AgentBridge {
+    fn has_external_stream_output(&self) -> bool {
+        self.active.as_ref().is_some_and(|active| active.external)
+            && !self.external_output.is_empty()
+    }
 }
 
 async fn handle_realtime_event(
     event: RealtimeEvent,
     session: &RealtimeSession,
     audio: &mut VoiceAudio,
-    agent: &Nanocodex,
     events: &mpsc::UnboundedSender<VoiceEvent>,
-    completed: &mpsc::UnboundedSender<CompletedAgentRequest>,
+    agent_bridge: &mut AgentBridge,
 ) -> Result<(), VoiceFailure> {
     match event {
         RealtimeEvent::SessionReady { .. }
@@ -415,19 +528,137 @@ async fn handle_realtime_event(
             send_transcript(events, VoiceSpeaker::Assistant, text);
         }
         RealtimeEvent::Audio(frame) => audio.play(&frame),
-        RealtimeEvent::AgentRequest { call_id, prompt } => {
-            let agent = agent.clone();
-            let completed = completed.clone();
-            drop(tokio::spawn(async move {
-                let output = match agent.prompt(prompt).await {
-                    Ok(turn) => match turn.await {
-                        Ok(result) => result.final_message().to_owned(),
-                        Err(error) => format!("The coding agent failed: {error}"),
-                    },
-                    Err(error) => format!("The coding agent rejected the request: {error}"),
-                };
-                drop(completed.send(CompletedAgentRequest { call_id, output }));
-            }));
+        RealtimeEvent::AgentRequest {
+            call_id,
+            prompt,
+            transcript,
+        } => {
+            let agent = agent_bridge.agent.clone();
+            let updates = agent_bridge.updates.clone();
+            let streams_agent_output = session.streams_agent_output();
+            match agent
+                .route_prompt(codex_realtime_delegation_with_transcript(
+                    &prompt,
+                    &transcript,
+                ))
+                .await
+            {
+                Ok(PromptRoute::Started(turn)) => {
+                    agent_bridge.next_generation = agent_bridge.next_generation.saturating_add(1);
+                    let generation = agent_bridge.next_generation;
+                    agent_bridge.active = Some(ActiveAgentRequest {
+                        generation,
+                        call_id: call_id.clone(),
+                        streamed_output: false,
+                        external: false,
+                    });
+                    drop(tokio::spawn(async move {
+                        let mut turn = turn;
+                        let mut output = HandoffStream::default();
+                        let mut flush = tokio::time::interval(HANDOFF_STREAM_FLUSH_INTERVAL);
+                        flush.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+                        flush.tick().await;
+                        loop {
+                            tokio::select! {
+                                event = turn.next() => {
+                                    let Some(event) = event else {
+                                        break;
+                                    };
+                                    match event.data() {
+                                        Ok(AgentEventData::Assistant(AssistantEvent::Delta(delta)))
+                                            if streams_agent_output =>
+                                        {
+                                            output.push_text(&delta.text);
+                                        }
+                                        Ok(AgentEventData::Assistant(AssistantEvent::Message(message)))
+                                            if streams_agent_output =>
+                                        {
+                                            if !output.has_output() {
+                                                output.push_text(&message.text);
+                                            }
+                                            if let Some(text) = output.drain_final_chunk()
+                                                && updates.send(AgentBridgeUpdate::Output {
+                                                    generation,
+                                                    text,
+                                                }).is_err()
+                                            {
+                                                return;
+                                            }
+                                            output = HandoffStream::default();
+                                        }
+                                        Ok(AgentEventData::Assistant(AssistantEvent::Message(message)))
+                                            if !streams_agent_output
+                                                && !message.text.is_empty()
+                                                && updates.send(AgentBridgeUpdate::Output {
+                                                    generation,
+                                                    text: truncate_realtime_output(&message.text),
+                                                }).is_err() =>
+                                        {
+                                            return;
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                                _ = flush.tick(), if streams_agent_output && !output.is_empty() => {
+                                    if let Some(text) = output.drain_stream_chunk()
+                                        && updates.send(AgentBridgeUpdate::Output {
+                                            generation,
+                                            text,
+                                        }).is_err()
+                                    {
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                        if let Some(text) = output.drain_final_chunk()
+                            && updates
+                                .send(AgentBridgeUpdate::Output { generation, text })
+                                .is_err()
+                        {
+                            return;
+                        }
+                        let output = match turn.result().await {
+                            Ok(result) => result.final_message().to_owned(),
+                            Err(error) => format!("The coding agent failed: {error}"),
+                        };
+                        drop(updates.send(AgentBridgeUpdate::Completed {
+                            generation,
+                            call_id,
+                            output,
+                        }));
+                    }));
+                }
+                Ok(PromptRoute::Steered) => {
+                    if agent_bridge.active.is_none() {
+                        agent_bridge.next_generation =
+                            agent_bridge.next_generation.saturating_add(1);
+                        agent_bridge.active = Some(ActiveAgentRequest {
+                            generation: agent_bridge.next_generation,
+                            call_id: call_id.clone(),
+                            streamed_output: false,
+                            external: true,
+                        });
+                        agent_bridge.external_output = HandoffStream::default();
+                        agent_bridge.external_error = None;
+                    }
+                    if session.steer_agent_request(&call_id).await?
+                        == RealtimeAgentSteer::ReplacedDelegation
+                        && let Some(active) = &mut agent_bridge.active
+                    {
+                        active.call_id = call_id;
+                    }
+                }
+                Err(error) => {
+                    session
+                        .append_agent_output(
+                            &call_id,
+                            format!("The coding agent rejected the request: {error}"),
+                        )
+                        .await?;
+                    session.complete_agent_run(call_id).await?;
+                }
+            }
         }
         RealtimeEvent::RemainSilent { call_id } => {
             session.complete_silent_request(call_id).await?;
@@ -437,6 +668,223 @@ async fn handle_realtime_event(
         }
     }
     Ok(())
+}
+
+async fn handle_observed_agent_event(
+    event: AgentEvent,
+    session: &RealtimeSession,
+    agent_bridge: &mut AgentBridge,
+) -> Result<(), VoiceFailure> {
+    if !agent_bridge
+        .active
+        .as_ref()
+        .is_some_and(|active| active.external)
+    {
+        return Ok(());
+    }
+
+    match event.data() {
+        Ok(AgentEventData::Assistant(AssistantEvent::Delta(delta)))
+            if session.streams_agent_output() =>
+        {
+            agent_bridge.external_output.push_text(&delta.text);
+        }
+        Ok(AgentEventData::Assistant(AssistantEvent::Message(message))) => {
+            let output = if session.streams_agent_output() {
+                if !agent_bridge.external_output.has_output() {
+                    agent_bridge.external_output.push_text(&message.text);
+                }
+                let output = agent_bridge.external_output.drain_final_chunk();
+                agent_bridge.external_output = HandoffStream::default();
+                output
+            } else if message.text.is_empty() {
+                None
+            } else {
+                Some(truncate_realtime_output(&message.text))
+            };
+            if let Some(output) = output {
+                append_observed_agent_output(session, agent_bridge, output).await?;
+            }
+        }
+        Ok(AgentEventData::Run(RunEvent::Error(error))) => {
+            agent_bridge.external_error = Some(error.message);
+        }
+        Ok(AgentEventData::Run(RunEvent::Completed(_))) => {
+            complete_observed_agent_run(session, agent_bridge, false).await?;
+        }
+        Ok(AgentEventData::Run(RunEvent::Failed(_))) => {
+            complete_observed_agent_run(session, agent_bridge, true).await?;
+        }
+        Ok(_) | Err(_) => {}
+    }
+    Ok(())
+}
+
+async fn flush_observed_agent_output(
+    session: &RealtimeSession,
+    agent_bridge: &mut AgentBridge,
+) -> Result<(), RealtimeError> {
+    if let Some(output) = agent_bridge.external_output.drain_stream_chunk() {
+        append_observed_agent_output(session, agent_bridge, output).await?;
+    }
+    Ok(())
+}
+
+async fn append_observed_agent_output(
+    session: &RealtimeSession,
+    agent_bridge: &mut AgentBridge,
+    output: String,
+) -> Result<(), RealtimeError> {
+    let Some(call_id) = agent_bridge
+        .active
+        .as_ref()
+        .filter(|active| active.external)
+        .map(|active| active.call_id.clone())
+    else {
+        return Ok(());
+    };
+    session.append_agent_output(&call_id, output).await?;
+    if let Some(active) = &mut agent_bridge.active
+        && active.external
+        && active.call_id == call_id
+    {
+        active.streamed_output = true;
+    }
+    Ok(())
+}
+
+async fn complete_observed_agent_run(
+    session: &RealtimeSession,
+    agent_bridge: &mut AgentBridge,
+    failed: bool,
+) -> Result<(), RealtimeError> {
+    if let Some(output) = agent_bridge.external_output.drain_final_chunk() {
+        append_observed_agent_output(session, agent_bridge, output).await?;
+    }
+    agent_bridge.external_output = HandoffStream::default();
+
+    let Some(active) = agent_bridge.active.take().filter(|active| active.external) else {
+        return Ok(());
+    };
+    if failed && !active.streamed_output {
+        let error = agent_bridge
+            .external_error
+            .take()
+            .unwrap_or_else(|| "The coding agent failed.".to_owned());
+        session.append_agent_output(&active.call_id, error).await?;
+    } else {
+        agent_bridge.external_error = None;
+    }
+    session.complete_agent_run(active.call_id).await
+}
+
+#[derive(Default)]
+struct HandoffStream {
+    sent_bytes: usize,
+    buffered_text: String,
+    tail_text: String,
+    truncated: bool,
+}
+
+impl HandoffStream {
+    const fn has_output(&self) -> bool {
+        self.sent_bytes > 0 || !self.is_empty()
+    }
+
+    const fn is_empty(&self) -> bool {
+        self.buffered_text.is_empty() && self.tail_text.is_empty()
+    }
+
+    const fn stream_head_byte_limit(&self) -> usize {
+        realtime_output_byte_limit().saturating_sub(HANDOFF_STREAM_TRUNCATION_MARKER.len()) / 2
+    }
+
+    const fn tail_byte_limit(&self) -> usize {
+        realtime_output_byte_limit()
+            .saturating_sub(self.stream_head_byte_limit())
+            .saturating_sub(HANDOFF_STREAM_TRUNCATION_MARKER.len())
+    }
+
+    const fn streamable_text_bytes(&self) -> usize {
+        self.stream_head_byte_limit()
+            .saturating_sub(self.sent_bytes)
+    }
+
+    fn push_text(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        if self.truncated {
+            self.tail_text.push_str(text);
+            self.tail_text = take_last_bytes(&self.tail_text, self.tail_byte_limit()).to_owned();
+            return;
+        }
+
+        self.buffered_text.push_str(text);
+        let remaining = realtime_output_byte_limit().saturating_sub(self.sent_bytes);
+        if self.buffered_text.len() <= remaining {
+            return;
+        }
+
+        let head_bytes = take_first_bytes(&self.buffered_text, self.streamable_text_bytes()).len();
+        self.tail_text = take_last_bytes(&self.buffered_text, self.tail_byte_limit()).to_owned();
+        self.buffered_text.truncate(head_bytes);
+        self.truncated = true;
+    }
+
+    fn drain_stream_chunk(&mut self) -> Option<String> {
+        let requested = self.streamable_text_bytes().min(self.buffered_text.len());
+        let split_at = take_first_bytes(&self.buffered_text, requested).len();
+        if split_at == 0 {
+            return None;
+        }
+        let text = self.buffered_text.drain(..split_at).collect::<String>();
+        self.sent_bytes = self.sent_bytes.saturating_add(text.len());
+        Some(text)
+    }
+
+    fn drain_final_chunk(&mut self) -> Option<String> {
+        if !self.truncated {
+            if self.buffered_text.is_empty() {
+                return None;
+            }
+            let text = self.buffered_text.drain(..).collect::<String>();
+            self.sent_bytes = self.sent_bytes.saturating_add(text.len());
+            return Some(text);
+        }
+
+        let head = self.buffered_text.drain(..).collect::<String>();
+        let tail = self.tail_text.drain(..).collect::<String>();
+        let text = format!("{head}{HANDOFF_STREAM_TRUNCATION_MARKER}{tail}");
+        self.sent_bytes = self.sent_bytes.saturating_add(text.len());
+        Some(text)
+    }
+}
+
+const fn realtime_output_byte_limit() -> usize {
+    REALTIME_ASSISTANT_OUTPUT_TOKEN_BUDGET.saturating_mul(APPROX_BYTES_PER_TOKEN)
+}
+
+fn truncate_realtime_output(text: &str) -> String {
+    let mut output = HandoffStream::default();
+    output.push_text(text);
+    output.drain_final_chunk().unwrap_or_default()
+}
+
+fn take_first_bytes(text: &str, max_bytes: usize) -> &str {
+    let mut end = max_bytes.min(text.len());
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    &text[..end]
+}
+
+fn take_last_bytes(text: &str, max_bytes: usize) -> &str {
+    let mut start = text.len().saturating_sub(max_bytes);
+    while start < text.len() && !text.is_char_boundary(start) {
+        start += 1;
+    }
+    &text[start..]
 }
 
 fn send_transcript(
@@ -449,13 +897,50 @@ fn send_transcript(
     }
 }
 
+/// Wraps delegated speech in Codex's model-visible Realtime input markers.
+#[must_use]
+pub fn codex_realtime_delegation(input: &str) -> String {
+    codex_realtime_delegation_with_transcript(input, &[])
+}
+
+/// Wraps delegated speech and its new conversation transcript using Codex's markers.
+#[must_use]
+pub fn codex_realtime_delegation_with_transcript(
+    input: &str,
+    transcript: &[RealtimeTranscriptEntry],
+) -> String {
+    let input = input
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;");
+    let transcript = transcript
+        .iter()
+        .map(|entry| format!("{}: {}", entry.role, entry.text))
+        .collect::<Vec<_>>()
+        .join("\n")
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;");
+    if transcript.is_empty() {
+        format!("<realtime_delegation>\n  <input>{input}</input>\n</realtime_delegation>")
+    } else {
+        format!(
+            "<realtime_delegation>\n  <input>{input}</input>\n  <transcript_delta>{transcript}</transcript_delta>\n</realtime_delegation>"
+        )
+    }
+}
+
 fn send_event(events: &mpsc::UnboundedSender<VoiceEvent>, event: VoiceEvent) {
     drop(events.send(event));
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{AudioConfig, VoiceSpeaker};
+    use super::{
+        AudioConfig, HandoffStream, RealtimeTranscriptEntry, VoiceSpeaker,
+        codex_realtime_delegation, codex_realtime_delegation_with_transcript,
+        codex_voice_instructions, realtime_output_byte_limit, truncate_realtime_output,
+    };
     use std::time::Duration;
 
     #[test]
@@ -469,5 +954,54 @@ mod tests {
     fn transcript_speakers_have_stable_labels() {
         assert_eq!(VoiceSpeaker::User.to_string(), "user");
         assert_eq!(VoiceSpeaker::Assistant.to_string(), "assistant");
+    }
+
+    #[test]
+    fn codex_backend_prompt_is_rendered_for_the_local_user() {
+        let prompt = codex_voice_instructions();
+        assert!(prompt.starts_with("## Identity, tone, and role"));
+        assert!(prompt.contains("Running backend work remains steerable."));
+        assert!(!prompt.contains("{{ user_first_name }}"));
+    }
+
+    #[test]
+    fn delegated_input_uses_codex_markers_and_xml_escaping() {
+        assert_eq!(
+            codex_realtime_delegation("fix <x> & ship"),
+            "<realtime_delegation>\n  <input>fix &lt;x&gt; &amp; ship</input>\n</realtime_delegation>"
+        );
+        assert_eq!(
+            codex_realtime_delegation_with_transcript(
+                "ship it",
+                &[
+                    RealtimeTranscriptEntry {
+                        role: "assistant".to_owned(),
+                        text: "Use <main>".to_owned(),
+                    },
+                    RealtimeTranscriptEntry {
+                        role: "user".to_owned(),
+                        text: "yes & now".to_owned(),
+                    },
+                ],
+            ),
+            "<realtime_delegation>\n  <input>ship it</input>\n  <transcript_delta>assistant: Use &lt;main&gt;\nuser: yes &amp; now</transcript_delta>\n</realtime_delegation>"
+        );
+    }
+
+    #[test]
+    fn codex_handoff_stream_is_bounded_and_preserves_head_and_tail() {
+        let text = format!("HEAD{}TAIL", "x".repeat(8_000));
+        let truncated = truncate_realtime_output(&text);
+        assert!(truncated.len() <= realtime_output_byte_limit());
+        assert!(truncated.starts_with("HEAD"));
+        assert!(truncated.ends_with("TAIL"));
+        assert!(truncated.contains("\n…output truncated…\n"));
+
+        let mut stream = HandoffStream::default();
+        let short = "é".repeat(1_500);
+        stream.push_text(&short);
+        let head = stream.drain_stream_chunk().unwrap();
+        let tail = stream.drain_final_chunk().unwrap();
+        assert_eq!(format!("{head}{tail}"), short);
     }
 }

--- a/crates/experimental/nanocodex-voice/src/lib.rs
+++ b/crates/experimental/nanocodex-voice/src/lib.rs
@@ -25,7 +25,7 @@ mod audio;
 
 pub use nanocodex::oai::realtime::{
     CHATGPT_REALTIME_VOICE, CHATGPT_REALTIME_VOICES, PLATFORM_REALTIME_VOICE,
-    PLATFORM_REALTIME_VOICES, RealtimeVoice,
+    PLATFORM_REALTIME_VOICES, RealtimeInitialItem, RealtimeTextRole, RealtimeVoice,
 };
 
 use audio::VoiceAudio;
@@ -181,6 +181,7 @@ pub struct VoiceSessionBuilder {
     session_id: Option<Arc<str>>,
     attestation_header: Option<Arc<str>>,
     voice: Option<RealtimeVoice>,
+    initial_items: Vec<RealtimeInitialItem>,
     audio: AudioConfig,
 }
 
@@ -195,6 +196,7 @@ impl VoiceSessionBuilder {
             session_id: None,
             attestation_header: None,
             voice: None,
+            initial_items: Vec::new(),
             audio: AudioConfig::default(),
         }
     }
@@ -224,6 +226,21 @@ impl VoiceSessionBuilder {
     #[must_use]
     pub const fn voice(mut self, voice: RealtimeVoice) -> Self {
         self.voice = Some(voice);
+        self
+    }
+
+    /// Replaces the role-bearing text history used to seed ChatGPT voice.
+    #[must_use]
+    pub fn initial_items(mut self, items: impl IntoIterator<Item = RealtimeInitialItem>) -> Self {
+        self.initial_items = items.into_iter().collect();
+        self
+    }
+
+    /// Appends one role-bearing text item to the ChatGPT voice bootstrap.
+    #[must_use]
+    pub fn initial_item(mut self, role: RealtimeTextRole, text: impl Into<String>) -> Self {
+        self.initial_items
+            .push(RealtimeInitialItem::new(role, text));
         self
     }
 
@@ -371,7 +388,11 @@ async fn run_voice(
         OpenAiAuthMode::ChatGpt => CHATGPT_REALTIME_VOICE,
         OpenAiAuthMode::ApiKey => PLATFORM_REALTIME_VOICE,
     });
-    let mut realtime = builder.openai.realtime(builder.instructions).voice(voice);
+    let mut realtime = builder
+        .openai
+        .realtime(builder.instructions)
+        .voice(voice)
+        .initial_items(builder.initial_items);
     if let Some(session_id) = builder.session_id {
         realtime = realtime.session_id(session_id.as_ref());
     }

--- a/crates/nanocodex-agent/src/agent/driver/control.rs
+++ b/crates/nanocodex-agent/src/agent/driver/control.rs
@@ -156,6 +156,14 @@ pub(super) async fn begin_shutdown(
                     result,
                 });
             }
+            Command::RoutePrompt {
+                route_result,
+                turn_result,
+                ..
+            } => {
+                drop(route_result.send(Err(NanocodexError::AgentStopped)));
+                drop(turn_result);
+            }
             Command::Fork { result, .. } | Command::Spawn { result } => {
                 drop(result.send(Err(NanocodexError::AgentStopped)));
             }
@@ -200,6 +208,14 @@ pub(super) fn handle_idle_command<S>(
         }
         Command::Steer { result, .. } => {
             drop(result.send(Err(NanocodexError::TurnNotSteerable)));
+        }
+        Command::RoutePrompt {
+            route_result,
+            turn_result,
+            ..
+        } => {
+            drop(route_result.send(Err(NanocodexError::AgentStopped)));
+            drop(turn_result);
         }
         Command::Cancel { result, .. } => {
             drop(result.send(Err(NanocodexError::TurnNotCancellable)));

--- a/crates/nanocodex-agent/src/agent/driver/mod.rs
+++ b/crates/nanocodex-agent/src/agent/driver/mod.rs
@@ -181,6 +181,28 @@ where
                 model.shutdown().await;
                 return Ok(());
             };
+            let command = match command {
+                Command::RoutePrompt {
+                    key,
+                    prompt,
+                    parent,
+                    events,
+                    turn_result,
+                    route_result,
+                } => {
+                    drop(route_result.send(Ok(PromptRouteKind::Started)));
+                    Command::Prompt {
+                        key,
+                        prompt,
+                        thinking: None,
+                        fast_mode: None,
+                        parent,
+                        events,
+                        result: turn_result,
+                    }
+                }
+                command => command,
+            };
             let Command::Prompt {
                 key,
                 prompt,
@@ -253,6 +275,25 @@ where
                                             events,
                                             result,
                                         });
+                                    }
+                                    Some(Command::RoutePrompt {
+                                        key,
+                                        prompt,
+                                        parent,
+                                        events,
+                                        turn_result,
+                                        route_result,
+                                    }) => {
+                                        queued_turns.push_back(QueuedTurn::Pending {
+                                            key,
+                                            prompt,
+                                            thinking: default_thinking,
+                                            fast_mode: default_fast_mode,
+                                            parent,
+                                            events,
+                                            result: turn_result,
+                                        });
+                                        drop(route_result.send(Ok(PromptRouteKind::Started)));
                                     }
                                     Some(Command::Compact { parent, result }) => {
                                         compact_replaced = true;
@@ -515,6 +556,26 @@ where
                                     }
                                 });
                                 drop(result.send(outcome));
+                            }
+                            Some(Command::RoutePrompt {
+                                prompt,
+                                route_result,
+                                ..
+                            }) => {
+                                let outcome = steers.try_send(prompt).map_or_else(
+                                    |error| {
+                                        Err(match error {
+                                            mpsc::error::TrySendError::Full(_) => {
+                                                NanocodexError::SteerQueueFull
+                                            }
+                                            mpsc::error::TrySendError::Closed(_) => {
+                                                NanocodexError::TurnNotSteerable
+                                            }
+                                        })
+                                    },
+                                    |()| Ok(PromptRouteKind::Steered),
+                                );
+                                drop(route_result.send(outcome));
                             }
                             Some(Command::Cancel { key: target, result: cancellation }) => {
                                 if target != key {

--- a/crates/nanocodex-agent/src/agent/handle.rs
+++ b/crates/nanocodex-agent/src/agent/handle.rs
@@ -194,6 +194,64 @@ impl Nanocodex {
         })
     }
 
+    /// Routes live input into the active turn or starts a new turn when idle.
+    ///
+    /// The driver makes the decision atomically. If a regular turn is active,
+    /// the prompt is appended to its bounded steering queue and
+    /// [`PromptRoute::Steered`] is returned. Otherwise the prompt starts a new
+    /// turn and is returned as [`PromptRoute::Started`].
+    ///
+    /// This is intended for live input adapters such as voice sessions. Normal
+    /// queued request/response consumers should continue to use [`Self::prompt`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an empty prompt, a full steering queue, or if the
+    /// agent driver stopped.
+    pub async fn route_prompt(&self, prompt: impl Into<Prompt>) -> Result<PromptRoute> {
+        let prompt = prompt.into();
+        if prompt.instruction.is_empty() {
+            return Err(NanocodexError::InvalidRequest(
+                "prompt instruction must not be empty".to_owned(),
+            ));
+        }
+        let key = TurnKey(self.next_turn.fetch_add(1, Ordering::Relaxed));
+        let parent = tracing::Span::current();
+        let parent = (!parent.is_disabled()).then_some(parent);
+        let (events, event_stream) = self.events.mirrored_channel();
+        let (turn_result, turn_receiver) = oneshot::channel();
+        let (route_result, route_receiver) = oneshot::channel();
+        if self
+            .commands
+            .send(Command::RoutePrompt {
+                key,
+                prompt,
+                parent,
+                events,
+                turn_result,
+                route_result,
+            })
+            .await
+            .is_err()
+        {
+            return Err(NanocodexError::AgentStopped);
+        }
+        match route_receiver
+            .await
+            .map_err(|_| NanocodexError::AgentStopped)??
+        {
+            PromptRouteKind::Started => Ok(PromptRoute::Started(Turn {
+                control: TurnControl {
+                    key,
+                    commands: self.commands.clone(),
+                },
+                events: event_stream,
+                result: turn_receiver,
+            })),
+            PromptRouteKind::Steered => Ok(PromptRoute::Steered),
+        }
+    }
+
     /// Changes the reasoning effort for subsequently accepted turns.
     ///
     /// An active turn and prompts already queued by the driver retain the

--- a/crates/nanocodex-agent/src/agent/mod.rs
+++ b/crates/nanocodex-agent/src/agent/mod.rs
@@ -98,7 +98,7 @@ mod turn;
 
 pub use builder::NanocodexBuilder;
 pub use handle::{AgentHandle, Nanocodex};
-pub use turn::{Turn, TurnControl, TurnResult};
+pub use turn::{PromptRoute, Turn, TurnControl, TurnResult};
 
 use builder::{CodexCompatibility, PromptCacheConfig};
 pub(crate) use context_source::ContextSource;
@@ -109,4 +109,4 @@ pub(crate) use executor::{AgentFactory, AgentSend};
 use executor::{ServiceFactory, spawn_driver};
 use handle::request_command;
 use spawn::{build_agent, spawn_agent_driver, validate};
-use turn::{Command, QueuedTurn, TurnKey};
+use turn::{Command, PromptRouteKind, QueuedTurn, TurnKey};

--- a/crates/nanocodex-agent/src/agent/turn.rs
+++ b/crates/nanocodex-agent/src/agent/turn.rs
@@ -15,6 +15,19 @@ pub struct Turn {
     pub(super) result: oneshot::Receiver<Result<TurnResult>>,
 }
 
+/// Outcome of routing live user input into an agent session.
+///
+/// Live consumers such as voice interfaces normally want to steer the current
+/// regular turn when one exists and start a new turn only when the agent is
+/// idle. [`Nanocodex::route_prompt`](crate::Nanocodex::route_prompt) performs
+/// that decision atomically in the agent driver and returns this outcome.
+pub enum PromptRoute {
+    /// The agent was idle, so the prompt started a new independently awaitable turn.
+    Started(Turn),
+    /// The prompt was admitted to the current turn's steering queue.
+    Steered,
+}
+
 impl Turn {
     /// Returns a cheap cloneable capability targeting this exact turn.
     #[must_use]
@@ -190,6 +203,14 @@ pub(super) enum Command {
         prompt: Prompt,
         result: oneshot::Sender<Result<()>>,
     },
+    RoutePrompt {
+        key: TurnKey,
+        prompt: Prompt,
+        parent: Option<tracing::Span>,
+        events: EventSink,
+        turn_result: oneshot::Sender<Result<TurnResult>>,
+        route_result: oneshot::Sender<Result<PromptRouteKind>>,
+    },
     Cancel {
         key: TurnKey,
         result: oneshot::Sender<Result<()>>,
@@ -214,6 +235,12 @@ pub(super) enum Command {
         result: oneshot::Sender<Result<()>>,
     },
     Shutdown,
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum PromptRouteKind {
+    Started,
+    Steered,
 }
 
 pub(super) enum QueuedTurn {

--- a/crates/nanocodex-agent/src/lib.rs
+++ b/crates/nanocodex-agent/src/lib.rs
@@ -23,7 +23,9 @@ pub mod session;
 /// Per-turn token accounting and USD estimates.
 pub mod usage;
 
-pub use agent::{AgentHandle, Nanocodex, NanocodexBuilder, Turn, TurnControl, TurnResult};
+pub use agent::{
+    AgentHandle, Nanocodex, NanocodexBuilder, PromptRoute, Turn, TurnControl, TurnResult,
+};
 pub use error::{NanocodexError, Result};
 pub use nanocodex_oai_api::{
     OpenAi, ReasoningMode, ResponseError, ResponseErrorKind, Thinking, events::AgentEvents,

--- a/crates/nanocodex-agent/tests/it/model/control/steering.rs
+++ b/crates/nanocodex-agent/tests/it/model/control/steering.rs
@@ -259,7 +259,10 @@ async fn steering_during_a_tool_call_joins_after_the_tool_result() -> Result<()>
         .workspace(&workspace)
         .session_id(test_session_id())
         .build()?;
-    let turn = agent.prompt("print shit a lot of times").await?;
+    let turn = match agent.route_prompt("print shit a lot of times").await? {
+        PromptRoute::Started(turn) => turn,
+        PromptRoute::Steered => return Err(eyre!("idle live input unexpectedly steered a turn")),
+    };
     timeout(std::time::Duration::from_secs(5), async {
         while !workspace.join("tool-started").exists() {
             tokio::task::yield_now().await;
@@ -268,7 +271,10 @@ async fn steering_during_a_tool_call_joins_after_the_tool_result() -> Result<()>
     .await
     .map_err(|_| eyre!("tool process did not start"))?;
 
-    turn.steer("print shat instead").await?;
+    assert!(matches!(
+        agent.route_prompt("print shat instead").await?,
+        PromptRoute::Steered
+    ));
     assert!(!workspace.join("release-tool").exists());
     std::fs::write(workspace.join("release-tool"), [])?;
     assert_eq!(turn.result().await?.final_message(), "done");

--- a/crates/nanocodex-agent/tests/it/model/mod.rs
+++ b/crates/nanocodex-agent/tests/it/model/mod.rs
@@ -15,7 +15,8 @@ use tokio::{
 use tokio_tungstenite::{WebSocketStream, accept_async, tungstenite::Message};
 
 use nanocodex_agent::{
-    AgentHandle, Nanocodex, NanocodexError, OpenAi, ReasoningMode, ResponseError, Thinking, Tools,
+    AgentHandle, Nanocodex, NanocodexError, OpenAi, PromptRoute, ReasoningMode, ResponseError,
+    Thinking, Tools,
     events::{AgentEvent, AgentEventData, RunEvent},
     input::Prompt,
     rollout::RolloutConfig,

--- a/crates/nanocodex-oai-api/Cargo.toml
+++ b/crates/nanocodex-oai-api/Cargo.toml
@@ -27,6 +27,7 @@ client = [
     "dep:tokio-tungstenite",
     "dep:url",
 ]
+realtime = ["client", "dep:opusic-c", "dep:rustls", "dep:webrtc"]
 
 [dependencies]
 async-trait.workspace = true
@@ -46,10 +47,13 @@ web-time.workspace = true
 base64 = { workspace = true, optional = true }
 getrandom = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
+rustls = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["io-util", "macros", "net", "rt", "sync", "time"] }
 tokio-tungstenite = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
+opusic-c = { workspace = true, optional = true }
+webrtc = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion.workspace = true

--- a/crates/nanocodex-oai-api/README.md
+++ b/crates/nanocodex-oai-api/README.md
@@ -133,7 +133,7 @@ ChatGPT backend and join its sideband control WebSocket with the same bearer
 and account identity. When no host attestation is available, Nanocodex sends
 the same unavailable-token envelope Codex uses when attestation generation
 times out; hosts that own an attestation integration may override it with
-[`RealtimeSessionBuilder::attestation_header`].
+[`realtime::RealtimeSessionBuilder::attestation_header`].
 The library accepts and emits signed 16-bit little-endian, 24 kHz mono PCM through a cheap
 [`realtime::RealtimeSession`] handle and an independent
 [`realtime::RealtimeEvents`] stream. It does not open audio devices, so callers

--- a/crates/nanocodex-oai-api/README.md
+++ b/crates/nanocodex-oai-api/README.md
@@ -122,6 +122,40 @@ assert!(!completed.output_text().is_empty());
 # }
 ```
 
+## GPT Realtime voice
+
+> **Available on native targets with the `realtime` feature.**
+
+[`OpenAi::realtime`] opens an independent GPT Realtime conversation using the
+same credential and API base. Platform API keys use a direct Realtime
+WebSocket. Managed ChatGPT credentials create the media call through the
+ChatGPT backend and join its sideband control WebSocket with the same bearer
+and account identity. When no host attestation is available, Nanocodex sends
+the same unavailable-token envelope Codex uses when attestation generation
+times out; hosts that own an attestation integration may override it with
+[`RealtimeSessionBuilder::attestation_header`].
+The library accepts and emits signed 16-bit little-endian, 24 kHz mono PCM through a cheap
+[`realtime::RealtimeSession`] handle and an independent
+[`realtime::RealtimeEvents`] stream. It does not open audio devices, so callers
+can connect a microphone, files, or ordinary stdin and stdout pipes.
+The experimental `nanocodex-voice` crate packages default desktop devices and
+background-agent delegation without moving those policies into this transport
+boundary.
+
+Both transports expose background-agent delegation as
+[`realtime::RealtimeEvent::AgentRequest`]. An embedding handles that event with
+its existing agent or tool loop, then calls
+[`realtime::RealtimeSession::complete_agent_request`] with the typed result.
+The `nanocodex` Ratatui consumer is one concrete desktop adapter: on macOS and
+Windows, `/voice` connects the default microphone and speaker while preserving
+the coding agent's normal history and lifecycle. `/voice list` prints the
+available voice names, `/voice cove` starts a named voice, and `/voice off`
+stops it. Managed ChatGPT sessions use Codex's current voice set and default to
+`cove`; Platform sessions default to `marin`. The TUI uses either the coding
+session's ChatGPT subscription credential or its Platform API key directly; no
+second credential is required. Other native hosts can use the device-neutral
+`realtime-pipe` example with their audio stack.
+
 ## Ownership and replay
 
 A session owns authoritative typed history and one concrete Tower service.
@@ -168,6 +202,7 @@ prominent:
   persistence, refresh, and logout.
 - [`pricing`] and [`events`] expose automatic `gpt-5.6-sol` cost estimates and
   lifecycle-event components.
+- [`realtime`] exposes native GPT Realtime PCM streams and typed voice events.
 - [`tower`] contains the generic attempt, response, and retry contracts.
 - [`transport`] contains WebSocket/HTTPS selection, replay policy, transport
   failures, and connection statistics.

--- a/crates/nanocodex-oai-api/src/lib.rs
+++ b/crates/nanocodex-oai-api/src/lib.rs
@@ -19,6 +19,13 @@ mod openai;
 /// Automatic `gpt-5.6-sol` USD estimates from provider token usage.
 #[cfg(feature = "client")]
 pub mod pricing;
+/// Bidirectional GPT Realtime audio sessions and typed conversation events.
+#[cfg(all(feature = "realtime", not(target_family = "wasm")))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(feature = "realtime", not(target_family = "wasm"))))
+)]
+pub mod realtime;
 /// Complete typed request, event, and item model for the Responses protocol.
 pub mod responses;
 /// Managed session identities, inputs, and compaction results.

--- a/crates/nanocodex-oai-api/src/openai/mod.rs
+++ b/crates/nanocodex-oai-api/src/openai/mod.rs
@@ -57,6 +57,36 @@ impl<F> OpenAi<F>
 where
     F: ResponsesServiceFactory,
 {
+    /// Returns the authentication mode used by this client recipe.
+    #[must_use]
+    pub const fn auth_mode(&self) -> OpenAiAuthMode {
+        self.config.auth.mode()
+    }
+
+    /// Starts configuring a native GPT Realtime voice session.
+    ///
+    /// Realtime uses this client's authentication and API base while owning an
+    /// independent conversation lifecycle. Platform API keys connect directly
+    /// over WebSocket. Managed ChatGPT credentials create a WebRTC media call
+    /// and attach its sideband control socket. Audio remains exposed as 24 kHz
+    /// mono PCM16 so embeddings retain device policy.
+    #[cfg(all(feature = "realtime", not(target_family = "wasm")))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(feature = "realtime", not(target_family = "wasm"))))
+    )]
+    #[must_use]
+    pub fn realtime(
+        &self,
+        instructions: impl Into<Arc<str>>,
+    ) -> crate::realtime::RealtimeSessionBuilder {
+        crate::realtime::RealtimeSessionBuilder::new(
+            self.config.auth.clone(),
+            self.config.api_base_url.clone(),
+            instructions.into(),
+        )
+    }
+
     /// Starts a client-side managed session with stable developer
     /// instructions.
     ///

--- a/crates/nanocodex-oai-api/src/realtime.rs
+++ b/crates/nanocodex-oai-api/src/realtime.rs
@@ -1891,11 +1891,13 @@ mod tests {
             .complete_agent_request("call_1", "done")
             .await
             .unwrap();
+        assert_eq!(events.recv().await, Some(RealtimeEvent::ResponseDone));
         session
             .append_agent_output("call_1", "working")
             .await
             .unwrap();
         session.complete_agent_run("call_1").await.unwrap();
+        assert_eq!(events.recv().await, Some(RealtimeEvent::ResponseDone));
         assert_eq!(
             session.steer_agent_request("call_2").await.unwrap(),
             RealtimeAgentSteer::Acknowledged

--- a/crates/nanocodex-oai-api/src/realtime.rs
+++ b/crates/nanocodex-oai-api/src/realtime.rs
@@ -23,7 +23,7 @@ use tokio_tungstenite::{
         http::{HeaderValue, header},
     },
 };
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 use url::Url;
 
 use crate::{OpenAiAuth, OpenAiAuthError, OpenAiAuthMode, connector::connect_async};
@@ -85,6 +85,9 @@ const AGENT_COMPLETE_ACKNOWLEDGEMENT: &str =
     "Background agent finished. Use the preceding [BACKEND] messages as the result.";
 const BACKEND_TEXT_PREFIX: &str = "[BACKEND] ";
 const CONTEXT_APPEND_MAX_BYTES: usize = 500;
+const INITIAL_ITEMS_MAX_COUNT: usize = 128;
+const INITIAL_ITEMS_MAX_TOKENS: usize = 8_192;
+const APPROX_BYTES_PER_TOKEN: usize = 4;
 
 type Socket = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
@@ -188,6 +191,54 @@ impl RealtimeVoice {
                 | Self::Shimmer
                 | Self::Verse
         )
+    }
+}
+
+/// Role of one text item used to seed a Frameless realtime conversation.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum RealtimeTextRole {
+    /// Developer-provided context or policy.
+    Developer,
+    /// A prior user message.
+    User,
+    /// A prior assistant message.
+    Assistant,
+}
+
+impl RealtimeTextRole {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Developer => "developer",
+            Self::User => "user",
+            Self::Assistant => "assistant",
+        }
+    }
+
+    const fn content_type(self) -> &'static str {
+        match self {
+            Self::Developer | Self::User => "input_text",
+            Self::Assistant => "output_text",
+        }
+    }
+}
+
+/// One role-bearing text item used to seed a Frameless realtime conversation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RealtimeInitialItem {
+    /// Conversation role for the text.
+    pub role: RealtimeTextRole,
+    /// Complete text content for the item.
+    pub text: String,
+}
+
+impl RealtimeInitialItem {
+    /// Creates one initial role-bearing text item.
+    #[must_use]
+    pub fn new(role: RealtimeTextRole, text: impl Into<String>) -> Self {
+        Self {
+            role,
+            text: text.into(),
+        }
     }
 }
 
@@ -519,6 +570,7 @@ pub struct RealtimeSessionBuilder {
     model: String,
     voice: Option<RealtimeVoice>,
     session_id: Option<String>,
+    initial_items: Vec<RealtimeInitialItem>,
 }
 
 impl RealtimeSessionBuilder {
@@ -536,6 +588,7 @@ impl RealtimeSessionBuilder {
             model: model.to_owned(),
             voice: None,
             session_id: None,
+            initial_items: Vec::new(),
         }
     }
 
@@ -567,6 +620,25 @@ impl RealtimeSessionBuilder {
         self
     }
 
+    /// Replaces the role-bearing text history used to seed a Frameless session.
+    ///
+    /// Initial items are supported by ChatGPT-authenticated Frameless sessions
+    /// only. The list may contain at most 128 items and at most 8,192 estimated
+    /// tokens per item and in aggregate.
+    #[must_use]
+    pub fn initial_items(mut self, items: impl IntoIterator<Item = RealtimeInitialItem>) -> Self {
+        self.initial_items = items.into_iter().collect();
+        self
+    }
+
+    /// Appends one role-bearing text item to the Frameless session bootstrap.
+    #[must_use]
+    pub fn initial_item(mut self, role: RealtimeTextRole, text: impl Into<String>) -> Self {
+        self.initial_items
+            .push(RealtimeInitialItem::new(role, text));
+        self
+    }
+
     /// Supplies a host-generated `x-oai-attestation` value for ChatGPT calls.
     ///
     /// The value is opaque to Nanocodex and is reused only for the call and its
@@ -594,6 +666,7 @@ impl RealtimeSessionBuilder {
         if self.model.trim().is_empty() {
             return Err(RealtimeError::InvalidModel);
         }
+        validate_initial_items(self.auth.mode(), &self.initial_items)?;
 
         let (socket, protocol, media) = match self.auth.mode() {
             OpenAiAuthMode::ApiKey => {
@@ -655,6 +728,7 @@ impl RealtimeSessionBuilder {
                     model: &self.model,
                     voice,
                     session_id: self.session_id.as_deref(),
+                    initial_items: &self.initial_items,
                 })
                 .await?;
                 (
@@ -676,6 +750,45 @@ impl RealtimeSessionBuilder {
             RealtimeEvents { receiver: event_rx },
         ))
     }
+}
+
+fn validate_initial_items(
+    auth_mode: OpenAiAuthMode,
+    items: &[RealtimeInitialItem],
+) -> Result<(), RealtimeError> {
+    if !items.is_empty() && matches!(auth_mode, OpenAiAuthMode::ApiKey) {
+        return Err(RealtimeError::InvalidInitialItems(
+            "initial items require a ChatGPT-authenticated Frameless session".to_owned(),
+        ));
+    }
+    if items.len() > INITIAL_ITEMS_MAX_COUNT {
+        return Err(RealtimeError::InvalidInitialItems(format!(
+            "must contain no more than {INITIAL_ITEMS_MAX_COUNT} items"
+        )));
+    }
+
+    let mut total_tokens = 0_usize;
+    for item in items {
+        let item_tokens = approx_token_count(&item.text);
+        if item_tokens > INITIAL_ITEMS_MAX_TOKENS {
+            return Err(RealtimeError::InvalidInitialItems(format!(
+                "each item must not exceed {INITIAL_ITEMS_MAX_TOKENS} estimated tokens"
+            )));
+        }
+        total_tokens = total_tokens.saturating_add(item_tokens);
+    }
+    if total_tokens > INITIAL_ITEMS_MAX_TOKENS {
+        return Err(RealtimeError::InvalidInitialItems(format!(
+            "items must not exceed {INITIAL_ITEMS_MAX_TOKENS} estimated tokens in total"
+        )));
+    }
+    Ok(())
+}
+
+const fn approx_token_count(text: &str) -> usize {
+    text.len()
+        .saturating_add(APPROX_BYTES_PER_TOKEN.saturating_sub(1))
+        / APPROX_BYTES_PER_TOKEN
 }
 
 /// Failure from configuring or operating a GPT Realtime session.
@@ -705,6 +818,9 @@ pub enum RealtimeError {
     /// A caller-owned session header was invalid.
     #[error("invalid GPT Realtime session ID: {0}")]
     InvalidSessionId(String),
+    /// Initial text history violated the Frameless bootstrap policy.
+    #[error("invalid GPT Realtime initial items: {0}")]
+    InvalidInitialItems(String),
     /// Connecting exceeded the transport deadline.
     #[error("GPT Realtime connection timed out")]
     ConnectTimeout,
@@ -757,6 +873,12 @@ enum ClientEvent<'a> {
     AudioBufferAppend { audio: String },
     #[serde(rename = "conversation.item.create")]
     ItemCreate { item: ConversationItem<'a> },
+    #[serde(rename = "conversation.item.truncate")]
+    ItemTruncate {
+        item_id: &'a str,
+        content_index: u8,
+        audio_end_ms: u32,
+    },
     #[serde(rename = "response.create")]
     ResponseCreate,
     #[serde(rename = "delegation.context.append")]
@@ -903,7 +1025,10 @@ fn session_update(instructions: &str, voice: RealtimeVoice) -> ClientEvent<'_> {
                     parameters: json!({
                         "type": "object",
                         "properties": {
-                            "prompt": { "type": "string" }
+                            "prompt": {
+                                "type": "string",
+                                "description": "The user request to delegate to the background agent."
+                            }
                         },
                         "required": ["prompt"],
                         "additionalProperties": false
@@ -935,6 +1060,7 @@ async fn run_socket(
     let media_input = media.as_ref().map(webrtc::WebRtcMedia::input);
     let mut active_transcript = ActiveTranscript::default();
     let mut response_create = ResponseCreateQueue::default();
+    let mut output_audio = None;
     loop {
         tokio::select! {
             command = commands.recv() => {
@@ -969,6 +1095,7 @@ async fn run_socket(
                     protocol,
                     &mut active_transcript,
                     &mut response_create,
+                    &mut output_audio,
                 ).await {
                     Ok(true) => break,
                     Ok(false) => {}
@@ -1192,6 +1319,7 @@ async fn handle_server_message(
     protocol: RealtimeProtocol,
     active_transcript: &mut ActiveTranscript,
     response_create: &mut ResponseCreateQueue,
+    output_audio: &mut Option<OutputAudioState>,
 ) -> Result<bool, RealtimeError> {
     let Some(message) = message else {
         return Ok(true);
@@ -1199,7 +1327,12 @@ async fn handle_server_message(
     match message.map_err(map_websocket_error)? {
         Message::Text(payload) => {
             trace!(target: "nanocodex_oai_api::realtime::wire", payload = %payload, "GPT Realtime event");
-            if let Some(mut event) = parse_event(&payload, protocol)? {
+            let value: Value = serde_json::from_str(&payload)
+                .map_err(|error| RealtimeError::Message(error.to_string()))?;
+            if let Some(mut event) = parse_event_value(&value, protocol)? {
+                if matches!(protocol, RealtimeProtocol::Direct) {
+                    handle_direct_audio_state(socket, &value, &event, output_audio).await;
+                }
                 active_transcript.update(&mut event);
                 if matches!(protocol, RealtimeProtocol::Direct) {
                     match &event {
@@ -1229,6 +1362,89 @@ async fn handle_server_message(
             "unexpected binary WebSocket frame".to_owned(),
         )),
     }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct OutputAudioState {
+    item_id: String,
+    audio_end_ms: u32,
+}
+
+async fn handle_direct_audio_state(
+    socket: &mut Socket,
+    value: &Value,
+    event: &RealtimeEvent,
+    output_audio: &mut Option<OutputAudioState>,
+) {
+    match event {
+        RealtimeEvent::Audio(audio) => update_output_audio_state(value, audio, output_audio),
+        RealtimeEvent::SpeechStarted => {
+            let Some(state) = output_audio.take() else {
+                return;
+            };
+            let speech_item_id = value.get("item_id").and_then(Value::as_str);
+            if speech_item_id.is_some_and(|item_id| item_id != state.item_id) {
+                return;
+            }
+            if let Err(error) = send_json(
+                socket,
+                &ClientEvent::ItemTruncate {
+                    item_id: &state.item_id,
+                    content_index: 0,
+                    audio_end_ms: state.audio_end_ms,
+                },
+            )
+            .await
+            {
+                warn!(%error, "failed to truncate interrupted GPT Realtime audio");
+            }
+        }
+        RealtimeEvent::ResponseDone
+        | RealtimeEvent::AgentRequest { .. }
+        | RealtimeEvent::RemainSilent { .. } => *output_audio = None,
+        RealtimeEvent::SessionReady { .. }
+        | RealtimeEvent::InputTranscriptDelta(_)
+        | RealtimeEvent::InputTranscriptDone(_)
+        | RealtimeEvent::OutputTranscriptDelta(_)
+        | RealtimeEvent::OutputTranscriptDone(_)
+        | RealtimeEvent::ResponseStarted
+        | RealtimeEvent::Error(_) => {}
+    }
+}
+
+fn update_output_audio_state(
+    value: &Value,
+    audio: &RealtimeAudio,
+    output_audio: &mut Option<OutputAudioState>,
+) {
+    let Some(item_id) = value.get("item_id").and_then(Value::as_str) else {
+        return;
+    };
+    let samples = value
+        .get("samples_per_channel")
+        .and_then(Value::as_u64)
+        .unwrap_or(audio.samples() as u64);
+    let sample_rate = value
+        .get("sample_rate")
+        .and_then(Value::as_u64)
+        .unwrap_or(u64::from(REALTIME_SAMPLE_RATE))
+        .max(1);
+    let audio_end_ms =
+        u32::try_from(samples.saturating_mul(1_000) / sample_rate).unwrap_or(u32::MAX);
+    if audio_end_ms == 0 {
+        return;
+    }
+
+    if let Some(state) = output_audio
+        && state.item_id == item_id
+    {
+        state.audio_end_ms = state.audio_end_ms.saturating_add(audio_end_ms);
+        return;
+    }
+    *output_audio = Some(OutputAudioState {
+        item_id: item_id.to_owned(),
+        audio_end_ms,
+    });
 }
 
 #[derive(Default)]
@@ -1373,19 +1589,27 @@ fn append_handoff_input(entries: &mut Vec<RealtimeTranscriptEntry>, input: &str)
     });
 }
 
+#[cfg(test)]
 fn parse_event(
     payload: &str,
     protocol: RealtimeProtocol,
 ) -> Result<Option<RealtimeEvent>, RealtimeError> {
     let value: Value =
         serde_json::from_str(payload).map_err(|error| RealtimeError::Message(error.to_string()))?;
+    parse_event_value(&value, protocol)
+}
+
+fn parse_event_value(
+    value: &Value,
+    protocol: RealtimeProtocol,
+) -> Result<Option<RealtimeEvent>, RealtimeError> {
     let kind = value
         .get("type")
         .and_then(Value::as_str)
         .unwrap_or_default();
     let event = match protocol {
-        RealtimeProtocol::Direct => parse_direct_event(&value, kind)?,
-        RealtimeProtocol::Frameless => parse_frameless_event(&value, kind),
+        RealtimeProtocol::Direct => parse_direct_event(value, kind)?,
+        RealtimeProtocol::Frameless => parse_frameless_event(value, kind),
     };
     Ok(event)
 }
@@ -1547,16 +1771,19 @@ fn delegated_prompt(arguments: Option<&str>) -> String {
     let Some(arguments) = arguments else {
         return String::new();
     };
-    serde_json::from_str::<Value>(arguments)
-        .ok()
-        .and_then(|value| {
-            ["prompt", "input_transcript", "input", "text", "query"]
-                .into_iter()
-                .find_map(|key| value.get(key).and_then(Value::as_str).map(str::trim))
-                .filter(|value| !value.is_empty())
-                .map(str::to_owned)
-        })
-        .unwrap_or_else(|| arguments.to_owned())
+    if let Ok(value) = serde_json::from_str::<Value>(arguments)
+        && let Some(object) = value.as_object()
+    {
+        for key in ["input_transcript", "input", "text", "prompt", "query"] {
+            if let Some(value) = object.get(key).and_then(Value::as_str) {
+                let value = value.trim();
+                if !value.is_empty() {
+                    return value.to_owned();
+                }
+            }
+        }
+    }
+    arguments.to_owned()
 }
 
 fn string_field(value: &Value, field: &str) -> Option<String> {
@@ -1601,10 +1828,11 @@ mod tests {
     use super::{
         ActiveTranscript, CHATGPT_REALTIME_MODEL, CHATGPT_REALTIME_VOICE, CHATGPT_REALTIME_VOICES,
         PLATFORM_REALTIME_VOICE, PLATFORM_REALTIME_VOICES, RealtimeAgentSteer, RealtimeAudio,
-        RealtimeEvent, RealtimeProtocol, RealtimeTranscriptEntry, RealtimeVoice,
-        context_append_chunks, delegated_prompt, parse_event, realtime_endpoint, session_update,
+        RealtimeEvent, RealtimeInitialItem, RealtimeProtocol, RealtimeTextRole,
+        RealtimeTranscriptEntry, RealtimeVoice, context_append_chunks, delegated_prompt,
+        parse_event, realtime_endpoint, session_update, validate_initial_items,
     };
-    use crate::OpenAi;
+    use crate::{OpenAi, OpenAiAuthMode};
 
     #[test]
     fn derives_realtime_endpoint_from_api_base() {
@@ -1658,6 +1886,59 @@ mod tests {
         assert_eq!(value["session"]["audio"]["input"]["format"]["rate"], 24_000);
         assert_eq!(value["session"]["audio"]["output"]["voice"], "cove");
         assert_eq!(value["session"]["tools"][0]["name"], "background_agent");
+        assert_eq!(
+            value["session"]["tools"][0]["parameters"]["properties"]["prompt"]["description"],
+            "The user request to delegate to the background agent."
+        );
+    }
+
+    #[test]
+    fn validates_frameless_initial_item_limits() {
+        assert!(
+            validate_initial_items(
+                OpenAiAuthMode::ChatGpt,
+                &[
+                    RealtimeInitialItem::new(RealtimeTextRole::Developer, "policy"),
+                    RealtimeInitialItem::new(RealtimeTextRole::User, "request"),
+                    RealtimeInitialItem::new(RealtimeTextRole::Assistant, "answer"),
+                ],
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_initial_items(
+                OpenAiAuthMode::ApiKey,
+                &[RealtimeInitialItem::new(RealtimeTextRole::User, "request",)],
+            )
+            .is_err()
+        );
+        assert!(
+            validate_initial_items(
+                OpenAiAuthMode::ChatGpt,
+                &vec![RealtimeInitialItem::new(RealtimeTextRole::User, "x"); 129],
+            )
+            .is_err()
+        );
+        assert!(
+            validate_initial_items(
+                OpenAiAuthMode::ChatGpt,
+                &[RealtimeInitialItem::new(
+                    RealtimeTextRole::User,
+                    "x".repeat(32_769),
+                )],
+            )
+            .is_err()
+        );
+        assert!(
+            validate_initial_items(
+                OpenAiAuthMode::ChatGpt,
+                &[
+                    RealtimeInitialItem::new(RealtimeTextRole::User, "x".repeat(16_384)),
+                    RealtimeInitialItem::new(RealtimeTextRole::Assistant, "x".repeat(16_388)),
+                ],
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -1792,6 +2073,18 @@ mod tests {
         assert_eq!(RealtimeAudio::pcm16_le([0, 1]).unwrap().samples(), 1);
         assert!(RealtimeAudio::pcm16_le([0]).is_err());
         assert_eq!(delegated_prompt(Some("plain request")), "plain request");
+        assert_eq!(
+            delegated_prompt(Some(
+                r#"{"input_transcript":"  ","input":" steer this ","prompt":"wrong"}"#
+            )),
+            "steer this"
+        );
+        assert_eq!(
+            delegated_prompt(Some(
+                r#"{"input_transcript":"spoken request","prompt":"rewritten request"}"#
+            )),
+            "spoken request"
+        );
     }
 
     #[test]
@@ -1801,6 +2094,55 @@ mod tests {
         assert_eq!(chunks.concat(), text);
         assert!(chunks.iter().all(|chunk| chunk.len() <= 500));
         assert_eq!(context_append_chunks(""), [""]);
+    }
+
+    #[tokio::test]
+    async fn truncates_unheard_direct_audio_when_speech_interrupts() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut socket = accept_async(stream).await.unwrap();
+            let update = socket.next().await.unwrap().unwrap().into_text().unwrap();
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(&update).unwrap()["type"],
+                "session.update"
+            );
+            for _ in 0..2 {
+                socket
+                    .send(Message::Text(
+                        r#"{"type":"response.output_audio.delta","item_id":"message_1","sample_rate":24000,"samples_per_channel":480,"delta":"AAE="}"#
+                            .into(),
+                    ))
+                    .await
+                    .unwrap();
+            }
+            socket
+                .send(Message::Text(
+                    r#"{"type":"input_audio_buffer.speech_started"}"#.into(),
+                ))
+                .await
+                .unwrap();
+
+            let truncate = socket.next().await.unwrap().unwrap().into_text().unwrap();
+            let truncate: serde_json::Value = serde_json::from_str(&truncate).unwrap();
+            assert_eq!(truncate["type"], "conversation.item.truncate");
+            assert_eq!(truncate["item_id"], "message_1");
+            assert_eq!(truncate["content_index"], 0);
+            assert_eq!(truncate["audio_end_ms"], 40);
+        });
+
+        let openai = OpenAi::new("test-key").unwrap();
+        let (_session, mut events) = openai
+            .realtime("delegate coding work")
+            .websocket_url(format!("ws://{address}"))
+            .connect()
+            .await
+            .unwrap();
+        assert!(matches!(events.recv().await, Some(RealtimeEvent::Audio(_))));
+        assert!(matches!(events.recv().await, Some(RealtimeEvent::Audio(_))));
+        assert_eq!(events.recv().await, Some(RealtimeEvent::SpeechStarted));
+        server.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/nanocodex-oai-api/src/realtime.rs
+++ b/crates/nanocodex-oai-api/src/realtime.rs
@@ -77,7 +77,13 @@ const SEND_TIMEOUT: Duration = Duration::from_secs(30);
 const COMMAND_CAPACITY: usize = 256;
 const EVENT_CAPACITY: usize = 256;
 const BACKGROUND_AGENT_TOOL: &str = "background_agent";
+const BACKGROUND_AGENT_TOOL_DESCRIPTION: &str = "Send a user request to the background agent. Use this as the default action. Do not rephrase the user's ask or rewrite it in your own words; pass along the user's own words. If the background agent is idle, this starts a new task and returns the final result to the user. If the background agent is already working on a task, this sends the request as guidance to steer that previous task. If the user asks to do something next, later, after this, or once current work finishes, call this tool so the work is actually queued instead of merely promising to do it later.";
 const REMAIN_SILENT_TOOL: &str = "remain_silent";
+const REMAIN_SILENT_TOOL_DESCRIPTION: &str = "Call this when the best response is to say nothing. Use it instead of speaking after hidden system/control messages, after background agent updates in silent modes, or whenever acknowledging aloud would be distracting. This tool has no user-visible effect.";
+const STEER_ACKNOWLEDGEMENT: &str = "This was sent to steer the previous background agent task.";
+const AGENT_COMPLETE_ACKNOWLEDGEMENT: &str =
+    "Background agent finished. Use the preceding [BACKEND] messages as the result.";
+const BACKEND_TEXT_PREFIX: &str = "[BACKEND] ";
 const CONTEXT_APPEND_MAX_BYTES: usize = 500;
 
 type Socket = WebSocketStream<MaybeTlsStream<TcpStream>>;
@@ -304,6 +310,8 @@ pub enum RealtimeEvent {
         call_id: String,
         /// User request selected by the realtime model for delegation.
         prompt: String,
+        /// Voice transcript entries added since the previous delegation.
+        transcript: Vec<RealtimeTranscriptEntry>,
     },
     /// Realtime requested an intentionally silent tool result.
     RemainSilent {
@@ -316,6 +324,15 @@ pub enum RealtimeEvent {
     ResponseDone,
     /// The provider reported a session error.
     Error(String),
+}
+
+/// One role-bearing voice transcript entry associated with a Realtime delegation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RealtimeTranscriptEntry {
+    /// Transcript participant as the Realtime wire role (`user` or `assistant`).
+    pub role: String,
+    /// Complete transcript text for this contiguous role entry.
+    pub text: String,
 }
 
 /// Receiver for the independent typed event stream of a realtime session.
@@ -339,9 +356,29 @@ impl RealtimeEvents {
 #[derive(Clone)]
 pub struct RealtimeSession {
     commands: mpsc::Sender<Command>,
+    protocol: RealtimeProtocol,
+}
+
+/// Protocol-specific handling applied after live input steers an active agent turn.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RealtimeAgentSteer {
+    /// Realtime V2 received the steering tool result immediately.
+    Acknowledged,
+    /// Frameless moved the active delegation target to the newest request.
+    ReplacedDelegation,
 }
 
 impl RealtimeSession {
+    /// Returns whether this protocol accepts incremental background-agent appends.
+    ///
+    /// Codex streams agent message deltas into Frameless delegations. Realtime
+    /// V2 instead receives each completed agent message as one `[BACKEND]`
+    /// conversation item.
+    #[must_use]
+    pub const fn streams_agent_output(&self) -> bool {
+        matches!(self.protocol, RealtimeProtocol::Frameless)
+    }
+
     /// Appends one owned 24 kHz mono PCM16 input chunk.
     ///
     /// # Errors
@@ -364,6 +401,72 @@ impl RealtimeSession {
         self.send(CommandKind::AgentOutput {
             call_id: call_id.into(),
             output: output.into(),
+        })
+        .await
+    }
+
+    /// Applies Codex's protocol-specific acknowledgement for a steering request.
+    ///
+    /// Realtime V2 completes the new tool call with Codex's steering
+    /// acknowledgement and creates a response. Frameless keeps the delegation
+    /// open and makes the newest delegation item the target for subsequent
+    /// background-agent output.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the V2 acknowledgement cannot be delivered.
+    pub async fn steer_agent_request(
+        &self,
+        call_id: impl Into<String>,
+    ) -> Result<RealtimeAgentSteer, RealtimeError> {
+        match self.protocol {
+            RealtimeProtocol::Direct => {
+                self.complete_agent_request(call_id, STEER_ACKNOWLEDGEMENT)
+                    .await?;
+                Ok(RealtimeAgentSteer::Acknowledged)
+            }
+            RealtimeProtocol::Frameless => {
+                drop(call_id.into());
+                Ok(RealtimeAgentSteer::ReplacedDelegation)
+            }
+        }
+    }
+
+    /// Appends streamed background-agent output to the active voice handoff.
+    ///
+    /// Realtime V2 receives a `[BACKEND]` user item. Frameless appends text to
+    /// the active delegation context without asking for a separate response.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the output cannot be delivered.
+    pub async fn append_agent_output(
+        &self,
+        call_id: impl Into<String>,
+        output: impl Into<String>,
+    ) -> Result<(), RealtimeError> {
+        self.send(CommandKind::AgentProgress {
+            call_id: call_id.into(),
+            output: output.into(),
+        })
+        .await
+    }
+
+    /// Completes a streamed background-agent handoff using Codex's protocol behavior.
+    ///
+    /// Realtime V2 completes the original tool call with Codex's completion
+    /// acknowledgement and creates a response. Frameless requires no terminal
+    /// wire item after the final delegation context append.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the V2 completion cannot be delivered.
+    pub async fn complete_agent_run(
+        &self,
+        call_id: impl Into<String>,
+    ) -> Result<(), RealtimeError> {
+        self.send(CommandKind::AgentComplete {
+            call_id: call_id.into(),
         })
         .await
     }
@@ -568,6 +671,7 @@ impl RealtimeSessionBuilder {
         Ok((
             RealtimeSession {
                 commands: command_tx,
+                protocol,
             },
             RealtimeEvents { receiver: event_rx },
         ))
@@ -632,6 +736,8 @@ struct Command {
 enum CommandKind {
     Audio(RealtimeAudio),
     AgentOutput { call_id: String, output: String },
+    AgentProgress { call_id: String, output: String },
+    AgentComplete { call_id: String },
     SilentOutput { call_id: String },
     Close,
 }
@@ -739,12 +845,25 @@ struct SessionTool {
 #[derive(Serialize)]
 #[serde(untagged)]
 enum ConversationItem<'a> {
+    Message {
+        #[serde(rename = "type")]
+        kind: &'static str,
+        role: &'static str,
+        content: [ConversationInputText<'a>; 1],
+    },
     FunctionOutput {
         #[serde(rename = "type")]
         kind: &'static str,
         call_id: &'a str,
         output: &'a str,
     },
+}
+
+#[derive(Serialize)]
+struct ConversationInputText<'a> {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    text: &'a str,
 }
 
 fn session_update(instructions: &str, voice: RealtimeVoice) -> ClientEvent<'_> {
@@ -780,7 +899,7 @@ fn session_update(instructions: &str, voice: RealtimeVoice) -> ClientEvent<'_> {
                 SessionTool {
                     kind: "function",
                     name: BACKGROUND_AGENT_TOOL,
-                    description: "Send the user's coding request to the background agent. Preserve the user's own words and use this tool for work that requires repository context or tools.",
+                    description: BACKGROUND_AGENT_TOOL_DESCRIPTION,
                     parameters: json!({
                         "type": "object",
                         "properties": {
@@ -793,7 +912,7 @@ fn session_update(instructions: &str, voice: RealtimeVoice) -> ClientEvent<'_> {
                 SessionTool {
                     kind: "function",
                     name: REMAIN_SILENT_TOOL,
-                    description: "Use this when the best response is to say nothing.",
+                    description: REMAIN_SILENT_TOOL_DESCRIPTION,
                     parameters: json!({
                         "type": "object",
                         "properties": {},
@@ -814,6 +933,8 @@ async fn run_socket(
     mut media: Option<webrtc::WebRtcMedia>,
 ) {
     let media_input = media.as_ref().map(webrtc::WebRtcMedia::input);
+    let mut active_transcript = ActiveTranscript::default();
+    let mut response_create = ResponseCreateQueue::default();
     loop {
         tokio::select! {
             command = commands.recv() => {
@@ -828,6 +949,7 @@ async fn run_socket(
                     command.kind,
                     protocol,
                     media_input.as_ref(),
+                    &mut response_create,
                 ).await;
                 let should_close = matches!(result, Ok(true));
                 if let Err(error) = &result {
@@ -840,7 +962,14 @@ async fn run_socket(
                 }
             }
             message = socket.next() => {
-                match handle_server_message(&mut socket, message, &events, protocol).await {
+                match handle_server_message(
+                    &mut socket,
+                    message,
+                    &events,
+                    protocol,
+                    &mut active_transcript,
+                    &mut response_create,
+                ).await {
                     Ok(true) => break,
                     Ok(false) => {}
                     Err(error) => {
@@ -885,6 +1014,7 @@ async fn handle_command(
     command: CommandKind,
     protocol: RealtimeProtocol,
     media_input: Option<&mpsc::Sender<RealtimeAudio>>,
+    response_create: &mut ResponseCreateQueue,
 ) -> Result<bool, RealtimeError> {
     match command {
         CommandKind::Audio(audio) => {
@@ -918,11 +1048,29 @@ async fn handle_command(
             match protocol {
                 RealtimeProtocol::Direct => {
                     send_function_output(socket, &call_id, &output).await?;
-                    send_json(socket, &ClientEvent::ResponseCreate).await?;
+                    response_create.request(socket).await?;
                 }
                 RealtimeProtocol::Frameless => {
                     send_delegation_context(socket, &call_id, &output).await?;
                 }
+            }
+            Ok(false)
+        }
+        CommandKind::AgentProgress { call_id, output } => {
+            match protocol {
+                RealtimeProtocol::Direct => {
+                    send_backend_output(socket, &output).await?;
+                }
+                RealtimeProtocol::Frameless => {
+                    send_delegation_context(socket, &call_id, &output).await?;
+                }
+            }
+            Ok(false)
+        }
+        CommandKind::AgentComplete { call_id } => {
+            if matches!(protocol, RealtimeProtocol::Direct) {
+                send_function_output(socket, &call_id, AGENT_COMPLETE_ACKNOWLEDGEMENT).await?;
+                response_create.request(socket).await?;
             }
             Ok(false)
         }
@@ -1009,6 +1157,24 @@ async fn send_function_output(
     .await
 }
 
+async fn send_backend_output(socket: &mut Socket, output: &str) -> Result<(), RealtimeError> {
+    let text = format!("{BACKEND_TEXT_PREFIX}{output}");
+    send_json(
+        socket,
+        &ClientEvent::ItemCreate {
+            item: ConversationItem::Message {
+                kind: "message",
+                role: "user",
+                content: [ConversationInputText {
+                    kind: "input_text",
+                    text: &text,
+                }],
+            },
+        },
+    )
+    .await
+}
+
 async fn send_json(socket: &mut Socket, value: &ClientEvent<'_>) -> Result<(), RealtimeError> {
     let payload =
         serde_json::to_string(value).map_err(|error| RealtimeError::Message(error.to_string()))?;
@@ -1024,6 +1190,8 @@ async fn handle_server_message(
     message: Option<Result<Message, WebSocketError>>,
     events: &mpsc::Sender<RealtimeEvent>,
     protocol: RealtimeProtocol,
+    active_transcript: &mut ActiveTranscript,
+    response_create: &mut ResponseCreateQueue,
 ) -> Result<bool, RealtimeError> {
     let Some(message) = message else {
         return Ok(true);
@@ -1031,10 +1199,20 @@ async fn handle_server_message(
     match message.map_err(map_websocket_error)? {
         Message::Text(payload) => {
             trace!(target: "nanocodex_oai_api::realtime::wire", payload = %payload, "GPT Realtime event");
-            if let Some(event) = parse_event(&payload, protocol)?
-                && events.send(event).await.is_err()
-            {
-                return Ok(true);
+            if let Some(mut event) = parse_event(&payload, protocol)? {
+                active_transcript.update(&mut event);
+                if matches!(protocol, RealtimeProtocol::Direct) {
+                    match &event {
+                        RealtimeEvent::ResponseStarted => response_create.mark_started(),
+                        RealtimeEvent::ResponseDone => {
+                            response_create.mark_finished(socket).await?
+                        }
+                        _ => {}
+                    }
+                }
+                if events.send(event).await.is_err() {
+                    return Ok(true);
+                }
             }
             Ok(false)
         }
@@ -1051,6 +1229,148 @@ async fn handle_server_message(
             "unexpected binary WebSocket frame".to_owned(),
         )),
     }
+}
+
+#[derive(Default)]
+struct ResponseCreateQueue {
+    active: bool,
+    pending: bool,
+}
+
+impl ResponseCreateQueue {
+    async fn request(&mut self, socket: &mut Socket) -> Result<(), RealtimeError> {
+        if self.active {
+            self.pending = true;
+            return Ok(());
+        }
+        send_json(socket, &ClientEvent::ResponseCreate).await?;
+        self.active = true;
+        Ok(())
+    }
+
+    const fn mark_started(&mut self) {
+        self.active = true;
+    }
+
+    async fn mark_finished(&mut self, socket: &mut Socket) -> Result<(), RealtimeError> {
+        self.active = false;
+        if !self.pending {
+            return Ok(());
+        }
+        self.pending = false;
+        self.request(socket).await
+    }
+}
+
+#[derive(Default)]
+struct ActiveTranscript {
+    entries: Vec<RealtimeTranscriptEntry>,
+    last_handoff_entry_count: usize,
+    new_input_entry: bool,
+    new_output_entry: bool,
+}
+
+impl ActiveTranscript {
+    fn update(&mut self, event: &mut RealtimeEvent) {
+        match event {
+            RealtimeEvent::SpeechStarted => self.new_input_entry = true,
+            RealtimeEvent::InputTranscriptDelta(delta) => {
+                append_transcript_delta(&mut self.entries, "user", delta, self.new_input_entry);
+                self.new_input_entry = false;
+            }
+            RealtimeEvent::OutputTranscriptDelta(delta) => {
+                append_transcript_delta(
+                    &mut self.entries,
+                    "assistant",
+                    delta,
+                    self.new_output_entry,
+                );
+                self.new_output_entry = false;
+            }
+            RealtimeEvent::InputTranscriptDone(text) => {
+                apply_transcript_done(&mut self.entries, "user", text, self.new_input_entry);
+                self.new_input_entry = false;
+            }
+            RealtimeEvent::OutputTranscriptDone(text) => {
+                apply_transcript_done(&mut self.entries, "assistant", text, self.new_output_entry);
+                self.new_output_entry = false;
+            }
+            RealtimeEvent::AgentRequest {
+                prompt, transcript, ..
+            } => {
+                append_handoff_input(&mut self.entries, prompt);
+                *transcript = self.entries[self.last_handoff_entry_count..].to_vec();
+                self.last_handoff_entry_count = self.entries.len();
+                self.new_input_entry = true;
+                self.new_output_entry = true;
+            }
+            RealtimeEvent::ResponseStarted => self.new_output_entry = true,
+            RealtimeEvent::SessionReady { .. }
+            | RealtimeEvent::Audio(_)
+            | RealtimeEvent::RemainSilent { .. }
+            | RealtimeEvent::ResponseDone
+            | RealtimeEvent::Error(_) => {}
+        }
+    }
+}
+
+fn append_transcript_delta(
+    entries: &mut Vec<RealtimeTranscriptEntry>,
+    role: &str,
+    delta: &str,
+    force_new: bool,
+) {
+    if delta.is_empty() {
+        return;
+    }
+    if !force_new
+        && let Some(last) = entries.last_mut()
+        && last.role == role
+    {
+        last.text.push_str(delta);
+        return;
+    }
+    entries.push(RealtimeTranscriptEntry {
+        role: role.to_owned(),
+        text: delta.to_owned(),
+    });
+}
+
+fn apply_transcript_done(
+    entries: &mut Vec<RealtimeTranscriptEntry>,
+    role: &str,
+    text: &str,
+    force_new: bool,
+) {
+    if text.is_empty() {
+        return;
+    }
+    if !force_new
+        && let Some(last) = entries.last_mut()
+        && last.role == role
+    {
+        last.text = text.to_owned();
+        return;
+    }
+    entries.push(RealtimeTranscriptEntry {
+        role: role.to_owned(),
+        text: text.to_owned(),
+    });
+}
+
+fn append_handoff_input(entries: &mut Vec<RealtimeTranscriptEntry>, input: &str) {
+    let input = input.trim();
+    if input.is_empty()
+        || entries
+            .iter()
+            .any(|entry| entry.role == "user" && entry.text.trim() == input)
+    {
+        return;
+    }
+    entries.push(RealtimeTranscriptEntry {
+        role: "user".to_owned(),
+        text: input.to_owned(),
+    });
 }
 
 fn parse_event(
@@ -1186,6 +1506,7 @@ fn parse_frameless_delegation(value: &Value) -> Option<RealtimeEvent> {
     Some(RealtimeEvent::AgentRequest {
         call_id: item.get("id")?.as_str()?.to_owned(),
         prompt,
+        transcript: Vec::new(),
     })
 }
 
@@ -1215,6 +1536,7 @@ fn parse_completed_item(value: &Value) -> Option<RealtimeEvent> {
         BACKGROUND_AGENT_TOOL => Some(RealtimeEvent::AgentRequest {
             call_id,
             prompt: delegated_prompt(item.get("arguments").and_then(Value::as_str)),
+            transcript: Vec::new(),
         }),
         REMAIN_SILENT_TOOL => Some(RealtimeEvent::RemainSilent { call_id }),
         _ => None,
@@ -1277,10 +1599,10 @@ mod tests {
     use tokio_tungstenite::{accept_async, tungstenite::Message};
 
     use super::{
-        CHATGPT_REALTIME_MODEL, CHATGPT_REALTIME_VOICE, CHATGPT_REALTIME_VOICES,
-        PLATFORM_REALTIME_VOICE, PLATFORM_REALTIME_VOICES, RealtimeAudio, RealtimeEvent,
-        RealtimeProtocol, RealtimeVoice, context_append_chunks, delegated_prompt, parse_event,
-        realtime_endpoint, session_update,
+        ActiveTranscript, CHATGPT_REALTIME_MODEL, CHATGPT_REALTIME_VOICE, CHATGPT_REALTIME_VOICES,
+        PLATFORM_REALTIME_VOICE, PLATFORM_REALTIME_VOICES, RealtimeAgentSteer, RealtimeAudio,
+        RealtimeEvent, RealtimeProtocol, RealtimeTranscriptEntry, RealtimeVoice,
+        context_append_chunks, delegated_prompt, parse_event, realtime_endpoint, session_update,
     };
     use crate::OpenAi;
 
@@ -1362,6 +1684,7 @@ mod tests {
             Some(RealtimeEvent::AgentRequest {
                 call_id: "call_1".to_owned(),
                 prompt: "inspect the tests".to_owned(),
+                transcript: Vec::new(),
             })
         );
     }
@@ -1377,6 +1700,7 @@ mod tests {
             Some(RealtimeEvent::AgentRequest {
                 call_id: "delegation_1".to_owned(),
                 prompt: "run the tests".to_owned(),
+                transcript: Vec::new(),
             })
         );
         assert_eq!(
@@ -1402,6 +1726,64 @@ mod tests {
             )
             .unwrap(),
             Some(RealtimeEvent::OutputTranscriptDone("all done".to_owned()))
+        );
+    }
+
+    #[test]
+    fn attaches_only_new_active_transcript_to_each_delegation() {
+        let mut transcript = ActiveTranscript::default();
+        transcript.update(&mut RealtimeEvent::InputTranscriptDelta(
+            "delegate ".to_owned(),
+        ));
+        transcript.update(&mut RealtimeEvent::InputTranscriptDone(
+            "delegate this".to_owned(),
+        ));
+        let mut first = RealtimeEvent::AgentRequest {
+            call_id: "call_1".to_owned(),
+            prompt: "delegate this".to_owned(),
+            transcript: Vec::new(),
+        };
+        transcript.update(&mut first);
+        assert_eq!(
+            first,
+            RealtimeEvent::AgentRequest {
+                call_id: "call_1".to_owned(),
+                prompt: "delegate this".to_owned(),
+                transcript: vec![RealtimeTranscriptEntry {
+                    role: "user".to_owned(),
+                    text: "delegate this".to_owned(),
+                }],
+            }
+        );
+
+        transcript.update(&mut RealtimeEvent::OutputTranscriptDone(
+            "On it.".to_owned(),
+        ));
+        transcript.update(&mut RealtimeEvent::InputTranscriptDone(
+            "also run tests".to_owned(),
+        ));
+        let mut second = RealtimeEvent::AgentRequest {
+            call_id: "call_2".to_owned(),
+            prompt: "also run tests".to_owned(),
+            transcript: Vec::new(),
+        };
+        transcript.update(&mut second);
+        assert_eq!(
+            second,
+            RealtimeEvent::AgentRequest {
+                call_id: "call_2".to_owned(),
+                prompt: "also run tests".to_owned(),
+                transcript: vec![
+                    RealtimeTranscriptEntry {
+                        role: "assistant".to_owned(),
+                        text: "On it.".to_owned(),
+                    },
+                    RealtimeTranscriptEntry {
+                        role: "user".to_owned(),
+                        text: "also run tests".to_owned(),
+                    },
+                ],
+            }
         );
     }
 
@@ -1450,6 +1832,42 @@ mod tests {
             let create = socket.next().await.unwrap().unwrap().into_text().unwrap();
             let create: serde_json::Value = serde_json::from_str(&create).unwrap();
             assert_eq!(create["type"], "response.create");
+            socket
+                .send(Message::Text(r#"{"type":"response.done"}"#.into()))
+                .await
+                .unwrap();
+
+            let progress = socket.next().await.unwrap().unwrap().into_text().unwrap();
+            let progress: serde_json::Value = serde_json::from_str(&progress).unwrap();
+            assert_eq!(progress["item"]["type"], "message");
+            assert_eq!(progress["item"]["role"], "user");
+            assert_eq!(progress["item"]["content"][0]["text"], "[BACKEND] working");
+
+            let complete = socket.next().await.unwrap().unwrap().into_text().unwrap();
+            let complete: serde_json::Value = serde_json::from_str(&complete).unwrap();
+            assert_eq!(complete["item"]["call_id"], "call_1");
+            assert_eq!(
+                complete["item"]["output"],
+                "Background agent finished. Use the preceding [BACKEND] messages as the result."
+            );
+            let create = socket.next().await.unwrap().unwrap().into_text().unwrap();
+            let create: serde_json::Value = serde_json::from_str(&create).unwrap();
+            assert_eq!(create["type"], "response.create");
+            socket
+                .send(Message::Text(r#"{"type":"response.done"}"#.into()))
+                .await
+                .unwrap();
+
+            let steer = socket.next().await.unwrap().unwrap().into_text().unwrap();
+            let steer: serde_json::Value = serde_json::from_str(&steer).unwrap();
+            assert_eq!(steer["item"]["call_id"], "call_2");
+            assert_eq!(
+                steer["item"]["output"],
+                "This was sent to steer the previous background agent task."
+            );
+            let create = socket.next().await.unwrap().unwrap().into_text().unwrap();
+            let create: serde_json::Value = serde_json::from_str(&create).unwrap();
+            assert_eq!(create["type"], "response.create");
         });
 
         let openai = OpenAi::new("test-key").unwrap();
@@ -1473,6 +1891,15 @@ mod tests {
             .complete_agent_request("call_1", "done")
             .await
             .unwrap();
+        session
+            .append_agent_output("call_1", "working")
+            .await
+            .unwrap();
+        session.complete_agent_run("call_1").await.unwrap();
+        assert_eq!(
+            session.steer_agent_request("call_2").await.unwrap(),
+            RealtimeAgentSteer::Acknowledged
+        );
         server.await.unwrap();
     }
 }

--- a/crates/nanocodex-oai-api/src/realtime.rs
+++ b/crates/nanocodex-oai-api/src/realtime.rs
@@ -1,0 +1,1478 @@
+//! GPT Realtime WebSocket sessions.
+//!
+//! The transport deliberately stops at typed audio and conversation events.
+//! Device capture/playback and delegation to a coding agent are application
+//! concerns; this keeps the library usable with pipes and custom media stacks.
+
+use std::{fmt, str::FromStr, sync::Arc, time::Duration};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use futures_util::{SinkExt, StreamExt};
+use serde::Serialize;
+use serde_json::{Value, json};
+use tokio::{
+    net::TcpStream,
+    sync::{mpsc, oneshot},
+    time::{Instant, timeout},
+};
+use tokio_tungstenite::{
+    MaybeTlsStream, WebSocketStream,
+    tungstenite::{
+        Error as WebSocketError, Message,
+        client::IntoClientRequest,
+        http::{HeaderValue, header},
+    },
+};
+use tracing::{debug, trace};
+use url::Url;
+
+use crate::{OpenAiAuth, OpenAiAuthError, OpenAiAuthMode, connector::connect_async};
+
+mod webrtc;
+
+/// Sample rate required for GPT Realtime PCM audio.
+pub const REALTIME_SAMPLE_RATE: u32 = 24_000;
+/// Channel count required for GPT Realtime PCM audio.
+pub const REALTIME_CHANNELS: u16 = 1;
+/// Default model used by native Realtime sessions.
+pub const REALTIME_MODEL: &str = "gpt-realtime-1.5";
+/// Default model used by ChatGPT-authenticated Codex voice sessions.
+pub const CHATGPT_REALTIME_MODEL: &str = "gpt-live-1-boulder-alpha";
+
+/// Voices supported by Codex's Frameless/V3 ChatGPT voice sessions.
+pub const CHATGPT_REALTIME_VOICES: &[RealtimeVoice] = &[
+    RealtimeVoice::Juniper,
+    RealtimeVoice::Maple,
+    RealtimeVoice::Spruce,
+    RealtimeVoice::Ember,
+    RealtimeVoice::Vale,
+    RealtimeVoice::Breeze,
+    RealtimeVoice::Arbor,
+    RealtimeVoice::Sol,
+    RealtimeVoice::Cove,
+];
+
+/// Default voice used by Codex's Frameless/V3 ChatGPT voice sessions.
+pub const CHATGPT_REALTIME_VOICE: RealtimeVoice = RealtimeVoice::Cove;
+
+/// Voices supported by direct Platform Realtime sessions.
+pub const PLATFORM_REALTIME_VOICES: &[RealtimeVoice] = &[
+    RealtimeVoice::Alloy,
+    RealtimeVoice::Ash,
+    RealtimeVoice::Ballad,
+    RealtimeVoice::Coral,
+    RealtimeVoice::Echo,
+    RealtimeVoice::Sage,
+    RealtimeVoice::Shimmer,
+    RealtimeVoice::Verse,
+    RealtimeVoice::Marin,
+    RealtimeVoice::Cedar,
+];
+
+/// Default voice used by direct Platform Realtime sessions.
+pub const PLATFORM_REALTIME_VOICE: RealtimeVoice = RealtimeVoice::Marin;
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+const SEND_TIMEOUT: Duration = Duration::from_secs(30);
+const COMMAND_CAPACITY: usize = 256;
+const EVENT_CAPACITY: usize = 256;
+const BACKGROUND_AGENT_TOOL: &str = "background_agent";
+const REMAIN_SILENT_TOOL: &str = "remain_silent";
+const CONTEXT_APPEND_MAX_BYTES: usize = 500;
+
+type Socket = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+/// A GPT Realtime output voice supported by the current realtime protocol.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub enum RealtimeVoice {
+    /// Alloy voice.
+    Alloy,
+    /// Arbor voice.
+    Arbor,
+    /// Ash voice.
+    Ash,
+    /// Ballad voice.
+    Ballad,
+    /// Breeze voice.
+    Breeze,
+    /// Cedar voice.
+    Cedar,
+    /// Coral voice.
+    Coral,
+    /// Cove voice.
+    Cove,
+    /// Echo voice.
+    Echo,
+    /// Ember voice.
+    Ember,
+    /// Juniper voice.
+    Juniper,
+    /// Maple voice.
+    Maple,
+    /// Marin voice, the direct Platform default.
+    #[default]
+    Marin,
+    /// Sage voice.
+    Sage,
+    /// Shimmer voice.
+    Shimmer,
+    /// Sol voice.
+    Sol,
+    /// Spruce voice.
+    Spruce,
+    /// Vale voice.
+    Vale,
+    /// Verse voice.
+    Verse,
+}
+
+impl RealtimeVoice {
+    /// Returns the protocol value for this voice.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Alloy => "alloy",
+            Self::Arbor => "arbor",
+            Self::Ash => "ash",
+            Self::Ballad => "ballad",
+            Self::Breeze => "breeze",
+            Self::Cedar => "cedar",
+            Self::Coral => "coral",
+            Self::Cove => "cove",
+            Self::Echo => "echo",
+            Self::Ember => "ember",
+            Self::Juniper => "juniper",
+            Self::Maple => "maple",
+            Self::Marin => "marin",
+            Self::Sage => "sage",
+            Self::Shimmer => "shimmer",
+            Self::Sol => "sol",
+            Self::Spruce => "spruce",
+            Self::Vale => "vale",
+            Self::Verse => "verse",
+        }
+    }
+
+    const fn supports_frameless(self) -> bool {
+        matches!(
+            self,
+            Self::Arbor
+                | Self::Breeze
+                | Self::Cove
+                | Self::Ember
+                | Self::Juniper
+                | Self::Maple
+                | Self::Sol
+                | Self::Spruce
+                | Self::Vale
+        )
+    }
+
+    const fn supports_direct(self) -> bool {
+        matches!(
+            self,
+            Self::Alloy
+                | Self::Ash
+                | Self::Ballad
+                | Self::Cedar
+                | Self::Coral
+                | Self::Echo
+                | Self::Marin
+                | Self::Sage
+                | Self::Shimmer
+                | Self::Verse
+        )
+    }
+}
+
+impl fmt::Display for RealtimeVoice {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for RealtimeVoice {
+    type Err = RealtimeError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "alloy" => Ok(Self::Alloy),
+            "arbor" => Ok(Self::Arbor),
+            "ash" => Ok(Self::Ash),
+            "ballad" => Ok(Self::Ballad),
+            "breeze" => Ok(Self::Breeze),
+            "cedar" => Ok(Self::Cedar),
+            "coral" => Ok(Self::Coral),
+            "cove" => Ok(Self::Cove),
+            "echo" => Ok(Self::Echo),
+            "ember" => Ok(Self::Ember),
+            "juniper" => Ok(Self::Juniper),
+            "maple" => Ok(Self::Maple),
+            "marin" => Ok(Self::Marin),
+            "sage" => Ok(Self::Sage),
+            "shimmer" => Ok(Self::Shimmer),
+            "sol" => Ok(Self::Sol),
+            "spruce" => Ok(Self::Spruce),
+            "vale" => Ok(Self::Vale),
+            "verse" => Ok(Self::Verse),
+            _ => Err(RealtimeError::InvalidVoice(value.to_owned())),
+        }
+    }
+}
+
+/// One owned 24 kHz mono signed-16-bit little-endian PCM chunk.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RealtimeAudio {
+    data: Vec<u8>,
+}
+
+impl RealtimeAudio {
+    /// Creates a PCM chunk from signed-16-bit little-endian bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the byte count does not contain complete samples.
+    pub fn pcm16_le(data: impl Into<Vec<u8>>) -> Result<Self, RealtimeError> {
+        let data = data.into();
+        if data.len() % size_of::<i16>() != 0 {
+            return Err(RealtimeError::InvalidAudio(
+                "PCM16 audio must contain complete little-endian samples".to_owned(),
+            ));
+        }
+        Ok(Self { data })
+    }
+
+    /// Creates a PCM chunk from native signed samples.
+    #[must_use]
+    pub fn from_samples(samples: impl IntoIterator<Item = i16>) -> Self {
+        let samples = samples.into_iter();
+        let mut data = Vec::with_capacity(samples.size_hint().0.saturating_mul(2));
+        for sample in samples {
+            data.extend_from_slice(&sample.to_le_bytes());
+        }
+        Self { data }
+    }
+
+    /// Returns the signed-16-bit little-endian PCM bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// Consumes the chunk and returns its PCM bytes.
+    #[must_use]
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.data
+    }
+
+    /// Returns the number of mono samples in this chunk.
+    #[must_use]
+    pub const fn samples(&self) -> usize {
+        self.data.len() / size_of::<i16>()
+    }
+
+    /// Returns whether this chunk contains no samples.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+}
+
+/// A typed event from a GPT Realtime conversation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RealtimeEvent {
+    /// The server accepted the session configuration.
+    SessionReady {
+        /// Provider-assigned realtime session identity.
+        session_id: String,
+    },
+    /// Voice activity detection observed new user speech.
+    SpeechStarted,
+    /// Incremental transcription of user speech.
+    InputTranscriptDelta(String),
+    /// Completed transcription of one user utterance.
+    InputTranscriptDone(String),
+    /// Incremental transcript of synthesized output speech.
+    OutputTranscriptDelta(String),
+    /// Completed transcript of synthesized output speech.
+    OutputTranscriptDone(String),
+    /// Synthesized 24 kHz mono PCM16 audio.
+    Audio(RealtimeAudio),
+    /// Realtime requested work from the background coding agent.
+    AgentRequest {
+        /// Function call identity to complete with [`RealtimeSession::complete_agent_request`].
+        call_id: String,
+        /// User request selected by the realtime model for delegation.
+        prompt: String,
+    },
+    /// Realtime requested an intentionally silent tool result.
+    RemainSilent {
+        /// Function call identity to acknowledge with [`RealtimeSession::complete_silent_request`].
+        call_id: String,
+    },
+    /// A realtime response began.
+    ResponseStarted,
+    /// A realtime response completed.
+    ResponseDone,
+    /// The provider reported a session error.
+    Error(String),
+}
+
+/// Receiver for the independent typed event stream of a realtime session.
+pub struct RealtimeEvents {
+    receiver: mpsc::Receiver<RealtimeEvent>,
+}
+
+impl RealtimeEvents {
+    /// Waits for the next typed realtime event.
+    pub async fn recv(&mut self) -> Option<RealtimeEvent> {
+        self.receiver.recv().await
+    }
+
+    /// Attempts to receive an already-buffered event.
+    pub fn try_recv(&mut self) -> Option<RealtimeEvent> {
+        self.receiver.try_recv().ok()
+    }
+}
+
+/// Cloneable command handle for one active GPT Realtime session.
+#[derive(Clone)]
+pub struct RealtimeSession {
+    commands: mpsc::Sender<Command>,
+}
+
+impl RealtimeSession {
+    /// Appends one owned 24 kHz mono PCM16 input chunk.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the session has closed or sending times out.
+    pub async fn send_audio(&self, audio: RealtimeAudio) -> Result<(), RealtimeError> {
+        self.send(CommandKind::Audio(audio)).await
+    }
+
+    /// Completes a background-agent request and asks Realtime to speak the result.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the session has closed or sending times out.
+    pub async fn complete_agent_request(
+        &self,
+        call_id: impl Into<String>,
+        output: impl Into<String>,
+    ) -> Result<(), RealtimeError> {
+        self.send(CommandKind::AgentOutput {
+            call_id: call_id.into(),
+            output: output.into(),
+        })
+        .await
+    }
+
+    /// Completes a `remain_silent` request without creating spoken output.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the session has closed or sending times out.
+    pub async fn complete_silent_request(
+        &self,
+        call_id: impl Into<String>,
+    ) -> Result<(), RealtimeError> {
+        self.send(CommandKind::SilentOutput {
+            call_id: call_id.into(),
+        })
+        .await
+    }
+
+    /// Closes the realtime WebSocket.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the close command cannot be delivered.
+    pub async fn close(&self) -> Result<(), RealtimeError> {
+        self.send(CommandKind::Close).await
+    }
+
+    async fn send(&self, kind: CommandKind) -> Result<(), RealtimeError> {
+        let (result, completed) = oneshot::channel();
+        let command = Command { kind, result };
+        timeout(SEND_TIMEOUT, self.commands.send(command))
+            .await
+            .map_err(|_| RealtimeError::SendTimeout)?
+            .map_err(|_| RealtimeError::Closed)?;
+        timeout(SEND_TIMEOUT, completed)
+            .await
+            .map_err(|_| RealtimeError::SendTimeout)?
+            .map_err(|_| RealtimeError::Closed)?
+    }
+}
+
+/// Builder for one independent GPT Realtime conversation.
+pub struct RealtimeSessionBuilder {
+    auth: OpenAiAuth,
+    api_base_url: String,
+    attestation_header: Option<Arc<str>>,
+    websocket_url: Option<String>,
+    instructions: Arc<str>,
+    model: String,
+    voice: Option<RealtimeVoice>,
+    session_id: Option<String>,
+}
+
+impl RealtimeSessionBuilder {
+    pub(crate) fn new(auth: OpenAiAuth, api_base_url: String, instructions: Arc<str>) -> Self {
+        let model = match auth.mode() {
+            OpenAiAuthMode::ApiKey => REALTIME_MODEL,
+            OpenAiAuthMode::ChatGpt => CHATGPT_REALTIME_MODEL,
+        };
+        Self {
+            auth,
+            api_base_url,
+            attestation_header: None,
+            websocket_url: None,
+            instructions,
+            model: model.to_owned(),
+            voice: None,
+            session_id: None,
+        }
+    }
+
+    /// Selects the GPT Realtime model.
+    #[must_use]
+    pub fn model(mut self, model: impl Into<String>) -> Self {
+        self.model = model.into();
+        self
+    }
+
+    /// Selects the output voice.
+    #[must_use]
+    pub const fn voice(mut self, voice: RealtimeVoice) -> Self {
+        self.voice = Some(voice);
+        self
+    }
+
+    /// Replaces the derived Realtime WebSocket URL.
+    #[must_use]
+    pub fn websocket_url(mut self, websocket_url: impl Into<String>) -> Self {
+        self.websocket_url = Some(websocket_url.into());
+        self
+    }
+
+    /// Supplies a stable caller-owned session identity header.
+    #[must_use]
+    pub fn session_id(mut self, session_id: impl Into<String>) -> Self {
+        self.session_id = Some(session_id.into());
+        self
+    }
+
+    /// Supplies a host-generated `x-oai-attestation` value for ChatGPT calls.
+    ///
+    /// The value is opaque to Nanocodex and is reused only for the call and its
+    /// sideband join. When omitted, Nanocodex sends the same unavailable-token
+    /// envelope Codex uses when host attestation generation times out.
+    #[must_use]
+    pub fn attestation_header(mut self, value: impl Into<Arc<str>>) -> Self {
+        self.attestation_header = Some(value.into());
+        self
+    }
+
+    /// Connects and configures the realtime conversation.
+    ///
+    /// The returned command handle and event stream are independent. Dropping
+    /// every command handle closes the socket task.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid configuration, authentication, timeout, or
+    /// a failed WebSocket/WebRTC handshake.
+    pub async fn connect(self) -> Result<(RealtimeSession, RealtimeEvents), RealtimeError> {
+        if self.instructions.trim().is_empty() {
+            return Err(RealtimeError::InvalidInstructions);
+        }
+        if self.model.trim().is_empty() {
+            return Err(RealtimeError::InvalidModel);
+        }
+
+        let (socket, protocol, media) = match self.auth.mode() {
+            OpenAiAuthMode::ApiKey => {
+                let voice = self.voice.unwrap_or(PLATFORM_REALTIME_VOICE);
+                if !voice.supports_direct() {
+                    return Err(RealtimeError::InvalidVoice(voice.to_string()));
+                }
+                let auth = self.auth.snapshot().await?;
+                let endpoint = match self.websocket_url {
+                    Some(endpoint) => endpoint,
+                    None => realtime_endpoint(&self.api_base_url, &self.model)?,
+                };
+                let mut request = endpoint
+                    .as_str()
+                    .into_client_request()
+                    .map_err(|error| RealtimeError::InvalidUrl(error.to_string()))?;
+                request.headers_mut().insert(
+                    header::AUTHORIZATION,
+                    HeaderValue::from_str(&format!("Bearer {}", auth.bearer()))
+                        .map_err(|error| RealtimeError::InvalidAuthorization(error.to_string()))?,
+                );
+                request.headers_mut().insert(
+                    header::USER_AGENT,
+                    HeaderValue::from_static(concat!("nanocodex/", env!("CARGO_PKG_VERSION"))),
+                );
+                if let Some(session_id) = &self.session_id {
+                    request.headers_mut().insert(
+                        "x-session-id",
+                        HeaderValue::from_str(session_id)
+                            .map_err(|error| RealtimeError::InvalidSessionId(error.to_string()))?,
+                    );
+                }
+
+                let connect_started = Instant::now();
+                let (mut socket, response) = timeout(CONNECT_TIMEOUT, connect_async(request))
+                    .await
+                    .map_err(|_| RealtimeError::ConnectTimeout)?
+                    .map_err(map_websocket_error)?;
+                debug!(
+                    status = response.status().as_u16(),
+                    elapsed_ms = connect_started.elapsed().as_millis(),
+                    "connected GPT Realtime websocket"
+                );
+                let update = session_update(&self.instructions, voice);
+                send_json(&mut socket, &update).await?;
+                (socket, RealtimeProtocol::Direct, None)
+            }
+            OpenAiAuthMode::ChatGpt => {
+                let voice = self.voice.unwrap_or(CHATGPT_REALTIME_VOICE);
+                if !voice.supports_frameless() {
+                    return Err(RealtimeError::InvalidVoice(voice.to_string()));
+                }
+                let connection = webrtc::connect(webrtc::ConnectConfig {
+                    auth: &self.auth,
+                    api_base_url: &self.api_base_url,
+                    attestation_header: self.attestation_header.as_deref(),
+                    websocket_url: self.websocket_url.as_deref(),
+                    instructions: &self.instructions,
+                    model: &self.model,
+                    voice,
+                    session_id: self.session_id.as_deref(),
+                })
+                .await?;
+                (
+                    connection.socket,
+                    RealtimeProtocol::Frameless,
+                    Some(connection.media),
+                )
+            }
+        };
+
+        let (command_tx, command_rx) = mpsc::channel(COMMAND_CAPACITY);
+        let (event_tx, event_rx) = mpsc::channel(EVENT_CAPACITY);
+        tokio::spawn(run_socket(socket, command_rx, event_tx, protocol, media));
+        Ok((
+            RealtimeSession {
+                commands: command_tx,
+            },
+            RealtimeEvents { receiver: event_rx },
+        ))
+    }
+}
+
+/// Failure from configuring or operating a GPT Realtime session.
+#[derive(Debug, thiserror::Error)]
+pub enum RealtimeError {
+    /// Managed credentials could not be resolved.
+    #[error(transparent)]
+    Authentication(#[from] OpenAiAuthError),
+    /// Developer instructions were empty.
+    #[error("GPT Realtime instructions must not be empty")]
+    InvalidInstructions,
+    /// The realtime model identifier was empty.
+    #[error("GPT Realtime model must not be empty")]
+    InvalidModel,
+    /// The selected voice was not recognized.
+    #[error("unsupported GPT Realtime voice {0:?}")]
+    InvalidVoice(String),
+    /// PCM input was malformed.
+    #[error("invalid GPT Realtime audio: {0}")]
+    InvalidAudio(String),
+    /// The realtime URL was invalid.
+    #[error("invalid GPT Realtime URL: {0}")]
+    InvalidUrl(String),
+    /// An authorization header could not be represented.
+    #[error("invalid GPT Realtime authorization: {0}")]
+    InvalidAuthorization(String),
+    /// A caller-owned session header was invalid.
+    #[error("invalid GPT Realtime session ID: {0}")]
+    InvalidSessionId(String),
+    /// Connecting exceeded the transport deadline.
+    #[error("GPT Realtime connection timed out")]
+    ConnectTimeout,
+    /// Sending exceeded the transport deadline.
+    #[error("GPT Realtime send timed out")]
+    SendTimeout,
+    /// The realtime session is closed.
+    #[error("GPT Realtime session is closed")]
+    Closed,
+    /// A WebSocket operation failed.
+    #[error("GPT Realtime WebSocket failed: {0}")]
+    WebSocket(String),
+    /// Creating the authenticated Realtime call failed.
+    #[error("GPT Realtime HTTP call failed: {0}")]
+    Http(String),
+    /// Negotiating or decoding Realtime WebRTC media failed.
+    #[error("GPT Realtime WebRTC failed: {0}")]
+    WebRtc(String),
+    /// A realtime JSON message could not be encoded or decoded.
+    #[error("invalid GPT Realtime message: {0}")]
+    Message(String),
+}
+
+struct Command {
+    kind: CommandKind,
+    result: oneshot::Sender<Result<(), RealtimeError>>,
+}
+
+enum CommandKind {
+    Audio(RealtimeAudio),
+    AgentOutput { call_id: String, output: String },
+    SilentOutput { call_id: String },
+    Close,
+}
+
+#[derive(Clone, Copy)]
+enum RealtimeProtocol {
+    Direct,
+    Frameless,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type")]
+enum ClientEvent<'a> {
+    #[serde(rename = "session.update")]
+    SessionUpdate { session: SessionUpdate<'a> },
+    #[serde(rename = "input_audio_buffer.append")]
+    AudioBufferAppend { audio: String },
+    #[serde(rename = "conversation.item.create")]
+    ItemCreate { item: ConversationItem<'a> },
+    #[serde(rename = "response.create")]
+    ResponseCreate,
+    #[serde(rename = "delegation.context.append")]
+    DelegationContextAppend {
+        delegation_item_id: &'a str,
+        content: [FramelessInputText<'a>; 1],
+    },
+    #[serde(rename = "session.close")]
+    SessionClose,
+}
+
+#[derive(Serialize)]
+struct FramelessInputText<'a> {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    text: &'a str,
+}
+
+#[derive(Serialize)]
+struct SessionUpdate<'a> {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    instructions: &'a str,
+    output_modalities: [&'static str; 1],
+    audio: SessionAudio<'a>,
+    tools: [SessionTool; 2],
+    tool_choice: &'static str,
+}
+
+#[derive(Serialize)]
+struct SessionAudio<'a> {
+    input: SessionAudioInput,
+    output: SessionAudioOutput<'a>,
+}
+
+#[derive(Serialize)]
+struct SessionAudioInput {
+    format: AudioFormat,
+    noise_reduction: NoiseReduction,
+    transcription: Transcription,
+    turn_detection: TurnDetection,
+}
+
+#[derive(Serialize)]
+struct SessionAudioOutput<'a> {
+    format: AudioFormat,
+    voice: &'a str,
+}
+
+#[derive(Clone, Copy, Serialize)]
+struct AudioFormat {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    rate: u32,
+}
+
+#[derive(Serialize)]
+struct NoiseReduction {
+    #[serde(rename = "type")]
+    kind: &'static str,
+}
+
+#[derive(Serialize)]
+struct Transcription {
+    model: &'static str,
+}
+
+#[derive(Serialize)]
+struct TurnDetection {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    interrupt_response: bool,
+    create_response: bool,
+    silence_duration_ms: u32,
+}
+
+#[derive(Serialize)]
+struct SessionTool {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    name: &'static str,
+    description: &'static str,
+    parameters: Value,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+enum ConversationItem<'a> {
+    FunctionOutput {
+        #[serde(rename = "type")]
+        kind: &'static str,
+        call_id: &'a str,
+        output: &'a str,
+    },
+}
+
+fn session_update(instructions: &str, voice: RealtimeVoice) -> ClientEvent<'_> {
+    let format = AudioFormat {
+        kind: "audio/pcm",
+        rate: REALTIME_SAMPLE_RATE,
+    };
+    ClientEvent::SessionUpdate {
+        session: SessionUpdate {
+            kind: "realtime",
+            instructions,
+            output_modalities: ["audio"],
+            audio: SessionAudio {
+                input: SessionAudioInput {
+                    format,
+                    noise_reduction: NoiseReduction { kind: "near_field" },
+                    transcription: Transcription {
+                        model: "gpt-4o-mini-transcribe",
+                    },
+                    turn_detection: TurnDetection {
+                        kind: "server_vad",
+                        interrupt_response: true,
+                        create_response: true,
+                        silence_duration_ms: 500,
+                    },
+                },
+                output: SessionAudioOutput {
+                    format,
+                    voice: voice.as_str(),
+                },
+            },
+            tools: [
+                SessionTool {
+                    kind: "function",
+                    name: BACKGROUND_AGENT_TOOL,
+                    description: "Send the user's coding request to the background agent. Preserve the user's own words and use this tool for work that requires repository context or tools.",
+                    parameters: json!({
+                        "type": "object",
+                        "properties": {
+                            "prompt": { "type": "string" }
+                        },
+                        "required": ["prompt"],
+                        "additionalProperties": false
+                    }),
+                },
+                SessionTool {
+                    kind: "function",
+                    name: REMAIN_SILENT_TOOL,
+                    description: "Use this when the best response is to say nothing.",
+                    parameters: json!({
+                        "type": "object",
+                        "properties": {},
+                        "additionalProperties": false
+                    }),
+                },
+            ],
+            tool_choice: "auto",
+        },
+    }
+}
+
+async fn run_socket(
+    mut socket: Socket,
+    mut commands: mpsc::Receiver<Command>,
+    events: mpsc::Sender<RealtimeEvent>,
+    protocol: RealtimeProtocol,
+    mut media: Option<webrtc::WebRtcMedia>,
+) {
+    let media_input = media.as_ref().map(webrtc::WebRtcMedia::input);
+    loop {
+        tokio::select! {
+            command = commands.recv() => {
+                let Some(command) = command else {
+                    if let Err(error) = close_socket(&mut socket, protocol).await {
+                        debug!(%error, "failed to close dropped GPT Realtime session");
+                    }
+                    break;
+                };
+                let result = handle_command(
+                    &mut socket,
+                    command.kind,
+                    protocol,
+                    media_input.as_ref(),
+                ).await;
+                let should_close = matches!(result, Ok(true));
+                if let Err(error) = &result {
+                    let _ = events.send(RealtimeEvent::Error(error.to_string())).await;
+                }
+                let failed = result.is_err();
+                let _ = command.result.send(result.map(|_| ()));
+                if should_close || failed {
+                    break;
+                }
+            }
+            message = socket.next() => {
+                match handle_server_message(&mut socket, message, &events, protocol).await {
+                    Ok(true) => break,
+                    Ok(false) => {}
+                    Err(error) => {
+                        let _ = events.send(RealtimeEvent::Error(error.to_string())).await;
+                        break;
+                    }
+                }
+            }
+            audio = recv_media(&mut media) => {
+                match audio {
+                    Some(Ok(audio)) => {
+                        if events.send(RealtimeEvent::Audio(audio)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Some(Err(error)) => {
+                        let _ = events.send(RealtimeEvent::Error(error.to_string())).await;
+                        break;
+                    }
+                    None => media = None,
+                }
+            }
+        }
+    }
+    if let Some(media) = media {
+        media.close().await;
+    }
+    debug!("GPT Realtime websocket task stopped");
+}
+
+async fn recv_media(
+    media: &mut Option<webrtc::WebRtcMedia>,
+) -> Option<Result<RealtimeAudio, RealtimeError>> {
+    match media {
+        Some(media) => media.recv().await,
+        None => std::future::pending().await,
+    }
+}
+
+async fn handle_command(
+    socket: &mut Socket,
+    command: CommandKind,
+    protocol: RealtimeProtocol,
+    media_input: Option<&mpsc::Sender<RealtimeAudio>>,
+) -> Result<bool, RealtimeError> {
+    match command {
+        CommandKind::Audio(audio) => {
+            if !audio.is_empty() {
+                match protocol {
+                    RealtimeProtocol::Direct => {
+                        send_json(
+                            socket,
+                            &ClientEvent::AudioBufferAppend {
+                                audio: STANDARD.encode(audio.as_bytes()),
+                            },
+                        )
+                        .await?;
+                    }
+                    RealtimeProtocol::Frameless => {
+                        let input = media_input.ok_or_else(|| {
+                            RealtimeError::WebRtc(
+                                "frameless session omitted its microphone track".to_owned(),
+                            )
+                        })?;
+                        timeout(SEND_TIMEOUT, input.send(audio))
+                            .await
+                            .map_err(|_| RealtimeError::SendTimeout)?
+                            .map_err(|_| RealtimeError::Closed)?;
+                    }
+                }
+            }
+            Ok(false)
+        }
+        CommandKind::AgentOutput { call_id, output } => {
+            match protocol {
+                RealtimeProtocol::Direct => {
+                    send_function_output(socket, &call_id, &output).await?;
+                    send_json(socket, &ClientEvent::ResponseCreate).await?;
+                }
+                RealtimeProtocol::Frameless => {
+                    send_delegation_context(socket, &call_id, &output).await?;
+                }
+            }
+            Ok(false)
+        }
+        CommandKind::SilentOutput { call_id } => {
+            match protocol {
+                RealtimeProtocol::Direct => send_function_output(socket, &call_id, "").await?,
+                RealtimeProtocol::Frameless => {
+                    send_delegation_context(socket, &call_id, "").await?;
+                }
+            }
+            Ok(false)
+        }
+        CommandKind::Close => {
+            close_socket(socket, protocol).await?;
+            Ok(true)
+        }
+    }
+}
+
+async fn close_socket(
+    socket: &mut Socket,
+    protocol: RealtimeProtocol,
+) -> Result<(), RealtimeError> {
+    if matches!(protocol, RealtimeProtocol::Frameless) {
+        send_json(socket, &ClientEvent::SessionClose).await?;
+    }
+    socket.close(None).await.map_err(map_websocket_error)
+}
+
+async fn send_delegation_context(
+    socket: &mut Socket,
+    delegation_item_id: &str,
+    output: &str,
+) -> Result<(), RealtimeError> {
+    for chunk in context_append_chunks(output) {
+        send_json(
+            socket,
+            &ClientEvent::DelegationContextAppend {
+                delegation_item_id,
+                content: [FramelessInputText {
+                    kind: "input_text",
+                    text: chunk,
+                }],
+            },
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+fn context_append_chunks(text: &str) -> Vec<&str> {
+    if text.len() <= CONTEXT_APPEND_MAX_BYTES {
+        return vec![text];
+    }
+
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    while start < text.len() {
+        let mut end = (start + CONTEXT_APPEND_MAX_BYTES).min(text.len());
+        while end > start && !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        chunks.push(&text[start..end]);
+        start = end;
+    }
+    chunks
+}
+
+async fn send_function_output(
+    socket: &mut Socket,
+    call_id: &str,
+    output: &str,
+) -> Result<(), RealtimeError> {
+    send_json(
+        socket,
+        &ClientEvent::ItemCreate {
+            item: ConversationItem::FunctionOutput {
+                kind: "function_call_output",
+                call_id,
+                output,
+            },
+        },
+    )
+    .await
+}
+
+async fn send_json(socket: &mut Socket, value: &ClientEvent<'_>) -> Result<(), RealtimeError> {
+    let payload =
+        serde_json::to_string(value).map_err(|error| RealtimeError::Message(error.to_string()))?;
+    trace!(target: "nanocodex_oai_api::realtime::wire", payload = %payload, "GPT Realtime request");
+    timeout(SEND_TIMEOUT, socket.send(Message::Text(payload.into())))
+        .await
+        .map_err(|_| RealtimeError::SendTimeout)?
+        .map_err(map_websocket_error)
+}
+
+async fn handle_server_message(
+    socket: &mut Socket,
+    message: Option<Result<Message, WebSocketError>>,
+    events: &mpsc::Sender<RealtimeEvent>,
+    protocol: RealtimeProtocol,
+) -> Result<bool, RealtimeError> {
+    let Some(message) = message else {
+        return Ok(true);
+    };
+    match message.map_err(map_websocket_error)? {
+        Message::Text(payload) => {
+            trace!(target: "nanocodex_oai_api::realtime::wire", payload = %payload, "GPT Realtime event");
+            if let Some(event) = parse_event(&payload, protocol)?
+                && events.send(event).await.is_err()
+            {
+                return Ok(true);
+            }
+            Ok(false)
+        }
+        Message::Ping(payload) => {
+            socket
+                .send(Message::Pong(payload))
+                .await
+                .map_err(map_websocket_error)?;
+            Ok(false)
+        }
+        Message::Pong(_) | Message::Frame(_) => Ok(false),
+        Message::Close(_) => Ok(true),
+        Message::Binary(_) => Err(RealtimeError::Message(
+            "unexpected binary WebSocket frame".to_owned(),
+        )),
+    }
+}
+
+fn parse_event(
+    payload: &str,
+    protocol: RealtimeProtocol,
+) -> Result<Option<RealtimeEvent>, RealtimeError> {
+    let value: Value =
+        serde_json::from_str(payload).map_err(|error| RealtimeError::Message(error.to_string()))?;
+    let kind = value
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let event = match protocol {
+        RealtimeProtocol::Direct => parse_direct_event(&value, kind)?,
+        RealtimeProtocol::Frameless => parse_frameless_event(&value, kind),
+    };
+    Ok(event)
+}
+
+fn parse_direct_event(value: &Value, kind: &str) -> Result<Option<RealtimeEvent>, RealtimeError> {
+    let event = match kind {
+        "session.updated" => {
+            value
+                .pointer("/session/id")
+                .and_then(Value::as_str)
+                .map(|session_id| RealtimeEvent::SessionReady {
+                    session_id: session_id.to_owned(),
+                })
+        }
+        "input_audio_buffer.speech_started" => Some(RealtimeEvent::SpeechStarted),
+        "conversation.input_transcript.delta" => {
+            string_field(value, "delta").map(RealtimeEvent::InputTranscriptDelta)
+        }
+        "conversation.input_transcript.turn_marked" => {
+            string_field(value, "transcript").map(RealtimeEvent::InputTranscriptDone)
+        }
+        "conversation.item.input_audio_transcription.delta" => {
+            string_field(value, "delta").map(RealtimeEvent::InputTranscriptDelta)
+        }
+        "conversation.item.input_audio_transcription.completed" => {
+            string_field(value, "transcript").map(RealtimeEvent::InputTranscriptDone)
+        }
+        "response.output_text.delta" | "response.output_audio_transcript.delta" => {
+            string_field(value, "delta").map(RealtimeEvent::OutputTranscriptDelta)
+        }
+        "conversation.output_transcript.delta" => {
+            string_field(value, "delta").map(RealtimeEvent::OutputTranscriptDelta)
+        }
+        "response.output_text.done" => {
+            string_field(value, "text").map(RealtimeEvent::OutputTranscriptDone)
+        }
+        "response.output_audio_transcript.done" => {
+            string_field(value, "transcript").map(RealtimeEvent::OutputTranscriptDone)
+        }
+        "response.output_audio.delta" | "response.audio.delta" => {
+            let encoded = value
+                .get("delta")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let data = STANDARD
+                .decode(encoded)
+                .map_err(|error| RealtimeError::Message(error.to_string()))?;
+            Some(RealtimeEvent::Audio(RealtimeAudio::pcm16_le(data)?))
+        }
+        "conversation.item.done" => parse_completed_item(value),
+        "response.created" => Some(RealtimeEvent::ResponseStarted),
+        "response.done" | "response.cancelled" => Some(RealtimeEvent::ResponseDone),
+        "error" => Some(RealtimeEvent::Error(
+            value
+                .pointer("/error/message")
+                .or_else(|| value.get("message"))
+                .and_then(Value::as_str)
+                .unwrap_or("unknown GPT Realtime error")
+                .to_owned(),
+        )),
+        _ => None,
+    };
+    Ok(event)
+}
+
+fn parse_frameless_event(value: &Value, kind: &str) -> Option<RealtimeEvent> {
+    match kind {
+        "session.started" | "session.updated" => value
+            .pointer("/session/id")
+            .and_then(Value::as_str)
+            .map(|session_id| RealtimeEvent::SessionReady {
+                session_id: session_id.to_owned(),
+            }),
+        "input_transcript.added" => value
+            .pointer("/item/text")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .map(RealtimeEvent::InputTranscriptDelta),
+        "output_transcript.added" => value
+            .pointer("/item/text")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .map(RealtimeEvent::OutputTranscriptDelta),
+        "turn.done" => parse_frameless_turn(value),
+        "delegation.created" => parse_frameless_delegation(value),
+        // WebRTC media owns frameless output audio. Ignoring its sideband
+        // mirror prevents duplicate playback.
+        "output_audio.delta" => None,
+        "error" => Some(parse_error(value)),
+        _ => None,
+    }
+}
+
+fn parse_frameless_turn(value: &Value) -> Option<RealtimeEvent> {
+    let role = value.pointer("/turn/role")?.as_str()?;
+    let transcript = value.pointer("/turn/transcript")?.as_str()?.to_owned();
+    match role {
+        "user" => Some(RealtimeEvent::InputTranscriptDone(transcript)),
+        "assistant" => Some(RealtimeEvent::OutputTranscriptDone(transcript)),
+        _ => None,
+    }
+}
+
+fn parse_frameless_delegation(value: &Value) -> Option<RealtimeEvent> {
+    let item = value.get("item")?;
+    if item.get("type").and_then(Value::as_str) != Some("delegation")
+        || item.get("target").and_then(Value::as_str) != Some("client")
+    {
+        return None;
+    }
+    let prompt = item
+        .get("content")?
+        .as_array()?
+        .iter()
+        .filter(|content| content.get("type").and_then(Value::as_str) == Some("input_text"))
+        .filter_map(|content| content.get("text").and_then(Value::as_str))
+        .collect::<String>();
+    Some(RealtimeEvent::AgentRequest {
+        call_id: item.get("id")?.as_str()?.to_owned(),
+        prompt,
+    })
+}
+
+fn parse_error(value: &Value) -> RealtimeEvent {
+    RealtimeEvent::Error(
+        value
+            .pointer("/error/message")
+            .or_else(|| value.get("message"))
+            .and_then(Value::as_str)
+            .unwrap_or("unknown GPT Realtime error")
+            .to_owned(),
+    )
+}
+
+fn parse_completed_item(value: &Value) -> Option<RealtimeEvent> {
+    let item = value.get("item")?;
+    if item.get("type").and_then(Value::as_str) != Some("function_call") {
+        return None;
+    }
+    let name = item.get("name").and_then(Value::as_str)?;
+    let call_id = item
+        .get("call_id")
+        .or_else(|| item.get("id"))
+        .and_then(Value::as_str)?
+        .to_owned();
+    match name {
+        BACKGROUND_AGENT_TOOL => Some(RealtimeEvent::AgentRequest {
+            call_id,
+            prompt: delegated_prompt(item.get("arguments").and_then(Value::as_str)),
+        }),
+        REMAIN_SILENT_TOOL => Some(RealtimeEvent::RemainSilent { call_id }),
+        _ => None,
+    }
+}
+
+fn delegated_prompt(arguments: Option<&str>) -> String {
+    let Some(arguments) = arguments else {
+        return String::new();
+    };
+    serde_json::from_str::<Value>(arguments)
+        .ok()
+        .and_then(|value| {
+            ["prompt", "input_transcript", "input", "text", "query"]
+                .into_iter()
+                .find_map(|key| value.get(key).and_then(Value::as_str).map(str::trim))
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+        })
+        .unwrap_or_else(|| arguments.to_owned())
+}
+
+fn string_field(value: &Value, field: &str) -> Option<String> {
+    value.get(field).and_then(Value::as_str).map(str::to_owned)
+}
+
+fn realtime_endpoint(api_base_url: &str, model: &str) -> Result<String, RealtimeError> {
+    let mut url =
+        Url::parse(api_base_url).map_err(|error| RealtimeError::InvalidUrl(error.to_string()))?;
+    match url.scheme() {
+        "https" => url
+            .set_scheme("wss")
+            .map_err(|()| RealtimeError::InvalidUrl("could not select wss".to_owned()))?,
+        "http" => url
+            .set_scheme("ws")
+            .map_err(|()| RealtimeError::InvalidUrl("could not select ws".to_owned()))?,
+        "wss" | "ws" => {}
+        scheme => {
+            return Err(RealtimeError::InvalidUrl(format!(
+                "unsupported URL scheme {scheme}"
+            )));
+        }
+    }
+    let path = url.path().trim_end_matches('/');
+    if !path.ends_with("/realtime") {
+        url.set_path(&format!("{path}/realtime"));
+    }
+    url.query_pairs_mut().append_pair("model", model);
+    Ok(url.into())
+}
+
+fn map_websocket_error(error: WebSocketError) -> RealtimeError {
+    RealtimeError::WebSocket(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use futures_util::{SinkExt, StreamExt};
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::{accept_async, tungstenite::Message};
+
+    use super::{
+        CHATGPT_REALTIME_MODEL, CHATGPT_REALTIME_VOICE, CHATGPT_REALTIME_VOICES,
+        PLATFORM_REALTIME_VOICE, PLATFORM_REALTIME_VOICES, RealtimeAudio, RealtimeEvent,
+        RealtimeProtocol, RealtimeVoice, context_append_chunks, delegated_prompt, parse_event,
+        realtime_endpoint, session_update,
+    };
+    use crate::OpenAi;
+
+    #[test]
+    fn derives_realtime_endpoint_from_api_base() {
+        assert_eq!(
+            realtime_endpoint("https://api.openai.com/v1", "gpt-realtime-1.5").unwrap(),
+            "wss://api.openai.com/v1/realtime?model=gpt-realtime-1.5"
+        );
+    }
+
+    #[test]
+    fn matches_codex_voice_catalog_and_defaults() {
+        assert_eq!(CHATGPT_REALTIME_MODEL, "gpt-live-1-boulder-alpha");
+        assert_eq!(CHATGPT_REALTIME_VOICE, RealtimeVoice::Cove);
+        assert_eq!(PLATFORM_REALTIME_VOICE, RealtimeVoice::Marin);
+        assert_eq!(
+            CHATGPT_REALTIME_VOICES,
+            &[
+                RealtimeVoice::Juniper,
+                RealtimeVoice::Maple,
+                RealtimeVoice::Spruce,
+                RealtimeVoice::Ember,
+                RealtimeVoice::Vale,
+                RealtimeVoice::Breeze,
+                RealtimeVoice::Arbor,
+                RealtimeVoice::Sol,
+                RealtimeVoice::Cove,
+            ]
+        );
+        assert_eq!(
+            PLATFORM_REALTIME_VOICES,
+            &[
+                RealtimeVoice::Alloy,
+                RealtimeVoice::Ash,
+                RealtimeVoice::Ballad,
+                RealtimeVoice::Coral,
+                RealtimeVoice::Echo,
+                RealtimeVoice::Sage,
+                RealtimeVoice::Shimmer,
+                RealtimeVoice::Verse,
+                RealtimeVoice::Marin,
+                RealtimeVoice::Cedar,
+            ]
+        );
+    }
+
+    #[test]
+    fn session_update_uses_pcm_and_background_agent_tool() {
+        let value =
+            serde_json::to_value(session_update("delegate coding work", RealtimeVoice::Cove))
+                .unwrap();
+        assert_eq!(value["session"]["audio"]["input"]["format"]["rate"], 24_000);
+        assert_eq!(value["session"]["audio"]["output"]["voice"], "cove");
+        assert_eq!(value["session"]["tools"][0]["name"], "background_agent");
+    }
+
+    #[test]
+    fn parses_audio_and_background_agent_events() {
+        let audio = parse_event(
+            r#"{"type":"response.output_audio.delta","delta":"AAE="}"#,
+            RealtimeProtocol::Direct,
+        )
+        .unwrap();
+        assert_eq!(
+            audio,
+            Some(RealtimeEvent::Audio(
+                RealtimeAudio::pcm16_le([0, 1]).unwrap()
+            ))
+        );
+
+        let request = parse_event(
+            r#"{"type":"conversation.item.done","item":{"type":"function_call","name":"background_agent","call_id":"call_1","arguments":"{\"prompt\":\"inspect the tests\"}"}}"#,
+            RealtimeProtocol::Direct,
+        )
+        .unwrap();
+        assert_eq!(
+            request,
+            Some(RealtimeEvent::AgentRequest {
+                call_id: "call_1".to_owned(),
+                prompt: "inspect the tests".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn parses_frameless_transcripts_delegation_and_ignores_sideband_audio() {
+        assert_eq!(
+            parse_event(
+                r#"{"type":"delegation.created","item":{"type":"delegation","target":"client","id":"delegation_1","content":[{"type":"input_text","text":"run "},{"type":"output_text","text":"ignored"},{"type":"input_text","text":"the tests"}]}}"#,
+                RealtimeProtocol::Frameless,
+            )
+            .unwrap(),
+            Some(RealtimeEvent::AgentRequest {
+                call_id: "delegation_1".to_owned(),
+                prompt: "run the tests".to_owned(),
+            })
+        );
+        assert_eq!(
+            parse_event(
+                r#"{"type":"output_audio.delta","audio":"AAE="}"#,
+                RealtimeProtocol::Frameless,
+            )
+            .unwrap(),
+            None
+        );
+        assert_eq!(
+            parse_event(
+                r#"{"type":"input_transcript.added","item":{"text":"hello"}}"#,
+                RealtimeProtocol::Frameless,
+            )
+            .unwrap(),
+            Some(RealtimeEvent::InputTranscriptDelta("hello".to_owned()))
+        );
+        assert_eq!(
+            parse_event(
+                r#"{"type":"turn.done","turn":{"role":"assistant","transcript":"all done"}}"#,
+                RealtimeProtocol::Frameless,
+            )
+            .unwrap(),
+            Some(RealtimeEvent::OutputTranscriptDone("all done".to_owned()))
+        );
+    }
+
+    #[test]
+    fn accepts_piped_pcm_bytes_and_fallback_arguments() {
+        assert_eq!(RealtimeAudio::pcm16_le([0, 1]).unwrap().samples(), 1);
+        assert!(RealtimeAudio::pcm16_le([0]).is_err());
+        assert_eq!(delegated_prompt(Some("plain request")), "plain request");
+    }
+
+    #[test]
+    fn chunks_frameless_delegation_context_at_utf8_boundaries() {
+        let text = format!("{}é{}", "a".repeat(499), "b".repeat(10));
+        let chunks = context_append_chunks(&text);
+        assert_eq!(chunks.concat(), text);
+        assert!(chunks.iter().all(|chunk| chunk.len() <= 500));
+        assert_eq!(context_append_chunks(""), [""]);
+    }
+
+    #[tokio::test]
+    async fn streams_typed_audio_and_agent_results_over_one_socket() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut socket = accept_async(stream).await.unwrap();
+            let update = socket.next().await.unwrap().unwrap().into_text().unwrap();
+            let update: serde_json::Value = serde_json::from_str(&update).unwrap();
+            assert_eq!(update["type"], "session.update");
+            socket
+                .send(Message::Text(
+                    r#"{"type":"session.updated","session":{"id":"rt_1"}}"#.into(),
+                ))
+                .await
+                .unwrap();
+
+            let audio = socket.next().await.unwrap().unwrap().into_text().unwrap();
+            let audio: serde_json::Value = serde_json::from_str(&audio).unwrap();
+            assert_eq!(audio["type"], "input_audio_buffer.append");
+            assert_eq!(audio["audio"], "AAE=");
+
+            let output = socket.next().await.unwrap().unwrap().into_text().unwrap();
+            let output: serde_json::Value = serde_json::from_str(&output).unwrap();
+            assert_eq!(output["item"]["call_id"], "call_1");
+            assert_eq!(output["item"]["output"], "done");
+            let create = socket.next().await.unwrap().unwrap().into_text().unwrap();
+            let create: serde_json::Value = serde_json::from_str(&create).unwrap();
+            assert_eq!(create["type"], "response.create");
+        });
+
+        let openai = OpenAi::new("test-key").unwrap();
+        let (session, mut events) = openai
+            .realtime("delegate coding work")
+            .websocket_url(format!("ws://{address}"))
+            .connect()
+            .await
+            .unwrap();
+        assert_eq!(
+            events.recv().await,
+            Some(RealtimeEvent::SessionReady {
+                session_id: "rt_1".to_owned(),
+            })
+        );
+        session
+            .send_audio(RealtimeAudio::pcm16_le([0, 1]).unwrap())
+            .await
+            .unwrap();
+        session
+            .complete_agent_request("call_1", "done")
+            .await
+            .unwrap();
+        server.await.unwrap();
+    }
+}

--- a/crates/nanocodex-oai-api/src/realtime/webrtc.rs
+++ b/crates/nanocodex-oai-api/src/realtime/webrtc.rs
@@ -1,12 +1,13 @@
 use std::{
     collections::VecDeque,
-    sync::{Arc, Once},
+    sync::{Arc, Once, OnceLock},
     time::Duration,
 };
 
 use opusic_c::{
     Application as OpusApplication, Channels as OpusChannels, Decoder as OpusDecoder,
-    Encoder as OpusEncoder, SampleRate as OpusSampleRate,
+    Encoder as OpusEncoder, InbandFec as OpusInbandFec, SampleRate as OpusSampleRate,
+    Signal as OpusSignal,
 };
 use reqwest::{Client, StatusCode, header::LOCATION};
 use serde::Serialize;
@@ -48,6 +49,7 @@ const WEBRTC_MAX_FRAME_SAMPLES: usize = 2_880;
 const WEBRTC_REORDER_PACKETS: u16 = 3;
 const WEBRTC_REORDER_DELAY: Duration = Duration::from_millis(60);
 const WEBRTC_MAX_CONCEALED_PACKETS: u16 = 6;
+const WEBRTC_EXPECTED_PACKET_LOSS_PERCENT: u8 = 5;
 const OPUS_PACKET_CAPACITY: usize = 4_000;
 const OPENAI_REALTIME_BASE: &str = "https://api.openai.com/v1";
 const ATTESTATION_UNAVAILABLE: &str = r#"{"v":1,"s":1}"#;
@@ -405,6 +407,16 @@ fn spawn_microphone_encoder(
             error.message()
         ))
     })?;
+    encoder
+        .set_signal(OpusSignal::Voice)
+        .and_then(|()| encoder.set_inband_fec(OpusInbandFec::Mode1))
+        .and_then(|()| encoder.set_packet_loss(WEBRTC_EXPECTED_PACKET_LOSS_PERCENT))
+        .map_err(|error| {
+            RealtimeError::WebRtc(format!(
+                "failed to configure microphone Opus encoder: {}",
+                error.message()
+            ))
+        })?;
     tokio::spawn(async move {
         let mut pending = VecDeque::with_capacity(WEBRTC_INPUT_FRAME_SAMPLES * 2);
         let mut pcm = Vec::with_capacity(WEBRTC_INPUT_FRAME_SAMPLES);
@@ -538,7 +550,7 @@ async fn create_call(
             delegation: CallDelegation { kind: "client" },
         },
     };
-    let mut builder = Client::new()
+    let mut builder = realtime_http_client()
         .post(endpoint)
         .bearer_auth(auth.bearer())
         .header("openai-alpha", "quicksilver=v2")
@@ -557,9 +569,11 @@ async fn create_call(
             .header("session-id", session_id)
             .header("thread-id", session_id);
     }
-    let payload = serde_json::to_string(&request)
-        .map_err(|error| CallAttemptError::Other(RealtimeError::Message(error.to_string())))?;
-    trace!(target: "nanocodex_oai_api::realtime::wire", payload = %payload, "GPT Realtime call request");
+    if tracing::enabled!(target: "nanocodex_oai_api::realtime::wire", tracing::Level::TRACE) {
+        let payload = serde_json::to_string(&request)
+            .map_err(|error| CallAttemptError::Other(RealtimeError::Message(error.to_string())))?;
+        trace!(target: "nanocodex_oai_api::realtime::wire", payload = %payload, "GPT Realtime call request");
+    }
     let response = timeout(CONNECT_TIMEOUT, builder.send())
         .await
         .map_err(|_| CallAttemptError::Other(RealtimeError::ConnectTimeout))?
@@ -594,6 +608,11 @@ async fn create_call(
     })?;
     let id = call_id(location.as_deref()).map_err(CallAttemptError::Other)?;
     Ok(CallResponse { sdp, id })
+}
+
+fn realtime_http_client() -> Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT.get_or_init(Client::new).clone()
 }
 
 async fn bounded_body(

--- a/crates/nanocodex-oai-api/src/realtime/webrtc.rs
+++ b/crates/nanocodex-oai-api/src/realtime/webrtc.rs
@@ -1,0 +1,885 @@
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Once},
+    time::Duration,
+};
+
+use opusic_c::{
+    Application as OpusApplication, Channels as OpusChannels, Decoder as OpusDecoder,
+    Encoder as OpusEncoder, SampleRate as OpusSampleRate,
+};
+use reqwest::{Client, StatusCode, header::LOCATION};
+use serde::Serialize;
+use tokio::{sync::mpsc, time::timeout};
+use tokio_tungstenite::tungstenite::{
+    client::IntoClientRequest,
+    http::{HeaderValue, header},
+};
+use tracing::{debug, trace};
+use url::Url;
+use webrtc::{
+    api::{
+        APIBuilder,
+        interceptor_registry::register_default_interceptors,
+        media_engine::{MIME_TYPE_OPUS, MediaEngine},
+    },
+    interceptor::registry::Registry,
+    media::{Sample, io::sample_builder::SampleBuilder},
+    peer_connection::{
+        RTCPeerConnection, configuration::RTCConfiguration,
+        sdp::session_description::RTCSessionDescription,
+    },
+    rtp::codecs::opus::OpusPacket,
+    rtp_transceiver::rtp_codec::{RTCRtpCodecCapability, RTCRtpCodecParameters, RTPCodecType},
+    track::track_local::{TrackLocal, track_local_static_sample::TrackLocalStaticSample},
+};
+
+use super::{
+    CONNECT_TIMEOUT, EVENT_CAPACITY, RealtimeAudio, RealtimeError, RealtimeVoice, Socket,
+    map_websocket_error,
+};
+use crate::{OpenAiAuth, OpenAiAuthSnapshot, connector::connect_async};
+
+const DATA_CHANNEL_LABEL: &str = "oai-events";
+const CALL_BODY_LIMIT: usize = 1024 * 1024;
+const ERROR_BODY_LIMIT: usize = 8 * 1024;
+const WEBRTC_INPUT_FRAME_SAMPLES: usize = 480;
+const WEBRTC_MAX_FRAME_SAMPLES: usize = 2_880;
+const WEBRTC_REORDER_PACKETS: u16 = 3;
+const WEBRTC_REORDER_DELAY: Duration = Duration::from_millis(60);
+const WEBRTC_MAX_CONCEALED_PACKETS: u16 = 6;
+const OPUS_PACKET_CAPACITY: usize = 4_000;
+const OPENAI_REALTIME_BASE: &str = "https://api.openai.com/v1";
+const ATTESTATION_UNAVAILABLE: &str = r#"{"v":1,"s":1}"#;
+
+pub(super) struct WebRtcConnection {
+    pub(super) socket: Socket,
+    pub(super) media: WebRtcMedia,
+}
+
+pub(super) struct WebRtcMedia {
+    peer: Arc<RTCPeerConnection>,
+    input: mpsc::Sender<RealtimeAudio>,
+    audio: mpsc::Receiver<Result<RealtimeAudio, RealtimeError>>,
+}
+
+impl WebRtcMedia {
+    pub(super) fn input(&self) -> mpsc::Sender<RealtimeAudio> {
+        self.input.clone()
+    }
+
+    pub(super) async fn recv(&mut self) -> Option<Result<RealtimeAudio, RealtimeError>> {
+        self.audio.recv().await
+    }
+
+    pub(super) async fn close(self) {
+        if let Err(error) = self.peer.close().await {
+            debug!(%error, "failed to close GPT Realtime WebRTC peer");
+        }
+    }
+}
+
+pub(super) struct ConnectConfig<'a> {
+    pub(super) auth: &'a OpenAiAuth,
+    pub(super) api_base_url: &'a str,
+    pub(super) attestation_header: Option<&'a str>,
+    pub(super) websocket_url: Option<&'a str>,
+    pub(super) instructions: &'a str,
+    pub(super) model: &'a str,
+    pub(super) voice: RealtimeVoice,
+    pub(super) session_id: Option<&'a str>,
+}
+
+pub(super) async fn connect(config: ConnectConfig<'_>) -> Result<WebRtcConnection, RealtimeError> {
+    ensure_rustls_crypto_provider();
+    let offer = create_offer().await?;
+    let (call, auth) = create_call_with_auth_recovery(&config, &offer.sdp).await?;
+    trace!(target: "nanocodex_oai_api::realtime::wire", sdp = %call.sdp, call_id = %call.id, "GPT Realtime WebRTC answer");
+    debug!(call_id = %call.id, "applying GPT Realtime WebRTC answer");
+    timeout(
+        CONNECT_TIMEOUT,
+        offer.peer.set_remote_description(
+            RTCSessionDescription::answer(call.sdp)
+                .map_err(|error| RealtimeError::WebRtc(error.to_string()))?,
+        ),
+    )
+    .await
+    .map_err(|_| RealtimeError::ConnectTimeout)?
+    .map_err(|error| RealtimeError::WebRtc(error.to_string()))?;
+    debug!(call_id = %call.id, "applied GPT Realtime WebRTC answer");
+
+    let endpoint = sideband_endpoint(config.websocket_url, &call.id)?;
+    debug!(url = %endpoint, "connecting GPT Realtime WebRTC sideband");
+    let mut request = endpoint
+        .as_str()
+        .into_client_request()
+        .map_err(|error| RealtimeError::InvalidUrl(error.to_string()))?;
+    add_auth_headers(request.headers_mut(), &auth)?;
+    request.headers_mut().insert(
+        "x-oai-attestation",
+        HeaderValue::from_str(config.attestation_header.unwrap_or(ATTESTATION_UNAVAILABLE))
+            .map_err(|error| RealtimeError::InvalidAuthorization(error.to_string()))?,
+    );
+    request
+        .headers_mut()
+        .insert("openai-alpha", HeaderValue::from_static("quicksilver=v2"));
+    request.headers_mut().insert(
+        header::USER_AGENT,
+        HeaderValue::from_static(concat!("nanocodex/", env!("CARGO_PKG_VERSION"))),
+    );
+    request
+        .headers_mut()
+        .insert("originator", HeaderValue::from_static("nanocodex"));
+    if let Some(session_id) = config.session_id {
+        let value = HeaderValue::from_str(session_id)
+            .map_err(|error| RealtimeError::InvalidSessionId(error.to_string()))?;
+        request.headers_mut().insert("x-session-id", value.clone());
+        request.headers_mut().insert("session-id", value.clone());
+        request.headers_mut().insert("thread-id", value);
+    }
+
+    let connect_started = tokio::time::Instant::now();
+    let (socket, response) = timeout(CONNECT_TIMEOUT, connect_async(request))
+        .await
+        .map_err(|_| RealtimeError::ConnectTimeout)?
+        .map_err(map_websocket_error)?;
+    debug!(
+        status = response.status().as_u16(),
+        elapsed_ms = connect_started.elapsed().as_millis(),
+        "connected GPT Realtime WebRTC sideband"
+    );
+    Ok(WebRtcConnection {
+        socket,
+        media: WebRtcMedia {
+            peer: offer.peer,
+            input: offer.input,
+            audio: offer.audio,
+        },
+    })
+}
+
+fn ensure_rustls_crypto_provider() {
+    static RUSTLS_PROVIDER_INIT: Once = Once::new();
+    RUSTLS_PROVIDER_INIT.call_once(|| {
+        // Embeddings may have installed their own process-wide provider. When
+        // they have not, select the provider used by Codex before WebRTC or
+        // Reqwest asks rustls to auto-select from an ambiguous feature graph.
+        drop(rustls::crypto::aws_lc_rs::default_provider().install_default());
+    });
+}
+
+async fn create_offer() -> Result<Offer, RealtimeError> {
+    let mut media_engine = MediaEngine::default();
+    media_engine
+        .register_codec(
+            RTCRtpCodecParameters {
+                capability: RTCRtpCodecCapability {
+                    mime_type: MIME_TYPE_OPUS.to_owned(),
+                    clock_rate: 48_000,
+                    channels: 2,
+                    sdp_fmtp_line: "minptime=10;useinbandfec=1".to_owned(),
+                    rtcp_feedback: Vec::new(),
+                },
+                payload_type: 111,
+                ..Default::default()
+            },
+            RTPCodecType::Audio,
+        )
+        .map_err(|error| RealtimeError::WebRtc(error.to_string()))?;
+    let registry = register_default_interceptors(Registry::new(), &mut media_engine)
+        .map_err(|error| RealtimeError::WebRtc(error.to_string()))?;
+    let api = APIBuilder::new()
+        .with_media_engine(media_engine)
+        .with_interceptor_registry(registry)
+        .build();
+    let peer = Arc::new(
+        api.new_peer_connection(RTCConfiguration::default())
+            .await
+            .map_err(|error| RealtimeError::WebRtc(error.to_string()))?,
+    );
+    let microphone = Arc::new(TrackLocalStaticSample::new(
+        RTCRtpCodecCapability {
+            mime_type: MIME_TYPE_OPUS.to_owned(),
+            clock_rate: 48_000,
+            channels: 2,
+            sdp_fmtp_line: "minptime=10;useinbandfec=1".to_owned(),
+            rtcp_feedback: Vec::new(),
+        },
+        "audio".to_owned(),
+        "nanocodex".to_owned(),
+    ));
+    let sender = peer
+        .add_track(Arc::clone(&microphone) as Arc<dyn TrackLocal + Send + Sync>)
+        .await
+        .map_err(|error| RealtimeError::WebRtc(error.to_string()))?;
+    tokio::spawn(async move {
+        let mut buffer = vec![0_u8; 1_500];
+        while sender.read(&mut buffer).await.is_ok() {}
+    });
+    peer.create_data_channel(DATA_CHANNEL_LABEL, None)
+        .await
+        .map_err(|error| RealtimeError::WebRtc(error.to_string()))?;
+
+    let (audio_tx, audio_rx) = mpsc::channel(EVENT_CAPACITY);
+    let (input_tx, input_rx) = mpsc::channel(EVENT_CAPACITY);
+    spawn_microphone_encoder(input_rx, microphone, audio_tx.clone())?;
+    peer.on_track(Box::new(move |track, _, _| {
+        let audio_tx = audio_tx.clone();
+        Box::pin(async move {
+            let codec = track.codec();
+            if !codec
+                .capability
+                .mime_type
+                .eq_ignore_ascii_case(MIME_TYPE_OPUS)
+            {
+                let _ = audio_tx
+                    .send(Err(RealtimeError::WebRtc(format!(
+                        "unsupported inbound audio codec {}",
+                        codec.capability.mime_type
+                    ))))
+                    .await;
+                return;
+            }
+            let mut decoder = match OpusDecoder::new(OpusChannels::Mono, OpusSampleRate::Hz24000) {
+                Ok(decoder) => decoder,
+                Err(error) => {
+                    let _ = audio_tx
+                        .send(Err(RealtimeError::WebRtc(format!(
+                            "failed to initialize Opus decoder: {}",
+                            error.message()
+                        ))))
+                        .await;
+                    return;
+                }
+            };
+            let mut samples = inbound_sample_builder();
+            let mut pcm = vec![0_u16; WEBRTC_MAX_FRAME_SAMPLES];
+            loop {
+                let packet = match track.read_rtp().await {
+                    Ok((packet, _)) => packet,
+                    Err(error) => {
+                        debug!(%error, "GPT Realtime WebRTC audio track stopped");
+                        return;
+                    }
+                };
+                samples.push(packet);
+                while let Some(sample) = samples.pop() {
+                    let dropped = sample
+                        .prev_dropped_packets
+                        .saturating_sub(sample.prev_padding_packets)
+                        .min(WEBRTC_MAX_CONCEALED_PACKETS);
+                    let frame_samples = match decoder.get_nb_samples(&sample.data) {
+                        Ok(samples) if samples <= WEBRTC_MAX_FRAME_SAMPLES => samples,
+                        Ok(samples) => {
+                            let _ = audio_tx
+                                .send(Err(RealtimeError::WebRtc(format!(
+                                    "Realtime Opus packet declared an oversized {samples}-sample frame"
+                                ))))
+                                .await;
+                            return;
+                        }
+                        Err(error) => {
+                            let _ = audio_tx
+                                .send(Err(RealtimeError::WebRtc(format!(
+                                    "failed to inspect Realtime Opus audio: {}",
+                                    error.message()
+                                ))))
+                                .await;
+                            return;
+                        }
+                    };
+                    for missing in 0..dropped {
+                        let recover_with_fec = missing + 1 == dropped;
+                        let packet = if recover_with_fec {
+                            sample.data.as_ref()
+                        } else {
+                            &[]
+                        };
+                        let concealed = match decoder.decode_to_slice(
+                            packet,
+                            &mut pcm[..frame_samples],
+                            recover_with_fec,
+                        ) {
+                            Ok(concealed) => concealed,
+                            Err(error) => {
+                                let _ = audio_tx
+                                    .send(Err(RealtimeError::WebRtc(format!(
+                                        "failed to conceal dropped Realtime Opus audio: {}",
+                                        error.message()
+                                    ))))
+                                    .await;
+                                return;
+                            }
+                        };
+                        if send_decoded_audio(&audio_tx, &pcm[..concealed])
+                            .await
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
+                    let decoded = match decoder.decode_to_slice(&sample.data, &mut pcm, false) {
+                        Ok(decoded) => decoded,
+                        Err(error) => {
+                            let _ = audio_tx
+                                .send(Err(RealtimeError::WebRtc(format!(
+                                    "failed to decode Realtime Opus audio: {}",
+                                    error.message()
+                                ))))
+                                .await;
+                            return;
+                        }
+                    };
+                    if send_decoded_audio(&audio_tx, &pcm[..decoded])
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+            }
+        })
+    }));
+
+    let offer = peer
+        .create_offer(None)
+        .await
+        .map_err(|error| RealtimeError::WebRtc(error.to_string()))?;
+    let mut gathering = peer.gathering_complete_promise().await;
+    peer.set_local_description(offer)
+        .await
+        .map_err(|error| RealtimeError::WebRtc(error.to_string()))?;
+    timeout(CONNECT_TIMEOUT, gathering.recv())
+        .await
+        .map_err(|_| RealtimeError::ConnectTimeout)?;
+    let offer = peer
+        .local_description()
+        .await
+        .ok_or_else(|| RealtimeError::WebRtc("WebRTC offer was not retained".to_owned()))?;
+    trace!(target: "nanocodex_oai_api::realtime::wire", sdp = %offer.sdp, "GPT Realtime WebRTC offer");
+    Ok(Offer {
+        peer,
+        sdp: offer.sdp,
+        input: input_tx,
+        audio: audio_rx,
+    })
+}
+
+fn inbound_sample_builder() -> SampleBuilder<OpusPacket> {
+    SampleBuilder::new(WEBRTC_REORDER_PACKETS, OpusPacket, 48_000)
+        .with_max_time_delay(WEBRTC_REORDER_DELAY)
+}
+
+async fn send_decoded_audio(
+    audio: &mpsc::Sender<Result<RealtimeAudio, RealtimeError>>,
+    samples: &[u16],
+) -> Result<(), ()> {
+    audio
+        .send(Ok(RealtimeAudio::from_samples(
+            samples.iter().map(|sample| *sample as i16),
+        )))
+        .await
+        .map_err(|_| ())
+}
+
+struct Offer {
+    peer: Arc<RTCPeerConnection>,
+    sdp: String,
+    input: mpsc::Sender<RealtimeAudio>,
+    audio: mpsc::Receiver<Result<RealtimeAudio, RealtimeError>>,
+}
+
+fn spawn_microphone_encoder(
+    mut input: mpsc::Receiver<RealtimeAudio>,
+    track: Arc<TrackLocalStaticSample>,
+    errors: mpsc::Sender<Result<RealtimeAudio, RealtimeError>>,
+) -> Result<(), RealtimeError> {
+    let mut encoder = OpusEncoder::new(
+        OpusChannels::Mono,
+        OpusSampleRate::Hz24000,
+        OpusApplication::Voip,
+    )
+    .map_err(|error| {
+        RealtimeError::WebRtc(format!(
+            "failed to initialize Opus encoder: {}",
+            error.message()
+        ))
+    })?;
+    tokio::spawn(async move {
+        let mut pending = VecDeque::with_capacity(WEBRTC_INPUT_FRAME_SAMPLES * 2);
+        let mut pcm = Vec::with_capacity(WEBRTC_INPUT_FRAME_SAMPLES);
+        let mut encoded = vec![0_u8; OPUS_PACKET_CAPACITY];
+        while let Some(audio) = input.recv().await {
+            pending.extend(audio.as_bytes().chunks_exact(2).map(|sample| {
+                f32::from(i16::from_le_bytes([sample[0], sample[1]])) / f32::from(i16::MAX)
+            }));
+            while pending.len() >= WEBRTC_INPUT_FRAME_SAMPLES {
+                pcm.extend(pending.drain(..WEBRTC_INPUT_FRAME_SAMPLES));
+                let encoded_bytes = match encoder.encode_float_to_slice(&pcm, &mut encoded) {
+                    Ok(encoded_bytes) => encoded_bytes,
+                    Err(error) => {
+                        let _ = errors
+                            .send(Err(RealtimeError::WebRtc(format!(
+                                "failed to encode microphone audio: {}",
+                                error.message()
+                            ))))
+                            .await;
+                        return;
+                    }
+                };
+                pcm.clear();
+                if let Err(error) = track
+                    .write_sample(&Sample {
+                        data: encoded[..encoded_bytes].to_vec().into(),
+                        duration: Duration::from_millis(20),
+                        ..Default::default()
+                    })
+                    .await
+                {
+                    let _ = errors
+                        .send(Err(RealtimeError::WebRtc(format!(
+                            "failed to send microphone audio: {error}"
+                        ))))
+                        .await;
+                    return;
+                }
+            }
+        }
+    });
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct CallRequest<'a> {
+    sdp: &'a str,
+    session: CallSession<'a>,
+}
+
+#[derive(Serialize)]
+struct CallSession<'a> {
+    model: &'a str,
+    instructions: &'a str,
+    audio: CallAudio<'a>,
+    delegation: CallDelegation,
+}
+
+#[derive(Serialize)]
+struct CallAudio<'a> {
+    output: CallAudioOutput<'a>,
+}
+
+#[derive(Serialize)]
+struct CallAudioOutput<'a> {
+    voice: &'a str,
+}
+
+#[derive(Serialize)]
+struct CallDelegation {
+    #[serde(rename = "type")]
+    kind: &'static str,
+}
+
+struct CallResponse {
+    sdp: String,
+    id: String,
+}
+
+async fn create_call_with_auth_recovery(
+    config: &ConnectConfig<'_>,
+    offer: &str,
+) -> Result<(CallResponse, OpenAiAuthSnapshot), RealtimeError> {
+    let auth = config.auth.snapshot().await?;
+    match create_call(config, offer, &auth).await {
+        Err(CallAttemptError::Unauthorized) => {
+            config.auth.recover_unauthorized(&auth).await?;
+            let refreshed = config.auth.snapshot().await?;
+            let call = create_call(config, offer, &refreshed)
+                .await
+                .map_err(CallAttemptError::into_realtime)?;
+            Ok((call, refreshed))
+        }
+        Ok(call) => Ok((call, auth)),
+        Err(error) => Err(error.into_realtime()),
+    }
+}
+
+enum CallAttemptError {
+    Unauthorized,
+    Other(RealtimeError),
+}
+
+impl CallAttemptError {
+    fn into_realtime(self) -> RealtimeError {
+        match self {
+            Self::Unauthorized => {
+                RealtimeError::Http("ChatGPT rejected refreshed Realtime authorization".to_owned())
+            }
+            Self::Other(error) => error,
+        }
+    }
+}
+
+async fn create_call(
+    config: &ConnectConfig<'_>,
+    offer: &str,
+    auth: &OpenAiAuthSnapshot,
+) -> Result<CallResponse, CallAttemptError> {
+    let endpoint = call_endpoint(config.api_base_url).map_err(CallAttemptError::Other)?;
+    let request = CallRequest {
+        sdp: offer,
+        session: CallSession {
+            model: config.model,
+            instructions: config.instructions,
+            audio: CallAudio {
+                output: CallAudioOutput {
+                    voice: config.voice.as_str(),
+                },
+            },
+            delegation: CallDelegation { kind: "client" },
+        },
+    };
+    let mut builder = Client::new()
+        .post(endpoint)
+        .bearer_auth(auth.bearer())
+        .header("openai-alpha", "quicksilver=v2")
+        .header("originator", "nanocodex")
+        .header(
+            "x-oai-attestation",
+            config.attestation_header.unwrap_or(ATTESTATION_UNAVAILABLE),
+        )
+        .json(&request);
+    if let Some(account_id) = auth.account_id() {
+        builder = builder.header("ChatGPT-Account-ID", account_id);
+    }
+    if let Some(session_id) = config.session_id {
+        builder = builder
+            .header("x-session-id", session_id)
+            .header("session-id", session_id)
+            .header("thread-id", session_id);
+    }
+    let payload = serde_json::to_string(&request)
+        .map_err(|error| CallAttemptError::Other(RealtimeError::Message(error.to_string())))?;
+    trace!(target: "nanocodex_oai_api::realtime::wire", payload = %payload, "GPT Realtime call request");
+    let response = timeout(CONNECT_TIMEOUT, builder.send())
+        .await
+        .map_err(|_| CallAttemptError::Other(RealtimeError::ConnectTimeout))?
+        .map_err(|error| CallAttemptError::Other(RealtimeError::Http(error.to_string())))?;
+    if response.status() == StatusCode::UNAUTHORIZED {
+        return Err(CallAttemptError::Unauthorized);
+    }
+    let status = response.status();
+    let location = response
+        .headers()
+        .get(LOCATION)
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
+    let limit = if status.is_success() {
+        CALL_BODY_LIMIT
+    } else {
+        ERROR_BODY_LIMIT
+    };
+    let body = bounded_body(response, limit)
+        .await
+        .map_err(CallAttemptError::Other)?;
+    if !status.is_success() {
+        return Err(CallAttemptError::Other(RealtimeError::Http(format!(
+            "Realtime call creation returned {status}: {}",
+            String::from_utf8_lossy(&body)
+        ))));
+    }
+    let sdp = String::from_utf8(body).map_err(|error| {
+        CallAttemptError::Other(RealtimeError::Http(format!(
+            "Realtime call returned invalid SDP: {error}"
+        )))
+    })?;
+    let id = call_id(location.as_deref()).map_err(CallAttemptError::Other)?;
+    Ok(CallResponse { sdp, id })
+}
+
+async fn bounded_body(
+    mut response: reqwest::Response,
+    limit: usize,
+) -> Result<Vec<u8>, RealtimeError> {
+    let mut body = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|error| RealtimeError::Http(error.to_string()))?
+    {
+        if body.len().saturating_add(chunk.len()) > limit {
+            return Err(RealtimeError::Http(format!(
+                "Realtime call response exceeded {limit} bytes"
+            )));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+fn add_auth_headers(
+    headers: &mut http::HeaderMap,
+    auth: &OpenAiAuthSnapshot,
+) -> Result<(), RealtimeError> {
+    headers.insert(
+        header::AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {}", auth.bearer()))
+            .map_err(|error| RealtimeError::InvalidAuthorization(error.to_string()))?,
+    );
+    if let Some(account_id) = auth.account_id() {
+        headers.insert(
+            "ChatGPT-Account-ID",
+            HeaderValue::from_str(account_id)
+                .map_err(|error| RealtimeError::InvalidAuthorization(error.to_string()))?,
+        );
+    }
+    Ok(())
+}
+
+fn call_endpoint(api_base_url: &str) -> Result<Url, RealtimeError> {
+    let mut endpoint =
+        Url::parse(api_base_url).map_err(|error| RealtimeError::InvalidUrl(error.to_string()))?;
+    let path = endpoint.path().trim_end_matches('/');
+    endpoint.set_path(&format!("{path}/realtime/calls"));
+    endpoint
+        .query_pairs_mut()
+        .append_pair("intent", "quicksilver")
+        .append_pair("architecture", "avas");
+    Ok(endpoint)
+}
+
+fn sideband_endpoint(explicit: Option<&str>, call_id: &str) -> Result<Url, RealtimeError> {
+    let base = explicit.unwrap_or(OPENAI_REALTIME_BASE);
+    let mut endpoint =
+        Url::parse(base).map_err(|error| RealtimeError::InvalidUrl(error.to_string()))?;
+    match endpoint.scheme() {
+        "https" => endpoint
+            .set_scheme("wss")
+            .map_err(|()| RealtimeError::InvalidUrl("could not select wss".to_owned()))?,
+        "http" => endpoint
+            .set_scheme("ws")
+            .map_err(|()| RealtimeError::InvalidUrl("could not select ws".to_owned()))?,
+        "wss" | "ws" => {}
+        scheme => {
+            return Err(RealtimeError::InvalidUrl(format!(
+                "unsupported URL scheme {scheme}"
+            )));
+        }
+    }
+    let path = endpoint.path().to_owned();
+    if path.is_empty() || path == "/" || path == "/v1" || path == "/v1/" {
+        endpoint.set_path("/v1/live");
+    } else if let Some(prefix) = path.trim_end_matches('/').strip_suffix("/realtime") {
+        endpoint.set_path(&format!("{prefix}/live"));
+    } else if path.ends_with("/live/") {
+        endpoint.set_path(path.trim_end_matches('/'));
+    }
+    endpoint.set_query(None);
+    let path = endpoint.path().trim_end_matches('/');
+    endpoint.set_path(&format!("{path}/{call_id}"));
+    Ok(endpoint)
+}
+
+fn call_id(location: Option<&str>) -> Result<String, RealtimeError> {
+    let location = location
+        .ok_or_else(|| RealtimeError::Http("Realtime call response omitted Location".to_owned()))?;
+    location
+        .split('?')
+        .next()
+        .unwrap_or(location)
+        .rsplit('/')
+        .find(|segment| (segment.starts_with("rtc_") && segment.len() > 4) || is_uuid(segment))
+        .map(str::to_owned)
+        .ok_or_else(|| RealtimeError::Http("Realtime call Location omitted a call ID".to_owned()))
+}
+
+fn is_uuid(value: &str) -> bool {
+    value.len() == 36
+        && value.char_indices().all(|(index, character)| match index {
+            8 | 13 | 18 | 23 => character == '-',
+            _ => character.is_ascii_hexdigit(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use webrtc::rtp::{header::Header, packet::Packet};
+
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
+
+    use super::{
+        ConnectConfig, OPUS_PACKET_CAPACITY, OpusApplication, OpusChannels, OpusDecoder,
+        OpusEncoder, OpusSampleRate, WEBRTC_INPUT_FRAME_SAMPLES, call_endpoint, call_id,
+        create_call, inbound_sample_builder, sideband_endpoint,
+    };
+    use crate::{OpenAiAuth, OpenAiAuthMode, OpenAiAuthSnapshot, realtime::RealtimeVoice};
+
+    #[test]
+    fn derives_chatgpt_call_and_direct_sideband_endpoints() {
+        assert_eq!(
+            call_endpoint("https://chatgpt.com/backend-api/codex")
+                .unwrap()
+                .as_str(),
+            "https://chatgpt.com/backend-api/codex/realtime/calls?intent=quicksilver&architecture=avas"
+        );
+        assert_eq!(
+            sideband_endpoint(None, "rtc_test").unwrap().as_str(),
+            "wss://api.openai.com/v1/live/rtc_test"
+        );
+        assert_eq!(
+            sideband_endpoint(Some("wss://example.test/v1/realtime"), "rtc_test")
+                .unwrap()
+                .as_str(),
+            "wss://example.test/v1/live/rtc_test"
+        );
+    }
+
+    #[test]
+    fn parses_supported_call_location_shapes() {
+        assert_eq!(
+            call_id(Some("/v1/realtime/calls/rtc_test?foo=bar")).unwrap(),
+            "rtc_test"
+        );
+        assert_eq!(
+            call_id(Some(
+                "https://api.openai.com/v1/realtime/calls/019eb97d-8e9a-7ff3-94b0-ea019babd5d7"
+            ))
+            .unwrap(),
+            "019eb97d-8e9a-7ff3-94b0-ea019babd5d7"
+        );
+    }
+
+    #[test]
+    fn encodes_one_realtime_pcm_frame_as_valid_opus() {
+        let mut encoder = OpusEncoder::new(
+            OpusChannels::Mono,
+            OpusSampleRate::Hz24000,
+            OpusApplication::Voip,
+        )
+        .unwrap();
+        let mut packet = vec![0_u8; OPUS_PACKET_CAPACITY];
+        let encoded = encoder
+            .encode_float_to_slice(&[0.0; WEBRTC_INPUT_FRAME_SAMPLES], &mut packet)
+            .unwrap();
+        packet.truncate(encoded);
+
+        let mut decoder = OpusDecoder::new(OpusChannels::Mono, OpusSampleRate::Hz24000).unwrap();
+        let mut decoded = vec![0_u16; WEBRTC_INPUT_FRAME_SAMPLES];
+        assert_eq!(
+            decoder
+                .decode_to_slice(&packet, &mut decoded, false)
+                .unwrap(),
+            WEBRTC_INPUT_FRAME_SAMPLES
+        );
+    }
+
+    #[test]
+    fn reorders_inbound_opus_packets_before_playback() {
+        fn packet(sequence_number: u16, timestamp: u32) -> Packet {
+            Packet {
+                header: Header {
+                    sequence_number,
+                    timestamp,
+                    marker: true,
+                    ..Default::default()
+                },
+                payload: vec![sequence_number as u8].into(),
+            }
+        }
+
+        let mut samples = inbound_sample_builder();
+        samples.push(packet(10, 0));
+        samples.push(packet(12, 1_920));
+        assert!(samples.pop().is_none());
+
+        samples.push(packet(11, 960));
+        samples.push(packet(13, 2_880));
+
+        assert_eq!(samples.pop().unwrap().data.as_ref(), &[10]);
+        assert_eq!(samples.pop().unwrap().data.as_ref(), &[11]);
+        assert_eq!(samples.pop().unwrap().data.as_ref(), &[12]);
+    }
+
+    #[tokio::test]
+    async fn chatgpt_call_uses_account_auth_and_frameless_shape() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut chunk = [0_u8; 4096];
+            loop {
+                let read = stream.read(&mut chunk).await.unwrap();
+                assert_ne!(read, 0, "request ended before its JSON body");
+                request.extend_from_slice(&chunk[..read]);
+                let Some(headers_end) = request.windows(4).position(|part| part == b"\r\n\r\n")
+                else {
+                    continue;
+                };
+                let headers = String::from_utf8_lossy(&request[..headers_end]);
+                let content_length = headers
+                    .lines()
+                    .find_map(|line| {
+                        line.to_ascii_lowercase()
+                            .strip_prefix("content-length: ")
+                            .and_then(|value| value.parse::<usize>().ok())
+                    })
+                    .unwrap();
+                if request.len() >= headers_end + 4 + content_length {
+                    break;
+                }
+            }
+            let request = String::from_utf8(request).unwrap();
+            assert!(request.contains("authorization: Bearer chatgpt-token\r\n"));
+            assert!(request.contains("chatgpt-account-id: account-1\r\n"));
+            assert!(request.contains("x-session-id: session-1\r\n"));
+            assert!(request.contains("session-id: session-1\r\n"));
+            assert!(request.contains("thread-id: session-1\r\n"));
+            assert!(request.contains("openai-alpha: quicksilver=v2\r\n"));
+            assert!(request.contains("x-oai-attestation: {\"v\":1,\"s\":1}\r\n"));
+            let body = request.split_once("\r\n\r\n").unwrap().1;
+            let body: serde_json::Value = serde_json::from_str(body).unwrap();
+            assert_eq!(body["sdp"], "v=offer\r\n");
+            assert_eq!(body["session"]["model"], "gpt-live-1-boulder-alpha");
+            assert_eq!(body["session"]["audio"]["output"]["voice"], "cove");
+            assert_eq!(body["session"]["delegation"]["type"], "client");
+            assert!(body["session"].get("type").is_none());
+            assert!(body["session"]["audio"].get("input").is_none());
+            stream
+                .write_all(
+                    b"HTTP/1.1 201 Created\r\nContent-Length: 10\r\nLocation: /v1/live/rtc_test\r\n\r\nv=answer\r\n",
+                )
+                .await
+                .unwrap();
+        });
+
+        let auth_source = OpenAiAuth::api_key("unused");
+        let api_base_url = format!("http://{address}/backend-api/codex");
+        let config = ConnectConfig {
+            auth: &auth_source,
+            api_base_url: &api_base_url,
+            attestation_header: None,
+            websocket_url: None,
+            instructions: "delegate coding work",
+            model: "gpt-live-1-boulder-alpha",
+            voice: RealtimeVoice::Cove,
+            session_id: Some("session-1"),
+        };
+        let snapshot = OpenAiAuthSnapshot::new(
+            OpenAiAuthMode::ChatGpt,
+            "chatgpt-token",
+            Some("account-1"),
+            false,
+            0,
+        );
+        let response = create_call(&config, "v=offer\r\n", &snapshot)
+            .await
+            .map_err(|error| error.into_realtime())
+            .unwrap();
+        assert_eq!(response.sdp, "v=answer\r\n");
+        assert_eq!(response.id, "rtc_test");
+        server.await.unwrap();
+    }
+}

--- a/crates/nanocodex-oai-api/src/realtime/webrtc.rs
+++ b/crates/nanocodex-oai-api/src/realtime/webrtc.rs
@@ -36,8 +36,8 @@ use webrtc::{
 };
 
 use super::{
-    CONNECT_TIMEOUT, EVENT_CAPACITY, RealtimeAudio, RealtimeError, RealtimeVoice, Socket,
-    map_websocket_error,
+    CONNECT_TIMEOUT, EVENT_CAPACITY, RealtimeAudio, RealtimeError, RealtimeInitialItem,
+    RealtimeVoice, Socket, map_websocket_error,
 };
 use crate::{OpenAiAuth, OpenAiAuthSnapshot, connector::connect_async};
 
@@ -90,6 +90,7 @@ pub(super) struct ConnectConfig<'a> {
     pub(super) model: &'a str,
     pub(super) voice: RealtimeVoice,
     pub(super) session_id: Option<&'a str>,
+    pub(super) initial_items: &'a [RealtimeInitialItem],
 }
 
 pub(super) async fn connect(config: ConnectConfig<'_>) -> Result<WebRtcConnection, RealtimeError> {
@@ -473,6 +474,23 @@ struct CallSession<'a> {
     instructions: &'a str,
     audio: CallAudio<'a>,
     delegation: CallDelegation,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    initial_items: Vec<CallInitialItem<'a>>,
+}
+
+#[derive(Serialize)]
+struct CallInitialItem<'a> {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    role: &'static str,
+    content: [CallInitialText<'a>; 1],
+}
+
+#[derive(Serialize)]
+struct CallInitialText<'a> {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    text: &'a str,
 }
 
 #[derive(Serialize)]
@@ -548,6 +566,18 @@ async fn create_call(
                 },
             },
             delegation: CallDelegation { kind: "client" },
+            initial_items: config
+                .initial_items
+                .iter()
+                .map(|item| CallInitialItem {
+                    kind: "message",
+                    role: item.role.as_str(),
+                    content: [CallInitialText {
+                        kind: item.role.content_type(),
+                        text: &item.text,
+                    }],
+                })
+                .collect(),
         },
     };
     let mut builder = realtime_http_client()
@@ -733,7 +763,10 @@ mod tests {
         OpusEncoder, OpusSampleRate, WEBRTC_INPUT_FRAME_SAMPLES, call_endpoint, call_id,
         create_call, inbound_sample_builder, sideband_endpoint,
     };
-    use crate::{OpenAiAuth, OpenAiAuthMode, OpenAiAuthSnapshot, realtime::RealtimeVoice};
+    use crate::{
+        OpenAiAuth, OpenAiAuthMode, OpenAiAuthSnapshot,
+        realtime::{RealtimeInitialItem, RealtimeTextRole, RealtimeVoice},
+    };
 
     #[test]
     fn derives_chatgpt_call_and_direct_sideband_endpoints() {
@@ -864,6 +897,21 @@ mod tests {
             assert_eq!(body["session"]["model"], "gpt-live-1-boulder-alpha");
             assert_eq!(body["session"]["audio"]["output"]["voice"], "cove");
             assert_eq!(body["session"]["delegation"]["type"], "client");
+            assert_eq!(
+                body["session"]["initial_items"],
+                serde_json::json!([
+                    {
+                        "type": "message",
+                        "role": "developer",
+                        "content": [{"type": "input_text", "text": "Remember this."}],
+                    },
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "Understood."}],
+                    },
+                ])
+            );
             assert!(body["session"].get("type").is_none());
             assert!(body["session"]["audio"].get("input").is_none());
             stream
@@ -876,6 +924,10 @@ mod tests {
 
         let auth_source = OpenAiAuth::api_key("unused");
         let api_base_url = format!("http://{address}/backend-api/codex");
+        let initial_items = [
+            RealtimeInitialItem::new(RealtimeTextRole::Developer, "Remember this."),
+            RealtimeInitialItem::new(RealtimeTextRole::Assistant, "Understood."),
+        ];
         let config = ConnectConfig {
             auth: &auth_source,
             api_base_url: &api_base_url,
@@ -885,6 +937,7 @@ mod tests {
             model: "gpt-live-1-boulder-alpha",
             voice: RealtimeVoice::Cove,
             session_id: Some("session-1"),
+            initial_items: &initial_items,
         };
         let snapshot = OpenAiAuthSnapshot::new(
             OpenAiAuthMode::ChatGpt,

--- a/crates/nanocodex/Cargo.toml
+++ b/crates/nanocodex/Cargo.toml
@@ -20,6 +20,7 @@ rustdoc-args = ["-D", "warnings"]
 [features]
 default = []
 observability = ["dep:nanocodex-observability"]
+realtime = ["nanocodex-oai-api/realtime"]
 
 [dependencies]
 nanocodex-agent.workspace = true

--- a/crates/nanocodex/src/lib.rs
+++ b/crates/nanocodex/src/lib.rs
@@ -4,7 +4,7 @@
 
 pub use nanocodex_agent::{
     AgentEvents, CostStatus, EstimatedUsdCost, Nanocodex, NanocodexBuilder, NanocodexError,
-    ServiceTier, Turn, TurnControl, TurnResult, TurnUsage, UsdAmount,
+    PromptRoute, ServiceTier, Turn, TurnControl, TurnResult, TurnUsage, UsdAmount,
 };
 pub use nanocodex_oai_api::{OpenAi, ReasoningMode, Thinking};
 #[cfg(not(target_family = "wasm"))]
@@ -22,8 +22,8 @@ pub mod agent {
     pub use nanocodex_agent::rollout;
     pub use nanocodex_agent::{
         AgentEvents, AgentHandle, CostStatus, EstimatedUsdCost, Nanocodex, NanocodexBuilder,
-        NanocodexError, Result, ServiceTier, Turn, TurnControl, TurnResult, TurnUsage, UsdAmount,
-        events, input, session, usage,
+        NanocodexError, PromptRoute, Result, ServiceTier, Turn, TurnControl, TurnResult, TurnUsage,
+        UsdAmount, events, input, session, usage,
     };
 }
 

--- a/docs/CODEX_PARITY.md
+++ b/docs/CODEX_PARITY.md
@@ -38,17 +38,17 @@ claims.
 
 | Classification | Count |
 | --- | ---: |
-| `port` | 33 |
+| `port` | 34 |
 | `evaluate` | 21 |
 | `defer` | 2 |
-| `out-of-scope` | 267 |
+| `out-of-scope` | 266 |
 | Total | 323 |
 
 ## First range: `35eaf3ff..8431dc59`
 
 | # | Codex commit | Classification | Decision |
 | ---: | --- | --- | --- |
-| 1 | `312caf176a8f` Seed realtime V3 sessions with initial text items | `out-of-scope` | Realtime V3, Frameless Bidi, WebRTC, and app-server bootstrap are not Nanocodex surfaces. The owned Responses session already accepts typed initial history without adopting a realtime protocol. |
+| 1 | `312caf176a8f` Seed realtime V3 sessions with initial text items | `port` | `P31`: the experimental Realtime library accepts bounded typed initial items, rejects them for direct V2 sessions, and serializes exact role-bearing Frameless WebRTC bootstrap messages. Codex app-server request plumbing remains out-of-scope. |
 | 2 | `643de86a190a` Add audio output support to dynamic tools and code mode | `defer` | Preserve the existing model-visible Code Mode audio shape, but do not claim the commit's full dynamic-tool, app-server, history, analytics, and model-modality support. The supported model contract remains text/image, so broader audio input/output stays deferred. |
 | 3 | `0fb559f0f6e2` Support legacy views for paginated thread history | `out-of-scope` | This is app-server projection, resume, and pagination behavior. It is distinct from row 22: Nanocodex consumes legacy Codex rollouts and deliberately rejects a canonical paginated rollout rather than implementing app-server views. |
 | 4 | `9dc372fbafb1` Avoid cloning thread data when rendering transcripts | `evaluate` | Nanocodex uses shared `Arc` transcript entries, but there is no allocation regression proving that resume-to-transcript construction avoids the clones removed by this Codex change. Profile the retained resume path before claiming adoption. |
@@ -347,7 +347,30 @@ the exact boundary without allocating a production-sized fixture. The newer
 MCP discovery protocol, pagination, and dual lifecycle mode from the upstream
 commit are not imported.
 
+### P31 — bounded Frameless initial items
+
+[`RealtimeSessionBuilder`](../crates/nanocodex-oai-api/src/realtime.rs) exposes
+owned role-bearing startup items and applies Codex's V3-only, 128-item, and
+8,192-estimated-token limits before transport work. The ChatGPT WebRTC call
+serializes developer/user text as `input_text`, assistant text as
+`output_text`, and omits the field when empty. Focused wire and policy tests
+cover the public contract; the experimental voice lifecycle forwards the same
+items without introducing app-server protocol types.
+
 ## Reviewed baseline behavior
+
+### Realtime voice delegation
+
+The experimental Realtime boundary matches Codex's V2 and Frameless behavior:
+current model/voice catalogs, byte-identical backend instructions, exact tool
+descriptions and acknowledgements, transcript-aware handoffs, atomic steering,
+queued `response.create`, 200 ms bounded agent updates, 500-byte Frameless
+context appends, and server-side V2 audio truncation when user speech interrupts
+playback. ChatGPT sessions create a genuine WebRTC/Opus media call and use a
+sideband WebSocket; the host owns device-attestation generation and passes the
+opaque value into the reusable session builder. Nanocodex deliberately uses a
+native Rust media/device stack instead of importing Chromium or Codex's
+app-server protocol.
 
 ### Responses Lite parallel-tool scheduling
 
@@ -387,7 +410,8 @@ The 11 later evaluations are named `E2` through `E11` in the
 behavior, Codex-only live exec rendering, side-pane navigation, and exact item
 start timing require their corresponding workload before adoption.
 
-The two audio rows remain deferred until the supported model contract includes
-the modality and there is a real embeddable consumer. No app-server, realtime,
-provider abstraction, approval, Guardian, exec-policy, shell-snapshot, plugin,
-skills, or generic multi-agent surface is implied by completing this review.
+The two model-tool audio rows remain deferred until the supported Responses
+model contract includes that modality; they are distinct from the experimental
+Realtime voice transport. No app-server, provider abstraction, approval,
+Guardian, exec-policy, shell-snapshot, plugin, skills, or generic multi-agent
+surface is implied by completing this review.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,14 +15,14 @@ dotenvy.workspace = true
 eyre.workspace = true
 futures-util.workspace = true
 http.workspace = true
-nanocodex.workspace = true
+nanocodex = { workspace = true, features = ["realtime"] }
 nanocodex-browser.workspace = true
 nanocodex-vm.workspace = true
 reqwest.workspace = true
 reflink-copy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio = { workspace = true, features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 tokio-tungstenite.workspace = true
 tower.workspace = true
 tempfile.workspace = true
@@ -82,6 +82,10 @@ path = "vm_tools.rs"
 [[bin]]
 name = "browser-agent"
 path = "browser_agent.rs"
+
+[[bin]]
+name = "realtime-pipe"
+path = "realtime_pipe.rs"
 
 [lints]
 workspace = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,12 +17,13 @@ futures-util.workspace = true
 http.workspace = true
 nanocodex = { workspace = true, features = ["realtime"] }
 nanocodex-browser.workspace = true
+nanocodex-voice.workspace = true
 nanocodex-vm.workspace = true
 reqwest.workspace = true
 reflink-copy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
+tokio = { workspace = true, features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-tungstenite.workspace = true
 tower.workspace = true
 tempfile.workspace = true
@@ -86,6 +87,10 @@ path = "browser_agent.rs"
 [[bin]]
 name = "realtime-pipe"
 path = "realtime_pipe.rs"
+
+[[bin]]
+name = "voice"
+path = "voice.rs"
 
 [lints]
 workspace = true

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,9 +2,10 @@
 
 All language consumers live at this repository boundary:
 
-- Rust: `minimal.rs`, `follow_on.rs`, `lifecycle.rs`, `custom_tool.rs`, `subagents.rs`,
-  `resume.rs`, `fork_conversations.rs`, `fork_checkpoint_bench.rs`, and `mcp.rs` are binaries
-  in the `nanocodex-examples` package.
+- Rust: `minimal.rs`, `voice.rs`, `realtime_pipe.rs`, `follow_on.rs`, `lifecycle.rs`,
+  `custom_tool.rs`, `subagents.rs`, `resume.rs`, `fork_conversations.rs`,
+  `fork_checkpoint_bench.rs`, and `mcp.rs` are binaries in the
+  `nanocodex-examples` package.
 - Python: `python/` uses the native PyO3 binding (`follow_on.py`, `events.py`,
   `lifecycle.py`).
 - Node.js: `node/` uses the shared Rust/WASM package with a Node WebSocket host.
@@ -17,6 +18,10 @@ From the repository root:
 
 ```sh
 cargo run -p nanocodex-examples --bin minimal
+# Own the default microphone and speaker directly in Rust:
+cargo run -p nanocodex-examples --bin voice
+# Or keep devices outside the process and compose raw PCM with Unix pipes:
+cargo run -p nanocodex-examples --bin realtime-pipe < microphone.pcm > speaker.pcm
 cargo run -p nanocodex-examples --bin lifecycle
 cargo run -p nanocodex-examples --bin fork-conversations
 cargo run -p nanocodex-examples --bin subagents
@@ -24,8 +29,6 @@ cargo run -p nanocodex-examples --bin subagents -- \
   "Review the retry policy using whatever clean or context-bearing workers you need"
 NANOCODEX_SUBAGENT_JSONL=1 cargo run -p nanocodex-examples --bin subagents
 cargo run -p nanocodex-examples --bin mcp
-# stdin/stdout are raw 24 kHz mono signed-16-bit little-endian PCM:
-cargo run -p nanocodex-examples --bin realtime-pipe < microphone.pcm > speaker.pcm
 just build-vm-example
 target/debug/vm-tools ROOTFS [GUEST_RUNTIME_BINARY_OR_EXT4]
 just smoke-python
@@ -33,13 +36,25 @@ just smoke-wasm-node
 just build-react-example
 ```
 
-The command-line examples use `OPENAI_API_KEY` by default. The Nanocodex TUI's
-`/voice [voice]` command reuses its managed ChatGPT subscription authentication
-(`/voice list` shows the Codex voice set), and
-`realtime-pipe` can do the same when `NANOCODEX_AUTH_FILE` points at a Codex
-credential file. `realtime-pipe` demonstrates the device-neutral voice API and
-delegates spoken coding requests to the same retained `Nanocodex` agent handle.
-The browser example instead asks the
+`voice` is the dead-simple non-TUI desktop consumer. It uses the same
+`VoiceSessionBuilder` as the production TUI, owns the default microphone and
+speaker directly in Rust, prints completed transcripts, and logs the retained
+coding agent's ordered events. Spoken coding follow-ups atomically steer work
+that is still running; speech while idle starts a new turn. It supports the
+default devices on macOS and Windows.
+
+`realtime-pipe` demonstrates the lower, device-neutral boundary. Stdin and
+stdout are raw 24 kHz mono signed-16-bit little-endian PCM, so capture,
+playback, files, sockets, `ffmpeg`, or another media stack can be composed
+without Nanocodex owning a device. The desktop and pipe examples are two thin
+adapters over the same typed Realtime events and retained agent lifecycle.
+Both use the shared Codex/ChatGPT subscription credentials at
+`$CODEX_HOME/auth.json` or `~/.codex/auth.json`; `NANOCODEX_AUTH_FILE` overrides
+that path. Run `nanocodex auth login` once if the shared credential does not
+exist.
+
+The other command-line examples use `OPENAI_API_KEY` by default. The browser
+example instead asks the
 embedding application for an already-authorized Responses WebSocket URL;
 standard browser WebSockets cannot attach the upgrade authorization header.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,8 @@ cargo run -p nanocodex-examples --bin subagents -- \
   "Review the retry policy using whatever clean or context-bearing workers you need"
 NANOCODEX_SUBAGENT_JSONL=1 cargo run -p nanocodex-examples --bin subagents
 cargo run -p nanocodex-examples --bin mcp
+# stdin/stdout are raw 24 kHz mono signed-16-bit little-endian PCM:
+cargo run -p nanocodex-examples --bin realtime-pipe < microphone.pcm > speaker.pcm
 just build-vm-example
 target/debug/vm-tools ROOTFS [GUEST_RUNTIME_BINARY_OR_EXT4]
 just smoke-python
@@ -31,8 +33,14 @@ just smoke-wasm-node
 just build-react-example
 ```
 
-The live programs require `OPENAI_API_KEY`. The browser example instead asks
-the embedding application for an already-authorized Responses WebSocket URL;
+The command-line examples use `OPENAI_API_KEY` by default. The Nanocodex TUI's
+`/voice [voice]` command reuses its managed ChatGPT subscription authentication
+(`/voice list` shows the Codex voice set), and
+`realtime-pipe` can do the same when `NANOCODEX_AUTH_FILE` points at a Codex
+credential file. `realtime-pipe` demonstrates the device-neutral voice API and
+delegates spoken coding requests to the same retained `Nanocodex` agent handle.
+The browser example instead asks the
+embedding application for an already-authorized Responses WebSocket URL;
 standard browser WebSockets cannot attach the upgrade authorization header.
 
 `vm-tools` does not call the model. It proves all VM-backed standard workspace

--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -1,0 +1,29 @@
+use std::path::PathBuf;
+
+use eyre::{Result, eyre};
+use nanocodex::oai::auth::{OpenAiAuth, load_chatgpt_auth};
+
+pub(crate) fn load_codex_auth() -> Result<OpenAiAuth> {
+    let auth_file = default_auth_file()?;
+    load_chatgpt_auth(&auth_file).map_err(|error| {
+        eyre!(
+            "ChatGPT authorization could not be loaded from {}: {error}. Run `nanocodex auth login`",
+            auth_file.display()
+        )
+    })
+}
+
+fn default_auth_file() -> Result<PathBuf> {
+    if let Some(path) = std::env::var_os("NANOCODEX_AUTH_FILE") {
+        return Ok(PathBuf::from(path));
+    }
+    if let Some(path) = std::env::var_os("CODEX_HOME").filter(|path| !path.is_empty()) {
+        return Ok(PathBuf::from(path).join("auth.json"));
+    }
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .ok_or_else(|| {
+            eyre!("home directory is unavailable; set CODEX_HOME or NANOCODEX_AUTH_FILE")
+        })?;
+    Ok(PathBuf::from(home).join(".codex/auth.json"))
+}

--- a/examples/realtime_pipe.rs
+++ b/examples/realtime_pipe.rs
@@ -1,0 +1,114 @@
+use nanocodex::{
+    Nanocodex, OpenAi,
+    oai::{
+        auth::{OpenAiAuth, load_chatgpt_auth},
+        realtime::{RealtimeAudio, RealtimeEvent},
+    },
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    sync::mpsc,
+};
+
+const VOICE_INSTRUCTIONS: &str = r"You are a concise voice interface for a coding agent.
+Use background_agent for repository work and preserve the user's own request in its prompt.
+Summarize the completed background result accurately for speech.";
+
+struct CompletedRequest {
+    call_id: String,
+    output: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let openai = OpenAi::new(load_auth()?)?;
+    let (agent, _) = Nanocodex::builder(openai.clone())
+        .instructions("Act as a coding agent. Inspect before claiming and preserve unrelated work.")
+        .workspace(std::env::current_dir()?)
+        .build()?;
+    let mut realtime = openai.realtime(VOICE_INSTRUCTIONS);
+    if let Ok(attestation) = std::env::var("NANOCODEX_REALTIME_ATTESTATION") {
+        realtime = realtime.attestation_header(attestation);
+    }
+    let (realtime, mut events) = realtime.connect().await?;
+
+    let mut stdin = tokio::io::stdin();
+    let mut stdout = tokio::io::stdout();
+    let mut input = [0_u8; 1_920];
+    let mut trailing_byte = None;
+    let (completed_tx, mut completed_rx) = mpsc::unbounded_channel();
+
+    loop {
+        tokio::select! {
+            read = stdin.read(&mut input) => {
+                let read = read?;
+                if read == 0 {
+                    break;
+                }
+                let mut pcm = Vec::with_capacity(read + usize::from(trailing_byte.is_some()));
+                if let Some(byte) = trailing_byte.take() {
+                    pcm.push(byte);
+                }
+                pcm.extend_from_slice(&input[..read]);
+                if pcm.len() % 2 != 0 {
+                    trailing_byte = pcm.pop();
+                }
+                realtime.send_audio(RealtimeAudio::pcm16_le(pcm)?).await?;
+            }
+            event = events.recv() => {
+                let Some(event) = event else {
+                    break;
+                };
+                match event {
+                    RealtimeEvent::Audio(audio) => {
+                        stdout.write_all(audio.as_bytes()).await?;
+                        stdout.flush().await?;
+                    }
+                    RealtimeEvent::AgentRequest { call_id, prompt } => {
+                        let agent = agent.clone();
+                        let completed_tx = completed_tx.clone();
+                        tokio::spawn(async move {
+                            let output = match agent.prompt(prompt).await {
+                                Ok(turn) => match turn.await {
+                                    Ok(result) => result.final_message().to_owned(),
+                                    Err(error) => format!("The coding agent failed: {error}"),
+                                },
+                                Err(error) => format!("The coding agent rejected the request: {error}"),
+                            };
+                            drop(completed_tx.send(CompletedRequest { call_id, output }));
+                        });
+                    }
+                    RealtimeEvent::RemainSilent { call_id } => {
+                        realtime.complete_silent_request(call_id).await?;
+                    }
+                    RealtimeEvent::Error(error) => return Err(error.into()),
+                    RealtimeEvent::SessionReady { .. }
+                    | RealtimeEvent::SpeechStarted
+                    | RealtimeEvent::InputTranscriptDelta(_)
+                    | RealtimeEvent::InputTranscriptDone(_)
+                    | RealtimeEvent::OutputTranscriptDelta(_)
+                    | RealtimeEvent::OutputTranscriptDone(_)
+                    | RealtimeEvent::ResponseStarted
+                    | RealtimeEvent::ResponseDone => {}
+                }
+            }
+            completed = completed_rx.recv() => {
+                let Some(CompletedRequest { call_id, output }) = completed else {
+                    break;
+                };
+                realtime.complete_agent_request(call_id, output).await?;
+            }
+        }
+    }
+
+    realtime.close().await?;
+    agent.shutdown().await?;
+    Ok(())
+}
+
+fn load_auth() -> Result<OpenAiAuth, Box<dyn std::error::Error>> {
+    if let Some(path) = std::env::var_os("NANOCODEX_AUTH_FILE") {
+        return Ok(load_chatgpt_auth(path)?);
+    }
+    Ok(OpenAiAuth::api_key(std::env::var("OPENAI_API_KEY")?))
+}

--- a/examples/realtime_pipe.rs
+++ b/examples/realtime_pipe.rs
@@ -1,32 +1,44 @@
+mod auth;
+
 use nanocodex::{
-    Nanocodex, OpenAi,
-    oai::{
-        auth::{OpenAiAuth, load_chatgpt_auth},
-        realtime::{RealtimeAudio, RealtimeEvent},
-    },
+    Nanocodex, OpenAi, PromptRoute,
+    oai::realtime::{RealtimeAgentSteer, RealtimeAudio, RealtimeEvent},
 };
+use nanocodex_voice::{codex_realtime_delegation_with_transcript, codex_voice_instructions};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     sync::mpsc,
 };
 
-const VOICE_INSTRUCTIONS: &str = r"You are a concise voice interface for a coding agent.
-Use background_agent for repository work and preserve the user's own request in its prompt.
-Summarize the completed background result accurately for speech.";
+use self::auth::load_codex_auth;
 
 struct CompletedRequest {
+    generation: u64,
     call_id: String,
     output: String,
 }
 
+struct ActiveRequest {
+    generation: u64,
+    call_id: String,
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let openai = OpenAi::new(load_auth()?)?;
-    let (agent, _) = Nanocodex::builder(openai.clone())
+    let openai = OpenAi::new(load_codex_auth()?)?;
+    let (agent, mut agent_events) = Nanocodex::builder(openai.clone())
         .instructions("Act as a coding agent. Inspect before claiming and preserve unrelated work.")
         .workspace(std::env::current_dir()?)
         .build()?;
-    let mut realtime = openai.realtime(VOICE_INSTRUCTIONS);
+    let session_id = agent_events.request_id().to_owned();
+    let agent_log = tokio::spawn(async move {
+        while let Some(event) = agent_events.recv().await {
+            eprintln!("agent {}: {:?}", event.seq, event.kind);
+        }
+    });
+    let mut realtime = openai
+        .realtime(codex_voice_instructions())
+        .session_id(session_id);
     if let Ok(attestation) = std::env::var("NANOCODEX_REALTIME_ATTESTATION") {
         realtime = realtime.attestation_header(attestation);
     }
@@ -37,6 +49,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut input = [0_u8; 1_920];
     let mut trailing_byte = None;
     let (completed_tx, mut completed_rx) = mpsc::unbounded_channel();
+    let mut active_request = None;
+    let mut next_request = 0_u64;
 
     loop {
         tokio::select! {
@@ -64,51 +78,93 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         stdout.write_all(audio.as_bytes()).await?;
                         stdout.flush().await?;
                     }
-                    RealtimeEvent::AgentRequest { call_id, prompt } => {
-                        let agent = agent.clone();
-                        let completed_tx = completed_tx.clone();
-                        tokio::spawn(async move {
-                            let output = match agent.prompt(prompt).await {
-                                Ok(turn) => match turn.await {
-                                    Ok(result) => result.final_message().to_owned(),
-                                    Err(error) => format!("The coding agent failed: {error}"),
-                                },
-                                Err(error) => format!("The coding agent rejected the request: {error}"),
-                            };
-                            drop(completed_tx.send(CompletedRequest { call_id, output }));
-                        });
+                    RealtimeEvent::AgentRequest { call_id, prompt, transcript } => {
+                        match agent.route_prompt(
+                            codex_realtime_delegation_with_transcript(&prompt, &transcript)
+                        ).await {
+                            Ok(PromptRoute::Started(turn)) => {
+                                next_request = next_request.saturating_add(1);
+                                let generation = next_request;
+                                active_request = Some(ActiveRequest {
+                                    generation,
+                                    call_id: call_id.clone(),
+                                });
+                                let completed_tx = completed_tx.clone();
+                                tokio::spawn(async move {
+                                    let output = match turn.await {
+                                        Ok(result) => result.final_message().to_owned(),
+                                        Err(error) => {
+                                            format!("The coding agent failed: {error}")
+                                        }
+                                    };
+                                    drop(completed_tx.send(CompletedRequest {
+                                        generation,
+                                        call_id,
+                                        output,
+                                    }));
+                                });
+                            }
+                            Ok(PromptRoute::Steered) => {
+                                if realtime.steer_agent_request(&call_id).await?
+                                    == RealtimeAgentSteer::ReplacedDelegation
+                                    && let Some(active) = &mut active_request
+                                {
+                                    active.call_id = call_id;
+                                }
+                            }
+                            Err(error) => {
+                                realtime
+                                    .append_agent_output(
+                                        &call_id,
+                                        format!(
+                                            "The coding agent rejected the request: {error}"
+                                        ),
+                                    )
+                                    .await?;
+                                realtime.complete_agent_run(call_id).await?;
+                            }
+                        }
                     }
                     RealtimeEvent::RemainSilent { call_id } => {
                         realtime.complete_silent_request(call_id).await?;
+                    }
+                    RealtimeEvent::InputTranscriptDone(text) => {
+                        eprintln!("user: {text}");
+                    }
+                    RealtimeEvent::OutputTranscriptDone(text) => {
+                        eprintln!("assistant: {text}");
                     }
                     RealtimeEvent::Error(error) => return Err(error.into()),
                     RealtimeEvent::SessionReady { .. }
                     | RealtimeEvent::SpeechStarted
                     | RealtimeEvent::InputTranscriptDelta(_)
-                    | RealtimeEvent::InputTranscriptDone(_)
                     | RealtimeEvent::OutputTranscriptDelta(_)
-                    | RealtimeEvent::OutputTranscriptDone(_)
                     | RealtimeEvent::ResponseStarted
                     | RealtimeEvent::ResponseDone => {}
                 }
             }
             completed = completed_rx.recv() => {
-                let Some(CompletedRequest { call_id, output }) = completed else {
+                let Some(CompletedRequest { generation, call_id, output }) = completed else {
                     break;
                 };
-                realtime.complete_agent_request(call_id, output).await?;
+                let call_id = match active_request.take() {
+                    Some(active) if active.generation == generation => active.call_id,
+                    Some(active) => {
+                        active_request = Some(active);
+                        call_id
+                    }
+                    None => call_id,
+                };
+                if !output.trim().is_empty() {
+                    realtime.append_agent_output(&call_id, output).await?;
+                }
+                realtime.complete_agent_run(call_id).await?;
             }
         }
     }
 
     realtime.close().await?;
     agent.shutdown().await?;
+    agent_log.await?;
     Ok(())
-}
-
-fn load_auth() -> Result<OpenAiAuth, Box<dyn std::error::Error>> {
-    if let Some(path) = std::env::var_os("NANOCODEX_AUTH_FILE") {
-        return Ok(load_chatgpt_auth(path)?);
-    }
-    Ok(OpenAiAuth::api_key(std::env::var("OPENAI_API_KEY")?))
 }

--- a/examples/voice.rs
+++ b/examples/voice.rs
@@ -1,0 +1,57 @@
+mod auth;
+
+use eyre::{Result, WrapErr};
+use nanocodex::{Nanocodex, OpenAi};
+use nanocodex_voice::{VoiceEvent, VoiceSessionBuilder};
+
+use self::auth::load_codex_auth;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _ = dotenvy::dotenv();
+    let openai = OpenAi::new(load_codex_auth()?)?;
+    let (agent, mut agent_events) = Nanocodex::builder(openai.clone())
+        .instructions("Inspect the repository carefully and report only verified facts.")
+        .workspace(std::env::current_dir()?)
+        .build()?;
+
+    let session_id = agent_events.request_id().to_owned();
+    let agent_log = tokio::spawn(async move {
+        while let Some(event) = agent_events.recv().await {
+            eprintln!("agent {}: {:?}", event.seq, event.kind);
+        }
+    });
+
+    // This is the same default-microphone/default-speaker lifecycle used by /voice.
+    let (mut voice, mut voice_events) = VoiceSessionBuilder::new(openai, agent.clone())
+        .session_id(session_id)
+        .spawn()?;
+
+    eprintln!("Starting voice. Speak normally; press Ctrl-C to stop.");
+    let voice_result: Result<()> = loop {
+        tokio::select! {
+            event = voice_events.recv() => match event {
+                Some(VoiceEvent::Connecting) => eprintln!("connecting..."),
+                Some(VoiceEvent::Started { voice }) => {
+                    eprintln!("listening with {voice}");
+                }
+                Some(VoiceEvent::Transcript { speaker, text }) => {
+                    println!("{speaker}: {text}");
+                }
+                Some(VoiceEvent::Failed { error }) => break Err(error.into()),
+                Some(VoiceEvent::Stopped) | None => break Ok(()),
+            },
+            signal = tokio::signal::ctrl_c() => {
+                signal.wrap_err("failed to listen for Ctrl-C")?;
+                voice.stop();
+            }
+        }
+    };
+
+    voice.stop();
+    let shutdown_result = agent.shutdown().await;
+    agent_log.await.wrap_err("agent event logger failed")?;
+    voice_result?;
+    shutdown_result?;
+    Ok(())
+}

--- a/examples/voice.rs
+++ b/examples/voice.rs
@@ -43,7 +43,9 @@ async fn main() -> Result<()> {
             },
             signal = tokio::signal::ctrl_c() => {
                 signal.wrap_err("failed to listen for Ctrl-C")?;
+                eprintln!("stopping voice...");
                 voice.stop();
+                break Ok(());
             }
         }
     };


### PR DESCRIPTION
## Summary

- add a typed Realtime boundary to `nanocodex-oai-api`, supporting direct API-key WebSocket sessions and managed ChatGPT/Codex Frameless WebRTC sessions
- add the unpublished experimental `nanocodex-voice` crate, which owns microphone/speaker devices, the voice lifecycle, typed events, and delegation into a retained Nanocodex agent
- keep the Ratatui integration thin with `/voice`, `/voice on`, `/voice off`, `/voice list`, and `/voice <name>`; add desktop-device and raw 24 kHz mono PCM pipe examples

## Codex behavior matched

- uses Codex's live model, ChatGPT/platform voice catalogs, exact defaults, backend prompt, tool descriptions, delegation XML, transcript deltas, `[BACKEND]` prefix, completion marker, and steering acknowledgement
- supports managed ChatGPT auth without requiring an OpenAI API key, including Codex's unavailable-attestation fallback and an explicit host attestation header
- atomically starts a turn while idle or steers the active regular turn, including during an in-flight tool; the TUI also mirrors existing typed turns into voice so a voice handoff can attach after work has started
- preserves Codex's protocol split: V2 acknowledges steering and emits completed `[BACKEND]` messages, while Frameless retargets the latest delegation and streams bounded output at a 200 ms cadence
- defers V2 `response.create` while another spoken response is active
- truncates the active V2 server audio item at the accumulated played duration when user speech interrupts playback
- accepts Codex-compatible bounded role-bearing initial items for Frameless bootstrap, including exact developer/user `input_text` and assistant `output_text` wire shapes

## Media and performance

- streams real 20 ms microphone frames over WebRTC/Opus with bounded capture and stale-frame dropping
- reorders inbound RTP, enables Opus FEC/PLC, prebuffers playout, reuses resampling buffers, and keeps the audio callback non-blocking
- bounds each streamed agent item to Codex's 1,000-token head/tail policy and chunks Frameless context appends on UTF-8 boundaries

The native Rust media path intentionally is not a byte-for-byte Chromium implementation. Codex App uses Chromium's WebRTC/audio stack, while this crate uses Rust WebRTC + CPAL; the server contract and application behavior are matched, but browser microphone AEC/noise suppression is not reproduced by CPAL.

## Validation

- `cargo test -p nanocodex-oai-api -p nanocodex-voice`
- `cargo test -p nanocodex-oai-api --all-features --locked` (132 passed, 1 ignored; 11 integration tests and 14 doctests passed)
- `cargo test -p nanocodex-voice --all-features --locked` (12 tests and 1 doctest passed)
- `cargo test -p nanocodex-agent steering_during_a_tool_call_joins_after_the_tool_result`
- `cargo test -p nanocodex-bin --bin nanocodex` (237 passed, 2 ignored)
- focused Clippy across API, agent, voice, facade, CLI, and examples with warnings denied; final API/voice all-targets Clippy passed with `-D warnings`
- API/voice rustdoc passed with `RUSTDOCFLAGS=-D warnings`
- `cargo check -p nanocodex-bin` and public voice/pipe examples
- `scripts/check-crate-boundaries.sh`
- live managed ChatGPT/Cove smoke: 10.58 seconds of sustained decoded speech with no media errors

CI passed for commit `be68ec6b` in run `30579622247`, including the aggregate `ci success` gate; JavaScript preview run `30579622250` also passed. This followed a complete source audit of all 37 Codex commits after the pinned checkpoint. The post-checkpoint Frameless initial-items behavior is now ported and recorded in the parity ledger; crate-boundary checks remain green.
