### PR TITLE
fix(vm): own guest command cleanup

### DIFF
--- a/crates/experimental/nanocodex-vm/Cargo.toml
+++ b/crates/experimental/nanocodex-vm/Cargo.toml
@@ -68,6 +68,7 @@ zstd = { workspace = true, optional = true }
 criterion.workspace = true
 nix.workspace = true
 reflink-copy.workspace = true
+shlex.workspace = true
 tempfile.workspace = true
 tracing-subscriber.workspace = true
 

--- a/crates/experimental/nanocodex-vm/README.md
+++ b/crates/experimental/nanocodex-vm/README.md
@@ -78,6 +78,30 @@ The default tool selection keeps web search, image generation, and
 `apply_patch`, and `view_image`, preserving their standard model-visible names
 and schemas.
 
+### Session control and cleanup
+
+Specialized applications that construct a lower-level
+[`tools::VmToolSession`] can run trusted setup and harness commands with
+[`tools::VmCommand`]. Commands have explicit time and combined-output bounds.
+Dropping an in-flight command request queues cancellation; the guest terminates
+the command's process group on cancellation, timeout, output overflow, or
+session shutdown.
+
+[`tools::VmCommand::mirror_output`] additionally truncates two harness-owned
+guest files before launch and updates them as stdout and stderr arrive. This is
+intended for observing a long-running command from another request. It does not
+relax the command's retained-output bound or change its terminal result.
+
+At an agent-lifecycle boundary,
+[`tools::VmToolSession::terminate_tool_processes`] cancels processes and
+interactive shells owned by the workspace-tool runtime while leaving the VM,
+filesystem, and host-control channel alive. It does not claim to kill a process
+that deliberately detached from the runtime's managed process group. Call
+[`tools::VmToolSession::memory_observation`] for best-effort peak host RSS,
+guest memory use, and guest OOM evidence. Missing telemetry is represented by
+absent fields so it cannot replace the command or agent failure being
+diagnosed.
+
 ## Host, VMM, and guest ownership
 
 The retained path has three processes:
@@ -242,8 +266,10 @@ The remaining control methods have these payloads:
 | `write_file` | `path`, base64 `contents`, Unix `mode`, optional `modified_unix_seconds` | `error` |
 | `create_directory` | `path`, Unix `mode`, optional `modified_unix_seconds` | `error` |
 | `read_file` | `path` | base64 `contents` or `error` |
-| `execute` | `program`, `arguments`, `current_directory`, `environment`, `timeout_millis`, `max_output_bytes` | `exit_code`, base64 `stdout`, base64 `stderr`, `error`, `timed_out`, `output_limit_exceeded` |
+| `memory` | none | optional `total_kib`, optional `minimum_available_kib`, `oom_kills`, `error` |
+| `execute` | `program`, `arguments`, `current_directory`, `environment`, `timeout_millis`, `max_output_bytes`, optional `stdout_mirror`, optional `stderr_mirror` | `exit_code`, base64 `stdout`, base64 `stderr`, `error`, `timed_out`, `output_limit_exceeded` |
 | `cancel` | `target_id` | `error` |
+| `terminate_tool_processes` | none | `error` |
 | `shutdown` | none | `error` |
 
 Concrete examples:
@@ -259,17 +285,24 @@ Concrete examples:
 {"kind":"execute","payload":{"id":5,"exit_code":0,"stdout":"b2s=","stderr":"","error":null,"timed_out":false,"output_limit_exceeded":false}}
 {"kind":"cancel","payload":{"id":6,"target_id":5}}
 {"kind":"cancel","payload":{"id":6,"error":null}}
