### PR TITLE
agent: model remote execution context explicitly

### DIFF
--- a/crates/nanocodex-agent/README.md
+++ b/crates/nanocodex-agent/README.md
@@ -40,6 +40,30 @@ and process state. Cloning [`Nanocodex`] only clones its command capability;
 [`Nanocodex::spawn`] creates a clean sibling and [`Nanocodex::fork`] creates an
 independent branch from committed history.
 
+## Remote tool environments
+
+When tools execute in a VM or remote workspace, provide one coherent snapshot
+of the facts described to the model. This prevents host time and `AGENTS.md`
+discovery from being mixed with a different tool filesystem:
+
+```rust,no_run
+use nanocodex_agent::{ExecutionEnvironment, Nanocodex, OpenAi};
+
+# fn build(openai: OpenAi) -> Result<(), Box<dyn std::error::Error>> {
+let environment = ExecutionEnvironment::new("2026-07-29", "Etc/UTC")
+    .project_instructions("Preserve generated files under build/.");
+let (_agent, _events) = Nanocodex::builder(openai)
+    .execution_environment(environment)
+    .build()?;
+# Ok(())
+# }
+```
+
+Omit [`ExecutionEnvironment::project_instructions`] when the remote workspace
+has no project instructions. Without an execution environment, native agents
+continue discovering date, timezone, and project instructions from the local
+embedding host.
+
 ## Typed events
 
 [`AgentEvents`] is optional and independent from turn results. Its raw

--- a/crates/nanocodex-agent/src/agent/builder.rs
+++ b/crates/nanocodex-agent/src/agent/builder.rs
@@ -108,6 +108,17 @@ impl<F> NanocodexBuilder<F> {
         self
     }
 
+    /// Describes the remote environment where model-visible tools execute.
+    ///
+    /// This replaces host date/time discovery and host `AGENTS.md` discovery
+    /// together, so one agent never mixes context from two machines. The
+    /// snapshot remains fixed for this agent lifecycle.
+    #[must_use]
+    pub fn execution_environment(mut self, environment: ExecutionEnvironment) -> Self {
+        self.codex.context.set_execution_environment(environment);
+        self
+    }
+
     /// Sets the root agent's `UUIDv7` session identity.
     ///
     /// The root identity also seeds its checkpoint lineage. Spawned siblings
@@ -234,6 +245,7 @@ where
     <F::Service as Service<ResponsesAttempt>>::Future: AgentSend,
 {
     validate(&builder.config, builder.prompt_cache.key.as_deref())?;
+    validate_execution_environment(builder.codex.context.execution_environment())?;
     let config = Arc::new(builder.config);
     let factory = builder.factory;
     let service_factory: ServiceFactory<F::Service> = Arc::new(move |config| factory.make(config));
@@ -247,6 +259,68 @@ where
         builder.resume,
         service_factory,
     )
