### PR TITLE
perf(eval): reuse prepared task images

### DIFF
--- a/harbor_adapter/environment.py
+++ b/harbor_adapter/environment.py
@@ -1,13 +1,19 @@
 """Docker optimizations for the local Harbor loop."""
 
 import asyncio
+import hashlib
+import json
+import os
+import re
 import shlex
 from pathlib import Path
 from typing import Any, override
 
+from harbor.constants import PACKAGE_CACHE_DIR
 from harbor.environments.docker.docker import DockerEnvironment
 from harbor.environments.docker.utils import (
     default_docker_platform,
+    docker_image_exists,
     ensure_docker_image_built,
 )
 from harbor.models.trial.config import ServiceVolumeConfig
@@ -16,6 +22,90 @@ _TOOLBOX_ROOT = "/opt/nanocodex-toolbox"
 _VERIFIER_ROOT = "/opt/nanocodex-verifier"
 _TOOLBOX_BUILD_LOCK = asyncio.Lock()
 _TOOLBOX_IMAGES: dict[tuple[Path, str], str] = {}
+_TASK_IMAGE_LOCKS: dict[tuple[str, str], asyncio.Lock] = {}
+_TASK_IMAGES: dict[tuple[str, str], str] = {}
+_TASK_IMAGE_RECORDS_DIR = Path(".nanocodex/harbor/task-images")
+_CONTENT_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _immutable_task_identity(environment_dir: Path) -> str | None:
+    """Return an identity only for Harbor's content-addressed package cache."""
+    try:
+        relative = environment_dir.resolve().relative_to(PACKAGE_CACHE_DIR.resolve())
+    except ValueError:
+        return None
+    parts = relative.parts
+    if len(parts) != 4 or parts[-1] != "environment":
+        return None
+    if not _CONTENT_HASH_RE.fullmatch(parts[-2]):
+        return None
+    return "/".join(parts[:-1])
+
+
+def _task_image_record_path(identity: str, platform: str) -> Path:
+    key = hashlib.sha256(f"{identity}\0{platform}".encode()).hexdigest()
+    return _TASK_IMAGE_RECORDS_DIR / f"{key}.json"
+
+
+async def _prepared_task_image(identity: str, platform: str) -> str | None:
+    path = _task_image_record_path(identity, platform)
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+        if record.get("identity") != identity or record.get("platform") != platform:
+            return None
+        image = record.get("image")
+        if not isinstance(image, str) or not image:
+            return None
+    except (AttributeError, json.JSONDecodeError, OSError):
+        return None
+    return image if await docker_image_exists(image) else None
+
+
+def _record_task_image(identity: str, platform: str, image: str) -> None:
+    path = _task_image_record_path(identity, platform)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(
+        json.dumps(
+            {"version": 1, "identity": identity, "platform": platform, "image": image},
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+async def _ensure_task_image(
+    *,
+    environment_name: str,
+    environment_dir: Path,
+    dockerfile_path: Path,
+    platform: str,
+    logger: Any,
+) -> str:
+    identity = _immutable_task_identity(environment_dir)
+    cache_identity = identity or str(environment_dir.resolve())
+    key = (cache_identity, platform)
+    lock = _TASK_IMAGE_LOCKS.setdefault(key, asyncio.Lock())
+    async with lock:
+        if image := _TASK_IMAGES.get(key):
+            return image
+        if identity and (image := await _prepared_task_image(identity, platform)):
+            _TASK_IMAGES[key] = image
+            return image
+        image = await ensure_docker_image_built(
+            docker_name=f"nanocodex/{environment_name}-task",
+            docker_build_context=environment_dir,
+            dockerfile_path=dockerfile_path,
+            build_args={},
+            platform=platform,
+            logger=logger,
+        )
+        _TASK_IMAGES[key] = image
+        if identity:
+            _record_task_image(identity, platform, image)
+        return image
 
 
 def _toolbox_mount_setup_command(
@@ -88,11 +178,10 @@ class FastDockerEnvironment(DockerEnvironment):
                     return image
 
             task_image, toolbox_image = await asyncio.gather(
-                ensure_docker_image_built(
-                    docker_name=f"nanocodex/{self.environment_name}-task",
-                    docker_build_context=self.environment_dir,
+                _ensure_task_image(
+                    environment_name=self.environment_name,
+                    environment_dir=self.environment_dir,
                     dockerfile_path=task_dockerfile,
-                    build_args={},
                     platform=platform,
                     logger=self.logger,
                 ),

--- a/harbor_adapter/test_agent.py
+++ b/harbor_adapter/test_agent.py
@@ -11,7 +11,7 @@ import time
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import yaml
 from harbor.models.agent.context import AgentContext
@@ -24,7 +24,12 @@ from harbor_adapter.agent import (
     _remote_binary_install_command,
 )
 from harbor_adapter.codex import ParityCodexAgent
-from harbor_adapter.environment import _toolbox_mount_setup_command
+from harbor_adapter import environment as environment_adapter
+from harbor_adapter.environment import (
+    _ensure_task_image,
+    _immutable_task_identity,
+    _toolbox_mount_setup_command,
+)
 from harbor_adapter.verifier import (
     _VERIFIER_OVERLAY_PATH_VALIDATION,
     _toolbox_library_path_setup_command,
@@ -790,6 +795,115 @@ class EnvironmentToolboxContractTests(unittest.TestCase):
                         )
                     else:
                         self.assertEqual(task_modules.readlink(), toolbox_modules)
+
+
+class TaskImageCacheContractTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        environment_adapter._TASK_IMAGES.clear()
+        environment_adapter._TASK_IMAGE_LOCKS.clear()
+
+    def tearDown(self) -> None:
+        environment_adapter._TASK_IMAGES.clear()
+        environment_adapter._TASK_IMAGE_LOCKS.clear()
+
+    async def test_prepared_package_image_survives_a_fresh_process_cache(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            package_cache = root / "packages"
+            environment_dir = (
+                package_cache / "org" / "task" / ("a" * 64) / "environment"
+            )
+            environment_dir.mkdir(parents=True)
+            dockerfile = environment_dir / "Dockerfile"
+            dockerfile.touch()
+            records = root / "records"
+            build = AsyncMock(return_value="nanocodex/task:prepared")
+
+            with (
+                patch.object(environment_adapter, "PACKAGE_CACHE_DIR", package_cache),
+                patch.object(environment_adapter, "_TASK_IMAGE_RECORDS_DIR", records),
+                patch.object(environment_adapter, "ensure_docker_image_built", build),
+                patch.object(
+                    environment_adapter,
+                    "docker_image_exists",
+                    AsyncMock(return_value=True),
+                ) as image_exists,
+            ):
+                first = await _ensure_task_image(
+                    environment_name="task",
+                    environment_dir=environment_dir,
+                    dockerfile_path=dockerfile,
+                    platform="linux/amd64",
+                    logger=logging.getLogger(__name__),
+                )
+                environment_adapter._TASK_IMAGES.clear()
+                second = await _ensure_task_image(
+                    environment_name="task",
+                    environment_dir=environment_dir,
+                    dockerfile_path=dockerfile,
+                    platform="linux/amd64",
+                    logger=logging.getLogger(__name__),
+                )
+
+            self.assertEqual(first, "nanocodex/task:prepared")
+            self.assertEqual(second, first)
+            build.assert_awaited_once()
+            image_exists.assert_awaited_once_with(first)
+            self.assertEqual(len(list(records.glob("*.json"))), 1)
+
+    async def test_missing_prepared_image_rebuilds_and_replaces_record(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            package_cache = root / "packages"
+            environment_dir = (
+                package_cache / "org" / "task" / ("b" * 64) / "environment"
+            )
+            environment_dir.mkdir(parents=True)
+            dockerfile = environment_dir / "Dockerfile"
+            dockerfile.touch()
+            records = root / "records"
+
+            with (
+                patch.object(environment_adapter, "PACKAGE_CACHE_DIR", package_cache),
+                patch.object(environment_adapter, "_TASK_IMAGE_RECORDS_DIR", records),
+                patch.object(
+                    environment_adapter,
+                    "ensure_docker_image_built",
+                    AsyncMock(side_effect=["old-image", "new-image"]),
+                ) as build,
+                patch.object(
+                    environment_adapter,
+                    "docker_image_exists",
+                    AsyncMock(return_value=False),
+                ),
+            ):
+                await _ensure_task_image(
+                    environment_name="task",
+                    environment_dir=environment_dir,
+                    dockerfile_path=dockerfile,
+                    platform="linux/arm64",
+                    logger=logging.getLogger(__name__),
+                )
+                environment_adapter._TASK_IMAGES.clear()
+                image = await _ensure_task_image(
+                    environment_name="task",
+                    environment_dir=environment_dir,
+                    dockerfile_path=dockerfile,
+                    platform="linux/arm64",
+                    logger=logging.getLogger(__name__),
+                )
+
+            self.assertEqual(image, "new-image")
+            self.assertEqual(build.await_count, 2)
+            record = json.loads(next(records.glob("*.json")).read_text())
+            self.assertEqual(record["image"], "new-image")
+
+    def test_mutable_local_task_does_not_receive_a_persistent_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            environment_dir = Path(directory) / "environment"
+            environment_dir.mkdir()
+
+            self.assertIsNone(_immutable_task_identity(environment_dir))
 
 
 class InterruptedRunContractTests(unittest.TestCase):


### PR DESCRIPTION
## Motivation

Install-only preparation creates content-addressed task images, but subsequent attempts repeatedly hash the same build contexts before discovering those images.

## Summary

- persist prepared task-image identities by immutable task revision and platform
- reuse validated prepared images across evaluation processes
- deduplicate image preparation within one process

## Key design considerations

- persist identities only for Harbor's content-addressed package cache
- validate image availability once before reuse and rebuild stale records
- keep mutable local tasks limited to process-local caching
