### PR TITLE
fix: restore realtime parity builds

### DIFF
--- a/crates/nanocodex-agent/src/agent/driver/mod.rs
+++ b/crates/nanocodex-agent/src/agent/driver/mod.rs
@@ -232,6 +232,7 @@ where
                     if let Some(checkpoint) = model.append_developer_message(text) {
                         latest_fork_checkpoint = Some(Arc::new(CommittedSession::new(
                             Arc::clone(&self.spawner.lineage_id),
+                            thread_model,
                             checkpoint,
                         )));
                     }
@@ -470,6 +471,7 @@ where
                         if let Some(checkpoint) = model.append_developer_message(text) {
                             latest_fork_checkpoint = Some(Arc::new(CommittedSession::new(
                                 Arc::clone(&self.spawner.lineage_id),
+                                thread_model,
                                 checkpoint,
                             )));
                         }
@@ -685,6 +687,7 @@ where
                                     .map(|checkpoint| {
                                         Arc::new(CommittedSession::new(
                                             Arc::clone(&self.spawner.lineage_id),
+                                            thread_model,
                                             checkpoint,
                                         ))
                                     })
@@ -807,6 +810,7 @@ where
                 if let Some(checkpoint) = model.append_developer_message(text) {
                     latest_fork_checkpoint = Some(Arc::new(CommittedSession::new(
                         Arc::clone(&self.spawner.lineage_id),
+                        thread_model,
                         checkpoint,
                     )));
                 }

--- a/examples/realtime_pipe.rs
+++ b/examples/realtime_pipe.rs
@@ -140,7 +140,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     | RealtimeEvent::InputTranscriptDelta(_)
                     | RealtimeEvent::OutputTranscriptDelta(_)
                     | RealtimeEvent::ResponseStarted
-                    | RealtimeEvent::ResponseDone => {}
+                    | RealtimeEvent::ResponseDone
+                    | RealtimeEvent::TranscriptTail(_) => {}
                 }
             }
             completed = completed_rx.recv() => {


### PR DESCRIPTION
## Summary
- pass the thread-selected model into every fork checkpoint created after developer-message updates
- handle the new transcript-tail event in the realtime pipe example
- restore workspace compilation after the realtime parity merge

## Validation
- `cargo +nightly fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --package nanocodex-agent --all-features` (130 tests + doctests)