### PR TITLE
feat(vm): add disposable guest overlays

### DIFF
--- a/crates/experimental/nanocodex-vm/Cargo.toml
+++ b/crates/experimental/nanocodex-vm/Cargo.toml
@@ -40,7 +40,7 @@ guest-runtime = ["dep:nix", "nanocodex-tools/workspace-runtime"]
 base64.workspace = true
 filetime.workspace = true
 nanocodex-tools = { path = "../../nanocodex-tools", version = "0.3.0", default-features = false }
-nix = { workspace = true, optional = true }
+nix = { workspace = true, optional = true, features = ["fs", "mount"] }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/experimental/nanocodex-vm/README.md
+++ b/crates/experimental/nanocodex-vm/README.md
@@ -67,6 +67,54 @@ workspace.shutdown().await?;
 # }
 ```
 
+High-fanout ephemeral attempts use guest OverlayFS instead of copying that
+retained workspace shape. [`host::VmConfig::overlay_ext4`] boots the runtime
+disk read-only, mounts the prepared task disk read-only as the lower layer,
+and sends all mutations to a fresh sparse ext4 upper created by
+[`host::create_sparse_overlay_disk`]. Reset is deletion of that upper disk;
+the host filesystem needs ordinary sparse-file support, not reflinks, XFS, or
+a host OverlayFS mount. Attempts configured for rootfs retention continue to
+use standalone private ext4 copies so retained artifacts remain self-contained.
+
+```no_run
+use nanocodex_vm::{
+    host::{
+        EgressLease, Network, VmConfig, create_sparse_overlay_disk,
+        overlay_guest_command,
+    },
+    tools::VmToolSession,
+};
+use tokio::process::Command;
+
+# async fn launch() -> Result<(), Box<dyn std::error::Error>> {
+let upper = ".nanocodex/attempts/018f/upper.ext4";
+create_sparse_overlay_disk(upper, 10 * 1024 * 1024 * 1024)?;
+let config = VmConfig::overlay_ext4(
+    ".cache/nanocodex/vm/runtime.ext4",
+    ".cache/nanocodex/vm/prepared-task.ext4",
+    upper,
+)
+.cpus(2)
+.memory_mib(1024)
+.network(Network::Disabled);
+let session = VmToolSession::spawn_configured(
+    Command::new("dedicated-vmm-process"),
+    config,
+    overlay_guest_command("/workspace", ""),
+    EgressLease::disabled(),
+)
+.await?;
+session.shutdown().await?;
+# std::fs::remove_file(upper)?;
+# Ok(())
+# }
+```
+
+The caller owns upper-disk retention and deletion. Drop all session/tool
+capabilities and complete [`tools::VmToolSession::shutdown`] before removing
+the disk. Overlay startup creates only the requested workspace; harness- or
+application-specific directories remain the caller's responsibility.
+
 [`VmWorkspace::tools`] returns a clone-cheap capability suitable for
 `NanocodexBuilder::tools_factory`. Every clone routes to the same retained
 guest runtime, filesystem, and interactive shell sessions. The non-cloneable

--- a/crates/experimental/nanocodex-vm/src/bin/nanocodex-vm-guest.rs
+++ b/crates/experimental/nanocodex-vm/src/bin/nanocodex-vm-guest.rs
@@ -1,13 +1,46 @@
 #[cfg(target_os = "linux")]
-use std::path::PathBuf;
+use std::{ffi::OsStr, io, path::PathBuf};
 
 #[cfg(target_os = "linux")]
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), nanocodex_vm::tools::VmGuestError> {
-    let workspace = std::env::args_os()
-        .nth(1)
-        .map_or_else(|| PathBuf::from("/workspace"), PathBuf::from);
-    nanocodex_vm::tools::serve_guest(workspace).await
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut arguments = std::env::args_os().skip(1);
+    let first = arguments.next();
+    if first.as_deref() == Some(OsStr::new("--overlay-root")) {
+        let workspace = arguments.next().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "--overlay-root requires a guest workspace",
+            )
+        })?;
+        let resolver = arguments.next().unwrap_or_default();
+        if arguments.next().is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "--overlay-root accepts only WORKSPACE and optional RESOLVER",
+            )
+            .into());
+        }
+        let resolver = resolver.to_string_lossy();
+        return nanocodex_vm::tools::serve_overlay_guest(
+            PathBuf::from(workspace),
+            (!resolver.is_empty()).then_some(resolver.as_ref()),
+        )
+        .await
+        .map_err(Into::into);
+    }
+
+    let workspace = first.map_or_else(|| PathBuf::from("/workspace"), PathBuf::from);
+    if arguments.next().is_some() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "guest runtime accepts only one workspace argument",
+        )
+        .into());
+    }
+    nanocodex_vm::tools::serve_guest(workspace)
+        .await
+        .map_err(Into::into)
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/crates/experimental/nanocodex-vm/src/config.rs
+++ b/crates/experimental/nanocodex-vm/src/config.rs
@@ -9,6 +9,15 @@ pub enum RootFilesystem {
     Directory(PathBuf),
     /// A raw ext4 image attached as the guest's writable root block device.
     Ext4(PathBuf),
+    /// A guest OverlayFS with an immutable ext4 lower and writable ext4 upper.
+    OverlayExt4 {
+        /// Read-only disk containing the static Nanocodex guest runtime.
+        runtime: PathBuf,
+        /// Read-only prepared task root.
+        lower: PathBuf,
+        /// Writable sparse disk receiving all attempt mutations.
+        upper: PathBuf,
+    },
 }
 
 /// Network access supplied to the guest by libkrun.
@@ -170,6 +179,30 @@ impl VmConfig {
         }
     }
 
+    /// Creates a VM whose effective root is assembled by the guest.
+    ///
+    /// The runtime disk boots read-only as `/dev/vda`; the immutable lower is
+    /// `/dev/vdb`; and the writable upper is `/dev/vdc`. Additional block
+    /// devices are attached after those three devices.
+    pub fn overlay_ext4(
+        runtime: impl Into<PathBuf>,
+        lower: impl Into<PathBuf>,
+        upper: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            root: RootFilesystem::OverlayExt4 {
+                runtime: runtime.into(),
+                lower: lower.into(),
+                upper: upper.into(),
+            },
+            cpus: 2,
+            memory_mib: 1_024,
+            network: Network::Internet,
+            block_devices: Vec::new(),
+            shared_directories: Vec::new(),
+        }
+    }
+
     /// Sets the number of virtual CPUs.
     #[must_use]
     pub const fn cpus(mut self, cpus: u8) -> Self {
@@ -205,11 +238,15 @@ impl VmConfig {
         self
     }
 
-    /// Returns the host root filesystem path.
+    /// Returns the host filesystem path that libkrun boots as the guest root.
+    ///
+    /// For an OverlayFS configuration this is the small runtime disk; inspect
+    /// [`Self::root_filesystem`] for its lower and upper layers.
     #[must_use]
     pub fn root(&self) -> &Path {
         match &self.root {
             RootFilesystem::Directory(path) | RootFilesystem::Ext4(path) => path,
+            RootFilesystem::OverlayExt4 { runtime, .. } => runtime,
         }
     }
 
@@ -301,6 +338,21 @@ mod tests {
         assert_eq!(
             config.root_filesystem(),
             &RootFilesystem::Ext4(PathBuf::from("rootfs.ext4"))
+        );
+    }
+
+    #[test]
+    fn overlay_root_owns_runtime_lower_and_upper_disks() {
+        let config = VmConfig::overlay_ext4("runtime.ext4", "base.ext4", "upper.ext4");
+
+        assert_eq!(config.root(), Path::new("runtime.ext4"));
+        assert_eq!(
+            config.root_filesystem(),
+            &RootFilesystem::OverlayExt4 {
+                runtime: PathBuf::from("runtime.ext4"),
+                lower: PathBuf::from("base.ext4"),
+                upper: PathBuf::from("upper.ext4"),
+            }
         );
     }
 

--- a/crates/experimental/nanocodex-vm/src/krun.rs
+++ b/crates/experimental/nanocodex-vm/src/krun.rs
@@ -21,7 +21,10 @@ use crate::{
 const ROOT_TAG: &std::ffi::CStr = c"/dev/root";
 const ROOT_BLOCK_ID: &std::ffi::CStr = c"vda";
 const ROOT_BLOCK_DEVICE: &std::ffi::CStr = c"/dev/vda";
+const OVERLAY_LOWER_BLOCK_ID: &std::ffi::CStr = c"nanocodex-overlay-lower";
+const OVERLAY_UPPER_BLOCK_ID: &std::ffi::CStr = c"nanocodex-overlay-upper";
 const EXT4_FILESYSTEM: &std::ffi::CStr = c"ext4";
+const READ_ONLY_MOUNT_OPTIONS: &std::ffi::CStr = c"ro";
 const TSI_HIJACK_INET: u32 = 1;
 const NET_FLAG_VFKIT: u32 = 1 << 0;
 const NET_FLAG_DHCP_CLIENT: u32 = 1 << 1;
@@ -138,6 +141,16 @@ pub struct KrunVm {
     context: Option<u32>,
 }
 
+enum ResolvedRoot {
+    Directory(PathBuf),
+    Ext4(PathBuf),
+    OverlayExt4 {
+        runtime: PathBuf,
+        lower: PathBuf,
+        upper: PathBuf,
+    },
+}
+
 impl KrunVm {
     /// Creates a libkrun configuration context.
     ///
@@ -153,22 +166,7 @@ impl KrunVm {
             return Err(VmError::InvalidConfig("memory must be nonzero"));
         }
 
-        let root = config
-            .root()
-            .canonicalize()
-            .map_err(|source| VmError::ResolveRoot {
-                path: config.root().to_path_buf(),
-                source,
-            })?;
-        match config.root_filesystem() {
-            RootFilesystem::Directory(_) if !root.is_dir() => {
-                return Err(VmError::RootNotDirectory(root));
-            }
-            RootFilesystem::Ext4(_) if !root.is_file() => {
-                return Err(VmError::RootNotFile(root));
-            }
-            RootFilesystem::Directory(_) | RootFilesystem::Ext4(_) => {}
-        }
+        let root = resolve_root(config.root_filesystem())?;
 
         let context = positive_context(krun::krun_create_ctx(), "create context")?;
         let vm = Self {
@@ -180,9 +178,9 @@ impl KrunVm {
             "configure VM",
         )?;
 
-        let root = c_string(root.as_os_str(), "root filesystem path")?;
-        match config.root_filesystem() {
-            RootFilesystem::Directory(_) => {
+        match root {
+            ResolvedRoot::Directory(root) => {
+                let root = c_string(root.as_os_str(), "root filesystem path")?;
                 // SAFETY: both C strings live through the call and libkrun copies their
                 // contents into the context before returning.
                 check(
@@ -198,26 +196,28 @@ impl KrunVm {
                     "attach root filesystem",
                 )?;
             }
-            RootFilesystem::Ext4(_) => {
-                // SAFETY: the path and block ID remain alive through each call;
-                // libkrun copies them into its context before returning.
-                check(
-                    unsafe {
-                        krun::krun_add_disk(context, ROOT_BLOCK_ID.as_ptr(), root.as_ptr(), false)
-                    },
-                    "attach root disk",
+            ResolvedRoot::Ext4(root) => {
+                attach_root_disk(context, &root, false)?;
+            }
+            ResolvedRoot::OverlayExt4 {
+                runtime,
+                lower,
+                upper,
+            } => {
+                attach_root_disk(context, &runtime, true)?;
+                attach_resolved_disk(
+                    context,
+                    OVERLAY_LOWER_BLOCK_ID,
+                    &lower,
+                    true,
+                    "attach immutable overlay lower disk",
                 )?;
-                // SAFETY: all strings are static and NUL terminated.
-                check(
-                    unsafe {
-                        krun::krun_set_root_disk_remount(
-                            context,
-                            ROOT_BLOCK_DEVICE.as_ptr(),
-                            EXT4_FILESYSTEM.as_ptr(),
-                            ptr::null(),
-                        )
-                    },
-                    "select root disk",
+                attach_resolved_disk(
+                    context,
+                    OVERLAY_UPPER_BLOCK_ID,
+                    &upper,
+                    false,
+                    "attach writable overlay upper disk",
                 )?;
             }
         }
@@ -334,6 +334,100 @@ impl KrunVm {
         self.context = None;
         Err(VmError::UnexpectedReturn)
     }
+}
+
+fn resolve_root(root: &RootFilesystem) -> Result<ResolvedRoot, VmError> {
+    match root {
+        RootFilesystem::Directory(path) => {
+            let resolved = resolve_root_path(path)?;
+            if !resolved.is_dir() {
+                return Err(VmError::RootNotDirectory(resolved));
+            }
+            Ok(ResolvedRoot::Directory(resolved))
+        }
+        RootFilesystem::Ext4(path) => {
+            let resolved = resolve_root_path(path)?;
+            if !resolved.is_file() {
+                return Err(VmError::RootNotFile(resolved));
+            }
+            Ok(ResolvedRoot::Ext4(resolved))
+        }
+        RootFilesystem::OverlayExt4 {
+            runtime,
+            lower,
+            upper,
+        } => {
+            let runtime = resolve_root_path(runtime)?;
+            if !runtime.is_file() {
+                return Err(VmError::RootNotFile(runtime));
+            }
+            let lower = resolve_block_path(lower)?;
+            if !lower.is_file() {
+                return Err(VmError::BlockDeviceNotFile(lower));
+            }
+            let upper = resolve_block_path(upper)?;
+            if !upper.is_file() {
+                return Err(VmError::BlockDeviceNotFile(upper));
+            }
+            Ok(ResolvedRoot::OverlayExt4 {
+                runtime,
+                lower,
+                upper,
+            })
+        }
+    }
+}
+
+fn resolve_root_path(path: &std::path::Path) -> Result<PathBuf, VmError> {
+    path.canonicalize().map_err(|source| VmError::ResolveRoot {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn resolve_block_path(path: &std::path::Path) -> Result<PathBuf, VmError> {
+    path.canonicalize()
+        .map_err(|source| VmError::ResolveBlockDevice {
+            path: path.to_path_buf(),
+            source,
+        })
+}
+
+fn attach_root_disk(context: u32, path: &std::path::Path, read_only: bool) -> Result<(), VmError> {
+    attach_resolved_disk(context, ROOT_BLOCK_ID, path, read_only, "attach root disk")?;
+    let options = if read_only {
+        READ_ONLY_MOUNT_OPTIONS.as_ptr()
+    } else {
+        ptr::null()
+    };
+    // SAFETY: all strings are static and NUL terminated.
+    check(
+        unsafe {
+            krun::krun_set_root_disk_remount(
+                context,
+                ROOT_BLOCK_DEVICE.as_ptr(),
+                EXT4_FILESYSTEM.as_ptr(),
+                options,
+            )
+        },
+        "select root disk",
+    )
+}
+
+fn attach_resolved_disk(
+    context: u32,
+    id: &std::ffi::CStr,
+    path: &std::path::Path,
+    read_only: bool,
+    operation: &'static str,
+) -> Result<(), VmError> {
+    let path = c_string(path.as_os_str(), "block device path")?;
+    // SAFETY: both strings remain valid through the call and libkrun copies
+    // their contents into its context before returning.
+    check(
+        unsafe { krun::krun_add_disk(context, id.as_ptr(), path.as_ptr(), read_only) },
+        operation,
+    )
 }
 
 fn attach_network(context: u32, network: &Network) -> Result<(), VmError> {

--- a/crates/experimental/nanocodex-vm/src/lib.rs
+++ b/crates/experimental/nanocodex-vm/src/lib.rs
@@ -58,6 +58,17 @@ pub mod image;
     )
 ))]
 mod krun;
+#[cfg(any(
+    all(feature = "guest-runtime", target_os = "linux"),
+    all(
+        feature = "host",
+        any(
+            all(target_os = "linux", not(target_env = "musl")),
+            all(target_os = "macos", target_arch = "aarch64")
+        )
+    )
+))]
+mod overlay;
 #[cfg(all(
     feature = "host",
     any(
@@ -109,6 +120,7 @@ pub mod host {
         },
         gvproxy::{Gvproxy, GvproxyError},
         krun::{KrunVm, KrunVmControl, VmError},
+        overlay::{OverlayDiskError, create_sparse_overlay_disk, overlay_guest_command},
         process::{PrivateVmProcessConfig, VmProcessConfig, VmProcessError},
     };
 }

--- a/crates/experimental/nanocodex-vm/src/overlay.rs
+++ b/crates/experimental/nanocodex-vm/src/overlay.rs
@@ -1,0 +1,373 @@
+#[cfg(all(
+    feature = "host",
+    any(
+        all(target_os = "linux", not(target_env = "musl")),
+        all(target_os = "macos", target_arch = "aarch64")
+    )
+))]
+use std::ffi::OsString;
+#[cfg(all(
+    feature = "host",
+    any(
+        all(target_os = "linux", not(target_env = "musl")),
+        all(target_os = "macos", target_arch = "aarch64")
+    )
+))]
+use std::os::unix::fs::PermissionsExt as _;
+use std::{fs, io, path::Path};
+
+#[cfg(all(
+    feature = "host",
+    any(
+        all(target_os = "linux", not(target_env = "musl")),
+        all(target_os = "macos", target_arch = "aarch64")
+    )
+))]
+use arcbox_ext4::{
+    Formatter,
+    constants::{file_mode, make_mode},
+    error::FormatError,
+};
+#[cfg(all(feature = "guest-runtime", target_os = "linux"))]
+use nix::{
+    errno::Errno,
+    mount::{MntFlags, MsFlags, mount, umount2},
+    unistd::{chdir, pivot_root},
+};
+use thiserror::Error;
+
+#[cfg(all(
+    feature = "host",
+    any(
+        all(target_os = "linux", not(target_env = "musl")),
+        all(target_os = "macos", target_arch = "aarch64")
+    )
+))]
+use crate::command::GuestCommand;
+
+#[cfg(all(
+    feature = "host",
+    any(
+        all(target_os = "linux", not(target_env = "musl")),
+        all(target_os = "macos", target_arch = "aarch64")
+    )
+))]
+const BLOCK_SIZE: u32 = 4_096;
+#[cfg(all(feature = "guest-runtime", target_os = "linux"))]
+const LOWER_DEVICE: &str = "/dev/vdb";
+#[cfg(all(feature = "guest-runtime", target_os = "linux"))]
+const UPPER_DEVICE: &str = "/dev/vdc";
+#[cfg(all(feature = "guest-runtime", target_os = "linux"))]
+const STAGING_ROOT: &str = "/mnt";
+#[cfg(all(feature = "guest-runtime", target_os = "linux"))]
+const LOWER_MOUNT: &str = "/mnt/nanocodex-lower";
+#[cfg(all(feature = "guest-runtime", target_os = "linux"))]
+const UPPER_MOUNT: &str = "/mnt/nanocodex-upper";
+#[cfg(all(feature = "guest-runtime", target_os = "linux"))]
+const MERGED_MOUNT: &str = "/mnt/nanocodex-root";
+#[cfg(all(feature = "guest-runtime", target_os = "linux"))]
+const UPPER_DIRECTORY: &str = "/mnt/nanocodex-upper/upper";
+#[cfg(all(feature = "guest-runtime", target_os = "linux"))]
+const WORK_DIRECTORY: &str = "/mnt/nanocodex-upper/work";
+#[cfg(all(feature = "guest-runtime", target_os = "linux"))]
+const OLD_ROOT_DIRECTORY: &str = ".nanocodex-old-root";
+
+/// Failure to create one sparse writable OverlayFS disk.
+#[cfg(all(
+    feature = "host",
+    any(
+        all(target_os = "linux", not(target_env = "musl")),
+        all(target_os = "macos", target_arch = "aarch64")
+    )
+))]
+#[derive(Debug, Error)]
+pub enum OverlayDiskError {
+    /// The destination path or its parent could not be accessed.
+    #[error("failed to create sparse OverlayFS disk: {0}")]
+    Io(#[from] io::Error),
+    /// The empty ext4 filesystem could not be formatted.
+    #[error("failed to format sparse OverlayFS disk: {0}")]
+    Format(#[from] FormatError),
+}
+
+/// Creates an empty sparse ext4 disk suitable for an OverlayFS upper layer.
+///
+/// The destination must not exist. Formatting happens through a private file
+/// in the destination directory and is published atomically, so interruption
+/// never exposes a partial attempt disk. The returned value is the logical
+/// disk size in bytes; physical allocation remains limited to ext4 metadata
+/// until the guest writes into the upper layer.
+///
+/// # Errors
+///
+/// Returns an error when the destination exists, its parent is unavailable,
+/// or the ext4 image cannot be formatted and published.
+#[cfg(all(
+    feature = "host",
+    any(
+        all(target_os = "linux", not(target_env = "musl")),
+        all(target_os = "macos", target_arch = "aarch64")
+    )
+))]
+pub fn create_sparse_overlay_disk(
+    destination: impl AsRef<Path>,
+    bytes: u64,
+) -> Result<u64, OverlayDiskError> {
+    let destination = destination.as_ref();
+    if fs::symlink_metadata(destination).is_ok() {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!("overlay disk already exists: {}", destination.display()),
+        )
+        .into());
+    }
+    let parent = destination.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "overlay disk destination has no parent directory",
+        )
+    })?;
+    let temporary = tempfile::Builder::new()
+        .prefix(".nanocodex-overlay.")
+        .tempfile_in(parent)?
+        .into_temp_path();
+    let mut formatter = Formatter::new(&temporary, BLOCK_SIZE, bytes)?;
+    for directory in ["/upper", "/work"] {
+        formatter.create(
+            directory,
+            make_mode(file_mode::S_IFDIR, 0o755),
+            None,
+            None,
+            None,
+            Some(0),
+            Some(0),
+            None,
+        )?;
+    }
+    formatter.close()?;
+    fs::set_permissions(&temporary, fs::Permissions::from_mode(0o600))?;
+    fs::hard_link(&temporary, destination)?;
+    Ok(fs::metadata(destination)?.len())
+}
+
+/// Builds the initial command for a guest configured with
+/// [`crate::host::VmConfig::overlay_ext4`].
+///
+/// The static runtime performs the mount and root transition before exposing
+/// the normal typed VM-tool protocol. An empty resolver string preserves the
+/// lower image's resolver configuration.
+#[cfg(all(
+    feature = "host",
+    any(
+        all(target_os = "linux", not(target_env = "musl")),
+        all(target_os = "macos", target_arch = "aarch64")
+    )
+))]
+pub fn overlay_guest_command(
+    workspace: impl Into<OsString>,
+    resolver_configuration: impl Into<OsString>,
+) -> GuestCommand {
+    GuestCommand::new("/nanocodex-vm-guest").args([
+        OsString::from("--overlay-root"),
+        workspace.into(),
+        resolver_configuration.into(),
+    ])
+}
+
+/// Failure while replacing the tiny guest runtime root with the attempt's
+/// immutable-lower, writable-upper OverlayFS root.
+#[cfg(all(feature = "guest-runtime", target_os = "linux"))]
+#[derive(Debug, Error)]
+#[error("guest OverlayFS setup failed while {operation}: {source}")]
+pub struct GuestOverlayError {
+    operation: &'static str,
+    #[source]
+    source: io::Error,
+}
+
+#[cfg(all(feature = "guest-runtime", target_os = "linux"))]
+impl GuestOverlayError {
+    const fn io(operation: &'static str, source: io::Error) -> Self {
+        Self { operation, source }
+    }
+
+    fn errno(operation: &'static str, source: Errno) -> Self {
+        Self::io(operation, io::Error::from_raw_os_error(source as i32))
+    }
+}
+
+#[cfg(all(feature = "guest-runtime", target_os = "linux"))]
+pub(crate) fn enter_guest_overlay_root(
+    resolver_configuration: Option<&str>,
+) -> Result<(), GuestOverlayError> {
+    mount(
+        Some("tmpfs"),
+        STAGING_ROOT,
+        Some("tmpfs"),
+        MsFlags::MS_NOSUID | MsFlags::MS_NODEV,
+        Some("mode=0755"),
+    )
+    .map_err(|error| GuestOverlayError::errno("mounting the staging tmpfs", error))?;
+    for directory in [LOWER_MOUNT, UPPER_MOUNT, MERGED_MOUNT] {
+        fs::create_dir_all(directory)
+            .map_err(|error| GuestOverlayError::io("creating overlay mount points", error))?;
+    }
+    mount(
+        Some(LOWER_DEVICE),
+        LOWER_MOUNT,
+        Some("ext4"),
+        MsFlags::MS_RDONLY | MsFlags::MS_RELATIME,
+        None::<&str>,
+    )
+    .map_err(|error| GuestOverlayError::errno("mounting the immutable lower disk", error))?;
+    mount(
+        Some(UPPER_DEVICE),
+        UPPER_MOUNT,
+        Some("ext4"),
+        MsFlags::MS_RELATIME,
+        None::<&str>,
+    )
+    .map_err(|error| GuestOverlayError::errno("mounting the writable upper disk", error))?;
+    for directory in [UPPER_DIRECTORY, WORK_DIRECTORY] {
+        fs::create_dir_all(directory)
+            .map_err(|error| GuestOverlayError::io("creating upper-layer directories", error))?;
+    }
+    let options =
+        format!("lowerdir={LOWER_MOUNT},upperdir={UPPER_DIRECTORY},workdir={WORK_DIRECTORY}");
+    mount(
+        Some("overlay"),
+        MERGED_MOUNT,
+        Some("overlay"),
+        MsFlags::MS_RELATIME,
+        Some(options.as_str()),
+    )
+    .map_err(|error| GuestOverlayError::errno("mounting the merged OverlayFS root", error))?;
+
+    for source in ["/dev", "/proc", "/sys"] {
+        let target = Path::new(MERGED_MOUNT).join(source.trim_start_matches('/'));
+        fs::create_dir_all(&target)
+            .map_err(|error| GuestOverlayError::io("creating virtual filesystem targets", error))?;
+        mount(
+            Some(source),
+            &target,
+            None::<&str>,
+            MsFlags::MS_BIND | MsFlags::MS_REC,
+            None::<&str>,
+        )
+        .map_err(|error| GuestOverlayError::errno("binding virtual filesystems", error))?;
+    }
+    let run = Path::new(MERGED_MOUNT).join("run");
+    fs::create_dir_all(&run)
+        .map_err(|error| GuestOverlayError::io("creating the guest runtime directory", error))?;
+    mount(
+        Some("tmpfs"),
+        &run,
+        Some("tmpfs"),
+        MsFlags::MS_NOSUID | MsFlags::MS_NODEV,
+        Some("mode=0755"),
+    )
+    .map_err(|error| GuestOverlayError::errno("mounting the guest runtime tmpfs", error))?;
+
+    let old_root = Path::new(MERGED_MOUNT).join(OLD_ROOT_DIRECTORY);
+    fs::create_dir_all(&old_root)
+        .map_err(|error| GuestOverlayError::io("creating the old-root mount point", error))?;
+    mount(
+        None::<&str>,
+        "/",
+        None::<&str>,
+        MsFlags::MS_REC | MsFlags::MS_PRIVATE,
+        None::<&str>,
+    )
+    .map_err(|error| GuestOverlayError::errno("privatizing the original root mount", error))?;
+    chdir(MERGED_MOUNT)
+        .map_err(|error| GuestOverlayError::errno("entering the merged root", error))?;
+    pivot_root(".", OLD_ROOT_DIRECTORY)
+        .map_err(|error| GuestOverlayError::errno("pivoting into the merged root", error))?;
+    chdir("/").map_err(|error| GuestOverlayError::errno("entering the guest root", error))?;
+    let old_root = Path::new("/").join(OLD_ROOT_DIRECTORY);
+    umount2(&old_root, MntFlags::MNT_DETACH)
+        .map_err(|error| GuestOverlayError::errno("detaching the original root", error))?;
+    fs::remove_dir(&old_root)
+        .map_err(|error| GuestOverlayError::io("removing the old-root mount point", error))?;
+    mount(
+        None::<&str>,
+        "/",
+        None::<&str>,
+        MsFlags::MS_REC | MsFlags::MS_SHARED,
+        None::<&str>,
+    )
+    .map_err(|error| GuestOverlayError::errno("sharing the merged root mount", error))?;
+
+    if let Some(resolver) = resolver_configuration.filter(|resolver| !resolver.is_empty()) {
+        let resolver = resolver.replace("\\n", "\n");
+        match fs::remove_file("/etc/resolv.conf") {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(GuestOverlayError::io(
+                    "replacing the guest resolver configuration",
+                    error,
+                ));
+            }
+        }
+        fs::write("/etc/resolv.conf", resolver)
+            .map_err(|error| GuestOverlayError::io("writing the guest resolver", error))?;
+    }
+    Ok(())
+}
+
+#[cfg(all(
+    test,
+    feature = "host",
+    any(
+        all(target_os = "linux", not(target_env = "musl")),
+        all(target_os = "macos", target_arch = "aarch64")
+    )
+))]
+mod tests {
+    use std::{
+        fs,
+        os::unix::fs::{MetadataExt as _, PermissionsExt as _},
+    };
+
+    use arcbox_ext4::Reader;
+
+    use super::create_sparse_overlay_disk;
+
+    #[test]
+    fn sparse_overlay_disk_is_private_and_contains_upper_and_work() {
+        let directory = tempfile::tempdir().unwrap();
+        let destination = directory.path().join("upper.ext4");
+        let bytes = 512 * 1024 * 1024;
+
+        assert_eq!(
+            create_sparse_overlay_disk(&destination, bytes).unwrap(),
+            bytes
+        );
+
+        let metadata = destination.metadata().unwrap();
+        assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
+        assert!(metadata.blocks().saturating_mul(512) < bytes / 4);
+        let mut reader = Reader::new(&destination).unwrap();
+        assert!(reader.stat("/upper").unwrap().1.is_dir());
+        assert!(reader.stat("/work").unwrap().1.is_dir());
+    }
+
+    #[test]
+    fn sparse_overlay_disk_never_replaces_an_existing_destination() {
+        let directory = tempfile::tempdir().unwrap();
+        let destination = directory.path().join("upper.ext4");
+        fs::write(&destination, b"sentinel").unwrap();
+
+        let error = create_sparse_overlay_disk(&destination, 512 * 1024 * 1024).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "failed to create sparse OverlayFS disk: overlay disk already exists: {}",
+                destination.display()
+            )
+        );
+        assert_eq!(fs::read(destination).unwrap(), b"sentinel");
+    }
+}

--- a/crates/experimental/nanocodex-vm/src/process.rs
+++ b/crates/experimental/nanocodex-vm/src/process.rs
@@ -14,7 +14,7 @@ use crate::{
     krun::{KrunVm, VmError},
 };
 
-const PROCESS_CONFIG_VERSION: u32 = 1;
+const PROCESS_CONFIG_VERSION: u32 = 2;
 
 /// Complete owned input for one dedicated VMM process.
 ///

--- a/crates/experimental/nanocodex-vm/src/tools/guest.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/guest.rs
@@ -34,6 +34,8 @@ use super::protocol::{
     MemoryResponse, ReadFileRequest, ReadFileResponse, SessionRequest, SessionResponse,
     ShutdownRequest, ToolResponse, WriteFileRequest,
 };
+#[cfg(all(feature = "guest-runtime", target_os = "linux"))]
+use crate::overlay::{GuestOverlayError, enter_guest_overlay_root};
 
 const MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 const MAX_CONTROL_FILE_BYTES: usize = 32 * 1024 * 1024;
@@ -141,6 +143,12 @@ fn parse_vmstat_oom_kills(contents: &str) -> Option<u64> {
 /// Failure while serving VM tool requests inside the guest.
 #[derive(Debug, Error)]
 pub enum VmGuestError {
+    /// The immutable lower and writable upper disks could not become the
+    /// guest's effective OverlayFS root.
+    #[cfg(all(feature = "guest-runtime", target_os = "linux"))]
+    #[error(transparent)]
+    Overlay(#[from] GuestOverlayError),
+
     /// Guest console I/O failed.
     #[error("VM tool console I/O failed: {0}")]
     Io(#[from] std::io::Error),
@@ -169,6 +177,16 @@ pub enum VmGuestError {
 #[cfg(feature = "guest-runtime")]
 pub(crate) async fn serve(workspace: &Path) -> Result<(), VmGuestError> {
     serve_io(workspace, tokio::io::stdin(), tokio::io::stdout()).await
+}
+
+#[cfg(all(feature = "guest-runtime", target_os = "linux"))]
+pub(crate) async fn serve_overlay(
+    workspace: &Path,
+    resolver_configuration: Option<&str>,
+) -> Result<(), VmGuestError> {
+    enter_guest_overlay_root(resolver_configuration)?;
+    tokio::fs::create_dir_all(workspace).await?;
+    serve(workspace).await
 }
 
 #[cfg(feature = "guest-runtime")]

--- a/crates/experimental/nanocodex-vm/src/tools/mod.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/mod.rs
@@ -122,6 +122,8 @@ use nanocodex_tools::{
     standard::{StandardTool, UpdatePlanTool},
 };
 
+#[cfg(all(feature = "guest-runtime", target_os = "linux"))]
+pub use crate::overlay::GuestOverlayError;
 #[cfg(feature = "guest-runtime")]
 pub use guest::VmGuestError;
 #[cfg(all(
@@ -310,6 +312,26 @@ impl Tool for VmTool {
 #[cfg(feature = "guest-runtime")]
 pub async fn serve_guest(workspace: impl AsRef<Path>) -> Result<(), VmGuestError> {
     guest::serve(workspace.as_ref()).await
+}
+
+/// Mounts the fixed immutable-lower and writable-upper block devices as the
+/// guest's OverlayFS root, then serves canonical workspace-tool requests.
+///
+/// This entry point is intended for the static `nanocodex-vm-guest` binary
+/// when the host selected an OverlayFS VM configuration. The optional resolver
+/// configuration uses the same `\\n` representation accepted by the existing
+/// raw-ext4 bootstrap.
+///
+/// # Errors
+///
+/// Returns an error when a block filesystem or OverlayFS cannot be mounted,
+/// the guest cannot pivot into the merged root, or tool protocol serving fails.
+#[cfg(all(feature = "guest-runtime", target_os = "linux"))]
+pub async fn serve_overlay_guest(
+    workspace: impl AsRef<Path>,
+    resolver_configuration: Option<&str>,
+) -> Result<(), VmGuestError> {
+    guest::serve_overlay(workspace.as_ref(), resolver_configuration).await
 }
 
 #[cfg(all(

--- a/crates/experimental/nanocodex-vm/src/tools/runtime_disk.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/runtime_disk.rs
@@ -17,7 +17,19 @@ use tracing::{info, info_span};
 const BLOCK_SIZE: u32 = 4_096;
 const DISK_BYTES: u64 = 128 * 1024 * 1024;
 const GUEST_PATH: &str = "/nanocodex-vm-guest";
-const IDENTITY_VERSION: &[u8] = b"nanocodex-vm-guest-runtime-v1\0";
+const RUNTIME_ROOT_DIRECTORIES: [&str; 10] = [
+    "/dev",
+    "/dev/pts",
+    "/dev/shm",
+    "/proc",
+    "/sys",
+    "/sys/fs",
+    "/sys/fs/cgroup",
+    "/mnt",
+    "/run",
+    "/tmp",
+];
+const IDENTITY_VERSION: &[u8] = b"nanocodex-vm-guest-runtime-v2-overlay-root\0";
 const RECORD_VERSION: u32 = 1;
 
 /// Whether preparing a guest runtime disk reused or created its cache entry.
@@ -205,6 +217,18 @@ impl GuestRuntimeDisk {
             .into_temp_path();
         let mut contents = bytes.as_slice();
         let mut formatter = Formatter::new(&temporary, BLOCK_SIZE, DISK_BYTES)?;
+        for directory in RUNTIME_ROOT_DIRECTORIES {
+            formatter.create(
+                directory,
+                make_mode(file_mode::S_IFDIR, 0o755),
+                None,
+                None,
+                None,
+                Some(0),
+                Some(0),
+                None,
+            )?;
+        }
         formatter.create(
             GUEST_PATH,
             make_mode(file_mode::S_IFREG, 0o755),
@@ -563,6 +587,13 @@ fn valid_cached_disk(path: &Path, binary: &[u8]) -> Result<bool, GuestRuntimeDis
     let Ok(mut reader) = Reader::new(path) else {
         return Ok(false);
     };
+    if RUNTIME_ROOT_DIRECTORIES.iter().any(|directory| {
+        !reader
+            .stat(directory)
+            .is_ok_and(|(_, inode)| inode.is_dir())
+    }) {
+        return Ok(false);
+    }
     let Ok((_, inode)) = reader.stat(GUEST_PATH) else {
         return Ok(false);
     };
@@ -587,6 +618,16 @@ fn validate_prepared_disk(path: &Path, binary: &[u8]) -> Result<(), GuestRuntime
             path: path.to_path_buf(),
             source: Some(source),
         })?;
+    if RUNTIME_ROOT_DIRECTORIES.iter().any(|directory| {
+        !reader
+            .stat(directory)
+            .is_ok_and(|(_, inode)| inode.is_dir())
+    }) {
+        return Err(GuestRuntimeDiskError::InvalidPreparedDisk {
+            path: path.to_path_buf(),
+            source: None,
+        });
+    }
     let (_, inode) =
         reader
             .stat(GUEST_PATH)
@@ -625,7 +666,10 @@ mod tests {
 
     use arcbox_ext4::Reader;
 
-    use super::{GUEST_PATH, GuestRuntimeDisk, GuestRuntimeDiskStatus, runtime_digest};
+    use super::{
+        GUEST_PATH, GuestRuntimeDisk, GuestRuntimeDiskStatus, RUNTIME_ROOT_DIRECTORIES,
+        runtime_digest,
+    };
 
     #[test]
     fn prepares_valid_content_addressed_disk_and_reuses_it() {
@@ -647,6 +691,9 @@ mod tests {
         );
 
         let mut reader = Reader::new(created.path()).unwrap();
+        for directory in RUNTIME_ROOT_DIRECTORIES {
+            assert!(reader.stat(directory).unwrap().1.is_dir());
+        }
         let (_, inode) = reader.stat(GUEST_PATH).unwrap();
         assert!(inode.is_reg());
         assert_eq!(inode.file_size(), bytes.len() as u64);

--- a/crates/experimental/nanocodex-vm/tests/image_live_build.rs
+++ b/crates/experimental/nanocodex-vm/tests/image_live_build.rs
@@ -1,11 +1,23 @@
-use std::{fs, path::PathBuf};
-
-use arcbox_ext4::Reader;
-use nanocodex_vm::{
-    host::EgressLease,
-    image::{CachePolicy, DiskStatus, VmImageBuilder},
-    tools::GuestRuntimeDisk,
+use std::{
+    fs,
+    io::{self, Read as _},
+    path::{Path, PathBuf},
 };
+
+use arcbox_ext4::{
+    Formatter, Reader,
+    constants::{file_mode, make_mode},
+};
+use nanocodex_vm::{
+    host::{
+        BlockDevice, EgressLease, Network, VmConfig, create_sparse_overlay_disk,
+        overlay_guest_command,
+    },
+    image::{CachePolicy, DiskStatus, VmImageBuilder},
+    tools::{GuestRuntimeDisk, VmCommand, VmToolSession},
+};
+use sha2::{Digest as _, Sha256};
+use tokio::process::Command;
 
 const DISK_BYTES: u64 = 512 * 1024 * 1024;
 
@@ -69,6 +81,162 @@ async fn run_instruction_uses_the_public_private_config_vmm_contract() {
         .expect("warm prepared image");
     assert_eq!(warm.disk_status(), DiskStatus::Hit);
     assert_eq!(warm.path(), image.path());
+}
+
+#[tokio::test]
+#[ignore = "requires a signed libkrun VMM, firmware, current guest ELF, and OCI cache"]
+async fn guest_overlay_resets_to_an_immutable_base_without_host_reflinks() {
+    let vmm = required_path("NANOCODEX_VM_IMAGE_VMM");
+    let guest = required_path("NANOCODEX_VM_IMAGE_RUNTIME");
+    let firmware = required_path("NANOCODEX_VM_IMAGE_FIRMWARE");
+    let cache = required_path("NANOCODEX_VM_IMAGE_CACHE");
+    let runtime =
+        GuestRuntimeDisk::prepare(guest, &cache).expect("content-addressed guest runtime disk");
+    let context = tempfile::tempdir().expect("build context");
+    fs::write(
+        context.path().join("Dockerfile"),
+        concat!(
+            "FROM alpine:3.24\n",
+            "RUN printf immutable-base > /nanocodex-overlay-base\n",
+            "WORKDIR /workspace\n",
+        ),
+    )
+    .expect("Dockerfile");
+    let builder = VmImageBuilder::new(&vmm, runtime.path())
+        .firmware_directory(&firmware)
+        .vmm_arg("vm-run-config")
+        .vmm_arg("--config");
+    let image = builder
+        .prepare(context.path(), DISK_BYTES, &cache, CachePolicy::Reuse)
+        .await
+        .expect("prepared image");
+    let base_digest = file_digest(image.path()).expect("base digest before attempts");
+    let attempts = tempfile::tempdir().expect("attempt disks");
+    let additional = attempts.path().join("additional.ext4");
+    format_probe_disk(&additional).expect("additional block disk");
+
+    let first_upper = attempts.path().join("first-upper.ext4");
+    create_sparse_overlay_disk(&first_upper, DISK_BYTES).expect("first sparse upper disk");
+    let first = spawn_overlay(
+        &vmm,
+        &firmware,
+        runtime.path(),
+        image.path(),
+        &first_upper,
+        Some(&additional),
+    )
+    .await;
+    let first_output = first
+        .command(VmCommand::new("/bin/sh").arg("-c").arg(
+            "set -eu; grep -qw overlay /proc/filesystems; \
+                 test \"$(cat /nanocodex-overlay-base)\" = immutable-base; \
+                 mkdir -p /mnt/nanocodex-additional; \
+                 mount -t ext4 -o ro /dev/vdd /mnt/nanocodex-additional; \
+                 test \"$(cat /mnt/nanocodex-additional/proof)\" = fourth-device; \
+                 printf attempt-one > /workspace/attempt-marker; \
+                 printf changed > /etc/nanocodex-overlay-proof; \
+                 rm /nanocodex-overlay-base",
+        ))
+        .await
+        .expect("first overlay command");
+    assert_eq!(first_output.exit_code, 0, "{:?}", first_output.stderr);
+    first.shutdown().await.expect("first overlay shutdown");
+
+    assert_eq!(
+        file_digest(image.path()).expect("base digest after first attempt"),
+        base_digest
+    );
+    let mut base = Reader::new(image.path()).expect("immutable base reader");
+    assert_eq!(
+        base.read_file("/nanocodex-overlay-base", 0, None)
+            .expect("base marker"),
+        b"immutable-base"
+    );
+    assert!(!base.exists("/workspace/attempt-marker"));
+    assert!(!base.exists("/etc/nanocodex-overlay-proof"));
+
+    let second_upper = attempts.path().join("second-upper.ext4");
+    create_sparse_overlay_disk(&second_upper, DISK_BYTES).expect("second sparse upper disk");
+    let second = spawn_overlay(
+        &vmm,
+        &firmware,
+        runtime.path(),
+        image.path(),
+        &second_upper,
+        None,
+    )
+    .await;
+    let second_output = second
+        .command(VmCommand::new("/bin/sh").arg("-c").arg(
+            "set -eu; test -f /nanocodex-overlay-base; \
+             test ! -e /workspace/attempt-marker; \
+             test ! -e /etc/nanocodex-overlay-proof",
+        ))
+        .await
+        .expect("second overlay command");
+    assert_eq!(second_output.exit_code, 0, "{:?}", second_output.stderr);
+    second.shutdown().await.expect("second overlay shutdown");
+    assert_eq!(
+        file_digest(image.path()).expect("base digest after second attempt"),
+        base_digest
+    );
+}
+
+async fn spawn_overlay(
+    vmm: &Path,
+    firmware: &Path,
+    runtime: &Path,
+    lower: &Path,
+    upper: &Path,
+    additional: Option<&Path>,
+) -> VmToolSession {
+    let mut config = VmConfig::overlay_ext4(runtime, lower, upper)
+        .cpus(2)
+        .memory_mib(768)
+        .network(Network::Disabled);
+    if let Some(additional) = additional {
+        config = config.block_device(BlockDevice::read_only("additional", additional));
+    }
+    let guest = overlay_guest_command("/workspace", "");
+    let mut command = Command::new(vmm);
+    command.args(["vm-run-config", "--config"]);
+    #[cfg(target_os = "linux")]
+    command.env("LD_LIBRARY_PATH", firmware);
+    #[cfg(target_os = "macos")]
+    command.env("DYLD_LIBRARY_PATH", firmware);
+    VmToolSession::spawn_configured(command, config, guest, EgressLease::disabled())
+        .await
+        .expect("overlay VM session")
+}
+
+fn format_probe_disk(path: &Path) -> Result<(), arcbox_ext4::error::FormatError> {
+    let mut formatter = Formatter::new(path, 4_096, 128 * 1024 * 1024)?;
+    let mut proof = b"fourth-device".as_slice();
+    formatter.create(
+        "/proof",
+        make_mode(file_mode::S_IFREG, 0o444),
+        None,
+        None,
+        Some(&mut proof),
+        Some(0),
+        Some(0),
+        None,
+    )?;
+    formatter.close()
+}
+
+fn file_digest(path: &Path) -> io::Result<[u8; 32]> {
+    let mut file = fs::File::open(path)?;
+    let mut digest = Sha256::new();
+    let mut buffer = [0_u8; 1024 * 1024];
+    loop {
+        let bytes = file.read(&mut buffer)?;
+        if bytes == 0 {
+            break;
+        }
+        digest.update(&buffer[..bytes]);
+    }
+    Ok(digest.finalize().into())
 }
 
 fn required_path(name: &str) -> PathBuf {


### PR DESCRIPTION
## Summary

- add an explicit `OverlayExt4` root shape: read-only runtime, read-only prepared lower, sparse writable upper
- atomically format private sparse upper disks without copying multi-gigabyte roots
- mount and pivot into the merged OverlayFS inside the static Linux guest
- keep extra block-device ordering and private VMM launch records typed and versioned
- document complete launch, ownership, shutdown, and upper-disk deletion order
- prove reset semantics and immutable-base preservation in the ignored live libkrun test

This is a stacked VM prerequisite extracted from #61. Its base is #98 because overlay guest startup uses that PR's cancellation/session lifecycle; this review diff contains only overlay behavior. After #98 merges, this PR can target `master`. It contains no evaluator, scheduler, CLI, dashboard, retained results, or benchmark tasks.

An eval-specific `/logs/verifier` side effect from the source patch was deliberately removed. Overlay startup creates only the caller-requested workspace.

## Validation

- `cargo test -p nanocodex-vm --lib` (108 passed)
- `cargo test -p nanocodex-vm --no-default-features --features guest-runtime --all-targets` (24 passed)
- host/all-feature and guest-only Clippy with warnings denied
- `cargo check -p nanocodex-vm --no-default-features --features guest-runtime --target aarch64-unknown-linux-musl --bin nanocodex-vm-guest`
- `cargo test -p nanocodex-vm --doc`
- `bash scripts/check-crate-boundaries.sh`

The ignored live test requires a signed VMM, firmware, guest ELF, and OCI cache.