### PR TITLE
feat(rivet): synchronize actor clients

### DIFF
--- a/examples/rivet-actors/README.md
+++ b/examples/rivet-actors/README.md
@@ -82,9 +82,17 @@ In another terminal:
 ```sh
 npm run repl --prefix examples/rivet-actors
 npm run smoke --prefix examples/rivet-actors
+npm run multiclient --prefix examples/rivet-actors
 npm run stress --prefix examples/rivet-actors
 npm run brutalize --prefix examples/rivet-actors
 ```
+
+`multiclient` attaches two independent realtime clients to one actor and
+requires both to receive the same accepted prompt, Nanocodex event stream, and
+durably committed terminal result. The browser uses the same broadcasts, so
+tabs or devices connected with the same actor key stay synchronized. A newly
+connected client also reconstructs any active prompt from `status()` before
+joining its remaining event stream.
 
 The REPL is intentionally disposable. It stores only the Rivet endpoint,
 actor key, and an unfinished turn ID/input in `.nanocodex/rivet-repl.json`.

--- a/examples/rivet-actors/package.json
+++ b/examples/rivet-actors/package.json
@@ -18,6 +18,7 @@
     "predev:subscription": "npm run build:web",
     "dev:subscription": "node scripts/run-local-server.mjs scripts/dev-subscription.ts",
     "deploy:subscription": "node --import tsx scripts/deploy-subscription.ts",
+    "multiclient": "node --import tsx scripts/multiclient-smoke.ts",
     "repl": "node --import tsx scripts/repl.ts",
     "smoke": "node --import tsx scripts/live-smoke.ts",
     "stress": "node --import tsx scripts/stress.ts",

--- a/examples/rivet-actors/scripts/multiclient-smoke.ts
+++ b/examples/rivet-actors/scripts/multiclient-smoke.ts
@@ -1,0 +1,62 @@
+import { randomUUID } from "node:crypto";
+
+import { createNanocodexClient } from "../src/client.js";
+
+const endpoint = process.env.RIVET_PUBLIC_ENDPOINT ?? "http://127.0.0.1:6420";
+const client = createNanocodexClient(endpoint);
+const session = client.nanocodex.getOrCreate([
+  process.env.NANOCODEX_MULTICLIENT_ACTOR_KEY ?? "nanocodex-multiclient-smoke",
+]);
+await session.reset();
+const first = session.connect();
+const second = session.connect();
+const accepted = [new Set<string>(), new Set<string>()];
+const completed = [new Set<string>(), new Set<string>()];
+const eventCounts = [0, 0];
+
+for (const [index, connection] of [first, second].entries()) {
+  connection.on("turnAccepted", (turn) => accepted[index]?.add(`${turn.id}:${turn.input}`));
+  connection.on("turnCompleted", (turn) => completed[index]?.add(`${turn.id}:${turn.final_message}`));
+  connection.on("agentEvent", () => {
+    eventCounts[index] = (eventCounts[index] ?? 0) + 1;
+  });
+}
+await Promise.all([first.ready, second.ready]);
+
+const request = {
+  id: randomUUID(),
+  input: "Reply with exactly RIVET_SYNC_OK and nothing else.",
+};
+try {
+  const started = await first.start(request);
+  if (started.replayed) throw new Error("fresh synchronized turn was unexpectedly replayed");
+  const result = await first.prompt(request);
+  if (result.final_message !== "RIVET_SYNC_OK") {
+    throw new Error(`unexpected synchronized result: ${result.final_message}`);
+  }
+  const acceptedKey = `${request.id}:${request.input}`;
+  const completedKey = `${request.id}:RIVET_SYNC_OK`;
+  await waitUntil(() => accepted.every((turns) => turns.has(acceptedKey))
+    && completed.every((turns) => turns.has(completedKey)));
+  if (eventCounts.some((count) => count === 0)) {
+    throw new Error(`one client missed the model event stream: ${eventCounts.join(",")}`);
+  }
+  console.log(JSON.stringify({
+    actor_session_id: (await first.status()).session_id,
+    accepted_clients: accepted.filter((turns) => turns.has(acceptedKey)).length,
+    completed_clients: completed.filter((turns) => turns.has(completedKey)).length,
+    event_counts: eventCounts,
+    status: "ok",
+  }));
+} finally {
+  await Promise.allSettled([first.dispose(), second.dispose()]);
+  await session.reset();
+}
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("timed out waiting for synchronized client events");
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}

