### PR TITLE
feat(experimental): add managed agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4917,8 +4917,10 @@ source = "git+https://github.com/tempoxyz/mpp-rs?rev=3e37469bb19434982b433ae44ea
 dependencies = [
  "alloy",
  "anyhow",
+ "async-stream",
  "async-trait",
  "base64",
+ "futures-core",
  "hex",
  "hmac 0.13.0",
  "http",
@@ -4956,6 +4958,56 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "nanocentaur"
+version = "0.3.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "chrono",
+ "criterion",
+ "futures-util",
+ "nanocodex-agent",
+ "nanocodex-egress",
+ "nanocodex-oai-api",
+ "nanocodex-vm",
+ "reflink-copy",
+ "reqwest",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "nanocentaur-server"
+version = "0.3.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "clap",
+ "eyre",
+ "futures-util",
+ "mpp",
+ "nanocentaur",
+ "nanocodex-oai-api",
+ "nanocodex-vm",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ members = [
     "crates/nanocodex-agent",
     "crates/experimental/nanocodex-browser",
     "crates/experimental/nanocodex-egress",
+    "crates/experimental/nanocentaur",
+    "crates/experimental/nanocentaur-server",
     "crates/experimental/nanocodex-voice",
     "crates/experimental/nanocodex-vm",
     "crates/nanocodex-oai-api",
@@ -67,6 +69,7 @@ krun = { package = "libkrun", version = "=2.0.0-dev", git = "https://github.com/
 mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "3e37469bb19434982b433ae44ea8c713f7ea923a", default-features = false }
 nanocodex = { version = "0.3.0", path = "crates/nanocodex" }
 nanocodex-agent = { version = "0.3.0", path = "crates/nanocodex-agent" }
+nanocentaur = { version = "0.3.0", path = "crates/experimental/nanocentaur" }
 nanocodex-browser = { version = "0.3.0", path = "crates/experimental/nanocodex-browser" }
 nanocodex-egress = { version = "0.3.0", path = "crates/experimental/nanocodex-egress" }
 nanocodex-voice = { version = "0.3.0", path = "crates/experimental/nanocodex-voice" }

--- a/PLAN.md
+++ b/PLAN.md
@@ -111,6 +111,12 @@ migration, and it must be independently mergeable.
     starts, with Codex's current `cove` default and Frameless model. Realtime
     coding handoffs atomically steer an active regular turn or start a new turn,
     so spoken follow-ups remain interactive during tool execution.
+12. [x] Reintroduce the managed-agent slice from PR #60 on current `master`:
+    durable SQLite-backed actors and event replay, tenant policy and admin APIs,
+    explicit steering/queueing/cancellation/forks, a thin REST/SSE server, and
+    VM-backed Nanocodex runtimes composed with the current host-owned secret
+    egress boundary. Browser, VM, and egress implementations remain owned by
+    their already-merged experimental crates.
 
 ## Current non-goals
 
@@ -120,6 +126,7 @@ migration, and it must be independently mergeable.
   the core library.
 - No new `.service(...)` transport design without a concrete consumer.
 - No cosmetic CLI/TUI lifecycle rewrite when existing behavior is accepted.
-- No further VM, browser, managed-agent, proxy, or experimental-crate work.
+- No further VM, browser, proxy, or experimental-crate expansion beyond the
+  managed-agent composition recorded above.
 - No benchmark, task, or verifier modification made solely to improve an eval
   score.

--- a/README.md
+++ b/README.md
@@ -252,9 +252,11 @@ Components whose public contracts are still maturing live under
 | --- | --- |
 | [`nanocodex-voice`](crates/experimental/nanocodex-voice/README.md) | Desktop GPT Realtime audio and reusable voice-to-agent lifecycle |
 | [`nanocodex-vm`](crates/experimental/nanocodex-vm/README.md) | VM lifecycle and images plus retained guest-backed workspace tools |
+| [`nanocentaur`](crates/experimental/nanocentaur/README.md) | Durable host-managed agents with policy, REST/SSE, VM tools, and secret egress |
 
-The CLI is a consumer of these crates. Voice and VM-backed tools remain thin,
-opt-in adapters over the stable library contracts.
+The CLI and Nanocentaur server are consumers of these crates. Voice,
+VM-backed tools, and managed hosting remain opt-in compositions over the
+stable library contracts.
 
 ### CLI and language bindings
 

--- a/crates/experimental/README.md
+++ b/crates/experimental/README.md
@@ -11,6 +11,8 @@ being exercised and revised:
   control, diagnostics, artifacts, and headed-browser VM composition.
 - [`nanocodex-egress`](nanocodex-egress/README.md): authenticated loopback
   HTTP(S) forwarding, application-owned middleware, and host-owned secrets.
+- [`nanocentaur`](nanocentaur/README.md): durable host-managed agents,
+  tenant policy, REST/SSE projection, and VM-backed runtime composition.
 
 Experimental means API stability, not reduced engineering standards. These
 packages remain workspace members and must pass the normal formatting, Clippy,

--- a/crates/experimental/nanocentaur-server/Cargo.toml
+++ b/crates/experimental/nanocentaur-server/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "nanocentaur-server"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+readme = "README.md"
+description = "REST server for host-managed Nanocodex agents"
+
+[features]
+default = []
+mpp = ["dep:mpp"]
+
+[[bin]]
+name = "nanocentaur"
+path = "src/main.rs"
+doc = false
+
+[dependencies]
+async-trait.workspace = true
+axum.workspace = true
+clap.workspace = true
+eyre.workspace = true
+futures-util.workspace = true
+mpp = { workspace = true, features = ["server", "tempo"], optional = true }
+nanocentaur.workspace = true
+nanocodex-oai-api.workspace = true
+nanocodex-vm.workspace = true
+reqwest = { workspace = true, features = ["json"] }
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+
+[lints]
+workspace = true

--- a/crates/experimental/nanocentaur-server/README.md
+++ b/crates/experimental/nanocentaur-server/README.md
@@ -1,0 +1,7 @@
+# nanocentaur-server
+
+Thin executable consumer of the experimental `nanocentaur` managed-agent
+library. It exposes the REST/SSE API, deterministic HTTP benchmark, optional
+MPP payment gate, and the application-owned libkrun VMM entrypoint.
+
+See the [managed-agent guide](../../../docs/nanocentaur.md).

--- a/crates/experimental/nanocentaur-server/src/main.rs
+++ b/crates/experimental/nanocentaur-server/src/main.rs
@@ -1,0 +1,451 @@
+#[cfg(feature = "mpp")]
+mod mpp_gate;
+
+use std::{
+    net::SocketAddr,
+    path::PathBuf,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use eyre::{Result, bail};
+use futures_util::{StreamExt, stream};
+use nanocentaur::{
+    AdminAuthorizer, AgentManager, ApiState, CapabilityEgress, CapabilityName,
+    CompositeSecretManager, ContentBlock, CreateAgent, CreateAgentResponse, CreateTurn,
+    EgressProvider, EnvironmentSecretManager, FileSecretManager, FreePaymentGate,
+    ManagedAgentFactory, ManagedEgress, MockAgentFactory, NanocodexAgentFactory, PaymentGate,
+    PolicyStore, ProxyProfile, SecretManager, SecretRef, TurnDelivery, TurnStatus, TurnView,
+    backend::run_vmm,
+};
+use nanocodex_oai_api::auth::OpenAiAuth;
+use nanocodex_vm::tools::GuestRuntimeDisk;
+use reqwest::Client;
+use serde::Serialize;
+use tracing_subscriber::EnvFilter;
+
+#[derive(Parser)]
+#[command(name = "nanocentaur")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Run the hosted-agent REST API.
+    Serve(Box<Serve>),
+    /// Exercise N independent agents through the real HTTP API.
+    Bench(Bench),
+    #[command(hide = true)]
+    Vmm {
+        #[arg(long)]
+        config: PathBuf,
+    },
+}
+
+#[derive(Args)]
+struct Serve {
+    #[arg(long, default_value = "127.0.0.1:3000")]
+    listen: SocketAddr,
+    #[arg(long, env = "NANOCENTAUR_API_KEY")]
+    api_key: String,
+    #[arg(long, env = "NANOCENTAUR_ADMIN_TOKEN")]
+    admin_token: String,
+    #[arg(long, default_value = ".nanocentaur")]
+    state_directory: PathBuf,
+    #[arg(long, value_enum, default_value_t = Backend::Mock)]
+    backend: Backend,
+    #[arg(long, default_value_t = 25)]
+    mock_delay_ms: u64,
+    #[arg(long, requires = "openai_api_key")]
+    rootfs: Option<PathBuf>,
+    #[arg(long, env = "OPENAI_API_KEY", requires = "rootfs")]
+    openai_api_key: Option<String>,
+    /// Static Linux guest runtime used with raw ext4 roots.
+    #[arg(long, env = "NANOCODEX_VM_GUEST_RUNTIME", requires = "rootfs")]
+    vm_guest_runtime: Option<PathBuf>,
+    /// Directory containing the platform libkrun firmware library.
+    #[arg(long, requires = "rootfs")]
+    firmware_directory: Option<PathBuf>,
+    #[arg(long = "allow-capability")]
+    allowed_capabilities: Vec<String>,
+    /// All non-tool capabilities use this server-owned proxy URL.
+    #[arg(long)]
+    egress_proxy_url: Option<String>,
+    /// Resolve the proxy URL from `NANOCENTAUR_SECRET_<KEY>` on the host.
+    #[arg(long, conflicts_with = "egress_proxy_url")]
+    egress_proxy_secret: Option<String>,
+    /// Host directory exposed as the `file` secret provider.
+    #[arg(long)]
+    secret_directory: Option<PathBuf>,
+    #[arg(long, value_enum, default_value_t = Payments::Free)]
+    payments: Payments,
+    #[cfg(feature = "mpp")]
+    #[command(flatten)]
+    mpp: MppArgs,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum Backend {
+    Mock,
+    Nanocodex,
+}
+
+#[derive(Clone, Copy, ValueEnum)]
+enum Payments {
+    Free,
+    Mpp,
+}
+
+#[cfg(feature = "mpp")]
+#[derive(Args)]
+struct MppArgs {
+    #[arg(long = "mpp-rpc-url", env = "NANOCENTAUR_MPP_RPC_URL")]
+    rpc_url: Option<String>,
+    #[arg(long = "mpp-currency", env = "NANOCENTAUR_MPP_CURRENCY")]
+    currency: Option<String>,
+    #[arg(long = "mpp-recipient", env = "NANOCENTAUR_MPP_RECIPIENT")]
+    recipient: Option<String>,
+    #[arg(long = "mpp-escrow", env = "NANOCENTAUR_MPP_ESCROW")]
+    escrow: Option<String>,
+    #[arg(long = "mpp-chain-id", env = "NANOCENTAUR_MPP_CHAIN_ID")]
+    chain_id: Option<u64>,
+    #[arg(long = "mpp-close-key", env = "NANOCENTAUR_MPP_CLOSE_KEY")]
+    close_key: Option<String>,
+    #[arg(
+        long = "mpp-challenge-secret",
+        env = "NANOCENTAUR_MPP_CHALLENGE_SECRET"
+    )]
+    challenge_secret: Option<String>,
+    #[arg(long = "mpp-unit-price", env = "NANOCENTAUR_MPP_UNIT_PRICE")]
+    unit_price: Option<u128>,
+    #[arg(
+        long = "mpp-suggested-deposit",
+        env = "NANOCENTAUR_MPP_SUGGESTED_DEPOSIT"
+    )]
+    suggested_deposit: Option<String>,
+    #[arg(long = "mpp-fee-payer", default_value_t = false)]
+    fee_payer: bool,
+}
+
+#[derive(Args)]
+struct Bench {
+    #[arg(long, default_value = "http://127.0.0.1:3000")]
+    url: String,
+    #[arg(long, env = "NANOCENTAUR_API_KEY")]
+    api_key: String,
+    #[arg(long, default_value_t = 32)]
+    agents: usize,
+    #[arg(long)]
+    concurrency: Option<usize>,
+}
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+    let command = Cli::parse().command;
+    if let Command::Vmm { config } = command {
+        return run_vmm(&config).map_err(Into::into);
+    }
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(async move {
+            match command {
+                Command::Serve(arguments) => serve(*arguments).await,
+                Command::Bench(arguments) => bench(arguments).await,
+                Command::Vmm { .. } => unreachable!("VMM mode returned before starting Tokio"),
+            }
+        })
+}
+
+async fn serve(arguments: Serve) -> Result<()> {
+    let capabilities = arguments
+        .allowed_capabilities
+        .iter()
+        .map(|name| CapabilityName::new(name.clone()))
+        .collect::<Result<Vec<_>, _>>()?;
+    let proxy_url = match (
+        arguments.egress_proxy_url.clone(),
+        arguments.egress_proxy_secret.clone(),
+    ) {
+        (Some(url), None) => Some(url),
+        (None, Some(key)) => EnvironmentSecretManager::new("NANOCENTAUR_SECRET_")
+            .resolve(&SecretRef::new("environment", key))
+            .await
+            .map(Some)?,
+        (None, None) => None,
+        (Some(_), Some(_)) => unreachable!("clap rejects conflicting proxy options"),
+    };
+    let proxy = proxy_url
+        .map(|url| ProxyProfile::new("configured", url).map(Arc::new))
+        .transpose()?;
+    let mut egress = CapabilityEgress::new();
+    for capability in capabilities
+        .iter()
+        .filter(|capability| !capability.as_str().starts_with("tools."))
+    {
+        egress = if let Some(profile) = &proxy {
+            egress.proxy(capability.clone(), Arc::clone(profile))
+        } else {
+            egress.direct(capability.clone())
+        };
+    }
+
+    let payments = payment_gate(&arguments)?;
+    let policy = Arc::new(PolicyStore::open(
+        arguments.state_directory.join("policy.sqlite"),
+    )?);
+    policy.bootstrap(
+        "standalone",
+        "Standalone API client",
+        &arguments.api_key,
+        "standalone",
+        capabilities,
+    )?;
+    let managed_egress: Arc<dyn EgressProvider> =
+        managed_egress(&arguments, Arc::clone(&policy), egress)?;
+
+    let factory: Arc<dyn ManagedAgentFactory> = match arguments.backend {
+        Backend::Mock => Arc::new(MockAgentFactory::new(Duration::from_millis(
+            arguments.mock_delay_ms,
+        ))),
+        Backend::Nanocodex => {
+            let rootfs = arguments
+                .rootfs
+                .clone()
+                .ok_or_else(|| eyre::eyre!("--rootfs is required for nanocodex backend"))?;
+            let api_key = arguments
+                .openai_api_key
+                .clone()
+                .ok_or_else(|| eyre::eyre!("--openai-api-key is required for nanocodex backend"))?;
+            let mut factory = NanocodexAgentFactory::new(
+                OpenAiAuth::api_key(api_key),
+                std::env::current_exe()?,
+                &rootfs,
+                &arguments.state_directory,
+                managed_egress,
+            );
+            if rootfs.is_file() {
+                let runtime = arguments
+                    .vm_guest_runtime
+                    .as_ref()
+                    .ok_or_else(|| eyre::eyre!("raw ext4 roots require --vm-guest-runtime ELF"))?;
+                let runtime =
+                    GuestRuntimeDisk::prepare(runtime, arguments.state_directory.join("vm-cache"))?;
+                factory = factory.guest_runtime_disk(runtime.path());
+            } else if arguments.vm_guest_runtime.is_some() {
+                bail!("--vm-guest-runtime is only valid with a raw ext4 root");
+            }
+            if let Some(firmware) = &arguments.firmware_directory {
+                factory = factory.firmware_directory(firmware);
+            }
+            Arc::new(factory)
+        }
+    };
+    let manager = Arc::new(AgentManager::new(factory, &arguments.state_directory)?);
+    let app = ApiState::new(
+        manager,
+        policy,
+        Arc::new(AdminAuthorizer::new(&arguments.admin_token)?),
+        payments,
+    )
+    .router();
+    let listener = tokio::net::TcpListener::bind(arguments.listen).await?;
+    tracing::info!(address = %arguments.listen, "nanocentaur listening");
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+fn managed_egress(
+    arguments: &Serve,
+    policy: Arc<PolicyStore>,
+    egress: CapabilityEgress,
+) -> Result<Arc<ManagedEgress>> {
+    let mut manager = CompositeSecretManager::new().provider(
+        "environment",
+        Arc::new(EnvironmentSecretManager::new("NANOCENTAUR_SECRET_")),
+    );
+    if let Some(directory) = &arguments.secret_directory {
+        manager = manager.provider("file", Arc::new(FileSecretManager::new(directory)?));
+    }
+    Ok(Arc::new(ManagedEgress::new(
+        policy,
+        Arc::new(manager),
+        egress,
+    )))
+}
+
+fn payment_gate(arguments: &Serve) -> Result<Arc<dyn PaymentGate>> {
+    match arguments.payments {
+        Payments::Free => Ok(Arc::new(FreePaymentGate)),
+        Payments::Mpp => {
+            #[cfg(feature = "mpp")]
+            {
+                use mpp_gate::{MppGateConfig, MppSessionGate};
+                let required = |value: &Option<String>, name: &str| {
+                    value
+                        .clone()
+                        .ok_or_else(|| eyre::eyre!("{name} is required with --payments mpp"))
+                };
+                let gate = MppSessionGate::new(MppGateConfig {
+                    rpc_url: required(&arguments.mpp.rpc_url, "--mpp-rpc-url")?,
+                    currency: required(&arguments.mpp.currency, "--mpp-currency")?,
+                    recipient: required(&arguments.mpp.recipient, "--mpp-recipient")?,
+                    escrow_contract: required(&arguments.mpp.escrow, "--mpp-escrow")?,
+                    chain_id: arguments
+                        .mpp
+                        .chain_id
+                        .ok_or_else(|| eyre::eyre!("--mpp-chain-id is required"))?,
+                    close_key: required(&arguments.mpp.close_key, "--mpp-close-key")?,
+                    challenge_secret: required(
+                        &arguments.mpp.challenge_secret,
+                        "--mpp-challenge-secret",
+                    )?,
+                    unit_price: arguments
+                        .mpp
+                        .unit_price
+                        .ok_or_else(|| eyre::eyre!("--mpp-unit-price is required"))?,
+                    suggested_deposit: arguments.mpp.suggested_deposit.clone(),
+                    fee_payer: arguments.mpp.fee_payer,
+                })?;
+                Ok(Arc::new(gate))
+            }
+            #[cfg(not(feature = "mpp"))]
+            {
+                bail!("rebuild with `--features mpp` to enable MPP sessions")
+            }
+        }
+    }
+}
+
+async fn bench(arguments: Bench) -> Result<()> {
+    if arguments.agents == 0 {
+        bail!("--agents must be greater than zero");
+    }
+    let concurrency = arguments.concurrency.unwrap_or(arguments.agents).max(1);
+    let client = Client::new();
+    let started = Instant::now();
+    let results = stream::iter(0..arguments.agents)
+        .map(|index| {
+            benchmark_agent(
+                client.clone(),
+                arguments.url.clone(),
+                arguments.api_key.clone(),
+                index,
+            )
+        })
+        .buffer_unordered(concurrency)
+        .collect::<Vec<_>>()
+        .await;
+    let elapsed = started.elapsed();
+    let mut latencies = results
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .map(|duration| duration.as_secs_f64() * 1_000.0)
+        .collect::<Vec<_>>();
+    latencies.sort_by(f64::total_cmp);
+    let output = BenchmarkReport {
+        agents: arguments.agents,
+        concurrency,
+        wall_ms: elapsed.as_secs_f64() * 1_000.0,
+        throughput_agents_per_second: count_as_f64(arguments.agents) / elapsed.as_secs_f64(),
+        latency_ms: LatencyReport {
+            p50: percentile(&latencies, 50, 100),
+            p95: percentile(&latencies, 95, 100),
+            max: latencies.last().copied().unwrap_or_default(),
+        },
+    };
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
+async fn benchmark_agent(
+    client: Client,
+    base_url: String,
+    api_key: String,
+    index: usize,
+) -> Result<Duration> {
+    let started = Instant::now();
+    let agent: CreateAgentResponse = client
+        .post(format!("{base_url}/v1/agent/new"))
+        .header("x-api-key", &api_key)
+        .json(&CreateAgent {
+            context_key: Some(format!("benchmark:{index}")),
+        })
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let agent_id = agent.agent_id;
+    let turn: nanocentaur::TurnActionResponse = client
+        .post(format!("{base_url}/v1/agent/{agent_id}/turn"))
+        .header("x-api-key", &api_key)
+        .header("idempotency-key", format!("benchmark-{index}"))
+        .json(&CreateTurn {
+            delivery: TurnDelivery::Steer,
+            content: vec![ContentBlock::Text {
+                text: format!("ping {index}"),
+            }],
+        })
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    let turn_id = turn.turn_id;
+    loop {
+        let terminal: TurnView = client
+            .get(format!("{base_url}/v1/agent/{agent_id}/turn/{turn_id}"))
+            .header("x-api-key", &api_key)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        match terminal.state {
+            TurnStatus::Completed => break,
+            TurnStatus::Failed | TurnStatus::Cancelled => {
+                bail!("agent {index} ended in {:?}", terminal.state);
+            }
+            TurnStatus::Queued | TurnStatus::Running => {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        }
+    }
+    Ok(started.elapsed())
+}
+
+#[derive(Serialize)]
+struct BenchmarkReport {
+    agents: usize,
+    concurrency: usize,
+    wall_ms: f64,
+    throughput_agents_per_second: f64,
+    latency_ms: LatencyReport,
+}
+
+#[derive(Serialize)]
+struct LatencyReport {
+    p50: f64,
+    p95: f64,
+    max: f64,
+}
+
+fn percentile(sorted: &[f64], numerator: usize, denominator: usize) -> f64 {
+    let last = sorted.len().saturating_sub(1);
+    let index = last
+        .saturating_mul(numerator)
+        .saturating_add(denominator / 2)
+        / denominator;
+    sorted.get(index).copied().unwrap_or_default()
+}
+
+fn count_as_f64(value: usize) -> f64 {
+    f64::from(u32::try_from(value).unwrap_or(u32::MAX))
+}

--- a/crates/experimental/nanocentaur-server/src/mpp_gate.rs
+++ b/crates/experimental/nanocentaur-server/src/mpp_gate.rs
@@ -1,0 +1,176 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::http::{HeaderMap, header};
+use mpp::{
+    Address, PaymentCredential, PrivateKeySigner, parse_authorization,
+    server::{
+        Mpp, SessionChallengeOptions, SessionChannelStore, SessionMethodConfig, TempoChargeMethod,
+        TempoConfig, TempoProvider, TempoSessionMethod, tempo, tempo_provider,
+    },
+};
+use nanocentaur::{
+    PaymentError, PaymentGate, PaymentManagementResponse, PaymentOutcome, PaymentReceipt,
+};
+
+type PaymentHandler = Mpp<TempoChargeMethod<TempoProvider>, TempoSessionMethod<TempoProvider>>;
+
+pub struct MppGateConfig {
+    pub rpc_url: String,
+    pub currency: String,
+    pub recipient: String,
+    pub escrow_contract: String,
+    pub chain_id: u64,
+    pub close_key: String,
+    pub challenge_secret: String,
+    pub unit_price: u128,
+    pub suggested_deposit: Option<String>,
+    pub fee_payer: bool,
+}
+
+pub struct MppSessionGate {
+    payment: PaymentHandler,
+    unit_price: u128,
+    currency: String,
+    recipient: String,
+    suggested_deposit: Option<String>,
+}
+
+impl MppSessionGate {
+    pub fn new(config: MppGateConfig) -> Result<Self, PaymentError> {
+        let signer: PrivateKeySigner = config
+            .close_key
+            .parse()
+            .map_err(|error| PaymentError::Configuration(format!("invalid close key: {error}")))?;
+        let signer_address = format!("{:#x}", signer.address());
+        if !signer_address.eq_ignore_ascii_case(&config.recipient) {
+            return Err(PaymentError::Configuration(
+                "MPP close key must sign for the configured recipient".to_owned(),
+            ));
+        }
+        let escrow_contract: Address = config.escrow_contract.parse().map_err(|error| {
+            PaymentError::Configuration(format!("invalid escrow contract: {error}"))
+        })?;
+        let store = Arc::new(SessionChannelStore::new());
+        let payment = Mpp::create(
+            tempo(TempoConfig {
+                recipient: &config.recipient,
+            })
+            .rpc_url(&config.rpc_url)
+            .currency(&config.currency)
+            .secret_key(&config.challenge_secret)
+            .fee_payer(config.fee_payer),
+        )
+        .map_err(|error| PaymentError::Configuration(error.to_string()))?;
+        let provider = tempo_provider(&config.rpc_url)
+            .map_err(|error| PaymentError::Configuration(error.to_string()))?;
+        let session = TempoSessionMethod::new(
+            provider,
+            store,
+            SessionMethodConfig {
+                escrow_contract,
+                chain_id: config.chain_id,
+                min_voucher_delta: config.unit_price,
+            },
+        )
+        .with_close_signer(signer);
+        Ok(Self {
+            payment: payment.with_session_method(session),
+            unit_price: config.unit_price,
+            currency: config.currency,
+            recipient: config.recipient,
+            suggested_deposit: config.suggested_deposit,
+        })
+    }
+}
+
+#[async_trait]
+impl PaymentGate for MppSessionGate {
+    async fn authorize(&self, headers: &HeaderMap) -> Result<PaymentOutcome, PaymentError> {
+        let Some(credential) = parse_credential(headers)? else {
+            let price = self.unit_price.to_string();
+            let challenge = self
+                .payment
+                .session_challenge_with_details(
+                    &price,
+                    &self.currency,
+                    &self.recipient,
+                    SessionChallengeOptions {
+                        unit_type: Some("agent_turn"),
+                        suggested_deposit: self.suggested_deposit.as_deref(),
+                        description: Some("one nanocentaur agent turn"),
+                        ..Default::default()
+                    },
+                )
+                .map_err(|error| PaymentError::Configuration(error.to_string()))?;
+            return Ok(PaymentOutcome::Challenge {
+                www_authenticate: challenge
+                    .to_header()
+                    .map_err(|error| PaymentError::Configuration(error.to_string()))?,
+            });
+        };
+
+        let verified = self
+            .payment
+            .verify_session(&credential)
+            .await
+            .map_err(|error| PaymentError::Verification(error.to_string()))?;
+        let receipt = PaymentReceipt {
+            header_value: verified
+                .receipt
+                .to_header()
+                .map_err(|error| PaymentError::Verification(error.to_string()))?,
+        };
+        if let Some(management) = verified.management_response {
+            return Ok(PaymentOutcome::Management {
+                body: serde_json::from_value::<PaymentManagementResponse>(management)
+                    .map_err(|error| PaymentError::Verification(error.to_string()))?,
+                receipt,
+            });
+        }
+        Ok(PaymentOutcome::Authorized(receipt))
+    }
+}
+
+fn parse_credential(headers: &HeaderMap) -> Result<Option<PaymentCredential>, PaymentError> {
+    headers
+        .get(header::AUTHORIZATION)
+        .map(|value| {
+            value
+                .to_str()
+                .map_err(|_| PaymentError::InvalidCredential)
+                .and_then(|value| {
+                    parse_authorization(value).map_err(|_| PaymentError::InvalidCredential)
+                })
+        })
+        .transpose()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn missing_credential_produces_an_mpp_session_challenge() {
+        let gate = MppSessionGate::new(MppGateConfig {
+            rpc_url: "http://127.0.0.1:1".to_owned(),
+            currency: "0x0000000000000000000000000000000000000001".to_owned(),
+            recipient: "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf".to_owned(),
+            escrow_contract: "0x0000000000000000000000000000000000000002".to_owned(),
+            chain_id: 1,
+            close_key: "0x0000000000000000000000000000000000000000000000000000000000000001"
+                .to_owned(),
+            challenge_secret: "test-only-challenge-secret".to_owned(),
+            unit_price: 25,
+            suggested_deposit: Some("250".to_owned()),
+            fee_payer: false,
+        })
+        .unwrap();
+        let outcome = gate.authorize(&HeaderMap::new()).await.unwrap();
+        let PaymentOutcome::Challenge { www_authenticate } = outcome else {
+            panic!("missing credential must return a challenge");
+        };
+        assert!(!www_authenticate.is_empty());
+        assert!(www_authenticate.contains("session"));
+    }
+}

--- a/crates/experimental/nanocentaur/Cargo.toml
+++ b/crates/experimental/nanocentaur/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "nanocentaur"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+readme = "README.md"
+description = "Host-managed Nanocodex sessions with capability-scoped VM tools"
+
+[dependencies]
+async-trait.workspace = true
+axum.workspace = true
+chrono.workspace = true
+futures-util.workspace = true
+nanocodex-agent.workspace = true
+nanocodex-egress.workspace = true
+nanocodex-oai-api.workspace = true
+nanocodex-vm.workspace = true
+reflink-copy.workspace = true
+rusqlite.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+tempfile.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+url.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+criterion.workspace = true
+reqwest.workspace = true
+tower.workspace = true
+tracing-subscriber.workspace = true
+
+[[bench]]
+name = "managed_api"
+harness = false
+
+[lints]
+workspace = true

--- a/crates/experimental/nanocentaur/README.md
+++ b/crates/experimental/nanocentaur/README.md
@@ -1,0 +1,14 @@
+# nanocentaur
+
+Experimental host-managed Nanocodex sessions with durable SQLite state,
+tenant policy, REST/SSE projection, VM-backed workspace tools, and host-owned
+secret egress.
+
+The normal embedding boundary is `AgentManager` plus a
+`ManagedAgentFactory`. `MockAgentFactory` provides a deterministic backend;
+`NanocodexAgentFactory` provisions the current `nanocodex-vm` workspace and
+resumes completed `SessionSnapshot` values. `ApiState` adds the Axum
+transport without becoming a second lifecycle owner.
+
+See the [managed-agent guide](../../../docs/nanocentaur.md) for API, durability,
+policy, egress, and server examples.

--- a/crates/experimental/nanocentaur/benches/managed_api.rs
+++ b/crates/experimental/nanocentaur/benches/managed_api.rs
@@ -122,7 +122,7 @@ impl ManagedHarness {
 
     async fn replay_turn(&self, idempotency_key: &str) -> TurnActionResponse {
         let (status, action) = self.submit_turn(idempotency_key).await;
-        assert_eq!(status, StatusCode::OK);
+        assert_eq!(status, StatusCode::ACCEPTED);
         action
     }
 

--- a/crates/experimental/nanocentaur/benches/managed_api.rs
+++ b/crates/experimental/nanocentaur/benches/managed_api.rs
@@ -1,0 +1,228 @@
+use std::{
+    hint::black_box,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{HeaderMap, Request, StatusCode, header},
+};
+use criterion::{Criterion, criterion_group, criterion_main};
+use nanocentaur::{
+    AdminAuthorizer, AgentEventPayload, AgentIdentity, AgentManager, ApiState, EventCursor,
+    FreePaymentGate, ManagedAgentFactory, MockAgentFactory, PolicyStore, TurnActionResponse,
+};
+use serde::de::DeserializeOwned;
+use tempfile::TempDir;
+use tokio::sync::Mutex;
+use tower::ServiceExt;
+
+const API_KEY: &str = "managed-benchmark-key";
+
+struct ManagedHarness {
+    app: Router,
+    manager: Arc<AgentManager>,
+    events: Mutex<EventCursor>,
+    agent_id: String,
+    _directory: TempDir,
+}
+
+impl ManagedHarness {
+    async fn new() -> Self {
+        let directory = tempfile::tempdir().expect("benchmark state directory");
+        let policy = Arc::new(
+            PolicyStore::open(directory.path().join("policy.sqlite"))
+                .expect("benchmark policy store"),
+        );
+        policy
+            .bootstrap(
+                "benchmark-client",
+                "Managed API benchmark",
+                API_KEY,
+                "benchmark-principal",
+                [],
+            )
+            .expect("benchmark policy bootstrap");
+        let factory: Arc<dyn ManagedAgentFactory> = Arc::new(MockAgentFactory::new(Duration::ZERO));
+        let manager = Arc::new(
+            AgentManager::new(Arc::clone(&factory), directory.path())
+                .expect("benchmark session store"),
+        );
+        let app = ApiState::new(
+            Arc::clone(&manager),
+            Arc::clone(&policy),
+            Arc::new(AdminAuthorizer::new("managed-benchmark-admin").expect("admin token")),
+            Arc::new(FreePaymentGate),
+        )
+        .router();
+
+        let response = app
+            .clone()
+            .oneshot(json_request(
+                "/v1/agent/new",
+                None,
+                r#"{"context_key":"managed-benchmark"}"#,
+            ))
+            .await
+            .expect("create agent response");
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let created: nanocentaur::CreateAgentResponse = response_json(response).await;
+        let identity = identity(&policy, &created.agent_id);
+        let events = manager
+            .events(identity, 0)
+            .await
+            .expect("benchmark event cursor");
+
+        Self {
+            app,
+            manager,
+            events: Mutex::new(events),
+            agent_id: created.agent_id,
+            _directory: directory,
+        }
+    }
+
+    async fn submit_turn(&self, idempotency_key: &str) -> (StatusCode, TurnActionResponse) {
+        let response = self
+            .app
+            .clone()
+            .oneshot(json_request(
+                &format!("/v1/agent/{}/turn", self.agent_id),
+                Some(idempotency_key),
+                r#"{"delivery":"enqueue","content":[{"type":"text","text":"Return exactly `done`."}]}"#,
+            ))
+            .await
+            .expect("turn response");
+        let status = response.status();
+        let action = response_json(response).await;
+        (status, action)
+    }
+
+    async fn submit_and_wait(&self, idempotency_key: &str) -> TurnActionResponse {
+        let (status, action) = self.submit_turn(idempotency_key).await;
+        assert_eq!(status, StatusCode::ACCEPTED);
+        let mut events = self.events.lock().await;
+        loop {
+            let event = events
+                .recv()
+                .await
+                .expect("managed event stream remains open");
+            if event.turn_id.as_deref() == Some(action.turn_id.as_str())
+                && matches!(event.payload, AgentEventPayload::TurnCompleted { .. })
+            {
+                return action;
+            }
+        }
+    }
+
+    async fn replay_turn(&self, idempotency_key: &str) -> TurnActionResponse {
+        let (status, action) = self.submit_turn(idempotency_key).await;
+        assert_eq!(status, StatusCode::OK);
+        action
+    }
+
+    async fn read_agent(&self) -> nanocentaur::AgentView {
+        let response = self
+            .app
+            .clone()
+            .oneshot(
+                Request::get(format!("/v1/agent/{}", self.agent_id))
+                    .header("x-api-key", API_KEY)
+                    .body(Body::empty())
+                    .expect("agent request"),
+            )
+            .await
+            .expect("agent response");
+        assert_eq!(response.status(), StatusCode::OK);
+        response_json(response).await
+    }
+}
+
+fn identity(policy: &PolicyStore, agent_id: &str) -> AgentIdentity {
+    let mut headers = HeaderMap::new();
+    headers.insert("x-api-key", API_KEY.parse().expect("benchmark API key"));
+    let client = policy
+        .authenticate(&headers)
+        .expect("benchmark client authentication");
+    policy
+        .agent(&client, agent_id)
+        .expect("benchmark agent identity")
+}
+
+fn json_request(uri: &str, idempotency_key: Option<&str>, body: &'static str) -> Request<Body> {
+    let mut request = Request::post(uri)
+        .header("x-api-key", API_KEY)
+        .header(header::CONTENT_TYPE, "application/json");
+    if let Some(idempotency_key) = idempotency_key {
+        request = request.header("idempotency-key", idempotency_key);
+    }
+    request.body(Body::from(body)).expect("JSON request")
+}
+
+async fn response_json<T: DeserializeOwned>(response: axum::response::Response) -> T {
+    let body = to_bytes(response.into_body(), 1024 * 1024)
+        .await
+        .expect("bounded response body");
+    serde_json::from_slice(&body).expect("typed benchmark response")
+}
+
+fn benchmark_managed_api(criterion: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .expect("benchmark runtime");
+    let harness = Arc::new(runtime.block_on(ManagedHarness::new()));
+    runtime.block_on(harness.submit_and_wait("managed-benchmark-replay"));
+    let turn_number = AtomicU64::new(1);
+
+    let mut group = criterion.benchmark_group("managed_api");
+    group.sample_size(20);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(2));
+
+    group.bench_function("authorized_agent_view", |bencher| {
+        bencher.to_async(&runtime).iter(|| {
+            let harness = Arc::clone(&harness);
+            async move {
+                black_box(harness.read_agent().await);
+            }
+        });
+    });
+
+    group.bench_function("idempotent_turn_replay", |bencher| {
+        bencher.to_async(&runtime).iter(|| {
+            let harness = Arc::clone(&harness);
+            async move {
+                black_box(harness.replay_turn("managed-benchmark-replay").await);
+            }
+        });
+    });
+
+    group.bench_function("accepted_turn_to_durable_terminal_event", |bencher| {
+        bencher.to_async(&runtime).iter(|| {
+            let harness = Arc::clone(&harness);
+            let turn_number = turn_number.fetch_add(1, Ordering::Relaxed);
+            async move {
+                black_box(
+                    harness
+                        .submit_and_wait(&format!("managed-benchmark-{turn_number}"))
+                        .await,
+                );
+            }
+        });
+    });
+    group.finish();
+
+    runtime
+        .block_on(harness.manager.shutdown())
+        .expect("managed benchmark shutdown");
+}
+
+criterion_group!(benches, benchmark_managed_api);
+criterion_main!(benches);

--- a/crates/experimental/nanocentaur/src/admin.rs
+++ b/crates/experimental/nanocentaur/src/admin.rs
@@ -121,6 +121,15 @@ fn authorize(state: &ApiState, headers: &HeaderMap) -> Result<(), ApiError> {
     Ok(())
 }
 
+async fn policy<T, F>(state: &ApiState, headers: &HeaderMap, operation: F) -> Result<T, ApiError>
+where
+    T: Send + 'static,
+    F: FnOnce(&crate::PolicyStore) -> Result<T, crate::PolicyError> + Send + 'static,
+{
+    authorize(state, headers)?;
+    state.policy_call(operation).await
+}
+
 fn observe_request(operation: &'static str, request: &impl Debug) {
     tracing::info!(
         target: "nanocentaur::observed",
@@ -136,10 +145,14 @@ async fn create_api_client(
     Json(request): Json<CreateApiClient>,
 ) -> Result<(StatusCode, Json<crate::ApiClientView>), ApiError> {
     observe_request("api_client.create", &request);
-    authorize(&state, &headers)?;
     Ok((
         StatusCode::CREATED,
-        Json(state.policy.create_api_client(request)?),
+        Json(
+            policy(&state, &headers, move |store| {
+                store.create_api_client(request)
+            })
+            .await?,
+        ),
     ))
 }
 
@@ -147,8 +160,9 @@ async fn list_api_clients(
     State(state): State<Arc<ApiState>>,
     headers: HeaderMap,
 ) -> Result<Json<Vec<crate::ApiClientView>>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.api_clients()?))
+    Ok(Json(
+        policy(&state, &headers, crate::PolicyStore::api_clients).await?,
+    ))
 }
 
 async fn get_api_client(
@@ -156,8 +170,9 @@ async fn get_api_client(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<Json<crate::ApiClientView>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.api_client(&id)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| store.api_client(&id)).await?,
+    ))
 }
 
 async fn patch_api_client(
@@ -167,8 +182,12 @@ async fn patch_api_client(
     Json(patch): Json<PatchApiClient>,
 ) -> Result<Json<crate::ApiClientView>, ApiError> {
     observe_request("api_client.patch", &patch);
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.patch_api_client(&id, patch)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| {
+            store.patch_api_client(&id, patch)
+        })
+        .await?,
+    ))
 }
 
 async fn delete_api_client(
@@ -176,8 +195,7 @@ async fn delete_api_client(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ApiError> {
-    authorize(&state, &headers)?;
-    state.policy.disable_api_client(&id)?;
+    policy(&state, &headers, move |store| store.disable_api_client(&id)).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -188,10 +206,14 @@ async fn add_api_key(
     Json(request): Json<CreateApiKey>,
 ) -> Result<(StatusCode, Json<crate::ApiKeyView>), ApiError> {
     observe_request("api_key.create", &request);
-    authorize(&state, &headers)?;
     Ok((
         StatusCode::CREATED,
-        Json(state.policy.add_api_key(&id, request)?),
+        Json(
+            policy(&state, &headers, move |store| {
+                store.add_api_key(&id, request)
+            })
+            .await?,
+        ),
     ))
 }
 
@@ -200,8 +222,10 @@ async fn delete_api_key(
     headers: HeaderMap,
     Path((id, key_id)): Path<(String, String)>,
 ) -> Result<StatusCode, ApiError> {
-    authorize(&state, &headers)?;
-    state.policy.delete_api_key(&id, &key_id)?;
+    policy(&state, &headers, move |store| {
+        store.delete_api_key(&id, &key_id)
+    })
+    .await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -211,10 +235,14 @@ async fn create_principal(
     Json(request): Json<CreatePrincipal>,
 ) -> Result<(StatusCode, Json<crate::PrincipalView>), ApiError> {
     observe_request("principal.create", &request);
-    authorize(&state, &headers)?;
     Ok((
         StatusCode::CREATED,
-        Json(state.policy.create_principal(request)?),
+        Json(
+            policy(&state, &headers, move |store| {
+                store.create_principal(request)
+            })
+            .await?,
+        ),
     ))
 }
 
@@ -222,8 +250,9 @@ async fn list_principals(
     State(state): State<Arc<ApiState>>,
     headers: HeaderMap,
 ) -> Result<Json<Vec<crate::PrincipalView>>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.principals()?))
+    Ok(Json(
+        policy(&state, &headers, crate::PolicyStore::principals).await?,
+    ))
 }
 
 async fn get_principal(
@@ -231,8 +260,9 @@ async fn get_principal(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<Json<crate::PrincipalView>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.principal(&id)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| store.principal(&id)).await?,
+    ))
 }
 
 async fn patch_principal(
@@ -242,8 +272,12 @@ async fn patch_principal(
     Json(patch): Json<PatchPrincipal>,
 ) -> Result<Json<crate::PrincipalView>, ApiError> {
     observe_request("principal.patch", &patch);
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.patch_principal(&id, patch)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| {
+            store.patch_principal(&id, patch)
+        })
+        .await?,
+    ))
 }
 
 async fn delete_principal(
@@ -251,8 +285,7 @@ async fn delete_principal(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ApiError> {
-    authorize(&state, &headers)?;
-    state.policy.disable_principal(&id)?;
+    policy(&state, &headers, move |store| store.disable_principal(&id)).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -262,10 +295,14 @@ async fn create_context_binding(
     Json(request): Json<CreateContextBinding>,
 ) -> Result<(StatusCode, Json<crate::ContextBindingView>), ApiError> {
     observe_request("context_binding.create", &request);
-    authorize(&state, &headers)?;
     Ok((
         StatusCode::CREATED,
-        Json(state.policy.create_context_binding(request)?),
+        Json(
+            policy(&state, &headers, move |store| {
+                store.create_context_binding(request)
+            })
+            .await?,
+        ),
     ))
 }
 
@@ -273,8 +310,9 @@ async fn list_context_bindings(
     State(state): State<Arc<ApiState>>,
     headers: HeaderMap,
 ) -> Result<Json<Vec<crate::ContextBindingView>>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.context_bindings()?))
+    Ok(Json(
+        policy(&state, &headers, crate::PolicyStore::context_bindings).await?,
+    ))
 }
 
 async fn get_context_binding(
@@ -282,8 +320,9 @@ async fn get_context_binding(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<Json<crate::ContextBindingView>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.context_binding(&id)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| store.context_binding(&id)).await?,
+    ))
 }
 
 async fn patch_context_binding(
@@ -293,8 +332,12 @@ async fn patch_context_binding(
     Json(patch): Json<PatchContextBinding>,
 ) -> Result<Json<crate::ContextBindingView>, ApiError> {
     observe_request("context_binding.patch", &patch);
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.patch_context_binding(&id, patch)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| {
+            store.patch_context_binding(&id, patch)
+        })
+        .await?,
+    ))
 }
 
 async fn delete_context_binding(
@@ -302,8 +345,10 @@ async fn delete_context_binding(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ApiError> {
-    authorize(&state, &headers)?;
-    state.policy.delete_context_binding(&id)?;
+    policy(&state, &headers, move |store| {
+        store.delete_context_binding(&id)
+    })
+    .await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -313,8 +358,12 @@ async fn resolve_context(
     Json(request): Json<ResolveContext>,
 ) -> Result<Json<crate::ResolvedContextView>, ApiError> {
     observe_request("context_binding.resolve", &request);
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.resolve_context(request)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| {
+            store.resolve_context(request)
+        })
+        .await?,
+    ))
 }
 
 async fn create_role(
@@ -323,10 +372,9 @@ async fn create_role(
     Json(request): Json<CreateRole>,
 ) -> Result<(StatusCode, Json<crate::RoleView>), ApiError> {
     observe_request("role.create", &request);
-    authorize(&state, &headers)?;
     Ok((
         StatusCode::CREATED,
-        Json(state.policy.create_role(request)?),
+        Json(policy(&state, &headers, move |store| store.create_role(request)).await?),
     ))
 }
 
@@ -334,8 +382,9 @@ async fn list_roles(
     State(state): State<Arc<ApiState>>,
     headers: HeaderMap,
 ) -> Result<Json<Vec<crate::RoleView>>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.roles()?))
+    Ok(Json(
+        policy(&state, &headers, crate::PolicyStore::roles).await?,
+    ))
 }
 
 async fn get_role(
@@ -343,8 +392,9 @@ async fn get_role(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<Json<crate::RoleView>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.role(&id)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| store.role(&id)).await?,
+    ))
 }
 
 async fn patch_role(
@@ -354,8 +404,9 @@ async fn patch_role(
     Json(patch): Json<PatchRole>,
 ) -> Result<Json<crate::RoleView>, ApiError> {
     observe_request("role.patch", &patch);
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.patch_role(&id, patch)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| store.patch_role(&id, patch)).await?,
+    ))
 }
 
 async fn delete_role(
@@ -363,8 +414,7 @@ async fn delete_role(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ApiError> {
-    authorize(&state, &headers)?;
-    state.policy.delete_role(&id)?;
+    policy(&state, &headers, move |store| store.delete_role(&id)).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -374,10 +424,14 @@ async fn create_permission(
     Json(request): Json<CreatePermission>,
 ) -> Result<(StatusCode, Json<crate::PermissionView>), ApiError> {
     observe_request("permission.create", &request);
-    authorize(&state, &headers)?;
     Ok((
         StatusCode::CREATED,
-        Json(state.policy.create_permission(request)?),
+        Json(
+            policy(&state, &headers, move |store| {
+                store.create_permission(request)
+            })
+            .await?,
+        ),
     ))
 }
 
@@ -385,8 +439,9 @@ async fn list_permissions(
     State(state): State<Arc<ApiState>>,
     headers: HeaderMap,
 ) -> Result<Json<Vec<crate::PermissionView>>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.permissions()?))
+    Ok(Json(
+        policy(&state, &headers, crate::PolicyStore::permissions).await?,
+    ))
 }
 
 async fn get_permission(
@@ -394,8 +449,9 @@ async fn get_permission(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<Json<crate::PermissionView>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.permission(&id)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| store.permission(&id)).await?,
+    ))
 }
 
 async fn delete_permission(
@@ -403,8 +459,7 @@ async fn delete_permission(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ApiError> {
-    authorize(&state, &headers)?;
-    state.policy.delete_permission(&id)?;
+    policy(&state, &headers, move |store| store.delete_permission(&id)).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -413,10 +468,10 @@ async fn add_principal_role(
     headers: HeaderMap,
     Path((principal_id, role_id)): Path<(String, String)>,
 ) -> Result<StatusCode, ApiError> {
-    authorize(&state, &headers)?;
-    state
-        .policy
-        .set_principal_role(&principal_id, &role_id, true)?;
+    policy(&state, &headers, move |store| {
+        store.set_principal_role(&principal_id, &role_id, true)
+    })
+    .await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -425,10 +480,10 @@ async fn remove_principal_role(
     headers: HeaderMap,
     Path((principal_id, role_id)): Path<(String, String)>,
 ) -> Result<StatusCode, ApiError> {
-    authorize(&state, &headers)?;
-    state
-        .policy
-        .set_principal_role(&principal_id, &role_id, false)?;
+    policy(&state, &headers, move |store| {
+        store.set_principal_role(&principal_id, &role_id, false)
+    })
+    .await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -437,8 +492,12 @@ async fn list_principal_roles(
     headers: HeaderMap,
     Path(principal_id): Path<String>,
 ) -> Result<Json<Vec<crate::RoleView>>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.principal_roles(&principal_id)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| {
+            store.principal_roles(&principal_id)
+        })
+        .await?,
+    ))
 }
 
 async fn add_role_permission(
@@ -446,10 +505,10 @@ async fn add_role_permission(
     headers: HeaderMap,
     Path((role_id, permission_id)): Path<(String, String)>,
 ) -> Result<StatusCode, ApiError> {
-    authorize(&state, &headers)?;
-    state
-        .policy
-        .set_role_permission(&role_id, &permission_id, true)?;
+    policy(&state, &headers, move |store| {
+        store.set_role_permission(&role_id, &permission_id, true)
+    })
+    .await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -458,10 +517,10 @@ async fn remove_role_permission(
     headers: HeaderMap,
     Path((role_id, permission_id)): Path<(String, String)>,
 ) -> Result<StatusCode, ApiError> {
-    authorize(&state, &headers)?;
-    state
-        .policy
-        .set_role_permission(&role_id, &permission_id, false)?;
+    policy(&state, &headers, move |store| {
+        store.set_role_permission(&role_id, &permission_id, false)
+    })
+    .await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -470,8 +529,12 @@ async fn list_role_permissions(
     headers: HeaderMap,
     Path(role_id): Path<String>,
 ) -> Result<Json<Vec<crate::PermissionView>>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.role_permissions(&role_id)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| {
+            store.role_permissions(&role_id)
+        })
+        .await?,
+    ))
 }
 
 async fn add_principal_permission(
@@ -479,10 +542,10 @@ async fn add_principal_permission(
     headers: HeaderMap,
     Path((principal_id, permission_id)): Path<(String, String)>,
 ) -> Result<StatusCode, ApiError> {
-    authorize(&state, &headers)?;
-    state
-        .policy
-        .set_principal_permission(&principal_id, &permission_id, true)?;
+    policy(&state, &headers, move |store| {
+        store.set_principal_permission(&principal_id, &permission_id, true)
+    })
+    .await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -491,10 +554,10 @@ async fn remove_principal_permission(
     headers: HeaderMap,
     Path((principal_id, permission_id)): Path<(String, String)>,
 ) -> Result<StatusCode, ApiError> {
-    authorize(&state, &headers)?;
-    state
-        .policy
-        .set_principal_permission(&principal_id, &permission_id, false)?;
+    policy(&state, &headers, move |store| {
+        store.set_principal_permission(&principal_id, &permission_id, false)
+    })
+    .await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -503,8 +566,12 @@ async fn list_principal_permissions(
     headers: HeaderMap,
     Path(principal_id): Path<String>,
 ) -> Result<Json<Vec<crate::PermissionView>>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.principal_permissions(&principal_id)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| {
+            store.principal_permissions(&principal_id)
+        })
+        .await?,
+    ))
 }
 
 async fn effective_permissions(
@@ -512,8 +579,12 @@ async fn effective_permissions(
     headers: HeaderMap,
     Path(principal_id): Path<String>,
 ) -> Result<Json<Vec<crate::PermissionView>>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.effective_permissions(&principal_id)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| {
+            store.effective_permissions(&principal_id)
+        })
+        .await?,
+    ))
 }
 
 async fn create_secret(
@@ -522,10 +593,9 @@ async fn create_secret(
     Json(request): Json<CreateSecret>,
 ) -> Result<(StatusCode, Json<crate::SecretView>), ApiError> {
     observe_request("secret.create", &request);
-    authorize(&state, &headers)?;
     Ok((
         StatusCode::CREATED,
-        Json(state.policy.create_secret(request)?),
+        Json(policy(&state, &headers, move |store| store.create_secret(request)).await?),
     ))
 }
 
@@ -533,8 +603,9 @@ async fn list_secrets(
     State(state): State<Arc<ApiState>>,
     headers: HeaderMap,
 ) -> Result<Json<Vec<crate::SecretView>>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.secrets()?))
+    Ok(Json(
+        policy(&state, &headers, crate::PolicyStore::secrets).await?,
+    ))
 }
 
 async fn get_secret(
@@ -542,8 +613,9 @@ async fn get_secret(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<Json<crate::SecretView>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.secret(&id)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| store.secret(&id)).await?,
+    ))
 }
 
 async fn patch_secret(
@@ -553,8 +625,12 @@ async fn patch_secret(
     Json(patch): Json<PatchSecret>,
 ) -> Result<Json<crate::SecretView>, ApiError> {
     observe_request("secret.patch", &patch);
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.patch_secret(&id, patch)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| {
+            store.patch_secret(&id, patch)
+        })
+        .await?,
+    ))
 }
 
 async fn delete_secret(
@@ -562,8 +638,7 @@ async fn delete_secret(
     headers: HeaderMap,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ApiError> {
-    authorize(&state, &headers)?;
-    state.policy.delete_secret(&id)?;
+    policy(&state, &headers, move |store| store.delete_secret(&id)).await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -572,8 +647,12 @@ async fn list_principal_secrets(
     headers: HeaderMap,
     Path(principal_id): Path<String>,
 ) -> Result<Json<Vec<crate::SecretView>>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.principal_secrets(&principal_id)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| {
+            store.principal_secrets(&principal_id)
+        })
+        .await?,
+    ))
 }
 
 async fn add_principal_secret(
@@ -581,10 +660,10 @@ async fn add_principal_secret(
     headers: HeaderMap,
     Path((principal_id, secret_id)): Path<(String, String)>,
 ) -> Result<StatusCode, ApiError> {
-    authorize(&state, &headers)?;
-    state
-        .policy
-        .set_principal_secret(&principal_id, &secret_id, true)?;
+    policy(&state, &headers, move |store| {
+        store.set_principal_secret(&principal_id, &secret_id, true)
+    })
+    .await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -593,10 +672,10 @@ async fn remove_principal_secret(
     headers: HeaderMap,
     Path((principal_id, secret_id)): Path<(String, String)>,
 ) -> Result<StatusCode, ApiError> {
-    authorize(&state, &headers)?;
-    state
-        .policy
-        .set_principal_secret(&principal_id, &secret_id, false)?;
+    policy(&state, &headers, move |store| {
+        store.set_principal_secret(&principal_id, &secret_id, false)
+    })
+    .await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -605,8 +684,9 @@ async fn list_role_secrets(
     headers: HeaderMap,
     Path(role_id): Path<String>,
 ) -> Result<Json<Vec<crate::SecretView>>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.role_secrets(&role_id)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| store.role_secrets(&role_id)).await?,
+    ))
 }
 
 async fn add_role_secret(
@@ -614,8 +694,10 @@ async fn add_role_secret(
     headers: HeaderMap,
     Path((role_id, secret_id)): Path<(String, String)>,
 ) -> Result<StatusCode, ApiError> {
-    authorize(&state, &headers)?;
-    state.policy.set_role_secret(&role_id, &secret_id, true)?;
+    policy(&state, &headers, move |store| {
+        store.set_role_secret(&role_id, &secret_id, true)
+    })
+    .await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -624,8 +706,10 @@ async fn remove_role_secret(
     headers: HeaderMap,
     Path((role_id, secret_id)): Path<(String, String)>,
 ) -> Result<StatusCode, ApiError> {
-    authorize(&state, &headers)?;
-    state.policy.set_role_secret(&role_id, &secret_id, false)?;
+    policy(&state, &headers, move |store| {
+        store.set_role_secret(&role_id, &secret_id, false)
+    })
+    .await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -634,6 +718,10 @@ async fn effective_secrets(
     headers: HeaderMap,
     Path(principal_id): Path<String>,
 ) -> Result<Json<Vec<crate::SecretView>>, ApiError> {
-    authorize(&state, &headers)?;
-    Ok(Json(state.policy.effective_secrets(&principal_id)?))
+    Ok(Json(
+        policy(&state, &headers, move |store| {
+            store.effective_secrets(&principal_id)
+        })
+        .await?,
+    ))
 }

--- a/crates/experimental/nanocentaur/src/admin.rs
+++ b/crates/experimental/nanocentaur/src/admin.rs
@@ -1,0 +1,639 @@
+use std::{fmt::Debug, sync::Arc};
+
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode},
+    routing::{delete, get, post, put},
+};
+
+use crate::{
+    ApiState, CreateApiClient, CreateApiKey, CreateContextBinding, CreatePermission,
+    CreatePrincipal, CreateRole, CreateSecret, PatchApiClient, PatchContextBinding, PatchPrincipal,
+    PatchRole, PatchSecret, ResolveContext, api::ApiError,
+};
+
+pub(crate) fn routes() -> Router<Arc<ApiState>> {
+    Router::new()
+        .route(
+            "/admin/v1/api-clients",
+            post(create_api_client).get(list_api_clients),
+        )
+        .route(
+            "/admin/v1/api-clients/{id}",
+            get(get_api_client)
+                .patch(patch_api_client)
+                .delete(delete_api_client),
+        )
+        .route("/admin/v1/api-clients/{id}/keys", post(add_api_key))
+        .route(
+            "/admin/v1/api-clients/{id}/keys/{key_id}",
+            delete(delete_api_key),
+        )
+        .route(
+            "/admin/v1/principals",
+            post(create_principal).get(list_principals),
+        )
+        .route(
+            "/admin/v1/principals/{id}",
+            get(get_principal)
+                .patch(patch_principal)
+                .delete(delete_principal),
+        )
+        .route(
+            "/admin/v1/context-bindings",
+            post(create_context_binding).get(list_context_bindings),
+        )
+        .route(
+            "/admin/v1/context-bindings/{id}",
+            get(get_context_binding)
+                .patch(patch_context_binding)
+                .delete(delete_context_binding),
+        )
+        .route("/admin/v1/context-bindings/resolve", post(resolve_context))
+        .route("/admin/v1/roles", post(create_role).get(list_roles))
+        .route(
+            "/admin/v1/roles/{id}",
+            get(get_role).patch(patch_role).delete(delete_role),
+        )
+        .route(
+            "/admin/v1/permissions",
+            post(create_permission).get(list_permissions),
+        )
+        .route(
+            "/admin/v1/permissions/{id}",
+            get(get_permission).delete(delete_permission),
+        )
+        .route(
+            "/admin/v1/principals/{principal_id}/roles",
+            get(list_principal_roles),
+        )
+        .route(
+            "/admin/v1/principals/{principal_id}/roles/{role_id}",
+            put(add_principal_role).delete(remove_principal_role),
+        )
+        .route(
+            "/admin/v1/roles/{role_id}/permissions",
+            get(list_role_permissions),
+        )
+        .route(
+            "/admin/v1/roles/{role_id}/permissions/{permission_id}",
+            put(add_role_permission).delete(remove_role_permission),
+        )
+        .route(
+            "/admin/v1/principals/{principal_id}/permissions",
+            get(list_principal_permissions),
+        )
+        .route(
+            "/admin/v1/principals/{principal_id}/permissions/{permission_id}",
+            put(add_principal_permission).delete(remove_principal_permission),
+        )
+        .route(
+            "/admin/v1/principals/{principal_id}/effective-permissions",
+            get(effective_permissions),
+        )
+        .route("/admin/v1/secrets", post(create_secret).get(list_secrets))
+        .route(
+            "/admin/v1/secrets/{id}",
+            get(get_secret).patch(patch_secret).delete(delete_secret),
+        )
+        .route(
+            "/admin/v1/principals/{principal_id}/secrets",
+            get(list_principal_secrets),
+        )
+        .route(
+            "/admin/v1/principals/{principal_id}/secrets/{secret_id}",
+            put(add_principal_secret).delete(remove_principal_secret),
+        )
+        .route("/admin/v1/roles/{role_id}/secrets", get(list_role_secrets))
+        .route(
+            "/admin/v1/roles/{role_id}/secrets/{secret_id}",
+            put(add_role_secret).delete(remove_role_secret),
+        )
+        .route(
+            "/admin/v1/principals/{principal_id}/effective-secrets",
+            get(effective_secrets),
+        )
+}
+
+fn authorize(state: &ApiState, headers: &HeaderMap) -> Result<(), ApiError> {
+    state.admin.authorize(headers)?;
+    Ok(())
+}
+
+fn observe_request(operation: &'static str, request: &impl Debug) {
+    tracing::info!(
+        target: "nanocentaur::observed",
+        operation,
+        request = ?request,
+        "admin request observed"
+    );
+}
+
+async fn create_api_client(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Json(request): Json<CreateApiClient>,
+) -> Result<(StatusCode, Json<crate::ApiClientView>), ApiError> {
+    observe_request("api_client.create", &request);
+    authorize(&state, &headers)?;
+    Ok((
+        StatusCode::CREATED,
+        Json(state.policy.create_api_client(request)?),
+    ))
+}
+
+async fn list_api_clients(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<crate::ApiClientView>>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.api_clients()?))
+}
+
+async fn get_api_client(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<Json<crate::ApiClientView>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.api_client(&id)?))
+}
+
+async fn patch_api_client(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(patch): Json<PatchApiClient>,
+) -> Result<Json<crate::ApiClientView>, ApiError> {
+    observe_request("api_client.patch", &patch);
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.patch_api_client(&id, patch)?))
+}
+
+async fn delete_api_client(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    authorize(&state, &headers)?;
+    state.policy.disable_api_client(&id)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn add_api_key(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(request): Json<CreateApiKey>,
+) -> Result<(StatusCode, Json<crate::ApiKeyView>), ApiError> {
+    observe_request("api_key.create", &request);
+    authorize(&state, &headers)?;
+    Ok((
+        StatusCode::CREATED,
+        Json(state.policy.add_api_key(&id, request)?),
+    ))
+}
+
+async fn delete_api_key(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path((id, key_id)): Path<(String, String)>,
+) -> Result<StatusCode, ApiError> {
+    authorize(&state, &headers)?;
+    state.policy.delete_api_key(&id, &key_id)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn create_principal(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Json(request): Json<CreatePrincipal>,
+) -> Result<(StatusCode, Json<crate::PrincipalView>), ApiError> {
+    observe_request("principal.create", &request);
+    authorize(&state, &headers)?;
+    Ok((
+        StatusCode::CREATED,
+        Json(state.policy.create_principal(request)?),
+    ))
+}
+
+async fn list_principals(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<crate::PrincipalView>>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.principals()?))
+}
+
+async fn get_principal(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<Json<crate::PrincipalView>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.principal(&id)?))
+}
+
+async fn patch_principal(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(patch): Json<PatchPrincipal>,
+) -> Result<Json<crate::PrincipalView>, ApiError> {
+    observe_request("principal.patch", &patch);
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.patch_principal(&id, patch)?))
+}
+
+async fn delete_principal(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    authorize(&state, &headers)?;
+    state.policy.disable_principal(&id)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn create_context_binding(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Json(request): Json<CreateContextBinding>,
+) -> Result<(StatusCode, Json<crate::ContextBindingView>), ApiError> {
+    observe_request("context_binding.create", &request);
+    authorize(&state, &headers)?;
+    Ok((
+        StatusCode::CREATED,
+        Json(state.policy.create_context_binding(request)?),
+    ))
+}
+
+async fn list_context_bindings(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<crate::ContextBindingView>>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.context_bindings()?))
+}
+
+async fn get_context_binding(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<Json<crate::ContextBindingView>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.context_binding(&id)?))
+}
+
+async fn patch_context_binding(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(patch): Json<PatchContextBinding>,
+) -> Result<Json<crate::ContextBindingView>, ApiError> {
+    observe_request("context_binding.patch", &patch);
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.patch_context_binding(&id, patch)?))
+}
+
+async fn delete_context_binding(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    authorize(&state, &headers)?;
+    state.policy.delete_context_binding(&id)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn resolve_context(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Json(request): Json<ResolveContext>,
+) -> Result<Json<crate::ResolvedContextView>, ApiError> {
+    observe_request("context_binding.resolve", &request);
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.resolve_context(request)?))
+}
+
+async fn create_role(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Json(request): Json<CreateRole>,
+) -> Result<(StatusCode, Json<crate::RoleView>), ApiError> {
+    observe_request("role.create", &request);
+    authorize(&state, &headers)?;
+    Ok((
+        StatusCode::CREATED,
+        Json(state.policy.create_role(request)?),
+    ))
+}
+
+async fn list_roles(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<crate::RoleView>>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.roles()?))
+}
+
+async fn get_role(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<Json<crate::RoleView>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.role(&id)?))
+}
+
+async fn patch_role(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(patch): Json<PatchRole>,
+) -> Result<Json<crate::RoleView>, ApiError> {
+    observe_request("role.patch", &patch);
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.patch_role(&id, patch)?))
+}
+
+async fn delete_role(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    authorize(&state, &headers)?;
+    state.policy.delete_role(&id)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn create_permission(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Json(request): Json<CreatePermission>,
+) -> Result<(StatusCode, Json<crate::PermissionView>), ApiError> {
+    observe_request("permission.create", &request);
+    authorize(&state, &headers)?;
+    Ok((
+        StatusCode::CREATED,
+        Json(state.policy.create_permission(request)?),
+    ))
+}
+
+async fn list_permissions(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<crate::PermissionView>>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.permissions()?))
+}
+
+async fn get_permission(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<Json<crate::PermissionView>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.permission(&id)?))
+}
+
+async fn delete_permission(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    authorize(&state, &headers)?;
+    state.policy.delete_permission(&id)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn add_principal_role(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path((principal_id, role_id)): Path<(String, String)>,
+) -> Result<StatusCode, ApiError> {
+    authorize(&state, &headers)?;
+    state
+        .policy
+        .set_principal_role(&principal_id, &role_id, true)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn remove_principal_role(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path((principal_id, role_id)): Path<(String, String)>,
+) -> Result<StatusCode, ApiError> {
+    authorize(&state, &headers)?;
+    state
+        .policy
+        .set_principal_role(&principal_id, &role_id, false)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn list_principal_roles(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(principal_id): Path<String>,
+) -> Result<Json<Vec<crate::RoleView>>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.principal_roles(&principal_id)?))
+}
+
+async fn add_role_permission(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path((role_id, permission_id)): Path<(String, String)>,
+) -> Result<StatusCode, ApiError> {
+    authorize(&state, &headers)?;
+    state
+        .policy
+        .set_role_permission(&role_id, &permission_id, true)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn remove_role_permission(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path((role_id, permission_id)): Path<(String, String)>,
+) -> Result<StatusCode, ApiError> {
+    authorize(&state, &headers)?;
+    state
+        .policy
+        .set_role_permission(&role_id, &permission_id, false)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn list_role_permissions(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(role_id): Path<String>,
+) -> Result<Json<Vec<crate::PermissionView>>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.role_permissions(&role_id)?))
+}
+
+async fn add_principal_permission(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path((principal_id, permission_id)): Path<(String, String)>,
+) -> Result<StatusCode, ApiError> {
+    authorize(&state, &headers)?;
+    state
+        .policy
+        .set_principal_permission(&principal_id, &permission_id, true)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn remove_principal_permission(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path((principal_id, permission_id)): Path<(String, String)>,
+) -> Result<StatusCode, ApiError> {
+    authorize(&state, &headers)?;
+    state
+        .policy
+        .set_principal_permission(&principal_id, &permission_id, false)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn list_principal_permissions(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(principal_id): Path<String>,
+) -> Result<Json<Vec<crate::PermissionView>>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.principal_permissions(&principal_id)?))
+}
+
+async fn effective_permissions(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(principal_id): Path<String>,
+) -> Result<Json<Vec<crate::PermissionView>>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.effective_permissions(&principal_id)?))
+}
+
+async fn create_secret(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Json(request): Json<CreateSecret>,
+) -> Result<(StatusCode, Json<crate::SecretView>), ApiError> {
+    observe_request("secret.create", &request);
+    authorize(&state, &headers)?;
+    Ok((
+        StatusCode::CREATED,
+        Json(state.policy.create_secret(request)?),
+    ))
+}
+
+async fn list_secrets(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+) -> Result<Json<Vec<crate::SecretView>>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.secrets()?))
+}
+
+async fn get_secret(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<Json<crate::SecretView>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.secret(&id)?))
+}
+
+async fn patch_secret(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(patch): Json<PatchSecret>,
+) -> Result<Json<crate::SecretView>, ApiError> {
+    observe_request("secret.patch", &patch);
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.patch_secret(&id, patch)?))
+}
+
+async fn delete_secret(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    authorize(&state, &headers)?;
+    state.policy.delete_secret(&id)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn list_principal_secrets(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(principal_id): Path<String>,
+) -> Result<Json<Vec<crate::SecretView>>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.principal_secrets(&principal_id)?))
+}
+
+async fn add_principal_secret(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path((principal_id, secret_id)): Path<(String, String)>,
+) -> Result<StatusCode, ApiError> {
+    authorize(&state, &headers)?;
+    state
+        .policy
+        .set_principal_secret(&principal_id, &secret_id, true)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn remove_principal_secret(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path((principal_id, secret_id)): Path<(String, String)>,
+) -> Result<StatusCode, ApiError> {
+    authorize(&state, &headers)?;
+    state
+        .policy
+        .set_principal_secret(&principal_id, &secret_id, false)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn list_role_secrets(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(role_id): Path<String>,
+) -> Result<Json<Vec<crate::SecretView>>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.role_secrets(&role_id)?))
+}
+
+async fn add_role_secret(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path((role_id, secret_id)): Path<(String, String)>,
+) -> Result<StatusCode, ApiError> {
+    authorize(&state, &headers)?;
+    state.policy.set_role_secret(&role_id, &secret_id, true)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn remove_role_secret(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path((role_id, secret_id)): Path<(String, String)>,
+) -> Result<StatusCode, ApiError> {
+    authorize(&state, &headers)?;
+    state.policy.set_role_secret(&role_id, &secret_id, false)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn effective_secrets(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(principal_id): Path<String>,
+) -> Result<Json<Vec<crate::SecretView>>, ApiError> {
+    authorize(&state, &headers)?;
+    Ok(Json(state.policy.effective_secrets(&principal_id)?))
+}

--- a/crates/experimental/nanocentaur/src/agent.rs
+++ b/crates/experimental/nanocentaur/src/agent.rs
@@ -1,0 +1,510 @@
+use std::{
+    collections::BTreeSet,
+    future::Future,
+    io,
+    path::{Path, PathBuf},
+    pin::Pin,
+    str::FromStr,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use async_trait::async_trait;
+use nanocodex_agent::{
+    AgentEvents, Nanocodex, NanocodexError, Thinking, TurnUsage,
+    events::AgentEvent,
+    input::Prompt,
+    session::{SessionId, SessionSnapshot},
+};
+use nanocodex_oai_api::{OpenAi, auth::OpenAiAuth};
+use nanocodex_vm::{VmWorkspace, host::VmProcessConfig};
+use tempfile::TempDir;
+use thiserror::Error;
+use tokio::sync::mpsc;
+
+use crate::{AgentCapabilities, CapabilityName, EgressContext, EgressProvider};
+
+const RUNTIME_EVENT_CAPACITY: usize = 256;
+
+// Keep this script printable ASCII without double quotes: libkrun currently
+// wraps every guest argument in double quotes without escaping embedded ones.
+const GUEST_WORKSPACE: &str = "/workspace";
+
+/// Immutable inputs used to construct or resume one hosted agent harness.
+#[derive(Clone)]
+pub struct AgentSpec {
+    /// Stable managed-service agent identifier.
+    pub agent_id: String,
+    /// Effective principal authorized for this runtime.
+    pub principal: String,
+    /// Instructions snapshotted when the managed agent was created.
+    pub instructions: Option<String>,
+    /// Optional model reasoning effort.
+    pub thinking: Option<Thinking>,
+    /// Live capability grant used to choose tools and egress.
+    pub capabilities: AgentCapabilities,
+    /// Last completed model boundary, when waking a durable session.
+    pub snapshot: Option<SessionSnapshot>,
+}
+
+/// Complete model result returned to the managed actor.
+pub struct AgentRunResult {
+    final_message: String,
+    snapshot: Option<SessionSnapshot>,
+    usage: TurnUsage,
+}
+
+impl AgentRunResult {
+    /// Creates one completed managed runtime result.
+    #[must_use]
+    pub fn new(
+        final_message: impl Into<String>,
+        snapshot: Option<SessionSnapshot>,
+        usage: TurnUsage,
+    ) -> Self {
+        Self {
+            final_message: final_message.into(),
+            snapshot,
+            usage,
+        }
+    }
+
+    /// Returns the final assistant text.
+    #[must_use]
+    pub fn final_message(&self) -> &str {
+        &self.final_message
+    }
+
+    /// Returns the serializable completed model boundary, when available.
+    #[must_use]
+    pub const fn snapshot(&self) -> Option<&SessionSnapshot> {
+        self.snapshot.as_ref()
+    }
+
+    /// Returns exact aggregate provider usage and optional USD estimate.
+    #[must_use]
+    pub const fn usage(&self) -> &TurnUsage {
+        &self.usage
+    }
+
+    pub(crate) fn into_parts(self) -> (String, Option<SessionSnapshot>, TurnUsage) {
+        (self.final_message, self.snapshot, self.usage)
+    }
+}
+
+/// One accepted managed turn and its independently awaitable result.
+#[must_use = "a managed turn continues running when dropped; await result() or retain its control"]
+pub struct ManagedTurn {
+    control: Arc<dyn ManagedTurnControl>,
+    result: Pin<Box<dyn Future<Output = Result<AgentRunResult, AgentError>> + Send>>,
+}
+
+impl ManagedTurn {
+    /// Creates a turn from one exact control capability and completion future.
+    pub fn new(
+        control: Arc<dyn ManagedTurnControl>,
+        result: impl Future<Output = Result<AgentRunResult, AgentError>> + Send + 'static,
+    ) -> Self {
+        Self {
+            control,
+            result: Box::pin(result),
+        }
+    }
+
+    /// Returns a cheap cloneable capability targeting this exact turn.
+    #[must_use]
+    pub fn control(&self) -> Arc<dyn ManagedTurnControl> {
+        Arc::clone(&self.control)
+    }
+
+    /// Waits for the final managed runtime result.
+    ///
+    /// # Errors
+    ///
+    /// Returns the backend execution or lifecycle error.
+    pub async fn result(self) -> Result<AgentRunResult, AgentError> {
+        self.await
+    }
+}
+
+impl Future for ManagedTurn {
+    type Output = Result<AgentRunResult, AgentError>;
+
+    fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        self.result.as_mut().poll(context)
+    }
+}
+
+/// Fresh runtime returned by a managed agent factory.
+pub struct SpawnedAgent {
+    agent: Arc<dyn ManagedAgent>,
+    events: mpsc::Receiver<AgentEvent>,
+}
+
+impl SpawnedAgent {
+    /// Creates a fresh runtime from its prompt capability and event receiver.
+    #[must_use]
+    pub fn new(agent: Arc<dyn ManagedAgent>, events: mpsc::Receiver<AgentEvent>) -> Self {
+        Self { agent, events }
+    }
+
+    /// Transfers the prompt capability and independent event receiver.
+    #[must_use]
+    pub fn into_parts(self) -> (Arc<dyn ManagedAgent>, mpsc::Receiver<AgentEvent>) {
+        (self.agent, self.events)
+    }
+}
+
+/// Prompt boundary required by Nanocentaur's durable actor.
+#[async_trait]
+pub trait ManagedAgent: Send + Sync {
+    /// Accepts one prompt in the runtime's ordered turn queue.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the live harness rejects the prompt.
+    async fn prompt(&self, prompt: Prompt) -> Result<ManagedTurn, AgentError>;
+}
+
+/// Cloneable controls for one accepted runtime turn.
+#[async_trait]
+pub trait ManagedTurnControl: Send + Sync {
+    /// Adds input to the active turn at the next safe response boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the turn is not active or its steer queue is full.
+    async fn steer(&self, prompt: Prompt) -> Result<(), AgentError>;
+
+    /// Stops the turn and its owned descendants.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the turn is already terminal.
+    async fn cancel(&self) -> Result<(), AgentError>;
+}
+
+/// Factory boundary used by the durable manager and deterministic tests.
+#[async_trait]
+pub trait ManagedAgentFactory: Send + Sync {
+    /// Creates a fresh runtime from one durable specification.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when policy, VM, tool, or model setup fails.
+    async fn create(&self, spec: AgentSpec) -> Result<SpawnedAgent, AgentError>;
+}
+
+/// Host-side Nanocodex runtime whose workspace tools execute in one VM.
+///
+/// VM roots are disposable copies. The durable model boundary and explicit
+/// host workspace remain outside the VM.
+pub struct NanocodexAgentFactory {
+    auth: OpenAiAuth,
+    vmm_executable: PathBuf,
+    rootfs_template: PathBuf,
+    state_directory: PathBuf,
+    guest_runtime_disk: Option<PathBuf>,
+    firmware_directory: Option<PathBuf>,
+    guest_shell: String,
+    egress: Arc<dyn EgressProvider>,
+}
+
+impl NanocodexAgentFactory {
+    /// Creates a VM-backed factory from explicit trusted host inputs.
+    #[must_use]
+    pub fn new(
+        auth: OpenAiAuth,
+        vmm_executable: impl Into<PathBuf>,
+        rootfs_template: impl Into<PathBuf>,
+        state_directory: impl Into<PathBuf>,
+        egress: Arc<dyn EgressProvider>,
+    ) -> Self {
+        Self {
+            auth,
+            vmm_executable: vmm_executable.into(),
+            rootfs_template: rootfs_template.into(),
+            state_directory: state_directory.into(),
+            guest_runtime_disk: None,
+            firmware_directory: None,
+            guest_shell: "sh".to_owned(),
+            egress,
+        }
+    }
+
+    /// Selects the prepared read-only guest-runtime disk required by raw ext4 roots.
+    #[must_use]
+    pub fn guest_runtime_disk(mut self, guest_runtime_disk: impl Into<PathBuf>) -> Self {
+        self.guest_runtime_disk = Some(guest_runtime_disk.into());
+        self
+    }
+
+    /// Selects the directory containing the platform libkrun firmware library.
+    #[must_use]
+    pub fn firmware_directory(mut self, firmware_directory: impl Into<PathBuf>) -> Self {
+        self.firmware_directory = Some(firmware_directory.into());
+        self
+    }
+
+    fn agent_paths(&self, agent_id: &str) -> Result<(TempDir, AgentRootfs), AgentError> {
+        let runtimes = self.state_directory.join("runtimes");
+        std::fs::create_dir_all(&runtimes)?;
+        let directory = tempfile::Builder::new()
+            .prefix(&format!("{agent_id}-"))
+            .tempdir_in(runtimes)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700))?;
+        }
+        let rootfs = copy_rootfs(&self.rootfs_template, directory.path())?;
+        Ok((directory, rootfs))
+    }
+}
+
+#[async_trait]
+impl ManagedAgentFactory for NanocodexAgentFactory {
+    async fn create(&self, spec: AgentSpec) -> Result<SpawnedAgent, AgentError> {
+        let egress_capabilities: BTreeSet<CapabilityName> = spec
+            .capabilities
+            .names()
+            .iter()
+            .filter(|capability| {
+                !capability.as_str().starts_with("tools.")
+                    && !capability.as_str().starts_with("agent.")
+            })
+            .cloned()
+            .collect();
+        let egress = self
+            .egress
+            .acquire(
+                &EgressContext::new(spec.agent_id.clone(), spec.principal.clone()),
+                &egress_capabilities,
+            )
+            .await?;
+        let (runtime_directory, rootfs) = self.agent_paths(&spec.agent_id)?;
+        let mut vm = VmWorkspace::builder(rootfs.path(), &self.vmm_executable)
+            .vmm_argument("vmm")
+            .vmm_argument("--config")
+            .guest_workspace(GUEST_WORKSPACE)
+            .shell(&self.guest_shell)
+            .cpus(2)
+            .memory_mib(1_024)
+            .egress(egress);
+        if let Some(runtime) = &self.guest_runtime_disk {
+            vm = vm.guest_runtime_disk(runtime);
+        }
+        if let Some(firmware) = &self.firmware_directory {
+            vm = vm.firmware_directory(firmware);
+        }
+        let vm = vm.launch().await?;
+        let tools = vm
+            .tools_builder()
+            .web_search(spec.capabilities.contains("tools.web_search"))
+            .image_generation(spec.capabilities.contains("tools.image_generation"))
+            .build()?;
+
+        let openai = OpenAi::new(self.auth.clone())?;
+        let mut builder = Nanocodex::builder(openai)
+            .workspace(GUEST_WORKSPACE)
+            .tools(tools);
+        if let Ok(session_id) = SessionId::from_str(&spec.agent_id) {
+            builder = builder.session_id(session_id);
+        }
+        if let Some(instructions) = spec.instructions {
+            builder = builder.instructions(instructions);
+        }
+        if let Some(thinking) = spec.thinking {
+            builder = builder.thinking(thinking);
+        }
+        if let Some(snapshot) = spec.snapshot {
+            builder = builder.resume(snapshot);
+        }
+        let (agent, events) = builder.build()?;
+        let (event_sender, event_receiver) = mpsc::channel(RUNTIME_EVENT_CAPACITY);
+        tokio::spawn(forward_events(events, event_sender));
+
+        Ok(SpawnedAgent::new(
+            Arc::new(NanocodexManagedAgent {
+                agent,
+                _vm: vm,
+                _runtime_directory: runtime_directory,
+            }),
+            event_receiver,
+        ))
+    }
+}
+
+enum AgentRootfs {
+    Directory(PathBuf),
+    Ext4(PathBuf),
+}
+
+impl AgentRootfs {
+    fn path(&self) -> &Path {
+        match self {
+            Self::Directory(path) | Self::Ext4(path) => path,
+        }
+    }
+}
+
+struct NanocodexManagedAgent {
+    agent: Nanocodex,
+    _vm: VmWorkspace,
+    _runtime_directory: TempDir,
+}
+
+#[async_trait]
+impl ManagedAgent for NanocodexManagedAgent {
+    async fn prompt(&self, prompt: Prompt) -> Result<ManagedTurn, AgentError> {
+        let turn = self.agent.prompt(prompt).await?;
+        let control = Arc::new(NanocodexTurnControl(turn.control()));
+        Ok(ManagedTurn::new(control, async move {
+            let result = turn.result().await.map_err(map_nanocodex_error)?;
+            Ok(AgentRunResult::new(
+                result.final_message(),
+                Some(result.snapshot()),
+                result.usage().clone(),
+            ))
+        }))
+    }
+}
+
+struct NanocodexTurnControl(nanocodex_agent::TurnControl);
+
+#[async_trait]
+impl ManagedTurnControl for NanocodexTurnControl {
+    async fn steer(&self, prompt: Prompt) -> Result<(), AgentError> {
+        self.0.steer(prompt).await.map_err(map_nanocodex_error)
+    }
+
+    async fn cancel(&self) -> Result<(), AgentError> {
+        self.0.cancel().await.map_err(map_nanocodex_error)
+    }
+}
+
+fn map_nanocodex_error(error: NanocodexError) -> AgentError {
+    match error {
+        NanocodexError::TurnNotSteerable => AgentError::TurnNotSteerable,
+        NanocodexError::SteerQueueFull => AgentError::SteerQueueFull,
+        NanocodexError::TurnNotCancellable => AgentError::TurnNotCancellable,
+        error => AgentError::Nanocodex(error),
+    }
+}
+
+async fn forward_events(mut events: AgentEvents, sender: mpsc::Sender<AgentEvent>) {
+    while let Some(event) = events.recv().await {
+        if sender.send(event).await.is_err() {
+            return;
+        }
+    }
+}
+
+/// Enters the blocking libkrun loop from a private typed launch record.
+///
+/// # Errors
+///
+/// Returns an error when the record cannot be read or the VM cannot run.
+pub fn run_vmm(config_path: &Path) -> Result<(), AgentError> {
+    VmProcessConfig::read(config_path)?.run()?;
+    Ok(())
+}
+
+/// Managed runtime setup or execution failure.
+#[derive(Debug, Error)]
+pub enum AgentError {
+    /// Steering targeted a queued or terminal turn.
+    #[error("the targeted turn is not active for steering")]
+    TurnNotSteerable,
+    /// The active turn's steering queue is full.
+    #[error("the active turn's steering queue is full")]
+    SteerQueueFull,
+    /// Cancellation targeted a terminal turn.
+    #[error("the targeted turn is no longer cancellable")]
+    TurnNotCancellable,
+    /// Managed egress policy or provisioning failed.
+    #[error("agent egress setup failed")]
+    Egress(#[from] crate::EgressError),
+    /// Filesystem or child-process I/O failed.
+    #[error("VM configuration I/O failed")]
+    Io(#[from] io::Error),
+    /// The configured rootfs template is not supported.
+    #[error("rootfs template is not a directory or ext4 file: {0}")]
+    InvalidRootfsTemplate(PathBuf),
+    /// The retained VM tool session failed.
+    #[error("VM tool session failed")]
+    VmWorkspace(#[from] nanocodex_vm::VmWorkspaceError),
+    /// The hypervisor failed.
+    #[error("VM setup failed")]
+    Vm(#[from] nanocodex_vm::host::VmError),
+    /// A private VM launch record failed.
+    #[error("private VM process configuration failed")]
+    VmProcess(#[from] nanocodex_vm::host::VmProcessError),
+    /// OpenAI client setup failed.
+    #[error("OpenAI client setup failed")]
+    OpenAi(#[from] nanocodex_oai_api::OpenAiError),
+    /// The owned agent lifecycle failed.
+    #[error("Nanocodex setup or execution failed")]
+    Nanocodex(#[from] nanocodex_agent::NanocodexError),
+    /// The configured tool registry failed to build.
+    #[error("Nanocodex tool setup failed")]
+    Tools(#[from] nanocodex_agent::tools::ToolsBuildError),
+    /// A caller-supplied runtime backend failed.
+    #[error("managed agent failed: {0}")]
+    Backend(String),
+}
+
+fn copy_rootfs(source: &Path, runtime: &Path) -> Result<AgentRootfs, AgentError> {
+    if source.is_file() {
+        let destination = runtime.join("rootfs.ext4");
+        reflink_copy::reflink_or_copy(source, &destination)?;
+        Ok(AgentRootfs::Ext4(destination))
+    } else if source.is_dir() {
+        let destination = runtime.join("rootfs");
+        copy_directory(source, &destination)?;
+        Ok(AgentRootfs::Directory(destination))
+    } else {
+        Err(AgentError::InvalidRootfsTemplate(source.to_owned()))
+    }
+}
+
+fn copy_directory(source: &Path, destination: &Path) -> Result<(), io::Error> {
+    std::fs::create_dir(destination)?;
+    std::fs::set_permissions(
+        destination,
+        std::fs::symlink_metadata(source)?.permissions(),
+    )?;
+    for entry in std::fs::read_dir(source)? {
+        let entry = entry?;
+        let source = entry.path();
+        let destination = destination.join(entry.file_name());
+        let metadata = std::fs::symlink_metadata(&source)?;
+        if metadata.file_type().is_symlink() {
+            copy_symlink(&source, &destination)?;
+        } else if metadata.is_dir() {
+            copy_directory(&source, &destination)?;
+        } else if metadata.is_file() {
+            reflink_copy::reflink_or_copy(&source, &destination)?;
+            std::fs::set_permissions(&destination, metadata.permissions())?;
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!("unsupported rootfs entry: {}", source.display()),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn copy_symlink(source: &Path, destination: &Path) -> Result<(), io::Error> {
+    std::os::unix::fs::symlink(std::fs::read_link(source)?, destination)
+}
+
+#[cfg(not(unix))]
+fn copy_symlink(_source: &Path, _destination: &Path) -> Result<(), io::Error> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "rootfs symlinks require a Unix host",
+    ))
+}

--- a/crates/experimental/nanocentaur/src/api.rs
+++ b/crates/experimental/nanocentaur/src/api.rs
@@ -36,6 +36,7 @@ pub struct ApiState {
     pub(crate) admin: Arc<AdminAuthorizer>,
     pub(crate) payments: Arc<dyn PaymentGate>,
     idempotency_locks: IdempotencyLocks,
+    agent_locks: AgentLocks,
 }
 
 impl ApiState {
@@ -48,18 +49,27 @@ impl ApiState {
         admin: Arc<AdminAuthorizer>,
         payments: Arc<dyn PaymentGate>,
     ) -> Self {
+        manager.attach_policy(Arc::clone(&policy));
         Self {
             manager,
             policy,
             admin,
             payments,
             idempotency_locks: IdempotencyLocks::default(),
+            agent_locks: AgentLocks::default(),
         }
     }
 
     /// Builds the REST/SSE router owned by this state.
     pub fn router(self) -> Router {
         router(Arc::new(self))
+    }
+
+    pub(crate) async fn policy_call<T>(
+        &self,
+        operation: impl FnOnce(&PolicyStore) -> Result<T, PolicyError>,
+    ) -> Result<T, ApiError> {
+        operation(&self.policy).map_err(Into::into)
     }
 }
 
@@ -70,6 +80,11 @@ struct IdempotencyLocks {
 
 type IdempotencyScope = (String, String);
 type IdempotencyLock = tokio::sync::Mutex<()>;
+
+#[derive(Default)]
+struct AgentLocks {
+    locks: tokio::sync::Mutex<HashMap<String, Weak<IdempotencyLock>>>,
+}
 
 impl IdempotencyLocks {
     async fn acquire(&self, agent_id: String, key: String) -> tokio::sync::OwnedMutexGuard<()> {
@@ -84,6 +99,25 @@ impl IdempotencyLocks {
             } else {
                 let lock = Arc::new(tokio::sync::Mutex::new(()));
                 locks.insert(scope, Arc::downgrade(&lock));
+                lock
+            }
+        };
+        lock.lock_owned().await
+    }
+}
+
+impl AgentLocks {
+    async fn acquire(&self, agent_id: String) -> tokio::sync::OwnedMutexGuard<()> {
+        let lock = {
+            let mut locks = self.locks.lock().await;
+            if locks.len() >= 1_024 {
+                locks.retain(|_, lock| lock.strong_count() > 0);
+            }
+            if let Some(lock) = locks.get(&agent_id).and_then(Weak::upgrade) {
+                lock
+            } else {
+                let lock = Arc::new(tokio::sync::Mutex::new(()));
+                locks.insert(agent_id, Arc::downgrade(&lock));
                 lock
             }
         };
@@ -175,10 +209,20 @@ async fn create_agent(
         request = ?request,
         "create agent request observed"
     );
-    let client = state.policy.authenticate(&headers)?;
-    let (identity, created) = state
-        .policy
-        .create_or_resolve_agent(&client, request.context_key.as_deref())?;
+    let context_key = request.context_key;
+    let (identity, created, client) = state
+        .policy_call(move |policy| {
+            let client = policy.authenticate(&headers)?;
+            let (identity, created) =
+                policy.create_or_resolve_agent(&client, context_key.as_deref())?;
+            Ok((identity, created, client))
+        })
+        .await?;
+    let _agent_guard = state.agent_locks.acquire(identity.id.clone()).await;
+    let agent_id = identity.id;
+    let identity = state
+        .policy_call(move |policy| policy.agent(&client, &agent_id))
+        .await?;
     let view = state.manager.register(identity).await?;
     let response = CreateAgentResponse {
         agent_id: view.agent_id,
@@ -201,7 +245,8 @@ async fn get_agent(
     headers: HeaderMap,
     Path(agent_id): Path<String>,
 ) -> Result<Json<crate::AgentView>, ApiError> {
-    let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.read")?;
+    let _agent_guard = state.agent_locks.acquire(agent_id.clone()).await;
+    let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.read").await?;
     Ok(Json(state.manager.get(identity).await?))
 }
 
@@ -210,9 +255,20 @@ async fn delete_agent(
     headers: HeaderMap,
     Path(agent_id): Path<String>,
 ) -> Result<StatusCode, ApiError> {
-    let (_, client) = authorize_agent(&state, &headers, &agent_id, "agent.delete")?;
+    let _agent_guard = state.agent_locks.acquire(agent_id.clone()).await;
+    let headers_for_delete = headers.clone();
+    let agent_for_delete = agent_id.clone();
+    let client = state
+        .policy_call(move |policy| {
+            let client = policy.authenticate(&headers_for_delete)?;
+            policy.begin_delete_agent(&client, &agent_for_delete)?;
+            Ok(client)
+        })
+        .await?;
     state.manager.delete(&agent_id).await?;
-    state.policy.delete_agent(&client, &agent_id)?;
+    state
+        .policy_call(move |policy| policy.finish_delete_agent(&client, &agent_id))
+        .await?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -228,7 +284,8 @@ async fn create_turn(
         request = ?request,
         "create turn request observed"
     );
-    let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.turn")?;
+    let _agent_guard = state.agent_locks.acquire(agent_id.clone()).await;
+    let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.turn").await?;
     let idempotency_key = idempotency_key(&headers)?;
     let _idempotency_guard = if let Some(key) = &idempotency_key {
         Some(
@@ -241,29 +298,60 @@ async fn create_turn(
         None
     };
     if let Some(key) = idempotency_key.as_deref()
-        && let Some(response) = state
+        && let Some(replay) = state
             .manager
-            .find_turn_by_idempotency_key(identity.clone(), key)
+            .find_turn_replay(identity.clone(), key, &request)
             .await?
     {
-        return Ok(Json(response).into_response());
+        let status = turn_action_status(replay.response.action);
+        let mut response = (status, Json(replay.response)).into_response();
+        if let Some(receipt) = replay.payment_receipt {
+            insert_receipt(&mut response, &receipt)?;
+        }
+        return Ok(response);
     }
+    crate::manager::validate_turn_request(&request)?;
 
     let receipt = match state.payments.authorize(&headers).await? {
         PaymentOutcome::Authorized(receipt) => receipt,
         outcome => return payment_response(outcome),
     };
-    let response = state
+    let receipt_header = HeaderValue::from_str(&receipt.header_value).map_err(|error| {
+        tracing::error!(%error, "payment gate returned an invalid receipt header");
+        ApiError::Internal
+    })?;
+    let response = match state
         .manager
-        .create_turn(identity, request, idempotency_key)
-        .await?;
-    let status = match response.action {
+        .create_turn_with_receipt(
+            identity,
+            request,
+            idempotency_key,
+            Some(receipt.header_value.clone()),
+        )
+        .await
+    {
+        Ok(response) => response,
+        Err(error) => {
+            let mut response = ApiError::from(error).into_response();
+            response
+                .headers_mut()
+                .insert(HeaderName::from_static("payment-receipt"), receipt_header);
+            return Ok(response);
+        }
+    };
+    let status = turn_action_status(response.action);
+    let mut response = (status, Json(response)).into_response();
+    response
+        .headers_mut()
+        .insert(HeaderName::from_static("payment-receipt"), receipt_header);
+    Ok(response)
+}
+
+const fn turn_action_status(action: TurnAction) -> StatusCode {
+    match action {
         TurnAction::Steered => StatusCode::OK,
         TurnAction::Started | TurnAction::Queued => StatusCode::ACCEPTED,
-    };
-    let mut response = (status, Json(response)).into_response();
-    insert_receipt(&mut response, &receipt.header_value)?;
-    Ok(response)
+    }
 }
 
 async fn get_turn(
@@ -271,7 +359,8 @@ async fn get_turn(
     headers: HeaderMap,
     Path((agent_id, turn_id)): Path<(String, String)>,
 ) -> Result<Json<TurnView>, ApiError> {
-    let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.read")?;
+    let _agent_guard = state.agent_locks.acquire(agent_id.clone()).await;
+    let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.read").await?;
     Ok(Json(state.manager.get_turn(identity, &turn_id).await?))
 }
 
@@ -286,7 +375,8 @@ async fn agent_events(
     Path(agent_id): Path<String>,
     Query(query): Query<EventsQuery>,
 ) -> Result<Response, ApiError> {
-    let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.read")?;
+    let _agent_guard = state.agent_locks.acquire(agent_id.clone()).await;
+    let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.read").await?;
     let after_event_id = last_event_id(&headers)?
         .or(query.after_event_id)
         .unwrap_or(0);
@@ -320,7 +410,8 @@ async fn cancel_turn(
     headers: HeaderMap,
     Path((agent_id, turn_id)): Path<(String, String)>,
 ) -> Result<Json<CancelTurnResponse>, ApiError> {
-    let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.cancel")?;
+    let _agent_guard = state.agent_locks.acquire(agent_id.clone()).await;
+    let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.cancel").await?;
     let cancelled = state.manager.cancel_turn(identity, &turn_id).await?;
     Ok(Json(CancelTurnResponse {
         cancel_requested: cancelled,
@@ -337,7 +428,8 @@ async fn evict_agent(
     headers: HeaderMap,
     Path(agent_id): Path<String>,
 ) -> Result<Json<EvictAgentResponse>, ApiError> {
-    let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.evict")?;
+    let _agent_guard = state.agent_locks.acquire(agent_id.clone()).await;
+    let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.evict").await?;
     let evicted = state.manager.evict(identity).await?;
     Ok(Json(EvictAgentResponse { evicted }))
 }
@@ -364,16 +456,50 @@ async fn fork_agent(
     agent_id: &str,
     turn_id: Option<&str>,
 ) -> Result<Response, ApiError> {
-    let (source, client) = authorize_agent(state, headers, agent_id, "agent.fork")?;
-    let target = state.policy.fork_agent(&client, agent_id)?;
+    let _agent_guard = state.agent_locks.acquire(agent_id.to_owned()).await;
+    let (source, client) = authorize_agent(state, headers, agent_id, "agent.fork").await?;
+    let client_for_fork = client.clone();
+    let source_agent_id = agent_id.to_owned();
+    let target = state
+        .policy_call(move |policy| policy.fork_agent(&client_for_fork, &source_agent_id))
+        .await?;
     match state.manager.fork(source, target.clone(), turn_id).await {
-        Ok(response) => Ok((StatusCode::CREATED, Json(response)).into_response()),
-        Err(error) => {
-            if let Err(cleanup_error) = state.policy.delete_agent(&client, &target.id) {
-                tracing::warn!(%cleanup_error, "failed to clean up fork registry record");
+        Ok(response) => {
+            let client_for_activation = client.clone();
+            let target_id = target.id.clone();
+            if let Err(error) = state
+                .policy_call(move |policy| {
+                    policy.activate_agent(&client_for_activation, &target_id)
+                })
+                .await
+            {
+                cleanup_failed_fork(state, &client, &target).await;
+                return Err(error);
             }
+            Ok((StatusCode::CREATED, Json(response)).into_response())
+        }
+        Err(error) => {
+            cleanup_failed_fork(state, &client, &target).await;
             Err(error.into())
         }
+    }
+}
+
+async fn cleanup_failed_fork(
+    state: &ApiState,
+    client: &crate::AuthenticatedClient,
+    target: &crate::AgentIdentity,
+) {
+    if let Err(error) = state.manager.delete(&target.id).await {
+        tracing::warn!(%error, "failed to clean up fork session state");
+    }
+    let client = client.clone();
+    let target_id = target.id.clone();
+    if let Err(error) = state
+        .policy_call(move |policy| policy.abort_provisioning_agent(&client, &target_id))
+        .await
+    {
+        tracing::warn!(error = ?error, "failed to clean up fork registry record");
     }
 }
 
@@ -381,20 +507,29 @@ async fn payment_session(
     State(state): State<Arc<ApiState>>,
     headers: HeaderMap,
 ) -> Result<Response, ApiError> {
-    let _ = state.policy.authenticate(&headers)?;
+    let authentication_headers = headers.clone();
+    state
+        .policy_call(move |policy| policy.authenticate(&authentication_headers).map(drop))
+        .await?;
     payment_response(state.payments.authorize(&headers).await?)
 }
 
-fn authorize_agent(
+async fn authorize_agent(
     state: &ApiState,
     headers: &HeaderMap,
     agent_id: &str,
-    permission: &str,
+    permission: &'static str,
 ) -> Result<(crate::AgentIdentity, crate::AuthenticatedClient), ApiError> {
-    let client = state.policy.authenticate(headers)?;
-    let identity = state.policy.agent(&client, agent_id)?;
-    require(&identity.principal, permission)?;
-    Ok((identity, client))
+    let headers = headers.clone();
+    let agent_id = agent_id.to_owned();
+    state
+        .policy_call(move |policy| {
+            let client = policy.authenticate(&headers)?;
+            let identity = policy.agent(&client, &agent_id)?;
+            require(&identity.principal, permission)?;
+            Ok((identity, client))
+        })
+        .await
 }
 
 fn payment_response(outcome: PaymentOutcome) -> Result<Response, ApiError> {
@@ -465,6 +600,7 @@ fn optional_header(
         .transpose()
 }
 
+#[derive(Debug)]
 pub(crate) enum ApiError {
     Authorization(AuthorizationError),
     Policy(PolicyError),
@@ -519,6 +655,11 @@ impl IntoResponse for ApiError {
                 StatusCode::CONFLICT,
                 "steer_queue_full",
                 "active turn steering queue is full",
+            ),
+            Self::Manager(ManagerError::IdempotencyConflict) => (
+                StatusCode::CONFLICT,
+                "idempotency_conflict",
+                "Idempotency-Key was already used for a different request",
             ),
             Self::Manager(ManagerError::AgentBusy) => (
                 StatusCode::CONFLICT,
@@ -753,10 +894,69 @@ mod tests {
             app.clone().oneshot(request()),
             app.clone().oneshot(request())
         );
-        let statuses = [first.unwrap().status(), second.unwrap().status()];
-        assert!(statuses.contains(&StatusCode::ACCEPTED));
-        assert!(statuses.contains(&StatusCode::OK));
+        let first = first.unwrap();
+        let second = second.unwrap();
+        let statuses = [first.status(), second.status()];
+        assert_eq!(statuses, [StatusCode::ACCEPTED, StatusCode::ACCEPTED]);
+        assert_eq!(first.headers()["payment-receipt"], "counted");
+        assert_eq!(second.headers()["payment-receipt"], "counted");
         assert_eq!(payments.authorizations.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn invalid_turns_are_rejected_before_payment_authorization() {
+        let factory: Arc<dyn ManagedAgentFactory> =
+            Arc::new(MockAgentFactory::new(Duration::from_millis(5)));
+        let directory = tempfile::tempdir().unwrap().keep();
+        let policy = Arc::new(PolicyStore::in_memory().unwrap());
+        policy
+            .bootstrap("test", "Test", "test-key", "test", [])
+            .unwrap();
+        let payments = Arc::new(CountingPaymentGate {
+            authorizations: AtomicUsize::new(0),
+        });
+        let state = Arc::new(ApiState::new(
+            Arc::new(AgentManager::new(factory, directory).unwrap()),
+            policy,
+            Arc::new(AdminAuthorizer::new("admin-key").unwrap()),
+            payments.clone(),
+        ));
+        let app = router(state);
+        let agent_id = create_test_agent(&app, "context:invalid-unpaid").await;
+        let response = app
+            .oneshot(
+                Request::post(format!("/v1/agent/{agent_id}/turn"))
+                    .header("x-api-key", "test-key")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"content":[]}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(payments.authorizations.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn idempotency_key_reuse_with_different_content_is_rejected() {
+        let app = test_app(Duration::from_millis(50));
+        let agent_id = create_test_agent(&app, "context:idempotency-conflict").await;
+        let send = |text: &'static str| {
+            Request::post(format!("/v1/agent/{agent_id}/turn"))
+                .header("x-api-key", "test-key")
+                .header("idempotency-key", "same-key")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(format!(
+                    r#"{{"content":[{{"type":"text","text":"{text}"}}]}}"#
+                )))
+                .unwrap()
+        };
+        let first = app.clone().oneshot(send("first")).await.unwrap();
+        assert_eq!(first.status(), StatusCode::ACCEPTED);
+        let conflict = app.oneshot(send("different")).await.unwrap();
+        assert_eq!(conflict.status(), StatusCode::CONFLICT);
+        let body = response_json::<serde_json::Value>(conflict).await;
+        assert_eq!(body["error"]["code"], "idempotency_conflict");
     }
 
     #[tokio::test]

--- a/crates/experimental/nanocentaur/src/api.rs
+++ b/crates/experimental/nanocentaur/src/api.rs
@@ -1,6 +1,7 @@
 use std::{
+    collections::HashMap,
     convert::Infallible,
-    sync::Arc,
+    sync::{Arc, Weak},
     time::{Duration, Instant},
 };
 
@@ -34,6 +35,7 @@ pub struct ApiState {
     pub(crate) policy: Arc<PolicyStore>,
     pub(crate) admin: Arc<AdminAuthorizer>,
     pub(crate) payments: Arc<dyn PaymentGate>,
+    idempotency_locks: IdempotencyLocks,
 }
 
 impl ApiState {
@@ -51,12 +53,41 @@ impl ApiState {
             policy,
             admin,
             payments,
+            idempotency_locks: IdempotencyLocks::default(),
         }
     }
 
     /// Builds the REST/SSE router owned by this state.
     pub fn router(self) -> Router {
         router(Arc::new(self))
+    }
+}
+
+#[derive(Default)]
+struct IdempotencyLocks {
+    locks: tokio::sync::Mutex<HashMap<IdempotencyScope, Weak<IdempotencyLock>>>,
+}
+
+type IdempotencyScope = (String, String);
+type IdempotencyLock = tokio::sync::Mutex<()>;
+
+impl IdempotencyLocks {
+    async fn acquire(&self, agent_id: String, key: String) -> tokio::sync::OwnedMutexGuard<()> {
+        let lock = {
+            let mut locks = self.locks.lock().await;
+            if locks.len() >= 1_024 {
+                locks.retain(|_, lock| lock.strong_count() > 0);
+            }
+            let scope = (agent_id, key);
+            if let Some(lock) = locks.get(&scope).and_then(Weak::upgrade) {
+                lock
+            } else {
+                let lock = Arc::new(tokio::sync::Mutex::new(()));
+                locks.insert(scope, Arc::downgrade(&lock));
+                lock
+            }
+        };
+        lock.lock_owned().await
     }
 }
 
@@ -179,10 +210,7 @@ async fn delete_agent(
     headers: HeaderMap,
     Path(agent_id): Path<String>,
 ) -> Result<StatusCode, ApiError> {
-    let (identity, client) = authorize_agent(&state, &headers, &agent_id, "agent.delete")?;
-    if state.manager.get(identity).await?.state == crate::AgentStatus::Running {
-        return Err(ManagerError::AgentBusy.into());
-    }
+    let (_, client) = authorize_agent(&state, &headers, &agent_id, "agent.delete")?;
     state.manager.delete(&agent_id).await?;
     state.policy.delete_agent(&client, &agent_id)?;
     Ok(StatusCode::NO_CONTENT)
@@ -202,6 +230,16 @@ async fn create_turn(
     );
     let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.turn")?;
     let idempotency_key = idempotency_key(&headers)?;
+    let _idempotency_guard = if let Some(key) = &idempotency_key {
+        Some(
+            state
+                .idempotency_locks
+                .acquire(agent_id.clone(), key.clone())
+                .await,
+        )
+    } else {
+        None
+    };
     if let Some(key) = idempotency_key.as_deref()
         && let Some(response) = state
             .manager
@@ -509,10 +547,7 @@ impl IntoResponse for ApiError {
                 | PolicyError::Io(_),
             )
             | Self::Manager(
-                ManagerError::ActorStopped
-                | ManagerError::Durability(_)
-                | ManagerError::Agent(_)
-                | ManagerError::Io(_),
+                ManagerError::ActorStopped | ManagerError::Durability(_) | ManagerError::Agent(_),
             )
             | Self::Authorization(AuthorizationError::InvalidConfiguration(_))
             | Self::Internal => (
@@ -547,6 +582,8 @@ impl ErrorResponse {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use std::{
         collections::BTreeSet,
         sync::{Arc, Mutex},
@@ -571,6 +608,21 @@ mod tests {
     };
 
     struct ConstantSecret;
+
+    struct CountingPaymentGate {
+        authorizations: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl PaymentGate for CountingPaymentGate {
+        async fn authorize(&self, _headers: &HeaderMap) -> Result<PaymentOutcome, PaymentError> {
+            self.authorizations.fetch_add(1, Ordering::Relaxed);
+            tokio::time::sleep(Duration::from_millis(25)).await;
+            Ok(PaymentOutcome::Authorized(crate::PaymentReceipt {
+                header_value: "counted".to_owned(),
+            }))
+        }
+    }
 
     #[async_trait]
     impl SecretManager for ConstantSecret {
@@ -666,6 +718,45 @@ mod tests {
         let body = response_json::<CreateAgentResponse>(response).await;
         assert_eq!(body.agent_id, first);
         assert!(!body.created);
+    }
+
+    #[tokio::test]
+    async fn concurrent_idempotent_turns_are_authorized_for_payment_once() {
+        let factory: Arc<dyn ManagedAgentFactory> =
+            Arc::new(MockAgentFactory::new(Duration::from_millis(50)));
+        let directory = tempfile::tempdir().unwrap().keep();
+        let policy = Arc::new(PolicyStore::in_memory().unwrap());
+        policy
+            .bootstrap("test", "Test", "test-key", "test", [])
+            .unwrap();
+        let payments = Arc::new(CountingPaymentGate {
+            authorizations: AtomicUsize::new(0),
+        });
+        let state = Arc::new(ApiState::new(
+            Arc::new(AgentManager::new(factory, directory).unwrap()),
+            policy,
+            Arc::new(AdminAuthorizer::new("admin-key").unwrap()),
+            payments.clone(),
+        ));
+        let app = router(state);
+        let agent_id = create_test_agent(&app, "context:paid-idempotency").await;
+        let request = || {
+            Request::post(format!("/v1/agent/{agent_id}/turn"))
+                .header("x-api-key", "test-key")
+                .header("idempotency-key", "same-paid-turn")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"content":[{"type":"text","text":"once"}]}"#))
+                .unwrap()
+        };
+
+        let (first, second) = tokio::join!(
+            app.clone().oneshot(request()),
+            app.clone().oneshot(request())
+        );
+        let statuses = [first.unwrap().status(), second.unwrap().status()];
+        assert!(statuses.contains(&StatusCode::ACCEPTED));
+        assert!(statuses.contains(&StatusCode::OK));
+        assert_eq!(payments.authorizations.load(Ordering::Relaxed), 1);
     }
 
     #[tokio::test]

--- a/crates/experimental/nanocentaur/src/api.rs
+++ b/crates/experimental/nanocentaur/src/api.rs
@@ -1,0 +1,938 @@
+use std::{
+    convert::Infallible,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use axum::{
+    Json, Router,
+    extract::{Path, Query, Request, State},
+    http::{HeaderMap, HeaderName, HeaderValue, StatusCode, header},
+    middleware::{self, Next},
+    response::{
+        IntoResponse, Response,
+        sse::{Event, KeepAlive, Sse},
+    },
+    routing::{get, post},
+};
+use futures_util::stream;
+use serde::{Deserialize, Serialize};
+use tracing::Instrument;
+
+use crate::{
+    AdminAuthorizer, AgentManager, AuthorizationError, CreateAgent, CreateAgentResponse,
+    CreateTurn, ManagerError, PaymentError, PaymentGate, PaymentOutcome, PolicyError, PolicyStore,
+    TurnAction, TurnView, require,
+};
+
+/// Application-owned components shared by the REST and SSE handlers.
+///
+/// Fields remain private so queueing, policy, payment, and secret mechanics
+/// cannot be replaced after the router starts.
+pub struct ApiState {
+    pub(crate) manager: Arc<AgentManager>,
+    pub(crate) policy: Arc<PolicyStore>,
+    pub(crate) admin: Arc<AdminAuthorizer>,
+    pub(crate) payments: Arc<dyn PaymentGate>,
+}
+
+impl ApiState {
+    /// Creates the complete managed HTTP boundary from application-owned
+    /// lifecycle, policy, authorization, and payment components.
+    #[must_use]
+    pub fn new(
+        manager: Arc<AgentManager>,
+        policy: Arc<PolicyStore>,
+        admin: Arc<AdminAuthorizer>,
+        payments: Arc<dyn PaymentGate>,
+    ) -> Self {
+        Self {
+            manager,
+            policy,
+            admin,
+            payments,
+        }
+    }
+
+    /// Builds the REST/SSE router owned by this state.
+    pub fn router(self) -> Router {
+        router(Arc::new(self))
+    }
+}
+
+fn router(state: Arc<ApiState>) -> Router {
+    Router::new()
+        .route("/health", get(health))
+        .route("/v1/agent/new", post(create_agent))
+        .route("/v1/agent/{agent_id}", get(get_agent).delete(delete_agent))
+        .route("/v1/agent/{agent_id}/turn", post(create_turn))
+        .route("/v1/agent/{agent_id}/turn/{turn_id}", get(get_turn))
+        .route(
+            "/v1/agent/{agent_id}/turn/{turn_id}/cancel",
+            post(cancel_turn),
+        )
+        .route("/v1/agent/{agent_id}/events", get(agent_events))
+        .route("/v1/agent/{agent_id}/fork", post(fork_latest))
+        .route(
+            "/v1/agent/{agent_id}/turn/{turn_id}/fork",
+            post(fork_from_turn),
+        )
+        .route("/v1/agent/{agent_id}/evict", post(evict_agent))
+        .route("/v1/payment-sessions", post(payment_session))
+        .merge(crate::admin::routes())
+        .layer(middleware::from_fn(trace_request))
+        .with_state(state)
+}
+
+async fn trace_request(request: Request, next: Next) -> Response {
+    let method = request.method().clone();
+    let uri = request.uri().clone();
+    let headers = request.headers().clone();
+    let span = tracing::info_span!(
+        parent: None,
+        "nanocentaur.http.request",
+        otel.kind = "server",
+        http.request.method = %method,
+        url.path = %uri.path(),
+        http.response.status_code = tracing::field::Empty,
+        duration_ns = tracing::field::Empty,
+    );
+    async move {
+        tracing::info!(
+            target: "nanocentaur::observed",
+            http_request_uri = %uri,
+            http_request_headers = ?headers,
+            "http request observed"
+        );
+        let started = Instant::now();
+        let response = next.run(request).await;
+        tracing::Span::current().record("http.response.status_code", response.status().as_u16());
+        tracing::Span::current().record(
+            "duration_ns",
+            u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX),
+        );
+        response
+    }
+    .instrument(span)
+    .await
+}
+
+#[derive(Serialize)]
+struct HealthResponse {
+    status: HealthStatus,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+enum HealthStatus {
+    Ok,
+}
+
+async fn health() -> Json<HealthResponse> {
+    Json(HealthResponse {
+        status: HealthStatus::Ok,
+    })
+}
+
+async fn create_agent(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Json(request): Json<CreateAgent>,
+) -> Result<Response, ApiError> {
+    tracing::info!(
+        target: "nanocentaur::observed",
+        request = ?request,
+        "create agent request observed"
+    );
+    let client = state.policy.authenticate(&headers)?;
+    let (identity, created) = state
+        .policy
+        .create_or_resolve_agent(&client, request.context_key.as_deref())?;
+    let view = state.manager.register(identity).await?;
+    let response = CreateAgentResponse {
+        agent_id: view.agent_id,
+        created,
+        state: view.state,
+    };
+    Ok((
+        if created {
+            StatusCode::CREATED
+        } else {
+            StatusCode::OK
+        },
+        Json(response),
+    )
+        .into_response())
+}
+
+async fn get_agent(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(agent_id): Path<String>,
+) -> Result<Json<crate::AgentView>, ApiError> {
+    let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.read")?;
+    Ok(Json(state.manager.get(identity).await?))
+}
+
+async fn delete_agent(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(agent_id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    let (identity, client) = authorize_agent(&state, &headers, &agent_id, "agent.delete")?;
+    if state.manager.get(identity).await?.state == crate::AgentStatus::Running {
+        return Err(ManagerError::AgentBusy.into());
+    }
+    state.manager.delete(&agent_id).await?;
+    state.policy.delete_agent(&client, &agent_id)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn create_turn(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(agent_id): Path<String>,
+    Json(request): Json<CreateTurn>,
+) -> Result<Response, ApiError> {
+    tracing::info!(
+        target: "nanocentaur::observed",
+        agent_id = %agent_id,
+        request = ?request,
+        "create turn request observed"
+    );
+    let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.turn")?;
+    let idempotency_key = idempotency_key(&headers)?;
+    if let Some(key) = idempotency_key.as_deref()
+        && let Some(response) = state
+            .manager
+            .find_turn_by_idempotency_key(identity.clone(), key)
+            .await?
+    {
+        return Ok(Json(response).into_response());
+    }
+
+    let receipt = match state.payments.authorize(&headers).await? {
+        PaymentOutcome::Authorized(receipt) => receipt,
+        outcome => return payment_response(outcome),
+    };
+    let response = state
+        .manager
+        .create_turn(identity, request, idempotency_key)
+        .await?;
+    let status = match response.action {
+        TurnAction::Steered => StatusCode::OK,
+        TurnAction::Started | TurnAction::Queued => StatusCode::ACCEPTED,
+    };
+    let mut response = (status, Json(response)).into_response();
+    insert_receipt(&mut response, &receipt.header_value)?;
+    Ok(response)
+}
+
+async fn get_turn(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path((agent_id, turn_id)): Path<(String, String)>,
+) -> Result<Json<TurnView>, ApiError> {
+    let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.read")?;
+    Ok(Json(state.manager.get_turn(identity, &turn_id).await?))
+}
+
+#[derive(Default, Deserialize)]
+struct EventsQuery {
+    after_event_id: Option<u64>,
+}
+
+async fn agent_events(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(agent_id): Path<String>,
+    Query(query): Query<EventsQuery>,
+) -> Result<Response, ApiError> {
+    let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.read")?;
+    let after_event_id = last_event_id(&headers)?
+        .or(query.after_event_id)
+        .unwrap_or(0);
+    let cursor = state.manager.events(identity, after_event_id).await?;
+    let output = stream::unfold(Some(cursor), |cursor| async move {
+        let mut cursor = cursor?;
+        let event = cursor.recv().await?;
+        let sse = Event::default()
+            .id(event.id.to_string())
+            .event(event.payload.event_name())
+            .json_data(&event)
+            .unwrap_or_else(|_| Event::default().event("stream.error").data("{}"));
+        Some((Ok::<Event, Infallible>(sse), Some(cursor)))
+    });
+    Ok(Sse::new(output)
+        .keep_alive(
+            KeepAlive::new()
+                .interval(Duration::from_secs(15))
+                .text("keepalive"),
+        )
+        .into_response())
+}
+
+#[derive(Serialize)]
+struct CancelTurnResponse {
+    cancel_requested: bool,
+}
+
+async fn cancel_turn(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path((agent_id, turn_id)): Path<(String, String)>,
+) -> Result<Json<CancelTurnResponse>, ApiError> {
+    let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.cancel")?;
+    let cancelled = state.manager.cancel_turn(identity, &turn_id).await?;
+    Ok(Json(CancelTurnResponse {
+        cancel_requested: cancelled,
+    }))
+}
+
+#[derive(Serialize)]
+struct EvictAgentResponse {
+    evicted: bool,
+}
+
+async fn evict_agent(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(agent_id): Path<String>,
+) -> Result<Json<EvictAgentResponse>, ApiError> {
+    let (identity, _) = authorize_agent(&state, &headers, &agent_id, "agent.evict")?;
+    let evicted = state.manager.evict(identity).await?;
+    Ok(Json(EvictAgentResponse { evicted }))
+}
+
+async fn fork_latest(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path(agent_id): Path<String>,
+) -> Result<Response, ApiError> {
+    fork_agent(&state, &headers, &agent_id, None).await
+}
+
+async fn fork_from_turn(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+    Path((agent_id, turn_id)): Path<(String, String)>,
+) -> Result<Response, ApiError> {
+    fork_agent(&state, &headers, &agent_id, Some(&turn_id)).await
+}
+
+async fn fork_agent(
+    state: &ApiState,
+    headers: &HeaderMap,
+    agent_id: &str,
+    turn_id: Option<&str>,
+) -> Result<Response, ApiError> {
+    let (source, client) = authorize_agent(state, headers, agent_id, "agent.fork")?;
+    let target = state.policy.fork_agent(&client, agent_id)?;
+    match state.manager.fork(source, target.clone(), turn_id).await {
+        Ok(response) => Ok((StatusCode::CREATED, Json(response)).into_response()),
+        Err(error) => {
+            if let Err(cleanup_error) = state.policy.delete_agent(&client, &target.id) {
+                tracing::warn!(%cleanup_error, "failed to clean up fork registry record");
+            }
+            Err(error.into())
+        }
+    }
+}
+
+async fn payment_session(
+    State(state): State<Arc<ApiState>>,
+    headers: HeaderMap,
+) -> Result<Response, ApiError> {
+    let _ = state.policy.authenticate(&headers)?;
+    payment_response(state.payments.authorize(&headers).await?)
+}
+
+fn authorize_agent(
+    state: &ApiState,
+    headers: &HeaderMap,
+    agent_id: &str,
+    permission: &str,
+) -> Result<(crate::AgentIdentity, crate::AuthenticatedClient), ApiError> {
+    let client = state.policy.authenticate(headers)?;
+    let identity = state.policy.agent(&client, agent_id)?;
+    require(&identity.principal, permission)?;
+    Ok((identity, client))
+}
+
+fn payment_response(outcome: PaymentOutcome) -> Result<Response, ApiError> {
+    match outcome {
+        PaymentOutcome::Challenge { www_authenticate } => {
+            let mut response = (
+                StatusCode::PAYMENT_REQUIRED,
+                Json(ErrorResponse::new(
+                    "payment_required",
+                    "payment authorization required",
+                )),
+            )
+                .into_response();
+            response.headers_mut().insert(
+                header::WWW_AUTHENTICATE,
+                HeaderValue::from_str(&www_authenticate).map_err(|_| ApiError::Internal)?,
+            );
+            Ok(response)
+        }
+        PaymentOutcome::Management { body, receipt } => {
+            let mut response = Json(body).into_response();
+            insert_receipt(&mut response, &receipt.header_value)?;
+            Ok(response)
+        }
+        PaymentOutcome::Authorized(receipt) => {
+            let mut response = StatusCode::NO_CONTENT.into_response();
+            insert_receipt(&mut response, &receipt.header_value)?;
+            Ok(response)
+        }
+    }
+}
+
+fn insert_receipt(response: &mut Response, value: &str) -> Result<(), ApiError> {
+    response.headers_mut().insert(
+        HeaderName::from_static("payment-receipt"),
+        HeaderValue::from_str(value).map_err(|_| ApiError::Internal)?,
+    );
+    Ok(())
+}
+
+fn idempotency_key(headers: &HeaderMap) -> Result<Option<String>, ApiError> {
+    optional_header(headers, "idempotency-key", "Idempotency-Key")
+}
+
+fn last_event_id(headers: &HeaderMap) -> Result<Option<u64>, ApiError> {
+    optional_header(headers, "last-event-id", "Last-Event-ID")?
+        .map(|value| {
+            value
+                .parse()
+                .map_err(|_| ApiError::BadHeader("Last-Event-ID"))
+        })
+        .transpose()
+}
+
+fn optional_header(
+    headers: &HeaderMap,
+    header_name: &'static str,
+    display_name: &'static str,
+) -> Result<Option<String>, ApiError> {
+    headers
+        .get(header_name)
+        .map(|value| {
+            value
+                .to_str()
+                .map(str::to_owned)
+                .map_err(|_| ApiError::BadHeader(display_name))
+        })
+        .transpose()
+}
+
+pub(crate) enum ApiError {
+    Authorization(AuthorizationError),
+    Policy(PolicyError),
+    Manager(ManagerError),
+    Payment(PaymentError),
+    BadHeader(&'static str),
+    Internal,
+}
+
+impl From<AuthorizationError> for ApiError {
+    fn from(error: AuthorizationError) -> Self {
+        Self::Authorization(error)
+    }
+}
+
+impl From<PolicyError> for ApiError {
+    fn from(error: PolicyError) -> Self {
+        Self::Policy(error)
+    }
+}
+
+impl From<ManagerError> for ApiError {
+    fn from(error: ManagerError) -> Self {
+        Self::Manager(error)
+    }
+}
+
+impl From<PaymentError> for ApiError {
+    fn from(error: PaymentError) -> Self {
+        Self::Payment(error)
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let (status, code, message) = match self {
+            Self::Authorization(AuthorizationError::Unauthenticated)
+            | Self::Policy(PolicyError::Unauthenticated) => (
+                StatusCode::UNAUTHORIZED,
+                "unauthenticated",
+                "authentication required",
+            ),
+            Self::Policy(PolicyError::Forbidden) => (
+                StatusCode::FORBIDDEN,
+                "permission_denied",
+                "permission denied",
+            ),
+            Self::Policy(PolicyError::NotFound) | Self::Manager(ManagerError::NotFound) => {
+                (StatusCode::NOT_FOUND, "not_found", "resource not found")
+            }
+            Self::Manager(ManagerError::SteerQueueFull) => (
+                StatusCode::CONFLICT,
+                "steer_queue_full",
+                "active turn steering queue is full",
+            ),
+            Self::Manager(ManagerError::AgentBusy) => (
+                StatusCode::CONFLICT,
+                "agent_busy",
+                "agent must be idle for this operation",
+            ),
+            Self::Manager(ManagerError::ForkBoundaryNotFound) => (
+                StatusCode::CONFLICT,
+                "fork_boundary_not_found",
+                "completed fork boundary was not found",
+            ),
+            Self::Manager(ManagerError::Invalid(message))
+            | Self::Policy(PolicyError::Invalid(message)) => {
+                (StatusCode::BAD_REQUEST, "invalid_request", message)
+            }
+            Self::Payment(PaymentError::InvalidCredential) => (
+                StatusCode::PAYMENT_REQUIRED,
+                "invalid_payment",
+                "invalid payment credential",
+            ),
+            Self::Payment(PaymentError::Configuration(_) | PaymentError::Verification(_))
+            | Self::Policy(
+                PolicyError::Poisoned
+                | PolicyError::Database(_)
+                | PolicyError::Json(_)
+                | PolicyError::Io(_),
+            )
+            | Self::Manager(
+                ManagerError::ActorStopped
+                | ManagerError::Durability(_)
+                | ManagerError::Agent(_)
+                | ManagerError::Io(_),
+            )
+            | Self::Authorization(AuthorizationError::InvalidConfiguration(_))
+            | Self::Internal => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_error",
+                "internal server error",
+            ),
+            Self::BadHeader(name) => (StatusCode::BAD_REQUEST, "invalid_header", name),
+        };
+        (status, Json(ErrorResponse::new(code, message))).into_response()
+    }
+}
+
+#[derive(Serialize)]
+struct ErrorResponse {
+    error: ErrorBody,
+}
+
+#[derive(Serialize)]
+struct ErrorBody {
+    code: &'static str,
+    message: &'static str,
+}
+
+impl ErrorResponse {
+    const fn new(code: &'static str, message: &'static str) -> Self {
+        Self {
+            error: ErrorBody { code, message },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::BTreeSet,
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use async_trait::async_trait;
+    use axum::{
+        body::{Body, to_bytes},
+        http::Request,
+        routing::get,
+    };
+    use serde::de::DeserializeOwned;
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::{
+        AdminAuthorizer, CapabilityEgress, CreateSecret, EgressContext, EgressProvider,
+        FreePaymentGate, ManagedAgentFactory, ManagedEgress, MockAgentFactory, PolicyStore,
+        SecretDelivery, SecretError, SecretGuestConfig, SecretHttpMethod, SecretManager, SecretRef,
+        SecretRequestRule,
+    };
+
+    struct ConstantSecret;
+
+    #[async_trait]
+    impl SecretManager for ConstantSecret {
+        async fn resolve(&self, _reference: &SecretRef) -> Result<String, SecretError> {
+            Ok("host-only".to_owned())
+        }
+    }
+
+    async fn response_json<T: DeserializeOwned>(response: Response) -> T {
+        serde_json::from_slice(&to_bytes(response.into_body(), 1024 * 1024).await.unwrap()).unwrap()
+    }
+
+    fn test_api_key_headers() -> HeaderMap {
+        HeaderMap::from_iter([(
+            HeaderName::from_static("x-api-key"),
+            HeaderValue::from_static("test-key"),
+        )])
+    }
+
+    fn test_app(delay: Duration) -> Router {
+        let factory: Arc<dyn ManagedAgentFactory> = Arc::new(MockAgentFactory::new(delay));
+        let directory = tempfile::tempdir().unwrap().keep();
+        let policy = Arc::new(PolicyStore::in_memory().unwrap());
+        policy
+            .bootstrap("test", "Test", "test-key", "test", [])
+            .unwrap();
+        let state = Arc::new(ApiState::new(
+            Arc::new(AgentManager::new(factory, directory).unwrap()),
+            policy,
+            Arc::new(AdminAuthorizer::new("admin-key").unwrap()),
+            Arc::new(FreePaymentGate),
+        ));
+        router(state)
+    }
+
+    async fn create_test_agent(app: &Router, context_key: &str) -> String {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post("/v1/agent/new")
+                    .header("x-api-key", "test-key")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(format!(r#"{{"context_key":"{context_key}"}}"#)))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        response_json::<CreateAgentResponse>(response)
+            .await
+            .agent_id
+    }
+
+    async fn wait_for_test_turn(app: &Router, agent_id: &str, turn_id: &str) -> TurnView {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let response = app
+                    .clone()
+                    .oneshot(
+                        Request::get(format!("/v1/agent/{agent_id}/turn/{turn_id}"))
+                            .header("x-api-key", "test-key")
+                            .body(Body::empty())
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
+                let turn = response_json::<TurnView>(response).await;
+                if turn.state.is_terminal() {
+                    return turn;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn context_key_creates_or_returns_the_same_agent() {
+        let app = test_app(Duration::from_millis(5));
+        let first = create_test_agent(&app, "context:1").await;
+        let response = app
+            .oneshot(
+                Request::post("/v1/agent/new")
+                    .header("x-api-key", "test-key")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"context_key":"context:1"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json::<CreateAgentResponse>(response).await;
+        assert_eq!(body.agent_id, first);
+        assert!(!body.created);
+    }
+
+    #[tokio::test]
+    async fn follow_on_messages_steer_unless_enqueue_is_explicit() {
+        let app = test_app(Duration::from_millis(100));
+        let agent_id = create_test_agent(&app, "context:steer").await;
+        let send = |body: &'static str| {
+            Request::post(format!("/v1/agent/{agent_id}/turn"))
+                .header("x-api-key", "test-key")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body))
+                .unwrap()
+        };
+        let started = app
+            .clone()
+            .oneshot(send(r#"{"content":[{"type":"text","text":"one"}]}"#))
+            .await
+            .unwrap();
+        let started = response_json::<crate::TurnActionResponse>(started).await;
+        assert_eq!(started.action, TurnAction::Started);
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let steered = app
+            .clone()
+            .oneshot(send(r#"{"content":[{"type":"text","text":"two"}]}"#))
+            .await
+            .unwrap();
+        let steered = response_json::<crate::TurnActionResponse>(steered).await;
+        assert_eq!(steered.action, TurnAction::Steered);
+        assert_eq!(steered.turn_id, started.turn_id);
+
+        let queued = app
+            .oneshot(send(
+                r#"{"delivery":"enqueue","content":[{"type":"text","text":"three"}]}"#,
+            ))
+            .await
+            .unwrap();
+        let queued = response_json::<crate::TurnActionResponse>(queued).await;
+        assert_eq!(queued.action, TurnAction::Queued);
+        assert_ne!(queued.turn_id, started.turn_id);
+    }
+
+    #[tokio::test]
+    async fn nested_turn_result_route_returns_content_blocks() {
+        let app = test_app(Duration::from_millis(5));
+        let agent_id = create_test_agent(&app, "context:result").await;
+        let created = app
+            .clone()
+            .oneshot(
+                Request::post(format!("/v1/agent/{agent_id}/turn"))
+                    .header("x-api-key", "test-key")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        r#"{"content":[{"type":"text","text":"hello"}]}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let turn_id = response_json::<crate::TurnActionResponse>(created)
+            .await
+            .turn_id;
+        wait_for_test_turn(&app, &agent_id, &turn_id).await;
+        let result = app
+            .oneshot(
+                Request::get(format!("/v1/agent/{agent_id}/turn/{turn_id}"))
+                    .header("x-api-key", "test-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let result = response_json::<TurnView>(result).await;
+        assert_eq!(result.state, crate::TurnStatus::Completed);
+        assert!(matches!(
+            result.output.first(),
+            Some(crate::ContentBlock::Text { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn completed_agent_can_fork_through_the_nested_route() {
+        let app = test_app(Duration::from_millis(5));
+        let agent_id = create_test_agent(&app, "context:fork").await;
+        let created = app
+            .clone()
+            .oneshot(
+                Request::post(format!("/v1/agent/{agent_id}/turn"))
+                    .header("x-api-key", "test-key")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        r#"{"content":[{"type":"text","text":"establish a boundary"}]}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let turn_id = response_json::<crate::TurnActionResponse>(created)
+            .await
+            .turn_id;
+        wait_for_test_turn(&app, &agent_id, &turn_id).await;
+
+        let forked = app
+            .oneshot(
+                Request::post(format!("/v1/agent/{agent_id}/turn/{turn_id}/fork"))
+                    .header("x-api-key", "test-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(forked.status(), StatusCode::CREATED);
+        let forked = response_json::<crate::ForkResponse>(forked).await;
+        assert_ne!(forked.agent_id, agent_id);
+        assert_eq!(
+            forked.forked_from.turn_id.as_deref(),
+            Some(turn_id.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_routes_reject_agent_credentials() {
+        let app = test_app(Duration::from_millis(5));
+        let response = app
+            .oneshot(
+                Request::get("/admin/v1/principals")
+                    .header("x-api-key", "test-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn admin_can_create_and_grant_a_typed_secret() {
+        let app = test_app(Duration::from_millis(5));
+        let create = app
+            .clone()
+            .oneshot(
+                Request::post("/admin/v1/secrets")
+                    .header("authorization", "Bearer admin-key")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        r#"{
+                            "id":"openai",
+                            "name":"OpenAI",
+                            "source":{"provider":"environment","key":"OPENAI"},
+                            "upstream":"https://api.openai.com",
+                            "rules":[{"methods":["POST"],"path_prefixes":["/v1/"]}],
+                            "delivery":{"type":"inject_header","header":"authorization","prefix":"Bearer "},
+                            "guest":{"base_url_env":"OPENAI_BASE_URL"}
+                        }"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(create.status(), StatusCode::CREATED);
+        let created = response_json::<crate::SecretView>(create).await;
+        assert_eq!(created.id, "openai");
+
+        let grant = app
+            .clone()
+            .oneshot(
+                Request::put("/admin/v1/principals/test/secrets/openai")
+                    .header("authorization", "Bearer admin-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(grant.status(), StatusCode::NO_CONTENT);
+        let effective = app
+            .oneshot(
+                Request::get("/admin/v1/principals/test/effective-secrets")
+                    .header("authorization", "Bearer admin-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let effective = response_json::<Vec<crate::SecretView>>(effective).await;
+        assert_eq!(effective.len(), 1);
+        assert_eq!(effective[0].source.key(), "OPENAI");
+    }
+
+    #[tokio::test]
+    async fn managed_secret_proxy_rechecks_live_grants() {
+        let observed = Arc::new(Mutex::new(Vec::<String>::new()));
+        let upstream_observed = Arc::clone(&observed);
+        let upstream = Router::new().route(
+            "/v1/models",
+            get(move |headers: HeaderMap| {
+                let observed = Arc::clone(&upstream_observed);
+                async move {
+                    observed.lock().unwrap().push(
+                        headers
+                            .get(header::AUTHORIZATION)
+                            .and_then(|value| value.to_str().ok())
+                            .unwrap_or_default()
+                            .to_owned(),
+                    );
+                    "ok"
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let upstream_address = listener.local_addr().unwrap();
+        let upstream_server =
+            tokio::spawn(async move { axum::serve(listener, upstream).await.unwrap() });
+
+        let policy = Arc::new(PolicyStore::in_memory().unwrap());
+        policy
+            .bootstrap("test", "Test", "test-key", "test", [])
+            .unwrap();
+        policy
+            .create_secret(CreateSecret {
+                id: Some("openai".to_owned()),
+                name: "OpenAI".to_owned(),
+                source: SecretRef::new("test", "openai"),
+                upstream: format!("http://{upstream_address}"),
+                rules: vec![
+                    SecretRequestRule::new()
+                        .method(SecretHttpMethod::Get)
+                        .path_prefix("/v1/"),
+                ],
+                delivery: SecretDelivery::inject_header("authorization", "Bearer "),
+                guest: SecretGuestConfig::new("OPENAI_BASE_URL"),
+            })
+            .unwrap();
+        policy.set_principal_secret("test", "openai", true).unwrap();
+        let client = policy.authenticate(&test_api_key_headers()).unwrap();
+        let (identity, _) = policy
+            .create_or_resolve_agent(&client, Some("secret-route"))
+            .unwrap();
+        let egress = ManagedEgress::new(
+            Arc::clone(&policy),
+            Arc::new(ConstantSecret),
+            CapabilityEgress::new(),
+        );
+        let lease = egress
+            .acquire(&EgressContext::new(identity.id, "test"), &BTreeSet::new())
+            .await
+            .unwrap();
+        let route = lease.guest_environment().get("OPENAI_BASE_URL").unwrap();
+        let proxy = lease.guest_environment().get("HTTP_PROXY").unwrap();
+        let client = reqwest::Client::builder()
+            .proxy(reqwest::Proxy::all(proxy).unwrap())
+            .build()
+            .unwrap();
+        let response = client
+            .get(format!("{route}/v1/models"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        assert_eq!(response.text().await.unwrap(), "ok");
+        assert_eq!(observed.lock().unwrap().as_slice(), ["Bearer host-only"]);
+
+        policy
+            .set_principal_secret("test", "openai", false)
+            .unwrap();
+        let denied = client.get(format!("{route}/v1/models")).send().await;
+        assert!(denied.is_err() || !denied.unwrap().status().is_success());
+        drop(lease);
+        upstream_server.abort();
+    }
+}

--- a/crates/experimental/nanocentaur/src/auth.rs
+++ b/crates/experimental/nanocentaur/src/auth.rs
@@ -1,0 +1,95 @@
+use axum::http::HeaderMap;
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+/// Separate credential for the policy administration surface. Agent API keys
+/// are resolved through `SQLite` and are never accepted by `/admin/v1/*`.
+pub struct AdminAuthorizer {
+    token_digest: [u8; 32],
+}
+
+impl AdminAuthorizer {
+    /// Constructs the separate administrator credential verifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the configured token is empty.
+    pub fn new(token: impl AsRef<str>) -> Result<Self, AuthorizationError> {
+        let token = token.as_ref();
+        if token.is_empty() {
+            return Err(AuthorizationError::InvalidConfiguration(
+                "admin token must not be empty",
+            ));
+        }
+        Ok(Self {
+            token_digest: Sha256::digest(token.as_bytes()).into(),
+        })
+    }
+
+    /// Verifies an administrator bearer token.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Unauthenticated` when the bearer token is absent or invalid.
+    pub fn authorize(&self, headers: &HeaderMap) -> Result<(), AuthorizationError> {
+        let token = headers
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.strip_prefix("Bearer "))
+            .filter(|value| !value.is_empty())
+            .ok_or(AuthorizationError::Unauthenticated)?;
+        let candidate: [u8; 32] = Sha256::digest(token.as_bytes()).into();
+        if constant_time_eq(&candidate, &self.token_digest) {
+            Ok(())
+        } else {
+            Err(AuthorizationError::Unauthenticated)
+        }
+    }
+}
+
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+/// Administrator credential configuration or verification failure.
+pub enum AuthorizationError {
+    /// The bearer token was absent or did not match.
+    #[error("authentication required")]
+    Unauthenticated,
+    /// The server supplied an unusable credential configuration.
+    #[error("invalid authorization configuration: {0}")]
+    InvalidConfiguration(&'static str),
+}
+
+fn constant_time_eq(left: &[u8; 32], right: &[u8; 32]) -> bool {
+    left.iter()
+        .zip(right)
+        .fold(0_u8, |difference, (left, right)| {
+            difference | (left ^ right)
+        })
+        == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::HeaderValue;
+
+    use super::*;
+
+    #[test]
+    fn admin_auth_only_accepts_its_bearer_token() {
+        let auth = AdminAuthorizer::new("admin-secret").unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            HeaderValue::from_static("Bearer admin-secret"),
+        );
+        assert!(auth.authorize(&headers).is_ok());
+
+        headers.insert(
+            "authorization",
+            HeaderValue::from_static("Bearer agent-key"),
+        );
+        assert_eq!(
+            auth.authorize(&headers).unwrap_err(),
+            AuthorizationError::Unauthenticated
+        );
+    }
+}

--- a/crates/experimental/nanocentaur/src/capabilities.rs
+++ b/crates/experimental/nanocentaur/src/capabilities.rs
@@ -1,0 +1,180 @@
+use std::{collections::BTreeSet, fmt, str::FromStr};
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+use thiserror::Error;
+
+const MAX_CAPABILITY_NAME_BYTES: usize = 64;
+
+/// A caller-requestable capability name such as `network.public` or
+/// `github.read`.
+#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct CapabilityName(String);
+
+impl CapabilityName {
+    /// Parses and validates a capability name.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error unless the name contains lowercase dot-separated
+    /// identifiers and fits the API's bounded representation.
+    pub fn new(value: impl Into<String>) -> Result<Self, CapabilityNameError> {
+        let value = value.into();
+        validate_capability_name(&value)?;
+        Ok(Self(value))
+    }
+
+    /// Returns the validated wire name.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for CapabilityName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("CapabilityName")
+            .field(&self.0)
+            .finish()
+    }
+}
+
+impl fmt::Display for CapabilityName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl FromStr for CapabilityName {
+    type Err = CapabilityNameError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+impl Serialize for CapabilityName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for CapabilityName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(de::Error::custom)
+    }
+}
+
+/// Flat, closed capability set fixed for the lifetime of one managed agent.
+///
+/// The server maps names to concrete tools, egress routes, and secret
+/// providers. Clients never provide proxy URLs or credentials.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct AgentCapabilities(BTreeSet<CapabilityName>);
+
+impl AgentCapabilities {
+    /// Creates a deduplicated closed capability set.
+    #[must_use]
+    pub fn new(capabilities: impl IntoIterator<Item = CapabilityName>) -> Self {
+        Self(capabilities.into_iter().collect())
+    }
+
+    /// Returns whether the set contains no capabilities.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns whether the exact validated capability name is present.
+    #[must_use]
+    pub fn contains(&self, name: &str) -> bool {
+        self.0.iter().any(|capability| capability.as_str() == name)
+    }
+
+    /// Returns the ordered capability names.
+    #[must_use]
+    pub const fn names(&self) -> &BTreeSet<CapabilityName> {
+        &self.0
+    }
+
+    /// Returns whether every capability is allowed by another set.
+    #[must_use]
+    pub fn is_subset(&self, allowed: &Self) -> bool {
+        self.0.is_subset(&allowed.0)
+    }
+}
+
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+/// Invalid capability name.
+pub enum CapabilityNameError {
+    /// The name was empty or exceeded the wire limit.
+    #[error("capability names must contain 1 to {MAX_CAPABILITY_NAME_BYTES} bytes")]
+    Length,
+    /// The name did not use lowercase dot-separated identifiers.
+    #[error(
+        "capability names must be lowercase dot-separated identifiers using letters, digits, `_`, or `-`"
+    )]
+    Syntax,
+}
+
+fn validate_capability_name(value: &str) -> Result<(), CapabilityNameError> {
+    if value.is_empty() || value.len() > MAX_CAPABILITY_NAME_BYTES {
+        return Err(CapabilityNameError::Length);
+    }
+    if value.split('.').all(valid_segment) {
+        Ok(())
+    } else {
+        Err(CapabilityNameError::Syntax)
+    }
+}
+
+fn valid_segment(segment: &str) -> bool {
+    let mut bytes = segment.bytes();
+    bytes.next().is_some_and(|byte| byte.is_ascii_lowercase())
+        && bytes.all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'_' | b'-')
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_namespaced_capabilities() {
+        let capability = CapabilityName::new("github.pull-requests_read").unwrap();
+        assert_eq!(capability.as_str(), "github.pull-requests_read");
+    }
+
+    #[test]
+    fn rejects_ambiguous_or_unbounded_names() {
+        for invalid in [
+            "",
+            ".github.read",
+            "github..read",
+            "GitHub.read",
+            "github/read",
+            "9github.read",
+        ] {
+            assert!(CapabilityName::new(invalid).is_err(), "{invalid}");
+        }
+        assert!(CapabilityName::new("a".repeat(65)).is_err());
+    }
+
+    #[test]
+    fn request_shape_is_a_deduplicated_flat_list() {
+        let capabilities = serde_json::from_str::<AgentCapabilities>(
+            r#"["github.read","tools.web_search","github.read"]"#,
+        )
+        .unwrap();
+        assert_eq!(capabilities.names().len(), 2);
+    }
+}

--- a/crates/experimental/nanocentaur/src/egress.rs
+++ b/crates/experimental/nanocentaur/src/egress.rs
@@ -1,0 +1,435 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+    path::PathBuf,
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use nanocodex_egress::{
+    EgressProxy, SecretEgress, SecretResolver, SecretResolverError, UnmatchedEgress,
+};
+pub use nanocodex_vm::host::EgressLease;
+use nanocodex_vm::host::{EgressError as LeaseError, EgressFile, Network};
+use thiserror::Error;
+use url::Url;
+
+use crate::{CapabilityName, PolicyStore};
+
+/// Server-derived identity supplied to an egress provider.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EgressContext {
+    agent_id: String,
+    principal: String,
+}
+
+impl EgressContext {
+    /// Creates an egress identity from authenticated managed-service state.
+    #[must_use]
+    pub fn new(agent_id: impl Into<String>, principal: impl Into<String>) -> Self {
+        Self {
+            agent_id: agent_id.into(),
+            principal: principal.into(),
+        }
+    }
+
+    /// Returns the managed agent identifier.
+    #[must_use]
+    pub fn agent_id(&self) -> &str {
+        &self.agent_id
+    }
+
+    /// Returns the effective principal identifier.
+    #[must_use]
+    pub fn principal(&self) -> &str {
+        &self.principal
+    }
+}
+
+/// Managed policy boundary that resolves capability names into one VM lease.
+#[async_trait]
+pub trait EgressProvider: Send + Sync {
+    /// Acquires outbound access for one authenticated managed agent.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a capability is denied, two routes conflict, or
+    /// host-side proxy provisioning fails.
+    async fn acquire(
+        &self,
+        context: &EgressContext,
+        requested: &BTreeSet<CapabilityName>,
+    ) -> Result<EgressLease, EgressError>;
+}
+
+/// One server-configured external proxy route.
+#[derive(Clone)]
+pub struct ProxyProfile {
+    name: String,
+    proxy_url: String,
+    no_proxy: String,
+    ca_certificate: Option<PathBuf>,
+}
+
+impl ProxyProfile {
+    /// Creates a profile after validating an absolute HTTP(S) proxy URL.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EgressError::InvalidProxyUrl`] for a relative or unsupported URL.
+    pub fn new(name: impl Into<String>, proxy_url: impl Into<String>) -> Result<Self, EgressError> {
+        let name = name.into();
+        let proxy_url = proxy_url.into();
+        let parsed = Url::parse(&proxy_url).map_err(|_| EgressError::InvalidProxyUrl)?;
+        if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+            return Err(EgressError::InvalidProxyUrl);
+        }
+        Ok(Self {
+            name,
+            proxy_url,
+            no_proxy: String::new(),
+            ca_certificate: None,
+        })
+    }
+
+    /// Sets the standard proxy bypass list exported to the guest.
+    #[must_use]
+    pub fn no_proxy(mut self, value: impl Into<String>) -> Self {
+        self.no_proxy = value.into();
+        self
+    }
+
+    /// Sets a certificate path already present inside the guest rootfs.
+    #[must_use]
+    pub fn ca_certificate(mut self, path: impl Into<PathBuf>) -> Self {
+        self.ca_certificate = Some(path.into());
+        self
+    }
+
+    fn lease(&self) -> Result<EgressLease, EgressError> {
+        let mut lease = EgressLease::internet();
+        for (name, value) in self.environment() {
+            lease.insert_environment(name, value)?;
+        }
+        Ok(lease)
+    }
+
+    fn environment(&self) -> BTreeMap<String, String> {
+        let mut environment = BTreeMap::from([
+            ("http_proxy".to_owned(), self.proxy_url.clone()),
+            ("https_proxy".to_owned(), self.proxy_url.clone()),
+            ("HTTP_PROXY".to_owned(), self.proxy_url.clone()),
+            ("HTTPS_PROXY".to_owned(), self.proxy_url.clone()),
+            ("no_proxy".to_owned(), self.no_proxy.clone()),
+            ("NO_PROXY".to_owned(), self.no_proxy.clone()),
+        ]);
+        if let Some(certificate) = &self.ca_certificate {
+            let certificate = certificate.to_string_lossy().into_owned();
+            environment.extend([
+                ("SSL_CERT_FILE".to_owned(), certificate.clone()),
+                ("REQUESTS_CA_BUNDLE".to_owned(), certificate.clone()),
+                ("CURL_CA_BUNDLE".to_owned(), certificate),
+            ]);
+        }
+        environment
+    }
+}
+
+impl fmt::Debug for ProxyProfile {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProxyProfile")
+            .field("name", &self.name)
+            .field("proxy_url", &"<redacted>")
+            .field("no_proxy", &self.no_proxy)
+            .field("ca_certificate", &self.ca_certificate)
+            .finish()
+    }
+}
+
+#[derive(Clone, Debug)]
+enum Route {
+    Direct,
+    Proxy(Arc<ProxyProfile>),
+}
+
+/// Static capability-to-network policy for direct or external-proxy egress.
+#[derive(Clone, Debug, Default)]
+pub struct CapabilityEgress {
+    routes: BTreeMap<CapabilityName, Route>,
+}
+
+impl CapabilityEgress {
+    /// Creates a fail-closed capability policy.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allows one capability to use direct internet access.
+    #[must_use]
+    pub fn direct(mut self, capability: CapabilityName) -> Self {
+        self.routes.insert(capability, Route::Direct);
+        self
+    }
+
+    /// Allows one capability through a server-owned external proxy.
+    #[must_use]
+    pub fn proxy(mut self, capability: CapabilityName, profile: Arc<ProxyProfile>) -> Self {
+        self.routes.insert(capability, Route::Proxy(profile));
+        self
+    }
+
+    /// Returns every capability configured by this server.
+    #[must_use]
+    pub fn configured_capabilities(&self) -> BTreeSet<CapabilityName> {
+        self.routes.keys().cloned().collect()
+    }
+}
+
+#[async_trait]
+impl EgressProvider for CapabilityEgress {
+    async fn acquire(
+        &self,
+        _context: &EgressContext,
+        requested: &BTreeSet<CapabilityName>,
+    ) -> Result<EgressLease, EgressError> {
+        if requested.is_empty() {
+            return Ok(EgressLease::disabled());
+        }
+
+        let mut proxy: Option<&Arc<ProxyProfile>> = None;
+        for capability in requested {
+            match self
+                .routes
+                .get(capability)
+                .ok_or_else(|| EgressError::CapabilityDenied(capability.clone()))?
+            {
+                Route::Direct => {}
+                Route::Proxy(candidate) => {
+                    if proxy.is_some_and(|selected| selected.name != candidate.name) {
+                        return Err(EgressError::ConflictingProxyProfiles);
+                    }
+                    proxy = Some(candidate);
+                }
+            }
+        }
+        proxy.map_or_else(|| Ok(EgressLease::internet()), |profile| profile.lease())
+    }
+}
+
+/// Managed composition of capability routing and live secret policy.
+///
+/// Secret references remain durable policy while values are resolved only in
+/// the host proxy after the active principal grant is rechecked.
+pub struct ManagedEgress {
+    policy: Arc<PolicyStore>,
+    secrets: Arc<dyn crate::SecretManager>,
+    capabilities: CapabilityEgress,
+}
+
+impl ManagedEgress {
+    /// Creates managed egress from durable policy, host secret providers, and
+    /// static capability routes.
+    #[must_use]
+    pub fn new(
+        policy: Arc<PolicyStore>,
+        secrets: Arc<dyn crate::SecretManager>,
+        capabilities: CapabilityEgress,
+    ) -> Self {
+        Self {
+            policy,
+            secrets,
+            capabilities,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct LiveSecretResolver {
+    policy: Arc<PolicyStore>,
+    secrets: Arc<dyn crate::SecretManager>,
+    context: EgressContext,
+}
+
+#[async_trait]
+impl SecretResolver for LiveSecretResolver {
+    async fn resolve(
+        &self,
+        reference: &nanocodex_egress::SecretRef,
+    ) -> Result<String, SecretResolverError> {
+        let configured = self
+            .policy
+            .agent_effective_secrets(self.context.agent_id(), self.context.principal())
+            .map_err(|_| SecretResolverError::Unavailable)?;
+        let reference = crate::SecretRef::new(reference.provider(), reference.key());
+        if !configured
+            .iter()
+            .any(|secret| secret.enabled && secret.source == reference)
+        {
+            return Err(SecretResolverError::Unavailable);
+        }
+        self.secrets
+            .resolve(&reference)
+            .await
+            .map_err(|_| SecretResolverError::Unavailable)
+    }
+}
+
+const GUEST_CA_PATH: &str = "/tmp/nanocodex/egress/nanocentaur-ca.pem";
+
+#[async_trait]
+impl EgressProvider for ManagedEgress {
+    async fn acquire(
+        &self,
+        context: &EgressContext,
+        requested: &BTreeSet<CapabilityName>,
+    ) -> Result<EgressLease, EgressError> {
+        let mut lease = self.capabilities.acquire(context, requested).await?;
+        let configured = self
+            .policy
+            .agent_effective_secrets(context.agent_id(), context.principal())
+            .map_err(|error| EgressError::Provider(error.to_string()))?;
+        if configured.is_empty() {
+            return Ok(lease);
+        }
+        if lease
+            .guest_environment()
+            .keys()
+            .any(|name| name.eq_ignore_ascii_case("http_proxy"))
+        {
+            return Err(EgressError::ConflictingProxyProfiles);
+        }
+
+        let mut rules = Vec::new();
+        let mut allow_loopback = false;
+        for secret in &configured {
+            let spec = secret
+                .to_spec()
+                .map_err(|error| EgressError::Provider(error.to_string()))?;
+            allow_loopback |= Url::parse(spec.upstream())
+                .ok()
+                .and_then(|url| url.host_str().map(str::to_owned))
+                .is_some_and(|host| {
+                    host.eq_ignore_ascii_case("localhost")
+                        || host
+                            .parse::<std::net::IpAddr>()
+                            .is_ok_and(|address| address.is_loopback())
+                });
+            rules.extend(
+                spec.egress_rules()
+                    .map_err(|error| EgressError::Provider(error.to_string()))?,
+            );
+        }
+
+        let unmatched = if matches!(lease.network(), Network::Internet) {
+            UnmatchedEgress::Allow
+        } else {
+            UnmatchedEgress::Deny
+        };
+        let resolver = LiveSecretResolver {
+            policy: Arc::clone(&self.policy),
+            secrets: Arc::clone(&self.secrets),
+            context: context.clone(),
+        };
+        let secrets = SecretEgress::builder(resolver)
+            .rules(rules)
+            .unmatched(unmatched)
+            .build()
+            .map_err(|error| EgressError::Provider(error.to_string()))?;
+        let proxy = EgressProxy::builder()
+            .allow_loopback_upstreams(allow_loopback)
+            .layer(secrets)
+            .spawn()
+            .await
+            .map_err(|error| EgressError::Provider(error.to_string()))?;
+        let route = proxy.route();
+        lease.insert_file(EgressFile::new(
+            GUEST_CA_PATH,
+            route.ca_certificate_pem(),
+            0o644,
+        ))?;
+        for (name, value) in route.environment(GUEST_CA_PATH) {
+            let name = name.into_string().map_err(|_| {
+                EgressError::Provider("egress environment name is not UTF-8".into())
+            })?;
+            let value = value.into_string().map_err(|_| {
+                EgressError::Provider("egress environment value is not UTF-8".into())
+            })?;
+            lease.insert_environment(name, value)?;
+        }
+        lease.retain(Arc::new(proxy));
+        Ok(lease)
+    }
+}
+
+/// Failure to authorize or provision managed VM egress.
+#[derive(Debug, Error)]
+pub enum EgressError {
+    /// A requested capability is not configured by this server.
+    #[error("egress capability `{0}` is not granted by this server")]
+    CapabilityDenied(CapabilityName),
+    /// Requested capabilities or secret injection require incompatible proxies.
+    #[error("requested capabilities require conflicting proxy profiles")]
+    ConflictingProxyProfiles,
+    /// An external proxy was not an absolute HTTP(S) URL.
+    #[error("proxy profile must use an absolute HTTP(S) URL")]
+    InvalidProxyUrl,
+    /// Reusable VM lease construction failed.
+    #[error(transparent)]
+    Lease(#[from] LeaseError),
+    /// A host policy, payment, secret, or proxy component failed.
+    #[error("egress provider failed: {0}")]
+    Provider(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn capability(name: &str) -> CapabilityName {
+        CapabilityName::new(name).unwrap()
+    }
+
+    #[tokio::test]
+    async fn no_capabilities_fail_closed_without_a_network_device() {
+        let lease = CapabilityEgress::new()
+            .acquire(&EgressContext::new("agent", "principal"), &BTreeSet::new())
+            .await
+            .unwrap();
+        assert_eq!(lease.network(), &Network::Disabled);
+        assert!(lease.guest_environment().is_empty());
+    }
+
+    #[tokio::test]
+    async fn proxy_capability_injects_only_server_owned_configuration() {
+        let profile = Arc::new(ProxyProfile::new("iron", "http://proxy.internal:8080").unwrap());
+        let provider =
+            CapabilityEgress::new().proxy(capability("github.read"), Arc::clone(&profile));
+        let lease = provider
+            .acquire(
+                &EgressContext::new("agent", "principal"),
+                &BTreeSet::from([capability("github.read")]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(lease.network(), &Network::Internet);
+        assert_eq!(
+            lease.guest_environment().get("HTTPS_PROXY"),
+            Some(&"http://proxy.internal:8080".to_owned())
+        );
+        assert!(!format!("{lease:?}").contains("proxy.internal"));
+    }
+
+    #[tokio::test]
+    async fn unknown_capabilities_are_denied() {
+        let error = CapabilityEgress::new()
+            .acquire(
+                &EgressContext::new("agent", "principal"),
+                &BTreeSet::from([capability("github.read")]),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(error, EgressError::CapabilityDenied(_)));
+    }
+}

--- a/crates/experimental/nanocentaur/src/egress.rs
+++ b/crates/experimental/nanocentaur/src/egress.rs
@@ -14,7 +14,7 @@ use nanocodex_vm::host::{EgressError as LeaseError, EgressFile, Network};
 use thiserror::Error;
 use url::Url;
 
-use crate::{CapabilityName, PolicyStore};
+use crate::{CapabilityName, PolicyStore, secrets::MANAGED_SECRET_PROVIDER};
 
 /// Server-derived identity supplied to an egress provider.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -250,6 +250,7 @@ struct LiveSecretResolver {
     policy: Arc<PolicyStore>,
     secrets: Arc<dyn crate::SecretManager>,
     context: EgressContext,
+    routes: BTreeMap<String, crate::SecretView>,
 }
 
 #[async_trait]
@@ -258,19 +259,22 @@ impl SecretResolver for LiveSecretResolver {
         &self,
         reference: &nanocodex_egress::SecretRef,
     ) -> Result<String, SecretResolverError> {
+        if reference.provider() != MANAGED_SECRET_PROVIDER {
+            return Err(SecretResolverError::Unavailable);
+        }
         let configured = self
             .policy
-            .agent_effective_secrets(self.context.agent_id(), self.context.principal())
+            .agent_effective_secret(
+                self.context.agent_id(),
+                self.context.principal(),
+                reference.key(),
+            )
             .map_err(|_| SecretResolverError::Unavailable)?;
-        let reference = crate::SecretRef::new(reference.provider(), reference.key());
-        if !configured
-            .iter()
-            .any(|secret| secret.enabled && secret.source == reference)
-        {
+        if self.routes.get(reference.key()) != Some(&configured) {
             return Err(SecretResolverError::Unavailable);
         }
         self.secrets
-            .resolve(&reference)
+            .resolve(&configured.source)
             .await
             .map_err(|_| SecretResolverError::Unavailable)
     }
@@ -331,6 +335,11 @@ impl EgressProvider for ManagedEgress {
             policy: Arc::clone(&self.policy),
             secrets: Arc::clone(&self.secrets),
             context: context.clone(),
+            routes: configured
+                .iter()
+                .cloned()
+                .map(|secret| (secret.id.clone(), secret))
+                .collect(),
         };
         let secrets = SecretEgress::builder(resolver)
             .rules(rules)
@@ -387,6 +396,18 @@ pub enum EgressError {
 mod tests {
     use super::*;
 
+    struct ConstantSecretManager;
+
+    #[async_trait]
+    impl crate::SecretManager for ConstantSecretManager {
+        async fn resolve(
+            &self,
+            _reference: &crate::SecretRef,
+        ) -> Result<String, crate::SecretError> {
+            Ok("host-secret".to_owned())
+        }
+    }
+
     fn capability(name: &str) -> CapabilityName {
         CapabilityName::new(name).unwrap()
     }
@@ -431,5 +452,83 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(error, EgressError::CapabilityDenied(_)));
+    }
+
+    #[tokio::test]
+    async fn live_revocation_is_scoped_by_route_even_when_sources_match() {
+        let policy = Arc::new(PolicyStore::in_memory().unwrap());
+        policy
+            .bootstrap("client", "Client", "api-key", "principal", [])
+            .unwrap();
+        for id in ["first", "second"] {
+            policy
+                .create_secret(crate::CreateSecret {
+                    id: Some(id.to_owned()),
+                    name: id.to_owned(),
+                    source: crate::SecretRef::new("environment", "SHARED_KEY"),
+                    upstream: "https://example.com".to_owned(),
+                    rules: Vec::new(),
+                    delivery: crate::SecretDelivery::inject_header("authorization", "Bearer "),
+                    guest: crate::SecretGuestConfig::new(format!(
+                        "{}_BASE_URL",
+                        id.to_ascii_uppercase()
+                    )),
+                })
+                .unwrap();
+            policy.set_principal_secret("principal", id, true).unwrap();
+        }
+        let headers = axum::http::HeaderMap::from_iter([(
+            axum::http::HeaderName::from_static("x-api-key"),
+            axum::http::HeaderValue::from_static("api-key"),
+        )]);
+        let client = policy.authenticate(&headers).unwrap();
+        let (identity, _) = policy
+            .create_or_resolve_agent(&client, Some("route-revocation"))
+            .unwrap();
+        let routes = policy
+            .agent_effective_secrets(&identity.id, "principal")
+            .unwrap()
+            .into_iter()
+            .map(|secret| (secret.id.clone(), secret))
+            .collect();
+        let resolver = LiveSecretResolver {
+            policy: Arc::clone(&policy),
+            secrets: Arc::new(ConstantSecretManager),
+            context: EgressContext::new(identity.id, "principal"),
+            routes,
+        };
+
+        policy
+            .set_principal_secret("principal", "first", false)
+            .unwrap();
+        let first = nanocodex_egress::SecretResolver::resolve(
+            &resolver,
+            &nanocodex_egress::SecretRef::new(MANAGED_SECRET_PROVIDER, "first"),
+        )
+        .await;
+        assert_eq!(first.unwrap_err(), SecretResolverError::Unavailable);
+        let second = nanocodex_egress::SecretResolver::resolve(
+            &resolver,
+            &nanocodex_egress::SecretRef::new(MANAGED_SECRET_PROVIDER, "second"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(second, "host-secret");
+
+        policy
+            .patch_secret(
+                "second",
+                crate::PatchSecret {
+                    source: Some(crate::SecretRef::new("environment", "ROTATED_KEY")),
+                    ..crate::PatchSecret::default()
+                },
+            )
+            .unwrap();
+        let stale_route = nanocodex_egress::SecretResolver::resolve(
+            &resolver,
+            &nanocodex_egress::SecretRef::new(MANAGED_SECRET_PROVIDER, "second"),
+        )
+        .await;
+        assert_eq!(stale_route.unwrap_err(), SecretResolverError::Unavailable);
     }
 }

--- a/crates/experimental/nanocentaur/src/egress.rs
+++ b/crates/experimental/nanocentaur/src/egress.rs
@@ -262,14 +262,16 @@ impl SecretResolver for LiveSecretResolver {
         if reference.provider() != MANAGED_SECRET_PROVIDER {
             return Err(SecretResolverError::Unavailable);
         }
-        let configured = self
-            .policy
-            .agent_effective_secret(
-                self.context.agent_id(),
-                self.context.principal(),
-                reference.key(),
-            )
-            .map_err(|_| SecretResolverError::Unavailable)?;
+        let policy = Arc::clone(&self.policy);
+        let agent_id = self.context.agent_id().to_owned();
+        let principal = self.context.principal().to_owned();
+        let secret_id = reference.key().to_owned();
+        let configured = tokio::task::spawn_blocking(move || {
+            policy.agent_effective_secret(&agent_id, &principal, &secret_id)
+        })
+        .await
+        .map_err(|_| SecretResolverError::Unavailable)?
+        .map_err(|_| SecretResolverError::Unavailable)?;
         if self.routes.get(reference.key()) != Some(&configured) {
             return Err(SecretResolverError::Unavailable);
         }
@@ -290,10 +292,15 @@ impl EgressProvider for ManagedEgress {
         requested: &BTreeSet<CapabilityName>,
     ) -> Result<EgressLease, EgressError> {
         let mut lease = self.capabilities.acquire(context, requested).await?;
-        let configured = self
-            .policy
-            .agent_effective_secrets(context.agent_id(), context.principal())
-            .map_err(|error| EgressError::Provider(error.to_string()))?;
+        let policy = Arc::clone(&self.policy);
+        let agent_id = context.agent_id().to_owned();
+        let principal = context.principal().to_owned();
+        let configured = tokio::task::spawn_blocking(move || {
+            policy.agent_effective_secrets(&agent_id, &principal)
+        })
+        .await
+        .map_err(|error| EgressError::Provider(error.to_string()))?
+        .map_err(|error| EgressError::Provider(error.to_string()))?;
         if configured.is_empty() {
             return Ok(lease);
         }

--- a/crates/experimental/nanocentaur/src/lib.rs
+++ b/crates/experimental/nanocentaur/src/lib.rs
@@ -1,0 +1,119 @@
+//! Durable, policy-aware managed agents built from Nanocodex components.
+//!
+//! Nanocentaur is the service layer above the headless
+//! [`nanocodex_agent`] SDK. It owns tenant authentication, capability and
+//! secret policy, `SQLite` command/event durability, actor wake-up, idempotency,
+//! forking, cancellation, and REST/SSE projection. Model execution, tools,
+//! context, VMs, and egress remain reusable lower-layer components.
+//!
+//! # Smallest complete server
+//!
+//! The mock factory exercises the same manager, persistence, policy, and HTTP
+//! boundaries without making a model request:
+//!
+//! ```no_run
+//! use std::{sync::Arc, time::Duration};
+//!
+//! use nanocentaur::{
+//!     AdminAuthorizer, AgentManager, ApiState, FreePaymentGate,
+//!     ManagedAgentFactory, MockAgentFactory, PolicyStore,
+//! };
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let state_directory = tempfile::tempdir()?;
+//! let policy = Arc::new(PolicyStore::in_memory()?);
+//! policy.bootstrap(
+//!     "local-client",
+//!     "Local development client",
+//!     "dev-api-key",
+//!     "local-principal",
+//!     [],
+//! )?;
+//! let factory: Arc<dyn ManagedAgentFactory> =
+//!     Arc::new(MockAgentFactory::new(Duration::from_millis(10)));
+//! let manager = Arc::new(AgentManager::new(factory, state_directory.path())?);
+//! let router = ApiState::new(
+//!     manager,
+//!     policy,
+//!     Arc::new(AdminAuthorizer::new("dev-admin-token")?),
+//!     Arc::new(FreePaymentGate),
+//! )
+//! .router();
+//!
+//! let listener = tokio::net::TcpListener::bind("127.0.0.1:3000").await?;
+//! axum::serve(listener, router).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Ownership
+//!
+//! [`AgentManager`] is the embeddable durable API. It owns lightweight
+//! per-agent actors and one `SQLite` session store. [`ManagedAgentFactory`] is
+//! the deliberate backend seam: [`NanocodexAgentFactory`] creates real
+//! VM-backed agents, while [`MockAgentFactory`] is deterministic for tests and
+//! harness benchmarks. [`ApiState`] adds transport; it does not become a
+//! second lifecycle owner.
+//!
+//! Each completed turn retains typed output, authoritative aggregate token
+//! usage, optional versioned USD cost, a session snapshot, and the exact
+//! ordered event stream. Restart and fork read those same durable records.
+
+#![deny(missing_docs, rustdoc::broken_intra_doc_links)]
+
+mod admin;
+mod agent;
+mod api;
+mod auth;
+mod capabilities;
+mod egress;
+mod manager;
+mod mock;
+mod payment;
+mod policy;
+mod secrets;
+mod session;
+
+pub use agent::{
+    AgentError, AgentRunResult, AgentSpec, ManagedAgent, ManagedAgentFactory, ManagedTurn,
+    ManagedTurnControl, NanocodexAgentFactory, SpawnedAgent,
+};
+pub use api::ApiState;
+pub use auth::{AdminAuthorizer, AuthorizationError};
+pub use capabilities::{AgentCapabilities, CapabilityName, CapabilityNameError};
+pub use egress::{
+    CapabilityEgress, EgressContext, EgressError, EgressLease, EgressProvider, ManagedEgress,
+    ProxyProfile,
+};
+pub use manager::{
+    AgentEvent, AgentEventPayload, AgentManager, AgentStatus, AgentView, ContentBlock, CreateAgent,
+    CreateAgentResponse, CreateTurn, EventCursor, ForkResponse, ForkSource, ManagerError,
+    TurnAction, TurnActionResponse, TurnDelivery, TurnFailure, TurnStatus, TurnView,
+};
+pub use mock::MockAgentFactory;
+pub use payment::{
+    FreePaymentGate, PaymentError, PaymentGate, PaymentManagementResponse, PaymentManagementStatus,
+    PaymentOutcome, PaymentReceipt,
+};
+pub use policy::{
+    AgentConfig, AgentIdentity, ApiClientView, ApiKeyView, AuthenticatedClient, ContextBindingView,
+    CreateApiClient, CreateApiKey, CreateContextBinding, CreatePermission, CreatePrincipal,
+    CreateRole, EffectivePrincipal, PatchApiClient, PatchContextBinding, PatchPrincipal, PatchRole,
+    PermissionView, PolicyError, PolicyStore, PrincipalMetadata, PrincipalView, ReasoningEffort,
+    ResolveContext, ResolvedContextView, RoleView, require,
+};
+pub use secrets::{
+    CompositeSecretManager, CreateSecret, EnvironmentSecretManager, FileSecretManager, PatchSecret,
+    SecretConfigError, SecretDelivery, SecretError, SecretGuestConfig, SecretHttpMethod,
+    SecretManager, SecretRef, SecretRequestRule, SecretSpec, SecretView,
+};
+
+/// Managed runtime backend contracts and the private VMM child entry point.
+pub mod backend {
+    pub use crate::agent::{
+        AgentError, AgentRunResult, AgentSpec, ManagedAgent, ManagedAgentFactory, ManagedTurn,
+        ManagedTurnControl, NanocodexAgentFactory, SpawnedAgent, run_vmm,
+    };
+    pub use crate::mock::MockAgentFactory;
+}

--- a/crates/experimental/nanocentaur/src/manager.rs
+++ b/crates/experimental/nanocentaur/src/manager.rs
@@ -31,6 +31,8 @@ const MAX_CONTENT_BLOCKS: usize = 64;
 const MAX_IDEMPOTENCY_KEY_BYTES: usize = 256;
 const EVENT_BROADCAST_CAPACITY: usize = 1_024;
 const AGENT_COMMAND_CAPACITY: usize = 64;
+const RUNTIME_EVENT_BATCH_SIZE: usize = 64;
+const EVENT_REPLAY_PAGE_SIZE: usize = 256;
 
 /// Request to create or resolve one managed agent.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -224,6 +226,9 @@ pub struct AgentEvent {
     /// Owning managed-agent identifier.
     pub agent_id: String,
     /// Associated durable turn, when known.
+    ///
+    /// Native runtime events leave this unset because their optional stream is
+    /// intentionally independent from managed turn-result completion.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub turn_id: Option<String>,
     /// Typed lifecycle or lossless native runtime payload.
@@ -314,7 +319,6 @@ pub struct AgentManager {
     factory: Arc<dyn ManagedAgentFactory>,
     agents: RwLock<HashMap<String, AgentHandle>>,
     sessions: SessionStore,
-    state_directory: PathBuf,
 }
 
 impl AgentManager {
@@ -334,7 +338,6 @@ impl AgentManager {
             factory,
             agents: RwLock::new(HashMap::new()),
             sessions,
-            state_directory,
         })
     }
 
@@ -445,19 +448,15 @@ impl AgentManager {
         })
     }
 
-    /// Deletes durable session state and the agent workspace.
+    /// Deletes durable session state after stopping any live runtime.
     pub async fn delete(&self, agent_id: &str) -> Result<(), ManagerError> {
-        let handle = self.agents.write().await.remove(agent_id);
-        if let Some(handle) = handle {
-            handle.shutdown().await?;
+        let mut agents = self.agents.write().await;
+        if let Some(handle) = agents.get(agent_id).cloned() {
+            handle.delete().await?;
         }
-        self.sessions.delete(agent_id.to_owned()).await?;
-        let directory = self.state_directory.join("workspaces").join(agent_id);
-        match std::fs::remove_dir_all(directory) {
-            Ok(()) => Ok(()),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(error) => Err(error.into()),
-        }
+        let result = self.sessions.delete(agent_id.to_owned()).await;
+        agents.remove(agent_id);
+        result.map_err(Into::into)
     }
 
     /// Stops every live harness without deleting its durable `SQLite` session.
@@ -487,7 +486,6 @@ impl AgentManager {
                 .await?;
             return Ok(handle);
         }
-        self.sessions.ensure_agent(identity.id.clone()).await?;
         let stored = self.sessions.load(identity.id.clone()).await?;
         let capabilities = identity.principal.permissions.clone();
         let secret_revision = identity.principal.secret_revision;
@@ -606,12 +604,17 @@ impl AgentHandle {
             sender: self.sender.clone(),
             receiver: subscription.receiver,
             after_event_id,
-            replay: subscription.replay,
+            replay: subscription.replay.events,
+            replay_exhausted: subscription.replay.exhausted,
         })
     }
 
     async fn shutdown(&self) -> Result<(), ManagerError> {
         self.request(|reply| AgentCommand::Shutdown { reply }).await
+    }
+
+    async fn delete(&self) -> Result<(), ManagerError> {
+        self.request(|reply| AgentCommand::Delete { reply }).await
     }
 
     async fn request<T>(
@@ -659,17 +662,17 @@ enum AgentCommand {
     },
     Replay {
         after_event_id: u64,
-        reply: Reply<VecDeque<AgentEvent>>,
+        reply: Reply<EventReplay>,
     },
-    RuntimeEvent(NativeAgentEvent),
+    RuntimeEvents(Vec<NativeAgentEvent>),
     TurnFinished {
         turn_id: String,
         result: Box<Result<AgentRunResult, AgentError>>,
     },
-    FinalizeTurn {
-        turn_id: String,
-    },
     Shutdown {
+        reply: Reply<()>,
+    },
+    Delete {
         reply: Reply<()>,
     },
 }
@@ -685,10 +688,10 @@ impl AgentCommand {
             Self::Evict { .. } => "evict",
             Self::Subscribe { .. } => "subscribe",
             Self::Replay { .. } => "replay",
-            Self::RuntimeEvent(_) => "runtime_event",
+            Self::RuntimeEvents(_) => "runtime_events",
             Self::TurnFinished { .. } => "turn_finished",
-            Self::FinalizeTurn { .. } => "finalize_turn",
             Self::Shutdown { .. } => "shutdown",
+            Self::Delete { .. } => "delete",
         }
     }
 }
@@ -703,12 +706,26 @@ struct StoredTurn {
     view: TurnView,
     inputs: Vec<Vec<ContentBlock>>,
     control: Option<Arc<dyn ManagedTurnControl>>,
-    snapshot: Option<SessionSnapshot>,
 }
 
 struct EventSubscription {
     receiver: broadcast::Receiver<AgentEvent>,
-    replay: VecDeque<AgentEvent>,
+    replay: EventReplay,
+}
+
+struct EventReplay {
+    events: VecDeque<AgentEvent>,
+    exhausted: bool,
+}
+
+impl EventReplay {
+    fn new(events: Vec<AgentEvent>) -> Self {
+        let exhausted = events.len() < EVENT_REPLAY_PAGE_SIZE;
+        Self {
+            events: events.into(),
+            exhausted,
+        }
+    }
 }
 
 struct AgentActor {
@@ -724,13 +741,9 @@ struct AgentActor {
     sessions: SessionStore,
     self_sender: AgentSender,
     active_turn: Option<String>,
-    runtime_event_turn: Option<String>,
-    runtime_terminal_turns: HashSet<String>,
-    pending_results: HashMap<String, Result<AgentRunResult, AgentError>>,
     cancel_requested: HashSet<String>,
     turns: HashMap<String, StoredTurn>,
     turn_order: VecDeque<String>,
-    requests_by_key: HashMap<String, TurnActionResponse>,
     runtime: Option<Runtime>,
     runtime_policy_dirty: bool,
     snapshot: Option<SessionSnapshot>,
@@ -750,13 +763,9 @@ impl AgentActor {
         let mut turns = HashMap::new();
         let mut turn_order = VecDeque::new();
         let mut cancel_requested = HashSet::new();
-        let mut snapshot = None;
         for turn in stored.turns {
             if turn.cancel_requested {
                 cancel_requested.insert(turn.view.turn_id.clone());
-            }
-            if turn.view.state == TurnStatus::Completed {
-                snapshot.clone_from(&turn.snapshot);
             }
             turn_order.push_back(turn.view.turn_id.clone());
             turns.insert(
@@ -765,7 +774,6 @@ impl AgentActor {
                     view: turn.view,
                     inputs: turn.inputs,
                     control: None,
-                    snapshot: turn.snapshot,
                 },
             );
         }
@@ -782,16 +790,12 @@ impl AgentActor {
             sessions,
             self_sender,
             active_turn: None,
-            runtime_event_turn: None,
-            runtime_terminal_turns: HashSet::new(),
-            pending_results: HashMap::new(),
             cancel_requested,
             turns,
             turn_order,
-            requests_by_key: stored.requests,
             runtime: None,
             runtime_policy_dirty: false,
-            snapshot,
+            snapshot: stored.snapshot,
             event_sender,
         }
     }
@@ -807,7 +811,6 @@ impl AgentActor {
         }
         while let Some(envelope) = receiver.recv().await {
             let command_name = envelope.command.name();
-            let should_stop = matches!(&envelope.command, AgentCommand::Shutdown { .. });
             let span = tracing::dispatcher::with_default(&envelope.dispatch, || {
                 tracing::info_span!(
                     parent: &envelope.parent,
@@ -818,7 +821,8 @@ impl AgentActor {
                         u64::try_from(envelope.queued_at.elapsed().as_nanos()).unwrap_or(u64::MAX),
                 )
             });
-            self.handle(envelope.command)
+            let should_stop = self
+                .handle(envelope.command)
                 .instrument(span)
                 .with_subscriber(envelope.dispatch)
                 .await;
@@ -828,7 +832,8 @@ impl AgentActor {
         }
     }
 
-    async fn handle(&mut self, command: AgentCommand) {
+    async fn handle(&mut self, command: AgentCommand) -> bool {
+        let mut should_stop = false;
         match command {
             AgentCommand::View { reply } => {
                 drop(reply.send(Ok(self.view())));
@@ -850,11 +855,15 @@ impl AgentActor {
                 drop(reply.send(result));
             }
             AgentCommand::GetTurn { turn_id, reply } => {
-                let result = self
-                    .turns
-                    .get(&turn_id)
-                    .map(|turn| turn.view.clone())
-                    .ok_or(ManagerError::NotFound);
+                let result = if let Some(turn) = self.turns.get(&turn_id) {
+                    Ok(turn.view.clone())
+                } else {
+                    match self.sessions.turn(self.id.clone(), turn_id).await {
+                        Ok(Some(turn)) => Ok(turn),
+                        Ok(None) => Err(ManagerError::NotFound),
+                        Err(error) => Err(error.into()),
+                    }
+                };
                 drop(reply.send(result));
             }
             AgentCommand::Cancel { turn_id, reply } => {
@@ -876,9 +885,9 @@ impl AgentActor {
                 let receiver = self.event_sender.subscribe();
                 let replay = self
                     .sessions
-                    .events_after(self.id.clone(), after_event_id)
+                    .events_after(self.id.clone(), after_event_id, EVENT_REPLAY_PAGE_SIZE)
                     .await
-                    .map(VecDeque::from)
+                    .map(EventReplay::new)
                     .map_err(ManagerError::from);
                 drop(reply.send(replay.map(|replay| EventSubscription { receiver, replay })));
             }
@@ -888,54 +897,34 @@ impl AgentActor {
             } => {
                 let replay = self
                     .sessions
-                    .events_after(self.id.clone(), after_event_id)
+                    .events_after(self.id.clone(), after_event_id, EVENT_REPLAY_PAGE_SIZE)
                     .await
-                    .map(VecDeque::from)
+                    .map(EventReplay::new)
                     .map_err(ManagerError::from);
                 drop(reply.send(replay));
             }
-            AgentCommand::RuntimeEvent(event) => {
-                self.handle_runtime_event(event).await;
+            AgentCommand::RuntimeEvents(events) => {
+                self.handle_runtime_events(events).await;
             }
             AgentCommand::TurnFinished { turn_id, result } => {
-                self.handle_turn_finished(turn_id, *result).await;
-            }
-            AgentCommand::FinalizeTurn { turn_id } => {
-                if let Some(result) = self.pending_results.remove(&turn_id) {
-                    self.finish_turn(&turn_id, result).await;
-                }
+                self.finish_turn(&turn_id, *result).await;
             }
             AgentCommand::Shutdown { reply } => {
                 self.runtime.take();
                 drop(reply.send(Ok(())));
+                should_stop = true;
+            }
+            AgentCommand::Delete { reply } => {
+                if self.active_turn.is_some() {
+                    drop(reply.send(Err(ManagerError::AgentBusy)));
+                } else {
+                    self.runtime.take();
+                    drop(reply.send(Ok(())));
+                    should_stop = true;
+                }
             }
         }
-    }
-
-    async fn handle_turn_finished(
-        &mut self,
-        turn_id: String,
-        result: Result<AgentRunResult, AgentError>,
-    ) {
-        if self.runtime_terminal_turns.remove(&turn_id) {
-            self.finish_turn(&turn_id, result).await;
-            return;
-        }
-        self.pending_results.insert(turn_id.clone(), result);
-        let sender = self.self_sender.clone();
-        let span = tracing::info_span!(
-            parent: &tracing::Span::current(),
-            "nanocentaur.turn.terminal_grace",
-            agent.id = self.id,
-            turn.id = turn_id,
-        );
-        tokio::spawn(
-            async move {
-                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-                drop(sender.send(AgentCommand::FinalizeTurn { turn_id }).await);
-            }
-            .instrument(span),
-        );
+        should_stop
     }
 
     fn apply_policy(&mut self, capabilities: AgentCapabilities, secret_revision: u64) {
@@ -983,9 +972,12 @@ impl AgentActor {
             "managed turn input observed"
         );
         if let Some(key) = &idempotency_key
-            && let Some(response) = self.requests_by_key.get(key)
+            && let Some(response) = self
+                .sessions
+                .find_request(self.id.clone(), key.clone())
+                .await?
         {
-            return Ok(response.clone());
+            return Ok(response);
         }
 
         let content = request.content;
@@ -1008,10 +1000,6 @@ impl AgentActor {
         let (action, state) = if self.active_turn.is_some() {
             (TurnAction::Queued, TurnStatus::Queued)
         } else {
-            self.active_turn = Some(turn_id.clone());
-            if self.runtime_event_turn.is_none() {
-                self.runtime_event_turn = Some(turn_id.clone());
-            }
             (TurnAction::Started, TurnStatus::Running)
         };
         let view = TurnView {
@@ -1048,6 +1036,9 @@ impl AgentActor {
                 },
             )
             .await?;
+        if action == TurnAction::Started {
+            self.active_turn = Some(turn_id.clone());
+        }
         self.publish(event);
         self.turn_order.push_back(turn_id.clone());
         self.turns.insert(
@@ -1056,10 +1047,8 @@ impl AgentActor {
                 view,
                 inputs: vec![content],
                 control: None,
-                snapshot: None,
             },
         );
-        self.remember_request(idempotency_key, &response);
         match managed.prompt(prompt).await {
             Ok(managed_turn) => self.attach_turn(turn_id, managed_turn),
             Err(error) => {
@@ -1111,7 +1100,6 @@ impl AgentActor {
                 if let Some(turn) = self.turns.get_mut(&active_id) {
                     turn.inputs.push(content);
                 }
-                self.remember_request(idempotency_key, &response);
                 Ok(Some(response))
             }
             Err(AgentError::TurnNotSteerable) => {
@@ -1177,9 +1165,16 @@ impl AgentActor {
         let (agent, mut events) = spawned.into_parts();
         let sender = self.self_sender.clone();
         tokio::spawn(async move {
-            while let Some(event) = events.recv().await {
+            let mut batch = Vec::with_capacity(RUNTIME_EVENT_BATCH_SIZE);
+            loop {
+                let received = events.recv_many(&mut batch, RUNTIME_EVENT_BATCH_SIZE).await;
+                if received == 0 {
+                    return;
+                }
+                let ready = batch;
+                batch = Vec::with_capacity(RUNTIME_EVENT_BATCH_SIZE);
                 if sender
-                    .send(AgentCommand::RuntimeEvent(event))
+                    .send(AgentCommand::RuntimeEvents(ready))
                     .await
                     .is_err()
                 {
@@ -1206,17 +1201,9 @@ impl AgentActor {
                     usage = ?usage,
                     "managed turn result observed"
                 );
-                self.snapshot.clone_from(&snapshot);
                 let output = vec![ContentBlock::Text {
                     text: final_message,
                 }];
-                if let Some(turn) = self.turns.get_mut(turn_id) {
-                    turn.view.state = TurnStatus::Completed;
-                    turn.view.output.clone_from(&output);
-                    turn.view.usage = Some(usage.clone());
-                    turn.view.completed_at = Some(completed_at);
-                    turn.snapshot.clone_from(&snapshot);
-                }
                 (
                     TurnStatus::Completed,
                     output.clone(),
@@ -1226,20 +1213,14 @@ impl AgentActor {
                     AgentEventPayload::TurnCompleted { output, usage },
                 )
             }
-            _ if cancelled => {
-                if let Some(turn) = self.turns.get_mut(turn_id) {
-                    turn.view.state = TurnStatus::Cancelled;
-                    turn.view.completed_at = Some(completed_at);
-                }
-                (
-                    TurnStatus::Cancelled,
-                    Vec::new(),
-                    None,
-                    None,
-                    None,
-                    AgentEventPayload::TurnCancelled,
-                )
-            }
+            _ if cancelled => (
+                TurnStatus::Cancelled,
+                Vec::new(),
+                None,
+                None,
+                None,
+                AgentEventPayload::TurnCancelled,
+            ),
             Ok(_) => {
                 // The guarded cancellation arm above is the only remaining
                 // successful-result path.
@@ -1247,11 +1228,6 @@ impl AgentActor {
             }
             Err(error) => {
                 tracing::warn!(agent_id = self.id, turn_id, %error, "turn failed");
-                if let Some(turn) = self.turns.get_mut(turn_id) {
-                    turn.view.state = TurnStatus::Failed;
-                    turn.view.error = Some("managed agent execution failed".to_owned());
-                    turn.view.completed_at = Some(completed_at);
-                }
                 (
                     TurnStatus::Failed,
                     Vec::new(),
@@ -1281,73 +1257,43 @@ impl AgentActor {
             )
             .await
         {
-            Ok(event) => self.publish(event),
+            Ok(finished) => {
+                if status == TurnStatus::Completed {
+                    self.snapshot = finished.snapshot;
+                }
+                self.publish(finished.event);
+            }
             Err(error) => {
                 tracing::error!(agent_id = self.id, turn_id, %error, "failed to persist terminal turn");
                 return;
             }
         }
+        self.turns.remove(turn_id);
+        self.turn_order.retain(|candidate| candidate != turn_id);
         self.advance_after(turn_id).await;
     }
 
-    async fn handle_runtime_event(&mut self, event: NativeAgentEvent) {
-        tracing::info!(
-            target: "nanocentaur::observed",
-            agent_id = %self.id,
-            event = ?event,
-            "native runtime event observed"
-        );
-        let kind = event.kind;
-        if kind == AgentEventKind::RunStarted && self.runtime_event_turn.is_none() {
-            if let Some(next) = self.turn_order.iter().find_map(|id| {
-                self.turns
-                    .get(id)
-                    .filter(|turn| turn.view.state == TurnStatus::Queued)
-                    .map(|_| id.clone())
-            }) {
-                self.active_turn = Some(next.clone());
-                if let Some(turn) = self.turns.get_mut(&next) {
-                    turn.view.state = TurnStatus::Running;
+    async fn handle_runtime_events(&mut self, events: Vec<NativeAgentEvent>) {
+        let events = events
+            .into_iter()
+            .map(|event| {
+                tracing::info!(
+                    target: "nanocentaur::observed",
+                    agent_id = %self.id,
+                    event = ?event,
+                    "native runtime event observed"
+                );
+                (None, AgentEventPayload::Runtime { event })
+            })
+            .collect();
+        match self.sessions.append_events(self.id.clone(), events).await {
+            Ok(events) => {
+                for event in events {
+                    self.publish(event);
                 }
-                match self
-                    .sessions
-                    .mark_started(self.id.clone(), next.clone())
-                    .await
-                {
-                    Ok(event) => self.publish(event),
-                    Err(error) => {
-                        tracing::error!(agent_id = self.id, turn_id = next, %error, "failed to persist queued turn start");
-                    }
-                }
-                self.runtime_event_turn = Some(next);
-            } else {
-                self.runtime_event_turn.clone_from(&self.active_turn);
             }
-        }
-        let turn_id = self.runtime_event_turn.clone();
-        let terminal = kind.is_terminal();
-        match self
-            .sessions
-            .append_event(
-                self.id.clone(),
-                turn_id.clone(),
-                AgentEventPayload::Runtime { event },
-            )
-            .await
-        {
-            Ok(event) => self.publish(event),
             Err(error) => {
-                tracing::error!(agent_id = self.id, %error, "failed to persist runtime event");
-            }
-        }
-        if terminal {
-            self.runtime_event_turn = None;
-            if let Some(turn_id) = turn_id {
-                if let Some(result) = self.pending_results.remove(&turn_id) {
-                    self.finish_turn(&turn_id, result).await;
-                } else {
-                    self.runtime_terminal_turns.insert(turn_id);
-                }
+                tracing::error!(agent_id = self.id, %error, "failed to persist runtime events");
             }
         }
     }
@@ -1362,34 +1308,29 @@ impl AgentActor {
                 .filter(|turn| turn.view.state == TurnStatus::Queued)
                 .map(|_| id.clone())
         });
-        self.active_turn.clone_from(&next);
         if let Some(next) = next {
-            if let Some(turn) = self.turns.get_mut(&next) {
-                turn.view.state = TurnStatus::Running;
-            }
             match self
                 .sessions
                 .mark_started(self.id.clone(), next.clone())
                 .await
             {
-                Ok(event) => self.publish(event),
+                Ok(event) => {
+                    self.active_turn = Some(next.clone());
+                    if let Some(turn) = self.turns.get_mut(&next) {
+                        turn.view.state = TurnStatus::Running;
+                    }
+                    self.publish(event);
+                }
                 Err(error) => {
                     tracing::error!(agent_id = self.id, turn_id = next, %error, "failed to persist queued turn start");
-                    return;
                 }
             }
-            if self.runtime_event_turn.is_none() {
-                self.runtime_event_turn = Some(next);
+        } else {
+            self.active_turn = None;
+            if self.runtime_policy_dirty {
+                self.runtime.take();
+                self.runtime_policy_dirty = false;
             }
-        } else if self.runtime_policy_dirty {
-            self.runtime.take();
-            self.runtime_policy_dirty = false;
-        }
-    }
-
-    fn remember_request(&mut self, idempotency_key: Option<String>, response: &TurnActionResponse) {
-        if let Some(key) = idempotency_key {
-            self.requests_by_key.insert(key, response.clone());
         }
     }
 
@@ -1475,7 +1416,6 @@ impl AgentActor {
             if !started {
                 started = true;
                 self.active_turn = Some(turn_id.clone());
-                self.runtime_event_turn = Some(turn_id.clone());
                 if let Some(turn) = self.turns.get_mut(&turn_id) {
                     turn.view.state = TurnStatus::Running;
                 }
@@ -1505,6 +1445,7 @@ pub struct EventCursor {
     receiver: broadcast::Receiver<AgentEvent>,
     after_event_id: u64,
     replay: VecDeque<AgentEvent>,
+    replay_exhausted: bool,
 }
 
 impl EventCursor {
@@ -1516,6 +1457,10 @@ impl EventCursor {
                 self.after_event_id = event.id;
                 return Some(event);
             }
+            if !self.replay_exhausted {
+                self.replay().await?;
+                continue;
+            }
             match self.receiver.recv().await {
                 Ok(event) if event.id > self.after_event_id => {
                     self.after_event_id = event.id;
@@ -1523,23 +1468,27 @@ impl EventCursor {
                 }
                 Ok(_) => {}
                 Err(broadcast::error::RecvError::Lagged(_)) => {
-                    let (reply, response) = oneshot::channel();
-                    if self
-                        .sender
-                        .send(AgentCommand::Replay {
-                            after_event_id: self.after_event_id,
-                            reply,
-                        })
-                        .await
-                        .is_err()
-                    {
-                        return None;
-                    }
-                    self.replay = response.await.ok()?.ok()?;
+                    self.replay_exhausted = false;
+                    self.replay().await?;
                 }
                 Err(broadcast::error::RecvError::Closed) => return None,
             }
         }
+    }
+
+    async fn replay(&mut self) -> Option<()> {
+        let (reply, response) = oneshot::channel();
+        self.sender
+            .send(AgentCommand::Replay {
+                after_event_id: self.after_event_id,
+                reply,
+            })
+            .await
+            .ok()?;
+        let replay = response.await.ok()?.ok()?;
+        self.replay = replay.events;
+        self.replay_exhausted = replay.exhausted;
+        Some(())
     }
 }
 
@@ -1654,9 +1603,6 @@ pub enum ManagerError {
     /// The configured backend agent failed.
     #[error("managed agent could not be created or controlled")]
     Agent(#[from] AgentError),
-    /// Workspace or state-directory mutation failed.
-    #[error("agent state filesystem failed")]
-    Io(#[from] std::io::Error),
 }
 
 impl From<SessionError> for ManagerError {
@@ -1672,6 +1618,7 @@ impl From<SessionError> for ManagerError {
 mod tests {
     use std::time::Duration;
 
+    use async_trait::async_trait;
     use nanocodex_agent::{CostStatus, TurnUsage};
     use nanocodex_oai_api::{
         pricing::{ServiceTier, estimate},
@@ -1680,7 +1627,46 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::{AgentConfig, EffectivePrincipal, MockAgentFactory};
+    use crate::{AgentConfig, EffectivePrincipal, ManagedTurn, MockAgentFactory, SpawnedAgent};
+
+    struct SilentFactory;
+
+    struct SilentAgent;
+
+    struct SilentTurnControl;
+
+    #[async_trait]
+    impl ManagedAgentFactory for SilentFactory {
+        async fn create(&self, _spec: AgentSpec) -> Result<SpawnedAgent, AgentError> {
+            let (_events, receiver) = mpsc::channel(1);
+            Ok(SpawnedAgent::new(Arc::new(SilentAgent), receiver))
+        }
+    }
+
+    #[async_trait]
+    impl ManagedAgent for SilentAgent {
+        async fn prompt(&self, _prompt: Prompt) -> Result<ManagedTurn, AgentError> {
+            Ok(ManagedTurn::new(
+                Arc::new(SilentTurnControl),
+                std::future::ready(Ok(AgentRunResult::new(
+                    "silent completion",
+                    None,
+                    TurnUsage::default(),
+                ))),
+            ))
+        }
+    }
+
+    #[async_trait]
+    impl ManagedTurnControl for SilentTurnControl {
+        async fn steer(&self, _prompt: Prompt) -> Result<(), AgentError> {
+            Err(AgentError::TurnNotSteerable)
+        }
+
+        async fn cancel(&self) -> Result<(), AgentError> {
+            Err(AgentError::TurnNotCancellable)
+        }
+    }
 
     fn identity(id: &str) -> AgentIdentity {
         AgentIdentity {
@@ -1794,6 +1780,90 @@ mod tests {
             }
         }
         assert!(saw_runtime);
+    }
+
+    #[tokio::test]
+    async fn completion_does_not_wait_for_optional_runtime_events() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = AgentManager::new(Arc::new(SilentFactory), directory.path()).unwrap();
+        let identity = identity("silent");
+        manager.register(identity.clone()).await.unwrap();
+        let response = manager
+            .create_turn(identity.clone(), turn("complete without events"), None)
+            .await
+            .unwrap();
+
+        let completed = tokio::time::timeout(
+            Duration::from_millis(250),
+            wait_for_completed(&manager, identity, &response.turn_id),
+        )
+        .await
+        .expect("turn results must remain independent from the event stream");
+        assert_eq!(completed.state, TurnStatus::Completed);
+        let [ContentBlock::Text { text }] = completed.output.as_slice() else {
+            panic!("expected one text output block");
+        };
+        assert_eq!(text, "silent completion");
+    }
+
+    #[tokio::test]
+    async fn deletion_is_rejected_atomically_while_a_turn_is_active() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = AgentManager::new(
+            Arc::new(MockAgentFactory::new(Duration::from_millis(100))),
+            directory.path(),
+        )
+        .unwrap();
+        let identity = identity("delete-race");
+        manager.register(identity.clone()).await.unwrap();
+        let response = manager
+            .create_turn(identity.clone(), turn("still running"), None)
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            manager.delete(&identity.id).await,
+            Err(ManagerError::AgentBusy)
+        ));
+        wait_for_completed(&manager, identity.clone(), &response.turn_id).await;
+        manager.delete(&identity.id).await.unwrap();
+        assert!(
+            manager
+                .sessions
+                .turn(identity.id, response.turn_id)
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn durable_event_replay_is_paged_without_losing_order() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = AgentManager::new(
+            Arc::new(MockAgentFactory::new(Duration::ZERO)),
+            directory.path(),
+        )
+        .unwrap();
+        let identity = identity("paged-replay");
+        manager.register(identity.clone()).await.unwrap();
+        let event_count = EVENT_REPLAY_PAGE_SIZE * 3 + 17;
+        manager
+            .sessions
+            .append_events(
+                identity.id.clone(),
+                (0..event_count)
+                    .map(|_| (None, AgentEventPayload::TurnCancelRequested))
+                    .collect(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = manager.events(identity, 0).await.unwrap();
+        for expected in 1..=event_count {
+            let event = events.recv().await.unwrap();
+            assert_eq!(event.id, u64::try_from(expected).unwrap());
+        }
     }
 
     #[tokio::test]

--- a/crates/experimental/nanocentaur/src/manager.rs
+++ b/crates/experimental/nanocentaur/src/manager.rs
@@ -1,0 +1,1963 @@
+#![allow(clippy::missing_errors_doc)]
+
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    path::PathBuf,
+    sync::Arc,
+};
+
+use chrono::{DateTime, Utc};
+use nanocodex_agent::{
+    TurnUsage,
+    events::{AgentEvent as NativeAgentEvent, AgentEventKind},
+    input::{ImageDetail, Prompt, UserInput},
+    session::SessionSnapshot,
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::sync::{RwLock, broadcast, mpsc, oneshot};
+use tracing::{Instrument, instrument::WithSubscriber};
+use url::Url;
+use uuid::Uuid;
+
+use crate::{
+    AgentCapabilities, AgentError, AgentIdentity, AgentRunResult, AgentSpec, ManagedAgent,
+    ManagedAgentFactory, ManagedTurnControl,
+    session::{CompletedTurn, NewTurn, SessionError, SessionStore, StoredSession},
+};
+
+const MAX_CONTENT_BYTES: usize = 1024 * 1024;
+const MAX_CONTENT_BLOCKS: usize = 64;
+const MAX_IDEMPOTENCY_KEY_BYTES: usize = 256;
+const EVENT_BROADCAST_CAPACITY: usize = 1_024;
+const AGENT_COMMAND_CAPACITY: usize = 64;
+
+/// Request to create or resolve one managed agent.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct CreateAgent {
+    /// Optional client-scoped key that makes creation idempotent.
+    pub context_key: Option<String>,
+}
+
+/// Result of creating or resolving a managed agent.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CreateAgentResponse {
+    /// Stable opaque managed-agent identifier.
+    pub agent_id: String,
+    /// Whether this request created a new durable identity.
+    pub created: bool,
+    /// Current live lifecycle state.
+    pub state: AgentStatus,
+}
+
+/// Current durable and live projection of one managed agent.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AgentView {
+    /// Stable opaque managed-agent identifier.
+    pub agent_id: String,
+    /// Whether a turn is currently active.
+    pub state: AgentStatus,
+    /// Number of accepted turns waiting behind the active turn.
+    pub queue_depth: usize,
+    /// Client-scoped create-or-resolve key, when one was supplied.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_key: Option<String>,
+    /// Durable creation timestamp.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Live state of one managed agent actor.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentStatus {
+    /// No turn is active.
+    Idle,
+    /// One turn is active; additional turns may be steered or queued.
+    Running,
+}
+
+/// Delivery policy for input submitted while another turn is active.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnDelivery {
+    /// Steer the active turn when possible; otherwise start a new turn.
+    #[default]
+    Steer,
+    /// Always create a distinct FIFO turn.
+    Enqueue,
+}
+
+/// Bounded typed input for one managed turn.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateTurn {
+    /// Steering versus explicit queueing policy.
+    #[serde(default)]
+    pub delivery: TurnDelivery,
+    /// Ordered user content blocks.
+    pub content: Vec<ContentBlock>,
+}
+
+/// One typed user or assistant content block.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum ContentBlock {
+    /// UTF-8 text.
+    Text {
+        /// Complete text content.
+        text: String,
+    },
+    /// Remote HTTP(S) image input.
+    ImageUrl {
+        /// Absolute image URL.
+        url: String,
+        /// Optional provider image-detail policy.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        detail: Option<ImageDetail>,
+    },
+    /// Remote HTTP(S) audio input.
+    AudioUrl {
+        /// Absolute audio URL.
+        url: String,
+    },
+}
+
+/// Scheduling action taken for accepted input.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnAction {
+    /// A new turn started immediately.
+    Started,
+    /// Input was appended to the active turn.
+    Steered,
+    /// A distinct turn entered the FIFO queue.
+    Queued,
+}
+
+/// Acceptance result for a managed turn request.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TurnActionResponse {
+    /// Scheduling action taken.
+    pub action: TurnAction,
+    /// Stable durable turn identifier.
+    pub turn_id: String,
+    /// State immediately after acceptance.
+    pub state: TurnStatus,
+}
+
+/// Durable projection of one managed turn.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TurnView {
+    /// Stable durable turn identifier.
+    pub turn_id: String,
+    /// Owning managed-agent identifier.
+    pub agent_id: String,
+    /// Current or terminal lifecycle state.
+    pub state: TurnStatus,
+    /// Complete assistant output for a successful terminal turn.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub output: Vec<ContentBlock>,
+    /// Stable public failure message, when failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Authoritative aggregate usage and optional versioned USD estimate.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage: Option<TurnUsage>,
+    /// Durable acceptance timestamp.
+    pub created_at: DateTime<Utc>,
+    /// Durable terminal timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+/// Durable lifecycle state of one turn.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnStatus {
+    /// Accepted behind another active turn.
+    Queued,
+    /// Currently executing.
+    Running,
+    /// Successfully committed.
+    Completed,
+    /// Ended without committing a successful result.
+    Failed,
+    /// Explicitly cancelled.
+    Cancelled,
+}
+
+impl TurnStatus {
+    /// Returns whether no further state transition is possible.
+    #[must_use]
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
+    }
+}
+
+/// Result of branching a new managed agent from committed history.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ForkResponse {
+    /// New managed-agent identifier.
+    pub agent_id: String,
+    /// Exact committed source boundary.
+    pub forked_from: ForkSource,
+    /// Initial state of the new agent.
+    pub state: AgentStatus,
+}
+
+/// Durable source boundary used for a fork.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ForkSource {
+    /// Source managed-agent identifier.
+    pub agent_id: String,
+    /// Exact completed turn, or `None` when no completed boundary existed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+}
+
+/// One monotonically ordered durable managed-agent event.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AgentEvent {
+    /// Agent-relative monotonic sequence.
+    pub id: u64,
+    /// Owning managed-agent identifier.
+    pub agent_id: String,
+    /// Associated durable turn, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub turn_id: Option<String>,
+    /// Typed lifecycle or lossless native runtime payload.
+    #[serde(flatten)]
+    pub payload: AgentEventPayload,
+    /// Durable observation timestamp.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Managed lifecycle events plus the lossless native Nanocodex firehose.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "type", content = "data")]
+pub enum AgentEventPayload {
+    /// A turn began execution.
+    #[serde(rename = "turn.started")]
+    TurnStarted {
+        /// State after the transition.
+        state: TurnStatus,
+    },
+    /// A distinct turn entered the queue.
+    #[serde(rename = "turn.queued")]
+    TurnQueued {
+        /// State after the transition.
+        state: TurnStatus,
+    },
+    /// Cancellation was durably requested.
+    #[serde(rename = "turn.cancel_requested")]
+    TurnCancelRequested,
+    /// A process restart moved an incomplete running turn back to the queue.
+    #[serde(rename = "turn.interrupted")]
+    TurnInterrupted {
+        /// Whether wake-up will retry the turn.
+        retrying: bool,
+    },
+    /// A successful result and usage were durably committed.
+    #[serde(rename = "turn.completed")]
+    TurnCompleted {
+        /// Complete assistant output.
+        output: Vec<ContentBlock>,
+        /// Aggregate provider usage and optional estimated USD cost.
+        usage: TurnUsage,
+    },
+    /// Cancellation reached its terminal boundary.
+    #[serde(rename = "turn.cancelled")]
+    TurnCancelled,
+    /// Execution reached a terminal failure.
+    #[serde(rename = "turn.failed")]
+    TurnFailed {
+        /// Stable public failure classification.
+        error: TurnFailure,
+    },
+    /// Lossless native event emitted by the owned agent lifecycle.
+    #[serde(rename = "runtime")]
+    Runtime {
+        /// Original typed Nanocodex event.
+        event: NativeAgentEvent,
+    },
+}
+
+/// Stable public managed-turn failure classification.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TurnFailure {
+    /// The backend agent failed after accepting the turn.
+    ManagedAgentExecutionFailed,
+}
+
+impl AgentEventPayload {
+    /// Returns the stable SSE event name for this payload.
+    #[must_use]
+    pub const fn event_name(&self) -> &'static str {
+        match self {
+            Self::TurnStarted { .. } => "turn.started",
+            Self::TurnQueued { .. } => "turn.queued",
+            Self::TurnCancelRequested => "turn.cancel_requested",
+            Self::TurnInterrupted { .. } => "turn.interrupted",
+            Self::TurnCompleted { .. } => "turn.completed",
+            Self::TurnCancelled => "turn.cancelled",
+            Self::TurnFailed { .. } => "turn.failed",
+            Self::Runtime { event } => runtime_event_name(event.kind),
+        }
+    }
+}
+
+/// Shared registry of lightweight actor handles. `SQLite` owns durable session
+/// state; each actor is a disposable live projection that owns one harness.
+pub struct AgentManager {
+    factory: Arc<dyn ManagedAgentFactory>,
+    agents: RwLock<HashMap<String, AgentHandle>>,
+    sessions: SessionStore,
+    state_directory: PathBuf,
+}
+
+impl AgentManager {
+    /// Opens the durable session store and prepares lazy agent wake-up.
+    ///
+    /// # Errors
+    ///
+    /// Returns a durability or filesystem error when the state directory
+    /// cannot be initialized.
+    pub fn new(
+        factory: Arc<dyn ManagedAgentFactory>,
+        state_directory: impl Into<PathBuf>,
+    ) -> Result<Self, ManagerError> {
+        let state_directory = state_directory.into();
+        let sessions = SessionStore::open(state_directory.join("sessions.sqlite"))?;
+        Ok(Self {
+            factory,
+            agents: RwLock::new(HashMap::new()),
+            sessions,
+            state_directory,
+        })
+    }
+
+    /// Registers or wakes an authorized durable agent.
+    pub async fn register(&self, identity: AgentIdentity) -> Result<AgentView, ManagerError> {
+        self.ensure(identity).await?.view().await
+    }
+
+    /// Returns current state, waking the disposable actor when necessary.
+    pub async fn get(&self, identity: AgentIdentity) -> Result<AgentView, ManagerError> {
+        self.ensure(identity).await?.view().await
+    }
+
+    /// Resolves an earlier accepted request by its agent-scoped key.
+    pub async fn find_turn_by_idempotency_key(
+        &self,
+        identity: AgentIdentity,
+        key: &str,
+    ) -> Result<Option<TurnActionResponse>, ManagerError> {
+        validate_idempotency_key(Some(key))?;
+        self.sessions
+            .find_request(identity.id, key.to_owned())
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Validates and durably accepts input for steering or FIFO execution.
+    pub async fn create_turn(
+        &self,
+        identity: AgentIdentity,
+        request: CreateTurn,
+        idempotency_key: Option<String>,
+    ) -> Result<TurnActionResponse, ManagerError> {
+        validate_content(&request.content)?;
+        validate_idempotency_key(idempotency_key.as_deref())?;
+        self.ensure(identity)
+            .await?
+            .create_turn(request, idempotency_key)
+            .await
+    }
+
+    /// Returns one durable turn projection.
+    pub async fn get_turn(
+        &self,
+        identity: AgentIdentity,
+        turn_id: &str,
+    ) -> Result<TurnView, ManagerError> {
+        self.ensure(identity)
+            .await?
+            .get_turn(turn_id.to_owned())
+            .await
+    }
+
+    /// Requests cancellation of one queued or active turn.
+    ///
+    /// Returns `true` when cancellation was newly accepted and `false` when
+    /// the backend had already reached a non-cancellable boundary.
+    pub async fn cancel_turn(
+        &self,
+        identity: AgentIdentity,
+        turn_id: &str,
+    ) -> Result<bool, ManagerError> {
+        self.ensure(identity)
+            .await?
+            .cancel(turn_id.to_owned())
+            .await
+    }
+
+    /// Drops one live harness while retaining all durable state.
+    ///
+    /// Returns whether a live actor was present.
+    pub async fn evict(&self, identity: AgentIdentity) -> Result<bool, ManagerError> {
+        self.ensure(identity).await?.evict().await
+    }
+
+    /// Opens an ordered replay-then-live cursor after an event sequence.
+    pub async fn events(
+        &self,
+        identity: AgentIdentity,
+        after_event_id: u64,
+    ) -> Result<EventCursor, ManagerError> {
+        self.ensure(identity).await?.subscribe(after_event_id).await
+    }
+
+    /// Branches committed history into a fresh agent and workspace.
+    ///
+    /// `turn_id = None` selects the latest completed turn.
+    pub async fn fork(
+        &self,
+        source_identity: AgentIdentity,
+        target_identity: AgentIdentity,
+        turn_id: Option<&str>,
+    ) -> Result<ForkResponse, ManagerError> {
+        let forked_from = self
+            .sessions
+            .fork(
+                source_identity.id,
+                target_identity.id.clone(),
+                turn_id.map(str::to_owned),
+            )
+            .await?;
+        let target_id = target_identity.id.clone();
+        self.ensure(target_identity).await?;
+        Ok(ForkResponse {
+            agent_id: target_id,
+            forked_from,
+            state: AgentStatus::Idle,
+        })
+    }
+
+    /// Deletes durable session state and the agent workspace.
+    pub async fn delete(&self, agent_id: &str) -> Result<(), ManagerError> {
+        let handle = self.agents.write().await.remove(agent_id);
+        if let Some(handle) = handle {
+            handle.shutdown().await?;
+        }
+        self.sessions.delete(agent_id.to_owned()).await?;
+        let directory = self.state_directory.join("workspaces").join(agent_id);
+        match std::fs::remove_dir_all(directory) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    /// Stops every live harness without deleting its durable `SQLite` session.
+    /// A later manager can wake the same agents from the event log.
+    pub async fn shutdown(&self) -> Result<(), ManagerError> {
+        let handles = self
+            .agents
+            .write()
+            .await
+            .drain()
+            .map(|(_, handle)| handle)
+            .collect::<Vec<_>>();
+        for handle in handles {
+            handle.shutdown().await?;
+        }
+        Ok(())
+    }
+
+    async fn ensure(&self, identity: AgentIdentity) -> Result<AgentHandle, ManagerError> {
+        let existing = self.agents.read().await.get(&identity.id).cloned();
+        if let Some(handle) = existing {
+            handle
+                .refresh_policy(
+                    identity.principal.permissions,
+                    identity.principal.secret_revision,
+                )
+                .await?;
+            return Ok(handle);
+        }
+        self.sessions.ensure_agent(identity.id.clone()).await?;
+        let stored = self.sessions.load(identity.id.clone()).await?;
+        let capabilities = identity.principal.permissions.clone();
+        let secret_revision = identity.principal.secret_revision;
+        let handle = {
+            let mut agents = self.agents.write().await;
+            if let Some(handle) = agents.get(&identity.id).cloned() {
+                handle
+            } else {
+                let id = identity.id.clone();
+                let (sender, receiver) = mpsc::channel(AGENT_COMMAND_CAPACITY);
+                let sender = AgentSender(sender);
+                let handle = AgentHandle {
+                    sender: sender.clone(),
+                };
+                let actor = AgentActor::new(
+                    identity,
+                    Arc::clone(&self.factory),
+                    self.sessions.clone(),
+                    stored,
+                    sender,
+                );
+                tokio::spawn(actor.run(receiver));
+                agents.insert(id, handle.clone());
+                handle
+            }
+        };
+        handle.refresh_policy(capabilities, secret_revision).await?;
+        Ok(handle)
+    }
+}
+
+#[derive(Clone)]
+struct AgentHandle {
+    sender: AgentSender,
+}
+
+#[derive(Clone)]
+struct AgentSender(mpsc::Sender<AgentCommandEnvelope>);
+
+struct AgentCommandEnvelope {
+    dispatch: tracing::Dispatch,
+    parent: tracing::Span,
+    queued_at: std::time::Instant,
+    command: AgentCommand,
+}
+
+impl AgentSender {
+    async fn send(
+        &self,
+        command: AgentCommand,
+    ) -> Result<(), mpsc::error::SendError<AgentCommandEnvelope>> {
+        self.0
+            .send(AgentCommandEnvelope {
+                dispatch: tracing::dispatcher::get_default(Clone::clone),
+                parent: tracing::Span::current(),
+                queued_at: std::time::Instant::now(),
+                command,
+            })
+            .await
+    }
+}
+
+impl AgentHandle {
+    async fn view(&self) -> Result<AgentView, ManagerError> {
+        self.request(|reply| AgentCommand::View { reply }).await
+    }
+
+    async fn refresh_policy(
+        &self,
+        capabilities: AgentCapabilities,
+        secret_revision: u64,
+    ) -> Result<(), ManagerError> {
+        self.request(|reply| AgentCommand::RefreshPolicy {
+            capabilities,
+            secret_revision,
+            reply,
+        })
+        .await
+    }
+
+    async fn create_turn(
+        &self,
+        request: CreateTurn,
+        idempotency_key: Option<String>,
+    ) -> Result<TurnActionResponse, ManagerError> {
+        self.request(|reply| AgentCommand::CreateTurn {
+            request,
+            idempotency_key,
+            reply,
+        })
+        .await
+    }
+
+    async fn get_turn(&self, turn_id: String) -> Result<TurnView, ManagerError> {
+        self.request(|reply| AgentCommand::GetTurn { turn_id, reply })
+            .await
+    }
+
+    async fn cancel(&self, turn_id: String) -> Result<bool, ManagerError> {
+        self.request(|reply| AgentCommand::Cancel { turn_id, reply })
+            .await
+    }
+
+    async fn evict(&self) -> Result<bool, ManagerError> {
+        self.request(|reply| AgentCommand::Evict { reply }).await
+    }
+
+    async fn subscribe(&self, after_event_id: u64) -> Result<EventCursor, ManagerError> {
+        let subscription = self
+            .request(|reply| AgentCommand::Subscribe {
+                after_event_id,
+                reply,
+            })
+            .await?;
+        Ok(EventCursor {
+            sender: self.sender.clone(),
+            receiver: subscription.receiver,
+            after_event_id,
+            replay: subscription.replay,
+        })
+    }
+
+    async fn shutdown(&self) -> Result<(), ManagerError> {
+        self.request(|reply| AgentCommand::Shutdown { reply }).await
+    }
+
+    async fn request<T>(
+        &self,
+        command: impl FnOnce(oneshot::Sender<Result<T, ManagerError>>) -> AgentCommand,
+    ) -> Result<T, ManagerError> {
+        let (reply, response) = oneshot::channel();
+        let command = command(reply);
+        self.sender
+            .send(command)
+            .await
+            .map_err(|_| ManagerError::ActorStopped)?;
+        response.await.map_err(|_| ManagerError::ActorStopped)?
+    }
+}
+
+enum AgentCommand {
+    View {
+        reply: Reply<AgentView>,
+    },
+    RefreshPolicy {
+        capabilities: AgentCapabilities,
+        secret_revision: u64,
+        reply: Reply<()>,
+    },
+    CreateTurn {
+        request: CreateTurn,
+        idempotency_key: Option<String>,
+        reply: Reply<TurnActionResponse>,
+    },
+    GetTurn {
+        turn_id: String,
+        reply: Reply<TurnView>,
+    },
+    Cancel {
+        turn_id: String,
+        reply: Reply<bool>,
+    },
+    Evict {
+        reply: Reply<bool>,
+    },
+    Subscribe {
+        after_event_id: u64,
+        reply: Reply<EventSubscription>,
+    },
+    Replay {
+        after_event_id: u64,
+        reply: Reply<VecDeque<AgentEvent>>,
+    },
+    RuntimeEvent(NativeAgentEvent),
+    TurnFinished {
+        turn_id: String,
+        result: Box<Result<AgentRunResult, AgentError>>,
+    },
+    FinalizeTurn {
+        turn_id: String,
+    },
+    Shutdown {
+        reply: Reply<()>,
+    },
+}
+
+impl AgentCommand {
+    const fn name(&self) -> &'static str {
+        match self {
+            Self::View { .. } => "view",
+            Self::RefreshPolicy { .. } => "refresh_policy",
+            Self::CreateTurn { .. } => "create_turn",
+            Self::GetTurn { .. } => "get_turn",
+            Self::Cancel { .. } => "cancel",
+            Self::Evict { .. } => "evict",
+            Self::Subscribe { .. } => "subscribe",
+            Self::Replay { .. } => "replay",
+            Self::RuntimeEvent(_) => "runtime_event",
+            Self::TurnFinished { .. } => "turn_finished",
+            Self::FinalizeTurn { .. } => "finalize_turn",
+            Self::Shutdown { .. } => "shutdown",
+        }
+    }
+}
+
+type Reply<T> = oneshot::Sender<Result<T, ManagerError>>;
+
+struct Runtime {
+    agent: Arc<dyn ManagedAgent>,
+}
+
+struct StoredTurn {
+    view: TurnView,
+    inputs: Vec<Vec<ContentBlock>>,
+    control: Option<Arc<dyn ManagedTurnControl>>,
+    snapshot: Option<SessionSnapshot>,
+}
+
+struct EventSubscription {
+    receiver: broadcast::Receiver<AgentEvent>,
+    replay: VecDeque<AgentEvent>,
+}
+
+struct AgentActor {
+    id: String,
+    principal_id: String,
+    context_key: Option<String>,
+    instructions: Option<String>,
+    thinking: Option<nanocodex_agent::Thinking>,
+    capabilities: AgentCapabilities,
+    secret_revision: u64,
+    created_at: DateTime<Utc>,
+    factory: Arc<dyn ManagedAgentFactory>,
+    sessions: SessionStore,
+    self_sender: AgentSender,
+    active_turn: Option<String>,
+    runtime_event_turn: Option<String>,
+    runtime_terminal_turns: HashSet<String>,
+    pending_results: HashMap<String, Result<AgentRunResult, AgentError>>,
+    cancel_requested: HashSet<String>,
+    turns: HashMap<String, StoredTurn>,
+    turn_order: VecDeque<String>,
+    requests_by_key: HashMap<String, TurnActionResponse>,
+    runtime: Option<Runtime>,
+    runtime_policy_dirty: bool,
+    snapshot: Option<SessionSnapshot>,
+    event_sender: broadcast::Sender<AgentEvent>,
+}
+
+impl AgentActor {
+    fn new(
+        identity: AgentIdentity,
+        factory: Arc<dyn ManagedAgentFactory>,
+        sessions: SessionStore,
+        stored: StoredSession,
+        self_sender: AgentSender,
+    ) -> Self {
+        let (event_sender, _) = broadcast::channel(EVENT_BROADCAST_CAPACITY);
+        let agent_config = identity.principal.agent_config;
+        let mut turns = HashMap::new();
+        let mut turn_order = VecDeque::new();
+        let mut cancel_requested = HashSet::new();
+        let mut snapshot = None;
+        for turn in stored.turns {
+            if turn.cancel_requested {
+                cancel_requested.insert(turn.view.turn_id.clone());
+            }
+            if turn.view.state == TurnStatus::Completed {
+                snapshot.clone_from(&turn.snapshot);
+            }
+            turn_order.push_back(turn.view.turn_id.clone());
+            turns.insert(
+                turn.view.turn_id.clone(),
+                StoredTurn {
+                    view: turn.view,
+                    inputs: turn.inputs,
+                    control: None,
+                    snapshot: turn.snapshot,
+                },
+            );
+        }
+        Self {
+            id: identity.id,
+            principal_id: identity.principal.id,
+            context_key: identity.context_key,
+            instructions: agent_config.instructions,
+            thinking: agent_config.reasoning_effort.map(Into::into),
+            capabilities: identity.principal.permissions,
+            secret_revision: identity.principal.secret_revision,
+            created_at: identity.created_at,
+            factory,
+            sessions,
+            self_sender,
+            active_turn: None,
+            runtime_event_turn: None,
+            runtime_terminal_turns: HashSet::new(),
+            pending_results: HashMap::new(),
+            cancel_requested,
+            turns,
+            turn_order,
+            requests_by_key: stored.requests,
+            runtime: None,
+            runtime_policy_dirty: false,
+            snapshot,
+            event_sender,
+        }
+    }
+
+    async fn run(mut self, mut receiver: mpsc::Receiver<AgentCommandEnvelope>) {
+        let recovery_span = tracing::info_span!(
+            parent: None,
+            "nanocentaur.agent.recover",
+            agent.id = self.id,
+        );
+        if let Err(error) = self.recover_pending().instrument(recovery_span).await {
+            tracing::error!(agent_id = self.id, %error, "failed to recover durable agent session");
+        }
+        while let Some(envelope) = receiver.recv().await {
+            let command_name = envelope.command.name();
+            let should_stop = matches!(&envelope.command, AgentCommand::Shutdown { .. });
+            let span = tracing::dispatcher::with_default(&envelope.dispatch, || {
+                tracing::info_span!(
+                    parent: &envelope.parent,
+                    "nanocentaur.agent.command",
+                    agent.id = self.id,
+                    agent.command = command_name,
+                    queue.duration_ns =
+                        u64::try_from(envelope.queued_at.elapsed().as_nanos()).unwrap_or(u64::MAX),
+                )
+            });
+            self.handle(envelope.command)
+                .instrument(span)
+                .with_subscriber(envelope.dispatch)
+                .await;
+            if should_stop {
+                return;
+            }
+        }
+    }
+
+    async fn handle(&mut self, command: AgentCommand) {
+        match command {
+            AgentCommand::View { reply } => {
+                drop(reply.send(Ok(self.view())));
+            }
+            AgentCommand::RefreshPolicy {
+                capabilities,
+                secret_revision,
+                reply,
+            } => {
+                self.apply_policy(capabilities, secret_revision);
+                drop(reply.send(Ok(())));
+            }
+            AgentCommand::CreateTurn {
+                request,
+                idempotency_key,
+                reply,
+            } => {
+                let result = self.create_turn(request, idempotency_key).await;
+                drop(reply.send(result));
+            }
+            AgentCommand::GetTurn { turn_id, reply } => {
+                let result = self
+                    .turns
+                    .get(&turn_id)
+                    .map(|turn| turn.view.clone())
+                    .ok_or(ManagerError::NotFound);
+                drop(reply.send(result));
+            }
+            AgentCommand::Cancel { turn_id, reply } => {
+                let result = self.cancel(&turn_id).await;
+                drop(reply.send(result));
+            }
+            AgentCommand::Evict { reply } => {
+                let result = if self.active_turn.is_some() {
+                    Ok(false)
+                } else {
+                    Ok(self.runtime.take().is_some())
+                };
+                drop(reply.send(result));
+            }
+            AgentCommand::Subscribe {
+                after_event_id,
+                reply,
+            } => {
+                let receiver = self.event_sender.subscribe();
+                let replay = self
+                    .sessions
+                    .events_after(self.id.clone(), after_event_id)
+                    .await
+                    .map(VecDeque::from)
+                    .map_err(ManagerError::from);
+                drop(reply.send(replay.map(|replay| EventSubscription { receiver, replay })));
+            }
+            AgentCommand::Replay {
+                after_event_id,
+                reply,
+            } => {
+                let replay = self
+                    .sessions
+                    .events_after(self.id.clone(), after_event_id)
+                    .await
+                    .map(VecDeque::from)
+                    .map_err(ManagerError::from);
+                drop(reply.send(replay));
+            }
+            AgentCommand::RuntimeEvent(event) => {
+                self.handle_runtime_event(event).await;
+            }
+            AgentCommand::TurnFinished { turn_id, result } => {
+                self.handle_turn_finished(turn_id, *result).await;
+            }
+            AgentCommand::FinalizeTurn { turn_id } => {
+                if let Some(result) = self.pending_results.remove(&turn_id) {
+                    self.finish_turn(&turn_id, result).await;
+                }
+            }
+            AgentCommand::Shutdown { reply } => {
+                self.runtime.take();
+                drop(reply.send(Ok(())));
+            }
+        }
+    }
+
+    async fn handle_turn_finished(
+        &mut self,
+        turn_id: String,
+        result: Result<AgentRunResult, AgentError>,
+    ) {
+        if self.runtime_terminal_turns.remove(&turn_id) {
+            self.finish_turn(&turn_id, result).await;
+            return;
+        }
+        self.pending_results.insert(turn_id.clone(), result);
+        let sender = self.self_sender.clone();
+        let span = tracing::info_span!(
+            parent: &tracing::Span::current(),
+            "nanocentaur.turn.terminal_grace",
+            agent.id = self.id,
+            turn.id = turn_id,
+        );
+        tokio::spawn(
+            async move {
+                tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                drop(sender.send(AgentCommand::FinalizeTurn { turn_id }).await);
+            }
+            .instrument(span),
+        );
+    }
+
+    fn apply_policy(&mut self, capabilities: AgentCapabilities, secret_revision: u64) {
+        if self.capabilities == capabilities && self.secret_revision == secret_revision {
+            return;
+        }
+        self.capabilities = capabilities;
+        self.secret_revision = secret_revision;
+        if self.active_turn.is_some() {
+            self.runtime_policy_dirty = true;
+        } else {
+            self.runtime.take();
+            self.runtime_policy_dirty = false;
+        }
+    }
+
+    fn view(&self) -> AgentView {
+        AgentView {
+            agent_id: self.id.clone(),
+            state: if self.active_turn.is_some() {
+                AgentStatus::Running
+            } else {
+                AgentStatus::Idle
+            },
+            queue_depth: self
+                .turns
+                .values()
+                .filter(|turn| turn.view.state == TurnStatus::Queued)
+                .count(),
+            context_key: self.context_key.clone(),
+            created_at: self.created_at,
+        }
+    }
+
+    async fn create_turn(
+        &mut self,
+        request: CreateTurn,
+        idempotency_key: Option<String>,
+    ) -> Result<TurnActionResponse, ManagerError> {
+        tracing::info!(
+            target: "nanocentaur::observed",
+            agent_id = %self.id,
+            request = ?request,
+            idempotency_key = ?idempotency_key,
+            "managed turn input observed"
+        );
+        if let Some(key) = &idempotency_key
+            && let Some(response) = self.requests_by_key.get(key)
+        {
+            return Ok(response.clone());
+        }
+
+        let content = request.content;
+        let prompt = to_prompt(content.clone());
+        if request.delivery == TurnDelivery::Steer
+            && let Some(response) = self
+                .steer_active(prompt.clone(), content.clone(), idempotency_key.clone())
+                .await?
+        {
+            return Ok(response);
+        }
+
+        self.ensure_runtime().await?;
+        let managed = self
+            .runtime
+            .as_ref()
+            .map(|runtime| Arc::clone(&runtime.agent))
+            .ok_or_else(|| AgentError::Backend("runtime disappeared".to_owned()))?;
+        let turn_id = Uuid::now_v7().to_string();
+        let (action, state) = if self.active_turn.is_some() {
+            (TurnAction::Queued, TurnStatus::Queued)
+        } else {
+            self.active_turn = Some(turn_id.clone());
+            if self.runtime_event_turn.is_none() {
+                self.runtime_event_turn = Some(turn_id.clone());
+            }
+            (TurnAction::Started, TurnStatus::Running)
+        };
+        let view = TurnView {
+            turn_id: turn_id.clone(),
+            agent_id: self.id.clone(),
+            state,
+            output: Vec::new(),
+            error: None,
+            usage: None,
+            created_at: Utc::now(),
+            completed_at: None,
+        };
+        let response = TurnActionResponse {
+            action,
+            turn_id: turn_id.clone(),
+            state,
+        };
+        let event_payload = match action {
+            TurnAction::Started => AgentEventPayload::TurnStarted { state },
+            TurnAction::Queued => AgentEventPayload::TurnQueued { state },
+            TurnAction::Steered => unreachable!(),
+        };
+        let event = self
+            .sessions
+            .record_turn(
+                self.id.clone(),
+                NewTurn {
+                    view: view.clone(),
+                    delivery: request.delivery,
+                    content: content.clone(),
+                    response: response.clone(),
+                    idempotency_key: idempotency_key.clone(),
+                    event: event_payload,
+                },
+            )
+            .await?;
+        self.publish(event);
+        self.turn_order.push_back(turn_id.clone());
+        self.turns.insert(
+            turn_id.clone(),
+            StoredTurn {
+                view,
+                inputs: vec![content],
+                control: None,
+                snapshot: None,
+            },
+        );
+        self.remember_request(idempotency_key, &response);
+        match managed.prompt(prompt).await {
+            Ok(managed_turn) => self.attach_turn(turn_id, managed_turn),
+            Err(error) => {
+                self.finish_turn(&turn_id, Err(error)).await;
+            }
+        }
+        Ok(response)
+    }
+
+    async fn steer_active(
+        &mut self,
+        prompt: Prompt,
+        content: Vec<ContentBlock>,
+        idempotency_key: Option<String>,
+    ) -> Result<Option<TurnActionResponse>, ManagerError> {
+        let Some(active_id) = self.active_turn.clone() else {
+            return Ok(None);
+        };
+        let Some(control) = self
+            .turns
+            .get(&active_id)
+            .and_then(|turn| turn.control.as_ref().map(Arc::clone))
+        else {
+            return Ok(None);
+        };
+        match control.steer(prompt).await {
+            Ok(()) => {
+                tracing::info!(
+                    target: "nanocentaur::observed",
+                    agent_id = %self.id,
+                    turn_id = %active_id,
+                    content = ?content,
+                    "managed steering input observed"
+                );
+                let response = TurnActionResponse {
+                    action: TurnAction::Steered,
+                    turn_id: active_id.clone(),
+                    state: TurnStatus::Running,
+                };
+                self.sessions
+                    .record_steer(
+                        self.id.clone(),
+                        active_id.clone(),
+                        content.clone(),
+                        response.clone(),
+                        idempotency_key.clone(),
+                    )
+                    .await?;
+                if let Some(turn) = self.turns.get_mut(&active_id) {
+                    turn.inputs.push(content);
+                }
+                self.remember_request(idempotency_key, &response);
+                Ok(Some(response))
+            }
+            Err(AgentError::TurnNotSteerable) => {
+                self.active_turn = None;
+                Ok(None)
+            }
+            Err(AgentError::SteerQueueFull) => Err(ManagerError::SteerQueueFull),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    async fn cancel(&mut self, turn_id: &str) -> Result<bool, ManagerError> {
+        tracing::info!(
+            target: "nanocentaur::observed",
+            agent_id = %self.id,
+            turn_id = %turn_id,
+            "managed cancellation observed"
+        );
+        let control = self
+            .turns
+            .get(turn_id)
+            .filter(|turn| !turn.view.state.is_terminal())
+            .and_then(|turn| turn.control.as_ref().map(Arc::clone))
+            .ok_or(ManagerError::NotFound)?;
+        match control.cancel().await {
+            Ok(()) => {
+                self.cancel_requested.insert(turn_id.to_owned());
+                let event = self
+                    .sessions
+                    .request_cancel(self.id.clone(), turn_id.to_owned())
+                    .await?;
+                self.publish(event);
+                Ok(true)
+            }
+            Err(AgentError::TurnNotCancellable) => Ok(false),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    async fn ensure_runtime(&mut self) -> Result<(), AgentError> {
+        if self.runtime.is_some() {
+            return Ok(());
+        }
+        let spec = AgentSpec {
+            agent_id: self.id.clone(),
+            principal: self.principal_id.clone(),
+            instructions: self.instructions.clone(),
+            thinking: self.thinking,
+            capabilities: self.capabilities.clone(),
+            snapshot: self.snapshot.clone(),
+        };
+        tracing::info!(
+            target: "nanocentaur::observed",
+            agent_id = %spec.agent_id,
+            principal_id = %spec.principal,
+            instructions = ?spec.instructions,
+            thinking = ?spec.thinking,
+            capabilities = ?spec.capabilities,
+            snapshot = ?spec.snapshot,
+            "managed runtime specification observed"
+        );
+        let spawned = self.factory.create(spec).await?;
+        let (agent, mut events) = spawned.into_parts();
+        let sender = self.self_sender.clone();
+        tokio::spawn(async move {
+            while let Some(event) = events.recv().await {
+                if sender
+                    .send(AgentCommand::RuntimeEvent(event))
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+            }
+        });
+        self.runtime = Some(Runtime { agent });
+        Ok(())
+    }
+
+    async fn finish_turn(&mut self, turn_id: &str, result: Result<AgentRunResult, AgentError>) {
+        let cancelled = self.cancel_requested.remove(turn_id);
+        let completed_at = Utc::now();
+        let (status, output, error, snapshot, usage, payload) = match result {
+            Ok(result) if !cancelled => {
+                let (final_message, snapshot, usage) = result.into_parts();
+                tracing::info!(
+                    target: "nanocentaur::observed",
+                    agent_id = %self.id,
+                    turn_id = %turn_id,
+                    final_message,
+                    snapshot = ?snapshot,
+                    usage = ?usage,
+                    "managed turn result observed"
+                );
+                self.snapshot.clone_from(&snapshot);
+                let output = vec![ContentBlock::Text {
+                    text: final_message,
+                }];
+                if let Some(turn) = self.turns.get_mut(turn_id) {
+                    turn.view.state = TurnStatus::Completed;
+                    turn.view.output.clone_from(&output);
+                    turn.view.usage = Some(usage.clone());
+                    turn.view.completed_at = Some(completed_at);
+                    turn.snapshot.clone_from(&snapshot);
+                }
+                (
+                    TurnStatus::Completed,
+                    output.clone(),
+                    None,
+                    snapshot,
+                    Some(usage.clone()),
+                    AgentEventPayload::TurnCompleted { output, usage },
+                )
+            }
+            _ if cancelled => {
+                if let Some(turn) = self.turns.get_mut(turn_id) {
+                    turn.view.state = TurnStatus::Cancelled;
+                    turn.view.completed_at = Some(completed_at);
+                }
+                (
+                    TurnStatus::Cancelled,
+                    Vec::new(),
+                    None,
+                    None,
+                    None,
+                    AgentEventPayload::TurnCancelled,
+                )
+            }
+            Ok(_) => {
+                // The guarded cancellation arm above is the only remaining
+                // successful-result path.
+                unreachable!("successful non-cancelled turns are handled first");
+            }
+            Err(error) => {
+                tracing::warn!(agent_id = self.id, turn_id, %error, "turn failed");
+                if let Some(turn) = self.turns.get_mut(turn_id) {
+                    turn.view.state = TurnStatus::Failed;
+                    turn.view.error = Some("managed agent execution failed".to_owned());
+                    turn.view.completed_at = Some(completed_at);
+                }
+                (
+                    TurnStatus::Failed,
+                    Vec::new(),
+                    Some("managed agent execution failed".to_owned()),
+                    None,
+                    None,
+                    AgentEventPayload::TurnFailed {
+                        error: TurnFailure::ManagedAgentExecutionFailed,
+                    },
+                )
+            }
+        };
+        match self
+            .sessions
+            .finish_turn(
+                self.id.clone(),
+                turn_id.to_owned(),
+                CompletedTurn {
+                    status,
+                    output,
+                    error,
+                    completed_at,
+                    snapshot,
+                    usage,
+                    event: payload,
+                },
+            )
+            .await
+        {
+            Ok(event) => self.publish(event),
+            Err(error) => {
+                tracing::error!(agent_id = self.id, turn_id, %error, "failed to persist terminal turn");
+                return;
+            }
+        }
+        self.advance_after(turn_id).await;
+    }
+
+    async fn handle_runtime_event(&mut self, event: NativeAgentEvent) {
+        tracing::info!(
+            target: "nanocentaur::observed",
+            agent_id = %self.id,
+            event = ?event,
+            "native runtime event observed"
+        );
+        let kind = event.kind;
+        if kind == AgentEventKind::RunStarted && self.runtime_event_turn.is_none() {
+            if let Some(next) = self.turn_order.iter().find_map(|id| {
+                self.turns
+                    .get(id)
+                    .filter(|turn| turn.view.state == TurnStatus::Queued)
+                    .map(|_| id.clone())
+            }) {
+                self.active_turn = Some(next.clone());
+                if let Some(turn) = self.turns.get_mut(&next) {
+                    turn.view.state = TurnStatus::Running;
+                }
+                match self
+                    .sessions
+                    .mark_started(self.id.clone(), next.clone())
+                    .await
+                {
+                    Ok(event) => self.publish(event),
+                    Err(error) => {
+                        tracing::error!(agent_id = self.id, turn_id = next, %error, "failed to persist queued turn start");
+                    }
+                }
+                self.runtime_event_turn = Some(next);
+            } else {
+                self.runtime_event_turn.clone_from(&self.active_turn);
+            }
+        }
+        let turn_id = self.runtime_event_turn.clone();
+        let terminal = kind.is_terminal();
+        match self
+            .sessions
+            .append_event(
+                self.id.clone(),
+                turn_id.clone(),
+                AgentEventPayload::Runtime { event },
+            )
+            .await
+        {
+            Ok(event) => self.publish(event),
+            Err(error) => {
+                tracing::error!(agent_id = self.id, %error, "failed to persist runtime event");
+            }
+        }
+        if terminal {
+            self.runtime_event_turn = None;
+            if let Some(turn_id) = turn_id {
+                if let Some(result) = self.pending_results.remove(&turn_id) {
+                    self.finish_turn(&turn_id, result).await;
+                } else {
+                    self.runtime_terminal_turns.insert(turn_id);
+                }
+            }
+        }
+    }
+
+    async fn advance_after(&mut self, completed_turn_id: &str) {
+        if self.active_turn.as_deref() != Some(completed_turn_id) {
+            return;
+        }
+        let next = self.turn_order.iter().find_map(|id| {
+            self.turns
+                .get(id)
+                .filter(|turn| turn.view.state == TurnStatus::Queued)
+                .map(|_| id.clone())
+        });
+        self.active_turn.clone_from(&next);
+        if let Some(next) = next {
+            if let Some(turn) = self.turns.get_mut(&next) {
+                turn.view.state = TurnStatus::Running;
+            }
+            match self
+                .sessions
+                .mark_started(self.id.clone(), next.clone())
+                .await
+            {
+                Ok(event) => self.publish(event),
+                Err(error) => {
+                    tracing::error!(agent_id = self.id, turn_id = next, %error, "failed to persist queued turn start");
+                    return;
+                }
+            }
+            if self.runtime_event_turn.is_none() {
+                self.runtime_event_turn = Some(next);
+            }
+        } else if self.runtime_policy_dirty {
+            self.runtime.take();
+            self.runtime_policy_dirty = false;
+        }
+    }
+
+    fn remember_request(&mut self, idempotency_key: Option<String>, response: &TurnActionResponse) {
+        if let Some(key) = idempotency_key {
+            self.requests_by_key.insert(key, response.clone());
+        }
+    }
+
+    fn publish(&self, event: AgentEvent) {
+        tracing::info!(
+            target: "nanocentaur::observed",
+            agent_id = %self.id,
+            event = ?event,
+            "durable managed event observed"
+        );
+        let _ = self.event_sender.send(event);
+    }
+
+    fn attach_turn(&mut self, turn_id: String, managed_turn: crate::ManagedTurn) {
+        if let Some(turn) = self.turns.get_mut(&turn_id) {
+            turn.control = Some(managed_turn.control());
+        }
+        let sender = self.self_sender.clone();
+        let span = tracing::info_span!(
+            parent: &tracing::Span::current(),
+            "nanocentaur.turn.result",
+            agent.id = self.id,
+            turn.id = turn_id,
+        );
+        tokio::spawn(
+            async move {
+                let result = managed_turn.result().await;
+                drop(
+                    sender
+                        .send(AgentCommand::TurnFinished {
+                            turn_id,
+                            result: Box::new(result),
+                        })
+                        .await,
+                );
+            }
+            .instrument(span),
+        );
+    }
+
+    async fn recover_pending(&mut self) -> Result<(), ManagerError> {
+        let pending = self
+            .turn_order
+            .iter()
+            .filter(|turn_id| {
+                self.turns
+                    .get(*turn_id)
+                    .is_some_and(|turn| !turn.view.state.is_terminal())
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if pending.is_empty() {
+            return Ok(());
+        }
+        self.ensure_runtime().await?;
+        let managed = self
+            .runtime
+            .as_ref()
+            .map(|runtime| Arc::clone(&runtime.agent))
+            .ok_or_else(|| AgentError::Backend("runtime disappeared".to_owned()))?;
+        let mut started = false;
+        for turn_id in pending {
+            if self.cancel_requested.contains(&turn_id) {
+                self.finish_turn(&turn_id, Err(AgentError::TurnNotCancellable))
+                    .await;
+                continue;
+            }
+            let inputs = self
+                .turns
+                .get(&turn_id)
+                .map(|turn| turn.inputs.clone())
+                .ok_or(ManagerError::NotFound)?;
+            let Some(first) = inputs.first().cloned() else {
+                self.finish_turn(
+                    &turn_id,
+                    Err(AgentError::Backend(
+                        "durable turn has no input content".to_owned(),
+                    )),
+                )
+                .await;
+                continue;
+            };
+            if !started {
+                started = true;
+                self.active_turn = Some(turn_id.clone());
+                self.runtime_event_turn = Some(turn_id.clone());
+                if let Some(turn) = self.turns.get_mut(&turn_id) {
+                    turn.view.state = TurnStatus::Running;
+                }
+                let event = self
+                    .sessions
+                    .mark_started(self.id.clone(), turn_id.clone())
+                    .await?;
+                self.publish(event);
+            }
+            match managed.prompt(to_prompt(first)).await {
+                Ok(managed_turn) => {
+                    for steer in inputs.iter().skip(1).cloned() {
+                        managed_turn.control().steer(to_prompt(steer)).await?;
+                    }
+                    self.attach_turn(turn_id, managed_turn);
+                }
+                Err(error) => self.finish_turn(&turn_id, Err(error)).await,
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Replay-then-live ordered event cursor for one managed agent.
+pub struct EventCursor {
+    sender: AgentSender,
+    receiver: broadcast::Receiver<AgentEvent>,
+    after_event_id: u64,
+    replay: VecDeque<AgentEvent>,
+}
+
+impl EventCursor {
+    /// Returns the next ordered event, recovering transparently after
+    /// broadcast lag by replaying from `SQLite`.
+    pub async fn recv(&mut self) -> Option<AgentEvent> {
+        loop {
+            if let Some(event) = self.replay.pop_front() {
+                self.after_event_id = event.id;
+                return Some(event);
+            }
+            match self.receiver.recv().await {
+                Ok(event) if event.id > self.after_event_id => {
+                    self.after_event_id = event.id;
+                    return Some(event);
+                }
+                Ok(_) => {}
+                Err(broadcast::error::RecvError::Lagged(_)) => {
+                    let (reply, response) = oneshot::channel();
+                    if self
+                        .sender
+                        .send(AgentCommand::Replay {
+                            after_event_id: self.after_event_id,
+                            reply,
+                        })
+                        .await
+                        .is_err()
+                    {
+                        return None;
+                    }
+                    self.replay = response.await.ok()?.ok()?;
+                }
+                Err(broadcast::error::RecvError::Closed) => return None,
+            }
+        }
+    }
+}
+
+const fn runtime_event_name(kind: AgentEventKind) -> &'static str {
+    match kind {
+        AgentEventKind::ApiEvent => "api.event",
+        AgentEventKind::AssistantDelta => "assistant.delta",
+        AgentEventKind::AssistantMessage => "assistant.message",
+        AgentEventKind::ReasoningSummaryDelta => "reasoning.summary.delta",
+        AgentEventKind::RunStarted => "run.started",
+        AgentEventKind::RunSteered => "run.steered",
+        AgentEventKind::RunError => "run.error",
+        AgentEventKind::RunCompleted => "run.completed",
+        AgentEventKind::RunFailed => "run.failed",
+        AgentEventKind::ToolCall => "tool.call",
+        AgentEventKind::ToolResult => "tool.result",
+        AgentEventKind::ModelWarmupStarted => "model.warmup.started",
+        AgentEventKind::ModelWarmupCompleted => "model.warmup.completed",
+        AgentEventKind::ModelWarmupFailed => "model.warmup.failed",
+        AgentEventKind::ModelCallStarted => "model.call.started",
+        AgentEventKind::ModelCallCompleted => "model.call.completed",
+        AgentEventKind::ModelCallFailed => "model.call.failed",
+        AgentEventKind::ModelCompactionStarted => "model.compaction.started",
+        AgentEventKind::ModelCompactionCompleted => "model.compaction.completed",
+        AgentEventKind::ModelCompactionFailed => "model.compaction.failed",
+        AgentEventKind::ModelAttemptStarted => "model.attempt.started",
+        AgentEventKind::ModelAttemptFailed => "model.attempt.failed",
+        AgentEventKind::ModelAttemptRetrying => "model.attempt.retrying",
+        AgentEventKind::ModelConnectionStarted => "model.connection.started",
+        AgentEventKind::ModelConnectionCompleted => "model.connection.completed",
+        AgentEventKind::ModelConnectionFailed => "model.connection.failed",
+    }
+}
+
+fn to_prompt(content: Vec<ContentBlock>) -> Prompt {
+    Prompt::content(content.into_iter().map(|block| match block {
+        ContentBlock::Text { text } => UserInput::Text { text },
+        ContentBlock::ImageUrl { url, detail } => UserInput::Image {
+            image_url: url,
+            detail,
+        },
+        ContentBlock::AudioUrl { url } => UserInput::Audio { audio_url: url },
+    }))
+}
+
+fn validate_content(content: &[ContentBlock]) -> Result<(), ManagerError> {
+    if content.is_empty() || content.len() > MAX_CONTENT_BLOCKS {
+        return Err(ManagerError::Invalid("content must contain 1 to 64 blocks"));
+    }
+    let encoded = serde_json::to_vec(content)
+        .map_err(|_| ManagerError::Invalid("content must be valid JSON"))?;
+    if encoded.len() > MAX_CONTENT_BYTES {
+        return Err(ManagerError::Invalid(
+            "content must not exceed 1048576 encoded bytes",
+        ));
+    }
+    for block in content {
+        match block {
+            ContentBlock::Text { text } if text.trim().is_empty() => {
+                return Err(ManagerError::Invalid("text blocks must not be empty"));
+            }
+            ContentBlock::ImageUrl { url, .. } | ContentBlock::AudioUrl { url } => {
+                let url = Url::parse(url).map_err(|_| {
+                    ManagerError::Invalid("media URLs must be absolute HTTP(S) URLs")
+                })?;
+                if !matches!(url.scheme(), "http" | "https") {
+                    return Err(ManagerError::Invalid(
+                        "media URLs must be absolute HTTP(S) URLs",
+                    ));
+                }
+            }
+            ContentBlock::Text { .. } => {}
+        }
+    }
+    Ok(())
+}
+
+fn validate_idempotency_key(value: Option<&str>) -> Result<(), ManagerError> {
+    if value.is_some_and(|value| value.is_empty() || value.len() > MAX_IDEMPOTENCY_KEY_BYTES) {
+        Err(ManagerError::Invalid(
+            "Idempotency-Key must contain 1 to 256 bytes",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Error)]
+/// Managed lifecycle, validation, or durability failure.
+pub enum ManagerError {
+    /// The authorized agent or turn does not exist.
+    #[error("agent or turn was not found")]
+    NotFound,
+    /// Request content or metadata violated a bounded public contract.
+    #[error("invalid request: {0}")]
+    Invalid(&'static str),
+    /// The active turn cannot accept additional steering immediately.
+    #[error("the active turn's steering queue is full")]
+    SteerQueueFull,
+    /// Forking requires an idle source.
+    #[error("agent must be idle before it can be forked")]
+    AgentBusy,
+    /// The requested completed fork boundary does not exist.
+    #[error("completed fork boundary was not found")]
+    ForkBoundaryNotFound,
+    /// The disposable in-process actor stopped unexpectedly.
+    #[error("agent actor stopped")]
+    ActorStopped,
+    /// `SQLite` command or replay persistence failed.
+    #[error("session durability failed: {0}")]
+    Durability(String),
+    /// The configured backend agent failed.
+    #[error("managed agent could not be created or controlled")]
+    Agent(#[from] AgentError),
+    /// Workspace or state-directory mutation failed.
+    #[error("agent state filesystem failed")]
+    Io(#[from] std::io::Error),
+}
+
+impl From<SessionError> for ManagerError {
+    fn from(error: SessionError) -> Self {
+        match error {
+            SessionError::ForkBoundaryNotFound => Self::ForkBoundaryNotFound,
+            error => Self::Durability(error.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use nanocodex_agent::{CostStatus, TurnUsage};
+    use nanocodex_oai_api::{
+        pricing::{ServiceTier, estimate},
+        responses::{InputTokenDetails, Usage},
+    };
+    use serde_json::json;
+
+    use super::*;
+    use crate::{AgentConfig, EffectivePrincipal, MockAgentFactory};
+
+    fn identity(id: &str) -> AgentIdentity {
+        AgentIdentity {
+            id: id.to_owned(),
+            owner_client_id: "client".to_owned(),
+            context_key: None,
+            principal: EffectivePrincipal {
+                id: "principal".to_owned(),
+                agent_config: AgentConfig::default(),
+                permissions: AgentCapabilities::default(),
+                secret_revision: 0,
+            },
+            created_at: Utc::now(),
+        }
+    }
+
+    fn turn(text: &str) -> CreateTurn {
+        CreateTurn {
+            delivery: TurnDelivery::Steer,
+            content: vec![ContentBlock::Text {
+                text: text.to_owned(),
+            }],
+        }
+    }
+
+    fn priced_usage() -> TurnUsage {
+        let estimated_cost = estimate(
+            &Usage {
+                input_tokens: 1_000,
+                input_tokens_details: Some(InputTokenDetails {
+                    cached_tokens: 100,
+                    cache_write_tokens: 50,
+                }),
+                output_tokens: 200,
+                output_tokens_details: None,
+                total_tokens: 1_200,
+            },
+            ServiceTier::Standard,
+        );
+        serde_json::from_value(json!({
+            "input_tokens": 1_000,
+            "cached_input_tokens": 100,
+            "cache_write_input_tokens": 50,
+            "output_tokens": 200,
+            "reasoning_output_tokens": 120,
+            "total_tokens": 1_200,
+            "estimated_cost": estimated_cost,
+            "cost_status": "estimated_from_usage"
+        }))
+        .unwrap()
+    }
+
+    async fn wait_for_completed(
+        manager: &AgentManager,
+        identity: AgentIdentity,
+        turn_id: &str,
+    ) -> TurnView {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let view = manager.get_turn(identity.clone(), turn_id).await.unwrap();
+                if view.state.is_terminal() {
+                    return view;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn agent_actor_owns_one_ordered_typed_event_stream() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = AgentManager::new(
+            Arc::new(MockAgentFactory::new(Duration::from_millis(5)).usage(priced_usage())),
+            directory.path(),
+        )
+        .unwrap();
+        let identity = identity("agent");
+        manager.register(identity.clone()).await.unwrap();
+        let mut events = manager.events(identity.clone(), 0).await.unwrap();
+        manager
+            .create_turn(
+                identity,
+                CreateTurn {
+                    delivery: TurnDelivery::Steer,
+                    content: vec![ContentBlock::Text {
+                        text: "hello".to_owned(),
+                    }],
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        let mut saw_runtime = false;
+        loop {
+            let event = tokio::time::timeout(Duration::from_secs(1), events.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            match event.payload {
+                AgentEventPayload::Runtime { .. } => saw_runtime = true,
+                AgentEventPayload::TurnCompleted { .. } => break,
+                AgentEventPayload::TurnStarted { .. }
+                | AgentEventPayload::TurnQueued { .. }
+                | AgentEventPayload::TurnCancelRequested
+                | AgentEventPayload::TurnInterrupted { .. }
+                | AgentEventPayload::TurnCancelled
+                | AgentEventPayload::TurnFailed { .. } => {}
+            }
+        }
+        assert!(saw_runtime);
+    }
+
+    #[tokio::test]
+    async fn completed_turns_events_and_idempotency_survive_restart() {
+        let directory = tempfile::tempdir().unwrap();
+        let identity = identity("durable");
+        let manager = AgentManager::new(
+            Arc::new(MockAgentFactory::new(Duration::from_millis(5)).usage(priced_usage())),
+            directory.path(),
+        )
+        .unwrap();
+        manager.register(identity.clone()).await.unwrap();
+        let response = manager
+            .create_turn(
+                identity.clone(),
+                turn("persist me"),
+                Some("request-1".to_owned()),
+            )
+            .await
+            .unwrap();
+        let completed = wait_for_completed(&manager, identity.clone(), &response.turn_id).await;
+        assert_eq!(completed.state, TurnStatus::Completed);
+        let completed_usage = completed.usage.clone().unwrap();
+        assert_eq!(
+            completed_usage.cost_status(),
+            CostStatus::EstimatedFromUsage
+        );
+        assert!(completed_usage.estimated_cost().is_some());
+        let mut first_events = manager.events(identity.clone(), 0).await.unwrap();
+        let (terminal_id, terminal_usage) = loop {
+            let event = first_events.recv().await.unwrap();
+            if let AgentEventPayload::TurnCompleted { usage, .. } = event.payload {
+                break (event.id, usage);
+            }
+        };
+        assert_eq!(terminal_usage, completed_usage);
+        manager.shutdown().await.unwrap();
+        drop(manager);
+
+        let restarted = AgentManager::new(
+            Arc::new(MockAgentFactory::new(Duration::from_millis(5))),
+            directory.path(),
+        )
+        .unwrap();
+        restarted.register(identity.clone()).await.unwrap();
+        let restored = restarted
+            .get_turn(identity.clone(), &response.turn_id)
+            .await
+            .unwrap();
+        assert_eq!(restored.state, TurnStatus::Completed);
+        assert_eq!(restored.usage.as_ref(), Some(&completed_usage));
+        assert_eq!(
+            restarted
+                .find_turn_by_idempotency_key(identity.clone(), "request-1")
+                .await
+                .unwrap()
+                .unwrap()
+                .turn_id,
+            response.turn_id
+        );
+        let mut replay = restarted.events(identity, 0).await.unwrap();
+        let last = loop {
+            let event = replay.recv().await.unwrap();
+            if event.id == terminal_id {
+                break event;
+            }
+        };
+        let AgentEventPayload::TurnCompleted { usage, .. } = last.payload else {
+            panic!("expected a durable terminal completion event");
+        };
+        assert_eq!(usage, completed_usage);
+    }
+
+    #[tokio::test]
+    async fn interrupted_running_turn_is_retried_from_sqlite() {
+        let directory = tempfile::tempdir().unwrap();
+        let identity = identity("interrupted");
+        let manager = AgentManager::new(
+            Arc::new(MockAgentFactory::new(Duration::from_secs(1))),
+            directory.path(),
+        )
+        .unwrap();
+        manager.register(identity.clone()).await.unwrap();
+        let response = manager
+            .create_turn(identity.clone(), turn("retry me"), None)
+            .await
+            .unwrap();
+        manager.shutdown().await.unwrap();
+        drop(manager);
+
+        let restarted = AgentManager::new(
+            Arc::new(MockAgentFactory::new(Duration::from_millis(5))),
+            directory.path(),
+        )
+        .unwrap();
+        restarted.register(identity.clone()).await.unwrap();
+        let completed = wait_for_completed(&restarted, identity.clone(), &response.turn_id).await;
+        assert_eq!(completed.state, TurnStatus::Completed);
+        let mut events = restarted.events(identity, 0).await.unwrap();
+        let mut interrupted = false;
+        loop {
+            match events.recv().await.unwrap().payload {
+                AgentEventPayload::TurnInterrupted { retrying } => interrupted = retrying,
+                AgentEventPayload::TurnCompleted { .. } => break,
+                AgentEventPayload::TurnStarted { .. }
+                | AgentEventPayload::TurnQueued { .. }
+                | AgentEventPayload::TurnCancelRequested
+                | AgentEventPayload::TurnCancelled
+                | AgentEventPayload::TurnFailed { .. }
+                | AgentEventPayload::Runtime { .. } => {}
+            }
+        }
+        assert!(interrupted);
+    }
+
+    #[tokio::test]
+    async fn fork_copies_session_history_without_copying_workspace() {
+        let directory = tempfile::tempdir().unwrap();
+        let source = identity("source");
+        let target = identity("target");
+        let manager = AgentManager::new(
+            Arc::new(MockAgentFactory::new(Duration::from_millis(5)).usage(priced_usage())),
+            directory.path(),
+        )
+        .unwrap();
+        manager.register(source.clone()).await.unwrap();
+        let response = manager
+            .create_turn(source.clone(), turn("branch here"), None)
+            .await
+            .unwrap();
+        wait_for_completed(&manager, source.clone(), &response.turn_id).await;
+        let source_workspace = directory.path().join("workspaces").join("source");
+        std::fs::create_dir_all(&source_workspace).unwrap();
+        std::fs::write(source_workspace.join("pet.txt"), "do not clone").unwrap();
+
+        let forked = manager
+            .fork(source, target.clone(), Some(response.turn_id.as_str()))
+            .await
+            .unwrap();
+        assert_eq!(
+            forked.forked_from.turn_id.as_deref(),
+            Some(response.turn_id.as_str())
+        );
+        let inherited = manager
+            .get_turn(target.clone(), &response.turn_id)
+            .await
+            .unwrap();
+        assert_eq!(inherited.state, TurnStatus::Completed);
+        assert_eq!(inherited.usage, Some(priced_usage()));
+        assert!(
+            !directory
+                .path()
+                .join("workspaces")
+                .join("target")
+                .join("pet.txt")
+                .exists()
+        );
+        let first = manager
+            .events(target, 0)
+            .await
+            .unwrap()
+            .recv()
+            .await
+            .unwrap();
+        assert_eq!(first.agent_id, "target");
+    }
+}

--- a/crates/experimental/nanocentaur/src/manager.rs
+++ b/crates/experimental/nanocentaur/src/manager.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     path::PathBuf,
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 
 use chrono::{DateTime, Utc};
@@ -14,6 +14,7 @@ use nanocodex_agent::{
     session::SessionSnapshot,
 };
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use thiserror::Error;
 use tokio::sync::{RwLock, broadcast, mpsc, oneshot};
 use tracing::{Instrument, instrument::WithSubscriber};
@@ -22,8 +23,10 @@ use uuid::Uuid;
 
 use crate::{
     AgentCapabilities, AgentError, AgentIdentity, AgentRunResult, AgentSpec, ManagedAgent,
-    ManagedAgentFactory, ManagedTurnControl,
-    session::{CompletedTurn, NewTurn, SessionError, SessionStore, StoredSession},
+    ManagedAgentFactory, ManagedTurnControl, PolicyStore,
+    session::{
+        CompletedTurn, NewTurn, SessionError, SessionStore, SteerRequestRecord, StoredSession,
+    },
 };
 
 const MAX_CONTENT_BYTES: usize = 1024 * 1024;
@@ -33,6 +36,11 @@ const EVENT_BROADCAST_CAPACITY: usize = 1_024;
 const AGENT_COMMAND_CAPACITY: usize = 64;
 const RUNTIME_EVENT_BATCH_SIZE: usize = 64;
 const EVENT_REPLAY_PAGE_SIZE: usize = 256;
+
+pub(crate) struct TurnReplay {
+    pub response: TurnActionResponse,
+    pub payment_receipt: Option<String>,
+}
 
 /// Request to create or resolve one managed agent.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -319,6 +327,7 @@ pub struct AgentManager {
     factory: Arc<dyn ManagedAgentFactory>,
     agents: RwLock<HashMap<String, AgentHandle>>,
     sessions: SessionStore,
+    policy: Arc<OnceLock<Arc<PolicyStore>>>,
 }
 
 impl AgentManager {
@@ -338,7 +347,12 @@ impl AgentManager {
             factory,
             agents: RwLock::new(HashMap::new()),
             sessions,
+            policy: Arc::new(OnceLock::new()),
         })
+    }
+
+    pub(crate) fn attach_policy(&self, policy: Arc<PolicyStore>) {
+        let _ = self.policy.set(policy);
     }
 
     /// Registers or wakes an authorized durable agent.
@@ -356,12 +370,37 @@ impl AgentManager {
         &self,
         identity: AgentIdentity,
         key: &str,
+        request: &CreateTurn,
     ) -> Result<Option<TurnActionResponse>, ManagerError> {
+        Ok(self
+            .find_turn_replay(identity, key, request)
+            .await?
+            .map(|replay| replay.response))
+    }
+
+    pub(crate) async fn find_turn_replay(
+        &self,
+        identity: AgentIdentity,
+        key: &str,
+        request: &CreateTurn,
+    ) -> Result<Option<TurnReplay>, ManagerError> {
         validate_idempotency_key(Some(key))?;
-        self.sessions
+        let request_hash = request_hash(request)?;
+        let stored = self
+            .sessions
             .find_request(identity.id, key.to_owned())
-            .await
-            .map_err(Into::into)
+            .await?;
+        stored
+            .map(|stored| {
+                if stored.request_hash.as_deref() != Some(request_hash.as_slice()) {
+                    return Err(ManagerError::IdempotencyConflict);
+                }
+                Ok(TurnReplay {
+                    response: stored.response,
+                    payment_receipt: stored.payment_receipt,
+                })
+            })
+            .transpose()
     }
 
     /// Validates and durably accepts input for steering or FIFO execution.
@@ -371,11 +410,23 @@ impl AgentManager {
         request: CreateTurn,
         idempotency_key: Option<String>,
     ) -> Result<TurnActionResponse, ManagerError> {
-        validate_content(&request.content)?;
+        self.create_turn_with_receipt(identity, request, idempotency_key, None)
+            .await
+    }
+
+    pub(crate) async fn create_turn_with_receipt(
+        &self,
+        identity: AgentIdentity,
+        request: CreateTurn,
+        idempotency_key: Option<String>,
+        payment_receipt: Option<String>,
+    ) -> Result<TurnActionResponse, ManagerError> {
+        validate_turn_request(&request)?;
         validate_idempotency_key(idempotency_key.as_deref())?;
+        let request_hash = request_hash(&request)?;
         self.ensure(identity)
             .await?
-            .create_turn(request, idempotency_key)
+            .create_turn(request, idempotency_key, request_hash, payment_receipt)
             .await
     }
 
@@ -439,8 +490,7 @@ impl AgentManager {
                 turn_id.map(str::to_owned),
             )
             .await?;
-        let target_id = target_identity.id.clone();
-        self.ensure(target_identity).await?;
+        let target_id = target_identity.id;
         Ok(ForkResponse {
             agent_id: target_id,
             forked_from,
@@ -476,44 +526,64 @@ impl AgentManager {
     }
 
     async fn ensure(&self, identity: AgentIdentity) -> Result<AgentHandle, ManagerError> {
-        let existing = self.agents.read().await.get(&identity.id).cloned();
-        if let Some(handle) = existing {
-            handle
-                .refresh_policy(
-                    identity.principal.permissions,
-                    identity.principal.secret_revision,
-                )
-                .await?;
-            return Ok(handle);
-        }
-        let stored = self.sessions.load(identity.id.clone()).await?;
-        let capabilities = identity.principal.permissions.clone();
-        let secret_revision = identity.principal.secret_revision;
-        let handle = {
-            let mut agents = self.agents.write().await;
-            if let Some(handle) = agents.get(&identity.id).cloned() {
-                handle
-            } else {
-                let id = identity.id.clone();
-                let (sender, receiver) = mpsc::channel(AGENT_COMMAND_CAPACITY);
-                let sender = AgentSender(sender);
-                let handle = AgentHandle {
-                    sender: sender.clone(),
-                };
-                let actor = AgentActor::new(
-                    identity,
-                    Arc::clone(&self.factory),
-                    self.sessions.clone(),
-                    stored,
-                    sender,
-                );
-                tokio::spawn(actor.run(receiver));
-                agents.insert(id, handle.clone());
-                handle
+        loop {
+            let capabilities = identity.principal.permissions.clone();
+            let secret_revision = identity.principal.secret_revision;
+            if let Some(handle) = self.agents.read().await.get(&identity.id).cloned() {
+                match handle.refresh_policy(capabilities, secret_revision).await {
+                    Ok(()) => return Ok(handle),
+                    Err(ManagerError::ActorStopped) => {
+                        let mut agents = self.agents.write().await;
+                        if agents
+                            .get(&identity.id)
+                            .is_some_and(|current| current.same_channel(&handle))
+                        {
+                            agents.remove(&identity.id);
+                        }
+                        continue;
+                    }
+                    Err(error) => return Err(error),
+                }
             }
-        };
-        handle.refresh_policy(capabilities, secret_revision).await?;
-        Ok(handle)
+            let stored = self.sessions.load(identity.id.clone()).await?;
+            let handle = {
+                let mut agents = self.agents.write().await;
+                if let Some(handle) = agents.get(&identity.id).cloned() {
+                    handle
+                } else {
+                    let id = identity.id.clone();
+                    let (sender, receiver) = mpsc::channel(AGENT_COMMAND_CAPACITY);
+                    let sender = AgentSender(sender);
+                    let handle = AgentHandle {
+                        sender: sender.clone(),
+                    };
+                    let actor = AgentActor::new(
+                        identity.clone(),
+                        Arc::clone(&self.factory),
+                        self.sessions.clone(),
+                        Arc::clone(&self.policy),
+                        stored,
+                        sender.downgrade(),
+                    );
+                    tokio::spawn(actor.run(receiver));
+                    agents.insert(id, handle.clone());
+                    handle
+                }
+            };
+            match handle.refresh_policy(capabilities, secret_revision).await {
+                Ok(()) => return Ok(handle),
+                Err(ManagerError::ActorStopped) => {
+                    let mut agents = self.agents.write().await;
+                    if agents
+                        .get(&identity.id)
+                        .is_some_and(|current| current.same_channel(&handle))
+                    {
+                        agents.remove(&identity.id);
+                    }
+                }
+                Err(error) => return Err(error),
+            }
+        }
     }
 }
 
@@ -525,6 +595,9 @@ struct AgentHandle {
 #[derive(Clone)]
 struct AgentSender(mpsc::Sender<AgentCommandEnvelope>);
 
+#[derive(Clone)]
+struct AgentWeakSender(mpsc::WeakSender<AgentCommandEnvelope>);
+
 struct AgentCommandEnvelope {
     dispatch: tracing::Dispatch,
     parent: tracing::Span,
@@ -533,6 +606,10 @@ struct AgentCommandEnvelope {
 }
 
 impl AgentSender {
+    fn downgrade(&self) -> AgentWeakSender {
+        AgentWeakSender(self.0.downgrade())
+    }
+
     async fn send(
         &self,
         command: AgentCommand,
@@ -548,7 +625,20 @@ impl AgentSender {
     }
 }
 
+impl AgentWeakSender {
+    async fn send(&self, command: AgentCommand) -> bool {
+        let Some(sender) = self.0.upgrade() else {
+            return false;
+        };
+        AgentSender(sender).send(command).await.is_ok()
+    }
+}
+
 impl AgentHandle {
+    fn same_channel(&self, other: &Self) -> bool {
+        self.sender.0.same_channel(&other.sender.0)
+    }
+
     async fn view(&self) -> Result<AgentView, ManagerError> {
         self.request(|reply| AgentCommand::View { reply }).await
     }
@@ -570,10 +660,14 @@ impl AgentHandle {
         &self,
         request: CreateTurn,
         idempotency_key: Option<String>,
+        request_hash: Vec<u8>,
+        payment_receipt: Option<String>,
     ) -> Result<TurnActionResponse, ManagerError> {
         self.request(|reply| AgentCommand::CreateTurn {
             request,
             idempotency_key,
+            request_hash,
+            payment_receipt,
             reply,
         })
         .await
@@ -643,6 +737,8 @@ enum AgentCommand {
     CreateTurn {
         request: CreateTurn,
         idempotency_key: Option<String>,
+        request_hash: Vec<u8>,
+        payment_receipt: Option<String>,
         reply: Reply<TurnActionResponse>,
     },
     GetTurn {
@@ -667,8 +763,17 @@ enum AgentCommand {
     RuntimeEvents(Vec<NativeAgentEvent>),
     TurnFinished {
         turn_id: String,
+        generation: u64,
         result: Box<Result<AgentRunResult, AgentError>>,
     },
+    RetryFinish {
+        turn_id: String,
+    },
+    RetryAdvance {
+        completed_turn_id: String,
+    },
+    RetryRuntimeEvents,
+    RetryRecovery,
     Shutdown {
         reply: Reply<()>,
     },
@@ -690,6 +795,10 @@ impl AgentCommand {
             Self::Replay { .. } => "replay",
             Self::RuntimeEvents(_) => "runtime_events",
             Self::TurnFinished { .. } => "turn_finished",
+            Self::RetryFinish { .. } => "retry_finish",
+            Self::RetryAdvance { .. } => "retry_advance",
+            Self::RetryRuntimeEvents => "retry_runtime_events",
+            Self::RetryRecovery => "retry_recovery",
             Self::Shutdown { .. } => "shutdown",
             Self::Delete { .. } => "delete",
         }
@@ -706,6 +815,8 @@ struct StoredTurn {
     view: TurnView,
     inputs: Vec<Vec<ContentBlock>>,
     control: Option<Arc<dyn ManagedTurnControl>>,
+    pending_completion: Option<CompletedTurn>,
+    generation: u64,
 }
 
 struct EventSubscription {
@@ -730,6 +841,7 @@ impl EventReplay {
 
 struct AgentActor {
     id: String,
+    owner_client_id: String,
     principal_id: String,
     context_key: Option<String>,
     instructions: Option<String>,
@@ -739,13 +851,16 @@ struct AgentActor {
     created_at: DateTime<Utc>,
     factory: Arc<dyn ManagedAgentFactory>,
     sessions: SessionStore,
-    self_sender: AgentSender,
+    policy: Arc<OnceLock<Arc<PolicyStore>>>,
+    self_sender: AgentWeakSender,
     active_turn: Option<String>,
     cancel_requested: HashSet<String>,
     turns: HashMap<String, StoredTurn>,
     turn_order: VecDeque<String>,
     runtime: Option<Runtime>,
     runtime_policy_dirty: bool,
+    pending_runtime_events: VecDeque<NativeAgentEvent>,
+    runtime_event_retry_scheduled: bool,
     snapshot: Option<SessionSnapshot>,
     event_sender: broadcast::Sender<AgentEvent>,
 }
@@ -755,8 +870,9 @@ impl AgentActor {
         identity: AgentIdentity,
         factory: Arc<dyn ManagedAgentFactory>,
         sessions: SessionStore,
+        policy: Arc<OnceLock<Arc<PolicyStore>>>,
         stored: StoredSession,
-        self_sender: AgentSender,
+        self_sender: AgentWeakSender,
     ) -> Self {
         let (event_sender, _) = broadcast::channel(EVENT_BROADCAST_CAPACITY);
         let agent_config = identity.principal.agent_config;
@@ -774,11 +890,14 @@ impl AgentActor {
                     view: turn.view,
                     inputs: turn.inputs,
                     control: None,
+                    pending_completion: None,
+                    generation: 0,
                 },
             );
         }
         Self {
             id: identity.id,
+            owner_client_id: identity.owner_client_id,
             principal_id: identity.principal.id,
             context_key: identity.context_key,
             instructions: agent_config.instructions,
@@ -788,6 +907,7 @@ impl AgentActor {
             created_at: identity.created_at,
             factory,
             sessions,
+            policy,
             self_sender,
             active_turn: None,
             cancel_requested,
@@ -795,6 +915,8 @@ impl AgentActor {
             turn_order,
             runtime: None,
             runtime_policy_dirty: false,
+            pending_runtime_events: VecDeque::new(),
+            runtime_event_retry_scheduled: false,
             snapshot: stored.snapshot,
             event_sender,
         }
@@ -808,6 +930,10 @@ impl AgentActor {
         );
         if let Err(error) = self.recover_pending().instrument(recovery_span).await {
             tracing::error!(agent_id = self.id, %error, "failed to recover durable agent session");
+            self.schedule_command(
+                AgentCommand::RetryRecovery,
+                std::time::Duration::from_millis(250),
+            );
         }
         while let Some(envelope) = receiver.recv().await {
             let command_name = envelope.command.name();
@@ -849,9 +975,13 @@ impl AgentActor {
             AgentCommand::CreateTurn {
                 request,
                 idempotency_key,
+                request_hash,
+                payment_receipt,
                 reply,
             } => {
-                let result = self.create_turn(request, idempotency_key).await;
+                let result = self
+                    .create_turn(request, idempotency_key, request_hash, payment_receipt)
+                    .await;
                 drop(reply.send(result));
             }
             AgentCommand::GetTurn { turn_id, reply } => {
@@ -904,10 +1034,47 @@ impl AgentActor {
                 drop(reply.send(replay));
             }
             AgentCommand::RuntimeEvents(events) => {
-                self.handle_runtime_events(events).await;
+                self.pending_runtime_events.extend(events);
+                self.flush_runtime_events().await;
             }
-            AgentCommand::TurnFinished { turn_id, result } => {
-                self.finish_turn(&turn_id, *result).await;
+            AgentCommand::TurnFinished {
+                turn_id,
+                generation,
+                result,
+            } => {
+                if self
+                    .turns
+                    .get(&turn_id)
+                    .is_some_and(|turn| turn.generation == generation)
+                {
+                    self.finish_turn(&turn_id, *result).await;
+                } else {
+                    tracing::debug!(
+                        agent_id = self.id,
+                        turn_id,
+                        generation,
+                        "ignored stale turn completion"
+                    );
+                }
+            }
+            AgentCommand::RetryFinish { turn_id } => {
+                self.persist_completion(&turn_id).await;
+            }
+            AgentCommand::RetryAdvance { completed_turn_id } => {
+                self.advance_after(&completed_turn_id).await;
+            }
+            AgentCommand::RetryRuntimeEvents => {
+                self.runtime_event_retry_scheduled = false;
+                self.flush_runtime_events().await;
+            }
+            AgentCommand::RetryRecovery => {
+                if let Err(error) = self.recover_pending().await {
+                    tracing::error!(agent_id = self.id, %error, "failed to recover durable agent session; retrying");
+                    self.schedule_command(
+                        AgentCommand::RetryRecovery,
+                        std::time::Duration::from_millis(250),
+                    );
+                }
             }
             AgentCommand::Shutdown { reply } => {
                 self.runtime.take();
@@ -963,6 +1130,8 @@ impl AgentActor {
         &mut self,
         request: CreateTurn,
         idempotency_key: Option<String>,
+        request_hash: Vec<u8>,
+        payment_receipt: Option<String>,
     ) -> Result<TurnActionResponse, ManagerError> {
         tracing::info!(
             target: "nanocentaur::observed",
@@ -972,30 +1141,34 @@ impl AgentActor {
             "managed turn input observed"
         );
         if let Some(key) = &idempotency_key
-            && let Some(response) = self
+            && let Some(stored) = self
                 .sessions
                 .find_request(self.id.clone(), key.clone())
                 .await?
         {
-            return Ok(response);
+            if stored.request_hash.as_deref() != Some(request_hash.as_slice()) {
+                return Err(ManagerError::IdempotencyConflict);
+            }
+            return Ok(stored.response);
         }
 
         let content = request.content;
         let prompt = to_prompt(content.clone());
         if request.delivery == TurnDelivery::Steer
+            && !self.runtime_policy_dirty
             && let Some(response) = self
-                .steer_active(prompt.clone(), content.clone(), idempotency_key.clone())
+                .steer_active(
+                    prompt.clone(),
+                    content.clone(),
+                    idempotency_key.clone(),
+                    request_hash.clone(),
+                    payment_receipt.clone(),
+                )
                 .await?
         {
             return Ok(response);
         }
 
-        self.ensure_runtime().await?;
-        let managed = self
-            .runtime
-            .as_ref()
-            .map(|runtime| Arc::clone(&runtime.agent))
-            .ok_or_else(|| AgentError::Backend("runtime disappeared".to_owned()))?;
         let turn_id = Uuid::now_v7().to_string();
         let (action, state) = if self.active_turn.is_some() {
             (TurnAction::Queued, TurnStatus::Queued)
@@ -1032,6 +1205,8 @@ impl AgentActor {
                     content: content.clone(),
                     response: response.clone(),
                     idempotency_key: idempotency_key.clone(),
+                    request_hash,
+                    payment_receipt,
                     event: event_payload,
                 },
             )
@@ -1047,15 +1222,80 @@ impl AgentActor {
                 view,
                 inputs: vec![content],
                 control: None,
+                pending_completion: None,
+                generation: 0,
             },
         );
-        match managed.prompt(prompt).await {
-            Ok(managed_turn) => self.attach_turn(turn_id, managed_turn),
-            Err(error) => {
-                self.finish_turn(&turn_id, Err(error)).await;
-            }
+        if action == TurnAction::Started {
+            self.start_turn(&turn_id).await;
         }
         Ok(response)
+    }
+
+    async fn start_turn(&mut self, turn_id: &str) {
+        let Some(content) = self
+            .turns
+            .get(turn_id)
+            .and_then(|turn| turn.inputs.first().cloned())
+        else {
+            self.finish_turn(
+                turn_id,
+                Err(AgentError::Backend(
+                    "durable turn has no input content".to_owned(),
+                )),
+            )
+            .await;
+            return;
+        };
+        if let Err(error) = self.refresh_runtime_policy().await {
+            self.finish_turn(turn_id, Err(error)).await;
+            return;
+        }
+        if let Err(error) = self.ensure_runtime().await {
+            self.finish_turn(turn_id, Err(error)).await;
+            return;
+        }
+        let managed = self
+            .runtime
+            .as_ref()
+            .map(|runtime| Arc::clone(&runtime.agent));
+        let Some(managed) = managed else {
+            self.finish_turn(
+                turn_id,
+                Err(AgentError::Backend("runtime disappeared".to_owned())),
+            )
+            .await;
+            return;
+        };
+        match managed.prompt(to_prompt(content)).await {
+            Ok(managed_turn) => {
+                self.attach_turn(turn_id.to_owned(), managed_turn);
+            }
+            Err(error) => self.finish_turn(turn_id, Err(error)).await,
+        }
+    }
+
+    async fn refresh_runtime_policy(&mut self) -> Result<(), AgentError> {
+        let Some(policy) = self.policy.get().cloned() else {
+            return Ok(());
+        };
+        let owner_client_id = self.owner_client_id.clone();
+        let agent_id = self.id.clone();
+        let identity = tokio::task::spawn_blocking(move || {
+            policy.agent_for_runtime(&owner_client_id, &agent_id)
+        })
+        .await
+        .map_err(|error| AgentError::Backend(format!("policy worker stopped: {error}")))?
+        .map_err(|error| AgentError::Backend(format!("runtime policy unavailable: {error}")))?;
+        let capabilities = identity.principal.permissions;
+        let secret_revision = identity.principal.secret_revision;
+        if self.capabilities != capabilities || self.secret_revision != secret_revision {
+            self.capabilities = capabilities;
+            self.secret_revision = secret_revision;
+            self.runtime.take();
+            self.runtime_policy_dirty = false;
+        }
+        Ok(())
     }
 
     async fn steer_active(
@@ -1063,6 +1303,8 @@ impl AgentActor {
         prompt: Prompt,
         content: Vec<ContentBlock>,
         idempotency_key: Option<String>,
+        request_hash: Vec<u8>,
+        payment_receipt: Option<String>,
     ) -> Result<Option<TurnActionResponse>, ManagerError> {
         let Some(active_id) = self.active_turn.clone() else {
             return Ok(None);
@@ -1074,6 +1316,28 @@ impl AgentActor {
         else {
             return Ok(None);
         };
+        let response = TurnActionResponse {
+            action: TurnAction::Steered,
+            turn_id: active_id.clone(),
+            state: TurnStatus::Running,
+        };
+        let ordinal = self
+            .sessions
+            .record_steer(
+                self.id.clone(),
+                active_id.clone(),
+                SteerRequestRecord {
+                    content: content.clone(),
+                    response: response.clone(),
+                    idempotency_key: idempotency_key.clone(),
+                    request_hash,
+                    payment_receipt,
+                },
+            )
+            .await?;
+        if let Some(turn) = self.turns.get_mut(&active_id) {
+            turn.inputs.push(content.clone());
+        }
         match control.steer(prompt).await {
             Ok(()) => {
                 tracing::info!(
@@ -1083,32 +1347,45 @@ impl AgentActor {
                     content = ?content,
                     "managed steering input observed"
                 );
-                let response = TurnActionResponse {
-                    action: TurnAction::Steered,
-                    turn_id: active_id.clone(),
-                    state: TurnStatus::Running,
-                };
-                self.sessions
-                    .record_steer(
-                        self.id.clone(),
-                        active_id.clone(),
-                        content.clone(),
-                        response.clone(),
-                        idempotency_key.clone(),
-                    )
-                    .await?;
-                if let Some(turn) = self.turns.get_mut(&active_id) {
-                    turn.inputs.push(content);
-                }
                 Ok(Some(response))
             }
             Err(AgentError::TurnNotSteerable) => {
+                self.undo_steer(&active_id, ordinal, idempotency_key)
+                    .await?;
                 self.active_turn = None;
                 Ok(None)
             }
-            Err(AgentError::SteerQueueFull) => Err(ManagerError::SteerQueueFull),
-            Err(error) => Err(error.into()),
+            Err(AgentError::SteerQueueFull) => {
+                self.undo_steer(&active_id, ordinal, idempotency_key)
+                    .await?;
+                Err(ManagerError::SteerQueueFull)
+            }
+            Err(error) => {
+                self.undo_steer(&active_id, ordinal, idempotency_key)
+                    .await?;
+                Err(error.into())
+            }
         }
+    }
+
+    async fn undo_steer(
+        &mut self,
+        turn_id: &str,
+        ordinal: i64,
+        idempotency_key: Option<String>,
+    ) -> Result<(), ManagerError> {
+        self.sessions
+            .undo_steer(
+                self.id.clone(),
+                turn_id.to_owned(),
+                ordinal,
+                idempotency_key,
+            )
+            .await?;
+        if let Some(turn) = self.turns.get_mut(turn_id) {
+            turn.inputs.pop();
+        }
+        Ok(())
     }
 
     async fn cancel(&mut self, turn_id: &str) -> Result<bool, ManagerError> {
@@ -1118,25 +1395,35 @@ impl AgentActor {
             turn_id = %turn_id,
             "managed cancellation observed"
         );
-        let control = self
+        let Some(turn) = self
             .turns
             .get(turn_id)
             .filter(|turn| !turn.view.state.is_terminal())
-            .and_then(|turn| turn.control.as_ref().map(Arc::clone))
-            .ok_or(ManagerError::NotFound)?;
-        match control.cancel().await {
-            Ok(()) => {
-                self.cancel_requested.insert(turn_id.to_owned());
-                let event = self
-                    .sessions
-                    .request_cancel(self.id.clone(), turn_id.to_owned())
-                    .await?;
-                self.publish(event);
-                Ok(true)
+        else {
+            return Err(ManagerError::NotFound);
+        };
+        let queued = turn.view.state == TurnStatus::Queued;
+        let control = turn.control.as_ref().map(Arc::clone);
+        let event = self
+            .sessions
+            .request_cancel(self.id.clone(), turn_id.to_owned())
+            .await?;
+        self.cancel_requested.insert(turn_id.to_owned());
+        self.publish(event);
+        if queued || control.is_none() {
+            if self.active_turn.as_deref() == Some(turn_id) {
+                self.runtime.take();
             }
-            Err(AgentError::TurnNotCancellable) => Ok(false),
-            Err(error) => Err(error.into()),
+            self.finish_turn(turn_id, Err(AgentError::TurnNotCancellable))
+                .await;
+            return Ok(true);
         }
+        if let Some(control) = control
+            && let Err(error) = control.cancel().await
+        {
+            tracing::warn!(agent_id = self.id, turn_id, %error, "durable cancellation could not reach live control");
+        }
+        Ok(true)
     }
 
     async fn ensure_runtime(&mut self) -> Result<(), AgentError> {
@@ -1173,11 +1460,7 @@ impl AgentActor {
                 }
                 let ready = batch;
                 batch = Vec::with_capacity(RUNTIME_EVENT_BATCH_SIZE);
-                if sender
-                    .send(AgentCommand::RuntimeEvents(ready))
-                    .await
-                    .is_err()
-                {
+                if !sender.send(AgentCommand::RuntimeEvents(ready)).await {
                     return;
                 }
             }
@@ -1240,21 +1523,40 @@ impl AgentActor {
                 )
             }
         };
+        let completed = CompletedTurn {
+            status,
+            output,
+            error,
+            completed_at,
+            snapshot,
+            usage,
+            event: payload,
+        };
+        let Some(turn) = self.turns.get_mut(turn_id) else {
+            tracing::warn!(
+                agent_id = self.id,
+                turn_id,
+                "completion targeted an unknown turn"
+            );
+            return;
+        };
+        turn.control = None;
+        turn.pending_completion = Some(completed);
+        self.persist_completion(turn_id).await;
+    }
+
+    async fn persist_completion(&mut self, turn_id: &str) {
+        let Some(completed) = self
+            .turns
+            .get(turn_id)
+            .and_then(|turn| turn.pending_completion.clone())
+        else {
+            return;
+        };
+        let status = completed.status;
         match self
             .sessions
-            .finish_turn(
-                self.id.clone(),
-                turn_id.to_owned(),
-                CompletedTurn {
-                    status,
-                    output,
-                    error,
-                    completed_at,
-                    snapshot,
-                    usage,
-                    event: payload,
-                },
-            )
+            .finish_turn(self.id.clone(), turn_id.to_owned(), completed)
             .await
         {
             Ok(finished) => {
@@ -1264,7 +1566,13 @@ impl AgentActor {
                 self.publish(finished.event);
             }
             Err(error) => {
-                tracing::error!(agent_id = self.id, turn_id, %error, "failed to persist terminal turn");
+                tracing::error!(agent_id = self.id, turn_id, %error, "failed to persist terminal turn; retrying");
+                self.schedule_command(
+                    AgentCommand::RetryFinish {
+                        turn_id: turn_id.to_owned(),
+                    },
+                    std::time::Duration::from_millis(250),
+                );
                 return;
             }
         }
@@ -1273,27 +1581,50 @@ impl AgentActor {
         self.advance_after(turn_id).await;
     }
 
-    async fn handle_runtime_events(&mut self, events: Vec<NativeAgentEvent>) {
-        let events = events
-            .into_iter()
-            .map(|event| {
-                tracing::info!(
-                    target: "nanocentaur::observed",
-                    agent_id = %self.id,
-                    event = ?event,
-                    "native runtime event observed"
-                );
-                (None, AgentEventPayload::Runtime { event })
-            })
-            .collect();
-        match self.sessions.append_events(self.id.clone(), events).await {
-            Ok(events) => {
-                for event in events {
-                    self.publish(event);
+    async fn flush_runtime_events(&mut self) {
+        while !self.pending_runtime_events.is_empty() {
+            let ready = self
+                .pending_runtime_events
+                .drain(
+                    ..self
+                        .pending_runtime_events
+                        .len()
+                        .min(RUNTIME_EVENT_BATCH_SIZE),
+                )
+                .collect::<Vec<_>>();
+            let events = ready
+                .iter()
+                .cloned()
+                .map(|event| {
+                    tracing::info!(
+                        target: "nanocentaur::observed",
+                        agent_id = %self.id,
+                        event = ?event,
+                        "native runtime event observed"
+                    );
+                    (None, AgentEventPayload::Runtime { event })
+                })
+                .collect();
+            match self.sessions.append_events(self.id.clone(), events).await {
+                Ok(events) => {
+                    for event in events {
+                        self.publish(event);
+                    }
                 }
-            }
-            Err(error) => {
-                tracing::error!(agent_id = self.id, %error, "failed to persist runtime events");
+                Err(error) => {
+                    for event in ready.into_iter().rev() {
+                        self.pending_runtime_events.push_front(event);
+                    }
+                    tracing::error!(agent_id = self.id, %error, "failed to persist runtime events; retrying");
+                    if !self.runtime_event_retry_scheduled {
+                        self.runtime_event_retry_scheduled = true;
+                        self.schedule_command(
+                            AgentCommand::RetryRuntimeEvents,
+                            std::time::Duration::from_millis(250),
+                        );
+                    }
+                    return;
+                }
             }
         }
     }
@@ -1309,6 +1640,10 @@ impl AgentActor {
                 .map(|_| id.clone())
         });
         if let Some(next) = next {
+            if self.runtime_policy_dirty {
+                self.runtime.take();
+                self.runtime_policy_dirty = false;
+            }
             match self
                 .sessions
                 .mark_started(self.id.clone(), next.clone())
@@ -1320,9 +1655,16 @@ impl AgentActor {
                         turn.view.state = TurnStatus::Running;
                     }
                     self.publish(event);
+                    Box::pin(self.start_turn(&next)).await;
                 }
                 Err(error) => {
-                    tracing::error!(agent_id = self.id, turn_id = next, %error, "failed to persist queued turn start");
+                    tracing::error!(agent_id = self.id, turn_id = next, %error, "failed to persist queued turn start; retrying");
+                    self.schedule_command(
+                        AgentCommand::RetryAdvance {
+                            completed_turn_id: completed_turn_id.to_owned(),
+                        },
+                        std::time::Duration::from_millis(250),
+                    );
                 }
             }
         } else {
@@ -1344,10 +1686,22 @@ impl AgentActor {
         let _ = self.event_sender.send(event);
     }
 
-    fn attach_turn(&mut self, turn_id: String, managed_turn: crate::ManagedTurn) {
-        if let Some(turn) = self.turns.get_mut(&turn_id) {
+    fn schedule_command(&self, command: AgentCommand, delay: std::time::Duration) {
+        let sender = self.self_sender.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(delay).await;
+            let _ = sender.send(command).await;
+        });
+    }
+
+    fn attach_turn(&mut self, turn_id: String, managed_turn: crate::ManagedTurn) -> u64 {
+        let generation = if let Some(turn) = self.turns.get_mut(&turn_id) {
+            turn.generation = turn.generation.wrapping_add(1);
             turn.control = Some(managed_turn.control());
-        }
+            turn.generation
+        } else {
+            return 0;
+        };
         let sender = self.self_sender.clone();
         let span = tracing::info_span!(
             parent: &tracing::Span::current(),
@@ -1358,82 +1712,119 @@ impl AgentActor {
         tokio::spawn(
             async move {
                 let result = managed_turn.result().await;
-                drop(
-                    sender
-                        .send(AgentCommand::TurnFinished {
-                            turn_id,
-                            result: Box::new(result),
-                        })
-                        .await,
-                );
+                let _ = sender
+                    .send(AgentCommand::TurnFinished {
+                        turn_id,
+                        generation,
+                        result: Box::new(result),
+                    })
+                    .await;
             }
             .instrument(span),
         );
+        generation
+    }
+
+    fn invalidate_attempt(&mut self, turn_id: &str, generation: u64) {
+        if let Some(turn) = self
+            .turns
+            .get_mut(turn_id)
+            .filter(|turn| turn.generation == generation)
+        {
+            turn.generation = turn.generation.wrapping_add(1);
+            turn.control = None;
+        }
+        self.runtime.take();
     }
 
     async fn recover_pending(&mut self) -> Result<(), ManagerError> {
-        let pending = self
+        let turn_id = self
             .turn_order
             .iter()
-            .filter(|turn_id| {
+            .find(|turn_id| {
                 self.turns
                     .get(*turn_id)
                     .is_some_and(|turn| !turn.view.state.is_terminal())
             })
-            .cloned()
-            .collect::<Vec<_>>();
-        if pending.is_empty() {
+            .cloned();
+        let Some(turn_id) = turn_id else {
+            return Ok(());
+        };
+        self.active_turn = Some(turn_id.clone());
+        if let Some(turn) = self.turns.get_mut(&turn_id) {
+            turn.view.state = TurnStatus::Running;
+        }
+        let event = self
+            .sessions
+            .mark_started(self.id.clone(), turn_id.clone())
+            .await?;
+        self.publish(event);
+        if self.cancel_requested.contains(&turn_id) {
+            self.finish_turn(&turn_id, Err(AgentError::TurnNotCancellable))
+                .await;
             return Ok(());
         }
-        self.ensure_runtime().await?;
-        let managed = self
-            .runtime
-            .as_ref()
-            .map(|runtime| Arc::clone(&runtime.agent))
-            .ok_or_else(|| AgentError::Backend("runtime disappeared".to_owned()))?;
-        let mut started = false;
-        for turn_id in pending {
-            if self.cancel_requested.contains(&turn_id) {
-                self.finish_turn(&turn_id, Err(AgentError::TurnNotCancellable))
-                    .await;
-                continue;
-            }
-            let inputs = self
-                .turns
-                .get(&turn_id)
-                .map(|turn| turn.inputs.clone())
-                .ok_or(ManagerError::NotFound)?;
-            let Some(first) = inputs.first().cloned() else {
-                self.finish_turn(
-                    &turn_id,
-                    Err(AgentError::Backend(
-                        "durable turn has no input content".to_owned(),
-                    )),
-                )
-                .await;
-                continue;
+        let inputs = self
+            .turns
+            .get(&turn_id)
+            .map(|turn| turn.inputs.clone())
+            .ok_or(ManagerError::NotFound)?;
+        let Some(first) = inputs.first().cloned() else {
+            self.finish_turn(
+                &turn_id,
+                Err(AgentError::Backend(
+                    "durable turn has no input content".to_owned(),
+                )),
+            )
+            .await;
+            return Ok(());
+        };
+        self.refresh_runtime_policy().await?;
+        for recovery_attempt in 1..=3 {
+            self.ensure_runtime().await?;
+            let managed = self
+                .runtime
+                .as_ref()
+                .map(|runtime| Arc::clone(&runtime.agent))
+                .ok_or_else(|| AgentError::Backend("runtime disappeared".to_owned()))?;
+            let managed_turn = match managed.prompt(to_prompt(first.clone())).await {
+                Ok(managed_turn) => managed_turn,
+                Err(error) => {
+                    self.finish_turn(&turn_id, Err(error)).await;
+                    return Ok(());
+                }
             };
-            if !started {
-                started = true;
-                self.active_turn = Some(turn_id.clone());
-                if let Some(turn) = self.turns.get_mut(&turn_id) {
-                    turn.view.state = TurnStatus::Running;
-                }
-                let event = self
-                    .sessions
-                    .mark_started(self.id.clone(), turn_id.clone())
-                    .await?;
-                self.publish(event);
-            }
-            match managed.prompt(to_prompt(first)).await {
-                Ok(managed_turn) => {
-                    for steer in inputs.iter().skip(1).cloned() {
-                        managed_turn.control().steer(to_prompt(steer)).await?;
+            let control = managed_turn.control();
+            let generation = self.attach_turn(turn_id.clone(), managed_turn);
+            let mut replay_error = None;
+            for steer in inputs.iter().skip(1) {
+                let mut retries = 0_u16;
+                loop {
+                    match control.steer(to_prompt(steer.clone())).await {
+                        Ok(()) => break,
+                        Err(AgentError::TurnNotSteerable) if retries < 1_000 => {
+                            retries += 1;
+                            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                        }
+                        Err(error) => {
+                            replay_error = Some(error);
+                            break;
+                        }
                     }
-                    self.attach_turn(turn_id, managed_turn);
                 }
-                Err(error) => self.finish_turn(&turn_id, Err(error)).await,
+                if replay_error.is_some() {
+                    break;
+                }
             }
+            let Some(error) = replay_error else {
+                return Ok(());
+            };
+            self.invalidate_attempt(&turn_id, generation);
+            if recovery_attempt == 3 {
+                self.finish_turn(&turn_id, Err(error)).await;
+                return Ok(());
+            }
+            tracing::warn!(agent_id = self.id, turn_id, recovery_attempt, %error, "retrying incomplete durable steer replay");
         }
         Ok(())
     }
@@ -1566,6 +1957,10 @@ fn validate_content(content: &[ContentBlock]) -> Result<(), ManagerError> {
     Ok(())
 }
 
+pub(crate) fn validate_turn_request(request: &CreateTurn) -> Result<(), ManagerError> {
+    validate_content(&request.content)
+}
+
 fn validate_idempotency_key(value: Option<&str>) -> Result<(), ManagerError> {
     if value.is_some_and(|value| value.is_empty() || value.len() > MAX_IDEMPOTENCY_KEY_BYTES) {
         Err(ManagerError::Invalid(
@@ -1574,6 +1969,12 @@ fn validate_idempotency_key(value: Option<&str>) -> Result<(), ManagerError> {
     } else {
         Ok(())
     }
+}
+
+fn request_hash(request: &CreateTurn) -> Result<Vec<u8>, ManagerError> {
+    let encoded = serde_json::to_vec(request)
+        .map_err(|_| ManagerError::Invalid("turn request must be valid JSON"))?;
+    Ok(Sha256::digest(encoded).to_vec())
 }
 
 #[derive(Debug, Error)]
@@ -1588,6 +1989,9 @@ pub enum ManagerError {
     /// The active turn cannot accept additional steering immediately.
     #[error("the active turn's steering queue is full")]
     SteerQueueFull,
+    /// An idempotency key was reused for a different normalized request.
+    #[error("the idempotency key belongs to a different request")]
+    IdempotencyConflict,
     /// Forking requires an idle source.
     #[error("agent must be idle before it can be forked")]
     AgentBusy,
@@ -1609,6 +2013,7 @@ impl From<SessionError> for ManagerError {
     fn from(error: SessionError) -> Self {
         match error {
             SessionError::ForkBoundaryNotFound => Self::ForkBoundaryNotFound,
+            SessionError::Deleted => Self::NotFound,
             error => Self::Durability(error.to_string()),
         }
     }
@@ -1627,13 +2032,55 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::{AgentConfig, EffectivePrincipal, ManagedTurn, MockAgentFactory, SpawnedAgent};
+    use crate::{
+        AgentConfig, CapabilityName, CreatePermission, EffectivePrincipal, ManagedTurn,
+        MockAgentFactory, SpawnedAgent,
+    };
 
     struct SilentFactory;
 
     struct SilentAgent;
 
     struct SilentTurnControl;
+
+    struct RejectingReplayFactory;
+
+    struct RejectingReplayAgent;
+
+    struct RejectingReplayControl;
+
+    #[async_trait]
+    impl ManagedAgentFactory for RejectingReplayFactory {
+        async fn create(&self, _spec: AgentSpec) -> Result<SpawnedAgent, AgentError> {
+            let (_sender, receiver) = mpsc::channel(1);
+            Ok(SpawnedAgent::new(Arc::new(RejectingReplayAgent), receiver))
+        }
+    }
+
+    #[async_trait]
+    impl ManagedAgent for RejectingReplayAgent {
+        async fn prompt(&self, _prompt: Prompt) -> Result<ManagedTurn, AgentError> {
+            Ok(ManagedTurn::new(
+                Arc::new(RejectingReplayControl),
+                std::future::ready(Ok(AgentRunResult::new(
+                    "incomplete recovery",
+                    None,
+                    TurnUsage::default(),
+                ))),
+            ))
+        }
+    }
+
+    #[async_trait]
+    impl ManagedTurnControl for RejectingReplayControl {
+        async fn steer(&self, _prompt: Prompt) -> Result<(), AgentError> {
+            Err(AgentError::Backend("replay rejected".to_owned()))
+        }
+
+        async fn cancel(&self) -> Result<(), AgentError> {
+            Err(AgentError::TurnNotCancellable)
+        }
+    }
 
     #[async_trait]
     impl ManagedAgentFactory for SilentFactory {
@@ -1737,6 +2184,53 @@ mod tests {
         .unwrap()
     }
 
+    struct RecordingFactory {
+        inner: MockAgentFactory,
+        capabilities: Arc<tokio::sync::Mutex<Vec<AgentCapabilities>>>,
+    }
+
+    struct DropFactory {
+        token: Arc<()>,
+    }
+
+    struct DropAgent {
+        _token: Arc<()>,
+    }
+
+    #[async_trait]
+    impl ManagedAgentFactory for DropFactory {
+        async fn create(&self, _spec: AgentSpec) -> Result<SpawnedAgent, AgentError> {
+            let (_sender, receiver) = mpsc::channel(1);
+            Ok(SpawnedAgent::new(
+                Arc::new(DropAgent {
+                    _token: Arc::clone(&self.token),
+                }),
+                receiver,
+            ))
+        }
+    }
+
+    #[async_trait]
+    impl ManagedAgent for DropAgent {
+        async fn prompt(&self, _prompt: Prompt) -> Result<ManagedTurn, AgentError> {
+            Ok(ManagedTurn::new(
+                Arc::new(SilentTurnControl),
+                std::future::pending(),
+            ))
+        }
+    }
+
+    #[async_trait]
+    impl ManagedAgentFactory for RecordingFactory {
+        async fn create(&self, spec: AgentSpec) -> Result<SpawnedAgent, AgentError> {
+            self.capabilities
+                .lock()
+                .await
+                .push(spec.capabilities.clone());
+            self.inner.create(spec).await
+        }
+    }
+
     #[tokio::test]
     async fn agent_actor_owns_one_ordered_typed_event_stream() {
         let directory = tempfile::tempdir().unwrap();
@@ -1780,6 +2274,195 @@ mod tests {
             }
         }
         assert!(saw_runtime);
+    }
+
+    #[tokio::test]
+    async fn steered_interrupted_turn_replays_all_inputs_after_restart() {
+        let directory = tempfile::tempdir().unwrap();
+        let identity = identity("steered-restart");
+        let manager = AgentManager::new(
+            Arc::new(MockAgentFactory::new(Duration::from_millis(250))),
+            directory.path(),
+        )
+        .unwrap();
+        manager.register(identity.clone()).await.unwrap();
+        let started = manager
+            .create_turn(identity.clone(), turn("first"), Some("first".to_owned()))
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let steered = manager
+            .create_turn(identity.clone(), turn("second"), Some("second".to_owned()))
+            .await
+            .unwrap();
+        assert_eq!(steered.action, TurnAction::Steered);
+        assert_eq!(steered.turn_id, started.turn_id);
+        manager.shutdown().await.unwrap();
+        drop(manager);
+
+        let restarted = AgentManager::new(
+            Arc::new(MockAgentFactory::new(Duration::from_millis(25))),
+            directory.path(),
+        )
+        .unwrap();
+        restarted.register(identity.clone()).await.unwrap();
+        let completed = wait_for_completed(&restarted, identity, &started.turn_id).await;
+        assert_eq!(completed.state, TurnStatus::Completed);
+    }
+
+    #[tokio::test]
+    async fn stale_completion_cannot_commit_after_steer_replay_is_rejected() {
+        let directory = tempfile::tempdir().unwrap();
+        let identity = identity("rejected-steer-replay");
+        let manager = AgentManager::new(
+            Arc::new(MockAgentFactory::new(Duration::from_millis(250))),
+            directory.path(),
+        )
+        .unwrap();
+        manager.register(identity.clone()).await.unwrap();
+        let started = manager
+            .create_turn(identity.clone(), turn("first"), Some("first".to_owned()))
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        manager
+            .create_turn(identity.clone(), turn("second"), Some("second".to_owned()))
+            .await
+            .unwrap();
+        manager.shutdown().await.unwrap();
+        drop(manager);
+
+        let restarted =
+            AgentManager::new(Arc::new(RejectingReplayFactory), directory.path()).unwrap();
+        restarted.register(identity.clone()).await.unwrap();
+        let failed = wait_for_completed(&restarted, identity, &started.turn_id).await;
+        assert_eq!(failed.state, TurnStatus::Failed);
+        assert!(failed.output.is_empty());
+    }
+
+    #[tokio::test]
+    async fn terminal_result_is_retained_until_sqlite_recovers() {
+        let directory = tempfile::tempdir().unwrap();
+        let identity = identity("terminal-retry");
+        let manager = AgentManager::new(
+            Arc::new(MockAgentFactory::new(Duration::from_millis(5))),
+            directory.path(),
+        )
+        .unwrap();
+        manager.register(identity.clone()).await.unwrap();
+        let connection =
+            rusqlite::Connection::open(directory.path().join("sessions.sqlite")).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TRIGGER reject_terminal_update
+                 BEFORE UPDATE OF state ON turns
+                 WHEN NEW.state IN ('completed', 'failed', 'cancelled')
+                 BEGIN SELECT RAISE(FAIL, 'injected terminal failure'); END;",
+            )
+            .unwrap();
+        let response = manager
+            .create_turn(identity.clone(), turn("persist eventually"), None)
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            manager
+                .get_turn(identity.clone(), &response.turn_id)
+                .await
+                .unwrap()
+                .state,
+            TurnStatus::Running
+        );
+        connection
+            .execute_batch("DROP TRIGGER reject_terminal_update")
+            .unwrap();
+        let completed = wait_for_completed(&manager, identity, &response.turn_id).await;
+        assert_eq!(completed.state, TurnStatus::Completed);
+    }
+
+    #[tokio::test]
+    async fn capability_rotation_happens_before_post_revocation_queue_work() {
+        let directory = tempfile::tempdir().unwrap();
+        let observed = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let policy = Arc::new(PolicyStore::in_memory().unwrap());
+        policy
+            .bootstrap(
+                "client",
+                "Client",
+                "key",
+                "principal",
+                [CapabilityName::new("network.old").unwrap()],
+            )
+            .unwrap();
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("x-api-key", axum::http::HeaderValue::from_static("key"));
+        let client = policy.authenticate(&headers).unwrap();
+        let (old_identity, _) = policy
+            .create_or_resolve_agent(&client, Some("capability-rotation"))
+            .unwrap();
+        let manager = AgentManager::new(
+            Arc::new(RecordingFactory {
+                inner: MockAgentFactory::new(Duration::from_millis(75)),
+                capabilities: Arc::clone(&observed),
+            }),
+            directory.path(),
+        )
+        .unwrap();
+        manager.attach_policy(Arc::clone(&policy));
+        manager.register(old_identity.clone()).await.unwrap();
+        let first = manager
+            .create_turn(old_identity.clone(), turn("first"), None)
+            .await
+            .unwrap();
+        let mut queued = turn("after revoke");
+        queued.delivery = TurnDelivery::Enqueue;
+        let second = manager
+            .create_turn(old_identity.clone(), queued, None)
+            .await
+            .unwrap();
+        assert_eq!(second.action, TurnAction::Queued);
+        policy
+            .set_principal_permission("principal", "network.old", false)
+            .unwrap();
+        let new_permission = policy
+            .create_permission(CreatePermission {
+                id: Some("network.new".to_owned()),
+                name: "network.new".to_owned(),
+                description: None,
+            })
+            .unwrap();
+        policy
+            .set_principal_permission("principal", &new_permission.id, true)
+            .unwrap();
+        wait_for_completed(&manager, old_identity.clone(), &first.turn_id).await;
+        wait_for_completed(&manager, old_identity, &second.turn_id).await;
+        let observed = observed.lock().await;
+        assert_eq!(observed.len(), 2);
+        assert!(observed[0].contains("network.old"));
+        assert!(observed[1].contains("network.new"));
+        assert!(!observed[1].contains("network.old"));
+    }
+
+    #[tokio::test]
+    async fn dropping_the_manager_releases_live_actor_runtime_ownership() {
+        let directory = tempfile::tempdir().unwrap();
+        let token = Arc::new(());
+        let token_weak = Arc::downgrade(&token);
+        let manager = AgentManager::new(Arc::new(DropFactory { token }), directory.path()).unwrap();
+        let identity = identity("drop-manager");
+        manager.register(identity.clone()).await.unwrap();
+        manager
+            .create_turn(identity, turn("stay pending"), None)
+            .await
+            .unwrap();
+        drop(manager);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while token_weak.upgrade().is_some() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
     }
 
     #[tokio::test]
@@ -1917,7 +2600,7 @@ mod tests {
         assert_eq!(restored.usage.as_ref(), Some(&completed_usage));
         assert_eq!(
             restarted
-                .find_turn_by_idempotency_key(identity.clone(), "request-1")
+                .find_turn_by_idempotency_key(identity.clone(), "request-1", &turn("persist me"),)
                 .await
                 .unwrap()
                 .unwrap()

--- a/crates/experimental/nanocentaur/src/mock.rs
+++ b/crates/experimental/nanocentaur/src/mock.rs
@@ -1,0 +1,196 @@
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use nanocodex_agent::{
+    TurnUsage,
+    events::{AgentEvent, AgentEventKind},
+    input::Prompt,
+};
+use serde::Serialize;
+use serde_json::value::to_raw_value;
+use tokio::sync::{Mutex, mpsc};
+
+use crate::{
+    AgentError, AgentRunResult, AgentSpec, ManagedAgent, ManagedAgentFactory, ManagedTurn,
+    ManagedTurnControl, SpawnedAgent,
+};
+
+const MOCK_EVENT_CAPACITY: usize = 256;
+
+/// Deterministic harness used by API tests and the no-model-cost concurrency
+/// benchmark. It models Nanocodex's per-agent FIFO and exact active-turn
+/// steering behavior.
+pub struct MockAgentFactory {
+    delay: Duration,
+    usage: TurnUsage,
+}
+
+impl MockAgentFactory {
+    /// Creates a deterministic backend with one fixed completion delay.
+    #[must_use]
+    pub fn new(delay: Duration) -> Self {
+        Self {
+            delay,
+            usage: TurnUsage::default(),
+        }
+    }
+
+    /// Replaces the deterministic usage returned by every mock turn.
+    #[must_use]
+    pub fn usage(mut self, usage: TurnUsage) -> Self {
+        self.usage = usage;
+        self
+    }
+}
+
+#[async_trait]
+impl ManagedAgentFactory for MockAgentFactory {
+    async fn create(&self, spec: AgentSpec) -> Result<SpawnedAgent, AgentError> {
+        let (sender, events) = mpsc::channel(MOCK_EVENT_CAPACITY);
+        Ok(SpawnedAgent::new(
+            Arc::new(MockAgent {
+                id: spec.agent_id,
+                delay: self.delay,
+                sender,
+                serial: Arc::new(Mutex::new(())),
+                next_event: Arc::new(AtomicU64::new(1)),
+                usage: self.usage.clone(),
+            }),
+            events,
+        ))
+    }
+}
+
+struct MockAgent {
+    id: String,
+    delay: Duration,
+    sender: mpsc::Sender<AgentEvent>,
+    serial: Arc<Mutex<()>>,
+    next_event: Arc<AtomicU64>,
+    usage: TurnUsage,
+}
+
+#[async_trait]
+impl ManagedAgent for MockAgent {
+    async fn prompt(&self, prompt: Prompt) -> Result<ManagedTurn, AgentError> {
+        let control = Arc::new(MockTurnControl {
+            state: AtomicU8::new(0),
+            cancelled: AtomicBool::new(false),
+            sender: self.sender.clone(),
+            next_event: Arc::clone(&self.next_event),
+        });
+        let run_control = Arc::clone(&control);
+        let serial = Arc::clone(&self.serial);
+        let sender = self.sender.clone();
+        let delay = self.delay;
+        let id = self.id.clone();
+        let usage = self.usage.clone();
+        Ok(ManagedTurn::new(control, async move {
+            let _serial = serial.lock().await;
+            run_control.state.store(1, Ordering::Release);
+            let _ = sender
+                .send(runtime_event(
+                    &run_control.next_event,
+                    AgentEventKind::RunStarted,
+                    EmptyPayload {},
+                ))
+                .await;
+            tokio::time::sleep(delay).await;
+            if run_control.cancelled.load(Ordering::Acquire) {
+                let _ = sender
+                    .send(runtime_event(
+                        &run_control.next_event,
+                        AgentEventKind::RunFailed,
+                        EmptyPayload {},
+                    ))
+                    .await;
+                run_control.state.store(2, Ordering::Release);
+                return Err(AgentError::TurnNotCancellable);
+            }
+            drop(prompt);
+            let final_message = format!("mock agent {id} completed");
+            let _ = sender
+                .send(runtime_event(
+                    &run_control.next_event,
+                    AgentEventKind::AssistantMessage,
+                    AssistantPayload {
+                        content: final_message.clone(),
+                    },
+                ))
+                .await;
+            let _ = sender
+                .send(runtime_event(
+                    &run_control.next_event,
+                    AgentEventKind::RunCompleted,
+                    EmptyPayload {},
+                ))
+                .await;
+            run_control.state.store(2, Ordering::Release);
+            Ok(AgentRunResult::new(final_message, None, usage))
+        }))
+    }
+}
+
+struct MockTurnControl {
+    state: AtomicU8,
+    cancelled: AtomicBool,
+    sender: mpsc::Sender<AgentEvent>,
+    next_event: Arc<AtomicU64>,
+}
+
+#[async_trait]
+impl ManagedTurnControl for MockTurnControl {
+    async fn steer(&self, prompt: Prompt) -> Result<(), AgentError> {
+        if self.state.load(Ordering::Acquire) != 1 {
+            return Err(AgentError::TurnNotSteerable);
+        }
+        drop(prompt);
+        let _ = self
+            .sender
+            .send(runtime_event(
+                &self.next_event,
+                AgentEventKind::RunSteered,
+                EmptyPayload {},
+            ))
+            .await;
+        Ok(())
+    }
+
+    async fn cancel(&self) -> Result<(), AgentError> {
+        if self.state.load(Ordering::Acquire) == 2 {
+            return Err(AgentError::TurnNotCancellable);
+        }
+        self.cancelled.store(true, Ordering::Release);
+        Ok(())
+    }
+}
+
+#[derive(Serialize)]
+struct EmptyPayload {}
+
+#[derive(Serialize)]
+struct AssistantPayload {
+    content: String,
+}
+
+fn runtime_event(
+    next_event: &AtomicU64,
+    kind: AgentEventKind,
+    payload: impl Serialize,
+) -> AgentEvent {
+    AgentEvent {
+        protocol_version: 1,
+        request_id: Arc::from("mock"),
+        seq: next_event.fetch_add(1, Ordering::Relaxed),
+        kind,
+        payload: to_raw_value(&payload)
+            .expect("mock event payload is serializable")
+            .into(),
+    }
+}

--- a/crates/experimental/nanocentaur/src/payment.rs
+++ b/crates/experimental/nanocentaur/src/payment.rs
@@ -1,0 +1,84 @@
+use async_trait::async_trait;
+use axum::http::HeaderMap;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Successful MPP proof returned to the client with a paid mutation.
+#[derive(Clone, Debug)]
+pub struct PaymentReceipt {
+    /// Receipt value returned in the configured response header.
+    pub header_value: String,
+}
+
+/// Body returned for a successful payment-protocol management request.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PaymentManagementResponse {
+    /// Management operation status.
+    pub status: PaymentManagementStatus,
+}
+
+/// Result of a payment-protocol management request.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PaymentManagementStatus {
+    /// The management request completed.
+    Ok,
+}
+
+/// A payment request is either billable application traffic, a protocol
+/// management message, or missing a credential and therefore challenged.
+#[derive(Clone, Debug)]
+pub enum PaymentOutcome {
+    /// Application traffic was authorized and may mutate state.
+    Authorized(PaymentReceipt),
+    /// The caller must satisfy the returned payment challenge.
+    Challenge {
+        /// Complete `WWW-Authenticate` challenge value.
+        www_authenticate: String,
+    },
+    /// A protocol management message completed without application mutation.
+    Management {
+        /// Management response body.
+        body: PaymentManagementResponse,
+        /// Receipt returned with the management response.
+        receipt: PaymentReceipt,
+    },
+}
+
+/// Ingress payment authorization boundary.
+#[async_trait]
+pub trait PaymentGate: Send + Sync {
+    /// Classifies and verifies one request from its headers.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed configuration or credential verification failure.
+    async fn authorize(&self, headers: &HeaderMap) -> Result<PaymentOutcome, PaymentError>;
+}
+
+/// Development/test gate. Production starts with an MPP gate in the binary.
+pub struct FreePaymentGate;
+
+#[async_trait]
+impl PaymentGate for FreePaymentGate {
+    async fn authorize(&self, _headers: &HeaderMap) -> Result<PaymentOutcome, PaymentError> {
+        Ok(PaymentOutcome::Authorized(PaymentReceipt {
+            header_value: "free-development-mode".to_owned(),
+        }))
+    }
+}
+
+#[derive(Debug, Error)]
+/// Ingress payment authorization failure.
+pub enum PaymentError {
+    /// The credential was absent, malformed, or invalid.
+    #[error("invalid payment credential")]
+    InvalidCredential,
+    /// Server-side payment policy was invalid.
+    #[error("payment configuration failed: {0}")]
+    Configuration(String),
+    /// Payment verification failed.
+    #[error("payment verification failed: {0}")]
+    Verification(String),
+}

--- a/crates/experimental/nanocentaur/src/policy.rs
+++ b/crates/experimental/nanocentaur/src/policy.rs
@@ -477,6 +477,7 @@ impl PolicyStore {
                 context_key TEXT,
                 principal_id TEXT NOT NULL REFERENCES principals(id),
                 agent_config_json TEXT NOT NULL,
+                lifecycle_state TEXT NOT NULL DEFAULT 'active',
                 created_at TEXT NOT NULL,
                 UNIQUE(owner_client_id, context_key)
             );
@@ -492,6 +493,7 @@ impl PolicyStore {
             );
             ",
         )?;
+        ensure_agent_lifecycle_column(&connection)?;
         Ok(Self {
             connection: Mutex::new(connection),
         })
@@ -590,15 +592,20 @@ impl PolicyStore {
         let mut connection = self.lock()?;
         let transaction = connection.transaction()?;
         if let Some(context_key) = context_key
-            && let Some(agent_id) = transaction
+            && let Some((agent_id, lifecycle_state)) = transaction
                 .query_row(
-                    "SELECT id FROM agents
+                    "SELECT id, lifecycle_state FROM agents
                      WHERE owner_client_id = ?1 AND context_key = ?2",
                     params![client.id, context_key],
-                    |row| row.get::<_, String>(0),
+                    |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
                 )
                 .optional()?
         {
+            if lifecycle_state != "active" {
+                return Err(PolicyError::Invalid(
+                    "agent lifecycle operation is still in progress",
+                ));
+            }
             let identity = agent_identity(&transaction, &client.id, &agent_id)?;
             require(&identity.principal, "agent.read")?;
             transaction.commit()?;
@@ -618,8 +625,9 @@ impl PolicyStore {
         let created_at = now();
         transaction.execute(
             "INSERT INTO agents
-             (id, owner_client_id, context_key, principal_id, agent_config_json, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+             (id, owner_client_id, context_key, principal_id, agent_config_json,
+              lifecycle_state, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, 'active', ?6)",
             params![
                 id,
                 client.id,
@@ -645,7 +653,16 @@ impl PolicyStore {
         agent_identity(&connection, &client.id, agent_id)
     }
 
-    /// Creates a fresh managed identity with the source agent's principal.
+    pub(crate) fn agent_for_runtime(
+        &self,
+        owner_client_id: &str,
+        agent_id: &str,
+    ) -> Result<AgentIdentity, PolicyError> {
+        let connection = self.lock()?;
+        agent_identity(&connection, owner_client_id, agent_id)
+    }
+
+    /// Creates a hidden provisioning identity with the source agent's principal.
     pub fn fork_agent(
         &self,
         client: &AuthenticatedClient,
@@ -659,34 +676,93 @@ impl PolicyStore {
         let created_at = now();
         transaction.execute(
             "INSERT INTO agents
-             (id, owner_client_id, context_key, principal_id, agent_config_json, created_at)
-             SELECT ?1, owner_client_id, NULL, principal_id, agent_config_json, ?2
+             (id, owner_client_id, context_key, principal_id, agent_config_json,
+              lifecycle_state, created_at)
+             SELECT ?1, owner_client_id, NULL, principal_id, agent_config_json,
+                    'provisioning', ?2
              FROM agents WHERE id = ?3 AND owner_client_id = ?4",
             params![id, created_at, source_agent_id, client.id],
         )?;
         audit(&transaction, &client.id, "agent.fork", "agent", &id)?;
-        let identity = agent_identity(&transaction, &client.id, &id)?;
+        let identity = agent_identity_any(&transaction, &client.id, &id)?;
         transaction.commit()?;
         Ok(identity)
     }
 
-    /// Deletes an agent identity owned by an authenticated API client.
-    pub fn delete_agent(
+    /// Makes an agent inaccessible before its runtime and session are removed.
+    pub fn begin_delete_agent(
+        &self,
+        client: &AuthenticatedClient,
+        agent_id: &str,
+    ) -> Result<AgentIdentity, PolicyError> {
+        let mut connection = self.lock()?;
+        let transaction = connection.transaction()?;
+        let identity = agent_identity_any(&transaction, &client.id, agent_id)?;
+        require(&identity.principal, "agent.delete")?;
+        transaction.execute(
+            "UPDATE agents SET lifecycle_state = 'deleting'
+             WHERE id = ?1 AND owner_client_id = ?2",
+            params![agent_id, client.id],
+        )?;
+        audit(
+            &transaction,
+            &client.id,
+            "agent.delete.begin",
+            "agent",
+            agent_id,
+        )?;
+        transaction.commit()?;
+        Ok(identity)
+    }
+
+    /// Removes an identity after its runtime and durable session are gone.
+    pub fn finish_delete_agent(
         &self,
         client: &AuthenticatedClient,
         agent_id: &str,
     ) -> Result<(), PolicyError> {
         let mut connection = self.lock()?;
         let transaction = connection.transaction()?;
-        let identity = agent_identity(&transaction, &client.id, agent_id)?;
-        require(&identity.principal, "agent.delete")?;
-        transaction.execute(
-            "DELETE FROM agents WHERE id = ?1 AND owner_client_id = ?2",
+        let removed = transaction.execute(
+            "DELETE FROM agents
+             WHERE id = ?1 AND owner_client_id = ?2 AND lifecycle_state = 'deleting'",
             params![agent_id, client.id],
         )?;
+        changed(removed)?;
         audit(&transaction, &client.id, "agent.delete", "agent", agent_id)?;
         transaction.commit()?;
         Ok(())
+    }
+
+    /// Publishes a fully copied fork identity.
+    pub fn activate_agent(
+        &self,
+        client: &AuthenticatedClient,
+        agent_id: &str,
+    ) -> Result<AgentIdentity, PolicyError> {
+        let mut connection = self.lock()?;
+        let transaction = connection.transaction()?;
+        changed(transaction.execute(
+            "UPDATE agents SET lifecycle_state = 'active'
+             WHERE id = ?1 AND owner_client_id = ?2 AND lifecycle_state = 'provisioning'",
+            params![agent_id, client.id],
+        )?)?;
+        let identity = agent_identity(&transaction, &client.id, agent_id)?;
+        transaction.commit()?;
+        Ok(identity)
+    }
+
+    /// Removes a hidden fork identity after session provisioning failed.
+    pub fn abort_provisioning_agent(
+        &self,
+        client: &AuthenticatedClient,
+        agent_id: &str,
+    ) -> Result<(), PolicyError> {
+        changed(self.lock()?.execute(
+            "DELETE FROM agents
+             WHERE id = ?1 AND owner_client_id = ?2 AND lifecycle_state = 'provisioning'",
+            params![agent_id, client.id],
+        )?)
     }
 
     /// Creates an API client and hashes its initial key.
@@ -1462,6 +1538,7 @@ impl PolicyStore {
                         s.delivery_json, s.guest_json, s.enabled, s.created_at, s.updated_at
                  FROM secrets s
                  JOIN agents a ON a.id = ?1 AND a.principal_id = ?2
+                              AND a.lifecycle_state = 'active'
                  JOIN api_clients c ON c.id = a.owner_client_id AND c.enabled = 1
                  JOIN principals p ON p.id = a.principal_id AND p.enabled = 1
                  WHERE s.id = ?3 AND s.enabled = 1 AND s.id IN (
@@ -1490,6 +1567,7 @@ impl PolicyStore {
                     s.delivery_json, s.guest_json, s.enabled, s.created_at, s.updated_at
              FROM secrets s
              JOIN agents a ON a.id = ?1 AND a.principal_id = ?2
+                          AND a.lifecycle_state = 'active'
              JOIN api_clients c ON c.id = a.owner_client_id AND c.enabled = 1
              JOIN principals p ON p.id = a.principal_id AND p.enabled = 1
              WHERE s.enabled = 1 AND s.id IN (
@@ -1513,6 +1591,19 @@ impl PolicyStore {
     fn lock(&self) -> Result<MutexGuard<'_, Connection>, PolicyError> {
         self.connection.lock().map_err(|_| PolicyError::Poisoned)
     }
+}
+
+fn ensure_agent_lifecycle_column(connection: &Connection) -> Result<(), PolicyError> {
+    let mut statement = connection.prepare("PRAGMA table_info(agents)")?;
+    let columns = statement
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<Result<Vec<_>, _>>()?;
+    if !columns.iter().any(|column| column == "lifecycle_state") {
+        connection.execute_batch(
+            "ALTER TABLE agents ADD COLUMN lifecycle_state TEXT NOT NULL DEFAULT 'active'",
+        )?;
+    }
+    Ok(())
 }
 
 /// Requires one capability in an effective principal.
@@ -1581,12 +1672,30 @@ fn agent_identity(
     owner_client_id: &str,
     agent_id: &str,
 ) -> Result<AgentIdentity, PolicyError> {
+    agent_identity_with_state(connection, owner_client_id, agent_id, true)
+}
+
+fn agent_identity_any(
+    connection: &Connection,
+    owner_client_id: &str,
+    agent_id: &str,
+) -> Result<AgentIdentity, PolicyError> {
+    agent_identity_with_state(connection, owner_client_id, agent_id, false)
+}
+
+fn agent_identity_with_state(
+    connection: &Connection,
+    owner_client_id: &str,
+    agent_id: &str,
+    active_only: bool,
+) -> Result<AgentIdentity, PolicyError> {
     let record = connection
         .query_row(
             "SELECT id, owner_client_id, context_key, principal_id,
                     agent_config_json, created_at
-             FROM agents WHERE id = ?1 AND owner_client_id = ?2",
-            params![agent_id, owner_client_id],
+             FROM agents WHERE id = ?1 AND owner_client_id = ?2
+               AND (?3 = 0 OR lifecycle_state = 'active')",
+            params![agent_id, owner_client_id, active_only],
             |row| {
                 Ok((
                     row.get::<_, String>(0)?,
@@ -2051,6 +2160,40 @@ mod tests {
                 .iter()
                 .any(|permission| permission.name == "github.read")
         );
+    }
+
+    #[test]
+    fn lifecycle_tombstones_hide_partial_delete_and_fork_states() {
+        let store = PolicyStore::in_memory().unwrap();
+        store
+            .bootstrap("client", "Client", "key", "principal", [])
+            .unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert("x-api-key", HeaderValue::from_static("key"));
+        let client = store.authenticate(&headers).unwrap();
+        let (source, _) = store
+            .create_or_resolve_agent(&client, Some("source"))
+            .unwrap();
+
+        let target = store.fork_agent(&client, &source.id).unwrap();
+        assert!(matches!(
+            store.agent(&client, &target.id),
+            Err(PolicyError::NotFound)
+        ));
+        store.activate_agent(&client, &target.id).unwrap();
+        assert!(store.agent(&client, &target.id).is_ok());
+
+        store.begin_delete_agent(&client, &source.id).unwrap();
+        assert!(matches!(
+            store.agent(&client, &source.id),
+            Err(PolicyError::NotFound)
+        ));
+        store.begin_delete_agent(&client, &source.id).unwrap();
+        store.finish_delete_agent(&client, &source.id).unwrap();
+        assert!(matches!(
+            store.begin_delete_agent(&client, &source.id),
+            Err(PolicyError::NotFound)
+        ));
     }
 
     fn test_secret(id: &str) -> CreateSecret {

--- a/crates/experimental/nanocentaur/src/policy.rs
+++ b/crates/experimental/nanocentaur/src/policy.rs
@@ -1,0 +1,2121 @@
+#![allow(clippy::missing_errors_doc, clippy::needless_pass_by_value)]
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::Path,
+    sync::{Mutex, MutexGuard},
+};
+
+use axum::http::HeaderMap;
+use chrono::{DateTime, Utc};
+use rusqlite::{Connection, OptionalExtension, Transaction, params};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::secrets::validate_secret;
+use crate::{
+    AgentCapabilities, CapabilityName, CreateSecret, PatchSecret, SecretDelivery,
+    SecretGuestConfig, SecretRef, SecretRequestRule, SecretView,
+};
+
+const MAX_CONTEXT_KEY_BYTES: usize = 512;
+const MAX_INSTRUCTIONS_BYTES: usize = 64 * 1024;
+
+/// Agent behavior snapshotted into each durable managed identity.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct AgentConfig {
+    /// Optional complete system instructions for new agent runtimes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+    /// Optional fixed reasoning effort.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<ReasoningEffort>,
+}
+
+/// Managed-policy spelling of the supported reasoning efforts.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasoningEffort {
+    /// Disable reasoning effort.
+    None,
+    /// Low effort.
+    Low,
+    /// Medium effort.
+    Medium,
+    /// High effort.
+    High,
+    /// Extra-high effort.
+    Xhigh,
+    /// Maximum supported effort.
+    Max,
+}
+
+impl From<ReasoningEffort> for nanocodex_agent::Thinking {
+    fn from(value: ReasoningEffort) -> Self {
+        match value {
+            ReasoningEffort::None => Self::None,
+            ReasoningEffort::Low => Self::Low,
+            ReasoningEffort::Medium => Self::Medium,
+            ReasoningEffort::High => Self::High,
+            ReasoningEffort::Xhigh => Self::Xhigh,
+            ReasoningEffort::Max => Self::Max,
+        }
+    }
+}
+
+/// Application-defined metadata retained with a principal.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct PrincipalMetadata {
+    /// Stable string labels for tenant-side lookup and audit.
+    pub labels: BTreeMap<String, String>,
+}
+
+/// API client authenticated from a stored key digest.
+#[derive(Clone, Debug)]
+pub struct AuthenticatedClient {
+    /// Stable API-client identifier.
+    pub id: String,
+    /// Principal selected when no context binding overrides it.
+    pub default_principal_id: String,
+}
+
+/// Current effective behavior and grants for one principal.
+#[derive(Clone, Debug)]
+pub struct EffectivePrincipal {
+    /// Stable principal identifier.
+    pub id: String,
+    /// Behavior snapshotted into newly created managed agents.
+    pub agent_config: AgentConfig,
+    /// Union of direct and role-derived permissions.
+    pub permissions: AgentCapabilities,
+    /// Changes whenever secret configuration or grants may affect this principal.
+    pub secret_revision: u64,
+}
+
+impl EffectivePrincipal {
+    /// Returns whether the effective capability set includes a permission.
+    #[must_use]
+    pub fn allows(&self, permission: &str) -> bool {
+        self.permissions.contains(permission)
+    }
+}
+
+/// Authorized durable identity used to wake one agent actor.
+#[derive(Clone, Debug)]
+pub struct AgentIdentity {
+    /// Stable opaque agent identifier.
+    pub id: String,
+    /// API client that owns and may address the agent.
+    pub owner_client_id: String,
+    /// Optional owner-scoped create-or-resolve key.
+    pub context_key: Option<String>,
+    /// Current effective principal policy.
+    pub principal: EffectivePrincipal,
+    /// Durable creation timestamp.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Administrative request to create an API client and its first key.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateApiClient {
+    /// Optional stable identifier; a `UUIDv7` is generated when omitted.
+    pub id: Option<String>,
+    /// Human-readable client name.
+    pub name: String,
+    /// Initial plaintext key, hashed before storage.
+    pub api_key: String,
+    /// Default principal used without a context binding.
+    pub default_principal_id: String,
+}
+
+/// Administrative view of an API client without key material.
+#[derive(Clone, Debug, Serialize)]
+pub struct ApiClientView {
+    /// Stable client identifier.
+    pub id: String,
+    /// Human-readable client name.
+    pub name: String,
+    /// Default principal identifier.
+    pub default_principal_id: String,
+    /// Whether its keys may authenticate.
+    pub enabled: bool,
+    /// Durable creation timestamp.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Partial API-client update.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct PatchApiClient {
+    /// Replaces the human-readable name.
+    pub name: Option<String>,
+    /// Replaces the default principal.
+    pub default_principal_id: Option<String>,
+    /// Enables or disables authentication.
+    pub enabled: Option<bool>,
+}
+
+/// Administrative request to add a key to an API client.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateApiKey {
+    /// Plaintext key hashed before durable storage.
+    pub api_key: String,
+}
+
+/// Administrative key metadata without secret key material.
+#[derive(Clone, Debug, Serialize)]
+pub struct ApiKeyView {
+    /// Stable key identifier.
+    pub id: String,
+    /// Durable creation timestamp.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Administrative request to create a principal.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreatePrincipal {
+    /// Optional stable identifier; a `UUIDv7` is generated when omitted.
+    pub id: Option<String>,
+    /// Human-readable principal name.
+    pub name: String,
+    /// Optional tenant-owned lookup identifier.
+    pub external_id: Option<String>,
+    /// Application-defined labels.
+    #[serde(default)]
+    pub metadata: PrincipalMetadata,
+    /// Agent behavior snapshotted for new identities.
+    #[serde(default)]
+    pub agent_config: AgentConfig,
+}
+
+/// Administrative principal view.
+#[derive(Clone, Debug, Serialize)]
+pub struct PrincipalView {
+    /// Stable principal identifier.
+    pub id: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Optional tenant-owned lookup identifier.
+    pub external_id: Option<String>,
+    /// Whether the principal may authorize agents and secrets.
+    pub enabled: bool,
+    /// Application-defined labels.
+    pub metadata: PrincipalMetadata,
+    /// Agent behavior for newly created identities.
+    pub agent_config: AgentConfig,
+    /// Durable creation timestamp.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Partial principal update.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct PatchPrincipal {
+    /// Replaces the human-readable name.
+    pub name: Option<String>,
+    /// Replaces, clears, or leaves the external identifier.
+    pub external_id: Option<Option<String>>,
+    /// Enables or disables the principal.
+    pub enabled: Option<bool>,
+    /// Replaces all application metadata.
+    pub metadata: Option<PrincipalMetadata>,
+    /// Replaces behavior for subsequently created agents.
+    pub agent_config: Option<AgentConfig>,
+}
+
+/// Administrative request to bind a client context to a principal.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateContextBinding {
+    /// Owning API-client identifier.
+    pub api_client_id: String,
+    /// Client-scoped context key.
+    pub context_key: String,
+    /// Principal selected for that context.
+    pub principal_id: String,
+}
+
+/// Durable client-context binding view.
+#[derive(Clone, Debug, Serialize)]
+pub struct ContextBindingView {
+    /// Stable binding identifier.
+    pub id: String,
+    /// Owning API-client identifier.
+    pub api_client_id: String,
+    /// Client-scoped context key.
+    pub context_key: String,
+    /// Selected principal identifier.
+    pub principal_id: String,
+    /// Durable creation timestamp.
+    pub created_at: DateTime<Utc>,
+}
+
+/// Partial context-binding update.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct PatchContextBinding {
+    /// Replaces the owner-scoped context key.
+    pub context_key: Option<String>,
+    /// Replaces the selected principal.
+    pub principal_id: Option<String>,
+}
+
+/// Administrative request to inspect context resolution.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResolveContext {
+    /// API client performing resolution.
+    pub api_client_id: String,
+    /// Client-scoped context key.
+    pub context_key: String,
+}
+
+/// Explanation of the principal selected for one context.
+#[derive(Clone, Debug, Serialize)]
+pub struct ResolvedContextView {
+    /// API client used for resolution.
+    pub api_client_id: String,
+    /// Requested context key.
+    pub context_key: String,
+    /// Selected principal identifier.
+    pub principal_id: String,
+    /// Stable resolution source such as a binding or client default.
+    pub source: &'static str,
+}
+
+/// Administrative request to create a reusable role.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateRole {
+    /// Optional stable identifier; a `UUIDv7` is generated when omitted.
+    pub id: Option<String>,
+    /// Human-readable unique role name.
+    pub name: String,
+    /// Optional administrative description.
+    pub description: Option<String>,
+}
+
+/// Administrative role view.
+#[derive(Clone, Debug, Serialize)]
+pub struct RoleView {
+    /// Stable role identifier.
+    pub id: String,
+    /// Human-readable unique name.
+    pub name: String,
+    /// Optional administrative description.
+    pub description: Option<String>,
+}
+
+/// Partial role update.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct PatchRole {
+    /// Replaces the unique name.
+    pub name: Option<String>,
+    /// Replaces, clears, or leaves the description.
+    pub description: Option<Option<String>>,
+}
+
+/// Administrative request to create a reusable permission.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreatePermission {
+    /// Optional stable identifier; the permission name is used when omitted.
+    pub id: Option<String>,
+    /// Validated capability name.
+    pub name: String,
+    /// Optional administrative description.
+    pub description: Option<String>,
+}
+
+/// Administrative permission view.
+#[derive(Clone, Debug, Serialize)]
+pub struct PermissionView {
+    /// Stable permission identifier.
+    pub id: String,
+    /// Validated capability name.
+    pub name: String,
+    /// Optional administrative description.
+    pub description: Option<String>,
+}
+
+/// `SQLite` is the durable source of truth for identities, context resolution,
+/// reusable roles, direct grants, and agent ownership.
+pub struct PolicyStore {
+    connection: Mutex<Connection>,
+}
+
+impl PolicyStore {
+    /// Opens or creates a durable `SQLite` policy database.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, PolicyError> {
+        if let Some(parent) = path.as_ref().parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        Self::from_connection(Connection::open(path)?)
+    }
+
+    /// Creates an isolated in-memory policy store for tests and embedding.
+    pub fn in_memory() -> Result<Self, PolicyError> {
+        Self::from_connection(Connection::open_in_memory()?)
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn from_connection(connection: Connection) -> Result<Self, PolicyError> {
+        connection.pragma_update(None, "foreign_keys", "ON")?;
+        connection.pragma_update(None, "journal_mode", "WAL")?;
+        connection.pragma_update(None, "synchronous", "NORMAL")?;
+        connection.busy_timeout(std::time::Duration::from_secs(5))?;
+        connection.execute_batch(
+            r"
+            CREATE TABLE IF NOT EXISTS principals (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                external_id TEXT UNIQUE,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                agent_config_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS api_clients (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                default_principal_id TEXT NOT NULL REFERENCES principals(id),
+                enabled INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS api_client_keys (
+                id TEXT PRIMARY KEY,
+                api_client_id TEXT NOT NULL REFERENCES api_clients(id) ON DELETE CASCADE,
+                key_hash BLOB NOT NULL UNIQUE,
+                created_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS context_bindings (
+                id TEXT PRIMARY KEY,
+                api_client_id TEXT NOT NULL REFERENCES api_clients(id) ON DELETE CASCADE,
+                context_key TEXT NOT NULL,
+                principal_id TEXT NOT NULL REFERENCES principals(id),
+                created_at TEXT NOT NULL,
+                UNIQUE(api_client_id, context_key)
+            );
+
+            CREATE TABLE IF NOT EXISTS roles (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS permissions (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS principal_roles (
+                principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE CASCADE,
+                role_id TEXT NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+                PRIMARY KEY(principal_id, role_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS role_permissions (
+                role_id TEXT NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+                permission_id TEXT NOT NULL REFERENCES permissions(id) ON DELETE CASCADE,
+                PRIMARY KEY(role_id, permission_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS principal_permissions (
+                principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE CASCADE,
+                permission_id TEXT NOT NULL REFERENCES permissions(id) ON DELETE CASCADE,
+                PRIMARY KEY(principal_id, permission_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS secrets (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                source_json TEXT NOT NULL,
+                upstream TEXT NOT NULL,
+                rules_json TEXT NOT NULL,
+                delivery_json TEXT NOT NULL,
+                guest_json TEXT NOT NULL,
+                enabled INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS principal_secrets (
+                principal_id TEXT NOT NULL REFERENCES principals(id) ON DELETE CASCADE,
+                secret_id TEXT NOT NULL REFERENCES secrets(id) ON DELETE CASCADE,
+                PRIMARY KEY(principal_id, secret_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS role_secrets (
+                role_id TEXT NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+                secret_id TEXT NOT NULL REFERENCES secrets(id) ON DELETE CASCADE,
+                PRIMARY KEY(role_id, secret_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS policy_state (
+                key TEXT PRIMARY KEY,
+                value INTEGER NOT NULL
+            );
+
+            INSERT OR IGNORE INTO policy_state (key, value)
+            VALUES ('secret_revision', 0);
+
+            CREATE TABLE IF NOT EXISTS agents (
+                id TEXT PRIMARY KEY,
+                owner_client_id TEXT NOT NULL REFERENCES api_clients(id),
+                context_key TEXT,
+                principal_id TEXT NOT NULL REFERENCES principals(id),
+                agent_config_json TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                UNIQUE(owner_client_id, context_key)
+            );
+
+            CREATE TABLE IF NOT EXISTS audit_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                actor TEXT NOT NULL,
+                action TEXT NOT NULL,
+                target_type TEXT NOT NULL,
+                target_id TEXT NOT NULL,
+                data_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL
+            );
+            ",
+        )?;
+        Ok(Self {
+            connection: Mutex::new(connection),
+        })
+    }
+
+    /// Idempotently creates the initial principal, client, key, and grants.
+    ///
+    /// Existing records are retained, making this safe on server restart.
+    pub fn bootstrap(
+        &self,
+        api_client_id: &str,
+        api_client_name: &str,
+        api_key: &str,
+        principal_id: &str,
+        permissions: impl IntoIterator<Item = CapabilityName>,
+    ) -> Result<(), PolicyError> {
+        validate_nonempty(api_client_id, "api client id")?;
+        validate_nonempty(api_key, "API key")?;
+        let now = now();
+        let mut connection = self.lock()?;
+        let transaction = connection.transaction()?;
+        transaction.execute(
+            "INSERT OR IGNORE INTO principals
+             (id, name, metadata_json, agent_config_json, created_at)
+             VALUES (?1, ?2, '{}', '{}', ?3)",
+            params![principal_id, principal_id, now],
+        )?;
+        transaction.execute(
+            "INSERT OR IGNORE INTO api_clients
+             (id, name, default_principal_id, created_at)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![api_client_id, api_client_name, principal_id, now],
+        )?;
+        transaction.execute(
+            "INSERT OR IGNORE INTO api_client_keys
+             (id, api_client_id, key_hash, created_at)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![
+                Uuid::now_v7().to_string(),
+                api_client_id,
+                hash_key(api_key).to_vec(),
+                now
+            ],
+        )?;
+        for permission in standard_agent_permissions().into_iter().chain(permissions) {
+            grant_direct(&transaction, principal_id, permission.as_str())?;
+        }
+        audit(
+            &transaction,
+            "bootstrap",
+            "bootstrap",
+            "api_client",
+            api_client_id,
+        )?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    /// Authenticates an agent API key from request headers.
+    pub fn authenticate(&self, headers: &HeaderMap) -> Result<AuthenticatedClient, PolicyError> {
+        let token = headers
+            .get("x-api-key")
+            .and_then(|value| value.to_str().ok())
+            .filter(|value| !value.is_empty())
+            .ok_or(PolicyError::Unauthenticated)?;
+        let digest = hash_key(token);
+        let connection = self.lock()?;
+        connection
+            .query_row(
+                "SELECT c.id, c.default_principal_id
+                 FROM api_client_keys k
+                 JOIN api_clients c ON c.id = k.api_client_id
+                 WHERE k.key_hash = ?1 AND c.enabled = 1",
+                params![digest.to_vec()],
+                |row| {
+                    Ok(AuthenticatedClient {
+                        id: row.get(0)?,
+                        default_principal_id: row.get(1)?,
+                    })
+                },
+            )
+            .optional()?
+            .ok_or(PolicyError::Unauthenticated)
+    }
+
+    /// Creates or resolves an owner-scoped agent identity.
+    ///
+    /// Returns the identity and whether it was newly created. Agent behavior
+    /// is snapshotted on creation while effective grants remain live.
+    pub fn create_or_resolve_agent(
+        &self,
+        client: &AuthenticatedClient,
+        context_key: Option<&str>,
+    ) -> Result<(AgentIdentity, bool), PolicyError> {
+        validate_context_key(context_key)?;
+        let mut connection = self.lock()?;
+        let transaction = connection.transaction()?;
+        if let Some(context_key) = context_key
+            && let Some(agent_id) = transaction
+                .query_row(
+                    "SELECT id FROM agents
+                     WHERE owner_client_id = ?1 AND context_key = ?2",
+                    params![client.id, context_key],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()?
+        {
+            let identity = agent_identity(&transaction, &client.id, &agent_id)?;
+            require(&identity.principal, "agent.read")?;
+            transaction.commit()?;
+            return Ok((identity, false));
+        }
+
+        let principal_id = resolve_principal_id(&transaction, client, context_key)?;
+        let config = principal_config(&transaction, &principal_id)?;
+        let principal = EffectivePrincipal {
+            id: principal_id.clone(),
+            agent_config: config.clone(),
+            permissions: effective_capabilities(&transaction, &principal_id)?,
+            secret_revision: secret_revision(&transaction)?,
+        };
+        require(&principal, "agent.new")?;
+        let id = Uuid::now_v7().to_string();
+        let created_at = now();
+        transaction.execute(
+            "INSERT INTO agents
+             (id, owner_client_id, context_key, principal_id, agent_config_json, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                id,
+                client.id,
+                context_key,
+                principal_id,
+                serde_json::to_string(&config)?,
+                created_at
+            ],
+        )?;
+        audit(&transaction, &client.id, "agent.create", "agent", &id)?;
+        let identity = agent_identity(&transaction, &client.id, &id)?;
+        transaction.commit()?;
+        Ok((identity, true))
+    }
+
+    /// Returns an agent owned by an authenticated API client.
+    pub fn agent(
+        &self,
+        client: &AuthenticatedClient,
+        agent_id: &str,
+    ) -> Result<AgentIdentity, PolicyError> {
+        let connection = self.lock()?;
+        agent_identity(&connection, &client.id, agent_id)
+    }
+
+    /// Creates a fresh managed identity with the source agent's principal.
+    pub fn fork_agent(
+        &self,
+        client: &AuthenticatedClient,
+        source_agent_id: &str,
+    ) -> Result<AgentIdentity, PolicyError> {
+        let mut connection = self.lock()?;
+        let transaction = connection.transaction()?;
+        let source = agent_identity(&transaction, &client.id, source_agent_id)?;
+        require(&source.principal, "agent.fork")?;
+        let id = Uuid::now_v7().to_string();
+        let created_at = now();
+        transaction.execute(
+            "INSERT INTO agents
+             (id, owner_client_id, context_key, principal_id, agent_config_json, created_at)
+             SELECT ?1, owner_client_id, NULL, principal_id, agent_config_json, ?2
+             FROM agents WHERE id = ?3 AND owner_client_id = ?4",
+            params![id, created_at, source_agent_id, client.id],
+        )?;
+        audit(&transaction, &client.id, "agent.fork", "agent", &id)?;
+        let identity = agent_identity(&transaction, &client.id, &id)?;
+        transaction.commit()?;
+        Ok(identity)
+    }
+
+    /// Deletes an agent identity owned by an authenticated API client.
+    pub fn delete_agent(
+        &self,
+        client: &AuthenticatedClient,
+        agent_id: &str,
+    ) -> Result<(), PolicyError> {
+        let mut connection = self.lock()?;
+        let transaction = connection.transaction()?;
+        let identity = agent_identity(&transaction, &client.id, agent_id)?;
+        require(&identity.principal, "agent.delete")?;
+        transaction.execute(
+            "DELETE FROM agents WHERE id = ?1 AND owner_client_id = ?2",
+            params![agent_id, client.id],
+        )?;
+        audit(&transaction, &client.id, "agent.delete", "agent", agent_id)?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    /// Creates an API client and hashes its initial key.
+    pub fn create_api_client(
+        &self,
+        request: CreateApiClient,
+    ) -> Result<ApiClientView, PolicyError> {
+        validate_nonempty(&request.name, "name")?;
+        validate_nonempty(&request.api_key, "API key")?;
+        let id = request.id.unwrap_or_else(|| Uuid::now_v7().to_string());
+        let created_at = now();
+        let mut connection = self.lock()?;
+        let transaction = connection.transaction()?;
+        transaction.execute(
+            "INSERT INTO api_clients
+             (id, name, default_principal_id, created_at) VALUES (?1, ?2, ?3, ?4)",
+            params![id, request.name, request.default_principal_id, created_at],
+        )?;
+        transaction.execute(
+            "INSERT INTO api_client_keys
+             (id, api_client_id, key_hash, created_at) VALUES (?1, ?2, ?3, ?4)",
+            params![
+                Uuid::now_v7().to_string(),
+                id,
+                hash_key(&request.api_key).to_vec(),
+                created_at
+            ],
+        )?;
+        audit(
+            &transaction,
+            "admin",
+            "api_client.create",
+            "api_client",
+            &id,
+        )?;
+        transaction.commit()?;
+        self.api_client(&id)
+    }
+
+    /// Lists all API clients without key material.
+    pub fn api_clients(&self) -> Result<Vec<ApiClientView>, PolicyError> {
+        let connection = self.lock()?;
+        let mut statement = connection.prepare(
+            "SELECT id, name, default_principal_id, enabled, created_at
+             FROM api_clients ORDER BY created_at, id",
+        )?;
+        collect_rows(statement.query_map([], api_client_row)?)
+    }
+
+    /// Returns one API client.
+    pub fn api_client(&self, id: &str) -> Result<ApiClientView, PolicyError> {
+        let connection = self.lock()?;
+        connection
+            .query_row(
+                "SELECT id, name, default_principal_id, enabled, created_at
+                 FROM api_clients WHERE id = ?1",
+                params![id],
+                api_client_row,
+            )
+            .optional()?
+            .ok_or(PolicyError::NotFound)
+    }
+
+    /// Applies a partial API-client update.
+    pub fn patch_api_client(
+        &self,
+        id: &str,
+        patch: PatchApiClient,
+    ) -> Result<ApiClientView, PolicyError> {
+        let connection = self.lock()?;
+        let current = query_api_client(&connection, id)?;
+        connection.execute(
+            "UPDATE api_clients SET name = ?2, default_principal_id = ?3, enabled = ?4
+             WHERE id = ?1",
+            params![
+                id,
+                patch.name.unwrap_or(current.name),
+                patch
+                    .default_principal_id
+                    .unwrap_or(current.default_principal_id),
+                patch.enabled.unwrap_or(current.enabled)
+            ],
+        )?;
+        drop(connection);
+        self.api_client(id)
+    }
+
+    /// Disables API-key authentication for one client.
+    pub fn disable_api_client(&self, id: &str) -> Result<(), PolicyError> {
+        changed(self.lock()?.execute(
+            "UPDATE api_clients SET enabled = 0 WHERE id = ?1",
+            params![id],
+        )?)
+    }
+
+    /// Adds a separately revocable hashed key to an API client.
+    pub fn add_api_key(
+        &self,
+        client_id: &str,
+        request: CreateApiKey,
+    ) -> Result<ApiKeyView, PolicyError> {
+        validate_nonempty(&request.api_key, "API key")?;
+        let view = ApiKeyView {
+            id: Uuid::now_v7().to_string(),
+            created_at: Utc::now(),
+        };
+        self.lock()?.execute(
+            "INSERT INTO api_client_keys (id, api_client_id, key_hash, created_at)
+             VALUES (?1, ?2, ?3, ?4)",
+            params![
+                view.id,
+                client_id,
+                hash_key(&request.api_key).to_vec(),
+                view.created_at.to_rfc3339()
+            ],
+        )?;
+        Ok(view)
+    }
+
+    /// Deletes one API-client key by its non-secret identifier.
+    pub fn delete_api_key(&self, client_id: &str, key_id: &str) -> Result<(), PolicyError> {
+        changed(self.lock()?.execute(
+            "DELETE FROM api_client_keys WHERE id = ?1 AND api_client_id = ?2",
+            params![key_id, client_id],
+        )?)
+    }
+
+    /// Creates a principal with agent configuration and metadata.
+    pub fn create_principal(&self, request: CreatePrincipal) -> Result<PrincipalView, PolicyError> {
+        validate_nonempty(&request.name, "name")?;
+        validate_agent_config(&request.agent_config)?;
+        let id = request.id.unwrap_or_else(|| Uuid::now_v7().to_string());
+        self.lock()?.execute(
+            "INSERT INTO principals
+             (id, name, external_id, metadata_json, agent_config_json, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                id,
+                request.name,
+                request.external_id,
+                serde_json::to_string(&request.metadata)?,
+                serde_json::to_string(&request.agent_config)?,
+                now()
+            ],
+        )?;
+        self.principal(&id)
+    }
+
+    /// Lists all principals.
+    pub fn principals(&self) -> Result<Vec<PrincipalView>, PolicyError> {
+        let connection = self.lock()?;
+        let mut statement = connection.prepare(
+            "SELECT id, name, external_id, enabled, metadata_json,
+                    agent_config_json, created_at
+             FROM principals ORDER BY created_at, id",
+        )?;
+        collect_rows(statement.query_map([], principal_row)?)
+    }
+
+    /// Returns one principal.
+    pub fn principal(&self, id: &str) -> Result<PrincipalView, PolicyError> {
+        let connection = self.lock()?;
+        query_principal(&connection, id)
+    }
+
+    /// Applies a partial principal update.
+    pub fn patch_principal(
+        &self,
+        id: &str,
+        patch: PatchPrincipal,
+    ) -> Result<PrincipalView, PolicyError> {
+        let connection = self.lock()?;
+        let current = query_principal(&connection, id)?;
+        if let Some(config) = &patch.agent_config {
+            validate_agent_config(config)?;
+        }
+        connection.execute(
+            "UPDATE principals SET name = ?2, external_id = ?3, enabled = ?4,
+             metadata_json = ?5, agent_config_json = ?6 WHERE id = ?1",
+            params![
+                id,
+                patch.name.unwrap_or(current.name),
+                patch.external_id.unwrap_or(current.external_id),
+                patch.enabled.unwrap_or(current.enabled),
+                serde_json::to_string(&patch.metadata.unwrap_or(current.metadata))?,
+                serde_json::to_string(&patch.agent_config.unwrap_or(current.agent_config))?
+            ],
+        )?;
+        drop(connection);
+        self.principal(id)
+    }
+
+    /// Disables a principal and its live agent/secret authorization.
+    pub fn disable_principal(&self, id: &str) -> Result<(), PolicyError> {
+        changed(self.lock()?.execute(
+            "UPDATE principals SET enabled = 0 WHERE id = ?1",
+            params![id],
+        )?)
+    }
+
+    /// Creates an explicit client-context-to-principal binding.
+    pub fn create_context_binding(
+        &self,
+        request: CreateContextBinding,
+    ) -> Result<ContextBindingView, PolicyError> {
+        validate_context_key(Some(&request.context_key))?;
+        let id = Uuid::now_v7().to_string();
+        self.lock()?.execute(
+            "INSERT INTO context_bindings
+             (id, api_client_id, context_key, principal_id, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                id,
+                request.api_client_id,
+                request.context_key,
+                request.principal_id,
+                now()
+            ],
+        )?;
+        self.context_binding(&id)
+    }
+
+    /// Lists all explicit context bindings.
+    pub fn context_bindings(&self) -> Result<Vec<ContextBindingView>, PolicyError> {
+        let connection = self.lock()?;
+        let mut statement = connection.prepare(
+            "SELECT id, api_client_id, context_key, principal_id, created_at
+             FROM context_bindings ORDER BY created_at, id",
+        )?;
+        collect_rows(statement.query_map([], context_binding_row)?)
+    }
+
+    /// Returns one context binding.
+    pub fn context_binding(&self, id: &str) -> Result<ContextBindingView, PolicyError> {
+        self.lock()?
+            .query_row(
+                "SELECT id, api_client_id, context_key, principal_id, created_at
+                 FROM context_bindings WHERE id = ?1",
+                params![id],
+                context_binding_row,
+            )
+            .optional()?
+            .ok_or(PolicyError::NotFound)
+    }
+
+    /// Applies a partial context-binding update.
+    pub fn patch_context_binding(
+        &self,
+        id: &str,
+        patch: PatchContextBinding,
+    ) -> Result<ContextBindingView, PolicyError> {
+        let current = self.context_binding(id)?;
+        let context_key = patch.context_key.unwrap_or(current.context_key);
+        validate_context_key(Some(&context_key))?;
+        self.lock()?.execute(
+            "UPDATE context_bindings SET context_key = ?2, principal_id = ?3 WHERE id = ?1",
+            params![
+                id,
+                context_key,
+                patch.principal_id.unwrap_or(current.principal_id)
+            ],
+        )?;
+        self.context_binding(id)
+    }
+
+    /// Deletes one explicit context binding.
+    pub fn delete_context_binding(&self, id: &str) -> Result<(), PolicyError> {
+        changed(
+            self.lock()?
+                .execute("DELETE FROM context_bindings WHERE id = ?1", params![id])?,
+        )
+    }
+
+    /// Resolves a context through an explicit binding or client default.
+    pub fn resolve_context(
+        &self,
+        request: ResolveContext,
+    ) -> Result<ResolvedContextView, PolicyError> {
+        validate_context_key(Some(&request.context_key))?;
+        let connection = self.lock()?;
+        let bound = connection
+            .query_row(
+                "SELECT principal_id FROM context_bindings
+                 WHERE api_client_id = ?1 AND context_key = ?2",
+                params![request.api_client_id, request.context_key],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        let (principal_id, source) = match bound {
+            Some(id) => (id, "binding"),
+            None => (
+                connection
+                    .query_row(
+                        "SELECT default_principal_id FROM api_clients
+                         WHERE id = ?1 AND enabled = 1",
+                        params![request.api_client_id],
+                        |row| row.get(0),
+                    )
+                    .optional()?
+                    .ok_or(PolicyError::NotFound)?,
+                "default",
+            ),
+        };
+        Ok(ResolvedContextView {
+            api_client_id: request.api_client_id,
+            context_key: request.context_key,
+            principal_id,
+            source,
+        })
+    }
+
+    /// Creates a reusable role.
+    pub fn create_role(&self, request: CreateRole) -> Result<RoleView, PolicyError> {
+        validate_nonempty(&request.name, "name")?;
+        let id = request.id.unwrap_or_else(|| Uuid::now_v7().to_string());
+        self.lock()?.execute(
+            "INSERT INTO roles (id, name, description) VALUES (?1, ?2, ?3)",
+            params![id, request.name, request.description],
+        )?;
+        self.role(&id)
+    }
+
+    /// Lists all roles.
+    pub fn roles(&self) -> Result<Vec<RoleView>, PolicyError> {
+        let connection = self.lock()?;
+        let mut statement =
+            connection.prepare("SELECT id, name, description FROM roles ORDER BY name, id")?;
+        collect_rows(statement.query_map([], role_row)?)
+    }
+
+    /// Returns one role.
+    pub fn role(&self, id: &str) -> Result<RoleView, PolicyError> {
+        self.lock()?
+            .query_row(
+                "SELECT id, name, description FROM roles WHERE id = ?1",
+                params![id],
+                role_row,
+            )
+            .optional()?
+            .ok_or(PolicyError::NotFound)
+    }
+
+    /// Applies a partial role update.
+    pub fn patch_role(&self, id: &str, patch: PatchRole) -> Result<RoleView, PolicyError> {
+        let current = self.role(id)?;
+        self.lock()?.execute(
+            "UPDATE roles SET name = ?2, description = ?3 WHERE id = ?1",
+            params![
+                id,
+                patch.name.unwrap_or(current.name),
+                patch.description.unwrap_or(current.description)
+            ],
+        )?;
+        self.role(id)
+    }
+
+    /// Deletes one role and its derived grants.
+    pub fn delete_role(&self, id: &str) -> Result<(), PolicyError> {
+        let mut connection = self.lock()?;
+        let transaction = connection.transaction()?;
+        changed(transaction.execute("DELETE FROM roles WHERE id = ?1", params![id])?)?;
+        bump_secret_revision(&transaction)?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    /// Creates a validated reusable permission.
+    pub fn create_permission(
+        &self,
+        request: CreatePermission,
+    ) -> Result<PermissionView, PolicyError> {
+        CapabilityName::new(request.name.clone())
+            .map_err(|_| PolicyError::Invalid("invalid permission name"))?;
+        let id = request.id.unwrap_or_else(|| Uuid::now_v7().to_string());
+        self.lock()?.execute(
+            "INSERT INTO permissions (id, name, description) VALUES (?1, ?2, ?3)",
+            params![id, request.name, request.description],
+        )?;
+        self.permission(&id)
+    }
+
+    /// Lists all permissions.
+    pub fn permissions(&self) -> Result<Vec<PermissionView>, PolicyError> {
+        let connection = self.lock()?;
+        let mut statement = connection
+            .prepare("SELECT id, name, description FROM permissions ORDER BY name, id")?;
+        collect_rows(statement.query_map([], permission_row)?)
+    }
+
+    /// Returns one permission.
+    pub fn permission(&self, id: &str) -> Result<PermissionView, PolicyError> {
+        self.lock()?
+            .query_row(
+                "SELECT id, name, description FROM permissions WHERE id = ?1",
+                params![id],
+                permission_row,
+            )
+            .optional()?
+            .ok_or(PolicyError::NotFound)
+    }
+
+    /// Deletes one permission and its direct and role grants.
+    pub fn delete_permission(&self, id: &str) -> Result<(), PolicyError> {
+        changed(
+            self.lock()?
+                .execute("DELETE FROM permissions WHERE id = ?1", params![id])?,
+        )
+    }
+
+    /// Adds or removes a role from a principal.
+    pub fn set_principal_role(
+        &self,
+        principal_id: &str,
+        role_id: &str,
+        present: bool,
+    ) -> Result<(), PolicyError> {
+        let mut connection = self.lock()?;
+        let transaction = connection.transaction()?;
+        set_join(
+            &transaction,
+            "principal_roles",
+            "principal_id",
+            principal_id,
+            "role_id",
+            role_id,
+            present,
+        )?;
+        bump_secret_revision(&transaction)?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    /// Lists roles directly granted to a principal.
+    pub fn principal_roles(&self, principal_id: &str) -> Result<Vec<RoleView>, PolicyError> {
+        let connection = self.lock()?;
+        let mut statement = connection.prepare(
+            "SELECT r.id, r.name, r.description FROM roles r
+             JOIN principal_roles pr ON pr.role_id = r.id
+             WHERE pr.principal_id = ?1 ORDER BY r.name, r.id",
+        )?;
+        collect_rows(statement.query_map(params![principal_id], role_row)?)
+    }
+
+    /// Adds or removes a permission from a role.
+    pub fn set_role_permission(
+        &self,
+        role_id: &str,
+        permission_id: &str,
+        present: bool,
+    ) -> Result<(), PolicyError> {
+        set_join(
+            &*self.lock()?,
+            "role_permissions",
+            "role_id",
+            role_id,
+            "permission_id",
+            permission_id,
+            present,
+        )
+    }
+
+    /// Lists permissions directly granted to a role.
+    pub fn role_permissions(&self, role_id: &str) -> Result<Vec<PermissionView>, PolicyError> {
+        let connection = self.lock()?;
+        let mut statement = connection.prepare(
+            "SELECT p.id, p.name, p.description FROM permissions p
+             JOIN role_permissions rp ON rp.permission_id = p.id
+             WHERE rp.role_id = ?1 ORDER BY p.name, p.id",
+        )?;
+        collect_rows(statement.query_map(params![role_id], permission_row)?)
+    }
+
+    /// Adds or removes a direct permission from a principal.
+    pub fn set_principal_permission(
+        &self,
+        principal_id: &str,
+        permission_id: &str,
+        present: bool,
+    ) -> Result<(), PolicyError> {
+        set_join(
+            &*self.lock()?,
+            "principal_permissions",
+            "principal_id",
+            principal_id,
+            "permission_id",
+            permission_id,
+            present,
+        )
+    }
+
+    /// Lists permissions directly granted to a principal.
+    pub fn principal_permissions(
+        &self,
+        principal_id: &str,
+    ) -> Result<Vec<PermissionView>, PolicyError> {
+        let connection = self.lock()?;
+        let mut statement = connection.prepare(
+            "SELECT p.id, p.name, p.description FROM permissions p
+             JOIN principal_permissions pp ON pp.permission_id = p.id
+             WHERE pp.principal_id = ?1 ORDER BY p.name, p.id",
+        )?;
+        collect_rows(statement.query_map(params![principal_id], permission_row)?)
+    }
+
+    /// Returns the union of direct and role-derived permissions.
+    pub fn effective_permissions(
+        &self,
+        principal_id: &str,
+    ) -> Result<Vec<PermissionView>, PolicyError> {
+        let connection = self.lock()?;
+        let mut statement = connection.prepare(
+            "SELECT DISTINCT p.id, p.name, p.description
+             FROM permissions p
+             WHERE p.id IN (
+                 SELECT permission_id FROM principal_permissions WHERE principal_id = ?1
+                 UNION
+                 SELECT rp.permission_id FROM role_permissions rp
+                 JOIN principal_roles pr ON pr.role_id = rp.role_id
+                 WHERE pr.principal_id = ?1
+             )
+             ORDER BY p.name, p.id",
+        )?;
+        collect_rows(statement.query_map(params![principal_id], permission_row)?)
+    }
+
+    /// Creates a validated host-side secret route without resolving its value.
+    pub fn create_secret(&self, request: CreateSecret) -> Result<SecretView, PolicyError> {
+        validate_secret(&request)
+            .map_err(|_| PolicyError::Invalid("invalid secret configuration"))?;
+        let id = request
+            .id
+            .clone()
+            .unwrap_or_else(|| Uuid::now_v7().to_string());
+        validate_nonempty(&id, "secret id")?;
+        let timestamp = now();
+        let mut connection = self.lock()?;
+        let transaction = connection.transaction()?;
+        transaction.execute(
+            "INSERT INTO secrets
+             (id, name, source_json, upstream, rules_json, delivery_json, guest_json,
+              enabled, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 1, ?8, ?8)",
+            params![
+                id,
+                request.name,
+                serde_json::to_string(&request.source)?,
+                request.upstream,
+                serde_json::to_string(&request.rules)?,
+                serde_json::to_string(&request.delivery)?,
+                serde_json::to_string(&request.guest)?,
+                timestamp,
+            ],
+        )?;
+        audit(&transaction, "admin", "secret.create", "secret", &id)?;
+        bump_secret_revision(&transaction)?;
+        let secret = query_secret(&transaction, &id)?;
+        transaction.commit()?;
+        Ok(secret)
+    }
+
+    /// Lists all configured secret routes.
+    pub fn secrets(&self) -> Result<Vec<SecretView>, PolicyError> {
+        let connection = self.lock()?;
+        let mut statement = connection.prepare(
+            "SELECT id, name, source_json, upstream, rules_json, delivery_json,
+                    guest_json, enabled, created_at, updated_at
+             FROM secrets ORDER BY name, id",
+        )?;
+        collect_rows(statement.query_map([], secret_row)?)
+    }
+
+    /// Returns one configured secret route.
+    pub fn secret(&self, id: &str) -> Result<SecretView, PolicyError> {
+        let connection = self.lock()?;
+        query_secret(&connection, id)
+    }
+
+    /// Applies a partial secret-route update and advances live revision.
+    pub fn patch_secret(&self, id: &str, patch: PatchSecret) -> Result<SecretView, PolicyError> {
+        let current = self.secret(id)?;
+        let merged = CreateSecret {
+            id: Some(id.to_owned()),
+            name: patch.name.unwrap_or(current.name),
+            source: patch.source.unwrap_or(current.source),
+            upstream: patch.upstream.unwrap_or(current.upstream),
+            rules: patch.rules.unwrap_or(current.rules),
+            delivery: patch.delivery.unwrap_or(current.delivery),
+            guest: patch.guest.unwrap_or(current.guest),
+        };
+        validate_secret(&merged)
+            .map_err(|_| PolicyError::Invalid("invalid secret configuration"))?;
+        let enabled = patch.enabled.unwrap_or(current.enabled);
+        let mut connection = self.lock()?;
+        let transaction = connection.transaction()?;
+        transaction.execute(
+            "UPDATE secrets
+             SET name = ?2, source_json = ?3, upstream = ?4, rules_json = ?5,
+                 delivery_json = ?6, guest_json = ?7, enabled = ?8, updated_at = ?9
+             WHERE id = ?1",
+            params![
+                id,
+                merged.name,
+                serde_json::to_string(&merged.source)?,
+                merged.upstream,
+                serde_json::to_string(&merged.rules)?,
+                serde_json::to_string(&merged.delivery)?,
+                serde_json::to_string(&merged.guest)?,
+                enabled,
+                now(),
+            ],
+        )?;
+        audit(&transaction, "admin", "secret.update", "secret", id)?;
+        bump_secret_revision(&transaction)?;
+        let secret = query_secret(&transaction, id)?;
+        transaction.commit()?;
+        Ok(secret)
+    }
+
+    /// Deletes a secret route and all of its grants.
+    pub fn delete_secret(&self, id: &str) -> Result<(), PolicyError> {
+        let mut connection = self.lock()?;
+        let transaction = connection.transaction()?;
+        changed(transaction.execute("DELETE FROM secrets WHERE id = ?1", params![id])?)?;
+        audit(&transaction, "admin", "secret.delete", "secret", id)?;
+        bump_secret_revision(&transaction)?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    /// Adds or removes a direct secret grant from a principal.
+    pub fn set_principal_secret(
+        &self,
+        principal_id: &str,
+        secret_id: &str,
+        present: bool,
+    ) -> Result<(), PolicyError> {
+        let mut connection = self.lock()?;
+        let transaction = connection.transaction()?;
+        set_join(
+            &transaction,
+            "principal_secrets",
+            "principal_id",
+            principal_id,
+            "secret_id",
+            secret_id,
+            present,
+        )?;
+        audit(
+            &transaction,
+            "admin",
+            if present {
+                "principal_secret.grant"
+            } else {
+                "principal_secret.revoke"
+            },
+            "secret",
+            secret_id,
+        )?;
+        bump_secret_revision(&transaction)?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    /// Lists secret routes directly granted to a principal.
+    pub fn principal_secrets(&self, principal_id: &str) -> Result<Vec<SecretView>, PolicyError> {
+        let connection = self.lock()?;
+        let mut statement = connection.prepare(
+            "SELECT s.id, s.name, s.source_json, s.upstream, s.rules_json,
+                    s.delivery_json, s.guest_json, s.enabled, s.created_at, s.updated_at
+             FROM secrets s
+             JOIN principal_secrets ps ON ps.secret_id = s.id
+             WHERE ps.principal_id = ?1
+             ORDER BY s.name, s.id",
+        )?;
+        collect_rows(statement.query_map(params![principal_id], secret_row)?)
+    }
+
+    /// Adds or removes a secret grant from a role.
+    pub fn set_role_secret(
+        &self,
+        role_id: &str,
+        secret_id: &str,
+        present: bool,
+    ) -> Result<(), PolicyError> {
+        let mut connection = self.lock()?;
+        let transaction = connection.transaction()?;
+        set_join(
+            &transaction,
+            "role_secrets",
+            "role_id",
+            role_id,
+            "secret_id",
+            secret_id,
+            present,
+        )?;
+        audit(
+            &transaction,
+            "admin",
+            if present {
+                "role_secret.grant"
+            } else {
+                "role_secret.revoke"
+            },
+            "secret",
+            secret_id,
+        )?;
+        bump_secret_revision(&transaction)?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    /// Lists secret routes directly granted to a role.
+    pub fn role_secrets(&self, role_id: &str) -> Result<Vec<SecretView>, PolicyError> {
+        let connection = self.lock()?;
+        let mut statement = connection.prepare(
+            "SELECT s.id, s.name, s.source_json, s.upstream, s.rules_json,
+                    s.delivery_json, s.guest_json, s.enabled, s.created_at, s.updated_at
+             FROM secrets s
+             JOIN role_secrets rs ON rs.secret_id = s.id
+             WHERE rs.role_id = ?1
+             ORDER BY s.name, s.id",
+        )?;
+        collect_rows(statement.query_map(params![role_id], secret_row)?)
+    }
+
+    /// Returns the enabled union of direct and role-derived secret routes.
+    pub fn effective_secrets(&self, principal_id: &str) -> Result<Vec<SecretView>, PolicyError> {
+        let connection = self.lock()?;
+        let mut statement = connection.prepare(
+            "SELECT DISTINCT s.id, s.name, s.source_json, s.upstream, s.rules_json,
+                    s.delivery_json, s.guest_json, s.enabled, s.created_at, s.updated_at
+             FROM secrets s
+             WHERE s.enabled = 1
+               AND EXISTS (
+                   SELECT 1 FROM principals p
+                   WHERE p.id = ?1 AND p.enabled = 1
+               )
+               AND s.id IN (
+                 SELECT secret_id FROM principal_secrets WHERE principal_id = ?1
+                 UNION
+                 SELECT rs.secret_id FROM role_secrets rs
+                 JOIN principal_roles pr ON pr.role_id = rs.role_id
+                 WHERE pr.principal_id = ?1
+             )
+             ORDER BY s.name, s.id",
+        )?;
+        collect_rows(statement.query_map(params![principal_id], secret_row)?)
+    }
+
+    /// Returns one enabled effective secret route.
+    pub fn effective_secret(
+        &self,
+        principal_id: &str,
+        secret_id: &str,
+    ) -> Result<SecretView, PolicyError> {
+        self.effective_secrets(principal_id)?
+            .into_iter()
+            .find(|secret| secret.id == secret_id)
+            .ok_or(PolicyError::Forbidden)
+    }
+
+    /// Authorizes one effective secret against a durable agent identity.
+    pub fn agent_effective_secret(
+        &self,
+        agent_id: &str,
+        principal_id: &str,
+        secret_id: &str,
+    ) -> Result<SecretView, PolicyError> {
+        let connection = self.lock()?;
+        connection
+            .query_row(
+                "SELECT DISTINCT s.id, s.name, s.source_json, s.upstream, s.rules_json,
+                        s.delivery_json, s.guest_json, s.enabled, s.created_at, s.updated_at
+                 FROM secrets s
+                 JOIN agents a ON a.id = ?1 AND a.principal_id = ?2
+                 JOIN api_clients c ON c.id = a.owner_client_id AND c.enabled = 1
+                 JOIN principals p ON p.id = a.principal_id AND p.enabled = 1
+                 WHERE s.id = ?3 AND s.enabled = 1 AND s.id IN (
+                     SELECT secret_id FROM principal_secrets WHERE principal_id = ?2
+                     UNION
+                     SELECT rs.secret_id FROM role_secrets rs
+                     JOIN principal_roles pr ON pr.role_id = rs.role_id
+                     WHERE pr.principal_id = ?2
+                 )",
+                params![agent_id, principal_id, secret_id],
+                secret_row,
+            )
+            .optional()?
+            .ok_or(PolicyError::Forbidden)
+    }
+
+    /// Returns all effective secrets after validating the agent/principal pair.
+    pub fn agent_effective_secrets(
+        &self,
+        agent_id: &str,
+        principal_id: &str,
+    ) -> Result<Vec<SecretView>, PolicyError> {
+        let connection = self.lock()?;
+        let mut statement = connection.prepare(
+            "SELECT DISTINCT s.id, s.name, s.source_json, s.upstream, s.rules_json,
+                    s.delivery_json, s.guest_json, s.enabled, s.created_at, s.updated_at
+             FROM secrets s
+             JOIN agents a ON a.id = ?1 AND a.principal_id = ?2
+             JOIN api_clients c ON c.id = a.owner_client_id AND c.enabled = 1
+             JOIN principals p ON p.id = a.principal_id AND p.enabled = 1
+             WHERE s.enabled = 1 AND s.id IN (
+                 SELECT secret_id FROM principal_secrets WHERE principal_id = ?2
+                 UNION
+                 SELECT rs.secret_id FROM role_secrets rs
+                 JOIN principal_roles pr ON pr.role_id = rs.role_id
+                 WHERE pr.principal_id = ?2
+             )
+             ORDER BY s.name, s.id",
+        )?;
+        collect_rows(statement.query_map(params![agent_id, principal_id], secret_row)?)
+    }
+
+    /// Returns the monotonic global secret-policy revision.
+    pub fn secret_revision(&self) -> Result<u64, PolicyError> {
+        let connection = self.lock()?;
+        secret_revision(&connection)
+    }
+
+    fn lock(&self) -> Result<MutexGuard<'_, Connection>, PolicyError> {
+        self.connection.lock().map_err(|_| PolicyError::Poisoned)
+    }
+}
+
+/// Requires one capability in an effective principal.
+///
+/// # Errors
+///
+/// Returns [`PolicyError::Forbidden`] when the capability is absent.
+pub fn require(principal: &EffectivePrincipal, permission: &str) -> Result<(), PolicyError> {
+    if principal.allows(permission) {
+        Ok(())
+    } else {
+        Err(PolicyError::Forbidden)
+    }
+}
+
+fn standard_agent_permissions() -> Vec<CapabilityName> {
+    [
+        "agent.new",
+        "agent.read",
+        "agent.turn",
+        "agent.cancel",
+        "agent.fork",
+        "agent.evict",
+        "agent.delete",
+    ]
+    .into_iter()
+    .map(|name| CapabilityName::new(name).expect("static permission is valid"))
+    .collect()
+}
+
+fn resolve_principal_id(
+    connection: &Transaction<'_>,
+    client: &AuthenticatedClient,
+    context_key: Option<&str>,
+) -> Result<String, PolicyError> {
+    let bound = context_key
+        .map(|context_key| {
+            connection
+                .query_row(
+                    "SELECT principal_id FROM context_bindings
+                     WHERE api_client_id = ?1 AND context_key = ?2",
+                    params![client.id, context_key],
+                    |row| row.get::<_, String>(0),
+                )
+                .optional()
+        })
+        .transpose()?
+        .flatten();
+    let principal_id = bound.unwrap_or_else(|| client.default_principal_id.clone());
+    let enabled = connection
+        .query_row(
+            "SELECT enabled FROM principals WHERE id = ?1",
+            params![principal_id],
+            |row| row.get::<_, bool>(0),
+        )
+        .optional()?
+        .ok_or(PolicyError::NotFound)?;
+    if !enabled {
+        return Err(PolicyError::Forbidden);
+    }
+    Ok(principal_id)
+}
+
+fn agent_identity(
+    connection: &Connection,
+    owner_client_id: &str,
+    agent_id: &str,
+) -> Result<AgentIdentity, PolicyError> {
+    let record = connection
+        .query_row(
+            "SELECT id, owner_client_id, context_key, principal_id,
+                    agent_config_json, created_at
+             FROM agents WHERE id = ?1 AND owner_client_id = ?2",
+            params![agent_id, owner_client_id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, String>(5)?,
+                ))
+            },
+        )
+        .optional()?
+        .ok_or(PolicyError::NotFound)?;
+    let enabled = connection
+        .query_row(
+            "SELECT enabled FROM principals WHERE id = ?1",
+            params![record.3],
+            |row| row.get::<_, bool>(0),
+        )
+        .optional()?
+        .ok_or(PolicyError::NotFound)?;
+    if !enabled {
+        return Err(PolicyError::Forbidden);
+    }
+    Ok(AgentIdentity {
+        id: record.0,
+        owner_client_id: record.1,
+        context_key: record.2,
+        principal: EffectivePrincipal {
+            id: record.3.clone(),
+            agent_config: serde_json::from_str(&record.4)?,
+            permissions: effective_capabilities(connection, &record.3)?,
+            secret_revision: secret_revision(connection)?,
+        },
+        created_at: parse_time(&record.5)?,
+    })
+}
+
+fn principal_config(
+    connection: &Connection,
+    principal_id: &str,
+) -> Result<AgentConfig, PolicyError> {
+    let encoded = connection
+        .query_row(
+            "SELECT agent_config_json FROM principals WHERE id = ?1 AND enabled = 1",
+            params![principal_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .ok_or(PolicyError::NotFound)?;
+    Ok(serde_json::from_str(&encoded)?)
+}
+
+fn effective_capabilities(
+    connection: &Connection,
+    principal_id: &str,
+) -> Result<AgentCapabilities, PolicyError> {
+    let mut statement = connection.prepare(
+        "SELECT DISTINCT p.name FROM permissions p
+         WHERE p.id IN (
+             SELECT permission_id FROM principal_permissions WHERE principal_id = ?1
+             UNION
+             SELECT rp.permission_id FROM role_permissions rp
+             JOIN principal_roles pr ON pr.role_id = rp.role_id
+             WHERE pr.principal_id = ?1
+         ) ORDER BY p.name",
+    )?;
+    let names = statement
+        .query_map(params![principal_id], |row| row.get::<_, String>(0))?
+        .collect::<Result<Vec<_>, _>>()?;
+    let capabilities = names
+        .into_iter()
+        .map(|name| {
+            CapabilityName::new(name)
+                .map_err(|_| PolicyError::Invalid("invalid permission stored in database"))
+        })
+        .collect::<Result<BTreeSet<_>, _>>()?;
+    Ok(AgentCapabilities::new(capabilities))
+}
+
+fn grant_direct(
+    transaction: &Transaction<'_>,
+    principal_id: &str,
+    permission_name: &str,
+) -> Result<(), PolicyError> {
+    let permission_id = permission_name;
+    transaction.execute(
+        "INSERT OR IGNORE INTO permissions (id, name) VALUES (?1, ?1)",
+        params![permission_id],
+    )?;
+    transaction.execute(
+        "INSERT OR IGNORE INTO principal_permissions (principal_id, permission_id)
+         VALUES (?1, ?2)",
+        params![principal_id, permission_id],
+    )?;
+    Ok(())
+}
+
+fn set_join(
+    connection: &Connection,
+    table: &'static str,
+    left_column: &'static str,
+    left: &str,
+    right_column: &'static str,
+    right: &str,
+    present: bool,
+) -> Result<(), PolicyError> {
+    let sql = if present {
+        format!("INSERT OR IGNORE INTO {table} ({left_column}, {right_column}) VALUES (?1, ?2)")
+    } else {
+        format!("DELETE FROM {table} WHERE {left_column} = ?1 AND {right_column} = ?2")
+    };
+    let changed = connection.execute(&sql, params![left, right])?;
+    if present && changed == 0 {
+        // The relation already exists, which is a successful idempotent PUT.
+        return Ok(());
+    }
+    if !present && changed == 0 {
+        return Err(PolicyError::NotFound);
+    }
+    Ok(())
+}
+
+fn audit(
+    transaction: &Transaction<'_>,
+    actor: &str,
+    action: &str,
+    target_type: &str,
+    target_id: &str,
+) -> Result<(), PolicyError> {
+    transaction.execute(
+        "INSERT INTO audit_log
+         (actor, action, target_type, target_id, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![actor, action, target_type, target_id, now()],
+    )?;
+    Ok(())
+}
+
+fn query_api_client(connection: &Connection, id: &str) -> Result<ApiClientView, PolicyError> {
+    connection
+        .query_row(
+            "SELECT id, name, default_principal_id, enabled, created_at
+             FROM api_clients WHERE id = ?1",
+            params![id],
+            api_client_row,
+        )
+        .optional()?
+        .ok_or(PolicyError::NotFound)
+}
+
+fn query_principal(connection: &Connection, id: &str) -> Result<PrincipalView, PolicyError> {
+    connection
+        .query_row(
+            "SELECT id, name, external_id, enabled, metadata_json,
+                    agent_config_json, created_at
+             FROM principals WHERE id = ?1",
+            params![id],
+            principal_row,
+        )
+        .optional()?
+        .ok_or(PolicyError::NotFound)
+}
+
+fn api_client_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ApiClientView> {
+    let created_at = row.get::<_, String>(4)?;
+    Ok(ApiClientView {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        default_principal_id: row.get(2)?,
+        enabled: row.get(3)?,
+        created_at: sqlite_time(&created_at)?,
+    })
+}
+
+fn principal_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PrincipalView> {
+    let metadata = row.get::<_, String>(4)?;
+    let agent_config = row.get::<_, String>(5)?;
+    let created_at = row.get::<_, String>(6)?;
+    Ok(PrincipalView {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        external_id: row.get(2)?,
+        enabled: row.get(3)?,
+        metadata: serde_json::from_str(&metadata).map_err(json_sql_error)?,
+        agent_config: serde_json::from_str(&agent_config).map_err(json_sql_error)?,
+        created_at: sqlite_time(&created_at)?,
+    })
+}
+
+fn context_binding_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ContextBindingView> {
+    let created_at = row.get::<_, String>(4)?;
+    Ok(ContextBindingView {
+        id: row.get(0)?,
+        api_client_id: row.get(1)?,
+        context_key: row.get(2)?,
+        principal_id: row.get(3)?,
+        created_at: sqlite_time(&created_at)?,
+    })
+}
+
+fn role_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RoleView> {
+    Ok(RoleView {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        description: row.get(2)?,
+    })
+}
+
+fn permission_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<PermissionView> {
+    Ok(PermissionView {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        description: row.get(2)?,
+    })
+}
+
+fn secret_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SecretView> {
+    let source = row.get::<_, String>(2)?;
+    let rules = row.get::<_, String>(4)?;
+    let delivery = row.get::<_, String>(5)?;
+    let guest = row.get::<_, String>(6)?;
+    let created_at = row.get::<_, String>(8)?;
+    let updated_at = row.get::<_, String>(9)?;
+    Ok(SecretView {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        source: serde_json::from_str::<SecretRef>(&source).map_err(json_sql_error)?,
+        upstream: row.get(3)?,
+        rules: serde_json::from_str::<Vec<SecretRequestRule>>(&rules).map_err(json_sql_error)?,
+        delivery: serde_json::from_str::<SecretDelivery>(&delivery).map_err(json_sql_error)?,
+        guest: serde_json::from_str::<SecretGuestConfig>(&guest).map_err(json_sql_error)?,
+        enabled: row.get(7)?,
+        created_at: sqlite_time(&created_at)?,
+        updated_at: sqlite_time(&updated_at)?,
+    })
+}
+
+fn query_secret(connection: &Connection, id: &str) -> Result<SecretView, PolicyError> {
+    connection
+        .query_row(
+            "SELECT id, name, source_json, upstream, rules_json, delivery_json,
+                    guest_json, enabled, created_at, updated_at
+             FROM secrets WHERE id = ?1",
+            params![id],
+            secret_row,
+        )
+        .optional()?
+        .ok_or(PolicyError::NotFound)
+}
+
+fn collect_rows<T>(
+    rows: rusqlite::MappedRows<'_, impl FnMut(&rusqlite::Row<'_>) -> rusqlite::Result<T>>,
+) -> Result<Vec<T>, PolicyError> {
+    Ok(rows.collect::<Result<Vec<_>, _>>()?)
+}
+
+fn sqlite_time(value: &str) -> rusqlite::Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|value| value.with_timezone(&Utc))
+        .map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                0,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })
+}
+
+fn json_sql_error(error: serde_json::Error) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(error))
+}
+
+fn parse_time(value: &str) -> Result<DateTime<Utc>, PolicyError> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|value| value.with_timezone(&Utc))
+        .map_err(|_| PolicyError::Invalid("invalid timestamp stored in database"))
+}
+
+fn now() -> String {
+    Utc::now().to_rfc3339()
+}
+
+fn hash_key(value: &str) -> [u8; 32] {
+    Sha256::digest(value.as_bytes()).into()
+}
+
+fn validate_context_key(value: Option<&str>) -> Result<(), PolicyError> {
+    if value.is_some_and(|value| {
+        value.is_empty()
+            || value.len() > MAX_CONTEXT_KEY_BYTES
+            || value.chars().any(char::is_control)
+    }) {
+        Err(PolicyError::Invalid(
+            "context_key must contain 1 to 512 non-control bytes",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_nonempty(value: &str, name: &'static str) -> Result<(), PolicyError> {
+    if value.trim().is_empty() {
+        Err(PolicyError::Invalid(name))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_agent_config(config: &AgentConfig) -> Result<(), PolicyError> {
+    if config.instructions.as_ref().is_some_and(|instructions| {
+        instructions.trim().is_empty() || instructions.len() > MAX_INSTRUCTIONS_BYTES
+    }) {
+        Err(PolicyError::Invalid(
+            "instructions must contain 1 to 65536 bytes",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+const fn changed(count: usize) -> Result<(), PolicyError> {
+    if count == 0 {
+        Err(PolicyError::NotFound)
+    } else {
+        Ok(())
+    }
+}
+
+fn secret_revision(connection: &Connection) -> Result<u64, PolicyError> {
+    let value = connection.query_row(
+        "SELECT value FROM policy_state WHERE key = 'secret_revision'",
+        [],
+        |row| row.get::<_, i64>(0),
+    )?;
+    u64::try_from(value).map_err(|_| PolicyError::Invalid("invalid secret revision"))
+}
+
+fn bump_secret_revision(connection: &Connection) -> Result<(), PolicyError> {
+    connection.execute(
+        "UPDATE policy_state SET value = value + 1 WHERE key = 'secret_revision'",
+        [],
+    )?;
+    Ok(())
+}
+
+#[derive(Debug, Error)]
+/// Authentication, authorization, validation, or policy-storage failure.
+pub enum PolicyError {
+    /// No stored API key matched the request.
+    #[error("authentication required")]
+    Unauthenticated,
+    /// The authenticated principal lacks the requested grant.
+    #[error("permission denied")]
+    Forbidden,
+    /// The requested policy record does not exist.
+    #[error("policy object was not found")]
+    NotFound,
+    /// A bounded policy input was invalid.
+    #[error("invalid policy input: {0}")]
+    Invalid(&'static str),
+    /// The in-process `SQLite` mutex was poisoned.
+    #[error("policy database lock was poisoned")]
+    Poisoned,
+    /// `SQLite` schema, query, or transaction failure.
+    #[error("policy database failed")]
+    Database(#[from] rusqlite::Error),
+    /// Durable JSON policy encoding or decoding failed.
+    #[error("policy JSON failed")]
+    Json(#[from] serde_json::Error),
+    /// Policy database filesystem setup failed.
+    #[error("policy filesystem failed")]
+    Io(#[from] std::io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::HeaderValue;
+
+    use super::*;
+
+    #[test]
+    fn context_resolution_is_scoped_and_agent_config_is_snapshotted() {
+        let store = PolicyStore::in_memory().unwrap();
+        store
+            .bootstrap("client", "Client", "key", "default", [])
+            .unwrap();
+        let channel = store
+            .create_principal(CreatePrincipal {
+                id: Some("channel".to_owned()),
+                name: "Channel".to_owned(),
+                external_id: None,
+                metadata: PrincipalMetadata::default(),
+                agent_config: AgentConfig {
+                    instructions: Some("channel instructions".to_owned()),
+                    ..AgentConfig::default()
+                },
+            })
+            .unwrap();
+        store
+            .create_context_binding(CreateContextBinding {
+                api_client_id: "client".to_owned(),
+                context_key: "channel:1".to_owned(),
+                principal_id: channel.id,
+            })
+            .unwrap();
+        store
+            .set_principal_permission("channel", "agent.new", true)
+            .unwrap();
+        store
+            .set_principal_permission("channel", "agent.read", true)
+            .unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert("x-api-key", HeaderValue::from_static("key"));
+        let client = store.authenticate(&headers).unwrap();
+        let (first, created) = store
+            .create_or_resolve_agent(&client, Some("channel:1"))
+            .unwrap();
+        assert!(created);
+        assert_eq!(first.principal.id, "channel");
+        assert_eq!(
+            first.principal.agent_config.instructions.as_deref(),
+            Some("channel instructions")
+        );
+        let (same, created) = store
+            .create_or_resolve_agent(&client, Some("channel:1"))
+            .unwrap();
+        assert!(!created);
+        assert_eq!(same.id, first.id);
+    }
+
+    #[test]
+    fn roles_and_direct_grants_union_into_effective_permissions() {
+        let store = PolicyStore::in_memory().unwrap();
+        store
+            .bootstrap("client", "Client", "key", "principal", [])
+            .unwrap();
+        let role = store
+            .create_role(CreateRole {
+                id: Some("reader".to_owned()),
+                name: "reader".to_owned(),
+                description: None,
+            })
+            .unwrap();
+        let permission = store
+            .create_permission(CreatePermission {
+                id: Some("github.read".to_owned()),
+                name: "github.read".to_owned(),
+                description: None,
+            })
+            .unwrap();
+        store
+            .set_principal_role("principal", &role.id, true)
+            .unwrap();
+        store
+            .set_role_permission(&role.id, &permission.id, true)
+            .unwrap();
+        assert!(
+            store
+                .effective_permissions("principal")
+                .unwrap()
+                .iter()
+                .any(|permission| permission.name == "github.read")
+        );
+    }
+
+    fn test_secret(id: &str) -> CreateSecret {
+        CreateSecret {
+            id: Some(id.to_owned()),
+            name: id.to_owned(),
+            source: SecretRef::new("environment", "OPENAI"),
+            upstream: "https://api.openai.com".to_owned(),
+            rules: vec![
+                SecretRequestRule::new()
+                    .method(crate::SecretHttpMethod::Get)
+                    .path_prefix("/v1/"),
+            ],
+            delivery: SecretDelivery::inject_header("authorization", "Bearer "),
+            guest: SecretGuestConfig::new("OPENAI_BASE_URL"),
+        }
+    }
+
+    #[test]
+    fn direct_and_role_secret_grants_survive_restart() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("policy.sqlite");
+        let store = PolicyStore::open(&path).unwrap();
+        store
+            .bootstrap("client", "Client", "key", "principal", [])
+            .unwrap();
+        store.create_secret(test_secret("direct")).unwrap();
+        store.create_secret(test_secret("role-secret")).unwrap();
+        let role = store
+            .create_role(CreateRole {
+                id: Some("role".to_owned()),
+                name: "role".to_owned(),
+                description: None,
+            })
+            .unwrap();
+        let before = store.secret_revision().unwrap();
+        store
+            .set_principal_secret("principal", "direct", true)
+            .unwrap();
+        store
+            .set_role_secret(&role.id, "role-secret", true)
+            .unwrap();
+        store
+            .set_principal_role("principal", &role.id, true)
+            .unwrap();
+
+        let effective = store.effective_secrets("principal").unwrap();
+        assert_eq!(
+            effective
+                .iter()
+                .map(|secret| secret.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["direct", "role-secret"]
+        );
+        assert!(store.secret_revision().unwrap() > before);
+
+        drop(store);
+        let store = PolicyStore::open(&path).unwrap();
+        assert_eq!(store.effective_secrets("principal").unwrap().len(), 2);
+        store
+            .set_principal_secret("principal", "direct", false)
+            .unwrap();
+        assert!(matches!(
+            store.effective_secret("principal", "direct"),
+            Err(PolicyError::Forbidden)
+        ));
+    }
+}

--- a/crates/experimental/nanocentaur/src/secrets.rs
+++ b/crates/experimental/nanocentaur/src/secrets.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use axum::http::HeaderName;
+use axum::http::{HeaderName, HeaderValue};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -18,6 +18,7 @@ const MAX_IDENTIFIER_BYTES: usize = 256;
 const MAX_ENVIRONMENT_NAME_BYTES: usize = 128;
 const MAX_HEADER_NAME_BYTES: usize = 128;
 const MAX_PATH_PREFIX_BYTES: usize = 2_048;
+pub(crate) const MANAGED_SECRET_PROVIDER: &str = "nanocentaur";
 
 /// Opaque host-side secret-manager reference.
 ///
@@ -176,13 +177,6 @@ impl SecretDelivery {
             Self::InjectHeader { header, .. } | Self::ReplaceHeader { header, .. } => header,
         }
     }
-
-    pub(crate) fn placeholder(&self) -> Option<&str> {
-        match self {
-            Self::InjectHeader { .. } => None,
-            Self::ReplaceHeader { placeholder, .. } => Some(placeholder),
-        }
-    }
 }
 
 /// Public guest configuration associated with one secret route.
@@ -322,8 +316,7 @@ impl SecretSpec {
         id: String,
         request: Option<&SecretRequestRule>,
     ) -> Result<nanocodex_egress::SecretRule, nanocodex_egress::SecretConfigError> {
-        let source =
-            nanocodex_egress::SecretRef::new(self.source.provider.clone(), self.source.key.clone());
+        let source = nanocodex_egress::SecretRef::new(MANAGED_SECRET_PROVIDER, self.id.clone());
         let mut builder = nanocodex_egress::SecretRule::builder(id, source, &self.upstream);
         if let Some(request) = request {
             for method in &request.methods {
@@ -346,15 +339,19 @@ impl SecretSpec {
             SecretDelivery::ReplaceHeader {
                 header,
                 placeholder,
-            } => builder
-                .replace_header(header, placeholder)
-                .child_environment(
-                    self.guest.base_url_environment.clone(),
-                    self.guest
-                        .placeholder_environment
-                        .clone()
-                        .unwrap_or_else(|| placeholder.clone()),
-                ),
+            } => {
+                let placeholder_environment = self
+                    .guest
+                    .placeholder_environment
+                    .clone()
+                    .ok_or(nanocodex_egress::SecretConfigError::MissingChildEnvironment)?;
+                builder
+                    .replace_header(header, placeholder)
+                    .child_environment(
+                        self.guest.base_url_environment.clone(),
+                        placeholder_environment,
+                    )
+            }
         };
         builder.build()
     }
@@ -422,6 +419,16 @@ fn validate_spec(spec: &SecretSpec) -> Result<(), SecretConfigError> {
     {
         return Err(SecretConfigError::InvalidUpstream);
     }
+    if upstream.scheme() == "http"
+        && !upstream.host_str().is_some_and(|host| {
+            host.eq_ignore_ascii_case("localhost")
+                || host
+                    .parse::<std::net::IpAddr>()
+                    .is_ok_and(|address| address.is_loopback())
+        })
+    {
+        return Err(SecretConfigError::InvalidUpstream);
+    }
     for rule in &spec.rules {
         for prefix in &rule.path_prefixes {
             if !valid_path_prefix(prefix) {
@@ -449,10 +456,17 @@ fn validate_spec(spec: &SecretSpec) -> Result<(), SecretConfigError> {
     if let Some(environment) = &spec.guest.placeholder_environment {
         validate_environment_name(environment)?;
     }
-    if let Some(placeholder) = spec.delivery.placeholder()
-        && spec.guest.placeholder_environment.as_deref() != Some(placeholder)
-    {
-        return Err(SecretConfigError::PlaceholderMismatch);
+    match (&spec.delivery, &spec.guest.placeholder_environment) {
+        (SecretDelivery::InjectHeader { .. }, None) => {}
+        (SecretDelivery::ReplaceHeader { placeholder, .. }, Some(environment))
+            if environment != &spec.guest.base_url_environment
+                && !placeholder.is_empty()
+                && placeholder.len() <= 4 * 1_024
+                && HeaderValue::from_str(placeholder).is_ok() => {}
+        (SecretDelivery::InjectHeader { .. }, Some(_))
+        | (SecretDelivery::ReplaceHeader { .. }, None | Some(_)) => {
+            return Err(SecretConfigError::InvalidPlaceholderConfiguration);
+        }
     }
     Ok(())
 }
@@ -728,9 +742,9 @@ pub enum SecretConfigError {
     /// A guest environment name was not an uppercase shell identifier.
     #[error("secret guest environment names must use uppercase shell identifier syntax")]
     InvalidEnvironmentName,
-    /// Replace delivery and guest placeholder configuration differed.
-    #[error("replace delivery placeholder must equal guest placeholder environment name")]
-    PlaceholderMismatch,
+    /// Delivery and guest placeholder environment configuration were incompatible.
+    #[error("secret delivery and guest placeholder environments are incompatible")]
+    InvalidPlaceholderConfiguration,
 }
 
 /// Administrative request for one host-resolved secret route.
@@ -775,7 +789,7 @@ pub struct PatchSecret {
 }
 
 /// Durable administrative view of one secret route.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SecretView {
     /// Stable route identifier.
     pub id: String,
@@ -872,6 +886,48 @@ mod tests {
         assert_eq!(spec.id(), "openai");
         assert_eq!(spec.upstream(), "https://api.openai.com");
         assert_eq!(spec.rules().len(), 1);
+    }
+
+    #[test]
+    fn replacement_exports_distinct_base_url_and_placeholder_variables() {
+        let spec = SecretSpec::builder(
+            "openai",
+            SecretRef::new("environment", "OPENAI_API_KEY"),
+            "https://api.openai.com",
+            SecretDelivery::replace_header("authorization", "Bearer public-placeholder"),
+            SecretGuestConfig::new("OPENAI_BASE_URL")
+                .placeholder_environment("OPENAI_AUTH_PLACEHOLDER"),
+        )
+        .build()
+        .unwrap();
+        let egress =
+            nanocodex_egress::SecretEgress::builder(nanocodex_egress::StaticSecretResolver::new())
+                .rules(spec.egress_rules().unwrap())
+                .build()
+                .unwrap();
+
+        assert_eq!(
+            egress.environment().get("OPENAI_BASE_URL"),
+            Some(std::ffi::OsStr::new("https://api.openai.com"))
+        );
+        assert_eq!(
+            egress.environment().get("OPENAI_AUTH_PLACEHOLDER"),
+            Some(std::ffi::OsStr::new("Bearer public-placeholder"))
+        );
+    }
+
+    #[test]
+    fn replacement_requires_a_placeholder_environment() {
+        let error = SecretSpec::builder(
+            "openai",
+            SecretRef::new("environment", "OPENAI_API_KEY"),
+            "https://api.openai.com",
+            SecretDelivery::replace_header("authorization", "public-placeholder"),
+            SecretGuestConfig::new("OPENAI_BASE_URL"),
+        )
+        .build()
+        .unwrap_err();
+        assert_eq!(error, SecretConfigError::InvalidPlaceholderConfiguration);
     }
 
     #[test]

--- a/crates/experimental/nanocentaur/src/secrets.rs
+++ b/crates/experimental/nanocentaur/src/secrets.rs
@@ -1,0 +1,957 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    env,
+    path::{Component, Path, PathBuf},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use axum::http::HeaderName;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::io::AsyncReadExt;
+use url::Url;
+
+const MAX_FILE_SECRET_BYTES: u64 = 1_024 * 1_024;
+const MAX_IDENTIFIER_BYTES: usize = 256;
+const MAX_ENVIRONMENT_NAME_BYTES: usize = 128;
+const MAX_HEADER_NAME_BYTES: usize = 128;
+const MAX_PATH_PREFIX_BYTES: usize = 2_048;
+
+/// Opaque host-side secret-manager reference.
+///
+/// The reference is safe configuration. This egress layer never places the
+/// value it resolves to in a guest lease, snapshot, model input, or durable
+/// agent state.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecretRef {
+    provider: String,
+    key: String,
+}
+
+impl SecretRef {
+    /// Creates a provider-qualified reference.
+    #[must_use]
+    pub fn new(provider: impl Into<String>, key: impl Into<String>) -> Self {
+        Self {
+            provider: provider.into(),
+            key: key.into(),
+        }
+    }
+
+    /// Returns the provider registry name.
+    #[must_use]
+    pub fn provider(&self) -> &str {
+        &self.provider
+    }
+
+    /// Returns the provider-owned opaque key.
+    #[must_use]
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+}
+
+/// HTTP method accepted by one secret request rule.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum SecretHttpMethod {
+    /// `GET`.
+    Get,
+    /// `POST`.
+    Post,
+    /// `PUT`.
+    Put,
+    /// `PATCH`.
+    Patch,
+    /// `DELETE`.
+    Delete,
+    /// `HEAD`.
+    Head,
+    /// `OPTIONS`.
+    Options,
+}
+
+impl SecretHttpMethod {
+    const fn as_http(self) -> nanocodex_egress::http::Method {
+        match self {
+            Self::Get => nanocodex_egress::http::Method::GET,
+            Self::Post => nanocodex_egress::http::Method::POST,
+            Self::Put => nanocodex_egress::http::Method::PUT,
+            Self::Patch => nanocodex_egress::http::Method::PATCH,
+            Self::Delete => nanocodex_egress::http::Method::DELETE,
+            Self::Head => nanocodex_egress::http::Method::HEAD,
+            Self::Options => nanocodex_egress::http::Method::OPTIONS,
+        }
+    }
+}
+
+/// Method and normalized path scope for one secret.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecretRequestRule {
+    methods: BTreeSet<SecretHttpMethod>,
+    path_prefixes: Vec<String>,
+}
+
+impl SecretRequestRule {
+    /// Creates a rule that initially accepts every supported method and path.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds one accepted method.
+    #[must_use]
+    pub fn method(mut self, method: SecretHttpMethod) -> Self {
+        self.methods.insert(method);
+        self
+    }
+
+    /// Adds one absolute path-segment prefix such as `/v1/responses`.
+    #[must_use]
+    pub fn path_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.path_prefixes.push(prefix.into());
+        self
+    }
+
+    /// Returns the accepted methods. An empty set accepts every supported method.
+    #[must_use]
+    pub const fn methods(&self) -> &BTreeSet<SecretHttpMethod> {
+        &self.methods
+    }
+
+    /// Returns accepted absolute path prefixes. An empty list accepts every path.
+    #[must_use]
+    pub fn path_prefixes(&self) -> &[String] {
+        &self.path_prefixes
+    }
+}
+
+/// Host-side credential delivery applied after request authorization.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum SecretDelivery {
+    /// Replaces the complete header with `prefix + resolved_secret`.
+    InjectHeader {
+        /// Header name, for example `authorization`.
+        header: String,
+        /// Non-secret prefix, for example `Bearer `.
+        prefix: String,
+    },
+    /// Replaces an exact placeholder inside a caller-supplied header.
+    ReplaceHeader {
+        /// Header name containing the placeholder.
+        header: String,
+        /// Public placeholder exported to the guest.
+        placeholder: String,
+    },
+}
+
+impl SecretDelivery {
+    /// Creates complete header injection.
+    #[must_use]
+    pub fn inject_header(header: impl Into<String>, prefix: impl Into<String>) -> Self {
+        Self::InjectHeader {
+            header: header.into(),
+            prefix: prefix.into(),
+        }
+    }
+
+    /// Creates placeholder replacement inside an existing header.
+    #[must_use]
+    pub fn replace_header(header: impl Into<String>, placeholder: impl Into<String>) -> Self {
+        Self::ReplaceHeader {
+            header: header.into(),
+            placeholder: placeholder.into(),
+        }
+    }
+
+    /// Returns the credential-bearing header name.
+    #[must_use]
+    pub fn header(&self) -> &str {
+        match self {
+            Self::InjectHeader { header, .. } | Self::ReplaceHeader { header, .. } => header,
+        }
+    }
+
+    pub(crate) fn placeholder(&self) -> Option<&str> {
+        match self {
+            Self::InjectHeader { .. } => None,
+            Self::ReplaceHeader { placeholder, .. } => Some(placeholder),
+        }
+    }
+}
+
+/// Public guest configuration associated with one secret route.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecretGuestConfig {
+    #[serde(rename = "base_url_env", alias = "base_url_environment")]
+    base_url_environment: String,
+    #[serde(
+        default,
+        rename = "placeholder_env",
+        alias = "placeholder_environment",
+        skip_serializing_if = "Option::is_none"
+    )]
+    placeholder_environment: Option<String>,
+}
+
+impl SecretGuestConfig {
+    /// Creates guest configuration exporting the route origin under one name.
+    #[must_use]
+    pub fn new(base_url_environment: impl Into<String>) -> Self {
+        Self {
+            base_url_environment: base_url_environment.into(),
+            placeholder_environment: None,
+        }
+    }
+
+    /// Exports the public replacement placeholder under one environment name.
+    #[must_use]
+    pub fn placeholder_environment(mut self, name: impl Into<String>) -> Self {
+        self.placeholder_environment = Some(name.into());
+        self
+    }
+
+    /// Returns the environment name receiving the route origin.
+    #[must_use]
+    pub fn base_url_environment(&self) -> &str {
+        &self.base_url_environment
+    }
+
+    /// Returns the environment name receiving a public placeholder.
+    #[must_use]
+    pub fn placeholder_environment_name(&self) -> Option<&str> {
+        self.placeholder_environment.as_deref()
+    }
+}
+
+/// Validated host-side secret route.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct SecretSpec {
+    id: String,
+    source: SecretRef,
+    upstream: String,
+    rules: Vec<SecretRequestRule>,
+    delivery: SecretDelivery,
+    guest: SecretGuestConfig,
+}
+
+impl SecretSpec {
+    /// Starts a validated secret-route builder.
+    #[must_use]
+    pub fn builder(
+        id: impl Into<String>,
+        source: SecretRef,
+        upstream: impl Into<String>,
+        delivery: SecretDelivery,
+        guest: SecretGuestConfig,
+    ) -> SecretSpecBuilder {
+        SecretSpecBuilder {
+            id: id.into(),
+            source,
+            upstream: upstream.into(),
+            rules: Vec::new(),
+            delivery,
+            guest,
+        }
+    }
+
+    /// Returns the stable policy identifier.
+    #[must_use]
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Returns the host secret-manager reference.
+    #[must_use]
+    pub const fn source(&self) -> &SecretRef {
+        &self.source
+    }
+
+    /// Returns the authorized HTTP(S) upstream base URL.
+    #[must_use]
+    pub fn upstream(&self) -> &str {
+        &self.upstream
+    }
+
+    /// Returns request authorization rules.
+    #[must_use]
+    pub fn rules(&self) -> &[SecretRequestRule] {
+        &self.rules
+    }
+
+    /// Returns the host-side header delivery policy.
+    #[must_use]
+    pub const fn delivery(&self) -> &SecretDelivery {
+        &self.delivery
+    }
+
+    /// Returns public guest configuration.
+    #[must_use]
+    pub const fn guest(&self) -> &SecretGuestConfig {
+        &self.guest
+    }
+
+    pub(crate) fn egress_rules(
+        &self,
+    ) -> Result<Vec<nanocodex_egress::SecretRule>, nanocodex_egress::SecretConfigError> {
+        if self.rules.is_empty() {
+            return Ok(vec![self.egress_rule(self.id.clone(), None)?]);
+        }
+        self.rules
+            .iter()
+            .enumerate()
+            .map(|(index, rule)| {
+                let id = if self.rules.len() == 1 {
+                    self.id.clone()
+                } else {
+                    format!("{}-{index}", self.id)
+                };
+                self.egress_rule(id, Some(rule))
+            })
+            .collect()
+    }
+
+    fn egress_rule(
+        &self,
+        id: String,
+        request: Option<&SecretRequestRule>,
+    ) -> Result<nanocodex_egress::SecretRule, nanocodex_egress::SecretConfigError> {
+        let source =
+            nanocodex_egress::SecretRef::new(self.source.provider.clone(), self.source.key.clone());
+        let mut builder = nanocodex_egress::SecretRule::builder(id, source, &self.upstream);
+        if let Some(request) = request {
+            for method in &request.methods {
+                builder = builder.method(method.as_http());
+            }
+            for prefix in &request.path_prefixes {
+                builder = builder.path_prefix(prefix);
+            }
+        }
+        builder = match &self.delivery {
+            SecretDelivery::InjectHeader { header, prefix } => builder
+                .inject_header(
+                    header,
+                    nanocodex_egress::SecretFormat::Affix {
+                        prefix: prefix.clone(),
+                        suffix: String::new(),
+                    },
+                )
+                .child_base_url_environment(self.guest.base_url_environment.clone()),
+            SecretDelivery::ReplaceHeader {
+                header,
+                placeholder,
+            } => builder
+                .replace_header(header, placeholder)
+                .child_environment(
+                    self.guest.base_url_environment.clone(),
+                    self.guest
+                        .placeholder_environment
+                        .clone()
+                        .unwrap_or_else(|| placeholder.clone()),
+                ),
+        };
+        builder.build()
+    }
+
+    pub(crate) fn validate(&self) -> Result<(), SecretConfigError> {
+        validate_spec(self)
+    }
+}
+
+/// Builder for one validated [`SecretSpec`].
+pub struct SecretSpecBuilder {
+    id: String,
+    source: SecretRef,
+    upstream: String,
+    rules: Vec<SecretRequestRule>,
+    delivery: SecretDelivery,
+    guest: SecretGuestConfig,
+}
+
+impl SecretSpecBuilder {
+    /// Adds one request authorization rule.
+    #[must_use]
+    pub fn rule(mut self, rule: SecretRequestRule) -> Self {
+        self.rules.push(rule);
+        self
+    }
+
+    /// Validates and creates the secret route.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed error for unsafe identifiers, origins, headers, paths,
+    /// environment names, or placeholder configuration.
+    pub fn build(self) -> Result<SecretSpec, SecretConfigError> {
+        let spec = SecretSpec {
+            id: self.id,
+            source: self.source,
+            upstream: self.upstream,
+            rules: self.rules,
+            delivery: self.delivery,
+            guest: self.guest,
+        };
+        spec.validate()?;
+        Ok(spec)
+    }
+}
+
+fn validate_spec(spec: &SecretSpec) -> Result<(), SecretConfigError> {
+    validate_identifier(&spec.id).ok_or(SecretConfigError::InvalidId)?;
+    if spec.source.provider.trim().is_empty()
+        || spec.source.key.trim().is_empty()
+        || spec.source.provider.len() > MAX_IDENTIFIER_BYTES
+        || spec.source.key.len() > 4 * 1_024
+    {
+        return Err(SecretConfigError::InvalidSource);
+    }
+    let upstream = Url::parse(&spec.upstream).map_err(|_| SecretConfigError::InvalidUpstream)?;
+    if !matches!(upstream.scheme(), "http" | "https")
+        || upstream.host_str().is_none()
+        || !upstream.username().is_empty()
+        || upstream.password().is_some()
+        || upstream.query().is_some()
+        || upstream.fragment().is_some()
+        || !valid_path_prefix(upstream.path())
+    {
+        return Err(SecretConfigError::InvalidUpstream);
+    }
+    for rule in &spec.rules {
+        for prefix in &rule.path_prefixes {
+            if !valid_path_prefix(prefix) {
+                return Err(SecretConfigError::InvalidPathPrefix);
+            }
+        }
+    }
+    let header = spec.delivery.header();
+    if header.is_empty()
+        || header.len() > MAX_HEADER_NAME_BYTES
+        || HeaderName::from_bytes(header.as_bytes()).is_err()
+        || [
+            "host",
+            "content-length",
+            "transfer-encoding",
+            "connection",
+            "proxy-authorization",
+        ]
+        .iter()
+        .any(|reserved| header.eq_ignore_ascii_case(reserved))
+    {
+        return Err(SecretConfigError::InvalidHeader);
+    }
+    validate_environment_name(&spec.guest.base_url_environment)?;
+    if let Some(environment) = &spec.guest.placeholder_environment {
+        validate_environment_name(environment)?;
+    }
+    if let Some(placeholder) = spec.delivery.placeholder()
+        && spec.guest.placeholder_environment.as_deref() != Some(placeholder)
+    {
+        return Err(SecretConfigError::PlaceholderMismatch);
+    }
+    Ok(())
+}
+
+fn validate_identifier(value: &str) -> Option<()> {
+    (!value.is_empty()
+        && value.len() <= MAX_IDENTIFIER_BYTES
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.')))
+    .then_some(())
+}
+
+fn valid_path_prefix(prefix: &str) -> bool {
+    prefix.starts_with('/')
+        && prefix.len() <= MAX_PATH_PREFIX_BYTES
+        && !prefix.contains('\\')
+        && !prefix.split('/').any(|segment| segment == "..")
+        && !contains_ambiguous_path_escape(prefix)
+}
+
+#[cfg(test)]
+pub(crate) fn safe_request_path(path: &str) -> Option<String> {
+    if path.contains('\\')
+        || path.split('/').any(|segment| segment == "..")
+        || contains_ambiguous_path_escape(path)
+    {
+        return None;
+    }
+    Some(format!("/{}", path.trim_start_matches('/')))
+}
+
+fn contains_ambiguous_path_escape(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'%' {
+            index += 1;
+            continue;
+        }
+        let encoded = bytes
+            .get(index + 1..index + 3)
+            .and_then(|digits| decode_hex_byte(digits[0], digits[1]));
+        let Some(encoded) = encoded else {
+            return true;
+        };
+        if matches!(encoded, b'%' | b'.' | b'/' | b'\\' | b'?' | b'#') {
+            return true;
+        }
+        index += 3;
+    }
+    false
+}
+
+fn decode_hex_byte(high: u8, low: u8) -> Option<u8> {
+    Some(hex_value(high)? << 4 | hex_value(low)?)
+}
+
+const fn hex_value(digit: u8) -> Option<u8> {
+    match digit {
+        b'0'..=b'9' => Some(digit - b'0'),
+        b'a'..=b'f' => Some(digit - b'a' + 10),
+        b'A'..=b'F' => Some(digit - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn validate_environment_name(value: &str) -> Result<(), SecretConfigError> {
+    let mut bytes = value.bytes();
+    let valid_start = bytes
+        .next()
+        .is_some_and(|byte| byte.is_ascii_uppercase() || byte == b'_');
+    if value.len() > MAX_ENVIRONMENT_NAME_BYTES
+        || !valid_start
+        || !bytes.all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || byte == b'_')
+    {
+        Err(SecretConfigError::InvalidEnvironmentName)
+    } else {
+        Ok(())
+    }
+}
+
+/// Pluggable host boundary for environment, Vault, cloud KMS, or Iron secrets.
+#[async_trait]
+pub trait SecretManager: Send + Sync {
+    /// Resolves one opaque reference without exposing it to the guest.
+    async fn resolve(&self, reference: &SecretRef) -> Result<String, SecretError>;
+}
+
+/// Bounded file-backed secret manager rooted at one canonical directory.
+pub struct FileSecretManager {
+    root: PathBuf,
+}
+
+impl FileSecretManager {
+    /// Creates a file provider suitable for Docker secrets, tmpfs, or CSI.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the root cannot be canonicalized or is not a
+    /// directory.
+    pub fn new(root: impl AsRef<Path>) -> Result<Self, SecretError> {
+        let root = std::fs::canonicalize(root).map_err(SecretError::Io)?;
+        if !root.is_dir() {
+            return Err(SecretError::InvalidRoot);
+        }
+        Ok(Self { root })
+    }
+}
+
+#[async_trait]
+impl SecretManager for FileSecretManager {
+    async fn resolve(&self, reference: &SecretRef) -> Result<String, SecretError> {
+        let relative = Path::new(&reference.key);
+        if relative.is_absolute()
+            || relative
+                .components()
+                .any(|component| !matches!(component, Component::Normal(_)))
+        {
+            return Err(SecretError::InvalidKey);
+        }
+        let canonical = tokio::fs::canonicalize(self.root.join(relative))
+            .await
+            .map_err(|error| {
+                if error.kind() == std::io::ErrorKind::NotFound {
+                    SecretError::NotFound {
+                        provider: reference.provider.clone(),
+                        key: reference.key.clone(),
+                    }
+                } else {
+                    SecretError::Io(error)
+                }
+            })?;
+        if !canonical.starts_with(&self.root) {
+            return Err(SecretError::InvalidKey);
+        }
+        let file = tokio::fs::File::open(canonical)
+            .await
+            .map_err(SecretError::Io)?;
+        let metadata = file.metadata().await.map_err(SecretError::Io)?;
+        if !metadata.is_file() || metadata.len() > MAX_FILE_SECRET_BYTES {
+            return Err(SecretError::InvalidFile);
+        }
+        let mut value = String::new();
+        file.take(MAX_FILE_SECRET_BYTES + 1)
+            .read_to_string(&mut value)
+            .await
+            .map_err(SecretError::Io)?;
+        if value.len() as u64 > MAX_FILE_SECRET_BYTES {
+            return Err(SecretError::InvalidFile);
+        }
+        Ok(value.trim_end_matches(['\r', '\n']).to_owned())
+    }
+}
+
+/// Host environment secret manager with an explicit variable prefix.
+pub struct EnvironmentSecretManager {
+    prefix: String,
+}
+
+impl EnvironmentSecretManager {
+    /// Creates an environment provider; `NANOCODEX_SECRET_` is a typical prefix.
+    #[must_use]
+    pub fn new(prefix: impl Into<String>) -> Self {
+        Self {
+            prefix: prefix.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl SecretManager for EnvironmentSecretManager {
+    async fn resolve(&self, reference: &SecretRef) -> Result<String, SecretError> {
+        let name = format!("{}{}", self.prefix, reference.key);
+        env::var(&name).map_err(|_| SecretError::NotFound {
+            provider: reference.provider.clone(),
+            key: reference.key.clone(),
+        })
+    }
+}
+
+/// Heterogeneous provider registry keyed by [`SecretRef::provider`].
+#[derive(Clone, Default)]
+pub struct CompositeSecretManager {
+    providers: BTreeMap<String, Arc<dyn SecretManager>>,
+}
+
+impl CompositeSecretManager {
+    /// Creates an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Installs or replaces one named host provider.
+    #[must_use]
+    pub fn provider(mut self, name: impl Into<String>, provider: Arc<dyn SecretManager>) -> Self {
+        self.providers.insert(name.into(), provider);
+        self
+    }
+}
+
+#[async_trait]
+impl SecretManager for CompositeSecretManager {
+    async fn resolve(&self, reference: &SecretRef) -> Result<String, SecretError> {
+        self.providers
+            .get(&reference.provider)
+            .ok_or_else(|| SecretError::UnknownProvider(reference.provider.clone()))?
+            .resolve(reference)
+            .await
+    }
+}
+
+/// Secret-manager resolution failure.
+#[derive(Debug, Error)]
+pub enum SecretError {
+    /// No manager is registered for the reference provider.
+    #[error("unknown secret provider `{0}`")]
+    UnknownProvider(String),
+    /// The provider could not find the requested key.
+    #[error("secret `{provider}:{key}` was not found")]
+    NotFound {
+        /// Provider registry name.
+        provider: String,
+        /// Opaque provider key.
+        key: String,
+    },
+    /// A provider returned an intentionally opaque failure.
+    #[error("secret provider failed: {0}")]
+    Provider(String),
+    /// A provider rejected the reference syntax.
+    #[error("secret reference `{provider}:{key}` is invalid")]
+    InvalidReference {
+        /// Provider registry name.
+        provider: String,
+        /// Rejected opaque key.
+        key: String,
+    },
+    /// A file key was not a safe relative path.
+    #[error("secret key is not a safe relative path")]
+    InvalidKey,
+    /// A file provider root was not a directory.
+    #[error("secret file provider root must be a directory")]
+    InvalidRoot,
+    /// A file secret was not a bounded regular UTF-8 file.
+    #[error("secret file must be a bounded regular UTF-8 file")]
+    InvalidFile,
+    /// A file provider operation failed.
+    #[error("secret file provider failed")]
+    Io(#[source] std::io::Error),
+}
+
+/// Invalid secret route configuration.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum SecretConfigError {
+    /// The secret ID was empty, too long, or contained unsafe bytes.
+    #[error("secret id must use 1 to 256 ASCII letters, digits, dots, dashes, or underscores")]
+    InvalidId,
+    /// The manager provider or key was empty or unbounded.
+    #[error("secret source provider and key must be non-empty and bounded")]
+    InvalidSource,
+    /// The upstream was not a credential-free absolute HTTP(S) base URL.
+    #[error(
+        "secret upstream must be a bounded absolute HTTP(S) base URL without credentials or query"
+    )]
+    InvalidUpstream,
+    /// A rule path was not an unambiguous bounded absolute prefix.
+    #[error("secret rule path prefixes must be safe bounded absolute paths")]
+    InvalidPathPrefix,
+    /// The delivery header was invalid or transport-owned.
+    #[error("secret delivery header is invalid or unsafe")]
+    InvalidHeader,
+    /// A guest environment name was not an uppercase shell identifier.
+    #[error("secret guest environment names must use uppercase shell identifier syntax")]
+    InvalidEnvironmentName,
+    /// Replace delivery and guest placeholder configuration differed.
+    #[error("replace delivery placeholder must equal guest placeholder environment name")]
+    PlaceholderMismatch,
+}
+
+/// Administrative request for one host-resolved secret route.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateSecret {
+    /// Optional stable route identifier. A UUID is generated when omitted.
+    pub id: Option<String>,
+    /// Human-readable administrative name.
+    pub name: String,
+    /// Opaque provider-qualified reference; never resolved into `SQLite`.
+    pub source: SecretRef,
+    /// Credential-free HTTP(S) origin eligible to receive the secret.
+    pub upstream: String,
+    /// Allowed method and path scopes.
+    #[serde(default)]
+    pub rules: Vec<SecretRequestRule>,
+    /// Host-side header injection behavior.
+    pub delivery: SecretDelivery,
+    /// Public environment projected into an authorized guest.
+    pub guest: SecretGuestConfig,
+}
+
+/// Partial administrative update for one secret route.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct PatchSecret {
+    /// Replaces the human-readable name.
+    pub name: Option<String>,
+    /// Replaces the provider-qualified reference.
+    pub source: Option<SecretRef>,
+    /// Replaces the fixed upstream origin.
+    pub upstream: Option<String>,
+    /// Replaces all request scopes.
+    pub rules: Option<Vec<SecretRequestRule>>,
+    /// Replaces host-side delivery behavior.
+    pub delivery: Option<SecretDelivery>,
+    /// Replaces public guest configuration.
+    pub guest: Option<SecretGuestConfig>,
+    /// Enables or disables the route.
+    pub enabled: Option<bool>,
+}
+
+/// Durable administrative view of one secret route.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SecretView {
+    /// Stable route identifier.
+    pub id: String,
+    /// Human-readable administrative name.
+    pub name: String,
+    /// Opaque provider-qualified reference.
+    pub source: SecretRef,
+    /// Fixed credential-free upstream origin.
+    pub upstream: String,
+    /// Allowed method and path scopes.
+    pub rules: Vec<SecretRequestRule>,
+    /// Host-side header injection behavior.
+    pub delivery: SecretDelivery,
+    /// Public environment projected into an authorized guest.
+    pub guest: SecretGuestConfig,
+    /// Whether this route can currently be granted.
+    pub enabled: bool,
+    /// Creation time.
+    pub created_at: DateTime<Utc>,
+    /// Last administrative update time.
+    pub updated_at: DateTime<Utc>,
+}
+
+impl SecretView {
+    /// Validates and projects this managed record into the reusable egress type.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when persisted route configuration violates the
+    /// current egress contract.
+    pub fn to_spec(&self) -> Result<SecretSpec, SecretConfigError> {
+        build_spec(
+            self.id.clone(),
+            self.source.clone(),
+            self.upstream.clone(),
+            self.rules.clone(),
+            self.delivery.clone(),
+            self.guest.clone(),
+        )
+    }
+}
+
+pub(crate) fn validate_secret(secret: &CreateSecret) -> Result<(), SecretConfigError> {
+    build_spec(
+        secret.id.clone().unwrap_or_else(|| "generated".to_owned()),
+        secret.source.clone(),
+        secret.upstream.clone(),
+        secret.rules.clone(),
+        secret.delivery.clone(),
+        secret.guest.clone(),
+    )
+    .map(drop)
+}
+
+fn build_spec(
+    id: String,
+    source: SecretRef,
+    upstream: String,
+    rules: Vec<SecretRequestRule>,
+    delivery: SecretDelivery,
+    guest: SecretGuestConfig,
+) -> Result<SecretSpec, SecretConfigError> {
+    let mut builder = SecretSpec::builder(id, source, upstream, delivery, guest);
+    for rule in rules {
+        builder = builder.rule(rule);
+    }
+    builder.build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn openai_spec() -> SecretSpec {
+        SecretSpec::builder(
+            "openai",
+            SecretRef::new("environment", "OPENAI_API_KEY"),
+            "https://api.openai.com",
+            SecretDelivery::inject_header("authorization", "Bearer "),
+            SecretGuestConfig::new("OPENAI_BASE_URL"),
+        )
+        .rule(
+            SecretRequestRule::new()
+                .method(SecretHttpMethod::Post)
+                .path_prefix("/v1/responses"),
+        )
+        .build()
+        .unwrap()
+    }
+
+    #[test]
+    fn builder_produces_a_scoped_route() {
+        let spec = openai_spec();
+        assert_eq!(spec.id(), "openai");
+        assert_eq!(spec.upstream(), "https://api.openai.com");
+        assert_eq!(spec.rules().len(), 1);
+    }
+
+    #[test]
+    fn rejects_credential_origins_and_ambiguous_prefixes() {
+        let error = SecretSpec::builder(
+            "openai",
+            SecretRef::new("environment", "OPENAI_API_KEY"),
+            "https://token@example.com",
+            SecretDelivery::inject_header("authorization", "Bearer "),
+            SecretGuestConfig::new("OPENAI_BASE_URL"),
+        )
+        .build()
+        .unwrap_err();
+        assert_eq!(error, SecretConfigError::InvalidUpstream);
+
+        let error = SecretSpec::builder(
+            "openai",
+            SecretRef::new("environment", "OPENAI_API_KEY"),
+            "https://api.openai.com",
+            SecretDelivery::inject_header("authorization", "Bearer "),
+            SecretGuestConfig::new("OPENAI_BASE_URL"),
+        )
+        .rule(SecretRequestRule::new().path_prefix("/v1/%2e%2e/admin"))
+        .build()
+        .unwrap_err();
+        assert_eq!(error, SecretConfigError::InvalidPathPrefix);
+
+        let error = SecretSpec::builder(
+            "../escape",
+            SecretRef::new("environment", "OPENAI_API_KEY"),
+            "https://api.openai.com",
+            SecretDelivery::inject_header("authorization", "Bearer "),
+            SecretGuestConfig::new("OPENAI_BASE_URL"),
+        )
+        .build()
+        .unwrap_err();
+        assert_eq!(error, SecretConfigError::InvalidId);
+    }
+
+    #[test]
+    fn request_paths_reject_every_ambiguous_encoding_before_policy_matching() {
+        assert_eq!(
+            safe_request_path("/allowed/resource").as_deref(),
+            Some("/allowed/resource")
+        );
+        for path in [
+            "/allowed/../admin",
+            "/allowed/%2e%2e/admin",
+            "/allowed/%2E%2E/admin",
+            "/allowed/%252e%252e/admin",
+            "/allowed%2f..%2fadmin",
+            "/allowed%5c..%5cadmin",
+            "/allowed\\..\\admin",
+            "/allowed/%",
+            "/allowed/%zz",
+        ] {
+            assert!(
+                safe_request_path(path).is_none(),
+                "ambiguous path was accepted: {path}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn file_provider_rejects_escape_and_oversized_values() {
+        let directory = tempfile::tempdir().unwrap();
+        let manager = FileSecretManager::new(directory.path()).unwrap();
+        let error = manager
+            .resolve(&SecretRef::new("file", "../outside"))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, SecretError::InvalidKey));
+
+        let path = directory.path().join("oversized");
+        let file = std::fs::File::create(path).unwrap();
+        file.set_len(MAX_FILE_SECRET_BYTES + 1).unwrap();
+        let error = manager
+            .resolve(&SecretRef::new("file", "oversized"))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, SecretError::InvalidFile));
+    }
+}

--- a/crates/experimental/nanocentaur/src/session.rs
+++ b/crates/experimental/nanocentaur/src/session.rs
@@ -1,0 +1,1155 @@
+use std::{collections::HashMap, path::Path, time::Instant};
+
+use chrono::{DateTime, Utc};
+use nanocodex_agent::session::SessionSnapshot;
+use rusqlite::{Connection, OptionalExtension, Transaction, params};
+use thiserror::Error;
+use tokio::sync::{mpsc, oneshot};
+
+use crate::{
+    AgentEvent, AgentEventPayload, ContentBlock, ForkSource, TurnAction, TurnActionResponse,
+    TurnDelivery, TurnStatus, TurnView,
+};
+
+const COMMAND_CAPACITY: usize = 256;
+
+#[derive(Clone)]
+pub(crate) struct SessionStore {
+    sender: mpsc::Sender<CommandEnvelope>,
+}
+
+struct CommandEnvelope {
+    dispatch: tracing::Dispatch,
+    parent: tracing::Span,
+    queued_at: Instant,
+    command: Command,
+}
+
+pub(crate) struct StoredSession {
+    pub turns: Vec<StoredTurn>,
+    pub requests: HashMap<String, TurnActionResponse>,
+}
+
+pub(crate) struct StoredTurn {
+    pub view: TurnView,
+    pub inputs: Vec<Vec<ContentBlock>>,
+    pub cancel_requested: bool,
+    pub snapshot: Option<SessionSnapshot>,
+}
+
+pub(crate) struct NewTurn {
+    pub view: TurnView,
+    pub delivery: TurnDelivery,
+    pub content: Vec<ContentBlock>,
+    pub response: TurnActionResponse,
+    pub idempotency_key: Option<String>,
+    pub event: AgentEventPayload,
+}
+
+pub(crate) struct CompletedTurn {
+    pub status: TurnStatus,
+    pub output: Vec<ContentBlock>,
+    pub error: Option<String>,
+    pub completed_at: DateTime<Utc>,
+    pub snapshot: Option<SessionSnapshot>,
+    pub usage: Option<nanocodex_agent::TurnUsage>,
+    pub event: AgentEventPayload,
+}
+
+impl SessionStore {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, SessionError> {
+        if let Some(parent) = path.as_ref().parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let connection = Connection::open(path)?;
+        configure(&connection)?;
+        let (sender, mut receiver) = mpsc::channel::<CommandEnvelope>(COMMAND_CAPACITY);
+        tokio::task::spawn_blocking(move || {
+            while let Some(envelope) = receiver.blocking_recv() {
+                let command = envelope.command.name();
+                let span = tracing::dispatcher::with_default(&envelope.dispatch, || {
+                    tracing::info_span!(
+                        parent: &envelope.parent,
+                        "nanocentaur.sqlite.command",
+                        db.system = "sqlite",
+                        db.operation.name = command,
+                        queue.duration_ns = u64::try_from(
+                            envelope.queued_at.elapsed().as_nanos()
+                        )
+                        .unwrap_or(u64::MAX),
+                    )
+                });
+                let _entered = span.enter();
+                envelope.command.execute(&connection);
+            }
+        });
+        Ok(Self { sender })
+    }
+
+    pub async fn ensure_agent(&self, agent_id: String) -> Result<(), SessionError> {
+        self.call(|reply| Command::EnsureAgent { agent_id, reply })
+            .await
+    }
+
+    pub async fn load(&self, agent_id: String) -> Result<StoredSession, SessionError> {
+        self.call(|reply| Command::Load { agent_id, reply }).await
+    }
+
+    pub async fn find_request(
+        &self,
+        agent_id: String,
+        key: String,
+    ) -> Result<Option<TurnActionResponse>, SessionError> {
+        self.call(|reply| Command::FindRequest {
+            agent_id,
+            key,
+            reply,
+        })
+        .await
+    }
+
+    pub async fn record_turn(
+        &self,
+        agent_id: String,
+        turn: NewTurn,
+    ) -> Result<AgentEvent, SessionError> {
+        self.call(|reply| Command::RecordTurn {
+            agent_id,
+            turn: Box::new(turn),
+            reply,
+        })
+        .await
+    }
+
+    pub async fn record_steer(
+        &self,
+        agent_id: String,
+        turn_id: String,
+        content: Vec<ContentBlock>,
+        response: TurnActionResponse,
+        idempotency_key: Option<String>,
+    ) -> Result<(), SessionError> {
+        self.call(|reply| Command::RecordSteer {
+            agent_id,
+            turn_id,
+            content,
+            response,
+            idempotency_key,
+            reply,
+        })
+        .await
+    }
+
+    pub async fn mark_started(
+        &self,
+        agent_id: String,
+        turn_id: String,
+    ) -> Result<AgentEvent, SessionError> {
+        self.call(|reply| Command::MarkStarted {
+            agent_id,
+            turn_id,
+            reply,
+        })
+        .await
+    }
+
+    pub async fn request_cancel(
+        &self,
+        agent_id: String,
+        turn_id: String,
+    ) -> Result<AgentEvent, SessionError> {
+        self.call(|reply| Command::RequestCancel {
+            agent_id,
+            turn_id,
+            reply,
+        })
+        .await
+    }
+
+    pub async fn finish_turn(
+        &self,
+        agent_id: String,
+        turn_id: String,
+        completed: CompletedTurn,
+    ) -> Result<AgentEvent, SessionError> {
+        self.call(|reply| Command::FinishTurn {
+            agent_id,
+            turn_id,
+            completed: Box::new(completed),
+            reply,
+        })
+        .await
+    }
+
+    pub async fn append_event(
+        &self,
+        agent_id: String,
+        turn_id: Option<String>,
+        payload: AgentEventPayload,
+    ) -> Result<AgentEvent, SessionError> {
+        self.call(|reply| Command::AppendEvent {
+            agent_id,
+            turn_id,
+            payload,
+            reply,
+        })
+        .await
+    }
+
+    pub async fn events_after(
+        &self,
+        agent_id: String,
+        after_event_id: u64,
+    ) -> Result<Vec<AgentEvent>, SessionError> {
+        self.call(|reply| Command::EventsAfter {
+            agent_id,
+            after_event_id,
+            reply,
+        })
+        .await
+    }
+
+    pub async fn fork(
+        &self,
+        source_agent_id: String,
+        target_agent_id: String,
+        turn_id: Option<String>,
+    ) -> Result<ForkSource, SessionError> {
+        self.call(|reply| Command::Fork {
+            source_agent_id,
+            target_agent_id,
+            turn_id,
+            reply,
+        })
+        .await
+    }
+
+    pub async fn delete(&self, agent_id: String) -> Result<(), SessionError> {
+        self.call(|reply| Command::Delete { agent_id, reply }).await
+    }
+
+    async fn call<T>(
+        &self,
+        command: impl FnOnce(oneshot::Sender<Result<T, SessionError>>) -> Command,
+    ) -> Result<T, SessionError> {
+        let (reply, response) = oneshot::channel();
+        let command = command(reply);
+        self.sender
+            .send(CommandEnvelope {
+                dispatch: tracing::dispatcher::get_default(Clone::clone),
+                parent: tracing::Span::current(),
+                queued_at: Instant::now(),
+                command,
+            })
+            .await
+            .map_err(|_| SessionError::Stopped)?;
+        response.await.map_err(|_| SessionError::Stopped)?
+    }
+}
+
+enum Command {
+    EnsureAgent {
+        agent_id: String,
+        reply: Reply<()>,
+    },
+    Load {
+        agent_id: String,
+        reply: Reply<StoredSession>,
+    },
+    FindRequest {
+        agent_id: String,
+        key: String,
+        reply: Reply<Option<TurnActionResponse>>,
+    },
+    RecordTurn {
+        agent_id: String,
+        turn: Box<NewTurn>,
+        reply: Reply<AgentEvent>,
+    },
+    RecordSteer {
+        agent_id: String,
+        turn_id: String,
+        content: Vec<ContentBlock>,
+        response: TurnActionResponse,
+        idempotency_key: Option<String>,
+        reply: Reply<()>,
+    },
+    MarkStarted {
+        agent_id: String,
+        turn_id: String,
+        reply: Reply<AgentEvent>,
+    },
+    RequestCancel {
+        agent_id: String,
+        turn_id: String,
+        reply: Reply<AgentEvent>,
+    },
+    FinishTurn {
+        agent_id: String,
+        turn_id: String,
+        completed: Box<CompletedTurn>,
+        reply: Reply<AgentEvent>,
+    },
+    AppendEvent {
+        agent_id: String,
+        turn_id: Option<String>,
+        payload: AgentEventPayload,
+        reply: Reply<AgentEvent>,
+    },
+    EventsAfter {
+        agent_id: String,
+        after_event_id: u64,
+        reply: Reply<Vec<AgentEvent>>,
+    },
+    Fork {
+        source_agent_id: String,
+        target_agent_id: String,
+        turn_id: Option<String>,
+        reply: Reply<ForkSource>,
+    },
+    Delete {
+        agent_id: String,
+        reply: Reply<()>,
+    },
+}
+
+type Reply<T> = oneshot::Sender<Result<T, SessionError>>;
+
+impl Command {
+    const fn name(&self) -> &'static str {
+        match self {
+            Self::EnsureAgent { .. } => "ensure_agent",
+            Self::Load { .. } => "load",
+            Self::FindRequest { .. } => "find_request",
+            Self::RecordTurn { .. } => "record_turn",
+            Self::RecordSteer { .. } => "record_steer",
+            Self::MarkStarted { .. } => "mark_started",
+            Self::RequestCancel { .. } => "request_cancel",
+            Self::FinishTurn { .. } => "finish_turn",
+            Self::AppendEvent { .. } => "append_event",
+            Self::EventsAfter { .. } => "events_after",
+            Self::Fork { .. } => "fork",
+            Self::Delete { .. } => "delete",
+        }
+    }
+
+    fn execute(self, connection: &Connection) {
+        match self {
+            Self::EnsureAgent { agent_id, reply } => {
+                drop(reply.send(ensure_agent(connection, &agent_id)));
+            }
+            Self::Load { agent_id, reply } => {
+                drop(reply.send(load(connection, &agent_id)));
+            }
+            Self::FindRequest {
+                agent_id,
+                key,
+                reply,
+            } => {
+                drop(reply.send(find_request(connection, &agent_id, &key)));
+            }
+            Self::RecordTurn {
+                agent_id,
+                turn,
+                reply,
+            } => {
+                drop(reply.send(record_turn(connection, &agent_id, *turn)));
+            }
+            Self::RecordSteer {
+                agent_id,
+                turn_id,
+                content,
+                response,
+                idempotency_key,
+                reply,
+            } => {
+                drop(reply.send(record_steer(
+                    connection,
+                    &agent_id,
+                    &turn_id,
+                    &content,
+                    &response,
+                    idempotency_key.as_deref(),
+                )));
+            }
+            Self::MarkStarted {
+                agent_id,
+                turn_id,
+                reply,
+            } => {
+                drop(reply.send(mark_started(connection, &agent_id, &turn_id)));
+            }
+            Self::RequestCancel {
+                agent_id,
+                turn_id,
+                reply,
+            } => {
+                drop(reply.send(request_cancel(connection, &agent_id, &turn_id)));
+            }
+            Self::FinishTurn {
+                agent_id,
+                turn_id,
+                completed,
+                reply,
+            } => {
+                drop(reply.send(finish_turn(connection, &agent_id, &turn_id, *completed)));
+            }
+            Self::AppendEvent {
+                agent_id,
+                turn_id,
+                payload,
+                reply,
+            } => {
+                drop(reply.send(append_event(
+                    connection,
+                    &agent_id,
+                    turn_id.as_deref(),
+                    payload,
+                )));
+            }
+            Self::EventsAfter {
+                agent_id,
+                after_event_id,
+                reply,
+            } => {
+                drop(reply.send(events_after(connection, &agent_id, after_event_id)));
+            }
+            Self::Fork {
+                source_agent_id,
+                target_agent_id,
+                turn_id,
+                reply,
+            } => {
+                drop(reply.send(fork(
+                    connection,
+                    &source_agent_id,
+                    &target_agent_id,
+                    turn_id.as_deref(),
+                )));
+            }
+            Self::Delete { agent_id, reply } => {
+                drop(reply.send(delete(connection, &agent_id)));
+            }
+        }
+    }
+}
+
+fn configure(connection: &Connection) -> Result<(), SessionError> {
+    connection.pragma_update(None, "foreign_keys", "ON")?;
+    connection.pragma_update(None, "journal_mode", "WAL")?;
+    connection.pragma_update(None, "synchronous", "NORMAL")?;
+    connection.busy_timeout(std::time::Duration::from_secs(5))?;
+    connection.execute_batch(
+        r"
+        CREATE TABLE IF NOT EXISTS session_agents (
+            id TEXT PRIMARY KEY,
+            created_at TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS turns (
+            agent_id TEXT NOT NULL REFERENCES session_agents(id) ON DELETE CASCADE,
+            id TEXT NOT NULL,
+            ordinal INTEGER NOT NULL,
+            delivery TEXT NOT NULL,
+            state TEXT NOT NULL,
+            output_json TEXT NOT NULL DEFAULT '[]',
+            usage_json TEXT,
+            error TEXT,
+            cancel_requested INTEGER NOT NULL DEFAULT 0,
+            attempt INTEGER NOT NULL DEFAULT 0,
+            checkpoint_json TEXT,
+            completion_event_id INTEGER,
+            created_at TEXT NOT NULL,
+            completed_at TEXT,
+            PRIMARY KEY(agent_id, id),
+            UNIQUE(agent_id, ordinal)
+        );
+
+        CREATE TABLE IF NOT EXISTS turn_inputs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_id TEXT NOT NULL,
+            turn_id TEXT NOT NULL,
+            ordinal INTEGER NOT NULL,
+            content_json TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            FOREIGN KEY(agent_id, turn_id) REFERENCES turns(agent_id, id) ON DELETE CASCADE,
+            UNIQUE(agent_id, turn_id, ordinal)
+        );
+
+        CREATE TABLE IF NOT EXISTS turn_requests (
+            agent_id TEXT NOT NULL REFERENCES session_agents(id) ON DELETE CASCADE,
+            idempotency_key TEXT NOT NULL,
+            action TEXT NOT NULL,
+            turn_id TEXT NOT NULL,
+            state TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY(agent_id, idempotency_key)
+        );
+
+        CREATE TABLE IF NOT EXISTS session_events (
+            agent_id TEXT NOT NULL REFERENCES session_agents(id) ON DELETE CASCADE,
+            id INTEGER NOT NULL,
+            turn_id TEXT,
+            payload_json TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY(agent_id, id)
+        );
+
+        CREATE TABLE IF NOT EXISTS session_forks (
+            agent_id TEXT PRIMARY KEY REFERENCES session_agents(id) ON DELETE CASCADE,
+            source_agent_id TEXT NOT NULL,
+            source_turn_id TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS turns_agent_state
+            ON turns(agent_id, state, ordinal);
+        CREATE INDEX IF NOT EXISTS events_agent_id
+            ON session_events(agent_id, id);
+        ",
+    )?;
+    ensure_turn_usage_column(connection)?;
+    Ok(())
+}
+
+fn ensure_turn_usage_column(connection: &Connection) -> Result<(), SessionError> {
+    let mut statement = connection.prepare("PRAGMA table_info(turns)")?;
+    let columns = statement
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<Result<Vec<_>, _>>()?;
+    if !columns.iter().any(|column| column == "usage_json") {
+        connection.execute_batch("ALTER TABLE turns ADD COLUMN usage_json TEXT")?;
+    }
+    Ok(())
+}
+
+fn ensure_agent(connection: &Connection, agent_id: &str) -> Result<(), SessionError> {
+    connection.execute(
+        "INSERT OR IGNORE INTO session_agents (id, created_at) VALUES (?1, ?2)",
+        params![agent_id, now()],
+    )?;
+    Ok(())
+}
+
+fn load(connection: &Connection, agent_id: &str) -> Result<StoredSession, SessionError> {
+    ensure_agent(connection, agent_id)?;
+    let transaction = connection.unchecked_transaction()?;
+    let interrupted = {
+        let mut statement = transaction.prepare(
+            "SELECT id FROM turns
+             WHERE agent_id = ?1 AND state = 'running'
+             ORDER BY ordinal",
+        )?;
+        statement
+            .query_map(params![agent_id], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    for turn_id in interrupted {
+        transaction.execute(
+            "UPDATE turns SET state = 'queued' WHERE agent_id = ?1 AND id = ?2",
+            params![agent_id, turn_id],
+        )?;
+        append_event_tx(
+            &transaction,
+            agent_id,
+            Some(&turn_id),
+            AgentEventPayload::TurnInterrupted { retrying: true },
+        )?;
+    }
+    transaction.commit()?;
+
+    let mut statement = connection.prepare(
+        "SELECT id, delivery, state, output_json, usage_json, error,
+                cancel_requested, checkpoint_json, created_at, completed_at
+         FROM turns WHERE agent_id = ?1 ORDER BY ordinal",
+    )?;
+    let turns = statement
+        .query_map(params![agent_id], |row| {
+            let turn_id: String = row.get(0)?;
+            let state: String = row.get(2)?;
+            let output_json: String = row.get(3)?;
+            let usage_json: Option<String> = row.get(4)?;
+            let checkpoint_json: Option<String> = row.get(7)?;
+            let created_at: String = row.get(8)?;
+            let completed_at: Option<String> = row.get(9)?;
+            Ok(StoredTurn {
+                view: TurnView {
+                    turn_id: turn_id.clone(),
+                    agent_id: agent_id.to_owned(),
+                    state: parse_status(&state)?,
+                    output: json_from_sql(&output_json)?,
+                    error: row.get(5)?,
+                    usage: usage_json.as_deref().map(json_from_sql).transpose()?,
+                    created_at: parse_time(&created_at)?,
+                    completed_at: completed_at.as_deref().map(parse_time).transpose()?,
+                },
+                inputs: load_inputs(connection, agent_id, &turn_id)?,
+                cancel_requested: row.get(6)?,
+                snapshot: checkpoint_json.as_deref().map(json_from_sql).transpose()?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut requests_statement = connection.prepare(
+        "SELECT idempotency_key, action, turn_id, state
+         FROM turn_requests WHERE agent_id = ?1",
+    )?;
+    let requests = requests_statement
+        .query_map(params![agent_id], |row| {
+            let key: String = row.get(0)?;
+            let action: String = row.get(1)?;
+            let state: String = row.get(3)?;
+            Ok((
+                key,
+                TurnActionResponse {
+                    action: parse_action(&action)?,
+                    turn_id: row.get(2)?,
+                    state: parse_status(&state)?,
+                },
+            ))
+        })?
+        .collect::<Result<HashMap<_, _>, _>>()?;
+    Ok(StoredSession { turns, requests })
+}
+
+fn load_inputs(
+    connection: &Connection,
+    agent_id: &str,
+    turn_id: &str,
+) -> rusqlite::Result<Vec<Vec<ContentBlock>>> {
+    let mut statement = connection.prepare(
+        "SELECT content_json FROM turn_inputs
+         WHERE agent_id = ?1 AND turn_id = ?2 ORDER BY ordinal",
+    )?;
+    statement
+        .query_map(params![agent_id, turn_id], |row| {
+            let encoded: String = row.get(0)?;
+            json_from_sql(&encoded)
+        })?
+        .collect()
+}
+
+fn find_request(
+    connection: &Connection,
+    agent_id: &str,
+    key: &str,
+) -> Result<Option<TurnActionResponse>, SessionError> {
+    connection
+        .query_row(
+            "SELECT action, turn_id, state FROM turn_requests
+             WHERE agent_id = ?1 AND idempotency_key = ?2",
+            params![agent_id, key],
+            |row| {
+                let action: String = row.get(0)?;
+                let state: String = row.get(2)?;
+                Ok(TurnActionResponse {
+                    action: parse_action(&action)?,
+                    turn_id: row.get(1)?,
+                    state: parse_status(&state)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(Into::into)
+}
+
+fn record_turn(
+    connection: &Connection,
+    agent_id: &str,
+    turn: NewTurn,
+) -> Result<AgentEvent, SessionError> {
+    let transaction = connection.unchecked_transaction()?;
+    ensure_agent_tx(&transaction, agent_id)?;
+    let ordinal: i64 = transaction.query_row(
+        "SELECT COALESCE(MAX(ordinal), 0) + 1 FROM turns WHERE agent_id = ?1",
+        params![agent_id],
+        |row| row.get(0),
+    )?;
+    transaction.execute(
+        "INSERT INTO turns
+         (agent_id, id, ordinal, delivery, state, output_json, error,
+          cancel_requested, attempt, created_at, completed_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, ?8, ?9, ?10)",
+        params![
+            agent_id,
+            turn.view.turn_id,
+            ordinal,
+            delivery_name(turn.delivery),
+            status_name(turn.view.state),
+            serde_json::to_string(&turn.view.output)?,
+            turn.view.error,
+            i64::from(turn.view.state == TurnStatus::Running),
+            turn.view.created_at.to_rfc3339(),
+            turn.view.completed_at.map(|time| time.to_rfc3339()),
+        ],
+    )?;
+    insert_input(&transaction, agent_id, &turn.view.turn_id, 1, &turn.content)?;
+    if let Some(key) = turn.idempotency_key {
+        insert_request(&transaction, agent_id, &key, &turn.response)?;
+    }
+    let event = append_event_tx(&transaction, agent_id, Some(&turn.view.turn_id), turn.event)?;
+    transaction.commit()?;
+    Ok(event)
+}
+
+fn record_steer(
+    connection: &Connection,
+    agent_id: &str,
+    turn_id: &str,
+    content: &[ContentBlock],
+    response: &TurnActionResponse,
+    idempotency_key: Option<&str>,
+) -> Result<(), SessionError> {
+    let transaction = connection.unchecked_transaction()?;
+    let ordinal: i64 = transaction.query_row(
+        "SELECT COALESCE(MAX(ordinal), 0) + 1 FROM turn_inputs
+         WHERE agent_id = ?1 AND turn_id = ?2",
+        params![agent_id, turn_id],
+        |row| row.get(0),
+    )?;
+    insert_input(&transaction, agent_id, turn_id, ordinal, content)?;
+    if let Some(key) = idempotency_key {
+        insert_request(&transaction, agent_id, key, response)?;
+    }
+    transaction.commit()?;
+    Ok(())
+}
+
+fn mark_started(
+    connection: &Connection,
+    agent_id: &str,
+    turn_id: &str,
+) -> Result<AgentEvent, SessionError> {
+    let transaction = connection.unchecked_transaction()?;
+    transaction.execute(
+        "UPDATE turns SET state = 'running', attempt = attempt + 1
+         WHERE agent_id = ?1 AND id = ?2",
+        params![agent_id, turn_id],
+    )?;
+    let event = append_event_tx(
+        &transaction,
+        agent_id,
+        Some(turn_id),
+        AgentEventPayload::TurnStarted {
+            state: TurnStatus::Running,
+        },
+    )?;
+    transaction.commit()?;
+    Ok(event)
+}
+
+fn request_cancel(
+    connection: &Connection,
+    agent_id: &str,
+    turn_id: &str,
+) -> Result<AgentEvent, SessionError> {
+    let transaction = connection.unchecked_transaction()?;
+    transaction.execute(
+        "UPDATE turns SET cancel_requested = 1 WHERE agent_id = ?1 AND id = ?2",
+        params![agent_id, turn_id],
+    )?;
+    let event = append_event_tx(
+        &transaction,
+        agent_id,
+        Some(turn_id),
+        AgentEventPayload::TurnCancelRequested,
+    )?;
+    transaction.commit()?;
+    Ok(event)
+}
+
+fn finish_turn(
+    connection: &Connection,
+    agent_id: &str,
+    turn_id: &str,
+    completed: CompletedTurn,
+) -> Result<AgentEvent, SessionError> {
+    let transaction = connection.unchecked_transaction()?;
+    let event = append_event_tx(&transaction, agent_id, Some(turn_id), completed.event)?;
+    transaction.execute(
+        "UPDATE turns
+         SET state = ?3, output_json = ?4, usage_json = ?5, error = ?6,
+             completed_at = ?7, checkpoint_json = ?8, completion_event_id = ?9
+         WHERE agent_id = ?1 AND id = ?2",
+        params![
+            agent_id,
+            turn_id,
+            status_name(completed.status),
+            serde_json::to_string(&completed.output)?,
+            completed
+                .usage
+                .as_ref()
+                .map(serde_json::to_string)
+                .transpose()?,
+            completed.error,
+            completed.completed_at.to_rfc3339(),
+            completed
+                .snapshot
+                .as_ref()
+                .map(serde_json::to_string)
+                .transpose()?,
+            event_id_to_sql(event.id)?,
+        ],
+    )?;
+    transaction.commit()?;
+    Ok(event)
+}
+
+fn append_event(
+    connection: &Connection,
+    agent_id: &str,
+    turn_id: Option<&str>,
+    payload: AgentEventPayload,
+) -> Result<AgentEvent, SessionError> {
+    let transaction = connection.unchecked_transaction()?;
+    let event = append_event_tx(&transaction, agent_id, turn_id, payload)?;
+    transaction.commit()?;
+    Ok(event)
+}
+
+fn append_event_tx(
+    transaction: &Transaction<'_>,
+    agent_id: &str,
+    turn_id: Option<&str>,
+    payload: AgentEventPayload,
+) -> Result<AgentEvent, SessionError> {
+    let id: i64 = transaction.query_row(
+        "SELECT COALESCE(MAX(id), 0) + 1 FROM session_events WHERE agent_id = ?1",
+        params![agent_id],
+        |row| row.get(0),
+    )?;
+    let id = event_id_from_sql(id)?;
+    let created_at = Utc::now();
+    transaction.execute(
+        "INSERT INTO session_events
+         (agent_id, id, turn_id, payload_json, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![
+            agent_id,
+            event_id_to_sql(id)?,
+            turn_id,
+            serde_json::to_string(&payload)?,
+            created_at.to_rfc3339(),
+        ],
+    )?;
+    Ok(AgentEvent {
+        id,
+        agent_id: agent_id.to_owned(),
+        turn_id: turn_id.map(str::to_owned),
+        payload,
+        created_at,
+    })
+}
+
+fn events_after(
+    connection: &Connection,
+    agent_id: &str,
+    after_event_id: u64,
+) -> Result<Vec<AgentEvent>, SessionError> {
+    let mut statement = connection.prepare(
+        "SELECT id, turn_id, payload_json, created_at
+         FROM session_events WHERE agent_id = ?1 AND id > ?2 ORDER BY id",
+    )?;
+    statement
+        .query_map(params![agent_id, event_id_to_sql(after_event_id)?], |row| {
+            let payload_json: String = row.get(2)?;
+            let created_at: String = row.get(3)?;
+            Ok(AgentEvent {
+                id: event_id_from_sql(row.get(0)?)?,
+                agent_id: agent_id.to_owned(),
+                turn_id: row.get(1)?,
+                payload: json_from_sql(&payload_json)?,
+                created_at: parse_time(&created_at)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}
+
+fn fork(
+    connection: &Connection,
+    source_agent_id: &str,
+    target_agent_id: &str,
+    selected_turn_id: Option<&str>,
+) -> Result<ForkSource, SessionError> {
+    let transaction = connection.unchecked_transaction()?;
+    let selected = match selected_turn_id {
+        Some(turn_id) => transaction
+            .query_row(
+                "SELECT id, ordinal, completion_event_id FROM turns
+                 WHERE agent_id = ?1 AND id = ?2 AND state = 'completed'",
+                params![source_agent_id, turn_id],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                },
+            )
+            .optional()?,
+        None => transaction
+            .query_row(
+                "SELECT id, ordinal, completion_event_id FROM turns
+                 WHERE agent_id = ?1 AND state = 'completed'
+                 ORDER BY ordinal DESC LIMIT 1",
+                params![source_agent_id],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, i64>(1)?,
+                        row.get::<_, i64>(2)?,
+                    ))
+                },
+            )
+            .optional()?,
+    }
+    .ok_or(SessionError::ForkBoundaryNotFound)?;
+    ensure_agent_tx(&transaction, target_agent_id)?;
+    transaction.execute(
+        "INSERT INTO turns
+         (agent_id, id, ordinal, delivery, state, output_json, usage_json, error,
+          cancel_requested, attempt, checkpoint_json, completion_event_id,
+          created_at, completed_at)
+         SELECT ?1, id, ordinal, delivery, state, output_json, usage_json, error,
+                cancel_requested, attempt, checkpoint_json, completion_event_id,
+                created_at, completed_at
+         FROM turns WHERE agent_id = ?2 AND ordinal <= ?3",
+        params![target_agent_id, source_agent_id, selected.1],
+    )?;
+    transaction.execute(
+        "INSERT INTO turn_inputs
+         (agent_id, turn_id, ordinal, content_json, created_at)
+         SELECT ?1, turn_id, ordinal, content_json, created_at
+         FROM turn_inputs
+         WHERE agent_id = ?2
+           AND turn_id IN (
+               SELECT id FROM turns WHERE agent_id = ?2 AND ordinal <= ?3
+           )",
+        params![target_agent_id, source_agent_id, selected.1],
+    )?;
+    transaction.execute(
+        "INSERT INTO session_events
+         (agent_id, id, turn_id, payload_json, created_at)
+         SELECT ?1, id, turn_id, payload_json, created_at
+         FROM session_events WHERE agent_id = ?2 AND id <= ?3",
+        params![target_agent_id, source_agent_id, selected.2],
+    )?;
+    transaction.execute(
+        "INSERT INTO session_forks
+         (agent_id, source_agent_id, source_turn_id, created_at)
+         VALUES (?1, ?2, ?3, ?4)",
+        params![target_agent_id, source_agent_id, selected.0, now()],
+    )?;
+    transaction.commit()?;
+    Ok(ForkSource {
+        agent_id: source_agent_id.to_owned(),
+        turn_id: Some(selected.0),
+    })
+}
+
+fn delete(connection: &Connection, agent_id: &str) -> Result<(), SessionError> {
+    connection.execute(
+        "DELETE FROM session_agents WHERE id = ?1",
+        params![agent_id],
+    )?;
+    Ok(())
+}
+
+fn ensure_agent_tx(transaction: &Transaction<'_>, agent_id: &str) -> Result<(), SessionError> {
+    transaction.execute(
+        "INSERT OR IGNORE INTO session_agents (id, created_at) VALUES (?1, ?2)",
+        params![agent_id, now()],
+    )?;
+    Ok(())
+}
+
+fn insert_input(
+    transaction: &Transaction<'_>,
+    agent_id: &str,
+    turn_id: &str,
+    ordinal: i64,
+    content: &[ContentBlock],
+) -> Result<(), SessionError> {
+    transaction.execute(
+        "INSERT INTO turn_inputs
+         (agent_id, turn_id, ordinal, content_json, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![
+            agent_id,
+            turn_id,
+            ordinal,
+            serde_json::to_string(content)?,
+            now(),
+        ],
+    )?;
+    Ok(())
+}
+
+fn insert_request(
+    transaction: &Transaction<'_>,
+    agent_id: &str,
+    key: &str,
+    response: &TurnActionResponse,
+) -> Result<(), SessionError> {
+    transaction.execute(
+        "INSERT INTO turn_requests
+         (agent_id, idempotency_key, action, turn_id, state, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            agent_id,
+            key,
+            action_name(response.action),
+            response.turn_id,
+            status_name(response.state),
+            now(),
+        ],
+    )?;
+    Ok(())
+}
+
+const fn status_name(status: TurnStatus) -> &'static str {
+    match status {
+        TurnStatus::Queued => "queued",
+        TurnStatus::Running => "running",
+        TurnStatus::Completed => "completed",
+        TurnStatus::Failed => "failed",
+        TurnStatus::Cancelled => "cancelled",
+    }
+}
+
+fn parse_status(value: &str) -> rusqlite::Result<TurnStatus> {
+    match value {
+        "queued" => Ok(TurnStatus::Queued),
+        "running" => Ok(TurnStatus::Running),
+        "completed" => Ok(TurnStatus::Completed),
+        "failed" => Ok(TurnStatus::Failed),
+        "cancelled" => Ok(TurnStatus::Cancelled),
+        _ => Err(invalid_sql("turn status")),
+    }
+}
+
+const fn delivery_name(delivery: TurnDelivery) -> &'static str {
+    match delivery {
+        TurnDelivery::Steer => "steer",
+        TurnDelivery::Enqueue => "enqueue",
+    }
+}
+
+const fn action_name(action: TurnAction) -> &'static str {
+    match action {
+        TurnAction::Started => "started",
+        TurnAction::Steered => "steered",
+        TurnAction::Queued => "queued",
+    }
+}
+
+fn parse_action(value: &str) -> rusqlite::Result<TurnAction> {
+    match value {
+        "started" => Ok(TurnAction::Started),
+        "steered" => Ok(TurnAction::Steered),
+        "queued" => Ok(TurnAction::Queued),
+        _ => Err(invalid_sql("turn action")),
+    }
+}
+
+fn parse_time(value: &str) -> rusqlite::Result<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|time| time.with_timezone(&Utc))
+        .map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                0,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })
+}
+
+fn json_from_sql<T: serde::de::DeserializeOwned>(value: &str) -> rusqlite::Result<T> {
+    serde_json::from_str(value).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(error))
+    })
+}
+
+fn invalid_sql(name: &'static str) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(
+        0,
+        rusqlite::types::Type::Text,
+        format!("invalid {name}").into(),
+    )
+}
+
+fn event_id_to_sql(value: u64) -> Result<i64, SessionError> {
+    i64::try_from(value).map_err(|_| SessionError::EventIdOverflow)
+}
+
+fn event_id_from_sql(value: i64) -> rusqlite::Result<u64> {
+    u64::try_from(value).map_err(|_| invalid_sql("event id"))
+}
+
+fn now() -> String {
+    Utc::now().to_rfc3339()
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum SessionError {
+    #[error("session SQLite actor stopped")]
+    Stopped,
+    #[error("completed fork boundary was not found")]
+    ForkBoundaryNotFound,
+    #[error("session event identifier exceeded SQLite's signed integer range")]
+    EventIdOverflow,
+    #[error("session SQLite failed")]
+    Database(#[from] rusqlite::Error),
+    #[error("session JSON encoding failed")]
+    Json(#[from] serde_json::Error),
+    #[error("session filesystem setup failed")]
+    Io(#[from] std::io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn existing_turn_table_gains_nullable_usage_without_rebuild() {
+        let connection = Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch(
+                r"
+                CREATE TABLE session_agents (
+                    id TEXT PRIMARY KEY,
+                    created_at TEXT NOT NULL
+                );
+                CREATE TABLE turns (
+                    agent_id TEXT NOT NULL REFERENCES session_agents(id) ON DELETE CASCADE,
+                    id TEXT NOT NULL,
+                    ordinal INTEGER NOT NULL,
+                    delivery TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    output_json TEXT NOT NULL DEFAULT '[]',
+                    error TEXT,
+                    cancel_requested INTEGER NOT NULL DEFAULT 0,
+                    attempt INTEGER NOT NULL DEFAULT 0,
+                    checkpoint_json TEXT,
+                    completion_event_id INTEGER,
+                    created_at TEXT NOT NULL,
+                    completed_at TEXT,
+                    PRIMARY KEY(agent_id, id),
+                    UNIQUE(agent_id, ordinal)
+                );
+                ",
+            )
+            .unwrap();
+
+        configure(&connection).unwrap();
+
+        let mut statement = connection.prepare("PRAGMA table_info(turns)").unwrap();
+        let columns = statement
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert!(columns.iter().any(|column| column == "usage_json"));
+    }
+}

--- a/crates/experimental/nanocentaur/src/session.rs
+++ b/crates/experimental/nanocentaur/src/session.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 
 const COMMAND_CAPACITY: usize = 256;
+const FULL_CHECKPOINT_INTERVAL: i64 = 32;
 
 #[derive(Clone)]
 pub(crate) struct SessionStore {
@@ -42,9 +43,26 @@ pub(crate) struct NewTurn {
     pub content: Vec<ContentBlock>,
     pub response: TurnActionResponse,
     pub idempotency_key: Option<String>,
+    pub request_hash: Vec<u8>,
+    pub payment_receipt: Option<String>,
     pub event: AgentEventPayload,
 }
 
+pub(crate) struct StoredRequest {
+    pub response: TurnActionResponse,
+    pub request_hash: Option<Vec<u8>>,
+    pub payment_receipt: Option<String>,
+}
+
+pub(crate) struct SteerRequestRecord {
+    pub content: Vec<ContentBlock>,
+    pub response: TurnActionResponse,
+    pub idempotency_key: Option<String>,
+    pub request_hash: Vec<u8>,
+    pub payment_receipt: Option<String>,
+}
+
+#[derive(Clone)]
 pub(crate) struct CompletedTurn {
     pub status: TurnStatus,
     pub output: Vec<ContentBlock>,
@@ -98,7 +116,7 @@ impl SessionStore {
         &self,
         agent_id: String,
         key: String,
-    ) -> Result<Option<TurnActionResponse>, SessionError> {
+    ) -> Result<Option<StoredRequest>, SessionError> {
         self.call(|reply| Command::FindRequest {
             agent_id,
             key,
@@ -137,15 +155,28 @@ impl SessionStore {
         &self,
         agent_id: String,
         turn_id: String,
-        content: Vec<ContentBlock>,
-        response: TurnActionResponse,
-        idempotency_key: Option<String>,
-    ) -> Result<(), SessionError> {
+        record: SteerRequestRecord,
+    ) -> Result<i64, SessionError> {
         self.call(|reply| Command::RecordSteer {
             agent_id,
             turn_id,
-            content,
-            response,
+            record: Box::new(record),
+            reply,
+        })
+        .await
+    }
+
+    pub async fn undo_steer(
+        &self,
+        agent_id: String,
+        turn_id: String,
+        ordinal: i64,
+        idempotency_key: Option<String>,
+    ) -> Result<(), SessionError> {
+        self.call(|reply| Command::UndoSteer {
+            agent_id,
+            turn_id,
+            ordinal,
             idempotency_key,
             reply,
         })
@@ -267,7 +298,7 @@ enum Command {
     FindRequest {
         agent_id: String,
         key: String,
-        reply: Reply<Option<TurnActionResponse>>,
+        reply: Reply<Option<StoredRequest>>,
     },
     GetTurn {
         agent_id: String,
@@ -282,8 +313,13 @@ enum Command {
     RecordSteer {
         agent_id: String,
         turn_id: String,
-        content: Vec<ContentBlock>,
-        response: TurnActionResponse,
+        record: Box<SteerRequestRecord>,
+        reply: Reply<i64>,
+    },
+    UndoSteer {
+        agent_id: String,
+        turn_id: String,
+        ordinal: i64,
         idempotency_key: Option<String>,
         reply: Reply<()>,
     },
@@ -336,6 +372,7 @@ impl Command {
             Self::GetTurn { .. } => "get_turn",
             Self::RecordTurn { .. } => "record_turn",
             Self::RecordSteer { .. } => "record_steer",
+            Self::UndoSteer { .. } => "undo_steer",
             Self::MarkStarted { .. } => "mark_started",
             Self::RequestCancel { .. } => "request_cancel",
             Self::FinishTurn { .. } => "finish_turn",
@@ -375,17 +412,23 @@ impl Command {
             Self::RecordSteer {
                 agent_id,
                 turn_id,
-                content,
-                response,
+                record,
+                reply,
+            } => {
+                drop(reply.send(record_steer(connection, &agent_id, &turn_id, &record)));
+            }
+            Self::UndoSteer {
+                agent_id,
+                turn_id,
+                ordinal,
                 idempotency_key,
                 reply,
             } => {
-                drop(reply.send(record_steer(
+                drop(reply.send(undo_steer(
                     connection,
                     &agent_id,
                     &turn_id,
-                    &content,
-                    &response,
+                    ordinal,
                     idempotency_key.as_deref(),
                 )));
             }
@@ -458,6 +501,11 @@ fn configure(connection: &Connection) -> Result<(), SessionError> {
             created_at TEXT NOT NULL
         );
 
+        CREATE TABLE IF NOT EXISTS session_tombstones (
+            agent_id TEXT PRIMARY KEY,
+            deleted_at TEXT NOT NULL
+        );
+
         CREATE TABLE IF NOT EXISTS turns (
             agent_id TEXT NOT NULL REFERENCES session_agents(id) ON DELETE CASCADE,
             id TEXT NOT NULL,
@@ -470,6 +518,10 @@ fn configure(connection: &Connection) -> Result<(), SessionError> {
             cancel_requested INTEGER NOT NULL DEFAULT 0,
             attempt INTEGER NOT NULL DEFAULT 0,
             checkpoint_json TEXT,
+            checkpoint_base_ordinal INTEGER,
+            checkpoint_prefix INTEGER,
+            checkpoint_suffix INTEGER,
+            checkpoint_data BLOB,
             completion_event_id INTEGER,
             created_at TEXT NOT NULL,
             completed_at TEXT,
@@ -494,6 +546,8 @@ fn configure(connection: &Connection) -> Result<(), SessionError> {
             action TEXT NOT NULL,
             turn_id TEXT NOT NULL,
             state TEXT NOT NULL,
+            request_hash BLOB,
+            payment_receipt TEXT,
             created_at TEXT NOT NULL,
             PRIMARY KEY(agent_id, idempotency_key)
         );
@@ -521,6 +575,8 @@ fn configure(connection: &Connection) -> Result<(), SessionError> {
         ",
     )?;
     ensure_turn_usage_column(connection)?;
+    ensure_turn_request_columns(connection)?;
+    ensure_checkpoint_columns(connection)?;
     Ok(())
 }
 
@@ -535,7 +591,41 @@ fn ensure_turn_usage_column(connection: &Connection) -> Result<(), SessionError>
     Ok(())
 }
 
+fn ensure_turn_request_columns(connection: &Connection) -> Result<(), SessionError> {
+    let mut statement = connection.prepare("PRAGMA table_info(turn_requests)")?;
+    let columns = statement
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<Result<Vec<_>, _>>()?;
+    if !columns.iter().any(|column| column == "request_hash") {
+        connection.execute_batch("ALTER TABLE turn_requests ADD COLUMN request_hash BLOB")?;
+    }
+    if !columns.iter().any(|column| column == "payment_receipt") {
+        connection.execute_batch("ALTER TABLE turn_requests ADD COLUMN payment_receipt TEXT")?;
+    }
+    Ok(())
+}
+
+fn ensure_checkpoint_columns(connection: &Connection) -> Result<(), SessionError> {
+    let mut statement = connection.prepare("PRAGMA table_info(turns)")?;
+    let columns = statement
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<Result<Vec<_>, _>>()?;
+    for (name, definition) in [
+        ("checkpoint_base_ordinal", "INTEGER"),
+        ("checkpoint_prefix", "INTEGER"),
+        ("checkpoint_suffix", "INTEGER"),
+        ("checkpoint_data", "BLOB"),
+    ] {
+        if !columns.iter().any(|column| column == name) {
+            connection
+                .execute_batch(&format!("ALTER TABLE turns ADD COLUMN {name} {definition}"))?;
+        }
+    }
+    Ok(())
+}
+
 fn ensure_agent(connection: &Connection, agent_id: &str) -> Result<(), SessionError> {
+    reject_tombstone(connection, agent_id)?;
     connection.execute(
         "INSERT OR IGNORE INTO session_agents (id, created_at) VALUES (?1, ?2)",
         params![agent_id, now()],
@@ -597,17 +687,9 @@ fn load(connection: &Connection, agent_id: &str) -> Result<StoredSession, Sessio
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;
-    let snapshot = connection
-        .query_row(
-            "SELECT checkpoint_json FROM turns
-             WHERE agent_id = ?1 AND state = 'completed' AND checkpoint_json IS NOT NULL
-             ORDER BY ordinal DESC LIMIT 1",
-            params![agent_id],
-            |row| row.get::<_, String>(0),
-        )
-        .optional()?
+    let snapshot = reconstruct_checkpoint(connection, agent_id, None)?
         .as_deref()
-        .map(json_from_sql)
+        .map(serde_json::from_slice)
         .transpose()?;
     Ok(StoredSession { turns, snapshot })
 }
@@ -633,19 +715,23 @@ fn find_request(
     connection: &Connection,
     agent_id: &str,
     key: &str,
-) -> Result<Option<TurnActionResponse>, SessionError> {
+) -> Result<Option<StoredRequest>, SessionError> {
     connection
         .query_row(
-            "SELECT action, turn_id, state FROM turn_requests
+            "SELECT action, turn_id, state, request_hash, payment_receipt FROM turn_requests
              WHERE agent_id = ?1 AND idempotency_key = ?2",
             params![agent_id, key],
             |row| {
                 let action: String = row.get(0)?;
                 let state: String = row.get(2)?;
-                Ok(TurnActionResponse {
-                    action: parse_action(&action)?,
-                    turn_id: row.get(1)?,
-                    state: parse_status(&state)?,
+                Ok(StoredRequest {
+                    response: TurnActionResponse {
+                        action: parse_action(&action)?,
+                        turn_id: row.get(1)?,
+                        state: parse_status(&state)?,
+                    },
+                    request_hash: row.get(3)?,
+                    payment_receipt: row.get(4)?,
                 })
             },
         )
@@ -717,7 +803,14 @@ fn record_turn(
     )?;
     insert_input(&transaction, agent_id, &turn.view.turn_id, 1, &turn.content)?;
     if let Some(key) = turn.idempotency_key {
-        insert_request(&transaction, agent_id, &key, &turn.response)?;
+        insert_request(
+            &transaction,
+            agent_id,
+            &key,
+            &turn.response,
+            &turn.request_hash,
+            turn.payment_receipt.as_deref(),
+        )?;
     }
     let event = append_event_tx(&transaction, agent_id, Some(&turn.view.turn_id), turn.event)?;
     transaction.commit()?;
@@ -728,10 +821,8 @@ fn record_steer(
     connection: &Connection,
     agent_id: &str,
     turn_id: &str,
-    content: &[ContentBlock],
-    response: &TurnActionResponse,
-    idempotency_key: Option<&str>,
-) -> Result<(), SessionError> {
+    record: &SteerRequestRecord,
+) -> Result<i64, SessionError> {
     let transaction = connection.unchecked_transaction()?;
     let ordinal: i64 = transaction.query_row(
         "SELECT COALESCE(MAX(ordinal), 0) + 1 FROM turn_inputs
@@ -739,9 +830,44 @@ fn record_steer(
         params![agent_id, turn_id],
         |row| row.get(0),
     )?;
-    insert_input(&transaction, agent_id, turn_id, ordinal, content)?;
+    insert_input(&transaction, agent_id, turn_id, ordinal, &record.content)?;
+    if let Some(key) = record.idempotency_key.as_deref() {
+        insert_request(
+            &transaction,
+            agent_id,
+            key,
+            &record.response,
+            &record.request_hash,
+            record.payment_receipt.as_deref(),
+        )?;
+    }
+    transaction.commit()?;
+    Ok(ordinal)
+}
+
+fn undo_steer(
+    connection: &Connection,
+    agent_id: &str,
+    turn_id: &str,
+    ordinal: i64,
+    idempotency_key: Option<&str>,
+) -> Result<(), SessionError> {
+    let transaction = connection.unchecked_transaction()?;
+    let removed = transaction.execute(
+        "DELETE FROM turn_inputs
+         WHERE agent_id = ?1 AND turn_id = ?2 AND ordinal = ?3",
+        params![agent_id, turn_id, ordinal],
+    )?;
+    if removed != 1 {
+        return Err(SessionError::InvalidState(
+            "durable steering input disappeared before compensation",
+        ));
+    }
     if let Some(key) = idempotency_key {
-        insert_request(&transaction, agent_id, key, response)?;
+        transaction.execute(
+            "DELETE FROM turn_requests WHERE agent_id = ?1 AND idempotency_key = ?2",
+            params![agent_id, key],
+        )?;
     }
     transaction.commit()?;
     Ok(())
@@ -790,6 +916,170 @@ fn request_cancel(
     Ok(event)
 }
 
+struct EncodedCheckpoint {
+    base_ordinal: Option<i64>,
+    prefix: i64,
+    suffix: i64,
+    data: Vec<u8>,
+}
+
+fn encode_checkpoint(
+    connection: &Connection,
+    agent_id: &str,
+    ordinal: i64,
+    snapshot: &SessionSnapshot,
+) -> Result<EncodedCheckpoint, SessionError> {
+    let encoded = serde_json::to_vec(snapshot)?;
+    let checkpoints_since_full = connection.query_row(
+        "SELECT COUNT(*) FROM turns
+         WHERE agent_id = ?1 AND ordinal < ?2 AND state = 'completed'
+           AND (checkpoint_data IS NOT NULL OR checkpoint_json IS NOT NULL)
+           AND ordinal > COALESCE((
+               SELECT MAX(ordinal) FROM turns
+               WHERE agent_id = ?1 AND ordinal < ?2 AND state = 'completed'
+                 AND (checkpoint_json IS NOT NULL OR
+                      (checkpoint_data IS NOT NULL AND checkpoint_base_ordinal IS NULL))
+           ), 0)",
+        params![agent_id, ordinal],
+        |row| row.get::<_, i64>(0),
+    )?;
+    if checkpoints_since_full >= FULL_CHECKPOINT_INTERVAL - 1 {
+        return Ok(full_checkpoint(encoded));
+    }
+    let previous_ordinal = connection
+        .query_row(
+            "SELECT ordinal FROM turns
+             WHERE agent_id = ?1 AND ordinal < ?2
+               AND state = 'completed'
+               AND (checkpoint_data IS NOT NULL OR checkpoint_json IS NOT NULL)
+             ORDER BY ordinal DESC LIMIT 1",
+            params![agent_id, ordinal],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?;
+    let Some(previous_ordinal) = previous_ordinal else {
+        return Ok(full_checkpoint(encoded));
+    };
+    let Some(previous) = reconstruct_checkpoint(connection, agent_id, Some(previous_ordinal))?
+    else {
+        return Ok(full_checkpoint(encoded));
+    };
+    let prefix = previous
+        .iter()
+        .zip(&encoded)
+        .take_while(|(left, right)| left == right)
+        .count();
+    let max_suffix = previous.len().min(encoded.len()).saturating_sub(prefix);
+    let suffix = previous
+        .iter()
+        .rev()
+        .zip(encoded.iter().rev())
+        .take(max_suffix)
+        .take_while(|(left, right)| left == right)
+        .count();
+    let delta = encoded[prefix..encoded.len() - suffix].to_vec();
+    if delta.len().saturating_add(24) >= encoded.len() {
+        return Ok(full_checkpoint(encoded));
+    }
+    Ok(EncodedCheckpoint {
+        base_ordinal: Some(previous_ordinal),
+        prefix: i64::try_from(prefix).map_err(|_| SessionError::CheckpointOverflow)?,
+        suffix: i64::try_from(suffix).map_err(|_| SessionError::CheckpointOverflow)?,
+        data: delta,
+    })
+}
+
+const fn full_checkpoint(data: Vec<u8>) -> EncodedCheckpoint {
+    EncodedCheckpoint {
+        base_ordinal: None,
+        prefix: 0,
+        suffix: 0,
+        data,
+    }
+}
+
+fn reconstruct_checkpoint(
+    connection: &Connection,
+    agent_id: &str,
+    through_ordinal: Option<i64>,
+) -> Result<Option<Vec<u8>>, SessionError> {
+    let start_ordinal = connection
+        .query_row(
+            "SELECT ordinal FROM turns
+             WHERE agent_id = ?1 AND state = 'completed'
+               AND (?2 IS NULL OR ordinal <= ?2)
+               AND (checkpoint_json IS NOT NULL OR
+                    (checkpoint_data IS NOT NULL AND checkpoint_base_ordinal IS NULL))
+             ORDER BY ordinal DESC LIMIT 1",
+            params![agent_id, through_ordinal],
+            |row| row.get::<_, i64>(0),
+        )
+        .optional()?;
+    let Some(start_ordinal) = start_ordinal else {
+        return Ok(None);
+    };
+    let mut statement = connection.prepare(
+        "SELECT ordinal, checkpoint_json, checkpoint_base_ordinal,
+                checkpoint_prefix, checkpoint_suffix, checkpoint_data
+         FROM turns
+         WHERE agent_id = ?1 AND state = 'completed'
+           AND (?2 IS NULL OR ordinal <= ?2)
+           AND ordinal >= ?3
+           AND (checkpoint_data IS NOT NULL OR checkpoint_json IS NOT NULL)
+         ORDER BY ordinal",
+    )?;
+    let rows = statement.query_map(params![agent_id, through_ordinal, start_ordinal], |row| {
+        Ok((
+            row.get::<_, i64>(0)?,
+            row.get::<_, Option<String>>(1)?,
+            row.get::<_, Option<i64>>(2)?,
+            row.get::<_, Option<i64>>(3)?,
+            row.get::<_, Option<i64>>(4)?,
+            row.get::<_, Option<Vec<u8>>>(5)?,
+        ))
+    })?;
+    let mut current: Option<Vec<u8>> = None;
+    let mut current_ordinal = None;
+    for row in rows {
+        let (ordinal, legacy, base, prefix, suffix, data) = row?;
+        let next = if let Some(data) = data {
+            if let Some(base) = base {
+                if current_ordinal != Some(base) {
+                    return Err(SessionError::InvalidState(
+                        "checkpoint delta base is not contiguous",
+                    ));
+                }
+                let previous = current.as_deref().ok_or(SessionError::InvalidState(
+                    "checkpoint delta is missing its base",
+                ))?;
+                let prefix = usize::try_from(prefix.unwrap_or_default())
+                    .map_err(|_| SessionError::CheckpointOverflow)?;
+                let suffix = usize::try_from(suffix.unwrap_or_default())
+                    .map_err(|_| SessionError::CheckpointOverflow)?;
+                if prefix > previous.len() || suffix > previous.len().saturating_sub(prefix) {
+                    return Err(SessionError::InvalidState(
+                        "checkpoint delta exceeds its base",
+                    ));
+                }
+                let mut decoded = Vec::with_capacity(prefix + data.len() + suffix);
+                decoded.extend_from_slice(&previous[..prefix]);
+                decoded.extend_from_slice(&data);
+                decoded.extend_from_slice(&previous[previous.len() - suffix..]);
+                decoded
+            } else {
+                data
+            }
+        } else {
+            legacy
+                .ok_or(SessionError::InvalidState("checkpoint payload is missing"))?
+                .into_bytes()
+        };
+        current = Some(next);
+        current_ordinal = Some(ordinal);
+    }
+    Ok(current)
+}
+
 fn finish_turn(
     connection: &Connection,
     agent_id: &str,
@@ -797,11 +1087,24 @@ fn finish_turn(
     completed: CompletedTurn,
 ) -> Result<FinishedTurn, SessionError> {
     let transaction = connection.unchecked_transaction()?;
+    let ordinal = transaction.query_row(
+        "SELECT ordinal FROM turns WHERE agent_id = ?1 AND id = ?2",
+        params![agent_id, turn_id],
+        |row| row.get::<_, i64>(0),
+    )?;
+    let checkpoint = completed
+        .snapshot
+        .as_ref()
+        .map(|snapshot| encode_checkpoint(&transaction, agent_id, ordinal, snapshot))
+        .transpose()?;
     let event = append_event_tx(&transaction, agent_id, Some(turn_id), completed.event)?;
     transaction.execute(
         "UPDATE turns
          SET state = ?3, output_json = ?4, usage_json = ?5, error = ?6,
-             completed_at = ?7, checkpoint_json = ?8, completion_event_id = ?9
+             completed_at = ?7, checkpoint_json = NULL,
+             checkpoint_base_ordinal = ?8, checkpoint_prefix = ?9,
+             checkpoint_suffix = ?10, checkpoint_data = ?11,
+             completion_event_id = ?12
          WHERE agent_id = ?1 AND id = ?2",
         params![
             agent_id,
@@ -815,11 +1118,18 @@ fn finish_turn(
                 .transpose()?,
             completed.error,
             completed.completed_at.to_rfc3339(),
-            completed
-                .snapshot
+            checkpoint
                 .as_ref()
-                .map(serde_json::to_string)
-                .transpose()?,
+                .and_then(|checkpoint| checkpoint.base_ordinal),
+            checkpoint
+                .as_ref()
+                .map_or(0, |checkpoint| checkpoint.prefix),
+            checkpoint
+                .as_ref()
+                .map_or(0, |checkpoint| checkpoint.suffix),
+            checkpoint
+                .as_ref()
+                .map(|checkpoint| checkpoint.data.as_slice()),
             event_id_to_sql(event.id)?,
         ],
     )?;
@@ -984,11 +1294,13 @@ fn fork(
     transaction.execute(
         "INSERT INTO turns
          (agent_id, id, ordinal, delivery, state, output_json, usage_json, error,
-          cancel_requested, attempt, checkpoint_json, completion_event_id,
-          created_at, completed_at)
+          cancel_requested, attempt, checkpoint_json, checkpoint_base_ordinal,
+          checkpoint_prefix, checkpoint_suffix, checkpoint_data,
+          completion_event_id, created_at, completed_at)
          SELECT ?1, id, ordinal, delivery, state, output_json, usage_json, error,
-                cancel_requested, attempt, checkpoint_json, completion_event_id,
-                created_at, completed_at
+                cancel_requested, attempt, checkpoint_json, checkpoint_base_ordinal,
+                checkpoint_prefix, checkpoint_suffix, checkpoint_data,
+                completion_event_id, created_at, completed_at
          FROM turns WHERE agent_id = ?2 AND ordinal <= ?3",
         params![target_agent_id, source_agent_id, selected.1],
     )?;
@@ -1024,19 +1336,39 @@ fn fork(
 }
 
 fn delete(connection: &Connection, agent_id: &str) -> Result<(), SessionError> {
-    connection.execute(
+    let transaction = connection.unchecked_transaction()?;
+    transaction.execute(
+        "INSERT OR IGNORE INTO session_tombstones (agent_id, deleted_at) VALUES (?1, ?2)",
+        params![agent_id, now()],
+    )?;
+    transaction.execute(
         "DELETE FROM session_agents WHERE id = ?1",
         params![agent_id],
     )?;
+    transaction.commit()?;
     Ok(())
 }
 
 fn ensure_agent_tx(transaction: &Transaction<'_>, agent_id: &str) -> Result<(), SessionError> {
+    reject_tombstone(transaction, agent_id)?;
     transaction.execute(
         "INSERT OR IGNORE INTO session_agents (id, created_at) VALUES (?1, ?2)",
         params![agent_id, now()],
     )?;
     Ok(())
+}
+
+fn reject_tombstone(connection: &Connection, agent_id: &str) -> Result<(), SessionError> {
+    let deleted = connection.query_row(
+        "SELECT EXISTS(SELECT 1 FROM session_tombstones WHERE agent_id = ?1)",
+        params![agent_id],
+        |row| row.get::<_, bool>(0),
+    )?;
+    if deleted {
+        Err(SessionError::Deleted)
+    } else {
+        Ok(())
+    }
 }
 
 fn insert_input(
@@ -1066,17 +1398,22 @@ fn insert_request(
     agent_id: &str,
     key: &str,
     response: &TurnActionResponse,
+    request_hash: &[u8],
+    payment_receipt: Option<&str>,
 ) -> Result<(), SessionError> {
     transaction.execute(
         "INSERT INTO turn_requests
-         (agent_id, idempotency_key, action, turn_id, state, created_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+         (agent_id, idempotency_key, action, turn_id, state, request_hash,
+          payment_receipt, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
         params![
             agent_id,
             key,
             action_name(response.action),
             response.turn_id,
             status_name(response.state),
+            request_hash,
+            payment_receipt,
             now(),
         ],
     )?;
@@ -1172,8 +1509,14 @@ pub(crate) enum SessionError {
     Stopped,
     #[error("completed fork boundary was not found")]
     ForkBoundaryNotFound,
+    #[error("managed session was permanently deleted")]
+    Deleted,
     #[error("session event identifier exceeded SQLite's signed integer range")]
     EventIdOverflow,
+    #[error("session checkpoint size exceeded supported integer bounds")]
+    CheckpointOverflow,
+    #[error("invalid durable session state: {0}")]
+    InvalidState(&'static str),
     #[error("session SQLite failed")]
     Database(#[from] rusqlite::Error),
     #[error("session JSON encoding failed")]
@@ -1226,5 +1569,76 @@ mod tests {
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
         assert!(columns.iter().any(|column| column == "usage_json"));
+    }
+
+    #[test]
+    fn checkpoint_deltas_reconstruct_shared_history_without_repeating_prefixes() {
+        let connection = Connection::open_in_memory().unwrap();
+        configure(&connection).unwrap();
+        ensure_agent(&connection, "agent").unwrap();
+        let first = br#"{"history":["a"]}"#.to_vec();
+        let second = br#"{"history":["a","b"]}"#.to_vec();
+        let prefix = first
+            .iter()
+            .zip(&second)
+            .take_while(|(left, right)| left == right)
+            .count();
+        let suffix = first
+            .iter()
+            .rev()
+            .zip(second.iter().rev())
+            .take(first.len().min(second.len()).saturating_sub(prefix))
+            .take_while(|(left, right)| left == right)
+            .count();
+        let delta = &second[prefix..second.len() - suffix];
+        for ordinal in 1..=2_i64 {
+            connection
+                .execute(
+                    "INSERT INTO turns
+                     (agent_id, id, ordinal, delivery, state, output_json,
+                      cancel_requested, attempt, created_at)
+                     VALUES ('agent', ?1, ?2, 'steer', 'completed', '[]', 0, 1, ?3)",
+                    params![format!("turn-{ordinal}"), ordinal, now()],
+                )
+                .unwrap();
+        }
+        connection
+            .execute(
+                "UPDATE turns SET checkpoint_data = ?1,
+                 checkpoint_prefix = 0, checkpoint_suffix = 0 WHERE ordinal = 1",
+                params![first],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "UPDATE turns SET checkpoint_base_ordinal = 1,
+                 checkpoint_prefix = ?1, checkpoint_suffix = ?2,
+                 checkpoint_data = ?3 WHERE ordinal = 2",
+                params![
+                    i64::try_from(prefix).unwrap(),
+                    i64::try_from(suffix).unwrap(),
+                    delta
+                ],
+            )
+            .unwrap();
+        assert_eq!(
+            reconstruct_checkpoint(&connection, "agent", None)
+                .unwrap()
+                .unwrap(),
+            second
+        );
+        assert!(delta.len() < second.len());
+    }
+
+    #[test]
+    fn deleted_session_ids_cannot_be_recreated_by_stale_authorization() {
+        let connection = Connection::open_in_memory().unwrap();
+        configure(&connection).unwrap();
+        ensure_agent(&connection, "deleted-agent").unwrap();
+        delete(&connection, "deleted-agent").unwrap();
+        assert!(matches!(
+            ensure_agent(&connection, "deleted-agent"),
+            Err(SessionError::Deleted)
+        ));
     }
 }

--- a/crates/experimental/nanocentaur/src/session.rs
+++ b/crates/experimental/nanocentaur/src/session.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::Path, time::Instant};
+use std::{path::Path, time::Instant};
 
 use chrono::{DateTime, Utc};
 use nanocodex_agent::session::SessionSnapshot;
@@ -27,14 +27,13 @@ struct CommandEnvelope {
 
 pub(crate) struct StoredSession {
     pub turns: Vec<StoredTurn>,
-    pub requests: HashMap<String, TurnActionResponse>,
+    pub snapshot: Option<SessionSnapshot>,
 }
 
 pub(crate) struct StoredTurn {
     pub view: TurnView,
     pub inputs: Vec<Vec<ContentBlock>>,
     pub cancel_requested: bool,
-    pub snapshot: Option<SessionSnapshot>,
 }
 
 pub(crate) struct NewTurn {
@@ -54,6 +53,11 @@ pub(crate) struct CompletedTurn {
     pub snapshot: Option<SessionSnapshot>,
     pub usage: Option<nanocodex_agent::TurnUsage>,
     pub event: AgentEventPayload,
+}
+
+pub(crate) struct FinishedTurn {
+    pub event: AgentEvent,
+    pub snapshot: Option<SessionSnapshot>,
 }
 
 impl SessionStore {
@@ -86,11 +90,6 @@ impl SessionStore {
         Ok(Self { sender })
     }
 
-    pub async fn ensure_agent(&self, agent_id: String) -> Result<(), SessionError> {
-        self.call(|reply| Command::EnsureAgent { agent_id, reply })
-            .await
-    }
-
     pub async fn load(&self, agent_id: String) -> Result<StoredSession, SessionError> {
         self.call(|reply| Command::Load { agent_id, reply }).await
     }
@@ -103,6 +102,19 @@ impl SessionStore {
         self.call(|reply| Command::FindRequest {
             agent_id,
             key,
+            reply,
+        })
+        .await
+    }
+
+    pub async fn turn(
+        &self,
+        agent_id: String,
+        turn_id: String,
+    ) -> Result<Option<TurnView>, SessionError> {
+        self.call(|reply| Command::GetTurn {
+            agent_id,
+            turn_id,
             reply,
         })
         .await
@@ -171,7 +183,7 @@ impl SessionStore {
         agent_id: String,
         turn_id: String,
         completed: CompletedTurn,
-    ) -> Result<AgentEvent, SessionError> {
+    ) -> Result<FinishedTurn, SessionError> {
         self.call(|reply| Command::FinishTurn {
             agent_id,
             turn_id,
@@ -181,16 +193,14 @@ impl SessionStore {
         .await
     }
 
-    pub async fn append_event(
+    pub async fn append_events(
         &self,
         agent_id: String,
-        turn_id: Option<String>,
-        payload: AgentEventPayload,
-    ) -> Result<AgentEvent, SessionError> {
-        self.call(|reply| Command::AppendEvent {
+        events: Vec<(Option<String>, AgentEventPayload)>,
+    ) -> Result<Vec<AgentEvent>, SessionError> {
+        self.call(|reply| Command::AppendEvents {
             agent_id,
-            turn_id,
-            payload,
+            events,
             reply,
         })
         .await
@@ -200,10 +210,12 @@ impl SessionStore {
         &self,
         agent_id: String,
         after_event_id: u64,
+        limit: usize,
     ) -> Result<Vec<AgentEvent>, SessionError> {
         self.call(|reply| Command::EventsAfter {
             agent_id,
             after_event_id,
+            limit,
             reply,
         })
         .await
@@ -248,10 +260,6 @@ impl SessionStore {
 }
 
 enum Command {
-    EnsureAgent {
-        agent_id: String,
-        reply: Reply<()>,
-    },
     Load {
         agent_id: String,
         reply: Reply<StoredSession>,
@@ -260,6 +268,11 @@ enum Command {
         agent_id: String,
         key: String,
         reply: Reply<Option<TurnActionResponse>>,
+    },
+    GetTurn {
+        agent_id: String,
+        turn_id: String,
+        reply: Reply<Option<TurnView>>,
     },
     RecordTurn {
         agent_id: String,
@@ -288,17 +301,17 @@ enum Command {
         agent_id: String,
         turn_id: String,
         completed: Box<CompletedTurn>,
-        reply: Reply<AgentEvent>,
+        reply: Reply<FinishedTurn>,
     },
-    AppendEvent {
+    AppendEvents {
         agent_id: String,
-        turn_id: Option<String>,
-        payload: AgentEventPayload,
-        reply: Reply<AgentEvent>,
+        events: Vec<(Option<String>, AgentEventPayload)>,
+        reply: Reply<Vec<AgentEvent>>,
     },
     EventsAfter {
         agent_id: String,
         after_event_id: u64,
+        limit: usize,
         reply: Reply<Vec<AgentEvent>>,
     },
     Fork {
@@ -318,15 +331,15 @@ type Reply<T> = oneshot::Sender<Result<T, SessionError>>;
 impl Command {
     const fn name(&self) -> &'static str {
         match self {
-            Self::EnsureAgent { .. } => "ensure_agent",
             Self::Load { .. } => "load",
             Self::FindRequest { .. } => "find_request",
+            Self::GetTurn { .. } => "get_turn",
             Self::RecordTurn { .. } => "record_turn",
             Self::RecordSteer { .. } => "record_steer",
             Self::MarkStarted { .. } => "mark_started",
             Self::RequestCancel { .. } => "request_cancel",
             Self::FinishTurn { .. } => "finish_turn",
-            Self::AppendEvent { .. } => "append_event",
+            Self::AppendEvents { .. } => "append_events",
             Self::EventsAfter { .. } => "events_after",
             Self::Fork { .. } => "fork",
             Self::Delete { .. } => "delete",
@@ -335,9 +348,6 @@ impl Command {
 
     fn execute(self, connection: &Connection) {
         match self {
-            Self::EnsureAgent { agent_id, reply } => {
-                drop(reply.send(ensure_agent(connection, &agent_id)));
-            }
             Self::Load { agent_id, reply } => {
                 drop(reply.send(load(connection, &agent_id)));
             }
@@ -347,6 +357,13 @@ impl Command {
                 reply,
             } => {
                 drop(reply.send(find_request(connection, &agent_id, &key)));
+            }
+            Self::GetTurn {
+                agent_id,
+                turn_id,
+                reply,
+            } => {
+                drop(reply.send(turn(connection, &agent_id, &turn_id)));
             }
             Self::RecordTurn {
                 agent_id,
@@ -394,25 +411,20 @@ impl Command {
             } => {
                 drop(reply.send(finish_turn(connection, &agent_id, &turn_id, *completed)));
             }
-            Self::AppendEvent {
+            Self::AppendEvents {
                 agent_id,
-                turn_id,
-                payload,
+                events,
                 reply,
             } => {
-                drop(reply.send(append_event(
-                    connection,
-                    &agent_id,
-                    turn_id.as_deref(),
-                    payload,
-                )));
+                drop(reply.send(append_events(connection, &agent_id, events)));
             }
             Self::EventsAfter {
                 agent_id,
                 after_event_id,
+                limit,
                 reply,
             } => {
-                drop(reply.send(events_after(connection, &agent_id, after_event_id)));
+                drop(reply.send(events_after(connection, &agent_id, after_event_id, limit)));
             }
             Self::Fork {
                 source_agent_id,
@@ -559,57 +571,45 @@ fn load(connection: &Connection, agent_id: &str) -> Result<StoredSession, Sessio
     transaction.commit()?;
 
     let mut statement = connection.prepare(
-        "SELECT id, delivery, state, output_json, usage_json, error,
-                cancel_requested, checkpoint_json, created_at, completed_at
-         FROM turns WHERE agent_id = ?1 ORDER BY ordinal",
+        "SELECT id, state, cancel_requested, created_at
+         FROM turns
+         WHERE agent_id = ?1 AND state IN ('queued', 'running')
+         ORDER BY ordinal",
     )?;
     let turns = statement
         .query_map(params![agent_id], |row| {
             let turn_id: String = row.get(0)?;
-            let state: String = row.get(2)?;
-            let output_json: String = row.get(3)?;
-            let usage_json: Option<String> = row.get(4)?;
-            let checkpoint_json: Option<String> = row.get(7)?;
-            let created_at: String = row.get(8)?;
-            let completed_at: Option<String> = row.get(9)?;
+            let state: String = row.get(1)?;
+            let created_at: String = row.get(3)?;
             Ok(StoredTurn {
                 view: TurnView {
                     turn_id: turn_id.clone(),
                     agent_id: agent_id.to_owned(),
                     state: parse_status(&state)?,
-                    output: json_from_sql(&output_json)?,
-                    error: row.get(5)?,
-                    usage: usage_json.as_deref().map(json_from_sql).transpose()?,
+                    output: Vec::new(),
+                    error: None,
+                    usage: None,
                     created_at: parse_time(&created_at)?,
-                    completed_at: completed_at.as_deref().map(parse_time).transpose()?,
+                    completed_at: None,
                 },
                 inputs: load_inputs(connection, agent_id, &turn_id)?,
-                cancel_requested: row.get(6)?,
-                snapshot: checkpoint_json.as_deref().map(json_from_sql).transpose()?,
+                cancel_requested: row.get(2)?,
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;
-
-    let mut requests_statement = connection.prepare(
-        "SELECT idempotency_key, action, turn_id, state
-         FROM turn_requests WHERE agent_id = ?1",
-    )?;
-    let requests = requests_statement
-        .query_map(params![agent_id], |row| {
-            let key: String = row.get(0)?;
-            let action: String = row.get(1)?;
-            let state: String = row.get(3)?;
-            Ok((
-                key,
-                TurnActionResponse {
-                    action: parse_action(&action)?,
-                    turn_id: row.get(2)?,
-                    state: parse_status(&state)?,
-                },
-            ))
-        })?
-        .collect::<Result<HashMap<_, _>, _>>()?;
-    Ok(StoredSession { turns, requests })
+    let snapshot = connection
+        .query_row(
+            "SELECT checkpoint_json FROM turns
+             WHERE agent_id = ?1 AND state = 'completed' AND checkpoint_json IS NOT NULL
+             ORDER BY ordinal DESC LIMIT 1",
+            params![agent_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .as_deref()
+        .map(json_from_sql)
+        .transpose()?;
+    Ok(StoredSession { turns, snapshot })
 }
 
 fn load_inputs(
@@ -646,6 +646,38 @@ fn find_request(
                     action: parse_action(&action)?,
                     turn_id: row.get(1)?,
                     state: parse_status(&state)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(Into::into)
+}
+
+fn turn(
+    connection: &Connection,
+    agent_id: &str,
+    turn_id: &str,
+) -> Result<Option<TurnView>, SessionError> {
+    connection
+        .query_row(
+            "SELECT state, output_json, usage_json, error, created_at, completed_at
+             FROM turns WHERE agent_id = ?1 AND id = ?2",
+            params![agent_id, turn_id],
+            |row| {
+                let state: String = row.get(0)?;
+                let output_json: String = row.get(1)?;
+                let usage_json: Option<String> = row.get(2)?;
+                let created_at: String = row.get(4)?;
+                let completed_at: Option<String> = row.get(5)?;
+                Ok(TurnView {
+                    turn_id: turn_id.to_owned(),
+                    agent_id: agent_id.to_owned(),
+                    state: parse_status(&state)?,
+                    output: json_from_sql(&output_json)?,
+                    error: row.get(3)?,
+                    usage: usage_json.as_deref().map(json_from_sql).transpose()?,
+                    created_at: parse_time(&created_at)?,
+                    completed_at: completed_at.as_deref().map(parse_time).transpose()?,
                 })
             },
         )
@@ -763,7 +795,7 @@ fn finish_turn(
     agent_id: &str,
     turn_id: &str,
     completed: CompletedTurn,
-) -> Result<AgentEvent, SessionError> {
+) -> Result<FinishedTurn, SessionError> {
     let transaction = connection.unchecked_transaction()?;
     let event = append_event_tx(&transaction, agent_id, Some(turn_id), completed.event)?;
     transaction.execute(
@@ -792,19 +824,42 @@ fn finish_turn(
         ],
     )?;
     transaction.commit()?;
-    Ok(event)
+    Ok(FinishedTurn {
+        event,
+        snapshot: completed.snapshot,
+    })
 }
 
-fn append_event(
+fn append_events(
     connection: &Connection,
     agent_id: &str,
-    turn_id: Option<&str>,
-    payload: AgentEventPayload,
-) -> Result<AgentEvent, SessionError> {
+    events: Vec<(Option<String>, AgentEventPayload)>,
+) -> Result<Vec<AgentEvent>, SessionError> {
+    if events.is_empty() {
+        return Ok(Vec::new());
+    }
     let transaction = connection.unchecked_transaction()?;
-    let event = append_event_tx(&transaction, agent_id, turn_id, payload)?;
+    let mut next_id: i64 = transaction.query_row(
+        "SELECT COALESCE(MAX(id), 0) + 1 FROM session_events WHERE agent_id = ?1",
+        params![agent_id],
+        |row| row.get(0),
+    )?;
+    let mut persisted = Vec::with_capacity(events.len());
+    for (turn_id, payload) in events {
+        let id = event_id_from_sql(next_id)?;
+        persisted.push(insert_event_tx(
+            &transaction,
+            agent_id,
+            turn_id.as_deref(),
+            id,
+            payload,
+        )?);
+        next_id = next_id
+            .checked_add(1)
+            .ok_or(SessionError::EventIdOverflow)?;
+    }
     transaction.commit()?;
-    Ok(event)
+    Ok(persisted)
 }
 
 fn append_event_tx(
@@ -819,6 +874,16 @@ fn append_event_tx(
         |row| row.get(0),
     )?;
     let id = event_id_from_sql(id)?;
+    insert_event_tx(transaction, agent_id, turn_id, id, payload)
+}
+
+fn insert_event_tx(
+    transaction: &Transaction<'_>,
+    agent_id: &str,
+    turn_id: Option<&str>,
+    id: u64,
+    payload: AgentEventPayload,
+) -> Result<AgentEvent, SessionError> {
     let created_at = Utc::now();
     transaction.execute(
         "INSERT INTO session_events
@@ -845,23 +910,33 @@ fn events_after(
     connection: &Connection,
     agent_id: &str,
     after_event_id: u64,
+    limit: usize,
 ) -> Result<Vec<AgentEvent>, SessionError> {
     let mut statement = connection.prepare(
         "SELECT id, turn_id, payload_json, created_at
-         FROM session_events WHERE agent_id = ?1 AND id > ?2 ORDER BY id",
+         FROM session_events
+         WHERE agent_id = ?1 AND id > ?2
+         ORDER BY id LIMIT ?3",
     )?;
     statement
-        .query_map(params![agent_id, event_id_to_sql(after_event_id)?], |row| {
-            let payload_json: String = row.get(2)?;
-            let created_at: String = row.get(3)?;
-            Ok(AgentEvent {
-                id: event_id_from_sql(row.get(0)?)?,
-                agent_id: agent_id.to_owned(),
-                turn_id: row.get(1)?,
-                payload: json_from_sql(&payload_json)?,
-                created_at: parse_time(&created_at)?,
-            })
-        })?
+        .query_map(
+            params![
+                agent_id,
+                event_id_to_sql(after_event_id)?,
+                i64::try_from(limit).map_err(|_| SessionError::EventIdOverflow)?
+            ],
+            |row| {
+                let payload_json: String = row.get(2)?;
+                let created_at: String = row.get(3)?;
+                Ok(AgentEvent {
+                    id: event_id_from_sql(row.get(0)?)?,
+                    agent_id: agent_id.to_owned(),
+                    turn_id: row.get(1)?,
+                    payload: json_from_sql(&payload_json)?,
+                    created_at: parse_time(&created_at)?,
+                })
+            },
+        )?
         .collect::<Result<Vec<_>, _>>()
         .map_err(Into::into)
 }

--- a/crates/experimental/nanocentaur/tests/tracing.rs
+++ b/crates/experimental/nanocentaur/tests/tracing.rs
@@ -1,0 +1,150 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use chrono::Utc;
+use nanocentaur::{
+    AgentCapabilities, AgentConfig, AgentIdentity, AgentManager, ContentBlock, CreateTurn,
+    EffectivePrincipal, MockAgentFactory, TurnDelivery,
+};
+use tracing::{Id, Instrument, Subscriber, info_span, span::Attributes};
+use tracing_subscriber::{Layer, layer::Context as LayerContext, prelude::*, registry::LookupSpan};
+
+#[derive(Clone, Default)]
+struct TraceCapture(Arc<Mutex<HashMap<u64, CapturedSpan>>>);
+
+#[derive(Clone, Debug)]
+struct CapturedSpan {
+    name: &'static str,
+    parent: Option<u64>,
+}
+
+impl<S> Layer<S> for TraceCapture
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_new_span(&self, attributes: &Attributes<'_>, id: &Id, context: LayerContext<'_, S>) {
+        let parent = attributes
+            .parent()
+            .map(|parent| parent.clone().into_u64())
+            .or_else(|| {
+                attributes
+                    .is_contextual()
+                    .then(|| context.current_span().id().map(Id::into_u64))
+                    .flatten()
+            });
+        self.0.lock().unwrap().insert(
+            id.clone().into_u64(),
+            CapturedSpan {
+                name: attributes.metadata().name(),
+                parent,
+            },
+        );
+    }
+}
+
+fn identity() -> AgentIdentity {
+    AgentIdentity {
+        id: "019c-0000-7000-8000-000000000001".to_owned(),
+        owner_client_id: "test-client".to_owned(),
+        context_key: Some("trace-test".to_owned()),
+        principal: EffectivePrincipal {
+            id: "test-principal".to_owned(),
+            agent_config: AgentConfig::default(),
+            permissions: AgentCapabilities::default(),
+            secret_revision: 0,
+        },
+        created_at: Utc::now(),
+    }
+}
+
+#[test]
+fn channel_work_keeps_explicit_bounded_parentage() {
+    let capture = TraceCapture::default();
+    let subscriber = tracing_subscriber::registry().with(capture.clone());
+    let dispatch = tracing::Dispatch::new(subscriber);
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    tracing::dispatcher::with_default(&dispatch, || {
+        runtime.block_on(
+            async {
+                let directory = tempfile::tempdir().unwrap();
+                let manager = AgentManager::new(
+                    Arc::new(MockAgentFactory::new(Duration::from_millis(1))),
+                    directory.path(),
+                )
+                .unwrap();
+                let identity = identity();
+                manager.register(identity.clone()).await.unwrap();
+                let accepted = manager
+                    .create_turn(
+                        identity.clone(),
+                        CreateTurn {
+                            delivery: TurnDelivery::Steer,
+                            content: vec![ContentBlock::Text {
+                                text: "Trace the complete managed operation.".to_owned(),
+                            }],
+                        },
+                        Some("trace-request-1".to_owned()),
+                    )
+                    .await
+                    .unwrap();
+                tokio::time::timeout(Duration::from_secs(2), async {
+                    loop {
+                        if manager
+                            .get_turn(identity.clone(), &accepted.turn_id)
+                            .await
+                            .unwrap()
+                            .state
+                            .is_terminal()
+                        {
+                            break;
+                        }
+                        tokio::task::yield_now().await;
+                    }
+                })
+                .await
+                .unwrap();
+                manager.shutdown().await.unwrap();
+            }
+            .instrument(info_span!("test.managed_request")),
+        );
+    });
+
+    let spans = capture.0.lock().unwrap();
+    let root = spans
+        .iter()
+        .find_map(|(id, span)| (span.name == "test.managed_request").then_some(*id))
+        .unwrap();
+    let agent_commands = spans
+        .iter()
+        .filter(|(_, span)| span.name == "nanocentaur.agent.command")
+        .map(|(id, _)| *id)
+        .collect::<Vec<_>>();
+    assert!(
+        agent_commands
+            .iter()
+            .any(|id| spans.get(id).and_then(|span| span.parent) == Some(root)),
+        "captured spans: {spans:?}",
+    );
+    assert!(
+        spans.values().any(|span| {
+            span.name == "nanocentaur.sqlite.command"
+                && span
+                    .parent
+                    .is_some_and(|parent| agent_commands.contains(&parent))
+        }),
+        "captured spans: {spans:?}"
+    );
+    assert!(
+        spans
+            .values()
+            .all(|span| !matches!(span.name, "nanocentaur.driver" | "nanocentaur.session"))
+    );
+}

--- a/docs/nanocentaur.md
+++ b/docs/nanocentaur.md
@@ -1,0 +1,214 @@
+# Nanocentaur managed agents
+
+Nanocentaur is the experimental host-managed agent layer built from Axum,
+Nanocodex, SQLite, `nanocodex-vm`, and `nanocodex-egress`. The library owns
+durable agent identity and policy; the server is a thin executable consumer.
+
+```text
+HTTP / SSE
+    |
+    v
+Axum handlers
+    |
+    +--> SQLite policy
+    |      API key + context key -> principal -> grants + agent config
+    |
+    `--> bounded agent command queue
+             |
+             v
+         per-agent actor
+           - live Nanocodex handle
+           - active turn control
+           - explicit queued turns
+           - disposable VM workspace
+             |
+             v
+         SQLite session actor
+           - accepted turns and idempotency keys
+           - append-only typed event log
+           - completed session snapshots
+```
+
+The actor owns live runtime state. SQLite remains authoritative across actor
+eviction and process restart. Each wake creates a fresh model transport and VM,
+then resumes from the last completed typed `SessionSnapshot`.
+
+## Agent API
+
+```text
+POST   /v1/agent/new
+GET    /v1/agent/:agent_id
+DELETE /v1/agent/:agent_id
+POST   /v1/agent/:agent_id/evict
+
+POST   /v1/agent/:agent_id/turn
+GET    /v1/agent/:agent_id/turn/:turn_id
+POST   /v1/agent/:agent_id/turn/:turn_id/cancel
+GET    /v1/agent/:agent_id/events
+
+POST   /v1/agent/:agent_id/fork
+POST   /v1/agent/:agent_id/turn/:turn_id/fork
+
+POST   /v1/payment-sessions
+GET    /health
+```
+
+Create or resolve an agent:
+
+```http
+POST /v1/agent/new
+X-API-Key: ...
+Content-Type: application/json
+
+{"context_key":"opaque-client-owned-key"}
+```
+
+The optional context key is scoped to the authenticated API client. It gives
+create-or-return behavior but does not carry authority.
+
+Send ordered typed content:
+
+```http
+POST /v1/agent/d18a.../turn
+X-API-Key: ...
+Idempotency-Key: client-message-42
+Content-Type: application/json
+
+{
+  "content": [
+    {"type":"text","text":"Inspect the failure"}
+  ]
+}
+```
+
+The default `steer` delivery follows the owned Nanocodex turn state: an idle
+agent starts a turn; a running agent receives steering. A completion race falls
+back from `TurnNotSteerable` to a new prompt. `"delivery":"enqueue"` always
+uses the driver's FIFO prompt queue. A full steering queue returns
+`409 steer_queue_full` and is never silently converted to enqueueing.
+
+The SSE stream spans turns and supports durable replay:
+
+```http
+GET /v1/agent/d18a.../events
+Accept: text/event-stream
+Last-Event-ID: 42
+```
+
+Managed control events and native `nanocodex_agent::events::AgentEvent` values
+remain typed through SQLite and SSE projection.
+
+## Durability and forks
+
+`$STATE_DIRECTORY/sessions.sqlite` stores agents, turns, input blocks,
+idempotency mappings, events, and fork lineage. Acceptance of a turn, its first
+input, its idempotency mapping, and its accepted event are one transaction.
+
+A process restart marks incomplete running turns interrupted, moves them back
+to queued, and wakes them under the same managed turn ID. Only completed model
+boundaries are persisted as Nanocodex snapshots.
+
+A fork copies durable model history through a selected completed turn into a
+new agent identity. It receives a fresh VM root and does not copy guest
+filesystem mutations. Applications that need durable artifacts must export
+them explicitly.
+
+## Policy and authorization
+
+The administration surface uses
+`Authorization: Bearer $NANOCENTAUR_ADMIN_TOKEN`. It manages:
+
+- API clients and rotatable API keys
+- principals and context bindings
+- roles and permissions
+- principal/role grants
+- host-resolved secret routes
+
+Roles contain grants. A principal's agent configuration owns instructions and
+reasoning effort, avoiding ambiguous prompt merging across roles. Effective
+permissions are checked before each managed operation; agent configuration is
+snapshotted at creation.
+
+## Managed secret egress
+
+Secret policy stores references, never values. The built-in server registers:
+
+- `environment`: resolves `NANOCENTAUR_SECRET_<KEY>`
+- `file`: resolves a bounded safe relative path under `--secret-directory`
+
+A route fixes the upstream, allowed methods and path prefixes, header delivery,
+and public guest variables. For example:
+
+```json
+{
+  "id": "openai",
+  "name": "OpenAI",
+  "source": {"provider":"environment","key":"OPENAI"},
+  "upstream": "https://api.openai.com",
+  "rules": [{"methods":["POST"],"path_prefixes":["/v1/"]}],
+  "delivery": {
+    "type":"inject_header",
+    "header":"authorization",
+    "prefix":"Bearer "
+  },
+  "guest": {"base_url_env":"OPENAI_BASE_URL"}
+}
+```
+
+For each VM wake, Nanocentaur creates an authenticated loopback proxy and an
+ephemeral interception CA using `nanocodex-egress`. The guest receives proxy
+variables, the public CA, origins, and public placeholders. The host resolves a
+secret only after destination, method, path, active agent, principal, and live
+grant checks pass. Revocation therefore affects the next request. The proxy
+owner is retained by the VM egress lease and disappears with that runtime.
+
+Capability routes are independent. No requested network capability produces a
+network-disabled lease; configured capabilities may select direct internet or
+one server-owned external proxy.
+
+## Running
+
+Mock backend:
+
+```bash
+cargo run -p nanocentaur-server -- serve \
+  --api-key local-development-key \
+  --admin-token local-admin-key \
+  --backend mock
+```
+
+Real VM-backed Nanocodex backend with a directory root containing
+`/usr/local/bin/nanocodex-vm-guest`:
+
+```bash
+cargo run -p nanocentaur-server -- serve \
+  --api-key "$NANOCENTAUR_API_KEY" \
+  --admin-token "$NANOCENTAUR_ADMIN_TOKEN" \
+  --backend nanocodex \
+  --rootfs ./rootfs \
+  --openai-api-key "$OPENAI_API_KEY" \
+  --allow-capability github.read
+```
+
+Raw ext4 roots additionally require `--vm-guest-runtime ELF`; the server
+prepares its read-only runtime disk through the current `nanocodex-vm`
+contract. Use `--firmware-directory` when libkrun firmware is not discoverable
+through the platform loader.
+
+The deterministic HTTP benchmark exercises authentication, SQLite durability,
+actors, turns, and polling without model or VM cost:
+
+```bash
+cargo run -p nanocentaur-server -- bench \
+  --api-key local-development-key \
+  --agents 32
+```
+
+MPP payment sessions remain opt-in:
+
+```bash
+cargo run -p nanocentaur-server --features mpp -- serve ...
+```
+
+Authorization and policy checks run before payment verification, so rejected
+callers are not charged.

--- a/docs/nanocentaur.md
+++ b/docs/nanocentaur.md
@@ -33,6 +33,10 @@ The actor owns live runtime state. SQLite remains authoritative across actor
 eviction and process restart. Each wake creates a fresh model transport and VM,
 then resumes from the last completed typed `SessionSnapshot`.
 
+Live actors retain only unfinished turn controls and inputs plus the latest
+completed snapshot. Completed turn views and old idempotency records remain in
+SQLite instead of growing every actor heap for the lifetime of a session.
+
 ## Agent API
 
 ```text
@@ -96,7 +100,12 @@ Last-Event-ID: 42
 ```
 
 Managed control events and native `nanocodex_agent::events::AgentEvent` values
-remain typed through SQLite and SSE projection.
+remain typed through SQLite and SSE projection. Managed lifecycle events carry
+the durable turn ID. Native runtime events remain session-ordered with no
+synthetic turn attribution, so delayed or absent optional events can never
+delay a typed turn result or be assigned to the wrong queued turn.
+Runtime-event bursts share bounded SQLite transactions, and replay is fetched
+in bounded pages before switching to the live broadcast tail.
 
 ## Durability and forks
 
@@ -159,8 +168,12 @@ For each VM wake, Nanocentaur creates an authenticated loopback proxy and an
 ephemeral interception CA using `nanocodex-egress`. The guest receives proxy
 variables, the public CA, origins, and public placeholders. The host resolves a
 secret only after destination, method, path, active agent, principal, and live
-grant checks pass. Revocation therefore affects the next request. The proxy
-owner is retained by the VM egress lease and disappears with that runtime.
+route-specific grant checks pass. Revocation therefore affects the next
+request even when several routes use the same host secret reference. A route
+configuration change also fails closed on an existing proxy until policy
+refresh replaces its VM runtime, preventing a rotated credential from being
+sent through stale destination rules. The proxy owner is retained by the VM
+egress lease and disappears with that runtime.
 
 Capability routes are independent. No requested network capability produces a
 network-disabled lease; configured capabilities may select direct internet or
@@ -211,4 +224,6 @@ cargo run -p nanocentaur-server --features mpp -- serve ...
 ```
 
 Authorization and policy checks run before payment verification, so rejected
-callers are not charged.
+callers are not charged. Concurrent requests sharing one agent-scoped
+idempotency key are serialized across lookup, payment authorization, and
+durable acceptance, preventing duplicate authorization for the same turn.

--- a/docs/nanocentaur.md
+++ b/docs/nanocentaur.md
@@ -24,9 +24,9 @@ Axum handlers
              |
              v
          SQLite session actor
-           - accepted turns and idempotency keys
+           - accepted turns and request-bound idempotency keys
            - append-only typed event log
-           - completed session snapshots
+           - bounded-delta session checkpoints
 ```
 
 The actor owns live runtime state. SQLite remains authoritative across actor
@@ -91,6 +91,11 @@ back from `TurnNotSteerable` to a new prompt. `"delivery":"enqueue"` always
 uses the driver's FIFO prompt queue. A full steering queue returns
 `409 steer_queue_full` and is never silently converted to enqueueing.
 
+An idempotency key is bound to the normalized turn request. Reusing it with a
+different body returns `409 idempotency_conflict`; an exact retry returns the
+original action, status, turn ID, and payment receipt without authorizing
+payment again.
+
 The SSE stream spans turns and supports durable replay:
 
 ```http
@@ -114,13 +119,28 @@ idempotency mappings, events, and fork lineage. Acceptance of a turn, its first
 input, its idempotency mapping, and its accepted event are one transaction.
 
 A process restart marks incomplete running turns interrupted, moves them back
-to queued, and wakes them under the same managed turn ID. Only completed model
-boundaries are persisted as Nanocodex snapshots.
+to queued, and wakes them under the same managed turn ID. Accepted steering
+inputs are replayed before the recovered attempt may commit; completions from
+abandoned attempts are ignored. Terminal results and native runtime events stay
+in actor memory and retry their SQLite transaction instead of being dropped on
+a transient storage failure.
+
+Only completed model boundaries are persisted as Nanocodex snapshots. Every
+32nd checkpoint is full; intermediate checkpoints retain a byte delta against
+the preceding completed boundary. Reconstruction begins at the nearest full
+checkpoint, bounding replay work while avoiding full-history duplication on
+every turn.
 
 A fork copies durable model history through a selected completed turn into a
 new agent identity. It receives a fresh VM root and does not copy guest
 filesystem mutations. Applications that need durable artifacts must export
 them explicitly.
+
+Policy identities use hidden `provisioning` and `deleting` lifecycle states
+while the separate session transaction completes. Deleted session IDs receive
+permanent tombstones, so stale authorization or another process cannot recreate
+their durable history. Failed fork provisioning is cleaned up before becoming
+visible, and interrupted deletion can be retried.
 
 ## Policy and authorization
 
@@ -137,6 +157,12 @@ Roles contain grants. A principal's agent configuration owns instructions and
 reasoning effort, avoiding ambiguous prompt merging across roles. Effective
 permissions are checked before each managed operation; agent configuration is
 snapshotted at creation.
+
+Effective capabilities and secret-policy revision are refreshed at every turn
+boundary. Queued prompts are not submitted to a runtime early, so work accepted
+before a revocation starts only after the old runtime has been replaced. An
+already-running turn keeps the capability snapshot it started with; managed
+secret requests still recheck live route grants independently.
 
 ## Managed secret egress
 
@@ -224,6 +250,8 @@ cargo run -p nanocentaur-server --features mpp -- serve ...
 ```
 
 Authorization and policy checks run before payment verification, so rejected
-callers are not charged. Concurrent requests sharing one agent-scoped
-idempotency key are serialized across lookup, payment authorization, and
-durable acceptance, preventing duplicate authorization for the same turn.
+callers are not charged. Turn shape validation also precedes payment. Concurrent
+requests sharing one agent-scoped idempotency key are serialized across lookup,
+payment authorization, and durable acceptance, preventing duplicate
+authorization for the same turn. If a later manager boundary rejects an
+authorized request, its error response still carries the payment receipt.


### PR DESCRIPTION
## Summary

- reintroduce only the managed-agent slice from #60 on current `master`
- add durable SQLite-backed actors, typed event replay, request-bound idempotency, steering, cancellation, forks, tenant policy, managed secret routing, REST/SSE, and optional MPP payments
- compose the browser, VM, egress, and NanoUSD/MPP work already on `master` instead of duplicating it
- align the library API with Nanocodex ownership: `AgentManager` owns disposable actors, each actor exclusively owns its live runtime, and SQLite owns accepted history

Supersedes #60.

## How it works

Nanocentaur is a hosted lifecycle around independent Nanocodex sessions, not a generic multi-agent scheduler.

1. An API key authenticates a client. An optional client-scoped context key gives create-or-return behavior for a durable agent identity; it carries no authority.
2. Current principal permissions and payment policy are checked before work is accepted.
3. A per-agent actor exclusively owns the Nanocodex handle, active turn control, FIFO queued turns, capability snapshot, and disposable VM runtime.
4. SQLite atomically records a turn, its first input, request hash/idempotency mapping, payment receipt, and accepted event before runtime submission.
5. Idle input starts a turn. Default delivery steers an active turn. Explicit `enqueue` waits in the actor-owned FIFO and is not submitted early.
6. On wake, the real backend acquires capability-derived egress, creates a disposable rootfs/libkrun VM, builds VM-backed tools, and creates or resumes Nanocodex from the latest completed typed `SessionSnapshot`.
7. Typed results and optional runtime events are independent. Terminal state, output, usage, event, and checkpoint commit atomically; runtime events are batched and SSE replay is paged before switching to the live tail.
8. Restart marks running work interrupted and retries it under the same managed turn ID. Every durably accepted steer is replayed before the recovered attempt may commit.
9. Forking copies committed model history through a selected completion into a fresh identity and VM. Guest filesystem state is intentionally not copied.
10. Managed secret values stay host-side and are resolved only after live route, destination, method, path, agent, principal, and grant checks.

The public boundary is `AgentManager + ManagedAgentFactory`. `ApiState` is a thin Axum projection; `NanocodexAgentFactory` is the VM-backed implementation and `MockAgentFactory` exercises the same lifecycle deterministically.

## Crash-safety and lifecycle hardening

- actors hold only weak self-senders, so dropping the manager releases runtimes instead of leaking immortal actor cycles
- queued turns remain durable but unsubmitted until active, preserving FIFO ownership and allowing policy refresh at the actual execution boundary
- effective capabilities and secret-policy revision are refreshed before every turn; revoked queued work cannot run on an old runtime
- steering and cancellation are persisted before their live side effects; failed live steering is transactionally compensated
- terminal results and runtime-event batches retry transient SQLite failures instead of disappearing or wedging the queue
- recovery uses attempt generations, so stale completions cannot commit if durable steer replay failed and the runtime was replaced
- dead actor handles are detected and replaced transparently
- policy identities use hidden `provisioning`/`deleting` states around the separate session transaction; failed forks are cleaned up and interrupted deletes are retryable
- session tombstones permanently prevent stale authorization or another process from recreating a deleted agent ID

## Idempotency, payment, and storage

- idempotency keys are bound to the SHA-256 hash of the normalized typed request
- a mismatched retry returns `409 idempotency_conflict`
- an exact retry restores the original action, HTTP status, turn ID, and payment receipt without reauthorizing payment
- same-key requests are serialized across lookup, payment authorization, and durable acceptance
- invalid turn shapes are rejected before payment; post-authorization manager errors still return the receipt
- completed snapshots use bounded delta checkpoints with a full checkpoint every 32 completed boundaries; reconstruction starts at the nearest full checkpoint instead of replaying the entire session
- legacy databases migrate in place

## API design review

- public policy is explicit; actor queue capacities, retry bookkeeping, runtime generations, SQLite commands, and replay mechanics remain private
- typed turn results stay independent from the optional event stream
- callers never pass prior messages, response IDs, tool results, or mutable runtime state back into the agent
- detailed APIs remain under their owning managed-agent crate; no provider portability or generic scheduler/app-server abstraction was added
- policy SQLite work used during VM/secret setup is moved off async workers, while bounded hot authorization reads avoid an extra blocking-pool context switch

## Performance

Current retained HTTP benchmark on the rebased branch:

- authorized agent view: ~54.4 us mean
- exact idempotent replay: ~50.9 us mean
- accepted turn to durable terminal event: ~1.57 ms mean

The final optimization rerun improved all three measured paths versus the preceding hardened implementation.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p nanocentaur -p nanocentaur-server --all-targets --all-features -- -D warnings`
- `cargo test -p nanocentaur --all-targets` (43 unit tests, tracing integration, benchmark smoke)
- `cargo test -p nanocentaur-server --all-targets --all-features`
- `cargo test -p nanocentaur --doc`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p nanocentaur --no-deps`
- `cargo check -p nanocodex-examples --bins`
- `scripts/check-crate-boundaries.sh`
- `scripts/check-experimental-boundary.sh`
- `cargo bench -p nanocentaur --bench managed_api -- --noplot`

Browser and base egress implementations remain out of this diff because they are already on `master`.
