### PR TITLE
feat(rivet): deploy subscription demo to Compute

### DIFF
--- a/examples/rivet-actors/README.md
+++ b/examples/rivet-actors/README.md
@@ -33,8 +33,10 @@ mode-`0600` Codex auth file for each connection. It never uses the refresh token
 or stores credentials in Rivet SQLite. Deployments can instead use the singleton
 `nanocodexAuth` actor to own dedicated rotating credentials, refresh five
 minutes early, single-flight concurrent refreshes, and retry one WebSocket
-upgrade after revision-guarded 401 recovery. In both paths bearer credentials
-remain in host code and never enter Nanocodex WASM.
+upgrade after revision-guarded 401 recovery. Disposable deployments may omit
+the refresh token and use only the current Codex access token, matching the
+Cloudflare demo. In both paths bearer credentials remain in host code and never
+enter Nanocodex WASM.
 
 ## Build and run
 
@@ -103,7 +105,12 @@ provider response cannot be resumed.
 The local Rivet endpoint is `http://127.0.0.1:6420`. Set
 `RIVET_PUBLIC_ENDPOINT` for another deployment. Set `NANOCODEX_WEB_HOST` or
 `NANOCODEX_WEB_PORT` to move the static browser client; it binds to loopback by
-default.
+default. On Rivet Compute it runs RivetKit's serverless listener on the injected
+`PORT`, satisfying the runner health check and serving both the actor routes and
+demo page from the same container. A fresh hosted page selects its same-origin
+`/api/rivet` endpoint automatically. A separately hosted static page can select
+a deployment without embedding it in source by adding
+`?endpoint=https%3A%2F%2F...` to the page URL.
 
 The smoke also forces the real model to invoke `runtimeInfo` and requires a
 completed Nanocodex `tool.call`/`tool.result` event pair, so it verifies the
@@ -124,8 +131,24 @@ stable defaults prevent repeated local runs from accumulating actor records.
 ## Deployment-managed subscription authentication
 
 The local command above is the safest demo path. A deployed actor cannot read
-your local Codex auth file, so give it dedicated rotating subscription
-credentials instead. This still does not require `OPENAI_API_KEY`:
+your local Codex auth file. For a disposable hosted demo, the deployment helper
+securely reads the current access token and account metadata, checks the auth
+file permissions and token lifetime, and does not copy the rotating refresh
+token:
+
+```sh
+export RIVET_CLOUD_TOKEN=cloud_api_xxxxx
+npm run deploy:subscription --prefix examples/rivet-actors
+```
+
+This is the same access-token-only policy as the Cloudflare demo. It keeps
+working until the current access token expires or ChatGPT rejects it; then run
+`codex login` and deploy again. `NANOCODEX_CODEX_AUTH_FILE`, `CODEX_HOME`, and
+`RIVET_NAMESPACE` override the auth path and target namespace.
+
+For a long-lived deployment, give the auth actor dedicated rotating
+subscription credentials instead. This still does not require
+`OPENAI_API_KEY`:
 
 ```sh
 export NANOCODEX_AUTH_MODE=chatgpt
@@ -190,18 +213,17 @@ npx @rivetkit/cli@2.3.10 deploy \
   --env OPENAI_API_KEY="$OPENAI_API_KEY"
 ```
 
-For deployment-managed ChatGPT authentication, replace the last two flags with
-the `NANOCODEX_AUTH_MODE`, capability, actor key, and dedicated ChatGPT
-credential variables documented above. Do not share that rotating refresh
-token with another deployment or local Codex installation.
+For ChatGPT subscription authentication, use the access-token-only helper from
+the preceding section. Set `CHATGPT_REFRESH_TOKEN` before invoking it only when
+that refresh token is dedicated to this deployment; never copy the refresh
+token still used by a local Codex installation.
 
