### PR TITLE
fix(mpp): prefer NanoUSD through mpp-rs selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3862,7 +3862,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3880,7 +3880,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4913,7 +4913,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/gakonst/mpp-rs?rev=ad1f4f79d918a1ca5605d5b417d7090238381328#ad1f4f79d918a1ca5605d5b417d7090238381328"
+source = "git+https://github.com/tempoxyz/mpp-rs?rev=3e37469bb19434982b433ae44ea8c713f7ea923a#3e37469bb19434982b433ae44ea8c713f7ea923a"
 dependencies = [
  "alloy",
  "anyhow",
@@ -6561,7 +6561,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6599,7 +6599,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3862,7 +3862,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -3880,7 +3880,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -4457,7 +4457,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "lru 0.16.4",
+ "lru 0.12.5",
  "nix 0.30.1",
  "rand 0.9.5",
  "virtio-bindings",
@@ -4913,7 +4913,7 @@ dependencies = [
 [[package]]
 name = "mpp"
 version = "0.11.0"
-source = "git+https://github.com/gakonst/mpp-rs?rev=b1a7088bc05da933923220e29028ff75dbcb1ea4#b1a7088bc05da933923220e29028ff75dbcb1ea4"
+source = "git+https://github.com/gakonst/mpp-rs?rev=ad1f4f79d918a1ca5605d5b417d7090238381328#ad1f4f79d918a1ca5605d5b417d7090238381328"
 dependencies = [
  "alloy",
  "anyhow",
@@ -6561,7 +6561,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6599,7 +6599,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -7160,7 +7160,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8746,7 +8746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -8755,7 +8755,7 @@ dependencies = [
 [[package]]
 name = "tempo-alloy"
 version = "1.10.1"
-source = "git+https://github.com/gakonst/tempo?rev=c2cf774b95ea920b671d311aa07c96051913c314#c2cf774b95ea920b671d311aa07c96051913c314"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -8795,7 +8795,7 @@ dependencies = [
 [[package]]
 name = "tempo-chainspec"
 version = "1.10.1"
-source = "git+https://github.com/gakonst/tempo?rev=c2cf774b95ea920b671d311aa07c96051913c314#c2cf774b95ea920b671d311aa07c96051913c314"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -8811,7 +8811,7 @@ dependencies = [
 [[package]]
 name = "tempo-contracts"
 version = "1.10.1"
-source = "git+https://github.com/gakonst/tempo?rev=c2cf774b95ea920b671d311aa07c96051913c314#c2cf774b95ea920b671d311aa07c96051913c314"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -8823,7 +8823,7 @@ dependencies = [
 [[package]]
 name = "tempo-hardfork"
 version = "1.10.1"
-source = "git+https://github.com/gakonst/tempo?rev=c2cf774b95ea920b671d311aa07c96051913c314#c2cf774b95ea920b671d311aa07c96051913c314"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
 dependencies = [
  "alloy-eips",
  "alloy-hardforks",
@@ -8834,7 +8834,7 @@ dependencies = [
 [[package]]
 name = "tempo-primitives"
 version = "1.10.1"
-source = "git+https://github.com/gakonst/tempo?rev=c2cf774b95ea920b671d311aa07c96051913c314#c2cf774b95ea920b671d311aa07c96051913c314"
+source = "git+https://github.com/tempoxyz/tempo?rev=bdc5c78c155d746d4e7f16d64b41ce791ba24580#bdc5c78c155d746d4e7f16d64b41ce791ba24580"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ hmac = "0.13.0"
 hudsucker = { version = "0.25.0", git = "https://github.com/gakonst/hudsucker", rev = "9a13609adc4b37b3e7fba28a320546bf672f0f4d", default-features = false, features = ["rcgen-ca", "ring", "rustls-client"] }
 ignore = "0.4.31"
 krun = { package = "libkrun", version = "=2.0.0-dev", git = "https://github.com/containers/libkrun", rev = "df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0", features = ["blk", "net"] }
-mpp = { version = "=0.11.0", git = "https://github.com/gakonst/mpp-rs", rev = "b1a7088bc05da933923220e29028ff75dbcb1ea4", default-features = false }
+mpp = { version = "=0.11.0", git = "https://github.com/gakonst/mpp-rs", rev = "ad1f4f79d918a1ca5605d5b417d7090238381328", default-features = false }
 nanocodex = { version = "0.3.0", path = "crates/nanocodex" }
 nanocodex-agent = { version = "0.3.0", path = "crates/nanocodex-agent" }
 nanocodex-browser = { version = "0.3.0", path = "crates/experimental/nanocodex-browser" }
@@ -126,7 +126,7 @@ toml = "1.1.3"
 tokio = "1.48.0"
 tokio-util = { version = "0.7", features = ["codec"] }
 tokio-tungstenite = { version = "0.30.0", default-features = false, features = ["connect", "rustls-tls-native-roots"] }
-tempo-alloy = { version = "=1.10.1", git = "https://github.com/gakonst/tempo", rev = "c2cf774b95ea920b671d311aa07c96051913c314" }
+tempo-alloy = { version = "=1.10.1", git = "https://github.com/tempoxyz/tempo", rev = "bdc5c78c155d746d4e7f16d64b41ce791ba24580" }
 tower = { version = "0.5.2", features = ["limit", "load-shed", "retry", "timeout", "util"] }
 tracing = { version = "0.1.44", default-features = false, features = ["std"] }
 tracing-appender = "0.2.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ hmac = "0.13.0"
 hudsucker = { version = "0.25.0", git = "https://github.com/gakonst/hudsucker", rev = "9a13609adc4b37b3e7fba28a320546bf672f0f4d", default-features = false, features = ["rcgen-ca", "ring", "rustls-client"] }
 ignore = "0.4.31"
 krun = { package = "libkrun", version = "=2.0.0-dev", git = "https://github.com/containers/libkrun", rev = "df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0", features = ["blk", "net"] }
-mpp = { version = "=0.11.0", git = "https://github.com/gakonst/mpp-rs", rev = "ad1f4f79d918a1ca5605d5b417d7090238381328", default-features = false }
+mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "3e37469bb19434982b433ae44ea8c713f7ea923a", default-features = false }
 nanocodex = { version = "0.3.0", path = "crates/nanocodex" }
 nanocodex-agent = { version = "0.3.0", path = "crates/nanocodex-agent" }
 nanocodex-browser = { version = "0.3.0", path = "crates/experimental/nanocodex-browser" }

--- a/bin/nanocodex/src/mpp.rs
+++ b/bin/nanocodex/src/mpp.rs
@@ -145,6 +145,7 @@ impl MppArgs {
         )?;
         let provider = provider
             .with_expected_chain_id(TEMPO_MAINNET_CHAIN_ID)
+            .with_preferred_currency(NANOUSD_ADDRESS)
             .with_autoswap(AutoswapConfig::new(NANOUSD_ADDRESS, self.swap_slippage_bps));
         let provider = CappedChargeProvider {
             provider,
@@ -177,6 +178,13 @@ where
 {
     fn supports(&self, method: &str, intent: &str) -> bool {
         self.provider.supports(method, intent)
+    }
+
+    fn select_challenge<'a>(
+        &self,
+        challenges: &[&'a PaymentChallenge],
+    ) -> Option<&'a PaymentChallenge> {
+        self.provider.select_challenge(challenges)
     }
 
     async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
@@ -377,11 +385,30 @@ mod tests {
         payments: Arc<AtomicUsize>,
         commits: Arc<AtomicUsize>,
         rollbacks: Arc<AtomicUsize>,
+        select_last: bool,
+    }
+
+    impl MockProvider {
+        fn selecting_last(mut self) -> Self {
+            self.select_last = true;
+            self
+        }
     }
 
     impl PaymentProvider for MockProvider {
         fn supports(&self, method: &str, intent: &str) -> bool {
             method == "tempo" && intent == "charge"
+        }
+
+        fn select_challenge<'a>(
+            &self,
+            challenges: &[&'a PaymentChallenge],
+        ) -> Option<&'a PaymentChallenge> {
+            if self.select_last {
+                challenges.last().copied()
+            } else {
+                challenges.first().copied()
+            }
         }
 
         async fn pay(&self, challenge: &PaymentChallenge) -> Result<PaymentCredential, MppError> {
@@ -432,6 +459,24 @@ mod tests {
         }))
         .unwrap();
         PaymentChallenge::new("challenge", "api.example.com", "tempo", "charge", request)
+    }
+
+    #[test]
+    fn capped_provider_preserves_inner_challenge_selection() {
+        let provider = CappedChargeProvider {
+            provider: MockProvider::default().selecting_last(),
+            max_charge: DEFAULT_MAX_EGRESS_CHARGE,
+        };
+        let first = challenge("1");
+        let mut preferred = challenge("1");
+        preferred.id = "preferred".to_owned();
+
+        assert_eq!(
+            provider
+                .select_challenge(&[&first, &preferred])
+                .map(|challenge| challenge.id.as_str()),
+            Some("preferred")
+        );
     }
 
     #[tokio::test]

--- a/deny.toml
+++ b/deny.toml
@@ -51,11 +51,11 @@ required-git-spec = "rev"
 allow-git = [
     "https://github.com/containers/libkrun",
     "https://github.com/gakonst/hudsucker",
-    "https://github.com/gakonst/mpp-rs",
     "https://github.com/gakonst/reqwest",
     "https://github.com/gakonst/rust-oci-client",
-    "https://github.com/gakonst/tempo",
     "https://github.com/openai-oss-forks/tokio-tungstenite",
     "https://github.com/openai-oss-forks/tungstenite-rs",
     "https://github.com/paradigmxyz/reth",
+    "https://github.com/tempoxyz/mpp-rs",
+    "https://github.com/tempoxyz/tempo",
 ]


### PR DESCRIPTION
## Summary
- pin mpp-rs PR tempoxyz/mpp-rs#371 and align Tempo SDK revisions
- configure `TempoAccountsProvider` to prefer NanoUSD among equivalent Charge offers
- delegate challenge selection through Nanocodex’s charge-cap wrapper
- avoid rewriting or reordering upstream `WWW-Authenticate` headers

This supersedes #91 with the MPPX-style provider selection policy in mpp-rs. It keeps the mpp-proxy multi-currency response intact, including the retry/offer behavior covered by tempoxyz/mpp#840.

Depends on https://github.com/tempoxyz/mpp-rs/pull/371.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p nanocodex-bin --features tempo capped_provider_preserves_inner_challenge_selection`
- `cargo clippy -p nanocodex-bin --features tempo --all-targets -- -D warnings`