### PR TITLE
feat(tui): add interactive session resume

### DIFF
--- a/bin/nanocodex/src/browser.rs
+++ b/bin/nanocodex/src/browser.rs
@@ -32,7 +32,7 @@ enum CookieSource {
 }
 
 /// Opt-in local browser configuration for normal agent sessions.
-#[derive(Args, Default)]
+#[derive(Args, Clone, Default)]
 pub(crate) struct BrowserArgs {
     /// Expose one private browser session to Code Mode as `tools.browser`.
     ///

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -41,6 +41,7 @@ struct SessionBuild {
     session_id: Option<SessionId>,
     snapshot: Option<SessionSnapshot>,
     rollout: Option<RolloutConfig>,
+    base_instructions: Option<String>,
 }
 
 #[derive(Args, Clone)]
@@ -285,7 +286,7 @@ impl AgentArgs {
         } else {
             builder.tools(tools)
         };
-        let builder = if let Some(instructions) = self.instructions {
+        let builder = if let Some(instructions) = self.instructions.or(session.base_instructions) {
             builder.instructions(instructions)
         } else {
             builder
@@ -316,6 +317,7 @@ fn prepare_session_build(
             session_id: None,
             snapshot: None,
             rollout: rollouts.then(|| RolloutConfig::new(codex_home)),
+            base_instructions: None,
         });
     };
     let restored = Path::new(session.workspace())
@@ -333,16 +335,27 @@ fn prepare_session_build(
             ));
         }
     }
+    let base_instructions = session.base_instructions().map(str::to_owned);
+    let continues_in_place = session.recorded_by_nanocodex();
     let (session_id, snapshot, rollout) = session.into_parts();
     Ok(SessionBuild {
         workspace: restored,
-        session_id: Some(
-            session_id
-                .parse()
-                .wrap_err("resumed Codex thread ID is not UUIDv7")?,
-        ),
+        session_id: continues_in_place
+            .then(|| {
+                session_id
+                    .parse()
+                    .wrap_err("resumed Codex thread ID is not UUIDv7")
+            })
+            .transpose()?,
         snapshot: Some(snapshot),
-        rollout: rollouts.then_some(rollout),
+        rollout: rollouts.then(|| {
+            if continues_in_place {
+                rollout
+            } else {
+                RolloutConfig::new(codex_home)
+            }
+        }),
+        base_instructions,
     })
 }
 

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -43,7 +43,7 @@ struct SessionBuild {
     rollout: Option<RolloutConfig>,
 }
 
-#[derive(Args)]
+#[derive(Args, Clone)]
 #[allow(
     clippy::struct_excessive_bools,
     reason = "independent CLI feature toggles are not one state machine"

--- a/bin/nanocodex/src/main.rs
+++ b/bin/nanocodex/src/main.rs
@@ -24,11 +24,11 @@ mod vm;
 #[path = "vm_unsupported.rs"]
 mod vm;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::{Args, Parser, Subcommand, builder::NonEmptyStringValueParser};
-use eyre::{Result, WrapErr};
-use nanocodex::agent::rollout::RolloutConfig;
+use eyre::{Result, WrapErr, eyre};
+use nanocodex::agent::rollout::{DurableSession, DurableSessionSummary, RolloutConfig};
 
 use config::AgentArgs;
 use observability::ObservabilityArgs;
@@ -94,9 +94,13 @@ struct RunCommand {
 
 #[derive(Args)]
 struct ResumeCommand {
-    /// Codex thread UUID to resume.
+    /// Codex thread UUID to resume. Omit it to choose from sessions interactively.
     #[arg(value_parser = NonEmptyStringValueParser::new())]
-    thread_id: String,
+    thread_id: Option<String>,
+
+    /// Show sessions from every workspace instead of only the current repository.
+    #[arg(long, conflicts_with = "thread_id")]
+    all: bool,
 
     #[command(flatten)]
     agent: AgentArgs,
@@ -140,19 +144,123 @@ async fn run(cli: Cli) -> Result<()> {
         }
         Some(Command::Resume(command)) => {
             let codex_home = config::default_codex_home()?;
-            let session = RolloutConfig::new(&codex_home)
-                .load_session(&command.thread_id)
-                .wrap_err_with(|| format!("failed to load Codex thread {}", command.thread_id))?;
+            let rollout = RolloutConfig::new(&codex_home);
+            let session = if let Some(thread_id) = command.thread_id.as_deref() {
+                rollout
+                    .load_session(thread_id)
+                    .wrap_err_with(|| format!("failed to load Codex thread {thread_id}"))?
+            } else {
+                let current =
+                    command.agent.cwd().canonicalize().wrap_err(
+                        "failed to resolve the current workspace for session discovery",
+                    )?;
+                let scope = repository_scope(&current);
+                let sessions = rollout
+                    .list_sessions()
+                    .wrap_err("failed to list resumable Codex sessions")?
+                    .into_iter()
+                    .filter(|session| command.all || session_matches_scope(session, &scope))
+                    .collect::<Vec<_>>();
+                if sessions.is_empty() {
+                    let hint = if command.all {
+                        String::new()
+                    } else {
+                        "; use `nanocodex resume --all` to search every workspace".to_owned()
+                    };
+                    return Err(eyre!(
+                        "no resumable sessions found for {}{hint}",
+                        scope.display()
+                    ));
+                }
+                let Some(thread_id) = tui::select_session(&sessions, command.all).await? else {
+                    return Ok(());
+                };
+                rollout
+                    .load_session(&thread_id)
+                    .wrap_err_with(|| format!("failed to load Codex thread {thread_id}"))?
+            };
             let workspace = PathBuf::from(session.workspace());
             let _observability = command.observability.install(true, &workspace)?;
-            tui::run(command.agent, command.vm, command.prompt, Some(session)).await
+            run_tui_session_loop(
+                command.agent,
+                command.vm,
+                command.prompt,
+                Some(session),
+                rollout,
+            )
+            .await
         }
         Some(Command::Update(command)) => command.run().await,
         None => {
             let _observability = cli.observability.install(true, cli.agent.cwd())?;
-            tui::run(cli.agent, cli.vm, cli.prompt, None).await
+            let codex_home = config::default_codex_home()?;
+            run_tui_session_loop(
+                cli.agent,
+                cli.vm,
+                cli.prompt,
+                None,
+                RolloutConfig::new(&codex_home),
+            )
+            .await
         }
     }
+}
+
+async fn run_tui_session_loop(
+    agent: AgentArgs,
+    vm: vm::VmArgs,
+    initial_prompt: Option<String>,
+    initial_session: Option<DurableSession>,
+    rollout: RolloutConfig,
+) -> Result<()> {
+    let mut prompt = initial_prompt;
+    let mut session = initial_session;
+    loop {
+        match tui::run(agent.clone(), vm.clone(), prompt.take(), session.take()).await? {
+            tui::TuiExit::Quit { session_id } => {
+                println!("{}", tui::resume_hint(&session_id));
+                return Ok(());
+            }
+            tui::TuiExit::Resume {
+                session_id,
+                workspace,
+            } => {
+                let scope = repository_scope(&workspace);
+                let sessions = rollout
+                    .list_sessions()
+                    .wrap_err("failed to list resumable Codex sessions")?
+                    .into_iter()
+                    .filter(|candidate| session_matches_scope(candidate, &scope))
+                    .collect::<Vec<_>>();
+                let selected = if sessions.is_empty() {
+                    None
+                } else {
+                    tui::select_session(&sessions, false).await?
+                };
+                let selected = selected.as_deref().unwrap_or(&session_id);
+                session = Some(
+                    rollout
+                        .load_session(selected)
+                        .wrap_err_with(|| format!("failed to load Codex thread {selected}"))?,
+                );
+            }
+        }
+    }
+}
+
+fn repository_scope(workspace: &Path) -> PathBuf {
+    workspace
+        .ancestors()
+        .find(|ancestor| ancestor.join(".git").exists())
+        .unwrap_or(workspace)
+        .to_path_buf()
+}
+
+fn session_matches_scope(session: &DurableSessionSummary, scope: &Path) -> bool {
+    session
+        .workspace()
+        .canonicalize()
+        .is_ok_and(|workspace| repository_scope(&workspace) == scope)
 }
 
 #[cfg(test)]
