### PR TITLE
perf(eval): skip redundant tool installation

### DIFF
--- a/evals/pytest/Dockerfile
+++ b/evals/pytest/Dockerfile
@@ -275,6 +275,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
 COPY bin/apt bin/python bin/toolbox-exec /opt/nanocodex-verifier/bin/
 RUN chmod 0755 /opt/nanocodex-verifier/bin/* && \
     ln -s python /opt/nanocodex-verifier/bin/python3 && \
-    for command in as curl expect gcc git ld mcopy mdir node readelf rg scp sftp socat ssh sshpass tesseract vim vncsnapshot oligotm primer3_core; do \
+    for command in as bash curl expect gcc git ld mcopy mdir node npm readelf rg scp sftp socat ssh sshpass tesseract vim vncsnapshot oligotm primer3_core; do \
         ln -s toolbox-exec "/opt/nanocodex-verifier/bin/$command"; \
     done

--- a/evals/pytest/Dockerfile
+++ b/evals/pytest/Dockerfile
@@ -26,6 +26,7 @@ RUN find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) \
         git \
         mtools \
         nodejs \
+        npm \
         openssh-client \
         primer3 \
         ripgrep \

--- a/evals/pytest/bin/toolbox-exec
+++ b/evals/pytest/bin/toolbox-exec
@@ -13,6 +13,15 @@ case "$command_name" in
         done
         executable="$root/usr/bin/node"
         ;;
+    npm)
+        for candidate in /usr/local/bin/npm /usr/bin/npm; do
+            if [ -x "$candidate" ]; then
+                exec "$candidate" "$@"
+            fi
+        done
+        set -- "$root/usr/share/nodejs/npm/bin/npm-cli.js" "$@"
+        executable="$root/usr/bin/node"
+        ;;
     vim)
         executable="$root/usr/bin/vim.basic"
         ;;

--- a/harbor_adapter/agent.py
+++ b/harbor_adapter/agent.py
@@ -70,12 +70,21 @@ def _cli_tools_install_command(*, install_node: bool) -> str:
 
     package_list = " ".join(packages)
     command_checks = " && ".join(
-        f"command -v {command} >/dev/null 2>&1" for command in checks
+        [
+            "curl_path=$(command -v curl)",
+            *(
+                f"command -v {command} >/dev/null 2>&1"
+                for command in checks
+                if command != "curl"
+            ),
+        ]
     )
     fast_path_checks = (
-        "(test -s /etc/ssl/certs/ca-certificates.crt || "
-        "test -s /opt/nanocodex-toolbox/etc/ssl/certs/ca-certificates.crt) && "
-        f"{command_checks}"
+        f"{command_checks} && "
+        'case "$curl_path" in '
+        "/opt/nanocodex-verifier/bin/curl) "
+        "test -s /opt/nanocodex-toolbox/etc/ssl/certs/ca-certificates.crt ;; "
+        "*) test -s /etc/ssl/certs/ca-certificates.crt ;; esac"
     )
     return (
         "PATH=$PATH:/opt/nanocodex-verifier/bin; export PATH; "

--- a/harbor_adapter/agent.py
+++ b/harbor_adapter/agent.py
@@ -69,11 +69,18 @@ def _cli_tools_install_command(*, install_node: bool) -> str:
         )
 
     package_list = " ".join(packages)
-    command_checks = "; ".join(
+    command_checks = " && ".join(
         f"command -v {command} >/dev/null 2>&1" for command in checks
     )
+    fast_path_checks = (
+        "(test -s /etc/ssl/certs/ca-certificates.crt || "
+        "test -s /opt/nanocodex-toolbox/etc/ssl/certs/ca-certificates.crt) && "
+        f"{command_checks}"
+    )
     return (
-        node_modules_cleanup
+        "PATH=$PATH:/opt/nanocodex-verifier/bin; export PATH; "
+        f"if ! {{ {fast_path_checks}; }}; then "
+        + node_modules_cleanup
         + "if ldd --version 2>&1 | grep -qi musl || "
         "[ -f /etc/alpine-release ]; then "
         f"apk add --no-cache {package_list}; "
@@ -83,10 +90,8 @@ def _cli_tools_install_command(*, install_node: bool) -> str:
         f"{package_list}; "
         "elif command -v yum >/dev/null 2>&1; then "
         f"yum install -y {package_list}; "
-        "else "
-        "echo 'No supported package manager found; checking preinstalled tools' >&2; "
-        "fi; "
-        f"{command_checks}"
+        "else echo 'No supported package manager found' >&2; exit 127; fi; fi; "
+        + fast_path_checks
     )
 
 

--- a/harbor_adapter/agent.py
+++ b/harbor_adapter/agent.py
@@ -84,7 +84,8 @@ def _cli_tools_install_command(*, install_node: bool) -> str:
         'case "$curl_path" in '
         "/opt/nanocodex-verifier/bin/curl) "
         "test -s /opt/nanocodex-toolbox/etc/ssl/certs/ca-certificates.crt ;; "
-        "*) test -s /etc/ssl/certs/ca-certificates.crt ;; esac"
+        "*) { test -s /etc/ssl/certs/ca-certificates.crt || "
+        "test -s /etc/pki/tls/certs/ca-bundle.crt; } ;; esac"
     )
     return (
         "PATH=$PATH:/opt/nanocodex-verifier/bin; export PATH; "
@@ -293,8 +294,16 @@ class NanocodexAgent(BaseInstalledAgent):
         await self._stage_agents_md(environment)
         arguments = self._run_arguments(instruction)
         agent_command = (
+            "if [ -s /etc/ssl/certs/ca-certificates.crt ]; then "
+            "ca_bundle=/etc/ssl/certs/ca-certificates.crt; "
+            "elif [ -s /etc/pki/tls/certs/ca-bundle.crt ]; then "
+            "ca_bundle=/etc/pki/tls/certs/ca-bundle.crt; "
+            "elif [ -s /opt/nanocodex-toolbox/etc/ssl/certs/ca-certificates.crt ]; then "
+            "ca_bundle=/opt/nanocodex-toolbox/etc/ssl/certs/ca-certificates.crt; "
+            "else echo 'No CA certificate bundle found' >&2; exit 1; fi; "
             f'api_key=$(<{self._API_KEY_FILE}) && test -n "$api_key" && '
             f'rm -f {self._API_KEY_FILE} && OPENAI_API_KEY="$api_key" '
+            'SSL_CERT_FILE="$ca_bundle" '
             + (
                 "NANOCODEX_SUBAGENT_JSONL=1 "
                 if getattr(self, "_subagents", False)

--- a/harbor_adapter/environment.py
+++ b/harbor_adapter/environment.py
@@ -23,6 +23,7 @@ def _toolbox_mount_setup_command(
     toolbox_root: str = _TOOLBOX_ROOT,
     verifier_root: str = _VERIFIER_ROOT,
     node_modules_root: str = "/usr/share/nodejs",
+    bash_path: str = "/bin/bash",
 ) -> str:
     toolbox_verifier_root = f"{toolbox_root}{_VERIFIER_ROOT}"
     toolbox_node_modules = f"{toolbox_root}/usr/share/nodejs"
@@ -30,6 +31,8 @@ def _toolbox_mount_setup_command(
     toolbox_verifier = shlex.quote(toolbox_verifier_root)
     node_modules = shlex.quote(node_modules_root)
     toolbox_modules = shlex.quote(toolbox_node_modules)
+    bash = shlex.quote(bash_path)
+    verifier_bash = shlex.quote(f"{verifier_root}/bin/bash")
     return (
         f"if [ -e {verifier} ] || [ -L {verifier} ]; then "
         f'test "$(readlink {verifier})" = {toolbox_verifier}; '
@@ -42,7 +45,9 @@ def _toolbox_mount_setup_command(
         f'task_node_entry={node_modules}/${{toolbox_node_entry##*/}}; '
         'if [ ! -e "$task_node_entry" ] && [ ! -L "$task_node_entry" ]; then '
         'ln -s "$toolbox_node_entry" "$task_node_entry"; fi; '
