### PR TITLE
feat(browser): import desktop profile cookies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5072,6 +5072,7 @@ dependencies = [
  "reflink-copy",
  "reqwest",
  "rusqlite",
+ "safari-binarycookies",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -7809,6 +7810,16 @@ name = "ryu-js"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
+
+[[package]]
+name = "safari-binarycookies"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e783a65d358025a7e136561508a39558145c6dcf3c6fdc67fbd33afda7629ac"
+dependencies = [
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "same-file"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ rusqlite = { version = "0.38", features = ["bundled"] }
 rquickjs = "0.12.1"
 rmcp = { version = "1.8.0", default-features = false, features = ["auth", "client", "reqwest-tls-no-provider", "transport-async-rw", "transport-streamable-http-client-reqwest"] }
 oauth2 = { version = "5.0", default-features = false }
+safari-binarycookies = "1.0.0"
 schemars = "0.8.22"
 self-replace = "1.5.0"
 semver = "1.0.27"

--- a/bin/nanocodex/src/browser.rs
+++ b/bin/nanocodex/src/browser.rs
@@ -2,7 +2,10 @@ use std::path::{Path, PathBuf};
 
 use clap::{Args, ValueEnum};
 use eyre::{Result, WrapErr, eyre};
-use nanocodex_browser::{BraveSession, Browser, BrowserProfileKind, BrowserTool};
+use nanocodex_browser::{
+    BraveSession, Browser, BrowserProfileKind, BrowserStorageState, BrowserTool,
+    FirefoxCookieSource, SafariCookieSource,
+};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 enum BrowserKind {
@@ -19,6 +22,13 @@ enum CookieSourceKind {
     Chrome,
     Chromium,
     Edge,
+    Firefox,
+    Safari,
+}
+
+enum CookieSource {
+    Chromium(BraveSession),
+    State(BrowserStorageState),
 }
 
 /// Opt-in local browser configuration for normal agent sessions.
@@ -38,7 +48,7 @@ pub(crate) struct BrowserArgs {
     )]
     browser: Option<BrowserKind>,
 
-    /// Copy cookies from a standard Chromium-family profile.
+    /// Copy cookies from a standard desktop browser profile.
     ///
     /// Pass a browser name to select the source profile. A bare flag or `true`
     /// automatically selects an installed profile.
@@ -96,8 +106,10 @@ impl BrowserArgs {
             }
         }
         if let Some(source) = self.cookies {
-            let source = cookie_source(source, kind)?;
-            builder = builder.cookie_source(source.copy_all_cookies());
+            builder = match cookie_source(source, kind)? {
+                CookieSource::Chromium(source) => builder.cookie_source(source.copy_all_cookies()),
+                CookieSource::State(state) => builder.storage_state(state),
+            };
         }
         let browser = builder
             .build()
@@ -106,16 +118,33 @@ impl BrowserArgs {
     }
 }
 
-fn cookie_source(source: CookieSourceKind, target: BrowserKind) -> Result<BraveSession> {
+fn cookie_source(source: CookieSourceKind, target: BrowserKind) -> Result<CookieSource> {
+    match source {
+        CookieSourceKind::Firefox => {
+            return FirefoxCookieSource::standard()
+                .and_then(|source| source.load())
+                .map(CookieSource::State)
+                .wrap_err("failed to load the standard Firefox cookie profile");
+        }
+        CookieSourceKind::Safari => {
+            return SafariCookieSource::standard()
+                .and_then(|source| source.load())
+                .map(CookieSource::State)
+                .wrap_err("failed to load the standard Safari cookie profile");
+        }
+        _ => {}
+    }
     let explicit = match source {
         CookieSourceKind::Auto => None,
         CookieSourceKind::Brave => Some(BrowserProfileKind::Brave),
         CookieSourceKind::Chrome => Some(BrowserProfileKind::Chrome),
         CookieSourceKind::Chromium => Some(BrowserProfileKind::Chromium),
         CookieSourceKind::Edge => Some(BrowserProfileKind::Edge),
+        CookieSourceKind::Firefox | CookieSourceKind::Safari => None,
     };
     if let Some(source) = explicit {
         return BraveSession::standard_for(source)
+            .map(CookieSource::Chromium)
             .wrap_err_with(|| format!("failed to locate the standard {} profile", source.name()));
     }
 
@@ -136,7 +165,20 @@ fn cookie_source(source: CookieSourceKind, target: BrowserKind) -> Result<BraveS
     preferences
         .into_iter()
         .find_map(|source| BraveSession::standard_for(source).ok())
-        .ok_or_else(|| eyre!("failed to locate an installed Chromium-family cookie profile"))
+        .map(CookieSource::Chromium)
+        .or_else(|| {
+            FirefoxCookieSource::standard()
+                .and_then(|source| source.load())
+                .ok()
+                .map(CookieSource::State)
+        })
+        .or_else(|| {
+            SafariCookieSource::standard()
+                .and_then(|source| source.load())
+                .ok()
+                .map(CookieSource::State)
+        })
+        .ok_or_else(|| eyre!("failed to locate an installed browser cookie profile"))
 }
 
 impl ConfiguredBrowser {

--- a/bin/nanocodex/src/browser.rs
+++ b/bin/nanocodex/src/browser.rs
@@ -28,7 +28,7 @@ pub(crate) struct BrowserArgs {
     )]
     browser: Option<BrowserKind>,
 
-    /// Copy every cookie from the standard Brave profile into the private session.
+    /// Copy every cookie from the standard Brave profile into the selected browser.
     #[arg(
         long,
         env = "NANOCODEX_BROWSER_COOKIES",
@@ -65,11 +65,13 @@ impl BrowserArgs {
         let mut builder = Browser::builder().file_root(workspace);
         match kind {
             BrowserKind::Chromium => {
-                if self.cookies {
-                    return Err(eyre!("--cookies=true requires --browser=brave"));
-                }
                 if let Some(executable) = &self.browser_executable {
                     builder = builder.executable(executable);
+                }
+                if self.cookies {
+                    let brave = BraveSession::standard()
+                        .wrap_err("failed to locate the standard Brave profile")?;
+                    builder = builder.brave_cookie_source(brave.copy_all_cookies());
                 }
             }
             BrowserKind::Brave => {
@@ -141,20 +143,5 @@ mod tests {
         assert!(!serialized.contains("browser"));
         assert!(runtime.contains("browser"));
         browser.shutdown().await.unwrap();
-    }
-
-    #[test]
-    fn cookies_require_brave_mode() {
-        let workspace = tempfile::tempdir().unwrap();
-        let error = BrowserArgs {
-            browser: Some(super::BrowserKind::Chromium),
-            cookies: true,
-            browser_executable: None,
-        }
-        .configure(workspace.path())
-        .err()
-        .unwrap();
-
-        assert!(error.to_string().contains("--browser=brave"));
     }
 }

--- a/bin/nanocodex/src/browser.rs
+++ b/bin/nanocodex/src/browser.rs
@@ -1,22 +1,42 @@
 use std::path::{Path, PathBuf};
 
-use clap::{ArgAction, Args};
-use eyre::{Result, WrapErr};
-use nanocodex_browser::{Browser, BrowserTool};
+use clap::{ArgAction, Args, ValueEnum};
+use eyre::{Result, WrapErr, eyre};
+use nanocodex_browser::{BraveSession, Browser, BrowserTool};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum BrowserKind {
+    #[value(alias = "true")]
+    Chromium,
+    Brave,
+}
 
 /// Opt-in local browser configuration for normal agent sessions.
 #[derive(Args, Default)]
 pub(crate) struct BrowserArgs {
-    /// Expose one private Chromium session to Code Mode as `tools.browser`.
+    /// Expose one private browser session to Code Mode as `tools.browser`.
     ///
-    /// Chromium starts lazily on the first browser action and remains alive for
-    /// the complete agent session.
+    /// Pass `brave` to use the standard Brave installation. A bare `--browser`
+    /// preserves the private Chromium default.
     #[arg(
         long,
         env = "NANOCODEX_BROWSER",
-        action = ArgAction::SetTrue
+        value_enum,
+        num_args = 0..=1,
+        default_missing_value = "chromium",
+        require_equals = true
     )]
-    browser: bool,
+    browser: Option<BrowserKind>,
+
+    /// Copy every cookie from the standard Brave profile into the private session.
+    #[arg(
+        long,
+        env = "NANOCODEX_BROWSER_COOKIES",
+        action = ArgAction::Set,
+        default_value_t = false,
+        requires = "browser"
+    )]
+    cookies: bool,
 
     /// Chrome or Chromium executable used by the browser tool.
     #[arg(