@@ -348,8 +456,47 @@ mod tests {
         let Some(Command::Resume(command)) = cli.command else {
             panic!("resume command was not parsed");
         };
-        assert_eq!(command.thread_id, "019c0d31-c308-7d91-bff4-5dca82d15ac6");
+        assert_eq!(
+            command.thread_id.as_deref(),
+            Some("019c0d31-c308-7d91-bff4-5dca82d15ac6")
+        );
         assert_eq!(command.prompt.as_deref(), Some("continue"));
         assert!(!command.agent.uses_tempo());
+    }
+
+    #[test]
+    fn resume_without_a_thread_id_opens_the_workspace_picker() {
+        let cli = Cli::try_parse_from(["nanocodex", "resume", "--all"]).unwrap();
+
+        let Some(Command::Resume(command)) = cli.command else {
+            panic!("resume command was not parsed");
+        };
+        assert!(command.thread_id.is_none());
+        assert!(command.all);
+    }
+
+    #[test]
+    fn resume_all_conflicts_with_an_explicit_thread_id() {
+        let error = Cli::try_parse_from([
+            "nanocodex",
+            "resume",
+            "019c0d31-c308-7d91-bff4-5dca82d15ac6",
+            "--all",
+        ])
+        .err()
+        .unwrap();
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn repository_scope_uses_the_nearest_git_ancestor() {
+        let directory = tempfile::tempdir().unwrap();
+        let repository = directory.path().join("repository");
+        let nested = repository.join("crates/example");
+        std::fs::create_dir_all(repository.join(".git")).unwrap();
+        std::fs::create_dir_all(&nested).unwrap();
+
+        assert_eq!(repository_scope(&nested), repository);
     }
 }

--- a/bin/nanocodex/src/mcp.rs
+++ b/bin/nanocodex/src/mcp.rs
@@ -34,7 +34,7 @@ const DEFAULT_MCP_SERVERS: [(&str, &str, &str); 3] = [
     ),
 ];
 
-#[derive(Args)]
+#[derive(Args, Clone)]
 pub(crate) struct McpArgs {
     /// Load the standard `OpenAI`, Tempo, and Cloudflare MCP servers.
     #[arg(

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -5,6 +5,7 @@ mod diff;
 mod external_editor;
 mod markdown;
 mod notification;
+mod resume_picker;
 mod scheduler;
 mod selection;
 mod telemetry;
@@ -53,6 +54,8 @@ use self::{
     transcript::TranscriptItem,
 };
 use crate::config::AgentArgs;
+
+pub(crate) use resume_picker::select_session;
 
 const BTW_BOUNDARY: &str = r"You are answering an ephemeral BTW side question.
 Treat inherited conversation history only as reference context. Do not resume or complete an
@@ -302,6 +305,7 @@ enum TerminalAction {
     Redraw,
     Ignore,
     Quit,
+    Resume,
     ExternalEditor,
 }
 
@@ -328,6 +332,7 @@ enum UiUpdate {
     RestoreTerminalGraphics,
     Ignore,
     Quit,
+    Resume,
     ExternalEditor,
 }
 
@@ -455,6 +460,7 @@ impl UiModel {
                     TerminalAction::Redraw => Ok(UiUpdate::Redraw(RedrawPriority::Immediate)),
                     TerminalAction::Ignore => Ok(UiUpdate::Ignore),
                     TerminalAction::Quit => Ok(UiUpdate::Quit),
+                    TerminalAction::Resume => Ok(UiUpdate::Resume),
                     TerminalAction::ExternalEditor => Ok(UiUpdate::ExternalEditor),
                 }
             }
