### PR TITLE
feat(egress): harden secret policy and VM routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3761,7 +3761,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 [[package]]
 name = "hudsucker"
 version = "0.25.0"
-source = "git+https://github.com/gakonst/hudsucker?rev=d718d2d5af9ce8cc328ea9560611f8b7708d2522#d718d2d5af9ce8cc328ea9560611f8b7708d2522"
+source = "git+https://github.com/gakonst/hudsucker?rev=9a13609adc4b37b3e7fba28a320546bf672f0f4d#9a13609adc4b37b3e7fba28a320546bf672f0f4d"
 dependencies = [
  "bstr",
  "futures",
@@ -3862,7 +3862,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -5100,6 +5100,7 @@ dependencies = [
  "rand 0.9.5",
  "reqwest",
  "reqwest-middleware",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -5116,6 +5117,7 @@ dependencies = [
  "http",
  "nanocodex",
  "nanocodex-browser",
+ "nanocodex-egress",
  "nanocodex-vm",
  "nanocodex-voice",
  "reflink-copy",
@@ -6559,7 +6561,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6597,7 +6599,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ hex = "0.4.3"
 http = "1.3.1"
 http-body-util = "0.1.3"
 hmac = "0.13.0"
-hudsucker = { version = "0.25.0", git = "https://github.com/gakonst/hudsucker", rev = "d718d2d5af9ce8cc328ea9560611f8b7708d2522", default-features = false, features = ["rcgen-ca", "ring", "rustls-client"] }
+hudsucker = { version = "0.25.0", git = "https://github.com/gakonst/hudsucker", rev = "9a13609adc4b37b3e7fba28a320546bf672f0f4d", default-features = false, features = ["rcgen-ca", "ring", "rustls-client"] }
 ignore = "0.4.31"
 krun = { package = "libkrun", version = "=2.0.0-dev", git = "https://github.com/containers/libkrun", rev = "df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0", features = ["blk", "net"] }
 mpp = { version = "=0.11.0", git = "https://github.com/gakonst/mpp-rs", rev = "b1a7088bc05da933923220e29028ff75dbcb1ea4", default-features = false }

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -231,7 +231,15 @@ impl AgentArgs {
         }
         let openai = openai.build()?;
         let realtime = (!mpp_enabled).then(|| openai.clone());
-        let configured_vm = vm.start().await?;
+        let vm_egress = if vm.is_enabled() {
+            mpp_adapter
+                .as_ref()
+                .map(MppAdapter::vm_egress_lease)
+                .transpose()?
+        } else {
+            None
+        };
+        let configured_vm = vm.start(vm_egress).await?;
         let mut tools = configured_vm
             .as_ref()
             .map_or_else(Tools::builder, ConfiguredVm::tools_builder)
@@ -243,9 +251,10 @@ impl AgentArgs {
             tools = tools.provider(provider);
         }
         if let Some(mpp_adapter) = &mpp_adapter {
-            tools = tools
-                .process_environment(mpp_adapter.tool_environment())
-                .remote_http_client(mpp_adapter.tool_http_client()?);
+            if configured_vm.is_none() {
+                tools = tools.process_environment(mpp_adapter.tool_environment());
+            }
+            tools = tools.remote_http_client(mpp_adapter.tool_http_client()?);
         }
         if let Some(browser) = &configured_browser {
             tools = tools.provider(browser.tool());

--- a/bin/nanocodex/src/mpp.rs
+++ b/bin/nanocodex/src/mpp.rs
@@ -1,5 +1,11 @@
 use std::path::PathBuf;
 
+#[cfg(any(
+    all(target_os = "linux", not(target_env = "musl")),
+    all(target_os = "macos", target_arch = "aarch64")
+))]
+use std::path::Path;
+
 mod egress;
 mod resource;
 
@@ -18,9 +24,27 @@ use mpp::{
 use nanocodex_egress::EgressProxy;
 use nanousd::{NANOUSD_ADDRESS, TEMPO_MAINNET_CHAIN_ID};
 
+#[cfg(any(
+    all(target_os = "linux", not(target_env = "musl")),
+    all(target_os = "macos", target_arch = "aarch64")
+))]
+use nanocodex_vm::host::{EgressFile, GUEST_EGRESS_ROOT};
+
+use crate::vm::EgressLease;
+
 const DEFAULT_MPP_API_BASE_URL: &str = "https://openai.mpp.tempo.xyz/v1";
 const DEFAULT_TEMPO_SWAP_SLIPPAGE_BPS: u16 = 100;
 const DEFAULT_MAX_EGRESS_CHARGE: u128 = 100_000;
+#[cfg(any(
+    all(target_os = "linux", not(target_env = "musl")),
+    all(target_os = "macos", target_arch = "aarch64")
+))]
+const GUEST_EGRESS_DIRECTORY: &str = "tempo";
+#[cfg(any(
+    all(target_os = "linux", not(target_env = "musl")),
+    all(target_os = "macos", target_arch = "aarch64")
+))]
+const GUEST_EGRESS_CA_FILENAME: &str = "egress-ca.pem";
 
 #[derive(Args, Clone)]
 pub(crate) struct MppArgs {
@@ -105,6 +129,16 @@ impl MppArgs {
         }
 
         resource::ensure_mpp_file_descriptor_capacity()?;
+        let api_base_url = normalize_api_base_url(&self.api_base_url)?;
+        let allow_loopback = reqwest::Url::parse(&api_base_url)
+            .ok()
+            .and_then(|url| url.host_str().map(str::to_owned))
+            .is_some_and(|host| {
+                host.eq_ignore_ascii_case("localhost")
+                    || host
+                        .parse::<std::net::IpAddr>()
+                        .is_ok_and(|address| address.is_loopback())
+            });
         let provider = self.wallet_store.map_or_else(
             TempoAccountsProvider::from_default_store,
             TempoAccountsProvider::from_store,
@@ -117,13 +151,14 @@ impl MppArgs {
             max_charge: self.egress_max_charge,
         };
         let egress = EgressProxy::builder()
+            .allow_loopback_upstreams(allow_loopback)
             .layer(TempoEgress::new(provider))
             .spawn()
             .await
             .wrap_err("failed to start the embedded MPP egress proxy")?;
 
         Ok(Some(MppAdapter {
-            api_base_url: normalize_api_base_url(&self.api_base_url)?,
+            api_base_url,
             mpp_api_key: self.mpp_api_key,
             egress: Some(egress),
         }))
@@ -221,6 +256,52 @@ impl MppAdapter {
         self.egress.as_ref().map_or_else(Vec::new, |egress| {
             egress.environment().into_iter().collect()
         })
+    }
+
+    #[cfg(any(
+        all(target_os = "linux", not(target_env = "musl")),
+        all(target_os = "macos", target_arch = "aarch64")
+    ))]
+    pub(crate) fn vm_egress_lease(&self) -> Result<EgressLease> {
+        let egress = self
+            .egress
+            .as_ref()
+            .ok_or_else(|| eyre!("MPP egress proxy is not running"))?;
+        let route = egress.route();
+        let guest_certificate = Path::new(GUEST_EGRESS_ROOT)
+            .join(GUEST_EGRESS_DIRECTORY)
+            .join(GUEST_EGRESS_CA_FILENAME);
+        let mut lease = EgressLease::internet();
+        lease
+            .insert_file(EgressFile::new(
+                &guest_certificate,
+                route.ca_certificate_pem(),
+                0o444,
+            ))
+            .wrap_err("failed to provision the MPP egress CA in the VM")?;
+        for (name, value) in route.environment(&guest_certificate) {
+            let name = name
+                .into_string()
+                .map_err(|_| eyre!("MPP egress environment name is not valid UTF-8"))?;
+            let value = value
+                .into_string()
+                .map_err(|_| eyre!("MPP egress environment value for {name} is not valid UTF-8"))?;
+            lease
+                .insert_environment(name, value)
+                .wrap_err("failed to configure MPP egress environment in the VM")?;
+        }
+        Ok(lease)
+    }
+
+    #[cfg(not(any(
+        all(target_os = "linux", not(target_env = "musl")),
+        all(target_os = "macos", target_arch = "aarch64")
+    )))]
+    pub(crate) fn vm_egress_lease(&self) -> Result<EgressLease> {
+        Err(eyre!(
+            "provider-backed VM egress is unsupported on {}",
+            std::env::consts::ARCH
+        ))
     }
 
     fn http_client_builder(&self) -> Result<reqwest::ClientBuilder> {
@@ -356,6 +437,42 @@ mod tests {
     #[tokio::test]
     async fn mpp_is_opt_in() {
         assert!(test_args().start().await.unwrap().is_none());
+    }
+
+    #[cfg(any(
+        all(target_os = "linux", not(target_env = "musl")),
+        all(target_os = "macos", target_arch = "aarch64")
+    ))]
+    #[tokio::test]
+    async fn vm_lease_contains_only_the_proxy_route_and_public_ca() {
+        let egress = EgressProxy::builder().spawn().await.unwrap();
+        let proxy_url = egress.route().proxy_url().to_owned();
+        let adapter = MppAdapter {
+            api_base_url: DEFAULT_MPP_API_BASE_URL.to_owned(),
+            mpp_api_key: None,
+            egress: Some(egress),
+        };
+
+        let lease = adapter.vm_egress_lease().unwrap();
+        let guest_certificate = Path::new(GUEST_EGRESS_ROOT)
+            .join(GUEST_EGRESS_DIRECTORY)
+            .join(GUEST_EGRESS_CA_FILENAME);
+
+        assert_eq!(
+            lease.guest_environment().get("HTTPS_PROXY"),
+            Some(&proxy_url)
+        );
+        assert_eq!(
+            lease.guest_environment().get("SSL_CERT_FILE"),
+            Some(&guest_certificate.to_string_lossy().into_owned())
+        );
+        let file = lease.guest_files().next().unwrap();
+        assert_eq!(file.guest_path(), guest_certificate);
+        assert!(file.contents().starts_with(b"-----BEGIN CERTIFICATE-----"));
+        assert!(lease.guest_environment().keys().all(|name| {
+            !name.contains("WALLET") && !name.contains("PRIVATE") && !name.contains("SECRET")
+        }));
+        adapter.shutdown().await.unwrap();
     }
 
     #[tokio::test]

--- a/bin/nanocodex/src/mpp/egress.rs
+++ b/bin/nanocodex/src/mpp/egress.rs
@@ -10,16 +10,18 @@ use nanocodex_egress::{
     EgressLayer,
     middleware::{
         Error, Extensions, Middleware, Next, Request, Response, Result as MiddlewareResult,
-        async_trait,
+        StatusCode, async_trait, buffer_response_body,
     },
 };
 
+const DEFAULT_MAX_PAYMENT_REQUIRED_BYTES: usize = 1024 * 1024;
 const MPP_REQUEST_ID: &str = "mpp-request-id";
 
 /// MPP payment and replay as one Tempo-owned outbound egress layer.
 pub(super) struct TempoEgress<P> {
     middleware: PaymentMiddleware<P>,
     _events: ClientEventSubscription,
+    max_payment_required_bytes: usize,
     request_id_prefix: String,
     request_ids: AtomicU64,
 }
@@ -40,9 +42,16 @@ where
         Self {
             middleware,
             _events: subscription,
+            max_payment_required_bytes: DEFAULT_MAX_PAYMENT_REQUIRED_BYTES,
             request_id_prefix: random_identifier(),
             request_ids: AtomicU64::new(1),
         }
+    }
+
+    #[cfg(test)]
+    const fn max_payment_required_bytes(mut self, max_bytes: usize) -> Self {
+        self.max_payment_required_bytes = max_bytes;
+        self
     }
 }
 
@@ -57,12 +66,21 @@ where
         extensions: &mut Extensions,
         next: Next<'_>,
     ) -> MiddlewareResult<Response> {
+        buffer_response_body(
+            extensions,
+            StatusCode::PAYMENT_REQUIRED,
+            self.max_payment_required_bytes,
+        );
         let request_id = self.request_ids.fetch_add(1, Ordering::Relaxed);
         let logical_request_id = format!("{}-{request_id}", self.request_id_prefix);
         tracing::Span::current().record("mpp.request.id", logical_request_id.as_str());
         let value = logical_request_id.parse().map_err(Error::middleware)?;
         request.headers_mut().insert(MPP_REQUEST_ID, value);
         self.middleware.handle(request, extensions, next).await
+    }
+
+    fn uses_response_buffering(&self) -> bool {
+        true
     }
 }
 
@@ -273,7 +291,7 @@ mod tests {
         provider: MockProvider,
         configure: impl FnOnce(EgressProxyBuilder) -> EgressProxyBuilder,
     ) -> EgressProxy {
-        configure(EgressProxy::builder())
+        configure(EgressProxy::builder().allow_loopback_upstreams(true))
             .layer(TempoEgress::new(provider))
             .spawn()
             .await
@@ -394,6 +412,43 @@ mod tests {
             rollbacks.load(Ordering::SeqCst),
             DEFAULT_MAX_PAYMENT_RETRIES
         );
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn oversized_challenge_body_fails_before_payment() {
+        let challenge = challenge_header("oversized-challenge");
+        let origin = spawn_origin(Router::new().route(
+            "/paid",
+            post(move || {
+                let challenge = challenge.clone();
+                async move {
+                    (
+                        AxumStatus::PAYMENT_REQUIRED,
+                        [(WWW_AUTHENTICATE, challenge)],
+                        "larger than four bytes",
+                    )
+                }
+            }),
+        ))
+        .await;
+        let provider = MockProvider::default();
+        let payments = Arc::clone(&provider.payments);
+        let egress = EgressProxy::builder()
+            .allow_loopback_upstreams(true)
+            .layer(TempoEgress::new(provider).max_payment_required_bytes(4))
+            .spawn()
+            .await
+            .unwrap();
+
+        let response = proxied_client(&egress)
+            .post(format!("{origin}/paid"))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), AxumStatus::BAD_GATEWAY);
+        assert_eq!(payments.load(Ordering::SeqCst), 0);
         egress.shutdown().await.unwrap();
     }
 

--- a/bin/nanocodex/src/mpp_disabled.rs
+++ b/bin/nanocodex/src/mpp_disabled.rs
@@ -43,6 +43,10 @@ impl MppAdapter {
         match *self {}
     }
 
+    pub(crate) const fn vm_egress_lease(&self) -> Result<crate::vm::EgressLease> {
+        match *self {}
+    }
+
     pub(crate) async fn shutdown(self) -> Result<()> {
         match self {}
     }

