### PR TITLE
fix(examples): remove duplicate transcript-tail arm

### DIFF
--- a/examples/realtime_pipe.rs
+++ b/examples/realtime_pipe.rs
@@ -145,8 +145,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     | RealtimeEvent::InputTranscriptDelta(_)
                     | RealtimeEvent::OutputTranscriptDelta(_)
                     | RealtimeEvent::ResponseStarted
-                    | RealtimeEvent::ResponseDone
-                    | RealtimeEvent::TranscriptTail(_) => {}
+                    | RealtimeEvent::ResponseDone => {}
                 }
             }
             completed = completed_rx.recv() => {


### PR DESCRIPTION
The two parallel realtime-parity repair PRs both handled `TranscriptTail`; after both merged, the explicit logging arm made the no-op arm unreachable. Remove only the duplicate no-op pattern.

Validated with `cargo clippy --locked --package nanocodex-examples --all-targets --all-features -- -D warnings`.