-{"kind":"shutdown","payload":{"id":7}}
-{"kind":"shutdown","payload":{"id":7,"error":null}}
+{"kind":"memory","payload":{"id":7}}
+{"kind":"memory","payload":{"id":7,"total_kib":786432,"minimum_available_kib":524288,"oom_kills":0,"error":null}}
+{"kind":"terminate_tool_processes","payload":{"id":8}}
+{"kind":"terminate_tool_processes","payload":{"id":8,"error":null}}
+{"kind":"shutdown","payload":{"id":9}}
+{"kind":"shutdown","payload":{"id":9,"error":null}}
 ```
 
 `write_file` creates parents and publishes through a sibling temporary file
 plus rename. `read_file` accepts only regular files and caps contents at
 32 MiB. `execute` clears the inherited environment, uses only the supplied
 pairs, captures combined output up to the requested bound, and kills the
-process group on timeout, output overflow, cancellation, or shutdown. It is a
-bounded one-response operation rather than a streaming terminal; retained
-interactive shells use the `exec_command`/`write_stdin` tool protocol.
+process group on timeout, output overflow, cancellation, or shutdown. Optional
+mirror paths receive the same stdout and stderr incrementally but do not alter
+that bound. `execute` is a bounded one-response operation rather than a
+streaming terminal; retained interactive shells use the
+`exec_command`/`write_stdin` tool protocol. `memory` reports the guest's
+minimum observed `MemAvailable` and OOM-kill counter over the session.
 
 Dropping a host request removes its pending response and queues a `cancel` with
 a fresh ID. The cancellation queue is bounded by the same 63 admission

--- a/crates/experimental/nanocodex-vm/src/tools/guest.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/guest.rs
@@ -6,7 +6,7 @@ use std::{
     process::{ExitStatus, Stdio},
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -19,6 +19,7 @@ use nix::{
 };
 use thiserror::Error;
 use tokio::{
+    fs::{File, OpenOptions},
     io::{
         AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt,
         BufReader,
@@ -30,8 +31,8 @@ use tokio::{
 
 use super::protocol::{
     CancelRequest, ControlResponse, CreateDirectoryRequest, ExecuteRequest, ExecuteResponse,
-    ReadFileRequest, ReadFileResponse, SessionRequest, SessionResponse, ShutdownRequest,
-    ToolResponse, WriteFileRequest,
+    MemoryResponse, ReadFileRequest, ReadFileResponse, SessionRequest, SessionResponse,
+    ShutdownRequest, ToolResponse, WriteFileRequest,
 };
 
 const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
@@ -39,6 +40,103 @@ const MAX_CONTROL_FILE_BYTES: usize = 32 * 1024 * 1024;
 #[cfg(feature = "guest-runtime")]
 const FILESYSTEM_SYNC_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_IN_FLIGHT_REQUESTS: usize = 64;
+const MEMORY_SAMPLE_INTERVAL: Duration = Duration::from_millis(100);
+
+#[derive(Default)]
+struct GuestMemoryMonitor {
+    total_kib: AtomicU64,
+    minimum_available_kib: AtomicU64,
+    initial_oom_kills: AtomicU64,
+    current_oom_kills: AtomicU64,
+    oom_baseline_ready: AtomicBool,
+}
+
+impl GuestMemoryMonitor {
+    async fn sample(&self) {
+        let (meminfo, vmstat) = tokio::join!(
+            tokio::fs::read_to_string("/proc/meminfo"),
+            tokio::fs::read_to_string("/proc/vmstat"),
+        );
+        if let Ok(meminfo) = meminfo
+            && let Some((total_kib, available_kib)) = parse_meminfo(&meminfo)
+        {
+            self.total_kib.store(total_kib, Ordering::Relaxed);
+            let _ = self
+                .minimum_available_kib
+                .fetch_min(available_kib, Ordering::Relaxed);
+        }
+        if let Ok(vmstat) = vmstat
+            && let Some(oom_kills) = parse_vmstat_oom_kills(&vmstat)
+        {
+            if self
+                .oom_baseline_ready
+                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                self.initial_oom_kills.store(oom_kills, Ordering::Relaxed);
+            }
+            self.current_oom_kills.store(oom_kills, Ordering::Relaxed);
+        }
+    }
+
+    async fn run(self: Arc<Self>) {
+        loop {
+            self.sample().await;
+            tokio::time::sleep(MEMORY_SAMPLE_INTERVAL).await;
+        }
+    }
+
+    fn response(&self, id: u64) -> MemoryResponse {
+        let total_kib = self.total_kib.load(Ordering::Relaxed);
+        let minimum_available_kib = self.minimum_available_kib.load(Ordering::Relaxed);
+        let available = total_kib > 0 && minimum_available_kib != u64::MAX;
+        MemoryResponse {
+            id,
+            total_kib: available.then_some(total_kib),
+            minimum_available_kib: available.then_some(minimum_available_kib),
+            oom_kills: self
+                .current_oom_kills
+                .load(Ordering::Relaxed)
+                .saturating_sub(self.initial_oom_kills.load(Ordering::Relaxed)),
+            error: (!available).then(|| "guest /proc memory telemetry is unavailable".to_owned()),
+        }
+    }
+}
+
+fn parse_meminfo(contents: &str) -> Option<(u64, u64)> {
+    let mut total = None;
+    let mut available = None;
+    for line in contents.lines() {
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let Some(value) = value
+            .split_whitespace()
+            .next()
+            .and_then(|value| value.parse::<u64>().ok())
+        else {
+            continue;
+        };
+        match key {
+            "MemTotal" => total = Some(value),
+            "MemAvailable" => available = Some(value),
+            _ => {}
+        }
+        if total.is_some() && available.is_some() {
+            break;
+        }
+    }
+    Some((total?, available?))
+}
+
+fn parse_vmstat_oom_kills(contents: &str) -> Option<u64> {
+    contents.lines().find_map(|line| {
+        let mut fields = line.split_whitespace();
+        let key = fields.next()?;
+        let value = fields.next()?;
+        (key == "oom_kill").then(|| value.parse().ok()).flatten()
+    })
+}
 
 /// Failure while serving VM tool requests inside the guest.
 #[derive(Debug, Error)]
@@ -111,6 +209,12 @@ where
             std::env::vars_os().collect(),
         ),
     );
+    let memory = Arc::new(GuestMemoryMonitor {
+        minimum_available_kib: AtomicU64::new(u64::MAX),
+        ..GuestMemoryMonitor::default()
+    });
+    memory.sample().await;
+    let memory_task = tokio::spawn(Arc::clone(&memory).run());
     let mut input = BufReader::new(input);
     let mut requests = JoinSet::<SessionResponse>::new();
     let mut active = HashMap::<u64, tokio::task::AbortHandle>::new();
@@ -156,14 +260,26 @@ where
                             });
                             write_response(&mut output, &response, max_frame_bytes).await?;
                         }
+                        SessionRequest::TerminateToolProcesses(request) => {
+                            runtime.control().cancel().await;
+                            let response =
+                                SessionResponse::TerminateToolProcesses(ControlResponse {
+                                    id: request.id,
+                                    error: None,
+                                });
+                            write_response(&mut output, &response, max_frame_bytes).await?;
+                        }
                         request => {
                             let id = request.id();
                             if active.contains_key(&id) {
                                 return Err(VmGuestError::DuplicateRequestId(id));
                             }
                             let runtime = Arc::clone(&runtime);
+                            let memory = Arc::clone(&memory);
                             let task =
-                                requests.spawn(async move { execute_request(runtime, request).await });
+                                requests.spawn(async move {
+                                    execute_request(runtime, memory, request).await
+                                });
                             active.insert(id, task);
                         }
                     }
@@ -175,6 +291,7 @@ where
     .await;
 
     runtime.control().cancel().await;
+    memory_task.abort();
     if let Some(request) = result? {
         let response = SessionResponse::Shutdown(sync(request).await);
         write_response(&mut output, &response, max_frame_bytes).await?;
@@ -215,6 +332,7 @@ async fn serve_test_io_with_frame_limit(
 
 async fn execute_request(
     runtime: Arc<WorkspaceToolRuntime>,
+    memory: Arc<GuestMemoryMonitor>,
     request: SessionRequest,
 ) -> SessionResponse {
     match request {
@@ -243,6 +361,7 @@ async fn execute_request(
             SessionResponse::CreateDirectory(create_directory(request).await)
         }
         SessionRequest::ReadFile(request) => SessionResponse::ReadFile(read_file(request).await),
+        SessionRequest::Memory(request) => SessionResponse::Memory(memory.response(request.id)),
         SessionRequest::Execute(request) => {
             SessionResponse::Execute(execute_command(request).await)
         }
@@ -250,6 +369,15 @@ async fn execute_request(
             SessionResponse::Cancel(ControlResponse {
                 id,
                 error: Some("cancel cannot be dispatched as a concurrent request".to_owned()),
+            })
+        }
+        SessionRequest::TerminateToolProcesses(request) => {
+            SessionResponse::TerminateToolProcesses(ControlResponse {
+                id: request.id,
+                error: Some(
+                    "tool-process termination cannot be dispatched as a concurrent request"
+                        .to_owned(),
+                ),
             })
         }
         SessionRequest::Shutdown(request) => SessionResponse::Shutdown(ControlResponse {
@@ -531,6 +659,14 @@ async fn read_file(request: ReadFileRequest) -> ReadFileResponse {
 }
 
 async fn execute_command(request: ExecuteRequest) -> ExecuteResponse {
+    let stdout_mirror = match open_output_mirror(request.stdout_mirror.as_deref()).await {
+        Ok(mirror) => mirror,
+        Err(error) => return failed_execute_response(request.id, error),
+    };
+    let stderr_mirror = match open_output_mirror(request.stderr_mirror.as_deref()).await {
+        Ok(mirror) => mirror,
+        Err(error) => return failed_execute_response(request.id, error),
+    };
     let environment = command_environment(std::env::vars_os(), &request.environment);
     let mut command = Command::new(&request.program);
     command
@@ -545,7 +681,15 @@ async fn execute_command(request: ExecuteRequest) -> ExecuteResponse {
     command.process_group(0);
 
     let timeout = Duration::from_millis(request.timeout_millis);
-    match command_output(&mut command, timeout, request.max_output_bytes).await {
+    match command_output(
+        &mut command,
+        timeout,
+        request.max_output_bytes,
+        stdout_mirror,
+        stderr_mirror,
+    )
+    .await
+    {
         Ok(CommandOutcome::Completed(output)) => ExecuteResponse {
             id: request.id,
             exit_code: Some(output.status.code().unwrap_or(1)),
@@ -573,15 +717,32 @@ async fn execute_command(request: ExecuteRequest) -> ExecuteResponse {
             timed_out: false,
             output_limit_exceeded: true,
         },
-        Err(error) => ExecuteResponse {
-            id: request.id,
-            exit_code: None,
-            stdout: None,
-            stderr: None,
-            error: Some(error.to_string()),
-            timed_out: false,
-            output_limit_exceeded: false,
-        },
+        Err(error) => failed_execute_response(request.id, error),
+    }
+}
+
+async fn open_output_mirror(path: Option<&str>) -> std::io::Result<Option<File>> {
+    match path {
+        Some(path) => OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(path)
+            .await
+            .map(Some),
+        None => Ok(None),
+    }
+}
+
+fn failed_execute_response(id: u64, error: std::io::Error) -> ExecuteResponse {
+    ExecuteResponse {
+        id,
+        exit_code: None,
+        stdout: None,
+        stderr: None,
+        error: Some(error.to_string()),
+        timed_out: false,
+        output_limit_exceeded: false,
     }
 }
 
@@ -615,6 +776,8 @@ async fn command_output(
     command: &mut Command,
     timeout: Duration,
     max_output_bytes: usize,
+    stdout_mirror: Option<File>,
+    stderr_mirror: Option<File>,
 ) -> std::io::Result<CommandOutcome> {
     let mut child = command.spawn()?;
     let process_group = child
@@ -637,12 +800,14 @@ async fn command_output(
         Arc::clone(&retained),
         max_output_bytes,
         limit_sender.clone(),
+        stdout_mirror,
     ));
     let mut stderr = tokio::spawn(read_bounded(
         stderr,
         Arc::clone(&retained),
         max_output_bytes,
         limit_sender,
+        stderr_mirror,
     ));
     let deadline = tokio::time::sleep(timeout);
     tokio::pin!(deadline);
@@ -720,6 +885,7 @@ async fn read_bounded(
     retained: Arc<AtomicUsize>,
     limit: usize,
     limit_sender: mpsc::Sender<()>,
+    mut mirror: Option<File>,
 ) -> std::io::Result<Vec<u8>> {
     let mut output = Vec::new();
     let mut buffer = [0_u8; 8 * 1024];
@@ -727,7 +893,14 @@ async fn read_bounded(
     loop {
         let read = reader.read(&mut buffer).await?;
         if read == 0 {
+            if let Some(mirror) = &mut mirror {
+                mirror.flush().await?;
+            }
             break;
+        }
+        if let Some(mirror) = &mut mirror {
+            mirror.write_all(&buffer[..read]).await?;
+            mirror.flush().await?;
         }
         let offset = retained.fetch_add(read, Ordering::Relaxed);
         let allowed = limit.saturating_sub(offset).min(read);
@@ -743,26 +916,43 @@ async fn read_bounded(
 #[cfg(test)]
 mod tests {
     use std::{
+        env,
         ffi::OsString,
         fs::{self, File},
+        process, thread,
         time::{Duration, Instant, UNIX_EPOCH},
     };
 
     use nanocodex_tools::{ToolInput, contract::ToolOutputBody, standard::StandardTool};
+    use nix::sys::signal::Signal;
+    use nix::{errno::Errno, sys::signal::kill, unistd::Pid};
     use serde_json::{json, value::to_raw_value};
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
     use super::super::protocol::{
         CancelRequest, ExecuteRequest, ReadFileRequest, ReadyRequest, SessionRequest,
-        SessionResponse, ShutdownRequest, ToolRequest, WireToolContext, WireToolInput,
+        SessionResponse, ShutdownRequest, TerminateToolProcessesRequest, ToolRequest,
+        WireToolContext, WireToolInput,
     };
     use super::{
-        atomic_write_file, command_environment, create_directory_path, execute_command, read_file,
-        serve_test_io, serve_test_io_with_frame_limit,
+        atomic_write_file, command_environment, create_directory_path, execute_command,
+        parse_meminfo, parse_vmstat_oom_kills, read_file, serve_test_io,
+        serve_test_io_with_frame_limit,
     };
 
     const DEFAULT_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
+    const DETACHED_PROCESS_PID_FILE_ENV: &str = "NANOCODEX_VM_TEST_DETACHED_PID_FILE";
     const PATH_TRACING_IMAGE_BYTES: u64 = 48_262_737;
+
+    #[test]
+    fn parses_guest_peak_memory_inputs() {
+        let meminfo = "MemTotal:       524288 kB\nmalformed\nMemAvailable:   131071 kB\n";
+        assert_eq!(parse_meminfo(meminfo), Some((524_288, 131_071)));
+        assert_eq!(
+            parse_vmstat_oom_kills("pgfault 12\noom_kill 3\npgmajfault 1\n"),
+            Some(3)
+        );
+    }
 
     #[test]
     fn trusted_commands_inherit_guest_environment_and_apply_explicit_overrides() {
@@ -833,6 +1023,8 @@ mod tests {
             environment: Vec::new(),
             timeout_millis: 100,
             max_output_bytes: DEFAULT_OUTPUT_BYTES,
+            stdout_mirror: None,
+            stderr_mirror: None,
         })
         .await;
 
@@ -859,6 +1051,8 @@ mod tests {
             environment: Vec::new(),
             timeout_millis: 5_000,
             max_output_bytes: 8,
+            stdout_mirror: None,
+            stderr_mirror: None,
         })
         .await;
 
@@ -867,6 +1061,47 @@ mod tests {
         assert!(response.error.is_none());
         assert!(response.stdout.is_none());
         assert!(response.stderr.is_none());
+    }
+
+    #[tokio::test]
+    async fn command_output_is_mirrored_before_the_process_exits() {
+        let directory = tempfile::tempdir().unwrap();
+        let stdout = directory.path().join("stdout");
+        let stderr = directory.path().join("stderr");
+        let execution = tokio::spawn(execute_command(ExecuteRequest {
+            id: 1,
+            program: "/bin/sh".to_owned(),
+            arguments: vec![
+                "-c".to_owned(),
+                "printf first; printf diagnostic >&2; sleep 0.5; printf second".to_owned(),
+            ],
+            current_directory: "/".to_owned(),
+            environment: Vec::new(),
+            timeout_millis: 5_000,
+            max_output_bytes: DEFAULT_OUTPUT_BYTES,
+            stdout_mirror: Some(stdout.to_string_lossy().into_owned()),
+            stderr_mirror: Some(stderr.to_string_lossy().into_owned()),
+        }));
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if fs::read(&stdout).is_ok_and(|contents| contents == b"first")
+                    && fs::read(&stderr).is_ok_and(|contents| contents == b"diagnostic")
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("mirrors should expose initial output while the process runs");
+        assert!(!execution.is_finished());
+
+        let response = execution.await.unwrap();
+        assert_eq!(response.stdout.as_deref(), Some(b"firstsecond".as_slice()));
+        assert_eq!(response.stderr.as_deref(), Some(b"diagnostic".as_slice()));
+        assert_eq!(fs::read(stdout).unwrap(), b"firstsecond");
+        assert_eq!(fs::read(stderr).unwrap(), b"diagnostic");
     }
 
     #[tokio::test]
@@ -913,6 +1148,8 @@ mod tests {
                 environment: Vec::new(),
                 timeout_millis: 5_000,
                 max_output_bytes: DEFAULT_OUTPUT_BYTES,
+                stdout_mirror: None,
+                stderr_mirror: None,
             }),
             SessionRequest::Execute(ExecuteRequest {
                 id: 1,
@@ -922,6 +1159,8 @@ mod tests {
                 environment: Vec::new(),
                 timeout_millis: 5_000,
                 max_output_bytes: DEFAULT_OUTPUT_BYTES,
+                stdout_mirror: None,
+                stderr_mirror: None,
             }),
         ] {
             host_write
@@ -976,6 +1215,8 @@ mod tests {
                 environment: Vec::new(),
                 timeout_millis: 60_000,
                 max_output_bytes: DEFAULT_OUTPUT_BYTES,
+                stdout_mirror: None,
+                stderr_mirror: None,
             }),
             SessionRequest::Shutdown(ShutdownRequest { id: 1 }),
         ] {
@@ -1019,6 +1260,8 @@ mod tests {
                 environment: Vec::new(),
                 timeout_millis: 60_000,
                 max_output_bytes: DEFAULT_OUTPUT_BYTES,
+                stdout_mirror: None,
+                stderr_mirror: None,
             }),
             SessionRequest::Cancel(CancelRequest {
                 id: 1,
@@ -1032,6 +1275,8 @@ mod tests {
                 environment: Vec::new(),
                 timeout_millis: 5_000,
                 max_output_bytes: DEFAULT_OUTPUT_BYTES,
+                stdout_mirror: None,
+                stderr_mirror: None,
             }),
         ] {
             host_write
@@ -1075,6 +1320,230 @@ mod tests {
             SessionResponse::Shutdown(response) if response.id == 3 && response.error.is_none()
         ));
         guest_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn tool_process_termination_kills_foreground_session_and_keeps_guest_ready() {
+        let workspace = tempfile::tempdir().unwrap();
+        let pid_file = workspace.path().join("foreground.pid");
+        let (host, guest) = tokio::io::duplex(64 * 1024);
+        let (host_read, mut host_write) = tokio::io::split(host);
+        let (guest_read, guest_write) = tokio::io::split(guest);
+        let guest_task = tokio::spawn({
+            let workspace = workspace.path().to_owned();
+            async move { serve_test_io(&workspace, guest_read, guest_write).await }
+        });
+        let command = format!("printf %s $$ > '{}'; exec sleep 30", pid_file.display());
+        let start = SessionRequest::Tool(ToolRequest {
+            id: 0,
+            tool: StandardTool::ExecCommand,
+            input: WireToolInput::from(ToolInput::Function(
+                to_raw_value(&json!({
+                    "cmd": command,
+                    "login": false,
+                    "yield_time_ms": 250,
+                }))
+                .unwrap(),
+            )),
+            context: WireToolContext {
+                model: "model".to_owned(),
+                session_id: "session".to_owned(),
+                call_id: "foreground".to_owned(),
+                output_token_budget: 10_000,
+            },
+        });
+        host_write
+            .write_all(&serde_json::to_vec(&start).unwrap())
+            .await
+            .unwrap();
+        host_write.write_all(b"\n").await.unwrap();
+
+        let mut responses = BufReader::new(host_read).lines();
+        let started = tokio::time::timeout(Duration::from_secs(2), responses.next_line())
+            .await
+            .expect("the foreground command must yield")
+            .unwrap()
+            .unwrap();
+        let SessionResponse::Tool(response) =
+            serde_json::from_str::<SessionResponse>(&started).unwrap()
+        else {
+            panic!("expected the foreground command response");
+        };
+        assert_eq!(response.id, 0);
+        assert!(response.error.is_none());
+        let execution = response.execution.expect("foreground command must execute");
+        assert!(
+            execution.success,
+            "foreground command failed: {:?}",
+            execution.output
+        );
+        let pid = fs::read_to_string(&pid_file)
+            .unwrap()
+            .parse::<i32>()
+            .unwrap();
+        assert_eq!(kill(Pid::from_raw(pid), None), Ok(()));
+
+        let terminate =
+            SessionRequest::TerminateToolProcesses(TerminateToolProcessesRequest { id: 1 });
+        host_write
+            .write_all(&serde_json::to_vec(&terminate).unwrap())
+            .await
+            .unwrap();
+        host_write.write_all(b"\n").await.unwrap();
+        let terminated = tokio::time::timeout(Duration::from_secs(2), responses.next_line())
+            .await
+            .expect("managed process termination must complete")
+            .unwrap()
+            .unwrap();
+        assert!(matches!(
+            serde_json::from_str::<SessionResponse>(&terminated).unwrap(),
+            SessionResponse::TerminateToolProcesses(response)
+                if response.id == 1 && response.error.is_none()
+        ));
+        assert_eq!(kill(Pid::from_raw(pid), None), Err(Errno::ESRCH));
+
+        let ready = SessionRequest::Ready(ReadyRequest { id: 2 });
+        host_write
+            .write_all(&serde_json::to_vec(&ready).unwrap())
+            .await
+            .unwrap();
+        host_write.write_all(b"\n").await.unwrap();
+        let ready = responses.next_line().await.unwrap().unwrap();
+        assert!(matches!(
+            serde_json::from_str::<SessionResponse>(&ready).unwrap(),
+            SessionResponse::Ready(response) if response.id == 2 && response.error.is_none()
+        ));
+
+        host_write
+            .write_all(
+                &serde_json::to_vec(&SessionRequest::Shutdown(ShutdownRequest { id: 3 })).unwrap(),
+            )
+            .await
+            .unwrap();
+        host_write.write_all(b"\n").await.unwrap();
+        drop(host_write);
+        let shutdown = responses.next_line().await.unwrap().unwrap();
+        assert!(matches!(
+            serde_json::from_str::<SessionResponse>(&shutdown).unwrap(),
+            SessionResponse::Shutdown(response) if response.id == 3 && response.error.is_none()
+        ));
+        guest_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn tool_process_termination_preserves_deliberately_detached_process() {
+        let workspace = tempfile::tempdir().unwrap();
+        let pid_file = workspace.path().join("detached.pid");
+        let (host, guest) = tokio::io::duplex(64 * 1024);
+        let (host_read, mut host_write) = tokio::io::split(host);
+        let (guest_read, guest_write) = tokio::io::split(guest);
+        let guest_task = tokio::spawn({
+            let workspace = workspace.path().to_owned();
+            async move { serve_test_io(&workspace, guest_read, guest_write).await }
+        });
+        let test_executable = env::current_exe().unwrap();
+        let test_executable = shlex::try_quote(test_executable.to_str().unwrap()).unwrap();
+        let pid_file_argument = shlex::try_quote(pid_file.to_str().unwrap()).unwrap();
+        let command = format!(
+            "{DETACHED_PROCESS_PID_FILE_ENV}={pid_file_argument} {test_executable} \
+             --exact tools::guest::tests::deliberately_detached_process_child --nocapture \
+             >/dev/null 2>&1 </dev/null & child=$!; \
+             while [ ! -s {pid_file_argument} ]; do kill -0 \"$child\" || exit 1; sleep 0.01; done"
+        );
+        let start = SessionRequest::Tool(ToolRequest {
+            id: 0,
+            tool: StandardTool::ExecCommand,
+            input: WireToolInput::from(ToolInput::Function(
+                to_raw_value(&json!({
+                    "cmd": command,
+                    "login": false,
+                }))
+                .unwrap(),
+            )),
+            context: WireToolContext {
+                model: "model".to_owned(),
+                session_id: "session".to_owned(),
+                call_id: "detached".to_owned(),
+                output_token_budget: 10_000,
+            },
+        });
+        host_write
+            .write_all(&serde_json::to_vec(&start).unwrap())
+            .await
+            .unwrap();
+        host_write.write_all(b"\n").await.unwrap();
+
+        let mut responses = BufReader::new(host_read).lines();
+        let started = tokio::time::timeout(Duration::from_secs(2), responses.next_line())
+            .await
+            .expect("the detaching command must complete")
+            .unwrap()
+            .unwrap();
+        let SessionResponse::Tool(response) =
+            serde_json::from_str::<SessionResponse>(&started).unwrap()
+        else {
+            panic!("expected the detaching command response");
+        };
+        assert_eq!(response.id, 0);
+        assert!(response.error.is_none());
+        let execution = response.execution.expect("detaching command must execute");
+        assert!(
+            execution.success,
+            "detaching command failed: {:?}",
+            execution.output
+        );
+        let pid = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if let Ok(pid) = fs::read_to_string(&pid_file) {
+                    break pid.parse::<i32>().unwrap();
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("the detached process must publish its PID");
+        assert_eq!(kill(Pid::from_raw(pid), None), Ok(()));
+
+        let terminate =
+            SessionRequest::TerminateToolProcesses(TerminateToolProcessesRequest { id: 1 });
+        host_write
+            .write_all(&serde_json::to_vec(&terminate).unwrap())
+            .await
+            .unwrap();
+        host_write.write_all(b"\n").await.unwrap();
+        let terminated = responses.next_line().await.unwrap().unwrap();
+        assert!(matches!(
+            serde_json::from_str::<SessionResponse>(&terminated).unwrap(),
+            SessionResponse::TerminateToolProcesses(response)
+                if response.id == 1 && response.error.is_none()
+        ));
+        assert_eq!(kill(Pid::from_raw(pid), None), Ok(()));
+        kill(Pid::from_raw(pid), Signal::SIGKILL).unwrap();
+
+        host_write
+            .write_all(
+                &serde_json::to_vec(&SessionRequest::Shutdown(ShutdownRequest { id: 2 })).unwrap(),
+            )
+            .await
+            .unwrap();
+        host_write.write_all(b"\n").await.unwrap();
+        drop(host_write);
+        let shutdown = responses.next_line().await.unwrap().unwrap();
+        assert!(matches!(
+            serde_json::from_str::<SessionResponse>(&shutdown).unwrap(),
+            SessionResponse::Shutdown(response) if response.id == 2 && response.error.is_none()
+        ));
+        guest_task.await.unwrap().unwrap();
+    }
+
+    #[test]
+    fn deliberately_detached_process_child() {
+        let Some(pid_file) = env::var_os(DETACHED_PROCESS_PID_FILE_ENV) else {
+            return;
+        };
+        nix::unistd::setsid().unwrap();
+        fs::write(pid_file, process::id().to_string()).unwrap();
+        thread::sleep(Duration::from_secs(30));
     }
 
     #[tokio::test]
@@ -1230,6 +1699,8 @@ mod tests {
                 environment: Vec::new(),
                 timeout_millis: 5_000,
                 max_output_bytes: DEFAULT_OUTPUT_BYTES,
+                stdout_mirror: None,
+                stderr_mirror: None,
             }),
         ] {
             host_write

--- a/crates/experimental/nanocodex-vm/src/tools/mod.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/mod.rs
@@ -140,8 +140,8 @@ pub use runtime_disk::{GuestRuntimeDisk, GuestRuntimeDiskError, GuestRuntimeDisk
     )
 ))]
 pub use session::{
-    VmCommand, VmCommandOutput, VmCommandPartialOutput, VmToolSession, VmToolSessionError,
-    VmToolSessionHandle,
+    VmCommand, VmCommandOutput, VmCommandPartialOutput, VmMemoryObservation, VmToolSession,
+    VmToolSessionError, VmToolSessionHandle,
 };
 
 /// One VM-aware execution capability shared by all proxied workspace tools.

--- a/crates/experimental/nanocodex-vm/src/tools/protocol.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/protocol.rs
@@ -10,8 +10,10 @@ pub(crate) enum SessionRequest {
     WriteFile(WriteFileRequest),
     CreateDirectory(CreateDirectoryRequest),
     ReadFile(ReadFileRequest),
+    Memory(MemoryRequest),
     Execute(ExecuteRequest),
     Cancel(CancelRequest),
+    TerminateToolProcesses(TerminateToolProcessesRequest),
     Shutdown(ShutdownRequest),
 }
 
@@ -24,8 +26,10 @@ impl SessionRequest {
             Self::WriteFile(request) => request.id,
             Self::CreateDirectory(request) => request.id,
             Self::ReadFile(request) => request.id,
+            Self::Memory(request) => request.id,
             Self::Execute(request) => request.id,
             Self::Cancel(request) => request.id,
+            Self::TerminateToolProcesses(request) => request.id,
             Self::Shutdown(request) => request.id,
         }
     }
@@ -39,8 +43,10 @@ pub(crate) enum SessionResponse {
     WriteFile(ControlResponse),
     CreateDirectory(ControlResponse),
     ReadFile(ReadFileResponse),
+    Memory(MemoryResponse),
     Execute(ExecuteResponse),
     Cancel(ControlResponse),
+    TerminateToolProcesses(ControlResponse),
     Shutdown(ControlResponse),
 }
 
@@ -52,8 +58,10 @@ impl SessionResponse {
             Self::WriteFile(response)
             | Self::CreateDirectory(response)
             | Self::Cancel(response)
+            | Self::TerminateToolProcesses(response)
             | Self::Shutdown(response) => response.id,
             Self::ReadFile(response) => response.id,
+            Self::Memory(response) => response.id,
             Self::Execute(response) => response.id,
         }
     }
@@ -62,6 +70,12 @@ impl SessionResponse {
 #[derive(Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ReadyRequest {
+    pub id: u64,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct TerminateToolProcessesRequest {
     pub id: u64,
 }
 
@@ -102,6 +116,12 @@ pub(crate) struct ReadFileRequest {
 
 #[derive(Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
+pub(crate) struct MemoryRequest {
+    pub id: u64,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ExecuteRequest {
     pub id: u64,
     pub program: String,
@@ -110,6 +130,10 @@ pub(crate) struct ExecuteRequest {
     pub environment: Vec<(String, String)>,
     pub timeout_millis: u64,
     pub max_output_bytes: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stdout_mirror: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stderr_mirror: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -132,6 +156,16 @@ pub(crate) struct ReadFileResponse {
     pub id: u64,
     #[serde(default, with = "optional_wire_bytes")]
     pub contents: Option<Vec<u8>>,
+    pub error: Option<String>,
+}
+
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct MemoryResponse {
+    pub id: u64,
+    pub total_kib: Option<u64>,
+    pub minimum_available_kib: Option<u64>,
+    pub oom_kills: u64,
     pub error: Option<String>,
 }
 
@@ -220,9 +254,9 @@ mod tests {
 
     use super::{
         CancelRequest, ControlResponse, CreateDirectoryRequest, ExecuteRequest, ExecuteResponse,
-        ReadFileRequest, ReadFileResponse, ReadyRequest, SessionRequest, SessionResponse,
-        ShutdownRequest, ToolRequest, ToolResponse, WireToolContext, WireToolInput,
-        WriteFileRequest,
+        MemoryRequest, MemoryResponse, ReadFileRequest, ReadFileResponse, ReadyRequest,
+        SessionRequest, SessionResponse, ShutdownRequest, TerminateToolProcessesRequest,
+        ToolRequest, ToolResponse, WireToolContext, WireToolInput, WriteFileRequest,
     };
 
     #[test]
@@ -239,6 +273,23 @@ mod tests {
         let encoded = serde_json::to_string(&request).unwrap();
 
         assert_eq!(encoded, r#"{"kind":"shutdown","payload":{"id":9}}"#);
+    }
+
+    #[test]
+    fn tool_process_termination_has_a_stable_typed_shape() {
+        let request =
+            SessionRequest::TerminateToolProcesses(TerminateToolProcessesRequest { id: 8 });
+        assert_eq!(
+            serde_json::to_string(&request).unwrap(),
+            r#"{"kind":"terminate_tool_processes","payload":{"id":8}}"#
+        );
+
+        let response =
+            SessionResponse::TerminateToolProcesses(ControlResponse { id: 8, error: None });
+        assert_eq!(
+            serde_json::to_string(&response).unwrap(),
+            r#"{"kind":"terminate_tool_processes","payload":{"id":8,"error":null}}"#
+        );
     }
 
     #[test]
@@ -396,6 +447,8 @@ mod tests {
             environment: vec![("PATH".to_owned(), "/usr/bin:/bin".to_owned())],
             timeout_millis: 60_000,
             max_output_bytes: 8_388_608,
+            stdout_mirror: None,
+            stderr_mirror: None,
         });
         assert_eq!(
             serde_json::to_string(&execute).unwrap(),
@@ -427,6 +480,23 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&cancel).unwrap(),
             r#"{"kind":"cancel","payload":{"id":6,"error":null}}"#
+        );
+
+        let memory = SessionRequest::Memory(MemoryRequest { id: 7 });
+        assert_eq!(
+            serde_json::to_string(&memory).unwrap(),
+            r#"{"kind":"memory","payload":{"id":7}}"#
+        );
+        let memory = SessionResponse::Memory(MemoryResponse {
+            id: 7,
+            total_kib: Some(524_288),
+            minimum_available_kib: Some(131_072),
+            oom_kills: 1,
+            error: None,
+        });
+        assert_eq!(
+            serde_json::to_string(&memory).unwrap(),
+            r#"{"kind":"memory","payload":{"id":7,"total_kib":524288,"minimum_available_kib":131072,"oom_kills":1,"error":null}}"#
         );
     }
 }

--- a/crates/experimental/nanocodex-vm/src/tools/session.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/session.rs
@@ -29,8 +29,9 @@ use super::{
     VmToolClient,
     protocol::{
         CancelRequest, ControlResponse, CreateDirectoryRequest, ExecuteRequest, ExecuteResponse,
-        ReadFileRequest, ReadFileResponse, ReadyRequest, SessionRequest, SessionResponse,
-        ShutdownRequest, ToolRequest, WireToolContext, WireToolInput, WriteFileRequest,
+        MemoryRequest, MemoryResponse, ReadFileRequest, ReadFileResponse, ReadyRequest,
+        SessionRequest, SessionResponse, ShutdownRequest, TerminateToolProcessesRequest,
+        ToolRequest, WireToolContext, WireToolInput, WriteFileRequest,
     },
 };
 
@@ -43,6 +44,10 @@ const MAX_HOST_IN_FLIGHT_REQUESTS: usize = MAX_GUEST_IN_FLIGHT_REQUESTS - 1;
 const REQUEST_QUEUE_CAPACITY: usize = MAX_GUEST_IN_FLIGHT_REQUESTS;
 const MAX_TERMINAL_STDERR_BYTES: usize = 64 * 1024;
 const TERMINAL_STDERR_DRAIN_GRACE: Duration = Duration::from_millis(250);
+const MEMORY_OBSERVATION_TIMEOUT: Duration = Duration::from_secs(1);
+#[cfg(target_os = "linux")]
+const HOST_MEMORY_SAMPLE_INTERVAL: Duration = Duration::from_millis(100);
+const KIB_PER_MIB: u64 = 1024;
 
 /// One trusted host-control command executed inside the guest.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -53,6 +58,8 @@ pub struct VmCommand {
     environment: Vec<(String, String)>,
     timeout: Duration,
     max_output_bytes: usize,
+    stdout_mirror: Option<String>,
+    stderr_mirror: Option<String>,
 }
 
 impl VmCommand {
@@ -67,6 +74,8 @@ impl VmCommand {
             environment: Vec::new(),
             timeout: Duration::from_mins(1),
             max_output_bytes: DEFAULT_COMMAND_OUTPUT_BYTES,
+            stdout_mirror: None,
+            stderr_mirror: None,
         }
     }
 
@@ -104,6 +113,19 @@ impl VmCommand {
         self.max_output_bytes = max_output_bytes;
         self
     }
+
+    /// Mirrors output into harness-owned guest files while retaining the same
+    /// bounded terminal output.
+    ///
+    /// The files are truncated before the process starts and updated as bytes
+    /// arrive, so another session request can observe long-running command
+    /// progress without weakening terminal output or timeout semantics.
+    #[must_use]
+    pub fn mirror_output(mut self, stdout: impl Into<String>, stderr: impl Into<String>) -> Self {
+        self.stdout_mirror = Some(stdout.into());
+        self.stderr_mirror = Some(stderr.into());
+        self
+    }
 }
 
 /// Complete output from one trusted host-control command in the guest.
@@ -124,6 +146,48 @@ pub struct VmCommandPartialOutput {
     pub stdout: Vec<u8>,
     /// Standard error captured before the command stopped.
     pub stderr: Vec<u8>,
+}
+
+/// Peak host and guest memory observed over one VM session.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct VmMemoryObservation {
+    host_peak_rss_mib: Option<u64>,
+    guest_total_mib: Option<u64>,
+    guest_peak_used_mib: Option<u64>,
+    guest_oom_kills: u64,
+    terminal_oom: bool,
+}
+
+impl VmMemoryObservation {
+    /// Returns the VMM process's peak resident set on supported Linux hosts.
+    #[must_use]
+    pub const fn host_peak_rss_mib(self) -> Option<u64> {
+        self.host_peak_rss_mib
+    }
+
+    /// Returns the guest kernel's total usable memory.
+    #[must_use]
+    pub const fn guest_total_mib(self) -> Option<u64> {
+        self.guest_total_mib
+    }
+
+    /// Returns peak guest memory use derived from minimum `MemAvailable`.
+    #[must_use]
+    pub const fn guest_peak_used_mib(self) -> Option<u64> {
+        self.guest_peak_used_mib
+    }
+
+    /// Returns the guest kernel's observed OOM-kill count for this session.
+    #[must_use]
+    pub const fn guest_oom_kills(self) -> u64 {
+        self.guest_oom_kills
+    }
+
+    /// Returns whether a guest counter or terminal kernel diagnostic confirms OOM.
+    #[must_use]
+    pub const fn oom_detected(self) -> bool {
+        self.guest_oom_kills > 0 || self.terminal_oom
+    }
 }
 
 /// Failure to start, use, provision, or stop one retained VM tool session.
@@ -190,6 +254,10 @@ pub enum VmToolSessionError {
     #[error("the VMM did not exit within {0:?} after guest shutdown")]
     ShutdownTimeout(Duration),
 
+    /// Managed guest tool processes did not stop before the deadline.
+    #[error("managed guest tool processes did not stop within {0:?}")]
+    ToolProcessTerminationTimeout(Duration),
+
     /// The VMM returned an unsuccessful status after guest shutdown.
     #[error("the VMM exited unsuccessfully after guest shutdown: {0}")]
     VmmExit(ExitStatus),
@@ -240,6 +308,7 @@ pub struct VmToolSessionHandle {
 struct VmToolSessionInner {
     spawned_at: Instant,
     next_id: AtomicU64,
+    host_peak_rss_kib: AtomicU64,
     closing: AtomicBool,
     lifecycle: StdMutex<SessionLifecycle>,
     input: mpsc::Sender<OutboundRequest>,
@@ -479,6 +548,7 @@ impl VmToolSession {
             let inner = Arc::new(VmToolSessionInner {
                 spawned_at: Instant::now(),
                 next_id: AtomicU64::new(0),
+                host_peak_rss_kib: AtomicU64::new(0),
                 closing: AtomicBool::new(false),
                 lifecycle: StdMutex::new(SessionLifecycle::default()),
                 input: input_sender,
@@ -500,6 +570,12 @@ impl VmToolSession {
                 Arc::downgrade(&inner),
             ));
             runtime.spawn(capture_terminal_stderr(stderr, Arc::downgrade(&inner)));
+            if let Some(process_id) = lock_unpoisoned(&inner.child)
+                .as_ref()
+                .and_then(tokio::process::Child::id)
+            {
+                runtime.spawn(monitor_host_memory(process_id, Arc::downgrade(&inner)));
+            }
             Ok(Self {
                 handle: VmToolSessionHandle {
                     inner,
@@ -643,6 +719,65 @@ impl VmToolSession {
     /// exceeds its deadline, or the typed response is invalid.
     pub async fn command(&self, command: VmCommand) -> Result<VmCommandOutput, VmToolSessionError> {
         self.handle.command(command).await
+    }
+
+    /// Returns the best-effort peak memory observed for this VM session.
+    ///
+    /// Host RSS remains available when the guest protocol has already failed.
+    /// Missing telemetry is represented by absent fields rather than an error
+    /// so diagnostics never obscure the attempt's primary result.
+    pub async fn memory_observation(&self) -> VmMemoryObservation {
+        self.handle.memory_observation().await
+    }
+
+    /// Terminates subprocesses retained by the guest workspace-tool runtime.
+    ///
+    /// This is a non-destructive agent-lifecycle boundary: the VM, filesystem,
+    /// and host-control channel remain available. Processes that deliberately
+    /// detached from the workspace tool's managed process group are not
+    /// terminated.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the guest cannot acknowledge cleanup before the
+    /// session's shutdown deadline or returns an invalid response.
+    pub async fn terminate_tool_processes(&self) -> Result<(), VmToolSessionError> {
+        let span = info_span!(
+            target: "nanocodex_vm",
+            "vm.session.terminate_tool_processes",
+            otel.kind = "internal",
+            otel.status_code = tracing::field::Empty,
+            vm.session.age_ns = tracing::field::Empty,
+            status = tracing::field::Empty,
+            error.message = tracing::field::Empty,
+            duration_ns = tracing::field::Empty,
+        );
+        let started_at = Instant::now();
+        let timeout = self.handle.inner.shutdown_timeout;
+        let result = async {
+            let response = tokio::time::timeout(
+                timeout,
+                self.handle.control_request(|id| {
+                    SessionRequest::TerminateToolProcesses(TerminateToolProcessesRequest { id })
+                }),
+            )
+            .await
+            .map_err(|_| VmToolSessionError::ToolProcessTerminationTimeout(timeout))??;
+            let SessionResponse::TerminateToolProcesses(response) = response else {
+                return Err(VmToolSessionError::Protocol(
+                    "expected a tool-process termination response",
+                ));
+            };
+            control_result(response)
+        }
+        .instrument(span.clone())
+        .await;
+        span.record(
+            "vm.session.age_ns",
+            elapsed_ns(self.handle.inner.spawned_at),
+        );
+        record_vm_result(&span, started_at, &result);
+        result
     }
 
     async fn terminate(&self) {
@@ -813,6 +948,61 @@ impl VmToolSessionHandle {
         span.record("vm.session.age_ns", elapsed_ns(self.inner.spawned_at));
         record_vm_result(&span, started_at, &result);
         result
+    }
+
+    /// Returns the best-effort peak memory observed for this VM session.
+    pub async fn memory_observation(&self) -> VmMemoryObservation {
+        let guest = self.memory_response().await.ok();
+        let host_peak_rss_kib = self.inner.host_peak_rss_kib.load(Ordering::Relaxed);
+        let terminal_oom =
+            terminal_oom_detected(&lock_unpoisoned(&self.inner.terminal).stderr_tail);
+
+        let (guest_total_mib, guest_peak_used_mib, guest_oom_kills) = guest.map_or(
+            (None, None, 0),
+            |MemoryResponse {
+                 total_kib,
+                 minimum_available_kib,
+                 oom_kills,
+                 ..
+             }| {
+                let peak_used_kib = total_kib.zip(minimum_available_kib).map(
+                    |(total_kib, minimum_available_kib)| {
+                        total_kib.saturating_sub(minimum_available_kib)
+                    },
+                );
+                (
+                    total_kib.map(kib_to_mib_ceil),
+                    peak_used_kib.map(kib_to_mib_ceil),
+                    oom_kills,
+                )
+            },
+        );
+        VmMemoryObservation {
+            host_peak_rss_mib: (host_peak_rss_kib != 0).then(|| kib_to_mib_ceil(host_peak_rss_kib)),
+            guest_total_mib,
+            guest_peak_used_mib,
+            guest_oom_kills,
+            terminal_oom,
+        }
+    }
+
+    async fn memory_response(&self) -> Result<MemoryResponse, VmToolSessionError> {
+        let response = tokio::time::timeout(
+            MEMORY_OBSERVATION_TIMEOUT,
+            self.control_request(|id| SessionRequest::Memory(MemoryRequest { id })),
+        )
+        .await
+        .map_err(|_| VmToolSessionError::GuestTimeout {
+            timeout: MEMORY_OBSERVATION_TIMEOUT,
+            output: VmCommandPartialOutput {
+                stdout: Vec::new(),
+                stderr: Vec::new(),
+            },
+        })??;
+        let SessionResponse::Memory(response) = response else {
+            return Err(VmToolSessionError::Protocol("expected a memory response"));
+        };
+        Ok(response)
     }
 
     async fn request(
@@ -1037,6 +1227,8 @@ impl VmToolSessionHandle {
                     environment: command.environment,
                     timeout_millis,
                     max_output_bytes,
+                    stdout_mirror: command.stdout_mirror,
+                    stderr_mirror: command.stderr_mirror,
                 })
             })
             .await?;
@@ -1398,6 +1590,58 @@ async fn capture_terminal_stderr(mut stderr: ChildStderr, inner: Weak<VmToolSess
     }
 }
 
+#[cfg(target_os = "linux")]
+async fn monitor_host_memory(process_id: u32, inner: Weak<VmToolSessionInner>) {
+    loop {
+        let Some(inner) = inner.upgrade() else {
+            return;
+        };
+        match tokio::fs::read_to_string(format!("/proc/{process_id}/status")).await {
+            Ok(status) => {
+                if let Some(rss_kib) = parse_linux_process_rss_kib(&status) {
+                    inner
+                        .host_peak_rss_kib
+                        .fetch_max(rss_kib, Ordering::Relaxed);
+                }
+            }
+            Err(_) if inner.closing.load(Ordering::Acquire) => return,
+            Err(_) => {}
+        }
+        tokio::time::sleep(HOST_MEMORY_SAMPLE_INTERVAL).await;
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+async fn monitor_host_memory(_process_id: u32, _inner: Weak<VmToolSessionInner>) {}
+
+#[cfg(any(target_os = "linux", test))]
+fn parse_linux_process_rss_kib(status: &str) -> Option<u64> {
+    status
+        .lines()
+        .filter_map(|line| {
+            let (key, value) = line.split_once(':')?;
+            matches!(key, "VmRSS" | "VmHWM")
+                .then(|| value.split_whitespace().next()?.parse::<u64>().ok())
+                .flatten()
+        })
+        .max()
+}
+
+fn terminal_oom_detected(stderr: &[u8]) -> bool {
+    let stderr = String::from_utf8_lossy(stderr).to_ascii_lowercase();
+    [
+        "out of memory: killed process",
+        "memory cgroup out of memory",
+        "oom-kill:",
+    ]
+    .iter()
+    .any(|diagnostic| stderr.contains(diagnostic))
+}
+
+const fn kib_to_mib_ceil(kib: u64) -> u64 {
+    kib.saturating_add(KIB_PER_MIB - 1) / KIB_PER_MIB
+}
+
 fn append_terminal_stderr(terminal: &mut TerminalDiagnostics, bytes: &[u8]) {
     if bytes.len() >= MAX_TERMINAL_STDERR_BYTES {
         terminal.stderr_tail.clear();
@@ -1547,8 +1791,10 @@ const fn set_request_id(request: &mut SessionRequest, id: u64) {
         SessionRequest::WriteFile(request) => request.id = id,
         SessionRequest::CreateDirectory(request) => request.id = id,
         SessionRequest::ReadFile(request) => request.id = id,
+        SessionRequest::Memory(request) => request.id = id,
         SessionRequest::Execute(request) => request.id = id,
         SessionRequest::Cancel(request) => request.id = id,
+        SessionRequest::TerminateToolProcesses(request) => request.id = id,
         SessionRequest::Shutdown(request) => request.id = id,
     }
 }
@@ -1669,10 +1915,22 @@ mod tracing_tests {
     };
 
     use super::{
-        VmCommand, VmCommandPartialOutput, VmToolSession, VmToolSessionError, lock_unpoisoned,
+        VmCommand, VmCommandPartialOutput, VmToolSession, VmToolSessionError, kib_to_mib_ceil,
+        lock_unpoisoned, parse_linux_process_rss_kib, terminal_oom_detected,
     };
 
     static TRACE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn parses_peak_linux_vmm_rss_and_confirmed_oom_diagnostics() {
+        let status = "Name:\tvm-run\nVmHWM:\t77824 kB\nVmRSS:\t65536 kB\n";
+        assert_eq!(parse_linux_process_rss_kib(status), Some(77_824));
+        assert_eq!(kib_to_mib_ceil(77_824), 76);
+        assert!(terminal_oom_detected(
+            b"kernel: Out of memory: Killed process 42 (agent)"
+        ));
+        assert!(!terminal_oom_detected(b"guest command exited 137"));
+    }
 
     #[derive(Clone, Default)]
     struct TraceCapture {
@@ -1843,6 +2101,36 @@ mod tracing_tests {
         runtime.block_on(async {
             let session = VmToolSession::spawn(&mut command).unwrap();
             session.ready().await.unwrap();
+        });
+    }
+
+    #[test]
+    fn managed_tool_process_termination_keeps_the_vm_session_open() {
+        let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
+        let terminated = r#"{"kind":"terminate_tool_processes","payload":{"id":0,"error":null}}"#;
+        let ready = r#"{"kind":"ready","payload":{"id":1,"error":null}}"#;
+        let shutdown = r#"{"kind":"shutdown","payload":{"id":2,"error":null}}"#;
+        let script = format!(
+            "IFS= read -r terminate\n\
+             case \"$terminate\" in *'\"kind\":\"terminate_tool_processes\"'*) ;; *) exit 91 ;; esac\n\
+             printf '%s\\n' '{terminated}'\n\
+             IFS= read -r ready\n\
+             printf '%s\\n' '{ready}'\n\
+             IFS= read -r shutdown\n\
+             printf '%s\\n' '{shutdown}'"
+        );
+        let mut command = tokio::process::Command::new("/bin/sh");
+        command.arg("-c").arg(script);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let session = VmToolSession::spawn(&mut command).unwrap();
+            session.terminate_tool_processes().await.unwrap();
+            session.ready().await.unwrap();
+            session.shutdown().await.unwrap();
         });
     }
 


### PR DESCRIPTION
## Summary

- multiplex guest requests with bounded admission while reserving control capacity
- make cancellation, timeout, output overflow, and shutdown terminate managed process groups
- add bounded live output mirrors for trusted harness commands
- expose non-destructive workspace-tool cleanup and best-effort VM memory/OOM observations
- document the complete same-revision host/guest wire contract

This is an independently reviewable VM lifecycle prerequisite extracted from #61. It contains no evaluator, CLI, dashboard, retained result, or benchmark-task code.

## Public contract

- `VmCommand` remains the trusted host-control command type; mirror files do not weaken its timeout or retained-output limits.
- `VmToolSession::terminate_tool_processes` leaves the VM, filesystem, and control channel alive.
- `VmMemoryObservation` is diagnostic and best-effort; missing telemetry cannot replace a primary run failure.
- protocol types remain private and require host/guest artifacts from the same revision.

## Validation

- `cargo test -p nanocodex-vm --lib` (105 passed)
- `cargo test -p nanocodex-vm --no-default-features --features guest-runtime --all-targets` (24 passed)
- `cargo clippy -p nanocodex-vm --all-targets --all-features -- -D warnings`
- `cargo test -p nanocodex-vm --doc`
- `bash scripts/check-crate-boundaries.sh`