### PR TITLE
feat(eval): add priority-processing fast path

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -13,6 +13,7 @@ hosted_agent_pr_provenance := hosted_agent_artifact + ".pr.json"
 hosted_agent_release_tag := env_var_or_default("NANOCODEX_HOSTED_AGENT_RELEASE_TAG", "nightly")
 hosted_agent_url := "https://github.com/gakonst/nanocodex/releases/download/" + hosted_agent_release_tag + "/nanocodex-x86_64-unknown-linux-musl"
 default_eval := "evals/terminal-bench-2.yaml"
+default_fast_eval := "evals/terminal-bench-2-1-fast.yaml"
 default_jobs := ".nanocodex/harbor/jobs"
 setup_jobs := ".nanocodex/harbor/setup"
 prepare_concurrency := env_var_or_default("HARBOR_PREPARE_CONCURRENCY", "4")
@@ -298,6 +299,12 @@ prepare-task task config=default_eval:
 eval config=default_eval: build-agent
     @test -x "{{harbor}}" || { echo "run 'just bootstrap' first" >&2; exit 2; }
     @job_name="$(date +%Y-%m-%d__%H-%M-%S)-eval-$BASHPID"; \
+        HARBOR_TELEMETRY=off "{{harbor}}" run --config "{{config}}" --job-name "$job_name" --n-concurrent "{{eval_concurrency}}"
+
+# Run the pinned Terminal-Bench suite with OpenAI priority processing enabled.
+eval-fast config=default_fast_eval: build-agent
+    @test -x "{{harbor}}" || { echo "run 'just bootstrap' first" >&2; exit 2; }
+    @job_name="$(date +%Y-%m-%d__%H-%M-%S)-eval-fast-$BASHPID"; \
         HARBOR_TELEMETRY=off "{{harbor}}" run --config "{{config}}" --job-name "$job_name" --n-concurrent "{{eval_concurrency}}"
 
 # Run one registry task through the configured agent, environment, and verifier.

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -73,6 +73,15 @@ pub(crate) struct AgentArgs {
     #[arg(long, env = "OPENAI_REASONING_MODE", default_value_t)]
     reasoning_mode: ReasoningMode,
 
+    /// Use priority processing for model requests.
+    #[arg(
+        long,
+        env = "NANOCODEX_FAST_MODE",
+        default_value_t = false,
+        action = ArgAction::Set
+    )]
+    fast_mode: bool,
+
     /// Replace the standard system/developer instructions.
     #[arg(long, value_parser = NonEmptyStringValueParser::new())]
     instructions: Option<String>,
