### PR TITLE
tools: align Code Mode contracts with Codex

### DIFF
--- a/bin/nanocodex/src/mcp.rs
+++ b/bin/nanocodex/src/mcp.rs
@@ -711,7 +711,7 @@ mod tests {
     use nanocodex::{oai::MODEL, tools::ToolContext};
     use nanocodex_observability::{LogFormat, LogOutput, ObservabilityBuilder};
     use nanocodex_tools::{
-        ToolInput, Tools,
+        ToolExposure, ToolInput, Tools,
         contract::DEFAULT_TOOL_OUTPUT_TOKENS,
         runtime::{DynamicToolProvider, ToolRuntime},
     };
@@ -803,7 +803,11 @@ enabled = false
         let mut args = args();
         args.mcp_codex_config = true;
         let mcp = args.build(codex_home.path()).unwrap().unwrap();
-        let tools = Tools::builder().provider(mcp.provider).build().unwrap();
+        let tools = Tools::builder()
+            .exposure(ToolExposure::DirectAndCodeMode)
+            .provider(mcp.provider)
+            .build()
+            .unwrap();
         let encoded = serde_json::to_string(
             &ToolRuntime::new_with_tools(".", None, None, &tools).model_specs("test-session"),
         )
@@ -1110,7 +1114,7 @@ tool_timeout_sec = 9.5
     }
 
     #[tokio::test]
