### PR TITLE
feat(cli): integrate deferred browser tooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4631,6 +4631,7 @@ dependencies = [
  "image",
  "mpp",
  "nanocodex",
+ "nanocodex-browser",
  "nanocodex-observability",
  "nanocodex-tools",
  "nanocodex-vm",

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -45,6 +45,7 @@ http-body-util = { workspace = true, optional = true }
 hudsucker = { workspace = true, optional = true }
 image.workspace = true
 nanocodex.workspace = true
+nanocodex-browser.workspace = true
 nanocodex-observability.workspace = true
 nanocodex-vm.workspace = true
 nix = { workspace = true, optional = true }

--- a/bin/nanocodex/src/browser.rs
+++ b/bin/nanocodex/src/browser.rs
@@ -1,0 +1,103 @@
+use std::path::{Path, PathBuf};
+
+use clap::{ArgAction, Args};
+use eyre::{Result, WrapErr};
+use nanocodex_browser::{Browser, BrowserTool};
+
+/// Opt-in local browser configuration for normal agent sessions.
+#[derive(Args, Default)]
+pub(crate) struct BrowserArgs {
+    /// Expose one private Chromium session to Code Mode as `tools.browser`.
+    ///
+    /// Chromium starts lazily on the first browser action and remains alive for
+    /// the complete agent session.
+    #[arg(
+        long,
+        env = "NANOCODEX_BROWSER",
+        action = ArgAction::SetTrue
+    )]
+    browser: bool,
+
+    /// Chrome or Chromium executable used by the browser tool.
+    #[arg(
+        long,
+        env = "NANOCODEX_BROWSER_EXECUTABLE",
+        value_name = "PATH",
+        requires = "browser"
+    )]
+    browser_executable: Option<PathBuf>,
+}
+
+pub(crate) struct ConfiguredBrowser {
+    browser: Browser,
+}
+
+impl BrowserArgs {
+    #[cfg(test)]
+    pub(crate) const fn is_enabled(&self) -> bool {
+        self.browser
+    }
+
+    pub(crate) fn configure(&self, workspace: &Path) -> Result<Option<ConfiguredBrowser>> {
+        if !self.browser {
+            return Ok(None);
+        }
+        let mut builder = Browser::builder().file_root(workspace);
+        if let Some(executable) = &self.browser_executable {
+            builder = builder.executable(executable);
+        }
+        let browser = builder
+            .build()
+            .wrap_err("failed to configure the browser tool")?;
+        Ok(Some(ConfiguredBrowser { browser }))
+    }
+}
+
+impl ConfiguredBrowser {
+    pub(crate) fn tool(&self) -> BrowserTool {
+        BrowserTool::from_browser(self.browser.clone())
+    }
+
+    pub(crate) async fn shutdown(self) -> Result<()> {
+        self.browser
+            .close()
+            .await
+            .wrap_err("failed to shut down the browser tool")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nanocodex::Tools;
+    use nanocodex_tools::runtime::ToolRuntime;
+
+    use super::BrowserArgs;
+
+    #[tokio::test]
+    async fn configured_browser_adds_no_model_facing_schema() {
+        let workspace = tempfile::tempdir().unwrap();
+        let baseline_tools = Tools::builder().build().unwrap();
+        let baseline = ToolRuntime::new_with_tools(workspace.path(), None, None, &baseline_tools)
+            .model_specs("browser-tui-test");
+        let browser = BrowserArgs {
+            browser: true,
+            browser_executable: None,
+        }
+        .configure(workspace.path())
+        .unwrap()
+        .unwrap();
+        let tools = Tools::builder().provider(browser.tool()).build().unwrap();
+        let runtime = ToolRuntime::new_with_tools(workspace.path(), None, None, &tools);
+        let definitions = runtime.model_specs("browser-tui-test");
+        let serialized = serde_json::to_string(&definitions).unwrap();
+
+        assert_eq!(
+            serde_json::to_vec(&definitions).unwrap(),
+            serde_json::to_vec(&baseline).unwrap(),
+            "enabling browser must not add any model-input schema bytes"
+        );
+        assert!(!serialized.contains("browser"));
+        assert!(runtime.contains("browser"));
+        browser.shutdown().await.unwrap();
+    }
+}

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -19,6 +19,7 @@ use nanocodex::{
     tools::mcp::McpHandle,
 };
 
+use crate::browser::{BrowserArgs, ConfiguredBrowser};
 use crate::mcp::{ConfiguredMcp, McpArgs};
 use crate::mpp::{MppAdapter, MppArgs};
 use crate::subagents::{self, ChildAgents};
@@ -30,6 +31,7 @@ pub(crate) struct ConfiguredAgent {
     pub(crate) child_agents: Option<Arc<ChildAgents>>,
     pub(crate) mpp_adapter: Option<MppAdapter>,
     pub(crate) mcp: Option<McpHandle>,
+    pub(crate) browser: Option<ConfiguredBrowser>,
     pub(crate) vm: Option<ConfiguredVm>,
 }
 
@@ -130,6 +132,9 @@ pub(crate) struct AgentArgs {
 
     #[command(flatten)]
     mpp: MppArgs,
+
+    #[command(flatten)]
+    browser: BrowserArgs,
 }
 
 impl AgentArgs {
@@ -140,6 +145,11 @@ impl AgentArgs {
     #[cfg(test)]
     pub(crate) const fn uses_tempo(&self) -> bool {
         self.mpp.is_enabled()
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn browser_enabled(&self) -> bool {
+        self.browser.is_enabled()
     }
 
     pub(crate) const fn thinking(&self) -> Thinking {
@@ -175,6 +185,7 @@ impl AgentArgs {
         let codex_home = default_codex_home()?;
         let responses_transport = self.responses_transport();
         let session = prepare_session_build(self.cwd, self.rollouts, &codex_home, durable)?;
+        let configured_browser = self.browser.configure(&session.workspace)?;
         let mpp_enabled = self.mpp.is_enabled();
         if mpp_enabled && !matches!(responses_transport, ResponsesTransport::Https) {
             return Err(eyre!(
@@ -226,6 +237,9 @@ impl AgentArgs {
                 .process_environment(mpp_adapter.tool_environment())
                 .remote_http_client(mpp_adapter.tool_http_client()?);
         }
+        if let Some(browser) = &configured_browser {
+            tools = tools.provider(browser.tool());
+        }
         let tools = tools.build()?;
         let child_agents = self.subagents.then(|| Arc::new(ChildAgents::default()));
         let mut builder = Nanocodex::builder(openai)
@@ -263,6 +277,7 @@ impl AgentArgs {
             child_agents,
             mpp_adapter,
             mcp: mcp_handle,
+            browser: configured_browser,
             vm: configured_vm,
         })
     }

--- a/bin/nanocodex/src/main.rs
+++ b/bin/nanocodex/src/main.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod browser;
 mod config;
 #[cfg(feature = "tempo")]
 mod credits;
@@ -222,6 +223,38 @@ mod tests {
             panic!("run command was not parsed");
         };
         assert!(run.vm.is_enabled());
+    }
+
+    #[test]
+    fn browser_tool_is_opt_in_for_tui_and_one_shot_runs() {
+        let tui = Cli::try_parse_from(["nanocodex"]).unwrap();
+        assert!(!tui.agent.browser_enabled());
+
+        let tui = Cli::try_parse_from(["nanocodex", "--browser"]).unwrap();
+        assert!(tui.agent.browser_enabled());
+
+        let run =
+            Cli::try_parse_from(["nanocodex", "run", "inspect example.com", "--browser"]).unwrap();
+        let Some(Command::Run(run)) = run.command else {
+            panic!("run command was not parsed");
+        };
+        assert!(run.agent.browser_enabled());
+    }
+
+    #[test]
+    fn browser_executable_requires_the_opt_in() {
+        let error = Cli::try_parse_from([
+            "nanocodex",
+            "--browser-executable",
+            "/Applications/Chromium.app/Contents/MacOS/Chromium",
+        ])
+        .err()
+        .unwrap();
+
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
     }
 
     #[test]

--- a/bin/nanocodex/src/run.rs
+++ b/bin/nanocodex/src/run.rs
@@ -56,6 +56,11 @@ impl Run {
         if let Some(child_agents) = configured.child_agents {
             child_agents.shutdown().await;
         }
+        let browser_shutdown_result = if let Some(browser) = configured.browser {
+            browser.shutdown().await
+        } else {
+            Ok(())
+        };
         let vm_shutdown_result = if let Some(vm) = configured.vm {
             vm.shutdown().await
         } else {
@@ -68,6 +73,7 @@ impl Run {
         };
         run_result?;
         agent_shutdown?;
+        browser_shutdown_result?;
         vm_shutdown_result?;
         shutdown_result
     }

--- a/bin/nanocodex/src/tui/app.rs
+++ b/bin/nanocodex/src/tui/app.rs
@@ -2938,6 +2938,9 @@ fn summarize_tool_arguments(tool: &str, arguments: &Value) -> String {
         {
             return summary;
         }
+        if tool == "browser" {
+            return summarize_browser_arguments(object);
+        }
         if let Some(summary) = summarize_mcp_arguments(tool, object) {
             return summary;
         }
@@ -2963,6 +2966,12 @@ fn summarize_tool_arguments(tool: &str, arguments: &Value) -> String {
 }
 
 fn present_tool_name(tool: &str, arguments: &Value) -> String {
+    if tool == "browser" {
+        return arguments.get("action").and_then(Value::as_str).map_or_else(
+            || "Browser".to_owned(),
+            |action| format!("Browser › {}", present_browser_action(action)),
+        );
+    }
     if tool == "tool_search" {
         return "MCP discovery".to_owned();
     }
@@ -2992,6 +3001,53 @@ fn present_tool_name(tool: &str, arguments: &Value) -> String {
         "Web"
     };
     name.to_owned()
+}
+
+fn present_browser_action(action: &str) -> String {
+    action
+        .split('_')
+        .enumerate()
+        .map(|(index, word)| match word {
+            "cpu" => "CPU".to_owned(),
+            "dom" => "DOM".to_owned(),
+            "har" => "HAR".to_owned(),
+            "html" => "HTML".to_owned(),
+            "pdf" => "PDF".to_owned(),
+            "url" => "URL".to_owned(),
+            _ if index == 0 => {
+                let mut word = word.to_owned();
+                if let Some(first) = word.get_mut(..1) {
+                    first.make_ascii_uppercase();
+                }
+                word
+            }
+            _ => word.to_owned(),
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn summarize_browser_arguments(object: &serde_json::Map<String, Value>) -> String {
+    for field in [
+        "url",
+        "url_contains",
+        "query",
+        "text",
+        "request_id",
+        "tab_id",
+        "frame_id",
+        "artifact_id",
+        "baseline_id",
+        "route_id",
+    ] {
+        if let Some(value) = object.get(field).and_then(Value::as_str) {
+            return compact_tool_text(value);
+        }
+    }
+    object
+        .get("target")
+        .map(compact_arguments)
+        .unwrap_or_default()
 }
 
 fn summarize_mcp_arguments(tool: &str, object: &serde_json::Map<String, Value>) -> Option<String> {
@@ -3277,6 +3333,42 @@ mod tests {
         assert_eq!(
             summarize_tool_arguments("web__run", &arguments),
             "Rust async cancellation · Tokio process groups"
+        );
+    }
+
+    #[test]
+    fn browser_tools_present_the_action_and_relevant_subject() {
+        let open = json!({
+            "action": "open",
+            "url": "https://example.com/products"
+        });
+        assert_eq!(present_tool_name("browser", &open), "Browser › Open");
+        assert_eq!(
+            summarize_tool_arguments("browser", &open),
+            "https://example.com/products"
+        );
+
+        let click = json!({
+            "action": "click",
+            "target": { "by": "ref", "reference": "@e7" }
+        });
+        assert_eq!(present_tool_name("browser", &click), "Browser › Click");
+        assert_eq!(
+            summarize_tool_arguments("browser", &click),
+            r#"{"by":"ref","reference":"@e7"}"#
+        );
+
+        assert_eq!(
+            present_tool_name("browser", &json!({ "action": "get_url" })),
+            "Browser › Get URL"
+        );
+        assert_eq!(
+            present_tool_name("browser", &json!({ "action": "get_html" })),
+            "Browser › Get HTML"
+        );
+        assert_eq!(
+            present_tool_name("browser", &json!({ "action": "cpu_profile_stop" })),
+            "Browser › CPU profile stop"
         );
     }
 

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -535,6 +535,7 @@ pub(crate) async fn run(
     let child_agents = configured.child_agents;
     let mpp_adapter = configured.mpp_adapter;
     let mcp = configured.mcp;
+    let browser = configured.browser;
     let vm = configured.vm;
     let (worker_tx, worker_rx) = mpsc::unbounded_channel();
     let (update_tx, mut update_rx) = mpsc::unbounded_channel();
@@ -663,7 +664,7 @@ pub(crate) async fn run(
     // Restore the terminal before disconnecting the paid WebSocket session.
     drop((terminal, worker_tx, agent_events));
     math_renderer.shutdown();
-    let shutdown_result = shutdown_runtime(worker, child_agents, mpp_adapter, vm).await;
+    let shutdown_result = shutdown_runtime(worker, child_agents, mpp_adapter, browser, vm).await;
     loop_result?;
     shutdown_result
 }
@@ -679,6 +680,7 @@ async fn shutdown_runtime(
     worker: tokio::task::JoinHandle<()>,
     child_agents: Option<std::sync::Arc<crate::subagents::ChildAgents>>,
     mpp_adapter: Option<crate::mpp::MppAdapter>,
+    browser: Option<crate::browser::ConfiguredBrowser>,
     vm: Option<crate::vm::ConfiguredVm>,
 ) -> Result<()> {
     worker.abort();
@@ -686,6 +688,11 @@ async fn shutdown_runtime(
     if let Some(child_agents) = child_agents {
         child_agents.shutdown().await;
     }
+    let browser_shutdown_result = if let Some(browser) = browser {
+        browser.shutdown().await
+    } else {
+        Ok(())
+    };
     let vm_shutdown_result = if let Some(vm) = vm {
         vm.shutdown().await
     } else {
@@ -701,6 +708,7 @@ async fn shutdown_runtime(
         Err(error) if error.is_cancelled() => {}
         Err(error) => return Err(error).wrap_err("TUI agent worker failed"),
     }
+    browser_shutdown_result?;
     vm_shutdown_result?;
     shutdown_result
 }

--- a/crates/experimental/nanocodex-browser/README.md
+++ b/crates/experimental/nanocodex-browser/README.md
@@ -17,7 +17,7 @@ use nanocodex_browser::BrowserTool;
 
 # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 let browser = BrowserTool::new()?;
-let tools = Tools::builder().tool(browser).build()?;
+let tools = Tools::builder().provider(browser).build()?;
 let openai = OpenAi::new(std::env::var("OPENAI_API_KEY")?)?;
 let (agent, _events) = Nanocodex::builder(openai).tools(tools).build()?;
 
@@ -31,9 +31,11 @@ println!("{}", result.final_message());
 # }
 ```
 
-The model reaches the tool as `await tools.browser(...)` inside Code Mode; it
-is not exposed as a second top-level model tool. A runnable version lives at
-`examples/browser_agent.rs`.
+The model reaches the tool as `await tools.browser(...)` inside Code Mode. Its
+full contract is discoverable at runtime through `ALL_TOOLS`, but provider
+registration keeps that contract out of the model-facing tool prefix. A
+runnable version lives at `examples/browser_agent.rs`. Callers that deliberately
+want the eager schema can register the same value with `.tool(browser)`.
 
 For isolation, one non-cloneable VM owner keeps the disposable browser alive
 and gives the agent a tool handle:
@@ -59,7 +61,7 @@ browser
     .await?;
 
 let tool = browser.tool();
-// Pass `tool` to `Tools::builder().tool(tool)`.
+// Pass `tool` to `Tools::builder().provider(tool)`.
 drop(tool);
 browser.shutdown().await?;
 # Ok(())
@@ -114,8 +116,9 @@ or an explicitly managed CDP endpoint.
   prepared ext4 image, VMM entry point, gvproxy, and libkrun firmware. Its
   default network lease permits internet access; callers must supply their
   egress lease and browser policy when stronger restrictions are required.
-- All browser actions are advertised together. The current Code Mode
-  description is about 67 KiB and is not deferred or capability-filtered.
+- All browser actions remain available together. Their roughly 67 KiB contract
+  is runtime-only with provider registration, so enabling browser adds no model
+  warmup schema bytes. The contract is not capability-filtered after discovery.
 - Lighthouse, CrUX, and video require caller-supplied external tooling or
   credentials. Brave profile transfer is harness-only and intentionally absent
   from the model-callable schema.

--- a/crates/experimental/nanocodex-browser/src/lib.rs
+++ b/crates/experimental/nanocodex-browser/src/lib.rs
@@ -9,7 +9,7 @@ pub mod vm;
 
 use std::{
     collections::BTreeMap,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, OnceLock},
 };
 
 use async_trait::async_trait;
@@ -17,7 +17,8 @@ use base64::{Engine as _, engine::general_purpose::STANDARD};
 use nanocodex_oai_api::ImageDetail;
 use nanocodex_tools::{
     Tool, ToolContext, ToolDefinition, ToolInput, ToolOutput, ToolResult,
-    contract::ToolOutputContent, runtime::schema_for,
+    contract::ToolOutputContent,
+    runtime::{DynamicToolProvider, schema_for},
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -3693,11 +3694,20 @@ impl BrowserTool {
     }
 }
 
+fn browser_tool_definition() -> ToolDefinition {
+    static DEFINITION: OnceLock<ToolDefinition> = OnceLock::new();
+    DEFINITION
+        .get_or_init(|| {
+            ToolDefinition::function("browser", TOOL_DESCRIPTION, schema_for::<BrowserAction>())
+                .with_output_schema(schema_for::<BrowserActionResult>())
+        })
+        .clone()
+}
+
 #[async_trait]
 impl Tool for BrowserTool {
     fn definition(&self) -> ToolDefinition {
-        ToolDefinition::function("browser", TOOL_DESCRIPTION, schema_for::<BrowserAction>())
-            .with_output_schema(schema_for::<BrowserActionResult>())
+        browser_tool_definition()
     }
 
     async fn execute(&self, input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
@@ -3750,6 +3760,46 @@ impl Tool for BrowserTool {
             content.insert(0, ToolOutputContent::InputText { text: encoded });
             Ok(ToolOutput::content(content).with_code_mode_value(code_mode_value))
         }
+    }
+}
+
+#[async_trait]
+impl DynamicToolProvider for BrowserTool {
+    fn start(&self) {}
+
+    fn direct_tools(&self) -> Vec<Arc<dyn Tool>> {
+        Vec::new()
+    }
+
+    fn available_definitions(&self) -> Vec<ToolDefinition> {
+        vec![browser_tool_definition()]
+    }
+
+    fn contains(&self, name: &str) -> bool {
+        name == "browser"
+    }
+
+    async fn execute(
+        &self,
+        name: &str,
+        input: serde_json::Value,
+        context: ToolContext<'_>,
+    ) -> Option<ToolOutput> {
+        if name != "browser" {
+            return None;
+        }
+        let input = match serde_json::value::to_raw_value(&input) {
+            Ok(input) => ToolInput::Function(input),
+            Err(error) => {
+                return Some(ToolOutput::error(format!(
+                    "failed to encode browser input: {error}"
+                )));
+            }
+        };
+        Some(match Tool::execute(self, input, context).await {
+            Ok(output) => output,
+            Err(error) => ToolOutput::error(error.to_string()),
+        })
     }
 }
 

--- a/crates/experimental/nanocodex-browser/src/tests.rs
+++ b/crates/experimental/nanocodex-browser/src/tests.rs
@@ -300,6 +300,58 @@ async fn code_mode_description_exposes_browser_action_schema() -> Result<()> {
 }
 
 #[tokio::test]
+async fn deferred_browser_is_discoverable_without_model_schema_bytes() -> Result<()> {
+    let baseline_tools = Tools::builder().without_defaults().build()?;
+    let baseline =
+        ToolRuntime::new_with_tools(".", None, None, &baseline_tools).model_specs("test-session");
+    let (browser, recording) = BrowserTool::recording();
+    let tools = Tools::builder()
+        .without_defaults()
+        .provider(browser)
+        .build()?;
+    let runtime = ToolRuntime::new_with_tools(".", None, None, &tools);
+    let specs = runtime.model_specs("test-session");
+
+    assert_eq!(
+        serde_json::to_vec(&specs)?,
+        serde_json::to_vec(&baseline)?,
+        "deferred browser registration must not change the model-facing tool prefix"
+    );
+    assert!(runtime.contains("browser"));
+
+    let execution = runtime
+        .execute_code(
+            r#"
+const browser = ALL_TOOLS.find((tool) => tool.name === "browser");
+if (!browser) throw new Error("browser metadata missing");
+const schema = JSON.stringify(browser.input_schema);
+const opened = await tools[browser.name]({
+  action: "open",
+  url: "https://example.com"
+});
+text({
+  name: browser.name,
+  hasOpen: schema.includes('"open"'),
+  hasSnapshot: schema.includes('"snapshot"'),
+  opened
+});
+"#,
+            context(),
+        )
+        .await;
+
+    assert!(execution.success);
+    assert_eq!(execution.nested_calls.len(), 1);
+    let output: Value = serde_json::from_str(execution_text(&execution.output)?)?;
+    assert_eq!(output["name"], "browser");
+    assert_eq!(output["hasOpen"], true);
+    assert_eq!(output["hasSnapshot"], true);
+    assert_eq!(output["opened"]["action"], "open");
+    assert_eq!(recording.actions()?.len(), 1);
+    Ok(())
+}
+
+#[tokio::test]
 #[ignore = "requires local Chromium or NANOCODEX_TEST_REMOTE_CDP_ENDPOINT"]
 #[allow(
     clippy::too_many_lines,

--- a/crates/nanocodex-tools/src/code_mode/bootstrap.js
+++ b/crates/nanocodex-tools/src/code_mode/bootstrap.js
@@ -248,10 +248,17 @@
     const EXIT = Symbol("exit");
     function exit() { throw EXIT; }
 
-    const allTools = Object.freeze(definitions.map((tool) => Object.freeze({
-      name: tool.name,
-      description: tool.description,
-    })));
+    const allTools = Object.freeze(definitions.map((tool) => {
+      const metadata = {
+        name: tool.name,
+        description: tool.description,
+      };
+      Object.defineProperties(metadata, {
+        input_schema: { value: tool.input_schema },
+        output_schema: { value: tool.output_schema },
+      });
+      return Object.freeze(metadata);
+    }));
     try {
       const script = new AsyncFunction(
         "tools",

--- a/crates/nanocodex-tools/src/code_mode/description.rs
+++ b/crates/nanocodex-tools/src/code_mode/description.rs
@@ -3,8 +3,6 @@ use std::fmt::Write as _;
 use nanocodex_oai_api::{responses::JsonSchema, tools::ToolDefinition};
 use serde_json::Value;
 
-const DEFERRED_NESTED_TOOLS_GUIDANCE: &str = r"Some deferred nested tools may be omitted from this description. They are still available on the global `tools` object and listed in `ALL_TOOLS`.
-To find one, filter `ALL_TOOLS` by `name` and `description`.";
 // Based on https://modelcontextprotocol.io/specification/draft/schema#calltoolresult.
 const MCP_TYPESCRIPT_PREAMBLE: &str = r#"type Role = "user" | "assistant";
 type MetaObject = Record<string, unknown>;
@@ -84,7 +82,7 @@ type CallToolResult<TStructured = { [key: string]: unknown }> = {
 };"#;
 const EXEC_DESCRIPTION: &str = r#"Run JavaScript code to orchestrate/compose tool calls
 - Evaluates the provided JavaScript code in a fresh V8 isolate as an async module.
-- All nested tools are available on the global `tools` object, for example `await tools.exec_command(...)`. Tool names are exposed as normalized JavaScript identifiers, for example `await tools.mcp__ologs__get_profile(...)`.
+- All nested tools are on global `tools`. For configured or deferred capabilities omitted here, check `ALL_TOOLS` before searching the workspace, then call a match as `await tools[tool.name](...)`.
 - Nested tool methods take either a string or an object as their input argument.
 - Nested tools return either an object or a string, based on the description.
 - Runs raw JavaScript -- no Node, no file system, no network access, no console.
@@ -105,15 +103,15 @@ const EXEC_DESCRIPTION: &str = r#"Run JavaScript code to orchestrate/compose too
 - `notify(value: string | number | boolean | undefined | null)`: immediately injects an extra `custom_tool_call_output` for the current `exec` call. Values are stringified like `text(...)`.
 - `setTimeout(callback: () => void, delayMs?: number)`: schedules a callback to run later and returns a timeout id. Pending timeouts do not keep `exec` alive by themselves; await an explicit promise if you need to wait for one.
 - `clearTimeout(timeoutId?: number)`: cancels a timeout created by `setTimeout`.
-- `ALL_TOOLS`: metadata for the enabled nested tools as `{ name, description }` entries.
+- `ALL_TOOLS`: enumerable `name`/`description` plus explicit `input_schema`/`output_schema`.
 - `yield_control()`: yields the accumulated output to the model immediately while the script keeps running."#;
 
-pub(super) fn exec_description(definitions: &[ToolDefinition], has_deferred_tools: bool) -> String {
+pub(super) fn exec_description(
+    definitions: &[ToolDefinition],
+    has_deferred_search: bool,
+) -> String {
     let mut description = EXEC_DESCRIPTION.to_owned();
-    if has_deferred_tools {
-        let _ = write!(description, "\n\n{DEFERRED_NESTED_TOOLS_GUIDANCE}");
-    }
-    if has_deferred_tools
+    if has_deferred_search
         || definitions.iter().any(|spec| {
             spec.output_schema()
                 .and_then(|schema| mcp_structured_content_schema(schema.as_value()))

--- a/crates/nanocodex-tools/src/code_mode/spec.rs
+++ b/crates/nanocodex-tools/src/code_mode/spec.rs
@@ -15,11 +15,11 @@ SOURCE: /[\s\S]+/
 
 pub(crate) fn exec_spec(
     definitions: &[ToolDefinition],
-    has_deferred_tools: bool,
+    has_deferred_search: bool,
 ) -> ToolDefinition {
     ToolDefinition::custom(
         "exec",
-        description::exec_description(definitions, has_deferred_tools),
+        description::exec_description(definitions, has_deferred_search),
         CustomToolFormat::grammar("lark", GRAMMAR),
     )
 }

--- a/crates/nanocodex-tools/src/code_mode/tests.rs
+++ b/crates/nanocodex-tools/src/code_mode/tests.rs
@@ -316,18 +316,20 @@ text({
 }
 
 #[tokio::test]
-async fn all_tools_exposes_only_codex_metadata_fields() -> Result<()> {
+async fn all_tools_exposes_runtime_only_tool_contracts() -> Result<()> {
     let workspace = temporary_workspace("all-tools-metadata")?;
     let tools = test_tools(&workspace);
     let history = Vec::new();
     let execution = tools
         .execute_code(
-            r"
+            r#"
 text(ALL_TOOLS.map((tool) => ({
   keys: Object.keys(tool).sort(),
   frozen: Object.isFrozen(tool),
+  hasInputSchema: typeof tool.input_schema === "object",
+  serializedSchema: JSON.stringify(tool).includes("input_schema"),
 })));
-",
+"#,
             test_context(&history),
         )
         .await;
@@ -339,7 +341,10 @@ text(ALL_TOOLS.map((tool) => ({
         .ok_or_else(|| eyre!("ALL_TOOLS output was not an array"))?;
     assert!(!tools.is_empty());
     assert!(tools.iter().all(|tool| {
-        tool["keys"] == serde_json::json!(["description", "name"]) && tool["frozen"] == true
+        tool["keys"] == serde_json::json!(["description", "name"])
+            && tool["frozen"] == true
+            && tool["hasInputSchema"] == true
+            && tool["serializedSchema"] == false
     }));
     std::fs::remove_dir_all(workspace)?;
     Ok(())

--- a/crates/nanocodex-tools/src/runtime/execution.rs
+++ b/crates/nanocodex-tools/src/runtime/execution.rs
@@ -167,6 +167,12 @@ impl ToolRuntime {
     /// session.
     #[must_use]
     pub fn model_specs(&self, _session_id: &str) -> Vec<ToolDefinition> {
+        let has_deferred_search = !self.registry.providers.is_empty()
+            && self
+                .registry
+                .definitions()
+                .iter()
+                .any(|definition| definition.name() == "tool_search");
         let (mut native, mut nested): (Vec<_>, Vec<_>) = self
             .registry
             .definitions()
@@ -175,7 +181,7 @@ impl ToolRuntime {
             .partition(|definition| matches!(definition, ToolDefinition::ToolSearch { .. }));
         nested.sort_by(|left, right| left.name().cmp(right.name()));
         native.extend([
-            code_mode::exec_spec(&nested, !self.registry.providers.is_empty()),
+            code_mode::exec_spec(&nested, has_deferred_search),
             code_mode::wait_spec(),
         ]);
         native.sort_by(|left, right| left.name().cmp(right.name()));

--- a/crates/nanocodex-tools/src/runtime/registry.rs
+++ b/crates/nanocodex-tools/src/runtime/registry.rs
@@ -309,5 +309,7 @@ fn definition_metadata(name: &str, definition: &ToolDefinition) -> Value {
         "tool_name": name,
         "description": definition.description(),
         "kind": kind,
+        "input_schema": definition.parameters().map(|schema| schema.as_value()),
+        "output_schema": definition.output_schema().map(|schema| schema.as_value()),
     })
 }

--- a/examples/browser_agent.rs
+++ b/examples/browser_agent.rs
@@ -6,7 +6,7 @@ use nanocodex_browser::BrowserTool;
 async fn main() -> Result<()> {
     let api_key = std::env::var("OPENAI_API_KEY").wrap_err("OPENAI_API_KEY is required")?;
     let browser = BrowserTool::new()?;
-    let tools = Tools::builder().tool(browser).build()?;
+    let tools = Tools::builder().provider(browser).build()?;
     let openai = OpenAi::new(api_key)?;
     let (agent, mut events) = Nanocodex::builder(openai)
         .instructions(

--- a/examples/tests/browser_agent.rs
+++ b/examples/tests/browser_agent.rs
@@ -58,8 +58,8 @@ async fn run_agent(browser: BrowserTool) -> Result<Value> {
         assert!(
             exec["description"]
                 .as_str()
-                .is_some_and(|description| description.contains("tools.browser")),
-            "Code Mode did not advertise the browser tool: {exec}"
+                .is_some_and(|description| !description.contains("tools.browser")),
+            "warmup unexpectedly included the browser schema: {exec}"
         );
         send_completed(&mut socket, "resp-warmup", &[], None).await?;
 
@@ -97,7 +97,10 @@ async fn run_agent(browser: BrowserTool) -> Result<Value> {
         Result::<Value>::Ok(continuation)
     });
 
-    let tools = Tools::builder().without_defaults().tool(browser).build()?;
+    let tools = Tools::builder()
+        .without_defaults()
+        .provider(browser)
+        .build()?;
     let openai = OpenAi::builder("test-key")
         .websocket_url(endpoint)
         .build()?;


### PR DESCRIPTION
## Summary

- add opt-in `--browser` support to both the interactive TUI and one-shot runner
- register `BrowserTool` as a runtime-only Code Mode provider, preserving the full typed contract without embedding its roughly 67 KiB schema in the model prefix
- expose deferred input/output contracts through non-enumerable `ALL_TOOLS` metadata and guide Code Mode to inspect configured capabilities before searching the workspace
- render browser actions as semantic TUI rows and shut Chromium down explicitly with the owning agent session

## What it can do

- lazily start one private Chromium session per Nanocodex process
- reuse that browser across Code Mode calls in the same agent session
- execute the complete typed browser action protocol through `tools.browser(...)`
- show actions such as `Browser › Open`, `Detect gate`, and `Snapshot` in the TUI
- select a Chrome/Chromium executable with `--browser-executable`

## Current boundaries

- browser support is opt-in and native-only
- local mode is a private browser profile, not an OS sandbox
- Chromium must be available locally unless a configured remote CDP path is used by an embedding consumer
- the full action schema is paid only when the model intentionally discovers it during browser work; it contributes zero warmup tokens
- this does not add browser/computer-use concepts to the core agent API

## Warmup measurement

Measured live with the same model, empty workspace, prompt, and disabled MCP/web/image tools:

| Build | Warmup input tokens |
| --- | ---: |
| `origin/master`, browser unavailable | 5,718 |
| this branch, browser off | 5,718 |
| this branch, browser on | 5,718 |

All runs reported zero cached warmup tokens. The deterministic regression also asserts byte-identical model-facing tool declarations with browser off and on.

## Live validation

- one-shot CLI discovered `browser` through `ALL_TOOLS`, called `tools.browser` for open/gate/snapshot, and returned the `Example Domain` heading
- interactive TUI displayed deferred discovery and semantic browser activity rows, returned the same heading, restored the terminal on Ctrl-C, and cleaned up Chromium

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --locked`
- `cargo test --package nanocodex-bin --features tempo --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`
- WASM warnings-denied Clippy matrix
- experimental and crate-boundary scripts
- `cargo deny check`
- `typos`