--- a/bin/nanocodex/src/vm.rs
+++ b/bin/nanocodex/src/vm.rs
@@ -16,6 +16,8 @@ use nanocodex_vm::{
 use tokio::time::sleep;
 use tracing::info;
 
+pub(crate) use nanocodex_vm::host::EgressLease;
+
 const DEFAULT_CPUS: u8 = 2;
 const DEFAULT_MEMORY_MIB: u32 = 1_024;
 const DEFAULT_EXT4_WORKSPACE: &str = "/app";
@@ -107,15 +109,19 @@ impl VmRunConfig {
 }
 
 impl VmArgs {
-    #[cfg(test)]
     pub(crate) const fn is_enabled(&self) -> bool {
         self.rootfs.is_some()
     }
 
-    pub(crate) async fn start(self) -> Result<Option<ConfiguredVm>> {
+    pub(crate) async fn start(self, egress: Option<EgressLease>) -> Result<Option<ConfiguredVm>> {
         let Some(rootfs) = self.rootfs else {
             return Ok(None);
         };
+        if self.vm_no_network && egress.is_some() {
+            return Err(eyre!(
+                "--vm-no-network cannot be combined with provider-backed VM egress"
+            ));
+        }
         let rootfs = rootfs
             .canonicalize()
             .wrap_err_with(|| format!("failed to resolve VM rootfs {}", rootfs.display()))?;
@@ -168,9 +174,15 @@ impl VmArgs {
                  contain /usr/local/bin/nanocodex-vm-guest"
             ));
         }
-        if self.vm_no_network {
+        let network = if self.vm_no_network {
             vm = vm.offline();
-        }
+            "disabled"
+        } else if let Some(egress) = egress {
+            vm = vm.egress(egress);
+            "provider_proxy"
+        } else {
+            "internet"
+        };
         let firmware = Path::new(DEFAULT_KRUNFW_DIRECTORY);
         let platform_firmware = if cfg!(target_os = "macos") {
             firmware.join("libkrunfw.5.dylib")
@@ -190,7 +202,7 @@ impl VmArgs {
             vm_workspace = workspace,
             vm_cpu_count = self.vm_cpus.unwrap_or(DEFAULT_CPUS),
             vm_memory_mib = self.vm_memory_mib.unwrap_or(DEFAULT_MEMORY_MIB),
-            vm_network = if self.vm_no_network { "disabled" } else { "internet" },
+            vm_network = network,
             "normal agent workspace tools are running in a VM"
         );
         Ok(Some(ConfiguredVm {

--- a/bin/nanocodex/src/vm_unsupported.rs
+++ b/bin/nanocodex/src/vm_unsupported.rs
@@ -66,6 +66,9 @@ pub(crate) struct ConfiguredVm {
     _private: (),
 }
 
+/// Placeholder for a provider-neutral VM route on unsupported hosts.
+pub(crate) enum EgressLease {}
+
 /// Private VMM entrypoint retained for command-line compatibility.
 #[derive(Args)]
 pub(crate) struct VmRunConfig {
@@ -81,12 +84,11 @@ impl VmRunConfig {
 }
 
 impl VmArgs {
-    #[cfg(test)]
     pub(crate) const fn is_enabled(&self) -> bool {
         self.rootfs.is_some()
     }
 
-    pub(crate) async fn start(self) -> Result<Option<ConfiguredVm>> {
+    pub(crate) async fn start(self, _egress: Option<EgressLease>) -> Result<Option<ConfiguredVm>> {
         match self.rootfs {
             Some(rootfs) => Err(unsupported_error(Some(&rootfs))),
             None => Ok(None),

--- a/crates/experimental/README.md
+++ b/crates/experimental/README.md
@@ -10,7 +10,7 @@ being exercised and revised:
 - [`nanocodex-browser`](nanocodex-browser/README.md): deterministic browser
   control, diagnostics, artifacts, and headed-browser VM composition.
 - [`nanocodex-egress`](nanocodex-egress/README.md): authenticated loopback
-  HTTP(S) forwarding and application-owned outbound middleware composition.
+  HTTP(S) forwarding, application-owned middleware, and host-owned secrets.
 
 Experimental means API stability, not reduced engineering standards. These
 packages remain workspace members and must pass the normal formatting, Clippy,

--- a/crates/experimental/nanocodex-egress/Cargo.toml
+++ b/crates/experimental/nanocodex-egress/Cargo.toml
@@ -8,7 +8,7 @@ authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-description = "Composable authenticated HTTP egress proxy"
+description = "Composable authenticated HTTP egress proxy with host-owned secrets"
 readme = "README.md"
 
 [dependencies]
@@ -21,6 +21,7 @@ hudsucker.workspace = true
 rand.workspace = true
 reqwest = { workspace = true, features = ["stream"] }
 reqwest-middleware.workspace = true
+serde_json.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["fs", "net", "rt", "sync"] }

--- a/crates/experimental/nanocodex-egress/README.md
+++ b/crates/experimental/nanocodex-egress/README.md
@@ -1,54 +1,110 @@
 # nanocodex-egress
 
 `nanocodex-egress` is Nanocodex's unpublished, experimental HTTP egress
-transport. It extracts the authenticated loopback proxy that previously lived
-inside the Tempo MPP adapter without changing the adapter's child-process
-contract.
+transport. It owns the authenticated loopback proxy shared by application
+protocol layers and host-side secret replacement.
 
 The crate owns proxy authentication, TLS interception, bounded replayable
-request bodies, forwarding concurrency, and lifecycle. Application protocols
-remain outside the crate and compose through `EgressLayer`; the Nanocodex
-binary implements its Tempo payment layer using MPP's request middleware.
+request bodies, aggregate memory and forwarding concurrency, setup deadlines,
+streaming responses, SSRF/DNS-rebinding guards, and bounded lifecycle.
+Application protocols remain outside the crate and compose through
+`EgressLayer`; the Nanocodex binary implements its Tempo payment layer using
+MPP's request middleware. The bundled layers provide static default-deny
+request policy, request-header filtering, and host-owned secrets.
 
 ```rust,no_run
 use nanocodex_egress::{
-    EgressLayer, EgressProxy,
-    middleware::{
-        Extensions, Next, Request, Response, Result as MiddlewareResult,
-        async_trait,
-    },
+    EgressProxy, SecretEgress, SecretRef, SecretRule, StaticSecretResolver,
 };
-
-struct ApplicationLayer;
-
-#[async_trait]
-impl EgressLayer for ApplicationLayer {
-    async fn handle(
-        &self,
-        request: Request,
-        extensions: &mut Extensions,
-        next: Next<'_>,
-    ) -> MiddlewareResult<Response> {
-        next.run(request, extensions).await
-    }
-}
+use nanocodex_egress::http::Method;
 
 # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+let reference = SecretRef::new("memory", "service-token");
+let resolver = StaticSecretResolver::new()
+    .with_secret(reference.clone(), "host-only-value");
+let rule = SecretRule::builder("service", reference, "https://service.example")
+    .method(Method::POST)
+    .path_prefix("/v1/execute")
+    .replace_header("authorization", "nanocodex-secret-service")
+    .child_environment("SERVICE_BASE_URL", "SERVICE_API_KEY")
+    .build()?;
+let secrets = SecretEgress::builder(resolver).rule(rule).build()?;
 let proxy = EgressProxy::builder()
-    .layer(ApplicationLayer)
+    .layer(secrets)
     .spawn()
     .await?;
 
 let child_environment = proxy.environment();
 assert!(!child_environment.is_empty());
+assert!(child_environment.iter().all(|(_, value)| value != "host-only-value"));
 assert!(proxy.ca_certificate_path().is_file());
 proxy.shutdown().await?;
 # Ok(())
 # }
 ```
 
-Layers run in builder order. The proxy keeps its random authentication
-credential and ephemeral CA in the host process, while `environment()`
-returns the same curl, Requests, Node, and MPP compatibility variables that the
-previous embedded MPP proxy exposed. Apply those variables only to tool child
-processes, not to Nanocodex's control-plane process.
+Layers run in builder order. Apply `environment()` only to tool child
+processes, not to Nanocodex's control-plane process. It contains the proxy's
+short-lived authentication capability, the ephemeral CA path, and each secret
+rule's public base URL and placeholder; it never contains a resolved secret.
+
+A secret rule binds one operation to an exact origin plus optional methods and
+path-segment prefixes. Replacement can scan any number of named headers, query
+values, the path, and a buffered body; injection can overwrite one header or
+query parameter. `SecretFormat` supports raw, Bearer, Basic, and fixed-affix
+wire values. Multiple rules may apply to one request, so independent
+credentials compose in declaration order. Requests to a claimed origin fail
+closed when method, path, or a required placeholder does not match. Remote
+upstreams must use HTTPS; plaintext HTTP is accepted only for deliberate
+loopback development services. The resolver runs only after policy accepts a
+request, allowing application-defined secret stores, refresh, rotation, JSON
+extraction, or short-lived token minting without putting those capabilities in
+child code.
+
+`SecretEgress` denies destinations not claimed by a rule by default. Set
+`UnmatchedEgress::Allow` only when another layer or the origin should receive
+unclaimed traffic. CONNECT tunnels are checked before an origin connection is
+opened, and layer-provided child variables cannot override proxy transport
+variables.
+
+`EgressPolicy` is an independent exact-origin/method/path allowlist with
+enforcing and observation-only warn modes. `HeaderAllowlist` strips all request
+headers except configured exact names and prefixes, optionally within matching
+request scopes. Put policy first, secret mutation next, and header filtering
+after mutation when composing them.
+
+The origin client denies loopback and the AWS/GCP metadata IPs by default,
+including after DNS resolution. `allow_loopback_upstreams(true)` is an explicit
+development escape hatch; metadata remains denied. Redirects are disabled, an
+unrecognized CONNECT can never fall back to an opaque tunnel, and protocol
+upgrades are rejected until they can run the same mutation pipeline. Ordinary
+SSE and other HTTP response bodies stream without full buffering.
+
+## Iron Proxy capability mapping
+
+The embedded API deliberately uses typed Rust builders rather than Iron's YAML,
+DNS server, or daemon control plane:
+
+- Built in: default-deny URL policy and warn mode, header allowlisting,
+  host-owned inject/replace secrets, header/query/path/body placements,
+  required placeholders, common formatters, ordered transforms, exact request
+  scoping, structured tracing, body/concurrency limits, SSRF guards, CONNECT,
+  HTTPS MITM, and streamed HTTP/SSE responses.
+- Supplied through `SecretResolver`: environment, file, AWS Secrets Manager,
+  AWS SSM, 1Password, Vault, OAuth/GCP token minting, caching, refresh, and JSON
+  extraction. The crate intentionally does not force those SDKs on embedders.
+- Supplied as application `EgressLayer`s: HMAC, AWS SigV4, OAuth/GCP auth,
+  annotation/body capture, external gRPC policy, LLM judge/circuit breaking,
+  synthetic responses, and response transforms. The layer receives the owned
+  replayable request and can wrap the rest of the ordered stack.
+- Owned elsewhere: MCP tool policy stays in `nanocodex-tools`; VM networking
+  and guest projection stay in `nanocodex-vm`; Tempo payment stays under
+  `bin/`. DNS interception, TPROXY/nftables deployment, SOCKS5, PostgreSQL MITM,
+  hot-reload management APIs, and a hosted control plane are daemon concerns,
+  not an embedded SDK transport.
+
+`EgressProxy::route()` exposes the same short-lived proxy capability and public
+CA for a host child, VM, or container path. The repository's
+[`secret-egress`](../../../examples/secret_egress.rs) example runs a real
+Nanocodex Code Mode `Promise.all` curl fanout both on the host and in a retained
+libkrun TSI VM; model traffic remains outside the tool egress route.

--- a/crates/experimental/nanocodex-egress/benches/proxy_round_trip.rs
+++ b/crates/experimental/nanocodex-egress/benches/proxy_round_trip.rs
@@ -57,7 +57,7 @@ fn benchmark_proxy_round_trip(criterion: &mut Criterion) {
 
     for (name, layers) in [("direct", 0_usize), ("two_layers", 2_usize)] {
         let proxy = runtime.block_on(async {
-            let mut builder = EgressProxy::builder();
+            let mut builder = EgressProxy::builder().allow_loopback_upstreams(true);
             if layers > 0 {
                 builder = builder.layer(MarkerLayer("one"));
             }

--- a/crates/experimental/nanocodex-egress/examples/composable.rs
+++ b/crates/experimental/nanocodex-egress/examples/composable.rs
@@ -1,23 +1,8 @@
 use std::error::Error;
 
 use nanocodex_egress::{
-    EgressLayer, EgressProxy,
-    middleware::{Extensions, Next, Request, Response, Result as MiddlewareResult, async_trait},
+    EgressProxy, SecretEgress, SecretRef, SecretRule, StaticSecretResolver, http::Method,
 };
-
-struct ApplicationLayer;
-
-#[async_trait]
-impl EgressLayer for ApplicationLayer {
-    async fn handle(
-        &self,
-        request: Request,
-        extensions: &mut Extensions,
-        next: Next<'_>,
-    ) -> MiddlewareResult<Response> {
-        next.run(request, extensions).await
-    }
-}
 
 fn main() -> Result<(), Box<dyn Error>> {
     tokio::runtime::Builder::new_current_thread()
@@ -27,13 +12,26 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 async fn run() -> Result<(), Box<dyn Error>> {
-    let proxy = EgressProxy::builder()
-        .layer(ApplicationLayer)
-        .spawn()
-        .await?;
+    let reference = SecretRef::new("memory", "service-token");
+    let resolver =
+        StaticSecretResolver::new().with_secret(reference.clone(), "host-only-example-value");
+    let rule = SecretRule::builder("service", reference, "https://service.example")
+        .method(Method::POST)
+        .path_prefix("/v1/execute")
+        .replace_header("authorization", "nanocodex-secret-service")
+        .child_environment("SERVICE_BASE_URL", "SERVICE_API_KEY")
+        .build()?;
+    let secrets = SecretEgress::builder(resolver).rule(rule).build()?;
+    let proxy = EgressProxy::builder().layer(secrets).spawn().await?;
 
+    assert!(
+        proxy
+            .environment()
+            .iter()
+            .all(|(_, value)| value != "host-only-example-value")
+    );
     println!(
-        "composed application egress with {} child variables",
+        "composed host-secret egress with {} child variables",
         proxy.environment().len()
     );
     proxy.shutdown().await?;

--- a/crates/experimental/nanocodex-egress/src/lib.rs
+++ b/crates/experimental/nanocodex-egress/src/lib.rs
@@ -1,11 +1,30 @@
-//! Composable authenticated HTTP egress proxy.
+//! Composable authenticated HTTP egress proxy with host-owned secrets.
 //!
 //! [`EgressProxy`] owns the loopback proxy, TLS interception, bounded request
 //! forwarding, and lifecycle. Applications compose protocol behavior through
 //! ordered [`EgressLayer`] implementations. Nanocodex uses that seam for MPP
 //! payment and replay while keeping wallet material in the host process.
+//! [`SecretEgress`] is an optional fail-closed layer that replaces public
+//! placeholders only for an authorized destination, method, and path.
 
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
+
+mod policy;
+mod secret;
+
+pub use policy::{
+    EgressPolicy, EgressPolicyBuilder, EgressPolicyRule, EgressPolicyRuleBuilder, HeaderAllowlist,
+    HeaderAllowlistBuilder, PolicyConfigError, PolicyMode,
+};
+pub use secret::{
+    SecretConfigError, SecretEgress, SecretEgressBuilder, SecretFormat, SecretRef, SecretResolver,
+    SecretResolverError, SecretRule, SecretRuleBuilder, StaticSecretResolver, UnmatchedEgress,
+};
+
+/// HTTP types used to define egress rules without depending on the proxy backend.
+pub mod http {
+    pub use hudsucker::hyper::{HeaderMap, Method, Uri, header};
+}
 
 /// The intentional extension seam for an application-defined [`EgressLayer`].
 ///
@@ -15,12 +34,25 @@
 pub mod middleware {
     pub use async_trait::async_trait;
     pub use http::Extensions;
-    pub use reqwest::{Request, Response};
+    pub use reqwest::{Request, Response, StatusCode};
     pub use reqwest_middleware::{Error, Middleware, Next, Result};
+
+    pub use super::ResponseBodyTooLarge;
+
+    /// Requests bounded buffering of a selected origin response body.
+    ///
+    /// Layers that need to inspect response headers and then retry through
+    /// [`Next`] can use this hook to drain the first response, preserving
+    /// origin connection reuse. When several layers request the same status,
+    /// the smallest limit wins.
+    pub fn buffer_response_body(extensions: &mut Extensions, status: StatusCode, max_bytes: usize) {
+        super::request_response_buffer(extensions, status, max_bytes);
+    }
 }
 
 use std::{
-    ffi::OsString,
+    collections::BTreeMap,
+    ffi::{OsStr, OsString},
     net::{IpAddr, Ipv4Addr, SocketAddr},
     num::NonZeroUsize,
     path::{Path, PathBuf},
@@ -28,19 +60,22 @@ use std::{
         Arc, Mutex,
         atomic::{AtomicU64, Ordering},
     },
+    time::Duration,
 };
 
 use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use futures_util::TryStreamExt;
-use http_body_util::{BodyExt, Limited};
+use http_body_util::{BodyExt, LengthLimitError, Limited};
 use hudsucker::{
     Body, HttpContext, HttpHandler, Proxy, RequestOrResponse,
     certificate_authority::CertificateAuthority,
     hyper::{
         Method, Request, Response, StatusCode,
+        body::Body as HttpBody,
         header::{
-            CONNECTION, HOST, PROXY_AUTHENTICATE, PROXY_AUTHORIZATION, TRANSFER_ENCODING, UPGRADE,
+            CONNECTION, CONTENT_LENGTH, HOST, PROXY_AUTHENTICATE, PROXY_AUTHORIZATION, TE, TRAILER,
+            TRANSFER_ENCODING, UPGRADE,
         },
         http::uri::Authority,
     },
@@ -50,7 +85,7 @@ use hudsucker::{
     },
     rustls::{
         ServerConfig,
-        crypto::ring,
+        crypto::{CryptoProvider, ring},
         pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
     },
 };
@@ -58,16 +93,161 @@ use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, Middleware, Next};
 use tempfile::TempDir;
 use tokio::{
     net::TcpListener,
-    sync::{Semaphore, oneshot},
+    sync::{OwnedSemaphorePermit, Semaphore, oneshot},
     task::JoinHandle,
 };
 use tracing::Instrument as _;
 
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+
 const DEFAULT_MAX_REQUEST_BYTES: usize = 16 * 1024 * 1024;
+const DEFAULT_MAX_BUFFERED_REQUEST_BYTES: usize = 64 * 1024 * 1024;
 const DEFAULT_MAX_CONCURRENT_CONNECTIONS: usize = 128;
 const DEFAULT_MAX_CONCURRENT_REQUESTS: usize = 128;
-const MAX_IDLE_CONNECTIONS_PER_ORIGIN: usize = 4;
-const CA_FILENAME: &str = "mpp-egress-ca.pem";
+const DEFAULT_MAX_IDLE_CONNECTIONS_PER_ORIGIN: usize = 32;
+const DEFAULT_REQUEST_SETUP_TIMEOUT: Duration = Duration::from_secs(30);
+const DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const CA_FILENAME: &str = "egress-ca.pem";
+const PROXY_ENVIRONMENT_NAMES: [&str; 13] = [
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "no_proxy",
+    "NO_PROXY",
+    "CURL_CA_BUNDLE",
+    "SSL_CERT_FILE",
+    "REQUESTS_CA_BUNDLE",
+    "NODE_EXTRA_CA_CERTS",
+    "GIT_SSL_CAINFO",
+];
+
+/// Child-process configuration contributed by an egress layer.
+///
+/// This type deliberately omits `Debug` so child capabilities are not exposed
+/// through incidental formatting. Values remain available through explicit
+/// collection APIs.
+#[derive(Clone, Default)]
+pub struct EgressEnvironment {
+    entries: Vec<(OsString, OsString)>,
+}
+
+impl EgressEnvironment {
+    /// Creates an environment from owned names and values.
+    #[must_use]
+    pub fn new(entries: impl IntoIterator<Item = (OsString, OsString)>) -> Self {
+        Self {
+            entries: entries.into_iter().collect(),
+        }
+    }
+
+    /// Iterates over variable names and values.
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = (&OsStr, &OsStr)> {
+        self.entries
+            .iter()
+            .map(|(name, value)| (name.as_os_str(), value.as_os_str()))
+    }
+
+    /// Returns the value for one exact variable name.
+    #[must_use]
+    pub fn get(&self, name: impl AsRef<OsStr>) -> Option<&OsStr> {
+        let name = name.as_ref();
+        self.entries
+            .iter()
+            .find_map(|(candidate, value)| (candidate == name).then_some(value.as_os_str()))
+    }
+
+    /// Returns the number of variables.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns whether the environment contains no variables.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl IntoIterator for EgressEnvironment {
+    type Item = (OsString, OsString);
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.entries.into_iter()
+    }
+}
+
+/// Host-visible metadata passed through egress layers.
+///
+/// CONNECT authorization sees immutable destination, method, and header
+/// metadata before the proxy opens an origin connection. This type deliberately
+/// omits `Debug` because headers may contain child-supplied credentials.
+#[derive(Clone)]
+pub struct EgressRequest {
+    method: Method,
+    uri: hudsucker::hyper::Uri,
+    headers: hudsucker::hyper::HeaderMap,
+}
+
+impl EgressRequest {
+    /// Creates request metadata for a policy or deterministic test.
+    #[must_use]
+    pub const fn new(
+        method: Method,
+        uri: hudsucker::hyper::Uri,
+        headers: hudsucker::hyper::HeaderMap,
+    ) -> Self {
+        Self {
+            method,
+            uri,
+            headers,
+        }
+    }
+
+    fn from_request(request: &Request<Body>) -> Self {
+        Self::new(
+            request.method().clone(),
+            request.uri().clone(),
+            request.headers().clone(),
+        )
+    }
+
+    /// Returns the immutable HTTP method.
+    #[must_use]
+    pub const fn method(&self) -> &Method {
+        &self.method
+    }
+
+    /// Returns the immutable absolute URI or CONNECT authority.
+    #[must_use]
+    pub const fn uri(&self) -> &hudsucker::hyper::Uri {
+        &self.uri
+    }
+
+    /// Returns the child-supplied CONNECT headers.
+    #[must_use]
+    pub const fn headers(&self) -> &hudsucker::hyper::HeaderMap {
+        &self.headers
+    }
+}
+
+/// Failure returned while an egress layer authorizes a request.
+#[derive(Clone, Copy, Debug, thiserror::Error, Eq, PartialEq)]
+pub enum EgressLayerError {
+    /// The authenticated child does not hold authority for this request.
+    #[error("egress request denied by host policy")]
+    Denied,
+    /// The request cannot be matched safely against policy.
+    #[error("egress request is invalid")]
+    InvalidRequest,
+    /// Policy or credential resolution is temporarily unavailable.
+    #[error("egress layer is unavailable")]
+    Unavailable,
+}
 
 /// One independently composable outbound HTTP behavior.
 ///
@@ -82,24 +262,234 @@ pub trait EgressLayer: Send + Sync + 'static {
         extensions: &mut ::http::Extensions,
         next: Next<'_>,
     ) -> reqwest_middleware::Result<reqwest::Response>;
+
+    /// Authorizes one CONNECT tunnel before any origin connection is opened.
+    async fn authorize_connect(&self, _request: &EgressRequest) -> Result<(), EgressLayerError> {
+        Ok(())
+    }
+
+    /// Returns public child configuration contributed by this layer.
+    fn environment(&self) -> EgressEnvironment {
+        EgressEnvironment::default()
+    }
+
+    /// Returns whether this layer may request bounded response buffering.
+    ///
+    /// Override this together with [`middleware::buffer_response_body`] so the
+    /// proxy installs the buffering middleware only when the stack needs it.
+    fn uses_response_buffering(&self) -> bool {
+        false
+    }
 }
 
 /// Private transport policy owned by one embedded proxy instance.
 #[derive(Clone, Debug)]
 struct ProxyPolicy {
     max_request_bytes: usize,
+    max_buffered_request_bytes: usize,
     max_concurrent_requests: usize,
     max_concurrent_connections: usize,
+    max_idle_connections_per_origin: usize,
+    request_setup_timeout: Duration,
+    graceful_shutdown_timeout: Duration,
+    allow_loopback_upstreams: bool,
 }
 
 impl Default for ProxyPolicy {
     fn default() -> Self {
         Self {
             max_request_bytes: DEFAULT_MAX_REQUEST_BYTES,
+            max_buffered_request_bytes: DEFAULT_MAX_BUFFERED_REQUEST_BYTES,
             max_concurrent_requests: DEFAULT_MAX_CONCURRENT_REQUESTS,
             max_concurrent_connections: DEFAULT_MAX_CONCURRENT_CONNECTIONS,
+            max_idle_connections_per_origin: DEFAULT_MAX_IDLE_CONNECTIONS_PER_ORIGIN,
+            request_setup_timeout: DEFAULT_REQUEST_SETUP_TIMEOUT,
+            graceful_shutdown_timeout: DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT,
+            allow_loopback_upstreams: false,
         }
     }
+}
+
+#[derive(Clone, Default)]
+struct BufferedResponseBodies(Vec<(reqwest::StatusCode, usize)>);
+
+fn request_response_buffer(
+    extensions: &mut ::http::Extensions,
+    status: reqwest::StatusCode,
+    max_bytes: usize,
+) {
+    let requested = extensions.get_or_insert_default::<BufferedResponseBodies>();
+    if let Some((_, configured)) = requested
+        .0
+        .iter_mut()
+        .find(|(candidate, _)| *candidate == status)
+    {
+        *configured = (*configured).min(max_bytes);
+    } else {
+        requested.0.push((status, max_bytes));
+    }
+}
+
+struct BufferRequestedResponses {
+    timeout: Duration,
+}
+
+#[async_trait]
+impl Middleware for BufferRequestedResponses {
+    async fn handle(
+        &self,
+        request: reqwest::Request,
+        extensions: &mut ::http::Extensions,
+        next: Next<'_>,
+    ) -> reqwest_middleware::Result<reqwest::Response> {
+        let response = next.run(request, extensions).await?;
+        let Some(limit) = extensions
+            .get::<BufferedResponseBodies>()
+            .and_then(|requested| {
+                requested
+                    .0
+                    .iter()
+                    .find(|(status, _)| *status == response.status())
+                    .map(|(_, limit)| *limit)
+            })
+        else {
+            return Ok(response);
+        };
+        let status = response.status();
+        let response: ::http::Response<reqwest::Body> = response.into();
+        let (parts, body) = response.into_parts();
+        let body = tokio::time::timeout(self.timeout, Limited::new(body, limit).collect())
+            .await
+            .map_err(|_| {
+                reqwest_middleware::Error::middleware(ResponseBodyReadTimeout {
+                    status,
+                    timeout: self.timeout,
+                })
+            })?
+            .map_err(|error| {
+                if error.downcast_ref::<LengthLimitError>().is_some() {
+                    reqwest_middleware::Error::middleware(ResponseBodyTooLarge { status, limit })
+                } else {
+                    reqwest_middleware::Error::middleware(ResponseBodyReadError {
+                        status,
+                        source: error,
+                    })
+                }
+            })?
+            .to_bytes();
+        record_body_content("egress.proxy.buffered.response.body", &body);
+        Ok(::http::Response::from_parts(parts, body).into())
+    }
+}
+
+#[derive(Clone, Copy)]
+struct GuardedResolver {
+    allow_loopback: bool,
+}
+
+impl Resolve for GuardedResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let host = name.as_str().to_owned();
+        let allow_loopback = self.allow_loopback;
+        Box::pin(async move {
+            let addresses = tokio::net::lookup_host((host.as_str(), 0))
+                .await?
+                .collect::<Vec<_>>();
+            if addresses.is_empty()
+                || addresses
+                    .iter()
+                    .any(|address| denied_upstream_ip(address.ip(), allow_loopback))
+            {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "upstream address denied by egress network policy",
+                )
+                .into());
+            }
+            Ok(Box::new(addresses.into_iter()) as Addrs)
+        })
+    }
+}
+
+fn denied_upstream_ip(address: IpAddr, allow_loopback: bool) -> bool {
+    let address = match address {
+        IpAddr::V6(address) => address
+            .to_ipv4_mapped()
+            .map_or(IpAddr::V6(address), IpAddr::V4),
+        address => address,
+    };
+    if !allow_loopback && address.is_loopback() {
+        return true;
+    }
+    match address {
+        IpAddr::V4(address) => address.octets() == [169, 254, 169, 254],
+        IpAddr::V6(address) => address.segments() == [0xfd00, 0x00ec, 0, 0, 0, 0, 0, 0x0254],
+    }
+}
+
+struct OriginResponseHeadersTimeout {
+    timeout: Duration,
+}
+
+#[async_trait]
+impl Middleware for OriginResponseHeadersTimeout {
+    async fn handle(
+        &self,
+        request: reqwest::Request,
+        extensions: &mut ::http::Extensions,
+        next: Next<'_>,
+    ) -> reqwest_middleware::Result<reqwest::Response> {
+        tokio::time::timeout(self.timeout, next.run(request, extensions))
+            .await
+            .map_err(|_| {
+                reqwest_middleware::Error::middleware(OriginResponseHeadersTimedOut {
+                    timeout: self.timeout,
+                })
+            })?
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("timed out after {timeout:?} while waiting for origin response headers")]
+struct OriginResponseHeadersTimedOut {
+    timeout: Duration,
+}
+
+/// A selected response exceeded the bounded buffering requested by a layer.
+#[derive(Debug, thiserror::Error)]
+#[error("{status} response body exceeds the configured {limit}-byte egress layer limit")]
+pub struct ResponseBodyTooLarge {
+    status: reqwest::StatusCode,
+    limit: usize,
+}
+
+impl ResponseBodyTooLarge {
+    /// Returns the selected response status.
+    #[must_use]
+    pub const fn status(&self) -> reqwest::StatusCode {
+        self.status
+    }
+
+    /// Returns the configured maximum body size in bytes.
+    #[must_use]
+    pub const fn limit(&self) -> usize {
+        self.limit
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("failed to read the selected {status} response body")]
+struct ResponseBodyReadError {
+    status: reqwest::StatusCode,
+    #[source]
+    source: Box<dyn std::error::Error + Send + Sync>,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("timed out after {timeout:?} while reading the selected {status} response body")]
+struct ResponseBodyReadTimeout {
+    status: reqwest::StatusCode,
+    timeout: Duration,
 }
 
 struct LayerMiddleware(Arc<dyn EgressLayer>);
@@ -116,12 +506,72 @@ impl Middleware for LayerMiddleware {
     }
 }
 
+/// A client-facing view of one running egress proxy.
+///
+/// The route contains a short-lived authenticated proxy URL and must not be
+/// logged. It remains valid only while the [`EgressProxy`] that produced it is
+/// alive. Callers can project the same route into a host child or an isolated
+/// runtime by choosing where that runtime receives the public CA.
+pub struct EgressRoute<'a> {
+    proxy_url: &'a str,
+    ca_certificate_pem: &'a [u8],
+    layer_environment: &'a EgressEnvironment,
+}
+
+impl EgressRoute<'_> {
+    /// Returns the authenticated HTTP proxy URL.
+    #[must_use]
+    pub const fn proxy_url(&self) -> &str {
+        self.proxy_url
+    }
+
+    /// Returns the public ephemeral CA in PEM encoding.
+    #[must_use]
+    pub const fn ca_certificate_pem(&self) -> &[u8] {
+        self.ca_certificate_pem
+    }
+
+    /// Returns proxy, CA, and layer variables for one child runtime.
+    ///
+    /// `certificate_path` is the path at which that runtime can read
+    /// [`Self::ca_certificate_pem`]. It may be a host, guest, or container
+    /// path. A caller using a separate network namespace must also make the
+    /// loopback proxy reachable there; libkrun TSI guests share host socket
+    /// reachability. The returned values include the short-lived proxy
+    /// capability and therefore must not be logged.
+    #[must_use]
+    pub fn environment(&self, certificate_path: impl AsRef<OsStr>) -> EgressEnvironment {
+        let proxy = OsString::from(self.proxy_url);
+        let certificate = certificate_path.as_ref().to_owned();
+        let mut environment = [
+            ("http_proxy", proxy.clone()),
+            ("https_proxy", proxy.clone()),
+            ("all_proxy", proxy.clone()),
+            ("HTTP_PROXY", proxy.clone()),
+            ("HTTPS_PROXY", proxy.clone()),
+            ("ALL_PROXY", proxy),
+            ("no_proxy", OsString::new()),
+            ("NO_PROXY", OsString::new()),
+            ("CURL_CA_BUNDLE", certificate.clone()),
+            ("SSL_CERT_FILE", certificate.clone()),
+            ("REQUESTS_CA_BUNDLE", certificate.clone()),
+            ("NODE_EXTRA_CA_CERTS", certificate.clone()),
+            ("GIT_SSL_CAINFO", certificate),
+        ]
+        .into_iter()
+        .map(|(name, value)| (OsString::from(name), value))
+        .collect::<Vec<_>>();
+        environment.extend(self.layer_environment.clone());
+        EgressEnvironment::new(environment)
+    }
+}
+
 /// A running authenticated loopback proxy and its ephemeral certificate authority.
 pub struct EgressProxy {
     proxy_url: String,
-    proxy_password: String,
-    proxy_authorization: String,
+    ca_certificate_pem: Vec<u8>,
     ca_certificate_path: PathBuf,
+    layer_environment: EgressEnvironment,
     _temp_dir: TempDir,
     shutdown_tx: Option<oneshot::Sender<()>>,
     task: Option<JoinHandle<Result<(), hudsucker::Error>>>,
@@ -145,11 +595,44 @@ impl EgressProxy {
         if policy.max_request_bytes == 0 {
             return Err(EgressError::ZeroMaxRequestBytes);
         }
+        if policy.max_request_bytes > u32::MAX as usize {
+            return Err(EgressError::MaxRequestBytesTooLarge {
+                configured: policy.max_request_bytes,
+                limit: u32::MAX as usize,
+            });
+        }
+        if policy.max_buffered_request_bytes < policy.max_request_bytes {
+            return Err(EgressError::BufferedRequestBudgetTooSmall {
+                configured: policy.max_buffered_request_bytes,
+                minimum: policy.max_request_bytes,
+            });
+        }
+        if policy.max_buffered_request_bytes > Semaphore::MAX_PERMITS {
+            return Err(EgressError::BufferedRequestBudgetTooLarge {
+                configured: policy.max_buffered_request_bytes,
+                limit: Semaphore::MAX_PERMITS,
+            });
+        }
         if policy.max_concurrent_requests == 0 {
             return Err(EgressError::ZeroMaxConcurrentRequests);
         }
+        if policy.max_concurrent_requests > Semaphore::MAX_PERMITS {
+            return Err(EgressError::MaxConcurrentRequestsTooLarge {
+                configured: policy.max_concurrent_requests,
+                limit: Semaphore::MAX_PERMITS,
+            });
+        }
+        if policy.request_setup_timeout.is_zero() {
+            return Err(EgressError::ZeroRequestSetupTimeout);
+        }
         let max_concurrent_connections = NonZeroUsize::new(policy.max_concurrent_connections)
             .ok_or(EgressError::ZeroMaxConcurrentConnections)?;
+        if max_concurrent_connections.get() > Semaphore::MAX_PERMITS {
+            return Err(EgressError::MaxConcurrentConnectionsTooLarge {
+                configured: max_concurrent_connections.get(),
+                limit: Semaphore::MAX_PERMITS,
+            });
+        }
 
         let listener = TcpListener::bind(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0))
             .await
@@ -157,7 +640,7 @@ impl EgressProxy {
         let address = listener.local_addr().map_err(EgressError::LocalAddress)?;
         let (authority, certificate_pem) = ephemeral_authority()?;
         let temp_dir = tempfile::Builder::new()
-            .prefix("nanocodex-mpp-egress-")
+            .prefix("nanocodex-egress-")
             .tempdir()
             .map_err(EgressError::TempDir)?;
         let ca_certificate_path = temp_dir.path().join(CA_FILENAME);
@@ -167,13 +650,28 @@ impl EgressProxy {
         let client = reqwest::Client::builder()
             .no_proxy()
             .redirect(reqwest::redirect::Policy::none())
-            .pool_max_idle_per_host(MAX_IDLE_CONNECTIONS_PER_ORIGIN)
+            .connect_timeout(policy.request_setup_timeout)
+            .dns_resolver(GuardedResolver {
+                allow_loopback: policy.allow_loopback_upstreams,
+            })
+            .pool_max_idle_per_host(policy.max_idle_connections_per_origin)
             .build()
             .map_err(EgressError::Client)?;
         let mut client_builder = ClientBuilder::new(client);
+        let layer_environment = collect_layer_environment(&layers)?;
         for layer in &layers {
             client_builder = client_builder.with(LayerMiddleware(Arc::clone(layer)));
         }
+        if layers.iter().any(|layer| layer.uses_response_buffering()) {
+            client_builder = client_builder.with(BufferRequestedResponses {
+                timeout: policy.request_setup_timeout,
+            });
+        }
+        // Keep this middleware innermost so the deadline covers each actual
+        // origin exchange without cancelling outer payment or secret logic.
+        client_builder = client_builder.with(OriginResponseHeadersTimeout {
+            timeout: policy.request_setup_timeout,
+        });
         let client = client_builder.build();
         let proxy_password = random_proxy_password();
         let proxy_authorization = format!(
@@ -182,12 +680,17 @@ impl EgressProxy {
         );
         let proxy_url = format!("http://nanocodex:{proxy_password}@{address}");
         let origin_permits = Arc::new(Semaphore::new(policy.max_concurrent_requests));
+        let buffered_request_bytes = Arc::new(Semaphore::new(policy.max_buffered_request_bytes));
+        let request_setup_timeout = policy.request_setup_timeout;
+        let graceful_shutdown_timeout = policy.graceful_shutdown_timeout;
         let handler = ProxyHandler {
             client,
             policy,
+            layers,
             origin_permits,
+            buffered_request_bytes,
             authentication: ProxyAuthentication {
-                authorization: proxy_authorization.clone().into(),
+                authorization: proxy_authorization.into(),
                 tunnel_authenticated: false,
             },
             request_ids: Arc::new(AtomicU64::new(1)),
@@ -198,18 +701,21 @@ impl EgressProxy {
             .with_ca(authority)
             .with_rustls_connector(ring::default_provider())
             .with_max_concurrent_connections(max_concurrent_connections)
+            .with_unrecognized_connect_tunneling(false)
+            .with_connect_setup_timeout(request_setup_timeout)
             .with_http_handler(handler)
             .with_graceful_shutdown(async move {
                 let _ = shutdown_rx.await;
             })
+            .with_graceful_shutdown_timeout(graceful_shutdown_timeout)
             .build()?;
         let task = tokio::spawn(proxy.start());
 
         Ok(Self {
             proxy_url,
-            proxy_password,
-            proxy_authorization,
+            ca_certificate_pem: certificate_pem.into_bytes(),
             ca_certificate_path,
+            layer_environment: EgressEnvironment::new(layer_environment),
             _temp_dir: temp_dir,
             shutdown_tx: Some(shutdown_tx),
             task: Some(task),
@@ -226,6 +732,16 @@ impl EgressProxy {
         self.proxy_url.clone()
     }
 
+    /// Borrows a route that can be projected into a host or isolated runtime.
+    #[must_use]
+    pub const fn route(&self) -> EgressRoute<'_> {
+        EgressRoute {
+            proxy_url: self.proxy_url.as_str(),
+            ca_certificate_pem: self.ca_certificate_pem.as_slice(),
+            layer_environment: &self.layer_environment,
+        }
+    }
+
     /// Returns environment overrides for curl and common HTTP runtimes.
     ///
     /// These values contain the proxy bearer capability. They should be applied
@@ -233,31 +749,10 @@ impl EgressProxy {
     /// process, so model/control-plane traffic is not intercepted.
     #[must_use]
     pub fn environment(&self) -> Vec<(OsString, OsString)> {
-        let proxy = OsString::from(self.proxy_url());
-        let certificate = self.ca_certificate_path.clone().into_os_string();
-        [
-            ("http_proxy", proxy.clone()),
-            ("https_proxy", proxy.clone()),
-            ("HTTP_PROXY", proxy.clone()),
-            ("HTTPS_PROXY", proxy),
-            ("no_proxy", OsString::new()),
-            ("NO_PROXY", OsString::new()),
-            ("CURL_CA_BUNDLE", certificate.clone()),
-            ("SSL_CERT_FILE", certificate.clone()),
-            ("REQUESTS_CA_BUNDLE", certificate.clone()),
-            ("NODE_EXTRA_CA_CERTS", certificate),
-            (
-                "NANOCODEX_MPP_EGRESS_PASSWORD",
-                OsString::from(&self.proxy_password),
-            ),
-            (
-                "NANOCODEX_MPP_EGRESS_AUTHORIZATION",
-                OsString::from(&self.proxy_authorization),
-            ),
-        ]
-        .into_iter()
-        .map(|(name, value)| (OsString::from(name), value))
-        .collect()
+        self.route()
+            .environment(self.ca_certificate_path.as_os_str())
+            .into_iter()
+            .collect()
     }
 
     /// Stops accepting traffic and waits for active proxy connections to drain.
@@ -314,6 +809,16 @@ impl EgressProxyBuilder {
         self
     }
 
+    /// Sets the aggregate reservation budget for replayable request bodies.
+    ///
+    /// Known body lengths reserve their exact size; unknown lengths reserve
+    /// the per-request maximum. This budget must fit one maximum-sized body.
+    #[must_use]
+    pub const fn max_buffered_request_bytes(mut self, max_bytes: usize) -> Self {
+        self.policy.max_buffered_request_bytes = max_bytes;
+        self
+    }
+
     /// Sets the maximum number of requests concurrently forwarded to origins.
     ///
     /// Additional child requests wait locally before entering outbound layers.
@@ -330,6 +835,41 @@ impl EgressProxyBuilder {
     #[must_use]
     pub const fn max_concurrent_connections(mut self, max_connections: usize) -> Self {
         self.policy.max_concurrent_connections = max_connections;
+        self
+    }
+
+    /// Sets the maximum idle origin connections retained per origin.
+    #[must_use]
+    pub const fn max_idle_connections_per_origin(mut self, max_connections: usize) -> Self {
+        self.policy.max_idle_connections_per_origin = max_connections;
+        self
+    }
+
+    /// Sets the bounded deadline for request-body reads, CONNECT setup,
+    /// origin connection establishment, and origin response headers.
+    ///
+    /// Successfully established streaming response bodies are not timed out.
+    #[must_use]
+    pub const fn request_setup_timeout(mut self, timeout: Duration) -> Self {
+        self.policy.request_setup_timeout = timeout;
+        self
+    }
+
+    /// Sets how long active connections may drain during proxy shutdown.
+    #[must_use]
+    pub const fn graceful_shutdown_timeout(mut self, timeout: Duration) -> Self {
+        self.policy.graceful_shutdown_timeout = timeout;
+        self
+    }
+
+    /// Allows explicit or DNS-resolved loopback origins.
+    ///
+    /// Loopback is denied by default to close credential-bearing SSRF and DNS
+    /// rebinding paths. Enable this only for a deliberate local development or
+    /// test origin. Cloud metadata addresses remain denied unconditionally.
+    #[must_use]
+    pub const fn allow_loopback_upstreams(mut self, allow: bool) -> Self {
+        self.policy.allow_loopback_upstreams = allow;
         self
     }
 
@@ -367,9 +907,9 @@ impl Drop for EgressProxy {
         if let Some(shutdown_tx) = self.shutdown_tx.take() {
             let _ = shutdown_tx.send(());
         }
-        if let Some(task) = self.task.take() {
-            task.abort();
-        }
+        // Detach so the server can deliver shutdown to accepted connections;
+        // its configured graceful timeout still bounds the remaining task.
+        let _ = self.task.take();
     }
 }
 
@@ -377,7 +917,9 @@ impl Drop for EgressProxy {
 struct ProxyHandler {
     client: ClientWithMiddleware,
     policy: ProxyPolicy,
+    layers: Vec<Arc<dyn EgressLayer>>,
     origin_permits: Arc<Semaphore>,
+    buffered_request_bytes: Arc<Semaphore>,
     authentication: ProxyAuthentication,
     request_ids: Arc<AtomicU64>,
 }
@@ -414,8 +956,8 @@ impl HttpHandler for ProxyHandler {
     ) -> RequestOrResponse {
         let request_id = self.request_ids.fetch_add(1, Ordering::Relaxed);
         let span = tracing::info_span!(
-            target: "mpp_egress",
-            "mpp.egress.request",
+            target: "nanocodex_egress",
+            "egress.proxy.request",
             request.id = request_id,
             mpp.request.id = tracing::field::Empty,
             client.address = %context.client_addr,
@@ -425,31 +967,50 @@ impl HttpHandler for ProxyHandler {
         );
         async move {
             tracing::info!(
-                target: "mpp_egress",
-                content_kind = "mpp.egress.request.headers",
-                content = ?request.headers(),
+                target: "nanocodex_egress",
+                content_kind = "egress.proxy.request.headers",
+                content = header_trace_content(request.headers()),
                 "trace content"
             );
             if !self.authentication.authorize(&request) {
                 tracing::warn!(
-                    target: "mpp_egress",
-                    stage = "mpp.egress.proxy_authentication.rejected",
+                    target: "nanocodex_egress",
+                    stage = "egress.proxy.authentication.rejected",
                     http.response.status_code = StatusCode::PROXY_AUTHENTICATION_REQUIRED.as_u16(),
-                    "MPP egress rejected an unauthenticated client"
+                    "egress proxy rejected an unauthenticated client"
                 );
                 return proxy_authentication_required().into();
             }
             tracing::info!(
-                target: "mpp_egress",
-                stage = "mpp.egress.proxy_authentication.accepted",
-                "MPP egress authenticated its child client"
+                target: "nanocodex_egress",
+                stage = "egress.proxy.authentication.accepted",
+                "egress proxy authenticated its child client"
             );
             request.headers_mut().remove(PROXY_AUTHORIZATION);
-            if request.method() == Method::CONNECT || is_upgrade(&request) {
+            if is_upgrade(&request) {
+                tracing::warn!(
+                    target: "nanocodex_egress",
+                    stage = "egress.proxy.protocol_upgrade.rejected",
+                    http.response.status_code = StatusCode::BAD_REQUEST.as_u16(),
+                    "egress proxy rejected an unsupported protocol upgrade"
+                );
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "protocol upgrades are not supported by the egress proxy",
+                )
+                .into();
+            }
+            if request.method() == Method::CONNECT {
+                let metadata = EgressRequest::from_request(&request);
+                for layer in &self.layers {
+                    if let Err(error) = layer.authorize_connect(&metadata).await {
+                        return layer_error_response(error).into();
+                    }
+                }
                 tracing::info!(
-                    target: "mpp_egress",
-                    stage = "mpp.egress.tunnel.forwarded",
-                    "MPP egress forwarded a protocol tunnel without payment handling"
+                    target: "nanocodex_egress",
+                    stage = "egress.proxy.tunnel.forwarded",
+                    "egress proxy forwarded a protocol tunnel"
                 );
                 return request.into();
             }
@@ -458,26 +1019,67 @@ impl HttpHandler for ProxyHandler {
                 Ok(response) => response.into(),
                 Err(ForwardError::RequestTooLarge) => {
                     tracing::warn!(
-                        target: "mpp_egress",
-                        stage = "mpp.egress.request.failed",
+                        target: "nanocodex_egress",
+                        stage = "egress.proxy.request.failed",
                         failure.kind = "request_too_large",
                         http.response.status_code = StatusCode::PAYLOAD_TOO_LARGE.as_u16(),
-                        "MPP egress rejected an unreplayable request body"
+                        "egress proxy rejected an unreplayable request body"
                     );
                     error_response(
                         StatusCode::PAYLOAD_TOO_LARGE,
-                        "request body exceeds the MPP egress replay limit",
+                        "request body exceeds the egress proxy replay limit",
                     )
                     .into()
                 }
-                Err(error) => {
+                Err(ForwardError::RequestBody(_)) => {
                     tracing::warn!(
-                        target: "mpp_egress",
-                        stage = "mpp.egress.request.failed",
+                        target: "nanocodex_egress",
+                        stage = "egress.proxy.request.failed",
+                        failure.kind = "request_body",
+                        http.response.status_code = StatusCode::BAD_REQUEST.as_u16(),
+                        "egress proxy could not read the child request body"
+                    );
+                    error_response(StatusCode::BAD_REQUEST, "failed to read request body").into()
+                }
+                Err(ForwardError::RequestBodyTimeout(timeout)) => {
+                    tracing::warn!(
+                        target: "nanocodex_egress",
+                        stage = "egress.proxy.request.failed",
+                        failure.kind = "request_body_timeout",
+                        http.response.status_code = StatusCode::REQUEST_TIMEOUT.as_u16(),
+                        ?timeout,
+                        "egress proxy timed out while reading the child request body"
+                    );
+                    error_response(StatusCode::REQUEST_TIMEOUT, "request body read timed out")
+                        .into()
+                }
+                Err(ForwardError::DeniedUpstream) => error_response(
+                    StatusCode::FORBIDDEN,
+                    "upstream address denied by egress network policy",
+                )
+                .into(),
+                Err(error) => {
+                    if let ForwardError::Layer(error) = &error
+                        && let Some(error) = middleware_layer_error(error)
+                    {
+                        return layer_error_response(*error).into();
+                    }
+                    if let ForwardError::Layer(error) = &error
+                        && middleware_origin_timeout(error).is_some()
+                    {
+                        return error_response(
+                            StatusCode::GATEWAY_TIMEOUT,
+                            "origin response headers timed out",
+                        )
+                        .into();
+                    }
+                    tracing::warn!(
+                        target: "nanocodex_egress",
+                        stage = "egress.proxy.request.failed",
                         failure.kind = "payment_or_forwarding",
                         http.response.status_code = StatusCode::BAD_GATEWAY.as_u16(),
                         error = %error,
-                        "MPP egress request failed"
+                        "egress proxy request failed"
                     );
                     error_response(StatusCode::BAD_GATEWAY, &error.to_string()).into()
                 }
@@ -490,34 +1092,70 @@ impl HttpHandler for ProxyHandler {
 
 impl ProxyHandler {
     async fn forward(&self, request: Request<Body>) -> Result<Response<Body>, ForwardError> {
-        let (mut parts, body) = request.into_parts();
-        let body = Limited::new(body, self.policy.max_request_bytes)
-            .collect()
-            .await
-            .map_err(|_| ForwardError::RequestTooLarge)?
-            .to_bytes();
-        record_body_content("mpp.egress.request.body", &body);
-        remove_hop_by_hop_request_headers(&mut parts.headers);
+        if request
+            .uri()
+            .host()
+            .and_then(|host| host.parse::<IpAddr>().ok())
+            .is_some_and(|address| {
+                denied_upstream_ip(address, self.policy.allow_loopback_upstreams)
+            })
+        {
+            return Err(ForwardError::DeniedUpstream);
+        }
         let queued = self.origin_permits.available_permits() == 0;
         if queued {
             tracing::info!(
-                target: "mpp_egress",
-                stage = "mpp.egress.origin.request.queued",
+                target: "nanocodex_egress",
+                stage = "egress.proxy.origin.request.queued",
                 origin.max_concurrent_requests = self.policy.max_concurrent_requests,
-                "MPP egress queued the request before contacting its origin"
+                "egress proxy queued the request before buffering its body"
             );
         }
-        let _origin_permit = self
-            .origin_permits
-            .acquire()
+        let origin_permit = Arc::clone(&self.origin_permits)
+            .acquire_owned()
             .await
             .map_err(|_| ForwardError::Unavailable)?;
+        let (mut parts, body) = request.into_parts();
+        let reservation = match body.size_hint().upper() {
+            Some(upper) if upper > self.policy.max_request_bytes as u64 => {
+                return Err(ForwardError::RequestTooLarge);
+            }
+            Some(upper) => usize::try_from(upper).map_err(|_| ForwardError::RequestTooLarge)?,
+            None => self.policy.max_request_bytes,
+        };
+        let reservation = u32::try_from(reservation).map_err(|_| ForwardError::RequestTooLarge)?;
+        let _buffered_body_permit = if reservation == 0 {
+            None
+        } else {
+            Some(
+                self.buffered_request_bytes
+                    .acquire_many(reservation)
+                    .await
+                    .map_err(|_| ForwardError::Unavailable)?,
+            )
+        };
+        let body = tokio::time::timeout(
+            self.policy.request_setup_timeout,
+            Limited::new(body, self.policy.max_request_bytes).collect(),
+        )
+        .await
+        .map_err(|_| ForwardError::RequestBodyTimeout(self.policy.request_setup_timeout))?
+        .map_err(|error| {
+            if error.downcast_ref::<LengthLimitError>().is_some() {
+                ForwardError::RequestTooLarge
+            } else {
+                ForwardError::RequestBody(error)
+            }
+        })?
+        .to_bytes();
+        record_body_content("egress.proxy.request.body", &body);
+        remove_hop_by_hop_request_headers(&mut parts.headers);
         tracing::info!(
-            target: "mpp_egress",
-            stage = "mpp.egress.origin.request.started",
+            target: "nanocodex_egress",
+            stage = "egress.proxy.origin.request.started",
             http.request.body.size = body.len(),
             request.queued = queued,
-            "MPP egress sent the original request"
+            "egress proxy sent the original request"
         );
 
         let builder = self
@@ -529,29 +1167,33 @@ impl ProxyHandler {
 
         let status = response.status();
         tracing::info!(
-            target: "mpp_egress",
-            stage = "mpp.egress.request.completed",
+            target: "nanocodex_egress",
+            stage = "egress.proxy.request.completed",
             http.response.status_code = status.as_u16(),
-            "MPP egress completed the request"
+            "egress proxy completed the request"
         );
-        Ok(convert_response(response, &tracing::Span::current()))
+        Ok(convert_response(
+            response,
+            &tracing::Span::current(),
+            origin_permit,
+        ))
     }
 }
 
 fn record_body_content(kind: &'static str, body: &[u8]) {
-    if !tracing::enabled!(target: "mpp_egress", tracing::Level::INFO) {
+    if !tracing::enabled!(target: "nanocodex_egress", tracing::Level::INFO) {
         return;
     }
     if let Ok(content) = std::str::from_utf8(body) {
         tracing::info!(
-            target: "mpp_egress",
+            target: "nanocodex_egress",
             content_kind = kind,
             content,
             "trace content"
         );
     } else {
         tracing::info!(
-            target: "mpp_egress",
+            target: "nanocodex_egress",
             content_kind = kind,
             content = ?body,
             "trace content"
@@ -559,18 +1201,40 @@ fn record_body_content(kind: &'static str, body: &[u8]) {
     }
 }
 
-fn convert_response(mut response: reqwest::Response, span: &tracing::Span) -> Response<Body> {
+fn header_trace_content(headers: &hudsucker::hyper::HeaderMap) -> String {
+    let entries = headers
+        .iter()
+        .map(|(name, value)| {
+            let (encoding, value) = match std::str::from_utf8(value.as_bytes()) {
+                Ok(value) => ("utf8", value.to_owned()),
+                Err(_) => ("base64", STANDARD.encode(value.as_bytes())),
+            };
+            serde_json::json!({
+                "name": name.as_str(),
+                "encoding": encoding,
+                "value": value,
+            })
+        })
+        .collect();
+    serde_json::Value::Array(entries).to_string()
+}
+
+fn convert_response(
+    mut response: reqwest::Response,
+    span: &tracing::Span,
+    origin_permit: OwnedSemaphorePermit,
+) -> Response<Body> {
     let status = response.status();
     let version = response.version();
     let mut headers = std::mem::take(response.headers_mut());
     remove_hop_by_hop_response_headers(&mut headers);
-    let trace_content = tracing::enabled!(target: "mpp_egress", tracing::Level::INFO);
+    let trace_content = tracing::enabled!(target: "nanocodex_egress", tracing::Level::INFO);
     if trace_content {
         span.in_scope(|| {
             tracing::info!(
-                target: "mpp_egress",
-                content_kind = "mpp.egress.response.headers",
-                content = ?headers,
+                target: "nanocodex_egress",
+                content_kind = "egress.proxy.response.headers",
+                content = header_trace_content(&headers),
                 "trace content"
             );
         });
@@ -578,15 +1242,17 @@ fn convert_response(mut response: reqwest::Response, span: &tracing::Span) -> Re
     let stream = response.bytes_stream();
     let body = if trace_content {
         let content_span = span.clone();
+        let error_span = span.clone();
         let mut chunk_index = 0_u64;
         Body::from_stream(
             stream
                 .map_ok(move |chunk| {
+                    let _origin_permit = &origin_permit;
                     content_span.in_scope(|| {
                         if let Ok(content) = std::str::from_utf8(&chunk) {
                             tracing::info!(
-                                target: "mpp_egress",
-                                content_kind = "mpp.egress.response.body",
+                                target: "nanocodex_egress",
+                                content_kind = "egress.proxy.response.body",
                                 response.chunk.index = chunk_index,
                                 response.chunk.size = chunk.len(),
                                 content,
@@ -594,8 +1260,8 @@ fn convert_response(mut response: reqwest::Response, span: &tracing::Span) -> Re
                             );
                         } else {
                             tracing::info!(
-                                target: "mpp_egress",
-                                content_kind = "mpp.egress.response.body",
+                                target: "nanocodex_egress",
+                                content_kind = "egress.proxy.response.body",
                                 response.chunk.index = chunk_index,
                                 response.chunk.size = chunk.len(),
                                 content = ?chunk.as_ref(),
@@ -606,16 +1272,36 @@ fn convert_response(mut response: reqwest::Response, span: &tracing::Span) -> Re
                     chunk_index = chunk_index.saturating_add(1);
                     chunk
                 })
-                .map_err(|_| hudsucker::Error::Unknown),
+                .map_err(move |error| response_stream_error(&error_span, error)),
         )
     } else {
-        Body::from_stream(stream.map_err(|_| hudsucker::Error::Unknown))
+        let error_span = span.clone();
+        Body::from_stream(
+            stream
+                .map_ok(move |chunk| {
+                    let _origin_permit = &origin_permit;
+                    chunk
+                })
+                .map_err(move |error| response_stream_error(&error_span, error)),
+        )
     };
     let mut response = Response::new(body);
     *response.status_mut() = status;
     *response.version_mut() = version;
     *response.headers_mut() = headers;
     response
+}
+
+fn response_stream_error(span: &tracing::Span, error: reqwest::Error) -> hudsucker::Error {
+    span.in_scope(|| {
+        tracing::warn!(
+            target: "nanocodex_egress",
+            stage = "egress.proxy.response.body.failed",
+            error = ?error,
+            "egress proxy failed while streaming the origin response body"
+        );
+    });
+    hudsucker::Error::Unknown
 }
 
 fn is_upgrade(request: &Request<Body>) -> bool {
@@ -635,20 +1321,34 @@ fn remove_hop_by_hop_request_headers(headers: &mut hudsucker::hyper::HeaderMap) 
     remove_connection_named_headers(headers);
     for name in [
         CONNECTION,
+        CONTENT_LENGTH,
         HOST,
         PROXY_AUTHORIZATION,
+        TE,
+        TRAILER,
         TRANSFER_ENCODING,
         UPGRADE,
     ] {
         headers.remove(name);
     }
+    headers.remove("keep-alive");
+    headers.remove("proxy-connection");
 }
 
 fn remove_hop_by_hop_response_headers(headers: &mut hudsucker::hyper::HeaderMap) {
     remove_connection_named_headers(headers);
-    for name in [CONNECTION, TRANSFER_ENCODING, UPGRADE] {
+    for name in [
+        CONNECTION,
+        PROXY_AUTHENTICATE,
+        TE,
+        TRAILER,
+        TRANSFER_ENCODING,
+        UPGRADE,
+    ] {
         headers.remove(name);
     }
+    headers.remove("keep-alive");
+    headers.remove("proxy-connection");
 }
 
 fn remove_connection_named_headers(headers: &mut hudsucker::hyper::HeaderMap) {
@@ -668,6 +1368,88 @@ fn remove_connection_named_headers(headers: &mut hudsucker::hyper::HeaderMap) {
     }
 }
 
+fn middleware_layer_error(error: &reqwest_middleware::Error) -> Option<&EgressLayerError> {
+    match error {
+        reqwest_middleware::Error::Middleware(error) => error.downcast_ref(),
+        reqwest_middleware::Error::Reqwest(_) => None,
+    }
+}
+
+fn middleware_origin_timeout(
+    error: &reqwest_middleware::Error,
+) -> Option<&OriginResponseHeadersTimedOut> {
+    match error {
+        reqwest_middleware::Error::Middleware(error) => error.downcast_ref(),
+        reqwest_middleware::Error::Reqwest(_) => None,
+    }
+}
+
+fn collect_layer_environment(
+    layers: &[Arc<dyn EgressLayer>],
+) -> Result<BTreeMap<OsString, OsString>, EgressError> {
+    let mut environment = BTreeMap::<OsString, OsString>::new();
+    for layer in layers {
+        for (name, value) in layer.environment() {
+            if !valid_environment_name(&name) {
+                return Err(EgressError::InvalidEnvironmentName(name));
+            }
+            if value.as_encoded_bytes().contains(&0) {
+                return Err(EgressError::InvalidEnvironmentValue(name));
+            }
+            if is_proxy_environment_name(&name) {
+                return Err(EgressError::EnvironmentConflict(name));
+            }
+            if let Some((existing_name, existing_value)) = environment
+                .iter()
+                .find(|(candidate, _)| environment_names_equal(candidate, &name))
+            {
+                if existing_name != &name || existing_value != &value {
+                    return Err(EgressError::EnvironmentConflict(name));
+                }
+                continue;
+            }
+            environment.insert(name, value);
+        }
+    }
+    Ok(environment)
+}
+
+fn valid_environment_name(name: &OsStr) -> bool {
+    let bytes = name.as_encoded_bytes();
+    !bytes.is_empty() && !bytes.contains(&0) && !bytes.contains(&b'=')
+}
+
+fn is_proxy_environment_name(name: &OsStr) -> bool {
+    name.to_str().is_some_and(|name| {
+        PROXY_ENVIRONMENT_NAMES
+            .iter()
+            .any(|owned| name.eq_ignore_ascii_case(owned))
+    })
+}
+
+fn environment_names_equal(left: &OsStr, right: &OsStr) -> bool {
+    match (left.to_str(), right.to_str()) {
+        (Some(left), Some(right)) => left.eq_ignore_ascii_case(right),
+        _ => left == right,
+    }
+}
+
+fn layer_error_response(error: EgressLayerError) -> Response<Body> {
+    let status = match error {
+        EgressLayerError::Denied => StatusCode::FORBIDDEN,
+        EgressLayerError::InvalidRequest => StatusCode::BAD_REQUEST,
+        EgressLayerError::Unavailable => StatusCode::BAD_GATEWAY,
+    };
+    tracing::warn!(
+        target: "nanocodex_egress",
+        stage = "egress.proxy.layer.rejected",
+        failure.kind = %error,
+        http.response.status_code = status.as_u16(),
+        "egress layer rejected the request"
+    );
+    error_response(status, &error.to_string())
+}
+
 fn error_response(status: StatusCode, message: &str) -> Response<Body> {
     let mut response = Response::new(Body::from(message.to_owned()));
     *response.status_mut() = status;
@@ -681,7 +1463,7 @@ fn proxy_authentication_required() -> Response<Body> {
     );
     response.headers_mut().insert(
         PROXY_AUTHENTICATE,
-        hudsucker::hyper::header::HeaderValue::from_static("Basic realm=\"nanocodex-mpp-egress\""),
+        hudsucker::hyper::header::HeaderValue::from_static("Basic realm=\"nanocodex-egress\""),
     );
     response
 }
@@ -703,6 +1485,8 @@ fn random_identifier() -> String {
 struct EphemeralAuthority {
     issuer: Issuer<'static, KeyPair>,
     private_key: PrivateKeyDer<'static>,
+    provider: Arc<CryptoProvider>,
+    fallback_server_config: Arc<ServerConfig>,
     cache: Mutex<std::collections::HashMap<Authority, Arc<ServerConfig>>>,
 }
 
@@ -714,37 +1498,23 @@ impl CertificateAuthority for EphemeralAuthority {
             return Arc::clone(config);
         }
 
-        let mut params = CertificateParams::default();
-        params.serial_number = Some(rand::random::<u64>().into());
-        let mut distinguished_name = DistinguishedName::new();
-        distinguished_name.push(DnType::CommonName, authority.host());
-        params.distinguished_name = distinguished_name;
-        params
-            .subject_alt_names
-            .push(authority.host().parse::<IpAddr>().map_or_else(
-                |_| {
-                    SanType::DnsName(
-                        Ia5String::try_from(authority.host())
-                            .expect("HTTP authority host must be a valid DNS IA5 string"),
-                    )
-                },
-                SanType::IpAddress,
-            ));
-        params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
-        params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
-        params.use_authority_key_identifier_extension = true;
-        let certificate = params
-            .signed_by(self.issuer.key(), &self.issuer)
-            .expect("valid CA parameters must sign an ephemeral leaf certificate");
-        let mut config = ServerConfig::builder()
-            .with_no_client_auth()
-            .with_single_cert(
-                vec![CertificateDer::from(certificate)],
-                self.private_key.clone_key(),
-            )
-            .expect("generated leaf certificate and private key must match");
-        config.alpn_protocols = vec![b"http/1.1".to_vec()];
-        let config = Arc::new(config);
+        let config = match leaf_server_config(
+            &self.issuer,
+            &self.private_key,
+            Arc::clone(&self.provider),
+            authority.host(),
+        ) {
+            Ok(config) => Arc::new(config),
+            Err(error) => {
+                tracing::warn!(
+                    target: "nanocodex_egress",
+                    authority = %authority,
+                    error = ?error,
+                    "egress proxy could not issue a destination certificate"
+                );
+                Arc::clone(&self.fallback_server_config)
+            }
+        };
 
         if let Ok(mut cache) = self.cache.lock()
             && cache.len() < 1_024
@@ -753,6 +1523,49 @@ impl CertificateAuthority for EphemeralAuthority {
         }
         config
     }
+}
+
+fn leaf_server_config(
+    issuer: &Issuer<'static, KeyPair>,
+    private_key: &PrivateKeyDer<'static>,
+    provider: Arc<CryptoProvider>,
+    host: &str,
+) -> Result<ServerConfig, LeafCertificateError> {
+    let mut params = CertificateParams::default();
+    params.serial_number = Some(rand::random::<u64>().into());
+    let mut distinguished_name = DistinguishedName::new();
+    distinguished_name.push(DnType::CommonName, host);
+    params.distinguished_name = distinguished_name;
+    let subject_name = match host.parse::<IpAddr>() {
+        Ok(address) => SanType::IpAddress(address),
+        Err(_) => SanType::DnsName(
+            Ia5String::try_from(host).map_err(|_| LeafCertificateError::InvalidDnsName)?,
+        ),
+    };
+    params.subject_alt_names.push(subject_name);
+    params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+    params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+    params.use_authority_key_identifier_extension = true;
+    let certificate = params.signed_by(issuer.key(), issuer)?;
+    let mut config = ServerConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()?
+        .with_no_client_auth()
+        .with_single_cert(
+            vec![CertificateDer::from(certificate)],
+            private_key.clone_key(),
+        )?;
+    config.alpn_protocols = vec![b"http/1.1".to_vec()];
+    Ok(config)
+}
+
+#[derive(Debug, thiserror::Error)]
+enum LeafCertificateError {
+    #[error("destination host is not a valid IA5 DNS name")]
+    InvalidDnsName,
+    #[error("failed to sign a destination certificate")]
+    Certificate(#[from] hudsucker::rcgen::Error),
+    #[error("failed to configure destination TLS")]
+    Tls(#[from] hudsucker::rustls::Error),
 }
 
 fn ephemeral_authority() -> Result<(EphemeralAuthority, String), EgressError> {
@@ -774,10 +1587,20 @@ fn ephemeral_authority() -> Result<(EphemeralAuthority, String), EgressError> {
     let private_key = PrivateKeyDer::from(PrivatePkcs8KeyDer::from(key_pair.serialize_der()));
     let issuer =
         Issuer::from_ca_cert_pem(&certificate_pem, key_pair).map_err(EgressError::Certificate)?;
+    let provider = Arc::new(ring::default_provider());
+    let fallback_server_config = leaf_server_config(
+        &issuer,
+        &private_key,
+        Arc::clone(&provider),
+        "invalid.invalid",
+    )
+    .map_err(|error| EgressError::LeafCertificate(Box::new(error)))?;
     Ok((
         EphemeralAuthority {
             issuer,
             private_key,
+            provider,
+            fallback_server_config: Arc::new(fallback_server_config),
             cache: Mutex::new(std::collections::HashMap::new()),
         },
         certificate_pem,
@@ -790,12 +1613,66 @@ pub enum EgressError {
     /// The replayable request-body limit was zero.
     #[error("egress max request bytes must be greater than zero")]
     ZeroMaxRequestBytes,
+    /// The per-request body limit cannot be represented by the body budget.
+    #[error("egress max request bytes {configured} exceeds the supported limit {limit}")]
+    MaxRequestBytesTooLarge {
+        /// Requested per-request limit.
+        configured: usize,
+        /// Maximum supported limit.
+        limit: usize,
+    },
+    /// The aggregate body budget could not fit one maximum-sized request.
+    #[error(
+        "egress buffered request budget {configured} must be at least the per-request limit {minimum}"
+    )]
+    BufferedRequestBudgetTooSmall {
+        /// Requested aggregate budget.
+        configured: usize,
+        /// Minimum valid aggregate budget.
+        minimum: usize,
+    },
+    /// The aggregate body budget exceeded the runtime semaphore capacity.
+    #[error("egress buffered request budget {configured} exceeds the supported limit {limit}")]
+    BufferedRequestBudgetTooLarge {
+        /// Requested aggregate budget.
+        configured: usize,
+        /// Maximum supported aggregate budget.
+        limit: usize,
+    },
     /// The forwarded-request concurrency limit was zero.
     #[error("egress max concurrent requests must be greater than zero")]
     ZeroMaxConcurrentRequests,
+    /// The forwarded-request limit exceeded the runtime semaphore capacity.
+    #[error("egress max concurrent requests {configured} exceeds the supported limit {limit}")]
+    MaxConcurrentRequestsTooLarge {
+        /// Requested forwarded-request limit.
+        configured: usize,
+        /// Maximum supported limit.
+        limit: usize,
+    },
     /// The accepted-connection concurrency limit was zero.
     #[error("egress max concurrent connections must be greater than zero")]
     ZeroMaxConcurrentConnections,
+    /// The connection limit exceeded the runtime semaphore capacity.
+    #[error("egress max concurrent connections {configured} exceeds the supported limit {limit}")]
+    MaxConcurrentConnectionsTooLarge {
+        /// Requested accepted-connection limit.
+        configured: usize,
+        /// Maximum supported limit.
+        limit: usize,
+    },
+    /// The bounded setup timeout was zero.
+    #[error("egress request setup timeout must be greater than zero")]
+    ZeroRequestSetupTimeout,
+    /// Two layers exported different values under the same child variable.
+    #[error("egress layers conflict on child environment variable {0:?}")]
+    EnvironmentConflict(OsString),
+    /// A layer exported an invalid child environment name.
+    #[error("egress layer exported an invalid child environment variable name {0:?}")]
+    InvalidEnvironmentName(OsString),
+    /// A layer exported a child environment value containing a NUL byte.
+    #[error("egress layer exported a NUL-containing value for child environment variable {0:?}")]
+    InvalidEnvironmentValue(OsString),
     /// The loopback listener could not be bound.
     #[error("failed to bind the egress proxy listener")]
     Bind(#[source] std::io::Error),
@@ -811,6 +1688,9 @@ pub enum EgressError {
     /// Ephemeral CA or leaf-certificate generation failed.
     #[error("failed to generate the ephemeral egress CA")]
     Certificate(#[source] hudsucker::rcgen::Error),
+    /// The fallback destination certificate or TLS configuration failed.
+    #[error("failed to configure ephemeral egress destination TLS")]
+    LeafCertificate(#[source] Box<dyn std::error::Error + Send + Sync>),
     /// The origin-facing HTTP client could not be built.
     #[error("failed to build the egress HTTP client")]
     Client(#[source] reqwest::Error),
@@ -826,6 +1706,12 @@ pub enum EgressError {
 enum ForwardError {
     #[error("request body is too large to replay")]
     RequestTooLarge,
+    #[error("failed to read the child request body")]
+    RequestBody(#[source] Box<dyn std::error::Error + Send + Sync>),
+    #[error("timed out after {0:?} while reading the child request body")]
+    RequestBodyTimeout(Duration),
+    #[error("upstream address denied by egress network policy")]
+    DeniedUpstream,
     #[error("egress proxy stopped while the request was queued")]
     Unavailable,
     #[error("egress layer or origin request failed: {0}")]
@@ -834,17 +1720,21 @@ enum ForwardError {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
+    use std::{
+        convert::Infallible,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
     };
 
     use super::*;
     use axum::{
         Router,
+        body::{Body as AxumBody, Bytes as AxumBytes},
         extract::Request,
         http::StatusCode as AxumStatus,
-        routing::{get, post},
+        routing::{any, get, post},
     };
     use futures_util::future::join_all;
 
@@ -876,6 +1766,80 @@ mod tests {
             tunnel_authenticated: false,
         };
         assert!(!fresh_connection.authorize(&unauthenticated_request()));
+    }
+
+    #[test]
+    fn invalid_destination_names_fail_without_panicking() {
+        let (authority, _) = ephemeral_authority().unwrap();
+        let result = leaf_server_config(
+            &authority.issuer,
+            &authority.private_key,
+            Arc::clone(&authority.provider),
+            "invalid-\u{80}-name",
+        );
+
+        assert!(matches!(result, Err(LeafCertificateError::InvalidDnsName)));
+    }
+
+    #[test]
+    fn header_trace_content_is_lossless_json() {
+        let mut headers = hudsucker::hyper::HeaderMap::new();
+        headers.append("x-text", "first".parse().unwrap());
+        headers.append("x-text", "second".parse().unwrap());
+        headers.insert(
+            "x-bytes",
+            hudsucker::hyper::header::HeaderValue::from_bytes(&[0xff, 0x80]).unwrap(),
+        );
+
+        let content: serde_json::Value =
+            serde_json::from_str(&header_trace_content(&headers)).unwrap();
+        assert_eq!(
+            content,
+            serde_json::json!([
+                {"name": "x-text", "encoding": "utf8", "value": "first"},
+                {"name": "x-text", "encoding": "utf8", "value": "second"},
+                {"name": "x-bytes", "encoding": "base64", "value": "/4A="},
+            ])
+        );
+    }
+
+    #[test]
+    fn strips_fixed_and_connection_named_hop_headers() {
+        let mut request = hudsucker::hyper::HeaderMap::new();
+        request.insert(CONNECTION, "x-private-hop".parse().unwrap());
+        for name in [
+            "content-length",
+            "host",
+            "keep-alive",
+            "proxy-authorization",
+            "proxy-connection",
+            "te",
+            "trailer",
+            "transfer-encoding",
+            "upgrade",
+            "x-private-hop",
+        ] {
+            request.insert(name, "value".parse().unwrap());
+        }
+        remove_hop_by_hop_request_headers(&mut request);
+        assert!(request.is_empty());
+
+        let mut response = hudsucker::hyper::HeaderMap::new();
+        response.insert(CONNECTION, "x-private-hop".parse().unwrap());
+        for name in [
+            "keep-alive",
+            "proxy-authenticate",
+            "proxy-connection",
+            "te",
+            "trailer",
+            "transfer-encoding",
+            "upgrade",
+            "x-private-hop",
+        ] {
+            response.insert(name, "value".parse().unwrap());
+        }
+        remove_hop_by_hop_response_headers(&mut response);
+        assert!(response.is_empty());
     }
 
     struct HeaderLayer(&'static str);
@@ -921,6 +1885,33 @@ mod tests {
         }
     }
 
+    struct EnvironmentLayer(&'static str, &'static str);
+
+    #[async_trait]
+    impl EgressLayer for EnvironmentLayer {
+        async fn handle(
+            &self,
+            request: reqwest::Request,
+            extensions: &mut ::http::Extensions,
+            next: Next<'_>,
+        ) -> reqwest_middleware::Result<reqwest::Response> {
+            next.run(request, extensions).await
+        }
+
+        fn environment(&self) -> EgressEnvironment {
+            EgressEnvironment::new([(self.0.into(), self.1.into())])
+        }
+    }
+
+    struct FixedSecret(&'static str);
+
+    #[async_trait]
+    impl SecretResolver for FixedSecret {
+        async fn resolve(&self, _reference: &SecretRef) -> Result<String, SecretResolverError> {
+            Ok(self.0.to_owned())
+        }
+    }
+
     #[tokio::test]
     async fn builder_reports_each_zero_transport_limit_without_binding() {
         assert!(matches!(
@@ -941,6 +1932,55 @@ mod tests {
                 .await,
             Err(EgressError::ZeroMaxConcurrentConnections)
         ));
+        assert!(matches!(
+            EgressProxy::builder()
+                .max_request_bytes(8)
+                .max_buffered_request_bytes(7)
+                .spawn()
+                .await,
+            Err(EgressError::BufferedRequestBudgetTooSmall {
+                configured: 7,
+                minimum: 8
+            })
+        ));
+        assert!(matches!(
+            EgressProxy::builder()
+                .request_setup_timeout(Duration::ZERO)
+                .spawn()
+                .await,
+            Err(EgressError::ZeroRequestSetupTimeout)
+        ));
+    }
+
+    #[tokio::test]
+    async fn layers_cannot_override_transport_environment() {
+        let result = EgressProxy::builder()
+            .layer(EnvironmentLayer("Https_Proxy", "http://attacker.invalid"))
+            .spawn()
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(EgressError::EnvironmentConflict(name)) if name == "Https_Proxy"
+        ));
+
+        let result = EgressProxy::builder()
+            .layer(EnvironmentLayer("INVALID=NAME", "value"))
+            .spawn()
+            .await;
+        assert!(matches!(
+            result,
+            Err(EgressError::InvalidEnvironmentName(_))
+        ));
+
+        let result = EgressProxy::builder()
+            .layer(EnvironmentLayer("SERVICE_VALUE", "value\0suffix"))
+            .spawn()
+            .await;
+        assert!(matches!(
+            result,
+            Err(EgressError::InvalidEnvironmentValue(_))
+        ));
     }
 
     async fn spawn_origin(app: Router) -> String {
@@ -950,6 +1990,10 @@ mod tests {
             axum::serve(listener, app).await.unwrap();
         });
         format!("http://{address}")
+    }
+
+    fn local_proxy_builder() -> EgressProxyBuilder {
+        EgressProxy::builder().allow_loopback_upstreams(true)
     }
 
     fn proxied_client(egress: &EgressProxy) -> reqwest::Client {
@@ -962,7 +2006,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_clients_without_the_ephemeral_proxy_credential() {
-        let egress = EgressProxy::builder().spawn().await.unwrap();
+        let egress = local_proxy_builder().spawn().await.unwrap();
         let mut proxy: reqwest::Url = egress.proxy_url().parse().unwrap();
         proxy.set_username("").unwrap();
         proxy.set_password(None).unwrap();
@@ -978,9 +2022,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn denies_loopback_and_cloud_metadata_upstreams_by_default() {
+        let origin = spawn_origin(Router::new().route("/", get(|| async { "unexpected" }))).await;
+        let egress = EgressProxy::builder().spawn().await.unwrap();
+        let client = proxied_client(&egress);
+
+        let loopback = client.get(origin).send().await.unwrap();
+        let metadata = client
+            .get("http://169.254.169.254/latest/meta-data/")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(loopback.status(), AxumStatus::FORBIDDEN);
+        assert_eq!(metadata.status(), AxumStatus::FORBIDDEN);
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn passes_ordinary_http_responses_through() {
         let origin = spawn_origin(Router::new().route("/plain", get(|| async { "plain" }))).await;
-        let egress = EgressProxy::builder().spawn().await.unwrap();
+        let egress = local_proxy_builder().spawn().await.unwrap();
 
         let response = proxied_client(&egress)
             .get(format!("{origin}/plain"))
@@ -990,6 +2052,36 @@ mod tests {
 
         assert_eq!(response.status(), AxumStatus::OK);
         assert_eq!(response.text().await.unwrap(), "plain");
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn rejects_protocol_upgrades_before_layers_or_origins() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let route_calls = Arc::clone(&calls);
+        let origin = spawn_origin(Router::new().route(
+            "/upgrade",
+            get(move || {
+                let calls = Arc::clone(&route_calls);
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    "unexpected"
+                }
+            }),
+        ))
+        .await;
+        let egress = local_proxy_builder().spawn().await.unwrap();
+
+        let response = proxied_client(&egress)
+            .get(format!("{origin}/upgrade"))
+            .header(CONNECTION, "upgrade")
+            .header(UPGRADE, "websocket")
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), AxumStatus::BAD_REQUEST);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
         egress.shutdown().await.unwrap();
     }
 
@@ -1007,7 +2099,7 @@ mod tests {
             }),
         ))
         .await;
-        let egress = EgressProxy::builder()
+        let egress = local_proxy_builder()
             .layer(HeaderLayer("first"))
             .layer(HeaderLayer("second"))
             .spawn()
@@ -1042,7 +2134,7 @@ mod tests {
             }),
         ))
         .await;
-        let egress = EgressProxy::builder()
+        let egress = local_proxy_builder()
             .layer(DenyLayer)
             .spawn()
             .await
@@ -1090,7 +2182,7 @@ mod tests {
             }),
         );
         let origin = spawn_origin(app).await;
-        let egress = EgressProxy::builder()
+        let egress = local_proxy_builder()
             .max_concurrent_requests(3)
             .spawn()
             .await
@@ -1121,6 +2213,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn request_permits_cover_streaming_response_bodies() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let route_calls = Arc::clone(&calls);
+        let origin = spawn_origin(Router::new().route(
+            "/stream",
+            get(move || {
+                let route_calls = Arc::clone(&route_calls);
+                async move {
+                    route_calls.fetch_add(1, Ordering::SeqCst);
+                    AxumBody::from_stream(futures_util::stream::pending::<
+                        Result<AxumBytes, Infallible>,
+                    >())
+                }
+            }),
+        ))
+        .await;
+        let egress = local_proxy_builder()
+            .max_concurrent_requests(1)
+            .spawn()
+            .await
+            .unwrap();
+        let client = proxied_client(&egress);
+
+        let first = client.get(format!("{origin}/stream")).send().await.unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        let second_client = client.clone();
+        let second_origin = origin.clone();
+        let second = tokio::spawn(async move {
+            second_client
+                .get(format!("{second_origin}/stream"))
+                .send()
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(!second.is_finished());
+
+        drop(first);
+        let second = tokio::time::timeout(Duration::from_secs(1), second)
+            .await
+            .expect("dropping a streamed response must release its request permit")
+            .unwrap()
+            .unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+
+        drop(second);
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn rejects_request_bodies_above_the_replay_limit() {
         let calls = Arc::new(AtomicUsize::new(0));
         let calls_for_route = Arc::clone(&calls);
@@ -1135,7 +2277,7 @@ mod tests {
             }),
         ))
         .await;
-        let egress = EgressProxy::builder()
+        let egress = local_proxy_builder()
             .max_request_bytes(4)
             .spawn()
             .await
@@ -1154,7 +2296,125 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn child_environment_matches_the_existing_mpp_proxy_contract() {
+    async fn bundled_secret_layer_replaces_only_at_the_authorized_origin() {
+        let origin = spawn_origin(Router::new().route(
+            "/allowed",
+            get(|request: Request| async move {
+                request
+                    .headers()
+                    .get("authorization")
+                    .and_then(|value| value.to_str().ok())
+                    .unwrap_or_default()
+                    .to_owned()
+            }),
+        ))
+        .await;
+        let placeholder = "nanocodex-secret-only-proof";
+        let rule = SecretRule::builder("test", SecretRef::new("test", "token"), &origin)
+            .method(Method::GET)
+            .path_prefix("/allowed")
+            .replace_header("authorization", placeholder)
+            .child_environment("TEST_BASE_URL", "TEST_API_KEY")
+            .build()
+            .unwrap();
+        let egress = local_proxy_builder()
+            .layer(
+                SecretEgress::builder(FixedSecret("host-only"))
+                    .rule(rule)
+                    .build()
+                    .unwrap(),
+            )
+            .spawn()
+            .await
+            .unwrap();
+
+        let response = proxied_client(&egress)
+            .get(format!("{origin}/allowed"))
+            .bearer_auth(placeholder)
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.text().await.unwrap(), "Bearer host-only");
+        let environment = egress.environment();
+        assert!(environment.iter().all(|(_, value)| value != "host-only"));
+        assert!(environment.iter().any(|(name, value)| {
+            name == "TEST_API_KEY" && value == "nanocodex-secret-only-proof"
+        }));
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn claimed_secret_origins_fail_closed_on_rule_mismatch() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let handler = {
+            let calls = Arc::clone(&calls);
+            move || {
+                let calls = Arc::clone(&calls);
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    "unexpected"
+                }
+            }
+        };
+        let origin = spawn_origin(
+            Router::new()
+                .route("/allowed", any(handler.clone()))
+                .route("/admin", any(handler)),
+        )
+        .await;
+        let placeholder = "nanocodex-secret-fail-closed";
+        let rule = SecretRule::builder("test", SecretRef::new("test", "token"), &origin)
+            .method(Method::GET)
+            .path_prefix("/allowed")
+            .replace_header("authorization", placeholder)
+            .child_environment("TEST_BASE_URL", "TEST_API_KEY")
+            .build()
+            .unwrap();
+        let egress = local_proxy_builder()
+            .layer(
+                SecretEgress::builder(FixedSecret("host-only"))
+                    .rule(rule)
+                    .unmatched(UnmatchedEgress::Allow)
+                    .build()
+                    .unwrap(),
+            )
+            .spawn()
+            .await
+            .unwrap();
+        let client = proxied_client(&egress);
+
+        let responses = [
+            client
+                .post(format!("{origin}/allowed"))
+                .bearer_auth(placeholder)
+                .send()
+                .await
+                .unwrap(),
+            client
+                .get(format!("{origin}/admin"))
+                .bearer_auth(placeholder)
+                .send()
+                .await
+                .unwrap(),
+            client
+                .get(format!("{origin}/allowed"))
+                .send()
+                .await
+                .unwrap(),
+        ];
+
+        assert!(
+            responses
+                .iter()
+                .all(|response| response.status() == AxumStatus::FORBIDDEN)
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn child_environment_contains_one_generic_proxy_capability() {
         let egress = EgressProxy::builder().spawn().await.unwrap();
         let environment = egress.environment();
         let value = |name: &str| {
@@ -1172,14 +2432,34 @@ mod tests {
             egress.ca_certificate_path()
         );
         assert!(egress.ca_certificate_path().is_file());
+        assert_eq!(value("ALL_PROXY"), OsString::from(egress.proxy_url()));
         assert_eq!(
-            value("NANOCODEX_MPP_EGRESS_PASSWORD"),
-            OsString::from(&egress.proxy_password)
+            PathBuf::from(value("GIT_SSL_CAINFO")),
+            egress.ca_certificate_path()
+        );
+        egress.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn route_projects_the_same_capability_into_an_isolated_runtime() {
+        let egress = EgressProxy::builder().spawn().await.unwrap();
+        let route = egress.route();
+        let environment = route.environment("/run/nanocodex/egress-ca.pem");
+
+        assert_eq!(
+            environment.get("HTTPS_PROXY"),
+            Some(OsStr::new(route.proxy_url()))
         );
         assert_eq!(
-            value("NANOCODEX_MPP_EGRESS_AUTHORIZATION"),
-            OsString::from(&egress.proxy_authorization)
+            environment.get("SSL_CERT_FILE"),
+            Some(OsStr::new("/run/nanocodex/egress-ca.pem"))
         );
+        assert!(
+            route
+                .ca_certificate_pem()
+                .starts_with(b"-----BEGIN CERTIFICATE-----")
+        );
+        assert_eq!(route.ca_certificate_pem(), egress.ca_certificate_pem);
         egress.shutdown().await.unwrap();
     }
 

--- a/crates/experimental/nanocodex-egress/src/policy.rs
+++ b/crates/experimental/nanocodex-egress/src/policy.rs
@@ -1,0 +1,544 @@
+use std::{borrow::Cow, collections::HashSet, sync::Arc};
+
+use async_trait::async_trait;
+use hudsucker::hyper::{Method, header::HeaderName, http::uri::Authority};
+use reqwest::Url;
+use thiserror::Error;
+
+use crate::{EgressLayer, EgressLayerError, EgressRequest};
+
+const MAX_PATH_PREFIX_BYTES: usize = 2_048;
+
+/// Enforcement behavior for a static egress policy.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum PolicyMode {
+    /// Reject requests that do not match an allow rule.
+    #[default]
+    Enforce,
+    /// Trace requests that would be rejected while allowing them onward.
+    Warn,
+}
+
+/// One validated exact-origin, method, and path allow rule.
+#[derive(Clone, Debug)]
+pub struct EgressPolicyRule {
+    upstream: Url,
+    methods: Vec<Method>,
+    path_prefixes: Vec<String>,
+}
+
+impl EgressPolicyRule {
+    /// Starts an allow rule for one credential-free HTTP(S) origin or base URL.
+    #[must_use]
+    pub fn builder(upstream: impl Into<String>) -> EgressPolicyRuleBuilder {
+        EgressPolicyRuleBuilder {
+            upstream: upstream.into(),
+            methods: Vec::new(),
+            path_prefixes: Vec::new(),
+        }
+    }
+
+    fn matches_request(&self, request: &reqwest::Request) -> bool {
+        matching_url(self, request.url())
+            && allows_method_and_path(self, request.method(), request.url().path())
+    }
+
+    fn matches_connect(&self, authority: &Authority) -> bool {
+        self.upstream.scheme() == "https"
+            && self
+                .upstream
+                .host_str()
+                .is_some_and(|host| host.eq_ignore_ascii_case(authority.host()))
+            && self.upstream.port_or_known_default() == authority.port_u16().or(Some(443))
+    }
+}
+
+/// Builder for one [`EgressPolicyRule`].
+pub struct EgressPolicyRuleBuilder {
+    upstream: String,
+    methods: Vec<Method>,
+    path_prefixes: Vec<String>,
+}
+
+impl EgressPolicyRuleBuilder {
+    /// Adds one accepted ordinary HTTP method. No methods means all.
+    #[must_use]
+    pub fn method(mut self, method: Method) -> Self {
+        if !self.methods.contains(&method) {
+            self.methods.push(method);
+        }
+        self
+    }
+
+    /// Adds one accepted path-segment prefix. No prefixes means the upstream
+    /// base path and everything beneath it.
+    #[must_use]
+    pub fn path_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.path_prefixes.push(prefix.into());
+        self
+    }
+
+    /// Validates and creates the rule.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for unsafe origins, methods, or paths.
+    pub fn build(self) -> Result<EgressPolicyRule, PolicyConfigError> {
+        let upstream =
+            Url::parse(&self.upstream).map_err(|_| PolicyConfigError::InvalidUpstream)?;
+        if !matches!(upstream.scheme(), "http" | "https")
+            || upstream.host_str().is_none()
+            || !upstream.username().is_empty()
+            || upstream.password().is_some()
+            || upstream.query().is_some()
+            || upstream.fragment().is_some()
+            || !valid_path_prefix(upstream.path())
+        {
+            return Err(PolicyConfigError::InvalidUpstream);
+        }
+        if self.methods.iter().any(|method| !ordinary_method(method)) {
+            return Err(PolicyConfigError::InvalidMethod);
+        }
+        if self
+            .path_prefixes
+            .iter()
+            .any(|prefix| !valid_path_prefix(prefix))
+        {
+            return Err(PolicyConfigError::InvalidPathPrefix);
+        }
+        Ok(EgressPolicyRule {
+            upstream,
+            methods: self.methods,
+            path_prefixes: self.path_prefixes,
+        })
+    }
+}
+
+/// Default-deny static request policy as one ordered egress layer.
+#[derive(Clone)]
+pub struct EgressPolicy {
+    rules: Arc<[EgressPolicyRule]>,
+    mode: PolicyMode,
+}
+
+impl EgressPolicy {
+    /// Starts an enforcing policy builder.
+    #[must_use]
+    pub const fn builder() -> EgressPolicyBuilder {
+        EgressPolicyBuilder {
+            rules: Vec::new(),
+            mode: PolicyMode::Enforce,
+        }
+    }
+
+    fn authorize_request(&self, request: &reqwest::Request) -> Result<(), EgressLayerError> {
+        if self.rules.iter().any(|rule| rule.matches_request(request)) {
+            return Ok(());
+        }
+        match self.mode {
+            PolicyMode::Enforce => Err(EgressLayerError::Denied),
+            PolicyMode::Warn => {
+                tracing::warn!(
+                    target: "nanocodex_egress",
+                    http_method = %request.method(),
+                    url = %request.url(),
+                    "static egress policy would deny request"
+                );
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Builder for [`EgressPolicy`].
+pub struct EgressPolicyBuilder {
+    rules: Vec<EgressPolicyRule>,
+    mode: PolicyMode,
+}
+
+impl EgressPolicyBuilder {
+    /// Appends one allow rule.
+    #[must_use]
+    pub fn rule(mut self, rule: EgressPolicyRule) -> Self {
+        self.rules.push(rule);
+        self
+    }
+
+    /// Selects enforce or observation-only warn behavior.
+    #[must_use]
+    pub const fn mode(mut self, mode: PolicyMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Creates the policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when no allow rule was configured.
+    pub fn build(self) -> Result<EgressPolicy, PolicyConfigError> {
+        if self.rules.is_empty() {
+            return Err(PolicyConfigError::MissingRules);
+        }
+        Ok(EgressPolicy {
+            rules: self.rules.into(),
+            mode: self.mode,
+        })
+    }
+}
+
+#[async_trait]
+impl EgressLayer for EgressPolicy {
+    async fn handle(
+        &self,
+        request: reqwest::Request,
+        extensions: &mut ::http::Extensions,
+        next: reqwest_middleware::Next<'_>,
+    ) -> reqwest_middleware::Result<reqwest::Response> {
+        self.authorize_request(&request)
+            .map_err(reqwest_middleware::Error::middleware)?;
+        next.run(request, extensions).await
+    }
+
+    async fn authorize_connect(&self, request: &EgressRequest) -> Result<(), EgressLayerError> {
+        let authority = request
+            .uri()
+            .authority()
+            .cloned()
+            .or_else(|| request.uri().to_string().parse().ok())
+            .ok_or(EgressLayerError::InvalidRequest)?;
+        if self
+            .rules
+            .iter()
+            .any(|rule| rule.matches_connect(&authority))
+        {
+            return Ok(());
+        }
+        match self.mode {
+            PolicyMode::Enforce => Err(EgressLayerError::Denied),
+            PolicyMode::Warn => Ok(()),
+        }
+    }
+}
+
+/// Default-deny request-header filter with optional request scoping.
+#[derive(Clone)]
+pub struct HeaderAllowlist {
+    headers: Arc<HashSet<HeaderName>>,
+    prefixes: Arc<[String]>,
+    rules: Arc<[EgressPolicyRule]>,
+}
+
+impl HeaderAllowlist {
+    /// Starts a header allowlist builder.
+    #[must_use]
+    pub fn builder() -> HeaderAllowlistBuilder {
+        HeaderAllowlistBuilder {
+            headers: HashSet::new(),
+            prefixes: Vec::new(),
+            rules: Vec::new(),
+            invalid_header: false,
+        }
+    }
+
+    fn applies(&self, request: &reqwest::Request) -> bool {
+        self.rules.is_empty() || self.rules.iter().any(|rule| rule.matches_request(request))
+    }
+
+    fn retain_headers(&self, request: &mut reqwest::Request) {
+        if !self.applies(request) {
+            return;
+        }
+        let stripped = request
+            .headers()
+            .keys()
+            .filter(|name| {
+                !self.headers.contains(*name)
+                    && !self
+                        .prefixes
+                        .iter()
+                        .any(|prefix| name.as_str().starts_with(prefix))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        for name in &stripped {
+            request.headers_mut().remove(name);
+        }
+        if !stripped.is_empty() {
+            let stripped = stripped.iter().map(HeaderName::as_str).collect::<Vec<_>>();
+            tracing::info!(
+                target: "nanocodex_egress",
+                stripped_headers = ?stripped,
+                "request header allowlist removed child headers"
+            );
+        }
+    }
+}
+
+/// Builder for [`HeaderAllowlist`].
+pub struct HeaderAllowlistBuilder {
+    headers: HashSet<HeaderName>,
+    prefixes: Vec<String>,
+    rules: Vec<EgressPolicyRule>,
+    invalid_header: bool,
+}
+
+impl HeaderAllowlistBuilder {
+    /// Allows one exact header name, matched case-insensitively.
+    #[must_use]
+    pub fn header(mut self, header: impl AsRef<str>) -> Self {
+        match HeaderName::from_bytes(header.as_ref().as_bytes()) {
+            Ok(header) => {
+                self.headers.insert(header);
+            }
+            Err(_) => self.invalid_header = true,
+        }
+        self
+    }
+
+    /// Allows headers whose lowercase names begin with this ASCII prefix.
+    #[must_use]
+    pub fn header_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.prefixes.push(prefix.into().to_ascii_lowercase());
+        self
+    }
+
+    /// Limits this filter to requests accepted by one scope rule. No rules
+    /// applies the filter to every ordinary request.
+    #[must_use]
+    pub fn rule(mut self, rule: EgressPolicyRule) -> Self {
+        self.rules.push(rule);
+        self
+    }
+
+    /// Validates and creates the filter.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an empty or invalid allowlist.
+    pub fn build(self) -> Result<HeaderAllowlist, PolicyConfigError> {
+        if self.invalid_header
+            || self.prefixes.iter().any(|prefix| {
+                prefix.is_empty()
+                    || HeaderName::from_bytes(format!("{prefix}x").as_bytes()).is_err()
+            })
+        {
+            return Err(PolicyConfigError::InvalidHeader);
+        }
+        if self.headers.is_empty() && self.prefixes.is_empty() {
+            return Err(PolicyConfigError::MissingHeaders);
+        }
+        Ok(HeaderAllowlist {
+            headers: Arc::new(self.headers),
+            prefixes: self.prefixes.into(),
+            rules: self.rules.into(),
+        })
+    }
+}
+
+#[async_trait]
+impl EgressLayer for HeaderAllowlist {
+    async fn handle(
+        &self,
+        mut request: reqwest::Request,
+        extensions: &mut ::http::Extensions,
+        next: reqwest_middleware::Next<'_>,
+    ) -> reqwest_middleware::Result<reqwest::Response> {
+        self.retain_headers(&mut request);
+        next.run(request, extensions).await
+    }
+}
+
+/// Invalid static-policy or header-filter configuration.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum PolicyConfigError {
+    /// A static policy contained no allow rules.
+    #[error("egress policy requires at least one allow rule")]
+    MissingRules,
+    /// An upstream was not a credential-free absolute HTTP(S) base URL.
+    #[error("egress policy upstream must be a credential-free absolute HTTP(S) base URL")]
+    InvalidUpstream,
+    /// A CONNECT or extension method was configured.
+    #[error("egress policy supports ordinary HTTP methods only")]
+    InvalidMethod,
+    /// A path prefix was relative or ambiguously encoded.
+    #[error("egress policy path prefixes must be safe bounded absolute paths")]
+    InvalidPathPrefix,
+    /// A header name or prefix was invalid.
+    #[error("header allowlist contains an invalid name or prefix")]
+    InvalidHeader,
+    /// A header allowlist did not contain any names or prefixes.
+    #[error("header allowlist requires at least one name or prefix")]
+    MissingHeaders,
+}
+
+fn matching_url(rule: &EgressPolicyRule, url: &Url) -> bool {
+    rule.upstream.scheme() == url.scheme()
+        && rule
+            .upstream
+            .host_str()
+            .zip(url.host_str())
+            .is_some_and(|(expected, actual)| expected.eq_ignore_ascii_case(actual))
+        && rule.upstream.port_or_known_default() == url.port_or_known_default()
+}
+
+fn allows_method_and_path(rule: &EgressPolicyRule, method: &Method, path: &str) -> bool {
+    let Some(path) = safe_request_path(path) else {
+        return false;
+    };
+    let Some(upstream) = safe_request_path(rule.upstream.path()) else {
+        return false;
+    };
+    ordinary_method(method)
+        && path_prefix_matches(&upstream, &path)
+        && (rule.methods.is_empty() || rule.methods.contains(method))
+        && (rule.path_prefixes.is_empty()
+            || rule
+                .path_prefixes
+                .iter()
+                .any(|prefix| path_prefix_matches(prefix, &path)))
+}
+
+const fn ordinary_method(method: &Method) -> bool {
+    matches!(
+        *method,
+        Method::GET
+            | Method::POST
+            | Method::PUT
+            | Method::PATCH
+            | Method::DELETE
+            | Method::HEAD
+            | Method::OPTIONS
+    )
+}
+
+fn path_prefix_matches(prefix: &str, path: &str) -> bool {
+    prefix == "/"
+        || path == prefix
+        || path
+            .strip_prefix(prefix)
+            .is_some_and(|suffix| prefix.ends_with('/') || suffix.starts_with('/'))
+}
+
+fn valid_path_prefix(prefix: &str) -> bool {
+    prefix.starts_with('/')
+        && prefix.len() <= MAX_PATH_PREFIX_BYTES
+        && safe_request_path(prefix).is_some()
+}
+
+fn safe_request_path(path: &str) -> Option<Cow<'_, str>> {
+    if path.contains('\\')
+        || path.split('/').any(|segment| segment == "..")
+        || contains_ambiguous_path_escape(path)
+    {
+        return None;
+    }
+    if path.starts_with('/') && !path.starts_with("//") {
+        Some(Cow::Borrowed(path))
+    } else {
+        Some(Cow::Owned(format!("/{}", path.trim_start_matches('/'))))
+    }
+}
+
+fn contains_ambiguous_path_escape(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'%' {
+            index += 1;
+            continue;
+        }
+        let encoded = bytes
+            .get(index + 1..index + 3)
+            .and_then(|digits| decode_hex_byte(digits[0], digits[1]));
+        let Some(encoded) = encoded else {
+            return true;
+        };
+        if matches!(encoded, b'%' | b'.' | b'/' | b'\\' | b'?' | b'#') {
+            return true;
+        }
+        index += 3;
+    }
+    false
+}
+
+fn decode_hex_byte(high: u8, low: u8) -> Option<u8> {
+    Some(hex_value(high)? << 4 | hex_value(low)?)
+}
+
+const fn hex_value(digit: u8) -> Option<u8> {
+    match digit {
+        b'0'..=b'9' => Some(digit - b'0'),
+        b'a'..=b'f' => Some(digit - b'a' + 10),
+        b'A'..=b'F' => Some(digit - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(method: Method, url: &str) -> reqwest::Request {
+        reqwest::Request::new(method, Url::parse(url).unwrap())
+    }
+
+    #[test]
+    fn static_policy_is_default_deny_and_path_segment_safe() {
+        let rule = EgressPolicyRule::builder("https://api.example.com/v1")
+            .method(Method::POST)
+            .path_prefix("/v1/messages")
+            .build()
+            .unwrap();
+        let policy = EgressPolicy::builder().rule(rule).build().unwrap();
+
+        assert!(
+            policy
+                .authorize_request(&request(
+                    Method::POST,
+                    "https://api.example.com/v1/messages/1"
+                ))
+                .is_ok()
+        );
+        assert_eq!(
+            policy.authorize_request(&request(
+                Method::POST,
+                "https://api.example.com/v1/messages-attacker"
+            )),
+            Err(EgressLayerError::Denied)
+        );
+        assert_eq!(
+            policy.authorize_request(&request(
+                Method::GET,
+                "https://attacker.invalid/v1/messages"
+            )),
+            Err(EgressLayerError::Denied)
+        );
+    }
+
+    #[test]
+    fn header_allowlist_supports_exact_names_prefixes_and_scopes() {
+        let scope = EgressPolicyRule::builder("https://api.example.com")
+            .build()
+            .unwrap();
+        let filter = HeaderAllowlist::builder()
+            .header("authorization")
+            .header_prefix("x-trace-")
+            .rule(scope)
+            .build()
+            .unwrap();
+        let mut request = request(Method::GET, "https://api.example.com/data");
+        for name in ["authorization", "x-trace-id", "cookie"] {
+            request.headers_mut().insert(
+                HeaderName::from_bytes(name.as_bytes()).unwrap(),
+                "value".parse().unwrap(),
+            );
+        }
+
+        filter.retain_headers(&mut request);
+
+        assert!(request.headers().contains_key("authorization"));
+        assert!(request.headers().contains_key("x-trace-id"));
+        assert!(!request.headers().contains_key("cookie"));
+    }
+}

--- a/crates/experimental/nanocodex-egress/src/secret.rs
+++ b/crates/experimental/nanocodex-egress/src/secret.rs
@@ -1,0 +1,1435 @@
+use std::{borrow::Cow, collections::BTreeMap, sync::Arc};
+
+use async_trait::async_trait;
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use hudsucker::hyper::{
+    Method,
+    header::{Entry, HeaderName, HeaderValue},
+    http::uri::Authority,
+};
+use reqwest::Url;
+use thiserror::Error;
+
+use crate::{EgressEnvironment, EgressLayer, EgressLayerError, EgressRequest};
+
+const MAX_IDENTIFIER_BYTES: usize = 256;
+const MAX_PLACEHOLDER_BYTES: usize = 4 * 1_024;
+const MAX_PATH_PREFIX_BYTES: usize = 2_048;
+
+/// Opaque reference understood only by a host-side [`SecretResolver`].
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct SecretRef {
+    provider: String,
+    key: String,
+}
+
+impl SecretRef {
+    /// Creates a provider-qualified reference without resolving its value.
+    #[must_use]
+    pub fn new(provider: impl Into<String>, key: impl Into<String>) -> Self {
+        Self {
+            provider: provider.into(),
+            key: key.into(),
+        }
+    }
+
+    /// Returns the application-defined provider name.
+    #[must_use]
+    pub fn provider(&self) -> &str {
+        &self.provider
+    }
+
+    /// Returns the provider-owned opaque lookup key.
+    #[must_use]
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+}
+
+/// Host-side secret resolution failure.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum SecretResolverError {
+    /// The referenced value does not exist or is not authorized.
+    #[error("secret is unavailable")]
+    Unavailable,
+}
+
+/// Resolves credential values on the host for already-authorized requests.
+///
+/// Implementations should avoid caching unless their backing provider defines
+/// an explicit rotation contract. Resolved values are never placed in child
+/// configuration or returned by this library.
+#[async_trait]
+pub trait SecretResolver: Send + Sync {
+    /// Resolves one opaque reference.
+    async fn resolve(&self, reference: &SecretRef) -> Result<String, SecretResolverError>;
+}
+
+#[async_trait]
+impl<R> SecretResolver for Arc<R>
+where
+    R: SecretResolver + ?Sized,
+{
+    async fn resolve(&self, reference: &SecretRef) -> Result<String, SecretResolverError> {
+        self.as_ref().resolve(reference).await
+    }
+}
+
+/// Host-memory resolver for small applications and deterministic tests.
+///
+/// This type deliberately omits `Debug` so formatting it cannot expose the
+/// values it owns. Use [`SecretResolver`] directly for external or rotating
+/// secret stores.
+#[derive(Clone, Default)]
+pub struct StaticSecretResolver {
+    values: BTreeMap<SecretRef, String>,
+}
+
+impl StaticSecretResolver {
+    /// Creates an empty resolver.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds or replaces one host-only value.
+    #[must_use]
+    pub fn with_secret(mut self, reference: SecretRef, value: impl Into<String>) -> Self {
+        self.values.insert(reference, value.into());
+        self
+    }
+}
+
+#[async_trait]
+impl SecretResolver for StaticSecretResolver {
+    async fn resolve(&self, reference: &SecretRef) -> Result<String, SecretResolverError> {
+        self.values
+            .get(reference)
+            .cloned()
+            .ok_or(SecretResolverError::Unavailable)
+    }
+}
+
+/// Host-side formatting applied before a secret is injected.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum SecretFormat {
+    /// Injects the resolved value unchanged.
+    #[default]
+    Raw,
+    /// Injects an RFC 6750-style `Bearer` credential.
+    Bearer,
+    /// Injects HTTP Basic credentials using a public username.
+    Basic {
+        /// Public username paired with the resolved secret as its password.
+        username: String,
+    },
+    /// Wraps the resolved value in fixed public text.
+    Affix {
+        /// Text placed before the resolved value.
+        prefix: String,
+        /// Text placed after the resolved value.
+        suffix: String,
+    },
+}
+
+impl SecretFormat {
+    fn apply(&self, value: &str) -> String {
+        match self {
+            Self::Raw => value.to_owned(),
+            Self::Bearer => format!("Bearer {value}"),
+            Self::Basic { username } => {
+                format!("Basic {}", STANDARD.encode(format!("{username}:{value}")))
+            }
+            Self::Affix { prefix, suffix } => format!("{prefix}{value}{suffix}"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SecretReplacement {
+    placeholder: String,
+    headers: Vec<HeaderName>,
+    query: bool,
+    path: bool,
+    body: bool,
+    require: bool,
+}
+
+#[derive(Clone, Debug)]
+enum SecretInjection {
+    Header(HeaderName, SecretFormat),
+    Query(String, SecretFormat),
+}
+
+#[derive(Clone, Debug)]
+enum SecretAction {
+    Replace(SecretReplacement),
+    Inject(SecretInjection),
+}
+
+#[derive(Clone, Debug)]
+struct ReplacementBuilder {
+    placeholder: String,
+    headers: Vec<String>,
+    query: bool,
+    path: bool,
+    body: bool,
+    require: bool,
+    conflicting_placeholder: bool,
+}
+
+#[derive(Clone, Debug)]
+enum InjectionBuilder {
+    Header(String, SecretFormat),
+    Query(String, SecretFormat),
+}
+
+/// One validated destination-bound secret injection or replacement rule.
+#[derive(Clone, Debug)]
+pub struct SecretRule {
+    id: String,
+    source: SecretRef,
+    upstream: Url,
+    methods: Vec<Method>,
+    path_prefixes: Vec<String>,
+    action: SecretAction,
+    base_url_environment: String,
+    placeholder_environment: Option<String>,
+}
+
+impl SecretRule {
+    /// Starts a rule builder for one credential-free HTTPS or loopback HTTP upstream.
+    #[must_use]
+    pub fn builder(
+        id: impl Into<String>,
+        source: SecretRef,
+        upstream: impl Into<String>,
+    ) -> SecretRuleBuilder {
+        SecretRuleBuilder {
+            id: id.into(),
+            source,
+            upstream: upstream.into(),
+            methods: Vec::new(),
+            path_prefixes: Vec::new(),
+            replacement: None,
+            replacement_required: true,
+            injection: None,
+            multiple_injections: false,
+            base_url_environment: None,
+            placeholder_environment: None,
+        }
+    }
+
+    /// Returns the stable non-secret rule identifier.
+    #[must_use]
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Returns the opaque host resolver reference.
+    #[must_use]
+    pub const fn source(&self) -> &SecretRef {
+        &self.source
+    }
+
+    /// Returns the authorized upstream base URL.
+    #[must_use]
+    pub fn upstream(&self) -> &str {
+        self.upstream.as_str().trim_end_matches('/')
+    }
+}
+
+/// Builder for one [`SecretRule`].
+pub struct SecretRuleBuilder {
+    id: String,
+    source: SecretRef,
+    upstream: String,
+    methods: Vec<Method>,
+    path_prefixes: Vec<String>,
+    replacement: Option<ReplacementBuilder>,
+    replacement_required: bool,
+    injection: Option<InjectionBuilder>,
+    multiple_injections: bool,
+    base_url_environment: Option<String>,
+    placeholder_environment: Option<String>,
+}
+
+impl SecretRuleBuilder {
+    /// Adds one accepted HTTP method. No methods means all ordinary methods.
+    #[must_use]
+    pub fn method(mut self, method: Method) -> Self {
+        if !self.methods.contains(&method) {
+            self.methods.push(method);
+        }
+        self
+    }
+
+    /// Adds one accepted path-segment prefix, such as `/v1/responses`.
+    #[must_use]
+    pub fn path_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.path_prefixes.push(prefix.into());
+        self
+    }
+
+    /// Selects the header and public placeholder replaced at egress.
+    #[must_use]
+    pub fn replace_header(
+        mut self,
+        header: impl Into<String>,
+        placeholder: impl Into<String>,
+    ) -> Self {
+        self.replacement_mut(placeholder.into())
+            .headers
+            .push(header.into());
+        self
+    }
+
+    /// Replaces the public placeholder in query parameter values.
+    #[must_use]
+    pub fn replace_query(mut self, placeholder: impl Into<String>) -> Self {
+        self.replacement_mut(placeholder.into()).query = true;
+        self
+    }
+
+    /// Replaces the public placeholder in the request path.
+    #[must_use]
+    pub fn replace_path(mut self, placeholder: impl Into<String>) -> Self {
+        self.replacement_mut(placeholder.into()).path = true;
+        self
+    }
+
+    /// Replaces the public placeholder in a buffered request body.
+    #[must_use]
+    pub fn replace_body(mut self, placeholder: impl Into<String>) -> Self {
+        self.replacement_mut(placeholder.into()).body = true;
+        self
+    }
+
+    /// Allows a matching request to proceed when no replacement location
+    /// contains the public placeholder.
+    ///
+    /// Replacement is required by default. Optional replacement is useful for
+    /// endpoints where authentication itself is optional; it must not be used
+    /// to weaken a credential boundary.
+    #[must_use]
+    pub const fn optional_replacement(mut self) -> Self {
+        self.replacement_required = false;
+        if let Some(replacement) = &mut self.replacement {
+            replacement.require = false;
+        }
+        self
+    }
+
+    /// Injects the resolved and formatted value into one request header,
+    /// replacing any child-provided value.
+    #[must_use]
+    pub fn inject_header(mut self, header: impl Into<String>, format: SecretFormat) -> Self {
+        self.multiple_injections |= self.injection.is_some();
+        self.injection = Some(InjectionBuilder::Header(header.into(), format));
+        self
+    }
+
+    /// Injects the resolved and formatted value into one query parameter,
+    /// replacing every child-provided value for that parameter.
+    #[must_use]
+    pub fn inject_query(mut self, parameter: impl Into<String>, format: SecretFormat) -> Self {
+        self.multiple_injections |= self.injection.is_some();
+        self.injection = Some(InjectionBuilder::Query(parameter.into(), format));
+        self
+    }
+
+    /// Names the child variables receiving the base URL and public placeholder.
+    #[must_use]
+    pub fn child_environment(
+        mut self,
+        base_url: impl Into<String>,
+        placeholder: impl Into<String>,
+    ) -> Self {
+        self.base_url_environment = Some(base_url.into());
+        self.placeholder_environment = Some(placeholder.into());
+        self
+    }
+
+    /// Names the child variable receiving only the public upstream base URL.
+    ///
+    /// Injection rules do not expose a placeholder and should use this method.
+    #[must_use]
+    pub fn child_base_url_environment(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url_environment = Some(base_url.into());
+        self
+    }
+
+    fn replacement_mut(&mut self, placeholder: String) -> &mut ReplacementBuilder {
+        let replacement = self.replacement.get_or_insert_with(|| ReplacementBuilder {
+            placeholder: placeholder.clone(),
+            headers: Vec::new(),
+            query: false,
+            path: false,
+            body: false,
+            require: self.replacement_required,
+            conflicting_placeholder: false,
+        });
+        if replacement.placeholder != placeholder {
+            replacement.conflicting_placeholder = true;
+        }
+        replacement.require = self.replacement_required;
+        replacement
+    }
+
+    /// Validates and creates the destination-bound rule.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for unsafe origins, paths, headers, placeholders, or
+    /// child environment names.
+    pub fn build(self) -> Result<SecretRule, SecretConfigError> {
+        validate_identifier(&self.id).ok_or(SecretConfigError::InvalidId)?;
+        if self.source.provider.trim().is_empty()
+            || self.source.key.trim().is_empty()
+            || self.source.provider.len() > MAX_IDENTIFIER_BYTES
+            || self.source.key.len() > 4 * 1_024
+        {
+            return Err(SecretConfigError::InvalidSource);
+        }
+        let upstream =
+            Url::parse(&self.upstream).map_err(|_| SecretConfigError::InvalidUpstream)?;
+        if !matches!(upstream.scheme(), "http" | "https")
+            || upstream.host_str().is_none()
+            || !upstream.username().is_empty()
+            || upstream.password().is_some()
+            || upstream.query().is_some()
+            || upstream.fragment().is_some()
+            || !valid_path_prefix(upstream.path())
+        {
+            return Err(SecretConfigError::InvalidUpstream);
+        }
+        if upstream.scheme() == "http" && !upstream.host_str().is_some_and(is_loopback_host) {
+            return Err(SecretConfigError::InsecureUpstream);
+        }
+        if self.methods.iter().any(|method| {
+            !matches!(
+                *method,
+                Method::GET
+                    | Method::POST
+                    | Method::PUT
+                    | Method::PATCH
+                    | Method::DELETE
+                    | Method::HEAD
+                    | Method::OPTIONS
+            )
+        }) {
+            return Err(SecretConfigError::InvalidMethod);
+        }
+        if self
+            .path_prefixes
+            .iter()
+            .any(|prefix| !valid_path_prefix(prefix))
+        {
+            return Err(SecretConfigError::InvalidPathPrefix);
+        }
+        if self.multiple_injections {
+            return Err(SecretConfigError::InvalidAction);
+        }
+        let action = match (self.replacement, self.injection) {
+            (Some(_), Some(_)) | (None, None) => return Err(SecretConfigError::InvalidAction),
+            (Some(replacement), None) => {
+                if replacement.conflicting_placeholder
+                    || replacement.placeholder.is_empty()
+                    || replacement.placeholder.len() > MAX_PLACEHOLDER_BYTES
+                    || HeaderValue::from_str(&replacement.placeholder).is_err()
+                    || (replacement.headers.is_empty()
+                        && !replacement.query
+                        && !replacement.path
+                        && !replacement.body)
+                {
+                    return Err(SecretConfigError::InvalidPlaceholder);
+                }
+                let mut headers = Vec::new();
+                for header in replacement.headers {
+                    let header = HeaderName::from_bytes(header.as_bytes())
+                        .map_err(|_| SecretConfigError::InvalidHeader)?;
+                    if is_transport_owned_header(&header) {
+                        return Err(SecretConfigError::InvalidHeader);
+                    }
+                    if !headers.contains(&header) {
+                        headers.push(header);
+                    }
+                }
+                SecretAction::Replace(SecretReplacement {
+                    placeholder: replacement.placeholder,
+                    headers,
+                    query: replacement.query,
+                    path: replacement.path,
+                    body: replacement.body,
+                    require: replacement.require,
+                })
+            }
+            (None, Some(InjectionBuilder::Header(header, format))) => {
+                let header = HeaderName::from_bytes(header.as_bytes())
+                    .map_err(|_| SecretConfigError::InvalidHeader)?;
+                if is_transport_owned_header(&header) {
+                    return Err(SecretConfigError::InvalidHeader);
+                }
+                SecretAction::Inject(SecretInjection::Header(header, format))
+            }
+            (None, Some(InjectionBuilder::Query(parameter, format))) => {
+                if parameter.is_empty()
+                    || parameter.len() > MAX_IDENTIFIER_BYTES
+                    || parameter.contains(['&', '=', '#', '\0'])
+                {
+                    return Err(SecretConfigError::InvalidQueryParameter);
+                }
+                SecretAction::Inject(SecretInjection::Query(parameter, format))
+            }
+        };
+        let base_url_environment = self
+            .base_url_environment
+            .ok_or(SecretConfigError::MissingChildEnvironment)?;
+        if !valid_environment_name(&base_url_environment) {
+            return Err(SecretConfigError::InvalidEnvironment);
+        }
+        let placeholder_environment = match (&action, self.placeholder_environment) {
+            (SecretAction::Replace(_), Some(environment)) => Some(environment),
+            (SecretAction::Replace(_), None) => {
+                return Err(SecretConfigError::MissingChildEnvironment);
+            }
+            (SecretAction::Inject(_), Some(_)) => {
+                return Err(SecretConfigError::InvalidEnvironment);
+            }
+            (SecretAction::Inject(_), None) => None,
+        };
+        if placeholder_environment.as_ref().is_some_and(|environment| {
+            !valid_environment_name(environment) || environment == &base_url_environment
+        }) {
+            return Err(SecretConfigError::InvalidEnvironment);
+        }
+        Ok(SecretRule {
+            id: self.id,
+            source: self.source,
+            upstream,
+            methods: self.methods,
+            path_prefixes: self.path_prefixes,
+            action,
+            base_url_environment,
+            placeholder_environment,
+        })
+    }
+}
+
+/// Policy for destinations not claimed by a secret rule.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum UnmatchedEgress {
+    /// Reject unmatched destinations before contacting them.
+    #[default]
+    Deny,
+    /// Forward unmatched destinations to later egress layers or the origin.
+    Allow,
+}
+
+/// Host-side secret replacement as one independently composable egress layer.
+#[derive(Clone)]
+pub struct SecretEgress {
+    resolver: Arc<dyn SecretResolver>,
+    rules: Arc<[SecretRule]>,
+    environment: EgressEnvironment,
+    unmatched: UnmatchedEgress,
+}
+
+impl SecretEgress {
+    /// Starts a fail-closed secret layer builder with one host-side resolver.
+    #[must_use]
+    pub fn builder<R>(resolver: R) -> SecretEgressBuilder
+    where
+        R: SecretResolver + 'static,
+    {
+        SecretEgressBuilder {
+            resolver: Arc::new(resolver),
+            rules: Vec::new(),
+            unmatched: UnmatchedEgress::Deny,
+        }
+    }
+
+    fn from_parts(
+        resolver: Arc<dyn SecretResolver>,
+        rules: Vec<SecretRule>,
+        unmatched: UnmatchedEgress,
+    ) -> Result<Self, SecretConfigError> {
+        if rules.is_empty() {
+            return Err(SecretConfigError::MissingRules);
+        }
+        let mut ids = BTreeMap::new();
+        let mut environment = BTreeMap::new();
+        for rule in &rules {
+            if ids.insert(rule.id.clone(), ()).is_some() {
+                return Err(SecretConfigError::DuplicateId(rule.id.clone()));
+            }
+            insert_environment(
+                &mut environment,
+                &rule.base_url_environment,
+                rule.upstream().to_owned(),
+            )?;
+            if let (SecretAction::Replace(replacement), Some(placeholder_environment)) =
+                (&rule.action, &rule.placeholder_environment)
+            {
+                insert_environment(
+                    &mut environment,
+                    placeholder_environment,
+                    replacement.placeholder.clone(),
+                )?;
+            }
+        }
+        Ok(Self {
+            resolver,
+            rules: rules.into(),
+            environment: EgressEnvironment::new(
+                environment
+                    .into_iter()
+                    .map(|(name, value)| (name.into(), value.into())),
+            ),
+            unmatched,
+        })
+    }
+
+    /// Returns child variables containing only public origins and placeholders.
+    #[must_use]
+    pub const fn environment(&self) -> &EgressEnvironment {
+        &self.environment
+    }
+}
+
+/// Builder for one host-owned secret replacement layer.
+pub struct SecretEgressBuilder {
+    resolver: Arc<dyn SecretResolver>,
+    rules: Vec<SecretRule>,
+    unmatched: UnmatchedEgress,
+}
+
+impl SecretEgressBuilder {
+    /// Appends one validated destination-bound rule.
+    #[must_use]
+    pub fn rule(mut self, rule: SecretRule) -> Self {
+        self.rules.push(rule);
+        self
+    }
+
+    /// Appends validated destination-bound rules in declaration order.
+    #[must_use]
+    pub fn rules(mut self, rules: impl IntoIterator<Item = SecretRule>) -> Self {
+        self.rules.extend(rules);
+        self
+    }
+
+    /// Selects policy for destinations not claimed by a secret rule.
+    #[must_use]
+    pub const fn unmatched(mut self, unmatched: UnmatchedEgress) -> Self {
+        self.unmatched = unmatched;
+        self
+    }
+
+    /// Validates unique IDs and child variables and creates the layer.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when there are no rules or when two rules claim the
+    /// same ID or environment name.
+    pub fn build(self) -> Result<SecretEgress, SecretConfigError> {
+        SecretEgress::from_parts(self.resolver, self.rules, self.unmatched)
+    }
+}
+
+impl SecretEgress {
+    async fn authorize_http_request(
+        &self,
+        request: &mut reqwest::Request,
+    ) -> Result<(), EgressLayerError> {
+        let rules = match select_rules(&self.rules, request)? {
+            RuleSelection::Apply(rules) => rules,
+            RuleSelection::Unmatched if self.unmatched == UnmatchedEgress::Allow => {
+                return Ok(());
+            }
+            RuleSelection::Unmatched => return Err(EgressLayerError::Denied),
+        };
+        for rule in rules {
+            apply_rule(self.resolver.as_ref(), request, rule).await?;
+            tracing::info!(
+                target: "nanocodex_egress",
+                secret_rule_id = %rule.id,
+                http.request.method = %request.method(),
+                "applied host-side secret policy"
+            );
+        }
+        tracing::info!(
+            target: "nanocodex_egress",
+            content_kind = "egress.secret.request.headers",
+            content = ?request.headers(),
+            "trace content"
+        );
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl EgressLayer for SecretEgress {
+    async fn handle(
+        &self,
+        mut request: reqwest::Request,
+        extensions: &mut ::http::Extensions,
+        next: reqwest_middleware::Next<'_>,
+    ) -> reqwest_middleware::Result<reqwest::Response> {
+        self.authorize_http_request(&mut request)
+            .await
+            .map_err(reqwest_middleware::Error::middleware)?;
+        next.run(request, extensions).await
+    }
+
+    async fn authorize_connect(&self, request: &EgressRequest) -> Result<(), EgressLayerError> {
+        authorize_connect_request(request, &self.rules, self.unmatched)
+    }
+
+    fn environment(&self) -> EgressEnvironment {
+        self.environment.clone()
+    }
+}
+
+fn authorize_connect_request(
+    request: &EgressRequest,
+    rules: &[SecretRule],
+    unmatched: UnmatchedEgress,
+) -> Result<(), EgressLayerError> {
+    if unmatched == UnmatchedEgress::Allow {
+        return Ok(());
+    }
+    let authority = request
+        .uri()
+        .authority()
+        .cloned()
+        .or_else(|| request.uri().to_string().parse().ok())
+        .ok_or(EgressLayerError::InvalidRequest)?;
+    rules
+        .iter()
+        .any(|rule| matching_upstream(rule, "https", &authority))
+        .then_some(())
+        .ok_or(EgressLayerError::Denied)
+}
+
+enum RuleSelection<'a> {
+    Apply(Vec<&'a SecretRule>),
+    Unmatched,
+}
+
+fn select_rules<'a>(
+    rules: &'a [SecretRule],
+    request: &reqwest::Request,
+) -> Result<RuleSelection<'a>, EgressLayerError> {
+    let path = safe_request_path(request.url().path()).ok_or(EgressLayerError::InvalidRequest)?;
+    let mut origin_matched = false;
+    let mut selected = Vec::new();
+    for rule in rules {
+        if !matching_upstream_url(rule, request.url()) {
+            continue;
+        }
+        origin_matched = true;
+        if !allows_request(rule, request.method(), &path) {
+            continue;
+        }
+        selected.push(rule);
+    }
+    if !selected.is_empty() {
+        Ok(RuleSelection::Apply(selected))
+    } else if origin_matched {
+        Err(EgressLayerError::Denied)
+    } else {
+        Ok(RuleSelection::Unmatched)
+    }
+}
+
+fn matching_upstream(rule: &SecretRule, scheme: &str, authority: &Authority) -> bool {
+    rule.upstream.scheme() == scheme
+        && rule
+            .upstream
+            .host_str()
+            .is_some_and(|host| host.eq_ignore_ascii_case(authority.host()))
+        && rule.upstream.port_or_known_default()
+            == authority
+                .port_u16()
+                .or_else(|| (scheme == "https").then_some(443))
+                .or_else(|| (scheme == "http").then_some(80))
+}
+
+fn matching_upstream_url(rule: &SecretRule, url: &Url) -> bool {
+    rule.upstream.scheme() == url.scheme()
+        && rule
+            .upstream
+            .host_str()
+            .zip(url.host_str())
+            .is_some_and(|(expected, actual)| expected.eq_ignore_ascii_case(actual))
+        && rule.upstream.port_or_known_default() == url.port_or_known_default()
+}
+
+fn allows_request(rule: &SecretRule, method: &Method, path: &str) -> bool {
+    let supported = matches!(
+        *method,
+        Method::GET
+            | Method::POST
+            | Method::PUT
+            | Method::PATCH
+            | Method::DELETE
+            | Method::HEAD
+            | Method::OPTIONS
+    );
+    let within_upstream = safe_request_path(rule.upstream.path())
+        .is_some_and(|prefix| path_prefix_matches(&prefix, path));
+    supported
+        && within_upstream
+        && (rule.methods.is_empty() || rule.methods.contains(method))
+        && (rule.path_prefixes.is_empty()
+            || rule
+                .path_prefixes
+                .iter()
+                .any(|prefix| path_prefix_matches(prefix, path)))
+}
+
+async fn apply_rule(
+    resolver: &dyn SecretResolver,
+    request: &mut reqwest::Request,
+    rule: &SecretRule,
+) -> Result<(), EgressLayerError> {
+    match &rule.action {
+        SecretAction::Replace(replacement) => {
+            let occurrences = replacement_occurrences(request, replacement)?;
+            if occurrences == 0 {
+                return if replacement.require {
+                    Err(EgressLayerError::Denied)
+                } else {
+                    Ok(())
+                };
+            }
+            let secret = resolve_secret(resolver, &rule.source).await?;
+            apply_replacement(request, replacement, &secret)
+        }
+        SecretAction::Inject(injection) => {
+            let secret = resolve_secret(resolver, &rule.source).await?;
+            apply_injection(request, injection, &secret)
+        }
+    }
+}
+
+async fn resolve_secret(
+    resolver: &dyn SecretResolver,
+    source: &SecretRef,
+) -> Result<String, EgressLayerError> {
+    resolver
+        .resolve(source)
+        .await
+        .map_err(|_| EgressLayerError::Unavailable)
+}
+
+fn replacement_occurrences(
+    request: &reqwest::Request,
+    replacement: &SecretReplacement,
+) -> Result<usize, EgressLayerError> {
+    let mut occurrences = 0;
+    for header in &replacement.headers {
+        for value in request.headers().get_all(header).iter() {
+            let value = value.to_str().map_err(|_| EgressLayerError::Denied)?;
+            let count = value.matches(&replacement.placeholder).count();
+            // A child must not smuggle an alternate credential alongside the
+            // public placeholder in a header claimed by this rule.
+            if count == 0 {
+                return Err(EgressLayerError::Denied);
+            }
+            occurrences += count;
+        }
+    }
+    if replacement.query {
+        occurrences += request
+            .url()
+            .query_pairs()
+            .map(|(_, value)| value.matches(&replacement.placeholder).count())
+            .sum::<usize>();
+    }
+    if replacement.path {
+        occurrences += request
+            .url()
+            .path()
+            .matches(&replacement.placeholder)
+            .count();
+    }
+    if replacement.body
+        && let Some(body) = request.body()
+    {
+        let body = body.as_bytes().ok_or(EgressLayerError::InvalidRequest)?;
+        occurrences += count_bytes(body, replacement.placeholder.as_bytes());
+    }
+    Ok(occurrences)
+}
+
+fn apply_replacement(
+    request: &mut reqwest::Request,
+    replacement: &SecretReplacement,
+    secret: &str,
+) -> Result<(), EgressLayerError> {
+    for header in &replacement.headers {
+        let Entry::Occupied(mut entry) = request.headers_mut().entry(header.clone()) else {
+            continue;
+        };
+        for value in entry.iter_mut() {
+            let current = value.to_str().map_err(|_| EgressLayerError::Denied)?;
+            *value = HeaderValue::from_str(&current.replace(&replacement.placeholder, secret))
+                .map_err(|_| EgressLayerError::Unavailable)?;
+        }
+    }
+    if replacement.query && request.url().query().is_some() {
+        let pairs = request
+            .url()
+            .query_pairs()
+            .map(|(key, value)| {
+                (
+                    key.into_owned(),
+                    value.replace(&replacement.placeholder, secret),
+                )
+            })
+            .collect::<Vec<_>>();
+        request
+            .url_mut()
+            .query_pairs_mut()
+            .clear()
+            .extend_pairs(pairs);
+    }
+    if replacement.path {
+        let path = request
+            .url()
+            .path()
+            .replace(&replacement.placeholder, secret);
+        request.url_mut().set_path(&path);
+    }
+    if replacement.body {
+        let body = request
+            .body()
+            .and_then(reqwest::Body::as_bytes)
+            .ok_or(EgressLayerError::InvalidRequest)?;
+        let body = replace_bytes(body, replacement.placeholder.as_bytes(), secret.as_bytes());
+        *request.body_mut() = Some(reqwest::Body::from(body));
+    }
+    Ok(())
+}
+
+fn apply_injection(
+    request: &mut reqwest::Request,
+    injection: &SecretInjection,
+    secret: &str,
+) -> Result<(), EgressLayerError> {
+    match injection {
+        SecretInjection::Header(header, format) => {
+            let value = HeaderValue::from_str(&format.apply(secret))
+                .map_err(|_| EgressLayerError::Unavailable)?;
+            request.headers_mut().insert(header, value);
+        }
+        SecretInjection::Query(parameter, format) => {
+            let value = format.apply(secret);
+            let mut pairs = request
+                .url()
+                .query_pairs()
+                .filter(|(key, _)| key != parameter)
+                .map(|(key, value)| (key.into_owned(), value.into_owned()))
+                .collect::<Vec<_>>();
+            pairs.push((parameter.clone(), value));
+            request
+                .url_mut()
+                .query_pairs_mut()
+                .clear()
+                .extend_pairs(pairs);
+        }
+    }
+    Ok(())
+}
+
+fn count_bytes(haystack: &[u8], needle: &[u8]) -> usize {
+    if needle.is_empty() {
+        return 0;
+    }
+    haystack
+        .windows(needle.len())
+        .filter(|window| *window == needle)
+        .count()
+}
+
+fn replace_bytes(haystack: &[u8], needle: &[u8], replacement: &[u8]) -> Vec<u8> {
+    let mut output = Vec::with_capacity(haystack.len());
+    let mut remaining = haystack;
+    while let Some(index) = remaining
+        .windows(needle.len())
+        .position(|window| window == needle)
+    {
+        output.extend_from_slice(&remaining[..index]);
+        output.extend_from_slice(replacement);
+        remaining = &remaining[index + needle.len()..];
+    }
+    output.extend_from_slice(remaining);
+    output
+}
+
+fn path_prefix_matches(prefix: &str, path: &str) -> bool {
+    prefix == "/"
+        || path == prefix
+        || path
+            .strip_prefix(prefix)
+            .is_some_and(|suffix| prefix.ends_with('/') || suffix.starts_with('/'))
+}
+
+fn valid_path_prefix(prefix: &str) -> bool {
+    prefix.starts_with('/')
+        && prefix.len() <= MAX_PATH_PREFIX_BYTES
+        && safe_request_path(prefix).is_some()
+}
+
+fn safe_request_path(path: &str) -> Option<Cow<'_, str>> {
+    if path.contains('\\')
+        || path.split('/').any(|segment| segment == "..")
+        || contains_ambiguous_path_escape(path)
+    {
+        return None;
+    }
+    if path.starts_with('/') && !path.starts_with("//") {
+        Some(Cow::Borrowed(path))
+    } else {
+        Some(Cow::Owned(format!("/{}", path.trim_start_matches('/'))))
+    }
+}
+
+fn contains_ambiguous_path_escape(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'%' {
+            index += 1;
+            continue;
+        }
+        let encoded = bytes
+            .get(index + 1..index + 3)
+            .and_then(|digits| decode_hex_byte(digits[0], digits[1]));
+        let Some(encoded) = encoded else {
+            return true;
+        };
+        if matches!(encoded, b'%' | b'.' | b'/' | b'\\' | b'?' | b'#') {
+            return true;
+        }
+        index += 3;
+    }
+    false
+}
+
+fn decode_hex_byte(high: u8, low: u8) -> Option<u8> {
+    Some(hex_value(high)? << 4 | hex_value(low)?)
+}
+
+const fn hex_value(digit: u8) -> Option<u8> {
+    match digit {
+        b'0'..=b'9' => Some(digit - b'0'),
+        b'a'..=b'f' => Some(digit - b'a' + 10),
+        b'A'..=b'F' => Some(digit - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn validate_identifier(value: &str) -> Option<()> {
+    (!value.is_empty()
+        && value.len() <= MAX_IDENTIFIER_BYTES
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.')))
+    .then_some(())
+}
+
+fn valid_environment_name(name: &str) -> bool {
+    let mut bytes = name.bytes();
+    bytes
+        .next()
+        .is_some_and(|byte| byte == b'_' || byte.is_ascii_uppercase())
+        && bytes.all(|byte| byte == b'_' || byte.is_ascii_uppercase() || byte.is_ascii_digit())
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|address| address.is_loopback())
+}
+
+fn is_transport_owned_header(header: &HeaderName) -> bool {
+    [
+        "host",
+        "content-length",
+        "transfer-encoding",
+        "connection",
+        "proxy-authorization",
+    ]
+    .iter()
+    .any(|reserved| header.as_str().eq_ignore_ascii_case(reserved))
+}
+
+fn insert_environment(
+    environment: &mut BTreeMap<String, String>,
+    name: &str,
+    value: String,
+) -> Result<(), SecretConfigError> {
+    if environment.get(name) == Some(&value) {
+        return Ok(());
+    }
+    if environment.insert(name.to_owned(), value).is_some() {
+        return Err(SecretConfigError::DuplicateEnvironment(name.to_owned()));
+    }
+    Ok(())
+}
+
+/// Invalid secret-rule configuration.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum SecretConfigError {
+    /// A secret layer was configured without any destination-bound rules.
+    #[error("secret egress requires at least one rule")]
+    MissingRules,
+    /// A rule ID was empty, unbounded, or contained unsupported bytes.
+    #[error("secret rule id must be a bounded ASCII identifier")]
+    InvalidId,
+    /// A resolver provider or key was empty or unbounded.
+    #[error("secret source must contain a bounded provider and key")]
+    InvalidSource,
+    /// An upstream was not a credential-free absolute HTTP(S) base URL.
+    #[error("secret upstream must be a credential-free absolute HTTP(S) base URL")]
+    InvalidUpstream,
+    /// A remote plaintext upstream could expose the resolved credential.
+    #[error("secret upstream must use HTTPS unless it is loopback")]
+    InsecureUpstream,
+    /// A CONNECT or extension method was configured for replacement.
+    #[error("secret rules support ordinary HTTP methods only")]
+    InvalidMethod,
+    /// A path prefix was relative or ambiguously encoded.
+    #[error("secret path prefixes must be safe bounded absolute paths")]
+    InvalidPathPrefix,
+    /// No action or more than one action was configured.
+    #[error("secret rule requires exactly one injection or replacement action")]
+    InvalidAction,
+    /// A header name was invalid or transport-owned.
+    #[error("secret replacement header is invalid or transport-owned")]
+    InvalidHeader,
+    /// An injected query parameter name was empty, unbounded, or ambiguous.
+    #[error("secret query parameter name is invalid")]
+    InvalidQueryParameter,
+    /// A placeholder was empty, unbounded, or not a valid header value.
+    #[error("secret placeholder must be a non-empty bounded HTTP header value")]
+    InvalidPlaceholder,
+    /// Child base URL and placeholder variables were not configured.
+    #[error("secret rule requires child base URL and placeholder variables")]
+    MissingChildEnvironment,
+    /// A child variable was invalid or both values used the same name.
+    #[error("secret child variables must be distinct uppercase shell identifiers")]
+    InvalidEnvironment,
+    /// Two rules used the same stable ID.
+    #[error("duplicate secret rule id `{0}`")]
+    DuplicateId(String),
+    /// Two rules claimed the same child variable.
+    #[error("duplicate secret child environment `{0}`")]
+    DuplicateEnvironment(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use hudsucker::hyper::{HeaderMap, Uri};
+
+    use super::*;
+
+    #[test]
+    fn secret_layer_rejects_an_empty_rule_set() {
+        let result = SecretEgress::builder(StaticSecretResolver::new()).build();
+        assert!(matches!(result, Err(SecretConfigError::MissingRules)));
+    }
+
+    #[test]
+    fn replacement_rule_exports_only_public_child_values() {
+        let rule = SecretRule::builder(
+            "openai",
+            SecretRef::new("environment", "OPENAI_API_KEY"),
+            "https://api.openai.com",
+        )
+        .method(Method::POST)
+        .path_prefix("/v1/responses")
+        .replace_header("authorization", "nanocodex-secret-openai")
+        .child_environment("OPENAI_BASE_URL", "OPENAI_API_KEY")
+        .build()
+        .unwrap();
+        struct Unavailable;
+        #[async_trait]
+        impl SecretResolver for Unavailable {
+            async fn resolve(&self, _reference: &SecretRef) -> Result<String, SecretResolverError> {
+                Err(SecretResolverError::Unavailable)
+            }
+        }
+        let rules = SecretEgress::builder(Unavailable)
+            .rule(rule)
+            .build()
+            .unwrap();
+        assert_eq!(
+            rules.environment().get("OPENAI_BASE_URL"),
+            Some(std::ffi::OsStr::new("https://api.openai.com"))
+        );
+        assert_eq!(
+            rules.environment().get("OPENAI_API_KEY"),
+            Some(std::ffi::OsStr::new("nanocodex-secret-openai"))
+        );
+    }
+
+    #[test]
+    fn rules_reject_ambiguous_paths_and_placeholders() {
+        let build = |path: &str, placeholder: &str| {
+            SecretRule::builder(
+                "openai",
+                SecretRef::new("environment", "OPENAI_API_KEY"),
+                "https://api.openai.com",
+            )
+            .path_prefix(path)
+            .replace_header("authorization", placeholder)
+            .child_environment("OPENAI_BASE_URL", "OPENAI_API_KEY")
+            .build()
+        };
+        assert_eq!(
+            build("/v1/%2e%2e/admin", "placeholder").unwrap_err(),
+            SecretConfigError::InvalidPathPrefix
+        );
+        assert_eq!(
+            build("/v1/responses", "").unwrap_err(),
+            SecretConfigError::InvalidPlaceholder
+        );
+
+        let insecure = SecretRule::builder(
+            "openai",
+            SecretRef::new("environment", "OPENAI_API_KEY"),
+            "http://api.openai.com",
+        )
+        .replace_header("authorization", "placeholder")
+        .child_environment("OPENAI_BASE_URL", "OPENAI_API_KEY")
+        .build();
+        assert_eq!(insecure.unwrap_err(), SecretConfigError::InsecureUpstream);
+
+        let multiple_injections = SecretRule::builder(
+            "invalid",
+            SecretRef::new("memory", "secret"),
+            "https://api.example.com",
+        )
+        .inject_header("authorization", SecretFormat::Bearer)
+        .inject_query("key", SecretFormat::Raw)
+        .child_base_url_environment("SERVICE_BASE_URL")
+        .build();
+        assert_eq!(
+            multiple_injections.unwrap_err(),
+            SecretConfigError::InvalidAction
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_replacement_headers_fail_closed() {
+        let reference = SecretRef::new("memory", "openai");
+        let rule = SecretRule::builder("openai", reference.clone(), "https://api.openai.com")
+            .method(Method::POST)
+            .path_prefix("/v1/responses")
+            .replace_header("authorization", "nanocodex-secret-openai")
+            .child_environment("OPENAI_BASE_URL", "OPENAI_API_KEY")
+            .build()
+            .unwrap();
+        let layer =
+            SecretEgress::builder(StaticSecretResolver::new().with_secret(reference, "host-only"))
+                .rule(rule)
+                .build()
+                .unwrap();
+        let mut request = reqwest::Request::new(
+            Method::POST,
+            Url::parse("https://api.openai.com/v1/responses").unwrap(),
+        );
+        request.headers_mut().append(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_static("Bearer nanocodex-secret-openai"),
+        );
+        request.headers_mut().append(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_static("Bearer attacker-controlled"),
+        );
+
+        assert_eq!(
+            layer.authorize_http_request(&mut request).await,
+            Err(EgressLayerError::Denied)
+        );
+    }
+
+    #[tokio::test]
+    async fn replaces_every_configured_request_location() {
+        let reference = SecretRef::new("memory", "service");
+        let rule = SecretRule::builder("service", reference.clone(), "https://api.example.com/v1")
+            .method(Method::POST)
+            .replace_header("x-api-key", "public-token")
+            .replace_query("public-token")
+            .replace_path("public-token")
+            .replace_body("public-token")
+            .child_environment("SERVICE_BASE_URL", "SERVICE_TOKEN")
+            .build()
+            .unwrap();
+        let layer =
+            SecretEgress::builder(StaticSecretResolver::new().with_secret(reference, "host-only"))
+                .rule(rule)
+                .build()
+                .unwrap();
+        let mut request = reqwest::Request::new(
+            Method::POST,
+            Url::parse(
+                "https://api.example.com/v1/public-token/action?key=public-token&keep=value",
+            )
+            .unwrap(),
+        );
+        request.headers_mut().insert(
+            HeaderName::from_static("x-api-key"),
+            HeaderValue::from_static("prefix-public-token-suffix"),
+        );
+        *request.body_mut() = Some(reqwest::Body::from("body=public-token"));
+
+        layer.authorize_http_request(&mut request).await.unwrap();
+
+        assert_eq!(request.url().path(), "/v1/host-only/action");
+        assert_eq!(
+            request
+                .url()
+                .query_pairs()
+                .collect::<BTreeMap<_, _>>()
+                .get("key")
+                .map(Cow::as_ref),
+            Some("host-only")
+        );
+        assert_eq!(request.headers()["x-api-key"], "prefix-host-only-suffix");
+        assert_eq!(
+            request.body().and_then(reqwest::Body::as_bytes),
+            Some(b"body=host-only".as_slice())
+        );
+    }
+
+    #[tokio::test]
+    async fn applies_multiple_injections_for_one_request() {
+        let bearer = SecretRef::new("memory", "bearer");
+        let basic = SecretRef::new("memory", "basic");
+        let query = SecretRef::new("memory", "query");
+        let resolver = StaticSecretResolver::new()
+            .with_secret(bearer.clone(), "bearer-secret")
+            .with_secret(basic.clone(), "basic-secret")
+            .with_secret(query.clone(), "query-secret");
+        let rule = |id: &str, source, action: fn(SecretRuleBuilder) -> SecretRuleBuilder| {
+            action(SecretRule::builder(
+                id,
+                source,
+                "https://api.example.com/v1",
+            ))
+            .child_base_url_environment("SERVICE_BASE_URL")
+            .build()
+            .unwrap()
+        };
+        let layer = SecretEgress::builder(resolver)
+            .rule(rule("bearer", bearer, |builder| {
+                builder.inject_header("authorization", SecretFormat::Bearer)
+            }))
+            .rule(rule("basic", basic, |builder| {
+                builder.inject_header(
+                    "x-basic",
+                    SecretFormat::Basic {
+                        username: "agent".to_owned(),
+                    },
+                )
+            }))
+            .rule(rule("query", query, |builder| {
+                builder.inject_query("api_key", SecretFormat::Raw)
+            }))
+            .build()
+            .unwrap();
+        let mut request = reqwest::Request::new(
+            Method::GET,
+            Url::parse("https://api.example.com/v1/data?api_key=child-value").unwrap(),
+        );
+        request.headers_mut().insert(
+            HeaderName::from_static("authorization"),
+            HeaderValue::from_static("Bearer child-value"),
+        );
+
+        layer.authorize_http_request(&mut request).await.unwrap();
+
+        assert_eq!(request.headers()["authorization"], "Bearer bearer-secret");
+        assert_eq!(
+            request.headers()["x-basic"],
+            "Basic YWdlbnQ6YmFzaWMtc2VjcmV0"
+        );
+        assert!(request.url().query().is_some_and(|query| {
+            query.contains("api_key=query-secret") && !query.contains("child-value")
+        }));
+    }
+
+    #[tokio::test]
+    async fn optional_replacement_does_not_resolve_an_unused_secret() {
+        struct Unavailable;
+        #[async_trait]
+        impl SecretResolver for Unavailable {
+            async fn resolve(&self, _reference: &SecretRef) -> Result<String, SecretResolverError> {
+                Err(SecretResolverError::Unavailable)
+            }
+        }
+        let rule = SecretRule::builder(
+            "optional",
+            SecretRef::new("unavailable", "secret"),
+            "https://api.example.com",
+        )
+        .optional_replacement()
+        .replace_query("public-token")
+        .child_environment("SERVICE_BASE_URL", "SERVICE_TOKEN")
+        .build()
+        .unwrap();
+        let layer = SecretEgress::builder(Unavailable)
+            .rule(rule)
+            .build()
+            .unwrap();
+        let mut request = reqwest::Request::new(
+            Method::GET,
+            Url::parse("https://api.example.com/data?anonymous=true").unwrap(),
+        );
+
+        layer.authorize_http_request(&mut request).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn connect_policy_only_opens_configured_tls_origins() {
+        let rule = SecretRule::builder(
+            "openai",
+            SecretRef::new("environment", "OPENAI_API_KEY"),
+            "https://api.openai.com",
+        )
+        .replace_header("authorization", "nanocodex-secret-openai")
+        .child_environment("OPENAI_BASE_URL", "OPENAI_API_KEY")
+        .build()
+        .unwrap();
+        let layer = SecretEgress::builder(StaticSecretResolver::new())
+            .rule(rule)
+            .build()
+            .unwrap();
+        let request = |authority: &'static str| {
+            EgressRequest::new(
+                Method::CONNECT,
+                Uri::from_static(authority),
+                HeaderMap::new(),
+            )
+        };
+
+        assert!(
+            layer
+                .authorize_connect(&request("api.openai.com:443"))
+                .await
+                .is_ok()
+        );
+        assert_eq!(
+            layer
+                .authorize_connect(&request("attacker.invalid:443"))
+                .await,
+            Err(EgressLayerError::Denied)
+        );
+    }
+}

--- a/docs/MPP.md
+++ b/docs/MPP.md
@@ -113,6 +113,33 @@ the Nanocodex process.
 MPP tracing records full request, response, challenge, and credential content.
 Operators must protect those traces like wallet and conversation data.
 
+### Agent-driven host and VM smoke
+
+This exercises the complete path through Nanocodex and Code Mode rather than
+calling the proxy on its own. The model fetches the live public catalog at
+`https://mpp.dev/api/services`, chooses endpoints within the configured charge
+cap, and fans curl subprocesses out from one `Promise.all` cell:
+
+```sh
+nanocodex run --provider.tempo \
+  "Use one Code Mode cell. Fetch https://mpp.dev/api/services, select eight safe HTTP service smoke requests whose advertised charges fit the configured cap, then use Promise.all over exec_command calls that each run curl -fsS. Verify every exit code and report the endpoint/status matrix."
+```
+
+Run the same model turn with every workspace command inside the retained VM:
+
+```sh
+nanocodex run --provider.tempo \
+  --vm .nanocodex/vm/session-rootfs.ext4 \
+  --vm-guest-runtime target/aarch64-unknown-linux-musl/debug/nanocodex-vm-guest \
+  "Use one Code Mode cell. Fetch https://mpp.dev/api/services, select eight safe HTTP service smoke requests whose advertised charges fit the configured cap, then use Promise.all over exec_command calls that each run curl -fsS. Verify every exit code and report the endpoint/status matrix."
+```
+
+Host mode applies the proxy route only to tool subprocesses. VM mode projects
+the same authenticated URL and public ephemeral CA through an `EgressLease`
+before tools become available; it does not put host filesystem paths or wallet
+material in the guest. Both modes keep model Responses traffic in the host
+process while routing its HTTPS client through the same Tempo payment layer.
+
 ## Credits onramp
 
 `nanocodex credits` and `nanousd-api` are separate from MPP settlement:

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,6 +17,7 @@ futures-util.workspace = true
 http.workspace = true
 nanocodex = { workspace = true, features = ["realtime"] }
 nanocodex-browser.workspace = true
+nanocodex-egress.workspace = true
 nanocodex-voice.workspace = true
 nanocodex-vm.workspace = true
 reqwest.workspace = true
@@ -79,6 +80,10 @@ path = "rollout_resume_bench.rs"
 [[bin]]
 name = "vm-tools"
 path = "vm_tools.rs"
+
+[[bin]]
+name = "secret-egress"
+path = "secret_egress.rs"
 
 [[bin]]
 name = "browser-agent"

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ All language consumers live at this repository boundary:
 
 - Rust: `minimal.rs`, `voice.rs`, `realtime_pipe.rs`, `follow_on.rs`, `lifecycle.rs`,
   `custom_tool.rs`, `subagents.rs`, `resume.rs`, `fork_conversations.rs`,
-  `fork_checkpoint_bench.rs`, and `mcp.rs` are binaries in the
+  `fork_checkpoint_bench.rs`, `secret_egress.rs`, and `mcp.rs` are binaries in the
   `nanocodex-examples` package.
 - Python: `python/` uses the native PyO3 binding (`follow_on.py`, `events.py`,
   `lifecycle.py`).
@@ -29,6 +29,7 @@ cargo run -p nanocodex-examples --bin subagents -- \
   "Review the retry policy using whatever clean or context-bearing workers you need"
 NANOCODEX_SUBAGENT_JSONL=1 cargo run -p nanocodex-examples --bin subagents
 cargo run -p nanocodex-examples --bin mcp
+cargo run -p nanocodex-examples --bin secret-egress -- host
 just build-vm-example
 target/debug/vm-tools ROOTFS [GUEST_RUNTIME_BINARY_OR_EXT4]
 just smoke-python
@@ -83,3 +84,20 @@ custom merged-event protocol.
 The MCP example defaults to the public OpenAI documentation MCP. Override
 `NANOCODEX_MCP_URL` for another Streamable HTTP server and set
 `NANOCODEX_MCP_BEARER_TOKEN` when it requires bearer authentication.
+
+`secret-egress` runs a real Nanocodex turn whose Code Mode cell fans out curl
+commands through an authenticated host-owned proxy. Set `OPENAI_API_KEY`,
+`NANOCODEX_SECRET_UPSTREAM`, and `NANOCODEX_SECRET_VALUE`; the model and its
+commands receive only `DEMO_SERVICE_BASE_URL` and the public
+`DEMO_SERVICE_TOKEN` placeholder. Use `NANOCODEX_SECRET_STRESS_REQUESTS` to
+change the default eight-way `Promise.all` fanout. The same example runs tools
+inside the retained VM while model traffic remains on the host:
+
+```sh
+cargo run -p nanocodex-examples --bin secret-egress -- \
+  vm ROOTFS [GUEST_RUNTIME_BINARY_OR_EXT4]
+```
+
+VM mode provisions the proxy's public CA and child environment through a
+provider-neutral `EgressLease`. It uses the default libkrun TSI network, under
+which the host loopback proxy is reachable from guest workspace commands.

--- a/examples/secret_egress.rs
+++ b/examples/secret_egress.rs
@@ -1,0 +1,183 @@
+use std::{
+    error::Error,
+    ffi::OsString,
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+use nanocodex::{Nanocodex, OpenAi, Tools};
+use nanocodex_egress::{EgressProxy, SecretEgress, SecretRef, SecretRule, StaticSecretResolver};
+use nanocodex_vm::{
+    VmWorkspace, VmWorkspaceBuilder,
+    host::{EgressFile, EgressLease, GUEST_EGRESS_ROOT, VmProcessConfig},
+    tools::GuestRuntimeDisk,
+};
+
+type AnyError = Box<dyn Error + Send + Sync>;
+
+const PLACEHOLDER: &str = "nanocodex-public-demo-token";
+const GUEST_CA: &str = "/tmp/nanocodex/egress/secret-egress-ca.pem";
+
+fn main() -> Result<(), AnyError> {
+    let arguments = std::env::args_os().skip(1).collect::<Vec<_>>();
+    if arguments.first().is_some_and(|value| value == "--vmm") {
+        let config = arguments
+            .get(1)
+            .cloned()
+            .map(PathBuf::from)
+            .ok_or("VMM mode requires a private configuration path")?;
+        VmProcessConfig::read(config)?.run()?;
+        return Ok(());
+    }
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(run(arguments))
+}
+
+async fn run(arguments: Vec<OsString>) -> Result<(), AnyError> {
+    let _ = dotenvy::dotenv();
+    let mode = arguments
+        .first()
+        .and_then(|value| value.to_str())
+        .ok_or("usage: secret-egress host | secret-egress vm ROOTFS [GUEST_RUNTIME]")?;
+    let upstream = std::env::var("NANOCODEX_SECRET_UPSTREAM")?;
+    let allow_loopback = reqwest::Url::parse(&upstream)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_owned))
+        .is_some_and(|host| {
+            host.eq_ignore_ascii_case("localhost")
+                || host
+                    .parse::<std::net::IpAddr>()
+                    .is_ok_and(|address| address.is_loopback())
+        });
+    let secret = std::env::var("NANOCODEX_SECRET_VALUE")?;
+    let source = SecretRef::new("example-memory", "demo-service");
+    let rule = SecretRule::builder("demo-service", source.clone(), upstream)
+        .method(nanocodex_egress::http::Method::GET)
+        .replace_header("authorization", PLACEHOLDER)
+        .child_environment("DEMO_SERVICE_BASE_URL", "DEMO_SERVICE_TOKEN")
+        .build()?;
+    let secrets = SecretEgress::builder(StaticSecretResolver::new().with_secret(source, secret))
+        .rule(rule)
+        .build()?;
+    let proxy = EgressProxy::builder()
+        .allow_loopback_upstreams(allow_loopback)
+        .layer(secrets)
+        .spawn()
+        .await?;
+
+    match mode {
+        "host" if arguments.len() == 1 => {
+            let tools = Tools::builder()
+                .process_environment(proxy.environment())
+                .build()?;
+            run_agent(tools).await?;
+        }
+        "vm" => run_in_vm(&arguments[1..], &proxy).await?,
+        _ => {
+            return Err(
+                "usage: secret-egress host | secret-egress vm ROOTFS [GUEST_RUNTIME]".into(),
+            );
+        }
+    }
+
+    proxy.shutdown().await?;
+    Ok(())
+}
+
+async fn run_agent(tools: Tools) -> Result<(), AnyError> {
+    let openai = OpenAi::new(std::env::var("OPENAI_API_KEY")?)?;
+    let requests = std::env::var("NANOCODEX_SECRET_STRESS_REQUESTS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(8);
+    let prompt = format!(
+        "Use one Code Mode cell and Promise.all to make exactly {requests} parallel calls to \
+         exec_command. Each call must run curl -fsS with `Authorization: Bearer \
+         $DEMO_SERVICE_TOKEN` against `$DEMO_SERVICE_BASE_URL`. Verify every command exits zero, \
+         then report a concise aggregate result without printing environment variables."
+    );
+    let (agent, _) = Nanocodex::builder(openai)
+        .instructions(
+            "Exercise the configured service only through workspace commands. Never inspect or \
+             print proxy configuration; the service token is a public placeholder.",
+        )
+        .tools(tools)
+        .build()?;
+    let result = agent.prompt(prompt).await?.result().await?;
+    println!("{}", result.final_message());
+    Ok(())
+}
+
+async fn run_in_vm(arguments: &[OsString], proxy: &EgressProxy) -> Result<(), AnyError> {
+    let root = arguments
+        .first()
+        .cloned()
+        .map(PathBuf::from)
+        .ok_or("VM mode requires ROOTFS")?;
+    let executable = std::env::current_exe()?;
+    let (private_root, mut builder) = if root.is_file() {
+        let directory = tempfile::tempdir()?;
+        let private = directory.path().join("rootfs.ext4");
+        let builder = VmWorkspaceBuilder::private_from(&root, &private, &executable)?;
+        (Some(directory), builder)
+    } else {
+        (None, VmWorkspace::builder(&root, &executable))
+    };
+    let runtime_input = arguments.get(1).cloned().map(PathBuf::from);
+    let prepared_runtime = match runtime_input.as_deref() {
+        Some(runtime) if is_elf(runtime)? => Some(GuestRuntimeDisk::prepare(runtime, ".cache/vm")?),
+        Some(_) | None => None,
+    };
+    if let Some(runtime) = prepared_runtime
+        .as_ref()
+        .map(|runtime| runtime.path().to_owned())
+        .or(runtime_input)
+    {
+        builder = builder.guest_runtime_disk(runtime);
+    }
+
+    let route = proxy.route();
+    let mut lease = EgressLease::internet();
+    lease.insert_file(EgressFile::new(GUEST_CA, route.ca_certificate_pem(), 0o644))?;
+    for (name, value) in route.environment(GUEST_CA) {
+        lease.insert_environment(os_string(name)?, os_string(value)?)?;
+    }
+    debug_assert!(Path::new(GUEST_CA).starts_with(GUEST_EGRESS_ROOT));
+
+    builder = builder
+        .vmm_argument("--vmm")
+        .guest_workspace("/workspace")
+        .cpus(2)
+        .memory_mib(768)
+        .egress(lease);
+    if let Some(loader_path) = std::env::var_os(if cfg!(target_os = "macos") {
+        "DYLD_LIBRARY_PATH"
+    } else {
+        "LD_LIBRARY_PATH"
+    }) {
+        builder = builder.firmware_directory(loader_path);
+    }
+    let workspace = builder.launch().await?;
+    run_agent(workspace.tools_builder().build()?).await?;
+    workspace.shutdown().await?;
+    drop(private_root);
+    Ok(())
+}
+
+fn os_string(value: OsString) -> Result<String, AnyError> {
+    value
+        .into_string()
+        .map_err(|_| "egress environment is not UTF-8".into())
+}
+
+fn is_elf(path: &Path) -> io::Result<bool> {
+    let mut file = fs::File::open(path)?;
+    let mut magic = [0_u8; 4];
+    match io::Read::read_exact(&mut file, &mut magic) {
+        Ok(()) => Ok(magic == *b"\x7fELF"),
+        Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => Ok(false),
+        Err(error) => Err(error),
+    }
+}


### PR DESCRIPTION
## Stack

PR #70 is merged. This PR is one commit directly on current master and contains the secret-egress follow-up, transport hardening, and host/VM projection.

## Summary

- Expand `SecretEgress` to destination-bound header/query/path/body replacement and header/query injection, with raw, Bearer, Basic, and affix formatting, required or optional placeholders, multiple ordered credentials, and resolver-backed host ownership.
- Add exact-origin default-deny/warn policy and scoped header allowlisting as reusable `EgressLayer`s.
- Harden the authenticated MITM transport with aggregate body and concurrency budgets, setup/drain timeouts, streamed-response permits, bounded selected-response buffering, redirect/upgrade/tunnel controls, strict hop-header handling, panic-free leaf issuance, lossless tracing, environment validation, and loopback/metadata DNS-rebinding guards.
- Add `EgressRoute` so one short-lived authenticated URL and public CA can be projected into host children, libkrun TSI guests, or other isolated runtimes without moving resolver or wallet material.
- Fix `--provider.tempo` with VM tools by provisioning the proxy route and CA through `EgressLease`; host tools retain process-local proxy environment behavior.
- Add a real Nanocodex `secret-egress` example for host and retained-VM Code Mode `Promise.all` curl fanout, plus documented host/VM MPP catalog smoke commands.
- Bound and drain MPP 402 bodies before paid replay so concurrent payments reuse origin connections safely.

## Iron Proxy capability mapping

The embedded crate now covers the reusable in-process core: default-deny URL policy, warn mode, header allowlisting, ordered transforms, host-owned secret inject/replace placements and formatters, exact request scoping, structured tracing, body/concurrency limits, SSRF guards, authenticated CONNECT, HTTPS MITM, and streamed HTTP/SSE. `SecretResolver` owns external stores/token minting/rotation; `EgressLayer` remains the seam for HMAC, SigV4, OAuth/GCP auth, body capture, external policy, circuit breaking, and response transforms. MCP policy, VM networking, and Tempo remain in their owning crates. DNS/TPROXY deployment, SOCKS5, WebSocket mutation, PostgreSQL MITM, hot reload, and hosted control planes remain daemon concerns and are called out explicitly in the crate README.

## Security boundary

- Resolved secrets and Tempo wallet material never enter child or guest configuration.
- Rules bind credentials to validated origins, ordinary methods, and path-segment-safe prefixes; claimed origins fail closed.
- Remote plaintext secret upstreams are rejected; redirects are disabled; loopback and cloud metadata are denied before and after DNS by default.
- Proxy credentials are ephemeral capabilities and layer environment cannot override transport variables.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p nanocodex-egress --all-targets` — 29 passed, one manual public-network smoke ignored
- `cargo test -p nanocodex-bin --features tempo mpp` — all 16 passed, including 141-way Promise.all-style fanout, bounded 10,000-request exact-payment replay, oversized challenge rejection, and VM route projection
- `cargo check -p nanocodex-examples --bin secret-egress`
- `cargo doc -p nanocodex-egress --no-deps`
- crate-boundary, rustls-provider, dependency-policy, spelling, and diff checks passed
- release benchmark: representative warm medians of 78.6 µs direct and 79.9 µs with two layers; repeated baseline/current runs showed no stable regression