-    async fn defaults_add_only_deferred_search_to_the_initial_tool_context() {
+    async fn defaults_keep_mcp_tool_schemas_deferred_in_code_mode_only() {
         let baseline_tools = Tools::builder().build().unwrap();
         let baseline = serde_json::to_vec(
             &ToolRuntime::new_with_tools(".", None, None, &baseline_tools)
@@ -1127,10 +1131,11 @@ tool_timeout_sec = 9.5
         .unwrap();
         let encoded = String::from_utf8(with_defaults.clone()).unwrap();
 
-        assert!(encoded.contains("tool_search"));
-        assert!(encoded.contains("openaiDeveloperDocs"));
-        assert!(encoded.contains("tempo"));
-        assert!(encoded.contains("cloudflare"));
+        assert!(encoded.contains("\"type\":\"tool_search\""));
+        assert!(encoded.contains("Some deferred nested tools may be omitted"));
+        assert!(encoded.contains("list_mcp_resource_templates"));
+        assert!(encoded.contains("list_mcp_resources"));
+        assert!(encoded.contains("read_mcp_resource"));
         assert!(!encoded.contains("mcp__openaiDeveloperDocs__"));
         assert!(!encoded.contains("mcp__tempo__"));
         assert!(!encoded.contains("mcp__cloudflare__"));

--- a/crates/experimental/nanocodex-browser/src/tests.rs
+++ b/crates/experimental/nanocodex-browser/src/tests.rs
@@ -355,15 +355,16 @@ async fn deferred_browser_is_discoverable_without_model_schema_bytes() -> Result
             r#"
 const browser = ALL_TOOLS.find((tool) => tool.name === "browser");
 if (!browser) throw new Error("browser metadata missing");
-const schema = JSON.stringify(browser.input_schema);
+if (typeof browser.description !== "string") {
+  throw new Error("browser description missing");
+}
 const opened = await tools[browser.name]({
   action: "open",
   url: "https://example.com"
 });
 text({
   name: browser.name,
-  hasOpen: schema.includes('"open"'),
-  hasSnapshot: schema.includes('"snapshot"'),
+  hasDescription: browser.description.length > 0,
   opened
 });
 "#,
@@ -375,8 +376,7 @@ text({
     assert_eq!(execution.nested_calls.len(), 1);
     let output: Value = serde_json::from_str(execution_text(&execution.output)?)?;
     assert_eq!(output["name"], "browser");
-    assert_eq!(output["hasOpen"], true);
-    assert_eq!(output["hasSnapshot"], true);
+    assert_eq!(output["hasDescription"], true);
     assert_eq!(output["opened"]["action"], "open");
     assert_eq!(recording.actions()?.len(), 1);
     Ok(())

--- a/crates/nanocodex-agent/src/model/run/responses.rs
+++ b/crates/nanocodex-agent/src/model/run/responses.rs
@@ -134,18 +134,12 @@ where
 }
 
 pub(super) fn unsupported_tool_message(tools: &ToolRuntime, call: &CodeCall) -> Option<String> {
-    if call.namespace.is_none() && matches!(call.name.as_str(), "exec" | "wait") {
-        return None;
-    }
-    if matches!(call.kind, CodeCallKind::Function) && tools.contains(&qualified_tool_name(call)) {
-        return None;
-    }
-    if call.namespace.is_some() && matches!(call.kind, CodeCallKind::Function) {
-        let qualified_name = qualified_tool_name(call);
-        return (!tools.contains(&qualified_name))
-            .then(|| format!("unsupported call: {qualified_name}"));
-    }
     let qualified_name = qualified_tool_name(call);
+    if (call.namespace.is_none() && matches!(call.name.as_str(), "exec" | "wait"))
+        || tools.contains(&qualified_name)
+    {
+        return None;
+    }
     Some(match &call.kind {
         CodeCallKind::Custom => format!("unsupported custom tool call: {qualified_name}"),
         CodeCallKind::Function => format!("unsupported call: {qualified_name}"),
@@ -154,7 +148,14 @@ pub(super) fn unsupported_tool_message(tools: &ToolRuntime, call: &CodeCall) -> 
 }
 
 pub(super) fn qualified_tool_name(call: &CodeCall) -> String {
-    format!("{}{}", call.namespace.as_deref().unwrap_or(""), call.name)
+    let Some(namespace) = call.namespace.as_deref() else {
+        return call.name.clone();
+    };
+    if namespace.ends_with('_') || call.name.starts_with('_') {
+        format!("{namespace}{}", call.name)
+    } else {
+        format!("{namespace}__{}", call.name)
+    }
 }
 
 pub(super) fn trace_model_input(request: &ResponsesAttempt) -> (usize, usize, Option<String>) {

--- a/crates/nanocodex-agent/src/model/run/tool_calls.rs
+++ b/crates/nanocodex-agent/src/model/run/tool_calls.rs
@@ -437,7 +437,11 @@ where
                 response_items: vec![response_item],
             });
         }
-        if matches!(call.kind, CodeCallKind::Function) && tools.contains(&qualified_name) {
+        let code_mode_entrypoint =
+            call.namespace.is_none() && matches!(call.name.as_str(), "exec" | "wait");
+        if !code_mode_entrypoint
+            && matches!(call.kind, CodeCallKind::Function | CodeCallKind::Custom)
+        {
             let context = ToolContext::new(
                 model.as_str(),
                 session_id,
@@ -445,17 +449,33 @@ where
                 &[],
                 DEFAULT_TOOL_OUTPUT_TOKENS,
             );
-            let execution = match RawValue::from_string(call.input.clone()) {
-                Ok(input) => {
+            let mut execution = match call.kind {
+                CodeCallKind::Function => match RawValue::from_string(call.input.clone()) {
+                    Ok(input) => {
+                        tools
+                            .execute_tool(&qualified_name, ToolInput::Function(input), context)
+                            .instrument(tool_span.clone())
+                            .await
+                    }
+                    Err(error) => ToolOutput::error(format!(
+                        "failed to encode {qualified_name} arguments: {error}"
+                    )),
+                },
+                CodeCallKind::Custom => {
                     tools
-                        .execute_tool(&qualified_name, ToolInput::Function(input), context)
+                        .execute_tool(
+                            &qualified_name,
+                            ToolInput::Freeform(call.input.clone()),
+                            context,
+                        )
                         .instrument(tool_span.clone())
                         .await
                 }
-                Err(error) => ToolOutput::error(format!(
-                    "failed to encode {qualified_name} arguments: {error}"
-                )),
+                CodeCallKind::ToolSearch => {
+                    unreachable!("tool search is not an ordinary direct tool")
+                }
             };
+            prepare_output_images(&mut execution.output).await;
             if let Some(content) = serialize_trace_content(&execution.output) {
                 record_span_content(tool_span, "tool.output", &content);
             }
@@ -469,7 +489,17 @@ where
                 success: execution.success,
                 duration_ns,
                 work_duration_ns: 0,
-                response_items: vec![function_tool_output(call.call_id, execution.output.clone())],
+                response_items: vec![match call.kind {
+                    CodeCallKind::Function => {
+                        function_tool_output(call.call_id, execution.output.clone())
+                    }
+                    CodeCallKind::Custom => {
+                        custom_tool_output(call.call_id, execution.output.clone())
+                    }
+                    CodeCallKind::ToolSearch => {
+                        unreachable!("tool search is not an ordinary direct tool")
+                    }
+                }],
                 output: execution.output,
                 metadata: execution.metadata,
             });

--- a/crates/nanocodex-agent/tests/it/model/tools/mod.rs
+++ b/crates/nanocodex-agent/tests/it/model/tools/mod.rs
@@ -5,6 +5,223 @@ mod panic;
 mod parallel;
 
 struct NativeToolSearch;
+struct NamespacedEcho;
+
+#[nanocodex_tools::contract::async_trait]
+impl nanocodex_tools::Tool for NamespacedEcho {
+    fn definition(&self) -> nanocodex_tools::ToolDefinition {
+        nanocodex_tools::ToolDefinition::function(
+            "test_namespace__echo",
+            "Echo one value.",
+            json!({
+                "type": "object",
+                "properties": {"value": {"type": "string"}},
+                "required": ["value"],
+                "additionalProperties": false
+            }),
+        )
+    }
+
+    async fn execute(
+        &self,
+        input: nanocodex_tools::ToolInput,
+        _context: nanocodex_tools::ToolContext<'_>,
+    ) -> nanocodex_tools::ToolResult {
+        let arguments: Value = input.decode_json()?;
+        Ok(nanocodex_tools::ToolOutput::text(
+            arguments["value"].as_str().unwrap_or_default(),
+        ))
+    }
+}
+
+#[tokio::test]
+async fn normal_code_mode_executes_direct_function_and_custom_tools() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("ws://{}", listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await?;
+        let mut socket = accept_async(stream).await?;
+
+        let warmup = next_json(&mut socket).await?;
+        let visible_tools = warmup["input"][0]["tools"]
+            .as_array()
+            .ok_or_else(|| eyre!("warmup tools were not an array"))?;
+        let names = visible_tools
+            .iter()
+            .filter_map(|definition| definition["name"].as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            [
+                "exec",
+                "wait",
+                "exec_command",
+                "write_stdin",
+                "update_plan",
+                "apply_patch",
+                "view_image",
+                "web",
+                "image_gen",
+                "test_namespace",
+            ]
+        );
+        let exec = visible_tools
+            .iter()
+            .find(|definition| definition["name"] == "exec")
+            .unwrap();
+        assert!(
+            !exec["description"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("### `update_plan`")
+        );
+        let update_plan = visible_tools
+            .iter()
+            .find(|definition| definition["name"] == "update_plan")
+            .unwrap();
+        assert!(
+            update_plan["description"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("exec tool declaration:")
+        );
+        let exec_command = visible_tools
+            .iter()
+            .find(|definition| definition["name"] == "exec_command")
+            .unwrap();
+        assert!(exec_command.get("output_schema").is_none());
+        let image_gen = visible_tools
+            .iter()
+            .find(|definition| definition["name"] == "image_gen")
+            .unwrap();
+        assert_eq!(image_gen["type"], "namespace");
+        assert_eq!(
+            image_gen["description"],
+            "Tools in the image_gen namespace."
+        );
+        assert_eq!(image_gen["tools"][0]["name"], "imagegen");
+        assert!(
+            image_gen["tools"][0]
+                .pointer("/parameters/properties/referenced_image_paths/maxItems")
+                .is_none()
+        );
+        assert!(
+            image_gen["tools"][0]["description"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("image_gen__imagegen(args:")
+        );
+        send_warmup(&mut socket, "resp-warmup").await?;
+
+        let generation = next_json(&mut socket).await?;
+        assert_eq!(generation["previous_response_id"], "resp-warmup");
+        send_json(
+            &mut socket,
+            completed_response(
+                "resp-direct-tools",
+                &[
+                    json!({
+                        "type": "function_call",
+                        "call_id": "call-plan",
+                        "name": "update_plan",
+                        "arguments": "{\"plan\":[{\"step\":\"exercise direct tools\",\"status\":\"completed\"}]}"
+                    }),
+                    json!({
+                        "type": "custom_tool_call",
+                        "call_id": "call-patch",
+                        "name": "apply_patch",
+                        "input": "*** Begin Patch\n*** Add File: direct-tool.txt\n+direct dispatch worked\n*** End Patch"
+                    }),
+                    json!({
+                        "type": "function_call",
+                        "call_id": "call-namespaced",
+                        "namespace": "test_namespace",
+                        "name": "echo",
+                        "arguments": "{\"value\":\"namespaced direct dispatch worked\"}"
+                    }),
+                    json!({
+                        "type": "function_call",
+                        "call_id": "call-shell",
+                        "name": "exec_command",
+                        "arguments": "{\"cmd\":\"printf direct-shell-dispatch-worked\",\"login\":false}"
+                    }),
+                ],
+            ),
+        )
+        .await?;
+
+        let continuation = next_json(&mut socket).await?;
+        assert_eq!(continuation["previous_response_id"], "resp-direct-tools");
+        let input = continuation["input"]
+            .as_array()
+            .ok_or_else(|| eyre!("continuation input was not an array"))?;
+        assert_eq!(input[0]["type"], "function_call_output");
+        assert_eq!(input[0]["call_id"], "call-plan");
+        assert_eq!(input[1]["type"], "custom_tool_call_output");
+        assert_eq!(input[1]["call_id"], "call-patch");
+        assert!(
+            !input[1]["output"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("unsupported"),
+            "{continuation}"
+        );
+        assert_eq!(input[2]["type"], "function_call_output");
+        assert_eq!(input[2]["call_id"], "call-namespaced");
+        assert_eq!(input[2]["output"], "namespaced direct dispatch worked");
+        assert_eq!(input[3]["type"], "function_call_output");
+        assert_eq!(input[3]["call_id"], "call-shell");
+        let shell_output = input[3]["output"]
+            .as_str()
+            .ok_or_else(|| eyre!("direct shell output was not text"))?;
+        assert!(shell_output.starts_with("Chunk ID: "), "{shell_output}");
+        assert!(shell_output.contains("\nWall time: "), "{shell_output}");
+        assert!(
+            shell_output.contains("\nProcess exited with code 0\n"),
+            "{shell_output}"
+        );
+        assert!(
+            shell_output.ends_with("\nOutput:\ndirect-shell-dispatch-worked"),
+            "{shell_output}"
+        );
+        send_final(&mut socket, "resp-final").await
+    });
+
+    let workspace = temporary_workspace("normal-code-mode-direct-tools")?;
+    let tools = Tools::builder()
+        .exposure(nanocodex_tools::ToolExposure::DirectAndCodeMode)
+        .tool(NamespacedEcho)
+        .build()?;
+    let openai = OpenAi::builder("test-key")
+        .websocket_url(&endpoint)
+        .build()?;
+    let (agent, events) = Nanocodex::builder(openai)
+        .thinking(Thinking::Low)
+        .workspace(&workspace)
+        .session_id(test_session_id())
+        .tools(tools)
+        .build()?;
+    let turn = agent.prompt("Use the direct tools.").await?;
+    drop(agent);
+    let mut output = Vec::new();
+    let (event_result, turn_result) = tokio::join!(events.write_jsonl(&mut output), turn.result());
+    event_result?;
+    turn_result?;
+    timeout(std::time::Duration::from_secs(5), server)
+        .await
+        .map_err(|_| eyre!("mock Responses server did not finish"))???;
+    assert_eq!(
+        std::fs::read_to_string(workspace.join("direct-tool.txt"))?,
+        "direct dispatch worked\n"
+    );
+    let output = String::from_utf8(output)?;
+    assert!(output.contains(r#""tool":"update_plan""#));
+    assert!(output.contains(r#""tool":"apply_patch""#));
+    assert!(output.contains(r#""tool":"test_namespace__echo""#));
+    assert!(output.contains(r#""tool":"exec_command""#));
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
 
 #[nanocodex_tools::contract::async_trait]
 impl nanocodex_tools::Tool for NativeToolSearch {
@@ -301,7 +518,10 @@ async fn mcp_tool_search_exposes_and_dispatches_a_native_namespace() -> Result<(
         )
         .build()?;
     let workspace = temporary_workspace("mcp-native-tool-search")?;
-    let tools = Tools::builder().provider(mcp).build()?;
+    let tools = Tools::builder()
+        .exposure(nanocodex_tools::ToolExposure::DirectAndCodeMode)
+        .provider(mcp)
+        .build()?;
     let openai = OpenAi::builder("test-key")
         .websocket_url(&endpoint)
         .build()?;
@@ -457,7 +677,7 @@ async fn unsupported_direct_tools_return_failed_results_to_the_model() -> Result
         assert_eq!(input[1]["call_id"], "call-function");
         assert_eq!(
             input[1]["output"],
-            "unsupported call: example::missing_function"
+            "unsupported call: example::__missing_function"
         );
         assert_client_item_id(&input[1], "fco");
         send_final(&mut socket, "resp-final").await

--- a/crates/nanocodex-oai-api/README.md
+++ b/crates/nanocodex-oai-api/README.md
@@ -193,6 +193,12 @@ that batteries-included composition. Consumers implementing their own loop can
 install definitions with [`SessionBuilder::tool_definitions`] and return paired
 tool outputs with [`session::ResponseInput::items`].
 
+[`tools::ToolDefinition::namespace`] represents the provider-native Responses
+namespace shape for related function tools. Function output schemas remain
+client-owned execution metadata: they are available through
+[`tools::ToolDefinition::output_schema`] for Code Mode declarations but are not
+serialized into the provider's function declaration.
+
 ## Going lower level
 
 The crate root keeps the normal conversation path and shared input policy

--- a/crates/nanocodex-oai-api/src/responses/tool.rs
+++ b/crates/nanocodex-oai-api/src/responses/tool.rs
@@ -17,9 +17,21 @@ pub enum ToolDefinition {
         strict: bool,
         /// JSON Schema accepted as function arguments.
         parameters: JsonSchema,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[serde(skip)]
         /// Optional JSON Schema produced by the function.
+        ///
+        /// This is client-owned Code Mode metadata and is not part of the
+        /// Responses tool declaration sent to the model.
         output_schema: Option<JsonSchema>,
+    },
+    /// Responses namespace containing related function tools.
+    Namespace {
+        /// Model-visible namespace name.
+        name: Box<str>,
+        /// Guidance describing the namespace as a whole.
+        description: Box<str>,
+        /// Function declarations exposed under this namespace.
+        tools: Vec<Self>,
     },
     /// Free-form custom tool constrained by a grammar.
     Custom {
@@ -93,6 +105,20 @@ impl ToolDefinition {
         }
     }
 
+    /// Creates a Responses namespace from function tool declarations.
+    #[must_use]
+    pub fn namespace(
+        name: impl Into<Box<str>>,
+        description: impl Into<Box<str>>,
+        tools: impl IntoIterator<Item = Self>,
+    ) -> Self {
+        Self::Namespace {
+            name: name.into(),
+            description: description.into(),
+            tools: tools.into_iter().collect(),
+        }
+    }
+
     /// Creates a provider-native deferred-tool search definition.
     ///
     /// ```
@@ -150,7 +176,9 @@ impl ToolDefinition {
     #[must_use]
     pub fn name(&self) -> &str {
         match self {
-            Self::Function { name, .. } | Self::Custom { name, .. } => name,
+            Self::Function { name, .. }
+            | Self::Namespace { name, .. }
+            | Self::Custom { name, .. } => name,
             Self::ToolSearch { .. } => "tool_search",
         }
     }
@@ -159,7 +187,9 @@ impl ToolDefinition {
     #[must_use]
     pub fn description(&self) -> &str {
         match self {
-            Self::Function { description, .. } | Self::Custom { description, .. } => description,
+            Self::Function { description, .. }
+            | Self::Namespace { description, .. }
+            | Self::Custom { description, .. } => description,
             Self::ToolSearch { description, .. } => description,
         }
     }
@@ -171,7 +201,7 @@ impl ToolDefinition {
             Self::Function { parameters, .. } | Self::ToolSearch { parameters, .. } => {
                 Some(parameters)
             }
-            Self::Custom { .. } => None,
+            Self::Namespace { .. } | Self::Custom { .. } => None,
         }
     }
 
@@ -180,7 +210,7 @@ impl ToolDefinition {
     pub const fn output_schema(&self) -> Option<&JsonSchema> {
         match self {
             Self::Function { output_schema, .. } => output_schema.as_ref(),
-            Self::Custom { .. } | Self::ToolSearch { .. } => None,
+            Self::Namespace { .. } | Self::Custom { .. } | Self::ToolSearch { .. } => None,
         }
     }
 }
@@ -252,6 +282,46 @@ mod tests {
     use serde_json::json;
 
     use super::{JsonSchema, ToolDefinition};
+
+    #[test]
+    fn namespace_serializes_function_children_without_client_output_metadata() {
+        let definition = ToolDefinition::namespace(
+            "image_gen",
+            "Tools in the image_gen namespace.",
+            [ToolDefinition::function(
+                "imagegen",
+                "Generate an image.",
+                json!({
+                    "type": "object",
+                    "properties": {"prompt": {"type": "string"}},
+                    "required": ["prompt"],
+                    "additionalProperties": false
+                }),
+            )
+            .with_output_schema(json!({"type": "object"}))],
+        );
+
+        assert_eq!(
+            serde_json::to_value(definition).unwrap(),
+            json!({
+                "type": "namespace",
+                "name": "image_gen",
+                "description": "Tools in the image_gen namespace.",
+                "tools": [{
+                    "type": "function",
+                    "name": "imagegen",
+                    "description": "Generate an image.",
+                    "strict": false,
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"prompt": {"type": "string"}},
+                        "required": ["prompt"],
+                        "additionalProperties": false
+                    }
+                }]
+            })
+        );
+    }
 
     #[test]
     fn tool_search_serializes_the_provider_native_shape() {

--- a/crates/nanocodex-tools/README.md
+++ b/crates/nanocodex-tools/README.md
@@ -138,12 +138,12 @@ let tools = Tools::builder().provider(mcp).build()?;
 # }
 ```
 
-Handshakes and discovery start with the owning runtime. Under
-`DirectAndCodeMode`, `mcp::Mcp` initially exposes the provider-native
-`tool_search`; Code Mode-only discovers the same deferred tools through
-`ALL_TOOLS`. Search results contain loadable MCP namespaces for direct model
-calls and also activate matching Code Mode definitions, keeping large catalogs
-out of the initial tool list.
+Handshakes and discovery start with the owning runtime. Both exposure policies
+keep the provider-native `tool_search` visible while omitting deferred MCP
+schemas from the initial request. Code Mode lists those deferred tools as
+compact name/description entries in `ALL_TOOLS`. Search results contain
+loadable MCP namespaces for direct model calls and also activate matching Code
+Mode definitions, keeping large catalogs out of the initial tool list.
 
 ## Companion workspace runtimes
 

--- a/crates/nanocodex-tools/README.md
+++ b/crates/nanocodex-tools/README.md
@@ -34,6 +34,30 @@ let tools = Tools::builder()
 # }
 ```
 
+`Tools` defaults to `ToolExposure::CodeModeOnly`, where ordinary tools are
+available through `exec` and only Code Mode entrypoints are directly visible.
+Select `ToolExposure::DirectAndCodeMode` when a consumer needs the same
+ordinary tools directly as well as through `exec`:
+
+```rust
+use nanocodex_tools::{ToolExposure, Tools};
+
+# fn build() -> Result<(), nanocodex_tools::ToolsBuildError> {
+let tools = Tools::builder()
+    .exposure(ToolExposure::DirectAndCodeMode)
+    .build()?;
+# Ok(())
+# }
+```
+
+Matching Codex, direct-plus-Code-Mode exposure keeps `exec` terse and
+adds each typed `exec` declaration to the corresponding direct tool; Code
+Mode-only instead carries the complete nested catalog in `exec`. Selection
+changes model-visible exposure, not registration or dispatch behavior.
+Namespaced Code Mode names such as `image_gen__imagegen` remain available to
+`exec`; normal Code Mode exposes the Codex-compatible `image_gen.imagegen`
+Responses namespace and routes its namespaced call to the same handler.
+
 Macro tools execute serially unless `parallel = true` explicitly marks their
 local effects as safe to overlap. This does not change the provider wire
 protocol.
@@ -114,10 +138,12 @@ let tools = Tools::builder().provider(mcp).build()?;
 # }
 ```
 
-Handshakes and discovery start with the owning runtime. `mcp::Mcp` exposes only
-the provider-native `tool_search` initially. Search results contain loadable MCP
-namespaces for direct model calls and also activate the matching definitions for
-Code Mode, keeping large catalogs out of the initial tool list.
+Handshakes and discovery start with the owning runtime. Under
+`DirectAndCodeMode`, `mcp::Mcp` initially exposes the provider-native
+`tool_search`; Code Mode-only discovers the same deferred tools through
+`ALL_TOOLS`. Search results contain loadable MCP namespaces for direct model
+calls and also activate matching Code Mode definitions, keeping large catalogs
+out of the initial tool list.
 
 ## Companion workspace runtimes
 
@@ -134,8 +160,9 @@ tool implementation or an alternate mode for normal native applications.
 ## Going lower level
 
 The crate root intentionally contains only the normal registry path:
-[`Tools`], `ToolsBuilder`, `ToolsBuildError`, [`Tool`], `tool`, and the
-types required by the `Tool` methods, plus
+[`Tools`], `ToolsBuilder`, `ToolsBuildError`, [`Tool`], `tool`, and the types
+required by the `Tool` methods. [`ToolExposure`] is the advanced declaration
+policy for consumers that compare direct and Code Mode calls. The root also exposes
 [`ambient_sensitive_environment`](crate::ambient_sensitive_environment) for
 deliberately restoring proxy-safe credential markers to tool subprocesses.
 

--- a/crates/nanocodex-tools/benches/mcp_tool_search.rs
+++ b/crates/nanocodex-tools/benches/mcp_tool_search.rs
@@ -10,6 +10,14 @@ use nanocodex_tools::{
 use serde_json::{json, value::to_raw_value};
 use tokio::runtime::Runtime;
 
+fn search_tool(provider: &Mcp) -> Arc<dyn Tool> {
+    provider
+        .direct_tools()
+        .into_iter()
+        .find(|tool| tool.definition().name() == "tool_search")
+        .expect("MCP must expose tool_search under direct exposure")
+}
+
 fn warm_provider(
     runtime: &Runtime,
     tool_count: usize,
@@ -28,11 +36,7 @@ fn warm_provider(
         let _runtime = runtime.enter();
         provider.start();
     }
-    let search = provider
-        .direct_tools()
-        .into_iter()
-        .next()
-        .expect("MCP must expose tool_search");
+    let search = search_tool(&provider);
     let input = to_raw_value(&json!({ "query": "deterministic echo message", "limit": 8 }))
         .expect("benchmark input must serialize");
     let context = ToolContext::new(
@@ -69,11 +73,7 @@ fn benchmark_search(c: &mut Criterion) {
                 .build()
                 .expect("benchmark MCP configuration must be valid");
             provider.start();
-            let search = provider
-                .direct_tools()
-                .into_iter()
-                .next()
-                .expect("MCP must expose tool_search");
+            let search = search_tool(&provider);
             let input = to_raw_value(&json!({ "query": "deterministic echo message", "limit": 8 }))
                 .expect("benchmark input must serialize");
             let result = search

--- a/crates/nanocodex-tools/src/code_mode/bootstrap.js
+++ b/crates/nanocodex-tools/src/code_mode/bootstrap.js
@@ -249,15 +249,10 @@
     function exit() { throw EXIT; }
 
     const allTools = Object.freeze(definitions.map((tool) => {
-      const metadata = {
+      return Object.freeze({
         name: tool.name,
         description: tool.description,
-      };
-      Object.defineProperties(metadata, {
-        input_schema: { value: tool.input_schema },
-        output_schema: { value: tool.output_schema },
       });
-      return Object.freeze(metadata);
     }));
     try {
       const script = new AsyncFunction(

--- a/crates/nanocodex-tools/src/code_mode/description.rs
+++ b/crates/nanocodex-tools/src/code_mode/description.rs
@@ -1,8 +1,10 @@
-use std::fmt::Write as _;
+use std::{collections::BTreeSet, fmt::Write as _};
 
 use nanocodex_oai_api::{responses::JsonSchema, tools::ToolDefinition};
 use serde_json::Value;
 
+const DEFERRED_NESTED_TOOLS_GUIDANCE: &str = r"Some deferred nested tools may be omitted from this description. They are still available on the global `tools` object and listed in `ALL_TOOLS`.
+To find one, filter `ALL_TOOLS` by `name` and `description`.";
 // Based on https://modelcontextprotocol.io/specification/draft/schema#calltoolresult.
 const MCP_TYPESCRIPT_PREAMBLE: &str = r#"type Role = "user" | "assistant";
 type MetaObject = Record<string, unknown>;
@@ -82,7 +84,7 @@ type CallToolResult<TStructured = { [key: string]: unknown }> = {
 };"#;
 const EXEC_DESCRIPTION: &str = r#"Run JavaScript code to orchestrate/compose tool calls
 - Evaluates the provided JavaScript code in a fresh V8 isolate as an async module.
-- All nested tools are on global `tools`. For configured or deferred capabilities omitted here, check `ALL_TOOLS` before searching the workspace, then call a match as `await tools[tool.name](...)`.
+- All nested tools are available on the global `tools` object, for example `await tools.exec_command(...)`. Tool names are exposed as normalized JavaScript identifiers, for example `await tools.mcp__ologs__get_profile(...)`.
 - Nested tool methods take either a string or an object as their input argument.
 - Nested tools return either an object or a string, based on the description.
 - Runs raw JavaScript -- no Node, no file system, no network access, no console.
@@ -103,15 +105,22 @@ const EXEC_DESCRIPTION: &str = r#"Run JavaScript code to orchestrate/compose too
 - `notify(value: string | number | boolean | undefined | null)`: immediately injects an extra `custom_tool_call_output` for the current `exec` call. Values are stringified like `text(...)`.
 - `setTimeout(callback: () => void, delayMs?: number)`: schedules a callback to run later and returns a timeout id. Pending timeouts do not keep `exec` alive by themselves; await an explicit promise if you need to wait for one.
 - `clearTimeout(timeoutId?: number)`: cancels a timeout created by `setTimeout`.
-- `ALL_TOOLS`: enumerable `name`/`description` plus explicit `input_schema`/`output_schema`.
+- `ALL_TOOLS`: metadata for the enabled nested tools as `{ name, description }` entries.
 - `yield_control()`: yields the accumulated output to the model immediately while the script keeps running."#;
 
 pub(super) fn exec_description(
     definitions: &[ToolDefinition],
-    has_deferred_search: bool,
+    has_deferred_tools: bool,
+    code_mode_only: bool,
 ) -> String {
     let mut description = EXEC_DESCRIPTION.to_owned();
-    if has_deferred_search
+    if has_deferred_tools {
+        let _ = write!(description, "\n\n{DEFERRED_NESTED_TOOLS_GUIDANCE}");
+    }
+    if !code_mode_only {
+        return description;
+    }
+    if has_deferred_tools
         || definitions.iter().any(|spec| {
             spec.output_schema()
                 .and_then(|schema| mcp_structured_content_schema(schema.as_value()))
@@ -123,30 +132,18 @@ pub(super) fn exec_description(
             "\n\nShared MCP Types:\n```ts\n{MCP_TYPESCRIPT_PREAMBLE}\n```"
         );
     }
+    let mut rendered_namespaces = BTreeSet::new();
     for spec in definitions {
-        let (input_name, input_type) = match spec {
-            ToolDefinition::Function { .. } => (
-                "args",
-                spec.parameters()
-                    .map(JsonSchema::as_value)
-                    .map_or_else(|| "unknown".to_owned(), render_json_schema_to_typescript),
-            ),
-            ToolDefinition::Custom { .. } => ("input", "string".to_owned()),
-            ToolDefinition::ToolSearch { .. } => continue,
-        };
-        let output_type = match spec.output_schema().map(JsonSchema::as_value) {
-            Some(schema) => match mcp_structured_content_schema(schema) {
-                Some(structured) => {
-                    let structured = render_json_schema_to_typescript(structured);
-                    if structured == "unknown" {
-                        "CallToolResult".to_owned()
-                    } else {
-                        format!("CallToolResult<{structured}>")
-                    }
-                }
-                None => render_json_schema_to_typescript(schema),
-            },
-            None => "unknown".to_owned(),
+        if let Some((namespace, _)) = code_mode_namespace_and_name(spec.name())
+            && rendered_namespaces.insert(namespace)
+        {
+            let _ = write!(
+                description,
+                "\n\n## {namespace}\nTools in the {namespace} namespace."
+            );
+        }
+        let Some(declaration) = exec_tool_declaration(spec) else {
+            continue;
         };
         let global_name = normalize_identifier(spec.name());
         let heading = if global_name == spec.name() {
@@ -156,13 +153,61 @@ pub(super) fn exec_description(
         };
         let _ = write!(
             description,
-            "\n\n{heading}\n{}\n\nexec tool declaration:\n```ts\n\
-declare const tools: {{ {global_name}({input_name}: {input_type}): Promise<{output_type}>; }};\n\
-```",
+            "\n\n{heading}\n{}\n\n{declaration}",
             spec.description(),
         );
     }
     description
+}
+
+pub(crate) fn augment_definition_for_code_mode(mut definition: ToolDefinition) -> ToolDefinition {
+    let Some(declaration) = exec_tool_declaration(&definition) else {
+        return definition;
+    };
+    match &mut definition {
+        ToolDefinition::Function { description, .. }
+        | ToolDefinition::Custom { description, .. } => {
+            *description = format!("{description}\n\n{declaration}").into();
+        }
+        ToolDefinition::Namespace { .. } | ToolDefinition::ToolSearch { .. } => {}
+    }
+    definition
+}
+
+fn exec_tool_declaration(spec: &ToolDefinition) -> Option<String> {
+    let (input_name, input_type) = match spec {
+        ToolDefinition::Function { .. } => (
+            "args",
+            spec.parameters()
+                .map(JsonSchema::as_value)
+                .map_or_else(|| "unknown".to_owned(), render_json_schema_to_typescript),
+        ),
+        ToolDefinition::Custom { .. } => ("input", "string".to_owned()),
+        ToolDefinition::Namespace { .. } | ToolDefinition::ToolSearch { .. } => return None,
+    };
+    let output_type = match spec.output_schema().map(JsonSchema::as_value) {
+        Some(schema) => match mcp_structured_content_schema(schema) {
+            Some(structured) => {
+                let structured = render_json_schema_to_typescript(structured);
+                if structured == "unknown" {
+                    "CallToolResult".to_owned()
+                } else {
+                    format!("CallToolResult<{structured}>")
+                }
+            }
+            None => render_json_schema_to_typescript(schema),
+        },
+        None => "unknown".to_owned(),
+    };
+    let global_name = normalize_identifier(spec.name());
+    Some(format!(
+        "exec tool declaration:\n```ts\ndeclare const tools: {{ {global_name}({input_name}: {input_type}): Promise<{output_type}>; }};\n```"
+    ))
+}
+
+fn code_mode_namespace_and_name(name: &str) -> Option<(&str, &str)> {
+    let (namespace, name) = name.split_once("__")?;
+    (!namespace.is_empty() && !name.is_empty()).then_some((namespace, name))
 }
 
 fn mcp_structured_content_schema(output_schema: &Value) -> Option<&Value> {
@@ -384,9 +429,11 @@ fn render_literal(value: &Value) -> String {
 
 #[cfg(test)]
 mod tests {
+    use nanocodex_oai_api::tools::ToolDefinition;
     use serde_json::json;
 
-    use super::render_json_schema_to_typescript;
+    use super::{exec_description, render_json_schema_to_typescript};
+    use crate::code_mode_order::sort_definitions;
 
     #[test]
     fn renders_described_object_as_typescript() {
@@ -403,5 +450,67 @@ mod tests {
             render_json_schema_to_typescript(&schema),
             "{\n  choice: \"one\" | \"two\";\n  // How many.\n  count?: number;\n}"
         );
+    }
+
+    #[test]
+    fn renders_nullable_schema_types() {
+        let schema = json!({
+            "type": ["array", "null"],
+            "items": {"type": "string"}
+        });
+        assert_eq!(
+            render_json_schema_to_typescript(&schema),
+            "Array<string> | null"
+        );
+    }
+
+    #[test]
+    fn sorts_plain_tools_before_namespaces_and_renders_namespace_header() {
+        let mut definitions = vec![
+            ToolDefinition::function(
+                "image_gen__imagegen",
+                "Generate an image.",
+                json!({"type": "object"}),
+            ),
+            ToolDefinition::function("write_stdin", "Write input.", json!({"type": "object"})),
+            ToolDefinition::function("apply_patch", "Apply a patch.", json!({"type": "object"})),
+        ];
+        sort_definitions(&mut definitions);
+        assert_eq!(
+            definitions
+                .iter()
+                .map(ToolDefinition::name)
+                .collect::<Vec<_>>(),
+            ["apply_patch", "write_stdin", "image_gen__imagegen"]
+        );
+
+        let description = exec_description(&definitions, false, true);
+        let namespace = description
+            .find("## image_gen\nTools in the image_gen namespace.")
+            .unwrap();
+        assert!(description.find("### `write_stdin`").unwrap() < namespace);
+        assert!(namespace < description.find("### `image_gen__imagegen`").unwrap());
+    }
+
+    #[test]
+    fn normal_code_mode_keeps_the_exec_description_terse() {
+        let definitions = vec![ToolDefinition::function(
+            "update_plan",
+            "Update the plan.",
+            json!({"type": "object"}),
+        )];
+
+        let description = exec_description(&definitions, false, false);
+
+        assert!(
+            description.contains(
+                "All nested tools are available on the global `tools` object, for example"
+            )
+        );
+        assert!(description.contains(
+            "`ALL_TOOLS`: metadata for the enabled nested tools as `{ name, description }` entries."
+        ));
+        assert!(!description.contains("### `update_plan`"));
+        assert!(!description.contains("declare const tools"));
     }
 }

--- a/crates/nanocodex-tools/src/code_mode/mod.rs
+++ b/crates/nanocodex-tools/src/code_mode/mod.rs
@@ -41,7 +41,6 @@ const INITIAL_YIELD: Duration = if cfg!(test) {
 const DEFAULT_WAIT_YIELD: Duration = Duration::from_secs(10);
 const OBSERVER_YIELD_GRACE: Duration = Duration::from_secs(1);
 const MIN_YIELD_FOR_OBSERVER_GRACE: Duration = Duration::from_secs(10);
-const NESTED_YIELD_GRACE: Duration = Duration::from_secs(5);
 const MAX_CONCURRENT_NESTED_CALLS: usize = 128;
 const MAX_JS_SAFE_INTEGER: u64 = (1_u64 << 53) - 1;
 const EXEC_PRAGMA_PREFIX: &str = "// @exec:";
@@ -140,7 +139,7 @@ struct CellObservationState {
 #[derive(Default)]
 struct ObservationBuffer {
     content: Vec<ToolOutputContent>,
-    nested_calls: Vec<(u64, NestedToolCall)>,
+    nested_calls: Vec<ObservedNestedCall>,
     notifications: Vec<CodeModeNotification>,
 }
 
@@ -160,12 +159,8 @@ enum CellUpdate {
         call_id: String,
         name: String,
         input: Value,
-        yield_after: Option<Duration>,
     },
-    NestedCall {
-        id: u64,
-        call: NestedToolCall,
-    },
+    NestedCall(ObservedNestedCall),
     Notification(CodeModeNotification),
     Content(ToolOutputContent),
     Yielded,
@@ -229,6 +224,13 @@ struct CompletedNestedCall {
     id: u64,
     value: Value,
     call: NestedToolCall,
+    shell_session_id: Option<i64>,
+}
+
+struct ObservedNestedCall {
+    id: u64,
+    call: NestedToolCall,
+    shell_session_id: Option<i64>,
 }
 
 enum CellTerminal {
@@ -343,7 +345,6 @@ impl CodeModeRuntime {
             .max_output_tokens
             .unwrap_or(context.output_token_budget)
             .max(1);
-        let extend_for_nested_calls = source.yield_time_ms.is_none();
         tracing::Span::current().record("output.max_tokens", output_token_budget);
         let context = context.with_output_token_budget(output_token_budget);
         let stored = self.stored.lock().await.clone();
@@ -376,7 +377,6 @@ impl CodeModeRuntime {
             started_at,
             ObservationMode::YieldAfter(yield_after),
             Some(output_token_budget),
-            extend_for_nested_calls,
             observer,
         )
         .await;
@@ -446,7 +446,6 @@ impl CodeModeRuntime {
                 started_at,
                 ObservationMode::Terminate,
                 Some(continued_output_token_budget),
-                false,
                 observer,
             )
             .await;
@@ -471,7 +470,6 @@ impl CodeModeRuntime {
             started_at,
             ObservationMode::YieldAfter(yield_time),
             Some(output_token_budget),
-            false,
             observer,
         )
         .await;
@@ -797,7 +795,6 @@ async fn observe_cell(
     started_at: Instant,
     mode: ObservationMode,
     max_output_tokens: Option<usize>,
-    extend_for_nested_calls: bool,
     observer: &mut dyn CodeModeObserver,
 ) -> (CodeModeExecution, bool) {
     let (yield_after, terminating) = match mode {
@@ -834,27 +831,16 @@ async fn observe_cell(
                 call_id,
                 name,
                 input,
-                yield_after: nested_yield_after,
             }) => {
-                if let Some(nested_yield_after) = nested_yield_after
-                    && let Some(yield_timer) = yield_timer.as_mut()
-                {
-                    maybe_extend_cell_yield(
-                        yield_timer.as_mut(),
-                        extend_for_nested_calls,
-                        nested_yield_after,
-                        &name,
-                    );
-                }
                 observer.update(CodeModeUpdate::NestedCallStarted {
                     call_id: &call_id,
                     name: &name,
                     input: &input,
                 });
             }
-            Some(CellUpdate::NestedCall { id, call }) => {
-                observer.update(CodeModeUpdate::NestedCallCompleted(&call));
-                observation.buffered.nested_calls.push((id, call));
+            Some(CellUpdate::NestedCall(call)) => {
+                observer.update(CodeModeUpdate::NestedCallCompleted(&call.call));
+                observation.buffered.nested_calls.push(call);
             }
             Some(CellUpdate::Notification(notification)) => {
                 observation.buffered.notifications.push(notification);
@@ -967,40 +953,12 @@ async fn observe_cell(
     }
 }
 
-fn maybe_extend_cell_yield(
-    mut timer: std::pin::Pin<&mut tokio::time::Sleep>,
-    enabled: bool,
-    nested_yield_after: Duration,
-    tool_name: &str,
-) {
-    if !enabled {
-        return;
-    }
-    let Some(extended_deadline) = tokio::time::Instant::now()
-        .checked_add(nested_yield_after)
-        .and_then(|deadline| deadline.checked_add(NESTED_YIELD_GRACE))
-    else {
-        return;
-    };
-    if extended_deadline <= timer.deadline() {
-        return;
-    }
-    timer.as_mut().reset(extended_deadline);
-    tracing::info!(
-        target: "nanocodex_tools",
-        stage = "code_mode.yield_extended",
-        tool.name = tool_name,
-        nested.yield_ms = nested_yield_after.as_millis(),
-        "extended Code Mode yield for nested tool wait"
-    );
-}
-
 fn running_observation(
     cell_id: u64,
     started_at: Instant,
     content: Vec<ToolOutputContent>,
     max_output_tokens: Option<usize>,
-    nested_calls: Vec<(u64, NestedToolCall)>,
+    nested_calls: Vec<ObservedNestedCall>,
     notifications: Vec<CodeModeNotification>,
 ) -> (CodeModeExecution, bool) {
     (
@@ -1023,7 +981,7 @@ fn observed_execution(
     started_at: Instant,
     mut content: Vec<ToolOutputContent>,
     max_output_tokens: Option<usize>,
-    nested_calls: Vec<(u64, NestedToolCall)>,
+    nested_calls: Vec<ObservedNestedCall>,
     notifications: Vec<CodeModeNotification>,
 ) -> CodeModeExecution {
     expose_running_shell_sessions(&mut content, &nested_calls);
@@ -1038,25 +996,20 @@ fn observed_execution(
 
 fn expose_running_shell_sessions(
     content: &mut Vec<ToolOutputContent>,
-    nested_calls: &[(u64, NestedToolCall)],
+    nested_calls: &[ObservedNestedCall],
 ) {
     let mut running = BTreeSet::new();
-    for (_, call) in nested_calls {
+    for observed in nested_calls {
+        let call = &observed.call;
         if !matches!(call.name.as_str(), "exec_command" | "write_stdin") {
             continue;
         }
-        let ToolOutputBody::Text(result) = &call.output else {
-            continue;
-        };
-        let result_session_id = serde_json::from_str::<Value>(result)
-            .ok()
-            .and_then(|result| result.get("session_id")?.as_i64());
         if call.name == "write_stdin"
             && let Some(input_session_id) = call.input.get("session_id").and_then(Value::as_i64)
         {
             running.remove(&input_session_id);
         }
-        if let Some(session_id) = result_session_id {
+        if let Some(session_id) = observed.shell_session_id {
             running.insert(session_id);
         }
     }
@@ -1107,9 +1060,8 @@ impl EmbeddedHost {
                     let Some(completed) = completed else {
                         continue;
                     };
-                    let id = completed.id;
                     let call = self.send_completed_call(cell_id, completed)?;
-                    let _ = updates.send(CellUpdate::NestedCall { id, call });
+                    let _ = updates.send(CellUpdate::NestedCall(call));
                 }
                 event = self.read_event() => {
                     let event = event.map_err(HostFailure::new)?;
@@ -1132,12 +1084,10 @@ impl EmbeddedHost {
                             id, name, input, ..
                         } => {
                             let nested_call_id = format!("{}/code-{id}", context.call_id);
-                            let yield_after = nested_tool_yield_after(&name, &input);
                             let _ = updates.send(CellUpdate::NestedCallStarted {
                                 call_id: nested_call_id,
                                 name: name.clone(),
                                 input: input.clone(),
-                                yield_after,
                             });
                             let permit = Arc::clone(&nested_call_permits);
                             let supports_parallel = tools.supports_parallel_tool_calls(&name);
@@ -1209,7 +1159,7 @@ impl EmbeddedHost {
         &mut self,
         cell_id: u64,
         completed: CompletedNestedCall,
-    ) -> Result<NestedToolCall, HostFailure> {
+    ) -> Result<ObservedNestedCall, HostFailure> {
         self.send_tool_result(
             cell_id,
             completed.id,
@@ -1217,31 +1167,12 @@ impl EmbeddedHost {
             completed.call.success,
         )
         .map_err(HostFailure::new)?;
-        Ok(completed.call)
+        Ok(ObservedNestedCall {
+            id: completed.id,
+            call: completed.call,
+            shell_session_id: completed.shell_session_id,
+        })
     }
-}
-
-fn nested_tool_yield_after(name: &str, input: &Value) -> Option<Duration> {
-    let input = input.as_object()?;
-    let (default, minimum, maximum) = match name {
-        "write_stdin"
-            if input
-                .get("chars")
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .is_empty() =>
-        {
-            (5_000, 5_000, 300_000)
-        }
-        "exec_command" => (10_000, 250, 30_000),
-        "write_stdin" => (250, 250, 30_000),
-        _ => return None,
-    };
-    let requested = input
-        .get("yield_time_ms")
-        .and_then(Value::as_u64)
-        .unwrap_or(default);
-    Some(Duration::from_millis(requested.clamp(minimum, maximum)))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1372,9 +1303,9 @@ impl HostFailure {
     }
 }
 
-fn ordered_calls(mut calls: Vec<(u64, NestedToolCall)>) -> Vec<NestedToolCall> {
-    calls.sort_unstable_by_key(|(id, _)| *id);
-    calls.into_iter().map(|(_, call)| call).collect()
+fn ordered_calls(mut calls: Vec<ObservedNestedCall>) -> Vec<NestedToolCall> {
+    calls.sort_unstable_by_key(|call| call.id);
+    calls.into_iter().map(|call| call.call).collect()
 }
 
 async fn execute_nested_call(
@@ -1400,9 +1331,14 @@ async fn execute_nested_call(
     let execution = tools.execute_nested(&name, input.clone(), context).await;
     let duration_ns = u64::try_from(started_at.elapsed().as_nanos()).unwrap_or(u64::MAX);
     let value = execution.code_mode_value();
+    let shell_session_id = execution
+        .process_trace()
+        .and_then(|process| process.session_id)
+        .or_else(|| value.get("session_id").and_then(Value::as_i64));
     CompletedNestedCall {
         id,
         value,
+        shell_session_id,
         call: NestedToolCall {
             call_id,
             name,

--- a/crates/nanocodex-tools/src/code_mode/spec.rs
+++ b/crates/nanocodex-tools/src/code_mode/spec.rs
@@ -15,11 +15,12 @@ SOURCE: /[\s\S]+/
 
 pub(crate) fn exec_spec(
     definitions: &[ToolDefinition],
-    has_deferred_search: bool,
+    has_deferred_tools: bool,
+    code_mode_only: bool,
 ) -> ToolDefinition {
     ToolDefinition::custom(
         "exec",
-        description::exec_description(definitions, has_deferred_search),
+        description::exec_description(definitions, has_deferred_tools, code_mode_only),
         CustomToolFormat::grammar("lark", GRAMMAR),
     )
 }

--- a/crates/nanocodex-tools/src/code_mode/tests.rs
+++ b/crates/nanocodex-tools/src/code_mode/tests.rs
@@ -15,7 +15,7 @@ use tokio::sync::Semaphore;
 use super::{
     CellError, CellLifecycle, CellObservationState, CellUpdate, CodeModeExecution,
     CodeModeObserver, CodeModeUpdate, LiveCell, NestedToolCall, ObservationBuffer, ObservationMode,
-    nested_tool_yield_after, observe_cell, observer_yield_timeout, parse_exec_source,
+    observe_cell, observer_yield_timeout, parse_exec_source,
 };
 use crate::{
     Tool, ToolContext, ToolInput, ToolOutput, ToolOutputBody, ToolOutputContent, ToolResult, Tools,
@@ -316,7 +316,7 @@ text({
 }
 
 #[tokio::test]
-async fn all_tools_exposes_runtime_only_tool_contracts() -> Result<()> {
+async fn all_tools_matches_codex_metadata_shape() -> Result<()> {
     let workspace = temporary_workspace("all-tools-metadata")?;
     let tools = test_tools(&workspace);
     let history = Vec::new();
@@ -327,6 +327,7 @@ text(ALL_TOOLS.map((tool) => ({
   keys: Object.keys(tool).sort(),
   frozen: Object.isFrozen(tool),
   hasInputSchema: typeof tool.input_schema === "object",
+  hasOutputSchema: typeof tool.output_schema === "object",
   serializedSchema: JSON.stringify(tool).includes("input_schema"),
 })));
 "#,
@@ -343,7 +344,8 @@ text(ALL_TOOLS.map((tool) => ({
     assert!(tools.iter().all(|tool| {
         tool["keys"] == serde_json::json!(["description", "name"])
             && tool["frozen"] == true
-            && tool["hasInputSchema"] == true
+            && tool["hasInputSchema"] == false
+            && tool["hasOutputSchema"] == false
             && tool["serializedSchema"] == false
     }));
     std::fs::remove_dir_all(workspace)?;
@@ -1762,57 +1764,6 @@ fn exec_pragma_rejects_unknown_fields() {
     assert!(error.contains("only supports"));
 }
 
-#[test]
-fn nested_shell_yields_follow_the_handlers_bounds() {
-    assert_eq!(
-        nested_tool_yield_after("exec_command", &serde_json::json!({ "cmd": "sleep 1" })),
-        Some(Duration::from_secs(10))
-    );
-    assert_eq!(
-        nested_tool_yield_after("write_stdin", &serde_json::json!({ "session_id": 1 }),),
-        Some(Duration::from_secs(5))
-    );
-    assert_eq!(
-        nested_tool_yield_after(
-            "write_stdin",
-            &serde_json::json!({ "session_id": 1, "chars": "x" }),
-        ),
-        Some(Duration::from_millis(250))
-    );
-    assert_eq!(
-        nested_tool_yield_after(
-            "exec_command",
-            &serde_json::json!({ "yield_time_ms": 45_000 }),
-        ),
-        Some(Duration::from_secs(30))
-    );
-    assert_eq!(
-        nested_tool_yield_after(
-            "write_stdin",
-            &serde_json::json!({ "session_id": 1, "yield_time_ms": 120_000 }),
-        ),
-        Some(Duration::from_mins(2))
-    );
-    assert_eq!(
-        nested_tool_yield_after(
-            "write_stdin",
-            &serde_json::json!({
-                "session_id": 1,
-                "chars": "x",
-                "yield_time_ms": 120_000,
-            }),
-        ),
-        Some(Duration::from_secs(30))
-    );
-    assert_eq!(
-        nested_tool_yield_after(
-            "apply_patch",
-            &serde_json::json!({ "yield_time_ms": 30_000 })
-        ),
-        None
-    );
-}
-
 #[tokio::test]
 async fn negative_shell_limits_fail_during_codex_compatible_argument_parsing() -> Result<()> {
     let workspace = temporary_workspace("negative-shell-limits")?;
@@ -1911,7 +1862,6 @@ async fn dropped_observer_preserves_consumed_output_for_the_next_observation() -
             std::time::Instant::now(),
             ObservationMode::YieldAfter(Duration::from_secs(60)),
             None,
-            false,
             &mut observer,
         )
         .await
@@ -1926,7 +1876,6 @@ async fn dropped_observer_preserves_consumed_output_for_the_next_observation() -
             call_id: "call/code-1".to_owned(),
             name: "test".to_owned(),
             input: Value::Null,
-            yield_after: None,
         })
         .expect("test cell should receive the observation barrier");
     tokio::time::timeout(Duration::from_secs(1), started_rx)
@@ -1952,7 +1901,6 @@ async fn dropped_observer_preserves_consumed_output_for_the_next_observation() -
         std::time::Instant::now(),
         ObservationMode::YieldAfter(Duration::from_secs(1)),
         None,
-        false,
         &mut super::IgnoreCodeModeUpdates,
     )
     .await;
@@ -1991,7 +1939,6 @@ async fn yield_deadline_preempts_already_buffered_runtime_output() {
         std::time::Instant::now(),
         ObservationMode::YieldAfter(Duration::ZERO),
         None,
-        false,
         &mut super::IgnoreCodeModeUpdates,
     )
     .await;
@@ -2011,7 +1958,6 @@ async fn yield_deadline_preempts_already_buffered_runtime_output() {
         std::time::Instant::now(),
         ObservationMode::YieldAfter(Duration::from_secs(1)),
         None,
-        false,
         &mut super::IgnoreCodeModeUpdates,
     )
     .await;
@@ -2023,7 +1969,7 @@ async fn yield_deadline_preempts_already_buffered_runtime_output() {
 }
 
 #[tokio::test]
-async fn default_cell_yield_extends_for_a_longer_nested_shell_wait() {
+async fn nested_tool_start_does_not_extend_the_outer_yield() {
     let (updates_tx, updates) = tokio::sync::mpsc::unbounded_channel();
     let (terminate, _terminate_rx) = tokio::sync::oneshot::channel();
     let task = tokio::spawn(async move {
@@ -2032,7 +1978,6 @@ async fn default_cell_yield_extends_for_a_longer_nested_shell_wait() {
                 call_id: "call/code-1".to_owned(),
                 name: "write_stdin".to_owned(),
                 input: serde_json::Value::Null,
-                yield_after: Some(Duration::from_millis(40)),
             })
             .expect("observer should receive the nested call");
         tokio::time::sleep(Duration::from_millis(15)).await;
@@ -2051,45 +1996,6 @@ async fn default_cell_yield_extends_for_a_longer_nested_shell_wait() {
         std::time::Instant::now(),
         ObservationMode::YieldAfter(Duration::from_millis(5)),
         None,
-        true,
-        &mut super::IgnoreCodeModeUpdates,
-    )
-    .await;
-
-    assert!(!running);
-    assert!(execution.success);
-    assert!(execution_output(&execution).contains("Script completed"));
-    cell.join().await;
-}
-
-#[tokio::test]
-async fn explicit_cell_yield_is_not_extended_by_a_nested_shell_wait() {
-    let (updates_tx, updates) = tokio::sync::mpsc::unbounded_channel();
-    let (terminate, _terminate_rx) = tokio::sync::oneshot::channel();
-    let task = tokio::spawn(async move {
-        updates_tx
-            .send(CellUpdate::NestedCallStarted {
-                call_id: "call/code-1".to_owned(),
-                name: "write_stdin".to_owned(),
-                input: serde_json::Value::Null,
-                yield_after: Some(Duration::from_millis(40)),
-            })
-            .expect("observer should receive the nested call");
-        tokio::time::sleep(Duration::from_millis(15)).await;
-        let _ = updates_tx.send(CellUpdate::Completed);
-    });
-    let cell = test_live_cell(1, updates, terminate, task);
-    let observation = cell
-        .begin_observation()
-        .expect("test cell should not already have an observer");
-
-    let (execution, running) = observe_cell(
-        &cell,
-        observation,
-        std::time::Instant::now(),
-        ObservationMode::YieldAfter(Duration::from_millis(5)),
-        None,
-        false,
         &mut super::IgnoreCodeModeUpdates,
     )
     .await;

--- a/crates/nanocodex-tools/src/code_mode_order.rs
+++ b/crates/nanocodex-tools/src/code_mode_order.rs
@@ -1,0 +1,39 @@
+use nanocodex_oai_api::tools::ToolDefinition;
+
+/// Matches Codex's Code Mode prompt order: plain tools first, followed by
+/// namespaced tools ordered by namespace and member name.
+pub(crate) fn sort_definitions(definitions: &mut [ToolDefinition]) {
+    definitions.sort_by(|left, right| {
+        let (left_namespace, left_name) = namespace_and_name(left.name())
+            .map_or((None, left.name()), |(namespace, name)| {
+                (Some(namespace), name)
+            });
+        let (right_namespace, right_name) = namespace_and_name(right.name())
+            .map_or((None, right.name()), |(namespace, name)| {
+                (Some(namespace), name)
+            });
+        left_namespace
+            .cmp(&right_namespace)
+            .then_with(|| left_name.cmp(right_name))
+            .then_with(|| left.name().cmp(right.name()))
+    });
+}
+
+/// Matches Codex's direct Code Mode prefix: shell, plan, patch, image view,
+/// then application and namespaced tools in their registration order.
+#[cfg(not(target_family = "wasm"))]
+pub(crate) fn sort_direct_definitions(definitions: &mut [ToolDefinition]) {
+    definitions.sort_by_key(|definition| match definition.name() {
+        "exec_command" => 0,
+        "write_stdin" => 1,
+        "update_plan" => 2,
+        "apply_patch" => 3,
+        "view_image" => 4,
+        _ => 5,
+    });
+}
+
+fn namespace_and_name(name: &str) -> Option<(&str, &str)> {
+    let (namespace, name) = name.split_once("__")?;
+    (!namespace.is_empty() && !name.is_empty()).then_some((namespace, name))
+}

--- a/crates/nanocodex-tools/src/hosted/runtime.rs
+++ b/crates/nanocodex-tools/src/hosted/runtime.rs
@@ -163,7 +163,7 @@ impl HostedToolRuntime {
                 }
             }
         });
-        definitions.sort_by(|left, right| left.name().cmp(right.name()));
+        crate::code_mode_order::sort_definitions(&mut definitions);
         if mode == HostedToolMode::Direct {
             if let Ok(mut names) = self.direct_tool_names.write() {
                 names.clear();

--- a/crates/nanocodex-tools/src/image_generation/mod.rs
+++ b/crates/nanocodex-tools/src/image_generation/mod.rs
@@ -190,14 +190,14 @@ impl Tool for ImageGenerationHandler {
                 "properties": {
                     "prompt": { "type": "string" },
                     "referenced_image_paths": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "maxItems": MAX_EDIT_IMAGES
+                        "type": ["array", "null"],
+                        "items": {
+                            "type": "string",
+                            "description": "A path that is guaranteed to be absolute and normalized (though it is not guaranteed to be canonicalized or exist on the filesystem).\n\nIMPORTANT: When deserializing an `AbsolutePathBuf`, a base path must be set using [AbsolutePathBufGuard::new]. If no base path is set, the deserialization will fail unless the path being deserialized is already absolute."
+                        }
                     },
                     "num_last_images_to_include": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": MAX_EDIT_IMAGES
+                        "type": ["integer", "null"]
                     }
                 },
                 "required": ["prompt"],

--- a/crates/nanocodex-tools/src/image_generation/tests.rs
+++ b/crates/nanocodex-tools/src/image_generation/tests.rs
@@ -171,9 +171,14 @@ fn exposes_codex_imagegen_shape() {
 
     assert_eq!(spec["name"], "image_gen__imagegen");
     assert_eq!(spec["strict"], false);
-    assert_eq!(
-        spec.pointer("/parameters/properties/referenced_image_paths/maxItems"),
-        Some(&json!(5))
+    assert!(
+        spec.pointer("/parameters/properties/referenced_image_paths/maxItems")
+            .is_none()
+    );
+    assert!(
+        spec.pointer("/parameters/properties/referenced_image_paths/items/description")
+            .and_then(Value::as_str)
+            .is_some_and(|description| description.contains("AbsolutePathBufGuard::new"))
     );
     assert!(
         spec["description"]

--- a/crates/nanocodex-tools/src/lib.rs
+++ b/crates/nanocodex-tools/src/lib.rs
@@ -17,6 +17,8 @@ mod apply_patch;
 #[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
 pub mod code_mode;
 #[cfg(feature = "native")]
+mod code_mode_order;
+#[cfg(feature = "native")]
 pub mod hosted;
 #[cfg(all(not(target_family = "wasm"), feature = "native"))]
 #[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
@@ -95,6 +97,9 @@ pub(crate) use nanocodex_oai_api::ImageDetail;
 #[cfg(all(not(target_family = "wasm"), feature = "native"))]
 #[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
 pub use nanocodex_tools_macros::tool;
+#[cfg(all(not(target_family = "wasm"), feature = "native"))]
+#[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
+pub use runtime::ToolExposure;
 #[cfg(feature = "native")]
 pub use runtime::Tools;
 #[cfg(all(not(target_family = "wasm"), feature = "native"))]

--- a/crates/nanocodex-tools/src/mcp/catalog.rs
+++ b/crates/nanocodex-tools/src/mcp/catalog.rs
@@ -37,10 +37,16 @@ pub(crate) struct ToolEntry {
 struct Catalog {
     entries: BTreeMap<String, Arc<ToolEntry>>,
     active: BTreeSet<String>,
+    clients: BTreeMap<String, Client>,
     failures: BTreeMap<String, String>,
     search_index: Option<Arc<SearchIndex>>,
     pending_servers: BTreeSet<String>,
     generations: BTreeMap<String, u64>,
+}
+
+pub(crate) struct ConnectedCatalog {
+    pub client: Client,
+    pub entries: Vec<ToolEntry>,
 }
 
 struct SearchIndex {
@@ -120,6 +126,7 @@ impl ProviderState {
             catalog: Mutex::new(Catalog {
                 entries: BTreeMap::new(),
                 active: BTreeSet::new(),
+                clients: BTreeMap::new(),
                 failures: BTreeMap::new(),
                 search_index: None,
                 pending_servers,
@@ -134,14 +141,14 @@ impl ProviderState {
         &self,
         server_name: &str,
         generation: u64,
-        result: Result<Vec<ToolEntry>, String>,
+        result: Result<ConnectedCatalog, String>,
     ) {
         let mut catalog = self.catalog();
         if catalog.generations.get(server_name).copied() != Some(generation) {
             return;
         }
         match result {
-            Ok(entries) => {
+            Ok(ConnectedCatalog { client, entries }) => {
                 let removed = catalog
                     .entries
                     .iter()
@@ -167,6 +174,7 @@ impl ProviderState {
                         .entries
                         .insert(entry.canonical_name.clone(), Arc::new(entry));
                 }
+                catalog.clients.insert(server_name.to_owned(), client);
                 let available = catalog.entries.keys().cloned().collect::<BTreeSet<_>>();
                 catalog.active.retain(|name| available.contains(name));
             }
@@ -265,20 +273,42 @@ impl ProviderState {
     pub(crate) fn available_definitions(&self) -> Vec<ToolDefinition> {
         let catalog = self.catalog();
         catalog
-            .active
-            .iter()
-            .filter_map(|name| catalog.entries.get(name))
+            .entries
+            .values()
             .map(|entry| entry.definition.clone())
             .collect()
     }
 
-    pub(crate) fn active_entry(&self, name: &str) -> Option<Arc<ToolEntry>> {
+    pub(crate) fn entry(&self, name: &str) -> Option<Arc<ToolEntry>> {
+        self.catalog().entries.get(name).cloned()
+    }
+
+    pub(crate) async fn ready_entry(&self, name: &str) -> Option<Arc<ToolEntry>> {
+        self.wait_for_startup().await;
+        self.entry(name)
+    }
+
+    pub(crate) async fn client(&self, server_name: &str) -> Result<Client, String> {
+        self.wait_for_startup().await;
         let catalog = self.catalog();
-        catalog
-            .active
-            .contains(name)
-            .then(|| catalog.entries.get(name).cloned())
-            .flatten()
+        if let Some(client) = catalog.clients.get(server_name) {
+            return Ok(Arc::clone(client));
+        }
+        if let Some(error) = catalog.failures.get(server_name) {
+            return Err(format!(
+                "MCP server `{server_name}` is unavailable: {error}"
+            ));
+        }
+        Err(format!("unknown MCP server `{server_name}`"))
+    }
+
+    pub(crate) async fn clients(&self) -> Vec<(String, Client)> {
+        self.wait_for_startup().await;
+        self.catalog()
+            .clients
+            .iter()
+            .map(|(name, client)| (name.clone(), Arc::clone(client)))
+            .collect()
     }
 
     async fn wait_for_startup(&self) {

--- a/crates/nanocodex-tools/src/mcp/client.rs
+++ b/crates/nanocodex-tools/src/mcp/client.rs
@@ -3,7 +3,10 @@ use std::{collections::HashMap, sync::Arc};
 use http::{HeaderName, HeaderValue, header::USER_AGENT};
 use rmcp::{
     ServiceExt,
-    model::{CallToolRequestParams, CallToolResult, Tool},
+    model::{
+        CallToolRequestParams, CallToolResult, ListResourceTemplatesResult, ListResourcesResult,
+        PaginatedRequestParams, ReadResourceRequestParams, ReadResourceResult, Tool,
+    },
     service::{RoleClient, RunningService},
     transport::{
         StreamableHttpClientTransport, streamable_http_client::StreamableHttpClientTransportConfig,
@@ -41,6 +44,36 @@ impl ClientInner {
         result
     }
 
+    pub(crate) async fn list_resources(
+        &self,
+        params: Option<PaginatedRequestParams>,
+    ) -> Result<ListResourcesResult, rmcp::service::ServiceError> {
+        let parent = Span::current();
+        let result = self.service.list_resources(params).await;
+        self.persist_oauth(&parent).await;
+        result
+    }
+
+    pub(crate) async fn list_resource_templates(
+        &self,
+        params: Option<PaginatedRequestParams>,
+    ) -> Result<ListResourceTemplatesResult, rmcp::service::ServiceError> {
+        let parent = Span::current();
+        let result = self.service.list_resource_templates(params).await;
+        self.persist_oauth(&parent).await;
+        result
+    }
+
+    pub(crate) async fn read_resource(
+        &self,
+        params: ReadResourceRequestParams,
+    ) -> Result<ReadResourceResult, rmcp::service::ServiceError> {
+        let parent = Span::current();
+        let result = self.service.read_resource(params).await;
+        self.persist_oauth(&parent).await;
+        result
+    }
+
     async fn list_all_tools(
         &self,
         parent: &Span,
@@ -52,6 +85,14 @@ impl ClientInner {
             tracing::warn!(%error, "failed to persist refreshed MCP OAuth credentials");
         }
         tools
+    }
+
+    async fn persist_oauth(&self, parent: &Span) {
+        if let Some(oauth) = &self.oauth
+            && let Err(error) = oauth.persist_if_changed(parent).await
+        {
+            tracing::warn!(%error, "failed to persist refreshed MCP OAuth credentials");
+        }
     }
 }
 

--- a/crates/nanocodex-tools/src/mcp/mod.rs
+++ b/crates/nanocodex-tools/src/mcp/mod.rs
@@ -4,6 +4,7 @@ mod catalog;
 mod client;
 mod config;
 mod oauth;
+mod resources;
 mod stdio;
 
 use std::{
@@ -17,7 +18,7 @@ use std::{
 
 use crate::{DynamicToolProvider, Tool, ToolContext, ToolInput, ToolOutput, ToolResult};
 use async_trait::async_trait;
-use catalog::{ProviderState, ToolEntry};
+use catalog::{ConnectedCatalog, ProviderState, ToolEntry};
 use nanocodex_oai_api::tools::ToolDefinition;
 use rmcp::model::CallToolRequestParams;
 use serde::Deserialize;
@@ -308,8 +309,14 @@ impl McpHandle {
                         )
                     })
                     .collect();
-                self.state
-                    .complete_server(server_name, generation, Ok(entries));
+                self.state.complete_server(
+                    server_name,
+                    generation,
+                    Ok(ConnectedCatalog {
+                        client: connected.client,
+                        entries,
+                    }),
+                );
                 Ok(count)
             }
             Err(error) => {
@@ -466,7 +473,7 @@ impl DynamicToolProvider for Mcp {
                 let result = client::connect(&name, &config, oauth_store, oauth_metadata, &span)
                     .await
                     .map(|connected| {
-                        connected
+                        let entries = connected
                             .tools
                             .into_iter()
                             .map(|tool| {
@@ -479,7 +486,11 @@ impl DynamicToolProvider for Mcp {
                                     config.supports_parallel_tool_calls,
                                 )
                             })
-                            .collect::<Vec<_>>()
+                            .collect::<Vec<_>>();
+                        ConnectedCatalog {
+                            client: connected.client,
+                            entries,
+                        }
                     });
                 span.record(
                     "status",
@@ -493,8 +504,8 @@ impl DynamicToolProvider for Mcp {
                     "otel.status_code",
                     if result.is_ok() { "OK" } else { "ERROR" },
                 );
-                if let Ok(tools) = &result {
-                    span.record("tool.count", tools.len());
+                if let Ok(catalog) = &result {
+                    span.record("tool.count", catalog.entries.len());
                 }
                 state.complete_server(&name, 0, result);
             }));
@@ -502,7 +513,22 @@ impl DynamicToolProvider for Mcp {
     }
 
     fn direct_tools(&self) -> Vec<Arc<dyn Tool>> {
-        vec![Arc::clone(&self.search) as Arc<dyn Tool>]
+        vec![
+            Arc::new(resources::ListMcpResourceTemplates::new(Arc::clone(
+                &self.state,
+            ))) as Arc<dyn Tool>,
+            Arc::new(resources::ListMcpResources::new(Arc::clone(&self.state))),
+            Arc::new(resources::ReadMcpResource::new(Arc::clone(&self.state))),
+            Arc::clone(&self.search) as Arc<dyn Tool>,
+        ]
+    }
+
+    fn direct_tools_for_exposure(&self, exposure: crate::ToolExposure) -> Vec<Arc<dyn Tool>> {
+        let mut tools = self.direct_tools();
+        if exposure == crate::ToolExposure::CodeModeOnly {
+            tools.retain(|tool| !matches!(tool.definition(), ToolDefinition::ToolSearch { .. }));
+        }
+        tools
     }
 
     fn available_definitions(&self) -> Vec<ToolDefinition> {
@@ -510,12 +536,12 @@ impl DynamicToolProvider for Mcp {
     }
 
     fn contains(&self, name: &str) -> bool {
-        self.state.active_entry(name).is_some()
+        self.state.entry(name).is_some()
     }
 
     fn supports_parallel_tool_calls(&self, name: &str) -> bool {
         self.state
-            .active_entry(name)
+            .entry(name)
             .is_some_and(|entry| entry.supports_parallel_tool_calls)
     }
 
@@ -525,7 +551,7 @@ impl DynamicToolProvider for Mcp {
         input: Value,
         _context: ToolContext<'_>,
     ) -> Option<ToolOutput> {
-        let entry = self.state.active_entry(name)?;
+        let entry = self.state.ready_entry(name).await?;
         let Value::Object(arguments) = input else {
             return Some(ToolOutput::error(format!(
                 "MCP tool {name} requires an object argument"
@@ -742,7 +768,8 @@ fn search_description(servers: &[NamedServer]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ToolOutputBody, contract::DEFAULT_TOOL_OUTPUT_TOKENS};
+    use crate::runtime::ToolRuntime;
+    use crate::{ToolOutputBody, Tools, contract::DEFAULT_TOOL_OUTPUT_TOKENS};
     use futures_util::future::join_all;
     use nanocodex_oai_api::MODEL;
     use serde_json::value::to_raw_value;
@@ -808,6 +835,130 @@ mod tests {
                     "additionalProperties": false
                 }
             })
+        );
+    }
+
+    #[tokio::test]
+    async fn code_mode_only_matches_codex_mcp_exposure() {
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/mcp-stdio-server.mjs");
+        let mcp = Mcp::builder()
+            .server(
+                "fixture",
+                McpServer::stdio("node").arg(fixture.to_string_lossy()),
+            )
+            .build()
+            .unwrap();
+        let handle = mcp.handle();
+        assert_eq!(handle.reload("fixture").await.unwrap(), 1);
+
+        let tools = Tools::builder()
+            .without_defaults()
+            .provider(mcp)
+            .build()
+            .unwrap();
+        let runtime = ToolRuntime::new_with_tools(".", None, None, &tools);
+        let specs = runtime.model_specs("test-session");
+        assert_eq!(
+            specs.iter().map(ToolDefinition::name).collect::<Vec<_>>(),
+            ["exec", "wait"],
+            "Code Mode-only must keep native tool_search off the top-level surface"
+        );
+
+        let description = specs[0].description();
+        for tool in [
+            "### `list_mcp_resource_templates`",
+            "### `list_mcp_resources`",
+            "### `read_mcp_resource`",
+        ] {
+            assert!(description.contains(tool), "missing {tool}: {description}");
+        }
+        assert!(description.contains("Some deferred nested tools may be omitted"));
+        assert!(
+            !description.contains("### `mcp__fixture__echo`"),
+            "deferred MCP schemas must not inflate the stable request prefix"
+        );
+
+        assert_eq!(
+            runtime
+                .model_contract("test-session")
+                .1
+                .into_iter()
+                .map(|(name, _)| name)
+                .collect::<Vec<_>>(),
+            [
+                "list_mcp_resource_templates",
+                "list_mcp_resources",
+                "mcp__fixture__echo",
+                "read_mcp_resource",
+            ],
+            "all deferred MCP tools must be callable through Code Mode from its first cell"
+        );
+
+        let resources = runtime
+            .execute_tool(
+                "list_mcp_resources",
+                ToolInput::Function(to_raw_value(&json!({})).unwrap()),
+                test_context("test-session", "list-resources"),
+            )
+            .await;
+        assert!(resources.success);
+        assert_eq!(
+            resources.code_mode_value()["resources"],
+            json!([
+                {
+                    "server": "fixture",
+                    "uri": "fixture://first",
+                    "name": "fixture-first",
+                    "mimeType": "text/plain"
+                },
+                {
+                    "server": "fixture",
+                    "uri": "fixture://second",
+                    "name": "fixture-second",
+                    "mimeType": "text/plain"
+                }
+            ]),
+            "aggregate listing must exhaust every server's pagination"
+        );
+
+        let templates = runtime
+            .execute_tool(
+                "list_mcp_resource_templates",
+                ToolInput::Function(to_raw_value(&json!({})).unwrap()),
+                test_context("test-session", "list-resource-templates"),
+            )
+            .await;
+        assert!(templates.success);
+        assert_eq!(
+            templates.code_mode_value()["resourceTemplates"][0],
+            json!({
+                "server": "fixture",
+                "uriTemplate": "fixture://item/{id}",
+                "name": "fixture-item",
+                "mimeType": "text/plain"
+            })
+        );
+
+        let read = runtime
+            .execute_tool(
+                "read_mcp_resource",
+                ToolInput::Function(
+                    to_raw_value(&json!({
+                        "server": "fixture",
+                        "uri": "fixture://first"
+                    }))
+                    .unwrap(),
+                ),
+                test_context("test-session", "read-resource"),
+            )
+            .await;
+        assert!(read.success);
+        assert_eq!(read.code_mode_value()["server"], "fixture");
+        assert_eq!(read.code_mode_value()["uri"], "fixture://first");
+        assert_eq!(
+            read.code_mode_value()["contents"][0]["text"],
+            "fixture resource body"
         );
     }
 

--- a/crates/nanocodex-tools/src/mcp/mod.rs
+++ b/crates/nanocodex-tools/src/mcp/mod.rs
@@ -523,14 +523,6 @@ impl DynamicToolProvider for Mcp {
         ]
     }
 
-    fn direct_tools_for_exposure(&self, exposure: crate::ToolExposure) -> Vec<Arc<dyn Tool>> {
-        let mut tools = self.direct_tools();
-        if exposure == crate::ToolExposure::CodeModeOnly {
-            tools.retain(|tool| !matches!(tool.definition(), ToolDefinition::ToolSearch { .. }));
-        }
-        tools
-    }
-
     fn available_definitions(&self) -> Vec<ToolDefinition> {
         self.state.available_definitions()
     }
@@ -861,8 +853,8 @@ mod tests {
         let specs = runtime.model_specs("test-session");
         assert_eq!(
             specs.iter().map(ToolDefinition::name).collect::<Vec<_>>(),
-            ["exec", "wait"],
-            "Code Mode-only must keep native tool_search off the top-level surface"
+            ["exec", "wait", "tool_search"],
+            "Code Mode-only must retain the discovery primitive while deferring MCP tools"
         );
 
         let description = specs[0].description();

--- a/crates/nanocodex-tools/src/mcp/resources.rs
+++ b/crates/nanocodex-tools/src/mcp/resources.rs
@@ -1,0 +1,301 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use nanocodex_oai_api::tools::ToolDefinition;
+use rmcp::model::{PaginatedRequestParams, ReadResourceRequestParams};
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+
+use crate::{Tool, ToolContext, ToolInput, ToolOutput, ToolResult};
+
+use super::catalog::ProviderState;
+
+const LIST_RESOURCES_DESCRIPTION: &str = "Lists resources provided by MCP servers. Resources allow servers to share data that provides context to language models, such as files, database schemas, or application-specific information. Prefer resources over web search when possible.";
+const LIST_RESOURCE_TEMPLATES_DESCRIPTION: &str = "Lists resource templates provided by MCP servers. Parameterized resource templates allow servers to share data that takes parameters and provides context to language models, such as files, database schemas, or application-specific information. Prefer resource templates over web search when possible.";
+const READ_RESOURCE_DESCRIPTION: &str =
+    "Read a specific resource from an MCP server given the server name and resource URI.";
+
+#[derive(Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct ListInput {
+    #[serde(default)]
+    server: Option<String>,
+    #[serde(default)]
+    cursor: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReadInput {
+    server: String,
+    uri: String,
+}
+
+pub(super) struct ListMcpResources {
+    state: Arc<ProviderState>,
+}
+
+impl ListMcpResources {
+    pub(super) const fn new(state: Arc<ProviderState>) -> Self {
+        Self { state }
+    }
+}
+
+pub(super) struct ListMcpResourceTemplates {
+    state: Arc<ProviderState>,
+}
+
+impl ListMcpResourceTemplates {
+    pub(super) const fn new(state: Arc<ProviderState>) -> Self {
+        Self { state }
+    }
+}
+
+pub(super) struct ReadMcpResource {
+    state: Arc<ProviderState>,
+}
+
+impl ReadMcpResource {
+    pub(super) const fn new(state: Arc<ProviderState>) -> Self {
+        Self { state }
+    }
+}
+
+#[async_trait]
+impl Tool for ListMcpResources {
+    fn definition(&self) -> ToolDefinition {
+        list_definition(
+            "list_mcp_resources",
+            LIST_RESOURCES_DESCRIPTION,
+            "resources",
+        )
+    }
+
+    fn supports_parallel_tool_calls(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
+        let input = input.decode_json::<ListInput>()?;
+        let value = list_resources(&self.state, input).await?;
+        Ok(ToolOutput::json(&value))
+    }
+}
+
+#[async_trait]
+impl Tool for ListMcpResourceTemplates {
+    fn definition(&self) -> ToolDefinition {
+        list_definition(
+            "list_mcp_resource_templates",
+            LIST_RESOURCE_TEMPLATES_DESCRIPTION,
+            "resource templates",
+        )
+    }
+
+    fn supports_parallel_tool_calls(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
+        let input = input.decode_json::<ListInput>()?;
+        let value = list_resource_templates(&self.state, input).await?;
+        Ok(ToolOutput::json(&value))
+    }
+}
+
+#[async_trait]
+impl Tool for ReadMcpResource {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::function(
+            "read_mcp_resource",
+            READ_RESOURCE_DESCRIPTION,
+            json!({
+                "type": "object",
+                "properties": {
+                    "server": {
+                        "type": "string",
+                        "description": "MCP server name exactly as configured. Must match the 'server' field returned by list_mcp_resources."
+                    },
+                    "uri": {
+                        "type": "string",
+                        "description": "Resource URI to read. Must be one of the URIs returned by list_mcp_resources."
+                    }
+                },
+                "required": ["server", "uri"],
+                "additionalProperties": false
+            }),
+        )
+    }
+
+    fn supports_parallel_tool_calls(&self) -> bool {
+        true
+    }
+
+    async fn execute(&self, input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
+        let input = input.decode_json::<ReadInput>()?;
+        let server = required("server", input.server)?;
+        let uri = required("uri", input.uri)?;
+        let client = self.state.client(&server).await?;
+        let result = client
+            .read_resource(ReadResourceRequestParams::new(&uri))
+            .await?;
+        let mut value = serde_json::to_value(result)?;
+        let object = value
+            .as_object_mut()
+            .ok_or("MCP resources/read returned a non-object result")?;
+        object.insert("server".to_owned(), Value::String(server));
+        object.insert("uri".to_owned(), Value::String(uri));
+        Ok(ToolOutput::json(&value))
+    }
+}
+
+fn list_definition(name: &str, description: &str, noun: &str) -> ToolDefinition {
+    ToolDefinition::function(
+        name,
+        description,
+        json!({
+            "type": "object",
+            "properties": {
+                "cursor": {
+                    "type": "string",
+                    "description": format!("Opaque cursor from a previous {name} call; omit for the first page.")
+                },
+                "server": {
+                    "type": "string",
+                    "description": format!("MCP server name. Omit to list {noun} from every configured server.")
+                }
+            },
+            "additionalProperties": false
+        }),
+    )
+}
+
+async fn list_resources(state: &ProviderState, input: ListInput) -> Result<Value, String> {
+    let cursor = normalized(input.cursor);
+    if let Some(server) = normalized(input.server) {
+        let params =
+            cursor.map(|cursor| PaginatedRequestParams::default().with_cursor(Some(cursor)));
+        let result = state
+            .client(&server)
+            .await?
+            .list_resources(params)
+            .await
+            .map_err(|error| format!("resources/list failed: {error}"))?;
+        let resources = with_server(result.resources, &server)?;
+        let mut payload = json!({ "server": server, "resources": resources });
+        if let Some(next_cursor) = result.next_cursor {
+            payload["nextCursor"] = Value::String(next_cursor);
+        }
+        return Ok(payload);
+    }
+    if cursor.is_some() {
+        return Err("cursor can only be used when a server is specified".to_owned());
+    }
+    let mut resources = Vec::new();
+    for (server, client) in state.clients().await {
+        let mut cursor = None;
+        loop {
+            let params = cursor
+                .clone()
+                .map(|cursor| PaginatedRequestParams::default().with_cursor(Some(cursor)));
+            let result = match client.list_resources(params).await {
+                Ok(result) => result,
+                Err(error) => {
+                    tracing::warn!(%error, %server, "failed to list MCP resources");
+                    break;
+                }
+            };
+            resources.extend(with_server(result.resources, &server)?);
+            let Some(next_cursor) = result.next_cursor else {
+                break;
+            };
+            if cursor.as_ref() == Some(&next_cursor) {
+                tracing::warn!(%server, "MCP resources/list returned a duplicate cursor");
+                break;
+            }
+            cursor = Some(next_cursor);
+        }
+    }
+    Ok(json!({ "resources": resources }))
+}
+
+async fn list_resource_templates(state: &ProviderState, input: ListInput) -> Result<Value, String> {
+    let cursor = normalized(input.cursor);
+    if let Some(server) = normalized(input.server) {
+        let params =
+            cursor.map(|cursor| PaginatedRequestParams::default().with_cursor(Some(cursor)));
+        let result = state
+            .client(&server)
+            .await?
+            .list_resource_templates(params)
+            .await
+            .map_err(|error| format!("resources/templates/list failed: {error}"))?;
+        let templates = with_server(result.resource_templates, &server)?;
+        let mut payload = json!({ "server": server, "resourceTemplates": templates });
+        if let Some(next_cursor) = result.next_cursor {
+            payload["nextCursor"] = Value::String(next_cursor);
+        }
+        return Ok(payload);
+    }
+    if cursor.is_some() {
+        return Err("cursor can only be used when a server is specified".to_owned());
+    }
+    let mut templates = Vec::new();
+    for (server, client) in state.clients().await {
+        let mut cursor = None;
+        loop {
+            let params = cursor
+                .clone()
+                .map(|cursor| PaginatedRequestParams::default().with_cursor(Some(cursor)));
+            let result = match client.list_resource_templates(params).await {
+                Ok(result) => result,
+                Err(error) => {
+                    tracing::warn!(%error, %server, "failed to list MCP resource templates");
+                    break;
+                }
+            };
+            templates.extend(with_server(result.resource_templates, &server)?);
+            let Some(next_cursor) = result.next_cursor else {
+                break;
+            };
+            if cursor.as_ref() == Some(&next_cursor) {
+                tracing::warn!(%server, "MCP resources/templates/list returned a duplicate cursor");
+                break;
+            }
+            cursor = Some(next_cursor);
+        }
+    }
+    Ok(json!({ "resourceTemplates": templates }))
+}
+
+fn with_server<T: serde::Serialize>(items: Vec<T>, server: &str) -> Result<Vec<Value>, String> {
+    items
+        .into_iter()
+        .map(|item| {
+            let value = serde_json::to_value(item).map_err(|error| error.to_string())?;
+            let Value::Object(mut object) = value else {
+                return Err("MCP resource entry was not an object".to_owned());
+            };
+            let mut tagged = Map::new();
+            tagged.insert("server".to_owned(), Value::String(server.to_owned()));
+            tagged.append(&mut object);
+            Ok(Value::Object(tagged))
+        })
+        .collect()
+}
+
+fn normalized(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let value = value.trim();
+        (!value.is_empty()).then(|| value.to_owned())
+    })
+}
+
+fn required(name: &str, value: String) -> Result<String, String> {
+    let value = value.trim();
+    if value.is_empty() {
+        Err(format!("{name} must not be empty"))
+    } else {
+        Ok(value.to_owned())
+    }
+}

--- a/crates/nanocodex-tools/src/runtime/execution.rs
+++ b/crates/nanocodex-tools/src/runtime/execution.rs
@@ -6,6 +6,8 @@ use super::*;
 /// normally owned privately by the higher-level agent driver.
 pub struct ToolRuntime {
     pub(super) registry: Arc<ToolRegistry>,
+    exposure: ToolExposure,
+    deferred_tools_guidance_enabled: bool,
     code_mode: code_mode::CodeModeRuntime,
     sessions: Arc<ShellSessions>,
     current_turn: Arc<AtomicU64>,
@@ -108,6 +110,8 @@ impl ToolRuntime {
         }
         Self {
             registry: Arc::new(ToolRegistry::from_ordered(handlers)),
+            exposure: ToolExposure::default(),
+            deferred_tools_guidance_enabled: false,
             code_mode: code_mode::CodeModeRuntime::new_with_turn(
                 code_mode_workspace,
                 Arc::clone(&current_turn),
@@ -127,8 +131,11 @@ impl ToolRuntime {
     #[must_use]
     pub fn with_tools(mut self, tools: &Tools) -> Self {
         tools.start_providers();
+        self.exposure = tools.exposure();
+        self.deferred_tools_guidance_enabled = tools.deferred_tools_guidance_enabled;
         let registry = Arc::make_mut(&mut self.registry);
         registry.extend(tools.registered.iter().cloned());
+        registry.extend(tools.provider_direct.iter().cloned());
         registry.providers.extend(tools.providers.iter().cloned());
         if let Some(working_directory) = &tools.working_directory {
             self.working_directory = Arc::clone(working_directory);
@@ -168,24 +175,44 @@ impl ToolRuntime {
     /// session.
     #[must_use]
     pub fn model_specs(&self, _session_id: &str) -> Vec<ToolDefinition> {
-        let has_deferred_search = !self.registry.providers.is_empty()
-            && self
-                .registry
-                .definitions()
-                .iter()
-                .any(|definition| definition.name() == "tool_search");
-        let (mut native, mut nested): (Vec<_>, Vec<_>) = self
+        let mut nested = self
             .registry
             .definitions()
             .iter()
+            .filter(|definition| !matches!(definition, ToolDefinition::ToolSearch { .. }))
             .cloned()
-            .partition(|definition| matches!(definition, ToolDefinition::ToolSearch { .. }));
-        nested.sort_by(|left, right| left.name().cmp(right.name()));
-        native.extend([
-            code_mode::exec_spec(&nested, has_deferred_search),
+            .collect::<Vec<_>>();
+        let mut direct = self
+            .registry
+            .definitions()
+            .iter()
+            .filter(|definition| {
+                self.exposure == ToolExposure::DirectAndCodeMode
+                    && !matches!(definition, ToolDefinition::ToolSearch { .. })
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if self.exposure == ToolExposure::DirectAndCodeMode {
+            direct = group_direct_code_mode_definitions(direct);
+            crate::code_mode_order::sort_direct_definitions(&mut direct);
+        }
+        crate::code_mode_order::sort_definitions(&mut nested);
+        let mut native = vec![
+            code_mode::exec_spec(
+                &nested,
+                self.deferred_tools_guidance_enabled,
+                self.exposure == ToolExposure::CodeModeOnly,
+            ),
             code_mode::wait_spec(),
-        ]);
-        native.sort_by(|left, right| left.name().cmp(right.name()));
+        ];
+        native.append(&mut direct);
+        native.extend(
+            self.registry
+                .definitions()
+                .iter()
+                .filter(|definition| matches!(definition, ToolDefinition::ToolSearch { .. }))
+                .cloned(),
+        );
         native
     }
 
@@ -298,6 +325,42 @@ impl ToolRuntime {
     ) -> ToolOutput {
         self.registry.execute_direct(name, input, context).await
     }
+}
+
+fn group_direct_code_mode_definitions(definitions: Vec<ToolDefinition>) -> Vec<ToolDefinition> {
+    let mut grouped = Vec::<ToolDefinition>::new();
+    for definition in definitions {
+        let canonical_name = definition.name().to_owned();
+        let mut definition = code_mode::description::augment_definition_for_code_mode(definition);
+        let Some((namespace, name)) = canonical_name.rsplit_once("__") else {
+            grouped.push(definition);
+            continue;
+        };
+        if namespace.is_empty() || name.is_empty() {
+            grouped.push(definition);
+            continue;
+        }
+        let ToolDefinition::Function {
+            name: direct_name, ..
+        } = &mut definition
+        else {
+            grouped.push(definition);
+            continue;
+        };
+        *direct_name = name.into();
+        if let Some(ToolDefinition::Namespace { tools, .. }) = grouped.iter_mut().find(
+            |group| matches!(group, ToolDefinition::Namespace { name, .. } if &**name == namespace),
+        ) {
+            tools.push(definition);
+        } else {
+            grouped.push(ToolDefinition::namespace(
+                namespace,
+                format!("Tools in the {namespace} namespace."),
+                [definition],
+            ));
+        }
+    }
+    grouped
 }
 
 impl ToolRuntimeControl {

--- a/crates/nanocodex-tools/src/runtime/mod.rs
+++ b/crates/nanocodex-tools/src/runtime/mod.rs
@@ -11,7 +11,7 @@ mod tests;
 pub use execution::{ToolRuntime, ToolRuntimeControl};
 pub(crate) use registry::ToolRegistry;
 pub use schema::schema_for;
-pub use selection::{DynamicToolProvider, Tools, ToolsBuildError, ToolsBuilder};
+pub use selection::{DynamicToolProvider, ToolExposure, Tools, ToolsBuildError, ToolsBuilder};
 
 use std::{
     any::Any,

--- a/crates/nanocodex-tools/src/runtime/registry.rs
+++ b/crates/nanocodex-tools/src/runtime/registry.rs
@@ -201,6 +201,11 @@ impl ToolRegistry {
                     ));
                 }
             },
+            ToolDefinition::Namespace { .. } => {
+                return ToolOutput::error(
+                    "Responses namespace definitions cannot execute as nested Code Mode tools",
+                );
+            }
             ToolDefinition::ToolSearch { .. } => {
                 return ToolOutput::error(
                     "provider-native tool_search cannot execute as a nested Code Mode tool",
@@ -300,6 +305,7 @@ impl ToolRegistry {
 fn definition_metadata(name: &str, definition: &ToolDefinition) -> Value {
     let kind = match definition {
         ToolDefinition::Function { .. } => "function",
+        ToolDefinition::Namespace { .. } => "namespace",
         ToolDefinition::Custom { .. } => "freeform",
         ToolDefinition::ToolSearch { .. } => "tool_search",
     };

--- a/crates/nanocodex-tools/src/runtime/selection.rs
+++ b/crates/nanocodex-tools/src/runtime/selection.rs
@@ -1,5 +1,16 @@
 use super::*;
 
+/// Nanocodex's model-visible tool exposure policy.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ToolExposure {
+    /// Expose normal tools only through Code Mode's `exec` entrypoint.
+    #[default]
+    CodeModeOnly,
+    /// Expose `exec` and `wait` before ordinary direct tools, while retaining
+    /// the same handlers for calls composed through Code Mode.
+    DirectAndCodeMode,
+}
+
 /// A lazily populated family of Code Mode tools.
 ///
 /// Providers start with the agent driver, advertise only their small direct
@@ -12,7 +23,16 @@ pub trait DynamicToolProvider: Send + Sync {
     /// Returns the provider's always-visible tools, such as `tool_search`.
     fn direct_tools(&self) -> Vec<Arc<dyn Tool>>;
 
-    /// Returns deferred tools currently activated for new Code Mode cells.
+    /// Returns the provider's direct tools for one model exposure policy.
+    ///
+    /// Providers normally expose the same tools under either policy. A provider may
+    /// hide discovery entrypoints in Code Mode-only when its deferred tools
+    /// are already callable through `ALL_TOOLS`, matching Codex's MCP policy.
+    fn direct_tools_for_exposure(&self, _exposure: ToolExposure) -> Vec<Arc<dyn Tool>> {
+        self.direct_tools()
+    }
+
+    /// Returns deferred tools currently callable from new Code Mode cells.
     fn available_definitions(&self) -> Vec<ToolDefinition>;
 
     /// Returns whether this provider currently exposes `name`.
@@ -22,16 +42,16 @@ pub trait DynamicToolProvider: Send + Sync {
             .any(|definition| definition.name() == name)
     }
 
-    /// Returns whether an activated deferred tool is safe to execute in parallel.
+    /// Returns whether a callable deferred tool is safe to execute in parallel.
     ///
     /// Providers are conservative by default. Implementations must return
-    /// `true` only for a currently activated tool with explicit safety
+    /// `true` only for a currently callable tool with explicit safety
     /// metadata.
     fn supports_parallel_tool_calls(&self, _name: &str) -> bool {
         false
     }
 
-    /// Executes an activated deferred tool, or returns `None` when this provider
+    /// Executes a callable deferred tool, or returns `None` when this provider
     /// does not currently expose `name`.
     ///
     /// The owning runtime converts handler panics into a failed `aborted`
@@ -47,6 +67,7 @@ pub trait DynamicToolProvider: Send + Sync {
 /// Declarative selection of the built-in tools installed for an agent.
 #[derive(Clone)]
 pub struct Tools {
+    exposure: ToolExposure,
     workspace: bool,
     web_search: bool,
     image_generation: bool,
@@ -55,12 +76,15 @@ pub struct Tools {
     process_environment: Arc<Vec<(OsString, OsString)>>,
     remote_http_client: Option<reqwest::Client>,
     pub(super) registered: Vec<Arc<dyn Tool>>,
+    pub(super) provider_direct: Vec<Arc<dyn Tool>>,
     pub(super) providers: Vec<Arc<dyn DynamicToolProvider>>,
+    pub(super) deferred_tools_guidance_enabled: bool,
 }
 
 impl Default for Tools {
     fn default() -> Self {
         Self {
+            exposure: ToolExposure::default(),
             workspace: true,
             web_search: true,
             image_generation: true,
@@ -69,7 +93,9 @@ impl Default for Tools {
             process_environment: Arc::new(Vec::new()),
             remote_http_client: None,
             registered: Vec::new(),
+            provider_direct: Vec::new(),
             providers: Vec::new(),
+            deferred_tools_guidance_enabled: false,
         }
     }
 }
@@ -79,6 +105,7 @@ impl fmt::Debug for Tools {
         let remote_http_client_configured = self.remote_http_client.is_some();
         formatter
             .debug_struct("Tools")
+            .field("exposure", &self.exposure)
             .field("workspace", &self.workspace)
             .field("web_search", &self.web_search)
             .field("image_generation", &self.image_generation)
@@ -93,6 +120,14 @@ impl fmt::Debug for Tools {
                 "registered",
                 &self
                     .registered
+                    .iter()
+                    .map(|tool| tool.definition().name().to_owned())
+                    .collect::<Vec<_>>(),
+            )
+            .field(
+                "provider_direct",
+                &self
+                    .provider_direct
                     .iter()
                     .map(|tool| tool.definition().name().to_owned())
                     .collect::<Vec<_>>(),
@@ -114,6 +149,12 @@ impl Tools {
     #[must_use]
     pub const fn into_builder(self) -> ToolsBuilder {
         ToolsBuilder { tools: self }
+    }
+
+    /// Returns the model-visible tool exposure policy.
+    #[must_use]
+    pub const fn exposure(&self) -> ToolExposure {
+        self.exposure
     }
 
     /// Returns whether the standard workspace tools are enabled.
@@ -198,6 +239,17 @@ pub enum ToolsBuildError {
 }
 
 impl ToolsBuilder {
+    /// Selects whether registered tools are also exposed directly to the model.
+    ///
+    /// The default is [`ToolExposure::CodeModeOnly`]. This changes only the
+    /// model-visible declaration set; all registered handlers remain callable
+    /// from Code Mode.
+    #[must_use]
+    pub const fn exposure(mut self, exposure: ToolExposure) -> Self {
+        self.tools.exposure = exposure;
+        self
+    }
+
     /// Starts from an empty built-in tool set.
     #[must_use]
     pub const fn without_defaults(mut self) -> Self {
@@ -278,8 +330,8 @@ impl ToolsBuilder {
     #[must_use]
     pub fn provider<P: DynamicToolProvider + 'static>(mut self, provider: P) -> Self {
         let provider: Arc<dyn DynamicToolProvider> = Arc::new(provider);
-        self.tools.registered.extend(provider.direct_tools());
         self.tools.providers.push(provider);
+        self.refresh_provider_direct();
         self
     }
 
@@ -288,7 +340,8 @@ impl ToolsBuilder {
     /// # Errors
     ///
     /// Returns an error for empty, duplicate, or enabled built-in tool names.
-    pub fn build(self) -> Result<Tools, ToolsBuildError> {
+    pub fn build(mut self) -> Result<Tools, ToolsBuildError> {
+        self.refresh_provider_direct();
         if self
             .tools
             .working_directory
@@ -305,8 +358,18 @@ impl ToolsBuilder {
         {
             return Err(ToolsBuildError::EmptyDefaultShell);
         }
-        let mut names = HashSet::with_capacity(self.tools.registered.len());
-        for tool in &self.tools.registered {
+        let mut names = HashSet::with_capacity(
+            self.tools
+                .registered
+                .len()
+                .saturating_add(self.tools.provider_direct.len()),
+        );
+        for tool in self
+            .tools
+            .registered
+            .iter()
+            .chain(&self.tools.provider_direct)
+        {
             let definition = tool.definition();
             let name = definition.name();
             if name.is_empty() {
@@ -320,6 +383,21 @@ impl ToolsBuilder {
             }
         }
         Ok(self.tools)
+    }
+
+    fn refresh_provider_direct(&mut self) {
+        self.tools.deferred_tools_guidance_enabled = self.tools.providers.iter().any(|provider| {
+            provider
+                .direct_tools()
+                .iter()
+                .any(|tool| matches!(tool.definition(), ToolDefinition::ToolSearch { .. }))
+        });
+        self.tools.provider_direct = self
+            .tools
+            .providers
+            .iter()
+            .flat_map(|provider| provider.direct_tools_for_exposure(self.tools.exposure))
+            .collect();
     }
 }
 

--- a/crates/nanocodex-tools/src/runtime/selection.rs
+++ b/crates/nanocodex-tools/src/runtime/selection.rs
@@ -25,9 +25,9 @@ pub trait DynamicToolProvider: Send + Sync {
 
     /// Returns the provider's direct tools for one model exposure policy.
     ///
-    /// Providers normally expose the same tools under either policy. A provider may
-    /// hide discovery entrypoints in Code Mode-only when its deferred tools
-    /// are already callable through `ALL_TOOLS`, matching Codex's MCP policy.
+    /// Providers normally expose the same tools under either policy. In
+    /// particular, discovery entrypoints such as `tool_search` remain visible
+    /// while the tools they discover stay deferred.
     fn direct_tools_for_exposure(&self, _exposure: ToolExposure) -> Vec<Arc<dyn Tool>> {
         self.direct_tools()
     }

--- a/crates/nanocodex-tools/src/runtime/tests.rs
+++ b/crates/nanocodex-tools/src/runtime/tests.rs
@@ -13,8 +13,8 @@ use serde_json::{Value, json, value::to_raw_value};
 use crate::{ToolOutputBody, ToolResult, contract::DEFAULT_TOOL_OUTPUT_TOKENS};
 
 use super::{
-    DynamicToolProvider, ImageGenerationConfig, Tool, ToolContext, ToolInput, ToolOutput,
-    ToolRuntime, Tools, WebSearchConfig,
+    DynamicToolProvider, ImageGenerationConfig, Tool, ToolContext, ToolExposure, ToolInput,
+    ToolOutput, ToolRuntime, Tools, WebSearchConfig,
 };
 
 struct Double;
@@ -477,6 +477,64 @@ fn model_description_is_stable_across_registration_order() {
 }
 
 #[test]
+fn exposure_controls_direct_visibility_without_removing_code_mode_access() {
+    let code_mode_only = Tools::builder()
+        .without_defaults()
+        .tool(Double)
+        .build()
+        .unwrap();
+    assert_eq!(code_mode_only.exposure(), ToolExposure::CodeModeOnly);
+    let code_mode_only = ToolRuntime::new_with_tools(".", None, None, &code_mode_only);
+    let code_mode_only_contract = code_mode_only.model_contract("test-session").1;
+    assert_eq!(
+        code_mode_only
+            .model_specs("test-session")
+            .iter()
+            .map(ToolDefinition::name)
+            .collect::<Vec<_>>(),
+        ["exec", "wait"]
+    );
+
+    let code_mode = Tools::builder()
+        .without_defaults()
+        .exposure(ToolExposure::DirectAndCodeMode)
+        .tool(Double)
+        .build()
+        .unwrap();
+    assert_eq!(code_mode.exposure(), ToolExposure::DirectAndCodeMode);
+    let code_mode = ToolRuntime::new_with_tools(".", None, None, &code_mode);
+    let code_mode_contract = code_mode.model_contract("test-session").1;
+    let specs = code_mode.model_specs("test-session");
+    assert_eq!(
+        specs.iter().map(ToolDefinition::name).collect::<Vec<_>>(),
+        ["exec", "wait", "double"]
+    );
+    let exec = specs
+        .iter()
+        .find(|definition| definition.name() == "exec")
+        .unwrap();
+    assert!(
+        !serde_json::to_value(exec).unwrap()["description"]
+            .as_str()
+            .is_some_and(|description| description.contains(
+                "declare const tools: { double(args: { value: number; }): Promise<unknown>; };"
+            )),
+        "normal Code Mode keeps exec terse like Codex"
+    );
+    let direct_double = specs
+        .iter()
+        .find(|definition| definition.name() == "double")
+        .unwrap();
+    assert!(
+        direct_double.description().contains(
+            "declare const tools: { double(args: { value: number; }): Promise<unknown>; };"
+        ),
+        "normal Code Mode augments each direct spec with its exec declaration"
+    );
+    assert_eq!(code_mode_contract, code_mode_only_contract);
+}
+
+#[test]
 fn tool_recipe_overrides_model_visible_environment_context() {
     let tools = Tools::builder()
         .without_defaults()
@@ -718,8 +776,8 @@ async fn code_mode_can_search_and_call_a_deferred_tool_in_one_cell() {
     assert!(
         model_specs_value[0]["description"]
             .as_str()
-            .is_some_and(|description| description.contains("Shared MCP Types:")),
-        "deferred MCP results need their stable shared type preamble before discovery"
+            .is_some_and(|description| !description.contains("Shared MCP Types:")),
+        "ordinary deferred providers must not opt into MCP-specific guidance"
     );
     let execution = runtime
         .execute_code(

--- a/crates/nanocodex-tools/src/shell/tool.rs
+++ b/crates/nanocodex-tools/src/shell/tool.rs
@@ -84,19 +84,59 @@ fn shell_execution(result: &super::ExecCommandResult) -> ToolOutput {
     if let Some(error) = &result.error {
         return ToolOutput::error(error);
     }
-    ToolOutput::json(&result).with_process_trace(
-        result.exit_code,
-        result.session_id,
-        result.original_token_count,
-        result.output.len(),
-        result.wall_time_seconds,
-    )
+    let code_mode_value = match serde_json::to_value(result) {
+        Ok(value) => value,
+        Err(error) => {
+            return ToolOutput::error(format!("failed to encode tool result: {error}"));
+        }
+    };
+    ToolOutput::text(shell_response_text(result))
+        .with_code_mode_value(code_mode_value)
+        .with_process_trace(
+            result.exit_code,
+            result.session_id,
+            result.original_token_count,
+            result.output.len(),
+            result.wall_time_seconds,
+        )
+}
+
+fn shell_response_text(result: &super::ExecCommandResult) -> String {
+    let mut sections = Vec::new();
+    if let Some(chunk_id) = result
+        .chunk_id
+        .as_deref()
+        .filter(|chunk_id| !chunk_id.is_empty())
+    {
+        sections.push(format!("Chunk ID: {chunk_id}"));
+    }
+    sections.push(format!(
+        "Wall time: {:.4} seconds",
+        result.wall_time_seconds
+    ));
+    if let Some(exit_code) = result.exit_code {
+        sections.push(format!("Process exited with code {exit_code}"));
+    }
+    if let Some(session_id) = result.session_id {
+        sections.push(format!("Process running with session ID {session_id}"));
+    }
+    if let Some(original_token_count) = result.original_token_count {
+        sections.push(format!("Original token count: {original_token_count}"));
+    }
+    sections.push("Output:".to_owned());
+    sections.push(result.output.clone());
+    sections.join("\n")
 }
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct ExecCommandArguments {
     cmd: String,
+    // Codex exposes these approval metadata fields even under a fixed
+    // full-access/never-ask policy. Nanocodex accepts but does not act on
+    // them; this does not add a second approval or sandbox policy owner.
+    #[serde(default)]
+    _justification: Option<String>,
     #[serde(default)]
     workdir: Option<String>,
     #[serde(default)]
@@ -109,6 +149,10 @@ struct ExecCommandArguments {
     yield_time_ms: Option<u64>,
     #[serde(default)]
     max_output_tokens: Option<usize>,
+    #[serde(default)]
+    _prefix_rule: Option<Vec<String>>,
+    #[serde(default)]
+    _sandbox_permissions: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -127,8 +171,11 @@ struct WriteStdinArguments {
 mod tests {
     use std::{path::PathBuf, sync::Arc};
 
-    use super::{ExecCommandHandler, Tool};
-    use crate::shell::ShellSessions;
+    use super::{ExecCommandHandler, Tool, shell_execution};
+    use crate::{
+        ToolOutputBody,
+        shell::{ExecCommandResult, ShellSessions},
+    };
 
     #[test]
     fn exec_command_exposes_codex_description_and_shell_parameter() {
@@ -146,6 +193,67 @@ mod tests {
             spec.pointer("/parameters/properties/shell/type")
                 .and_then(serde_json::Value::as_str),
             Some("string")
+        );
+    }
+
+    #[test]
+    fn shell_results_use_codex_text_directly_and_json_in_code_mode() {
+        let result = ExecCommandResult {
+            error: None,
+            chunk_id: Some("a1b2c3".to_owned()),
+            wall_time_seconds: 0.68754,
+            exit_code: Some(0),
+            session_id: None,
+            original_token_count: Some(7),
+            output: "hello\n".to_owned(),
+        };
+
+        let output = shell_execution(&result);
+        let ToolOutputBody::Text(direct) = &output.output else {
+            panic!("shell output should be plain text");
+        };
+        assert_eq!(
+            direct,
+            "Chunk ID: a1b2c3\n\
+             Wall time: 0.6875 seconds\n\
+             Process exited with code 0\n\
+             Original token count: 7\n\
+             Output:\n\
+             hello\n"
+        );
+        assert_eq!(
+            output.code_mode_value(),
+            serde_json::json!({
+                "chunk_id": "a1b2c3",
+                "wall_time_seconds": 0.68754,
+                "exit_code": 0,
+                "original_token_count": 7,
+                "output": "hello\n",
+            })
+        );
+    }
+
+    #[test]
+    fn running_shell_result_names_the_session() {
+        let result = ExecCommandResult {
+            error: None,
+            chunk_id: None,
+            wall_time_seconds: 10.0,
+            exit_code: None,
+            session_id: Some(42),
+            original_token_count: None,
+            output: String::new(),
+        };
+
+        let output = shell_execution(&result);
+        let ToolOutputBody::Text(direct) = output.output else {
+            panic!("shell output should be plain text");
+        };
+        assert_eq!(
+            direct,
+            "Wall time: 10.0000 seconds\n\
+             Process running with session ID 42\n\
+             Output:\n"
         );
     }
 }

--- a/crates/nanocodex-tools/src/standard.rs
+++ b/crates/nanocodex-tools/src/standard.rs
@@ -66,6 +66,10 @@ fn exec_command_definition(name: &'static str) -> ToolDefinition {
             "type": "object",
             "properties": {
                 "cmd": { "type": "string", "description": "Shell command to execute." },
+                "justification": {
+                    "type": "string",
+                    "description": "User-facing approval question for `require_escalated`; omit otherwise."
+                },
                 "workdir": {
                     "type": "string",
                     "description": "Working directory for the command. Defaults to the turn cwd."
@@ -89,6 +93,16 @@ fn exec_command_definition(name: &'static str) -> ToolDefinition {
                 "max_output_tokens": {
                     "type": "number",
                     "description": "Output token budget. Defaults to 10000 tokens; larger requests may be capped by policy."
+                },
+                "prefix_rule": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Reusable approval prefix for `cmd`, only with `sandbox_permissions: \"require_escalated\"`; for example [\"git\", \"pull\"]."
+                },
+                "sandbox_permissions": {
+                    "type": "string",
+                    "enum": ["use_default", "require_escalated"],
+                    "description": "Per-command sandbox override. Defaults to `use_default`; use `require_escalated` for unsandboxed execution."
                 }
             },
             "required": ["cmd"],
@@ -247,7 +261,8 @@ mod tests {
 
     #[test]
     fn shell_contract_matches_codex_unified_exec() {
-        let exec = definition(StandardTool::ExecCommand);
+        let exec_definition = StandardTool::ExecCommand.definition();
+        let exec = serde_json::to_value(&exec_definition).unwrap();
         assert_eq!(
             exec["description"],
             "Runs a command in a PTY, returning output or a session ID for ongoing interaction."
@@ -269,7 +284,8 @@ mod tests {
             "number"
         );
 
-        let write = definition(StandardTool::WriteStdin);
+        let write_definition = StandardTool::WriteStdin.definition();
+        let write = serde_json::to_value(&write_definition).unwrap();
         assert_eq!(
             write["description"],
             "Writes characters to an existing unified exec session and returns recent output."
@@ -289,7 +305,16 @@ mod tests {
             write["parameters"]["properties"]["max_output_tokens"]["type"],
             "number"
         );
-        assert_eq!(exec["output_schema"], write["output_schema"]);
+        assert!(exec.get("output_schema").is_none());
+        assert!(write.get("output_schema").is_none());
+        assert_eq!(
+            exec_definition
+                .output_schema()
+                .map(nanocodex_oai_api::responses::JsonSchema::as_value),
+            write_definition
+                .output_schema()
+                .map(nanocodex_oai_api::responses::JsonSchema::as_value)
+        );
     }
 
     #[test]
@@ -301,9 +326,11 @@ mod tests {
         );
         assert_eq!(patch["format"]["definition"], APPLY_PATCH_GRAMMAR);
 
+        let image_definition = StandardTool::ViewImage.definition();
         let image = definition(StandardTool::ViewImage);
+        assert!(image.get("output_schema").is_none());
         assert_eq!(
-            image["output_schema"]["properties"]["detail"]["description"],
+            image_definition.output_schema().unwrap().as_value()["properties"]["detail"]["description"],
             "Image detail hint returned by view_image. Returns `high` for default resized behavior or `original` when original resolution is preserved."
         );
     }

--- a/crates/nanocodex-tools/src/workspace_runtime.rs
+++ b/crates/nanocodex-tools/src/workspace_runtime.rs
@@ -150,7 +150,7 @@ impl WorkspaceToolRuntimeControl {
 
 #[cfg(test)]
 mod tests {
-    use nanocodex_oai_api::tools::{ToolInput, ToolOutputBody};
+    use nanocodex_oai_api::tools::ToolInput;
     use serde_json::value::to_raw_value;
     use tempfile::tempdir;
 
@@ -220,10 +220,6 @@ mod tests {
             .await;
 
         assert!(output.success);
-        let ToolOutputBody::Text(output) = output.output else {
-            panic!("shell command should return text");
-        };
-        let output = serde_json::from_str::<serde_json::Value>(&output).unwrap();
-        assert_eq!(output["output"], "from-image");
+        assert_eq!(output.code_mode_value()["output"], "from-image");
     }
 }

--- a/crates/nanocodex-tools/tests/fixtures/mcp-stdio-server.mjs
+++ b/crates/nanocodex-tools/tests/fixtures/mcp-stdio-server.mjs
@@ -28,7 +28,7 @@ lines.on("line", (line) => {
       id: request.id,
       result: {
         protocolVersion: request.params.protocolVersion,
-        capabilities: { tools: {} },
+        capabilities: { tools: {}, resources: {} },
         serverInfo: { name: "nanocodex-test-mcp", version: "0.1.0" },
       },
     });
@@ -73,5 +73,43 @@ lines.on("line", (line) => {
         },
       });
     }, delayMs);
+  } else if (request.method === "resources/list") {
+    const secondPage = request.params?.cursor === "fixture-next";
+    send({
+      jsonrpc: "2.0",
+      id: request.id,
+      result: {
+        resources: [{
+          uri: secondPage ? "fixture://second" : "fixture://first",
+          name: secondPage ? "fixture-second" : "fixture-first",
+          mimeType: "text/plain",
+        }],
+        ...(secondPage ? {} : { nextCursor: "fixture-next" }),
+      },
+    });
+  } else if (request.method === "resources/templates/list") {
+    send({
+      jsonrpc: "2.0",
+      id: request.id,
+      result: {
+        resourceTemplates: [{
+          uriTemplate: "fixture://item/{id}",
+          name: "fixture-item",
+          mimeType: "text/plain",
+        }],
+      },
+    });
+  } else if (request.method === "resources/read") {
+    send({
+      jsonrpc: "2.0",
+      id: request.id,
+      result: {
+        contents: [{
+          uri: request.params.uri,
+          mimeType: "text/plain",
+          text: "fixture resource body",
+        }],
+      },
+    });
   }
 });

--- a/crates/nanocodex/tests/it/tool_macro.rs
+++ b/crates/nanocodex/tests/it/tool_macro.rs
@@ -11,14 +11,19 @@ async fn add(left: i64, right: i64) -> Result<i64, &'static str> {
 
 #[tokio::test]
 async fn macro_generates_schema_and_executes_through_public_tool_trait() {
-    let definition = serde_json::to_value(add.definition()).unwrap();
-    assert_eq!(definition["name"], "add_numbers");
-    assert_eq!(definition["parameters"]["type"], "object");
+    let definition = add.definition();
+    let serialized = serde_json::to_value(&definition).unwrap();
+    assert_eq!(serialized["name"], "add_numbers");
+    assert_eq!(serialized["parameters"]["type"], "object");
     assert_eq!(
-        definition["parameters"]["required"],
+        serialized["parameters"]["required"],
         json!(["left", "right"])
     );
-    assert_eq!(definition["output_schema"]["type"], "integer");
+    assert_eq!(
+        definition.output_schema().unwrap().as_value()["type"],
+        "integer"
+    );
+    assert!(serialized.get("output_schema").is_none());
 
     let execution = add
         .execute(


### PR DESCRIPTION
Extracted from #61 as an independently mergeable Code Mode vertical slice.

What this changes:
- matches the Codex exec and wait descriptions and the exact ALL_TOOLS name/description runtime shape
- adds provider-native Responses namespaces while retaining output schemas as client-owned Code Mode metadata
- makes direct tool declarations an explicit ToolExposure policy, with CodeModeOnly remaining the default
- aligns shell output, nested yield behavior, MCP discovery/resources, tool ordering, and direct/custom dispatch
- updates the crate README and public examples without pulling in eval, VM, CLI, or dashboard code

Validation:
- nanocodex-tools all-target tests and MCP benchmarks
- nanocodex-agent tool integration tests
- facade tool-macro integration test
- nanocodex-oai-api and nanocodex-tools doctests
- warnings-denied Clippy for OAI, tools, and agent
- crate-boundary policy