### PR TITLE
fix(egress): preserve middleware error chains

### DIFF
--- a/crates/experimental/nanocodex-egress/src/lib.rs
+++ b/crates/experimental/nanocodex-egress/src/lib.rs
@@ -1714,7 +1714,7 @@ enum ForwardError {
     DeniedUpstream,
     #[error("egress proxy stopped while the request was queued")]
     Unavailable,
-    #[error("egress layer or origin request failed: {0}")]
+    #[error("egress layer or origin request failed: {0:#}")]
     Layer(#[source] reqwest_middleware::Error),
 }
 
@@ -1779,6 +1779,26 @@ mod tests {
         );
 
         assert!(matches!(result, Err(LeafCertificateError::InvalidDnsName)));
+    }
+
+    #[test]
+    fn layer_errors_preserve_the_middleware_error_chain() {
+        #[derive(Debug, thiserror::Error)]
+        #[error("required amount 104650 exceeds maximum 100000")]
+        struct ChargeLimitExceeded;
+
+        #[derive(Debug, thiserror::Error)]
+        #[error("payment failed")]
+        struct PaymentFailed(#[source] ChargeLimitExceeded);
+
+        let error = ForwardError::Layer(reqwest_middleware::Error::middleware(PaymentFailed(
+            ChargeLimitExceeded,
+        )));
+
+        assert_eq!(
+            error.to_string(),
+            "egress layer or origin request failed: payment failed: required amount 104650 exceeds maximum 100000"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- render the complete `reqwest-middleware` source chain in egress forwarding errors
- preserve actionable payment-policy failures instead of collapsing them to `payment failed`
- add a regression test covering nested middleware errors

A Tempo charge above Nanocodex local limit previously surfaced only as an HTTP 502 ending in `payment failed`. The complete chain now includes the requested and maximum amounts.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p nanocodex-egress`
- `cargo clippy -p nanocodex-egress --all-targets -- -D warnings`
- live Tempo-provider cap rejection smoke