@@ -532,6 +538,7 @@ enum SubmitIntent {
 #[derive(Debug, Eq, PartialEq)]
 enum Submission {
     Prompt(SubmittedPrompt),
+    Resume,
     Btw(Option<SubmittedPrompt>),
     CloseBtw,
     Cancel,
@@ -542,6 +549,23 @@ enum Submission {
     McpLogin(String),
     McpReload(String),
     InvalidCommand(String),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SubmitAction {
+    Continue,
+    Resume,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) enum TuiExit {
+    Quit {
+        session_id: String,
+    },
+    Resume {
+        session_id: String,
+        workspace: PathBuf,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -561,7 +585,7 @@ pub(crate) async fn run(
     vm: crate::vm::VmArgs,
     initial_prompt: Option<String>,
     resume: Option<DurableSession>,
-) -> Result<()> {
+) -> Result<TuiExit> {
     let initial_model = resume
         .as_ref()
         .map_or_else(|| config.model(), DurableSession::model);
@@ -630,7 +654,7 @@ pub(crate) async fn run(
 
     submit_initial_prompt(&mut ui.app, &root_session_id, &worker_tx, initial_prompt)?;
 
-    let loop_result: Result<()> = async {
+    let loop_result: Result<TuiExit> = async {
         loop {
             view_telemetry.observe(&ui.app);
             render_due_frame(
@@ -662,8 +686,15 @@ pub(crate) async fn run(
                     math_renderer.reupload_all();
                     ui.app.invalidate_math_layouts();
                     scheduler.request_immediate(Instant::now());
+                } else if update == UiUpdate::Resume {
+                    break Ok(TuiExit::Resume {
+                        session_id: root_session_id.to_string(),
+                        workspace: ui.app.cwd.clone(),
+                    });
                 } else if apply_update(update, &mut scheduler) {
-                    break Ok(());
+                    break Ok(TuiExit::Quit {
+                        session_id: root_session_id.to_string(),
+                    });
                 }
             }
             event = agent_events.recv_timed(), if ui.agent_events_open => {
@@ -675,7 +706,9 @@ pub(crate) async fn run(
                     &mut agent_events,
                     event,
                 )? {
-                    return Ok(());
+                    return Ok(TuiExit::Quit {
+                        session_id: root_session_id.to_string(),
+                    });
                 }
             }
             update = update_rx.recv(), if ui.worker_updates_open => {
@@ -695,15 +728,25 @@ pub(crate) async fn run(
                         matches!(update, UiUpdate::Redraw(RedrawPriority::Streaming)),
                     );
                 }
+                if update == UiUpdate::Resume {
+                    break Ok(TuiExit::Resume {
+                        session_id: root_session_id.to_string(),
+                        workspace: ui.app.cwd.clone(),
+                    });
+                }
                 if apply_update(update, &mut scheduler) {
-                    break Ok(());
+                    break Ok(TuiExit::Quit {
+                        session_id: root_session_id.to_string(),
+                    });
                 }
             }
             _ = ticker.tick(), if ui.app.main.running
                 || ui.app.btw.as_ref().is_some_and(|btw| btw.conversation.running)
                 || ui.app.mouse_selection_needs_redraw() => {
                 if apply_update(ui.update(UiAction::Tick, &worker_tx)?, &mut scheduler) {
-                    break Ok(());
+                    break Ok(TuiExit::Quit {
+                        session_id: root_session_id.to_string(),
+                    });
                 }
             }
             _ = math_update_rx.recv() => {
@@ -719,8 +762,13 @@ pub(crate) async fn run(
     drop((terminal, worker_tx, agent_events));
     math_renderer.shutdown();
     let shutdown_result = shutdown_runtime(worker, child_agents, mpp_adapter, browser, vm).await;
-    loop_result?;
-    shutdown_result
+    let exit = loop_result?;
+    shutdown_result?;
+    Ok(exit)
+}
+
+pub(crate) fn resume_hint(session_id: &str) -> String {
+    format!("Resume this session with:\n  nanocodex resume {session_id}")
 }
 
 fn resolve_cwd(config: &AgentArgs) -> Result<PathBuf> {
@@ -731,13 +779,12 @@ fn resolve_cwd(config: &AgentArgs) -> Result<PathBuf> {
 }
 
 async fn shutdown_runtime(
-    worker: tokio::task::JoinHandle<()>,
+    worker: tokio::task::JoinHandle<Result<()>>,
     child_agents: Option<std::sync::Arc<crate::subagents::ChildAgents>>,
     mpp_adapter: Option<crate::mpp::MppAdapter>,
     browser: Option<crate::browser::ConfiguredBrowser>,
     vm: Option<crate::vm::ConfiguredVm>,
 ) -> Result<()> {
-    worker.abort();
     let worker_result = worker.await;
     if let Some(child_agents) = child_agents {
         child_agents.shutdown().await;
@@ -758,8 +805,7 @@ async fn shutdown_runtime(
         Ok(())
     };
     match worker_result {
-        Ok(()) => {}
-        Err(error) if error.is_cancelled() => {}
+        Ok(result) => result.wrap_err("failed to shut down the TUI agent worker")?,
         Err(error) => return Err(error).wrap_err("TUI agent worker failed"),
     }
     browser_shutdown_result?;
@@ -920,7 +966,7 @@ fn submit_initial_prompt(
     if let Some(prompt) = initial_prompt {
         app.input = prompt;
         app.cursor = app.input.len();
-        submit(app, root_session_id, worker, SubmitIntent::Immediate)?;
+        let _ = submit(app, root_session_id, worker, SubmitIntent::Immediate)?;
     }
     Ok(())
 }
@@ -934,7 +980,7 @@ fn apply_update(update: UiUpdate, scheduler: &mut RenderScheduler) -> bool {
         UiUpdate::Redraw(RedrawPriority::InputBurst) => scheduler.request_input_burst(now),
         UiUpdate::RedrawAnimation => scheduler.request_animation(now),
         UiUpdate::Ignore | UiUpdate::ExternalEditor => {}
-        UiUpdate::Quit => return true,
+        UiUpdate::Quit | UiUpdate::Resume => return true,
     }
     false
 }
@@ -1074,7 +1120,7 @@ fn spawn_agent_worker(
     mcp: Option<McpHandle>,
     mut commands: mpsc::UnboundedReceiver<WorkerCommand>,
     updates: mpsc::UnboundedSender<WorkerEvent>,
-) -> tokio::task::JoinHandle<()> {
+) -> tokio::task::JoinHandle<Result<()>> {
     tokio::spawn(async move {
         let (finished_tx, mut finished_rx) = mpsc::unbounded_channel::<FinishedTurn>();
         let mut worker = AgentWorker {
@@ -1110,6 +1156,7 @@ fn spawn_agent_worker(
             }
         }
         worker.stop_voice().await;
+        worker.shutdown_agents().await
     })
 }
 
@@ -1156,6 +1203,24 @@ struct AgentWorker {
 }
 
 impl AgentWorker {
+    async fn shutdown_agents(&self) -> Result<()> {
+        let mut first_error = None;
+        for branch in std::iter::once(&self.main).chain(&self.archived_main) {
+            if let Err(error) = branch.agent.shutdown().await
+                && first_error.is_none()
+            {
+                first_error = Some(eyre::Report::new(error));
+            }
+        }
+        if let Some(branch) = &self.btw
+            && let Err(error) = branch.agent.shutdown().await
+            && first_error.is_none()
+        {
+            first_error = Some(eyre::Report::new(error));
+        }
+        first_error.map_or(Ok(()), Err)
+    }
+
     async fn handle_command(&mut self, command: WorkerCommand) {
         match command {
             WorkerCommand::Prompt {
@@ -2286,7 +2351,13 @@ fn handle_key(
         {
             app.insert_char('\n');
         }
-        KeyCode::Enter => submit(app, root_session_id, commands, SubmitIntent::Immediate)?,
+        KeyCode::Enter => {
+            if submit(app, root_session_id, commands, SubmitIntent::Immediate)?
+                == SubmitAction::Resume
+            {
+                return Ok(TerminalAction::Resume);
+            }
+        }
         KeyCode::Char(character) => app.insert_char(character),
         KeyCode::Backspace => app.backspace(),
         KeyCode::Delete => app.delete(),
@@ -2301,7 +2372,10 @@ fn handle_key(
         KeyCode::Esc if key.kind == KeyEventKind::Repeat => {}
         KeyCode::Esc => handle_escape_key(app, commands)?,
         KeyCode::Tab if app.has_input() => {
-            submit(app, root_session_id, commands, SubmitIntent::Queue)?;
+            if submit(app, root_session_id, commands, SubmitIntent::Queue)? == SubmitAction::Resume
+            {
+                return Ok(TerminalAction::Resume);
+            }
         }
         KeyCode::Tab | KeyCode::BackTab => app.toggle_focus(),
         KeyCode::Insert
@@ -2600,11 +2674,12 @@ fn submit(
     root_session_id: &str,
     commands: &mpsc::UnboundedSender<WorkerCommand>,
     intent: SubmitIntent,
-) -> Result<()> {
+) -> Result<SubmitAction> {
     let Some(input) = app.take_submission() else {
-        return Ok(());
+        return Ok(SubmitAction::Continue);
     };
     match classify_submission(input) {
+        Submission::Resume => return Ok(SubmitAction::Resume),
         Submission::Prompt(prompt) => {
             let target = app.focus;
             if matches!(intent, SubmitIntent::Immediate) && app.is_running(target) {
@@ -2671,7 +2746,7 @@ fn submit(
         Submission::Trace => {
             let Some(session_id) = active_session_id(app, root_session_id) else {
                 app.push_active_error("BTW traces are available after the fork finishes");
-                return Ok(());
+                return Ok(SubmitAction::Continue);
             };
             match open_session_traces(session_id) {
                 Ok(()) => app.set_active_status("Opened session traces in Jaeger"),
@@ -2694,7 +2769,7 @@ fn submit(
         }
         Submission::InvalidCommand(error) => app.push_active_error(error),
     }
-    Ok(())
+    Ok(SubmitAction::Continue)
 }
 
 fn send_command(
@@ -2709,6 +2784,9 @@ fn send_command(
 fn classify_submission(input: impl Into<SubmittedPrompt>) -> Submission {
     let mut input = input.into();
     let trimmed = input.display().trim();
+    if trimmed == "/resume" {
+        return Submission::Resume;
+    }
     if trimmed == "/btw" {
         return Submission::Btw(None);
     }
@@ -2871,8 +2949,8 @@ mod tests {
         BTW_BOUNDARY, PaneId, RedrawPriority, Submission, TerminalAction, UiAction, UiModel,
         UiUpdate, VoiceControl, WorkerCommand, WorkerEvent, active_session_id,
         apply_main_agent_event_batch, classify_submission, handle_key, handle_worker_update,
-        paste_clipboard_image, prepare_btw_prompt, report_cancel_outcome, session_trace_url,
-        spawn_agent_worker,
+        paste_clipboard_image, prepare_btw_prompt, report_cancel_outcome, resume_hint,
+        session_trace_url, spawn_agent_worker,
     };
     use crate::tui::{
         app::App,
@@ -2911,6 +2989,7 @@ mod tests {
             classify_submission(" /trace ".to_owned()),
             Submission::Trace
         );
+        assert_eq!(classify_submission(" /resume "), Submission::Resume);
         assert_eq!(
             classify_submission(" /voice "),
             Submission::Voice(VoiceControl::Toggle)
@@ -2978,6 +3057,10 @@ mod tests {
             Submission::Prompt("/trace-this".into())
         );
         assert_eq!(
+            classify_submission("/resume-later"),
+            Submission::Prompt("/resume-later".into())
+        );
+        assert_eq!(
             classify_submission("/fastest"),
             Submission::Prompt("/fastest".into())
         );
@@ -2985,6 +3068,33 @@ mod tests {
             classify_submission("/modeling"),
             Submission::Prompt("/modeling".into())
         );
+    }
+
+    #[test]
+    fn exit_hint_prints_the_exact_resume_command() {
+        assert_eq!(
+            resume_hint("019c0d31-c308-7d91-bff4-5dca82d15ac6"),
+            "Resume this session with:\n  nanocodex resume 019c0d31-c308-7d91-bff4-5dca82d15ac6"
+        );
+    }
+
+    #[test]
+    fn resume_command_exits_into_the_session_picker() {
+        let (commands, mut worker) = mpsc::unbounded_channel();
+        let mut app = App::new("/workspace".into());
+        app.input = "/resume".to_owned();
+        app.cursor = app.input.len();
+
+        let action = handle_key(
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+            &mut app,
+            "main-session",
+            &commands,
+        )
+        .unwrap();
+
+        assert_eq!(action, TerminalAction::Resume);
+        assert!(worker.try_recv().is_err());
     }
 
     #[test]
@@ -3395,7 +3505,7 @@ mod tests {
         }
 
         drop(commands);
-        worker.await?;
+        worker.await??;
         Ok(())
     }
 

--- a/bin/nanocodex/src/tui/resume_picker.rs
+++ b/bin/nanocodex/src/tui/resume_picker.rs
@@ -1,0 +1,382 @@
+use crossterm::event::{Event, EventStream, KeyCode, KeyEventKind, KeyModifiers};
+use eyre::{Result, WrapErr};
+use futures_util::StreamExt;
+use nanocodex::agent::rollout::DurableSessionSummary;
+use ratatui::{
+    Frame,
+    layout::{Alignment, Constraint, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use super::terminal::TerminalSession;
+
+pub(crate) async fn select_session(
+    sessions: &[DurableSessionSummary],
+    show_all: bool,
+) -> Result<Option<String>> {
+    let choices = sessions.iter().map(ResumeChoice::from).collect::<Vec<_>>();
+    let mut picker = ResumePicker::new(choices);
+    let mut terminal = TerminalSession::enter().wrap_err("failed to initialize resume picker")?;
+    let mut events = EventStream::new();
+    loop {
+        terminal.draw(|frame| render(frame, &mut picker, show_all))?;
+        let event = events
+            .next()
+            .await
+            .transpose()?
+            .ok_or_else(|| std::io::Error::from(std::io::ErrorKind::UnexpectedEof))?;
+        let Event::Key(key) = event else {
+            continue;
+        };
+        if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+            continue;
+        }
+        if key.modifiers.contains(KeyModifiers::CONTROL) {
+            match key.code {
+                KeyCode::Char('c') => return Ok(None),
+                KeyCode::Char('u') => picker.clear_query(),
+                _ => {}
+            }
+            continue;
+        }
+        match key.code {
+            KeyCode::Up => picker.move_selection(-1),
+            KeyCode::Down => picker.move_selection(1),
+            KeyCode::Home => picker.select_first(),
+            KeyCode::End => picker.select_last(),
+            KeyCode::Backspace => picker.pop_query(),
+            KeyCode::Char(character) => picker.push_query(character),
+            KeyCode::Enter => return Ok(picker.selected_thread_id().map(str::to_owned)),
+            KeyCode::Esc => return Ok(None),
+            _ => {}
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct ResumeChoice {
+    thread_id: String,
+    workspace: String,
+    updated: String,
+    prompt: String,
+}
+
+impl From<&DurableSessionSummary> for ResumeChoice {
+    fn from(summary: &DurableSessionSummary) -> Self {
+        Self {
+            thread_id: summary.thread_id().to_owned(),
+            workspace: summary.workspace().display().to_string(),
+            updated: updated_label(summary.updated_at()),
+            prompt: summary
+                .first_prompt()
+                .map(compact_prompt)
+                .unwrap_or_default(),
+        }
+    }
+}
+
+fn updated_label(updated_at: std::time::SystemTime) -> String {
+    let elapsed = std::time::SystemTime::now()
+        .duration_since(updated_at)
+        .unwrap_or_default();
+    let seconds = elapsed.as_secs();
+    if seconds < 60 {
+        "now".to_owned()
+    } else if seconds < 60 * 60 {
+        format!("{}m ago", seconds / 60)
+    } else if seconds < 24 * 60 * 60 {
+        format!("{}h ago", seconds / (60 * 60))
+    } else {
+        format!("{}d ago", seconds / (24 * 60 * 60))
+    }
+}
+
+fn compact_prompt(prompt: &str) -> String {
+    prompt.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+struct ResumePicker {
+    choices: Vec<ResumeChoice>,
+    visible: Vec<usize>,
+    query: String,
+    state: ListState,
+}
+
+impl ResumePicker {
+    fn new(choices: Vec<ResumeChoice>) -> Self {
+        let visible = (0..choices.len()).collect::<Vec<_>>();
+        let mut state = ListState::default();
+        if !visible.is_empty() {
+            state.select(Some(0));
+        }
+        Self {
+            choices,
+            visible,
+            query: String::new(),
+            state,
+        }
+    }
+
+    fn move_selection(&mut self, direction: isize) {
+        let Some(selected) = self.state.selected() else {
+            return;
+        };
+        let last = self.visible.len().saturating_sub(1);
+        self.state
+            .select(Some(selected.saturating_add_signed(direction).min(last)));
+    }
+
+    fn select_first(&mut self) {
+        if !self.visible.is_empty() {
+            self.state.select(Some(0));
+        }
+    }
+
+    fn select_last(&mut self) {
+        if !self.visible.is_empty() {
+            self.state.select(Some(self.visible.len() - 1));
+        }
+    }
+
+    fn push_query(&mut self, character: char) {
+        self.query.push(character);
+        self.rebuild_visible();
+    }
+
+    fn pop_query(&mut self) {
+        let _ = self.query.pop();
+        self.rebuild_visible();
+    }
+
+    fn clear_query(&mut self) {
+        self.query.clear();
+        self.rebuild_visible();
+    }
+
+    fn rebuild_visible(&mut self) {
+        let query = self.query.to_lowercase();
+        self.visible = self
+            .choices
+            .iter()
+            .enumerate()
+            .filter_map(|(index, choice)| {
+                (choice.prompt.to_lowercase().contains(&query)
+                    || choice.workspace.to_lowercase().contains(&query)
+                    || choice.thread_id.to_lowercase().contains(&query))
+                .then_some(index)
+            })
+            .collect();
+        self.state.select((!self.visible.is_empty()).then_some(0));
+    }
+
+    fn selected_thread_id(&self) -> Option<&str> {
+        self.state
+            .selected()
+            .and_then(|visible| self.visible.get(visible))
+            .and_then(|choice| self.choices.get(*choice))
+            .map(|choice| choice.thread_id.as_str())
+    }
+}
+
+fn render(frame: &mut Frame<'_>, picker: &mut ResumePicker, show_all: bool) {
+    let [header, sessions, footer] = Layout::vertical([
+        Constraint::Length(4),
+        Constraint::Min(3),
+        Constraint::Length(3),
+    ])
+    .areas(frame.area());
+    render_header(frame, picker, header, show_all);
+    render_sessions(frame, picker, sessions);
+    render_footer(frame, picker, footer);
+}
+
+fn render_header(frame: &mut Frame<'_>, picker: &ResumePicker, area: Rect, show_all: bool) {
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            "Resume a previous session",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ))),
+        Rect::new(area.x, area.y, area.width, 1),
+    );
+    let [search, options] =
+        Layout::horizontal([Constraint::Percentage(55), Constraint::Percentage(45)])
+            .areas(Rect::new(area.x, area.y.saturating_add(2), area.width, 1));
+    let search_line = if picker.query.is_empty() {
+        Line::from(Span::styled(
+            "Type to search",
+            Style::default().fg(Color::DarkGray),
+        ))
+    } else {
+        Line::from(vec![
+            Span::styled("Search: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(&picker.query),
+            Span::styled("▌", Style::default().fg(Color::Cyan)),
+        ])
+    };
+    frame.render_widget(Paragraph::new(search_line), search);
+    let filter = if show_all { "All" } else { "Cwd" };
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("Filter: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!("[{filter}]"),
+                Style::default().fg(Color::LightMagenta),
+            ),
+            Span::styled("   Sort: ", Style::default().fg(Color::DarkGray)),
+            Span::styled("[Updated]", Style::default().fg(Color::White)),
+        ]))
+        .alignment(Alignment::Right),
+        options,
+    );
+}
+
+fn render_sessions(frame: &mut Frame<'_>, picker: &mut ResumePicker, area: Rect) {
+    let row_width = usize::from(area.width).saturating_sub(2);
+    let items = picker.visible.iter().filter_map(|index| {
+        let choice = picker.choices.get(*index)?;
+        let age = format!("{:>7}", choice.updated);
+        let prompt_width = row_width.saturating_sub(age.width()).saturating_sub(2);
+        Some(ListItem::new(Line::from(vec![
+            Span::styled(age, Style::default().fg(Color::DarkGray)),
+            Span::raw("  "),
+            Span::raw(truncate_with_ellipsis(&choice.prompt, prompt_width)),
+        ])))
+    });
+    let list = List::new(items).highlight_symbol("› ").highlight_style(
+        Style::default()
+            .fg(Color::LightYellow)
+            .bg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD),
+    );
+    frame.render_stateful_widget(list, area, &mut picker.state);
+}
+
+fn render_footer(frame: &mut Frame<'_>, picker: &ResumePicker, area: Rect) {
+    let block = Block::default().borders(Borders::TOP);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    let [controls, count] =
+        Layout::horizontal([Constraint::Min(1), Constraint::Length(16)]).areas(inner);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("enter", Style::default().fg(Color::White)),
+            Span::styled(" resume   ", Style::default().fg(Color::DarkGray)),
+            Span::styled("esc", Style::default().fg(Color::White)),
+            Span::styled(" cancel   ", Style::default().fg(Color::DarkGray)),
+            Span::styled("↑/↓", Style::default().fg(Color::White)),
+            Span::styled(" browse", Style::default().fg(Color::DarkGray)),
+        ])),
+        controls,
+    );
+    let selected = picker.state.selected().map_or(0, |index| index + 1);
+    frame.render_widget(
+        Paragraph::new(format!("{selected} / {}", picker.visible.len()))
+            .style(Style::default().fg(Color::DarkGray))
+            .alignment(Alignment::Right),
+        count,
+    );
+}
+
+fn truncate_with_ellipsis(text: &str, width: usize) -> String {
+    if text.width() <= width {
+        return text.to_owned();
+    }
+    if width == 0 {
+        return String::new();
+    }
+    let target = width.saturating_sub(1);
+    let mut truncated = String::new();
+    let mut used = 0_usize;
+    for character in text.chars() {
+        let character_width = character.width().unwrap_or(0);
+        if used.saturating_add(character_width) > target {
+            break;
+        }
+        truncated.push(character);
+        used = used.saturating_add(character_width);
+    }
+    truncated.push('…');
+    truncated
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::{Terminal, backend::TestBackend};
+
+    use super::*;
+
+    fn choices() -> Vec<ResumeChoice> {
+        ["one", "two", "three"]
+            .into_iter()
+            .map(|thread_id| ResumeChoice {
+                thread_id: thread_id.to_owned(),
+                workspace: "/workspace/nanocodex".to_owned(),
+                updated: "3m ago".to_owned(),
+                prompt: format!("{thread_id} prompt"),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn selection_is_bounded_and_can_jump_to_each_end() {
+        let mut picker = ResumePicker::new(choices());
+        assert_eq!(picker.selected_thread_id(), Some("one"));
+
+        picker.move_selection(-1);
+        assert_eq!(picker.selected_thread_id(), Some("one"));
+        picker.select_last();
+        picker.move_selection(1);
+        assert_eq!(picker.selected_thread_id(), Some("three"));
+        picker.select_first();
+        assert_eq!(picker.selected_thread_id(), Some("one"));
+    }
+
+    #[test]
+    fn search_filters_prompts_and_resets_the_selection() {
+        let mut picker = ResumePicker::new(choices());
+        for character in "two".chars() {
+            picker.push_query(character);
+        }
+        assert_eq!(picker.visible.len(), 1);
+        assert_eq!(picker.selected_thread_id(), Some("two"));
+
+        picker.clear_query();
+        assert_eq!(picker.visible.len(), 3);
+        assert_eq!(picker.selected_thread_id(), Some("one"));
+    }
+
+    #[test]
+    fn picker_renders_a_compact_single_line_session_list() {
+        let mut picker = ResumePicker::new(choices());
+        let mut terminal = Terminal::new(TestBackend::new(72, 12)).unwrap();
+        terminal
+            .draw(|frame| {
+                render(frame, &mut picker, false);
+            })
+            .unwrap();
+
+        let rendered = terminal.backend().buffer().content().to_owned();
+        assert!(rendered.iter().any(|cell| cell.symbol() == "›"));
+        let text = rendered
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<String>();
+        assert!(text.contains("Resume a previous session"));
+        assert!(text.contains("Type to search"));
+        assert!(text.contains("Filter:"));
+        assert!(text.contains("one prompt"));
+        assert!(!text.contains("/workspace/nanocodex"));
+    }
+
+    #[test]
+    fn prompt_preview_is_single_line_and_width_truncated() {
+        assert_eq!(compact_prompt("  fix\n  the\tthing "), "fix the thing");
+        assert_eq!(truncate_with_ellipsis("abcdefgh", 5), "abcd…");
+        assert_eq!(truncate_with_ellipsis("界界界", 5), "界界…");
+    }
+}

--- a/bin/nanocodex/src/vm.rs
+++ b/bin/nanocodex/src/vm.rs
@@ -29,7 +29,7 @@ const CAPABILITY_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 const CAPABILITY_DRAIN_INTERVAL: Duration = Duration::from_millis(10);
 
 /// Opt-in VM workspace-tool configuration for normal agent sessions.
-#[derive(Args, Default)]
+#[derive(Args, Clone, Default)]
 pub(crate) struct VmArgs {
     /// Run workspace-mutating tools in this writable VM root filesystem.
     ///

--- a/bin/nanocodex/src/vm_unsupported.rs
+++ b/bin/nanocodex/src/vm_unsupported.rs
@@ -5,7 +5,7 @@ use eyre::{Result, eyre};
 use nanocodex::tools::ToolsBuilder;
 
 /// VM arguments retained on builds whose host cannot run libkrun.
-#[derive(Args, Default)]
+#[derive(Args, Clone, Default)]
 pub(crate) struct VmArgs {
     /// Run workspace-mutating tools in this writable VM root filesystem.
     #[arg(long = "vm", visible_alias = "vm-rootfs", value_name = "ROOTFS")]

--- a/crates/nanocodex-agent/src/rollout/load.rs
+++ b/crates/nanocodex-agent/src/rollout/load.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::collections::HashMap;
 
 /// Lightweight metadata used to discover a resumable rollout before loading it.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -48,6 +49,7 @@ pub struct DurableSession {
     model: Model,
     snapshot: SessionSnapshot,
     transcript: Vec<RolloutTranscriptItem>,
+    recorded_by_nanocodex: bool,
 }
 
 impl DurableSession {
@@ -81,6 +83,7 @@ impl DurableSession {
             model: materialized.model,
             snapshot,
             transcript: materialized.transcript,
+            recorded_by_nanocodex: materialized.recorded_by_nanocodex,
         })
     }
 
@@ -94,6 +97,18 @@ impl DurableSession {
     #[must_use]
     pub fn workspace(&self) -> &str {
         self.snapshot.workspace()
+    }
+
+    /// Returns the stable instructions retained by the originating session.
+    #[must_use]
+    pub fn base_instructions(&self) -> Option<&str> {
+        self.snapshot.base_instructions()
+    }
+
+    /// Returns whether this rollout can be continued in place by Nanocodex.
+    #[must_use]
+    pub const fn recorded_by_nanocodex(&self) -> bool {
+        self.recorded_by_nanocodex
     }
 
     /// Returns the model selected at the latest committed rollout boundary.
@@ -159,10 +174,17 @@ pub(super) fn list_sessions(codex_home: &Path) -> io::Result<Vec<DurableSessionS
     ] {
         collect_rollout_paths(&root, &mut paths)?;
     }
-    let mut sessions = Vec::with_capacity(paths.len());
+    let mut sessions = HashMap::with_capacity(paths.len());
     for path in paths {
         match summarize_rollout(&path) {
-            Ok(session) => sessions.push(session),
+            Ok(session) => {
+                let replace = sessions.get(session.thread_id()).is_none_or(
+                    |existing: &DurableSessionSummary| session.updated_at() > existing.updated_at(),
+                );
+                if replace {
+                    sessions.insert(session.thread_id().to_owned(), session);
+                }
+            }
             Err(error)
                 if matches!(
                     error.kind(),
@@ -171,6 +193,7 @@ pub(super) fn list_sessions(codex_home: &Path) -> io::Result<Vec<DurableSessionS
             Err(error) => return Err(error),
         }
     }
+    let mut sessions = sessions.into_values().collect::<Vec<_>>();
     sessions.sort_by(|left, right| {
         right
             .updated_at
@@ -216,7 +239,8 @@ fn summarize_rollout(path: &Path) -> io::Result<DurableSessionSummary> {
     })?;
     let mut thread_id = None;
     let mut workspace = None;
-    let mut first_prompt = None;
+    let mut first_event_prompt = None;
+    let mut first_response_prompt = None;
     for (index, line) in BufReader::new(File::open(path)?).lines().enumerate() {
         let line = line?;
         let value: serde_json::Value = serde_json::from_str(&line).map_err(|error| {
@@ -243,25 +267,27 @@ fn summarize_rollout(path: &Path) -> io::Result<DurableSessionSummary> {
                     ));
                 }
                 validate_legacy_history_mode(payload)?;
+                validate_root_session(payload)?;
                 thread_id = id.map(str::to_owned);
                 workspace = payload
                     .get("cwd")
                     .and_then(serde_json::Value::as_str)
                     .map(PathBuf::from);
             }
-            Some("event_msg") if first_prompt.is_none() => {
+            Some("event_msg") if first_event_prompt.is_none() => {
                 if let Some(RolloutTranscriptItem::User(prompt)) =
                     visible_rollout_event(&value["payload"])
                 {
-                    first_prompt = Some(prompt);
+                    first_event_prompt = Some(prompt);
                 }
             }
-            Some("response_item") if first_prompt.is_none() => {
-                first_prompt = visible_response_prompt(&value["payload"]);
+            Some("response_item") if first_response_prompt.is_none() => {
+                first_response_prompt = visible_response_prompt(&value["payload"])
+                    .filter(|prompt| !is_injected_context(prompt));
             }
             _ => {}
         }
-        if workspace.is_some() && first_prompt.is_some() {
+        if workspace.is_some() && first_event_prompt.is_some() {
             break;
         }
     }
@@ -283,21 +309,52 @@ fn summarize_rollout(path: &Path) -> io::Result<DurableSessionSummary> {
             ),
         )
     })?;
-    let first_prompt = first_prompt.ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "Codex rollout {} has no resumable user prompt",
-                path.display()
-            ),
-        )
-    })?;
+    let first_prompt = first_event_prompt
+        .or(first_response_prompt)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Codex rollout {} has no resumable user prompt",
+                    path.display()
+                ),
+            )
+        })?;
     Ok(DurableSessionSummary {
         thread_id,
         workspace,
         updated_at: std::fs::metadata(path)?.modified()?,
         first_prompt: Some(first_prompt),
     })
+}
+
+fn validate_root_session(payload: &serde_json::Value) -> io::Result<()> {
+    let is_child = payload
+        .get("parent_thread_id")
+        .is_some_and(|value| !value.is_null())
+        || payload
+            .get("forked_from_id")
+            .is_some_and(|value| !value.is_null())
+        || payload
+            .get("thread_source")
+            .and_then(serde_json::Value::as_str)
+            == Some("subagent")
+        || payload
+            .get("source")
+            .and_then(|source| source.get("subagent"))
+            .is_some();
+    if is_child {
+        return Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "child and fork rollouts are not top-level resumable sessions",
+        ));
+    }
+    Ok(())
+}
+
+fn is_injected_context(prompt: &str) -> bool {
+    prompt.starts_with("# AGENTS.md instructions for ")
+        || prompt.starts_with("<environment_context>")
 }
 
 fn visible_response_prompt(payload: &serde_json::Value) -> Option<String> {
@@ -365,10 +422,16 @@ fn find_rollout_path(codex_home: &Path, thread_id: &str) -> io::Result<Option<Pa
 fn materialize_rollout(path: &Path, thread_id: &str) -> io::Result<MaterializedRollout> {
     let mut workspace = None;
     let mut base_instructions = None;
+    let mut recorded_by_nanocodex = false;
     let mut history = Vec::new();
+    let mut pending_history = Vec::new();
     let mut transcript = Vec::new();
+    let mut pending_transcript = Vec::new();
     let mut context_baseline = None;
+    let mut pending_context_baseline = None;
     let mut model = Model::Sol;
+    let mut pending_model = None;
+    let mut active_turn = false;
     for (index, line) in BufReader::new(File::open(path)?).lines().enumerate() {
         let line = line?;
         let value: serde_json::Value = serde_json::from_str(&line).map_err(|error| {
@@ -394,6 +457,10 @@ fn materialize_rollout(path: &Path, thread_id: &str) -> io::Result<MaterializedR
                 base_instructions = payload["base_instructions"]["text"]
                     .as_str()
                     .map(str::to_owned);
+                recorded_by_nanocodex = payload
+                    .get("originator")
+                    .and_then(serde_json::Value::as_str)
+                    == Some("nanocodex");
                 workspace = Some(
                     payload
                         .get("cwd")
@@ -408,8 +475,13 @@ fn materialize_rollout(path: &Path, thread_id: &str) -> io::Result<MaterializedR
                 );
             }
             Some("response_item") => {
+                let target_transcript = if active_turn {
+                    &mut pending_transcript
+                } else {
+                    &mut transcript
+                };
                 if let Some(item) = visible_tool_call(&value["payload"]) {
-                    transcript.push(item);
+                    target_transcript.push(item);
                 }
                 let item = serde_json::from_value(value["payload"].clone()).map_err(|error| {
                     io::Error::new(
@@ -421,7 +493,11 @@ fn materialize_rollout(path: &Path, thread_id: &str) -> io::Result<MaterializedR
                         ),
                     )
                 })?;
-                history.push(item);
+                if active_turn {
+                    pending_history.push(item);
+                } else {
+                    history.push(item);
+                }
             }
             Some("compacted") => {
                 history = serde_json::from_value(value["payload"]["replacement_history"].clone())
@@ -435,34 +511,79 @@ fn materialize_rollout(path: &Path, thread_id: &str) -> io::Result<MaterializedR
                         ),
                     )
                 })?;
+                pending_history.clear();
                 context_baseline = None;
+                pending_context_baseline = None;
             }
             Some("turn_context") => {
                 if let Some(selected) = value["payload"]["model"]
                     .as_str()
                     .and_then(|model| model.parse().ok())
                 {
-                    model = selected;
+                    if active_turn {
+                        pending_model = Some(selected);
+                    } else {
+                        model = selected;
+                    }
                 }
             }
             Some("world_state") => {
                 if let Some(state) = value["payload"]["state"].get("nanocodex_context") {
-                    context_baseline =
-                        Some(serde_json::from_value(state.clone()).map_err(|error| {
-                            io::Error::new(
-                                io::ErrorKind::InvalidData,
-                                format!(
-                                    "failed to decode context snapshot at {} line {}: {error}",
-                                    path.display(),
-                                    index + 1
-                                ),
-                            )
-                        })?);
+                    let state = serde_json::from_value(state.clone()).map_err(|error| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!(
+                                "failed to decode context snapshot at {} line {}: {error}",
+                                path.display(),
+                                index + 1
+                            ),
+                        )
+                    })?;
+                    if active_turn {
+                        pending_context_baseline = Some(state);
+                    } else {
+                        context_baseline = Some(state);
+                    }
                 }
             }
             Some("event_msg") => {
-                if let Some(item) = visible_rollout_event(&value["payload"]) {
-                    transcript.push(item);
+                let payload = &value["payload"];
+                match payload.get("type").and_then(serde_json::Value::as_str) {
+                    Some("task_started") => {
+                        active_turn = true;
+                        pending_history.clear();
+                        pending_transcript.clear();
+                        pending_context_baseline = None;
+                        pending_model = None;
+                    }
+                    Some("task_complete") => {
+                        history.append(&mut pending_history);
+                        transcript.append(&mut pending_transcript);
+                        if let Some(baseline) = pending_context_baseline.take() {
+                            context_baseline = Some(baseline);
+                        }
+                        if let Some(selected) = pending_model.take() {
+                            model = selected;
+                        }
+                        active_turn = false;
+                    }
+                    Some("turn_aborted") => {
+                        pending_history.clear();
+                        pending_transcript.clear();
+                        pending_context_baseline = None;
+                        pending_model = None;
+                        active_turn = false;
+                    }
+                    _ => {
+                        let target = if active_turn {
+                            &mut pending_transcript
+                        } else {
+                            &mut transcript
+                        };
+                        if let Some(item) = visible_rollout_event(payload) {
+                            target.push(item);
+                        }
+                    }
                 }
             }
             _ => {}
@@ -491,6 +612,7 @@ fn materialize_rollout(path: &Path, thread_id: &str) -> io::Result<MaterializedR
         history,
         transcript,
         context_baseline,
+        recorded_by_nanocodex,
     })
 }
 
@@ -501,6 +623,7 @@ struct MaterializedRollout {
     history: Vec<ResponseItem>,
     transcript: Vec<RolloutTranscriptItem>,
     context_baseline: Option<ContextBaseline>,
+    recorded_by_nanocodex: bool,
 }
 
 pub(in crate::rollout) fn visible_rollout_event(

--- a/crates/nanocodex-agent/src/rollout/load.rs
+++ b/crates/nanocodex-agent/src/rollout/load.rs
@@ -1,5 +1,40 @@
 use super::*;
 
+/// Lightweight metadata used to discover a resumable rollout before loading it.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DurableSessionSummary {
+    thread_id: String,
+    workspace: PathBuf,
+    updated_at: std::time::SystemTime,
+    first_prompt: Option<String>,
+}
+
+impl DurableSessionSummary {
+    /// Returns the stable thread UUID accepted by [`RolloutConfig::load_session`].
+    #[must_use]
+    pub fn thread_id(&self) -> &str {
+        &self.thread_id
+    }
+
+    /// Returns the workspace recorded when the session was created.
+    #[must_use]
+    pub fn workspace(&self) -> &Path {
+        &self.workspace
+    }
+
+    /// Returns the rollout file's last modification time.
+    #[must_use]
+    pub const fn updated_at(&self) -> std::time::SystemTime {
+        self.updated_at
+    }
+
+    /// Returns the first visible user prompt when one has been recorded.
+    #[must_use]
+    pub fn first_prompt(&self) -> Option<&str> {
+        self.first_prompt.as_deref()
+    }
+}
+
 /// A completed model boundary materialized from a Codex-compatible rollout.
 ///
 /// This value is intentionally single-use: [`Self::into_parts`] transfers the
@@ -114,6 +149,171 @@ pub enum RolloutTranscriptItem {
         /// Serialized tool arguments sent by the model.
         arguments: String,
     },
+}
+
+pub(super) fn list_sessions(codex_home: &Path) -> io::Result<Vec<DurableSessionSummary>> {
+    let mut paths = Vec::new();
+    for root in [
+        codex_home.join("sessions"),
+        codex_home.join("archived_sessions"),
+    ] {
+        collect_rollout_paths(&root, &mut paths)?;
+    }
+    let mut sessions = Vec::with_capacity(paths.len());
+    for path in paths {
+        match summarize_rollout(&path) {
+            Ok(session) => sessions.push(session),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::InvalidData | io::ErrorKind::Unsupported
+                ) => {}
+            Err(error) => return Err(error),
+        }
+    }
+    sessions.sort_by(|left, right| {
+        right
+            .updated_at
+            .cmp(&left.updated_at)
+            .then_with(|| right.thread_id.cmp(&left.thread_id))
+    });
+    Ok(sessions)
+}
+
+fn collect_rollout_paths(directory: &Path, paths: &mut Vec<PathBuf>) -> io::Result<()> {
+    let entries = match std::fs::read_dir(directory) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    for entry in entries {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_rollout_paths(&entry.path(), paths)?;
+        } else if file_type.is_file() && rollout_thread_id(&entry.path()).is_some() {
+            paths.push(entry.path());
+        }
+    }
+    Ok(())
+}
+
+fn rollout_thread_id(path: &Path) -> Option<&str> {
+    let name = path.file_name()?.to_str()?.strip_suffix(".jsonl")?;
+    let start = name.len().checked_sub(36)?;
+    let thread_id = name.get(start..)?;
+    (name.as_bytes().get(start.checked_sub(1)?) == Some(&b'-')
+        && uuid::Uuid::parse_str(thread_id).is_ok())
+    .then_some(thread_id)
+}
+
+fn summarize_rollout(path: &Path) -> io::Result<DurableSessionSummary> {
+    let filename_thread_id = rollout_thread_id(path).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid Codex rollout filename {}", path.display()),
+        )
+    })?;
+    let mut thread_id = None;
+    let mut workspace = None;
+    let mut first_prompt = None;
+    for (index, line) in BufReader::new(File::open(path)?).lines().enumerate() {
+        let line = line?;
+        let value: serde_json::Value = serde_json::from_str(&line).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "failed to decode {} line {} while listing sessions: {error}",
+                    path.display(),
+                    index + 1
+                ),
+            )
+        })?;
+        match value.get("type").and_then(serde_json::Value::as_str) {
+            Some("session_meta") if workspace.is_none() => {
+                let payload = &value["payload"];
+                let id = payload.get("id").and_then(serde_json::Value::as_str);
+                if id != Some(filename_thread_id) {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "Codex rollout thread ID does not match filename {}",
+                            path.display()
+                        ),
+                    ));
+                }
+                validate_legacy_history_mode(payload)?;
+                thread_id = id.map(str::to_owned);
+                workspace = payload
+                    .get("cwd")
+                    .and_then(serde_json::Value::as_str)
+                    .map(PathBuf::from);
+            }
+            Some("event_msg") if first_prompt.is_none() => {
+                if let Some(RolloutTranscriptItem::User(prompt)) =
+                    visible_rollout_event(&value["payload"])
+                {
+                    first_prompt = Some(prompt);
+                }
+            }
+            Some("response_item") if first_prompt.is_none() => {
+                first_prompt = visible_response_prompt(&value["payload"]);
+            }
+            _ => {}
+        }
+        if workspace.is_some() && first_prompt.is_some() {
+            break;
+        }
+    }
+    let thread_id = thread_id.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "Codex rollout {} is missing session metadata",
+                path.display()
+            ),
+        )
+    })?;
+    let workspace = workspace.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "Codex rollout {} session metadata is missing its workspace",
+                path.display()
+            ),
+        )
+    })?;
+    let first_prompt = first_prompt.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "Codex rollout {} has no resumable user prompt",
+                path.display()
+            ),
+        )
+    })?;
+    Ok(DurableSessionSummary {
+        thread_id,
+        workspace,
+        updated_at: std::fs::metadata(path)?.modified()?,
+        first_prompt: Some(first_prompt),
+    })
+}
+
+fn visible_response_prompt(payload: &serde_json::Value) -> Option<String> {
+    if payload.get("type")?.as_str()? != "message" || payload.get("role")?.as_str()? != "user" {
+        return None;
+    }
+    let prompt = payload
+        .get("content")?
+        .as_array()?
+        .iter()
+        .filter(|content| {
+            content.get("type").and_then(serde_json::Value::as_str) == Some("input_text")
+        })
+        .filter_map(|content| content.get("text").and_then(serde_json::Value::as_str))
+        .collect::<String>();
+    (!prompt.is_empty()).then_some(prompt)
 }
 
 fn find_rollout_path(codex_home: &Path, thread_id: &str) -> io::Result<Option<PathBuf>> {

--- a/crates/nanocodex-agent/src/rollout/mod.rs
+++ b/crates/nanocodex-agent/src/rollout/mod.rs
@@ -5,7 +5,7 @@ mod wire;
 #[cfg(test)]
 mod tests;
 
-pub use load::{DurableSession, RolloutTranscriptItem};
+pub use load::{DurableSession, DurableSessionSummary, RolloutTranscriptItem};
 pub use store::RolloutInfo;
 pub(crate) use store::{RolloutOrigin, RolloutRecorder, RolloutTurn};
 
@@ -67,6 +67,21 @@ impl RolloutConfig {
     /// exist, or its rollout is malformed or incompatible.
     pub fn load_session(&self, thread_id: &str) -> io::Result<DurableSession> {
         DurableSession::load(&self.codex_home, thread_id)
+    }
+
+    /// Lists compatible Codex and Nanocodex sessions beneath this Codex home,
+    /// newest first.
+    ///
+    /// The returned summaries read only enough rollout data to support session
+    /// discovery. Loading the selected durable boundary remains explicit through
+    /// [`Self::load_session`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the session directories or compatible rollout
+    /// files cannot be read. Malformed or unsupported rollouts are omitted.
+    pub fn list_sessions(&self) -> io::Result<Vec<DurableSessionSummary>> {
+        load::list_sessions(&self.codex_home)
     }
 
     pub(crate) fn resumed(mut self, rollout_path: PathBuf) -> Self {

--- a/crates/nanocodex-agent/src/rollout/tests.rs
+++ b/crates/nanocodex-agent/src/rollout/tests.rs
@@ -77,6 +77,7 @@ fn loads_codex_rollout_without_a_nanocodex_sidecar() {
                 "id": thread_id,
                 "cwd": home.path(),
                 "originator": "codex-tui",
+                "base_instructions": {"text": "retained Codex instructions"},
                 "history_mode": "legacy",
                 "context_window": {"window_id": "window-1"}
             }
@@ -91,6 +92,18 @@ fn loads_codex_rollout_without_a_nanocodex_sidecar() {
                 "model": "gpt-5.5",
                 "effort": "high",
                 "summary": "auto"
+            }
+        }),
+        serde_json::json!({
+            "timestamp": "2026-07-24T12:00:01Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{
+                    "type": "input_text",
+                    "text": "# AGENTS.md instructions for /worktree\n\ninjected context"
+                }]
             }
         }),
         serde_json::json!({
@@ -196,6 +209,11 @@ fn loads_codex_rollout_without_a_nanocodex_sidecar() {
     );
     assert_eq!(session.rollout_path(), path.canonicalize().unwrap());
     assert_eq!(session.model(), Model::Sol);
+    assert!(!session.recorded_by_nanocodex());
+    assert_eq!(
+        session.base_instructions(),
+        Some("retained Codex instructions")
+    );
     let snapshot = serde_json::to_value(session.snapshot()).expect("encode snapshot");
     assert!(snapshot.get("request_prefix").is_none());
     assert_eq!(snapshot["history"].as_array().map(Vec::len), Some(2));
@@ -211,6 +229,86 @@ fn loads_codex_rollout_without_a_nanocodex_sidecar() {
             RolloutTranscriptItem::Assistant("visible answer".to_owned()),
         ]
     );
+}
+
+#[test]
+fn session_listing_deduplicates_roots_and_omits_child_rollouts() {
+    let home = tempdir().expect("temporary Codex home");
+    let root_id = "019c0d31-c308-7d91-bff4-5dca82d15ac6";
+    let child_id = "019c0d31-c308-7d91-bff4-5dca82d15ac7";
+    let active = home.path().join("sessions/2026/07/24");
+    let archived = home.path().join("archived_sessions");
+    std::fs::create_dir_all(&active).expect("create active directory");
+    std::fs::create_dir_all(&archived).expect("create archive directory");
+
+    let root_path = active.join(format!("rollout-2026-07-24T12-00-00-{root_id}.jsonl"));
+    let mut root = File::create(&root_path).expect("create root rollout");
+    for value in [
+        serde_json::json!({
+            "type": "session_meta",
+            "payload": {
+                "id": root_id,
+                "cwd": home.path(),
+                "source": "cli",
+                "thread_source": "user",
+                "history_mode": "legacy"
+            }
+        }),
+        serde_json::json!({
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "# AGENTS.md instructions for /worktree"}]
+            }
+        }),
+        serde_json::json!({
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": "actual task"}
+        }),
+    ] {
+        write_line(&mut root, &value).expect("write root rollout");
+    }
+    root.flush().expect("flush root rollout");
+    std::fs::copy(
+        &root_path,
+        archived.join(format!("rollout-2026-07-24T13-00-00-{root_id}.jsonl")),
+    )
+    .expect("copy duplicate root rollout");
+
+    let child_path = active.join(format!("rollout-2026-07-24T12-30-00-{child_id}.jsonl"));
+    let mut child = File::create(child_path).expect("create child rollout");
+    for value in [
+        serde_json::json!({
+            "type": "session_meta",
+            "payload": {
+                "id": child_id,
+                "cwd": home.path(),
+                "parent_thread_id": root_id,
+                "source": {"subagent": {"other": "guardian"}},
+                "thread_source": "subagent",
+                "history_mode": "legacy"
+            }
+        }),
+        serde_json::json!({
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "internal child task"}]
+            }
+        }),
+    ] {
+        write_line(&mut child, &value).expect("write child rollout");
+    }
+    child.flush().expect("flush child rollout");
+
+    let sessions = RolloutConfig::new(home.path())
+        .list_sessions()
+        .expect("list root sessions");
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].thread_id(), root_id);
+    assert_eq!(sessions[0].first_prompt(), Some("actual task"));
 }
 
 #[test]