-Once the pool is ready, mint a client-safe public token and use the resulting
-endpoint with the REPL, smoke driver, or browser client:
+Once the pool is ready, copy a client-safe publishable endpoint from the
+namespace's **Connect** page in the Rivet dashboard. Use that endpoint with the
+REPL, smoke driver, or browser client:
 
 ```sh
-RIVET_PUBLIC_TOKEN="$(npx @rivetkit/cli@2.3.10 token create \
-  --kind public --namespace production)"
-export RIVET_PUBLIC_ENDPOINT="https://production:${RIVET_PUBLIC_TOKEN}@api.rivet.dev"
+export RIVET_PUBLIC_ENDPOINT='https://<namespace>:pk_...@api.rivet.dev'
 npm run smoke --prefix examples/rivet-actors
 npm run repl --prefix examples/rivet-actors
 ```

--- a/examples/rivet-actors/package.json
+++ b/examples/rivet-actors/package.json
@@ -17,6 +17,7 @@
     "dev": "node scripts/run-local-server.mjs --env-file src/server.ts",
     "predev:subscription": "npm run build:web",
     "dev:subscription": "node scripts/run-local-server.mjs scripts/dev-subscription.ts",
+    "deploy:subscription": "node --import tsx scripts/deploy-subscription.ts",
     "repl": "node --import tsx scripts/repl.ts",
     "smoke": "node --import tsx scripts/live-smoke.ts",
     "stress": "node --import tsx scripts/stress.ts",

--- a/examples/rivet-actors/scripts/deploy-subscription.ts
+++ b/examples/rivet-actors/scripts/deploy-subscription.ts
@@ -1,0 +1,69 @@
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createCodexAuthFileProvider } from "../src/codex-auth-file.js";
+
+const cloudToken = requiredSecret("RIVET_CLOUD_TOKEN");
+const codexHome = process.env.CODEX_HOME ?? join(homedir(), ".codex");
+const authFile = resolve(process.env.NANOCODEX_CODEX_AUTH_FILE ?? join(codexHome, "auth.json"));
+const auth = await createCodexAuthFileProvider(authFile).snapshot();
+const namespace = process.env.RIVET_NAMESPACE?.trim() || "production";
+const actorKey = process.env.NANOCODEX_AUTH_ACTOR_KEY?.trim()
+  || `nanocodex-subscription-${namespace}`;
+const capability = process.env.NANOCODEX_AUTH_CAPABILITY?.trim()
+  || randomBytes(32).toString("base64url");
+const repository = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+const environment = [
+  "NANOCODEX_AUTH_MODE=chatgpt",
+  `NANOCODEX_AUTH_ACTOR_KEY=${actorKey}`,
+  `NANOCODEX_AUTH_CAPABILITY=${capability}`,
+  `CHATGPT_ACCESS_TOKEN=${auth.bearerToken}`,
+  `CHATGPT_ACCOUNT_ID=${auth.accountId}`,
+  `CHATGPT_FEDRAMP=${String(auth.fedramp)}`,
+];
+const refreshToken = process.env.CHATGPT_REFRESH_TOKEN?.trim();
+if (refreshToken) environment.push(`CHATGPT_REFRESH_TOKEN=${refreshToken}`);
+
+process.stderr.write(
+  `Deploying the current Codex subscription access token to Rivet namespace ${namespace}; `
+    + `${refreshToken ? "dedicated refresh is enabled" : "no refresh token will be copied"}.\n`,
+);
+const child = spawn("npx", [
+  "@rivetkit/cli@2.3.10",
+  "deploy",
+  "--token",
+  cloudToken,
+  "--dockerfile",
+  "examples/rivet-actors/Dockerfile",
+  "--build-context",
+  ".",
+  "--namespace",
+  namespace,
+  ...environment.flatMap((value) => ["--env", value]),
+], {
+  cwd: repository,
+  env: process.env,
+  stdio: "inherit",
+});
+
+const exit = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+  (resolveExit, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => resolveExit({ code, signal }));
+  },
+);
+if (exit.code !== 0) {
+  throw new Error(exit.signal
+    ? `Rivet deployment exited on ${exit.signal}`
+    : `Rivet deployment exited with status ${String(exit.code)}`);
+}
+
+function requiredSecret(name: string): string {
+  const value = process.env[name];
+  if (!value?.trim()) throw new Error(`${name} is not configured`);
+  return value;
+}

