### PR TITLE
perf(eval): disable rollout persistence

### DIFF
--- a/harbor_adapter/agent.py
+++ b/harbor_adapter/agent.py
@@ -335,6 +335,8 @@ class NanocodexAgent(BaseInstalledAgent):
             self._model,
             "--thinking",
             self._effort,
+            "--rollouts",
+            "false",
             "--fast-mode",
             str(getattr(self, "_fast_mode", False)).lower(),
             "--web-search",

--- a/harbor_adapter/test_agent.py
+++ b/harbor_adapter/test_agent.py
@@ -344,6 +344,20 @@ class ModelContractTests(unittest.TestCase):
                 )
 
 
+class RolloutContractTests(unittest.TestCase):
+    def test_eval_runs_always_disable_rollout_persistence(self) -> None:
+        agent = object.__new__(NanocodexAgent)
+        agent._model = DEFAULT_MODEL
+        agent._effort = "low"
+        agent._web_search = False
+        agent._subagents = False
+
+        arguments = agent._run_arguments("test prompt")
+        rollouts = arguments.index("--rollouts")
+
+        self.assertEqual(arguments[rollouts : rollouts + 2], ["--rollouts", "false"])
+
+
 class WebSearchContractTests(unittest.TestCase):
     def test_run_arguments_always_pass_web_search_explicitly(self) -> None:
         agent = object.__new__(NanocodexAgent)


### PR DESCRIPTION
## Motivation

Evaluation jobs already retain structured events and trajectories, so local rollout persistence duplicates artifacts and adds unnecessary filesystem work.

## Summary

- disable rollout persistence for Harbor evaluation runs
- add an explicit adapter contract test for the CLI argument

## Key design considerations

- leave the CLI default unchanged for interactive consumers
- scope the policy to the evaluation adapter