+}
+
+fn validate_execution_environment(environment: Option<&ExecutionEnvironment>) -> Result<()> {
+    let Some(environment) = environment else {
+        return Ok(());
+    };
+    if environment.current_date.trim().is_empty() {
+        return Err(NanocodexError::InvalidRequest(
+            "execution-environment current date must not be empty".to_owned(),
+        ));
+    }
+    if !is_iso_date(environment.current_date.trim()) {
+        return Err(NanocodexError::InvalidRequest(
+            "execution-environment current date must use YYYY-MM-DD".to_owned(),
+        ));
+    }
+    if environment.timezone.trim().is_empty() {
+        return Err(NanocodexError::InvalidRequest(
+            "execution-environment timezone must not be empty".to_owned(),
+        ));
+    }
+    if environment
+        .project_instructions
+        .as_deref()
+        .is_some_and(|instructions| instructions.trim().is_empty())
+    {
+        return Err(NanocodexError::InvalidRequest(
+            "execution-environment project instructions must not be empty".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn is_iso_date(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.len() != 10 || bytes[4] != b'-' || bytes[7] != b'-' {
+        return false;
+    }
+    let Some(year) = decimal(&bytes[..4]) else {
+        return false;
+    };
+    let Some(month) = decimal(&bytes[5..7]) else {
+        return false;
+    };
+    let Some(day) = decimal(&bytes[8..]) else {
+        return false;
+    };
+    let days = match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if year % 400 == 0 || (year % 4 == 0 && year % 100 != 0) => 29,
+        2 => 28,
+        _ => return false,
+    };
+    (1..=days).contains(&day)
+}
+
+fn decimal(bytes: &[u8]) -> Option<u32> {
+    bytes.iter().try_fold(0_u32, |value, byte| {
+        byte.is_ascii_digit()
+            .then(|| value * 10 + u32::from(*byte - b'0'))
+    })
 }
 
 #[cfg(test)]
@@ -263,6 +337,34 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn execution_environment_requires_complete_model_visible_context() {
+        assert!(
+            validate_execution_environment(Some(&ExecutionEnvironment::new(
+                "2026-07-29",
+                "Etc/UTC",
+            )))
+            .is_ok()
+        );
+        assert!(
+            validate_execution_environment(Some(&ExecutionEnvironment::new("July 29", "Etc/UTC",)))
+                .is_err()
+        );
+        assert!(
+            validate_execution_environment(Some(&ExecutionEnvironment::new(
+                "2026-02-29",
+                "Etc/UTC",
+            )))
+            .is_err()
+        );
+        assert!(
+            validate_execution_environment(Some(
+                &ExecutionEnvironment::new("2026-07-29", "Etc/UTC").project_instructions(" "),
+            ))
+            .is_err()
+        );
+    }
 
     #[derive(Clone)]
     struct ObservingFactory {

--- a/crates/nanocodex-agent/src/agent/context_source/agents_md.rs
+++ b/crates/nanocodex-agent/src/agent/context_source/agents_md.rs
@@ -69,10 +69,18 @@ pub(super) fn load_instructions(
             None
         }
     };
+    combine_instructions(global_instructions, project_instructions.as_deref())
+}
+
+pub(super) fn combine_instructions(
+    global_instructions: Option<&str>,
+    project_instructions: Option<&str>,
+) -> Option<String> {
     match (global_instructions, project_instructions) {
         (Some(global), Some(project)) => Some(format!("{global}{PROJECT_DOC_SEPARATOR}{project}")),
         (Some(global), None) => Some(global.to_owned()),
-        (None, project) => project,
+        (None, Some(project)) => Some(project.to_owned()),
+        (None, None) => None,
     }
 }
 

--- a/crates/nanocodex-agent/src/agent/context_source/mod.rs
+++ b/crates/nanocodex-agent/src/agent/context_source/mod.rs
@@ -9,5 +9,46 @@ mod platform;
 #[path = "web.rs"]
 mod platform;
 
+/// Model-visible facts owned by a remote tool-execution environment.
+///
+/// Configure this when tools operate somewhere other than the embedding
+/// process. Without it, native agents discover project instructions, date,
+/// and timezone from the embedding host.
+#[derive(Clone, Debug)]
+pub struct ExecutionEnvironment {
+    pub(crate) current_date: std::sync::Arc<str>,
+    pub(crate) timezone: std::sync::Arc<str>,
+    pub(crate) project_instructions: Option<std::sync::Arc<str>>,
+}
+
+impl ExecutionEnvironment {
+    /// Creates an environment with no project-instruction snapshot.
+    ///
+    /// The date must use `YYYY-MM-DD`; the timezone should be the name exposed
+    /// by the execution environment, such as `Etc/UTC`. Invalid values are
+    /// rejected when the agent is built. Omitting project instructions means
+    /// that the remote workspace has none and suppresses host discovery.
+    #[must_use]
+    pub fn new(
+        current_date: impl Into<std::sync::Arc<str>>,
+        timezone: impl Into<std::sync::Arc<str>>,
+    ) -> Self {
+        Self {
+            current_date: current_date.into(),
+            timezone: timezone.into(),
+            project_instructions: None,
+        }
+    }
+
+    /// Adds the complete project-instruction snapshot visible in the remote
+    /// workspace. An empty snapshot is rejected; omit this method when the
+    /// remote workspace has no project instructions.
+    #[must_use]
+    pub fn project_instructions(mut self, instructions: impl Into<std::sync::Arc<str>>) -> Self {
+        self.project_instructions = Some(instructions.into());
+        self
+    }
+}
+
 pub(crate) use platform::ContextSource;
 pub(super) use platform::ContextSourceConfig;

--- a/crates/nanocodex-agent/src/agent/context_source/native.rs
+++ b/crates/nanocodex-agent/src/agent/context_source/native.rs
@@ -3,12 +3,13 @@ use std::{
     sync::Arc,
 };
 
-use super::agents_md::{load_global_instructions, load_instructions};
+use super::agents_md::{combine_instructions, load_global_instructions, load_instructions};
 use crate::{NanocodexError, Result};
 
 #[derive(Clone, Default)]
 pub(crate) struct ContextSourceConfig {
     codex_home: Option<PathBuf>,
+    execution_environment: Option<super::ExecutionEnvironment>,
 }
 
 impl ContextSourceConfig {
@@ -20,9 +21,18 @@ impl ContextSourceConfig {
         self.codex_home.as_deref()
     }
 
+    pub(crate) fn set_execution_environment(&mut self, environment: super::ExecutionEnvironment) {
+        self.execution_environment = Some(environment);
+    }
+
+    pub(crate) const fn execution_environment(&self) -> Option<&super::ExecutionEnvironment> {
+        self.execution_environment.as_ref()
+    }
+
     pub(crate) fn build(&self) -> ContextSource {
         ContextSource {
             global_instructions: load_global_instructions(self.codex_home()),
+            execution_environment: self.execution_environment.clone(),
         }
     }
 }
@@ -30,6 +40,7 @@ impl ContextSourceConfig {
 #[derive(Clone)]
 pub(crate) struct ContextSource {
     global_instructions: Option<Arc<str>>,
+    execution_environment: Option<super::ExecutionEnvironment>,
 }
 
 impl ContextSource {
@@ -53,11 +64,22 @@ impl ContextSource {
     }
 
     pub(crate) fn project_instructions(&self, workspace: &str) -> Option<String> {
-        load_instructions(Path::new(workspace), self.global_instructions.as_deref())
+        if let Some(environment) = &self.execution_environment {
+            combine_instructions(
+                self.global_instructions.as_deref(),
+                environment.project_instructions.as_deref(),
+            )
+        } else {
+            load_instructions(Path::new(workspace), self.global_instructions.as_deref())
+        }
     }
 
     pub(crate) fn global_instructions(&self) -> Option<Arc<str>> {
         self.global_instructions.as_ref().map(Arc::clone)
+    }
+
+    pub(crate) const fn execution_environment(&self) -> Option<&super::ExecutionEnvironment> {
+        self.execution_environment.as_ref()
     }
 
     pub(crate) fn with_fallback_global(mut self, fallback: Option<Arc<str>>) -> Self {
@@ -65,5 +87,29 @@ impl ContextSource {
             self.global_instructions = fallback;
         }
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_project_snapshot_replaces_native_workspace_discovery() {
+        let workspace = tempfile::tempdir().unwrap();
+        std::fs::write(workspace.path().join("AGENTS.md"), "host instructions").unwrap();
+        let mut config = ContextSourceConfig::default();
+        config.set_execution_environment(
+            super::super::ExecutionEnvironment::new("2026-07-29", "Etc/UTC")
+                .project_instructions("guest instructions"),
+        );
+
+        assert_eq!(
+            config
+                .build()
+                .project_instructions(workspace.path().to_str().unwrap())
+                .as_deref(),
+            Some("guest instructions")
+        );
     }
 }

--- a/crates/nanocodex-agent/src/agent/context_source/web.rs
+++ b/crates/nanocodex-agent/src/agent/context_source/web.rs
@@ -3,28 +3,50 @@ use std::sync::Arc;
 use crate::Result;
 
 #[derive(Clone, Default)]
-pub(crate) struct ContextSourceConfig;
+pub(crate) struct ContextSourceConfig {
+    execution_environment: Option<super::ExecutionEnvironment>,
+}
 
 impl ContextSourceConfig {
-    pub(crate) const fn build(&self) -> ContextSource {
-        ContextSource
+    pub(crate) fn set_execution_environment(&mut self, environment: super::ExecutionEnvironment) {
+        self.execution_environment = Some(environment);
+    }
+
+    pub(crate) const fn execution_environment(&self) -> Option<&super::ExecutionEnvironment> {
+        self.execution_environment.as_ref()
+    }
+
+    pub(crate) fn build(&self) -> ContextSource {
+        ContextSource {
+            execution_environment: self.execution_environment.clone(),
+        }
     }
 }
 
 #[derive(Clone)]
-pub(crate) struct ContextSource;
+pub(crate) struct ContextSource {
+    execution_environment: Option<super::ExecutionEnvironment>,
+}
 
 impl ContextSource {
     pub(crate) fn resolve_workspace(&self, requested: Option<&str>) -> Result<String> {
         Ok(requested.unwrap_or(".").to_owned())
     }
 
-    pub(crate) const fn project_instructions(&self, _workspace: &str) -> Option<String> {
-        None
+    pub(crate) fn project_instructions(&self, _workspace: &str) -> Option<String> {
+        self.execution_environment
+            .as_ref()?
+            .project_instructions
+            .as_deref()
+            .map(str::to_owned)
     }
 
     pub(crate) const fn global_instructions(&self) -> Option<Arc<str>> {
         None
+    }
+
+    pub(crate) const fn execution_environment(&self) -> Option<&super::ExecutionEnvironment> {
+        self.execution_environment.as_ref()
     }
 
     pub(crate) fn with_fallback_global(self, _fallback: Option<Arc<str>>) -> Self {

--- a/crates/nanocodex-agent/src/agent/mod.rs
+++ b/crates/nanocodex-agent/src/agent/mod.rs
@@ -98,6 +98,7 @@ mod spawn;
 mod turn;
 
 pub use builder::NanocodexBuilder;
+pub use context_source::ExecutionEnvironment;
 pub use handle::{AgentHandle, Nanocodex};
 pub use session_context::AgentSessionContext;
 pub use turn::{PromptRoute, Turn, TurnControl, TurnResult};

--- a/crates/nanocodex-agent/src/lib.rs
+++ b/crates/nanocodex-agent/src/lib.rs
@@ -24,8 +24,8 @@ pub mod session;
 pub mod usage;
 
 pub use agent::{
-    AgentHandle, AgentSessionContext, Nanocodex, NanocodexBuilder, PromptRoute, Turn, TurnControl,
-    TurnResult,
+    AgentHandle, AgentSessionContext, ExecutionEnvironment, Nanocodex, NanocodexBuilder,
+    PromptRoute, Turn, TurnControl, TurnResult,
 };
 pub use error::{NanocodexError, Result};
 pub use nanocodex_oai_api::{

--- a/crates/nanocodex-agent/src/model/context.rs
+++ b/crates/nanocodex-agent/src/model/context.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use chrono::{Local, Utc};
 use nanocodex_oai_api::responses::{ContentItem, MessageRole, ResponseItem};
 
+use crate::agent::ExecutionEnvironment;
+
 const REPLACEMENT_NOTICE: &str =
     "These AGENTS.md instructions replace all previously provided AGENTS.md instructions.";
 const REMOVAL_NOTICE: &str = "The previously provided AGENTS.md instructions no longer apply.";
@@ -67,8 +69,18 @@ impl ContextState {
         }
     }
 
-    pub(crate) fn capture(&self, cwd: &str, shell: &str) -> ContextSnapshot {
-        ContextSnapshot::capture(cwd, shell, self.selected_agents_md.as_deref())
+    pub(crate) fn capture(
+        &self,
+        cwd: &str,
+        shell: &str,
+        execution_environment: Option<&ExecutionEnvironment>,
+    ) -> ContextSnapshot {
+        ContextSnapshot::capture(
+            cwd,
+            shell,
+            self.selected_agents_md.as_deref(),
+            execution_environment,
+        )
     }
 
     pub(crate) fn update(&mut self, current: ContextSnapshot) -> Option<ContextUpdate> {
@@ -103,9 +115,26 @@ impl ContextState {
 }
 
 impl ContextSnapshot {
-    pub(crate) fn capture(cwd: &str, shell: &str, agents_md: Option<&str>) -> Self {
-        let (current_date, timezone) = local_time_context();
-        Self::capture_at(cwd, shell, agents_md, &current_date, &timezone)
+    pub(crate) fn capture(
+        cwd: &str,
+        shell: &str,
+        agents_md: Option<&str>,
+        execution_environment: Option<&ExecutionEnvironment>,
+    ) -> Self {
+        let detected;
+        let local_time = if let Some(configured) = execution_environment {
+            configured
+        } else {
+            detected = detected_execution_environment();
+            &detected
+        };
+        Self::capture_at(
+            cwd,
+            shell,
+            agents_md,
+            &local_time.current_date,
+            &local_time.timezone,
+        )
     }
 
     pub(super) fn capture_at(
@@ -369,12 +398,14 @@ fn between<'a>(text: &'a str, start: &str, end: &str) -> Option<&'a str> {
     Some(&text[start..end])
 }
 
-fn local_time_context() -> (String, String) {
+fn detected_execution_environment() -> ExecutionEnvironment {
     match iana_time_zone::get_timezone() {
-        Ok(timezone) => (Local::now().format("%Y-%m-%d").to_string(), timezone),
-        Err(_) => (
+        Ok(timezone) => {
+            ExecutionEnvironment::new(Local::now().format("%Y-%m-%d").to_string(), timezone)
+        }
+        Err(_) => ExecutionEnvironment::new(
             Utc::now().format("%Y-%m-%d").to_string(),
-            "Etc/UTC".to_owned(),
+            Arc::from("Etc/UTC"),
         ),
     }
 }
@@ -385,6 +416,16 @@ mod tests {
 
     fn text(item: &ResponseItem) -> String {
         serde_json::to_string(item).expect("context item serializes")
+    }
+
+    #[test]
+    fn configured_local_time_replaces_the_embedding_host_context() {
+        let configured = ExecutionEnvironment::new("2026-07-29", "/UTC");
+        let snapshot = ContextSnapshot::capture("/app", "bash", None, Some(&configured));
+        let rendered = text(&snapshot.full_item());
+
+        assert!(rendered.contains("<current_date>2026-07-29</current_date>"));
+        assert!(rendered.contains("<timezone>/UTC</timezone>"));
     }
 
     #[test]

--- a/crates/nanocodex-agent/src/model/run/mod.rs
+++ b/crates/nanocodex-agent/src/model/run/mod.rs
@@ -359,7 +359,11 @@ impl<S> ModelRun<S> {
         let factory = self.attempt_factory(&tools);
         let context = ContextState::new(selected_agents_md, ContextBaseline::Missing);
         let canonical_context = context
-            .capture(tools.working_directory(), tools.default_shell_name())
+            .capture(
+                tools.working_directory(),
+                tools.default_shell_name(),
+                self.context_source.execution_environment(),
+            )
             .full_item();
         Ok(ModelSessionState {
             workspace,

--- a/crates/nanocodex-agent/src/model/run/turn.rs
+++ b/crates/nanocodex-agent/src/model/run/turn.rs
@@ -343,6 +343,7 @@ where
         let current_context = session.context.capture(
             session.tools.working_directory(),
             session.tools.default_shell_name(),
+            self.context_source.execution_environment(),
         );
         let canonical_context = current_context.full_item();
         if let Some(update) = session.context.update(current_context) {
@@ -420,8 +421,11 @@ where
             let factory = self.attempt_factory(&tools).for_logical_turn(logical_turn);
             let user_content = prepare_user_input(&task.instruction).await;
             let mut context = ContextState::new(selected_agents_md, ContextBaseline::Missing);
-            let context_snapshot =
-                context.capture(tools.working_directory(), tools.default_shell_name());
+            let context_snapshot = context.capture(
+                tools.working_directory(),
+                tools.default_shell_name(),
+                self.context_source.execution_environment(),
+            );
             let mut history = task_input(user_content, &context_snapshot);
             if !self.pending_developer_messages.is_empty() {
                 let user = history

--- a/crates/nanocodex-agent/tests/it/model/context.rs
+++ b/crates/nanocodex-agent/tests/it/model/context.rs
@@ -1,6 +1,54 @@
 use super::*;
 
 #[tokio::test]
+async fn execution_environment_suppresses_host_context_discovery() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let endpoint = format!("ws://{}", listener.local_addr()?);
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await?;
+        let mut socket = accept_async(stream).await?;
+        assert_warmup(&next_json(&mut socket).await?);
+        send_warmup(&mut socket, "resp-warmup").await?;
+
+        let request = next_json(&mut socket).await?.to_string();
+        assert!(request.contains("remote task prompt"));
+        assert!(request.contains("<current_date>2026-07-29</current_date>"));
+        assert!(request.contains("<timezone>Etc/UTC</timezone>"));
+        assert!(!request.contains("host-only instructions"));
+        assert!(!request.contains("# AGENTS.md instructions"));
+        send_final(&mut socket, "resp-final").await
+    });
+
+    let workspace = temporary_workspace("remote-empty-agents-context")?;
+    std::fs::write(workspace.join("AGENTS.md"), "host-only instructions\n")?;
+    let openai = OpenAi::builder("test-key")
+        .websocket_url(endpoint)
+        .build()?;
+    let (agent, events) = Nanocodex::builder(openai)
+        .thinking(Thinking::Low)
+        .workspace(&workspace)
+        .execution_environment(ExecutionEnvironment::new("2026-07-29", "Etc/UTC"))
+        .session_id(test_session_id())
+        .build()?;
+    assert_eq!(
+        agent
+            .prompt("remote task prompt")
+            .await?
+            .result()
+            .await?
+            .final_message(),
+        "done"
+    );
+
+    drop((agent, events));
+    timeout(std::time::Duration::from_secs(5), server)
+        .await
+        .map_err(|_| eyre!("mock Responses server did not finish"))???;
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn ordinary_turns_keep_creation_time_agents_md() -> Result<()> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let endpoint = format!("ws://{}", listener.local_addr()?);

--- a/crates/nanocodex-agent/tests/it/model/mod.rs
+++ b/crates/nanocodex-agent/tests/it/model/mod.rs
@@ -15,8 +15,8 @@ use tokio::{
 use tokio_tungstenite::{WebSocketStream, accept_async, tungstenite::Message};
 
 use nanocodex_agent::{
-    AgentHandle, Model, Nanocodex, NanocodexError, OpenAi, PromptRoute, ReasoningMode,
-    ResponseError, Thinking, Tools,
+    AgentHandle, ExecutionEnvironment, Model, Nanocodex, NanocodexError, OpenAi, PromptRoute,
+    ReasoningMode, ResponseError, Thinking, Tools,
     events::{AgentEvent, AgentEventData, RunEvent},
     input::Prompt,
     rollout::RolloutConfig,


### PR DESCRIPTION
Extracted from #61 as an independent agent API slice.

This replaces separate stringly date/time and hidden project-snapshot knobs with one typed ExecutionEnvironment. Supplying it atomically replaces host date/time and host AGENTS.md discovery, so an agent cannot accidentally describe one machine while its tools operate on another. Omitting project instructions explicitly represents a remote workspace without them.

The builder validates YYYY-MM-DD dates, non-empty timezones, and non-empty supplied instruction snapshots. Native host discovery remains unchanged when no execution environment is configured. The same public API compiles for browser WASM.

Documentation includes a complete VM/remote-workspace example.

Validation:
- focused model-context unit and integration tests
- public doctests
- warnings-denied Clippy for all agent targets
- wasm32-unknown-unknown cargo check
- crate-boundary policy