### PR TITLE
oai: account for usage-uncertain Responses attempts

### DIFF
--- a/crates/nanocodex-agent/src/model/telemetry.rs
+++ b/crates/nanocodex-agent/src/model/telemetry.rs
@@ -169,6 +169,7 @@ pub(super) struct RunStats {
     pub(super) websocket_reconnects: u32,
     pub(super) response_attempts: u32,
     pub(super) response_retries: u32,
+    pub(super) billing_uncertain_response_attempts: u32,
     pub(super) connection_duration_ns: u64,
     pub(super) retry_backoff_duration_ns: u64,
     pub(super) model_duration_ns: u64,
@@ -187,6 +188,7 @@ impl RunStats {
         self.websocket_reconnects = delta.websocket_reconnects;
         self.response_attempts = delta.response_attempts;
         self.response_retries = delta.response_retries;
+        self.billing_uncertain_response_attempts = delta.billing_uncertain_response_attempts;
         self.connection_duration_ns = delta.connection_duration_ns;
         self.retry_backoff_duration_ns = delta.retry_backoff_duration_ns;
     }

--- a/crates/nanocodex-agent/tests/it/model/recovery/failures.rs
+++ b/crates/nanocodex-agent/tests/it/model/recovery/failures.rs
@@ -103,9 +103,11 @@ async fn warmup_failure_falls_back_to_a_full_first_request() -> Result<()> {
         .await
         .map_err(|_| eyre!("mock Responses server did not finish"))???;
     assert!(output.contains("\"model.warmup.failed\""));
+    assert!(output.contains("\"billing_uncertain\":false"));
     assert!(output.contains("\"purpose\":\"warmup_fallback\""));
     assert!(output.contains("\"connection_attempts\":2"));
     assert!(output.contains("\"websocket_reconnects\":1"));
+    assert!(output.contains("\"billing_uncertain_response_attempts\":0"));
     assert!(output.contains("\"run.completed\""));
     std::fs::remove_dir_all(workspace)?;
     Ok(())

--- a/crates/nanocodex-agent/tests/it/model/recovery/reconnect.rs
+++ b/crates/nanocodex-agent/tests/it/model/recovery/reconnect.rs
@@ -132,9 +132,11 @@ async fn receive_reset_reconnects_without_replaying_completed_tools() -> Result<
     assert_eq!(std::fs::read_to_string(workspace.join("marker.txt"))?, "x");
     assert!(output.contains("\"model.attempt.retrying\""));
     assert!(output.contains("failed to receive a Responses WebSocket frame"));
+    assert!(output.contains("\"billing_uncertain\":true"));
     assert!(output.contains("\"purpose\":\"reconnect\""));
     assert!(output.contains("\"connection_attempts\":2"));
     assert!(output.contains("\"websocket_reconnects\":1"));
+    assert!(output.contains("\"billing_uncertain_response_attempts\":1"));
     assert!(output.contains("\"model_calls\":2"));
     assert!(!output.contains("\"model.call.failed\""));
     assert!(output.contains("\"run.completed\""));

--- a/crates/nanocodex-oai-api/README.md
+++ b/crates/nanocodex-oai-api/README.md
@@ -175,6 +175,15 @@ The higher-level `nanocodex-agent` crate decides *when* to compact and how to
 execute tools. This crate implements the provider operation and atomic history
 replacement without embedding agent policy.
 
+## Attempt accounting
+
+Transport metrics distinguish physical Responses attempts from retries. A sent
+attempt that is cancelled or fails before a provider terminal event increments
+`billing_uncertain_response_attempts`; its `ModelAttemptFailed` event also sets
+`billing_uncertain`. This does not assume that the provider charged the request.
+It records that observed token usage is only a lower bound, while completed and
+provider-rejected responses remain exact.
+
 ## Contract-only builds
 
 The default `client` feature remains the complete OpenAI boundary, including

--- a/crates/nanocodex-oai-api/src/events/data.rs
+++ b/crates/nanocodex-oai-api/src/events/data.rs
@@ -211,6 +211,8 @@ pub struct RunMetrics {
     pub response_attempts: u32,
     /// Retried Responses attempts.
     pub response_retries: u32,
+    /// Sent attempts that ended before provider usage was observed.
+    pub billing_uncertain_response_attempts: u32,
     /// Nanoseconds spent establishing connections.
     pub connection_duration_ns: u64,
     /// Nanoseconds spent in SDK retry backoff.

--- a/crates/nanocodex-oai-api/src/tower/attempt.rs
+++ b/crates/nanocodex-oai-api/src/tower/attempt.rs
@@ -72,6 +72,7 @@ pub struct TransportStats {
     pub(crate) websocket_reconnects: AtomicU32,
     pub(crate) response_attempts: AtomicU32,
     pub(crate) response_retries: AtomicU32,
+    pub(crate) billing_uncertain_response_attempts: AtomicU32,
     pub(crate) connection_duration_ns: AtomicU64,
     pub(crate) retry_backoff_duration_ns: AtomicU64,
 }
@@ -83,6 +84,7 @@ pub struct TransportStatsSnapshot {
     websocket_reconnects: u32,
     response_attempts: u32,
     response_retries: u32,
+    billing_uncertain_response_attempts: u32,
     connection_duration_ns: u64,
     retry_backoff_duration_ns: u64,
 }
@@ -96,6 +98,9 @@ impl TransportStats {
             websocket_reconnects: self.websocket_reconnects.load(Ordering::Relaxed),
             response_attempts: self.response_attempts.load(Ordering::Relaxed),
             response_retries: self.response_retries.load(Ordering::Relaxed),
+            billing_uncertain_response_attempts: self
+                .billing_uncertain_response_attempts
+                .load(Ordering::Relaxed),
             connection_duration_ns: self.connection_duration_ns.load(Ordering::Relaxed),
             retry_backoff_duration_ns: self.retry_backoff_duration_ns.load(Ordering::Relaxed),
         }
@@ -118,6 +123,9 @@ impl TransportStats {
             response_retries: after
                 .response_retries
                 .saturating_sub(before.response_retries),
+            billing_uncertain_response_attempts: after
+                .billing_uncertain_response_attempts
+                .saturating_sub(before.billing_uncertain_response_attempts),
             connection_duration_ns: after
                 .connection_duration_ns
                 .saturating_sub(before.connection_duration_ns),
@@ -139,6 +147,8 @@ pub struct TransportStatsDelta {
     pub response_attempts: u32,
     /// Responses retries after the first physical attempt.
     pub response_retries: u32,
+    /// Sent attempts that ended before provider usage was observed.
+    pub billing_uncertain_response_attempts: u32,
     /// Nanoseconds spent establishing connections.
     pub connection_duration_ns: u64,
     /// Nanoseconds spent waiting for owned retry backoff.

--- a/crates/nanocodex-oai-api/src/tower/service.rs
+++ b/crates/nanocodex-oai-api/src/tower/service.rs
@@ -100,27 +100,41 @@ impl ConnectionState {
     }
 }
 
-struct WebSocketAttemptGuard<'a> {
+struct AttemptGuard<'a> {
     connection: &'a mut ConnectionState,
     request: &'a ResponsesAttempt,
+    transport: ResponsesTransport,
     started_at: Instant,
     span: tracing::Span,
     completed: bool,
+    request_sent: bool,
 }
 
-impl<'a> WebSocketAttemptGuard<'a> {
+impl<'a> AttemptGuard<'a> {
     fn new(
         connection: &'a mut ConnectionState,
         request: &'a ResponsesAttempt,
+        transport: ResponsesTransport,
         started_at: Instant,
     ) -> Self {
         Self {
             connection,
             request,
+            transport,
             started_at,
             span: tracing::Span::current(),
             completed: false,
+            request_sent: false,
         }
+    }
+
+    const fn mark_request_sent(&mut self) {
+        self.request_sent = true;
+    }
+
+    #[cfg(not(target_family = "wasm"))]
+    const fn mark_provider_terminal(&mut self) {
+        self.request_sent = false;
     }
 
     const fn complete(&mut self) {
@@ -128,7 +142,7 @@ impl<'a> WebSocketAttemptGuard<'a> {
     }
 }
 
-impl Deref for WebSocketAttemptGuard<'_> {
+impl Deref for AttemptGuard<'_> {
     type Target = ConnectionState;
 
     fn deref(&self) -> &Self::Target {
@@ -136,21 +150,32 @@ impl Deref for WebSocketAttemptGuard<'_> {
     }
 }
 
-impl DerefMut for WebSocketAttemptGuard<'_> {
+impl DerefMut for AttemptGuard<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.connection
     }
 }
 
-impl Drop for WebSocketAttemptGuard<'_> {
+impl Drop for AttemptGuard<'_> {
     fn drop(&mut self) {
         if !self.completed {
-            let generation = self.connection.generation;
-            self.connection.cancel_in_flight();
+            let generation = if matches!(self.transport, ResponsesTransport::WebSocket) {
+                self.connection.cancel_in_flight();
+                self.connection.generation
+            } else {
+                0
+            };
             self.span.record("status", "cancelled");
             self.span.record("otel.status_code", "ERROR");
             self.span.record("duration_ns", elapsed_ns(self.started_at));
-            let message = "Responses WebSocket attempt cancelled before a provider terminal event";
+            let message = "Responses attempt cancelled before a provider terminal event";
+            if self.request_sent {
+                self.request
+                    .observer
+                    .stats
+                    .billing_uncertain_response_attempts
+                    .fetch_add(1, Ordering::Relaxed);
+            }
             if let Err(error) = self.request.observer.emit(
                 AgentEventKind::ModelAttemptFailed,
                 AttemptFailed {
@@ -162,6 +187,7 @@ impl Drop for WebSocketAttemptGuard<'_> {
                     failure_phase: FailurePhase::Completion,
                     error_class: "cancelled",
                     retryable: false,
+                    billing_uncertain: self.request_sent,
                     connection_generation: generation,
                     error: message,
                 },
@@ -179,8 +205,9 @@ impl Drop for WebSocketAttemptGuard<'_> {
                 phase = self.request.kind.phase(),
                 model.call_index = self.request.call_index,
                 attempt = self.request.attempt,
+                transport = self.transport.as_str(),
                 connection.generation = generation,
-                "Responses WebSocket attempt cancelled before a provider terminal event"
+                "Responses attempt cancelled before a provider terminal event"
             );
         }
     }
@@ -285,17 +312,14 @@ impl ResponsesService {
                 connection_generation: connection.generation,
             },
         )?;
+        let mut guard = AttemptGuard::new(connection, request, transport, started_at);
         let result = if matches!(transport, ResponsesTransport::WebSocket) {
-            let mut guard = WebSocketAttemptGuard::new(connection, request, started_at);
-            let result = self
-                .run_inner(&mut guard, request, started_at, transport)
-                .await;
-            guard.complete();
-            result
+            self.run_websocket(&mut guard, request, started_at).await
         } else {
-            self.run_inner(connection, request, started_at, transport)
-                .await
+            https::run(self, &mut guard, request, started_at).await
         };
+        guard.complete();
+        drop(guard);
         tracing::Span::current().record(
             "status",
             if result.is_ok() {
@@ -311,6 +335,13 @@ impl ResponsesService {
         tracing::Span::current().record("duration_ns", elapsed_ns(started_at));
         connection.capture_turn_state();
         if let Err(failure) = &result {
+            if failure.billing_uncertain() {
+                request
+                    .observer
+                    .stats
+                    .billing_uncertain_response_attempts
+                    .fetch_add(1, Ordering::Relaxed);
+            }
             if matches!(request.kind, ResponsesAttemptKind::Warmup) {
                 connection.invalidate(ConnectionPurpose::WarmupFallback);
             } else if failure.retry_advice.is_some() {
@@ -328,6 +359,7 @@ impl ResponsesService {
                     failure_phase: failure.phase,
                     error_class: failure.error_class(),
                     retryable: failure.is_retryable() || failure.is_checkpoint_missing(),
+                    billing_uncertain: failure.billing_uncertain(),
                     connection_generation: failure.connection_generation,
                     error: &message,
                 },
@@ -336,24 +368,9 @@ impl ResponsesService {
         result
     }
 
-    async fn run_inner(
-        &self,
-        connection: &mut ConnectionState,
-        request: &ResponsesAttempt,
-        started_at: Instant,
-        transport: ResponsesTransport,
-    ) -> Result<ResponsesServiceResponse, ResponsesServiceError> {
-        match transport {
-            ResponsesTransport::WebSocket => {
-                self.run_websocket(connection, request, started_at).await
-            }
-            ResponsesTransport::Https => https::run(self, connection, request, started_at).await,
-        }
-    }
-
     async fn run_websocket(
         &self,
-        connection: &mut ConnectionState,
+        connection: &mut AttemptGuard<'_>,
         request: &ResponsesAttempt,
         started_at: Instant,
     ) -> Result<ResponsesServiceResponse, ResponsesServiceError> {
@@ -387,6 +404,14 @@ impl ResponsesService {
                 event: encoded.raw(),
             },
         )?;
+        if connection.socket.is_none() {
+            return Err(ResponsesServiceError::invalid_attempt_state(
+                "connection completed without installing a WebSocket",
+                FailurePhase::Connect,
+                generation,
+            ));
+        }
+        connection.mark_request_sent();
         let socket = connection.socket.as_mut().ok_or_else(|| {
             ResponsesServiceError::invalid_attempt_state(
                 "connection completed without installing a WebSocket",
@@ -397,15 +422,18 @@ impl ResponsesService {
         let send_started_at = Instant::now();
         socket.send(encoded).await.map_err(|error| {
             ResponsesServiceError::responses(error, FailurePhase::Send, generation)
+                .with_billing_uncertain()
         })?;
         let send_duration_ns = elapsed_ns(send_started_at);
         span.record("request.send.duration_ns", send_duration_ns);
         let output = match request.kind {
-            ResponsesAttemptKind::Warmup => ResponsesOutput::Warmup(
-                receive_warmup(socket, request)
-                    .await
-                    .map_err(|error| error.with_connection_generation(generation))?,
-            ),
+            ResponsesAttemptKind::Warmup => {
+                ResponsesOutput::Warmup(receive_warmup(socket, request).await.map_err(|error| {
+                    error
+                        .with_connection_generation(generation)
+                        .with_billing_uncertain_unless_provider_terminal()
+                })?)
+            }
             ResponsesAttemptKind::Generation => ResponsesOutput::Generation(
                 stream::receive(
                     socket,
@@ -415,7 +443,11 @@ impl ResponsesService {
                     started_at,
                 )
                 .await
-                .map_err(|error| error.with_connection_generation(generation))?,
+                .map_err(|error| {
+                    error
+                        .with_connection_generation(generation)
+                        .with_billing_uncertain_unless_provider_terminal()
+                })?,
             ),
             ResponsesAttemptKind::Compaction => ResponsesOutput::Compaction(
                 stream::receive_compaction(
@@ -426,7 +458,11 @@ impl ResponsesService {
                     started_at,
                 )
                 .await
-                .map_err(|error| error.with_connection_generation(generation))?,
+                .map_err(|error| {
+                    error
+                        .with_connection_generation(generation)
+                        .with_billing_uncertain_unless_provider_terminal()
+                })?,
             ),
         };
         let pipeline_stats = match &output {
@@ -868,7 +904,7 @@ mod tests {
 
     use web_time::Instant;
 
-    use super::{ConnectionPurpose, ConnectionState, WebSocketAttemptGuard};
+    use super::{AttemptGuard, ConnectionPurpose, ConnectionState};
 
     #[test]
     fn logical_turn_boundaries_reset_but_same_turn_calls_reuse_turn_state() {
@@ -893,6 +929,8 @@ mod tests {
         connection.next_purpose = ConnectionPurpose::Initial;
 
         let (events, mut receiver) = crate::EventSink::channel("cancelled-attempt".to_owned());
+        let stats = Arc::new(crate::TransportStats::default());
+        let before = stats.snapshot();
         let factory = crate::ResponsesAttemptFactory::new(
             crate::responses::RequestProfile::new(
                 "cancelled-attempt",
@@ -900,13 +938,14 @@ mod tests {
                 Arc::from([]),
             ),
             events,
-            Arc::new(crate::TransportStats::default()),
+            Arc::clone(&stats),
         );
         let request = factory.warmup(crate::Model::Sol, crate::Thinking::High, false);
 
-        drop(WebSocketAttemptGuard::new(
+        drop(AttemptGuard::new(
             &mut connection,
             &request,
+            crate::ResponsesTransport::WebSocket,
             Instant::now(),
         ));
 
@@ -925,5 +964,49 @@ mod tests {
             serde_json::from_str::<serde_json::Value>(event.payload.get()).unwrap()["error_class"],
             "cancelled"
         );
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(event.payload.get()).unwrap()["billing_uncertain"],
+            false
+        );
+        assert_eq!(stats.since(before).billing_uncertain_response_attempts, 0);
+    }
+
+    #[test]
+    fn cancelling_a_sent_attempt_marks_billing_uncertain_for_each_transport() {
+        for transport in [
+            crate::ResponsesTransport::WebSocket,
+            crate::ResponsesTransport::Https,
+        ] {
+            let mut connection = ConnectionState::new();
+            let (events, mut receiver) =
+                crate::EventSink::channel(format!("sent-{}-attempt", transport.as_str()));
+            let stats = Arc::new(crate::TransportStats::default());
+            let before = stats.snapshot();
+            let factory = crate::ResponsesAttemptFactory::new(
+                crate::responses::RequestProfile::new(
+                    "sent-attempt",
+                    "sent-attempt",
+                    Arc::from([]),
+                ),
+                events,
+                Arc::clone(&stats),
+            );
+            let request = factory.warmup(crate::Model::Sol, crate::Thinking::High, false);
+
+            let mut guard = AttemptGuard::new(&mut connection, &request, transport, Instant::now());
+            guard.mark_request_sent();
+            drop(guard);
+
+            let event = receiver
+                .try_recv_timed()
+                .expect("cancellation must remain observable")
+                .event;
+            assert_eq!(event.kind, crate::AgentEventKind::ModelAttemptFailed);
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(event.payload.get()).unwrap()["billing_uncertain"],
+                true
+            );
+            assert_eq!(stats.since(before).billing_uncertain_response_attempts, 1);
+        }
     }
 }

--- a/crates/nanocodex-oai-api/src/tower/service/https/host.rs
+++ b/crates/nanocodex-oai-api/src/tower/service/https/host.rs
@@ -4,11 +4,11 @@ use crate::tower::{
     ResponsesAttempt, ResponsesServiceError, ResponsesServiceResponse, service_error::FailurePhase,
 };
 
-use super::super::{ConnectionState, ResponsesService};
+use super::super::{AttemptGuard, ResponsesService};
 
 pub(crate) async fn run(
     _service: &ResponsesService,
-    _connection: &mut ConnectionState,
+    _connection: &mut AttemptGuard<'_>,
     _request: &ResponsesAttempt,
     _started_at: Instant,
 ) -> Result<ResponsesServiceResponse, ResponsesServiceError> {

--- a/crates/nanocodex-oai-api/src/tower/service/https/native.rs
+++ b/crates/nanocodex-oai-api/src/tower/service/https/native.rs
@@ -12,11 +12,11 @@ use crate::{
     },
 };
 
-use super::super::{ConnectionState, ResponsesService, record_pipeline_stats, required_call_index};
+use super::super::{AttemptGuard, ResponsesService, record_pipeline_stats, required_call_index};
 
 pub(crate) async fn run(
     service: &ResponsesService,
-    connection: &mut ConnectionState,
+    connection: &mut AttemptGuard<'_>,
     request: &ResponsesAttempt,
     started_at: Instant,
 ) -> Result<ResponsesServiceResponse, ResponsesServiceError> {
@@ -55,14 +55,18 @@ pub(crate) async fn run(
         },
     )?;
     let send_started_at = Instant::now();
-    let (mut response, metadata) = send_with_auth_recovery(
-        service,
-        request.profile.session_id(),
-        connection.turn_state.as_deref(),
-        &encoded,
-    )
-    .await
-    .map_err(|error| ResponsesServiceError::responses(error, FailurePhase::Send, 0))?;
+    let (mut response, metadata) =
+        send_with_auth_recovery(service, request.profile.session_id(), &encoded, connection)
+            .await
+            .map_err(|error| {
+                let billing_uncertain = matches!(error, ResponsesError::HttpRequest { .. });
+                let error = ResponsesServiceError::responses(error, FailurePhase::Send, 0);
+                if billing_uncertain {
+                    error.with_billing_uncertain()
+                } else {
+                    error
+                }
+            })?;
     connection.observe_turn_state(metadata.turn_state.as_deref());
     let send_duration_ns = elapsed_ns(send_started_at);
     span.record("request.send.duration_ns", send_duration_ns);
@@ -75,7 +79,8 @@ pub(crate) async fn run(
                 required_call_index(request)?,
                 started_at,
             )
-            .await?,
+            .await
+            .map_err(ResponsesServiceError::with_billing_uncertain_unless_provider_terminal)?,
         ),
         ResponsesAttemptKind::Compaction => ResponsesOutput::Compaction(
             stream::receive_compaction(
@@ -85,7 +90,8 @@ pub(crate) async fn run(
                 required_call_index(request)?,
                 started_at,
             )
-            .await?,
+            .await
+            .map_err(ResponsesServiceError::with_billing_uncertain_unless_provider_terminal)?,
         ),
         ResponsesAttemptKind::Warmup => unreachable!("warmup rejected above"),
     };
@@ -120,10 +126,12 @@ impl ResponseEventSource for ResponsesHttpStream {
 async fn send_with_auth_recovery(
     service: &ResponsesService,
     session_id: &str,
-    turn_state: Option<&str>,
     request: &EncodedRequest,
+    guard: &mut AttemptGuard<'_>,
 ) -> Result<(ResponsesHttpStream, HttpMetadata), ResponsesError> {
     let auth = service.auth_snapshot().await?;
+    let turn_state = guard.turn_state.clone();
+    guard.mark_request_sent();
     match service
         .platform
         .http()
@@ -131,7 +139,7 @@ async fn send_with_auth_recovery(
             &service.config.api_base_url,
             &auth,
             session_id,
-            turn_state,
+            turn_state.as_deref(),
             request,
         )
         .await
@@ -139,6 +147,7 @@ async fn send_with_auth_recovery(
         Err(ResponsesError::HttpRejected { status: 401, .. })
             if auth.mode() == OpenAiAuthMode::ChatGpt =>
         {
+            guard.mark_provider_terminal();
             service
                 .config
                 .auth
@@ -148,6 +157,7 @@ async fn send_with_auth_recovery(
                     detail: error.to_string(),
                 })?;
             let refreshed = service.auth_snapshot().await?;
+            guard.mark_request_sent();
             service
                 .platform
                 .http()
@@ -155,7 +165,7 @@ async fn send_with_auth_recovery(
                     &service.config.api_base_url,
                     &refreshed,
                     session_id,
-                    turn_state,
+                    turn_state.as_deref(),
                     request,
                 )
                 .await

--- a/crates/nanocodex-oai-api/src/tower/service_error.rs
+++ b/crates/nanocodex-oai-api/src/tower/service_error.rs
@@ -13,6 +13,7 @@ pub struct ResponsesServiceError {
     class: &'static str,
     pub(crate) retry_advice: Option<RetryAdvice>,
     pub(crate) connection_generation: u32,
+    billing_uncertain: bool,
 }
 
 impl ResponsesServiceError {
@@ -29,6 +30,7 @@ impl ResponsesServiceError {
             class,
             retry_advice,
             connection_generation,
+            billing_uncertain: false,
         }
     }
 
@@ -89,6 +91,35 @@ impl ResponsesServiceError {
     pub(crate) const fn with_connection_generation(mut self, connection_generation: u32) -> Self {
         self.connection_generation = connection_generation;
         self
+    }
+
+    pub(crate) const fn with_billing_uncertain(mut self) -> Self {
+        self.billing_uncertain = true;
+        self
+    }
+
+    pub(crate) const fn with_billing_uncertain_unless_provider_terminal(mut self) -> Self {
+        let provider_terminal = matches!(
+            self.responses_error(),
+            Some(
+                ResponsesError::Api { .. }
+                    | ResponsesError::ContextWindowExceeded { .. }
+                    | ResponsesError::InvalidImageRequest { .. }
+                    | ResponsesError::HttpRejected { .. }
+            )
+        );
+        self.billing_uncertain = !provider_terminal;
+        self
+    }
+
+    /// Returns whether a request may have reached the provider without a
+    /// terminal event reporting usage.
+    ///
+    /// This classification is populated by the standard Responses service. It
+    /// does not assert that the provider charged the request.
+    #[must_use]
+    pub const fn billing_uncertain(&self) -> bool {
+        self.billing_uncertain
     }
 
     /// Returns a stable low-cardinality error class.

--- a/crates/nanocodex-oai-api/src/transport/telemetry.rs
+++ b/crates/nanocodex-oai-api/src/transport/telemetry.rs
@@ -70,6 +70,7 @@ pub(crate) struct AttemptFailed<'a> {
     pub(crate) failure_phase: FailurePhase,
     pub(crate) error_class: &'static str,
     pub(crate) retryable: bool,
+    pub(crate) billing_uncertain: bool,
     pub(crate) connection_generation: u32,
     pub(crate) error: &'a str,
 }


### PR DESCRIPTION
Extracted from #61 as an independent OAI/Tower behavior fix.

The standard service now tracks whether a physical request may have reached the provider before cancellation or a non-terminal transport failure. Such attempts increment billing_uncertain_response_attempts and mark ModelAttemptFailed with billing_uncertain. Completed responses and explicit provider rejections remain exact; this classification never claims that a request was charged.

The attempt guard covers both WebSocket and HTTPS. Managed-auth 401 recovery resets sent state after the known rejection and marks it again only when the replacement request starts. ResponsesServiceError exposes the same conservative classification to caller middleware.

The OAI README documents how to interpret the metric as lower-bound usage accounting.

Validation:
- focused transport cancellation tests for WebSocket and HTTPS
- agent failure and reconnect integration tests
- OAI doctests
- warnings-denied Clippy for OAI and agent
- wasm32-unknown-unknown OAI check
- crate-boundary policy