--- a/examples/rivet-actors/src/auth.ts
+++ b/examples/rivet-actors/src/auth.ts
@@ -136,6 +136,11 @@ async function refresh(database: RawAccess, vars: AuthVars, rejectedRevision: nu
 }
 
 async function performRefresh(database: RawAccess, current: CredentialRow): Promise<CredentialRow> {
+  if (!current.refresh_token) {
+    throw new Error(
+      "ChatGPT access token needs rotation; run `codex login` and redeploy the subscription demo",
+    );
+  }
   const response = await fetch(process.env.CHATGPT_TOKEN_ENDPOINT ?? DEFAULT_TOKEN_ENDPOINT, {
     method: "POST",
     signal: AbortSignal.timeout(25_000),
@@ -200,7 +205,7 @@ async function performRefresh(database: RawAccess, current: CredentialRow): Prom
 
 async function seed(database: RawAccess): Promise<CredentialRow> {
   const accessToken = requiredSecret("CHATGPT_ACCESS_TOKEN");
-  const refreshToken = requiredSecret("CHATGPT_REFRESH_TOKEN");
+  const refreshToken = optionalString(process.env.CHATGPT_REFRESH_TOKEN) ?? "";
   const accountId = requiredSecret("CHATGPT_ACCOUNT_ID");
   const row: CredentialRow = {
     access_token: accessToken,

--- a/examples/rivet-actors/src/server.ts
+++ b/examples/rivet-actors/src/server.ts
@@ -1,28 +1,56 @@
 import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 import { registry } from "./registry.js";
 import { startWebClient } from "./web-server.js";
 
-const web = await startWebClient({
-  ...(process.env.NANOCODEX_WEB_HOST === undefined
-    ? {}
-    : { host: process.env.NANOCODEX_WEB_HOST }),
-  ...(process.env.NANOCODEX_WEB_PORT === undefined
-    ? {}
-    : { port: Number(process.env.NANOCODEX_WEB_PORT) }),
-});
-process.stderr.write(`Nanocodex browser client: ${web.url}\n`);
+const computePort = process.env.PORT ?? process.env.RIVET_PORT;
 const stopping = shutdownSignal();
-try {
-  const first = await Promise.race([
-    registry.startAndWait().then(() => ({ kind: "ready" as const })),
-    stopping.then((signal) => ({ kind: "signal" as const, signal })),
-  ]);
-  const signal = first.kind === "signal" ? first.signal : await stopping;
-  process.exitCode = signal === "SIGINT" ? 130 : 143;
-} finally {
-  await Promise.race([registry.shutdown(), delay(15_000)]);
-  await web.close();
+if (process.env.RIVETKIT_RUNTIME_MODE === "serverless") {
+  await runServerless(stopping);
+} else {
+  await runEnvoy(stopping);
+}
+
+async function runServerless(stopping: Promise<"SIGINT" | "SIGTERM">): Promise<void> {
+  const listening = registry.listen({
+    host: process.env.NANOCODEX_WEB_HOST ?? "0.0.0.0",
+    port: parsePort(process.env.NANOCODEX_WEB_PORT ?? computePort ?? "3000"),
+    publicDir: fileURLToPath(new URL("../web/", import.meta.url)),
+  });
+  try {
+    const first = await Promise.race([
+      listening.then(() => ({ kind: "stopped" as const })),
+      stopping.then((signal) => ({ kind: "signal" as const, signal })),
+    ]);
+    if (first.kind === "signal") process.exitCode = first.signal === "SIGINT" ? 130 : 143;
+  } finally {
+    await Promise.race([registry.shutdown(), delay(15_000)]);
+    await Promise.race([listening, delay(15_000)]);
+  }
+}
+
+async function runEnvoy(stopping: Promise<"SIGINT" | "SIGTERM">): Promise<void> {
+  const web = await startWebClient({
+    ...(process.env.NANOCODEX_WEB_HOST === undefined && computePort === undefined
+      ? {}
+      : { host: process.env.NANOCODEX_WEB_HOST ?? "0.0.0.0" }),
+    ...(process.env.NANOCODEX_WEB_PORT === undefined && computePort === undefined
+      ? {}
+      : { port: parsePort(process.env.NANOCODEX_WEB_PORT ?? computePort) }),
+  });
+  process.stderr.write(`Nanocodex browser client: ${web.url}\n`);
+  try {
+    const first = await Promise.race([
+      registry.startAndWait().then(() => ({ kind: "ready" as const })),
+      stopping.then((signal) => ({ kind: "signal" as const, signal })),
+    ]);
+    const signal = first.kind === "signal" ? first.signal : await stopping;
+    process.exitCode = signal === "SIGINT" ? 130 : 143;
+  } finally {
+    await Promise.race([registry.shutdown(), delay(15_000)]);
+    await web.close();
+  }
 }
 
 function shutdownSignal(): Promise<"SIGINT" | "SIGTERM"> {
@@ -50,4 +78,12 @@ function terminateLocalEngineChildren(): void {
 
 function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds).unref());
+}
+
+function parsePort(raw: string | undefined): number {
+  const port = Number(raw);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`web port must be an integer between 1 and 65535; got ${JSON.stringify(raw)}`);
+  }
+  return port;
 }

--- a/examples/rivet-actors/src/web-server.ts
+++ b/examples/rivet-actors/src/web-server.ts
@@ -27,7 +27,7 @@ export async function startWebClient(options: { host?: string; port?: number } =
         "cache-control": "no-store",
         "content-security-policy": "default-src 'none'; connect-src http: https: ws: wss:; script-src 'self'; style-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
       }, request.method === "HEAD");
-    } else if (pathname === "/app.js") {
+    } else if (pathname === "/app.js" || pathname === "/dist/app.js") {
       send(response, 200, "text/javascript; charset=utf-8", script, {
         "cache-control": "public, max-age=3600",
       }, request.method === "HEAD");

--- a/examples/rivet-actors/test/actors.test.ts
+++ b/examples/rivet-actors/test/actors.test.ts
@@ -201,6 +201,27 @@ describe.sequential("Nanocodex Rivet Actors", () => {
     expect((await session.status()).auth_mode).toBe("chatgpt");
   });
 
+  test("runs a disposable subscription deployment without copying the refresh token", async (context) => {
+    resetMock();
+    configureAccessTokenOnlySubscription();
+    const { client } = await setupTest(context, registry);
+    const auth = client.nanocodexAuth.getOrCreate([authActorKey]);
+
+    expect(await auth.snapshot(createCapabilityProof("snapshot"))).toMatchObject({
+      accountId: ACCOUNT_ID,
+      revision: 0,
+    });
+    const session = client.nanocodex.getOrCreate([`access-only-${crypto.randomUUID()}`]);
+    const result = await session.prompt({
+      id: "access-only-turn",
+      input: "Reply with exactly ACCESS_ONLY_OK",
+    });
+    expect(result.final_message).toBe("ACCESS_ONLY_OK");
+    await expect(auth.recover(createCapabilityProof("recover:0"), 0))
+      .rejects.toThrow(/internal error/i);
+    expect(refreshCount).toBe(0);
+  });
+
   test("bounds prompt size and active turn fan-in", async (context) => {
     resetMock();
     configureApiKey();
@@ -258,6 +279,12 @@ function configureSubscription(): void {
   process.env.NANOCODEX_AUTH_ACTOR_KEY = authActorKey;
   process.env.NANOCODEX_AUTH_CAPABILITY = AUTH_CAPABILITY;
   delete process.env.OPENAI_API_KEY;
+}
+
+function configureAccessTokenOnlySubscription(): void {
+  configureSubscription();
+  process.env.CHATGPT_ACCESS_TOKEN = VALID_ACCESS_TOKEN;
+  delete process.env.CHATGPT_REFRESH_TOKEN;
 }
 
 function resetMock(): void {

--- a/examples/rivet-actors/test/web-server.test.ts
+++ b/examples/rivet-actors/test/web-server.test.ts
@@ -17,10 +17,11 @@ describe("browser client", () => {
     expect(page.headers.get("content-security-policy")).toContain("frame-ancestors 'none'");
     expect(await page.text()).toContain("Inference outlives the tab.");
 
-    const script = await fetch(`${web.url}/app.js`);
+    const script = await fetch(`${web.url}/dist/app.js`);
     const source = await script.text();
     expect(script.headers.get("content-type")).toContain("text/javascript");
     expect(source).toContain("localStorage");
+    expect(source).toContain("URLSearchParams");
     expect(source).not.toContain("OPENAI_API_KEY");
     expect(source).not.toContain("CHATGPT_ACCESS_TOKEN");
   });

--- a/examples/rivet-actors/web/_headers
+++ b/examples/rivet-actors/web/_headers
@@ -1,0 +1,10 @@
+/*
+  Content-Security-Policy: default-src 'none'; connect-src http: https: ws: wss:; script-src 'self'; style-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'
+  Cross-Origin-Opener-Policy: same-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=()
+  Referrer-Policy: no-referrer
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+
+/index.html
+  Cache-Control: no-store

--- a/examples/rivet-actors/web/app.ts
+++ b/examples/rivet-actors/web/app.ts
@@ -31,11 +31,16 @@ type NanocodexClient = ReturnType<typeof makeClient>;
 type Session = ReturnType<NanocodexClient["nanocodex"]["getOrCreate"]>;
 type Connection = ReturnType<Session["connect"]>;
 
+const requestedEndpoint = new URLSearchParams(location.search).get("endpoint")?.trim();
+const defaultEndpoint = requestedEndpoint || (location.hostname === "127.0.0.1" || location.hostname === "localhost"
+  ? "http://127.0.0.1:6420"
+  : `${location.origin}/api/rivet`);
 let state = loadState() ?? {
-  endpoint: "http://127.0.0.1:6420",
+  endpoint: defaultEndpoint,
   actorKey: crypto.randomUUID(),
   messages: [],
 };
+if (requestedEndpoint) state.endpoint = requestedEndpoint;
 let client: NanocodexClient | undefined;
 let connection: Connection | undefined;
 let generation = 0;
@@ -51,7 +56,7 @@ ui.connect.addEventListener("click", () => void connect());
 ui.newActor.addEventListener("click", () => {
   void detach();
   state = {
-    endpoint: ui.endpoint.value.trim() || "http://127.0.0.1:6420",
+    endpoint: ui.endpoint.value.trim() || defaultEndpoint,
     actorKey: crypto.randomUUID(),
     messages: [],
   };

--- a/examples/rivet-actors/web/index.html
+++ b/examples/rivet-actors/web/index.html
@@ -27,6 +27,6 @@
     </form>
     <footer><span id="activity">idle</span><span>Rust/WASM · RivetKit · SQLite actor state</span></footer>
   </main>
-  <script type="module" src="/app.js"></script>
+  <script type="module" src="/dist/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- deploy the current Codex ChatGPT subscription access token without copying the local rotating refresh token
- run RivetKit in Compute serverless mode on the injected port and serve the browser demo from the actor image
- support one-click static demo endpoints and document publishable endpoint setup

## Validation

- `npm run check --prefix examples/rivet-actors` (9 tests)
- `npm run build --prefix examples/rivet-actors`
- Rivet Compute hosted smoke: 3 turns, WASM tool call, unload/restore
- browser E2E against the public hosted page: `LIVE_UI_OK`, 32 durable events