### PR TITLE
feat(voice): add Codex realtime parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5292,6 +5292,8 @@ dependencies = [
  "cpal",
  "futures-util",
  "nanocodex",
+ "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -1104,6 +1104,7 @@ fn spawn_agent_worker(
                 }
             }
         }
+        worker.stop_voice().await;
     })
 }
 
@@ -1196,11 +1197,11 @@ impl AgentWorker {
                     let _ = voice.observe_agent_event(event);
                 }
             }
-            WorkerCommand::Voice(control) => self.control_voice(control),
+            WorkerCommand::Voice(control) => self.control_voice(control).await,
         }
     }
 
-    fn control_voice(&mut self, control: VoiceControl) {
+    async fn control_voice(&mut self, control: VoiceControl) {
         let running = self.voice_running();
         match control {
             VoiceControl::List => {
@@ -1214,15 +1215,11 @@ impl AgentWorker {
                 return;
             }
             VoiceControl::Stop => {
-                if let Some(active) = self.voice.as_mut() {
-                    active.stop();
-                }
+                self.stop_voice().await;
                 return;
             }
             VoiceControl::Toggle if running => {
-                if let Some(active) = self.voice.as_mut() {
-                    active.stop();
-                }
+                self.stop_voice().await;
                 return;
             }
             VoiceControl::Start(_) if running => {
@@ -1269,6 +1266,17 @@ impl AgentWorker {
 
     fn voice_running(&self) -> bool {
         self.voice.as_ref().is_some_and(VoiceSession::is_running)
+    }
+
+    async fn stop_voice(&mut self) {
+        let Some(mut voice) = self.voice.take() else {
+            return;
+        };
+        if let Err(error) = voice.shutdown().await {
+            drop(self.updates.send(WorkerEvent::VoiceFailed {
+                error: format!("failed to stop voice cleanly: {error}"),
+            }));
+        }
     }
 
     fn mcp_login(&self, name: String) {

--- a/crates/experimental/nanocodex-voice/Cargo.toml
+++ b/crates/experimental/nanocodex-voice/Cargo.toml
@@ -16,6 +16,7 @@ description = "Experimental desktop GPT Realtime voice sessions for Nanocodex ag
 [dependencies]
 futures-util.workspace = true
 nanocodex = { workspace = true, features = ["realtime"] }
+serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "sync"] }
 tracing.workspace = true
@@ -23,6 +24,9 @@ whoami.workspace = true
 
 [target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
 cpal.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/experimental/nanocodex-voice/README.md
+++ b/crates/experimental/nanocodex-voice/README.md
@@ -13,10 +13,10 @@ acknowledges the steering tool call immediately; Frameless retargets the open
 delegation to the newest request. Neither path waits behind the active turn as
 a second queued request.
 
-If another UI can start work through the same agent before voice does, mirror
-its session-wide `AgentEvent`s through `VoiceSession::observe_agent_event`.
-That lets the voice handoff attach to the already-running turn, stream its
-remaining output, and announce completion. The Nanocodex TUI wires this path
+While voice is active, mirror work started by typed input through
+`VoiceSession::observe_agent_event`. The result joins an open handoff when one
+exists and otherwise reaches Realtime as a standalone update, so the voice
+model stays synchronized with typed work. The Nanocodex TUI wires this path
 automatically.
 
 Voice-started coding work remains independently controllable when the audio
@@ -26,12 +26,17 @@ embedding's normal interrupt gesture through `VoiceAgentControl::cancel`.
 Stopping voice disconnects Realtime; cancelling the controller interrupts the
 coding turn.
 
-The default conversational prompt, local first-name rendering, delegation
-markers, tool descriptions, and protocol-specific steering acknowledgement are
-ported from Codex's Realtime implementation. Callers can still replace the
-conversation prompt with `VoiceSessionBuilder::instructions`, or reuse the
-rendered default and delegation envelope independently through
-`codex_voice_instructions()` and `codex_realtime_delegation()`.
+The crate owns Codex's Realtime policy: lifecycle developer markers, bounded
+startup context, transcript-tail flushing, typed-turn mirroring, delegation
+markers, tool descriptions, handoff routing, and protocol-specific steering.
+`nanocodex-agent` only supplies protocol-neutral live-input, developer-context,
+and read-only session-context capabilities.
+
+The builder exposes V1/V2/V3, WebSocket/WebRTC, conversation/transcription,
+audio/text output, initial items, client-managed handoffs, responses-as-items,
+item prefixes, thinking/commentary/BEM routing, configurable BEM prefixes,
+startup-context policy, and tail-flush policy. Defaults follow Codex for the
+selected authentication mode.
 
 ```rust,no_run
 use nanocodex::{Nanocodex, OpenAi};
@@ -50,7 +55,7 @@ while let Some(event) = events.recv().await {
         VoiceEvent::Connecting | VoiceEvent::Started { .. } => {}
     }
 }
-voice.stop();
+voice.shutdown().await?;
 let _cancelled = agent_control.cancel().await?;
 # Ok(())
 # }

--- a/crates/experimental/nanocodex-voice/src/lib.rs
+++ b/crates/experimental/nanocodex-voice/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 use std::{
+    collections::BTreeMap,
     io,
     sync::{Arc, Mutex, MutexGuard},
     time::Duration,
@@ -16,6 +17,7 @@ use nanocodex::{
             RealtimeAgentSteer, RealtimeError, RealtimeEvent, RealtimeSession,
             RealtimeTranscriptEntry,
         },
+        responses::MessagePhase,
     },
 };
 use tokio::sync::{mpsc, oneshot};
@@ -26,10 +28,13 @@ mod audio;
 #[allow(clippy::missing_const_for_fn)]
 #[path = "audio_unsupported.rs"]
 mod audio;
+mod startup_context;
 
 pub use nanocodex::oai::realtime::{
     CHATGPT_REALTIME_VOICE, CHATGPT_REALTIME_VOICES, PLATFORM_REALTIME_VOICE,
-    PLATFORM_REALTIME_VOICES, RealtimeInitialItem, RealtimeTextRole, RealtimeVoice,
+    PLATFORM_REALTIME_VOICES, RealtimeInitialItem, RealtimeInputTextRole, RealtimeOutputModality,
+    RealtimeResponseHandoffMode, RealtimeSessionMode, RealtimeTextRole, RealtimeTransport,
+    RealtimeVersion, RealtimeVoice,
 };
 
 use audio::VoiceAudio;
@@ -41,6 +46,23 @@ const HANDOFF_STREAM_FLUSH_INTERVAL: Duration = Duration::from_millis(200);
 const REALTIME_ASSISTANT_OUTPUT_TOKEN_BUDGET: usize = 1_000;
 const APPROX_BYTES_PER_TOKEN: usize = 4;
 const HANDOFF_STREAM_TRUNCATION_MARKER: &str = "\n…output truncated…\n";
+const REALTIME_SESSION_ENDED_HANDOFF_INSTRUCTION: &str = "The user just ended their realtime session. Here is the remaining handoff/transcript tail. You probably do not have to do anything; acknowledge the handoff unless the transcript itself asks for something.";
+const REALTIME_START_INSTRUCTIONS: &str = concat!(
+    "<realtime_conversation>\n\n",
+    "Realtime conversation started.\n\n",
+    "You are operating as a backend executor behind an intermediary. The user does not talk to you directly. Any response you produce will be consumed by the intermediary and may be summarized before the user sees it.\n\n",
+    "When invoked, you receive the latest conversation transcript and any relevant mode or metadata. The intermediary may invoke you even when backend help is not actually needed. Use the transcript to decide whether you should do work. If backend help is unnecessary, avoid verbose responses that add user-visible latency.\n\n",
+    "When user text is routed from realtime, treat it as a transcript. It may be unpunctuated or contain recognition errors.\n\n",
+    "- Keep responses concise and action-oriented. Your updates should help the intermediary respond to the user.\n\n",
+    "</realtime_conversation>"
+);
+const REALTIME_END_INSTRUCTIONS: &str = concat!(
+    "<realtime_conversation>\n\n",
+    "Realtime conversation ended.\n\n",
+    "Subsequent user input will return to typed text rather than transcript-style text. Do not assume recognition errors or missing punctuation once realtime has ended. Resume normal chat behavior.\n\n",
+    "Reason: inactive\n\n",
+    "</realtime_conversation>"
+);
 
 /// Desktop capture and playback policy.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -142,16 +164,17 @@ impl VoiceEvents {
 /// A running desktop voice lifecycle.
 pub struct VoiceSession {
     stop: Option<oneshot::Sender<()>>,
+    finished: Option<oneshot::Receiver<Result<(), String>>>,
     agent_events: mpsc::UnboundedSender<AgentEvent>,
     agent_control: VoiceAgentControl,
-    task: std::thread::JoinHandle<()>,
+    task: Option<std::thread::JoinHandle<()>>,
 }
 
 impl VoiceSession {
     /// Returns whether the owned voice thread is still running.
     #[must_use]
     pub fn is_running(&self) -> bool {
-        !self.task.is_finished()
+        self.task.as_ref().is_some_and(|task| !task.is_finished())
     }
 
     /// Requests a clean stop without blocking the caller.
@@ -159,6 +182,29 @@ impl VoiceSession {
         if let Some(stop) = self.stop.take() {
             let _ = stop.send(());
         }
+    }
+
+    /// Requests a clean stop and joins the owned voice lifecycle.
+    ///
+    /// This waits for media cleanup, the Realtime close handshake,
+    /// transcript-tail routing, and the agent lifecycle end marker.
+    ///
+    /// # Errors
+    ///
+    /// Returns the terminal lifecycle failure or a voice-thread join failure.
+    pub async fn shutdown(&mut self) -> Result<(), VoiceShutdownError> {
+        self.stop();
+        let outcome = match self.finished.take() {
+            Some(finished) => finished
+                .await
+                .map_err(|_| VoiceShutdownError::CompletionChannel)?,
+            None => Ok(()),
+        };
+        if let Some(task) = self.task.take() {
+            task.join()
+                .map_err(|_| VoiceShutdownError::ThreadPanicked)?;
+        }
+        outcome.map_err(VoiceShutdownError::Lifecycle)
     }
 
     /// Returns a reusable controller for coding turns started by this voice lifecycle.
@@ -183,11 +229,12 @@ impl VoiceSession {
         self.agent_control.cancel().await
     }
 
-    /// Mirrors one session-wide agent event into an active externally-started handoff.
+    /// Mirrors one session-wide event from work started outside this lifecycle.
     ///
-    /// Embeddings whose typed UI can start a turn before voice is enabled should
-    /// pass that agent's normal [`AgentEvent`] stream here. Events for turns
-    /// started by this voice session are already mirrored internally.
+    /// Embeddings with typed input should pass the agent's normal [`AgentEvent`]
+    /// stream here while voice is active. Output joins an active handoff when
+    /// one exists, or is sent to Realtime as a standalone result. Events for
+    /// turns started by this voice session are already mirrored internally.
     #[must_use]
     pub fn observe_agent_event(&self, event: AgentEvent) -> bool {
         self.agent_events.send(event).is_ok()
@@ -282,7 +329,19 @@ pub struct VoiceSessionBuilder {
     session_id: Option<Arc<str>>,
     attestation_header: Option<Arc<str>>,
     voice: Option<RealtimeVoice>,
+    model: Option<String>,
+    version: Option<RealtimeVersion>,
+    transport: Option<RealtimeTransport>,
+    session_mode: RealtimeSessionMode,
+    output_modality: RealtimeOutputModality,
+    client_managed_handoffs: bool,
+    codex_responses_as_items: bool,
+    codex_response_item_prefix: Option<String>,
+    codex_response_handoff_mode: RealtimeResponseHandoffMode,
+    codex_response_handoff_channel_prefixes: BTreeMap<String, Vec<String>>,
     initial_items: Vec<RealtimeInitialItem>,
+    include_startup_context: bool,
+    flush_transcript_tail_on_session_end: bool,
     audio: AudioConfig,
     agent_control: VoiceAgentControl,
 }
@@ -298,7 +357,19 @@ impl VoiceSessionBuilder {
             session_id: None,
             attestation_header: None,
             voice: None,
+            model: None,
+            version: None,
+            transport: None,
+            session_mode: RealtimeSessionMode::Conversational,
+            output_modality: RealtimeOutputModality::Audio,
+            client_managed_handoffs: false,
+            codex_responses_as_items: false,
+            codex_response_item_prefix: None,
+            codex_response_handoff_mode: RealtimeResponseHandoffMode::Thinking,
+            codex_response_handoff_channel_prefixes: BTreeMap::new(),
             initial_items: Vec::new(),
+            include_startup_context: true,
+            flush_transcript_tail_on_session_end: true,
             audio: AudioConfig::default(),
             agent_control: VoiceAgentControl::default(),
         }
@@ -332,6 +403,79 @@ impl VoiceSessionBuilder {
         self
     }
 
+    /// Selects the realtime model explicitly.
+    #[must_use]
+    pub fn model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    /// Selects realtime protocol V1, V2, or V3.
+    #[must_use]
+    pub const fn version(mut self, version: RealtimeVersion) -> Self {
+        self.version = Some(version);
+        self
+    }
+
+    /// Selects WebSocket or owned WebRTC transport.
+    #[must_use]
+    pub const fn transport(mut self, transport: RealtimeTransport) -> Self {
+        self.transport = Some(transport);
+        self
+    }
+
+    /// Selects conversational or transcription-only operation.
+    #[must_use]
+    pub const fn session_mode(mut self, mode: RealtimeSessionMode) -> Self {
+        self.session_mode = mode;
+        self
+    }
+
+    /// Selects text or synthesized-audio model output.
+    #[must_use]
+    pub const fn output_modality(mut self, modality: RealtimeOutputModality) -> Self {
+        self.output_modality = modality;
+        self
+    }
+
+    /// Lets the embedding manage all coding-agent handoff output itself.
+    #[must_use]
+    pub const fn client_managed_handoffs(mut self, managed: bool) -> Self {
+        self.client_managed_handoffs = managed;
+        self
+    }
+
+    /// Sends automatic coding-agent responses as realtime conversation items.
+    #[must_use]
+    pub const fn codex_responses_as_items(mut self, as_items: bool) -> Self {
+        self.codex_responses_as_items = as_items;
+        self
+    }
+
+    /// Prefixes automatic coding-agent response items.
+    #[must_use]
+    pub fn codex_response_item_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.codex_response_item_prefix = Some(prefix.into());
+        self
+    }
+
+    /// Selects thinking, commentary, or BEM-tag handoff routing.
+    #[must_use]
+    pub const fn codex_response_handoff_mode(mut self, mode: RealtimeResponseHandoffMode) -> Self {
+        self.codex_response_handoff_mode = mode;
+        self
+    }
+
+    /// Replaces BEM prefixes keyed by `analysis`, `commentary`, and `final`.
+    #[must_use]
+    pub fn codex_response_handoff_channel_prefixes(
+        mut self,
+        prefixes: BTreeMap<String, Vec<String>>,
+    ) -> Self {
+        self.codex_response_handoff_channel_prefixes = prefixes;
+        self
+    }
+
     /// Replaces the role-bearing text history used to seed ChatGPT voice.
     #[must_use]
     pub fn initial_items(mut self, items: impl IntoIterator<Item = RealtimeInitialItem>) -> Self {
@@ -344,6 +488,23 @@ impl VoiceSessionBuilder {
     pub fn initial_item(mut self, role: RealtimeTextRole, text: impl Into<String>) -> Self {
         self.initial_items
             .push(RealtimeInitialItem::new(role, text));
+        self
+    }
+
+    /// Enables or disables Codex's bounded realtime startup context.
+    ///
+    /// This defaults to `true` and includes current-thread history, recent
+    /// rollout work, and a shallow workspace map in the voice model prompt.
+    #[must_use]
+    pub const fn include_startup_context(mut self, include: bool) -> Self {
+        self.include_startup_context = include;
+        self
+    }
+
+    /// Enables or disables routing an unconsumed transcript tail when voice ends.
+    #[must_use]
+    pub const fn flush_transcript_tail_on_session_end(mut self, flush: bool) -> Self {
+        self.flush_transcript_tail_on_session_end = flush;
         self
     }
 
@@ -375,17 +536,19 @@ impl VoiceSessionBuilder {
         let (events, receiver) = mpsc::unbounded_channel();
         let (agent_events, observed_agent_events) = mpsc::unbounded_channel();
         let (stop, stopped) = oneshot::channel();
+        let (finished, completion) = oneshot::channel();
         let agent_control = self.agent_control.clone();
         let task = std::thread::Builder::new()
             .name("nanocodex-voice".to_owned())
-            .spawn(move || run_thread(self, events, observed_agent_events, stopped))
+            .spawn(move || run_thread(self, events, observed_agent_events, stopped, finished))
             .map_err(VoiceError::Spawn)?;
         Ok((
             VoiceSession {
                 stop: Some(stop),
+                finished: Some(completion),
                 agent_events,
                 agent_control,
-                task,
+                task: Some(task),
             },
             VoiceEvents { receiver },
         ))
@@ -416,12 +579,29 @@ pub enum VoiceError {
     Spawn(#[source] io::Error),
 }
 
+/// Failure while joining an owned desktop voice lifecycle.
+#[derive(Debug, thiserror::Error)]
+pub enum VoiceShutdownError {
+    /// The lifecycle stopped with a runtime, transport, audio, or agent failure.
+    #[error("voice lifecycle failed: {0}")]
+    Lifecycle(String),
+    /// The lifecycle thread panicked.
+    #[error("voice lifecycle thread panicked")]
+    ThreadPanicked,
+    /// The lifecycle exited without publishing its terminal result.
+    #[error("voice lifecycle completion channel closed")]
+    CompletionChannel,
+}
+
 /// Terminal failure from an active desktop voice lifecycle.
 #[derive(Debug, thiserror::Error)]
 pub enum VoiceFailure {
     /// The dedicated async runtime could not be initialized.
     #[error("failed to create voice runtime: {0}")]
     Runtime(String),
+    /// The coding-agent session rejected a lifecycle context update.
+    #[error(transparent)]
+    Agent(#[from] NanocodexError),
     /// The GPT Realtime transport failed.
     #[error(transparent)]
     Realtime(#[from] RealtimeError),
@@ -468,6 +648,7 @@ fn run_thread(
     events: mpsc::UnboundedSender<VoiceEvent>,
     observed_agent_events: mpsc::UnboundedReceiver<AgentEvent>,
     stopped: oneshot::Receiver<()>,
+    finished: oneshot::Sender<Result<(), String>>,
 ) {
     let runtime = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -475,39 +656,97 @@ fn run_thread(
     {
         Ok(runtime) => runtime,
         Err(error) => {
+            let message = error.to_string();
             send_event(
                 &events,
                 VoiceEvent::Failed {
-                    error: VoiceFailure::Runtime(error.to_string()),
+                    error: VoiceFailure::Runtime(message.clone()),
                 },
             );
+            drop(finished.send(Err(message)));
             return;
         }
     };
-    let terminal =
-        match runtime.block_on(run_voice(builder, &events, observed_agent_events, stopped)) {
-            Ok(()) => VoiceEvent::Stopped,
-            Err(error) => VoiceEvent::Failed { error },
-        };
+    let result = runtime.block_on(run_voice(builder, &events, observed_agent_events, stopped));
+    let completion = result.as_ref().map_err(ToString::to_string).copied();
+    let terminal = match result {
+        Ok(()) => VoiceEvent::Stopped,
+        Err(error) => VoiceEvent::Failed { error },
+    };
     send_event(&events, terminal);
+    drop(finished.send(completion));
 }
 
 async fn run_voice(
+    mut builder: VoiceSessionBuilder,
+    events: &mpsc::UnboundedSender<VoiceEvent>,
+    observed_agent_events: mpsc::UnboundedReceiver<AgentEvent>,
+    stopped: oneshot::Receiver<()>,
+) -> Result<(), VoiceFailure> {
+    let lifecycle_agent = builder.agent.clone();
+    let context = lifecycle_agent
+        .append_developer_message(REALTIME_START_INSTRUCTIONS)
+        .await?;
+    if builder.include_startup_context {
+        let rollout = lifecycle_agent
+            .rollout()
+            .map(|rollout| rollout.path().to_path_buf());
+        if let Some(startup) = startup_context::build(&context, rollout.as_deref()) {
+            builder.instructions = Arc::from(format!("{}\n\n{startup}", builder.instructions));
+        }
+    }
+    let result = run_active_voice(builder, events, observed_agent_events, stopped).await;
+    let ended = lifecycle_agent
+        .append_developer_message(REALTIME_END_INSTRUCTIONS)
+        .await
+        .map(|_| ());
+    match (result, ended) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Ok(())) => Ok(()),
+        (Ok(()), Err(error)) => Err(error.into()),
+    }
+}
+
+async fn run_active_voice(
     builder: VoiceSessionBuilder,
     events: &mpsc::UnboundedSender<VoiceEvent>,
     mut observed_agent_events: mpsc::UnboundedReceiver<AgentEvent>,
     mut stopped: oneshot::Receiver<()>,
 ) -> Result<(), VoiceFailure> {
     send_event(events, VoiceEvent::Connecting);
-    let voice = builder.voice.unwrap_or(match builder.openai.auth_mode() {
-        OpenAiAuthMode::ChatGpt => CHATGPT_REALTIME_VOICE,
-        OpenAiAuthMode::ApiKey => PLATFORM_REALTIME_VOICE,
-    });
+    let default_version = match builder.openai.auth_mode() {
+        OpenAiAuthMode::ChatGpt => RealtimeVersion::V3,
+        OpenAiAuthMode::ApiKey => RealtimeVersion::V2,
+    };
+    let voice = builder
+        .voice
+        .unwrap_or(match builder.version.unwrap_or(default_version) {
+            RealtimeVersion::V1 | RealtimeVersion::V3 => CHATGPT_REALTIME_VOICE,
+            RealtimeVersion::V2 => PLATFORM_REALTIME_VOICE,
+        });
     let mut realtime = builder
         .openai
         .realtime(builder.instructions)
         .voice(voice)
-        .initial_items(builder.initial_items);
+        .initial_items(builder.initial_items)
+        .session_mode(builder.session_mode)
+        .output_modality(builder.output_modality)
+        .client_managed_handoffs(builder.client_managed_handoffs)
+        .codex_responses_as_items(builder.codex_responses_as_items)
+        .codex_response_handoff_mode(builder.codex_response_handoff_mode)
+        .codex_response_handoff_channel_prefixes(builder.codex_response_handoff_channel_prefixes);
+    if let Some(model) = builder.model {
+        realtime = realtime.model(model);
+    }
+    if let Some(version) = builder.version {
+        realtime = realtime.version(version);
+    }
+    if let Some(transport) = builder.transport {
+        realtime = realtime.transport(transport);
+    }
+    if let Some(prefix) = builder.codex_response_item_prefix {
+        realtime = realtime.codex_response_item_prefix(prefix);
+    }
     if let Some(session_id) = builder.session_id {
         realtime = realtime.session_id(session_id.as_ref());
     }
@@ -528,6 +767,7 @@ async fn run_voice(
         next_generation: 0,
         external_output: HandoffStream::default(),
         external_error: None,
+        observing_external_turn: false,
         control: builder.agent_control,
     };
     let mut external_flush = tokio::time::interval(HANDOFF_STREAM_FLUSH_INTERVAL);
@@ -535,6 +775,7 @@ async fn run_voice(
     external_flush.tick().await;
     send_event(events, VoiceEvent::Started { voice });
 
+    let mut transport_closed = false;
     let result = loop {
         tokio::select! {
             _ = &mut stopped => break Ok(()),
@@ -548,6 +789,7 @@ async fn run_voice(
             }
             event = realtime_events.recv() => {
                 let Some(event) = event else {
+                    transport_closed = true;
                     break Ok(());
                 };
                 if let Err(error) = handle_realtime_event(
@@ -556,6 +798,7 @@ async fn run_voice(
                     &mut audio,
                     events,
                     &mut agent_bridge,
+                    builder.flush_transcript_tail_on_session_end,
                 ).await {
                     break Err(error);
                 }
@@ -565,11 +808,15 @@ async fn run_voice(
                     break Ok(());
                 };
                 match update {
-                    AgentBridgeUpdate::Output { generation, text } => {
+                    AgentBridgeUpdate::Output { generation, text, phase } => {
                         if let Some(active) = &mut agent_bridge.active
                             && active.generation == generation
                         {
-                            session.append_agent_output(&active.call_id, text).await?;
+                            if !session.client_managed_handoffs() {
+                                session
+                                    .append_agent_output_with_phase(&active.call_id, text, phase)
+                                    .await?;
+                            }
                             active.streamed_output = true;
                         }
                     }
@@ -578,20 +825,29 @@ async fn run_voice(
                         call_id,
                         output,
                     } => {
-                        let (call_id, streamed_output) = match agent_bridge.active.take() {
+                        let completed = match agent_bridge.active.take() {
                             Some(active) if active.generation == generation => {
-                                (active.call_id, active.streamed_output)
+                                Some((active.call_id, active.streamed_output))
                             }
                             Some(active) => {
                                 agent_bridge.active = Some(active);
-                                (call_id, false)
+                                None
                             }
-                            None => (call_id, false),
+                            None => None,
                         };
-                        if !streamed_output && !output.trim().is_empty() {
+                        let Some((call_id, streamed_output)) = completed else {
+                            drop(call_id);
+                            continue;
+                        };
+                        if !session.client_managed_handoffs()
+                            && !streamed_output
+                            && !output.trim().is_empty()
+                        {
                             session.append_agent_output(&call_id, output).await?;
                         }
-                        session.complete_agent_run(call_id).await?;
+                        if !session.client_managed_handoffs() {
+                            session.complete_agent_run(call_id).await?;
+                        }
                     }
                 }
             }
@@ -606,7 +862,12 @@ async fn run_voice(
             }
         }
     };
-    drop(session.close().await);
+    if !transport_closed {
+        let tail = session.close_with_transcript_tail().await?;
+        if builder.flush_transcript_tail_on_session_end {
+            route_transcript_tail(&agent_bridge.agent, &tail).await?;
+        }
+    }
     result
 }
 
@@ -614,6 +875,7 @@ enum AgentBridgeUpdate {
     Output {
         generation: u64,
         text: String,
+        phase: Option<MessagePhase>,
     },
     Completed {
         generation: u64,
@@ -636,6 +898,7 @@ struct AgentBridge {
     next_generation: u64,
     external_output: HandoffStream,
     external_error: Option<String>,
+    observing_external_turn: bool,
     control: VoiceAgentControl,
 }
 
@@ -652,6 +915,7 @@ async fn handle_realtime_event(
     audio: &mut VoiceAudio,
     events: &mpsc::UnboundedSender<VoiceEvent>,
     agent_bridge: &mut AgentBridge,
+    flush_transcript_tail_on_session_end: bool,
 ) -> Result<(), VoiceFailure> {
     match event {
         RealtimeEvent::SessionReady { .. }
@@ -659,6 +923,11 @@ async fn handle_realtime_event(
         | RealtimeEvent::OutputTranscriptDelta(_)
         | RealtimeEvent::ResponseStarted
         | RealtimeEvent::ResponseDone => {}
+        RealtimeEvent::TranscriptTail(tail) => {
+            if flush_transcript_tail_on_session_end {
+                route_transcript_tail(&agent_bridge.agent, &tail).await?;
+            }
+        }
         RealtimeEvent::SpeechStarted => audio.interrupt(),
         RealtimeEvent::InputTranscriptDone(text) => {
             send_transcript(events, VoiceSpeaker::User, text);
@@ -709,11 +978,13 @@ async fn handle_realtime_event(
                                         Ok(AgentEventData::Assistant(AssistantEvent::Delta(delta)))
                                             if streams_agent_output =>
                                         {
+                                            output.phase = delta.phase;
                                             output.push_text(&delta.text);
                                         }
                                         Ok(AgentEventData::Assistant(AssistantEvent::Message(message)))
                                             if streams_agent_output =>
                                         {
+                                            output.phase = message.phase;
                                             if !output.has_output() {
                                                 output.push_text(&message.text);
                                             }
@@ -721,6 +992,7 @@ async fn handle_realtime_event(
                                                 && updates.send(AgentBridgeUpdate::Output {
                                                     generation,
                                                     text,
+                                                    phase: output.phase,
                                                 }).is_err()
                                             {
                                                 break;
@@ -733,6 +1005,7 @@ async fn handle_realtime_event(
                                                 && updates.send(AgentBridgeUpdate::Output {
                                                     generation,
                                                     text: truncate_realtime_output(&message.text),
+                                                    phase: message.phase,
                                                 }).is_err() =>
                                         {
                                             break;
@@ -745,6 +1018,7 @@ async fn handle_realtime_event(
                                         && updates.send(AgentBridgeUpdate::Output {
                                             generation,
                                             text,
+                                            phase: output.phase,
                                         }).is_err()
                                     {
                                         break;
@@ -753,7 +1027,11 @@ async fn handle_realtime_event(
                             }
                         }
                         if let Some(text) = output.drain_final_chunk() {
-                            drop(updates.send(AgentBridgeUpdate::Output { generation, text }));
+                            drop(updates.send(AgentBridgeUpdate::Output {
+                                generation,
+                                text,
+                                phase: output.phase,
+                            }));
                         }
                         let output = match turn.result().await {
                             Ok(result) => result.final_message().to_owned(),
@@ -788,13 +1066,15 @@ async fn handle_realtime_event(
                     }
                 }
                 Err(error) => {
-                    session
-                        .append_agent_output(
-                            &call_id,
-                            format!("The coding agent rejected the request: {error}"),
-                        )
-                        .await?;
-                    session.complete_agent_run(call_id).await?;
+                    if !session.client_managed_handoffs() {
+                        session
+                            .append_agent_output(
+                                &call_id,
+                                format!("The coding agent rejected the request: {error}"),
+                            )
+                            .await?;
+                        session.complete_agent_run(call_id).await?;
+                    }
                 }
             }
         }
@@ -813,21 +1093,47 @@ async fn handle_observed_agent_event(
     session: &RealtimeSession,
     agent_bridge: &mut AgentBridge,
 ) -> Result<(), VoiceFailure> {
-    if !agent_bridge
-        .active
-        .as_ref()
-        .is_some_and(|active| active.external)
-    {
+    if session.client_managed_handoffs() {
         return Ok(());
     }
-
     match event.data() {
+        Ok(AgentEventData::Run(RunEvent::Started(_))) => {
+            if agent_bridge.active.is_none() {
+                agent_bridge.observing_external_turn = true;
+                agent_bridge.external_output = HandoffStream::default();
+                agent_bridge.external_error = None;
+            }
+        }
         Ok(AgentEventData::Assistant(AssistantEvent::Delta(delta)))
-            if session.streams_agent_output() =>
+            if session.streams_agent_output()
+                && agent_bridge
+                    .active
+                    .as_ref()
+                    .is_some_and(|active| active.external) =>
         {
+            agent_bridge.external_output.phase = delta.phase;
             agent_bridge.external_output.push_text(&delta.text);
         }
         Ok(AgentEventData::Assistant(AssistantEvent::Message(message))) => {
+            if agent_bridge.active.is_none() && agent_bridge.observing_external_turn {
+                if !message.text.trim().is_empty() {
+                    session
+                        .append_standalone_agent_output_with_phase(
+                            truncate_realtime_output(&message.text),
+                            message.phase,
+                        )
+                        .await?;
+                }
+                return Ok(());
+            }
+            if !agent_bridge
+                .active
+                .as_ref()
+                .is_some_and(|active| active.external)
+            {
+                return Ok(());
+            }
+            agent_bridge.external_output.phase = message.phase;
             let output = if session.streams_agent_output() {
                 if !agent_bridge.external_output.has_output() {
                     agent_bridge.external_output.push_text(&message.text);
@@ -841,21 +1147,66 @@ async fn handle_observed_agent_event(
                 Some(truncate_realtime_output(&message.text))
             };
             if let Some(output) = output {
-                append_observed_agent_output(session, agent_bridge, output).await?;
+                append_observed_agent_output(session, agent_bridge, output, message.phase).await?;
             }
         }
         Ok(AgentEventData::Run(RunEvent::Error(error))) => {
             agent_bridge.external_error = Some(error.message);
         }
         Ok(AgentEventData::Run(RunEvent::Completed(_))) => {
-            complete_observed_agent_run(session, agent_bridge, false).await?;
+            if agent_bridge
+                .active
+                .as_ref()
+                .is_some_and(|active| active.external)
+            {
+                complete_observed_agent_run(session, agent_bridge, false).await?;
+            }
+            agent_bridge.observing_external_turn = false;
         }
         Ok(AgentEventData::Run(RunEvent::Failed(_))) => {
-            complete_observed_agent_run(session, agent_bridge, true).await?;
+            if agent_bridge
+                .active
+                .as_ref()
+                .is_some_and(|active| active.external)
+            {
+                complete_observed_agent_run(session, agent_bridge, true).await?;
+            }
+            agent_bridge.observing_external_turn = false;
         }
         Ok(_) | Err(_) => {}
     }
     Ok(())
+}
+
+async fn route_transcript_tail(
+    agent: &Nanocodex,
+    tail: &[RealtimeTranscriptEntry],
+) -> Result<(), VoiceFailure> {
+    let Some(prompt) = codex_realtime_tail_delegation(tail) else {
+        return Ok(());
+    };
+    drop(agent.route_prompt(prompt).await?);
+    Ok(())
+}
+
+/// Wraps an unconsumed session tail in Codex's tail-flush delegation markers.
+#[must_use]
+pub fn codex_realtime_tail_delegation(tail: &[RealtimeTranscriptEntry]) -> Option<String> {
+    if tail.is_empty() {
+        return None;
+    }
+    let transcript = tail
+        .iter()
+        .map(|entry| format!("{}: {}", entry.role, entry.text))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let source = "  <source>transcript_tail_flush</source>\n";
+    let input = escape_xml(REALTIME_SESSION_ENDED_HANDOFF_INSTRUCTION);
+    let transcript = escape_xml(&transcript);
+    let prompt = format!(
+        "<realtime_delegation>\n{source}  <input>{input}</input>\n  <transcript_delta>{transcript}</transcript_delta>\n</realtime_delegation>"
+    );
+    Some(prompt)
 }
 
 async fn flush_observed_agent_output(
@@ -863,7 +1214,8 @@ async fn flush_observed_agent_output(
     agent_bridge: &mut AgentBridge,
 ) -> Result<(), RealtimeError> {
     if let Some(output) = agent_bridge.external_output.drain_stream_chunk() {
-        append_observed_agent_output(session, agent_bridge, output).await?;
+        let phase = agent_bridge.external_output.phase;
+        append_observed_agent_output(session, agent_bridge, output, phase).await?;
     }
     Ok(())
 }
@@ -872,6 +1224,7 @@ async fn append_observed_agent_output(
     session: &RealtimeSession,
     agent_bridge: &mut AgentBridge,
     output: String,
+    phase: Option<MessagePhase>,
 ) -> Result<(), RealtimeError> {
     let Some(call_id) = agent_bridge
         .active
@@ -881,7 +1234,9 @@ async fn append_observed_agent_output(
     else {
         return Ok(());
     };
-    session.append_agent_output(&call_id, output).await?;
+    session
+        .append_agent_output_with_phase(&call_id, output, phase)
+        .await?;
     if let Some(active) = &mut agent_bridge.active
         && active.external
         && active.call_id == call_id
@@ -897,7 +1252,8 @@ async fn complete_observed_agent_run(
     failed: bool,
 ) -> Result<(), RealtimeError> {
     if let Some(output) = agent_bridge.external_output.drain_final_chunk() {
-        append_observed_agent_output(session, agent_bridge, output).await?;
+        let phase = agent_bridge.external_output.phase;
+        append_observed_agent_output(session, agent_bridge, output, phase).await?;
     }
     agent_bridge.external_output = HandoffStream::default();
 
@@ -918,6 +1274,7 @@ async fn complete_observed_agent_run(
 
 #[derive(Default)]
 struct HandoffStream {
+    phase: Option<MessagePhase>,
     sent_bytes: usize,
     buffered_text: String,
     tail_text: String,
@@ -1047,18 +1404,13 @@ pub fn codex_realtime_delegation_with_transcript(
     input: &str,
     transcript: &[RealtimeTranscriptEntry],
 ) -> String {
-    let input = input
-        .replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;");
+    let input = escape_xml(input);
     let transcript = transcript
         .iter()
         .map(|entry| format!("{}: {}", entry.role, entry.text))
         .collect::<Vec<_>>()
-        .join("\n")
-        .replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;");
+        .join("\n");
+    let transcript = escape_xml(&transcript);
     if transcript.is_empty() {
         format!("<realtime_delegation>\n  <input>{input}</input>\n</realtime_delegation>")
     } else {
@@ -1068,6 +1420,12 @@ pub fn codex_realtime_delegation_with_transcript(
     }
 }
 
+fn escape_xml(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
 fn send_event(events: &mpsc::UnboundedSender<VoiceEvent>, event: VoiceEvent) {
     drop(events.send(event));
 }
@@ -1075,8 +1433,9 @@ fn send_event(events: &mpsc::UnboundedSender<VoiceEvent>, event: VoiceEvent) {
 #[cfg(test)]
 mod tests {
     use super::{
-        AudioConfig, HandoffStream, RealtimeTranscriptEntry, VoiceAgentControl, VoiceSpeaker,
-        codex_realtime_delegation, codex_realtime_delegation_with_transcript,
+        AudioConfig, HandoffStream, REALTIME_END_INSTRUCTIONS, REALTIME_START_INSTRUCTIONS,
+        RealtimeTranscriptEntry, VoiceAgentControl, VoiceSpeaker, codex_realtime_delegation,
+        codex_realtime_delegation_with_transcript, codex_realtime_tail_delegation,
         codex_voice_instructions, realtime_output_byte_limit, truncate_realtime_output,
     };
     use std::time::Duration;
@@ -1137,6 +1496,29 @@ mod tests {
                 ],
             ),
             "<realtime_delegation>\n  <input>ship it</input>\n  <transcript_delta>assistant: Use &lt;main&gt;\nuser: yes &amp; now</transcript_delta>\n</realtime_delegation>"
+        );
+    }
+
+    #[test]
+    fn lifecycle_and_tail_flush_markers_match_codex() {
+        assert!(
+            REALTIME_START_INSTRUCTIONS
+                .starts_with("<realtime_conversation>\n\nRealtime conversation started.")
+        );
+        assert!(REALTIME_END_INSTRUCTIONS.contains("Reason: inactive"));
+        assert_eq!(
+            codex_realtime_tail_delegation(&[RealtimeTranscriptEntry {
+                role: "user".to_owned(),
+                text: "ship <it>".to_owned(),
+            }])
+            .unwrap(),
+            concat!(
+                "<realtime_delegation>\n",
+                "  <source>transcript_tail_flush</source>\n",
+                "  <input>The user just ended their realtime session. Here is the remaining handoff/transcript tail. You probably do not have to do anything; acknowledge the handoff unless the transcript itself asks for something.</input>\n",
+                "  <transcript_delta>user: ship &lt;it&gt;</transcript_delta>\n",
+                "</realtime_delegation>"
+            )
         );
     }
 

--- a/crates/experimental/nanocodex-voice/src/startup_context.rs
+++ b/crates/experimental/nanocodex-voice/src/startup_context.rs
@@ -1,0 +1,393 @@
+use std::{
+    cmp::Reverse,
+    ffi::OsStr,
+    fs::{self, DirEntry, File},
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+};
+
+use nanocodex::{
+    AgentSessionContext,
+    oai::responses::{ContentItem, MessageRole, ResponseItem},
+};
+
+const CURRENT_THREAD_BUDGET: usize = 1_200;
+const RECENT_WORK_BUDGET: usize = 2_200;
+const WORKSPACE_BUDGET: usize = 1_600;
+const NOTES_BUDGET: usize = 300;
+const TOTAL_BUDGET: usize = 5_300;
+const TURN_BUDGET: usize = 300;
+const APPROX_BYTES_PER_TOKEN: usize = 4;
+const MAX_RECENT_THREADS: usize = 40;
+const MAX_RECENT_GROUPS: usize = 8;
+const MAX_ASK_CHARS: usize = 240;
+const TREE_DEPTH: usize = 2;
+const TREE_ENTRIES: usize = 20;
+const NOISY_DIRS: &[&str] = &[
+    ".git",
+    ".next",
+    ".pytest_cache",
+    ".ruff_cache",
+    "__pycache__",
+    "build",
+    "dist",
+    "node_modules",
+    "out",
+    "target",
+];
+
+pub(super) fn build(context: &AgentSessionContext, rollout: Option<&Path>) -> Option<String> {
+    let current = current_thread(context.history());
+    let recent = rollout.and_then(recent_work);
+    let workspace = workspace_map(Path::new(context.workspace()));
+    if current.is_none() && recent.is_none() && workspace.is_none() {
+        return None;
+    }
+
+    let mut parts = vec![concat!(
+        "Startup context from Codex.\n",
+        "This is background context about recent work and machine/workspace layout. It may be incomplete or stale. Use it to inform responses, and do not repeat it back unless relevant."
+    ).to_owned()];
+    section(&mut parts, "Current Thread", current, CURRENT_THREAD_BUDGET);
+    section(&mut parts, "Recent Work", recent, RECENT_WORK_BUDGET);
+    section(
+        &mut parts,
+        "Machine / Workspace Map",
+        workspace,
+        WORKSPACE_BUDGET,
+    );
+    section(
+        &mut parts,
+        "Notes",
+        Some("Built at realtime startup from the current thread history, local thread metadata, and a bounded local workspace scan. This excludes repo memory instructions, AGENTS files, project-doc prompt blends, and memory summaries.".to_owned()),
+        NOTES_BUDGET,
+    );
+    Some(truncate(
+        &format!(
+            "<startup_context>\n{}\n</startup_context>",
+            parts.join("\n\n")
+        ),
+        TOTAL_BUDGET,
+    ))
+}
+
+fn current_thread(history: &[ResponseItem]) -> Option<String> {
+    let mut turns: Vec<(Vec<String>, Vec<String>)> = Vec::new();
+    let mut user = Vec::new();
+    let mut assistant = Vec::new();
+    for item in history {
+        let ResponseItem::Message { role, content, .. } = item else {
+            continue;
+        };
+        let text = content
+            .iter()
+            .filter_map(|part| match part {
+                ContentItem::InputText { text } | ContentItem::OutputText { text, .. } => {
+                    Some(text.as_ref())
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim()
+            .to_owned();
+        if text.is_empty() || contextual(&text) {
+            continue;
+        }
+        match role {
+            MessageRole::User => {
+                if !user.is_empty() || !assistant.is_empty() {
+                    turns.push((std::mem::take(&mut user), std::mem::take(&mut assistant)));
+                }
+                user.push(text);
+            }
+            MessageRole::Assistant if !user.is_empty() || !assistant.is_empty() => {
+                assistant.push(text);
+            }
+            MessageRole::Developer | MessageRole::Assistant => {}
+        }
+    }
+    if !user.is_empty() || !assistant.is_empty() {
+        turns.push((user, assistant));
+    }
+    if turns.is_empty() {
+        return None;
+    }
+
+    let mut output = String::from(
+        "Most recent user/assistant turns from this exact thread. Use them for continuity when responding.",
+    );
+    let mut remaining = CURRENT_THREAD_BUDGET.saturating_sub(tokens(&output));
+    for (index, (user, assistant)) in turns.into_iter().rev().enumerate() {
+        if remaining == 0 {
+            break;
+        }
+        let mut turn = if index == 0 {
+            "### Latest turn".to_owned()
+        } else {
+            format!("### Previous turn {index}")
+        };
+        if !user.is_empty() {
+            turn.push_str("\nUser:\n");
+            turn.push_str(&user.join("\n\n"));
+        }
+        if !assistant.is_empty() {
+            turn.push_str("\n\nAssistant:\n");
+            turn.push_str(&assistant.join("\n\n"));
+        }
+        let turn = truncate(&turn, TURN_BUDGET.min(remaining));
+        remaining = remaining.saturating_sub(tokens(&turn));
+        output.push_str("\n\n");
+        output.push_str(&turn);
+    }
+    Some(output)
+}
+
+fn contextual(text: &str) -> bool {
+    text.starts_with("# AGENTS.md instructions")
+        || [
+            "<environment_context>",
+            "<permissions instructions>",
+            "<realtime_conversation>",
+            "<turn_aborted>",
+        ]
+        .iter()
+        .any(|marker| text.starts_with(marker))
+}
+
+fn recent_work(rollout: &Path) -> Option<String> {
+    let sessions = rollout.ancestors().nth(4)?.join("sessions");
+    let mut files = Vec::new();
+    collect_rollouts(&sessions, &mut files);
+    files.sort_by_key(|path| Reverse(path.metadata().and_then(|meta| meta.modified()).ok()));
+    let mut groups: Vec<(String, Vec<String>)> = Vec::new();
+    for path in files.into_iter().take(MAX_RECENT_THREADS) {
+        let Some((cwd, ask)) = rollout_summary(&path) else {
+            continue;
+        };
+        if let Some((_, asks)) = groups.iter_mut().find(|(group, _)| *group == cwd) {
+            asks.push(ask);
+        } else if groups.len() < MAX_RECENT_GROUPS {
+            groups.push((cwd, vec![ask]));
+        }
+    }
+    (!groups.is_empty()).then(|| {
+        groups
+            .into_iter()
+            .map(|(cwd, asks)| {
+                format!(
+                    "### Directory: {cwd}\nRecent sessions: {}\nRecent asks:\n{}",
+                    asks.len(),
+                    asks.into_iter()
+                        .map(|ask| format!("- {ask}"))
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    })
+}
+
+fn collect_rollouts(root: &Path, output: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rollouts(&path, output);
+        } else if path.extension() == Some(OsStr::new("jsonl")) {
+            output.push(path);
+        }
+    }
+}
+
+fn rollout_summary(path: &Path) -> Option<(String, String)> {
+    let mut cwd = None;
+    let mut ask = None;
+    for line in BufReader::new(File::open(path).ok()?)
+        .lines()
+        .map_while(Result::ok)
+    {
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        match value.get("type").and_then(serde_json::Value::as_str) {
+            Some("session_meta") => cwd = value["payload"]["cwd"].as_str().map(str::to_owned),
+            Some("event_msg") if value["payload"]["type"] == "user_message" => {
+                ask = value["payload"]["message"]
+                    .as_str()
+                    .map(|text| text.chars().take(MAX_ASK_CHARS).collect());
+            }
+            _ => {}
+        }
+    }
+    Some((cwd?, ask?))
+}
+
+fn workspace_map(workspace: &Path) -> Option<String> {
+    if !workspace.is_dir() {
+        return None;
+    }
+    let git_root = workspace
+        .ancestors()
+        .find(|path| path.join(".git").exists())
+        .map(Path::to_path_buf);
+    let user_root = std::env::var_os("HOME").map(PathBuf::from);
+    let mut lines = vec![
+        format!("Current working directory: {}", workspace.display()),
+        format!("Working directory name: {}", name(workspace)),
+    ];
+    if let Some(root) = &git_root {
+        lines.push(format!("Git root: {}", root.display()));
+        lines.push(format!("Git project: {}", name(root)));
+    }
+    if let Some(root) = &user_root {
+        lines.push(format!("User root: {}", root.display()));
+    }
+    append_tree(&mut lines, "Working directory tree:", workspace);
+    if let Some(root) = git_root.as_deref().filter(|root| *root != workspace) {
+        append_tree(&mut lines, "Git root tree:", root);
+    }
+    if let Some(root) = user_root
+        .as_deref()
+        .filter(|root| *root != workspace && Some(*root) != git_root.as_deref())
+    {
+        append_tree(&mut lines, "User root tree:", root);
+    }
+    Some(lines.join("\n"))
+}
+
+fn append_tree(lines: &mut Vec<String>, heading: &str, root: &Path) {
+    let mut tree = Vec::new();
+    collect_tree(root, 0, &mut tree);
+    if !tree.is_empty() {
+        lines.push(String::new());
+        lines.push(heading.to_owned());
+        lines.extend(tree);
+    }
+}
+
+fn collect_tree(root: &Path, depth: usize, output: &mut Vec<String>) {
+    if depth >= TREE_DEPTH {
+        return;
+    }
+    let Ok(mut entries) = fs::read_dir(root).map(|entries| {
+        entries
+            .flatten()
+            .filter(|entry| !noisy(&entry.file_name()))
+            .collect::<Vec<DirEntry>>()
+    }) else {
+        return;
+    };
+    entries.sort_by_key(|entry| (!entry.path().is_dir(), entry.file_name()));
+    let total = entries.len();
+    for entry in entries.into_iter().take(TREE_ENTRIES) {
+        let path = entry.path();
+        let directory = path.is_dir();
+        output.push(format!(
+            "{}- {}{}",
+            "  ".repeat(depth),
+            name(&path),
+            if directory { "/" } else { "" }
+        ));
+        if directory {
+            collect_tree(&path, depth + 1, output);
+        }
+    }
+    if total > TREE_ENTRIES {
+        output.push(format!(
+            "{}- ... {} more entries",
+            "  ".repeat(depth),
+            total - TREE_ENTRIES
+        ));
+    }
+}
+
+fn noisy(name: &OsStr) -> bool {
+    let name = name.to_string_lossy();
+    name.starts_with('.') || NOISY_DIRS.iter().any(|noisy| *noisy == name)
+}
+
+fn name(path: &Path) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+fn section(parts: &mut Vec<String>, title: &str, body: Option<String>, budget: usize) {
+    let Some(body) = body.filter(|body| !body.trim().is_empty()) else {
+        return;
+    };
+    let heading = format!("## {title}\n");
+    let body = truncate(&body, budget.saturating_sub(tokens(&heading)));
+    if !body.is_empty() {
+        parts.push(format!("{heading}{body}"));
+    }
+}
+
+const fn tokens(text: &str) -> usize {
+    text.len().saturating_add(APPROX_BYTES_PER_TOKEN - 1) / APPROX_BYTES_PER_TOKEN
+}
+
+fn truncate(text: &str, budget: usize) -> String {
+    let max = budget.saturating_mul(APPROX_BYTES_PER_TOKEN);
+    if text.len() <= max {
+        return text.to_owned();
+    }
+    let marker = "\n…truncated…\n";
+    let keep = max.saturating_sub(marker.len());
+    let mut end = keep / 2;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut start = text.len().saturating_sub(keep.saturating_sub(end));
+    while start < text.len() && !text.is_char_boundary(start) {
+        start += 1;
+    }
+    format!("{}{marker}{}", &text[..end], &text[start..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_thread_skips_context_and_keeps_recent_turns() {
+        let history = vec![
+            ResponseItem::message(
+                MessageRole::User,
+                [ContentItem::input_text(
+                    "<environment_context>hidden</environment_context>",
+                )],
+            ),
+            ResponseItem::message(
+                MessageRole::User,
+                [ContentItem::input_text("fix the parser")],
+            ),
+            ResponseItem::message(
+                MessageRole::Assistant,
+                [ContentItem::output_text("parser fixed")],
+            ),
+        ];
+        let context = current_thread(&history).unwrap();
+        assert!(context.contains("### Latest turn"));
+        assert!(context.contains("fix the parser"));
+        assert!(context.contains("parser fixed"));
+        assert!(!context.contains("environment_context"));
+        assert!(tokens(&context) <= CURRENT_THREAD_BUDGET);
+    }
+
+    #[test]
+    fn workspace_tree_is_bounded_and_filters_noisy_directories() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::create_dir(directory.path().join("src")).unwrap();
+        fs::create_dir(directory.path().join("target")).unwrap();
+        fs::write(directory.path().join("src/lib.rs"), "fn main() {}").unwrap();
+        let context = workspace_map(directory.path()).unwrap();
+        assert!(context.contains("src/"));
+        assert!(context.contains("lib.rs"));
+        assert!(!context.contains("target/"));
+    }
+}

--- a/crates/nanocodex-agent/src/agent/driver/control.rs
+++ b/crates/nanocodex-agent/src/agent/driver/control.rs
@@ -167,6 +167,9 @@ pub(super) async fn begin_shutdown(
             Command::Fork { result, .. } | Command::Spawn { result } => {
                 drop(result.send(Err(NanocodexError::AgentStopped)));
             }
+            Command::AppendDeveloperMessage { result, .. } => {
+                drop(result.send(Err(NanocodexError::AgentStopped)));
+            }
             Command::Steer { result, .. }
             | Command::Cancel { result, .. }
             | Command::SetThinking { result, .. }
@@ -225,6 +228,9 @@ pub(super) fn handle_idle_command<S>(
         }
         Command::Shutdown => {}
         Command::Compact { result, .. } => {
+            drop(result.send(Err(NanocodexError::AgentStopped)));
+        }
+        Command::AppendDeveloperMessage { result, .. } => {
             drop(result.send(Err(NanocodexError::AgentStopped)));
         }
         Command::Prompt { .. } => {}

--- a/crates/nanocodex-agent/src/agent/driver/mod.rs
+++ b/crates/nanocodex-agent/src/agent/driver/mod.rs
@@ -79,6 +79,7 @@ where
         let mut latest_fork_checkpoint = inherited_checkpoint;
         let mut queued_turns = VecDeque::new();
         let mut pending_compact = None;
+        let mut pending_developer_messages = Vec::new();
         let mut commands_open = true;
         loop {
             let command = loop {
@@ -223,6 +224,20 @@ where
                     drop(result.send(Ok(())));
                     continue;
                 }
+                if let Command::AppendDeveloperMessage { text, result } = command {
+                    if let Some(checkpoint) = model.append_developer_message(text) {
+                        latest_fork_checkpoint = Some(Arc::new(CommittedSession::new(
+                            Arc::clone(&self.spawner.lineage_id),
+                            checkpoint,
+                        )));
+                    }
+                    drop(result.send(agent_session_context(
+                        latest_fork_checkpoint.as_deref(),
+                        self.workspace.as_deref(),
+                        &self.spawner.context_source,
+                    )));
+                    continue;
+                }
                 if let Command::Compact { parent, result } = command {
                     logical_turn_index = logical_turn_index.saturating_add(1);
                     let span = agent_compact_span(
@@ -333,6 +348,14 @@ where
                                         default_fast_mode = enabled;
                                         drop(result.send(Ok(())));
                                     }
+                                    Some(Command::AppendDeveloperMessage { text, result }) => {
+                                        pending_developer_messages.push(text);
+                                        drop(result.send(agent_session_context(
+                                            latest_fork_checkpoint.as_deref(),
+                                            self.workspace.as_deref(),
+                                            &self.spawner.context_source,
+                                        )));
+                                    }
                                     Some(Command::Shutdown) => {
                                         if let Some(cancel) = cancel_compaction.take() {
                                             let _ = cancel.send(());
@@ -432,6 +455,14 @@ where
                         "duration_ns",
                         u64::try_from(compact_started.elapsed().as_nanos()).unwrap_or(u64::MAX),
                     );
+                    for text in pending_developer_messages.drain(..) {
+                        if let Some(checkpoint) = model.append_developer_message(text) {
+                            latest_fork_checkpoint = Some(Arc::new(CommittedSession::new(
+                                Arc::clone(&self.spawner.lineage_id),
+                                checkpoint,
+                            )));
+                        }
+                    }
                     drop(result.send(outcome));
                     continue;
                 }
@@ -626,6 +657,24 @@ where
                                 default_fast_mode = enabled;
                                 drop(result.send(Ok(())));
                             }
+                            Some(Command::AppendDeveloperMessage { text, result }) => {
+                                pending_developer_messages.push(text);
+                                let checkpoint = fork_snapshot_rx
+                                    .borrow_and_update()
+                                    .clone()
+                                    .map(|checkpoint| {
+                                        Arc::new(CommittedSession::new(
+                                            Arc::clone(&self.spawner.lineage_id),
+                                            checkpoint,
+                                        ))
+                                    })
+                                    .or_else(|| latest_fork_checkpoint.clone());
+                                drop(result.send(agent_session_context(
+                                    checkpoint.as_deref(),
+                                    self.workspace.as_deref(),
+                                    &self.spawner.context_source,
+                                )));
+                            }
                             Some(Command::Compact { parent, result }) => {
                                 pending_compact = Some((parent, result));
                                 if let Some(cancel) = cancel.take() {
@@ -729,6 +778,14 @@ where
                 if outcome.is_ok() { "OK" } else { "ERROR" },
             );
             drop(result.send(outcome));
+            for text in pending_developer_messages.drain(..) {
+                if let Some(checkpoint) = model.append_developer_message(text) {
+                    latest_fork_checkpoint = Some(Arc::new(CommittedSession::new(
+                        Arc::clone(&self.spawner.lineage_id),
+                        checkpoint,
+                    )));
+                }
+            }
             if let Some(cancel_result) = cancel_result {
                 let outcome = if was_cancelled {
                     Ok(())
@@ -739,4 +796,16 @@ where
             }
         }
     }
+}
+
+fn agent_session_context(
+    checkpoint: Option<&CommittedSession>,
+    configured_workspace: Option<&str>,
+    context_source: &ContextSource,
+) -> Result<AgentSessionContext> {
+    let workspace = checkpoint
+        .map(|checkpoint| checkpoint.model().workspace().to_owned())
+        .or_else(|| configured_workspace.map(str::to_owned))
+        .map_or_else(|| context_source.resolve_workspace(None), Ok)?;
+    Ok(AgentSessionContext::new(checkpoint, workspace))
 }

--- a/crates/nanocodex-agent/src/agent/handle.rs
+++ b/crates/nanocodex-agent/src/agent/handle.rs
@@ -201,8 +201,8 @@ impl Nanocodex {
     /// [`PromptRoute::Steered`] is returned. Otherwise the prompt starts a new
     /// turn and is returned as [`PromptRoute::Started`].
     ///
-    /// This is intended for live input adapters such as voice sessions. Normal
-    /// queued request/response consumers should continue to use [`Self::prompt`].
+    /// This is intended for live input adapters. Normal queued request/response
+    /// consumers should continue to use [`Self::prompt`].
     ///
     /// # Errors
     ///
@@ -319,6 +319,33 @@ impl Nanocodex {
         let parent = tracing::Span::current();
         let parent = (!parent.is_disabled()).then_some(parent);
         request_command(&self.commands, |result| Command::Compact { parent, result }).await
+    }
+
+    /// Appends adapter-owned developer context at the next safe model boundary.
+    ///
+    /// The returned read-only view is captured from the latest safe boundary
+    /// and is suitable for building adapter bootstrap context. If a turn is
+    /// active, the message is retained immediately and becomes model-visible
+    /// before the next turn.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for empty text or after the agent driver has stopped.
+    pub async fn append_developer_message(
+        &self,
+        text: impl Into<String>,
+    ) -> Result<AgentSessionContext> {
+        let text = text.into();
+        if text.trim().is_empty() {
+            return Err(NanocodexError::InvalidRequest(
+                "developer message must not be empty".to_owned(),
+            ));
+        }
+        request_command(&self.commands, |result| Command::AppendDeveloperMessage {
+            text,
+            result,
+        })
+        .await
     }
 
     /// Starts a clean sibling agent with the same private configuration,

--- a/crates/nanocodex-agent/src/agent/mod.rs
+++ b/crates/nanocodex-agent/src/agent/mod.rs
@@ -93,11 +93,13 @@ mod driver;
 mod durability;
 mod executor;
 mod handle;
+mod session_context;
 mod spawn;
 mod turn;
 
 pub use builder::NanocodexBuilder;
 pub use handle::{AgentHandle, Nanocodex};
+pub use session_context::AgentSessionContext;
 pub use turn::{PromptRoute, Turn, TurnControl, TurnResult};
 
 use builder::{CodexCompatibility, PromptCacheConfig};

--- a/crates/nanocodex-agent/src/agent/session_context.rs
+++ b/crates/nanocodex-agent/src/agent/session_context.rs
@@ -1,0 +1,33 @@
+use nanocodex_oai_api::responses::ResponseItem;
+
+use crate::session::CommittedSession;
+
+/// Read-only model context exposed to session adapters.
+///
+/// The history is complete and unredacted and can contain reasoning and tool
+/// inputs or outputs. Applications must protect it like a session snapshot.
+#[derive(Clone, Debug)]
+pub struct AgentSessionContext {
+    workspace: String,
+    history: Vec<ResponseItem>,
+}
+
+impl AgentSessionContext {
+    pub(super) fn new(checkpoint: Option<&CommittedSession>, workspace: String) -> Self {
+        let history =
+            checkpoint.map_or_else(Vec::new, |checkpoint| checkpoint.model().snapshot_history());
+        Self { workspace, history }
+    }
+
+    /// Returns the absolute workspace owned by the agent session.
+    #[must_use]
+    pub fn workspace(&self) -> &str {
+        &self.workspace
+    }
+
+    /// Returns complete model-visible history at the latest safe boundary.
+    #[must_use]
+    pub fn history(&self) -> &[ResponseItem] {
+        &self.history
+    }
+}

--- a/crates/nanocodex-agent/src/agent/turn.rs
+++ b/crates/nanocodex-agent/src/agent/turn.rs
@@ -17,10 +17,10 @@ pub struct Turn {
 
 /// Outcome of routing live user input into an agent session.
 ///
-/// Live consumers such as voice interfaces normally want to steer the current
-/// regular turn when one exists and start a new turn only when the agent is
-/// idle. [`Nanocodex::route_prompt`](crate::Nanocodex::route_prompt) performs
-/// that decision atomically in the agent driver and returns this outcome.
+/// Live input adapters normally want to steer the current regular turn when
+/// one exists and start a new turn only when the agent is idle.
+/// [`Nanocodex::route_prompt`](crate::Nanocodex::route_prompt) performs that
+/// decision atomically in the agent driver and returns this outcome.
 pub enum PromptRoute {
     /// The agent was idle, so the prompt started a new independently awaitable turn.
     Started(Turn),
@@ -233,6 +233,10 @@ pub(super) enum Command {
     Compact {
         parent: Option<tracing::Span>,
         result: oneshot::Sender<Result<()>>,
+    },
+    AppendDeveloperMessage {
+        text: String,
+        result: oneshot::Sender<Result<AgentSessionContext>>,
     },
     Shutdown,
 }

--- a/crates/nanocodex-agent/src/lib.rs
+++ b/crates/nanocodex-agent/src/lib.rs
@@ -24,7 +24,8 @@ pub mod session;
 pub mod usage;
 
 pub use agent::{
-    AgentHandle, Nanocodex, NanocodexBuilder, PromptRoute, Turn, TurnControl, TurnResult,
+    AgentHandle, AgentSessionContext, Nanocodex, NanocodexBuilder, PromptRoute, Turn, TurnControl,
+    TurnResult,
 };
 pub use error::{NanocodexError, Result};
 pub use nanocodex_oai_api::{

--- a/crates/nanocodex-agent/src/model/run/mod.rs
+++ b/crates/nanocodex-agent/src/model/run/mod.rs
@@ -88,6 +88,7 @@ pub(crate) struct ModelRun<S> {
     context_source: ContextSource,
     global_instructions: Option<Arc<str>>,
     force_compaction: bool,
+    pending_developer_messages: Vec<ResponseItem>,
 }
 
 pub(crate) enum ModelTurnOutcome {
@@ -229,6 +230,7 @@ impl<S> ModelRun<S> {
             context_source,
             global_instructions,
             force_compaction: false,
+            pending_developer_messages: Vec::new(),
         }
     }
 
@@ -292,6 +294,7 @@ impl<S> ModelRun<S> {
             context_source,
             global_instructions,
             force_compaction: false,
+            pending_developer_messages: Vec::new(),
         }
     }
 
@@ -310,6 +313,30 @@ impl<S> ModelRun<S> {
         if let Some(tools) = &self.active_tools {
             tools.cancel().await;
         }
+    }
+
+    pub(crate) fn append_developer_message(&mut self, text: String) -> Option<ModelCheckpoint> {
+        let item = ResponseItem::message(
+            MessageRole::Developer,
+            [ContentItem::InputText {
+                text: text.into_boxed_str(),
+            }],
+        );
+        let Some(session) = &mut self.session else {
+            self.pending_developer_messages.push(item);
+            return None;
+        };
+        session.conversation.append([item]);
+        session.conversation.commit_tail();
+        Some(ModelCheckpoint {
+            workspace: session.workspace.clone(),
+            conversation: session.conversation.clone(),
+            request_prefix: session.factory.profile().shared_prefix(),
+            prompt_cache_key: Arc::from(session.factory.profile().prompt_cache_key()),
+            preserve_inherited_delta: false,
+            global_instructions: self.global_instructions.clone(),
+            context_baseline: session.context.baseline(),
+        })
     }
 
     fn empty_session(&mut self, requested_workspace: Option<&str>) -> Result<ModelSessionState> {

--- a/crates/nanocodex-agent/src/model/run/turn.rs
+++ b/crates/nanocodex-agent/src/model/run/turn.rs
@@ -418,7 +418,14 @@ where
             let mut context = ContextState::new(selected_agents_md, ContextBaseline::Missing);
             let context_snapshot =
                 context.capture(tools.working_directory(), tools.default_shell_name());
-            let history = task_input(user_content, &context_snapshot);
+            let mut history = task_input(user_content, &context_snapshot);
+            if !self.pending_developer_messages.is_empty() {
+                let user = history
+                    .pop()
+                    .expect("task input always ends with user input");
+                history.append(&mut self.pending_developer_messages);
+                history.push(user);
+            }
             context.establish(context_snapshot);
             let conversation = ConversationState::new(history)?;
             let mut session = ModelSessionState {

--- a/crates/nanocodex-agent/tests/it/lifecycle/control.rs
+++ b/crates/nanocodex-agent/tests/it/lifecycle/control.rs
@@ -103,6 +103,69 @@ async fn turn_result_does_not_wait_for_attempt_event_producers_to_close() {
 }
 
 #[tokio::test]
+async fn adapter_developer_context_is_visible_at_safe_model_boundaries() {
+    let (retained, mut retained_attempts) = mpsc::unbounded_channel();
+    let openai = OpenAi::builder("test")
+        .service(move || RetainingCompletedService {
+            retained: retained.clone(),
+        })
+        .build()
+        .unwrap();
+    let tools = Tools::builder().without_defaults().build().unwrap();
+    let (agent, events) = Nanocodex::builder(openai).tools(tools).build().unwrap();
+
+    let initial = agent
+        .append_developer_message("adapter session started")
+        .await
+        .unwrap();
+    assert!(initial.history().is_empty());
+    assert!(!initial.workspace().is_empty());
+
+    agent
+        .prompt("first request")
+        .await
+        .unwrap()
+        .result()
+        .await
+        .unwrap();
+    let first = retained_attempts.recv().await.unwrap();
+    let first_items = first.input_items().collect::<Vec<_>>();
+    assert!(matches!(
+        first_items.as_slice(),
+        [
+            ..,
+            ResponseItem::Message {
+                role: MessageRole::Developer,
+                ..
+            },
+            ResponseItem::Message {
+                role: MessageRole::User,
+                ..
+            }
+        ]
+    ));
+
+    let completed = agent
+        .append_developer_message("adapter session ended")
+        .await
+        .unwrap();
+    assert!(completed.history().iter().any(|item| matches!(
+        item,
+        ResponseItem::Message {
+            role: MessageRole::Developer,
+            content,
+            ..
+        } if content.iter().any(|part| matches!(
+            part,
+            ContentItem::InputText { text } if text.as_ref() == "adapter session ended"
+        ))
+    )));
+
+    agent.shutdown().await.unwrap();
+    drop((agent, events));
+}
+
+#[tokio::test]
 async fn dropping_every_command_handle_cancels_an_in_flight_attempt() {
     let started = Arc::new(AtomicBool::new(false));
     let dropped = Arc::new(AtomicBool::new(false));

--- a/crates/nanocodex-oai-api/src/realtime.rs
+++ b/crates/nanocodex-oai-api/src/realtime.rs
@@ -4,7 +4,13 @@
 //! Device capture/playback and delegation to a coding agent are application
 //! concerns; this keeps the library usable with pipes and custom media stacks.
 
-use std::{fmt, str::FromStr, sync::Arc, time::Duration};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fmt,
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use futures_util::{SinkExt, StreamExt};
@@ -12,7 +18,7 @@ use serde::Serialize;
 use serde_json::{Value, json};
 use tokio::{
     net::TcpStream,
-    sync::{mpsc, oneshot},
+    sync::{mpsc, oneshot, watch},
     time::{Instant, timeout},
 };
 use tokio_tungstenite::{
@@ -26,7 +32,9 @@ use tokio_tungstenite::{
 use tracing::{debug, trace, warn};
 use url::Url;
 
-use crate::{OpenAiAuth, OpenAiAuthError, OpenAiAuthMode, connector::connect_async};
+use crate::{
+    OpenAiAuth, OpenAiAuthError, OpenAiAuthMode, connector::connect_async, responses::MessagePhase,
+};
 
 mod webrtc;
 
@@ -88,6 +96,90 @@ const CONTEXT_APPEND_MAX_BYTES: usize = 500;
 const INITIAL_ITEMS_MAX_COUNT: usize = 128;
 const INITIAL_ITEMS_MAX_TOKENS: usize = 8_192;
 const APPROX_BYTES_PER_TOKEN: usize = 4;
+const AGENT_FINAL_MESSAGE_PREFIX: &str = "\"Agent Final Message\":\n\n";
+const STANDALONE_HANDOFF_ID: &str = "codex";
+
+/// Realtime wire protocol version.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum RealtimeVersion {
+    /// Legacy Quicksilver handoff protocol.
+    V1,
+    /// Native GPT Realtime function-tool protocol.
+    #[default]
+    V2,
+    /// Frameless Bidi client-delegation protocol.
+    V3,
+}
+
+/// Realtime transport selected for a session.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RealtimeTransport {
+    /// A directly owned WebSocket.
+    WebSocket,
+    /// An owned WebRTC call with a sideband WebSocket.
+    WebRtc,
+}
+
+/// Realtime session behavior.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum RealtimeSessionMode {
+    /// Full conversational input and output.
+    #[default]
+    Conversational,
+    /// Input transcription without model responses.
+    Transcription,
+}
+
+/// Realtime model output modality.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum RealtimeOutputModality {
+    /// Text model output.
+    Text,
+    /// Synthesized audio output.
+    #[default]
+    Audio,
+}
+
+/// Routing policy for coding-agent output in Frameless sessions.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum RealtimeResponseHandoffMode {
+    /// Hidden thinking context without an explicit semantic channel.
+    #[default]
+    Thinking,
+    /// Commentary context that should not be spoken as a final answer.
+    Commentary,
+    /// Select commentary or speakable routing from BEM channel prefixes.
+    BemTags,
+}
+
+/// Role of text appended to a running realtime conversation.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum RealtimeInputTextRole {
+    /// User-authored text.
+    #[default]
+    User,
+    /// Developer-authored context.
+    Developer,
+    /// Assistant-authored prior output.
+    Assistant,
+}
+
+impl RealtimeInputTextRole {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Developer => "developer",
+            Self::Assistant => "assistant",
+        }
+    }
+
+    const fn content_type(self) -> &'static str {
+        match self {
+            Self::Assistant => "output_text",
+            Self::User | Self::Developer => "input_text",
+        }
+    }
+}
 
 type Socket = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
@@ -373,6 +465,8 @@ pub enum RealtimeEvent {
     ResponseStarted,
     /// A realtime response completed.
     ResponseDone,
+    /// Transcript entries not yet included in a background-agent handoff when the transport ended.
+    TranscriptTail(Vec<RealtimeTranscriptEntry>),
     /// The provider reported a session error.
     Error(String),
 }
@@ -408,6 +502,8 @@ impl RealtimeEvents {
 pub struct RealtimeSession {
     commands: mpsc::Sender<Command>,
     protocol: RealtimeProtocol,
+    client_managed_handoffs: bool,
+    closed: watch::Receiver<bool>,
 }
 
 /// Protocol-specific handling applied after live input steers an active agent turn.
@@ -427,7 +523,16 @@ impl RealtimeSession {
     /// conversation item.
     #[must_use]
     pub const fn streams_agent_output(&self) -> bool {
-        matches!(self.protocol, RealtimeProtocol::Frameless)
+        matches!(
+            self.protocol,
+            RealtimeProtocol::V1 | RealtimeProtocol::Frameless
+        )
+    }
+
+    /// Returns whether the embedding, rather than automatic bridge policy, owns handoff output.
+    #[must_use]
+    pub const fn client_managed_handoffs(&self) -> bool {
+        self.client_managed_handoffs
     }
 
     /// Appends one owned 24 kHz mono PCM16 input chunk.
@@ -436,7 +541,39 @@ impl RealtimeSession {
     ///
     /// Returns an error when the session has closed or sending times out.
     pub async fn send_audio(&self, audio: RealtimeAudio) -> Result<(), RealtimeError> {
-        self.send(CommandKind::Audio(audio)).await
+        self.send(CommandKind::Audio(audio)).await.map(|_| ())
+    }
+
+    /// Appends role-bearing text to the running realtime conversation.
+    ///
+    /// V2 user text receives Codex's `[USER]` prefix. Other versions preserve
+    /// caller text unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the text cannot be delivered.
+    pub async fn send_text(
+        &self,
+        role: RealtimeInputTextRole,
+        text: impl Into<String>,
+    ) -> Result<(), RealtimeError> {
+        self.send(CommandKind::Text {
+            role,
+            text: text.into(),
+        })
+        .await
+        .map(|_| ())
+    }
+
+    /// Appends text that the realtime model should treat as directly speakable.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the speech context cannot be delivered.
+    pub async fn append_speech(&self, text: impl Into<String>) -> Result<(), RealtimeError> {
+        self.send(CommandKind::Speech { text: text.into() })
+            .await
+            .map(|_| ())
     }
 
     /// Completes a background-agent request and asks Realtime to speak the result.
@@ -454,6 +591,7 @@ impl RealtimeSession {
             output: output.into(),
         })
         .await
+        .map(|_| ())
     }
 
     /// Applies Codex's protocol-specific acknowledgement for a steering request.
@@ -476,7 +614,7 @@ impl RealtimeSession {
                     .await?;
                 Ok(RealtimeAgentSteer::Acknowledged)
             }
-            RealtimeProtocol::Frameless => {
+            RealtimeProtocol::V1 | RealtimeProtocol::Frameless => {
                 drop(call_id.into());
                 Ok(RealtimeAgentSteer::ReplacedDelegation)
             }
@@ -496,11 +634,62 @@ impl RealtimeSession {
         call_id: impl Into<String>,
         output: impl Into<String>,
     ) -> Result<(), RealtimeError> {
+        self.append_agent_output_with_phase(call_id, output, None)
+            .await
+    }
+
+    /// Appends coding-agent output with its commentary/final phase.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the output cannot be delivered.
+    pub async fn append_agent_output_with_phase(
+        &self,
+        call_id: impl Into<String>,
+        output: impl Into<String>,
+        phase: Option<MessagePhase>,
+    ) -> Result<(), RealtimeError> {
         self.send(CommandKind::AgentProgress {
             call_id: call_id.into(),
             output: output.into(),
+            phase,
         })
         .await
+        .map(|_| ())
+    }
+
+    /// Sends completed coding-agent output when no realtime delegation is active.
+    ///
+    /// Realtime V2 receives a `[BACKEND]` conversation item and creates a
+    /// response. Frameless receives a session-level context append.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the output cannot be delivered.
+    pub async fn append_standalone_agent_output(
+        &self,
+        output: impl Into<String>,
+    ) -> Result<(), RealtimeError> {
+        self.append_standalone_agent_output_with_phase(output, None)
+            .await
+    }
+
+    /// Sends standalone coding-agent output with its commentary/final phase.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the output cannot be delivered.
+    pub async fn append_standalone_agent_output_with_phase(
+        &self,
+        output: impl Into<String>,
+        phase: Option<MessagePhase>,
+    ) -> Result<(), RealtimeError> {
+        self.send(CommandKind::StandaloneAgentOutput {
+            output: output.into(),
+            phase,
+        })
+        .await
+        .map(|_| ())
     }
 
     /// Completes a streamed background-agent handoff using Codex's protocol behavior.
@@ -520,6 +709,7 @@ impl RealtimeSession {
             call_id: call_id.into(),
         })
         .await
+        .map(|_| ())
     }
 
     /// Completes a `remain_silent` request without creating spoken output.
@@ -535,6 +725,7 @@ impl RealtimeSession {
             call_id: call_id.into(),
         })
         .await
+        .map(|_| ())
     }
 
     /// Closes the realtime WebSocket.
@@ -543,10 +734,29 @@ impl RealtimeSession {
     ///
     /// Returns an error when the close command cannot be delivered.
     pub async fn close(&self) -> Result<(), RealtimeError> {
-        self.send(CommandKind::Close).await
+        self.close_with_transcript_tail().await.map(|_| ())
     }
 
-    async fn send(&self, kind: CommandKind) -> Result<(), RealtimeError> {
+    /// Closes the realtime transport and returns transcript not yet handed to the agent.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the close command cannot be delivered.
+    pub async fn close_with_transcript_tail(
+        &self,
+    ) -> Result<Vec<RealtimeTranscriptEntry>, RealtimeError> {
+        let tail = match self.send(CommandKind::Close).await? {
+            CommandOutcome::Closed(tail) => tail,
+            CommandOutcome::Continue => Vec::new(),
+        };
+        let mut closed = self.closed.clone();
+        if !*closed.borrow() {
+            closed.changed().await.map_err(|_| RealtimeError::Closed)?;
+        }
+        Ok(tail)
+    }
+
+    async fn send(&self, kind: CommandKind) -> Result<CommandOutcome, RealtimeError> {
         let (result, completed) = oneshot::channel();
         let command = Command { kind, result };
         timeout(SEND_TIMEOUT, self.commands.send(command))
@@ -567,35 +777,119 @@ pub struct RealtimeSessionBuilder {
     attestation_header: Option<Arc<str>>,
     websocket_url: Option<String>,
     instructions: Arc<str>,
-    model: String,
+    model: Option<String>,
     voice: Option<RealtimeVoice>,
     session_id: Option<String>,
     initial_items: Vec<RealtimeInitialItem>,
+    version: Option<RealtimeVersion>,
+    transport: Option<RealtimeTransport>,
+    session_mode: RealtimeSessionMode,
+    output_modality: RealtimeOutputModality,
+    client_managed_handoffs: bool,
+    codex_responses_as_items: bool,
+    codex_response_item_prefix: Option<String>,
+    codex_response_handoff_mode: RealtimeResponseHandoffMode,
+    codex_response_handoff_channel_prefixes: BTreeMap<String, Vec<String>>,
 }
 
 impl RealtimeSessionBuilder {
-    pub(crate) fn new(auth: OpenAiAuth, api_base_url: String, instructions: Arc<str>) -> Self {
-        let model = match auth.mode() {
-            OpenAiAuthMode::ApiKey => REALTIME_MODEL,
-            OpenAiAuthMode::ChatGpt => CHATGPT_REALTIME_MODEL,
-        };
+    pub(crate) const fn new(
+        auth: OpenAiAuth,
+        api_base_url: String,
+        instructions: Arc<str>,
+    ) -> Self {
         Self {
             auth,
             api_base_url,
             attestation_header: None,
             websocket_url: None,
             instructions,
-            model: model.to_owned(),
+            model: None,
             voice: None,
             session_id: None,
             initial_items: Vec::new(),
+            version: None,
+            transport: None,
+            session_mode: RealtimeSessionMode::Conversational,
+            output_modality: RealtimeOutputModality::Audio,
+            client_managed_handoffs: false,
+            codex_responses_as_items: false,
+            codex_response_item_prefix: None,
+            codex_response_handoff_mode: RealtimeResponseHandoffMode::Thinking,
+            codex_response_handoff_channel_prefixes: BTreeMap::new(),
         }
     }
 
     /// Selects the GPT Realtime model.
     #[must_use]
     pub fn model(mut self, model: impl Into<String>) -> Self {
-        self.model = model.into();
+        self.model = Some(model.into());
+        self
+    }
+
+    /// Selects the realtime wire protocol version.
+    #[must_use]
+    pub const fn version(mut self, version: RealtimeVersion) -> Self {
+        self.version = Some(version);
+        self
+    }
+
+    /// Selects the realtime transport explicitly.
+    #[must_use]
+    pub const fn transport(mut self, transport: RealtimeTransport) -> Self {
+        self.transport = Some(transport);
+        self
+    }
+
+    /// Selects conversational or transcription-only operation.
+    #[must_use]
+    pub const fn session_mode(mut self, mode: RealtimeSessionMode) -> Self {
+        self.session_mode = mode;
+        self
+    }
+
+    /// Selects text or audio model output.
+    #[must_use]
+    pub const fn output_modality(mut self, modality: RealtimeOutputModality) -> Self {
+        self.output_modality = modality;
+        self
+    }
+
+    /// Lets the embedding own all coding-agent handoff responses.
+    #[must_use]
+    pub const fn client_managed_handoffs(mut self, managed: bool) -> Self {
+        self.client_managed_handoffs = managed;
+        self
+    }
+
+    /// Sends automatic coding-agent responses as conversation items.
+    #[must_use]
+    pub const fn codex_responses_as_items(mut self, as_items: bool) -> Self {
+        self.codex_responses_as_items = as_items;
+        self
+    }
+
+    /// Prefixes automatic coding-agent response items.
+    #[must_use]
+    pub fn codex_response_item_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.codex_response_item_prefix = Some(prefix.into());
+        self
+    }
+
+    /// Selects Frameless coding-agent handoff channel routing.
+    #[must_use]
+    pub const fn codex_response_handoff_mode(mut self, mode: RealtimeResponseHandoffMode) -> Self {
+        self.codex_response_handoff_mode = mode;
+        self
+    }
+
+    /// Replaces BEM prefixes keyed by `analysis`, `commentary`, and `final`.
+    #[must_use]
+    pub fn codex_response_handoff_channel_prefixes(
+        mut self,
+        prefixes: BTreeMap<String, Vec<String>>,
+    ) -> Self {
+        self.codex_response_handoff_channel_prefixes = prefixes;
         self
     }
 
@@ -663,21 +957,57 @@ impl RealtimeSessionBuilder {
         if self.instructions.trim().is_empty() {
             return Err(RealtimeError::InvalidInstructions);
         }
-        if self.model.trim().is_empty() {
+        if self
+            .model
+            .as_ref()
+            .is_some_and(|model| model.trim().is_empty())
+        {
             return Err(RealtimeError::InvalidModel);
         }
-        validate_initial_items(self.auth.mode(), &self.initial_items)?;
+        let version = self.version.unwrap_or(match self.auth.mode() {
+            OpenAiAuthMode::ApiKey => RealtimeVersion::V2,
+            OpenAiAuthMode::ChatGpt => RealtimeVersion::V3,
+        });
+        let protocol = match version {
+            RealtimeVersion::V1 => RealtimeProtocol::V1,
+            RealtimeVersion::V2 => RealtimeProtocol::Direct,
+            RealtimeVersion::V3 => RealtimeProtocol::Frameless,
+        };
+        let transport = self.transport.unwrap_or(if version == RealtimeVersion::V3 {
+            RealtimeTransport::WebRtc
+        } else {
+            RealtimeTransport::WebSocket
+        });
+        let model = self.model.unwrap_or_else(|| match version {
+            RealtimeVersion::V1 | RealtimeVersion::V2 => REALTIME_MODEL.to_owned(),
+            RealtimeVersion::V3 => CHATGPT_REALTIME_MODEL.to_owned(),
+        });
+        validate_realtime_configuration(
+            version,
+            transport,
+            self.session_mode,
+            self.output_modality,
+            &self.initial_items,
+        )?;
+        validate_initial_items(version, &self.initial_items)?;
+        let voice = self.voice.unwrap_or(match version {
+            RealtimeVersion::V1 | RealtimeVersion::V3 => CHATGPT_REALTIME_VOICE,
+            RealtimeVersion::V2 => PLATFORM_REALTIME_VOICE,
+        });
+        validate_voice(version, voice)?;
 
-        let (socket, protocol, media) = match self.auth.mode() {
-            OpenAiAuthMode::ApiKey => {
-                let voice = self.voice.unwrap_or(PLATFORM_REALTIME_VOICE);
-                if !voice.supports_direct() {
-                    return Err(RealtimeError::InvalidVoice(voice.to_string()));
-                }
+        let output_policy = OutputPolicy {
+            codex_responses_as_items: self.codex_responses_as_items,
+            codex_response_item_prefix: self.codex_response_item_prefix,
+            handoff_mode: self.codex_response_handoff_mode,
+            channel_prefixes: self.codex_response_handoff_channel_prefixes,
+        };
+        let (socket, media) = match transport {
+            RealtimeTransport::WebSocket => {
                 let auth = self.auth.snapshot().await?;
                 let endpoint = match self.websocket_url {
                     Some(endpoint) => endpoint,
-                    None => realtime_endpoint(&self.api_base_url, &self.model)?,
+                    None => realtime_endpoint(&self.api_base_url, &model)?,
                 };
                 let mut request = endpoint
                     .as_str()
@@ -688,6 +1018,19 @@ impl RealtimeSessionBuilder {
                     HeaderValue::from_str(&format!("Bearer {}", auth.bearer()))
                         .map_err(|error| RealtimeError::InvalidAuthorization(error.to_string()))?,
                 );
+                match version {
+                    RealtimeVersion::V1 => {
+                        request
+                            .headers_mut()
+                            .insert("openai-alpha", HeaderValue::from_static("quicksilver=v1"));
+                    }
+                    RealtimeVersion::V3 => {
+                        request
+                            .headers_mut()
+                            .insert("openai-alpha", HeaderValue::from_static("quicksilver=v2"));
+                    }
+                    RealtimeVersion::V2 => {}
+                }
                 request.headers_mut().insert(
                     header::USER_AGENT,
                     HeaderValue::from_static(concat!("nanocodex/", env!("CARGO_PKG_VERSION"))),
@@ -710,42 +1053,49 @@ impl RealtimeSessionBuilder {
                     elapsed_ms = connect_started.elapsed().as_millis(),
                     "connected GPT Realtime websocket"
                 );
-                let update = session_update(&self.instructions, voice);
+                let update = configured_session_update(
+                    &self.instructions,
+                    &model,
+                    voice,
+                    version,
+                    self.session_mode,
+                    self.output_modality,
+                    &self.initial_items,
+                );
                 send_json(&mut socket, &update).await?;
-                (socket, RealtimeProtocol::Direct, None)
+                (socket, None)
             }
-            OpenAiAuthMode::ChatGpt => {
-                let voice = self.voice.unwrap_or(CHATGPT_REALTIME_VOICE);
-                if !voice.supports_frameless() {
-                    return Err(RealtimeError::InvalidVoice(voice.to_string()));
-                }
+            RealtimeTransport::WebRtc => {
                 let connection = webrtc::connect(webrtc::ConnectConfig {
                     auth: &self.auth,
                     api_base_url: &self.api_base_url,
                     attestation_header: self.attestation_header.as_deref(),
                     websocket_url: self.websocket_url.as_deref(),
                     instructions: &self.instructions,
-                    model: &self.model,
+                    model: &model,
                     voice,
                     session_id: self.session_id.as_deref(),
                     initial_items: &self.initial_items,
+                    version,
                 })
                 .await?;
-                (
-                    connection.socket,
-                    RealtimeProtocol::Frameless,
-                    Some(connection.media),
-                )
+                (connection.socket, Some(connection.media))
             }
         };
 
         let (command_tx, command_rx) = mpsc::channel(COMMAND_CAPACITY);
         let (event_tx, event_rx) = mpsc::channel(EVENT_CAPACITY);
-        tokio::spawn(run_socket(socket, command_rx, event_tx, protocol, media));
+        let (closed_tx, closed) = watch::channel(false);
+        tokio::spawn(async move {
+            run_socket(socket, command_rx, event_tx, protocol, media, output_policy).await;
+            closed_tx.send_replace(true);
+        });
         Ok((
             RealtimeSession {
                 commands: command_tx,
                 protocol,
+                client_managed_handoffs: self.client_managed_handoffs,
+                closed,
             },
             RealtimeEvents { receiver: event_rx },
         ))
@@ -753,12 +1103,12 @@ impl RealtimeSessionBuilder {
 }
 
 fn validate_initial_items(
-    auth_mode: OpenAiAuthMode,
+    version: RealtimeVersion,
     items: &[RealtimeInitialItem],
 ) -> Result<(), RealtimeError> {
-    if !items.is_empty() && matches!(auth_mode, OpenAiAuthMode::ApiKey) {
+    if !items.is_empty() && version != RealtimeVersion::V3 {
         return Err(RealtimeError::InvalidInitialItems(
-            "initial items require a ChatGPT-authenticated Frameless session".to_owned(),
+            "initial items require realtime v3".to_owned(),
         ));
     }
     if items.len() > INITIAL_ITEMS_MAX_COUNT {
@@ -785,6 +1135,48 @@ fn validate_initial_items(
     Ok(())
 }
 
+fn validate_realtime_configuration(
+    version: RealtimeVersion,
+    transport: RealtimeTransport,
+    session_mode: RealtimeSessionMode,
+    output_modality: RealtimeOutputModality,
+    initial_items: &[RealtimeInitialItem],
+) -> Result<(), RealtimeError> {
+    if transport == RealtimeTransport::WebRtc && version == RealtimeVersion::V2 {
+        return Err(RealtimeError::InvalidConfiguration(
+            "AVAS WebRTC requires realtime v1 or v3".to_owned(),
+        ));
+    }
+    if version != RealtimeVersion::V2 && output_modality == RealtimeOutputModality::Text {
+        return Err(RealtimeError::InvalidConfiguration(
+            "text output modality requires realtime v2".to_owned(),
+        ));
+    }
+    if version != RealtimeVersion::V2 && session_mode == RealtimeSessionMode::Transcription {
+        return Err(RealtimeError::InvalidConfiguration(
+            "transcription mode requires realtime v2".to_owned(),
+        ));
+    }
+    if version != RealtimeVersion::V3 && !initial_items.is_empty() {
+        return Err(RealtimeError::InvalidInitialItems(
+            "initial items require realtime v3".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_voice(version: RealtimeVersion, voice: RealtimeVoice) -> Result<(), RealtimeError> {
+    let supported = match version {
+        RealtimeVersion::V1 | RealtimeVersion::V3 => voice.supports_frameless(),
+        RealtimeVersion::V2 => voice.supports_direct(),
+    };
+    if supported {
+        Ok(())
+    } else {
+        Err(RealtimeError::InvalidVoice(voice.to_string()))
+    }
+}
+
 const fn approx_token_count(text: &str) -> usize {
     text.len()
         .saturating_add(APPROX_BYTES_PER_TOKEN.saturating_sub(1))
@@ -803,6 +1195,9 @@ pub enum RealtimeError {
     /// The realtime model identifier was empty.
     #[error("GPT Realtime model must not be empty")]
     InvalidModel,
+    /// The selected protocol, transport, or mode combination is unsupported.
+    #[error("invalid GPT Realtime configuration: {0}")]
+    InvalidConfiguration(String),
     /// The selected voice was not recognized.
     #[error("unsupported GPT Realtime voice {0:?}")]
     InvalidVoice(String),
@@ -846,22 +1241,97 @@ pub enum RealtimeError {
 
 struct Command {
     kind: CommandKind,
-    result: oneshot::Sender<Result<(), RealtimeError>>,
+    result: oneshot::Sender<Result<CommandOutcome, RealtimeError>>,
 }
 
 enum CommandKind {
     Audio(RealtimeAudio),
-    AgentOutput { call_id: String, output: String },
-    AgentProgress { call_id: String, output: String },
-    AgentComplete { call_id: String },
-    SilentOutput { call_id: String },
+    Text {
+        role: RealtimeInputTextRole,
+        text: String,
+    },
+    Speech {
+        text: String,
+    },
+    AgentOutput {
+        call_id: String,
+        output: String,
+    },
+    AgentProgress {
+        call_id: String,
+        output: String,
+        phase: Option<MessagePhase>,
+    },
+    StandaloneAgentOutput {
+        output: String,
+        phase: Option<MessagePhase>,
+    },
+    AgentComplete {
+        call_id: String,
+    },
+    SilentOutput {
+        call_id: String,
+    },
     Close,
 }
 
-#[derive(Clone, Copy)]
+enum CommandOutcome {
+    Continue,
+    Closed(Vec<RealtimeTranscriptEntry>),
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
 enum RealtimeProtocol {
+    V1,
     Direct,
     Frameless,
+}
+
+struct OutputPolicy {
+    codex_responses_as_items: bool,
+    codex_response_item_prefix: Option<String>,
+    handoff_mode: RealtimeResponseHandoffMode,
+    channel_prefixes: BTreeMap<String, Vec<String>>,
+}
+
+#[derive(Default)]
+struct OutputRoutingState {
+    bem_channels: HashMap<String, BemChannelParser>,
+}
+
+#[derive(Default)]
+struct SocketState {
+    active_transcript: ActiveTranscript,
+    response_create: ResponseCreateQueue,
+    output_audio: Option<OutputAudioState>,
+    output_routing: OutputRoutingState,
+}
+
+#[derive(Default)]
+struct BemChannelParser {
+    buffered_text: String,
+    phase: Option<MessagePhase>,
+}
+
+impl BemChannelParser {
+    fn push(&mut self, text: &str, prefixes: &BTreeMap<String, Vec<String>>) -> Option<String> {
+        if self.phase.is_some() {
+            return Some(text.to_owned());
+        }
+
+        self.buffered_text.push_str(text);
+        self.phase = bem_phase(&self.buffered_text, prefixes);
+        self.phase?;
+        Some(std::mem::take(&mut self.buffered_text))
+    }
+
+    const fn phase(&self) -> Option<MessagePhase> {
+        self.phase
+    }
+
+    fn finish(&mut self) -> String {
+        std::mem::take(&mut self.buffered_text)
+    }
 }
 
 #[derive(Serialize)]
@@ -871,6 +1341,8 @@ enum ClientEvent<'a> {
     SessionUpdate { session: SessionUpdate<'a> },
     #[serde(rename = "input_audio_buffer.append")]
     AudioBufferAppend { audio: String },
+    #[serde(rename = "input_audio.append")]
+    AudioAppend { audio: String },
     #[serde(rename = "conversation.item.create")]
     ItemCreate { item: ConversationItem<'a> },
     #[serde(rename = "conversation.item.truncate")]
@@ -884,10 +1356,30 @@ enum ClientEvent<'a> {
     #[serde(rename = "delegation.context.append")]
     DelegationContextAppend {
         delegation_item_id: &'a str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        channel: Option<RealtimeContextAppendChannel>,
         content: [FramelessInputText<'a>; 1],
+    },
+    #[serde(rename = "session.context.append")]
+    SessionContextAppend {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        channel: Option<RealtimeContextAppendChannel>,
+        content: [FramelessInputText<'a>; 1],
+    },
+    #[serde(rename = "conversation.handoff.append")]
+    ConversationHandoffAppend {
+        handoff_id: &'a str,
+        output_text: &'a str,
     },
     #[serde(rename = "session.close")]
     SessionClose,
+}
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum RealtimeContextAppendChannel {
+    Speakable,
+    Commentary,
 }
 
 #[derive(Serialize)]
@@ -1050,18 +1542,91 @@ fn session_update(instructions: &str, voice: RealtimeVoice) -> ClientEvent<'_> {
     }
 }
 
+fn configured_session_update(
+    instructions: &str,
+    model: &str,
+    voice: RealtimeVoice,
+    version: RealtimeVersion,
+    mode: RealtimeSessionMode,
+    output: RealtimeOutputModality,
+    initial_items: &[RealtimeInitialItem],
+) -> Value {
+    match version {
+        RealtimeVersion::V1 => json!({
+            "type": "session.update",
+            "session": {
+                "type": "quicksilver",
+                "instructions": instructions,
+                "audio": {
+                    "input": {
+                        "format": { "type": "audio/pcm", "rate": REALTIME_SAMPLE_RATE }
+                    },
+                    "output": { "voice": voice.as_str() }
+                }
+            }
+        }),
+        RealtimeVersion::V2 if mode == RealtimeSessionMode::Transcription => json!({
+            "type": "session.update",
+            "session": {
+                "type": "transcription",
+                "audio": {
+                    "input": {
+                        "format": { "type": "audio/pcm", "rate": REALTIME_SAMPLE_RATE },
+                        "transcription": { "model": "gpt-4o-mini-transcribe" }
+                    }
+                }
+            }
+        }),
+        RealtimeVersion::V2 => {
+            let mut value = serde_json::to_value(session_update(instructions, voice))
+                .expect("typed realtime session update serializes");
+            value["session"]["output_modalities"] = json!([match output {
+                RealtimeOutputModality::Text => "text",
+                RealtimeOutputModality::Audio => "audio",
+            }]);
+            value
+        }
+        RealtimeVersion::V3 => {
+            let items = initial_items
+                .iter()
+                .map(|item| {
+                    json!({
+                        "type": "message",
+                        "role": item.role.as_str(),
+                        "content": [{
+                            "type": item.role.content_type(),
+                            "text": item.text,
+                        }],
+                    })
+                })
+                .collect::<Vec<_>>();
+            let mut session = json!({
+                "model": model,
+                "instructions": instructions,
+                "audio": { "output": { "voice": voice.as_str() } },
+                "delegation": { "type": "client" },
+            });
+            if !items.is_empty() {
+                session["initial_items"] = Value::Array(items);
+            }
+            json!({ "type": "session.update", "session": session })
+        }
+    }
+}
+
 async fn run_socket(
     mut socket: Socket,
     mut commands: mpsc::Receiver<Command>,
     events: mpsc::Sender<RealtimeEvent>,
     protocol: RealtimeProtocol,
     mut media: Option<webrtc::WebRtcMedia>,
+    output_policy: OutputPolicy,
 ) {
     let media_input = media.as_ref().map(webrtc::WebRtcMedia::input);
-    let mut active_transcript = ActiveTranscript::default();
-    let mut response_create = ResponseCreateQueue::default();
-    let mut output_audio = None;
+    let mut state = SocketState::default();
+    let mut tail_returned = false;
     loop {
+        let has_webrtc_media = media.is_some();
         tokio::select! {
             command = commands.recv() => {
                 let Some(command) = command else {
@@ -1075,14 +1640,16 @@ async fn run_socket(
                     command.kind,
                     protocol,
                     media_input.as_ref(),
-                    &mut response_create,
+                    &mut state,
+                    &output_policy,
                 ).await;
-                let should_close = matches!(result, Ok(true));
+                let should_close = matches!(result, Ok(CommandOutcome::Closed(_)));
+                tail_returned = should_close;
                 if let Err(error) = &result {
                     let _ = events.send(RealtimeEvent::Error(error.to_string())).await;
                 }
                 let failed = result.is_err();
-                let _ = command.result.send(result.map(|_| ()));
+                let _ = command.result.send(result);
                 if should_close || failed {
                     break;
                 }
@@ -1093,9 +1660,8 @@ async fn run_socket(
                     message,
                     &events,
                     protocol,
-                    &mut active_transcript,
-                    &mut response_create,
-                    &mut output_audio,
+                    &mut state,
+                    has_webrtc_media,
                 ).await {
                     Ok(true) => break,
                     Ok(false) => {}
@@ -1121,6 +1687,12 @@ async fn run_socket(
             }
         }
     }
+    if !tail_returned {
+        let tail = state.active_transcript.take_tail();
+        if !tail.is_empty() {
+            let _ = events.send(RealtimeEvent::TranscriptTail(tail)).await;
+        }
+    }
     if let Some(media) = media {
         media.close().await;
     }
@@ -1141,12 +1713,22 @@ async fn handle_command(
     command: CommandKind,
     protocol: RealtimeProtocol,
     media_input: Option<&mpsc::Sender<RealtimeAudio>>,
-    response_create: &mut ResponseCreateQueue,
-) -> Result<bool, RealtimeError> {
+    state: &mut SocketState,
+    output_policy: &OutputPolicy,
+) -> Result<CommandOutcome, RealtimeError> {
     match command {
         CommandKind::Audio(audio) => {
             if !audio.is_empty() {
                 match protocol {
+                    RealtimeProtocol::V1 => {
+                        send_json(
+                            socket,
+                            &ClientEvent::AudioAppend {
+                                audio: STANDARD.encode(audio.as_bytes()),
+                            },
+                        )
+                        .await?;
+                    }
                     RealtimeProtocol::Direct => {
                         send_json(
                             socket,
@@ -1157,64 +1739,243 @@ async fn handle_command(
                         .await?;
                     }
                     RealtimeProtocol::Frameless => {
-                        let input = media_input.ok_or_else(|| {
-                            RealtimeError::WebRtc(
-                                "frameless session omitted its microphone track".to_owned(),
+                        if let Some(input) = media_input {
+                            timeout(SEND_TIMEOUT, input.send(audio))
+                                .await
+                                .map_err(|_| RealtimeError::SendTimeout)?
+                                .map_err(|_| RealtimeError::Closed)?;
+                        } else {
+                            send_json(
+                                socket,
+                                &ClientEvent::AudioAppend {
+                                    audio: STANDARD.encode(audio.as_bytes()),
+                                },
                             )
-                        })?;
-                        timeout(SEND_TIMEOUT, input.send(audio))
-                            .await
-                            .map_err(|_| RealtimeError::SendTimeout)?
-                            .map_err(|_| RealtimeError::Closed)?;
+                            .await?;
+                        }
                     }
                 }
             }
-            Ok(false)
+            Ok(CommandOutcome::Continue)
+        }
+        CommandKind::Text { role, mut text } => {
+            if protocol == RealtimeProtocol::Direct
+                && role == RealtimeInputTextRole::User
+                && !text.is_empty()
+                && !text.starts_with("[USER] ")
+            {
+                text = format!("[USER] {text}");
+            }
+            send_conversation_text(socket, role, &text).await?;
+            Ok(CommandOutcome::Continue)
+        }
+        CommandKind::Speech { text } => {
+            let text = realtime_backend_output(protocol, text);
+            match protocol {
+                RealtimeProtocol::V1 => {
+                    send_handoff_append(socket, STANDALONE_HANDOFF_ID, &text).await?;
+                }
+                RealtimeProtocol::Direct => {
+                    send_backend_output(socket, &text).await?;
+                    state.response_create.request(socket).await?;
+                }
+                RealtimeProtocol::Frameless => {
+                    send_session_context(
+                        socket,
+                        &text,
+                        Some(RealtimeContextAppendChannel::Speakable),
+                    )
+                    .await?;
+                }
+            }
+            Ok(CommandOutcome::Continue)
         }
         CommandKind::AgentOutput { call_id, output } => {
             match protocol {
+                RealtimeProtocol::V1 => {
+                    send_function_output(socket, &call_id, &output).await?;
+                }
                 RealtimeProtocol::Direct => {
                     send_function_output(socket, &call_id, &output).await?;
-                    response_create.request(socket).await?;
+                    state.response_create.request(socket).await?;
                 }
                 RealtimeProtocol::Frameless => {
-                    send_delegation_context(socket, &call_id, &output).await?;
+                    send_delegation_context(socket, &call_id, &output, None).await?;
                 }
             }
-            Ok(false)
+            Ok(CommandOutcome::Continue)
         }
-        CommandKind::AgentProgress { call_id, output } => {
-            match protocol {
-                RealtimeProtocol::Direct => {
-                    send_backend_output(socket, &output).await?;
-                }
-                RealtimeProtocol::Frameless => {
-                    send_delegation_context(socket, &call_id, &output).await?;
+        CommandKind::AgentProgress {
+            call_id,
+            output,
+            phase,
+        } => {
+            let Some((output, phase)) = route_streamed_output(
+                protocol,
+                &call_id,
+                output,
+                phase,
+                output_policy,
+                &mut state.output_routing,
+            ) else {
+                return Ok(CommandOutcome::Continue);
+            };
+            send_agent_progress(socket, protocol, &call_id, output, phase, output_policy).await?;
+            Ok(CommandOutcome::Continue)
+        }
+        CommandKind::StandaloneAgentOutput { mut output, phase } => {
+            let phase = standalone_output_phase(protocol, &output, phase, output_policy);
+            let channel = output_channel(&output, phase, output_policy);
+            output = realtime_backend_output(protocol, output);
+            if output_policy.codex_responses_as_items {
+                send_response_item(socket, protocol, &output, channel, output_policy).await?;
+            } else {
+                match protocol {
+                    RealtimeProtocol::V1 => {
+                        if !matches!(phase, Some(MessagePhase::Commentary)) {
+                            output = format!("{AGENT_FINAL_MESSAGE_PREFIX}{output}");
+                        }
+                        send_handoff_append(socket, STANDALONE_HANDOFF_ID, &output).await?;
+                    }
+                    RealtimeProtocol::Direct => {
+                        send_backend_output(socket, &output).await?;
+                        state.response_create.request(socket).await?;
+                    }
+                    RealtimeProtocol::Frameless => {
+                        send_session_context(socket, &output, channel).await?;
+                    }
                 }
             }
-            Ok(false)
+            Ok(CommandOutcome::Continue)
         }
         CommandKind::AgentComplete { call_id } => {
-            if matches!(protocol, RealtimeProtocol::Direct) {
-                send_function_output(socket, &call_id, AGENT_COMPLETE_ACKNOWLEDGEMENT).await?;
-                response_create.request(socket).await?;
+            if let Some(mut parser) = state.output_routing.bem_channels.remove(&call_id) {
+                let output = parser.finish();
+                if !output.is_empty() {
+                    warn!(%call_id, "BEM output ended before a recognized channel header was received");
+                    send_agent_progress(
+                        socket,
+                        protocol,
+                        &call_id,
+                        output,
+                        Some(MessagePhase::FinalAnswer),
+                        output_policy,
+                    )
+                    .await?;
+                }
             }
-            Ok(false)
+            if matches!(protocol, RealtimeProtocol::Direct) {
+                let acknowledgement = if output_policy.codex_responses_as_items {
+                    ""
+                } else {
+                    AGENT_COMPLETE_ACKNOWLEDGEMENT
+                };
+                send_function_output(socket, &call_id, acknowledgement).await?;
+                state.response_create.request(socket).await?;
+            }
+            Ok(CommandOutcome::Continue)
         }
         CommandKind::SilentOutput { call_id } => {
             match protocol {
-                RealtimeProtocol::Direct => send_function_output(socket, &call_id, "").await?,
+                RealtimeProtocol::V1 | RealtimeProtocol::Direct => {
+                    send_function_output(socket, &call_id, "").await?
+                }
                 RealtimeProtocol::Frameless => {
-                    send_delegation_context(socket, &call_id, "").await?;
+                    send_delegation_context(socket, &call_id, "", None).await?;
                 }
             }
-            Ok(false)
+            Ok(CommandOutcome::Continue)
         }
         CommandKind::Close => {
+            let tail = state.active_transcript.take_tail();
             close_socket(socket, protocol).await?;
-            Ok(true)
+            Ok(CommandOutcome::Closed(tail))
         }
     }
+}
+
+fn route_streamed_output(
+    protocol: RealtimeProtocol,
+    call_id: &str,
+    output: String,
+    phase: Option<MessagePhase>,
+    policy: &OutputPolicy,
+    state: &mut OutputRoutingState,
+) -> Option<(String, Option<MessagePhase>)> {
+    if protocol != RealtimeProtocol::Frameless
+        || policy.handoff_mode != RealtimeResponseHandoffMode::BemTags
+    {
+        return Some((output, phase));
+    }
+
+    let parser = state.bem_channels.entry(call_id.to_owned()).or_default();
+    let output = parser.push(&output, &policy.channel_prefixes)?;
+    Some((output, parser.phase()))
+}
+
+fn standalone_output_phase(
+    protocol: RealtimeProtocol,
+    output: &str,
+    phase: Option<MessagePhase>,
+    policy: &OutputPolicy,
+) -> Option<MessagePhase> {
+    if protocol == RealtimeProtocol::Frameless
+        && policy.handoff_mode == RealtimeResponseHandoffMode::BemTags
+    {
+        bem_phase(output, &policy.channel_prefixes).or(Some(MessagePhase::FinalAnswer))
+    } else {
+        phase
+    }
+}
+
+async fn send_agent_progress(
+    socket: &mut Socket,
+    protocol: RealtimeProtocol,
+    call_id: &str,
+    output: String,
+    phase: Option<MessagePhase>,
+    output_policy: &OutputPolicy,
+) -> Result<(), RealtimeError> {
+    let channel = output_channel(&output, phase, output_policy);
+    let output = realtime_backend_output(protocol, output);
+    if output_policy.codex_responses_as_items {
+        return send_response_item(socket, protocol, &output, channel, output_policy).await;
+    }
+
+    match protocol {
+        RealtimeProtocol::V1 => {
+            if matches!(phase, Some(MessagePhase::Commentary)) {
+                send_handoff_append(socket, call_id, &output).await
+            } else {
+                send_function_output(socket, call_id, &output).await
+            }
+        }
+        RealtimeProtocol::Direct => send_backend_output(socket, &output).await,
+        RealtimeProtocol::Frameless => {
+            send_delegation_context(socket, call_id, &output, channel).await
+        }
+    }
+}
+
+async fn send_session_context(
+    socket: &mut Socket,
+    output: &str,
+    channel: Option<RealtimeContextAppendChannel>,
+) -> Result<(), RealtimeError> {
+    for chunk in context_append_chunks(output) {
+        send_json(
+            socket,
+            &ClientEvent::SessionContextAppend {
+                channel,
+                content: [FramelessInputText {
+                    kind: "input_text",
+                    text: chunk,
+                }],
+            },
+        )
+        .await?;
+    }
+    Ok(())
 }
 
 async fn close_socket(
@@ -1231,12 +1992,14 @@ async fn send_delegation_context(
     socket: &mut Socket,
     delegation_item_id: &str,
     output: &str,
+    channel: Option<RealtimeContextAppendChannel>,
 ) -> Result<(), RealtimeError> {
     for chunk in context_append_chunks(output) {
         send_json(
             socket,
             &ClientEvent::DelegationContextAppend {
                 delegation_item_id,
+                channel,
                 content: [FramelessInputText {
                     kind: "input_text",
                     text: chunk,
@@ -1246,6 +2009,116 @@ async fn send_delegation_context(
         .await?;
     }
     Ok(())
+}
+
+async fn send_handoff_append(
+    socket: &mut Socket,
+    handoff_id: &str,
+    output: &str,
+) -> Result<(), RealtimeError> {
+    send_json(
+        socket,
+        &ClientEvent::ConversationHandoffAppend {
+            handoff_id,
+            output_text: output,
+        },
+    )
+    .await
+}
+
+async fn send_conversation_text(
+    socket: &mut Socket,
+    role: RealtimeInputTextRole,
+    text: &str,
+) -> Result<(), RealtimeError> {
+    send_json(
+        socket,
+        &ClientEvent::ItemCreate {
+            item: ConversationItem::Message {
+                kind: "message",
+                role: role.as_str(),
+                content: [ConversationInputText {
+                    kind: role.content_type(),
+                    text,
+                }],
+            },
+        },
+    )
+    .await
+}
+
+async fn send_response_item(
+    socket: &mut Socket,
+    protocol: RealtimeProtocol,
+    output: &str,
+    channel: Option<RealtimeContextAppendChannel>,
+    policy: &OutputPolicy,
+) -> Result<(), RealtimeError> {
+    let output = policy
+        .codex_response_item_prefix
+        .as_deref()
+        .filter(|prefix| !prefix.is_empty())
+        .map_or_else(
+            || output.to_owned(),
+            |prefix| format!("{prefix}\n\n{output}"),
+        );
+    if protocol == RealtimeProtocol::Frameless {
+        send_session_context(socket, &output, channel).await
+    } else {
+        send_conversation_text(socket, RealtimeInputTextRole::Developer, &output).await
+    }
+}
+
+fn output_channel(
+    output: &str,
+    phase: Option<MessagePhase>,
+    policy: &OutputPolicy,
+) -> Option<RealtimeContextAppendChannel> {
+    match policy.handoff_mode {
+        RealtimeResponseHandoffMode::Thinking => None,
+        RealtimeResponseHandoffMode::Commentary => Some(RealtimeContextAppendChannel::Commentary),
+        RealtimeResponseHandoffMode::BemTags => {
+            match phase.or_else(|| bem_phase(output, &policy.channel_prefixes)) {
+                Some(MessagePhase::Commentary) => Some(RealtimeContextAppendChannel::Commentary),
+                Some(MessagePhase::FinalAnswer) | None => {
+                    Some(RealtimeContextAppendChannel::Speakable)
+                }
+            }
+        }
+    }
+}
+
+fn bem_phase(text: &str, prefixes: &BTreeMap<String, Vec<String>>) -> Option<MessagePhase> {
+    for (channel, default, phase) in [
+        (
+            "analysis",
+            "<|start|>assistant<|channel|>analysis<|message|>",
+            MessagePhase::Commentary,
+        ),
+        (
+            "commentary",
+            "<|start|>assistant<|channel|>commentary<|message|>",
+            MessagePhase::Commentary,
+        ),
+        (
+            "final",
+            "<|start|>assistant<|channel|>final<|message|>",
+            MessagePhase::FinalAnswer,
+        ),
+    ] {
+        let matches = prefixes.get(channel).map_or_else(
+            || text.starts_with(default),
+            |prefixes| {
+                prefixes
+                    .iter()
+                    .any(|prefix| !prefix.is_empty() && text.starts_with(prefix))
+            },
+        );
+        if matches {
+            return Some(phase);
+        }
+    }
+    None
 }
 
 fn context_append_chunks(text: &str) -> Vec<&str> {
@@ -1285,7 +2158,11 @@ async fn send_function_output(
 }
 
 async fn send_backend_output(socket: &mut Socket, output: &str) -> Result<(), RealtimeError> {
-    let text = format!("{BACKEND_TEXT_PREFIX}{output}");
+    let text = if output.starts_with(BACKEND_TEXT_PREFIX) {
+        output.to_owned()
+    } else {
+        format!("{BACKEND_TEXT_PREFIX}{output}")
+    };
     send_json(
         socket,
         &ClientEvent::ItemCreate {
@@ -1302,7 +2179,18 @@ async fn send_backend_output(socket: &mut Socket, output: &str) -> Result<(), Re
     .await
 }
 
-async fn send_json(socket: &mut Socket, value: &ClientEvent<'_>) -> Result<(), RealtimeError> {
+fn realtime_backend_output(protocol: RealtimeProtocol, output: String) -> String {
+    if protocol == RealtimeProtocol::V1
+        || output.is_empty()
+        || output.starts_with(BACKEND_TEXT_PREFIX)
+    {
+        output
+    } else {
+        format!("{BACKEND_TEXT_PREFIX}{output}")
+    }
+}
+
+async fn send_json<T: Serialize>(socket: &mut Socket, value: &T) -> Result<(), RealtimeError> {
     let payload =
         serde_json::to_string(value).map_err(|error| RealtimeError::Message(error.to_string()))?;
     trace!(target: "nanocodex_oai_api::realtime::wire", payload = %payload, "GPT Realtime request");
@@ -1317,9 +2205,8 @@ async fn handle_server_message(
     message: Option<Result<Message, WebSocketError>>,
     events: &mpsc::Sender<RealtimeEvent>,
     protocol: RealtimeProtocol,
-    active_transcript: &mut ActiveTranscript,
-    response_create: &mut ResponseCreateQueue,
-    output_audio: &mut Option<OutputAudioState>,
+    state: &mut SocketState,
+    has_webrtc_media: bool,
 ) -> Result<bool, RealtimeError> {
     let Some(message) = message else {
         return Ok(true);
@@ -1330,15 +2217,22 @@ async fn handle_server_message(
             let value: Value = serde_json::from_str(&payload)
                 .map_err(|error| RealtimeError::Message(error.to_string()))?;
             if let Some(mut event) = parse_event_value(&value, protocol)? {
-                if matches!(protocol, RealtimeProtocol::Direct) {
-                    handle_direct_audio_state(socket, &value, &event, output_audio).await;
+                if has_webrtc_media
+                    && protocol == RealtimeProtocol::Frameless
+                    && matches!(event, RealtimeEvent::Audio(_))
+                {
+                    return Ok(false);
                 }
-                active_transcript.update(&mut event);
+                if matches!(protocol, RealtimeProtocol::Direct) {
+                    handle_direct_audio_state(socket, &value, &event, &mut state.output_audio)
+                        .await;
+                }
+                state.active_transcript.update(&mut event);
                 if matches!(protocol, RealtimeProtocol::Direct) {
                     match &event {
-                        RealtimeEvent::ResponseStarted => response_create.mark_started(),
+                        RealtimeEvent::ResponseStarted => state.response_create.mark_started(),
                         RealtimeEvent::ResponseDone => {
-                            response_create.mark_finished(socket).await?
+                            state.response_create.mark_finished(socket).await?
                         }
                         _ => {}
                     }
@@ -1408,6 +2302,7 @@ async fn handle_direct_audio_state(
         | RealtimeEvent::OutputTranscriptDelta(_)
         | RealtimeEvent::OutputTranscriptDone(_)
         | RealtimeEvent::ResponseStarted
+        | RealtimeEvent::TranscriptTail(_)
         | RealtimeEvent::Error(_) => {}
     }
 }
@@ -1487,6 +2382,16 @@ struct ActiveTranscript {
 }
 
 impl ActiveTranscript {
+    fn take_tail(&mut self) -> Vec<RealtimeTranscriptEntry> {
+        let tail = self.entries[self.last_handoff_entry_count..]
+            .iter()
+            .filter(|entry| !entry.text.trim().is_empty())
+            .cloned()
+            .collect();
+        self.last_handoff_entry_count = self.entries.len();
+        tail
+    }
+
     fn update(&mut self, event: &mut RealtimeEvent) {
         match event {
             RealtimeEvent::SpeechStarted => self.new_input_entry = true,
@@ -1525,6 +2430,7 @@ impl ActiveTranscript {
             | RealtimeEvent::Audio(_)
             | RealtimeEvent::RemainSilent { .. }
             | RealtimeEvent::ResponseDone
+            | RealtimeEvent::TranscriptTail(_)
             | RealtimeEvent::Error(_) => {}
         }
     }
@@ -1608,8 +2514,63 @@ fn parse_event_value(
         .and_then(Value::as_str)
         .unwrap_or_default();
     let event = match protocol {
+        RealtimeProtocol::V1 => parse_v1_event(value, kind)?,
         RealtimeProtocol::Direct => parse_direct_event(value, kind)?,
         RealtimeProtocol::Frameless => parse_frameless_event(value, kind),
+    };
+    Ok(event)
+}
+
+fn parse_v1_event(value: &Value, kind: &str) -> Result<Option<RealtimeEvent>, RealtimeError> {
+    let event = match kind {
+        "session.updated" => {
+            value
+                .pointer("/session/id")
+                .and_then(Value::as_str)
+                .map(|session_id| RealtimeEvent::SessionReady {
+                    session_id: session_id.to_owned(),
+                })
+        }
+        "conversation.output_audio.delta" => {
+            let encoded = value
+                .get("delta")
+                .or_else(|| value.get("data"))
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            let data = STANDARD
+                .decode(encoded)
+                .map_err(|error| RealtimeError::Message(error.to_string()))?;
+            Some(RealtimeEvent::Audio(RealtimeAudio::pcm16_le(data)?))
+        }
+        "conversation.input_transcript.delta"
+        | "conversation.item.input_audio_transcription.delta" => {
+            string_field(value, "delta").map(RealtimeEvent::InputTranscriptDelta)
+        }
+        "conversation.input_transcript.turn_marked"
+        | "conversation.item.input_audio_transcription.completed" => {
+            string_field(value, "transcript").map(RealtimeEvent::InputTranscriptDone)
+        }
+        "conversation.output_transcript.delta"
+        | "response.output_text.delta"
+        | "response.output_audio_transcript.delta" => {
+            string_field(value, "delta").map(RealtimeEvent::OutputTranscriptDelta)
+        }
+        "response.output_audio_transcript.done" => {
+            string_field(value, "transcript").map(RealtimeEvent::OutputTranscriptDone)
+        }
+        "conversation.handoff.requested" => {
+            let call_id = value.get("handoff_id").and_then(Value::as_str);
+            let prompt = value.get("input_transcript").and_then(Value::as_str);
+            call_id
+                .zip(prompt)
+                .map(|(call_id, prompt)| RealtimeEvent::AgentRequest {
+                    call_id: call_id.to_owned(),
+                    prompt: prompt.to_owned(),
+                    transcript: Vec::new(),
+                })
+        }
+        "error" => Some(parse_error(value)),
+        _ => None,
     };
     Ok(event)
 }
@@ -1695,9 +2656,13 @@ fn parse_frameless_event(value: &Value, kind: &str) -> Option<RealtimeEvent> {
             .map(RealtimeEvent::OutputTranscriptDelta),
         "turn.done" => parse_frameless_turn(value),
         "delegation.created" => parse_frameless_delegation(value),
-        // WebRTC media owns frameless output audio. Ignoring its sideband
-        // mirror prevents duplicate playback.
-        "output_audio.delta" => None,
+        "output_audio.delta" => value
+            .get("audio")
+            .or_else(|| value.get("delta"))
+            .and_then(Value::as_str)
+            .and_then(|audio| STANDARD.decode(audio).ok())
+            .and_then(|audio| RealtimeAudio::pcm16_le(audio).ok())
+            .map(RealtimeEvent::Audio),
         "error" => Some(parse_error(value)),
         _ => None,
     }
@@ -1828,11 +2793,13 @@ mod tests {
     use super::{
         ActiveTranscript, CHATGPT_REALTIME_MODEL, CHATGPT_REALTIME_VOICE, CHATGPT_REALTIME_VOICES,
         PLATFORM_REALTIME_VOICE, PLATFORM_REALTIME_VOICES, RealtimeAgentSteer, RealtimeAudio,
-        RealtimeEvent, RealtimeInitialItem, RealtimeProtocol, RealtimeTextRole,
-        RealtimeTranscriptEntry, RealtimeVoice, context_append_chunks, delegated_prompt,
-        parse_event, realtime_endpoint, session_update, validate_initial_items,
+        RealtimeEvent, RealtimeInitialItem, RealtimeOutputModality, RealtimeProtocol,
+        RealtimeResponseHandoffMode, RealtimeSessionMode, RealtimeTextRole,
+        RealtimeTranscriptEntry, RealtimeTransport, RealtimeVersion, RealtimeVoice,
+        configured_session_update, context_append_chunks, delegated_prompt, parse_event,
+        realtime_endpoint, session_update, validate_initial_items, validate_realtime_configuration,
     };
-    use crate::{OpenAi, OpenAiAuthMode};
+    use crate::OpenAi;
 
     #[test]
     fn derives_realtime_endpoint_from_api_base() {
@@ -1893,10 +2860,99 @@ mod tests {
     }
 
     #[test]
+    fn versioned_session_updates_match_codex_shapes() {
+        let v1 = configured_session_update(
+            "delegate",
+            "gpt-realtime-1.5",
+            RealtimeVoice::Cove,
+            RealtimeVersion::V1,
+            RealtimeSessionMode::Conversational,
+            RealtimeOutputModality::Audio,
+            &[],
+        );
+        assert_eq!(v1["session"]["type"], "quicksilver");
+        assert_eq!(v1["session"]["audio"]["output"]["voice"], "cove");
+
+        let transcription = configured_session_update(
+            "delegate",
+            "gpt-realtime-1.5",
+            RealtimeVoice::Marin,
+            RealtimeVersion::V2,
+            RealtimeSessionMode::Transcription,
+            RealtimeOutputModality::Audio,
+            &[],
+        );
+        assert_eq!(transcription["session"]["type"], "transcription");
+        assert!(transcription["session"].get("tools").is_none());
+
+        let v3 = configured_session_update(
+            "delegate",
+            "gpt-live-1-boulder-alpha",
+            RealtimeVoice::Cove,
+            RealtimeVersion::V3,
+            RealtimeSessionMode::Conversational,
+            RealtimeOutputModality::Audio,
+            &[RealtimeInitialItem::new(RealtimeTextRole::User, "hello")],
+        );
+        assert_eq!(v3["session"]["delegation"]["type"], "client");
+        assert_eq!(v3["session"]["initial_items"][0]["role"], "user");
+    }
+
+    #[test]
+    fn validates_version_transport_mode_and_modality() {
+        assert!(
+            validate_realtime_configuration(
+                RealtimeVersion::V1,
+                RealtimeTransport::WebRtc,
+                RealtimeSessionMode::Conversational,
+                RealtimeOutputModality::Audio,
+                &[],
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_realtime_configuration(
+                RealtimeVersion::V2,
+                RealtimeTransport::WebRtc,
+                RealtimeSessionMode::Conversational,
+                RealtimeOutputModality::Audio,
+                &[],
+            )
+            .is_err()
+        );
+        assert!(
+            validate_realtime_configuration(
+                RealtimeVersion::V3,
+                RealtimeTransport::WebSocket,
+                RealtimeSessionMode::Conversational,
+                RealtimeOutputModality::Text,
+                &[],
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn parses_v1_handoffs() {
+        assert_eq!(
+            parse_event(
+                r#"{"type":"conversation.handoff.requested","handoff_id":"handoff_1","item_id":"item_1","input_transcript":"inspect the parser"}"#,
+                RealtimeProtocol::V1,
+            )
+            .unwrap(),
+            Some(RealtimeEvent::AgentRequest {
+                call_id: "handoff_1".to_owned(),
+                prompt: "inspect the parser".to_owned(),
+                transcript: Vec::new(),
+            })
+        );
+    }
+
+    #[test]
     fn validates_frameless_initial_item_limits() {
         assert!(
             validate_initial_items(
-                OpenAiAuthMode::ChatGpt,
+                RealtimeVersion::V3,
                 &[
                     RealtimeInitialItem::new(RealtimeTextRole::Developer, "policy"),
                     RealtimeInitialItem::new(RealtimeTextRole::User, "request"),
@@ -1907,21 +2963,21 @@ mod tests {
         );
         assert!(
             validate_initial_items(
-                OpenAiAuthMode::ApiKey,
+                RealtimeVersion::V2,
                 &[RealtimeInitialItem::new(RealtimeTextRole::User, "request",)],
             )
             .is_err()
         );
         assert!(
             validate_initial_items(
-                OpenAiAuthMode::ChatGpt,
+                RealtimeVersion::V3,
                 &vec![RealtimeInitialItem::new(RealtimeTextRole::User, "x"); 129],
             )
             .is_err()
         );
         assert!(
             validate_initial_items(
-                OpenAiAuthMode::ChatGpt,
+                RealtimeVersion::V3,
                 &[RealtimeInitialItem::new(
                     RealtimeTextRole::User,
                     "x".repeat(32_769),
@@ -1931,7 +2987,7 @@ mod tests {
         );
         assert!(
             validate_initial_items(
-                OpenAiAuthMode::ChatGpt,
+                RealtimeVersion::V3,
                 &[
                     RealtimeInitialItem::new(RealtimeTextRole::User, "x".repeat(16_384)),
                     RealtimeInitialItem::new(RealtimeTextRole::Assistant, "x".repeat(16_388)),
@@ -1971,7 +3027,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_frameless_transcripts_delegation_and_ignores_sideband_audio() {
+    fn parses_frameless_transcripts_delegation_and_websocket_audio() {
         assert_eq!(
             parse_event(
                 r#"{"type":"delegation.created","item":{"type":"delegation","target":"client","id":"delegation_1","content":[{"type":"input_text","text":"run "},{"type":"output_text","text":"ignored"},{"type":"input_text","text":"the tests"}]}}"#,
@@ -1990,7 +3046,9 @@ mod tests {
                 RealtimeProtocol::Frameless,
             )
             .unwrap(),
-            None
+            Some(RealtimeEvent::Audio(
+                RealtimeAudio::pcm16_le([0, 1]).unwrap()
+            ))
         );
         assert_eq!(
             parse_event(
@@ -2094,6 +3152,76 @@ mod tests {
         assert_eq!(chunks.concat(), text);
         assert!(chunks.iter().all(|chunk| chunk.len() <= 500));
         assert_eq!(context_append_chunks(""), [""]);
+    }
+
+    #[tokio::test]
+    async fn frameless_buffers_bem_headers_and_routes_response_items() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut socket = accept_async(stream).await.unwrap();
+            let update = socket.next().await.unwrap().unwrap().into_text().unwrap();
+            let update: serde_json::Value = serde_json::from_str(&update).unwrap();
+            assert_eq!(update["type"], "session.update");
+
+            let commentary = socket.next().await.unwrap().unwrap().into_text().unwrap();
+            let commentary: serde_json::Value = serde_json::from_str(&commentary).unwrap();
+            assert_eq!(commentary["type"], "session.context.append");
+            assert_eq!(commentary["channel"], "commentary");
+            assert_eq!(
+                commentary["content"][0]["text"],
+                "item prefix\n\n[BACKEND] <|start|>assistant<|channel|>commentary<|message|>still working<|end|>"
+            );
+
+            let final_answer = socket.next().await.unwrap().unwrap().into_text().unwrap();
+            let final_answer: serde_json::Value = serde_json::from_str(&final_answer).unwrap();
+            assert_eq!(final_answer["type"], "session.context.append");
+            assert_eq!(final_answer["channel"], "speakable");
+            assert_eq!(
+                final_answer["content"][0]["text"],
+                "item prefix\n\n[BACKEND] no BEM envelope"
+            );
+
+            let close = socket.next().await.unwrap().unwrap().into_text().unwrap();
+            let close: serde_json::Value = serde_json::from_str(&close).unwrap();
+            assert_eq!(close["type"], "session.close");
+            assert!(socket.next().await.unwrap().unwrap().is_close());
+        });
+
+        let openai = OpenAi::new("test-key").unwrap();
+        let (session, _events) = openai
+            .realtime("delegate coding work")
+            .version(RealtimeVersion::V3)
+            .transport(RealtimeTransport::WebSocket)
+            .codex_responses_as_items(true)
+            .codex_response_item_prefix("item prefix")
+            .codex_response_handoff_mode(RealtimeResponseHandoffMode::BemTags)
+            .websocket_url(format!("ws://{address}"))
+            .connect()
+            .await
+            .unwrap();
+        session
+            .append_agent_output("call_1", "<|start|>assistant<|chan")
+            .await
+            .unwrap();
+        session
+            .append_agent_output("call_1", "nel|>commentary<|message|>still working<|end|>")
+            .await
+            .unwrap();
+        session.complete_agent_run("call_1").await.unwrap();
+        session
+            .append_standalone_agent_output("no BEM envelope")
+            .await
+            .unwrap();
+        assert!(
+            session
+                .close_with_transcript_tail()
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        server.await.unwrap();
     }
 
     #[tokio::test]
@@ -2243,6 +3371,64 @@ mod tests {
         assert_eq!(
             session.steer_agent_request("call_2").await.unwrap(),
             RealtimeAgentSteer::Acknowledged
+        );
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn standalone_output_and_close_return_unconsumed_transcript_tail() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut socket = accept_async(stream).await.unwrap();
+            let _update = socket.next().await.unwrap().unwrap();
+            socket
+                .send(Message::Text(
+                    r#"{"type":"conversation.item.input_audio_transcription.completed","transcript":"one last request"}"#.into(),
+                ))
+                .await
+                .unwrap();
+
+            let item = socket.next().await.unwrap().unwrap().into_text().unwrap();
+            let item: serde_json::Value = serde_json::from_str(&item).unwrap();
+            assert_eq!(item["item"]["role"], "user");
+            assert_eq!(item["item"]["content"][0]["text"], "[BACKEND] done");
+            let create = socket.next().await.unwrap().unwrap().into_text().unwrap();
+            let create: serde_json::Value = serde_json::from_str(&create).unwrap();
+            assert_eq!(create["type"], "response.create");
+            socket
+                .send(Message::Text(r#"{"type":"response.done"}"#.into()))
+                .await
+                .unwrap();
+            let close = socket.next().await.unwrap().unwrap();
+            assert!(close.is_close());
+        });
+
+        let openai = OpenAi::new("test-key").unwrap();
+        let (session, mut events) = openai
+            .realtime("delegate coding work")
+            .websocket_url(format!("ws://{address}"))
+            .connect()
+            .await
+            .unwrap();
+        assert_eq!(
+            events.recv().await,
+            Some(RealtimeEvent::InputTranscriptDone(
+                "one last request".to_owned()
+            ))
+        );
+        session
+            .append_standalone_agent_output("done")
+            .await
+            .unwrap();
+        assert_eq!(events.recv().await, Some(RealtimeEvent::ResponseDone));
+        assert_eq!(
+            session.close_with_transcript_tail().await.unwrap(),
+            vec![RealtimeTranscriptEntry {
+                role: "user".to_owned(),
+                text: "one last request".to_owned(),
+            }]
         );
         server.await.unwrap();
     }

--- a/crates/nanocodex-oai-api/src/realtime/webrtc.rs
+++ b/crates/nanocodex-oai-api/src/realtime/webrtc.rs
@@ -11,12 +11,16 @@ use opusic_c::{
 };
 use reqwest::{Client, StatusCode, header::LOCATION};
 use serde::Serialize;
-use tokio::{sync::mpsc, time::timeout};
+use serde_json::{Value, json};
+use tokio::{
+    sync::mpsc,
+    time::{sleep, timeout},
+};
 use tokio_tungstenite::tungstenite::{
     client::IntoClientRequest,
     http::{HeaderValue, header},
 };
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 use url::Url;
 use webrtc::{
     api::{
@@ -37,7 +41,7 @@ use webrtc::{
 
 use super::{
     CONNECT_TIMEOUT, EVENT_CAPACITY, RealtimeAudio, RealtimeError, RealtimeInitialItem,
-    RealtimeVoice, Socket, map_websocket_error,
+    RealtimeVersion, RealtimeVoice, Socket, map_websocket_error,
 };
 use crate::{OpenAiAuth, OpenAiAuthSnapshot, connector::connect_async};
 
@@ -91,6 +95,7 @@ pub(super) struct ConnectConfig<'a> {
     pub(super) voice: RealtimeVoice,
     pub(super) session_id: Option<&'a str>,
     pub(super) initial_items: &'a [RealtimeInitialItem],
+    pub(super) version: RealtimeVersion,
 }
 
 pub(super) async fn connect(config: ConnectConfig<'_>) -> Result<WebRtcConnection, RealtimeError> {
@@ -111,21 +116,98 @@ pub(super) async fn connect(config: ConnectConfig<'_>) -> Result<WebRtcConnectio
     .map_err(|error| RealtimeError::WebRtc(error.to_string()))?;
     debug!(call_id = %call.id, "applied GPT Realtime WebRTC answer");
 
-    let endpoint = sideband_endpoint(config.websocket_url, &call.id)?;
+    let (mut socket, response) = connect_sideband(&config, &auth, &call.id).await?;
+    debug!(
+        status = response.status().as_u16(),
+        "connected GPT Realtime WebRTC sideband"
+    );
+    if config.version == RealtimeVersion::V1 {
+        let update = json!({
+            "type": "session.update",
+            "session": {
+                "type": "quicksilver",
+                "instructions": config.instructions,
+                "audio": {
+                    "input": {
+                        "format": { "type": "audio/pcm", "rate": super::REALTIME_SAMPLE_RATE }
+                    },
+                    "output": { "voice": config.voice.as_str() }
+                }
+            }
+        });
+        super::send_json(&mut socket, &update).await?;
+    }
+    Ok(WebRtcConnection {
+        socket,
+        media: WebRtcMedia {
+            peer: offer.peer,
+            input: offer.input,
+            audio: offer.audio,
+        },
+    })
+}
+
+async fn connect_sideband(
+    config: &ConnectConfig<'_>,
+    auth: &OpenAiAuthSnapshot,
+    call_id: &str,
+) -> Result<
+    (
+        Socket,
+        tokio_tungstenite::tungstenite::http::Response<Option<Vec<u8>>>,
+    ),
+    RealtimeError,
+> {
+    let endpoint = sideband_endpoint(config.websocket_url, call_id)?;
     debug!(url = %endpoint, "connecting GPT Realtime WebRTC sideband");
+    let mut last_error = None;
+    for attempt in 0..=3_u32 {
+        let connect_started = tokio::time::Instant::now();
+        let request = sideband_request(config, auth, &endpoint)?;
+        match timeout(CONNECT_TIMEOUT, connect_async(request)).await {
+            Ok(Ok((socket, response))) => {
+                debug!(
+                    attempt,
+                    elapsed_ms = connect_started.elapsed().as_millis(),
+                    "joined GPT Realtime WebRTC sideband"
+                );
+                return Ok((socket, response));
+            }
+            Ok(Err(error)) => last_error = Some(map_websocket_error(error)),
+            Err(_) => last_error = Some(RealtimeError::ConnectTimeout),
+        }
+        if attempt < 3 {
+            let delay = Duration::from_millis(100_u64.saturating_mul(1_u64 << attempt));
+            warn!(
+                attempt,
+                delay_ms = delay.as_millis(),
+                "retrying GPT Realtime sideband join"
+            );
+            sleep(delay).await;
+        }
+    }
+    Err(last_error.unwrap_or(RealtimeError::ConnectTimeout))
+}
+
+fn sideband_request(
+    config: &ConnectConfig<'_>,
+    auth: &OpenAiAuthSnapshot,
+    endpoint: &Url,
+) -> Result<tokio_tungstenite::tungstenite::http::Request<()>, RealtimeError> {
     let mut request = endpoint
         .as_str()
         .into_client_request()
         .map_err(|error| RealtimeError::InvalidUrl(error.to_string()))?;
-    add_auth_headers(request.headers_mut(), &auth)?;
+    add_auth_headers(request.headers_mut(), auth)?;
     request.headers_mut().insert(
         "x-oai-attestation",
         HeaderValue::from_str(config.attestation_header.unwrap_or(ATTESTATION_UNAVAILABLE))
             .map_err(|error| RealtimeError::InvalidAuthorization(error.to_string()))?,
     );
-    request
-        .headers_mut()
-        .insert("openai-alpha", HeaderValue::from_static("quicksilver=v2"));
+    request.headers_mut().insert(
+        "openai-alpha",
+        HeaderValue::from_static(alpha_header(config.version)),
+    );
     request.headers_mut().insert(
         header::USER_AGENT,
         HeaderValue::from_static(concat!("nanocodex/", env!("CARGO_PKG_VERSION"))),
@@ -141,24 +223,7 @@ pub(super) async fn connect(config: ConnectConfig<'_>) -> Result<WebRtcConnectio
         request.headers_mut().insert("thread-id", value);
     }
 
-    let connect_started = tokio::time::Instant::now();
-    let (socket, response) = timeout(CONNECT_TIMEOUT, connect_async(request))
-        .await
-        .map_err(|_| RealtimeError::ConnectTimeout)?
-        .map_err(map_websocket_error)?;
-    debug!(
-        status = response.status().as_u16(),
-        elapsed_ms = connect_started.elapsed().as_millis(),
-        "connected GPT Realtime WebRTC sideband"
-    );
-    Ok(WebRtcConnection {
-        socket,
-        media: WebRtcMedia {
-            peer: offer.peer,
-            input: offer.input,
-            audio: offer.audio,
-        },
-    })
+    Ok(request)
 }
 
 fn ensure_rustls_crypto_provider() {
@@ -465,53 +530,63 @@ fn spawn_microphone_encoder(
 #[derive(Serialize)]
 struct CallRequest<'a> {
     sdp: &'a str,
-    session: CallSession<'a>,
-}
-
-#[derive(Serialize)]
-struct CallSession<'a> {
-    model: &'a str,
-    instructions: &'a str,
-    audio: CallAudio<'a>,
-    delegation: CallDelegation,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    initial_items: Vec<CallInitialItem<'a>>,
-}
-
-#[derive(Serialize)]
-struct CallInitialItem<'a> {
-    #[serde(rename = "type")]
-    kind: &'static str,
-    role: &'static str,
-    content: [CallInitialText<'a>; 1],
-}
-
-#[derive(Serialize)]
-struct CallInitialText<'a> {
-    #[serde(rename = "type")]
-    kind: &'static str,
-    text: &'a str,
-}
-
-#[derive(Serialize)]
-struct CallAudio<'a> {
-    output: CallAudioOutput<'a>,
-}
-
-#[derive(Serialize)]
-struct CallAudioOutput<'a> {
-    voice: &'a str,
-}
-
-#[derive(Serialize)]
-struct CallDelegation {
-    #[serde(rename = "type")]
-    kind: &'static str,
+    session: Value,
 }
 
 struct CallResponse {
     sdp: String,
     id: String,
+}
+
+fn call_session(config: &ConnectConfig<'_>) -> Value {
+    match config.version {
+        RealtimeVersion::V1 => json!({
+            "type": "quicksilver",
+            "model": config.model,
+            "instructions": config.instructions,
+            "audio": {
+                "input": {
+                    "format": { "type": "audio/pcm", "rate": super::REALTIME_SAMPLE_RATE }
+                },
+                "output": { "voice": config.voice.as_str() }
+            }
+        }),
+        RealtimeVersion::V2 => unreachable!("realtime v2 does not support AVAS WebRTC"),
+        RealtimeVersion::V3 => {
+            let initial_items = config
+                .initial_items
+                .iter()
+                .map(|item| {
+                    json!({
+                        "type": "message",
+                        "role": item.role.as_str(),
+                        "content": [{
+                            "type": item.role.content_type(),
+                            "text": item.text,
+                        }],
+                    })
+                })
+                .collect::<Vec<_>>();
+            let mut session = json!({
+                "model": config.model,
+                "instructions": config.instructions,
+                "audio": { "output": { "voice": config.voice.as_str() } },
+                "delegation": { "type": "client" },
+            });
+            if !initial_items.is_empty() {
+                session["initial_items"] = Value::Array(initial_items);
+            }
+            session
+        }
+    }
+}
+
+const fn alpha_header(version: RealtimeVersion) -> &'static str {
+    match version {
+        RealtimeVersion::V1 => "quicksilver=v1",
+        RealtimeVersion::V2 => "",
+        RealtimeVersion::V3 => "quicksilver=v2",
+    }
 }
 
 async fn create_call_with_auth_recovery(
@@ -557,33 +632,12 @@ async fn create_call(
     let endpoint = call_endpoint(config.api_base_url).map_err(CallAttemptError::Other)?;
     let request = CallRequest {
         sdp: offer,
-        session: CallSession {
-            model: config.model,
-            instructions: config.instructions,
-            audio: CallAudio {
-                output: CallAudioOutput {
-                    voice: config.voice.as_str(),
-                },
-            },
-            delegation: CallDelegation { kind: "client" },
-            initial_items: config
-                .initial_items
-                .iter()
-                .map(|item| CallInitialItem {
-                    kind: "message",
-                    role: item.role.as_str(),
-                    content: [CallInitialText {
-                        kind: item.role.content_type(),
-                        text: &item.text,
-                    }],
-                })
-                .collect(),
-        },
+        session: call_session(config),
     };
     let mut builder = realtime_http_client()
         .post(endpoint)
         .bearer_auth(auth.bearer())
-        .header("openai-alpha", "quicksilver=v2")
+        .header("openai-alpha", alpha_header(config.version))
         .header("originator", "nanocodex")
         .header(
             "x-oai-attestation",
@@ -765,7 +819,7 @@ mod tests {
     };
     use crate::{
         OpenAiAuth, OpenAiAuthMode, OpenAiAuthSnapshot,
-        realtime::{RealtimeInitialItem, RealtimeTextRole, RealtimeVoice},
+        realtime::{RealtimeInitialItem, RealtimeTextRole, RealtimeVersion, RealtimeVoice},
     };
 
     #[test]
@@ -938,6 +992,7 @@ mod tests {
             voice: RealtimeVoice::Cove,
             session_id: Some("session-1"),
             initial_items: &initial_items,
+            version: RealtimeVersion::V3,
         };
         let snapshot = OpenAiAuthSnapshot::new(
             OpenAiAuthMode::ChatGpt,

--- a/crates/nanocodex/src/lib.rs
+++ b/crates/nanocodex/src/lib.rs
@@ -3,8 +3,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use nanocodex_agent::{
-    AgentEvents, CostStatus, EstimatedUsdCost, Nanocodex, NanocodexBuilder, NanocodexError,
-    PromptRoute, ServiceTier, Turn, TurnControl, TurnResult, TurnUsage, UsdAmount,
+    AgentEvents, AgentSessionContext, CostStatus, EstimatedUsdCost, Nanocodex, NanocodexBuilder,
+    NanocodexError, PromptRoute, ServiceTier, Turn, TurnControl, TurnResult, TurnUsage, UsdAmount,
 };
 pub use nanocodex_oai_api::{OpenAi, ReasoningMode, Thinking};
 #[cfg(not(target_family = "wasm"))]
@@ -21,9 +21,9 @@ pub mod agent {
     #[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
     pub use nanocodex_agent::rollout;
     pub use nanocodex_agent::{
-        AgentEvents, AgentHandle, CostStatus, EstimatedUsdCost, Nanocodex, NanocodexBuilder,
-        NanocodexError, PromptRoute, Result, ServiceTier, Turn, TurnControl, TurnResult, TurnUsage,
-        UsdAmount, events, input, session, usage,
+        AgentEvents, AgentHandle, AgentSessionContext, CostStatus, EstimatedUsdCost, Nanocodex,
+        NanocodexBuilder, NanocodexError, PromptRoute, Result, ServiceTier, Turn, TurnControl,
+        TurnResult, TurnUsage, UsdAmount, events, input, session, usage,
     };
 }
 

--- a/docs/CODEX_PARITY.md
+++ b/docs/CODEX_PARITY.md
@@ -361,16 +361,21 @@ items without introducing app-server protocol types.
 
 ### Realtime voice delegation
 
-The experimental Realtime boundary matches Codex's V2 and Frameless behavior:
-current model/voice catalogs, byte-identical backend instructions, exact tool
-descriptions and acknowledgements, transcript-aware handoffs, atomic steering,
-queued `response.create`, 200 ms bounded agent updates, 500-byte Frameless
-context appends, and server-side V2 audio truncation when user speech interrupts
-playback. ChatGPT sessions create a genuine WebRTC/Opus media call and use a
-sideband WebSocket; the host owns device-attestation generation and passes the
-opaque value into the reusable session builder. Nanocodex deliberately uses a
-native Rust media/device stack instead of importing Chromium or Codex's
-app-server protocol.
+The experimental Realtime boundary matches Codex's V1, V2, and Frameless/V3
+behavior: lifecycle developer context, bounded 5,300-token startup context,
+typed-turn mirroring, transcript-tail flushing, current model/voice catalogs,
+byte-identical backend instructions, exact tools and acknowledgements, atomic
+steering, queued `response.create`, 200 ms bounded agent updates, 500-byte
+Frameless appends, BEM commentary/speakable routing, responses-as-items, and V2
+audio truncation on interruption. Protocol/transport, transcription/text
+output, client-managed handoffs, initial items, channel prefixes, startup
+context, and tail flushing are explicit builder policies. Shutdown awaits the
+transport/media lifecycle before the agent is stopped.
+
+All Realtime orchestration remains in `nanocodex-voice`; the agent crate exposes
+only protocol-neutral live-input, developer-message, and read-only session
+context hooks. ChatGPT WebRTC uses native Rust WebRTC/Opus with a sideband
+WebSocket, while the host owns device-attestation generation.
 
 ### Responses Lite parallel-tool scheduling
 

--- a/examples/voice.rs
+++ b/examples/voice.rs
@@ -50,10 +50,11 @@ async fn main() -> Result<()> {
         }
     };
 
-    voice.stop();
+    let voice_shutdown = voice.shutdown().await;
     let shutdown_result = agent.shutdown().await;
     agent_log.await.wrap_err("agent event logger failed")?;
     voice_result?;
+    voice_shutdown?;
     shutdown_result?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

- add Codex realtime lifecycle markers, bounded startup context, typed-turn mirroring, transcript-tail flushing, and awaitable shutdown
- expose V1/V2/V3 transport and handoff policy, including transcription/text modes, responses-as-items, client-managed handoffs, and BEM channel routing
- keep realtime orchestration in nanocodex-voice while nanocodex-agent exposes only protocol-neutral adapter hooks

## Verification

- cargo test -p nanocodex-agent --test it
- cargo test -p nanocodex-oai-api --features realtime --lib
- cargo test -p nanocodex-voice --lib
- cargo check -p nanocodex-examples --bin voice
- cargo check -p nanocodex-bin
- cargo clippy for nanocodex-oai-api, nanocodex-agent, nanocodex-voice, and nanocodex-bin with warnings denied
