### PR TITLE
fix: cancel voice-started turns from the TUI

### DIFF
--- a/bin/nanocodex/src/tui/app.rs
+++ b/bin/nanocodex/src/tui/app.rs
@@ -2262,6 +2262,16 @@ impl App {
         }
     }
 
+    pub(super) fn cancel_settled(&mut self, target: PaneId) {
+        if let Some(conversation) = self.conversation_mut(target) {
+            conversation.status = if conversation.running {
+                "Working".to_owned()
+            } else {
+                "Ready".to_owned()
+            };
+        }
+    }
+
     pub(super) fn cancel_failed(&mut self, target: PaneId, error: String) {
         if let Some(conversation) = self.conversation_mut(target) {
             conversation.push_output(TranscriptItem::Error(error));

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -34,8 +34,8 @@ use nanocodex::{
     tools::mcp::McpHandle,
 };
 use nanocodex_voice::{
-    CHATGPT_REALTIME_VOICES, PLATFORM_REALTIME_VOICES, RealtimeVoice, VoiceEvent, VoiceEvents,
-    VoiceSession, VoiceSessionBuilder, VoiceSpeaker,
+    CHATGPT_REALTIME_VOICES, PLATFORM_REALTIME_VOICES, RealtimeVoice, VoiceAgentControl,
+    VoiceEvent, VoiceEvents, VoiceSession, VoiceSessionBuilder, VoiceSpeaker,
 };
 use ratatex::{Ratatex, TerminalProfile};
 use tokio::{
@@ -148,6 +148,9 @@ enum WorkerEvent {
         error: String,
     },
     CancelAccepted {
+        target: PaneId,
+    },
+    CancelSettled {
         target: PaneId,
     },
     CancelFailed {
@@ -952,6 +955,7 @@ fn handle_worker_update(
         }
         WorkerEvent::SteerFailed { target, id, error } => app.steer_failed(target, id, error),
         WorkerEvent::CancelAccepted { target } => app.cancel_accepted(target),
+        WorkerEvent::CancelSettled { target } => app.cancel_settled(target),
         WorkerEvent::CancelFailed { target, error } => app.cancel_failed(target, error),
         WorkerEvent::InterruptedSteersResubmitted {
             target,
@@ -1085,6 +1089,7 @@ fn spawn_agent_worker(
             mcp,
             realtime,
             voice: None,
+            voice_agent_control: VoiceAgentControl::default(),
         };
         loop {
             tokio::select! {
@@ -1141,6 +1146,7 @@ struct AgentWorker {
     mcp: Option<McpHandle>,
     realtime: Option<OpenAi>,
     voice: Option<VoiceSession>,
+    voice_agent_control: VoiceAgentControl,
 }
 
 impl AgentWorker {
@@ -1245,7 +1251,8 @@ impl AgentWorker {
             return;
         };
         let mut builder = VoiceSessionBuilder::new(realtime, self.main.agent.clone())
-            .session_id(Arc::clone(&self.main.request_id));
+            .session_id(Arc::clone(&self.main.request_id))
+            .agent_control(self.voice_agent_control.clone());
         if let Some(voice) = voice {
             builder = builder.voice(voice);
         }
@@ -1514,7 +1521,11 @@ impl AgentWorker {
                     (Some(&branch.turns), branch.request_id.as_ref())
                 }),
         };
-        let _ = cancel_turn(turns, session_id, target, &self.updates).await;
+        let mut outcome = cancel_turn(turns, session_id, target).await;
+        if matches!(outcome, Ok(false)) && matches!(target, PaneId::Main) {
+            outcome = self.voice_agent_control.cancel().await;
+        }
+        let _ = report_cancel_outcome(outcome, target, &self.updates);
     }
 
     async fn interrupt_for_steers(
@@ -1559,7 +1570,11 @@ impl AgentWorker {
                     (Some(&branch.turns), branch.request_id.as_ref())
                 }),
         };
-        if !cancel_turn(turns, session_id, target, &self.updates).await {
+        if !report_cancel_outcome(
+            cancel_turn(turns, session_id, target).await,
+            target,
+            &self.updates,
+        ) {
             drop(
                 self.updates
                     .send(WorkerEvent::InterruptedSteersKept { target, prompt_id }),
@@ -1684,13 +1699,11 @@ impl AgentWorker {
             return;
         };
         if !self.main.turns.is_empty()
-            && !cancel_turn(
-                Some(&self.main.turns),
-                &self.main.request_id,
+            && !report_cancel_outcome(
+                cancel_turn(Some(&self.main.turns), &self.main.request_id, PaneId::Main).await,
                 PaneId::Main,
                 &self.updates,
             )
-            .await
         {
             drop(self.updates.send(WorkerEvent::MainBranchOpenFailed {
                 id: new_branch_id,
@@ -2012,9 +2025,7 @@ async fn cancel_turn(
     turns: Option<&VecDeque<TrackedTurn>>,
     session_id: &str,
     target: PaneId,
-    updates: &mpsc::UnboundedSender<WorkerEvent>,
-) -> bool {
-    let mut outcome = Err(NanocodexError::TurnNotCancellable);
+) -> Result<bool, NanocodexError> {
     for turn in turns.into_iter().flatten() {
         let started_at = Instant::now();
         let span = info_span!(
@@ -2045,14 +2056,22 @@ async fn cancel_turn(
                     "otel.status_code",
                     if result.is_ok() { "OK" } else { "ERROR" },
                 );
-                outcome = result;
-                break;
+                return result.map(|()| true);
             }
         }
     }
-    let accepted = outcome.is_ok();
+    Ok(false)
+}
+
+fn report_cancel_outcome(
+    outcome: Result<bool, NanocodexError>,
+    target: PaneId,
+    updates: &mpsc::UnboundedSender<WorkerEvent>,
+) -> bool {
+    let accepted = matches!(outcome, Ok(true));
     let event = match outcome {
-        Ok(()) => WorkerEvent::CancelAccepted { target },
+        Ok(true) => WorkerEvent::CancelAccepted { target },
+        Ok(false) => WorkerEvent::CancelSettled { target },
         Err(error) => WorkerEvent::CancelFailed {
             target,
             error: error.to_string(),
@@ -2839,7 +2858,8 @@ mod tests {
         BTW_BOUNDARY, PaneId, RedrawPriority, Submission, TerminalAction, UiAction, UiModel,
         UiUpdate, VoiceControl, WorkerCommand, WorkerEvent, active_session_id,
         apply_main_agent_event_batch, classify_submission, handle_key, handle_worker_update,
-        paste_clipboard_image, prepare_btw_prompt, session_trace_url, spawn_agent_worker,
+        paste_clipboard_image, prepare_btw_prompt, report_cancel_outcome, session_trace_url,
+        spawn_agent_worker,
     };
     use crate::tui::{
         app::App,
@@ -3688,6 +3708,32 @@ mod tests {
             })
         ));
         assert_eq!(app.input, "preserved draft");
+    }
+
+    #[test]
+    fn already_settled_cancel_is_quiet() -> eyre::Result<()> {
+        let (updates, mut update_rx) = mpsc::unbounded_channel();
+        assert!(!report_cancel_outcome(Ok(false), PaneId::Main, &updates));
+        assert!(matches!(
+            update_rx.try_recv(),
+            Ok(WorkerEvent::CancelSettled {
+                target: PaneId::Main
+            })
+        ));
+
+        let (commands, _) = mpsc::unbounded_channel();
+        let mut app = App::new("/workspace".into());
+        app.cancel_pending(PaneId::Main);
+        handle_worker_update(
+            &mut app,
+            WorkerEvent::CancelSettled {
+                target: PaneId::Main,
+            },
+            &commands,
+        )?;
+        assert_eq!(app.main.status, "Ready");
+        assert!(app.main.transcript.is_empty());
+        Ok(())
     }
 
     #[test]

--- a/crates/experimental/nanocodex-voice/README.md
+++ b/crates/experimental/nanocodex-voice/README.md
@@ -19,6 +19,13 @@ That lets the voice handoff attach to the already-running turn, stream its
 remaining output, and announce completion. The Nanocodex TUI wires this path
 automatically.
 
+Voice-started coding work remains independently controllable when the audio
+session stops or reconnects. Retain a `VoiceAgentControl`, pass it to each
+replacement session with `VoiceSessionBuilder::agent_control`, and route the
+embedding's normal interrupt gesture through `VoiceAgentControl::cancel`.
+Stopping voice disconnects Realtime; cancelling the controller interrupts the
+coding turn.
+
 The default conversational prompt, local first-name rendering, delegation
 markers, tool descriptions, and protocol-specific steering acknowledgement are
 ported from Codex's Realtime implementation. Callers can still replace the
@@ -28,10 +35,13 @@ rendered default and delegation envelope independently through
 
 ```rust,no_run
 use nanocodex::{Nanocodex, OpenAi};
-use nanocodex_voice::{VoiceEvent, VoiceSessionBuilder};
+use nanocodex_voice::{VoiceAgentControl, VoiceEvent, VoiceSessionBuilder};
 
 # async fn example(openai: OpenAi, agent: Nanocodex) -> Result<(), Box<dyn std::error::Error>> {
-let (mut voice, mut events) = VoiceSessionBuilder::new(openai, agent).spawn()?;
+let agent_control = VoiceAgentControl::default();
+let (mut voice, mut events) = VoiceSessionBuilder::new(openai, agent)
+    .agent_control(agent_control.clone())
+    .spawn()?;
 while let Some(event) = events.recv().await {
     match event {
         VoiceEvent::Transcript { speaker, text } => println!("{speaker}: {text}"),
@@ -41,6 +51,7 @@ while let Some(event) = events.recv().await {
     }
 }
 voice.stop();
+let _cancelled = agent_control.cancel().await?;
 # Ok(())
 # }
 ```

--- a/crates/experimental/nanocodex-voice/src/lib.rs
+++ b/crates/experimental/nanocodex-voice/src/lib.rs
@@ -1,10 +1,14 @@
 #![doc = include_str!("../README.md")]
 
-use std::{io, sync::Arc, time::Duration};
+use std::{
+    io,
+    sync::{Arc, Mutex, MutexGuard},
+    time::Duration,
+};
 
 use futures_util::StreamExt;
 use nanocodex::{
-    Nanocodex, OpenAi, PromptRoute,
+    Nanocodex, NanocodexError, OpenAi, PromptRoute, TurnControl,
     agent::events::{AgentEvent, AgentEventData, AssistantEvent, RunEvent},
     oai::{
         auth::OpenAiAuthMode,
@@ -139,6 +143,7 @@ impl VoiceEvents {
 pub struct VoiceSession {
     stop: Option<oneshot::Sender<()>>,
     agent_events: mpsc::UnboundedSender<AgentEvent>,
+    agent_control: VoiceAgentControl,
     task: std::thread::JoinHandle<()>,
 }
 
@@ -156,6 +161,28 @@ impl VoiceSession {
         }
     }
 
+    /// Returns a reusable controller for coding turns started by this voice lifecycle.
+    ///
+    /// An embedding can retain this controller across voice reconnects and route its
+    /// normal interrupt gesture through [`VoiceAgentControl::cancel`].
+    #[must_use]
+    pub fn agent_control(&self) -> VoiceAgentControl {
+        self.agent_control.clone()
+    }
+
+    /// Cancels the unfinished coding turn started by this voice lifecycle, if any.
+    ///
+    /// Returns `true` when cancellation was accepted and `false` when no voice-owned
+    /// turn remains. A turn completing concurrently with cancellation is treated as
+    /// already settled rather than as an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the agent driver rejects cancellation for another reason.
+    pub async fn cancel_agent_turn(&self) -> Result<bool, NanocodexError> {
+        self.agent_control.cancel().await
+    }
+
     /// Mirrors one session-wide agent event into an active externally-started handoff.
     ///
     /// Embeddings whose typed UI can start a turn before voice is enabled should
@@ -165,6 +192,80 @@ impl VoiceSession {
     pub fn observe_agent_event(&self, event: AgentEvent) -> bool {
         self.agent_events.send(event).is_ok()
     }
+}
+
+/// Reusable interrupt capability for coding turns launched by a voice session.
+///
+/// Share one controller across replacement [`VoiceSession`]s when the embedding
+/// wants its normal interrupt action to keep targeting work started before a
+/// Realtime reconnect.
+#[derive(Clone, Default)]
+pub struct VoiceAgentControl {
+    active: Arc<Mutex<Option<ActiveVoiceAgentTurn>>>,
+}
+
+impl VoiceAgentControl {
+    /// Returns whether a voice-started coding turn is currently retained.
+    #[must_use]
+    pub fn has_active_turn(&self) -> bool {
+        self.active().is_some()
+    }
+
+    /// Cancels the retained voice-started coding turn, if any.
+    ///
+    /// Returns `true` when cancellation was accepted and `false` when no turn
+    /// remains. Completion racing with cancellation is an idempotent success.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the agent driver rejects cancellation for another reason.
+    pub async fn cancel(&self) -> Result<bool, NanocodexError> {
+        let Some(active) = self.active() else {
+            return Ok(false);
+        };
+        match active.control.cancel().await {
+            Ok(()) => Ok(true),
+            Err(NanocodexError::TurnNotCancellable) => {
+                self.clear(active.generation);
+                Ok(false)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    fn active(&self) -> Option<ActiveVoiceAgentTurn> {
+        self.lock().clone()
+    }
+
+    fn set(&self, generation: u64, control: TurnControl) {
+        *self.lock() = Some(ActiveVoiceAgentTurn {
+            generation,
+            control,
+        });
+    }
+
+    fn clear(&self, generation: u64) {
+        let mut active = self.lock();
+        if active
+            .as_ref()
+            .is_some_and(|active| active.generation == generation)
+        {
+            *active = None;
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Option<ActiveVoiceAgentTurn>> {
+        match self.active.lock() {
+            Ok(active) => active,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ActiveVoiceAgentTurn {
+    generation: u64,
+    control: TurnControl,
 }
 
 impl Drop for VoiceSession {
@@ -183,6 +284,7 @@ pub struct VoiceSessionBuilder {
     voice: Option<RealtimeVoice>,
     initial_items: Vec<RealtimeInitialItem>,
     audio: AudioConfig,
+    agent_control: VoiceAgentControl,
 }
 
 impl VoiceSessionBuilder {
@@ -198,6 +300,7 @@ impl VoiceSessionBuilder {
             voice: None,
             initial_items: Vec::new(),
             audio: AudioConfig::default(),
+            agent_control: VoiceAgentControl::default(),
         }
     }
 
@@ -251,6 +354,16 @@ impl VoiceSessionBuilder {
         self
     }
 
+    /// Shares a voice-started turn controller with the embedding.
+    ///
+    /// Reuse the same controller for replacement sessions so an interrupt can
+    /// still cancel a coding turn launched before the voice transport changed.
+    #[must_use]
+    pub fn agent_control(mut self, control: VoiceAgentControl) -> Self {
+        self.agent_control = control;
+        self
+    }
+
     /// Spawns the owned desktop lifecycle and its independent event stream.
     ///
     /// # Errors
@@ -262,6 +375,7 @@ impl VoiceSessionBuilder {
         let (events, receiver) = mpsc::unbounded_channel();
         let (agent_events, observed_agent_events) = mpsc::unbounded_channel();
         let (stop, stopped) = oneshot::channel();
+        let agent_control = self.agent_control.clone();
         let task = std::thread::Builder::new()
             .name("nanocodex-voice".to_owned())
             .spawn(move || run_thread(self, events, observed_agent_events, stopped))
@@ -270,6 +384,7 @@ impl VoiceSessionBuilder {
             VoiceSession {
                 stop: Some(stop),
                 agent_events,
+                agent_control,
                 task,
             },
             VoiceEvents { receiver },
@@ -413,6 +528,7 @@ async fn run_voice(
         next_generation: 0,
         external_output: HandoffStream::default(),
         external_error: None,
+        control: builder.agent_control,
     };
     let mut external_flush = tokio::time::interval(HANDOFF_STREAM_FLUSH_INTERVAL);
     external_flush.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -520,6 +636,7 @@ struct AgentBridge {
     next_generation: u64,
     external_output: HandoffStream,
     external_error: Option<String>,
+    control: VoiceAgentControl,
 }
 
 impl AgentBridge {
@@ -568,12 +685,14 @@ async fn handle_realtime_event(
                 Ok(PromptRoute::Started(turn)) => {
                     agent_bridge.next_generation = agent_bridge.next_generation.saturating_add(1);
                     let generation = agent_bridge.next_generation;
+                    agent_bridge.control.set(generation, turn.control());
                     agent_bridge.active = Some(ActiveAgentRequest {
                         generation,
                         call_id: call_id.clone(),
                         streamed_output: false,
                         external: false,
                     });
+                    let agent_control = agent_bridge.control.clone();
                     drop(tokio::spawn(async move {
                         let mut turn = turn;
                         let mut output = HandoffStream::default();
@@ -604,7 +723,7 @@ async fn handle_realtime_event(
                                                     text,
                                                 }).is_err()
                                             {
-                                                return;
+                                                break;
                                             }
                                             output = HandoffStream::default();
                                         }
@@ -616,7 +735,7 @@ async fn handle_realtime_event(
                                                     text: truncate_realtime_output(&message.text),
                                                 }).is_err() =>
                                         {
-                                            return;
+                                            break;
                                         }
                                         _ => {}
                                     }
@@ -628,22 +747,19 @@ async fn handle_realtime_event(
                                             text,
                                         }).is_err()
                                     {
-                                        return;
+                                        break;
                                     }
                                 }
                             }
                         }
-                        if let Some(text) = output.drain_final_chunk()
-                            && updates
-                                .send(AgentBridgeUpdate::Output { generation, text })
-                                .is_err()
-                        {
-                            return;
+                        if let Some(text) = output.drain_final_chunk() {
+                            drop(updates.send(AgentBridgeUpdate::Output { generation, text }));
                         }
                         let output = match turn.result().await {
                             Ok(result) => result.final_message().to_owned(),
                             Err(error) => format!("The coding agent failed: {error}"),
                         };
+                        agent_control.clear(generation);
                         drop(updates.send(AgentBridgeUpdate::Completed {
                             generation,
                             call_id,
@@ -959,7 +1075,7 @@ fn send_event(events: &mpsc::UnboundedSender<VoiceEvent>, event: VoiceEvent) {
 #[cfg(test)]
 mod tests {
     use super::{
-        AudioConfig, HandoffStream, RealtimeTranscriptEntry, VoiceSpeaker,
+        AudioConfig, HandoffStream, RealtimeTranscriptEntry, VoiceAgentControl, VoiceSpeaker,
         codex_realtime_delegation, codex_realtime_delegation_with_transcript,
         codex_voice_instructions, realtime_output_byte_limit, truncate_realtime_output,
     };
@@ -976,6 +1092,20 @@ mod tests {
     fn transcript_speakers_have_stable_labels() {
         assert_eq!(VoiceSpeaker::User.to_string(), "user");
         assert_eq!(VoiceSpeaker::Assistant.to_string(), "assistant");
+    }
+
+    #[test]
+    fn unused_agent_control_is_an_idempotent_interrupt() {
+        let control = VoiceAgentControl::default();
+        assert!(!control.has_active_turn());
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test runtime should build");
+        assert!(
+            !runtime
+                .block_on(control.cancel())
+                .expect("cancel should be idle")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- retain a reusable `VoiceAgentControl` across Realtime voice sessions
- route TUI Esc and `/cancel` to voice-started coding turns when no normal tracked turn is active
- treat a completion/cancellation race as an idempotent settled state instead of rendering `the targeted turn has already completed or been cancelled`
- keep `/voice off` scoped to the Realtime transport, matching Codex, while preserving the coding-turn interrupt capability

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p nanocodex-voice -p nanocodex-bin --all-targets --locked -- -D warnings`
- `cargo test -p nanocodex-voice --locked`
- `cargo test -p nanocodex-bin --bin nanocodex --locked` (238 passed, 2 ignored)
- `scripts/check-crate-boundaries.sh`