### PR TITLE
fix(agent): preserve model in adapter checkpoints

### DIFF
--- a/crates/nanocodex-agent/src/agent/driver/mod.rs
+++ b/crates/nanocodex-agent/src/agent/driver/mod.rs
@@ -232,6 +232,7 @@ where
                     if let Some(checkpoint) = model.append_developer_message(text) {
                         latest_fork_checkpoint = Some(Arc::new(CommittedSession::new(
                             Arc::clone(&self.spawner.lineage_id),
+                            thread_model,
                             checkpoint,
                         )));
                     }
@@ -470,6 +471,7 @@ where
                         if let Some(checkpoint) = model.append_developer_message(text) {
                             latest_fork_checkpoint = Some(Arc::new(CommittedSession::new(
                                 Arc::clone(&self.spawner.lineage_id),
+                                thread_model,
                                 checkpoint,
                             )));
                         }
@@ -685,6 +687,7 @@ where
                                     .map(|checkpoint| {
                                         Arc::new(CommittedSession::new(
                                             Arc::clone(&self.spawner.lineage_id),
+                                            thread_model,
                                             checkpoint,
                                         ))
                                     })
@@ -807,6 +810,7 @@ where
                 if let Some(checkpoint) = model.append_developer_message(text) {
                     latest_fork_checkpoint = Some(Arc::new(CommittedSession::new(
                         Arc::clone(&self.spawner.lineage_id),
+                        thread_model,
                         checkpoint,
                     )));
                 }

--- a/examples/realtime_pipe.rs
+++ b/examples/realtime_pipe.rs
@@ -134,6 +134,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     RealtimeEvent::OutputTranscriptDone(text) => {
                         eprintln!("assistant: {text}");
                     }
+                    RealtimeEvent::TranscriptTail(tail) => {
+                        for entry in tail {
+                            eprintln!("{}: {}", entry.role, entry.text);
+                        }
+                    }
                     RealtimeEvent::Error(error) => return Err(error.into()),
                     RealtimeEvent::SessionReady { .. }
                     | RealtimeEvent::SpeechStarted


### PR DESCRIPTION
## Summary

- pass the thread-selected model through the four adapter developer-context checkpoints added by #82
- handle transcript-tail events in the raw realtime pipe example

This fixes the semantic merge with #80 that caused the post-merge all-features and bindings builds to fail.

## Verification

- cargo check --locked --package nanocodex-agent
- cargo check --locked --package nanocodex-examples --bins
- cargo test --locked --package nanocodex-agent --test it adapter_developer_context_is_visible_at_safe_model_boundaries
- cargo clippy --workspace --all-targets --all-features -- -D warnings
