### PR TITLE
feat(tools): expose application-owned terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ next safe model boundary. Both use shared Codex/ChatGPT subscription auth, not
 an API key. Set `NANOCODEX_AUTH_FILE` to override the normal Codex credential
 path.
 
+Native applications can independently call `agent.terminals()` before a turn
+to subscribe to raw PTYs created with `tty: true`. The resulting capability
+provides opened/output/exited notifications, exact-byte input, bounded recovery
+snapshots, and resize control without selecting a renderer, focus policy, or
+key bindings. Terminal input and unredacted output are recorded by tracing and
+must receive the same protection as agent conversations.
+
 ## Thesis
 
 ### Small, excellent building blocks
@@ -221,8 +228,8 @@ services remain concrete and nameable—no boxing or global client is required.
 
 The model-facing tool runtime: the `Tool` contract, heterogeneous `Tools`
 registry, standard workspace tools, shell and process lifecycle, Code Mode,
-deferred `tool_search`, remote dispatch, and MCP. MCP is always available on
-native targets.
+raw application-owned terminal control, deferred `tool_search`, remote
+dispatch, and MCP. MCP is always available on native targets.
 
 Applications can implement `Tool` directly or use the reexported `#[tool]`
 macro. The separate `nanocodex-tools-macros` package exists only for Rust's