-        "done; fi"
+        "done; fi; "
+        f"if [ -e {bash} ] || [ -L {bash} ]; then test -x {bash}; "
+        f"else ln -s {verifier_bash} {bash}; fi"
     )
 
 

--- a/harbor_adapter/test_agent.py
+++ b/harbor_adapter/test_agent.py
@@ -48,6 +48,12 @@ class CliToolInstallContractTests(unittest.TestCase):
             self.assertIn(package_manager, command)
         for executable in ("curl", "bash", "node", "npm", "rg"):
             self.assertIn(f"command -v {executable}", command)
+        self.assertLess(command.index("command -v curl"), command.index("apk add"))
+        self.assertIn("PATH=$PATH:/opt/nanocodex-verifier/bin", command)
+        self.assertIn(
+            "/opt/nanocodex-toolbox/etc/ssl/certs/ca-certificates.crt",
+            command,
+        )
         self.assertIn(
             '"/opt/nanocodex-toolbox/usr/share/nodejs"',
             command,
@@ -63,6 +69,70 @@ class CliToolInstallContractTests(unittest.TestCase):
         self.assertNotIn("command -v npm", command)
         for package in ("ca-certificates", "curl", "bash", "ripgrep"):
             self.assertIn(package, command)
+
+    def test_preinstalled_tools_skip_package_managers(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            certificate = root / "ca-certificates.crt"
+            certificate.write_text("test certificate", encoding="utf-8")
+            marker = root / "package-manager-ran"
+            for command in ("curl", "bash", "rg", "node", "npm"):
+                executable = bin_dir / command
+                executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+                executable.chmod(0o755)
+            for manager in ("apk", "apt-get", "yum"):
+                executable = bin_dir / manager
+                executable.write_text(
+                    f"#!/bin/sh\ntouch {marker}\nexit 99\n", encoding="utf-8"
+                )
+                executable.chmod(0o755)
+
+            command = _cli_tools_install_command(install_node=True).replace(
+                "/etc/ssl/certs/ca-certificates.crt", str(certificate)
+            )
+            subprocess.run(
+                ["sh", "-c", command],
+                check=True,
+                env={"PATH": f"{bin_dir}:/usr/bin:/bin"},
+            )
+
+            self.assertFalse(marker.exists())
+
+    def test_missing_tool_uses_package_manager_then_rechecks(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            certificate = root / "ca-certificates.crt"
+            certificate.write_text("test certificate", encoding="utf-8")
+            marker = root / "package-manager-ran"
+            for command in ("curl", "bash"):
+                executable = bin_dir / command
+                executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+                executable.chmod(0o755)
+            apt_get = bin_dir / "apt-get"
+            apt_get.write_text(
+                "#!/bin/sh\n"
+                f"touch {marker}\n"
+                f"printf '#!/bin/sh\\nexit 0\\n' > {bin_dir / 'rg'}\n"
+                f"chmod 0755 {bin_dir / 'rg'}\n",
+                encoding="utf-8",
+            )
+            apt_get.chmod(0o755)
+
+            command = _cli_tools_install_command(install_node=False).replace(
+                "/etc/ssl/certs/ca-certificates.crt", str(certificate)
+            )
+            subprocess.run(
+                ["sh", "-c", command],
+                check=True,
+                env={"PATH": f"{bin_dir}:/usr/bin:/bin"},
+            )
+
+            self.assertTrue(marker.exists())
+            self.assertTrue((bin_dir / "rg").exists())
 
     def test_agent_install_applies_the_tool_policy_before_uploading(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -602,7 +672,7 @@ class VerifierOverlayContractTests(unittest.TestCase):
         self.assertIn('"install -y curl gcc"', verifier)
         self.assertIn("        gcc \\", dockerfile)
         self.assertIn("        libc6-dev", dockerfile)
-        self.assertIn("for command in as curl expect gcc git ld", dockerfile)
+        self.assertIn("for command in as bash curl expect gcc git ld", dockerfile)
         self.assertIn('export GCC_EXEC_PREFIX="$root/usr/lib/gcc/"', toolbox_exec)
         self.assertIn('set -- "--sysroot=$root" "$@"', toolbox_exec)
         self.assertIn(
@@ -737,6 +807,20 @@ class VerifierOverlayContractTests(unittest.TestCase):
 
 
 class EnvironmentToolboxContractTests(unittest.TestCase):
+    def test_toolbox_exposes_every_agent_install_fallback(self) -> None:
+        repository = Path(__file__).resolve().parents[1]
+        dockerfile = (repository / "evals" / "pytest" / "Dockerfile").read_text(
+            encoding="utf-8"
+        )
+        toolbox_exec = (
+            repository / "evals" / "pytest" / "bin" / "toolbox-exec"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("as bash curl", dockerfile)
+        self.assertIn("node npm readelf rg", dockerfile)
+        self.assertIn('npm)', toolbox_exec)
+        self.assertIn('npm/bin/npm-cli.js', toolbox_exec)
+
     def test_node_modules_fast_path_and_merge_preserve_task_entries(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/harbor_adapter/test_agent.py
+++ b/harbor_adapter/test_agent.py
@@ -54,6 +54,7 @@ class CliToolInstallContractTests(unittest.TestCase):
             "/opt/nanocodex-toolbox/etc/ssl/certs/ca-certificates.crt",
             command,
         )
+        self.assertIn("/etc/pki/tls/certs/ca-bundle.crt", command)
         self.assertIn(
             '"/opt/nanocodex-toolbox/usr/share/nodejs"',
             command,
@@ -182,6 +183,15 @@ class CliToolInstallContractTests(unittest.TestCase):
 
             self.assertFalse(marker.exists())
             self.assertFalse(task_certificate.exists())
+
+    def test_yum_ca_bundle_is_an_accepted_native_certificate_location(self) -> None:
+        command = _cli_tools_install_command(install_node=False)
+
+        self.assertIn(
+            "test -s /etc/ssl/certs/ca-certificates.crt || "
+            "test -s /etc/pki/tls/certs/ca-bundle.crt",
+            command,
+        )
 
     def test_missing_tool_uses_package_manager_then_rechecks(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -901,6 +911,7 @@ class EnvironmentToolboxContractTests(unittest.TestCase):
 
         self.assertIn("as bash curl", dockerfile)
         self.assertIn("node npm readelf rg", dockerfile)
+        self.assertIn("nodejs \\\n        npm", dockerfile)
         self.assertIn('npm)', toolbox_exec)
         self.assertIn('npm/bin/npm-cli.js', toolbox_exec)
 
@@ -919,8 +930,10 @@ class EnvironmentToolboxContractTests(unittest.TestCase):
                     task_root = root / f"task-{has_task_modules}"
                     verifier = task_root / "opt" / "nanocodex-verifier"
                     task_modules = task_root / "usr" / "share" / "nodejs"
+                    bash = task_root / "bin" / "bash"
                     verifier.parent.mkdir(parents=True)
                     task_modules.parent.mkdir(parents=True)
+                    bash.parent.mkdir(parents=True)
                     if has_task_modules:
                         task_modules.mkdir()
                         owned_module = task_modules / "font-awesome"
@@ -937,6 +950,7 @@ class EnvironmentToolboxContractTests(unittest.TestCase):
                                 toolbox_root=str(toolbox),
                                 verifier_root=str(verifier),
                                 node_modules_root=str(task_modules),
+                                bash_path=str(bash),
                             ),
                         ],
                         check=True,
@@ -957,6 +971,7 @@ class EnvironmentToolboxContractTests(unittest.TestCase):
                         )
                     else:
                         self.assertEqual(task_modules.readlink(), toolbox_modules)
+                    self.assertEqual(bash.readlink(), verifier / "bin" / "bash")
 
 
 class InterruptedRunContractTests(unittest.TestCase):
@@ -1106,6 +1121,11 @@ class RunCancellationContractTests(unittest.IsolatedAsyncioTestCase):
 
             command = agent.exec_as_agent.await_args.args[1]
             self.assertIn("set -o pipefail", command)
+            self.assertIn('SSL_CERT_FILE="$ca_bundle"', command)
+            self.assertIn(
+                "/opt/nanocodex-toolbox/etc/ssl/certs/ca-certificates.crt",
+                command,
+            )
             self.assertIn('tee "$events_tmp"', command)
             self.assertNotIn("tee /logs/agent/events.jsonl", command)
             self.assertNotIn('mv "$events_tmp"', command)

--- a/harbor_adapter/test_agent.py
+++ b/harbor_adapter/test_agent.py
@@ -100,6 +100,89 @@ class CliToolInstallContractTests(unittest.TestCase):
 
             self.assertFalse(marker.exists())
 
+    def test_native_curl_without_native_ca_uses_package_manager(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            task_certificate = root / "task-ca-certificates.crt"
+            toolbox_certificate = root / "toolbox-ca-certificates.crt"
+            toolbox_certificate.write_text("test certificate", encoding="utf-8")
+            marker = root / "package-manager-ran"
+            for command in ("curl", "bash", "rg"):
+                executable = bin_dir / command
+                executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+                executable.chmod(0o755)
+            apt_get = bin_dir / "apt-get"
+            apt_get.write_text(
+                "#!/bin/sh\n"
+                f"touch {marker}\n"
+                f"printf 'test certificate' > {task_certificate}\n",
+                encoding="utf-8",
+            )
+            apt_get.chmod(0o755)
+
+            command = _cli_tools_install_command(install_node=False).replace(
+                "/opt/nanocodex-toolbox/etc/ssl/certs/ca-certificates.crt",
+                str(toolbox_certificate),
+            ).replace(
+                "/etc/ssl/certs/ca-certificates.crt",
+                str(task_certificate),
+            )
+            subprocess.run(
+                ["sh", "-c", command],
+                check=True,
+                env={"PATH": f"{bin_dir}:/usr/bin:/bin"},
+            )
+
+            self.assertTrue(marker.exists())
+            self.assertTrue(task_certificate.exists())
+
+    def test_toolbox_curl_with_toolbox_ca_skips_package_managers(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            bin_dir = root / "bin"
+            toolbox_bin = root / "toolbox-bin"
+            bin_dir.mkdir()
+            toolbox_bin.mkdir()
+            task_certificate = root / "missing-task-ca-certificates.crt"
+            toolbox_certificate = root / "toolbox-ca-certificates.crt"
+            toolbox_certificate.write_text("test certificate", encoding="utf-8")
+            marker = root / "package-manager-ran"
+            for command in ("bash", "rg"):
+                executable = bin_dir / command
+                executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+                executable.chmod(0o755)
+            curl = toolbox_bin / "curl"
+            curl.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            curl.chmod(0o755)
+            apt_get = bin_dir / "apt-get"
+            apt_get.write_text(
+                f"#!/bin/sh\ntouch {marker}\nexit 99\n", encoding="utf-8"
+            )
+            apt_get.chmod(0o755)
+
+            command = (
+                _cli_tools_install_command(install_node=False)
+                .replace("/opt/nanocodex-verifier/bin", str(toolbox_bin))
+                .replace(
+                    "/opt/nanocodex-toolbox/etc/ssl/certs/ca-certificates.crt",
+                    str(toolbox_certificate),
+                )
+                .replace(
+                    "/etc/ssl/certs/ca-certificates.crt",
+                    str(task_certificate),
+                )
+            )
+            subprocess.run(
+                ["/bin/sh", "-c", command],
+                check=True,
+                env={"PATH": str(bin_dir)},
+            )
+
+            self.assertFalse(marker.exists())
+            self.assertFalse(task_certificate.exists())
+
     def test_missing_tool_uses_package_manager_then_rechecks(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)


### PR DESCRIPTION
## Motivation

Repeated package-manager updates and installs add avoidable setup latency when the shared toolbox already contains every required command and CA bundle.

## Summary

- preflight required commands and certificates before invoking a package manager
- expose shell and package-manager shims from the shared toolbox
- retain installation and post-install validation as the fallback

## Key design considerations

- require the complete tool set before taking the fast path
- preserve task-owned Node modules when shared modules are mounted