--- a/crates/nanocodex-agent/src/rollout/tests.rs
+++ b/crates/nanocodex-agent/src/rollout/tests.rs
@@ -145,10 +145,51 @@ fn loads_codex_rollout_without_a_nanocodex_sidecar() {
         write_line(&mut file, &value).expect("write rollout line");
     }
     file.flush().expect("flush rollout");
+    let archived_thread_id = "019c0d31-c308-7d91-bff4-5dca82d15ac7";
+    let archived_directory = home.path().join("archived_sessions");
+    std::fs::create_dir_all(&archived_directory).expect("create archived rollout directory");
+    let archived_path = archived_directory.join(format!(
+        "rollout-2026-07-24T13-00-00-{archived_thread_id}.jsonl"
+    ));
+    let archived_rollout = std::fs::read_to_string(&path)
+        .expect("read rollout for archive fixture")
+        .replace(thread_id, archived_thread_id);
+    std::fs::write(&archived_path, archived_rollout).expect("write archived rollout");
+    File::open(&path)
+        .unwrap()
+        .set_times(
+            std::fs::FileTimes::new()
+                .set_modified(std::time::UNIX_EPOCH + std::time::Duration::from_secs(1)),
+        )
+        .unwrap();
+    File::open(&archived_path)
+        .unwrap()
+        .set_times(
+            std::fs::FileTimes::new()
+                .set_modified(std::time::UNIX_EPOCH + std::time::Duration::from_secs(2)),
+        )
+        .unwrap();
+    std::fs::write(
+        directory.join("rollout-2026-07-24T14-00-00-019c0d31-c308-7d91-bff4-5dca82d15ac8.jsonl"),
+        "incomplete rollout line",
+    )
+    .expect("write malformed rollout");
 