@@ -35,16 +55,37 @@ pub(crate) struct ConfiguredBrowser {
 impl BrowserArgs {
     #[cfg(test)]
     pub(crate) const fn is_enabled(&self) -> bool {
-        self.browser
+        self.browser.is_some()
     }
 
     pub(crate) fn configure(&self, workspace: &Path) -> Result<Option<ConfiguredBrowser>> {
-        if !self.browser {
+        let Some(kind) = self.browser else {
             return Ok(None);
-        }
+        };
         let mut builder = Browser::builder().file_root(workspace);
-        if let Some(executable) = &self.browser_executable {
-            builder = builder.executable(executable);
+        match kind {
+            BrowserKind::Chromium => {
+                if self.cookies {
+                    return Err(eyre!("--cookies=true requires --browser=brave"));
+                }
+                if let Some(executable) = &self.browser_executable {
+                    builder = builder.executable(executable);
+                }
+            }
+            BrowserKind::Brave => {
+                if self.browser_executable.is_some() {
+                    return Err(eyre!(
+                        "--browser-executable cannot be combined with --browser=brave"
+                    ));
+                }
+                let brave = BraveSession::standard()
+                    .wrap_err("failed to locate the standard Brave profile")?;
+                builder = if self.cookies {
+                    builder.brave_session(brave.copy_all_cookies())
+                } else {
+                    builder.executable(brave.executable().to_path_buf())
+                };
+            }
         }
         let browser = builder
             .build()
@@ -80,7 +121,8 @@ mod tests {
         let baseline = ToolRuntime::new_with_tools(workspace.path(), None, None, &baseline_tools)
             .model_specs("browser-tui-test");
         let browser = BrowserArgs {
-            browser: true,
+            browser: Some(super::BrowserKind::Chromium),
+            cookies: false,
             browser_executable: None,
         }
         .configure(workspace.path())
@@ -99,5 +141,20 @@ mod tests {
         assert!(!serialized.contains("browser"));
         assert!(runtime.contains("browser"));
         browser.shutdown().await.unwrap();
+    }
+
+    #[test]
+    fn cookies_require_brave_mode() {
+        let workspace = tempfile::tempdir().unwrap();
+        let error = BrowserArgs {
+            browser: Some(super::BrowserKind::Chromium),
+            cookies: true,
+            browser_executable: None,
+        }
+        .configure(workspace.path())
+        .err()
+        .unwrap();
+
+        assert!(error.to_string().contains("--browser=brave"));
     }
 }

--- a/bin/nanocodex/src/browser.rs
+++ b/bin/nanocodex/src/browser.rs
@@ -1,14 +1,24 @@
 use std::path::{Path, PathBuf};
 
-use clap::{ArgAction, Args, ValueEnum};
+use clap::{Args, ValueEnum};
 use eyre::{Result, WrapErr, eyre};
-use nanocodex_browser::{BraveSession, Browser, BrowserTool};
+use nanocodex_browser::{BraveSession, Browser, BrowserProfileKind, BrowserTool};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 enum BrowserKind {
     #[value(alias = "true")]
     Chromium,
     Brave,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+enum CookieSourceKind {
+    #[value(alias = "true")]
+    Auto,
+    Brave,
+    Chrome,
+    Chromium,
+    Edge,
 }
 
 /// Opt-in local browser configuration for normal agent sessions.
@@ -28,15 +38,20 @@ pub(crate) struct BrowserArgs {
     )]
     browser: Option<BrowserKind>,
 
-    /// Copy every cookie from the standard Brave profile into the selected browser.
+    /// Copy cookies from a standard Chromium-family profile.
+    ///
+    /// Pass a browser name to select the source profile. A bare flag or `true`
+    /// automatically selects an installed profile.
     #[arg(
         long,
         env = "NANOCODEX_BROWSER_COOKIES",
-        action = ArgAction::Set,
-        default_value_t = false,
+        value_enum,
+        num_args = 0..=1,
+        default_missing_value = "auto",
+        require_equals = true,
         requires = "browser"
     )]
-    cookies: bool,
+    cookies: Option<CookieSourceKind>,
 
     /// Chrome or Chromium executable used by the browser tool.
     #[arg(
@@ -68,11 +83,6 @@ impl BrowserArgs {
                 if let Some(executable) = &self.browser_executable {
                     builder = builder.executable(executable);
                 }
-                if self.cookies {
-                    let brave = BraveSession::standard()
-                        .wrap_err("failed to locate the standard Brave profile")?;
-                    builder = builder.brave_cookie_source(brave.copy_all_cookies());
-                }
             }
             BrowserKind::Brave => {
                 if self.browser_executable.is_some() {
@@ -82,18 +92,51 @@ impl BrowserArgs {
                 }
                 let brave = BraveSession::standard()
                     .wrap_err("failed to locate the standard Brave profile")?;
-                builder = if self.cookies {
-                    builder.brave_session(brave.copy_all_cookies())
-                } else {
-                    builder.executable(brave.executable().to_path_buf())
-                };
+                builder = builder.executable(brave.executable().to_path_buf());
             }
+        }
+        if let Some(source) = self.cookies {
+            let source = cookie_source(source, kind)?;
+            builder = builder.cookie_source(source.copy_all_cookies());
         }
         let browser = builder
             .build()
             .wrap_err("failed to configure the browser tool")?;
         Ok(Some(ConfiguredBrowser { browser }))
     }
+}
+
+fn cookie_source(source: CookieSourceKind, target: BrowserKind) -> Result<BraveSession> {
+    let explicit = match source {
+        CookieSourceKind::Auto => None,
+        CookieSourceKind::Brave => Some(BrowserProfileKind::Brave),
+        CookieSourceKind::Chrome => Some(BrowserProfileKind::Chrome),
+        CookieSourceKind::Chromium => Some(BrowserProfileKind::Chromium),
+        CookieSourceKind::Edge => Some(BrowserProfileKind::Edge),
+    };
+    if let Some(source) = explicit {
+        return BraveSession::standard_for(source)
+            .wrap_err_with(|| format!("failed to locate the standard {} profile", source.name()));
+    }
+
+    let preferences = match target {
+        BrowserKind::Brave => [
+            BrowserProfileKind::Brave,
+            BrowserProfileKind::Chrome,
+            BrowserProfileKind::Chromium,
+            BrowserProfileKind::Edge,
+        ],
+        BrowserKind::Chromium => [
+            BrowserProfileKind::Chrome,
+            BrowserProfileKind::Chromium,
+            BrowserProfileKind::Brave,
+            BrowserProfileKind::Edge,
+        ],
+    };
+    preferences
+        .into_iter()
+        .find_map(|source| BraveSession::standard_for(source).ok())
+        .ok_or_else(|| eyre!("failed to locate an installed Chromium-family cookie profile"))
 }
 
 impl ConfiguredBrowser {
@@ -124,7 +167,7 @@ mod tests {
             .model_specs("browser-tui-test");
         let browser = BrowserArgs {
             browser: Some(super::BrowserKind::Chromium),
-            cookies: false,
+            cookies: None,
             browser_executable: None,
         }
         .configure(workspace.path())

--- a/bin/nanocodex/src/main.rs
+++ b/bin/nanocodex/src/main.rs
@@ -244,12 +244,28 @@ mod tests {
         let tui = Cli::try_parse_from(["nanocodex", "--browser"]).unwrap();
         assert!(tui.agent.browser_enabled());
 
+        let brave =
+            Cli::try_parse_from(["nanocodex", "--browser=brave", "--cookies=true"]).unwrap();
+        assert!(brave.agent.browser_enabled());
+
         let run =
             Cli::try_parse_from(["nanocodex", "run", "inspect example.com", "--browser"]).unwrap();
         let Some(Command::Run(run)) = run.command else {
             panic!("run command was not parsed");
         };
         assert!(run.agent.browser_enabled());
+    }
+
+    #[test]
+    fn browser_cookies_require_an_opted_in_browser() {
+        let error = Cli::try_parse_from(["nanocodex", "--cookies=true"])
+            .err()
+            .unwrap();
+
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
     }
 
     #[test]

--- a/bin/nanocodex/src/main.rs
+++ b/bin/nanocodex/src/main.rs
@@ -248,6 +248,9 @@ mod tests {
             Cli::try_parse_from(["nanocodex", "--browser=brave", "--cookies=true"]).unwrap();
         assert!(brave.agent.browser_enabled());
 
+        let chromium = Cli::try_parse_from(["nanocodex", "--browser", "--cookies=true"]).unwrap();
+        assert!(chromium.agent.browser_enabled());
+
         let run =
             Cli::try_parse_from(["nanocodex", "run", "inspect example.com", "--browser"]).unwrap();
         let Some(Command::Run(run)) = run.command else {

--- a/bin/nanocodex/src/main.rs
+++ b/bin/nanocodex/src/main.rs
@@ -255,6 +255,14 @@ mod tests {
             Cli::try_parse_from(["nanocodex", "--browser=brave", "--cookies=chrome"]).unwrap();
         assert!(chrome_source.agent.browser_enabled());
 
+        let firefox_source =
+            Cli::try_parse_from(["nanocodex", "--browser", "--cookies=firefox"]).unwrap();
+        assert!(firefox_source.agent.browser_enabled());
+
+        let safari_source =
+            Cli::try_parse_from(["nanocodex", "--browser", "--cookies=safari"]).unwrap();
+        assert!(safari_source.agent.browser_enabled());
+
         let run =
             Cli::try_parse_from(["nanocodex", "run", "inspect example.com", "--browser"]).unwrap();
         let Some(Command::Run(run)) = run.command else {

--- a/bin/nanocodex/src/main.rs
+++ b/bin/nanocodex/src/main.rs
@@ -251,6 +251,10 @@ mod tests {
         let chromium = Cli::try_parse_from(["nanocodex", "--browser", "--cookies=true"]).unwrap();
         assert!(chromium.agent.browser_enabled());
 
+        let chrome_source =
+            Cli::try_parse_from(["nanocodex", "--browser=brave", "--cookies=chrome"]).unwrap();
+        assert!(chrome_source.agent.browser_enabled());
+
         let run =
             Cli::try_parse_from(["nanocodex", "run", "inspect example.com", "--browser"]).unwrap();
         let Some(Command::Run(run)) = run.command else {

--- a/crates/experimental/nanocodex-browser/Cargo.toml
+++ b/crates/experimental/nanocodex-browser/Cargo.toml
@@ -31,6 +31,7 @@ percent-encoding.workspace = true
 reflink-copy.workspace = true
 reqwest = { workspace = true, features = ["query", "stream"] }
 rusqlite = { workspace = true, features = ["backup"] }
+safari-binarycookies.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/experimental/nanocodex-browser/README.md
+++ b/crates/experimental/nanocodex-browser/README.md
@@ -107,20 +107,27 @@ or an explicitly managed CDP endpoint.
 - Harness-owned cookies/storage, virtual passkeys, allowlisted source-browser handoff,
   upload roots, browser egress policy, remote CDP, and libkrun VM composition.
 
-The Nanocodex CLI can copy a standard Chromium-family profile's complete
-cookie database into either supported session-private browser. A bare cookie
-flag auto-detects a source; `brave`, `chrome`, `chromium`, and `edge` select it
-explicitly:
+The Nanocodex CLI can copy a standard desktop browser profile's complete cookie
+database into either supported session-private browser. A bare cookie flag
+auto-detects a source; `brave`, `chrome`, `chromium`, `edge`, `firefox`, and
+`safari` select it explicitly:
 
 ```console
 nanocodex --browser --cookies
 nanocodex --browser --cookies=chrome
 nanocodex --browser=brave --cookies=edge
+nanocodex --browser --cookies=firefox
+nanocodex --browser --cookies=safari
 ```
 
-The source profile remains open, is never mutated, and cookie values remain
-outside the model-callable browser schema. This mode deliberately gives the
-agent authenticated access to every site represented in the selected profile.
+Chromium-family sources use their own executable as a short-lived decryption
+broker. Firefox is copied with SQLite's online backup API. Safari's bounded
+binary-cookie decoder may require granting the Nanocodex process macOS access
+to Safari's sandboxed profile. Source profiles are never mutated.
+
+The source profile is never mutated, and cookie values remain outside the
+model-callable browser schema. This mode deliberately gives the agent
+authenticated access to every site represented in the selected profile.
 
 ## Current boundaries
 

--- a/crates/experimental/nanocodex-browser/README.md
+++ b/crates/experimental/nanocodex-browser/README.md
@@ -107,10 +107,11 @@ or an explicitly managed CDP endpoint.
 - Harness-owned cookies/storage, virtual passkeys, allowlisted Brave handoff,
   upload roots, browser egress policy, remote CDP, and libkrun VM composition.
 
-The Nanocodex CLI can launch the standard Brave installation and copy its
-complete cookie database into the session-private profile:
+The Nanocodex CLI can copy the standard Brave profile's complete cookie
+database into either supported session-private browser:
 
 ```console
+nanocodex --browser --cookies=true
 nanocodex --browser=brave --cookies=true
 ```
 

--- a/crates/experimental/nanocodex-browser/README.md
+++ b/crates/experimental/nanocodex-browser/README.md
@@ -107,6 +107,17 @@ or an explicitly managed CDP endpoint.
 - Harness-owned cookies/storage, virtual passkeys, allowlisted Brave handoff,
   upload roots, browser egress policy, remote CDP, and libkrun VM composition.
 
+The Nanocodex CLI can launch the standard Brave installation and copy its
+complete cookie database into the session-private profile:
+
+```console
+nanocodex --browser=brave --cookies=true
+```
+
+The source profile remains open, is never mutated, and cookie values remain
+outside the model-callable browser schema. This mode deliberately gives the
+agent authenticated access to every site represented in the selected profile.
+
 ## Current boundaries
 
 - This package is unpublished and its API is not stable. It currently targets
@@ -120,8 +131,8 @@ or an explicitly managed CDP endpoint.
   is runtime-only with provider registration, so enabling browser adds no model
   warmup schema bytes. The contract is not capability-filtered after discovery.
 - Lighthouse, CrUX, and video require caller-supplied external tooling or
-  credentials. Brave profile transfer is harness-only and intentionally absent
-  from the model-callable schema.
+  credentials. Brave profile transfer remains harness-owned and intentionally
+  absent from the model-callable schema.
 - Cloned browser handles share one session and serialized action stream. Call
   `Browser::close` or `BrowserVm::shutdown` when deterministic cleanup matters.
 - The crate consumes `nanocodex-vm` unconditionally today, so local-only builds

--- a/crates/experimental/nanocodex-browser/README.md
+++ b/crates/experimental/nanocodex-browser/README.md
@@ -104,15 +104,18 @@ or an explicitly managed CDP endpoint.
   errors, network bodies, WebSocket messages, HAR, and React diagnostics.
 - Screenshots, PDF, visual/session/performance traces, video, CPU profiles,
   coverage, heap inspection, accessibility/axe, Lighthouse, and CrUX actions.
-- Harness-owned cookies/storage, virtual passkeys, allowlisted Brave handoff,
+- Harness-owned cookies/storage, virtual passkeys, allowlisted source-browser handoff,
   upload roots, browser egress policy, remote CDP, and libkrun VM composition.
 
-The Nanocodex CLI can copy the standard Brave profile's complete cookie
-database into either supported session-private browser:
+The Nanocodex CLI can copy a standard Chromium-family profile's complete
+cookie database into either supported session-private browser. A bare cookie
+flag auto-detects a source; `brave`, `chrome`, `chromium`, and `edge` select it
+explicitly:
 
 ```console
-nanocodex --browser --cookies=true
-nanocodex --browser=brave --cookies=true
+nanocodex --browser --cookies
+nanocodex --browser --cookies=chrome
+nanocodex --browser=brave --cookies=edge
 ```
 
 The source profile remains open, is never mutated, and cookie values remain

--- a/crates/experimental/nanocodex-browser/src/cookie_source.rs
+++ b/crates/experimental/nanocodex-browser/src/cookie_source.rs
@@ -122,28 +122,31 @@ impl SafariCookieSource {
     /// # Errors
     ///
     /// Returns an error on other platforms or when the store is unavailable.
-    pub fn standard() -> Result<Self, BrowserCookieSourceError> {
-        #[cfg(not(target_os = "macos"))]
-        {
-            Err(BrowserCookieSourceError::StandardProfileUnavailable { browser: "Safari" })
-        }
+    #[cfg(not(target_os = "macos"))]
+    pub const fn standard() -> Result<Self, BrowserCookieSourceError> {
+        Err(BrowserCookieSourceError::StandardProfileUnavailable { browser: "Safari" })
+    }
 
-        #[cfg(target_os = "macos")]
-        {
-            let home =
-                env::var_os("HOME").ok_or(BrowserCookieSourceError::HomeDirectoryUnavailable)?;
-            let home = PathBuf::from(home);
-            let candidates = [
-                home.join(
-                    "Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies",
-                ),
-                home.join("Library/Cookies/Cookies.binarycookies"),
-            ];
-            let path = candidates.into_iter().find(|path| path.is_file()).ok_or(
-                BrowserCookieSourceError::StandardProfileUnavailable { browser: "Safari" },
-            )?;
-            Self::new(path)
-        }
+    /// Locates Safari's standard sandboxed cookie store on macOS.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the store is unavailable.
+    #[cfg(target_os = "macos")]
+    pub fn standard() -> Result<Self, BrowserCookieSourceError> {
+        let home = env::var_os("HOME").ok_or(BrowserCookieSourceError::HomeDirectoryUnavailable)?;
+        let home = PathBuf::from(home);
+        let candidates = [
+            home.join(
+                "Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies",
+            ),
+            home.join("Library/Cookies/Cookies.binarycookies"),
+        ];
+        let path = candidates
+            .into_iter()
+            .find(|path| path.is_file())
+            .ok_or(BrowserCookieSourceError::StandardProfileUnavailable { browser: "Safari" })?;
+        Self::new(path)
     }
 
     /// Uses an explicit Safari/WebKit `.binarycookies` file.

--- a/crates/experimental/nanocodex-browser/src/cookie_source.rs
+++ b/crates/experimental/nanocodex-browser/src/cookie_source.rs
@@ -1,0 +1,353 @@
+//! Harness-owned cookie import from non-Chromium profile stores.
+
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use std::env;
+
+use rusqlite::{Connection, OpenFlags, backup::Backup};
+
+use crate::{BrowserCookie, BrowserCookieSameSite, BrowserStorageState};
+
+/// A Firefox profile whose persistent cookies can seed a private browser.
+#[derive(Clone, Debug)]
+pub struct FirefoxCookieSource {
+    profile_directory: PathBuf,
+}
+
+impl FirefoxCookieSource {
+    /// Locates Firefox's selected standard profile.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when Firefox has no standard profile with a cookie
+    /// database on the current platform.
+    pub fn standard() -> Result<Self, BrowserCookieSourceError> {
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        {
+            Err(BrowserCookieSourceError::StandardProfileUnavailable { browser: "Firefox" })
+        }
+
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        {
+            let home =
+                env::var_os("HOME").ok_or(BrowserCookieSourceError::HomeDirectoryUnavailable)?;
+            #[cfg(target_os = "macos")]
+            let root = PathBuf::from(home).join("Library/Application Support/Firefox");
+            #[cfg(target_os = "linux")]
+            let root = PathBuf::from(home).join(".mozilla/firefox");
+            let contents = std::fs::read_to_string(root.join("profiles.ini"))?;
+            let profile_directory = selected_firefox_profile(&root, &contents).ok_or(
+                BrowserCookieSourceError::StandardProfileUnavailable { browser: "Firefox" },
+            )?;
+            Self::new(profile_directory)
+        }
+    }
+
+    /// Uses an explicit Firefox profile directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `cookies.sqlite` is unavailable.
+    pub fn new(profile_directory: impl Into<PathBuf>) -> Result<Self, BrowserCookieSourceError> {
+        let profile_directory = profile_directory.into();
+        let cookies = profile_directory.join("cookies.sqlite");
+        if !cookies.is_file() {
+            return Err(BrowserCookieSourceError::CookieStoreUnavailable { path: cookies });
+        }
+        Ok(Self { profile_directory })
+    }
+
+    /// Copies and loads persistent cookies without mutating or locking Firefox.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the SQLite online backup or typed query fails.
+    pub fn load(&self) -> Result<BrowserStorageState, BrowserCookieSourceError> {
+        let source = Connection::open_with_flags(
+            self.profile_directory.join("cookies.sqlite"),
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        let mut snapshot = Connection::open_in_memory()?;
+        let backup = Backup::new(&source, &mut snapshot)?;
+        backup.run_to_completion(64, Duration::from_millis(5), None)?;
+        drop(backup);
+
+        let now = chrono::Utc::now().timestamp();
+        let mut statement = snapshot.prepare(
+            "SELECT name, value, host, path, expiry, isSecure, isHttpOnly, sameSite
+             FROM moz_cookies
+             WHERE originAttributes = '' AND expiry > ?1",
+        )?;
+        let cookies = statement
+            .query_map([now], |row| {
+                let same_site = match row.get::<_, i64>(7)? {
+                    0 => Some(BrowserCookieSameSite::None),
+                    1 => Some(BrowserCookieSameSite::Lax),
+                    2 => Some(BrowserCookieSameSite::Strict),
+                    _ => None,
+                };
+                Ok(BrowserCookie {
+                    name: row.get(0)?,
+                    value: row.get(1)?,
+                    domain: row.get(2)?,
+                    path: row.get(3)?,
+                    expires_epoch_seconds: Some(row.get::<_, i64>(4)? as f64),
+                    secure: row.get::<_, i64>(5)? != 0,
+                    http_only: row.get::<_, i64>(6)? != 0,
+                    same_site,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(BrowserStorageState {
+            cookies,
+            origins: Vec::new(),
+        })
+    }
+}
+
+/// A Safari/WebKit binary cookie store that can seed a private browser.
+#[derive(Clone, Debug)]
+pub struct SafariCookieSource {
+    cookie_store: PathBuf,
+}
+
+impl SafariCookieSource {
+    /// Locates Safari's standard sandboxed cookie store on macOS.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on other platforms or when the store is unavailable.
+    pub fn standard() -> Result<Self, BrowserCookieSourceError> {
+        #[cfg(not(target_os = "macos"))]
+        {
+            Err(BrowserCookieSourceError::StandardProfileUnavailable { browser: "Safari" })
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            let home =
+                env::var_os("HOME").ok_or(BrowserCookieSourceError::HomeDirectoryUnavailable)?;
+            let home = PathBuf::from(home);
+            let candidates = [
+                home.join(
+                    "Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies",
+                ),
+                home.join("Library/Cookies/Cookies.binarycookies"),
+            ];
+            let path = candidates.into_iter().find(|path| path.is_file()).ok_or(
+                BrowserCookieSourceError::StandardProfileUnavailable { browser: "Safari" },
+            )?;
+            Self::new(path)
+        }
+    }
+
+    /// Uses an explicit Safari/WebKit `.binarycookies` file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the file is unavailable.
+    pub fn new(cookie_store: impl Into<PathBuf>) -> Result<Self, BrowserCookieSourceError> {
+        let cookie_store = cookie_store.into();
+        if !cookie_store.is_file() {
+            return Err(BrowserCookieSourceError::CookieStoreUnavailable { path: cookie_store });
+        }
+        Ok(Self { cookie_store })
+    }
+
+    /// Loads unexpired Safari cookies into harness-owned browser state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when macOS denies access or the bounded decoder rejects
+    /// a malformed cookie file.
+    pub fn load(&self) -> Result<BrowserStorageState, BrowserCookieSourceError> {
+        let now = chrono::Utc::now().timestamp();
+        let jar = safari_binarycookies::from_path(&self.cookie_store)?;
+        let cookies = jar
+            .cookies()
+            .filter(|cookie| cookie.expires_unix() > now)
+            .map(|cookie| BrowserCookie {
+                name: cookie.name.clone(),
+                value: cookie.value.clone(),
+                domain: cookie.domain.clone(),
+                path: cookie.path.clone(),
+                expires_epoch_seconds: Some(cookie.expires_unix() as f64),
+                http_only: cookie.is_http_only(),
+                secure: cookie.is_secure(),
+                same_site: None,
+            })
+            .collect();
+        Ok(BrowserStorageState {
+            cookies,
+            origins: Vec::new(),
+        })
+    }
+}
+
+fn selected_firefox_profile(root: &Path, contents: &str) -> Option<PathBuf> {
+    let mut sections = Vec::<(String, BTreeMap<String, String>)>::new();
+    let mut current = None::<(String, BTreeMap<String, String>)>;
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        if let Some(section) = line
+            .strip_prefix('[')
+            .and_then(|line| line.strip_suffix(']'))
+        {
+            if let Some(section) = current.take() {
+                sections.push(section);
+            }
+            current = Some((section.to_owned(), BTreeMap::new()));
+        } else if let Some((key, value)) = line.split_once('=')
+            && let Some((_, values)) = &mut current
+        {
+            values.insert(key.trim().to_owned(), value.trim().to_owned());
+        }
+    }
+    if let Some(section) = current {
+        sections.push(section);
+    }
+
+    let install_candidates = sections
+        .iter()
+        .filter(|(name, _)| name.starts_with("Install"))
+        .filter_map(|(_, values)| values.get("Default").map(|path| root.join(path)));
+    let profile_candidates = sections
+        .iter()
+        .filter(|(name, values)| {
+            name.starts_with("Profile") && values.get("Default").is_some_and(|value| value == "1")
+        })
+        .chain(
+            sections
+                .iter()
+                .filter(|(name, _)| name.starts_with("Profile")),
+        )
+        .filter_map(|(_, values)| {
+            let path = values.get("Path")?;
+            Some(
+                if values.get("IsRelative").is_some_and(|value| value == "0") {
+                    PathBuf::from(path)
+                } else {
+                    root.join(path)
+                },
+            )
+        });
+    install_candidates
+        .chain(profile_candidates)
+        .find(|profile| profile.join("cookies.sqlite").is_file())
+}
+
+/// Failures while discovering or loading a browser cookie source.
+#[derive(Debug, thiserror::Error)]
+pub enum BrowserCookieSourceError {
+    #[error("the home directory is unavailable")]
+    HomeDirectoryUnavailable,
+    #[error("the standard {browser} cookie profile is unavailable")]
+    StandardProfileUnavailable { browser: &'static str },
+    #[error("browser cookie store is unavailable at {path}")]
+    CookieStoreUnavailable { path: PathBuf },
+    #[error("browser cookie store I/O failed")]
+    Io(#[from] std::io::Error),
+    #[error("Firefox cookie snapshot failed")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("Safari cookie decode failed")]
+    Safari(#[from] safari_binarycookies::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn firefox_source_snapshots_transferable_unexpired_cookies() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("cookies.sqlite");
+        let database = Connection::open(&path).unwrap();
+        database
+            .execute_batch(
+                "CREATE TABLE moz_cookies (
+                    name TEXT NOT NULL,
+                    value TEXT NOT NULL,
+                    host TEXT NOT NULL,
+                    path TEXT NOT NULL,
+                    expiry INTEGER NOT NULL,
+                    isSecure INTEGER NOT NULL,
+                    isHttpOnly INTEGER NOT NULL,
+                    sameSite INTEGER NOT NULL,
+                    originAttributes TEXT NOT NULL
+                );",
+            )
+            .unwrap();
+        let expiry = chrono::Utc::now().timestamp() + 3_600;
+        database
+            .execute(
+                "INSERT INTO moz_cookies VALUES (?1, ?2, ?3, ?4, ?5, 1, 1, 2, '')",
+                ("session", "test-value", ".example.com", "/", expiry),
+            )
+            .unwrap();
+        database
+            .execute(
+                "INSERT INTO moz_cookies VALUES ('expired', 'old', '.example.com', '/', 1, 0, 0, 0, '')",
+                [],
+            )
+            .unwrap();
+        database
+            .execute(
+                "INSERT INTO moz_cookies VALUES ('container', 'private', '.example.com', '/', ?1, 0, 0, 0, '^userContextId=1')",
+                [expiry],
+            )
+            .unwrap();
+        drop(database);
+
+        let state = FirefoxCookieSource::new(directory.path())
+            .unwrap()
+            .load()
+            .unwrap();
+
+        assert_eq!(state.cookies.len(), 1);
+        let cookie = &state.cookies[0];
+        assert_eq!(cookie.name, "session");
+        assert_eq!(cookie.value, "test-value");
+        assert_eq!(cookie.domain, ".example.com");
+        assert!(cookie.secure);
+        assert!(cookie.http_only);
+        assert_eq!(cookie.same_site, Some(BrowserCookieSameSite::Strict));
+    }
+
+    #[test]
+    fn selected_firefox_profile_prefers_the_locked_install() {
+        let directory = tempfile::tempdir().unwrap();
+        let selected = directory.path().join("Profiles/selected.default-release");
+        std::fs::create_dir_all(&selected).unwrap();
+        std::fs::write(selected.join("cookies.sqlite"), []).unwrap();
+        let profiles = "[Profile0]\nPath=Profiles/other.default\nDefault=1\n\
+                        [InstallABC]\nDefault=Profiles/selected.default-release\nLocked=1\n";
+
+        assert_eq!(
+            selected_firefox_profile(directory.path(), profiles),
+            Some(selected)
+        );
+    }
+
+    #[test]
+    fn selected_firefox_profile_supports_absolute_paths() {
+        let root = tempfile::tempdir().unwrap();
+        let profile = tempfile::tempdir().unwrap();
+        std::fs::write(profile.path().join("cookies.sqlite"), []).unwrap();
+        let profiles = format!(
+            "[Profile0]\nPath={}\nIsRelative=0\nDefault=1\n",
+            profile.path().display()
+        );
+
+        assert_eq!(
+            selected_firefox_profile(root.path(), &profiles),
+            Some(profile.path().to_owned())
+        );
+    }
+}

--- a/crates/experimental/nanocodex-browser/src/lib.rs
+++ b/crates/experimental/nanocodex-browser/src/lib.rs
@@ -3158,6 +3158,7 @@ pub struct BrowserBuilder {
     executable: Option<std::path::PathBuf>,
     cdp_endpoint: Option<url::Url>,
     brave_session: Option<BraveSession>,
+    launch_brave_executable: bool,
     virtual_authenticator: Option<VirtualAuthenticator>,
     react_diagnostics: Option<ReactDiagnostics>,
     egress_policy: Option<BrowserEgressPolicy>,
@@ -3198,6 +3199,20 @@ impl BrowserBuilder {
     #[must_use]
     pub fn brave_session(mut self, session: BraveSession) -> Self {
         self.brave_session = Some(session);
+        self.launch_brave_executable = true;
+        self
+    }
+
+    /// Seeds the selected browser with cookies from a Brave profile.
+    ///
+    /// Unlike [`Self::brave_session`], this does not select Brave as the
+    /// browser executable. An explicitly configured Chrome or Chromium binary,
+    /// or the normal auto-detected browser, launches with the private cookie
+    /// snapshot instead.
+    #[must_use]
+    pub fn brave_cookie_source(mut self, session: BraveSession) -> Self {
+        self.brave_session = Some(session);
+        self.launch_brave_executable = false;
         self
     }
 
@@ -3304,11 +3319,6 @@ impl BrowserBuilder {
     /// Returns an error when the private runtime directory cannot be created.
     pub fn build(self) -> Result<Browser, BrowserBuildError> {
         nanocodex_oai_api::transport::install_default_rustls_crypto_provider();
-        if self.executable.is_some() && self.brave_session.is_some() {
-            return Err(BrowserBuildError::Configuration {
-                message: "`executable` and `brave_session` cannot both be configured".to_owned(),
-            });
-        }
         if self.cdp_endpoint.is_some() && self.executable.is_some() {
             return Err(BrowserBuildError::Configuration {
                 message: "`cdp_endpoint` cannot be combined with `executable`".to_owned(),
@@ -3390,6 +3400,7 @@ impl BrowserBuilder {
                 self.executable,
                 self.cdp_endpoint,
                 self.brave_session,
+                self.launch_brave_executable,
                 self.virtual_authenticator,
                 self.react_diagnostics,
                 egress_policy,

--- a/crates/experimental/nanocodex-browser/src/lib.rs
+++ b/crates/experimental/nanocodex-browser/src/lib.rs
@@ -3370,14 +3370,19 @@ impl BrowserBuilder {
             .transpose()
             .map_err(BrowserBuildError::Io)?;
         let egress_policy = self.egress_policy.or_else(|| {
-            self.brave_session.as_ref().map(|session| {
-                session
-                    .allowed_origins()
-                    .iter()
-                    .cloned()
-                    .fold(BrowserEgressPolicy::deny_by_default(), |policy, origin| {
-                        policy.allow_origin(origin)
-                    })
+            self.brave_session.as_ref().and_then(|session| {
+                if session.copies_all_cookies() {
+                    return None;
+                }
+                Some(
+                    session
+                        .allowed_origins()
+                        .iter()
+                        .cloned()
+                        .fold(BrowserEgressPolicy::deny_by_default(), |policy, origin| {
+                            policy.allow_origin(origin)
+                        }),
+                )
             })
         });
         Ok(Browser {

--- a/crates/experimental/nanocodex-browser/src/lib.rs
+++ b/crates/experimental/nanocodex-browser/src/lib.rs
@@ -80,7 +80,7 @@ pub use features::{
     BrowserWebVitals,
 };
 pub use native::{BrowserBuildError, BrowserError};
-pub use session::{BraveSession, BraveSessionError};
+pub use session::{BraveSession, BraveSessionError, BrowserProfileKind};
 
 const TOOL_DESCRIPTION: &str = r"Control one server-managed browser session.
 
@@ -3203,14 +3203,14 @@ impl BrowserBuilder {
         self
     }
 
-    /// Seeds the selected browser with cookies from a Brave profile.
+    /// Seeds the selected browser with cookies from a Chromium-family profile.
     ///
     /// Unlike [`Self::brave_session`], this does not select Brave as the
     /// browser executable. An explicitly configured Chrome or Chromium binary,
     /// or the normal auto-detected browser, launches with the private cookie
     /// snapshot instead.
     #[must_use]
-    pub fn brave_cookie_source(mut self, session: BraveSession) -> Self {
+    pub fn cookie_source(mut self, session: BraveSession) -> Self {
         self.brave_session = Some(session);
         self.launch_brave_executable = false;
         self

--- a/crates/experimental/nanocodex-browser/src/lib.rs
+++ b/crates/experimental/nanocodex-browser/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![deny(unsafe_code, rustdoc::broken_intra_doc_links)]
 
+mod cookie_source;
 mod features;
 mod native;
 mod session;
@@ -56,6 +57,7 @@ where
     }
 }
 
+pub use cookie_source::{BrowserCookieSourceError, FirefoxCookieSource, SafariCookieSource};
 pub use features::{
     BrowserAccessibilityAudit, BrowserAccessibilityImpact, BrowserAccessibilityViolation,
     BrowserAfterAction, BrowserAxeAudit, BrowserAxeFinding, BrowserAxeNode, BrowserBreakpoint,

--- a/crates/experimental/nanocodex-browser/src/native.rs
+++ b/crates/experimental/nanocodex-browser/src/native.rs
@@ -692,7 +692,7 @@ impl Session {
             && launch_brave_executable
             && brave_session.is_some();
         let imported_cookies = if !opens_brave_profile && let Some(brave_session) = brave_session {
-            Some(export_brave_cookies(runtime_dir, brave_session).await?)
+            Some(export_profile_cookies(runtime_dir, brave_session).await?)
         } else {
             None
         };
@@ -711,7 +711,7 @@ impl Session {
                 .window_size(1280, 720)
                 .new_headless_mode();
             if opens_brave_profile {
-                config = brave_launch_config(config).arg("restore-last-session");
+                config = profile_launch_config(config).arg("restore-last-session");
             }
             if let Some(executable) = executable {
                 config = config.chrome_executable(executable);
@@ -846,7 +846,7 @@ impl Session {
         runtime_dir: &Path,
         brave_session: &BraveSession,
     ) -> Result<(), BrowserError> {
-        let cookies = export_brave_cookies(runtime_dir, brave_session).await?;
+        let cookies = export_profile_cookies(runtime_dir, brave_session).await?;
         trace_serialized("session.refreshed_brave_cookies", &cookies);
         replace_browser_cookies(&self.browser, cookies).await?;
         Ok(())
@@ -1562,7 +1562,7 @@ fn validate_snapshot_wire(
     Ok(())
 }
 
-async fn export_brave_cookies(
+async fn export_profile_cookies(
     runtime_dir: &Path,
     brave_session: &BraveSession,
 ) -> Result<Vec<CookieParam>, BrowserError> {
@@ -1571,7 +1571,7 @@ async fn export_brave_cookies(
         .tempdir_in(runtime_dir)?;
     brave_session.prepare(broker_profile.path()).await?;
 
-    let config = brave_launch_config(
+    let config = profile_launch_config(
         BrowserConfig::builder()
             .user_data_dir(broker_profile.path())
             .new_headless_mode(),
@@ -1605,7 +1605,7 @@ async fn export_brave_cookies(
         browser_cookie_count = cookies.len(),
         browser_cookie_origin_count = brave_session.allowed_origins().len(),
         browser_cookie_all_origins = brave_session.copies_all_cookies(),
-        "prepared Brave cookies for a dedicated remote browser"
+        "prepared source-profile cookies for a dedicated browser"
     );
     Ok(cookies)
 }
@@ -5739,7 +5739,7 @@ fn build_config(builder: BrowserConfigBuilder) -> Result<BrowserConfig, BrowserE
         .map_err(|message| BrowserError::Configuration { message })
 }
 
-fn brave_launch_config(builder: BrowserConfigBuilder) -> BrowserConfigBuilder {
+fn profile_launch_config(builder: BrowserConfigBuilder) -> BrowserConfigBuilder {
     // Chromiumoxide's Puppeteer-derived defaults select `password-store=basic`
     // and `use-mock-keychain`. Those are appropriate for an empty automation
     // profile but make real Brave cookie ciphertext undecryptable. Keep the
@@ -6434,8 +6434,8 @@ mod tests {
     use super::{
         BrowserConfig, Chromium, Diagnostics, GateSignals, MAX_ACTION_INPUT_BYTES,
         MAX_CONSOLE_ENTRIES, MAX_DIAGNOSTIC_TEXT_BYTES, MAX_NETWORK_REQUESTS, NetworkSource,
-        allowed_cookie_params, brave_launch_config, build_config, classify_gate, close_chromium,
-        cookie_param, diagnostic_limit, trace_browser_configuration, validate_url,
+        allowed_cookie_params, build_config, classify_gate, close_chromium, cookie_param,
+        diagnostic_limit, profile_launch_config, trace_browser_configuration, validate_url,
     };
     use crate::{
         BraveSession, Browser, BrowserAction, BrowserActionResult, BrowserConsoleEntry,
@@ -6780,7 +6780,7 @@ mod tests {
         profile: &std::path::Path,
         value: &str,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let config = brave_launch_config(
+        let config = profile_launch_config(
             BrowserConfig::builder()
                 .user_data_dir(profile)
                 .new_headless_mode(),

--- a/crates/experimental/nanocodex-browser/src/native.rs
+++ b/crates/experimental/nanocodex-browser/src/native.rs
@@ -142,6 +142,7 @@ pub(crate) struct NativeBrowser {
     executable: Option<PathBuf>,
     cdp_endpoint: Option<Url>,
     brave_session: Option<BraveSession>,
+    launch_brave_executable: bool,
     virtual_authenticator: Option<VirtualAuthenticator>,
     react_diagnostics: Option<ReactDiagnostics>,
     egress_policy: Option<BrowserEgressPolicy>,
@@ -644,6 +645,7 @@ fn trace_browser_configuration(owner: &NativeBrowser) {
         "executable": owner.executable,
         "cdpEndpoint": owner.cdp_endpoint,
         "braveSession": owner.brave_session.as_ref().map(BraveSession::trace_value),
+        "launchBraveExecutable": owner.launch_brave_executable,
         "virtualAuthenticator": owner.virtual_authenticator.is_some(),
         "reactDiagnostics": owner.react_diagnostics.map(|diagnostics| {
             serde_json::json!({
@@ -673,6 +675,7 @@ impl Session {
         let executable = owner.executable.as_deref();
         let cdp_endpoint = owner.cdp_endpoint.as_ref();
         let brave_session = owner.brave_session.as_ref();
+        let launch_brave_executable = owner.launch_brave_executable;
         let virtual_authenticator = owner.virtual_authenticator;
         let react_diagnostics = owner.react_diagnostics;
         let egress_policy = owner.egress_policy.clone();
@@ -684,8 +687,11 @@ impl Session {
         tokio::fs::create_dir_all(&output_dir).await?;
         tokio::fs::create_dir_all(&download_dir).await?;
 
-        let imported_cookies = if let (Some(_), Some(brave_session)) = (cdp_endpoint, brave_session)
-        {
+        let opens_brave_profile = cdp_endpoint.is_none()
+            && executable.is_none()
+            && launch_brave_executable
+            && brave_session.is_some();
+        let imported_cookies = if !opens_brave_profile && let Some(brave_session) = brave_session {
             Some(export_brave_cookies(runtime_dir, brave_session).await?)
         } else {
             None
@@ -693,9 +699,7 @@ impl Session {
         if let Some(cookies) = &imported_cookies {
             trace_serialized("session.imported_brave_cookies", cookies);
         }
-        if cdp_endpoint.is_none()
-            && let Some(brave_session) = brave_session
-        {
+        if opens_brave_profile && let Some(brave_session) = brave_session {
             brave_session.prepare(&profile).await?;
         }
 
@@ -706,12 +710,13 @@ impl Session {
                 .user_data_dir(&profile)
                 .window_size(1280, 720)
                 .new_headless_mode();
-            if let Some(brave_session) = brave_session {
-                config = brave_launch_config(config)
-                    .chrome_executable(brave_session.executable())
-                    .arg("restore-last-session");
-            } else if let Some(executable) = executable {
+            if opens_brave_profile {
+                config = brave_launch_config(config).arg("restore-last-session");
+            }
+            if let Some(executable) = executable {
                 config = config.chrome_executable(executable);
+            } else if launch_brave_executable && let Some(brave_session) = brave_session {
+                config = config.chrome_executable(brave_session.executable());
             }
             if egress_policy.is_some() {
                 config = config
@@ -2053,6 +2058,7 @@ impl NativeBrowser {
         executable: Option<PathBuf>,
         cdp_endpoint: Option<Url>,
         brave_session: Option<BraveSession>,
+        launch_brave_executable: bool,
         virtual_authenticator: Option<VirtualAuthenticator>,
         react_diagnostics: Option<ReactDiagnostics>,
         egress_policy: Option<BrowserEgressPolicy>,
@@ -2071,6 +2077,7 @@ impl NativeBrowser {
             executable,
             cdp_endpoint,
             brave_session,
+            launch_brave_executable,
             virtual_authenticator,
             react_diagnostics,
             egress_policy,

--- a/crates/experimental/nanocodex-browser/src/native.rs
+++ b/crates/experimental/nanocodex-browser/src/native.rs
@@ -1591,27 +1591,34 @@ async fn export_brave_cookies(
     let cookies = exported?;
     shutdown?;
 
-    let cookies = allowed_cookie_params(cookies, brave_session.allowed_origins());
+    let cookies = allowed_cookie_params(
+        cookies,
+        (!brave_session.copies_all_cookies()).then(|| brave_session.allowed_origins()),
+    );
     info!(
         target: "nanocodex_browser",
         browser_cookie_count = cookies.len(),
         browser_cookie_origin_count = brave_session.allowed_origins().len(),
-        "prepared allowlisted Brave cookies for a dedicated remote browser"
+        browser_cookie_all_origins = brave_session.copies_all_cookies(),
+        "prepared Brave cookies for a dedicated remote browser"
     );
     Ok(cookies)
 }
 
-fn allowed_cookie_params(cookies: Vec<Cookie>, allowed_origins: &[Url]) -> Vec<CookieParam> {
-    let allowed_hosts = allowed_origins
-        .iter()
-        .filter_map(Url::host_str)
-        .collect::<Vec<_>>();
+fn allowed_cookie_params(
+    cookies: Vec<Cookie>,
+    allowed_origins: Option<&[Url]>,
+) -> Vec<CookieParam> {
+    let allowed_hosts =
+        allowed_origins.map(|origins| origins.iter().filter_map(Url::host_str).collect::<Vec<_>>());
     cookies
         .into_iter()
         .filter(|cookie| {
-            allowed_hosts
-                .iter()
-                .any(|allowed| cookie_applies_to(&cookie.domain, allowed))
+            allowed_hosts.as_ref().is_none_or(|hosts| {
+                hosts
+                    .iter()
+                    .any(|allowed| cookie_applies_to(&cookie.domain, allowed))
+            })
         })
         .filter_map(cookie_param)
         .collect()
@@ -6666,10 +6673,25 @@ mod tests {
         ];
         let allowed = [url::Url::parse("https://console.example.com").expect("valid test origin")];
 
-        let parameters = allowed_cookie_params(cookies, &allowed);
+        let parameters = allowed_cookie_params(cookies, Some(&allowed));
 
         assert_eq!(parameters.len(), 1);
         assert_eq!(parameters[0].domain.as_deref(), Some(".example.com"));
+    }
+
+    #[test]
+    fn remote_cookie_mapping_can_preserve_every_domain() {
+        let cookies = vec![
+            test_cookie(".example.com", false, None),
+            test_cookie("sibling.example.net", false, None),
+            test_cookie("console.example.com", false, Some(true)),
+        ];
+
+        let parameters = allowed_cookie_params(cookies, None);
+
+        assert_eq!(parameters.len(), 2);
+        assert_eq!(parameters[0].domain.as_deref(), Some(".example.com"));
+        assert_eq!(parameters[1].domain.as_deref(), Some("sibling.example.net"));
     }
 
     #[tokio::test]

--- a/crates/experimental/nanocodex-browser/src/session.rs
+++ b/crates/experimental/nanocodex-browser/src/session.rs
@@ -10,18 +10,20 @@ use std::env;
 use rusqlite::{Connection, OpenFlags, backup::Backup};
 use url::Url;
 
-/// An allowlisted, cookie-backed snapshot of an existing Brave profile.
+/// A cookie-backed snapshot of an existing Brave profile.
 ///
 /// This is designed for authenticated headless automation while the ordinary
-/// Brave window remains open. Only cookies applicable to an explicitly allowed
-/// origin are copied. The source profile is never passed to the launched
-/// browser and is never mutated.
+/// Brave window remains open. Callers may copy cookies applicable to an
+/// explicit origin allowlist or deliberately opt into every cookie in the
+/// selected profile. The source profile is never passed to the launched browser
+/// and is never mutated.
 #[derive(Clone, Debug)]
 pub struct BraveSession {
     executable: PathBuf,
     user_data_dir: PathBuf,
     profile_directory: PathBuf,
     allowed_origins: Vec<Url>,
+    copy_all_cookies: bool,
     include_site_data: bool,
 }
 
@@ -70,6 +72,7 @@ impl BraveSession {
             user_data_dir: user_data_dir.into(),
             profile_directory: PathBuf::from("Default"),
             allowed_origins: Vec::new(),
+            copy_all_cookies: false,
             include_site_data: false,
         }
     }
@@ -89,6 +92,17 @@ impl BraveSession {
         self
     }
 
+    /// Copies every cookie from the selected Brave profile.
+    ///
+    /// This deliberately gives the dedicated browser the profile's complete
+    /// authenticated cookie state. Cookie values remain outside the
+    /// model-callable browser action schema.
+    #[must_use]
+    pub const fn copy_all_cookies(mut self) -> Self {
+        self.copy_all_cookies = true;
+        self
+    }
+
     /// Also copies `localStorage`, `IndexedDB`, and storage-bucket metadata.
     ///
     /// Brave must be closed when the lazy browser launch takes this snapshot
@@ -101,7 +115,9 @@ impl BraveSession {
         self
     }
 
-    pub(crate) fn executable(&self) -> &Path {
+    /// Returns the Brave executable selected by this session.
+    #[must_use]
+    pub fn executable(&self) -> &Path {
         &self.executable
     }
 
@@ -113,17 +129,28 @@ impl BraveSession {
         self.include_site_data
     }
 
+    pub(crate) const fn copies_all_cookies(&self) -> bool {
+        self.copy_all_cookies
+    }
+
     pub(crate) fn trace_value(&self) -> serde_json::Value {
         serde_json::json!({
             "executable": self.executable,
             "userDataDirectory": self.user_data_dir,
             "profileDirectory": self.profile_directory,
             "allowedOrigins": self.allowed_origins,
+            "copyAllCookies": self.copy_all_cookies,
             "includeSiteData": self.include_site_data,
         })
     }
 
     pub(crate) fn validate_handoff_url(&self, url: &Url) -> Result<(), BraveSessionError> {
+        if self.copy_all_cookies
+            && matches!(url.scheme(), "http" | "https")
+            && url.host_str().is_some()
+        {
+            return Ok(());
+        }
         if self
             .allowed_origins
             .iter()
@@ -181,14 +208,15 @@ impl BraveSession {
         tokio::fs::create_dir_all(&target_profile).await?;
         tokio::fs::copy(source_local_state, target_user_data_dir.join("Local State")).await?;
 
-        let allowed_hosts = self
-            .allowed_origins
-            .iter()
-            .filter_map(Url::host_str)
-            .map(str::to_owned)
-            .collect::<Vec<_>>();
+        let allowed_hosts = (!self.copy_all_cookies).then(|| {
+            self.allowed_origins
+                .iter()
+                .filter_map(Url::host_str)
+                .map(str::to_owned)
+                .collect::<Vec<_>>()
+        });
         tokio::task::spawn_blocking(move || {
-            snapshot_cookies(&source_cookies, &target_cookies, &allowed_hosts)
+            snapshot_cookies(&source_cookies, &target_cookies, allowed_hosts.as_deref())
         })
         .await
         .map_err(BraveSessionError::SnapshotTask)??;
@@ -211,7 +239,7 @@ impl BraveSession {
 
     pub(crate) fn validate(&self) -> Result<(), BraveSessionError> {
         self.validate_paths()?;
-        if self.allowed_origins.is_empty() {
+        if self.allowed_origins.is_empty() && !self.copy_all_cookies {
             return Err(BraveSessionError::MissingAllowedOrigin);
         }
         for origin in &self.allowed_origins {
@@ -255,7 +283,7 @@ impl BraveSession {
 fn snapshot_cookies(
     source: &Path,
     target: &Path,
-    allowed_hosts: &[String],
+    allowed_hosts: Option<&[String]>,
 ) -> Result<(), BraveSessionError> {
     let source = Connection::open_with_flags(
         source,
@@ -266,28 +294,32 @@ fn snapshot_cookies(
     backup.run_to_completion(64, Duration::from_millis(5), None)?;
     drop(backup);
 
-    let mut statement = target.prepare("SELECT rowid, host_key FROM cookies")?;
-    let rows = statement.query_map([], |row| {
-        Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
-    })?;
-    let mut rejected = Vec::new();
-    for row in rows {
-        let (row_id, cookie_host) = row?;
-        if !allowed_hosts
-            .iter()
-            .any(|allowed| cookie_applies_to(&cookie_host, allowed))
+    if let Some(allowed_hosts) = allowed_hosts {
+        let mut statement = target.prepare("SELECT rowid, host_key FROM cookies")?;
+        let rows = statement.query_map([], |row| {
+            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
+        })?;
+        let mut rejected = Vec::new();
+        for row in rows {
+            let (row_id, cookie_host) = row?;
+            if !allowed_hosts
+                .iter()
+                .any(|allowed| cookie_applies_to(&cookie_host, allowed))
+            {
+                rejected.push(row_id);
+            }
+        }
+        drop(statement);
+        let transaction = target.transaction()?;
         {
-            rejected.push(row_id);
+            let mut delete = transaction.prepare("DELETE FROM cookies WHERE rowid = ?1")?;
+            for row_id in rejected {
+                delete.execute([row_id])?;
+            }
         }
+        transaction.commit()?;
     }
-    drop(statement);
     let transaction = target.transaction()?;
-    {
-        let mut delete = transaction.prepare("DELETE FROM cookies WHERE rowid = ?1")?;
-        for row_id in rejected {
-            delete.execute([row_id])?;
-        }
-    }
     transaction.execute(
         "UPDATE cookies
          SET is_persistent = 1, has_expires = 1, expires_utc = ?1
@@ -464,7 +496,7 @@ mod tests {
         super::snapshot_cookies(
             &source_path,
             &target_path,
-            &["console.example.com".to_owned()],
+            Some(&["console.example.com".to_owned()]),
         )?;
 
         let source = Connection::open(source_path)?;
@@ -488,6 +520,55 @@ mod tests {
             target.query_row("SELECT is_persistent FROM cookies", [], |row| row
                 .get::<_, i64>(0))?,
             1
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn all_cookie_snapshot_keeps_every_domain() -> Result<(), Box<dyn Error>> {
+        let directory = tempdir()?;
+        let source_path = directory.path().join("source.sqlite");
+        let target_path = directory.path().join("target.sqlite");
+        let source = Connection::open(&source_path)?;
+        source.execute(
+            "CREATE TABLE cookies(
+                host_key TEXT NOT NULL,
+                encrypted_value BLOB NOT NULL,
+                is_persistent INTEGER NOT NULL,
+                has_expires INTEGER NOT NULL,
+                expires_utc INTEGER NOT NULL
+            )",
+            [],
+        )?;
+        source.execute(
+            "INSERT INTO cookies(
+                host_key, encrypted_value, is_persistent, has_expires, expires_utc
+            ) VALUES (?1, ?2, 0, 0, 0)",
+            (".example.com", b"first".as_slice()),
+        )?;
+        source.execute(
+            "INSERT INTO cookies(
+                host_key, encrypted_value, is_persistent, has_expires, expires_utc
+            ) VALUES (?1, ?2, 1, 1, 1)",
+            ("dashboard.stripe.com", b"second".as_slice()),
+        )?;
+        drop(source);
+
+        super::snapshot_cookies(&source_path, &target_path, None)?;
+
+        let target = Connection::open(target_path)?;
+        assert_eq!(
+            target.query_row("SELECT COUNT(*) FROM cookies", [], |row| row
+                .get::<_, i64>(0))?,
+            2
+        );
+        assert_eq!(
+            target.query_row(
+                "SELECT COUNT(*) FROM cookies WHERE is_persistent = 1",
+                [],
+                |row| row.get::<_, i64>(0),
+            )?,
+            2
         );
         Ok(())
     }

--- a/crates/experimental/nanocodex-browser/src/session.rs
+++ b/crates/experimental/nanocodex-browser/src/session.rs
@@ -10,10 +10,32 @@ use std::env;
 use rusqlite::{Connection, OpenFlags, backup::Backup};
 use url::Url;
 
-/// A cookie-backed snapshot of an existing Brave profile.
+/// A standard Chromium-family browser profile that can supply cookies.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BrowserProfileKind {
+    Brave,
+    Chrome,
+    Chromium,
+    Edge,
+}
+
+impl BrowserProfileKind {
+    /// Returns the browser's display name.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Brave => "Brave",
+            Self::Chrome => "Google Chrome",
+            Self::Chromium => "Chromium",
+            Self::Edge => "Microsoft Edge",
+        }
+    }
+}
+
+/// A cookie-backed snapshot of an existing Chromium-family profile.
 ///
 /// This is designed for authenticated headless automation while the ordinary
-/// Brave window remains open. Callers may copy cookies applicable to an
+/// source browser remains open. Callers may copy cookies applicable to an
 /// explicit origin allowlist or deliberately opt into every cookie in the
 /// selected profile. The source profile is never passed to the launched browser
 /// and is never mutated.
@@ -35,27 +57,76 @@ impl BraveSession {
     /// Returns an error when the platform has no standard location, the home
     /// directory is unavailable, or Brave is not installed there.
     pub fn standard() -> Result<Self, BraveSessionError> {
+        Self::standard_for(BrowserProfileKind::Brave)
+    }
+
+    /// Locates a standard Chromium-family installation and user-data directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the platform has no standard location, the home
+    /// directory is unavailable, or the selected browser is not installed.
+    pub fn standard_for(browser: BrowserProfileKind) -> Result<Self, BraveSessionError> {
         #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         {
-            Err(BraveSessionError::StandardInstallationUnavailable)
+            Err(BraveSessionError::StandardInstallationUnavailable {
+                browser: browser.name(),
+            })
         }
 
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         {
             let home = env::var_os("HOME").ok_or(BraveSessionError::HomeDirectoryUnavailable)?;
             #[cfg(target_os = "macos")]
-            let (executable, user_data_dir) = (
-                PathBuf::from("/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"),
-                PathBuf::from(home).join("Library/Application Support/BraveSoftware/Brave-Browser"),
-            );
+            let (executable, user_data_dir) = match browser {
+                BrowserProfileKind::Brave => (
+                    PathBuf::from("/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"),
+                    PathBuf::from(&home)
+                        .join("Library/Application Support/BraveSoftware/Brave-Browser"),
+                ),
+                BrowserProfileKind::Chrome => (
+                    PathBuf::from("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
+                    PathBuf::from(&home).join("Library/Application Support/Google/Chrome"),
+                ),
+                BrowserProfileKind::Chromium => (
+                    PathBuf::from("/Applications/Chromium.app/Contents/MacOS/Chromium"),
+                    PathBuf::from(&home).join("Library/Application Support/Chromium"),
+                ),
+                BrowserProfileKind::Edge => (
+                    PathBuf::from("/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"),
+                    PathBuf::from(&home).join("Library/Application Support/Microsoft Edge"),
+                ),
+            };
+            #[cfg(target_os = "linux")]
+            let (executables, user_data_directory): (&[&str], &str) = match browser {
+                BrowserProfileKind::Brave => (
+                    &["/usr/bin/brave-browser", "/usr/bin/brave-browser-stable"],
+                    ".config/BraveSoftware/Brave-Browser",
+                ),
+                BrowserProfileKind::Chrome => (
+                    &["/usr/bin/google-chrome", "/usr/bin/google-chrome-stable"],
+                    ".config/google-chrome",
+                ),
+                BrowserProfileKind::Chromium => (
+                    &["/usr/bin/chromium", "/usr/bin/chromium-browser"],
+                    ".config/chromium",
+                ),
+                BrowserProfileKind::Edge => (
+                    &["/usr/bin/microsoft-edge", "/usr/bin/microsoft-edge-stable"],
+                    ".config/microsoft-edge",
+                ),
+            };
             #[cfg(target_os = "linux")]
             let (executable, user_data_dir) = (
-                ["/usr/bin/brave-browser", "/usr/bin/brave-browser-stable"]
-                    .into_iter()
+                executables
+                    .iter()
+                    .copied()
                     .map(PathBuf::from)
                     .find(|path| path.is_file())
-                    .ok_or(BraveSessionError::StandardInstallationUnavailable)?,
-                PathBuf::from(home).join(".config/BraveSoftware/Brave-Browser"),
+                    .ok_or(BraveSessionError::StandardInstallationUnavailable {
+                        browser: browser.name(),
+                    })?,
+                PathBuf::from(home).join(user_data_directory),
             );
 
             let session = Self::new(executable, user_data_dir);
@@ -64,7 +135,7 @@ impl BraveSession {
         }
     }
 
-    /// Creates a Brave session from explicit executable and user-data paths.
+    /// Creates a profile session from explicit executable and user-data paths.
     #[must_use]
     pub fn new(executable: impl Into<PathBuf>, user_data_dir: impl Into<PathBuf>) -> Self {
         Self {
@@ -92,7 +163,7 @@ impl BraveSession {
         self
     }
 
-    /// Copies every cookie from the selected Brave profile.
+    /// Copies every cookie from the selected source profile.
     ///
     /// This deliberately gives the dedicated browser the profile's complete
     /// authenticated cookie state. Cookie values remain outside the
@@ -105,7 +176,7 @@ impl BraveSession {
 
     /// Also copies `localStorage`, `IndexedDB`, and storage-bucket metadata.
     ///
-    /// Brave must be closed when the lazy browser launch takes this snapshot
+    /// The source browser must be closed when the lazy launch takes this snapshot
     /// because those stores use `LevelDB` and do not provide `SQLite`'s online
     /// backup guarantee. On APFS, Rust uses copy-on-write clones for the files,
     /// so the private snapshot consumes space only as either side changes.
@@ -115,7 +186,7 @@ impl BraveSession {
         self
     }
 
-    /// Returns the Brave executable selected by this session.
+    /// Returns the source browser executable selected by this session.
     #[must_use]
     pub fn executable(&self) -> &Path {
         &self.executable
@@ -382,35 +453,35 @@ fn copy_directory(source: &Path, target: &Path) -> Result<(), std::io::Error> {
 pub enum BraveSessionError {
     #[error("the home directory is unavailable")]
     HomeDirectoryUnavailable,
-    #[error("the standard Brave installation is unavailable on this platform")]
-    StandardInstallationUnavailable,
-    #[error("Brave executable does not exist at {path}")]
+    #[error("the standard {browser} installation is unavailable on this platform")]
+    StandardInstallationUnavailable { browser: &'static str },
+    #[error("source browser executable does not exist at {path}")]
     ExecutableUnavailable { path: PathBuf },
-    #[error("Brave user-data directory does not exist at {path}")]
+    #[error("source browser user-data directory does not exist at {path}")]
     UserDataUnavailable { path: PathBuf },
-    #[error("Brave profile directory must be one relative path component, got {directory}")]
+    #[error("source profile directory must be one relative path component, got {directory}")]
     InvalidProfileDirectory { directory: PathBuf },
     #[error("at least one HTTP(S) origin must be explicitly allowed")]
     MissingAllowedOrigin,
-    #[error("Brave session origin must contain only a scheme, host, and optional port: {origin}")]
+    #[error("profile session origin must contain only a scheme, host, and optional port: {origin}")]
     InvalidOrigin { origin: Url },
-    #[error("authentication handoff URL is outside the Brave session allowlist: {url}")]
+    #[error("authentication handoff URL is outside the profile session allowlist: {url}")]
     HandoffOriginNotAllowed { url: Url },
-    #[error("Brave cookie database is unavailable under {profile}")]
+    #[error("source cookie database is unavailable under {profile}")]
     CookiesUnavailable { profile: PathBuf },
     #[error(
-        "Brave must be closed before copying site data from {user_data_dir}; cookie-only snapshots remain available while Brave is running"
+        "the source browser must be closed before copying site data from {user_data_dir}; cookie-only snapshots remain available while it is running"
     )]
     SourceBrowserRunning { user_data_dir: PathBuf },
-    #[error("Brave session filesystem operation failed")]
+    #[error("profile session filesystem operation failed")]
     Io(#[from] std::io::Error),
-    #[error("Brave cookie snapshot failed")]
+    #[error("cookie snapshot failed")]
     Sqlite(#[from] rusqlite::Error),
-    #[error("Brave cookie snapshot task failed")]
+    #[error("cookie snapshot task failed")]
     SnapshotTask(#[source] tokio::task::JoinError),
     #[error("the system clock is before the Unix epoch")]
     SystemClock(#[source] std::time::SystemTimeError),
-    #[error("temporary Brave cookie expiration does not fit Chromium's timestamp range")]
+    #[error("temporary cookie expiration does not fit Chromium's timestamp range")]
     CookieExpiryOverflow,
 }
 

--- a/crates/experimental/nanocodex-browser/src/tests.rs
+++ b/crates/experimental/nanocodex-browser/src/tests.rs
@@ -55,6 +55,24 @@ fn browser_accepts_an_explicit_all_cookie_brave_session() -> Result<()> {
 }
 
 #[test]
+fn browser_cookie_source_is_independent_from_the_browser_executable() -> Result<()> {
+    let directory = tempfile::tempdir()?;
+    let brave_executable = directory.path().join("brave");
+    let chromium_executable = directory.path().join("chromium");
+    std::fs::write(&brave_executable, [])?;
+    std::fs::write(&chromium_executable, [])?;
+    let user_data = directory.path().join("user-data");
+    std::fs::create_dir(&user_data)?;
+    let cookies = BraveSession::new(brave_executable, user_data).copy_all_cookies();
+
+    Browser::builder()
+        .executable(chromium_executable)
+        .brave_cookie_source(cookies)
+        .build()?;
+    Ok(())
+}
+
+#[test]
 fn harness_owned_browser_secrets_are_redacted_from_debug_output() {
     let state = BrowserStorageState {
         cookies: vec![BrowserCookie {

--- a/crates/experimental/nanocodex-browser/src/tests.rs
+++ b/crates/experimental/nanocodex-browser/src/tests.rs
@@ -42,6 +42,19 @@ fn remote_browser_accepts_cookie_only_brave_sessions() -> Result<()> {
 }
 
 #[test]
+fn browser_accepts_an_explicit_all_cookie_brave_session() -> Result<()> {
+    let directory = tempfile::tempdir()?;
+    let executable = directory.path().join("brave");
+    std::fs::write(&executable, [])?;
+    let user_data = directory.path().join("user-data");
+    std::fs::create_dir(&user_data)?;
+    let brave = BraveSession::new(executable, user_data).copy_all_cookies();
+
+    Browser::builder().brave_session(brave).build()?;
+    Ok(())
+}
+
+#[test]
 fn harness_owned_browser_secrets_are_redacted_from_debug_output() {
     let state = BrowserStorageState {
         cookies: vec![BrowserCookie {

--- a/crates/experimental/nanocodex-browser/src/tests.rs
+++ b/crates/experimental/nanocodex-browser/src/tests.rs
@@ -67,7 +67,7 @@ fn browser_cookie_source_is_independent_from_the_browser_executable() -> Result<
 
     Browser::builder()
         .executable(chromium_executable)
-        .brave_cookie_source(cookies)
+        .cookie_source(cookies)
         .build()?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add `--browser=brave` target selection while preserving bare `--browser` as private Chromium
- keep the cookie source independent from the target browser
- support automatic or explicit sources with `--cookies`, `--cookies=chrome`, `--cookies=brave`, `--cookies=chromium`, `--cookies=edge`, `--cookies=firefox`, and `--cookies=safari`
- keep cookie transfer harness-owned and outside the model-callable schema

## Implementation
- Chromium-family profiles use their matching browser as a short-lived decryption broker
- Firefox uses SQLite online backup and typed `moz_cookies` extraction; expired and container-scoped cookies are excluded
- Safari uses a bounded, safe `Cookies.binarycookies` decoder; macOS may require permission to read Safari sandbox data
- every source is normalized into typed storage state and injected into the private target browser
- source profiles are never mutated

## Validation
- `cargo fmt --all`
- `cargo test -p nanocodex-browser cookie_source::tests`
- `cargo test -p nanocodex-bin browser_tool_is_opt_in_for_tui_and_one_shot_runs`
- `cargo clippy -p nanocodex-browser -p nanocodex-bin --all-targets -- -D warnings`
- `cargo deny check`