--- a/crates/nanocodex-agent/README.md
+++ b/crates/nanocodex-agent/README.md
@@ -99,6 +99,43 @@ agent.shutdown().await?;
 # }
 ```
 
+## Application-owned terminals
+
+An embedding application can build an interactive terminal experience without
+adopting Nanocodex's CLI or a particular TUI stack. Subscribe before prompting,
+then render raw PTY output and choose when keyboard focus should attach:
+
+```rust,no_run
+use nanocodex_agent::{
+    Nanocodex, OpenAi,
+    tools::terminal::TerminalEvent,
+};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let openai = OpenAi::new(std::env::var("OPENAI_API_KEY")?)?;
+let (agent, _agent_events) = Nanocodex::builder(openai).build()?;
+let terminals = agent.terminals();
+let mut terminal_events = terminals.subscribe();
+
+let _turn = agent.prompt("Run the interactive command in a PTY.").await?;
+while let Some(event) = terminal_events.recv().await? {
+    match event {
+        TerminalEvent::Opened(info) => terminals.write(info.id, b"input\n").await?,
+        TerminalEvent::Output { bytes, .. } => drop(bytes),
+        TerminalEvent::Exited { .. } => break,
+        _ => {}
+    }
+}
+agent.shutdown().await?;
+# Ok(())
+# }
+```
+
+This stream is independent from [`AgentEvents`]. It is emitted only for
+`exec_command` calls that request `tty: true`; ordinary piped commands remain
+headless. Terminal rendering, attachment, detachment, and key bindings belong
+to the embedding application.
+
 ## Components
 
 - [`events`](nanocodex_agent::events) contains the complete typed lifecycle
@@ -112,7 +149,7 @@ agent.shutdown().await?;
 - [`transport`](nanocodex_agent::transport) exposes advanced Responses and
   Tower configuration.
 - [`tools`](nanocodex_agent::tools) exposes the complete tool implementation
-  surface.
+  surface, including raw terminal control and events.
 
 OpenAI API-key and managed ChatGPT credentials belong to
 [`nanocodex_oai_api::auth`], independently of this lifecycle crate.

--- a/crates/nanocodex-agent/src/agent/handle.rs
+++ b/crates/nanocodex-agent/src/agent/handle.rs
@@ -12,6 +12,8 @@ pub struct Nanocodex {
     pub(super) session_id: SessionId,
     pub(super) durability: Durability,
     pub(super) shutdown: DriverShutdown,
+    #[cfg(not(target_family = "wasm"))]
+    pub(super) terminals: nanocodex_tools::terminal::TerminalControl,
 }
 
 impl Clone for Nanocodex {
@@ -24,6 +26,8 @@ impl Clone for Nanocodex {
             session_id: self.session_id,
             durability: self.durability.clone(),
             shutdown: self.shutdown.clone(),
+            #[cfg(not(target_family = "wasm"))]
+            terminals: self.terminals.clone(),
         }
     }
 }
@@ -92,6 +96,19 @@ impl Nanocodex {
     #[must_use]
     pub const fn session_id(&self) -> SessionId {
         self.session_id
+    }
+
+    /// Returns raw lifecycle, output, input, and resize control for PTYs owned
+    /// by this agent's workspace-tool runtime.
+    ///
+    /// Subscribe before starting a turn to observe every output chunk. The
+    /// returned capability is independent from [`AgentEvents`] and does not
+    /// affect turn results when unused.
+    #[cfg(not(target_family = "wasm"))]
+    #[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
+    #[must_use]
+    pub fn terminals(&self) -> nanocodex_tools::terminal::TerminalControl {
+        self.terminals.clone()
     }
 
     /// Returns the Codex-compatible rollout identity and path when recording is enabled.

--- a/crates/nanocodex-agent/src/agent/spawn.rs
+++ b/crates/nanocodex-agent/src/agent/spawn.rs
@@ -151,6 +151,8 @@ where
             commands: commands.downgrade(),
         })?
         .for_session(&session_id_text);
+    #[cfg(not(target_family = "wasm"))]
+    let terminals = nanocodex_tools::__private::terminal_control(&tools);
     let durability = spawner.durability.start(
         &session_id_text,
         workspace.as_deref(),
@@ -188,6 +190,8 @@ where
         session_id,
         durability: durability.clone(),
         shutdown: shutdown.clone(),
+        #[cfg(not(target_family = "wasm"))]
+        terminals,
     };
     // Start discovery before returning the handle so an idle CLI or TUI immediately
     // contributes its human think time to provider prewarming.

--- a/crates/nanocodex-agent/tests/it/model/tools/mod.rs
+++ b/crates/nanocodex-agent/tests/it/model/tools/mod.rs
@@ -3,6 +3,7 @@ use super::*;
 mod environment;
 mod panic;
 mod parallel;
+mod terminal;
 
 struct NativeToolSearch;
 struct NamespacedEcho;

--- a/crates/nanocodex-agent/tests/it/model/tools/terminal.rs
+++ b/crates/nanocodex-agent/tests/it/model/tools/terminal.rs
@@ -1,0 +1,96 @@
+use super::*;
+
+#[cfg(unix)]
+#[tokio::test]
+async fn agent_terminal_capability_controls_its_private_tool_runtime() -> Result<()> {
+    use nanocodex_agent::tools::terminal::{TerminalEvent, TerminalSize};
+
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("ws://{}", listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await?;
+        let mut socket = accept_async(stream).await?;
+        assert_warmup(&next_json(&mut socket).await?);
+        send_warmup(&mut socket, "resp-warmup").await?;
+
+        let generation = next_json(&mut socket).await?;
+        assert_eq!(generation["previous_response_id"], "resp-warmup");
+        send_json(
+            &mut socket,
+            completed_response(
+                "resp-terminal",
+                &[json!({
+                    "type": "custom_tool_call",
+                    "call_id": "call-terminal-cell",
+                    "name": "exec",
+                    "input": concat!(
+                        "const result = await tools.exec_command({",
+                        "cmd: \"stty -echo; printf ready; read value; printf 'got:%s' \\\"$value\\\"\", ",
+                        "tty: true, yield_time_ms: 5_000",
+                        "}); text(result.output);"
+                    )
+                })],
+            ),
+        )
+        .await?;
+
+        let continuation = next_json(&mut socket).await?;
+        let output = continuation["input"][0]["output"].to_string();
+        assert!(output.contains("readygot:hello"), "{output}");
+        send_final(&mut socket, "resp-final").await
+    });
+
+    let workspace = temporary_workspace("agent-terminal-control")?;
+    let openai = OpenAi::builder("test-key")
+        .websocket_url(endpoint)
+        .build()?;
+    let (agent, events) = Nanocodex::builder(openai)
+        .thinking(Thinking::Low)
+        .workspace(&workspace)
+        .session_id(test_session_id())
+        .build()?;
+    let terminals = agent.terminals();
+    let mut terminal_events = terminals.subscribe();
+    let turn = agent.prompt("run an interactive terminal command").await?;
+
+    let opened = timeout(std::time::Duration::from_secs(5), async {
+        loop {
+            if let Some(TerminalEvent::Opened(info)) = terminal_events.recv().await.unwrap() {
+                break info;
+            }
+        }
+    })
+    .await
+    .map_err(|_| eyre!("agent PTY did not open"))?;
+    assert!(!opened.call_id.is_empty());
+    terminals
+        .resize(opened.id, TerminalSize::new(30, 90))
+        .await?;
+    timeout(std::time::Duration::from_secs(5), async {
+        let mut output = Vec::new();
+        loop {
+            if let Some(TerminalEvent::Output { bytes, .. }) = terminal_events.recv().await.unwrap()
+            {
+                output.extend_from_slice(&bytes);
+                if output.ends_with(b"ready") {
+                    break;
+                }
+            }
+        }
+    })
+    .await
+    .map_err(|_| eyre!("agent PTY did not reach its input prompt"))?;
+    terminals.write(opened.id, b"hello\n").await?;
+
+    assert_eq!(turn.result().await?.final_message(), "done");
+    let snapshot = terminals.snapshot(opened.id)?;
+    assert_eq!(snapshot.output.as_ref(), b"readygot:hello");
+    assert_eq!(snapshot.exit_code, Some(0));
+
+    drop((agent, events));
+    timeout(std::time::Duration::from_secs(5), server)
+        .await
+        .map_err(|_| eyre!("mock Responses server did not finish"))???;
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}

--- a/crates/nanocodex-tools/README.md
+++ b/crates/nanocodex-tools/README.md
@@ -114,6 +114,48 @@ execution outside Rust. Implement [`hosted::CodeModeHost`] and pass it to
 notification, observer, and owned-context types as native Code Mode. The
 [`hosted`] module documentation includes a complete host implementation.
 
+## Embed model-created terminals
+
+[`runtime::ToolRuntime::terminals`] exposes raw PTYs without choosing a terminal
+renderer, focus policy, or key bindings. Subscribe before executing a model
+turn, feed `TerminalEvent::Output` bytes into the application's terminal
+emulator, and route user input and pane resizes through the cloneable control:
+
+```rust,no_run
+use nanocodex_tools::{
+    runtime::ToolRuntime,
+    terminal::{TerminalEvent, TerminalSize},
+};
+
+# async fn observe() -> Result<(), Box<dyn std::error::Error>> {
+let runtime = ToolRuntime::new(".", None, None);
+let terminals = runtime.terminals();
+let mut events = terminals.subscribe();
+
+while let Some(event) = events.recv().await? {
+    match event {
+        TerminalEvent::Opened(info) => {
+            terminals.resize(info.id, TerminalSize::new(40, 120)).await?;
+        }
+        TerminalEvent::Output { bytes, .. } => {
+            // Feed exact bytes into the application's terminal emulator.
+            drop(bytes);
+        }
+        TerminalEvent::Exited { .. } => break,
+        _ => {}
+    }
+}
+# Ok(())
+# }
+```
+
+Terminal observation never consumes model-visible shell output. Raw output is
+not redacted. Human input is not added to model history, but terminal input and
+output are recorded verbatim by tracing and may contain credentials. Event
+delivery is bounded; a lagging consumer can rebuild from
+[`terminal::TerminalControl::snapshots`] while the retained raw-byte window is
+not truncated.
+
 ## MCP is native and always available
 
 MCP is not a feature flag. Native consumers configure stdio or Streamable HTTP
@@ -171,6 +213,8 @@ deliberately restoring proxy-safe credential markers to tool subprocesses.
 - [`hosted`] contains the portable application-owned Code Mode boundary.
 - [`runtime`] contains the stateful per-agent executor, built-in connection
   configuration, and dynamic-provider contract.
+- [`terminal`] contains raw PTY lifecycle events, bounded snapshots, exact-byte
+  input, and resize control for application-owned terminal experiences.
 - [`code_mode`] contains cell results, notifications, and nested-tool updates.
 - `mcp` contains transport configuration, authentication, discovery, login,
   and runtime control.

--- a/crates/nanocodex-tools/src/lib.rs
+++ b/crates/nanocodex-tools/src/lib.rs
@@ -39,6 +39,20 @@ mod runtime_config;
 mod shell;
 #[cfg(all(not(target_family = "wasm"), feature = "workspace-runtime"))]
 #[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
+/// Raw PTY lifecycle, output, and application control.
+///
+/// Output snapshots and events are exact process bytes and are not redacted.
+/// Human input is likewise exact and is recorded by tracing. Applications must
+/// protect terminal data with the same access and retention policy as agent
+/// conversations and tool activity.
+pub mod terminal {
+    pub use crate::shell::{
+        TerminalControl, TerminalError, TerminalEvent, TerminalEventError, TerminalEvents,
+        TerminalId, TerminalInfo, TerminalSize, TerminalSnapshot,
+    };
+}
+#[cfg(all(not(target_family = "wasm"), feature = "workspace-runtime"))]
+#[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
 pub mod standard;
 #[cfg(all(not(target_family = "wasm"), feature = "workspace-runtime"))]
 mod view_image;
@@ -126,6 +140,14 @@ pub mod __private {
     pub use crate::runtime::schema_for;
     #[cfg(not(target_family = "wasm"))]
     pub use crate::{Tool, ToolContext, ToolDefinition, ToolInput, ToolOutput, ToolResult};
+
+    /// Returns the fresh terminal capability bound by [`crate::Tools::for_session`].
+    #[cfg(all(not(target_family = "wasm"), feature = "native"))]
+    pub fn terminal_control(tools: &crate::Tools) -> crate::terminal::TerminalControl {
+        tools
+            .terminal_control()
+            .unwrap_or_else(crate::terminal::TerminalControl::new)
+    }
 
     /// Builds the direct Responses tool prefix and the nested Code Mode name map together.
     #[cfg(feature = "native")]

--- a/crates/nanocodex-tools/src/runtime/execution.rs
+++ b/crates/nanocodex-tools/src/runtime/execution.rs
@@ -13,6 +13,7 @@ pub struct ToolRuntime {
     current_turn: Arc<AtomicU64>,
     default_shell_name: Arc<str>,
     working_directory: Arc<str>,
+    terminals: crate::terminal::TerminalControl,
 }
 
 #[doc(hidden)]
@@ -40,6 +41,7 @@ impl ToolRuntime {
             true,
             Arc::new(Vec::new()),
             None,
+            None,
         )
     }
 
@@ -58,6 +60,7 @@ impl ToolRuntime {
             tools.workspace_enabled(),
             tools.process_environment(),
             tools.remote_http_client(),
+            tools.terminal_control(),
         )
         .with_tools(tools)
     }
@@ -69,13 +72,16 @@ impl ToolRuntime {
         workspace_enabled: bool,
         process_environment: Arc<Vec<(OsString, OsString)>>,
         remote_http_client: Option<reqwest::Client>,
+        terminals: Option<crate::terminal::TerminalControl>,
     ) -> Self {
         nanocodex_oai_api::transport::install_default_rustls_crypto_provider();
         let workspace = workspace.into();
         let current_turn = Arc::new(AtomicU64::new(0));
-        let sessions = Arc::new(ShellSessions::with_environment_and_turn(
+        let terminals = terminals.unwrap_or_else(crate::terminal::TerminalControl::new);
+        let sessions = Arc::new(ShellSessions::with_environment_turn_and_terminals(
             process_environment,
             Arc::clone(&current_turn),
+            terminals.clone(),
         ));
         let default_shell_name = Arc::from(sessions.default_shell_name());
         let working_directory = Arc::from(workspace.to_string_lossy().into_owned());
@@ -120,6 +126,7 @@ impl ToolRuntime {
             current_turn,
             default_shell_name,
             working_directory,
+            terminals,
         }
     }
 
@@ -156,6 +163,13 @@ impl ToolRuntime {
     #[must_use]
     pub fn working_directory(&self) -> &str {
         &self.working_directory
+    }
+
+    /// Returns the application-facing control and subscription capability for
+    /// PTYs created by this runtime's `exec_command` tool.
+    #[must_use]
+    pub fn terminals(&self) -> crate::terminal::TerminalControl {
+        self.terminals.clone()
     }
 
     #[doc(hidden)]

--- a/crates/nanocodex-tools/src/runtime/selection.rs
+++ b/crates/nanocodex-tools/src/runtime/selection.rs
@@ -79,6 +79,7 @@ pub struct Tools {
     pub(super) provider_direct: Vec<Arc<dyn Tool>>,
     pub(super) providers: Vec<Arc<dyn DynamicToolProvider>>,
     pub(super) deferred_tools_guidance_enabled: bool,
+    pub(super) terminals: Option<crate::terminal::TerminalControl>,
 }
 
 impl Default for Tools {
@@ -96,6 +97,7 @@ impl Default for Tools {
             provider_direct: Vec::new(),
             providers: Vec::new(),
             deferred_tools_guidance_enabled: false,
+            terminals: None,
         }
     }
 }
@@ -133,6 +135,7 @@ impl fmt::Debug for Tools {
                     .collect::<Vec<_>>(),
             )
             .field("provider_count", &self.providers.len())
+            .field("terminal_control_bound", &self.terminals.is_some())
             .finish()
     }
 }
@@ -183,7 +186,12 @@ impl Tools {
     #[must_use]
     pub fn for_session(mut self, session_id: &str) -> Self {
         self.insert_process_environment(CODEX_THREAD_ID_ENV_VAR.into(), session_id.into());
+        self.terminals = Some(crate::terminal::TerminalControl::new());
         self
+    }
+
+    pub(crate) fn terminal_control(&self) -> Option<crate::terminal::TerminalControl> {
+        self.terminals.clone()
     }
 
     pub(super) fn process_environment(&self) -> Arc<Vec<(OsString, OsString)>> {

--- a/crates/nanocodex-tools/src/shell/mod.rs
+++ b/crates/nanocodex-tools/src/shell/mod.rs
@@ -1,12 +1,17 @@
 mod output;
 mod process;
 mod selection;
+mod terminal;
 mod tool;
 
 #[cfg(feature = "native")]
 pub(crate) use process::ProcessGroupGuard;
 #[cfg(feature = "native")]
 pub use process::ambient_sensitive_environment;
+pub use terminal::{
+    TerminalControl, TerminalError, TerminalEvent, TerminalEventError, TerminalEvents, TerminalId,
+    TerminalInfo, TerminalSize, TerminalSnapshot,
+};
 pub(crate) use tool::{ExecCommandHandler, WriteStdinHandler};
 
 use std::{
@@ -14,8 +19,8 @@ use std::{
     ffi::OsString,
     path::{Path, PathBuf},
     sync::{
-        Arc,
-        atomic::{AtomicI64, AtomicU64, Ordering},
+        Arc, Mutex as StdMutex,
+        atomic::{AtomicU64, Ordering},
     },
     time::{Duration, Instant},
 };
@@ -32,6 +37,7 @@ const MAX_LIVE_SESSIONS: usize = 64;
 
 pub(crate) struct ExecCommand {
     script: String,
+    call_id: Arc<str>,
     workdir: Option<String>,
     shell: Option<String>,
     login: Option<bool>,
@@ -41,7 +47,7 @@ pub(crate) struct ExecCommand {
 }
 
 impl ExecCommand {
-    pub(crate) const fn new(
+    pub(crate) fn new(
         script: String,
         workdir: Option<String>,
         shell: Option<String>,
@@ -52,6 +58,7 @@ impl ExecCommand {
     ) -> Self {
         Self {
             script,
+            call_id: Arc::from(""),
             workdir,
             shell,
             login,
@@ -59,6 +66,11 @@ impl ExecCommand {
             yield_time_ms,
             max_output_tokens,
         }
+    }
+
+    pub(crate) fn with_call_id(mut self, call_id: impl Into<Arc<str>>) -> Self {
+        self.call_id = call_id.into();
+        self
     }
 }
 
@@ -103,10 +115,10 @@ pub(crate) struct ExecCommandResult {
 
 pub(crate) struct ShellSessions {
     sessions: Mutex<SessionStore>,
-    next_session_id: AtomicI64,
     current_turn: Arc<AtomicU64>,
     default_shell: selection::Shell,
     environment: Arc<Vec<(OsString, OsString)>>,
+    terminals: TerminalControl,
 }
 
 impl ShellSessions {
@@ -124,12 +136,20 @@ impl ShellSessions {
         environment: Arc<Vec<(OsString, OsString)>>,
         current_turn: Arc<AtomicU64>,
     ) -> Self {
+        Self::with_environment_turn_and_terminals(environment, current_turn, TerminalControl::new())
+    }
+
+    pub(crate) fn with_environment_turn_and_terminals(
+        environment: Arc<Vec<(OsString, OsString)>>,
+        current_turn: Arc<AtomicU64>,
+        terminals: TerminalControl,
+    ) -> Self {
         Self {
             sessions: Mutex::new(SessionStore::default()),
-            next_session_id: AtomicI64::new(1),
             current_turn,
             default_shell: selection::default_user_shell(),
             environment,
+            terminals,
         }
     }
 
@@ -144,7 +164,7 @@ impl ShellSessions {
         workspace: &Path,
     ) -> ExecCommandResult {
         let started_at = Instant::now();
-        let session_id = self.next_session_id.fetch_add(1, Ordering::Relaxed);
+        let session_id = self.terminals.next_session_id();
         let workdir = resolve_workdir(workspace, command.workdir.as_deref());
         let shell = command.shell.as_deref().map_or_else(
             || self.default_shell.clone(),
@@ -176,6 +196,12 @@ impl ShellSessions {
             self.current_turn.load(Ordering::Acquire),
             spawned,
             secrets,
+            TerminalLaunch {
+                command: Arc::from(command.script),
+                call_id: command.call_id,
+                working_directory: Arc::from(workdir.as_path()),
+                control: self.terminals.clone(),
+            },
         );
         let _interaction_guard = session.interaction.lock().await;
         let pruned = self.sessions.lock().await.insert(Arc::clone(&session));
@@ -341,10 +367,19 @@ struct Session {
     child: Mutex<process::ProcessChild>,
     stdin: Mutex<Option<process::ProcessStdin>>,
     process_group: Mutex<process::ProcessGroupGuard>,
-    drains: Mutex<Option<Vec<JoinHandle<()>>>>,
+    drains: StdMutex<Option<Vec<JoinHandle<()>>>>,
     captured: Arc<Mutex<CapturedOutput>>,
     secrets: Vec<String>,
     active_interactions: AtomicU64,
+    terminal: Option<process::ProcessTerminal>,
+    terminals: TerminalControl,
+}
+
+struct TerminalLaunch {
+    command: Arc<str>,
+    call_id: Arc<str>,
+    working_directory: Arc<Path>,
+    control: TerminalControl,
 }
 
 impl Session {
@@ -353,10 +388,45 @@ impl Session {
         turn_id: u64,
         spawned: process::SpawnedProcess,
         secrets: Vec<String>,
+        terminal_launch: TerminalLaunch,
     ) -> Arc<Self> {
-        let tty = matches!(spawned.stdin.as_ref(), Some(process::ProcessStdin::Pty(_)));
+        let TerminalLaunch {
+            command,
+            call_id,
+            working_directory,
+            control: terminals,
+        } = terminal_launch;
+        let tty = spawned.terminal.is_some();
         let captured = Arc::new(Mutex::new(CapturedOutput::default()));
-        let drains = match spawned.output {
+        let output = spawned.output;
+        let session = Arc::new(Self {
+            id,
+            turn_id: AtomicU64::new(turn_id),
+            tty,
+            interaction: Mutex::new(()),
+            child: Mutex::new(spawned.child),
+            stdin: Mutex::new(spawned.stdin),
+            process_group: Mutex::new(spawned.process_group),
+            drains: StdMutex::new(None),
+            captured: Arc::clone(&captured),
+            secrets,
+            active_interactions: AtomicU64::new(0),
+            terminal: spawned.terminal,
+            terminals: terminals.clone(),
+        });
+        if tty {
+            terminals.register(
+                &session,
+                TerminalInfo {
+                    id: TerminalId::new(id),
+                    call_id,
+                    command,
+                    working_directory,
+                    size: TerminalSize::default(),
+                },
+            );
+        }
+        let drains = match output {
             process::ProcessOutput::Pipes { stdout, stderr } => vec![
                 tokio::spawn(output::drain(
                     stdout,
@@ -373,21 +443,35 @@ impl Session {
                 reader,
                 Arc::clone(&captured),
                 MAX_CAPTURE_BYTES,
+                Some((terminals, TerminalId::new(id))),
             )],
         };
-        Arc::new(Self {
-            id,
-            turn_id: AtomicU64::new(turn_id),
-            tty,
-            interaction: Mutex::new(()),
-            child: Mutex::new(spawned.child),
-            stdin: Mutex::new(spawned.stdin),
-            process_group: Mutex::new(spawned.process_group),
-            drains: Mutex::new(Some(drains)),
-            captured,
-            secrets,
-            active_interactions: AtomicU64::new(0),
-        })
+        *session
+            .drains
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(drains);
+        if let Some(mut terminal) = session.terminal.clone() {
+            let session = Arc::downgrade(&session);
+            tokio::spawn(async move {
+                let exit_code = match terminal.wait().await {
+                    Ok(exit_code) => exit_code,
+                    Err(error) => {
+                        tracing::warn!(%error, "failed to observe tool terminal exit");
+                        1
+                    }
+                };
+                let Some(session) = session.upgrade() else {
+                    return;
+                };
+                let _interaction = session.interaction.lock().await;
+                let _ = session.process_group.lock().await.terminate_and_disarm();
+                session.finish_drains().await;
+                session
+                    .terminals
+                    .exited(TerminalId::new(session.id), exit_code);
+            });
+        }
+        session
     }
 
     fn begin_interaction(&self) -> ActiveInteraction<'_> {
@@ -415,14 +499,19 @@ impl Session {
         // wait path. Own it before the idempotent reap/drain cleanup so a
         // cancellation acknowledgement is a real process-cleanup boundary.
         let _interaction = self.interaction.lock().await;
-        if let Err(error) = self.child.lock().await.wait().await {
-            tracing::warn!(
-                shell.session.id = self.id,
-                %error,
-                "failed to reap terminated shell process"
-            );
-        }
+        let exit_code = match self.child.lock().await.wait().await {
+            Ok(exit_code) => exit_code,
+            Err(error) => {
+                tracing::warn!(
+                    shell.session.id = self.id,
+                    %error,
+                    "failed to reap terminated shell process"
+                );
+                1
+            }
+        };
         self.finish_drains().await;
+        self.terminals.exited(TerminalId::new(self.id), exit_code);
     }
 
     async fn interrupt(&self) -> std::io::Result<()> {
@@ -430,11 +519,23 @@ impl Session {
     }
 
     async fn write(&self, chars: &str) -> std::io::Result<()> {
+        self.write_bytes(chars.as_bytes()).await
+    }
+
+    async fn write_bytes(&self, bytes: &[u8]) -> std::io::Result<()> {
         let mut stdin = self.stdin.lock().await;
         let stdin = stdin.as_mut().ok_or_else(|| {
             std::io::Error::new(std::io::ErrorKind::BrokenPipe, "stdin is closed")
         })?;
-        stdin.write(chars.as_bytes()).await
+        stdin.write(bytes).await
+    }
+
+    async fn resize(&self, size: TerminalSize) -> std::io::Result<()> {
+        let terminal = self
+            .terminal
+            .as_ref()
+            .ok_or_else(|| std::io::Error::other("session is not attached to a terminal"))?;
+        terminal.resize(size).await
     }
 
     async fn wait_for_output(
@@ -451,6 +552,7 @@ impl Session {
             Ok(Ok(exit_code)) => {
                 let _ = self.process_group.lock().await.terminate_and_disarm();
                 self.finish_drains().await;
+                self.terminals.exited(TerminalId::new(self.id), exit_code);
                 Some(exit_code)
             }
             Ok(Err(error)) => {
@@ -460,6 +562,8 @@ impl Session {
                     .lock()
                     .await
                     .push(message.as_bytes(), MAX_CAPTURE_BYTES);
+                self.finish_drains().await;
+                self.terminals.exited(TerminalId::new(self.id), 1);
                 Some(1)
             }
             Err(_) => None,
@@ -484,7 +588,11 @@ impl Session {
     }
 
     async fn finish_drains(&self) {
-        let handles = self.drains.lock().await.take();
+        let handles = self
+            .drains
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
         let Some(handles) = handles else {
             return;
         };
@@ -660,7 +768,9 @@ mod tests {
 
     #[cfg(unix)]
     use super::WriteStdin;
-    use super::{CapturedOutput, ExecCommand, ShellSessions, generate_chunk_id};
+    use super::{
+        CapturedOutput, ExecCommand, ShellSessions, TerminalEvent, TerminalSize, generate_chunk_id,
+    };
 
     #[test]
     fn chunk_ids_match_codex_shape() {
@@ -955,6 +1065,152 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn cancelled_pty_emits_one_terminal_exit_boundary() {
+        let sessions = Arc::new(ShellSessions::new());
+        let terminals = sessions.terminals.clone();
+        let mut events = terminals.subscribe();
+        let execution = {
+            let sessions = Arc::clone(&sessions);
+            tokio::spawn(async move {
+                sessions
+                    .execute(
+                        ExecCommand::new(
+                            "sleep 30".to_owned(),
+                            None,
+                            None,
+                            Some(false),
+                            true,
+                            Some(30_000),
+                            None,
+                        ),
+                        std::path::Path::new("/"),
+                    )
+                    .await
+            })
+        };
+        let id = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if let Some(TerminalEvent::Opened(info)) = events.recv().await.unwrap() {
+                    break info.id;
+                }
+            }
+        })
+        .await
+        .expect("PTY should open before cancellation");
+
+        sessions.terminate_all().await;
+        let result = execution.await.expect("execution task should not panic");
+        let exit_code = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if let Some(TerminalEvent::Exited {
+                    id: exited,
+                    exit_code,
+                    ..
+                }) = events.recv().await.unwrap()
+                    && exited == id
+                {
+                    break exit_code;
+                }
+            }
+        })
+        .await
+        .expect("cancelled PTY should emit an exit boundary");
+        assert_eq!(result.exit_code, Some(exit_code));
+        assert_eq!(terminals.snapshot(id).unwrap().exit_code, Some(exit_code));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn terminal_exit_is_pushed_without_a_model_poll() {
+        let sessions = ShellSessions::new();
+        let terminals = sessions.terminals.clone();
+        let mut events = terminals.subscribe();
+        let result = sessions
+            .execute(
+                ExecCommand::new(
+                    "sleep 0.5; printf done".to_owned(),
+                    None,
+                    None,
+                    Some(false),
+                    true,
+                    Some(250),
+                    None,
+                ),
+                std::path::Path::new("/"),
+            )
+            .await;
+        assert_eq!(result.exit_code, None);
+
+        let id = tokio::time::timeout(Duration::from_secs(2), async {
+            let mut id = None;
+            loop {
+                match events.recv().await.unwrap().unwrap() {
+                    TerminalEvent::Opened(info) => id = Some(info.id),
+                    TerminalEvent::Exited { id: exited, .. } if Some(exited) == id => break exited,
+                    _ => {}
+                }
+            }
+        })
+        .await
+        .expect("terminal exit should not depend on another model tool call");
+        let snapshot = terminals.snapshot(id).unwrap();
+        assert_eq!(snapshot.output.as_ref(), b"done");
+        assert_eq!(snapshot.exit_code, Some(0));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn replacement_shell_runtimes_keep_terminal_ids_unique() {
+        use std::sync::atomic::AtomicU64;
+
+        let terminals = super::TerminalControl::new();
+        let first = ShellSessions::with_environment_turn_and_terminals(
+            Arc::new(Vec::new()),
+            Arc::new(AtomicU64::new(0)),
+            terminals.clone(),
+        );
+        let second = ShellSessions::with_environment_turn_and_terminals(
+            Arc::new(Vec::new()),
+            Arc::new(AtomicU64::new(0)),
+            terminals,
+        );
+        let first_result = first
+            .execute(
+                ExecCommand::new(
+                    "sleep 30".to_owned(),
+                    None,
+                    None,
+                    Some(false),
+                    true,
+                    Some(250),
+                    None,
+                ),
+                std::path::Path::new("/"),
+            )
+            .await;
+        let second_result = second
+            .execute(
+                ExecCommand::new(
+                    "sleep 30".to_owned(),
+                    None,
+                    None,
+                    Some(false),
+                    true,
+                    Some(250),
+                    None,
+                ),
+                std::path::Path::new("/"),
+            )
+            .await;
+
+        assert_eq!(first_result.session_id, Some(1));
+        assert_eq!(second_result.session_id, Some(2));
+        first.terminate_all().await;
+        second.terminate_all().await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn tty_command_has_a_terminal_and_accepts_stdin() {
         let ready =
             std::env::temp_dir().join(format!("nanocodex-pty-ready-{}", std::process::id()));
@@ -995,6 +1251,151 @@ mod tests {
             format!("{}{}", first.output, second.output),
             "readygot:hello"
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn terminal_control_streams_without_consuming_model_output() {
+        let sessions = ShellSessions::new();
+        let terminals = sessions.terminals.clone();
+        let mut events = terminals.subscribe();
+        let first = sessions
+            .execute(
+                ExecCommand::new(
+                    "stty -echo; printf ready; read value; printf 'got:%s' \"$value\"".to_owned(),
+                    None,
+                    None,
+                    Some(false),
+                    true,
+                    Some(250),
+                    None,
+                )
+                .with_call_id("call-terminal"),
+                std::path::Path::new("/"),
+            )
+            .await;
+        assert_eq!(first.session_id, Some(1));
+
+        let opened = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if let Some(TerminalEvent::Opened(info)) = events.recv().await.unwrap() {
+                    break info;
+                }
+            }
+        })
+        .await
+        .expect("terminal should emit an opened event");
+        assert_eq!(opened.call_id.as_ref(), "call-terminal");
+        assert_eq!(opened.size, TerminalSize::default());
+
+        terminals
+            .write(opened.id, b"hello\n")
+            .await
+            .expect("human terminal input should be accepted");
+        let second = sessions
+            .write_stdin(WriteStdin::new(1, String::new(), Some(5_000), None))
+            .await;
+        assert_eq!(second.exit_code, Some(0));
+        assert_eq!(
+            format!("{}{}", first.output, second.output),
+            "readygot:hello"
+        );
+
+        let mut streamed = Vec::new();
+        let (exit_code, output_end) = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                match events
+                    .recv()
+                    .await
+                    .unwrap()
+                    .expect("terminal stream should stay open")
+                {
+                    TerminalEvent::Output { bytes, .. } => streamed.extend_from_slice(&bytes),
+                    TerminalEvent::Exited {
+                        exit_code,
+                        output_end,
+                        ..
+                    } => break (exit_code, output_end),
+                    TerminalEvent::Opened(_) => {}
+                }
+            }
+        })
+        .await
+        .expect("terminal should emit a final exit event");
+        assert_eq!(exit_code, 0);
+        assert_eq!(streamed, b"readygot:hello");
+        assert_eq!(output_end, u64::try_from(streamed.len()).unwrap());
+
+        let snapshot = terminals
+            .snapshot(opened.id)
+            .expect("completed terminal should remain available");
+        assert_eq!(snapshot.output.as_ref(), streamed);
+        assert_eq!(snapshot.exit_code, Some(0));
+        assert!(!snapshot.is_truncated());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn terminal_control_resizes_the_child_pty() {
+        let sessions = ShellSessions::new();
+        let terminals = sessions.terminals.clone();
+        let mut events = terminals.subscribe();
+        let first = sessions
+            .execute(
+                ExecCommand::new(
+                    "stty -echo; printf before:; stty size; read value; printf after:; stty size"
+                        .to_owned(),
+                    None,
+                    None,
+                    Some(false),
+                    true,
+                    Some(250),
+                    None,
+                ),
+                std::path::Path::new("/"),
+            )
+            .await;
+        assert_eq!(first.session_id, Some(1));
+        let id = loop {
+            if let Some(TerminalEvent::Opened(info)) = events.recv().await.unwrap() {
+                break info.id;
+            }
+        };
+
+        terminals
+            .resize(id, TerminalSize::new(40, 100))
+            .await
+            .expect("live PTY should accept a resize");
+        terminals.write(id, b"\n").await.unwrap();
+        let second = sessions
+            .write_stdin(WriteStdin::new(1, String::new(), Some(5_000), None))
+            .await;
+        let output = format!("{}{}", first.output, second.output);
+        assert!(output.contains("before:24 80"), "{output:?}");
+        assert!(output.contains("after:40 100"), "{output:?}");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn tty_commands_receive_a_terminal_environment() {
+        let sessions = ShellSessions::new();
+        let result = sessions
+            .execute(
+                ExecCommand::new(
+                    "printf %s \"$TERM\"".to_owned(),
+                    None,
+                    None,
+                    Some(false),
+                    true,
+                    Some(1_000),
+                    None,
+                ),
+                std::path::Path::new("/"),
+            )
+            .await;
+
+        assert_eq!(result.exit_code, Some(0));
+        assert_eq!(result.output, "xterm-256color");
     }
 
     #[cfg(unix)]

--- a/crates/nanocodex-tools/src/shell/output.rs
+++ b/crates/nanocodex-tools/src/shell/output.rs
@@ -6,6 +6,7 @@ use tokio::{
 };
 
 use super::CapturedOutput;
+use super::{TerminalControl, TerminalId};
 
 const DEFAULT_MAX_OUTPUT_TOKENS: usize = 10_000;
 const MAX_OUTPUT_BYTES: usize = 1024 * 1024;
@@ -47,15 +48,24 @@ pub(super) fn drain_blocking(
     mut pipe: Box<dyn Read + Send>,
     captured: Arc<Mutex<CapturedOutput>>,
     capture_limit: usize,
+    terminal: Option<(TerminalControl, TerminalId)>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::task::spawn_blocking(move || {
+        if let Some((control, id)) = &terminal {
+            control.opened(*id);
+        }
         let mut buffer = [0_u8; READ_BUFFER_LENGTH];
         loop {
             match pipe.read(&mut buffer) {
                 Ok(0) => return,
-                Ok(length) => captured
-                    .blocking_lock()
-                    .push(&buffer[..length], capture_limit),
+                Ok(length) => {
+                    captured
+                        .blocking_lock()
+                        .push(&buffer[..length], capture_limit);
+                    if let Some((control, id)) = &terminal {
+                        control.output(*id, &buffer[..length]);
+                    }
+                }
                 Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
                 // PTY masters commonly report EIO when their slave closes.
                 Err(_) => return,

--- a/crates/nanocodex-tools/src/shell/process.rs
+++ b/crates/nanocodex-tools/src/shell/process.rs
@@ -13,10 +13,11 @@ use nix::{
     sys::signal::{Signal, killpg},
     unistd::Pid,
 };
-use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+use portable_pty::{CommandBuilder, MasterPty, PtySize, native_pty_system};
 use tokio::process::{Child, ChildStderr, ChildStdout, Command};
-use tokio::task::JoinHandle;
+use tokio::sync::watch;
 
+use super::TerminalSize;
 use super::selection::Shell;
 
 const SENSITIVE_ENV_PARTS: [&str; 11] = [
@@ -51,6 +52,67 @@ pub(super) struct SpawnedProcess {
     pub(super) stdin: Option<ProcessStdin>,
     pub(super) output: ProcessOutput,
     pub(super) process_group: ProcessGroupGuard,
+    pub(super) terminal: Option<ProcessTerminal>,
+}
+
+#[derive(Clone)]
+pub(super) struct ProcessTerminal {
+    master: Arc<StdMutex<Box<dyn MasterPty>>>,
+    exit: watch::Receiver<Option<PtyExit>>,
+}
+
+impl ProcessTerminal {
+    pub(super) async fn resize(&self, size: TerminalSize) -> io::Result<()> {
+        let master = Arc::clone(&self.master);
+        tokio::task::spawn_blocking(move || {
+            master
+                .lock()
+                .map_err(|_| io::Error::other("PTY master lock poisoned"))?
+                .resize(PtySize {
+                    rows: size.rows,
+                    cols: size.columns,
+                    pixel_width: 0,
+                    pixel_height: 0,
+                })
+                .map_err(pty_error)
+        })
+        .await
+        .map_err(|error| io::Error::other(format!("PTY resize task failed: {error}")))?
+    }
+
+    pub(super) async fn wait(&mut self) -> io::Result<i32> {
+        wait_for_pty_exit(&mut self.exit).await
+    }
+}
+
+#[derive(Clone)]
+pub(super) enum PtyExit {
+    Exited(i32),
+    Failed {
+        kind: io::ErrorKind,
+        message: String,
+    },
+}
+
+impl PtyExit {
+    fn into_result(self) -> io::Result<i32> {
+        match self {
+            Self::Exited(exit_code) => Ok(exit_code),
+            Self::Failed { kind, message } => Err(io::Error::new(kind, message)),
+        }
+    }
+}
+
+async fn wait_for_pty_exit(receiver: &mut watch::Receiver<Option<PtyExit>>) -> io::Result<i32> {
+    loop {
+        if let Some(exit) = receiver.borrow().clone() {
+            return exit.into_result();
+        }
+        receiver
+            .changed()
+            .await
+            .map_err(|_| io::Error::other("PTY wait task ended without an exit status"))?;
+    }
 }
 
 pub(super) enum ProcessChild {
@@ -59,8 +121,7 @@ pub(super) enum ProcessChild {
         exit_code: Option<i32>,
     },
     Pty {
-        wait: Option<JoinHandle<io::Result<i32>>>,
-        exit_code: Option<i32>,
+        exit: watch::Receiver<Option<PtyExit>>,
     },
 }
 
@@ -78,26 +139,7 @@ impl ProcessChild {
                 *cached = Some(exit_code);
                 Ok(exit_code)
             }
-            Self::Pty {
-                wait,
-                exit_code: cached,
-            } => {
-                if let Some(exit_code) = *cached {
-                    return Ok(exit_code);
-                }
-                // Await by mutable reference so a yield timeout can cancel
-                // this wait without detaching and losing the sole join handle.
-                let result = wait
-                    .as_mut()
-                    .ok_or_else(|| io::Error::other("PTY wait result is unavailable"))?
-                    .await;
-                let exit_code = result.map_err(|error| {
-                    io::Error::other(format!("PTY wait task failed: {error}"))
-                })??;
-                *wait = None;
-                *cached = Some(exit_code);
-                Ok(exit_code)
-            }
+            Self::Pty { exit } => wait_for_pty_exit(exit).await,
         }
     }
 }
@@ -184,6 +226,7 @@ fn spawn_pipes(
             exit_code: None,
         },
         process_group: ProcessGroupGuard::new(pid),
+        terminal: None,
     })
 }
 
@@ -212,6 +255,8 @@ fn spawn_pty(
     for (name, value) in environment {
         command.env(name, value);
     }
+    command.env("TERM", "xterm-256color");
+    command.env_remove("NO_COLOR");
 
     let mut child = pair.slave.spawn_command(command).map_err(pty_error)?;
     let pid = child
@@ -219,20 +264,28 @@ fn spawn_pty(
         .ok_or_else(|| io::Error::other("spawned PTY command without a process identifier"))?;
     let reader = pair.master.try_clone_reader().map_err(pty_error)?;
     let writer = pair.master.take_writer().map_err(pty_error)?;
-    let wait = tokio::task::spawn_blocking(move || {
-        child
-            .wait()
-            .map(|status| i32::try_from(status.exit_code()).unwrap_or(i32::MAX))
+    let (exit_sender, exit) = watch::channel(None);
+    let terminal = ProcessTerminal {
+        master: Arc::new(StdMutex::new(pair.master)),
+        exit: exit.clone(),
+    };
+    tokio::task::spawn_blocking(move || {
+        let status = match child.wait() {
+            Ok(status) => PtyExit::Exited(i32::try_from(status.exit_code()).unwrap_or(i32::MAX)),
+            Err(error) => PtyExit::Failed {
+                kind: error.kind(),
+                message: error.to_string(),
+            },
+        };
+        exit_sender.send_replace(Some(status));
     });
 
     Ok(SpawnedProcess {
-        child: ProcessChild::Pty {
-            wait: Some(wait),
-            exit_code: None,
-        },
+        child: ProcessChild::Pty { exit },
         stdin: Some(ProcessStdin::Pty(Arc::new(StdMutex::new(writer)))),
         output: ProcessOutput::Pty(reader),
         process_group: ProcessGroupGuard::new(pid),
+        terminal: Some(terminal),
     })
 }
 

--- a/crates/nanocodex-tools/src/shell/terminal.rs
+++ b/crates/nanocodex-tools/src/shell/terminal.rs
@@ -1,0 +1,553 @@
+use std::{
+    collections::{HashMap, VecDeque},
+    fmt, io,
+    path::Path,
+    sync::{
+        Arc, Mutex as StdMutex, Weak,
+        atomic::{AtomicI64, Ordering},
+    },
+};
+
+use tokio::sync::broadcast;
+use tracing::info;
+
+use super::Session;
+
+const EVENT_CAPACITY: usize = 256;
+const MAX_ARCHIVED_TERMINALS: usize = 16;
+const MAX_TERMINAL_OUTPUT_BYTES: usize = 1024 * 1024;
+
+/// Opaque identity for one PTY owned by a tool runtime.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct TerminalId(i64);
+
+impl fmt::Display for TerminalId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// Character-cell dimensions for a PTY.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TerminalSize {
+    /// Number of terminal rows.
+    pub rows: u16,
+    /// Number of terminal columns.
+    pub columns: u16,
+}
+
+impl TerminalSize {
+    /// Creates a character-cell terminal size.
+    #[must_use]
+    pub const fn new(rows: u16, columns: u16) -> Self {
+        Self { rows, columns }
+    }
+}
+
+impl Default for TerminalSize {
+    fn default() -> Self {
+        Self::new(24, 80)
+    }
+}
+
+/// Stable metadata for one attachable PTY.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct TerminalInfo {
+    /// Runtime-scoped terminal identity.
+    pub id: TerminalId,
+    /// Provider identity of the `exec_command` call that opened the terminal.
+    pub call_id: Arc<str>,
+    /// Exact shell command supplied by the model.
+    pub command: Arc<str>,
+    /// Resolved working directory used to launch the command.
+    pub working_directory: Arc<Path>,
+    /// Initial or most recently requested terminal size.
+    pub size: TerminalSize,
+}
+
+/// One push notification from the optional raw PTY stream.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum TerminalEvent {
+    /// A model-requested command opened an attachable PTY.
+    Opened(TerminalInfo),
+    /// Exact output bytes were read from the PTY.
+    Output {
+        /// Terminal that produced the bytes.
+        id: TerminalId,
+        /// Absolute byte offset of the first byte in this chunk.
+        offset: u64,
+        /// Exact bytes in process order.
+        bytes: Arc<[u8]>,
+    },
+    /// The PTY process exited after all available output was drained.
+    Exited {
+        /// Terminal that exited.
+        id: TerminalId,
+        /// Process exit status.
+        exit_code: i32,
+        /// Absolute offset immediately after the final observed output byte.
+        output_end: u64,
+    },
+}
+
+/// Bounded non-consuming raw output retained for attachment or lag recovery.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct TerminalSnapshot {
+    /// Terminal metadata captured with this snapshot.
+    pub info: TerminalInfo,
+    /// Absolute offset of the first retained byte.
+    pub output_start: u64,
+    /// Absolute offset immediately after the last retained byte.
+    pub output_end: u64,
+    /// Retained exact PTY bytes.
+    pub output: Arc<[u8]>,
+    /// Exit status, or `None` while the process remains live.
+    pub exit_code: Option<i32>,
+}
+
+impl TerminalSnapshot {
+    /// Returns whether earlier output was discarded from the bounded snapshot.
+    #[must_use]
+    pub const fn is_truncated(&self) -> bool {
+        self.output_start != 0
+    }
+}
+
+/// Failure while controlling or observing an application-facing PTY.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum TerminalError {
+    /// The terminal is not active and no retained snapshot exists.
+    #[error("unknown terminal {0}")]
+    Unknown(TerminalId),
+    /// The terminal already exited and cannot accept more control operations.
+    #[error("terminal {0} has exited")]
+    Exited(TerminalId),
+    /// A resize requested an empty character-cell dimension.
+    #[error("terminal dimensions must be non-zero")]
+    InvalidSize,
+    /// Writing exact bytes to the PTY failed.
+    #[error("failed to write to terminal {id}: {source}")]
+    Write {
+        /// Terminal that rejected the write.
+        id: TerminalId,
+        /// Underlying PTY failure.
+        #[source]
+        source: io::Error,
+    },
+    /// Resizing the PTY failed.
+    #[error("failed to resize terminal {id}: {source}")]
+    Resize {
+        /// Terminal that rejected the resize.
+        id: TerminalId,
+        /// Underlying PTY failure.
+        #[source]
+        source: io::Error,
+    },
+}
+
+/// Failure while receiving terminal lifecycle notifications.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+pub enum TerminalEventError {
+    /// The receiver fell behind the bounded event stream.
+    #[error("terminal event receiver lagged by {skipped} events")]
+    Lagged {
+        /// Number of notifications discarded for this receiver.
+        skipped: u64,
+    },
+}
+
+/// Receiving half of an optional, runtime-scoped terminal event stream.
+pub struct TerminalEvents {
+    receiver: broadcast::Receiver<TerminalEvent>,
+}
+
+impl TerminalEvents {
+    /// Receives the next terminal event, `None` when all controls are dropped,
+    /// or a lag error that can be recovered with [`TerminalControl::snapshots`].
+    pub async fn recv(&mut self) -> Result<Option<TerminalEvent>, TerminalEventError> {
+        match self.receiver.recv().await {
+            Ok(event) => Ok(Some(event)),
+            Err(broadcast::error::RecvError::Closed) => Ok(None),
+            Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                Err(TerminalEventError::Lagged { skipped })
+            }
+        }
+    }
+}
+
+/// Cloneable control and subscription capability for PTYs owned by one runtime.
+#[derive(Clone)]
+pub struct TerminalControl {
+    hub: Arc<TerminalHub>,
+}
+
+impl fmt::Debug for TerminalControl {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TerminalControl")
+            .finish_non_exhaustive()
+    }
+}
+
+impl TerminalControl {
+    pub(crate) fn new() -> Self {
+        let (events, _) = broadcast::channel(EVENT_CAPACITY);
+        Self {
+            hub: Arc::new(TerminalHub {
+                state: StdMutex::new(TerminalState::default()),
+                events,
+                next_session_id: AtomicI64::new(1),
+            }),
+        }
+    }
+
+    /// Subscribes to PTYs opened after this call.
+    ///
+    /// Call this before starting a model turn. Existing live and recently
+    /// completed terminals remain available through [`Self::snapshots`].
+    #[must_use]
+    pub fn subscribe(&self) -> TerminalEvents {
+        TerminalEvents {
+            receiver: self.hub.events.subscribe(),
+        }
+    }
+
+    /// Returns bounded non-consuming snapshots for live and recently completed PTYs.
+    #[must_use]
+    pub fn snapshots(&self) -> Vec<TerminalSnapshot> {
+        self.hub.snapshots()
+    }
+
+    /// Returns one bounded non-consuming PTY snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TerminalError::Unknown`] after an unknown or expired identity.
+    pub fn snapshot(&self, id: TerminalId) -> Result<TerminalSnapshot, TerminalError> {
+        self.hub.snapshot(id)
+    }
+
+    /// Writes exact bytes directly to a live PTY.
+    ///
+    /// Input is not added to model history. It is emitted verbatim through
+    /// tracing and may contain credentials or other sensitive values.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an unknown or completed terminal or a PTY write failure.
+    pub async fn write(
+        &self,
+        id: TerminalId,
+        input: impl AsRef<[u8]>,
+    ) -> Result<(), TerminalError> {
+        let input = input.as_ref();
+        trace_terminal_input(id, input);
+        let session = self.hub.live_session(id)?;
+        session
+            .write_bytes(input)
+            .await
+            .map_err(|source| TerminalError::Write { id, source })
+    }
+
+    /// Changes the character-cell dimensions of a live PTY.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for zero dimensions, an unknown or completed terminal,
+    /// or an operating-system resize failure.
+    pub async fn resize(&self, id: TerminalId, size: TerminalSize) -> Result<(), TerminalError> {
+        if size.rows == 0 || size.columns == 0 {
+            return Err(TerminalError::InvalidSize);
+        }
+        let session = self.hub.live_session(id)?;
+        session
+            .resize(size)
+            .await
+            .map_err(|source| TerminalError::Resize { id, source })?;
+        self.hub.record_size(id, size);
+        Ok(())
+    }
+
+    pub(super) fn register(&self, session: &Arc<Session>, info: TerminalInfo) {
+        self.hub.register(session, info);
+    }
+
+    pub(super) fn next_session_id(&self) -> i64 {
+        self.hub.next_session_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    pub(super) fn opened(&self, id: TerminalId) {
+        self.hub.opened(id);
+    }
+
+    pub(super) fn output(&self, id: TerminalId, bytes: &[u8]) {
+        self.hub.output(id, bytes);
+    }
+
+    pub(super) fn exited(&self, id: TerminalId, exit_code: i32) {
+        self.hub.exited(id, exit_code);
+    }
+}
+
+fn trace_terminal_input(id: TerminalId, input: &[u8]) {
+    info!(
+        target: "nanocodex_tools",
+        terminal_id = %id,
+        input_bytes = input.len(),
+        sensitive = true,
+        terminal.input = ?input,
+        "writing human input to tool terminal"
+    );
+}
+
+struct TerminalHub {
+    state: StdMutex<TerminalState>,
+    events: broadcast::Sender<TerminalEvent>,
+    next_session_id: AtomicI64,
+}
+
+#[derive(Default)]
+struct TerminalState {
+    active: HashMap<TerminalId, ActiveTerminal>,
+    archives: VecDeque<TerminalSnapshot>,
+}
+
+struct ActiveTerminal {
+    info: TerminalInfo,
+    session: Weak<Session>,
+    output: RetainedOutput,
+}
+
+#[derive(Default)]
+struct RetainedOutput {
+    bytes: VecDeque<u8>,
+    start: u64,
+    end: u64,
+}
+
+impl RetainedOutput {
+    fn push(&mut self, bytes: &[u8]) -> u64 {
+        let offset = self.end;
+        self.end = self
+            .end
+            .saturating_add(u64::try_from(bytes.len()).unwrap_or(u64::MAX));
+        self.bytes.extend(bytes);
+        let overflow = self.bytes.len().saturating_sub(MAX_TERMINAL_OUTPUT_BYTES);
+        self.bytes.drain(..overflow);
+        self.start = self
+            .start
+            .saturating_add(u64::try_from(overflow).unwrap_or(u64::MAX));
+        offset
+    }
+
+    fn snapshot(&self, info: TerminalInfo, exit_code: Option<i32>) -> TerminalSnapshot {
+        TerminalSnapshot {
+            info,
+            output_start: self.start,
+            output_end: self.end,
+            output: self.bytes.iter().copied().collect::<Vec<_>>().into(),
+            exit_code,
+        }
+    }
+}
+
+impl TerminalHub {
+    fn state(&self) -> std::sync::MutexGuard<'_, TerminalState> {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    fn register(&self, session: &Arc<Session>, info: TerminalInfo) {
+        self.state().active.insert(
+            info.id,
+            ActiveTerminal {
+                info,
+                session: Arc::downgrade(session),
+                output: RetainedOutput::default(),
+            },
+        );
+    }
+
+    fn opened(&self, id: TerminalId) {
+        let info = self
+            .state()
+            .active
+            .get(&id)
+            .map(|active| active.info.clone());
+        if let Some(info) = info {
+            drop(self.events.send(TerminalEvent::Opened(info)));
+        }
+    }
+
+    fn output(&self, id: TerminalId, bytes: &[u8]) {
+        if bytes.is_empty() {
+            return;
+        }
+        let offset = {
+            let mut state = self.state();
+            let Some(active) = state.active.get_mut(&id) else {
+                return;
+            };
+            active.output.push(bytes)
+        };
+        info!(
+            target: "nanocodex_tools",
+            terminal_id = %id,
+            output_offset = offset,
+            output_bytes = bytes.len(),
+            terminal.output = ?bytes,
+            "observed tool terminal output"
+        );
+        drop(self.events.send(TerminalEvent::Output {
+            id,
+            offset,
+            bytes: Arc::from(bytes),
+        }));
+    }
+
+    fn exited(&self, id: TerminalId, exit_code: i32) {
+        let snapshot = {
+            let mut state = self.state();
+            let Some(active) = state.active.remove(&id) else {
+                return;
+            };
+            let snapshot = active.output.snapshot(active.info, Some(exit_code));
+            state.archives.push_back(snapshot.clone());
+            while state.archives.len() > MAX_ARCHIVED_TERMINALS {
+                state.archives.pop_front();
+            }
+            snapshot
+        };
+        drop(self.events.send(TerminalEvent::Exited {
+            id,
+            exit_code,
+            output_end: snapshot.output_end,
+        }));
+    }
+
+    fn live_session(&self, id: TerminalId) -> Result<Arc<Session>, TerminalError> {
+        let state = self.state();
+        if let Some(active) = state.active.get(&id) {
+            return active.session.upgrade().ok_or(TerminalError::Exited(id));
+        }
+        if state.archives.iter().any(|snapshot| snapshot.info.id == id) {
+            return Err(TerminalError::Exited(id));
+        }
+        Err(TerminalError::Unknown(id))
+    }
+
+    fn record_size(&self, id: TerminalId, size: TerminalSize) {
+        if let Some(active) = self.state().active.get_mut(&id) {
+            active.info.size = size;
+        }
+    }
+
+    fn snapshots(&self) -> Vec<TerminalSnapshot> {
+        let state = self.state();
+        let mut snapshots = state.archives.iter().cloned().collect::<Vec<_>>();
+        snapshots.extend(
+            state
+                .active
+                .values()
+                .map(|active| active.output.snapshot(active.info.clone(), None)),
+        );
+        snapshots.sort_unstable_by_key(|snapshot| snapshot.info.id);
+        snapshots
+    }
+
+    fn snapshot(&self, id: TerminalId) -> Result<TerminalSnapshot, TerminalError> {
+        let state = self.state();
+        if let Some(active) = state.active.get(&id) {
+            return Ok(active.output.snapshot(active.info.clone(), None));
+        }
+        state
+            .archives
+            .iter()
+            .find(|snapshot| snapshot.info.id == id)
+            .cloned()
+            .ok_or(TerminalError::Unknown(id))
+    }
+}
+
+impl TerminalId {
+    pub(super) const fn new(id: i64) -> Self {
+        Self(id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{io::Write, sync::Arc};
+
+    use super::{
+        MAX_TERMINAL_OUTPUT_BYTES, RetainedOutput, StdMutex, TerminalId, trace_terminal_input,
+    };
+
+    struct TraceWriter(Arc<StdMutex<Vec<u8>>>);
+
+    impl Write for TraceWriter {
+        fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .extend_from_slice(buffer);
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn tracing_preserves_exact_human_input_bytes() {
+        let captured = Arc::new(StdMutex::new(Vec::new()));
+        let writer = Arc::clone(&captured);
+        let subscriber = tracing_subscriber::fmt()
+            .without_time()
+            .with_ansi(false)
+            .with_writer(move || TraceWriter(Arc::clone(&writer)))
+            .finish();
+        let dispatch = tracing::Dispatch::new(subscriber);
+
+        tracing::dispatcher::with_default(&dispatch, || {
+            trace_terminal_input(TerminalId::new(7), b"swordfish\n");
+        });
+
+        let output = String::from_utf8(
+            captured
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone(),
+        )
+        .expect("trace output should be UTF-8");
+        assert!(output.contains("terminal_id=7"));
+        assert!(output.contains("input_bytes=10"));
+        assert!(
+            output.contains("terminal.input=[115, 119, 111, 114, 100, 102, 105, 115, 104, 10]"),
+            "{output}"
+        );
+    }
+
+    #[test]
+    fn retained_output_reports_the_absolute_window_after_truncation() {
+        let mut output = RetainedOutput::default();
+        let bytes = vec![b'x'; MAX_TERMINAL_OUTPUT_BYTES + 7];
+
+        assert_eq!(output.push(&bytes), 0);
+        assert_eq!(output.start, 7);
+        assert_eq!(
+            output.end,
+            u64::try_from(MAX_TERMINAL_OUTPUT_BYTES + 7).unwrap()
+        );
+        assert_eq!(output.bytes.len(), MAX_TERMINAL_OUTPUT_BYTES);
+        assert_eq!(output.push(b"tail"), output.end - 4);
+        assert_eq!(output.start, 11);
+    }
+}

--- a/crates/nanocodex-tools/src/shell/tool.rs
+++ b/crates/nanocodex-tools/src/shell/tool.rs
@@ -31,7 +31,7 @@ impl Tool for ExecCommandHandler {
         true
     }
 
-    async fn execute(&self, input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
+    async fn execute(&self, input: ToolInput, context: ToolContext<'_>) -> ToolResult {
         let arguments = input.decode_json::<ExecCommandArguments>()?;
         let command = ExecCommand::new(
             arguments.cmd,
@@ -41,7 +41,8 @@ impl Tool for ExecCommandHandler {
             arguments.tty,
             arguments.yield_time_ms,
             arguments.max_output_tokens,
-        );
+        )
+        .with_call_id(context.call_id());
         let result = self.sessions.execute(command, &self.workspace).await;
         Ok(shell_execution(&result))
     }

--- a/crates/nanocodex-tools/tests/it/main.rs
+++ b/crates/nanocodex-tools/tests/it/main.rs
@@ -2,6 +2,7 @@
 
 mod oauth;
 mod support;
+mod terminal;
 mod tool_macro;
 mod tracing;
 

--- a/crates/nanocodex-tools/tests/it/terminal.rs
+++ b/crates/nanocodex-tools/tests/it/terminal.rs
@@ -1,0 +1,84 @@
+#[cfg(unix)]
+#[tokio::test]
+async fn public_runtime_terminal_capability_controls_a_model_pty() {
+    use nanocodex_tools::{
+        ToolContext,
+        contract::{DEFAULT_TOOL_OUTPUT_TOKENS, ToolInput},
+        runtime::ToolRuntime,
+        terminal::TerminalEvent,
+    };
+    use serde_json::{json, value::to_raw_value};
+
+    let runtime = ToolRuntime::new("/", None, None);
+    let terminals = runtime.terminals();
+    let mut events = terminals.subscribe();
+    let context = ToolContext::new(
+        "test-model",
+        "test-session",
+        "call-public-terminal",
+        &[],
+        DEFAULT_TOOL_OUTPUT_TOKENS,
+    );
+    let started = runtime
+        .execute_tool(
+            "exec_command",
+            ToolInput::Function(
+                to_raw_value(&json!({
+                    "cmd": "stty -echo; printf ready; read value; printf 'got:%s' \"$value\"",
+                    "tty": true,
+                    "yield_time_ms": 250
+                }))
+                .unwrap(),
+            ),
+            context,
+        )
+        .await;
+    let session_id = started.code_mode_value()["session_id"]
+        .as_i64()
+        .expect("yielded command should expose its model session ID");
+    let opened = loop {
+        if let Some(TerminalEvent::Opened(info)) = events.recv().await.unwrap() {
+            break info;
+        }
+    };
+    assert_eq!(opened.call_id.as_ref(), "call-public-terminal");
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        let mut output = Vec::new();
+        loop {
+            if let Some(TerminalEvent::Output { bytes, .. }) = events.recv().await.unwrap() {
+                output.extend_from_slice(&bytes);
+                if output.ends_with(b"ready") {
+                    break;
+                }
+            }
+        }
+    })
+    .await
+    .expect("PTY should reach its input prompt");
+    terminals.write(opened.id, b"hello\n").await.unwrap();
+    let completed = runtime
+        .execute_tool(
+            "write_stdin",
+            ToolInput::Function(
+                to_raw_value(&json!({
+                    "session_id": session_id,
+                    "yield_time_ms": 5_000
+                }))
+                .unwrap(),
+            ),
+            ToolContext::new(
+                "test-model",
+                "test-session",
+                "call-public-poll",
+                &[],
+                DEFAULT_TOOL_OUTPUT_TOKENS,
+            ),
+        )
+        .await;
+    assert_eq!(completed.code_mode_value()["exit_code"], 0);
+    assert_eq!(
+        terminals.snapshot(opened.id).unwrap().output.as_ref(),
+        b"readygot:hello"
+    );
+}


### PR DESCRIPTION
## Summary

This replaces the opinionated TUI direction explored in #33 with a native, library-level PTY boundary for embedding applications such as [Tact](https://github.com/clabby/tact).

- expose `TerminalControl` from both `Nanocodex::terminals()` and standalone `ToolRuntime::terminals()`
- stream typed opened/output/exited events with exact raw bytes and absolute offsets
- support exact-byte input, PTY resize, and bounded snapshots for attachment and lag recovery
- observe terminal exit independently from model polling while preserving the existing model-visible shell output
- keep rendering, focus, attachment, key bindings, and other interaction policy entirely application-owned

There is no new `interactive` tool-schema flag and no built-in Ratatui behavior. Existing `tty: true` commands become attachable; ordinary piped commands are unchanged. PTYs advertise `TERM=xterm-256color` and remove `NO_COLOR` so an embedding terminal emulator can render real terminal applications.

## Lifecycle and security

Terminal IDs and state are scoped to one agent/runtime. The event channel and retained output are bounded, controls hold only weak process capabilities, and completed snapshots are archived within fixed limits. `Exited` is emitted only after available PTY output has drained, including when the model never polls the yielded command again.

Terminal input does not enter model history. Exact terminal input and unredacted raw output are recorded in tracing, so embedding applications must protect traces and terminal data like agent conversations and tool activity.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p nanocodex-tools -p nanocodex-agent -p nanocodex --all-targets -- -D warnings`
- `cargo test -p nanocodex-tools -p nanocodex-agent -p nanocodex`
- `cargo check -p nanocodex-tools --no-default-features --features workspace-runtime`
- `cargo check -p nanocodex-wasm --target wasm32-unknown-unknown`
- `cargo check -p nanocodex-examples --bins`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p nanocodex-tools -p nanocodex-agent -p nanocodex --all-features --no-deps`
- `./scripts/check-crate-boundaries.sh`
- `git diff --check`