-    let session = RolloutConfig::new(home.path())
-        .load_session(thread_id)
-        .expect("load Codex rollout");
+    let rollout = RolloutConfig::new(home.path());
+    let summaries = rollout.list_sessions().expect("list Codex rollouts");
+    assert_eq!(summaries.len(), 2);
+    assert_eq!(summaries[0].thread_id(), archived_thread_id);
+    assert_eq!(summaries[1].thread_id(), thread_id);
+    assert_eq!(summaries[1].workspace(), home.path());
+    assert_eq!(summaries[1].first_prompt(), Some("visible prompt"));
+    assert!(
+        summaries[1]
+            .updated_at()
+            .duration_since(std::time::UNIX_EPOCH)
+            .is_ok()
+    );
+
+    let session = rollout.load_session(thread_id).expect("load Codex rollout");
     assert_eq!(
         Path::new(session.workspace()).canonicalize().unwrap(),
         home.path().canonicalize().unwrap()

--- a/crates/nanocodex-agent/src/session.rs
+++ b/crates/nanocodex-agent/src/session.rs
@@ -160,6 +160,10 @@ impl SessionSnapshot {
         &self.workspace
     }
 
+    pub(crate) fn base_instructions(&self) -> Option<&str> {
+        self.base_instructions.as_deref()
+    }
+
     pub(crate) fn into_resume(self) -> Result<SessionResume> {
         if self.version != SESSION_SNAPSHOT_VERSION {
             return Err(NanocodexError::InvalidSessionSnapshot(format!(


### PR DESCRIPTION
## Summary

- let `nanocodex resume` open a searchable repository-scoped session picker when no thread ID is supplied, with `--all` for cross-workspace discovery
- list only top-level user sessions, deduplicate active/archive copies, and prefer real user prompts over injected AGENTS context
- resume Codex rollouts through their latest completed boundary while preserving their stored instructions, including when the originating Codex process has an incomplete active turn
- continue imported Codex history under a fresh Nanocodex thread so the original Codex rollout remains untouched; native Nanocodex sessions continue in place
- add `/resume` inside the TUI so users can flush the current durable session and switch threads without leaving Nanocodex
- present sessions in a compact one-line selector with search, timestamps, Unicode-aware truncation, and keyboard navigation
- print the exact `nanocodex resume <thread-id>` command after the TUI exits

## Validation

- `cargo +1.97.0 test -p nanocodex-agent rollout::tests` (12 passed)
- `cargo +1.97.0 test -p nanocodex-bin` (251 passed, 4 ignored across unit and integration targets)
- `cargo +1.97.0 clippy -p nanocodex-agent -p nanocodex-bin --all-targets -- -D warnings`
- `cargo +1.97.0 check -p nanocodex-examples --all-targets`
- `cargo +1.97.0 build -p nanocodex-bin`
- `cargo +1.97.0 fmt --all -- --check`
- `git diff --check`
- live picker smoke against the local Codex rollout corpus: 3 root sessions shown, guardian and BTW forks omitted
- live resume smoke against an active Codex thread: restored the latest completed boundary and emitted a fresh Nanocodex resume ID on exit