@@ -265,6 +274,7 @@ impl AgentArgs {
             .model(self.model)
             .reasoning_mode(self.reasoning_mode)
             .thinking(self.thinking)
+            .fast_mode(self.fast_mode)
             .workspace(session.workspace)
             .codex_home(codex_home);
         if let Some(session_id) = session.session_id {
@@ -522,6 +532,17 @@ mod tests {
             .expect("the CLI should expose the subagents argument");
 
         assert_eq!(subagents.get_default_values(), ["false"]);
+    }
+
+    #[test]
+    fn fast_mode_is_opt_in() {
+        let command = crate::Cli::command();
+        let fast_mode = command
+            .get_arguments()
+            .find(|argument| argument.get_id() == "fast_mode")
+            .expect("the CLI should expose the fast-mode argument");
+
+        assert_eq!(fast_mode.get_default_values(), ["false"]);
     }
 
     #[test]

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -170,6 +170,10 @@ impl AgentArgs {
         self.thinking
     }
 
+    pub(crate) const fn fast_mode(&self) -> bool {
+        self.fast_mode
+    }
+
     pub(crate) const fn model(&self) -> Model {
         self.model
     }

--- a/bin/nanocodex/src/tui/app.rs
+++ b/bin/nanocodex/src/tui/app.rs
@@ -1256,6 +1256,11 @@ impl App {
         self
     }
 
+    pub(super) const fn with_fast_mode(mut self, enabled: bool) -> Self {
+        self.fast_mode = enabled;
+        self
+    }
+
     pub(super) fn set_math_renderer(&mut self, renderer: Ratatex) {
         self.main.transcript.set_math_renderer(renderer.clone());
         for branch in &mut self.main_branches {
@@ -3316,6 +3321,13 @@ mod tests {
             app.main.transcript.latest_user_message(),
             Some("visible prompt")
         );
+    }
+
+    #[test]
+    fn configured_fast_mode_seeds_the_tui_state() {
+        let app = App::new(std::path::PathBuf::from("/worktree")).with_fast_mode(true);
+
+        assert!(app.fast_mode());
     }
 
     #[test]

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -566,6 +566,7 @@ pub(crate) async fn run(
         .as_ref()
         .map_or_else(|| config.model(), DurableSession::model);
     let initial_thinking = config.thinking();
+    let initial_fast_mode = config.fast_mode();
     let restored_transcript = resume
         .as_ref()
         .map(|session| session.transcript().to_vec())
@@ -619,7 +620,8 @@ pub(crate) async fn run(
     let mut ticker = ui_ticker();
     let mut app = App::new(cwd)
         .with_model(initial_model)
-        .with_thinking(initial_thinking);
+        .with_thinking(initial_thinking)
+        .with_fast_mode(initial_fast_mode);
     app.set_math_renderer(math_renderer.clone());
     app.restore_transcript(restored_transcript);
     let mut ui = UiModel::new(app, Arc::clone(&root_session_id));

--- a/evals/terminal-bench-2-1-fast.yaml
+++ b/evals/terminal-bench-2-1-fast.yaml
@@ -1,0 +1,23 @@
+# Terminal-Bench 2.1 release 6 using OpenAI priority processing. Keep this
+# separate from the standard-tier baseline so cost and latency remain explicit.
+jobs_dir: .nanocodex/harbor/jobs
+
+agents:
+  - import_path: harbor_adapter.agent:NanocodexAgent
+    model_name: openai/gpt-5.6-sol
+    env:
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+    kwargs:
+      effort: low
+      fast_mode: true
+      web_search: false
+
+datasets:
+  - name: terminal-bench/terminal-bench-2-1
+    ref: "6"
+
+environment:
+  import_path: harbor_adapter.environment:FastDockerEnvironment
+
+verifier:
+  import_path: harbor_adapter.verifier:PytestVerifier

--- a/harbor_adapter/agent.py
+++ b/harbor_adapter/agent.py
@@ -129,6 +129,7 @@ class NanocodexAgent(BaseInstalledAgent):
         binary_sha256: str | None = None,
         model_name: str | None = None,
         effort: str = "low",
+        fast_mode: bool = False,
         web_search: bool = True,
         subagents: bool = False,
         install_node: bool = False,
@@ -165,6 +166,7 @@ class NanocodexAgent(BaseInstalledAgent):
             supported = ", ".join(sorted(SUPPORTED_MODELS))
             raise ValueError(f"nanocodex supports only {supported}, got {self._model}")
         self._effort = effort
+        self._fast_mode = fast_mode
         self._web_search = web_search
         self._subagents = subagents
         self._install_node = install_node
@@ -310,6 +312,8 @@ class NanocodexAgent(BaseInstalledAgent):
             self._model,
             "--thinking",
             self._effort,
+            "--fast-mode",
+            str(getattr(self, "_fast_mode", False)).lower(),
             "--web-search",
             str(self._web_search).lower(),
             "--subagents",

--- a/harbor_adapter/test_agent.py
+++ b/harbor_adapter/test_agent.py
@@ -140,6 +140,7 @@ class ModelContractTests(unittest.TestCase):
         agent = object.__new__(NanocodexAgent)
         agent._model = "gpt-5.6-luna"
         agent._effort = "low"
+        agent._fast_mode = False
         agent._web_search = False
         agent._subagents = False
 
@@ -147,6 +148,23 @@ class ModelContractTests(unittest.TestCase):
             agent._run_arguments("test prompt")[2:4],
             ["--model", "gpt-5.6-luna"],
         )
+
+    def test_run_arguments_forward_fast_mode_explicitly(self) -> None:
+        agent = object.__new__(NanocodexAgent)
+        agent._model = DEFAULT_MODEL
+        agent._effort = "low"
+        agent._web_search = False
+        agent._subagents = False
+
+        agent._fast_mode = True
+        arguments = agent._run_arguments("test prompt")
+        fast_mode = arguments.index("--fast-mode")
+        self.assertEqual(arguments[fast_mode : fast_mode + 2], ["--fast-mode", "true"])
+
+        agent._fast_mode = False
+        arguments = agent._run_arguments("test prompt")
+        fast_mode = arguments.index("--fast-mode")
+        self.assertEqual(arguments[fast_mode : fast_mode + 2], ["--fast-mode", "false"])
 
     def test_constructor_rejects_models_outside_the_supported_pair(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -163,6 +181,7 @@ class WebSearchContractTests(unittest.TestCase):
         agent = object.__new__(NanocodexAgent)
         agent._model = DEFAULT_MODEL
         agent._effort = "low"
+        agent._fast_mode = False
 
         agent._web_search = True
         agent._subagents = False
@@ -182,6 +201,7 @@ class WebSearchContractTests(unittest.TestCase):
         agent = object.__new__(NanocodexAgent)
         agent._model = DEFAULT_MODEL
         agent._effort = "low"
+        agent._fast_mode = False
         agent._web_search = False
         agent._subagents = False
 
@@ -197,6 +217,18 @@ class WebSearchContractTests(unittest.TestCase):
         )
 
         self.assertIs(config["agents"][0]["kwargs"]["web_search"], False)
+
+    def test_fast_eval_enables_priority_processing(self) -> None:
+        repository = Path(__file__).resolve().parents[1]
+        config = yaml.safe_load(
+            (repository / "evals" / "terminal-bench-2-1-fast.yaml").read_text(
+                encoding="utf-8"
+            )
+        )
+
+        kwargs = config["agents"][0]["kwargs"]
+        self.assertIs(kwargs["fast_mode"], True)
+        self.assertIs(kwargs["web_search"], False)
 
     def test_terminal_bench_arms_do_not_enable_subagents(self) -> None:
         repository = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Motivation

Priority processing should be opt-in and measurable without changing the standard-tier evaluation baseline.

## Summary

- expose priority processing through the CLI, environment, and Harbor adapter
- add a pinned fast evaluation configuration and dedicated recipe
- cover defaults and argument forwarding

## Key design considerations

- keep standard evaluation behavior unchanged
- make the pricing and latency policy explicit at the configuration boundary