--- a/examples/rivet-actors/src/actors.ts
+++ b/examples/rivet-actors/src/actors.ts
@@ -32,7 +32,12 @@ const wasmBytes = readFile(new URL(import.meta.resolve("nanocodex/wasm")));
 
 type ModelAuthMode = "api_key" | "chatgpt";
 
+type PromptAdmission =
+  | { kind: "fresh" }
+  | { kind: "terminal"; completed: TurnCompleted };
+
 type InFlightTurn = {
+  admission: Promise<PromptAdmission>;
   input: string;
   inputHash: string;
   operation: Promise<TurnCompleted>;
@@ -160,27 +165,17 @@ export const nanocodex = actor({
   },
   actions: {
     start: async (c, request: PromptRequest): Promise<TurnAccepted> => {
-      const completed = await completedReplay(c.db, request);
-      if (completed) {
-        return {
-          type: "turn_accepted",
-          id: request.id,
-          input: request.input,
-          replayed: true,
-        };
-      }
       const started = startPrompt(c, request, true);
       void started.operation.catch(() => {});
+      const admission = await started.admission;
       return {
         type: "turn_accepted",
         id: request.id,
         input: request.input,
-        replayed: started.replayed,
+        replayed: started.replayed || admission.kind === "terminal",
       };
     },
     prompt: async (c, request: PromptRequest): Promise<TurnCompleted> => {
-      const completed = await completedReplay(c.db, request);
-      if (completed) return completed;
       return startPrompt(c, request, false).operation;
     },
     steer: async (c, id: string, input: string): Promise<void> => {
@@ -252,23 +247,39 @@ function startPrompt(
     throw userError(`at most ${MAX_ACTIVE_TURNS} turns may be active`);
   }
 
-  const running = runPrompt(context, request, inputHash, !detached);
+  const admission = classifyPrompt(context, request, inputHash);
+  const running = admission.then((result) => result.kind === "terminal"
+    ? result.completed
+    : runPrompt(context, request, inputHash, !detached));
   let inFlight: InFlightTurn;
   const operation = running.finally(() => {
     if (context.vars.inFlight.get(request.id) === inFlight) {
       context.vars.inFlight.delete(request.id);
     }
   });
-  inFlight = { input: request.input, inputHash, operation };
+  inFlight = { admission, input: request.input, inputHash, operation };
   context.vars.inFlight.set(request.id, inFlight);
   context.keepAwake(operation);
+  return { ...inFlight, replayed: false };
+}
+
+async function classifyPrompt(
+  context: SessionContext,
+  request: PromptRequest,
+  inputHash: string,
+): Promise<PromptAdmission> {
+  const stored = await terminal(context.db, request.id);
+  if (stored) {
+    if (stored.input_hash !== inputHash) throw userError(`turn ${request.id} already has different input`);
+    return { kind: "terminal", completed: parseTerminal(stored.payload) };
+  }
   context.broadcast("turnAccepted", {
     type: "turn_accepted",
     id: request.id,
     input: request.input,
     replayed: false,
   } satisfies TurnAccepted);
-  return { ...inFlight, replayed: false };
+  return { kind: "fresh" };
 }
 
 async function runPrompt(
@@ -277,14 +288,6 @@ async function runPrompt(
   inputHash: string,
   cancelOnContextAbort: boolean,
 ): Promise<TurnCompleted> {
-  const stored = await terminal(context.db, request.id);
-  if (stored) {
-    if (stored.input_hash !== inputHash) throw userError(`turn ${request.id} already has different input`);
-    const completed = parseTerminal(stored.payload);
-    context.broadcast("turnCompleted", completed);
-    return completed;
-  }
-
   let turn: Turn | undefined;
   const onAbort = () => {
     void turn?.cancel().catch(() => {});
@@ -479,19 +482,6 @@ async function terminal(database: RawAccess, id: string): Promise<TerminalRow | 
     "SELECT input_hash, payload FROM terminal_turns WHERE id = ?",
     id,
   ))[0];
-}
-
-async function completedReplay(
-  database: RawAccess,
-  request: PromptRequest,
-): Promise<TurnCompleted | undefined> {
-  validatePrompt(request);
-  const stored = await terminal(database, request.id);
-  if (!stored) return undefined;
-  if (stored.input_hash !== hashInput(request.input)) {
-    throw userError(`turn ${request.id} already has different input`);
-  }
-  return parseTerminal(stored.payload);
 }
 
 function parseTerminal(payload: string): TurnCompleted {

--- a/examples/rivet-actors/src/actors.ts
+++ b/examples/rivet-actors/src/actors.ts
@@ -33,6 +33,7 @@ const wasmBytes = readFile(new URL(import.meta.resolve("nanocodex/wasm")));
 type ModelAuthMode = "api_key" | "chatgpt";
 
 type InFlightTurn = {
+  input: string;
   inputHash: string;
   operation: Promise<TurnCompleted>;
 };
@@ -60,7 +61,13 @@ export type TurnCompleted = {
 export type TurnAccepted = {
   type: "turn_accepted";
   id: string;
+  input: string;
   replayed: boolean;
+};
+
+export type ActiveTurn = {
+  id: string;
+  input: string;
 };
 
 export type TurnFailed = {
@@ -75,6 +82,7 @@ export type SessionStatus = {
   completed_turns: number;
   last_active: number;
   active_turns: string[];
+  active_turn_details: ActiveTurn[];
   agent_loaded: boolean;
   auth_mode: ModelAuthMode;
 };
@@ -146,20 +154,33 @@ export const nanocodex = actor({
   }),
   events: {
     agentEvent: event<AgentEvent>(),
+    turnAccepted: event<TurnAccepted>(),
     turnCompleted: event<TurnCompleted>(),
     turnFailed: event<TurnFailed>(),
   },
   actions: {
     start: async (c, request: PromptRequest): Promise<TurnAccepted> => {
+      const completed = await completedReplay(c.db, request);
+      if (completed) {
+        return {
+          type: "turn_accepted",
+          id: request.id,
+          input: request.input,
+          replayed: true,
+        };
+      }
       const started = startPrompt(c, request, true);
       void started.operation.catch(() => {});
       return {
         type: "turn_accepted",
         id: request.id,
+        input: request.input,
         replayed: started.replayed,
       };
     },
     prompt: async (c, request: PromptRequest): Promise<TurnCompleted> => {
+      const completed = await completedReplay(c.db, request);
+      if (completed) return completed;
       return startPrompt(c, request, false).operation;
     },
     steer: async (c, id: string, input: string): Promise<void> => {
@@ -183,6 +204,10 @@ export const nanocodex = actor({
         completed_turns: row.completed_turns,
         last_active: row.last_active,
         active_turns: [...c.vars.inFlight.keys()],
+        active_turn_details: [...c.vars.inFlight].map(([id, turn]) => ({
+          id,
+          input: turn.input,
+        })),
         agent_loaded: c.vars.agent !== undefined,
         auth_mode: modelAuthMode(),
       };
@@ -234,9 +259,15 @@ function startPrompt(
       context.vars.inFlight.delete(request.id);
     }
   });
-  inFlight = { inputHash, operation };
+  inFlight = { input: request.input, inputHash, operation };
   context.vars.inFlight.set(request.id, inFlight);
   context.keepAwake(operation);
+  context.broadcast("turnAccepted", {
+    type: "turn_accepted",
+    id: request.id,
+    input: request.input,
+    replayed: false,
+  } satisfies TurnAccepted);
   return { ...inFlight, replayed: false };
 }
 
@@ -249,7 +280,9 @@ async function runPrompt(
   const stored = await terminal(context.db, request.id);
   if (stored) {
     if (stored.input_hash !== inputHash) throw userError(`turn ${request.id} already has different input`);
-    return parseTerminal(stored.payload);
+    const completed = parseTerminal(stored.payload);
+    context.broadcast("turnCompleted", completed);
+    return completed;
   }
 
   let turn: Turn | undefined;
@@ -446,6 +479,19 @@ async function terminal(database: RawAccess, id: string): Promise<TerminalRow | 
     "SELECT input_hash, payload FROM terminal_turns WHERE id = ?",
     id,
   ))[0];
+}
+
+async function completedReplay(
+  database: RawAccess,
+  request: PromptRequest,
+): Promise<TurnCompleted | undefined> {
+  validatePrompt(request);
+  const stored = await terminal(database, request.id);
+  if (!stored) return undefined;
+  if (stored.input_hash !== hashInput(request.input)) {
+    throw userError(`turn ${request.id} already has different input`);
+  }
+  return parseTerminal(stored.payload);
 }
 
 function parseTerminal(payload: string): TurnCompleted {

--- a/examples/rivet-actors/test/actors.test.ts
+++ b/examples/rivet-actors/test/actors.test.ts
@@ -147,6 +147,7 @@ describe.sequential("Nanocodex Rivet Actors", () => {
     await expect(session.start(request)).resolves.toEqual({
       type: "turn_accepted",
       id: request.id,
+      input: request.input,
       replayed: false,
     });
     expect((await session.status()).active_turns).toContain(request.id);
@@ -169,6 +170,80 @@ describe.sequential("Nanocodex Rivet Actors", () => {
     expect(completed.final_message).toBe("DETACHED_OK");
     expect((await session.status()).active_turns).not.toContain(request.id);
     expect(modelRequests).toBe(requestsAfterDetachedCompletion);
+  });
+
+  test("synchronizes accepted turns and durable results across connected clients", async (context) => {
+    resetMock();
+    configureApiKey();
+    responseDelayMs = 100;
+    const { client } = await setupTest(context, registry);
+    const session = client.nanocodex.getOrCreate([`multiclient-${crypto.randomUUID()}`]);
+    const first = session.connect();
+    const second = session.connect();
+    const firstAccepted: string[] = [];
+    const secondAccepted: string[] = [];
+    const firstCompleted: string[] = [];
+    const secondCompleted: string[] = [];
+    first.on("turnAccepted", (turn) => firstAccepted.push(`${turn.id}:${turn.input}`));
+    second.on("turnAccepted", (turn) => secondAccepted.push(`${turn.id}:${turn.input}`));
+    first.on("turnCompleted", (turn) => firstCompleted.push(`${turn.id}:${turn.final_message}`));
+    second.on("turnCompleted", (turn) => secondCompleted.push(`${turn.id}:${turn.final_message}`));
+    await Promise.all([first.ready, second.ready]);
+
+    const request = {
+      id: "shared-turn",
+      input: "Reply with exactly SYNC_OK",
+    };
+    await session.start(request);
+    await vi.waitFor(() => {
+      expect(firstAccepted).toEqual(["shared-turn:Reply with exactly SYNC_OK"]);
+      expect(secondAccepted).toEqual(firstAccepted);
+    });
+    expect(await session.status()).toMatchObject({
+      active_turns: [request.id],
+      active_turn_details: [request],
+    });
+
+    const completed = await session.prompt(request);
+    expect(completed.final_message).toBe("SYNC_OK");
+    await vi.waitFor(() => {
+      expect(firstCompleted).toEqual(["shared-turn:SYNC_OK"]);
+      expect(secondCompleted).toEqual(firstCompleted);
+    });
+    const requestsAfterCompletion = modelRequests;
+    expect((await session.prompt(request)).final_message).toBe("SYNC_OK");
+    expect(modelRequests).toBe(requestsAfterCompletion);
+    await Promise.all([first.dispose(), second.dispose()]);
+  });
+
+  test("reconstructs an active prompt for a client that reconnects mid-turn", async (context) => {
+    resetMock();
+    configureApiKey();
+    responseDelayMs = 1_000;
+    const { client } = await setupTest(context, registry);
+    const session = client.nanocodex.getOrCreate([`reconnect-${crypto.randomUUID()}`]);
+    const first = session.connect();
+    await first.ready;
+    const request = {
+      id: "reconnected-turn",
+      input: "Reply with exactly RECONNECTED_OK",
+    };
+    await session.start(request);
+    await first.dispose();
+
+    const reconnected = session.connect();
+    const completed: string[] = [];
+    reconnected.on("turnCompleted", (turn) => completed.push(`${turn.id}:${turn.final_message}`));
+    await reconnected.ready;
+    expect(await reconnected.status()).toMatchObject({
+      active_turns: [request.id],
+      active_turn_details: [request],
+    });
+    expect((await reconnected.prompt(request)).final_message).toBe("RECONNECTED_OK");
+    await vi.waitFor(() => {
+      expect(completed).toEqual(["reconnected-turn:RECONNECTED_OK"]);
+    });
+    await reconnected.dispose();
   });
 
   test("single-flights rotating subscription credentials and retries a rejected upgrade", async (context) => {

--- a/examples/rivet-actors/test/web-server.test.ts
+++ b/examples/rivet-actors/test/web-server.test.ts
@@ -22,6 +22,9 @@ describe("browser client", () => {
     expect(script.headers.get("content-type")).toContain("text/javascript");
     expect(source).toContain("localStorage");
     expect(source).toContain("URLSearchParams");
+    expect(source).toContain("turnAccepted");
+    expect(source).toContain("assistant.delta");
+    expect(source).toContain("storage");
     expect(source).not.toContain("OPENAI_API_KEY");
     expect(source).not.toContain("CHATGPT_ACCESS_TOKEN");
   });

--- a/examples/rivet-actors/web/app.ts
+++ b/examples/rivet-actors/web/app.ts
@@ -3,14 +3,18 @@ import { createClient } from "rivetkit/client";
 import type { registry } from "../src/registry.js";
 
 type PendingTurn = { id: string; input: string };
-type Message = { role: "you" | "agent" | "error"; text: string };
+type ActiveTurn = { id: string; input: string };
+type Message = { role: "you" | "agent" | "error"; text: string; turnId?: string };
 type WebState = {
   endpoint: string;
   actorKey: string;
   pending?: PendingTurn;
+  activeTurns: ActiveTurn[];
   messages: Message[];
 };
+
 const STORAGE_KEY = "nanocodex.rivet.web.v1";
+const MAX_STREAMED_TEXT_BYTES = 1024 * 1024;
 const byId = <T extends HTMLElement>(id: string) => document.getElementById(id) as T;
 const ui = {
   activity: byId<HTMLSpanElement>("activity"),
@@ -35,16 +39,13 @@ const requestedEndpoint = new URLSearchParams(location.search).get("endpoint")?.
 const defaultEndpoint = requestedEndpoint || (location.hostname === "127.0.0.1" || location.hostname === "localhost"
   ? "http://127.0.0.1:6420"
   : `${location.origin}/api/rivet`);
-let state = loadState() ?? {
-  endpoint: defaultEndpoint,
-  actorKey: crypto.randomUUID(),
-  messages: [],
-};
+let state = loadState() ?? freshState(defaultEndpoint);
 if (requestedEndpoint) state.endpoint = requestedEndpoint;
 let client: NanocodexClient | undefined;
 let connection: Connection | undefined;
 let generation = 0;
 let eventCount = 0;
+let streamedText = "";
 
 ui.endpoint.value = state.endpoint;
 ui.actorKey.value = state.actorKey;
@@ -52,14 +53,14 @@ renderMessages();
 saveState();
 void connect();
 
+window.addEventListener("storage", (event) => {
+  if (event.key === STORAGE_KEY) syncStoredState(event.newValue);
+});
 ui.connect.addEventListener("click", () => void connect());
 ui.newActor.addEventListener("click", () => {
   void detach();
-  state = {
-    endpoint: ui.endpoint.value.trim() || defaultEndpoint,
-    actorKey: crypto.randomUUID(),
-    messages: [],
-  };
+  state = freshState(ui.endpoint.value.trim() || defaultEndpoint);
+  streamedText = "";
   ui.actorKey.value = state.actorKey;
   ui.actor.textContent = "not resolved";
   saveState();
@@ -73,11 +74,11 @@ ui.form.addEventListener("submit", (event) => {
   if (!input) return setActivity("prompt is empty", true);
   if (!connection) return setActivity("connect to the actor first", true);
   if (state.pending) return setActivity("one durable turn is already pending", true);
-  state.pending = { id: crypto.randomUUID(), input };
-  state.messages.push({ role: "you", text: input });
+  const pending = { id: crypto.randomUUID(), input };
+  state.pending = pending;
+  observeTurn(pending.id, pending.input);
   ui.input.value = "";
   saveState();
-  renderMessages();
   void runPending(connection, generation);
 });
 
@@ -89,6 +90,8 @@ async function connect(): Promise<void> {
   state.endpoint = endpoint.replace(/\/$/, "");
   state.actorKey = actorKey;
   saveState();
+  eventCount = 0;
+  streamedText = "";
   setStatus("connecting", "warn");
   const activeGeneration = ++generation;
   try {
@@ -96,11 +99,31 @@ async function connect(): Promise<void> {
     const handle = client.nanocodex.getOrCreate([state.actorKey]);
     const nextConnection = handle.connect();
     connection = nextConnection;
+    nextConnection.on("turnAccepted", (accepted) => {
+      if (activeGeneration !== generation) return;
+      observeTurn(accepted.id, accepted.input);
+      setStatus(accepted.replayed ? "resuming" : "running", "ok");
+      setActivity((accepted.replayed ? "rejoined " : "started ") + shortId(accepted.id));
+    });
     nextConnection.on("agentEvent", (event) => {
       if (activeGeneration !== generation) return;
       eventCount += 1;
       const kind = event && typeof event === "object" && "type" in event ? String(event.type) : "agent event";
+      const delta = kind === "assistant.delta"
+        && event.payload && typeof event.payload === "object" && "text" in event.payload
+        ? event.payload.text
+        : undefined;
+      if (typeof delta === "string") {
+        streamedText = (streamedText + delta).slice(-MAX_STREAMED_TEXT_BYTES);
+        renderMessages();
+      }
       setActivity(kind + " · " + eventCount + " events");
+    });
+    nextConnection.on("turnCompleted", (completed) => {
+      if (activeGeneration === generation) completeTurn(completed.id, completed.final_message);
+    });
+    nextConnection.on("turnFailed", (failed) => {
+      if (activeGeneration === generation) failTurn(failed.id, failed.error);
     });
     nextConnection.onStatusChange((status) => {
       if (activeGeneration === generation) setStatus(status, status === "connected" ? "ok" : "warn");
@@ -109,7 +132,8 @@ async function connect(): Promise<void> {
     const [actorId, sessionStatus] = await Promise.all([handle.resolve(), nextConnection.status()]);
     if (activeGeneration !== generation) return;
     ui.actor.textContent = actorId;
-    setStatus("ready", "ok");
+    for (const turn of sessionStatus.active_turn_details) observeTurn(turn.id, turn.input);
+    setStatus(sessionStatus.active_turns.length > 0 ? "running" : "ready", "ok");
     setActivity(sessionStatus.completed_turns + " committed turns");
     if (state.pending) void runPending(nextConnection, activeGeneration);
   } catch (error) {
@@ -126,24 +150,13 @@ async function runPending(active: Connection, activeGeneration: number): Promise
   try {
     const accepted = await active.start(pending);
     if (activeGeneration !== generation) return;
+    observeTurn(accepted.id, accepted.input);
     setStatus(accepted.replayed ? "resuming" : "running", "ok");
     setActivity((accepted.replayed ? "rejoined " : "started ") + shortId(pending.id) + "; detach any time");
     const completed = await active.prompt(pending);
-    if (activeGeneration !== generation || state.pending?.id !== completed.id) return;
-    state.messages.push({ role: "agent", text: completed.final_message });
-    delete state.pending;
-    saveState();
-    renderMessages();
-    setStatus("ready", "ok");
-    setActivity("committed durably · " + eventCount + " events");
+    if (activeGeneration === generation) completeTurn(completed.id, completed.final_message);
   } catch (error) {
-    if (activeGeneration !== generation) return;
-    state.messages.push({ role: "error", text: errorMessage(error) });
-    delete state.pending;
-    saveState();
-    renderMessages();
-    setStatus("failed", "bad");
-    setActivity(errorMessage(error), true);
+    if (activeGeneration === generation) failTurn(pending.id, errorMessage(error));
   }
 }
 
@@ -155,17 +168,57 @@ async function detach(showMessage = true): Promise<void> {
   client = undefined;
   await Promise.allSettled([oldConnection?.dispose(), oldClient?.dispose()]);
   if (showMessage) {
-    setStatus(state.pending ? "detached · resumable" : "detached", "warn");
+    setStatus(state.pending || state.activeTurns.length > 0 ? "detached · resumable" : "detached", "warn");
     setActivity("safe to close; inference and state remain with the actor");
   }
 }
 
+function observeTurn(id: string, input: string): void {
+  const current = state.activeTurns.find((turn) => turn.id === id);
+  if (current) current.input = input;
+  else state.activeTurns.push({ id, input });
+  if (!hasMessage("you", id)) state.messages.push({ role: "you", text: input, turnId: id });
+  saveState();
+  renderMessages();
+}
+
+function completeTurn(id: string, finalMessage: string): void {
+  finishTurn(id);
+  if (!hasMessage("agent", id)) {
+    state.messages.push({ role: "agent", text: finalMessage, turnId: id });
+  }
+  streamedText = "";
+  saveState();
+  renderMessages();
+  setStatus(state.activeTurns.length > 0 ? "running" : "ready", "ok");
+  setActivity("committed durably · " + eventCount + " events");
+}
+
+function failTurn(id: string, error: string): void {
+  finishTurn(id);
+  if (!hasMessage("error", id)) state.messages.push({ role: "error", text: error, turnId: id });
+  streamedText = "";
+  saveState();
+  renderMessages();
+  setStatus("failed", "bad");
+  setActivity(error, true);
+}
+
+function finishTurn(id: string): void {
+  if (state.pending?.id === id) delete state.pending;
+  state.activeTurns = state.activeTurns.filter((turn) => turn.id !== id);
+}
+
+function hasMessage(role: Message["role"], id: string): boolean {
+  return state.messages.some((message) => message.role === role && message.turnId === id);
+}
+
 function renderMessages(): void {
   ui.transcript.replaceChildren();
-  if (!state.messages.length) {
+  if (!state.messages.length && !streamedText) {
     const empty = document.createElement("article");
     empty.className = "system";
-    empty.textContent = "Send a prompt, detach during inference, then reload to rejoin the idempotent turn.";
+    empty.textContent = "Open this actor in another tab to watch prompts, streaming output, and durable results stay synchronized.";
     ui.transcript.append(empty);
   }
   for (const message of state.messages) {
@@ -178,28 +231,73 @@ function renderMessages(): void {
     article.append(label, text);
     ui.transcript.append(article);
   }
+  if (streamedText) {
+    const article = document.createElement("article");
+    article.className = "agent live";
+    const label = document.createElement("strong");
+    label.textContent = "agent · live";
+    const text = document.createElement("div");
+    text.textContent = streamedText;
+    article.append(label, text);
+    ui.transcript.append(article);
+  }
   ui.transcript.scrollTop = ui.transcript.scrollHeight;
 }
 
+function freshState(endpoint: string): WebState {
+  return {
+    endpoint,
+    actorKey: crypto.randomUUID(),
+    activeTurns: [],
+    messages: [],
+  };
+}
+
 function loadState(): WebState | undefined {
+  return parseStoredState(localStorage.getItem(STORAGE_KEY));
+}
+
+function parseStoredState(encoded: string | null): WebState | undefined {
   try {
-    const value = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "null") as Partial<WebState> | null;
+    const value = JSON.parse(encoded ?? "null") as Partial<WebState> | null;
     if (!value || typeof value.endpoint !== "string" || typeof value.actorKey !== "string") return undefined;
+    const pending = value.pending;
     return {
       endpoint: value.endpoint,
       actorKey: value.actorKey,
-      messages: Array.isArray(value.messages) ? value.messages.slice(-50) : [],
-      ...(value.pending && typeof value.pending.id === "string" && typeof value.pending.input === "string"
-        ? { pending: value.pending }
-        : {}),
+      activeTurns: Array.isArray(value.activeTurns)
+        ? value.activeTurns.filter(isTurn).slice(-16)
+        : [],
+      messages: Array.isArray(value.messages)
+        ? value.messages.filter(isMessage).slice(-50)
+        : [],
+      ...(pending && isTurn(pending) ? { pending } : {}),
     };
   } catch {
     return undefined;
   }
 }
 
+function syncStoredState(encoded: string | null): void {
+  const incoming = parseStoredState(encoded);
+  if (!incoming) return;
+  const previousPendingId = state.pending?.id;
+  const changedActor = incoming.endpoint !== state.endpoint || incoming.actorKey !== state.actorKey;
+  state = incoming;
+  ui.endpoint.value = state.endpoint;
+  ui.actorKey.value = state.actorKey;
+  renderMessages();
+  if (changedActor) {
+    ui.actor.textContent = "not resolved";
+    void connect();
+  } else if (previousPendingId !== state.pending?.id && connection) {
+    void runPending(connection, generation);
+  }
+}
+
 function saveState(): void {
   state.messages = state.messages.slice(-50);
+  state.activeTurns = state.activeTurns.slice(-16);
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
   } catch {
@@ -209,6 +307,19 @@ function saveState(): void {
     }));
     localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
   }
+}
+
+function isTurn(value: unknown): value is ActiveTurn {
+  return Boolean(value && typeof value === "object"
+    && "id" in value && typeof value.id === "string"
+    && "input" in value && typeof value.input === "string");
+}
+
+function isMessage(value: unknown): value is Message {
+  if (!value || typeof value !== "object") return false;
+  if (!("role" in value) || !["you", "agent", "error"].includes(String(value.role))) return false;
+  if (!("text" in value) || typeof value.text !== "string") return false;
+  return !("turnId" in value) || value.turnId === undefined || typeof value.turnId === "string";
 }
 
 function setStatus(text: string, tone?: "ok" | "warn" | "bad"): void {

--- a/examples/rivet-actors/web/index.html
+++ b/examples/rivet-actors/web/index.html
@@ -19,7 +19,7 @@
       <button id="new-actor" type="button" class="secondary">New actor</button>
       <button id="detach" type="button" class="secondary">Detach</button>
     </section>
-    <p class="meta">Actor <code id="actor">not resolved</code>. This page persists only endpoint, actor key, transcript, and unfinished turn ID—not model credentials or agent state.</p>
+    <p class="meta">Actor <code id="actor">not resolved</code>. Open the same actor key in another tab to synchronize prompts, streaming output, and durable results. This page never stores model credentials or agent state.</p>
     <section id="transcript" class="transcript" aria-live="polite"></section>
     <form id="prompt-form">
       <textarea id="prompt" rows="3" maxlength="1048576" placeholder="Ask the durable actor…" required></textarea>


### PR DESCRIPTION
## Summary

- broadcast accepted prompts with inputs and expose active-turn details for reconnecting clients
- reconcile accepted/completed/failed turns and assistant deltas across browser tabs and devices
- synchronize browser-local durable state across tabs and add a hosted multiclient smoke driver

## Validation

- `npm run check --prefix examples/rivet-actors` (11 tests)
- `npm run build --prefix examples/rivet-actors`
- deterministic two-client fanout and mid-turn reconnect coverage