### PR TITLE
feat(cloudflare): restore Durable Object demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
             js/tui-react/package-lock.json
             examples/node/package-lock.json
             examples/rivet-actors/package-lock.json
+            examples/cloudflare-workers/package-lock.json
             examples/vercel-workflows/package-lock.json
             examples/react-vite/package-lock.json
       - uses: taiki-e/install-action@3522286d40783523f9c7880e33f785905b4c20d0 # v2
@@ -172,6 +173,7 @@ jobs:
           npm ci --prefix js/tui-react
           npm ci --prefix examples/node
           npm ci --prefix examples/rivet-actors
+          npm ci --prefix examples/cloudflare-workers
           npm ci --prefix examples/vercel-workflows
           npm ci --prefix examples/react-vite
       - name: Test JS runtime
@@ -189,6 +191,7 @@ jobs:
           node --test examples/browser-cdn/*.test.mjs
           npm test --prefix examples/node
           npm run check --prefix examples/rivet-actors
+          npm run check --prefix examples/cloudflare-workers
           npm run check --prefix examples/vercel-workflows
           npm test --prefix examples/react-vite
           npm run build --prefix examples/react-vite

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ examples/vercel-workflows/node_modules/
 examples/vercel-workflows/workflows/nanocodex.wasm
 examples/react-vite/node_modules/
 examples/react-vite/test-results/
+examples/cloudflare-workers/dist/
+examples/cloudflare-workers/node_modules/
+examples/cloudflare-workers/src/nanocodex.wasm
 jobs/
 trials/
 /generated_images/

--- a/Justfile
+++ b/Justfile
@@ -91,6 +91,11 @@ build-rivet-example: build-wasm
     npm ci --prefix examples/rivet-actors
     npm run check --prefix examples/rivet-actors
 
+# Type-check, test, and bundle the Cloudflare Durable Object WASM consumer.
+build-cloudflare-example: build-wasm
+    npm ci --prefix examples/cloudflare-workers
+    npm run check --prefix examples/cloudflare-workers
+
 # Type-check, test, and bundle the Vercel Workflow actor consumer.
 build-vercel-example: build-wasm
     npm ci --prefix examples/vercel-workflows

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,8 @@ All language consumers live at this repository boundary:
   package directly, with no install or build step.
 - Rivet Actors: `rivet-actors/` runs the same harness as a durable,
   SQLite-backed Rivet Actor.
+- Cloudflare Workers: `cloudflare-workers/` runs the Rust/WASM harness inside a
+  SQLite-backed Durable Object and proves hibernation-safe session recovery.
 - Vercel Workflows: `vercel-workflows/` runs Nanocodex as a durable Workflow
   actor with replayable state and synchronized native WebSocket clients.
 
@@ -40,6 +42,7 @@ just smoke-python
 just smoke-wasm-node
 just build-react-example
 just build-rivet-example
+just build-cloudflare-example
 just build-vercel-example
 ```
 

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -49,6 +49,13 @@ codex login
 npm run dev:subscription --prefix examples/cloudflare-workers
 ```
 
+Open <http://127.0.0.1:8787> for the deliberately thin browser client, or use
+the REPL below. The page stores its session capability, bounded transcript, and
+unfinished turn in browser local storage. Reloading resubmits the same
+idempotent turn ID and rejoins or replays the Durable Object result. Enter
+`local-admin-token` once to create a local session; this is the example's
+router token, not a model credential.
+
 The launcher securely reads `$CODEX_HOME/auth.json` (normally
 `~/.codex/auth.json`), requires it to be mode `0600`, and gives workerd only the
 current access token and account metadata through a temporary mode-`0600` env
@@ -62,6 +69,14 @@ access token behind the singleton auth Durable Object and the launcher clears
 any credential retained by an older run before accepting the new login.
 `GET /auth/chatgpt` reports non-secret status and `DELETE /auth/chatgpt` clears
 the durable copy; both routes require the admin bearer token.
+
+Local workerd's outbound TLS/WebSocket fingerprint can be rejected by
+`chatgpt.com` even when the same subscription succeeds in Codex and from a
+deployed Worker. `dev:subscription` therefore starts a random-capability,
+loopback-only WebSocket bridge for model egress. The bridge forwards bounded
+frames and only the explicit Codex handshake headers; it does not read the
+Codex auth file or persist credentials. Deployed Workers do not use this local
+bridge and connect directly from Cloudflare's edge.
 
 Start workerd in one terminal and run the live probes in another:
 
@@ -88,9 +103,10 @@ inference. If the Worker process itself dies before a turn commits, reopening
 the REPL resubmits the same turn from the last committed snapshot; a partial
 provider response cannot be resumed.
 
-The smoke performs a real model turn, verifies duplicate suppression, waits for
-idle teardown, then proves that a follow-on remembers history after the agent
-is reconstructed. `stress` drives ping round trips through one object, `soak`
+The smoke performs real model turns, verifies duplicate suppression and a
+completed `runtimeInfo` tool call/result pair, waits for idle teardown, then
+proves that a follow-on remembers history after the agent is reconstructed.
+`stress` drives ping round trips through one object, `soak`
 checks parallel sessions for cross-session leakage and duplicate model calls,
 and `fanout` broadcasts a bursty model stream to 64 attached clients. Override
 their `NANOCODEX_*` environment variables to change the workload.
@@ -103,10 +119,10 @@ it also validates the bearer/account headers and serves rotating OAuth tokens,
 so the full Rust/WASM driver, snapshot, idle shutdown, restore, and auth-retry
 paths execute.
 
-If `chatgpt.com` denies the local workerd runtime even though the same login
-works in Codex, use the mock for deterministic local validation and run the
-real subscription smoke from a deployed Worker. Treat the deployed edge check
-as the release gate.
+The Worker selects the WASM binding's CSP-safe direct-tool mode because Workers
+forbid `eval` and `new Function`. This retains Nanocodex's typed Rust tool
+lifecycle and caller-defined handlers without shipping a JavaScript evaluator.
+Node-based consumers may continue to use Code Mode when their host permits it.
 
 ## Validate and deploy
 

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -70,13 +70,11 @@ any credential retained by an older run before accepting the new login.
 `GET /auth/chatgpt` reports non-secret status and `DELETE /auth/chatgpt` clears
 the durable copy; both routes require the admin bearer token.
 
-Local workerd's outbound TLS/WebSocket fingerprint can be rejected by
-`chatgpt.com` even when the same subscription succeeds in Codex and from a
-deployed Worker. `dev:subscription` therefore starts a random-capability,
-loopback-only WebSocket bridge for model egress. The bridge forwards bounded
-frames and only the explicit Codex handshake headers; it does not read the
-Codex auth file or persist credentials. Deployed Workers do not use this local
-bridge and connect directly from Cloudflare's edge.
+`chatgpt.com` can reject serverless-provider egress even when the same
+subscription succeeds in Codex. `dev:subscription` therefore starts a
+random-capability, loopback-only WebSocket bridge for model egress. The bridge
+forwards bounded frames and only the explicit Codex handshake headers; it does
+not read the Codex auth file or persist credentials.
 
 Start workerd in one terminal and run the live probes in another:
 
@@ -103,9 +101,10 @@ inference. If the Worker process itself dies before a turn commits, reopening
 the REPL resubmits the same turn from the last committed snapshot; a partial
 provider response cannot be resumed.
 
-The smoke performs real model turns, verifies duplicate suppression and a
-completed `runtimeInfo` tool call/result pair, waits for idle teardown, then
-proves that a follow-on remembers history after the agent is reconstructed.
+The smoke performs real model turns, verifies duplicate suppression, detaches
+its client, waits for idle teardown, reconnects to the durable snapshot, proves
+that a follow-on remembers history, and requires a completed `runtimeInfo` tool
+call/result pair.
 `stress` drives ping round trips through one object, `soak`
 checks parallel sessions for cross-session leakage and duplicate model calls,
 and `fanout` broadcasts a bursty model stream to 64 attached clients. Override
@@ -135,6 +134,31 @@ npx wrangler secret put CHATGPT_ACCOUNT_ID
 npx wrangler secret put NANOCODEX_ADMIN_TOKEN
 npx wrangler deploy
 ```
+
+At the time this example was validated, the ChatGPT edge rejected direct
+Cloudflare Worker egress with HTTP 403. That is an upstream egress-policy
+boundary, not a WASM or Durable Object failure. A deployed subscription demo
+therefore needs a non-Cloudflare WebSocket relay. Run the included bounded,
+capability-gated relay on such a host:
+
+```sh
+NANOCODEX_EGRESS_PORT=8791 \
+  npm run relay:subscription --prefix examples/cloudflare-workers
+```
+
+Expose port 8791 with TLS, preserve the printed `/v1/<capability>` path, and set
+the complete public `wss://` URL as `OPENAI_WEBSOCKET_URL` before deployment.
+For a disposable personal demo, a Cloudflare Quick Tunnel can expose the local
+port; use a stable relay under your control for anything long-lived. The relay
+still requires the Worker's bearer credential in addition to the unguessable
+path, never reads `auth.json`, bounds queued data, and forwards only the
+allowlisted handshake headers. Rotate the route by restarting it.
+
+The real edge validation for this example used only the current subscription
+access token and account ID—no API key and no refresh token—and completed three
+turns across client detach, object unload, snapshot restore, and a hosted tool
+call. That access-token-only deployment naturally stops authenticating when the
+token expires. Configure a dedicated refresh token only for a long-lived demo.
 
 For a long-lived deployment, the singleton auth Durable Object stores the
 dedicated credential in SQLite, refreshes it five minutes before expiry, and

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -1,0 +1,158 @@
+# Nanocodex on Cloudflare Durable Objects
+
+This example runs the real Rust/WASM Nanocodex harness inside one SQLite-backed
+Durable Object per agent session. The front Worker only authenticates session
+creation and routes capability URLs; the object owns the agent, OpenAI
+Responses WebSocket, client sockets, typed history, tools, and durable commits.
+
+```text
+client WebSocket ──> Worker router ──> one NanocodexSession object per session
+                                         ├─ Rust/WASM Nanocodex driver
+                                         ├─ persistent model WebSocket
+                                         ├─ hibernatable client sockets
+                                         └─ SQLite snapshot + terminal turns
+
+ChatGPT subscription ───────────────> one NanocodexSubscriptionAuth object
+                                         └─ SQLite token rotation + 401 recovery
+```
+
+Hot follow-on turns reuse the same WASM agent, cache identity, typed history,
+and upstream socket. Each completed turn atomically commits its Nanocodex
+snapshot and terminal client result. Failed partial turns never enter durable
+history. Repeating a completed client turn ID returns the stored terminal result
+without another model call; duplicates received during cold initialization are
+coalesced before the first await for the same reason.
+
+An outbound WebSocket prevents a Durable Object from hibernating while it is
+retained. A one-shot idle alarm therefore shuts down Nanocodex after 30 seconds
+(configurable), closing the OpenAI socket. Client WebSockets use Cloudflare's
+hibernation API and remain connected. Their next command wakes the object and
+resumes complete client-owned typed history from SQLite. See Cloudflare's
+[Durable Object lifecycle](https://developers.cloudflare.com/durable-objects/concepts/durable-object-lifecycle/)
+and [WebSocket hibernation](https://developers.cloudflare.com/durable-objects/best-practices/websockets/)
+documentation for the underlying behavior.
+
+## Run locally
+
+From the repository root, build the optimized WASM package and install the
+example:
+
+```sh
+just build-wasm
+npm ci --prefix examples/cloudflare-workers
+```
+
+Create `examples/cloudflare-workers/.dev.vars` (it is ignored by Git). API-key
+mode is the default:
+
+```dotenv
+OPENAI_API_KEY=your-key
+NANOCODEX_ADMIN_TOKEN=local-admin-token
+AGENT_IDLE_TIMEOUT_MS=1000
+```
+
+To use an existing ChatGPT/Codex subscription instead, set
+`NANOCODEX_AUTH_MODE=chatgpt` in `wrangler.jsonc` and provide the three values
+from a Codex login:
+
+```dotenv
+CHATGPT_ACCESS_TOKEN=your-access-token
+CHATGPT_REFRESH_TOKEN=your-refresh-token
+CHATGPT_ACCOUNT_ID=your-account-id
+# CHATGPT_FEDRAMP=true
+NANOCODEX_ADMIN_TOKEN=local-admin-token
+AGENT_IDLE_TIMEOUT_MS=1000
+```
+
+The access token is sent only by the Worker host during the upstream WebSocket
+upgrade; it never crosses into WASM or a client event. A singleton auth Durable
+Object stores rotated credentials in SQLite, refreshes JWTs five minutes before
+expiry, and performs one revision-guarded refresh-and-retry when an upstream
+upgrade returns 401. This avoids a refresh-token race when many session objects
+reconnect together. `GET /auth/chatgpt` reports non-secret status and
+`DELETE /auth/chatgpt` clears the durable copy so changed secrets are re-seeded;
+both routes require the admin bearer token.
+
+Start workerd in one terminal and run the live probes in another:
+
+```sh
+npm run dev --prefix examples/cloudflare-workers
+npm run smoke --prefix examples/cloudflare-workers
+npm run stress --prefix examples/cloudflare-workers
+npm run soak --prefix examples/cloudflare-workers
+npm run fanout --prefix examples/cloudflare-workers
+```
+
+The smoke performs a real model turn, verifies duplicate suppression, waits for
+idle teardown, then proves that a follow-on remembers history after the agent
+is reconstructed. `stress` drives ping round trips through one object, `soak`
+checks parallel sessions for cross-session leakage and duplicate model calls,
+and `fanout` broadcasts a bursty model stream to 64 attached clients. Override
+their `NANOCODEX_*` environment variables to change the workload.
+
+For deterministic transport and subscription-refresh development without model
+usage, run `npm run mock:openai`, set
+`OPENAI_WEBSOCKET_URL=ws://127.0.0.1:8790` in API-key mode, and run the same
+probes. The mock speaks the actual streamed Responses protocol. In ChatGPT mode
+it also validates the bearer/account headers and serves rotating OAuth tokens,
+so the full Rust/WASM driver, snapshot, idle shutdown, restore, and auth-retry
+paths execute.
+
+The local workerd runtime can itself be denied by `chatgpt.com`'s edge even
+when the same credential opens the native WebSocket successfully. Use the mock
+for deterministic local validation and run the real subscription smoke from a
+deployed Worker. Treat that deployed edge check as a release gate.
+
+## Validate and deploy
+
+```sh
+npm run check --prefix examples/cloudflare-workers
+cd examples/cloudflare-workers
+npx wrangler secret put OPENAI_API_KEY
+npx wrangler secret put NANOCODEX_ADMIN_TOKEN
+npx wrangler deploy
+```
+
+For ChatGPT mode, omit `OPENAI_API_KEY` and upload the subscription credentials
+as secrets instead:
+
+```sh
+npx wrangler secret put CHATGPT_ACCESS_TOKEN
+npx wrangler secret put CHATGPT_REFRESH_TOKEN
+npx wrangler secret put CHATGPT_ACCOUNT_ID
+npx wrangler secret put NANOCODEX_ADMIN_TOKEN
+npx wrangler deploy
+```
+
+Codex stores these fields under `tokens.access_token`, `tokens.refresh_token`,
+and `tokens.account_id` in `$CODEX_HOME/auth.json` (normally
+`~/.codex/auth.json`). Do not commit, log, or paste that file wholesale. These
+are bearer credentials for the subscription account; restrict Worker and
+Durable Object access accordingly and follow the account's applicable terms.
+Refresh tokens rotate: bootstrap the Worker from a dedicated login and do not
+let another Codex installation or Worker deployment keep refreshing the same
+credential, or one of them will eventually retain an invalidated token.
+
+`npm run check` type-checks, runs the Worker-native Durable Object suite
+(including forced eviction with a live hibernatable client socket), and asks
+Wrangler to build the complete WASM deployment without uploading it.
+
+`POST /sessions` requires `Authorization: Bearer $NANOCODEX_ADMIN_TOKEN` and
+returns a random session ID plus WebSocket URL. The session ID is then a bearer
+capability: do not log or expose it. Production applications can replace this
+small router policy with their own authentication while leaving the object and
+Nanocodex lifecycle unchanged.
+
+Client WebSocket commands are JSON objects:
+
+```jsonc
+{ "type": "prompt", "id": "client-turn-1", "input": "Hello" }
+{ "type": "steer", "id": "client-turn-1", "input": "Be concise" }
+{ "type": "cancel", "id": "client-turn-1" }
+{ "type": "status" }
+{ "type": "ping", "nonce": "health-1" }
+```
+
+The object streams contractual Nanocodex events as `{ "type": "event", ... }`
+and emits exactly one application terminal message, `turn_completed` or
+`turn_failed`, for each accepted client turn.

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -77,11 +77,27 @@ Start workerd in one terminal and run the live probes in another:
 
 ```sh
 npm run dev --prefix examples/cloudflare-workers
+npm run repl --prefix examples/cloudflare-workers
 npm run smoke --prefix examples/cloudflare-workers
 npm run stress --prefix examples/cloudflare-workers
 npm run soak --prefix examples/cloudflare-workers
 npm run fanout --prefix examples/cloudflare-workers
 ```
+
+The REPL is intentionally disposable. It stores only the session capability
+URL and an unfinished turn ID/input in `.nanocodex/cloudflare-repl.json`; the
+WASM agent, model socket, history, and execution remain in the Durable Object.
+The file is mode `0600` because the session URL is a bearer capability. Press
+Ctrl-C during inference to drop only the local WebSocket. Re-running the same
+command reconnects and resubmits the idempotent turn ID, which either joins the
+active turn or replays its committed terminal result. Use `/status` or `/exit`
+at the prompt. Set `NANOCODEX_REPL_STATE` to isolate another local REPL state
+file.
+
+This demonstrates durable client detachment, not distributed exactly-once
+inference. If the Worker process itself dies before a turn commits, reopening
+the REPL resubmits the same turn from the last committed snapshot; a partial
+provider response cannot be resumed.
 
 The smoke performs a real model turn, verifies duplicate suppression, waits for
 idle teardown, then proves that a follow-on remembers history after the agent

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -81,6 +81,7 @@ Start workerd in one terminal and run the live probes in another:
 ```sh
 npm run repl --prefix examples/cloudflare-workers
 npm run smoke --prefix examples/cloudflare-workers
+npm run multiclient --prefix examples/cloudflare-workers
 npm run stress --prefix examples/cloudflare-workers
 npm run soak --prefix examples/cloudflare-workers
 npm run fanout --prefix examples/cloudflare-workers
@@ -105,6 +106,9 @@ The smoke performs real model turns, verifies duplicate suppression, detaches
 its client, waits for idle teardown, reconnects to the durable snapshot, proves
 that a follow-on remembers history, and requires a completed `runtimeInfo` tool
 call/result pair.
+`multiclient` attaches at least two clients before prompting and requires every
+client to receive the same accepted turn, assistant-delta stream, event count,
+and terminal result without reconnecting.
 `stress` drives ping round trips through one object, `soak`
 checks parallel sessions for cross-session leakage and duplicate model calls,
 and `fanout` broadcasts a bursty model stream to 64 attached clients. Override

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -42,41 +42,30 @@ just build-wasm
 npm ci --prefix examples/cloudflare-workers
 ```
 
-Create `examples/cloudflare-workers/.dev.vars` (it is ignored by Git). API-key
-mode is the default:
+Sign in once with Codex, then start the subscription-backed Worker:
 
-```dotenv
-OPENAI_API_KEY=your-key
-NANOCODEX_ADMIN_TOKEN=local-admin-token
-AGENT_IDLE_TIMEOUT_MS=1000
+```sh
+codex login
+npm run dev:subscription --prefix examples/cloudflare-workers
 ```
 
-To use an existing ChatGPT/Codex subscription instead, set
-`NANOCODEX_AUTH_MODE=chatgpt` in `wrangler.jsonc` and provide the three values
-from a Codex login:
-
-```dotenv
-CHATGPT_ACCESS_TOKEN=your-access-token
-CHATGPT_REFRESH_TOKEN=your-refresh-token
-CHATGPT_ACCOUNT_ID=your-account-id
-# CHATGPT_FEDRAMP=true
-NANOCODEX_ADMIN_TOKEN=local-admin-token
-AGENT_IDLE_TIMEOUT_MS=1000
-```
+The launcher securely reads `$CODEX_HOME/auth.json` (normally
+`~/.codex/auth.json`), requires it to be mode `0600`, and gives workerd only the
+current access token and account metadata through a temporary mode-`0600` env
+file. It never reads, copies, rotates, or persists the Codex CLI refresh token.
+The temporary file is removed when Wrangler exits. If the access token expires,
+run `codex login` and restart this command.
 
 The access token is sent only by the Worker host during the upstream WebSocket
-upgrade; it never crosses into WASM or a client event. A singleton auth Durable
-Object stores rotated credentials in SQLite, refreshes JWTs five minutes before
-expiry, and performs one revision-guarded refresh-and-retry when an upstream
-upgrade returns 401. This avoids a refresh-token race when many session objects
-reconnect together. `GET /auth/chatgpt` reports non-secret status and
-`DELETE /auth/chatgpt` clears the durable copy so changed secrets are re-seeded;
-both routes require the admin bearer token.
+upgrade; it never crosses into WASM or a client event. Local workerd keeps the
+access token behind the singleton auth Durable Object and the launcher clears
+any credential retained by an older run before accepting the new login.
+`GET /auth/chatgpt` reports non-secret status and `DELETE /auth/chatgpt` clears
+the durable copy; both routes require the admin bearer token.
 
 Start workerd in one terminal and run the live probes in another:
 
 ```sh
-npm run dev --prefix examples/cloudflare-workers
 npm run repl --prefix examples/cloudflare-workers
 npm run smoke --prefix examples/cloudflare-workers
 npm run stress --prefix examples/cloudflare-workers
@@ -114,25 +103,16 @@ it also validates the bearer/account headers and serves rotating OAuth tokens,
 so the full Rust/WASM driver, snapshot, idle shutdown, restore, and auth-retry
 paths execute.
 
-The local workerd runtime can itself be denied by `chatgpt.com`'s edge even
-when the same credential opens the native WebSocket successfully. Use the mock
-for deterministic local validation and run the real subscription smoke from a
-deployed Worker. Treat that deployed edge check as a release gate.
+If `chatgpt.com` denies the local workerd runtime even though the same login
+works in Codex, use the mock for deterministic local validation and run the
+real subscription smoke from a deployed Worker. Treat the deployed edge check
+as the release gate.
 
 ## Validate and deploy
 
 ```sh
 npm run check --prefix examples/cloudflare-workers
 cd examples/cloudflare-workers
-npx wrangler secret put OPENAI_API_KEY
-npx wrangler secret put NANOCODEX_ADMIN_TOKEN
-npx wrangler deploy
-```
-
-For ChatGPT mode, omit `OPENAI_API_KEY` and upload the subscription credentials
-as secrets instead:
-
-```sh
 npx wrangler secret put CHATGPT_ACCESS_TOKEN
 npx wrangler secret put CHATGPT_REFRESH_TOKEN
 npx wrangler secret put CHATGPT_ACCOUNT_ID
@@ -140,14 +120,19 @@ npx wrangler secret put NANOCODEX_ADMIN_TOKEN
 npx wrangler deploy
 ```
 
-Codex stores these fields under `tokens.access_token`, `tokens.refresh_token`,
-and `tokens.account_id` in `$CODEX_HOME/auth.json` (normally
-`~/.codex/auth.json`). Do not commit, log, or paste that file wholesale. These
-are bearer credentials for the subscription account; restrict Worker and
-Durable Object access accordingly and follow the account's applicable terms.
-Refresh tokens rotate: bootstrap the Worker from a dedicated login and do not
-let another Codex installation or Worker deployment keep refreshing the same
-credential, or one of them will eventually retain an invalidated token.
+For a long-lived deployment, the singleton auth Durable Object stores the
+dedicated credential in SQLite, refreshes it five minutes before expiry, and
+performs one revision-guarded refresh-and-retry when an upstream upgrade returns
+401. This avoids a refresh-token race when many sessions reconnect together.
+Use a dedicated Codex subscription login for the deployment: refresh tokens
+rotate, so sharing one between a local Codex installation and a Worker can
+invalidate either copy. Do not commit, log, or paste `auth.json` wholesale;
+restrict Worker and Durable Object access and follow the account's applicable
+terms.
+
+API-key mode remains available as an explicit alternative by setting
+`NANOCODEX_AUTH_MODE=api_key` and providing `OPENAI_API_KEY`, but it is not used
+by this demo.
 
 `npm run check` type-checks, runs the Worker-native Durable Object suite
 (including forced eviction with a live hibernatable client socket), and asks

--- a/examples/cloudflare-workers/package-lock.json
+++ b/examples/cloudflare-workers/package-lock.json
@@ -1,0 +1,2893 @@
+{
+  "name": "nanocodex-cloudflare-workers-example",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nanocodex-cloudflare-workers-example",
+      "version": "0.1.0",
+      "dependencies": {
+        "nanocodex": "file:../../js/bindings"
+      },
+      "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "^0.19.0",
+        "@cloudflare/workers-types": "^5.20260730.1",
+        "typescript": "5.9.3",
+        "vitest": "^4.0.18",
+        "wrangler": "^4.115.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      }
+    },
+    "../../js/bindings": {
+      "name": "nanocodex",
+      "version": "0.3.0",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "ws": "^8.18.3"
+      },
+      "devDependencies": {
+        "pkg-pr-new": "0.0.79",
+        "typescript": "5.9.3"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/vitest-pool-workers": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.19.0.tgz",
+      "integrity": "sha512-6t6zs1YBoAo9jJVpA8pTxPWYEY3c/ai07MWZYJ4vkUc5cyW9PHfMB6tFhDsRg7eLS+i26NMuB3aUOlBKdRiwhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cjs-module-lexer": "1.2.3",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260722.1",
+        "wrangler": "4.115.0",
+        "zod": "3.25.76"
+      },
+      "peerDependencies": {
+        "@vitest/runner": "^4.1.0",
+        "@vitest/snapshot": "^4.1.0",
+        "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260722.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260722.1.tgz",
+      "integrity": "sha512-vZOP8vIS3NwnuaO+gz0FZ7kIGeiO3bZmxV35Ph9zOXKSREhDFlH7wQ7mkCdhW3O4jnXsew+XT7b+DNEI2CcJGQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260722.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260722.1.tgz",
+      "integrity": "sha512-EmIQymihDq6WNdER4+LF8Qn80yqayBUpJ+tkOO7wmY8pmgfyXjIUFNXotl21AHovTeu2seR7HdVUgeN/BilCWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260722.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260722.1.tgz",
+      "integrity": "sha512-jvZ3k9fxcnEn04s80CgIYxQfpOyAiz/8qC42DP8EBa9tR27qWyg9wmm31zIobVlrgBZn/+8NfdP73avRGcQOjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260722.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260722.1.tgz",
+      "integrity": "sha512-BOSB55SMNdy+DA5uj2WirgiNanpHGis5PVvXH1wSfvjRKr4JGgWK+EZzxz0RFUo6QjjQQC/NimEzNZ7va7jmKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260722.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260722.1.tgz",
+      "integrity": "sha512-sYM8YgUpKnRz2xjvdJLX1Ojzoi4MlA4gk8WTTExhGydjYB2UTs5NIbv0ZmpKgMoK9io3ixgmiW56ZnTbcWOdiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260730.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260730.1.tgz",
+      "integrity": "sha512-3e1cBXcPTwXBk2ur0CfxZKQKL6X7vUZlOn1R7VYU0zZVJcSKFcq1AoOZM+ps0LuL0uTAxdcLg+qwXrBXVu+UuQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "2.0.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-2.0.1.tgz",
+      "integrity": "sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-wasm32/node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.0.tgz",
+      "integrity": "sha512-kDoONqMa+VnZ4vvvu/ZUurpJ4gkZU57e7g69qpNgWhYcZFPUHZM2CEMKm+cG6ufDVALbjMvfmMjFVqaK7uEMnA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^2.0.0-alpha.3",
+        "@emnapi/runtime": "^2.0.0-alpha.3"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260722.1",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260722.1.tgz",
+      "integrity": "sha512-FJIg4omaCb2wwSyOeRosEdmVRi3JzGAOOH3pa3twmmtvWECl6BVZMIDwJbjByLKRyU+mrfk0M/n3oSiojFZvSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.28.0",
+        "workerd": "1.20260722.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/miniflare/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nanocodex": {
+      "resolved": "../../js/bindings",
+      "link": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260722.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260722.1.tgz",
+      "integrity": "sha512-NycKuc1x2onvsRfGGpM093vRlLFU2zHDAM0+APpccfg4+gZxDGCH27RmdDvkeBuoZyYqgLo3oAfF6re4mvC3vQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260722.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260722.1",
+        "@cloudflare/workerd-linux-64": "1.20260722.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260722.1",
+        "@cloudflare/workerd-windows-64": "1.20260722.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.115.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.115.0.tgz",
+      "integrity": "sha512-+upG2VW66M1sjb43yzgUZ6Ss8iYpJ6+7F3U4GF8TY5EYd+08sYdS54d24AEwCnhuef3J9KlSPusqiqR9WYy1UA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260722.1",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260722.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260722.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -11,6 +11,7 @@
     "build": "wrangler deploy --dry-run --outdir dist",
     "check": "npm run typecheck && npm test && npm run build",
     "dev": "wrangler dev",
+    "dev:subscription": "node scripts/dev-subscription.mjs",
     "fanout": "node scripts/fanout.mjs",
     "mock:openai": "node scripts/mock-openai.mjs",
     "repl": "node scripts/repl.mjs",
@@ -18,7 +19,9 @@
     "soak": "node scripts/soak.mjs",
     "stress": "node scripts/stress.mjs",
     "pretest": "node scripts/prepare-wasm.mjs",
-    "test": "vitest run",
+    "test": "npm run test:node && npm run test:worker",
+    "test:node": "node --test test-node/*.test.mjs",
+    "test:worker": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -13,6 +13,7 @@
     "dev": "wrangler dev",
     "fanout": "node scripts/fanout.mjs",
     "mock:openai": "node scripts/mock-openai.mjs",
+    "repl": "node scripts/repl.mjs",
     "smoke": "node scripts/live-smoke.mjs",
     "soak": "node scripts/soak.mjs",
     "stress": "node scripts/stress.mjs",

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -17,6 +17,7 @@
     "dev:subscription": "node scripts/dev-subscription.mjs",
     "fanout": "node scripts/fanout.mjs",
     "mock:openai": "node scripts/mock-openai.mjs",
+    "relay:subscription": "node scripts/subscription-egress-relay.mjs",
     "repl": "node scripts/repl.mjs",
     "smoke": "node scripts/live-smoke.mjs",
     "soak": "node scripts/soak.mjs",

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "nanocodex-cloudflare-workers-example",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "scripts": {
+    "prebuild": "node scripts/prepare-wasm.mjs",
+    "build": "wrangler deploy --dry-run --outdir dist",
+    "check": "npm run typecheck && npm test && npm run build",
+    "dev": "wrangler dev",
+    "fanout": "node scripts/fanout.mjs",
+    "mock:openai": "node scripts/mock-openai.mjs",
+    "smoke": "node scripts/live-smoke.mjs",
+    "soak": "node scripts/soak.mjs",
+    "stress": "node scripts/stress.mjs",
+    "pretest": "node scripts/prepare-wasm.mjs",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "nanocodex": "file:../../js/bindings"
+  },
+  "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.19.0",
+    "@cloudflare/workers-types": "^5.20260730.1",
+    "typescript": "5.9.3",
+    "vitest": "^4.0.18",
+    "wrangler": "^4.115.0",
+    "ws": "^8.18.3"
+  }
+}

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -7,10 +7,13 @@
     "node": ">=22.13.0"
   },
   "scripts": {
-    "prebuild": "node scripts/prepare-wasm.mjs",
+    "prepare:wasm": "node scripts/prepare-wasm.mjs",
+    "prebuild": "npm run prepare:wasm",
     "build": "wrangler deploy --dry-run --outdir dist",
     "check": "npm run typecheck && npm test && npm run build",
+    "predev": "npm run prepare:wasm",
     "dev": "wrangler dev",
+    "predev:subscription": "npm run prepare:wasm",
     "dev:subscription": "node scripts/dev-subscription.mjs",
     "fanout": "node scripts/fanout.mjs",
     "mock:openai": "node scripts/mock-openai.mjs",
@@ -18,7 +21,7 @@
     "smoke": "node scripts/live-smoke.mjs",
     "soak": "node scripts/soak.mjs",
     "stress": "node scripts/stress.mjs",
-    "pretest": "node scripts/prepare-wasm.mjs",
+    "pretest": "npm run prepare:wasm",
     "test": "npm run test:node && npm run test:worker",
     "test:node": "node --test test-node/*.test.mjs",
     "test:worker": "vitest run",

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -17,6 +17,7 @@
     "dev:subscription": "node scripts/dev-subscription.mjs",
     "fanout": "node scripts/fanout.mjs",
     "mock:openai": "node scripts/mock-openai.mjs",
+    "multiclient": "node scripts/multiclient-smoke.mjs",
     "relay:subscription": "node scripts/subscription-egress-relay.mjs",
     "repl": "node scripts/repl.mjs",
     "smoke": "node scripts/live-smoke.mjs",

--- a/examples/cloudflare-workers/scripts/codex-auth-file.mjs
+++ b/examples/cloudflare-workers/scripts/codex-auth-file.mjs
@@ -1,0 +1,97 @@
+import { open } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const MAX_AUTH_FILE_BYTES = 64 * 1024;
+const MIN_ACCESS_TOKEN_TTL_MS = 5 * 60_000;
+
+export async function readCodexSubscription(path) {
+  const authPath = resolve(path);
+  let file;
+  try {
+    file = await open(authPath, "r");
+  } catch (error) {
+    throw new Error(`cannot open Codex auth file: ${errorMessage(error)}`);
+  }
+
+  let encoded;
+  try {
+    const metadata = await file.stat();
+    if (!metadata.isFile()) throw new Error(`Codex auth path is not a file: ${authPath}`);
+    if (metadata.size > MAX_AUTH_FILE_BYTES) {
+      throw new Error(`Codex auth file exceeds ${MAX_AUTH_FILE_BYTES} bytes`);
+    }
+    if (process.platform !== "win32" && (metadata.mode & 0o077) !== 0) {
+      throw new Error("Codex auth file must not be accessible by group or other users");
+    }
+    encoded = await file.readFile();
+  } catch (error) {
+    throw new Error(`cannot read Codex auth file: ${errorMessage(error)}`);
+  } finally {
+    await file.close();
+  }
+  if (encoded.byteLength > MAX_AUTH_FILE_BYTES) {
+    throw new Error(`Codex auth file exceeds ${MAX_AUTH_FILE_BYTES} bytes`);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(encoded.toString("utf8"));
+  } catch (error) {
+    throw new Error(`cannot parse Codex auth file: ${errorMessage(error)}`);
+  }
+  if (!isRecord(parsed) || parsed.auth_mode !== "chatgpt" || !isRecord(parsed.tokens)) {
+    throw new Error("Codex auth file does not contain a ChatGPT subscription login");
+  }
+
+  const accessToken = requiredString(parsed.tokens.access_token, "access token");
+  const idToken = optionalString(parsed.tokens.id_token);
+  const idClaims = idToken === undefined ? undefined : jwtPayload(idToken);
+  const authClaims = idClaims?.["https://api.openai.com/auth"];
+  const accountId = optionalString(parsed.tokens.account_id)
+    ?? (isRecord(authClaims) ? optionalString(authClaims.chatgpt_account_id) : undefined);
+  if (accountId === undefined) throw new Error("Codex auth file is missing the ChatGPT account ID");
+
+  const accessClaims = jwtPayload(accessToken);
+  const expiresAt = typeof accessClaims?.exp === "number" && Number.isFinite(accessClaims.exp)
+    ? accessClaims.exp * 1_000
+    : undefined;
+  if (expiresAt === undefined || expiresAt <= Date.now() + MIN_ACCESS_TOKEN_TTL_MS) {
+    throw new Error("Codex access token expires too soon; run `codex login` and retry");
+  }
+
+  return Object.freeze({
+    accessToken,
+    accountId,
+    fedramp: isRecord(authClaims) && authClaims.chatgpt_account_is_fedramp === true,
+    expiresAt,
+  });
+}
+
+function jwtPayload(token) {
+  const encoded = token.split(".")[1];
+  if (!encoded) return undefined;
+  try {
+    const value = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"));
+    return isRecord(value) ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function requiredString(value, name) {
+  const normalized = optionalString(value);
+  if (normalized === undefined) throw new Error(`Codex auth file is missing the ${name}`);
+  return normalized;
+}
+
+function optionalString(value) {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/examples/cloudflare-workers/scripts/dev-subscription.mjs
+++ b/examples/cloudflare-workers/scripts/dev-subscription.mjs
@@ -5,6 +5,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { readCodexSubscription } from "./codex-auth-file.mjs";
+import { startSubscriptionEgressProxy } from "./subscription-egress-proxy.mjs";
 
 const exampleRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const codexHome = process.env.CODEX_HOME ?? join(homedir(), ".codex");
@@ -14,6 +15,9 @@ const adminToken = process.env.NANOCODEX_ADMIN_TOKEN ?? "local-admin-token";
 const auth = await readCodexSubscription(authPath);
 const temporaryDirectory = await mkdtemp(join(tmpdir(), "nanocodex-cloudflare-subscription-"));
 const envPath = join(temporaryDirectory, "subscription.env");
+const egress = await startSubscriptionEgressProxy({
+  upstreamUrl: process.env.OPENAI_WEBSOCKET_URL,
+});
 
 await writeFile(envPath, [
   envLine("CHATGPT_ACCESS_TOKEN", auth.accessToken),
@@ -21,6 +25,7 @@ await writeFile(envPath, [
   envLine("CHATGPT_FEDRAMP", String(auth.fedramp)),
   envLine("NANOCODEX_ADMIN_TOKEN", adminToken),
   envLine("NANOCODEX_AUTH_MODE", "chatgpt"),
+  envLine("OPENAI_WEBSOCKET_URL", egress.url),
   envLine("AGENT_IDLE_TIMEOUT_MS", process.env.AGENT_IDLE_TIMEOUT_MS ?? "1000"),
   "",
 ].join("\n"), { mode: 0o600 });
@@ -45,12 +50,14 @@ for (const signal of ["SIGINT", "SIGTERM"]) {
 try {
   await resetStoredCredential(child);
   process.stderr.write(
-    `Using the Codex subscription login at ${authPath}; its refresh token is not used or copied.\n`,
+    `Using the Codex subscription login at ${authPath}; its refresh token is not used or copied.\n` +
+    "Local model egress uses a capability-protected loopback bridge; deployed Workers connect directly.\n",
   );
   const [code, signal] = await childExit;
   process.exitCode = code ?? signalExitCode(signal ?? parentSignal);
 } finally {
   if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+  await egress.close();
   await rm(temporaryDirectory, { recursive: true, force: true });
 }
 

--- a/examples/cloudflare-workers/scripts/dev-subscription.mjs
+++ b/examples/cloudflare-workers/scripts/dev-subscription.mjs
@@ -1,0 +1,96 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { readCodexSubscription } from "./codex-auth-file.mjs";
+
+const exampleRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const codexHome = process.env.CODEX_HOME ?? join(homedir(), ".codex");
+const authPath = resolve(process.env.NANOCODEX_CODEX_AUTH_FILE ?? join(codexHome, "auth.json"));
+const workerUrl = (process.env.NANOCODEX_WORKER_URL ?? "http://127.0.0.1:8787").replace(/\/$/, "");
+const adminToken = process.env.NANOCODEX_ADMIN_TOKEN ?? "local-admin-token";
+const auth = await readCodexSubscription(authPath);
+const temporaryDirectory = await mkdtemp(join(tmpdir(), "nanocodex-cloudflare-subscription-"));
+const envPath = join(temporaryDirectory, "subscription.env");
+
+await writeFile(envPath, [
+  envLine("CHATGPT_ACCESS_TOKEN", auth.accessToken),
+  envLine("CHATGPT_ACCOUNT_ID", auth.accountId),
+  envLine("CHATGPT_FEDRAMP", String(auth.fedramp)),
+  envLine("NANOCODEX_ADMIN_TOKEN", adminToken),
+  envLine("NANOCODEX_AUTH_MODE", "chatgpt"),
+  envLine("AGENT_IDLE_TIMEOUT_MS", process.env.AGENT_IDLE_TIMEOUT_MS ?? "1000"),
+  "",
+].join("\n"), { mode: 0o600 });
+
+const wrangler = join(exampleRoot, "node_modules", "wrangler", "bin", "wrangler.js");
+const child = spawn(process.execPath, [wrangler, "dev", "--env-file", envPath, ...process.argv.slice(2)], {
+  cwd: exampleRoot,
+  stdio: "inherit",
+});
+const childExit = new Promise((resolveExit, rejectExit) => {
+  child.once("error", rejectExit);
+  child.once("exit", (code, signal) => resolveExit([code, signal]));
+});
+let parentSignal;
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, () => {
+    parentSignal = signal;
+    if (child.exitCode === null && child.signalCode === null) child.kill(signal);
+  });
+}
+
+try {
+  await resetStoredCredential(child);
+  process.stderr.write(
+    `Using the Codex subscription login at ${authPath}; its refresh token is not used or copied.\n`,
+  );
+  const [code, signal] = await childExit;
+  process.exitCode = code ?? signalExitCode(signal ?? parentSignal);
+} finally {
+  if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+  await rm(temporaryDirectory, { recursive: true, force: true });
+}
+
+async function resetStoredCredential(processHandle) {
+  let lastError;
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (processHandle.exitCode !== null || processHandle.signalCode !== null) {
+      throw new Error("Wrangler exited before the subscription demo became ready");
+    }
+    try {
+      const health = await fetch(`${workerUrl}/health`);
+      if (health.ok) {
+        const reset = await fetch(`${workerUrl}/auth/chatgpt`, {
+          method: "DELETE",
+          headers: { authorization: `Bearer ${adminToken}` },
+        });
+        if (!reset.ok) {
+          throw new Error(`credential reset failed with HTTP ${reset.status}: ${await reset.text()}`);
+        }
+        return;
+      }
+      lastError = new Error(`health check returned HTTP ${health.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
+  }
+  throw new Error(`Wrangler did not become ready: ${errorMessage(lastError)}`);
+}
+
+function envLine(name, value) {
+  return `${name}=${JSON.stringify(value)}`;
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function signalExitCode(signal) {
+  if (signal === "SIGINT") return 130;
+  if (signal === "SIGTERM") return 143;
+  return signal ? 1 : 0;
+}

--- a/examples/cloudflare-workers/scripts/dev-subscription.mjs
+++ b/examples/cloudflare-workers/scripts/dev-subscription.mjs
@@ -17,6 +17,10 @@ const temporaryDirectory = await mkdtemp(join(tmpdir(), "nanocodex-cloudflare-su
 const envPath = join(temporaryDirectory, "subscription.env");
 const egress = await startSubscriptionEgressProxy({
   upstreamUrl: process.env.OPENAI_WEBSOCKET_URL,
+  onEvent: ({ type, status, code }) => {
+    const detail = status === undefined ? (code === undefined ? "" : ` code=${code}`) : ` status=${status}`;
+    process.stderr.write(`[subscription-egress] ${type}${detail}\n`);
+  },
 });
 
 await writeFile(envPath, [
@@ -51,7 +55,7 @@ try {
   await resetStoredCredential(child);
   process.stderr.write(
     `Using the Codex subscription login at ${authPath}; its refresh token is not used or copied.\n` +
-    "Local model egress uses a capability-protected loopback bridge; deployed Workers connect directly.\n",
+    "Model egress uses a capability-protected loopback bridge.\n",
   );
   const [code, signal] = await childExit;
   process.exitCode = code ?? signalExitCode(signal ?? parentSignal);

--- a/examples/cloudflare-workers/scripts/fanout.mjs
+++ b/examples/cloudflare-workers/scripts/fanout.mjs
@@ -1,0 +1,90 @@
+import { randomUUID } from "node:crypto";
+import WebSocket from "ws";
+
+const baseUrl = process.env.NANOCODEX_WORKER_URL ?? "http://127.0.0.1:8787";
+const adminToken = process.env.NANOCODEX_ADMIN_TOKEN ?? "local-admin-token";
+const clients = Number(process.env.NANOCODEX_FANOUT_CLIENTS ?? 64);
+const burst = Number(process.env.NANOCODEX_FANOUT_EVENTS ?? 512);
+const timeoutMs = Number(process.env.NANOCODEX_FANOUT_TIMEOUT_MS ?? 60_000);
+
+if (!Number.isSafeInteger(clients) || clients < 1 || clients > 64) throw new Error("clients must be 1-64");
+if (!Number.isSafeInteger(burst) || burst < 1 || burst > 4_096) throw new Error("events must be 1-4096");
+
+const created = await fetch(`${baseUrl}/sessions`, {
+  method: "POST",
+  headers: { authorization: `Bearer ${adminToken}` },
+});
+if (!created.ok) throw new Error(`session creation failed with HTTP ${created.status}: ${await created.text()}`);
+const session = await created.json();
+const sockets = [];
+
+try {
+  const receivers = await Promise.all(Array.from({ length: clients }, async () => {
+    const socket = new WebSocket(session.websocket_url);
+    sockets.push(socket);
+    let events = 0;
+    const ready = deferred();
+    const terminal = deferred();
+    socket.on("message", (data) => {
+      const message = JSON.parse(String(data));
+      if (message.type === "ready") ready.resolve();
+      if (message.type === "event") events += 1;
+      if (message.type === "turn_completed" || message.type === "turn_failed") terminal.resolve(message);
+    });
+    await withTimeout(ready.promise, 10_000, "WebSocket ready timed out");
+    return { socket, terminal, eventCount: () => events };
+  }));
+
+  const id = randomUUID();
+  const started = performance.now();
+  receivers[0].socket.send(JSON.stringify({ type: "prompt", id, input: `Emit BURST_${burst}` }));
+  const terminals = await withTimeout(
+    Promise.all(receivers.map(({ terminal }) => terminal.promise)),
+    timeoutMs,
+    "fanout terminal timed out",
+  );
+  const elapsedMs = performance.now() - started;
+  for (const terminal of terminals) {
+    if (terminal.type !== "turn_completed" || terminal.final_message !== "BURST_OK") {
+      throw new Error(`unexpected terminal: ${JSON.stringify(terminal)}`);
+    }
+  }
+  const counts = receivers.map(({ eventCount }) => eventCount());
+  if (new Set(counts).size !== 1 || counts[0] < burst) {
+    throw new Error(`clients observed inconsistent event streams: ${JSON.stringify(counts)}`);
+  }
+  const deliveries = counts.reduce((sum, count) => sum + count, 0);
+  console.log(JSON.stringify({
+    clients,
+    upstream_events: counts[0],
+    websocket_deliveries: deliveries,
+    elapsed_ms: Math.round(elapsedMs),
+    deliveries_per_second: Math.round(deliveries / (elapsedMs / 1000)),
+    status: "ok",
+  }));
+} finally {
+  for (const socket of sockets) socket.terminate();
+  await fetch(`${baseUrl}/sessions/${session.session_id}`, { method: "DELETE" }).catch(() => {});
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+async function withTimeout(promise, milliseconds, message) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => { timer = setTimeout(() => reject(new Error(message)), milliseconds); }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/examples/cloudflare-workers/scripts/live-smoke.mjs
+++ b/examples/cloudflare-workers/scripts/live-smoke.mjs
@@ -1,0 +1,155 @@
+import { randomUUID } from "node:crypto";
+import WebSocket from "ws";
+
+const baseUrl = process.env.NANOCODEX_WORKER_URL ?? "http://127.0.0.1:8787";
+const adminToken = process.env.NANOCODEX_ADMIN_TOKEN ?? "local-admin-token";
+const terminalTimeoutMs = Number(process.env.NANOCODEX_SMOKE_TIMEOUT_MS ?? 180_000);
+
+const session = await createSession();
+const socket = new WebSocket(session.websocket_url);
+const inbox = createInbox(socket);
+
+try {
+  await inbox.next((message) => message.type === "ready", 10_000);
+
+  const firstId = randomUUID();
+  const firstStarted = performance.now();
+  socket.send(JSON.stringify({
+    type: "prompt",
+    id: firstId,
+    input: "Reply with exactly EDGE_OK and nothing else.",
+  }));
+  socket.send(JSON.stringify({
+    type: "prompt",
+    id: firstId,
+    input: "This in-flight duplicate must not reach the model.",
+  }));
+  const first = await terminal(inbox, firstId, terminalTimeoutMs);
+  const firstMs = performance.now() - firstStarted;
+  if (!String(first.final_message).includes("EDGE_OK")) {
+    throw new Error(`first turn returned an unexpected answer: ${first.final_message}`);
+  }
+
+  socket.send(JSON.stringify({ type: "prompt", id: firstId, input: "must not run" }));
+  const replay = await terminal(inbox, firstId, 10_000);
+  if (replay.final_message !== first.final_message) {
+    throw new Error("completed turn replay changed its terminal result");
+  }
+
+  const idleStarted = performance.now();
+  const idleState = await pollState(
+    (state) => state.completed_turns === 1 && state.agent_loaded === false,
+    20_000,
+  );
+  const idleShutdownMs = performance.now() - idleStarted;
+
+  const secondId = randomUUID();
+  const secondStarted = performance.now();
+  socket.send(JSON.stringify({
+    type: "prompt",
+    id: secondId,
+    input: "What exact token did I ask you to return previously? Reply with only that token.",
+  }));
+  const second = await terminal(inbox, secondId, terminalTimeoutMs);
+  const restoreMs = performance.now() - secondStarted;
+  if (!String(second.final_message).includes("EDGE_OK")) {
+    throw new Error(`restored turn lost conversation history: ${second.final_message}`);
+  }
+
+  const finalState = await state();
+  if (finalState.completed_turns !== 2 || finalState.has_snapshot !== true) {
+    throw new Error(`unexpected final state: ${JSON.stringify(finalState)}`);
+  }
+
+  const authStatus = finalState.auth_mode === "chatgpt" ? await subscriptionStatus() : undefined;
+  console.log(JSON.stringify({
+    session_id: session.session_id,
+    first_turn_ms: Math.round(firstMs),
+    idle_shutdown_ms: Math.round(idleShutdownMs),
+    restored_turn_ms: Math.round(restoreMs),
+    completed_turns: finalState.completed_turns,
+    idle_state: idleState.agent_loaded ? "loaded" : "unloaded",
+    ...(authStatus === undefined ? {} : { auth_revision: authStatus.revision }),
+    status: "ok",
+  }));
+} finally {
+  inbox.close();
+  socket.close(1000, "smoke complete");
+  await fetch(`${baseUrl}/sessions/${session.session_id}`, { method: "DELETE" }).catch(() => {});
+}
+
+async function createSession() {
+  const response = await fetch(`${baseUrl}/sessions`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${adminToken}` },
+  });
+  if (!response.ok) throw new Error(`session creation failed with HTTP ${response.status}: ${await response.text()}`);
+  return response.json();
+}
+
+async function state() {
+  const response = await fetch(`${baseUrl}/sessions/${session.session_id}`);
+  if (!response.ok) throw new Error(`state failed with HTTP ${response.status}: ${await response.text()}`);
+  return response.json();
+}
+
+async function subscriptionStatus() {
+  const response = await fetch(`${baseUrl}/auth/chatgpt`, {
+    headers: { authorization: `Bearer ${adminToken}` },
+  });
+  if (!response.ok) throw new Error(`auth status failed with HTTP ${response.status}: ${await response.text()}`);
+  return response.json();
+}
+
+async function pollState(predicate, timeoutMs) {
+  const deadline = performance.now() + timeoutMs;
+  while (performance.now() < deadline) {
+    const current = await state();
+    if (predicate(current)) return current;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`state did not reach the expected condition within ${timeoutMs}ms`);
+}
+
+async function terminal(inbox, id, timeoutMs) {
+  const message = await inbox.next(
+    (candidate) => ["turn_completed", "turn_failed"].includes(candidate.type) && candidate.id === id,
+    timeoutMs,
+  );
+  if (message.type === "turn_failed") throw new Error(`turn ${id} failed: ${message.error}`);
+  return message;
+}
+
+function createInbox(ws) {
+  const queued = [];
+  const waiters = [];
+  const onMessage = (data) => {
+    const message = JSON.parse(String(data));
+    const index = waiters.findIndex(({ predicate }) => predicate(message));
+    if (index === -1) queued.push(message);
+    else waiters.splice(index, 1)[0].resolve(message);
+  };
+  ws.on("message", onMessage);
+  return {
+    next(predicate, timeoutMs) {
+      const index = queued.findIndex(predicate);
+      if (index !== -1) return Promise.resolve(queued.splice(index, 1)[0]);
+      return new Promise((resolve, reject) => {
+        const waiter = { predicate, resolve };
+        waiters.push(waiter);
+        const timer = setTimeout(() => {
+          const pending = waiters.indexOf(waiter);
+          if (pending !== -1) waiters.splice(pending, 1);
+          reject(new Error(`WebSocket message timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+        waiter.resolve = (message) => {
+          clearTimeout(timer);
+          resolve(message);
+        };
+      });
+    },
+    close() {
+      ws.off("message", onMessage);
+    },
+  };
+}

--- a/examples/cloudflare-workers/scripts/live-smoke.mjs
+++ b/examples/cloudflare-workers/scripts/live-smoke.mjs
@@ -7,7 +7,10 @@ const terminalTimeoutMs = Number(process.env.NANOCODEX_SMOKE_TIMEOUT_MS ?? 180_0
 
 const session = await createSession();
 const socket = new WebSocket(session.websocket_url);
-const inbox = createInbox(socket);
+const agentEvents = [];
+const inbox = createInbox(socket, (message) => {
+  if (message.type === "event") agentEvents.push(message.event);
+});
 
 try {
   await inbox.next((message) => message.type === "ready", 10_000);
@@ -56,8 +59,26 @@ try {
     throw new Error(`restored turn lost conversation history: ${second.final_message}`);
   }
 
+  const toolId = randomUUID();
+  socket.send(JSON.stringify({
+    type: "prompt",
+    id: toolId,
+    input: "You must call runtimeInfo exactly once. Then reply with only the runtime value returned by that tool.",
+  }));
+  const toolTurn = await terminal(inbox, toolId, terminalTimeoutMs);
+  if (!String(toolTurn.final_message).includes("cloudflare-durable-object")) {
+    throw new Error(`runtimeInfo tool returned an unexpected answer: ${toolTurn.final_message}`);
+  }
+  const toolCall = agentEvents.find((event) =>
+    event.type === "tool.call" && event.payload?.tool === "runtimeInfo");
+  const toolResult = agentEvents.find((event) =>
+    event.type === "tool.result" && event.payload?.call_id === toolCall?.payload?.call_id);
+  if (!toolCall || !toolResult || toolResult.payload?.status !== "completed") {
+    throw new Error("runtimeInfo did not produce a completed tool.call/tool.result event pair");
+  }
+
   const finalState = await state();
-  if (finalState.completed_turns !== 2 || finalState.has_snapshot !== true) {
+  if (finalState.completed_turns !== 3 || finalState.has_snapshot !== true) {
     throw new Error(`unexpected final state: ${JSON.stringify(finalState)}`);
   }
 
@@ -67,6 +88,8 @@ try {
     first_turn_ms: Math.round(firstMs),
     idle_shutdown_ms: Math.round(idleShutdownMs),
     restored_turn_ms: Math.round(restoreMs),
+    agent_events: agentEvents.length,
+    tool_call: toolCall.payload.tool,
     completed_turns: finalState.completed_turns,
     idle_state: idleState.agent_loaded ? "loaded" : "unloaded",
     ...(authStatus === undefined ? {} : { auth_revision: authStatus.revision }),
@@ -120,11 +143,12 @@ async function terminal(inbox, id, timeoutMs) {
   return message;
 }
 
-function createInbox(ws) {
+function createInbox(ws, observe = () => {}) {
   const queued = [];
   const waiters = [];
   const onMessage = (data) => {
     const message = JSON.parse(String(data));
+    observe(message);
     const index = waiters.findIndex(({ predicate }) => predicate(message));
     if (index === -1) queued.push(message);
     else waiters.splice(index, 1)[0].resolve(message);

--- a/examples/cloudflare-workers/scripts/live-smoke.mjs
+++ b/examples/cloudflare-workers/scripts/live-smoke.mjs
@@ -4,17 +4,20 @@ import WebSocket from "ws";
 const baseUrl = process.env.NANOCODEX_WORKER_URL ?? "http://127.0.0.1:8787";
 const adminToken = process.env.NANOCODEX_ADMIN_TOKEN ?? "local-admin-token";
 const terminalTimeoutMs = Number(process.env.NANOCODEX_SMOKE_TIMEOUT_MS ?? 180_000);
+const idleTimeoutMs = Number(process.env.NANOCODEX_SMOKE_IDLE_TIMEOUT_MS ?? 45_000);
+let currentStage = "create-session";
 
 const session = await createSession();
-const socket = new WebSocket(session.websocket_url);
+progress("session-created");
 const agentEvents = [];
-const inbox = createInbox(socket, (message) => {
-  if (message.type === "event") agentEvents.push(message.event);
-});
+let { socket, inbox } = connectClient();
 
 try {
+  currentStage = "websocket-ready";
   await inbox.next((message) => message.type === "ready", 10_000);
+  progress("websocket-ready");
 
+  currentStage = "first-turn";
   const firstId = randomUUID();
   const firstStarted = performance.now();
   socket.send(JSON.stringify({
@@ -28,24 +31,41 @@ try {
     input: "This in-flight duplicate must not reach the model.",
   }));
   const first = await terminal(inbox, firstId, terminalTimeoutMs);
+  progress("first-turn-completed");
   const firstMs = performance.now() - firstStarted;
   if (!String(first.final_message).includes("EDGE_OK")) {
     throw new Error(`first turn returned an unexpected answer: ${first.final_message}`);
   }
 
+  currentStage = "terminal-replay";
   socket.send(JSON.stringify({ type: "prompt", id: firstId, input: "must not run" }));
   const replay = await terminal(inbox, firstId, 10_000);
   if (replay.final_message !== first.final_message) {
     throw new Error("completed turn replay changed its terminal result");
   }
+  progress("terminal-replay-verified");
 
+  currentStage = "client-detach";
+  inbox.close();
+  await disconnect(socket);
+  progress("client-detached");
+
+  currentStage = "idle-unload";
   const idleStarted = performance.now();
   const idleState = await pollState(
     (state) => state.completed_turns === 1 && state.agent_loaded === false,
-    20_000,
+    idleTimeoutMs,
   );
   const idleShutdownMs = performance.now() - idleStarted;
+  progress("idle-unload-verified");
 
+  currentStage = "client-reconnect";
+  ({ socket, inbox } = connectClient());
+  const resumed = await inbox.next((message) => message.type === "ready", 10_000);
+  if (resumed.restored !== true) throw new Error("reconnected session was not restored from a snapshot");
+  progress("client-reconnected");
+
+  currentStage = "restored-turn";
   const secondId = randomUUID();
   const secondStarted = performance.now();
   socket.send(JSON.stringify({
@@ -54,11 +74,13 @@ try {
     input: "What exact token did I ask you to return previously? Reply with only that token.",
   }));
   const second = await terminal(inbox, secondId, terminalTimeoutMs);
+  progress("restored-turn-completed");
   const restoreMs = performance.now() - secondStarted;
   if (!String(second.final_message).includes("EDGE_OK")) {
     throw new Error(`restored turn lost conversation history: ${second.final_message}`);
   }
 
+  currentStage = "tool-turn";
   const toolId = randomUUID();
   socket.send(JSON.stringify({
     type: "prompt",
@@ -66,6 +88,7 @@ try {
     input: "You must call runtimeInfo exactly once. Then reply with only the runtime value returned by that tool.",
   }));
   const toolTurn = await terminal(inbox, toolId, terminalTimeoutMs);
+  progress("tool-turn-completed");
   if (!String(toolTurn.final_message).includes("cloudflare-durable-object")) {
     throw new Error(`runtimeInfo tool returned an unexpected answer: ${toolTurn.final_message}`);
   }
@@ -95,10 +118,31 @@ try {
     ...(authStatus === undefined ? {} : { auth_revision: authStatus.revision }),
     status: "ok",
   }));
+} catch (error) {
+  const diagnosticState = await state().catch((stateError) => ({ error: errorMessage(stateError) }));
+  const eventTypes = Object.entries(Object.groupBy(agentEvents, (event) => event.type))
+    .map(([type, events]) => [type, events.length]);
+  console.error(JSON.stringify({
+    stage: currentStage,
+    error: errorMessage(error),
+    state: diagnosticState,
+    event_types: Object.fromEntries(eventTypes),
+    last_event: agentEvents.at(-1)?.type,
+  }));
+  throw error;
 } finally {
   inbox.close();
   socket.close(1000, "smoke complete");
   await fetch(`${baseUrl}/sessions/${session.session_id}`, { method: "DELETE" }).catch(() => {});
+}
+
+function progress(stage) {
+  currentStage = stage;
+  process.stderr.write(`[smoke] ${stage}\n`);
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
 }
 
 async function createSession() {
@@ -112,7 +156,12 @@ async function createSession() {
 
 async function state() {
   const response = await fetch(`${baseUrl}/sessions/${session.session_id}`);
-  if (!response.ok) throw new Error(`state failed with HTTP ${response.status}: ${await response.text()}`);
+  if (!response.ok) {
+    throw Object.assign(
+      new Error(`state failed with HTTP ${response.status}: ${await response.text()}`),
+      { status: response.status },
+    );
+  }
   return response.json();
 }
 
@@ -126,12 +175,45 @@ async function subscriptionStatus() {
 
 async function pollState(predicate, timeoutMs) {
   const deadline = performance.now() + timeoutMs;
+  let lastError;
   while (performance.now() < deadline) {
-    const current = await state();
-    if (predicate(current)) return current;
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    try {
+      const current = await state();
+      if (predicate(current)) return current;
+      lastError = undefined;
+    } catch (error) {
+      if (Number(error?.status) < 500) throw error;
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
   }
-  throw new Error(`state did not reach the expected condition within ${timeoutMs}ms`);
+  throw new Error(
+    `state did not reach the expected condition within ${timeoutMs}ms` +
+      (lastError ? `: ${errorMessage(lastError)}` : ""),
+  );
+}
+
+function connectClient() {
+  const socket = new WebSocket(session.websocket_url);
+  const inbox = createInbox(socket, (message) => {
+    if (message.type === "event") agentEvents.push(message.event);
+  });
+  return { socket, inbox };
+}
+
+function disconnect(socket) {
+  if (socket.readyState === WebSocket.CLOSED) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      socket.terminate();
+      resolve();
+    }, 2_000);
+    socket.once("close", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    socket.close(1000, "smoke detach");
+  });
 }
 
 async function terminal(inbox, id, timeoutMs) {

--- a/examples/cloudflare-workers/scripts/mock-openai.mjs
+++ b/examples/cloudflare-workers/scripts/mock-openai.mjs
@@ -1,8 +1,12 @@
 import { createServer } from "node:http";
-import { WebSocketServer } from "ws";
+import { WebSocket, WebSocketServer } from "ws";
 
 const port = Number(process.env.NANOCODEX_MOCK_OPENAI_PORT ?? 8790);
+const responseDelayMs = Number(process.env.NANOCODEX_MOCK_DELAY_MS ?? 0);
 const accountId = process.env.NANOCODEX_MOCK_CHATGPT_ACCOUNT_ID ?? "local-chatgpt-account";
+if (!Number.isFinite(responseDelayMs) || responseDelayMs < 0 || responseDelayMs > 60_000) {
+  throw new Error("NANOCODEX_MOCK_DELAY_MS must be between 0 and 60000");
+}
 const accessToken = jwt({ exp: Math.floor(Date.now() / 1000) + 3_600 });
 const idToken = jwt({
   exp: Math.floor(Date.now() / 1000) + 3_600,
@@ -51,7 +55,7 @@ server.on("upgrade", (request, socket, head) => {
 });
 
 sockets.on("connection", (socket) => {
-  socket.on("message", (data) => {
+  socket.on("message", async (data) => {
     const request = JSON.parse(data.toString("utf8"));
     const encoded = JSON.stringify(request.input ?? []);
     const exactToken = encoded.match(/Reply with exactly ([A-Z0-9_-]{1,128})/)?.[1];
@@ -78,6 +82,10 @@ sockets.on("connection", (socket) => {
       } : {}),
       usage: null,
     };
+    if (responseDelayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, responseDelayMs));
+    }
+    if (socket.readyState !== WebSocket.OPEN) return;
     socket.send(JSON.stringify({ type: "response.completed", response }));
   });
 });

--- a/examples/cloudflare-workers/scripts/mock-openai.mjs
+++ b/examples/cloudflare-workers/scripts/mock-openai.mjs
@@ -1,0 +1,113 @@
+import { createServer } from "node:http";
+import { WebSocketServer } from "ws";
+
+const port = Number(process.env.NANOCODEX_MOCK_OPENAI_PORT ?? 8790);
+const accountId = process.env.NANOCODEX_MOCK_CHATGPT_ACCOUNT_ID ?? "local-chatgpt-account";
+const accessToken = jwt({ exp: Math.floor(Date.now() / 1000) + 3_600 });
+const idToken = jwt({
+  exp: Math.floor(Date.now() / 1000) + 3_600,
+  "https://api.openai.com/auth": {
+    chatgpt_account_id: accountId,
+    chatgpt_account_is_fedramp: false,
+  },
+});
+const server = createServer(async (request, response) => {
+  if (request.method !== "POST" || request.url !== "/oauth/token") {
+    response.writeHead(404).end();
+    return;
+  }
+  const body = await readBody(request, 16 * 1024);
+  const refresh = JSON.parse(body);
+  if (refresh.grant_type !== "refresh_token" || refresh.refresh_token !== currentRefreshToken) {
+    response.writeHead(401, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: { code: "refresh_token_invalidated" } }));
+    return;
+  }
+  currentRefreshToken = `local-rotated-refresh-token-${++refreshCount}`;
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end(JSON.stringify({
+    access_token: accessToken,
+    refresh_token: currentRefreshToken,
+    id_token: idToken,
+  }));
+});
+const sockets = new WebSocketServer({ noServer: true });
+let nextResponse = 1;
+let currentRefreshToken = "local-refresh-token";
+let refreshCount = 0;
+
+server.on("upgrade", (request, socket, head) => {
+  const subscription = request.url?.includes("/backend-api/codex/responses");
+  if (subscription && (
+    request.headers.authorization !== `Bearer ${accessToken}`
+    || request.headers["chatgpt-account-id"] !== accountId
+  )) {
+    socket.end("HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n");
+    return;
+  }
+  sockets.handleUpgrade(request, socket, head, (websocket) => {
+    sockets.emit("connection", websocket, request);
+  });
+});
+
+sockets.on("connection", (socket) => {
+  socket.on("message", (data) => {
+    const request = JSON.parse(data.toString("utf8"));
+    const encoded = JSON.stringify(request.input ?? []);
+    const exactToken = encoded.match(/Reply with exactly ([A-Z0-9_-]{1,128})/)?.[1];
+    const burstCount = Number(encoded.match(/Emit BURST_(\d{1,4})/)?.[1] ?? 0);
+    const hasUserPrompt = encoded.includes("Reply with exactly EDGE_OK")
+      || encoded.includes("What exact token did I ask you to return previously?");
+    for (let index = 0; index < burstCount; index += 1) {
+      socket.send(JSON.stringify({
+        type: "response.output_text.delta",
+        output_index: 0,
+        content_index: 0,
+        delta: "x",
+      }));
+    }
+    const response = {
+      id: `mock-response-${nextResponse++}`,
+      status: "completed",
+      ...(exactToken || hasUserPrompt || burstCount > 0 ? {
+        output: [{
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: exactToken ?? (burstCount > 0 ? "BURST_OK" : "EDGE_OK") }],
+        }],
+      } : {}),
+      usage: null,
+    };
+    socket.send(JSON.stringify({ type: "response.completed", response }));
+  });
+});
+
+await new Promise((resolve, reject) => {
+  server.listen(port, "127.0.0.1", resolve);
+  server.once("error", reject);
+});
+console.log(`mock Responses + OAuth server listening on http://127.0.0.1:${port}`);
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => {
+    for (const socket of sockets.clients) socket.terminate();
+    sockets.close();
+    server.close(() => process.exit(0));
+  });
+}
+
+function jwt(payload) {
+  const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "none" })}.${encode(payload)}.local`;
+}
+
+async function readBody(request, limit) {
+  const chunks = [];
+  let bytes = 0;
+  for await (const chunk of request) {
+    bytes += chunk.length;
+    if (bytes > limit) throw new Error(`request exceeded ${limit} bytes`);
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}

--- a/examples/cloudflare-workers/scripts/multiclient-smoke.mjs
+++ b/examples/cloudflare-workers/scripts/multiclient-smoke.mjs
@@ -1,0 +1,102 @@
+import { randomUUID } from "node:crypto";
+import WebSocket from "ws";
+
+const baseUrl = process.env.NANOCODEX_WORKER_URL ?? "http://127.0.0.1:8787";
+const adminToken = process.env.NANOCODEX_ADMIN_TOKEN ?? "local-admin-token";
+const clientCount = Number(process.env.NANOCODEX_MULTICLIENT_CLIENTS ?? 2);
+const timeoutMs = Number(process.env.NANOCODEX_MULTICLIENT_TIMEOUT_MS ?? 120_000);
+
+if (!Number.isSafeInteger(clientCount) || clientCount < 2 || clientCount > 64) {
+  throw new Error("NANOCODEX_MULTICLIENT_CLIENTS must be 2-64");
+}
+
+const created = await fetch(`${baseUrl}/sessions`, {
+  method: "POST",
+  headers: { authorization: `Bearer ${adminToken}` },
+});
+if (!created.ok) throw new Error(`session creation failed with HTTP ${created.status}: ${await created.text()}`);
+const session = await created.json();
+const sockets = [];
+
+try {
+  const receivers = await Promise.all(Array.from({ length: clientCount }, async () => {
+    const socket = new WebSocket(session.websocket_url);
+    sockets.push(socket);
+    const ready = deferred();
+    const terminal = deferred();
+    let accepted = false;
+    let events = 0;
+    let text = "";
+    socket.on("message", (encoded) => {
+      const message = JSON.parse(String(encoded));
+      if (message.type === "ready") ready.resolve();
+      if (message.type === "turn_accepted") accepted = true;
+      if (message.type === "event") {
+        events += 1;
+        if (message.event?.type === "assistant.delta" && typeof message.event.payload?.text === "string") {
+          text += message.event.payload.text;
+        }
+      }
+      if (message.type === "turn_completed" || message.type === "turn_failed") terminal.resolve(message);
+    });
+    await withTimeout(ready.promise, 10_000, "WebSocket ready timed out");
+    return { socket, terminal, accepted: () => accepted, events: () => events, text: () => text };
+  }));
+
+  const id = randomUUID();
+  receivers[0].socket.send(JSON.stringify({
+    type: "prompt",
+    id,
+    input: "Reply with exactly MULTICLIENT_OK and nothing else.",
+  }));
+  const terminals = await withTimeout(
+    Promise.all(receivers.map(({ terminal }) => terminal.promise)),
+    timeoutMs,
+    "shared turn timed out",
+  );
+  const first = terminals[0];
+  if (first.type !== "turn_completed" || !first.final_message.includes("MULTICLIENT_OK")) {
+    throw new Error(`unexpected terminal: ${JSON.stringify(first)}`);
+  }
+  if (terminals.some((terminal) => JSON.stringify(terminal) !== JSON.stringify(first))) {
+    throw new Error("clients received different terminal results");
+  }
+  if (receivers.some(({ accepted }) => !accepted())) throw new Error("a client missed turn_accepted");
+  const eventCounts = receivers.map(({ events }) => events());
+  const streamed = receivers.map(({ text }) => text());
+  if (new Set(eventCounts).size !== 1) throw new Error(`event counts diverged: ${eventCounts.join(",")}`);
+  if (!streamed[0] || new Set(streamed).size !== 1) throw new Error("assistant streams diverged");
+  console.log(JSON.stringify({
+    session_id: session.session_id,
+    clients: clientCount,
+    events_per_client: eventCounts[0],
+    streamed_bytes_per_client: Buffer.byteLength(streamed[0]),
+    terminal: first.final_message,
+    status: "ok",
+  }));
+} finally {
+  for (const socket of sockets) socket.terminate();
+  await fetch(`${baseUrl}/sessions/${session.session_id}`, { method: "DELETE" }).catch(() => {});
+}
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+async function withTimeout(promise, milliseconds, message) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => { timer = setTimeout(() => reject(new Error(message)), milliseconds); }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/examples/cloudflare-workers/scripts/prepare-wasm.mjs
+++ b/examples/cloudflare-workers/scripts/prepare-wasm.mjs
@@ -1,0 +1,9 @@
+import { copyFile, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const wasmSource = fileURLToPath(import.meta.resolve("nanocodex/wasm"));
+const wasmTarget = resolve(dirname(fileURLToPath(import.meta.url)), "../src/nanocodex.wasm");
+
+await mkdir(dirname(wasmTarget), { recursive: true });
+await copyFile(wasmSource, wasmTarget);

--- a/examples/cloudflare-workers/scripts/repl.mjs
+++ b/examples/cloudflare-workers/scripts/repl.mjs
@@ -1,0 +1,198 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { createInterface } from "node:readline";
+
+import WebSocket from "ws";
+
+const baseUrl = (process.env.NANOCODEX_WORKER_URL ?? "http://127.0.0.1:8787").replace(/\/$/, "");
+const adminToken = process.env.NANOCODEX_ADMIN_TOKEN ?? "local-admin-token";
+const statePath = resolve(process.env.NANOCODEX_REPL_STATE ?? ".nanocodex/cloudflare-repl.json");
+let state = await loadState();
+let client;
+let input;
+let interrupted = false;
+
+if (state && state.base_url !== baseUrl) {
+  throw new Error(
+    `${statePath} belongs to ${state.base_url}; set NANOCODEX_REPL_STATE to use another Worker`,
+  );
+}
+if (!state) {
+  const session = await createSession();
+  state = {
+    base_url: baseUrl,
+    session_id: session.session_id,
+    websocket_url: session.websocket_url,
+  };
+  await saveState();
+}
+
+const detach = () => {
+  if (interrupted) return;
+  interrupted = true;
+  input?.close();
+  client?.close();
+  process.stderr.write(state.pending
+    ? "\nDetached. Re-run the REPL to resume this turn.\n"
+    : "\nREPL closed.\n");
+  process.exitCode = 130;
+};
+process.once("SIGINT", detach);
+
+try {
+  client = connect(state.websocket_url);
+  const ready = await client.ready;
+  process.stdout.write(
+    `Nanocodex Cloudflare REPL (${state.session_id}${ready.restored ? ", restored" : ""})\n`,
+  );
+  if (state.pending) await completePending(state.pending, true);
+
+  input = createInterface({ input: process.stdin, output: process.stdout, prompt: "nanocodex> " });
+  input.on("SIGINT", detach);
+  input.prompt();
+  for await (const line of input) {
+    const prompt = line.trim();
+    if (!prompt) {
+      input.prompt();
+      continue;
+    }
+    if (prompt === "/exit" || prompt === "/quit") break;
+    if (prompt === "/status") {
+      process.stdout.write(`${JSON.stringify(await sessionStatus())}\n`);
+      input.prompt();
+      continue;
+    }
+
+    const pending = { id: randomUUID(), input: prompt };
+    state.pending = pending;
+    await saveState();
+    await completePending(pending, false);
+    if (interrupted) break;
+    input.prompt();
+  }
+} catch (error) {
+  if (!interrupted) throw error;
+} finally {
+  input?.close();
+  client?.close();
+}
+
+async function completePending(pending, resumed) {
+  process.stderr.write(
+    `${resumed ? "Resuming" : "Starting"} ${pending.id}. Ctrl-C detaches.\n`,
+  );
+  const terminal = await client.prompt(pending);
+  if (state.pending?.id === pending.id) {
+    delete state.pending;
+    await saveState();
+  }
+  if (terminal.type === "turn_failed") {
+    throw new Error(`turn ${terminal.id} failed: ${terminal.error}`);
+  }
+  process.stdout.write(`${terminal.final_message}\n`);
+}
+
+function connect(url) {
+  const socket = new WebSocket(url);
+  let readySettled = false;
+  let resolveReady;
+  let rejectReady;
+  const waiters = new Map();
+  const ready = new Promise((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+
+  socket.on("message", (data) => {
+    const message = JSON.parse(String(data));
+    if (message.type === "ready" && !readySettled) {
+      readySettled = true;
+      resolveReady(message);
+      return;
+    }
+    if (message.type !== "turn_completed" && message.type !== "turn_failed") return;
+    const waiter = waiters.get(message.id);
+    if (!waiter) return;
+    waiters.delete(message.id);
+    waiter.resolve(message);
+  });
+  socket.on("close", (code, reason) => {
+    const error = new Error(`session WebSocket closed with code ${code}: ${String(reason)}`);
+    if (!readySettled) {
+      readySettled = true;
+      rejectReady(error);
+    }
+    for (const waiter of waiters.values()) waiter.reject(error);
+    waiters.clear();
+  });
+  socket.on("error", (error) => {
+    if (!readySettled) {
+      readySettled = true;
+      rejectReady(error);
+    }
+  });
+
+  return {
+    ready,
+    prompt(pending) {
+      if (waiters.has(pending.id)) throw new Error(`turn ${pending.id} already has a local waiter`);
+      const terminal = new Promise((resolve, reject) => {
+        waiters.set(pending.id, { resolve, reject });
+      });
+      socket.send(JSON.stringify({ type: "prompt", ...pending }));
+      return terminal;
+    },
+    close() {
+      if (socket.readyState !== WebSocket.CLOSED) socket.terminate();
+    },
+  };
+}
+
+async function createSession() {
+  const response = await fetch(`${baseUrl}/sessions`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${adminToken}` },
+  });
+  if (!response.ok) {
+    throw new Error(`session creation failed with HTTP ${response.status}: ${await response.text()}`);
+  }
+  return response.json();
+}
+
+async function sessionStatus() {
+  const response = await fetch(`${baseUrl}/sessions/${state.session_id}`);
+  if (!response.ok) throw new Error(`session status failed with HTTP ${response.status}: ${await response.text()}`);
+  return response.json();
+}
+
+async function loadState() {
+  try {
+    const parsed = JSON.parse(await readFile(statePath, "utf8"));
+    if (typeof parsed.base_url !== "string"
+      || typeof parsed.session_id !== "string"
+      || typeof parsed.websocket_url !== "string") {
+      throw new Error("missing Worker URL or session capability");
+    }
+    if (parsed.pending && (
+      typeof parsed.pending.id !== "string" || typeof parsed.pending.input !== "string"
+    )) {
+      throw new Error("invalid pending turn");
+    }
+    return parsed;
+  } catch (error) {
+    if (error?.code === "ENOENT") return undefined;
+    throw new Error(`cannot read ${statePath}: ${errorMessage(error)}`);
+  }
+}
+
+async function saveState() {
+  await mkdir(dirname(statePath), { recursive: true, mode: 0o700 });
+  const temporary = `${statePath}.${process.pid}.tmp`;
+  await writeFile(temporary, `${JSON.stringify(state)}\n`, { mode: 0o600 });
+  await rename(temporary, statePath);
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/examples/cloudflare-workers/scripts/soak.mjs
+++ b/examples/cloudflare-workers/scripts/soak.mjs
@@ -1,0 +1,109 @@
+import { randomUUID } from "node:crypto";
+import WebSocket from "ws";
+
+const baseUrl = process.env.NANOCODEX_WORKER_URL ?? "http://127.0.0.1:8787";
+const adminToken = process.env.NANOCODEX_ADMIN_TOKEN ?? "local-admin-token";
+const sessionCount = Number(process.env.NANOCODEX_SOAK_SESSIONS ?? 16);
+const timeoutMs = Number(process.env.NANOCODEX_SOAK_TIMEOUT_MS ?? 60_000);
+
+if (!Number.isSafeInteger(sessionCount) || sessionCount < 1 || sessionCount > 128) {
+  throw new Error("sessions must be 1-128");
+}
+
+const sessions = [];
+const sockets = [];
+const started = performance.now();
+try {
+  await Promise.all(Array.from({ length: sessionCount }, async () => {
+    sessions.push(await createSession());
+  }));
+  const clients = await Promise.all(sessions.map(async (session, index) => {
+    const socket = new WebSocket(session.websocket_url);
+    sockets.push(socket);
+    const inbox = createInbox(socket);
+    await inbox.next((message) => message.type === "ready", 10_000);
+    return { inbox, index, session, socket };
+  }));
+
+  await Promise.all(clients.map(async ({ inbox, index, socket }) => {
+    const id = randomUUID();
+    const token = `SESSION_${String(index).padStart(3, "0")}`;
+    socket.send(JSON.stringify({ type: "prompt", id, input: `Reply with exactly ${token}` }));
+    socket.send(JSON.stringify({
+      type: "prompt",
+      id,
+      input: "Reply with exactly DUPLICATE_MUST_NOT_RUN",
+    }));
+    const result = await inbox.next(
+      (message) => ["turn_completed", "turn_failed"].includes(message.type) && message.id === id,
+      timeoutMs,
+    );
+    if (result.type === "turn_failed") throw new Error(`session ${index} failed: ${result.error}`);
+    if (result.final_message !== token) {
+      throw new Error(`session ${index} crossed streams: expected ${token}, got ${result.final_message}`);
+    }
+  }));
+
+  const states = await Promise.all(sessions.map(async ({ session_id }) => {
+    const response = await fetch(`${baseUrl}/sessions/${session_id}`);
+    if (!response.ok) throw new Error(`state failed with HTTP ${response.status}`);
+    return response.json();
+  }));
+  if (states.some((state) => state.completed_turns !== 1 || state.has_snapshot !== true)) {
+    throw new Error(`unexpected durable states: ${JSON.stringify(states)}`);
+  }
+
+  const elapsedMs = performance.now() - started;
+  console.log(JSON.stringify({
+    sessions: sessionCount,
+    completed_turns: states.reduce((sum, state) => sum + state.completed_turns, 0),
+    elapsed_ms: Math.round(elapsedMs),
+    turns_per_second: Math.round(sessionCount / (elapsedMs / 1000)),
+    status: "ok",
+  }));
+} finally {
+  for (const socket of sockets) socket.terminate();
+  await Promise.all(sessions.map(({ session_id }) => fetch(`${baseUrl}/sessions/${session_id}`, {
+    method: "DELETE",
+  }).catch(() => {})));
+}
+
+async function createSession() {
+  const response = await fetch(`${baseUrl}/sessions`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${adminToken}` },
+  });
+  if (!response.ok) throw new Error(`session creation failed with HTTP ${response.status}: ${await response.text()}`);
+  return response.json();
+}
+
+function createInbox(socket) {
+  const messages = [];
+  const waiters = [];
+  const onMessage = (data) => {
+    const message = JSON.parse(String(data));
+    const index = waiters.findIndex(({ predicate }) => predicate(message));
+    if (index === -1) messages.push(message);
+    else waiters.splice(index, 1)[0].resolve(message);
+  };
+  socket.on("message", onMessage);
+  return {
+    next(predicate, timeout) {
+      const index = messages.findIndex(predicate);
+      if (index !== -1) return Promise.resolve(messages.splice(index, 1)[0]);
+      return new Promise((resolve, reject) => {
+        const waiter = { predicate, resolve };
+        waiters.push(waiter);
+        const timer = setTimeout(() => {
+          const pending = waiters.indexOf(waiter);
+          if (pending !== -1) waiters.splice(pending, 1);
+          reject(new Error(`WebSocket message timed out after ${timeout}ms`));
+        }, timeout);
+        waiter.resolve = (message) => {
+          clearTimeout(timer);
+          resolve(message);
+        };
+      });
+    },
+  };
+}

--- a/examples/cloudflare-workers/scripts/stress.mjs
+++ b/examples/cloudflare-workers/scripts/stress.mjs
@@ -1,0 +1,91 @@
+import WebSocket from "ws";
+
+const baseUrl = process.env.NANOCODEX_WORKER_URL ?? "http://127.0.0.1:8787";
+const adminToken = process.env.NANOCODEX_ADMIN_TOKEN ?? "local-admin-token";
+const clients = Number(process.env.NANOCODEX_STRESS_CLIENTS ?? 32);
+const pingsPerClient = Number(process.env.NANOCODEX_STRESS_PINGS ?? 128);
+const expected = clients * pingsPerClient;
+
+if (!Number.isSafeInteger(clients) || clients < 1 || clients > 256) throw new Error("clients must be 1-256");
+if (!Number.isSafeInteger(pingsPerClient) || pingsPerClient < 1 || pingsPerClient > 10_000) {
+  throw new Error("pings per client must be 1-10000");
+}
+
+const created = await fetch(`${baseUrl}/sessions`, {
+  method: "POST",
+  headers: { authorization: `Bearer ${adminToken}` },
+});
+if (!created.ok) throw new Error(`session creation failed with HTTP ${created.status}: ${await created.text()}`);
+const session = await created.json();
+const sockets = [];
+
+try {
+  await Promise.all(Array.from({ length: clients }, async () => {
+    const socket = new WebSocket(session.websocket_url);
+    await onceMessage(socket, (message) => message.type === "ready", 10_000);
+    sockets.push(socket);
+  }));
+
+  let received = 0;
+  const seen = new Set();
+  const completed = Promise.withResolvers();
+  const started = performance.now();
+  for (const [client, socket] of sockets.entries()) {
+    socket.on("message", (data) => {
+      const message = JSON.parse(String(data));
+      if (message.type !== "pong") return;
+      seen.add(message.nonce);
+      received += 1;
+      if (received === expected) completed.resolve();
+    });
+    for (let ping = 0; ping < pingsPerClient; ping += 1) {
+      socket.send(JSON.stringify({ type: "ping", nonce: `${client}:${ping}` }));
+    }
+  }
+  await withTimeout(completed.promise, 30_000, "stress run timed out");
+  const elapsedMs = performance.now() - started;
+  if (seen.size !== expected) throw new Error(`received ${seen.size} unique nonces, expected ${expected}`);
+
+  console.log(JSON.stringify({
+    clients,
+    messages: expected,
+    elapsed_ms: Math.round(elapsedMs),
+    messages_per_second: Math.round(expected / (elapsedMs / 1000)),
+    status: "ok",
+  }));
+} finally {
+  for (const socket of sockets) socket.close(1000, "stress complete");
+  await fetch(`${baseUrl}/sessions/${session.session_id}`, { method: "DELETE" }).catch(() => {});
+}
+
+function onceMessage(socket, predicate, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const onError = (error) => finish(() => reject(error));
+    const timer = setTimeout(() => finish(() => reject(new Error("WebSocket open timed out"))), timeoutMs);
+    const onMessage = (data) => {
+      const message = JSON.parse(String(data));
+      if (!predicate(message)) return;
+      finish(() => resolve(message));
+    };
+    socket.on("message", onMessage);
+    socket.on("error", onError);
+    function finish(done) {
+      clearTimeout(timer);
+      socket.off("message", onMessage);
+      socket.off("error", onError);
+      done();
+    }
+  });
+}
+
+async function withTimeout(promise, timeoutMs, message) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => { timer = setTimeout(() => reject(new Error(message)), timeoutMs); }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/examples/cloudflare-workers/scripts/subscription-egress-proxy.mjs
+++ b/examples/cloudflare-workers/scripts/subscription-egress-proxy.mjs
@@ -29,6 +29,7 @@ export async function startSubscriptionEgressProxy(options = {}) {
     response.end("not found\n");
   });
   const websocketServer = new WebSocketServer({ noServer: true, maxPayload: MAX_BUFFERED_BYTES });
+  const emit = (type, detail = {}) => options.onEvent?.({ type, ...detail });
 
   server.on("connection", (socket) => {
     sockets.add(socket);
@@ -43,12 +44,14 @@ export async function startSubscriptionEgressProxy(options = {}) {
       return;
     }
     if (pathname !== path) {
+      emit("client.rejected", { status: 404 });
       rejectUpgrade(socket, 404, "not found");
       return;
     }
 
     const authorization = request.headers.authorization;
     if (typeof authorization !== "string" || !authorization.startsWith("Bearer ")) {
+      emit("client.rejected", { status: 401 });
       rejectUpgrade(socket, 401, "missing authorization");
       return;
     }
@@ -59,19 +62,32 @@ export async function startSubscriptionEgressProxy(options = {}) {
       maxPayload: MAX_BUFFERED_BYTES,
     });
     let upgraded = false;
+    let settled = false;
     upstream.once("open", () => {
+      if (settled || socket.destroyed) {
+        upstream.terminate();
+        return;
+      }
+      settled = true;
+      emit("upstream.open");
       websocketServer.handleUpgrade(request, socket, head, (client) => {
         upgraded = true;
-        bridge(client, upstream);
+        emit("client.open");
+        bridge(client, upstream, emit);
       });
     });
     upstream.once("unexpected-response", (_upstreamRequest, response) => {
-      if (upgraded || socket.destroyed) return;
+      if (settled || socket.destroyed) return;
+      settled = true;
+      emit("upstream.rejected", { status: response.statusCode ?? 502 });
       rejectUpgrade(socket, response.statusCode ?? 502, "upstream WebSocket rejected");
       upstream.terminate();
     });
     upstream.once("error", () => {
-      if (!upgraded && !socket.destroyed) rejectUpgrade(socket, 502, "upstream WebSocket failed");
+      if (settled || socket.destroyed) return;
+      settled = true;
+      emit("upstream.error");
+      rejectUpgrade(socket, 502, "upstream WebSocket failed");
     });
     socket.once("close", () => {
       if (!upgraded && upstream.readyState !== WebSocket.CLOSED) upstream.terminate();
@@ -105,7 +121,7 @@ function forwardedHeaders(source) {
   return headers;
 }
 
-function bridge(left, right) {
+function bridge(left, right, emit) {
   let closed = false;
   const relay = (source, destination) => (data, isBinary) => {
     if (closed || destination.readyState !== WebSocket.OPEN) return;
@@ -125,14 +141,26 @@ function bridge(left, right) {
   };
   left.on("message", relay(left, right));
   right.on("message", relay(right, left));
-  left.once("close", (code, reason) => closePeer(right, code, reason));
-  right.once("close", (code, reason) => closePeer(left, code, reason));
-  left.once("error", () => right.terminate());
-  right.once("error", () => left.terminate());
+  left.once("close", (code) => {
+    emit("client.close", { code });
+    closePeer(right, code);
+  });
+  right.once("close", (code) => {
+    emit("upstream.close", { code });
+    closePeer(left, code);
+  });
+  left.once("error", () => {
+    emit("client.error");
+    right.terminate();
+  });
+  right.once("error", () => {
+    emit("upstream.error");
+    left.terminate();
+  });
 }
 
-function closePeer(peer, code, reason) {
-  if (peer.readyState === WebSocket.OPEN) peer.close(safeCloseCode(code), reason.toString().slice(0, 120));
+function closePeer(peer, code) {
+  if (peer.readyState === WebSocket.OPEN) peer.close(safeCloseCode(code), "relay peer closed");
   else if (peer.readyState === WebSocket.CONNECTING) peer.terminate();
 }
 
@@ -142,7 +170,9 @@ function safeCloseCode(code) {
 }
 
 function rejectUpgrade(socket, status, message) {
+  if (socket.destroyed || socket.writableEnded) return;
   const body = `${message}\n`;
+  socket.once("error", () => {});
   socket.end(
     `HTTP/1.1 ${status} ${message}\r\nContent-Type: text/plain\r\nCache-Control: no-store\r\nContent-Length: ${Buffer.byteLength(body)}\r\nConnection: close\r\n\r\n${body}`,
   );

--- a/examples/cloudflare-workers/scripts/subscription-egress-proxy.mjs
+++ b/examples/cloudflare-workers/scripts/subscription-egress-proxy.mjs
@@ -1,0 +1,149 @@
+import { randomBytes } from "node:crypto";
+import { createServer } from "node:http";
+
+import WebSocket, { WebSocketServer } from "ws";
+
+const DEFAULT_UPSTREAM = "wss://chatgpt.com/backend-api/codex/responses";
+const MAX_BUFFERED_BYTES = 32 * 1024 * 1024;
+const FORWARDED_HEADERS = [
+  "authorization",
+  "chatgpt-account-id",
+  "openai-beta",
+  "session-id",
+  "thread-id",
+  "user-agent",
+  "x-client-request-id",
+  "x-codex-turn-state",
+  "x-openai-fedramp",
+  "x-openai-internal-codex-responses-lite",
+  "x-responsesapi-include-timing-metrics",
+];
+
+export async function startSubscriptionEgressProxy(options = {}) {
+  const upstreamUrl = options.upstreamUrl ?? DEFAULT_UPSTREAM;
+  const capability = randomBytes(32).toString("base64url");
+  const path = `/v1/${capability}`;
+  const sockets = new Set();
+  const server = createServer((_request, response) => {
+    response.writeHead(404, { "content-type": "text/plain", "cache-control": "no-store" });
+    response.end("not found\n");
+  });
+  const websocketServer = new WebSocketServer({ noServer: true, maxPayload: MAX_BUFFERED_BYTES });
+
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+  server.on("upgrade", (request, socket, head) => {
+    let pathname;
+    try {
+      pathname = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+    } catch {
+      rejectUpgrade(socket, 400, "bad request");
+      return;
+    }
+    if (pathname !== path) {
+      rejectUpgrade(socket, 404, "not found");
+      return;
+    }
+
+    const authorization = request.headers.authorization;
+    if (typeof authorization !== "string" || !authorization.startsWith("Bearer ")) {
+      rejectUpgrade(socket, 401, "missing authorization");
+      return;
+    }
+
+    const upstream = new WebSocket(upstreamUrl, {
+      handshakeTimeout: 15_000,
+      headers: forwardedHeaders(request.headers),
+      maxPayload: MAX_BUFFERED_BYTES,
+    });
+    let upgraded = false;
+    upstream.once("open", () => {
+      websocketServer.handleUpgrade(request, socket, head, (client) => {
+        upgraded = true;
+        bridge(client, upstream);
+      });
+    });
+    upstream.once("unexpected-response", (_upstreamRequest, response) => {
+      if (upgraded || socket.destroyed) return;
+      rejectUpgrade(socket, response.statusCode ?? 502, "upstream WebSocket rejected");
+      upstream.terminate();
+    });
+    upstream.once("error", () => {
+      if (!upgraded && !socket.destroyed) rejectUpgrade(socket, 502, "upstream WebSocket failed");
+    });
+    socket.once("close", () => {
+      if (!upgraded && upstream.readyState !== WebSocket.CLOSED) upstream.terminate();
+    });
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(options.port ?? 0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("subscription proxy did not bind TCP");
+
+  return {
+    url: `ws://127.0.0.1:${address.port}${path}`,
+    async close() {
+      websocketServer.clients.forEach((client) => client.terminate());
+      sockets.forEach((socket) => socket.destroy());
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    },
+  };
+}
+
+function forwardedHeaders(source) {
+  const headers = {};
+  for (const name of FORWARDED_HEADERS) {
+    const value = source[name];
+    if (typeof value === "string") headers[name] = value;
+    else if (Array.isArray(value) && value[0]) headers[name] = value[0];
+  }
+  return headers;
+}
+
+function bridge(left, right) {
+  let closed = false;
+  const relay = (source, destination) => (data, isBinary) => {
+    if (closed || destination.readyState !== WebSocket.OPEN) return;
+    if (destination.bufferedAmount + data.byteLength > MAX_BUFFERED_BYTES) {
+      closed = true;
+      source.close(1013, "relay backpressure limit");
+      destination.close(1013, "relay backpressure limit");
+      return;
+    }
+    destination.send(data, { binary: isBinary }, (error) => {
+      if (error && !closed) {
+        closed = true;
+        source.terminate();
+        destination.terminate();
+      }
+    });
+  };
+  left.on("message", relay(left, right));
+  right.on("message", relay(right, left));
+  left.once("close", (code, reason) => closePeer(right, code, reason));
+  right.once("close", (code, reason) => closePeer(left, code, reason));
+  left.once("error", () => right.terminate());
+  right.once("error", () => left.terminate());
+}
+
+function closePeer(peer, code, reason) {
+  if (peer.readyState === WebSocket.OPEN) peer.close(safeCloseCode(code), reason.toString().slice(0, 120));
+  else if (peer.readyState === WebSocket.CONNECTING) peer.terminate();
+}
+
+function safeCloseCode(code) {
+  const standard = code >= 1000 && code <= 1014 && ![1004, 1005, 1006].includes(code);
+  return standard || (code >= 3000 && code <= 4999) ? code : 1011;
+}
+
+function rejectUpgrade(socket, status, message) {
+  const body = `${message}\n`;
+  socket.end(
+    `HTTP/1.1 ${status} ${message}\r\nContent-Type: text/plain\r\nCache-Control: no-store\r\nContent-Length: ${Buffer.byteLength(body)}\r\nConnection: close\r\n\r\n${body}`,
+  );
+}

--- a/examples/cloudflare-workers/scripts/subscription-egress-relay.mjs
+++ b/examples/cloudflare-workers/scripts/subscription-egress-relay.mjs
@@ -1,0 +1,30 @@
+import { startSubscriptionEgressProxy } from "./subscription-egress-proxy.mjs";
+
+const port = Number(process.env.NANOCODEX_EGRESS_PORT ?? 8_791);
+if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+  throw new Error("NANOCODEX_EGRESS_PORT must be an integer from 1 through 65535");
+}
+
+const proxy = await startSubscriptionEgressProxy({
+  port,
+  upstreamUrl: process.env.OPENAI_WEBSOCKET_URL,
+  onEvent: ({ type, status, code }) => {
+    const detail = status === undefined ? (code === undefined ? "" : ` code=${code}`) : ` status=${status}`;
+    process.stderr.write(`[subscription-egress] ${type}${detail}\n`);
+  },
+});
+
+process.stdout.write(`${proxy.url}\n`);
+process.stderr.write(
+  `Subscription egress relay is bound to 127.0.0.1:${port}. ` +
+  "Preserve the printed capability path when exposing it.\n",
+);
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, async () => {
+    await proxy.close();
+    process.exit(0);
+  });
+}
+
+await new Promise(() => {});

--- a/examples/cloudflare-workers/src/index.ts
+++ b/examples/cloudflare-workers/src/index.ts
@@ -8,6 +8,7 @@ import type {
 } from "nanocodex";
 import { Agent } from "nanocodex/browser";
 import nanocodexWasm from "./nanocodex.wasm";
+import { webAsset } from "./web";
 import {
   NanocodexSubscriptionAuth,
   type SubscriptionSnapshot,
@@ -82,6 +83,10 @@ const json = (body: unknown, init: ResponseInit = {}) => Response.json(body, {
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
+    if (request.method === "GET") {
+      const asset = webAsset(url.pathname);
+      if (asset) return asset;
+    }
     if (request.method === "GET" && url.pathname === "/health") {
       return json({ service: "nanocodex", runtime: "cloudflare-durable-objects", status: "ok" });
     }
@@ -355,6 +360,10 @@ export class NanocodexSession extends DurableObject<Env> {
       resume,
       workspace: "/workspace",
       instructions: "You are Nanocodex running inside a Cloudflare Durable Object.",
+      // Workers forbid eval/new Function. Direct mode keeps caller-defined
+      // tools in the WASM lifecycle while dispatching handlers through the
+      // typed host bridge without dynamic code generation.
+      toolMode: "direct",
       createWebSocket: authMode === "api_key"
         ? openAiWebSocket
         : (endpoint, id, request) => openSubscriptionWebSocket(auth, endpoint, id, request),

--- a/examples/cloudflare-workers/src/index.ts
+++ b/examples/cloudflare-workers/src/index.ts
@@ -1,0 +1,661 @@
+import { DurableObject } from "cloudflare:workers";
+import type {
+  DefaultAgent,
+  EventWatcher,
+  SessionSnapshot,
+  Turn,
+  TurnResult,
+} from "nanocodex";
+import { Agent } from "nanocodex/browser";
+import nanocodexWasm from "./nanocodex.wasm";
+import {
+  NanocodexSubscriptionAuth,
+  type SubscriptionSnapshot,
+} from "./subscription-auth";
+
+export { NanocodexSubscriptionAuth } from "./subscription-auth";
+
+import {
+  type ClientCommand,
+  ProtocolError,
+  type ServerMessage,
+  type TurnCompleted,
+  parseCommand,
+} from "./protocol";
+
+const MAX_CLIENT_MESSAGE_BYTES = 1024 * 1024;
+const MAX_ACTIVE_TURNS = 16;
+const MAX_CLIENT_CONNECTIONS = 64;
+const MAX_TERMINAL_TURNS = 256;
+const OPENAI_WEBSOCKET_BETA = "responses_websockets=2026-02-06";
+const CHATGPT_WEBSOCKET_URL = "wss://chatgpt.com/backend-api/codex/responses";
+const CHATGPT_API_BASE_URL = "https://chatgpt.com/backend-api/codex";
+const SESSION_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const encoder = new TextEncoder();
+const ENCODED_PONG = JSON.stringify({ type: "pong" });
+
+export interface Env {
+  NANOCODEX_SESSIONS: DurableObjectNamespace<NanocodexSession>;
+  NANOCODEX_AUTH: DurableObjectNamespace<NanocodexSubscriptionAuth>;
+  OPENAI_API_KEY?: string;
+  NANOCODEX_ADMIN_TOKEN: string;
+  NANOCODEX_AUTH_MODE?: string;
+  AGENT_IDLE_TIMEOUT_MS?: string;
+  OPENAI_WEBSOCKET_URL?: string;
+  CHATGPT_ACCESS_TOKEN?: string;
+  CHATGPT_ACCOUNT_ID?: string;
+  CHATGPT_FEDRAMP?: string;
+  CHATGPT_REFRESH_TOKEN?: string;
+  CHATGPT_TOKEN_ENDPOINT?: string;
+}
+
+type SessionRow = {
+  session_id: string;
+  snapshot: string | null;
+  completed_turns: number;
+  last_active: number;
+};
+
+type TerminalRow = { payload: string };
+type SessionStatusRow = {
+  session_id: string;
+  has_snapshot: number;
+  completed_turns: number;
+  last_active: number;
+};
+
+type BrowserAuthRequest = {
+  accountId?: string;
+  authorization: "bearer" | "host_managed";
+  bearerToken?: string;
+  fedramp?: boolean;
+  turnState?: string;
+};
+
+type ModelAuthMode = "api_key" | "chatgpt";
+
+const json = (body: unknown, init: ResponseInit = {}) => Response.json(body, {
+  ...init,
+  headers: { "cache-control": "no-store", ...init.headers },
+});
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.method === "GET" && url.pathname === "/health") {
+      return json({ service: "nanocodex", runtime: "cloudflare-durable-objects", status: "ok" });
+    }
+    if (request.method === "POST" && url.pathname === "/sessions") {
+      if (!env.NANOCODEX_ADMIN_TOKEN) {
+        return json({ error: "NANOCODEX_ADMIN_TOKEN is not configured" }, { status: 503 });
+      }
+      if (!authorized(request, env.NANOCODEX_ADMIN_TOKEN)) {
+        return json({ error: "unauthorized" }, { status: 401 });
+      }
+      const sessionId = uuidV7();
+      const stub = env.NANOCODEX_SESSIONS.getByName(sessionId);
+      const initialized = await stub.fetch("https://session.internal/initialize", {
+        method: "PUT",
+        body: sessionId,
+      });
+      if (!initialized.ok) return json({ error: "session initialization failed" }, { status: 503 });
+      const websocketUrl = new URL(`/sessions/${sessionId}/ws`, url);
+      websocketUrl.protocol = websocketUrl.protocol === "https:" ? "wss:" : "ws:";
+      return json({ session_id: sessionId, websocket_url: websocketUrl.href }, { status: 201 });
+    }
+    if (url.pathname === "/auth/chatgpt") {
+      if (!env.NANOCODEX_ADMIN_TOKEN || !authorized(request, env.NANOCODEX_ADMIN_TOKEN)) {
+        return json({ error: "unauthorized" }, { status: 401 });
+      }
+      const auth = env.NANOCODEX_AUTH.getByName("subscription");
+      if (request.method === "GET") return auth.fetch("https://auth.internal/status");
+      if (request.method === "DELETE") {
+        return auth.fetch("https://auth.internal/credentials", { method: "DELETE" });
+      }
+      return json({ error: "method_not_allowed" }, { status: 405 });
+    }
+
+    const match = url.pathname.match(/^\/sessions\/([^/]+)(?:\/(ws))?$/);
+    if (!match || !SESSION_ID.test(match[1] ?? "")) {
+      return json({ error: "not_found" }, { status: 404 });
+    }
+    const sessionId = match[1]!;
+    const stub = env.NANOCODEX_SESSIONS.getByName(sessionId);
+    if (match[2] === "ws") {
+      if (request.method !== "GET" || request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+        return new Response("Expected WebSocket upgrade", { status: 426 });
+      }
+      return stub.fetch("https://session.internal/socket", request);
+    }
+    if (request.method === "GET") return stub.fetch("https://session.internal/state");
+    if (request.method === "DELETE") return stub.fetch("https://session.internal/session", { method: "DELETE" });
+    return json({ error: "method_not_allowed" }, { status: 405 });
+  },
+};
+
+export class NanocodexSession extends DurableObject<Env> {
+  #agent?: DefaultAgent;
+  #agentPromise?: Promise<DefaultAgent>;
+  #events?: EventWatcher;
+  readonly #turns = new Map<string, Turn>();
+  readonly #pendingTurnIds = new Set<string>();
+
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    this.ctx.storage.sql.exec(`
+      CREATE TABLE IF NOT EXISTS session_state (
+        singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+        session_id TEXT NOT NULL UNIQUE,
+        snapshot TEXT,
+        completed_turns INTEGER NOT NULL DEFAULT 0,
+        last_active INTEGER NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS terminal_turns (
+        id TEXT PRIMARY KEY,
+        payload TEXT NOT NULL,
+        completed_at INTEGER NOT NULL
+      );
+    `);
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.method === "PUT" && url.pathname === "/initialize") {
+      const sessionId = await request.text();
+      if (!SESSION_ID.test(sessionId)) return new Response(null, { status: 400 });
+      const currentId = this.#sessionId();
+      if (currentId && currentId !== sessionId) return new Response(null, { status: 409 });
+      if (!currentId) {
+        this.ctx.storage.sql.exec(
+          "INSERT INTO session_state (singleton, session_id, last_active) VALUES (1, ?, ?)",
+          sessionId,
+          Date.now(),
+        );
+      }
+      return new Response(null, { status: 204 });
+    }
+    if (request.method === "GET" && url.pathname === "/socket") return this.#upgrade();
+    if (request.method === "GET" && url.pathname === "/state") {
+      const session = this.#sessionStatus();
+      if (!session) return json({ error: "not_found" }, { status: 404 });
+      return json({
+        session_id: session.session_id,
+        has_snapshot: session.has_snapshot !== 0,
+        completed_turns: session.completed_turns,
+        last_active: session.last_active,
+        active_turns: this.#activeTurnIds(),
+        agent_loaded: this.#agent !== undefined,
+        connected_clients: this.ctx.getWebSockets().length,
+        auth_mode: modelAuthMode(this.env),
+      });
+    }
+    if (request.method === "DELETE" && url.pathname === "/session") {
+      await this.#stop();
+      for (const socket of this.ctx.getWebSockets()) closeSocket(socket, 1000, "session deleted");
+      this.ctx.storage.transactionSync(() => {
+        this.ctx.storage.sql.exec("DELETE FROM terminal_turns");
+        this.ctx.storage.sql.exec("DELETE FROM session_state");
+      });
+      await this.ctx.storage.deleteAlarm();
+      return new Response(null, { status: 204 });
+    }
+    return json({ error: "not_found" }, { status: 404 });
+  }
+
+  async webSocketMessage(socket: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    if (typeof message !== "string") {
+      this.#send(socket, { type: "error", code: "binary_unsupported", message: "text frames are required" });
+      return;
+    }
+    if (message.length > MAX_CLIENT_MESSAGE_BYTES
+      || encoder.encode(message).byteLength > MAX_CLIENT_MESSAGE_BYTES) {
+      closeSocket(socket, 1009, "message exceeds 1 MiB");
+      return;
+    }
+    let command: ClientCommand;
+    try {
+      command = parseCommand(message);
+    } catch (error) {
+      const protocol = error instanceof ProtocolError ? error : new ProtocolError("invalid_message", errorMessage(error));
+      this.#send(socket, { type: "error", code: protocol.code, message: protocol.message });
+      return;
+    }
+    await this.#dispatch(socket, command);
+  }
+
+  webSocketClose(socket: WebSocket, code: number, reason: string): void {
+    closeSocket(socket, code, reason || "peer closed");
+  }
+
+  webSocketError(socket: WebSocket): void {
+    closeSocket(socket, 1011, "WebSocket failed");
+  }
+
+  async alarm(): Promise<void> {
+    if (this.#turns.size > 0 || this.#pendingTurnIds.size > 0 || this.#agentPromise) {
+      await this.ctx.storage.setAlarm(Date.now() + this.#idleTimeoutMs());
+      return;
+    }
+    await this.#shutdownAgent();
+  }
+
+  #upgrade(): Response {
+    const session = this.#sessionStatus();
+    if (!session) return new Response("Unknown session", { status: 404 });
+    if (this.ctx.getWebSockets("client").length >= MAX_CLIENT_CONNECTIONS) {
+      return new Response("Session client limit reached", { status: 429 });
+    }
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+    server.serializeAttachment({ sessionId: session.session_id });
+    this.ctx.acceptWebSocket(server, ["client"]);
+    this.#send(server, {
+      type: "ready",
+      session_id: session.session_id,
+      restored: session.has_snapshot !== 0,
+      active_turns: this.#activeTurnIds(),
+    });
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  async #dispatch(socket: WebSocket, command: ClientCommand): Promise<void> {
+    if (command.type === "ping") {
+      if (command.nonce === undefined) this.#sendEncoded(socket, ENCODED_PONG);
+      else this.#send(socket, { type: "pong", nonce: command.nonce });
+      return;
+    }
+    if (command.type === "status") {
+      this.#send(socket, {
+        type: "status",
+        active_turns: this.#activeTurnIds(),
+        agent_loaded: this.#agent !== undefined,
+        connected_clients: this.ctx.getWebSockets().length,
+      });
+      return;
+    }
+    if (command.type === "steer" || command.type === "cancel") {
+      const turn = this.#turns.get(command.id);
+      if (!turn) {
+        this.#send(socket, { type: "error", code: "turn_not_active", message: `turn ${command.id} is not active` });
+        return;
+      }
+      try {
+        if (command.type === "steer") await turn.steer({ input: command.input });
+        else await turn.cancel();
+      } catch (error) {
+        this.#send(socket, { type: "error", code: `${command.type}_failed`, message: errorMessage(error) });
+      }
+      return;
+    }
+
+    const terminal = this.#terminal(command.id);
+    if (terminal) {
+      this.#sendEncoded(socket, terminal);
+      return;
+    }
+    if (this.#turns.has(command.id) || this.#pendingTurnIds.has(command.id)) {
+      this.#send(socket, { type: "turn_accepted", id: command.id, replayed: true });
+      return;
+    }
+    if (this.#turns.size + this.#pendingTurnIds.size >= MAX_ACTIVE_TURNS) {
+      this.#send(socket, { type: "error", code: "turn_queue_full", message: `at most ${MAX_ACTIVE_TURNS} turns may be active` });
+      return;
+    }
+    this.#pendingTurnIds.add(command.id);
+    this.#broadcast({ type: "turn_accepted", id: command.id, replayed: false });
+    try {
+      const agent = await this.#ensureAgent();
+      if (this.#agent !== agent) throw new Error("agent became unavailable while accepting the turn");
+      const turn = agent.turn.prompt({ input: command.input });
+      this.#turns.set(command.id, turn);
+      this.#pendingTurnIds.delete(command.id);
+      this.ctx.waitUntil(this.#complete(command.id, turn));
+    } catch (error) {
+      this.#pendingTurnIds.delete(command.id);
+      this.#broadcast({ type: "turn_failed", id: command.id, error: errorMessage(error) });
+      if (this.#turns.size === 0 && this.#agent) {
+        await this.ctx.storage.setAlarm(Date.now() + this.#idleTimeoutMs());
+      }
+    }
+  }
+
+  async #ensureAgent(): Promise<DefaultAgent> {
+    if (this.#agent) return this.#agent;
+    if (this.#agentPromise) return this.#agentPromise;
+    this.#agentPromise = this.#createAgent();
+    try {
+      this.#agent = await this.#agentPromise;
+      return this.#agent;
+    } finally {
+      this.#agentPromise = undefined;
+    }
+  }
+
+  async #createAgent(): Promise<DefaultAgent> {
+    const session = this.#session();
+    if (!session) throw new Error("session is not initialized");
+    const authMode = modelAuthMode(this.env);
+    if (authMode === "api_key" && !this.env.OPENAI_API_KEY) {
+      throw new Error("OPENAI_API_KEY is not configured");
+    }
+    const resume = session.snapshot === null
+      ? undefined
+      : JSON.parse(session.snapshot) as SessionSnapshot;
+    const auth = this.env.NANOCODEX_AUTH.getByName("subscription");
+    const authorization = authMode === "api_key"
+      ? { apiKey: this.env.OPENAI_API_KEY! }
+      : { hostAuth: true as const };
+    const agent = await Agent.create({
+      ...authorization,
+      module: nanocodexWasm,
+      websocketUrl: this.env.OPENAI_WEBSOCKET_URL
+        ?? (authMode === "chatgpt" ? CHATGPT_WEBSOCKET_URL : undefined),
+      apiBaseUrl: authMode === "chatgpt" ? CHATGPT_API_BASE_URL : undefined,
+      sessionId: session.session_id,
+      resume,
+      workspace: "/workspace",
+      instructions: "You are Nanocodex running inside a Cloudflare Durable Object.",
+      createWebSocket: authMode === "api_key"
+        ? openAiWebSocket
+        : (endpoint, id, request) => openSubscriptionWebSocket(auth, endpoint, id, request),
+      tools: {
+        runtimeInfo: {
+          description: "Return information about the current agent runtime.",
+          parameters: { type: "object", additionalProperties: false },
+          handler: () => ({ runtime: "cloudflare-durable-object", session_id: session.session_id }),
+        },
+      },
+    });
+    this.#events = agent.events.watch();
+    this.#events.onEvent((event) => this.#broadcast({ type: "event", event }));
+    return agent;
+  }
+
+  async #complete(id: string, turn: Turn): Promise<void> {
+    try {
+      let result: TurnResult;
+      try {
+        result = await turn.result();
+      } catch (error) {
+        this.#broadcast({ type: "turn_failed", id, error: errorMessage(error) });
+        return;
+      }
+      const terminal: TurnCompleted = {
+        type: "turn_completed",
+        id,
+        final_message: result.finalMessage,
+        usage: result.usage,
+      };
+      const snapshot = JSON.stringify(result.snapshot);
+      const payload = JSON.stringify(terminal);
+      const completedAt = Date.now();
+      try {
+        this.ctx.storage.transactionSync(() => {
+          this.ctx.storage.sql.exec(
+            "UPDATE session_state SET snapshot = ?, completed_turns = completed_turns + 1, last_active = ? WHERE singleton = 1",
+            snapshot,
+            completedAt,
+          );
+          this.ctx.storage.sql.exec(
+            "INSERT OR REPLACE INTO terminal_turns (id, payload, completed_at) VALUES (?, ?, ?)",
+            id,
+            payload,
+            completedAt,
+          );
+          this.ctx.storage.sql.exec(
+            "DELETE FROM terminal_turns WHERE id NOT IN (SELECT id FROM terminal_turns ORDER BY completed_at DESC, rowid DESC LIMIT ?)",
+            MAX_TERMINAL_TURNS,
+          );
+        });
+      } catch (error) {
+        // The in-memory driver has observed this completed turn, but durable
+        // state has not. Drop it so the next prompt cannot continue from a
+        // history prefix that clients cannot recover after eviction.
+        await this.#shutdownAgent();
+        this.#broadcast({ type: "turn_failed", id, error: `durable commit failed: ${errorMessage(error)}` });
+        return;
+      }
+      this.#broadcastEncoded(payload);
+    } finally {
+      this.#turns.delete(id);
+      turn.dispose();
+      if (this.#turns.size === 0) {
+        await this.ctx.storage.setAlarm(Date.now() + this.#idleTimeoutMs());
+      }
+    }
+  }
+
+  async #stop(): Promise<void> {
+    const cancellations = [...this.#turns.values()].map(async (turn) => {
+      try { await turn.cancel(); } catch { /* A terminal turn needs no cancellation. */ }
+    });
+    await Promise.all(cancellations);
+    await this.#shutdownAgent();
+    this.#turns.clear();
+    this.#pendingTurnIds.clear();
+  }
+
+  async #shutdownAgent(): Promise<void> {
+    let agent = this.#agent;
+    if (!agent && this.#agentPromise) {
+      try { agent = await this.#agentPromise; } catch { return; }
+    }
+    this.#agent = undefined;
+    this.#events?.off();
+    this.#events = undefined;
+    if (!agent) return;
+    try {
+      await agent.session.shutdown();
+    } catch (error) {
+      console.error("Nanocodex idle shutdown failed", errorMessage(error));
+    }
+  }
+
+  #session(): SessionRow | undefined {
+    return this.ctx.storage.sql.exec<SessionRow>(
+      "SELECT session_id, snapshot, completed_turns, last_active FROM session_state WHERE singleton = 1",
+    ).toArray()[0];
+  }
+
+  #sessionId(): string | undefined {
+    return this.ctx.storage.sql.exec<{ session_id: string }>(
+      "SELECT session_id FROM session_state WHERE singleton = 1",
+    ).toArray()[0]?.session_id;
+  }
+
+  #sessionStatus(): SessionStatusRow | undefined {
+    return this.ctx.storage.sql.exec<SessionStatusRow>(
+      `SELECT session_id, snapshot IS NOT NULL AS has_snapshot, completed_turns, last_active
+       FROM session_state WHERE singleton = 1`,
+    ).toArray()[0];
+  }
+
+  #terminal(id: string): string | undefined {
+    const row = this.ctx.storage.sql.exec<TerminalRow>(
+      "SELECT payload FROM terminal_turns WHERE id = ?",
+      id,
+    ).toArray()[0];
+    return row?.payload;
+  }
+
+  #activeTurnIds(): string[] {
+    return [...this.#pendingTurnIds, ...this.#turns.keys()];
+  }
+
+  #idleTimeoutMs(): number {
+    const configured = Number(this.env.AGENT_IDLE_TIMEOUT_MS ?? 30_000);
+    return Number.isFinite(configured) ? Math.min(15 * 60_000, Math.max(1_000, configured)) : 30_000;
+  }
+
+  #broadcast(message: ServerMessage): void {
+    this.#broadcastEncoded(JSON.stringify(message));
+  }
+
+  #broadcastEncoded(encoded: string): void {
+    for (const socket of this.ctx.getWebSockets("client")) this.#sendEncoded(socket, encoded);
+  }
+
+  #send(socket: WebSocket, message: ServerMessage): void {
+    this.#sendEncoded(socket, JSON.stringify(message));
+  }
+
+  #sendEncoded(socket: WebSocket, encoded: string): void {
+    if (socket.readyState !== WebSocket.OPEN) return;
+    try { socket.send(encoded); } catch { closeSocket(socket, 1011, "send failed"); }
+  }
+}
+
+async function openAiWebSocket(
+  endpoint: string,
+  sessionId: string,
+  request: BrowserAuthRequest,
+) {
+  if (request.authorization !== "bearer" || !request.bearerToken) {
+    throw new Error("the API-key WebSocket requires bearer authorization");
+  }
+  return upgradeOpenAiWebSocket(endpoint, sessionId, {
+    bearerToken: request.bearerToken,
+    accountId: request.accountId,
+    fedramp: request.fedramp,
+    turnState: request.turnState,
+  });
+}
+
+async function openSubscriptionWebSocket(
+  auth: DurableObjectStub<NanocodexSubscriptionAuth>,
+  endpoint: string,
+  sessionId: string,
+  request: BrowserAuthRequest,
+) {
+  if (request.authorization !== "host_managed") {
+    throw new Error("the ChatGPT WebSocket requires host-managed authorization");
+  }
+  let snapshot = await subscriptionSnapshot(auth, "/snapshot");
+  try {
+    return await upgradeOpenAiWebSocket(endpoint, sessionId, { ...snapshot, turnState: request.turnState });
+  } catch (error) {
+    if (Number((error as { status?: unknown })?.status) !== 401) throw error;
+    snapshot = await subscriptionSnapshot(auth, "/recover", snapshot.revision);
+    return upgradeOpenAiWebSocket(endpoint, sessionId, { ...snapshot, turnState: request.turnState });
+  }
+}
+
+async function subscriptionSnapshot(
+  auth: DurableObjectStub<NanocodexSubscriptionAuth>,
+  path: "/snapshot" | "/recover",
+  revision?: number,
+): Promise<SubscriptionSnapshot> {
+  const response = await auth.fetch(`https://auth.internal${path}`, {
+    method: "POST",
+    ...(revision === undefined ? {} : {
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ revision }),
+    }),
+  });
+  if (!response.ok) {
+    const detail = await readBoundedText(response, 4_096);
+    throw new Error(`ChatGPT authorization failed with HTTP ${response.status}: ${detail}`);
+  }
+  return response.json<SubscriptionSnapshot>();
+}
+
+async function upgradeOpenAiWebSocket(
+  endpoint: string,
+  sessionId: string,
+  request: { bearerToken: string; accountId?: string; fedramp?: boolean; turnState?: string },
+) {
+  const url = new URL(endpoint);
+  if (url.protocol === "wss:") url.protocol = "https:";
+  if (url.protocol === "ws:") url.protocol = "http:";
+  const headers = new Headers({
+    Authorization: `Bearer ${request.bearerToken}`,
+    Upgrade: "websocket",
+    "OpenAI-Beta": OPENAI_WEBSOCKET_BETA,
+    "x-openai-internal-codex-responses-lite": "true",
+    "session-id": sessionId,
+    "thread-id": sessionId,
+    "x-client-request-id": sessionId,
+    "x-responsesapi-include-timing-metrics": "true",
+    "User-Agent": "nanocodex-cloudflare-workers/0.1.0",
+  });
+  if (request.accountId) headers.set("ChatGPT-Account-ID", request.accountId);
+  if (request.fedramp) headers.set("X-OpenAI-Fedramp", "true");
+  if (request.turnState) headers.set("x-codex-turn-state", request.turnState);
+  const response = await fetch(url, { headers });
+  const socket = response.webSocket;
+  if (!socket) {
+    const body = await readBoundedText(response, 4_096);
+    const error = Object.assign(
+      new Error(`OpenAI WebSocket upgrade failed with HTTP ${response.status}: ${body}`),
+      { status: response.status, body },
+    );
+    const retryAfterHeader = response.headers.get("retry-after");
+    const retryAfter = Number(retryAfterHeader);
+    if (retryAfterHeader !== null && Number.isFinite(retryAfter) && retryAfter >= 0) {
+      Object.assign(error, { retryAfter });
+    }
+    throw error;
+  }
+  socket.accept();
+  return {
+    socket,
+    status: response.status,
+    requestId: response.headers.get("x-request-id") ?? undefined,
+    serverModel: response.headers.get("openai-model") ?? undefined,
+    reasoningIncluded: response.headers.has("x-reasoning-included"),
+    turnState: response.headers.get("x-codex-turn-state") ?? undefined,
+  };
+}
+
+function modelAuthMode(env: Env): ModelAuthMode {
+  const configured = env.NANOCODEX_AUTH_MODE ?? "api_key";
+  if (configured === "api_key" || configured === "chatgpt") return configured;
+  throw new Error("NANOCODEX_AUTH_MODE must be api_key or chatgpt");
+}
+
+function authorized(request: Request, expected: string): boolean {
+  const value = request.headers.get("authorization");
+  return value !== null && value === `Bearer ${expected}`;
+}
+
+function uuidV7(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  let timestamp = BigInt(Date.now());
+  for (let index = 5; index >= 0; index -= 1) {
+    bytes[index] = Number(timestamp & 0xffn);
+    timestamp >>= 8n;
+  }
+  bytes[6] = (bytes[6]! & 0x0f) | 0x70;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function closeSocket(socket: WebSocket, code: number, reason: string): void {
+  if (socket.readyState !== WebSocket.CONNECTING && socket.readyState !== WebSocket.OPEN) return;
+  const standard = code >= 1000 && code <= 1014 && ![1004, 1005, 1006].includes(code);
+  const safeCode = standard || (code >= 3000 && code <= 4999) ? code : 1011;
+  socket.close(safeCode, reason.slice(0, 120));
+}
+
+async function readBoundedText(response: Response, limit: number): Promise<string> {
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let total = 0;
+  let body = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) return body + decoder.decode();
+    total += value.byteLength;
+    if (total > limit) {
+      await reader.cancel();
+      return `${body}${decoder.decode(value.subarray(0, Math.max(0, limit - (total - value.byteLength))))}`;
+    }
+    body += decoder.decode(value, { stream: true });
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/examples/cloudflare-workers/src/index.ts
+++ b/examples/cloudflare-workers/src/index.ts
@@ -2,6 +2,7 @@ import { DurableObject } from "cloudflare:workers";
 import type {
   DefaultAgent,
   EventWatcher,
+  PromptInput,
   SessionSnapshot,
   Turn,
   TurnResult,
@@ -17,6 +18,7 @@ import {
 export { NanocodexSubscriptionAuth } from "./subscription-auth";
 
 import {
+  type ActiveTurn,
   type ClientCommand,
   ProtocolError,
   type ServerMessage,
@@ -144,6 +146,7 @@ export class NanocodexSession extends DurableObject<Env> {
   #events?: EventWatcher;
   readonly #turns = new Map<string, Turn>();
   readonly #pendingTurnIds = new Set<string>();
+  readonly #turnInputs = new Map<string, PromptInput>();
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
@@ -189,6 +192,7 @@ export class NanocodexSession extends DurableObject<Env> {
         completed_turns: session.completed_turns,
         last_active: session.last_active,
         active_turns: this.#activeTurnIds(),
+        active_turn_details: this.#activeTurnDetails(),
         agent_loaded: this.#agent !== undefined,
         connected_clients: this.ctx.getWebSockets().length,
         auth_mode: modelAuthMode(this.env),
@@ -259,6 +263,7 @@ export class NanocodexSession extends DurableObject<Env> {
       session_id: session.session_id,
       restored: session.has_snapshot !== 0,
       active_turns: this.#activeTurnIds(),
+      active_turn_details: this.#activeTurnDetails(),
     });
     return new Response(null, { status: 101, webSocket: client });
   }
@@ -273,6 +278,7 @@ export class NanocodexSession extends DurableObject<Env> {
       this.#send(socket, {
         type: "status",
         active_turns: this.#activeTurnIds(),
+        active_turn_details: this.#activeTurnDetails(),
         agent_loaded: this.#agent !== undefined,
         connected_clients: this.ctx.getWebSockets().length,
       });
@@ -299,7 +305,16 @@ export class NanocodexSession extends DurableObject<Env> {
       return;
     }
     if (this.#turns.has(command.id) || this.#pendingTurnIds.has(command.id)) {
-      this.#send(socket, { type: "turn_accepted", id: command.id, replayed: true });
+      const input = this.#turnInputs.get(command.id);
+      if (input !== undefined && JSON.stringify(input) !== JSON.stringify(command.input)) {
+        this.#send(socket, {
+          type: "error",
+          code: "turn_id_conflict",
+          message: `turn ${command.id} is already active with different input`,
+        });
+        return;
+      }
+      this.#send(socket, { type: "turn_accepted", id: command.id, input: input ?? command.input, replayed: true });
       return;
     }
     if (this.#turns.size + this.#pendingTurnIds.size >= MAX_ACTIVE_TURNS) {
@@ -307,7 +322,8 @@ export class NanocodexSession extends DurableObject<Env> {
       return;
     }
     this.#pendingTurnIds.add(command.id);
-    this.#broadcast({ type: "turn_accepted", id: command.id, replayed: false });
+    this.#turnInputs.set(command.id, command.input);
+    this.#broadcast({ type: "turn_accepted", id: command.id, input: command.input, replayed: false });
     try {
       const agent = await this.#ensureAgent();
       if (this.#agent !== agent) throw new Error("agent became unavailable while accepting the turn");
@@ -317,6 +333,7 @@ export class NanocodexSession extends DurableObject<Env> {
       this.ctx.waitUntil(this.#complete(command.id, turn));
     } catch (error) {
       this.#pendingTurnIds.delete(command.id);
+      this.#turnInputs.delete(command.id);
       this.#broadcast({ type: "turn_failed", id: command.id, error: errorMessage(error) });
       if (this.#turns.size === 0 && this.#agent) {
         await this.ctx.storage.setAlarm(Date.now() + this.#idleTimeoutMs());
@@ -427,6 +444,7 @@ export class NanocodexSession extends DurableObject<Env> {
       this.#broadcastEncoded(payload);
     } finally {
       this.#turns.delete(id);
+      this.#turnInputs.delete(id);
       turn.dispose();
       if (this.#turns.size === 0) {
         await this.ctx.storage.setAlarm(Date.now() + this.#idleTimeoutMs());
@@ -442,6 +460,7 @@ export class NanocodexSession extends DurableObject<Env> {
     await this.#shutdownAgent();
     this.#turns.clear();
     this.#pendingTurnIds.clear();
+    this.#turnInputs.clear();
   }
 
   async #shutdownAgent(): Promise<void> {
@@ -489,6 +508,13 @@ export class NanocodexSession extends DurableObject<Env> {
 
   #activeTurnIds(): string[] {
     return [...this.#pendingTurnIds, ...this.#turns.keys()];
+  }
+
+  #activeTurnDetails(): ActiveTurn[] {
+    return this.#activeTurnIds().flatMap((id) => {
+      const input = this.#turnInputs.get(id);
+      return input === undefined ? [] : [{ id, input }];
+    });
   }
 
   #idleTimeoutMs(): number {

--- a/examples/cloudflare-workers/src/index.ts
+++ b/examples/cloudflare-workers/src/index.ts
@@ -605,6 +605,10 @@ async function upgradeOpenAiWebSocket(
     }
     throw error;
   }
+  // Workers compatibility dates on or after 2026-03-17 deliver binary
+  // WebSocket frames as Blob by default. The WASM host accepts text and
+  // ArrayBuffer frames, so pin the stable representation before accept().
+  socket.binaryType = "arraybuffer";
   socket.accept();
   return {
     socket,

--- a/examples/cloudflare-workers/src/protocol.ts
+++ b/examples/cloudflare-workers/src/protocol.ts
@@ -14,13 +14,18 @@ export type TurnCompleted = {
   usage: TurnUsage;
 };
 
+export type ActiveTurn = {
+  id: string;
+  input: PromptInput;
+};
+
 export type ServerMessage =
-  | { type: "ready"; session_id: string; restored: boolean; active_turns: string[] }
-  | { type: "turn_accepted"; id: string; replayed: boolean }
+  | { type: "ready"; session_id: string; restored: boolean; active_turns: string[]; active_turn_details: ActiveTurn[] }
+  | { type: "turn_accepted"; id: string; input: PromptInput; replayed: boolean }
   | TurnCompleted
   | { type: "turn_failed"; id: string; error: string }
   | { type: "event"; event: AgentEvent }
-  | { type: "status"; active_turns: string[]; agent_loaded: boolean; connected_clients: number }
+  | { type: "status"; active_turns: string[]; active_turn_details: ActiveTurn[]; agent_loaded: boolean; connected_clients: number }
   | { type: "pong"; nonce?: string }
   | { type: "error"; code: string; message: string };
 

--- a/examples/cloudflare-workers/src/protocol.ts
+++ b/examples/cloudflare-workers/src/protocol.ts
@@ -1,0 +1,83 @@
+import type { AgentEvent, PromptInput, TurnUsage } from "nanocodex";
+
+export type ClientCommand =
+  | { type: "prompt"; id: string; input: PromptInput }
+  | { type: "steer"; id: string; input: PromptInput }
+  | { type: "cancel"; id: string }
+  | { type: "status" }
+  | { type: "ping"; nonce?: string };
+
+export type TurnCompleted = {
+  type: "turn_completed";
+  id: string;
+  final_message: string;
+  usage: TurnUsage;
+};
+
+export type ServerMessage =
+  | { type: "ready"; session_id: string; restored: boolean; active_turns: string[] }
+  | { type: "turn_accepted"; id: string; replayed: boolean }
+  | TurnCompleted
+  | { type: "turn_failed"; id: string; error: string }
+  | { type: "event"; event: AgentEvent }
+  | { type: "status"; active_turns: string[]; agent_loaded: boolean; connected_clients: number }
+  | { type: "pong"; nonce?: string }
+  | { type: "error"; code: string; message: string };
+
+const TURN_ID = /^[A-Za-z0-9._:-]{1,128}$/;
+const PROMPT_ITEM_TYPES = new Set(["text", "image", "audio"]);
+
+export function parseCommand(encoded: string): ClientCommand {
+  let value: unknown;
+  try {
+    value = JSON.parse(encoded);
+  } catch {
+    throw new ProtocolError("invalid_json", "messages must be JSON objects");
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ProtocolError("invalid_message", "messages must be JSON objects");
+  }
+  const command = value as Record<string, unknown>;
+  if (command.type === "ping") {
+    if (command.nonce !== undefined && typeof command.nonce !== "string") {
+      throw new ProtocolError("invalid_nonce", "ping nonce must be a string");
+    }
+    return { type: "ping", ...(command.nonce === undefined ? {} : { nonce: command.nonce }) };
+  }
+  if (command.type === "status") return { type: "status" };
+  if (!["prompt", "steer", "cancel"].includes(String(command.type))) {
+    throw new ProtocolError("unknown_command", "supported commands are prompt, steer, cancel, status, and ping");
+  }
+  if (typeof command.id !== "string" || !TURN_ID.test(command.id)) {
+    throw new ProtocolError("invalid_turn_id", "turn id must be 1-128 safe ASCII characters");
+  }
+  const type = command.type as "prompt" | "steer" | "cancel";
+  if (command.type === "cancel") return { type: "cancel", id: command.id };
+  validateInput(command.input);
+  return { type, id: command.id, input: command.input as PromptInput };
+}
+
+function validateInput(input: unknown): void {
+  if (typeof input === "string") {
+    if (!input.trim()) throw new ProtocolError("empty_prompt", "prompt input must not be empty");
+    return;
+  }
+  if (!Array.isArray(input) || input.length === 0) {
+    throw new ProtocolError("invalid_prompt", "prompt input must be text or a non-empty content array");
+  }
+  for (const item of input) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      throw new ProtocolError("invalid_prompt", "prompt content entries must be objects");
+    }
+    const type = (item as Record<string, unknown>).type;
+    if (!PROMPT_ITEM_TYPES.has(String(type))) {
+      throw new ProtocolError("invalid_prompt", "prompt content supports text, image, and audio entries");
+    }
+  }
+}
+
+export class ProtocolError extends Error {
+  constructor(readonly code: string, message: string) {
+    super(message);
+  }
+}

--- a/examples/cloudflare-workers/src/subscription-auth.ts
+++ b/examples/cloudflare-workers/src/subscription-auth.ts
@@ -104,7 +104,7 @@ export class NanocodexSubscriptionAuth extends DurableObject<SubscriptionAuthEnv
 
   #seed(): CredentialRow {
     const accessToken = requiredSecret(this.env.CHATGPT_ACCESS_TOKEN, "CHATGPT_ACCESS_TOKEN");
-    const refreshToken = requiredSecret(this.env.CHATGPT_REFRESH_TOKEN, "CHATGPT_REFRESH_TOKEN");
+    const refreshToken = optionalString(this.env.CHATGPT_REFRESH_TOKEN) ?? "";
     const accountId = requiredSecret(this.env.CHATGPT_ACCOUNT_ID, "CHATGPT_ACCOUNT_ID");
     const now = Date.now();
     const expiresAt = jwtExpiration(accessToken);
@@ -147,6 +147,11 @@ export class NanocodexSubscriptionAuth extends DurableObject<SubscriptionAuthEnv
   }
 
   async #performRefresh(current: CredentialRow): Promise<CredentialRow> {
+    if (!current.refresh_token) {
+      throw new Error(
+        "ChatGPT access token needs rotation; run `codex login` and restart the local subscription demo",
+      );
+    }
     const response = await fetch(this.env.CHATGPT_TOKEN_ENDPOINT ?? DEFAULT_TOKEN_ENDPOINT, {
       method: "POST",
       headers: { "content-type": "application/json" },

--- a/examples/cloudflare-workers/src/subscription-auth.ts
+++ b/examples/cloudflare-workers/src/subscription-auth.ts
@@ -1,0 +1,302 @@
+import { DurableObject } from "cloudflare:workers";
+
+const OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
+const DEFAULT_TOKEN_ENDPOINT = "https://auth.openai.com/oauth/token";
+const REFRESH_EARLY_MS = 5 * 60_000;
+const MAX_TOKEN_RESPONSE_BYTES = 16 * 1024;
+
+export interface SubscriptionAuthEnv {
+  CHATGPT_ACCESS_TOKEN?: string;
+  CHATGPT_ACCOUNT_ID?: string;
+  CHATGPT_FEDRAMP?: string;
+  CHATGPT_REFRESH_TOKEN?: string;
+  CHATGPT_TOKEN_ENDPOINT?: string;
+}
+
+export type SubscriptionSnapshot = {
+  bearerToken: string;
+  accountId: string;
+  fedramp: boolean;
+  revision: number;
+};
+
+type CredentialRow = {
+  access_token: string;
+  refresh_token: string;
+  account_id: string;
+  fedramp: number;
+  revision: number;
+  expires_at: number | null;
+  refreshed_at: number;
+};
+
+type RefreshResponse = {
+  access_token?: unknown;
+  refresh_token?: unknown;
+  id_token?: unknown;
+};
+
+export class NanocodexSubscriptionAuth extends DurableObject<SubscriptionAuthEnv> {
+  #refreshing?: { revision: number; promise: Promise<CredentialRow> };
+
+  constructor(ctx: DurableObjectState, env: SubscriptionAuthEnv) {
+    super(ctx, env);
+    this.ctx.storage.sql.exec(`
+      CREATE TABLE IF NOT EXISTS credentials (
+        singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+        access_token TEXT NOT NULL,
+        refresh_token TEXT NOT NULL,
+        account_id TEXT NOT NULL,
+        fedramp INTEGER NOT NULL,
+        revision INTEGER NOT NULL,
+        expires_at INTEGER,
+        refreshed_at INTEGER NOT NULL
+      );
+    `);
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    try {
+      if (request.method === "POST" && url.pathname === "/snapshot") {
+        let current = this.#credential();
+        if (!current) current = this.#seed();
+        if (current.expires_at !== null && current.expires_at <= Date.now() + REFRESH_EARLY_MS) {
+          current = await this.#refresh(current.revision);
+        }
+        return Response.json(toSnapshot(current), { headers: { "cache-control": "no-store" } });
+      }
+      if (request.method === "POST" && url.pathname === "/recover") {
+        const body = await request.json<{ revision?: unknown }>();
+        if (!Number.isSafeInteger(body.revision) || Number(body.revision) < 0) {
+          return Response.json({ error: "invalid revision" }, { status: 400 });
+        }
+        let current = this.#credential();
+        if (!current) current = this.#seed();
+        current = await this.#refresh(Number(body.revision));
+        return Response.json(toSnapshot(current), { headers: { "cache-control": "no-store" } });
+      }
+      if (request.method === "GET" && url.pathname === "/status") {
+        const current = this.#credential();
+        return Response.json({
+          configured: current !== undefined,
+          account_id: current?.account_id,
+          revision: current?.revision,
+          expires_at: current?.expires_at,
+          refreshed_at: current?.refreshed_at,
+        }, { headers: { "cache-control": "no-store" } });
+      }
+      if (request.method === "DELETE" && url.pathname === "/credentials") {
+        if (this.#refreshing) {
+          try { await this.#refreshing.promise; } catch { /* Reset still wins after a failed refresh. */ }
+        }
+        this.ctx.storage.sql.exec("DELETE FROM credentials");
+        return new Response(null, { status: 204 });
+      }
+      return Response.json({ error: "not_found" }, { status: 404 });
+    } catch (error) {
+      return Response.json({ error: safeError(error) }, {
+        status: 503,
+        headers: { "cache-control": "no-store" },
+      });
+    }
+  }
+
+  #seed(): CredentialRow {
+    const accessToken = requiredSecret(this.env.CHATGPT_ACCESS_TOKEN, "CHATGPT_ACCESS_TOKEN");
+    const refreshToken = requiredSecret(this.env.CHATGPT_REFRESH_TOKEN, "CHATGPT_REFRESH_TOKEN");
+    const accountId = requiredSecret(this.env.CHATGPT_ACCOUNT_ID, "CHATGPT_ACCOUNT_ID");
+    const now = Date.now();
+    const expiresAt = jwtExpiration(accessToken);
+    const fedramp = this.env.CHATGPT_FEDRAMP === "true";
+    this.ctx.storage.sql.exec(
+      `INSERT INTO credentials
+       (singleton, access_token, refresh_token, account_id, fedramp, revision, expires_at, refreshed_at)
+       VALUES (1, ?, ?, ?, ?, 0, ?, ?)`,
+      accessToken,
+      refreshToken,
+      accountId,
+      fedramp ? 1 : 0,
+      expiresAt,
+      now,
+    );
+    return {
+      access_token: accessToken,
+      refresh_token: refreshToken,
+      account_id: accountId,
+      fedramp: fedramp ? 1 : 0,
+      revision: 0,
+      expires_at: expiresAt,
+      refreshed_at: now,
+    };
+  }
+
+  async #refresh(rejectedRevision: number): Promise<CredentialRow> {
+    const current = this.#credential();
+    if (!current) throw new Error("ChatGPT credentials are not initialized");
+    if (current.revision !== rejectedRevision) return current;
+
+    if (this.#refreshing?.revision === rejectedRevision) return this.#refreshing.promise;
+    const promise = this.#performRefresh(current);
+    this.#refreshing = { revision: rejectedRevision, promise };
+    try {
+      return await promise;
+    } finally {
+      if (this.#refreshing?.promise === promise) this.#refreshing = undefined;
+    }
+  }
+
+  async #performRefresh(current: CredentialRow): Promise<CredentialRow> {
+    const response = await fetch(this.env.CHATGPT_TOKEN_ENDPOINT ?? DEFAULT_TOKEN_ENDPOINT, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        client_id: OAUTH_CLIENT_ID,
+        grant_type: "refresh_token",
+        refresh_token: current.refresh_token,
+      }),
+    });
+    const encoded = await readBoundedText(response, MAX_TOKEN_RESPONSE_BYTES);
+    if (!response.ok) {
+      const code = parseRefreshErrorCode(encoded);
+      throw new Error(code
+        ? `ChatGPT token refresh was rejected: ${code}`
+        : `ChatGPT token refresh failed with HTTP ${response.status}`);
+    }
+    let refreshed: RefreshResponse;
+    try {
+      refreshed = JSON.parse(encoded) as RefreshResponse;
+    } catch {
+      throw new Error("ChatGPT token refresh returned invalid JSON");
+    }
+    const accessToken = optionalString(refreshed.access_token);
+    if (accessToken === undefined) throw new Error("ChatGPT token refresh omitted access_token");
+    const refreshToken = optionalString(refreshed.refresh_token) ?? current.refresh_token;
+    const idToken = optionalString(refreshed.id_token);
+    const claims = idToken === undefined ? undefined : jwtPayload(idToken);
+    const claimedAccount = nestedString(claims, "https://api.openai.com/auth", "chatgpt_account_id");
+    if (claimedAccount !== undefined && claimedAccount !== current.account_id) {
+      throw new Error("the refreshed ChatGPT credential changed accounts");
+    }
+    const claimedFedramp = nestedBoolean(
+      claims,
+      "https://api.openai.com/auth",
+      "chatgpt_account_is_fedramp",
+    );
+    const next: CredentialRow = {
+      access_token: accessToken,
+      refresh_token: refreshToken,
+      account_id: current.account_id,
+      fedramp: claimedFedramp === undefined ? current.fedramp : (claimedFedramp ? 1 : 0),
+      revision: current.revision + 1,
+      expires_at: jwtExpiration(accessToken),
+      refreshed_at: Date.now(),
+    };
+    this.ctx.storage.sql.exec(
+      `UPDATE credentials SET
+         access_token = ?, refresh_token = ?, fedramp = ?, revision = ?, expires_at = ?, refreshed_at = ?
+       WHERE singleton = 1 AND revision = ?`,
+      next.access_token,
+      next.refresh_token,
+      next.fedramp,
+      next.revision,
+      next.expires_at,
+      next.refreshed_at,
+      current.revision,
+    );
+    return next;
+  }
+
+  #credential(): CredentialRow | undefined {
+    return this.ctx.storage.sql.exec<CredentialRow>(
+      `SELECT access_token, refresh_token, account_id, fedramp, revision, expires_at, refreshed_at
+       FROM credentials WHERE singleton = 1`,
+    ).toArray()[0];
+  }
+}
+
+function toSnapshot(row: CredentialRow): SubscriptionSnapshot {
+  return {
+    bearerToken: row.access_token,
+    accountId: row.account_id,
+    fedramp: row.fedramp !== 0,
+    revision: row.revision,
+  };
+}
+
+function requiredSecret(value: string | undefined, name: string): string {
+  if (!value?.trim()) throw new Error(`${name} is not configured`);
+  return value;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function jwtExpiration(token: string): number | null {
+  const payload = jwtPayload(token);
+  return typeof payload?.exp === "number" && Number.isFinite(payload.exp)
+    ? payload.exp * 1000
+    : null;
+}
+
+function jwtPayload(token: string): Record<string, unknown> | undefined {
+  const encoded = token.split(".")[1];
+  if (!encoded) return undefined;
+  try {
+    const base64 = encoded.replaceAll("-", "+").replaceAll("_", "/").padEnd(
+      encoded.length + ((4 - encoded.length % 4) % 4),
+      "=",
+    );
+    return JSON.parse(atob(base64)) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+function nestedString(value: Record<string, unknown> | undefined, objectKey: string, key: string) {
+  const nested = value?.[objectKey];
+  if (!nested || typeof nested !== "object" || Array.isArray(nested)) return undefined;
+  const found = (nested as Record<string, unknown>)[key];
+  return typeof found === "string" ? found : undefined;
+}
+
+function nestedBoolean(value: Record<string, unknown> | undefined, objectKey: string, key: string) {
+  const nested = value?.[objectKey];
+  if (!nested || typeof nested !== "object" || Array.isArray(nested)) return undefined;
+  const found = (nested as Record<string, unknown>)[key];
+  return typeof found === "boolean" ? found : undefined;
+}
+
+async function readBoundedText(response: Response, limit: number): Promise<string> {
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let total = 0;
+  let body = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) return body + decoder.decode();
+    total += value.byteLength;
+    if (total > limit) {
+      await reader.cancel();
+      throw new Error(`ChatGPT token response exceeded ${limit} bytes`);
+    }
+    body += decoder.decode(value, { stream: true });
+  }
+}
+
+function parseRefreshErrorCode(body: string): string | undefined {
+  try {
+    const parsed = JSON.parse(body) as { error?: unknown };
+    if (typeof parsed.error === "string") return parsed.error;
+    if (parsed.error && typeof parsed.error === "object" && !Array.isArray(parsed.error)) {
+      return optionalString((parsed.error as Record<string, unknown>).code);
+    }
+  } catch { /* The status remains sufficient when the body is not JSON. */ }
+  return undefined;
+}
+
+function safeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/examples/cloudflare-workers/src/wasm.d.ts
+++ b/examples/cloudflare-workers/src/wasm.d.ts
@@ -1,0 +1,4 @@
+declare module "*.wasm" {
+  const module: WebAssembly.Module;
+  export default module;
+}

--- a/examples/cloudflare-workers/src/web.ts
+++ b/examples/cloudflare-workers/src/web.ts
@@ -1,0 +1,244 @@
+const SECURITY_HEADERS = {
+  "cache-control": "no-store",
+  "cross-origin-opener-policy": "same-origin",
+  "permissions-policy": "camera=(), microphone=(), geolocation=()",
+  "referrer-policy": "no-referrer",
+  "x-content-type-options": "nosniff",
+  "x-frame-options": "DENY",
+};
+
+export function webAsset(pathname: string): Response | undefined {
+  if (pathname === "/" || pathname === "/index.html") {
+    return new Response(HTML, {
+      headers: {
+        ...SECURITY_HEADERS,
+        "content-security-policy": "default-src 'none'; connect-src 'self' ws: wss:; script-src 'self'; style-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'",
+        "content-type": "text/html; charset=utf-8",
+      },
+    });
+  }
+  if (pathname === "/app.js") {
+    return new Response(APP, {
+      headers: { ...SECURITY_HEADERS, "content-type": "text/javascript; charset=utf-8" },
+    });
+  }
+  if (pathname === "/app.css") {
+    return new Response(CSS, {
+      headers: { ...SECURITY_HEADERS, "content-type": "text/css; charset=utf-8" },
+    });
+  }
+  return undefined;
+}
+
+const HTML = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Nanocodex · Cloudflare Durable Agent</title>
+  <link rel="stylesheet" href="/app.css">
+</head>
+<body>
+  <main>
+    <header>
+      <div><p class="eyebrow">NANOCODEX / CLOUDFLARE</p><h1>Durable agent, disposable client.</h1></div>
+      <span id="status" class="pill">no session</span>
+    </header>
+    <section class="setup">
+      <label>Session creation token <input id="admin" type="password" autocomplete="off" placeholder="local-admin-token"></label>
+      <button id="new-session" type="button">New session</button>
+      <button id="reconnect" type="button" class="secondary">Reconnect</button>
+      <button id="detach" type="button" class="secondary">Detach</button>
+    </section>
+    <p class="meta">Session <code id="session">none</code>. The browser stores only this session capability, transcript, and any unfinished turn. Subscription credentials stay in the Worker host.</p>
+    <section id="transcript" class="transcript" aria-live="polite">
+      <article class="system">Create a session, send a prompt, then detach or close this tab. Reopen it to resume the same durable turn.</article>
+    </section>
+    <form id="prompt-form">
+      <textarea id="prompt" rows="3" maxlength="1048576" placeholder="Ask the durable agent…" required></textarea>
+      <button id="send" type="submit">Run durably</button>
+    </form>
+    <footer><span id="activity">idle</span><span>Rust/WASM · Durable Objects · Responses WebSocket</span></footer>
+  </main>
+  <script type="module" src="/app.js"></script>
+</body>
+</html>`;
+
+const APP = `const STORAGE_KEY = "nanocodex.cloudflare.web.v1";
+const byId = (id) => document.getElementById(id);
+const ui = {
+  activity: byId("activity"), admin: byId("admin"), detach: byId("detach"),
+  form: byId("prompt-form"), input: byId("prompt"), newSession: byId("new-session"),
+  reconnect: byId("reconnect"), send: byId("send"), session: byId("session"),
+  status: byId("status"), transcript: byId("transcript"),
+};
+let state = loadState();
+let socket;
+let ready = false;
+let eventCount = 0;
+
+if (["127.0.0.1", "localhost"].includes(location.hostname)) ui.admin.placeholder = "local-admin-token";
+renderState();
+if (state) connect();
+
+ui.newSession.addEventListener("click", async () => {
+  const token = ui.admin.value.trim();
+  if (!token) return setActivity("session creation token required", true);
+  setBusy(true);
+  try {
+    const response = await fetch("/sessions", {
+      method: "POST",
+      headers: { authorization: "Bearer " + token },
+    });
+    if (!response.ok) throw new Error("session creation failed with HTTP " + response.status);
+    const created = await response.json();
+    if (socket) socket.close(1000, "new session");
+    state = { session_id: created.session_id, websocket_url: created.websocket_url, messages: [] };
+    saveState();
+    renderState();
+    connect();
+  } catch (error) {
+    setActivity(errorMessage(error), true);
+  } finally {
+    setBusy(false);
+    ui.admin.value = "";
+  }
+});
+
+ui.reconnect.addEventListener("click", connect);
+ui.detach.addEventListener("click", () => {
+  if (socket) socket.close(1000, "client detached");
+  ready = false;
+  setStatus(state && state.pending ? "detached · turn running" : "detached", "warn");
+  setActivity("safe to close; durable state remains in the object");
+});
+
+ui.form.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const input = ui.input.value.trim();
+  if (!input || !state) return setActivity(state ? "prompt is empty" : "create a session first", true);
+  if (state.pending) return setActivity("one durable turn is already pending", true);
+  state.pending = { id: crypto.randomUUID(), input };
+  state.messages.push({ role: "you", text: input });
+  ui.input.value = "";
+  saveState();
+  renderMessages();
+  sendPending();
+});
+
+function connect() {
+  if (!state) return setActivity("create a session first", true);
+  if (socket && (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING)) return;
+  ready = false;
+  eventCount = 0;
+  setStatus("connecting", "warn");
+  socket = new WebSocket(state.websocket_url);
+  socket.addEventListener("open", () => setActivity("connected; waiting for durable object"));
+  socket.addEventListener("message", (event) => onMessage(event.data));
+  socket.addEventListener("close", () => {
+    ready = false;
+    setStatus(state && state.pending ? "detached · resumable" : "detached", "warn");
+  });
+  socket.addEventListener("error", () => setActivity("WebSocket connection failed", true));
+}
+
+function onMessage(encoded) {
+  let message;
+  try { message = JSON.parse(encoded); } catch { return setActivity("invalid server message", true); }
+  if (message.type === "ready") {
+    ready = true;
+    setStatus(message.restored ? "restored" : "ready", "ok");
+    socket.send(JSON.stringify({ type: "status" }));
+    sendPending();
+  } else if (message.type === "turn_accepted") {
+    setStatus(message.replayed ? "resuming" : "running", "ok");
+    setActivity((message.replayed ? "rejoined " : "started ") + shortId(message.id));
+  } else if (message.type === "event") {
+    eventCount += 1;
+    const kind = message.event && message.event.type ? message.event.type : "agent event";
+    setActivity(kind + " · " + eventCount + " events");
+  } else if (message.type === "turn_completed") {
+    if (!state || !state.pending || state.pending.id !== message.id) return;
+    state.messages.push({ role: "agent", text: message.final_message });
+    delete state.pending;
+    saveState();
+    renderMessages();
+    setStatus("ready", "ok");
+    setActivity("committed durably · " + eventCount + " events");
+  } else if (message.type === "turn_failed") {
+    if (state && state.pending && state.pending.id === message.id) delete state.pending;
+    if (state) state.messages.push({ role: "error", text: message.error });
+    saveState();
+    renderMessages();
+    setStatus("failed", "bad");
+    setActivity(message.error, true);
+  } else if (message.type === "error") {
+    setActivity(message.code + ": " + message.message, true);
+  }
+}
+
+function sendPending() {
+  if (!ready || !state || !state.pending) return;
+  socket.send(JSON.stringify({ type: "prompt", id: state.pending.id, input: state.pending.input }));
+  setStatus("running", "ok");
+  setActivity("turn " + shortId(state.pending.id) + " is durable; detach any time");
+}
+
+function renderState() {
+  ui.session.textContent = state ? state.session_id : "none";
+  renderMessages();
+  if (state && state.pending) {
+    setStatus("pending · reconnecting", "warn");
+    setActivity("resuming unfinished turn " + shortId(state.pending.id));
+  }
+}
+
+function renderMessages() {
+  ui.transcript.replaceChildren();
+  const messages = state && state.messages ? state.messages : [];
+  if (!messages.length) {
+    const empty = document.createElement("article");
+    empty.className = "system";
+    empty.textContent = "Send a prompt, detach during inference, then reload to prove the client is disposable.";
+    ui.transcript.append(empty);
+  }
+  for (const message of messages) {
+    const article = document.createElement("article");
+    article.className = message.role;
+    const label = document.createElement("strong");
+    label.textContent = message.role;
+    const text = document.createElement("div");
+    text.textContent = message.text;
+    article.append(label, text);
+    ui.transcript.append(article);
+  }
+  ui.transcript.scrollTop = ui.transcript.scrollHeight;
+}
+
+function loadState() {
+  try {
+    const value = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    if (!value || typeof value.session_id !== "string" || typeof value.websocket_url !== "string") return undefined;
+    value.messages = Array.isArray(value.messages) ? value.messages.slice(-50) : [];
+    return value;
+  } catch { return undefined; }
+}
+
+function saveState() {
+  if (!state) return localStorage.removeItem(STORAGE_KEY);
+  state.messages = state.messages.slice(-50);
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); }
+  catch {
+    state.messages = state.messages.slice(-10).map((message) => ({ ...message, text: message.text.slice(-20000) }));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  }
+}
+
+function setBusy(busy) { ui.newSession.disabled = busy; }
+function setStatus(text, tone) { ui.status.textContent = text; ui.status.dataset.tone = tone || ""; }
+function setActivity(text, bad) { ui.activity.textContent = text; ui.activity.dataset.bad = bad ? "true" : "false"; }
+function shortId(id) { return id.slice(0, 8); }
+function errorMessage(error) { return error instanceof Error ? error.message : String(error); }
+`;
+
+const CSS = `:root{color-scheme:dark;--bg:#0b0d0c;--panel:#121614;--line:#28302b;--ink:#edf5ef;--muted:#89948d;--acid:#b8ff62;--red:#ff746c}*{box-sizing:border-box}body{margin:0;background:radial-gradient(circle at 80% 0,#193022 0,transparent 32rem),var(--bg);color:var(--ink);font:15px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace}main{width:min(940px,calc(100% - 32px));margin:0 auto;min-height:100vh;padding:48px 0 28px;display:grid;grid-template-rows:auto auto auto 1fr auto auto;gap:18px}header{display:flex;align-items:end;justify-content:space-between;gap:24px}h1{font:600 clamp(28px,6vw,54px)/1.03 system-ui,sans-serif;letter-spacing:-.045em;margin:5px 0}.eyebrow{color:var(--acid);font-size:12px;letter-spacing:.14em;margin:0}.pill{border:1px solid var(--line);border-radius:99px;padding:7px 11px;color:var(--muted);white-space:nowrap}.pill[data-tone=ok]{border-color:#466d35;color:var(--acid)}.pill[data-tone=bad],[data-bad=true]{color:var(--red)}.pill[data-tone=warn]{color:#ffd580}.setup{display:flex;gap:8px;align-items:end;flex-wrap:wrap}.setup label{display:grid;gap:5px;flex:1;min-width:240px;color:var(--muted);font-size:12px}input,textarea,button{font:inherit}input,textarea{width:100%;border:1px solid var(--line);border-radius:8px;background:#0d100f;color:var(--ink);padding:11px 12px;outline:none}input:focus,textarea:focus{border-color:#597f42;box-shadow:0 0 0 3px #b8ff6214}button{border:1px solid var(--acid);border-radius:8px;background:var(--acid);color:#10150d;padding:11px 14px;font-weight:700;cursor:pointer}button.secondary{background:transparent;color:var(--ink);border-color:var(--line)}button:disabled{opacity:.45;cursor:wait}.meta{color:var(--muted);font-size:12px;margin:0}.meta code{color:var(--ink);word-break:break-all}.transcript{min-height:280px;max-height:56vh;overflow:auto;border:1px solid var(--line);border-radius:12px;background:#101311d9;padding:14px}.transcript article{max-width:86%;padding:12px 14px;margin:8px 0;border-radius:9px;white-space:pre-wrap;overflow-wrap:anywhere}.transcript strong{display:block;color:var(--muted);font-size:10px;text-transform:uppercase;letter-spacing:.12em;margin-bottom:5px}.transcript .you{margin-left:auto;background:#24301f}.transcript .agent{background:#171c19;border:1px solid var(--line)}.transcript .system{color:var(--muted);font-style:italic}.transcript .error{border:1px solid #5b302d;color:#ffc0bb}form{display:grid;grid-template-columns:1fr auto;gap:9px;align-items:stretch}textarea{resize:vertical;min-height:78px}footer{display:flex;justify-content:space-between;gap:16px;color:var(--muted);font-size:11px}@media(max-width:620px){main{padding-top:24px}header{display:block}.pill{display:inline-block;margin-top:10px}form{grid-template-columns:1fr}footer{display:grid}.transcript article{max-width:96%}}`;

--- a/examples/cloudflare-workers/src/web.ts
+++ b/examples/cloudflare-workers/src/web.ts
@@ -45,7 +45,7 @@ const HTML = `<!doctype html>
       <span id="status" class="pill">no session</span>
     </header>
     <section class="setup">
-      <label>Session creation token <input id="admin" type="password" autocomplete="off" placeholder="local-admin-token"></label>
+      <label>Session creation token <input id="admin" type="password" autocomplete="off" placeholder="Paste the deployment admin token"></label>
       <button id="new-session" type="button">New session</button>
       <button id="reconnect" type="button" class="secondary">Reconnect</button>
       <button id="detach" type="button" class="secondary">Detach</button>
@@ -90,6 +90,7 @@ ui.newSession.addEventListener("click", async () => {
       method: "POST",
       headers: { authorization: "Bearer " + token },
     });
+    if (response.status === 401) throw new Error("session creation token rejected; enter this deployment's NANOCODEX_ADMIN_TOKEN");
     if (!response.ok) throw new Error("session creation failed with HTTP " + response.status);
     const created = await response.json();
     if (socket) socket.close(1000, "new session");
@@ -97,11 +98,11 @@ ui.newSession.addEventListener("click", async () => {
     saveState();
     renderState();
     connect();
+    ui.admin.value = "";
   } catch (error) {
     setActivity(errorMessage(error), true);
   } finally {
     setBusy(false);
-    ui.admin.value = "";
   }
 });
 

--- a/examples/cloudflare-workers/src/web.ts
+++ b/examples/cloudflare-workers/src/web.ts
@@ -76,8 +76,12 @@ let state = loadState();
 let socket;
 let ready = false;
 let eventCount = 0;
+let streamedText = "";
 
 if (["127.0.0.1", "localhost"].includes(location.hostname)) ui.admin.placeholder = "local-admin-token";
+window.addEventListener("storage", (event) => {
+  if (event.key === STORAGE_KEY) syncStoredState(event.newValue);
+});
 renderState();
 if (state) connect();
 
@@ -120,7 +124,7 @@ ui.form.addEventListener("submit", (event) => {
   if (!input || !state) return setActivity(state ? "prompt is empty" : "create a session first", true);
   if (state.pending) return setActivity("one durable turn is already pending", true);
   state.pending = { id: crypto.randomUUID(), input };
-  state.messages.push({ role: "you", text: input });
+  state.messages.push({ role: "you", text: input, turn_id: state.pending.id });
   ui.input.value = "";
   saveState();
   renderMessages();
@@ -149,30 +153,46 @@ function onMessage(encoded) {
   if (message.type === "ready") {
     ready = true;
     setStatus(message.restored ? "restored" : "ready", "ok");
+    for (const turn of message.active_turn_details || []) observeTurn(turn.id, turn.input);
     socket.send(JSON.stringify({ type: "status" }));
     sendPending();
   } else if (message.type === "turn_accepted") {
+    observeTurn(message.id, message.input);
     setStatus(message.replayed ? "resuming" : "running", "ok");
     setActivity((message.replayed ? "rejoined " : "started ") + shortId(message.id));
   } else if (message.type === "event") {
     eventCount += 1;
     const kind = message.event && message.event.type ? message.event.type : "agent event";
+    const delta = kind === "assistant.delta" && message.event.payload && message.event.payload.text;
+    if (typeof delta === "string") {
+      streamedText = (streamedText + delta).slice(-1048576);
+      renderMessages();
+    }
     setActivity(kind + " · " + eventCount + " events");
   } else if (message.type === "turn_completed") {
-    if (!state || !state.pending || state.pending.id !== message.id) return;
-    state.messages.push({ role: "agent", text: message.final_message });
-    delete state.pending;
+    if (!state) return;
+    finishTurn(message.id);
+    if (!hasMessage("agent", message.id)) {
+      state.messages.push({ role: "agent", text: message.final_message, turn_id: message.id });
+    }
+    streamedText = "";
     saveState();
     renderMessages();
     setStatus("ready", "ok");
     setActivity("committed durably · " + eventCount + " events");
   } else if (message.type === "turn_failed") {
-    if (state && state.pending && state.pending.id === message.id) delete state.pending;
-    if (state) state.messages.push({ role: "error", text: message.error });
+    if (!state) return;
+    finishTurn(message.id);
+    if (!hasMessage("error", message.id)) {
+      state.messages.push({ role: "error", text: message.error, turn_id: message.id });
+    }
+    streamedText = "";
     saveState();
     renderMessages();
     setStatus("failed", "bad");
     setActivity(message.error, true);
+  } else if (message.type === "status") {
+    for (const turn of message.active_turn_details || []) observeTurn(turn.id, turn.input);
   } else if (message.type === "error") {
     setActivity(message.code + ": " + message.message, true);
   }
@@ -197,7 +217,7 @@ function renderState() {
 function renderMessages() {
   ui.transcript.replaceChildren();
   const messages = state && state.messages ? state.messages : [];
-  if (!messages.length) {
+  if (!messages.length && !streamedText) {
     const empty = document.createElement("article");
     empty.className = "system";
     empty.textContent = "Send a prompt, detach during inference, then reload to prove the client is disposable.";
@@ -213,21 +233,98 @@ function renderMessages() {
     article.append(label, text);
     ui.transcript.append(article);
   }
+  if (streamedText) {
+    const article = document.createElement("article");
+    article.className = "agent live";
+    const label = document.createElement("strong");
+    label.textContent = "agent · live";
+    const text = document.createElement("div");
+    text.textContent = streamedText;
+    article.append(label, text);
+    ui.transcript.append(article);
+  }
   ui.transcript.scrollTop = ui.transcript.scrollHeight;
 }
 
 function loadState() {
+  return parseStoredState(localStorage.getItem(STORAGE_KEY));
+}
+
+function parseStoredState(encoded) {
   try {
-    const value = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    const value = JSON.parse(encoded);
     if (!value || typeof value.session_id !== "string" || typeof value.websocket_url !== "string") return undefined;
     value.messages = Array.isArray(value.messages) ? value.messages.slice(-50) : [];
+    value.active_turns = Array.isArray(value.active_turns) ? value.active_turns.slice(-16) : [];
     return value;
   } catch { return undefined; }
+}
+
+function syncStoredState(encoded) {
+  const incoming = parseStoredState(encoded);
+  const previousPendingId = state && state.pending && state.pending.id;
+  const changedSession = Boolean((!state && incoming)
+    || (state && !incoming)
+    || (state && incoming && (state.session_id !== incoming.session_id || state.websocket_url !== incoming.websocket_url)));
+  if (changedSession && socket) {
+    socket.close(1000, "session changed in another tab");
+    socket = undefined;
+    ready = false;
+  }
+  state = incoming;
+  renderState();
+  if (!state) return;
+  if (changedSession || !socket || socket.readyState === WebSocket.CLOSED) connect();
+  else if (previousPendingId !== (state.pending && state.pending.id)) sendPending();
+}
+
+function observeTurn(id, input) {
+  if (!state || typeof id !== "string") return;
+  let changed = false;
+  if (!Array.isArray(state.active_turns)) {
+    state.active_turns = [];
+    changed = true;
+  }
+  const current = state.active_turns.find((turn) => turn && turn.id === id);
+  if (current && JSON.stringify(current.input) !== JSON.stringify(input)) {
+    current.input = input;
+    changed = true;
+  } else if (!current) {
+    state.active_turns.push({ id, input });
+    changed = true;
+  }
+  const text = displayInput(input);
+  if (text && !hasMessage("you", id)) {
+    state.messages.push({ role: "you", text, turn_id: id });
+    changed = true;
+  }
+  if (changed) saveState();
+  renderMessages();
+}
+
+function finishTurn(id) {
+  if (!state) return;
+  if (state.pending && state.pending.id === id) delete state.pending;
+  state.active_turns = (state.active_turns || []).filter((turn) => turn && turn.id !== id);
+}
+
+function hasMessage(role, id) {
+  return Boolean(state && state.messages.some((message) => message.role === role && message.turn_id === id));
+}
+
+function displayInput(input) {
+  if (typeof input === "string") return input;
+  if (!Array.isArray(input)) return "";
+  return input.map((item) => {
+    if (item && item.type === "text" && typeof item.text === "string") return item.text;
+    return item && typeof item.type === "string" ? "[" + item.type + "]" : "[content]";
+  }).join("\\n");
 }
 
 function saveState() {
   if (!state) return localStorage.removeItem(STORAGE_KEY);
   state.messages = state.messages.slice(-50);
+  state.active_turns = (state.active_turns || []).slice(-16);
   try { localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); }
   catch {
     state.messages = state.messages.slice(-10).map((message) => ({ ...message, text: message.text.slice(-20000) }));

--- a/examples/cloudflare-workers/test-node/codex-auth-file.test.mjs
+++ b/examples/cloudflare-workers/test-node/codex-auth-file.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, test } from "node:test";
+
+import { readCodexSubscription } from "../scripts/codex-auth-file.mjs";
+
+const temporaryDirectories = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) =>
+    rm(path, { recursive: true, force: true })
+  ));
+});
+
+test("reads only the current protected subscription access credential", async () => {
+  const path = await authFile("access-one");
+  const auth = await readCodexSubscription(path);
+  assert.equal(auth.accountId, "account-123");
+  assert.equal(auth.fedramp, false);
+  assert.match(auth.accessToken, /^[^.]+\.[^.]+\./);
+  assert.equal("refreshToken" in auth, false);
+});
+
+test("rejects an auth file readable by other users", { skip: process.platform === "win32" }, async () => {
+  const path = await authFile("access-token", 0o644);
+  await assert.rejects(readCodexSubscription(path), /group or other users/);
+});
+
+test("rejects an access token near expiry", async () => {
+  const path = await authFile("expiring", 0o600, 60);
+  await assert.rejects(readCodexSubscription(path), /expires too soon/);
+});
+
+async function authFile(tokenMarker, mode = 0o600, ttlSeconds = 3_600) {
+  const directory = await mkdtemp(join(tmpdir(), "nanocodex-cloudflare-auth-test-"));
+  temporaryDirectories.push(directory);
+  const path = join(directory, "auth.json");
+  const expiresAt = Math.floor(Date.now() / 1_000) + ttlSeconds;
+  await writeFile(path, JSON.stringify({
+    auth_mode: "chatgpt",
+    tokens: {
+      access_token: jwt({ exp: expiresAt, marker: tokenMarker }),
+      account_id: "account-123",
+      id_token: jwt({
+        exp: expiresAt,
+        "https://api.openai.com/auth": {
+          chatgpt_account_id: "account-123",
+          chatgpt_account_is_fedramp: false,
+        },
+      }),
+      refresh_token: "must-not-be-used",
+    },
+  }), { mode });
+  return path;
+}
+
+function jwt(payload) {
+  return `${Buffer.from("{}").toString("base64url")}.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.signature`;
+}

--- a/examples/cloudflare-workers/test-node/subscription-egress-proxy.test.mjs
+++ b/examples/cloudflare-workers/test-node/subscription-egress-proxy.test.mjs
@@ -47,6 +47,29 @@ test("subscription egress proxy is capability-gated and relays headers and frame
   }
 });
 
+test("an upstream rejection settles once and leaves the proxy alive", async () => {
+  const upstream = createServer((_request, response) => {
+    response.writeHead(403, { "content-type": "text/plain" });
+    response.end("denied");
+  });
+  upstream.on("upgrade", (_request, socket) => {
+    socket.end("HTTP/1.1 403 Forbidden\r\nContent-Length: 6\r\nConnection: close\r\n\r\ndenied");
+  });
+  await listen(upstream);
+  const address = upstream.address();
+  assert(address && typeof address !== "string");
+  const proxy = await startSubscriptionEgressProxy({
+    upstreamUrl: `ws://127.0.0.1:${address.port}/responses`,
+  });
+  try {
+    assert.equal(await rejected(proxy.url), 403);
+    assert.equal(await rejected(proxy.url.replace(/\/v1\/[^/]+$/, "/wrong")), 404);
+  } finally {
+    await proxy.close();
+    await new Promise((resolve, reject) => upstream.close((error) => error ? reject(error) : resolve()));
+  }
+});
+
 function listen(server) {
   return new Promise((resolve, reject) => {
     server.once("error", reject);

--- a/examples/cloudflare-workers/test-node/subscription-egress-proxy.test.mjs
+++ b/examples/cloudflare-workers/test-node/subscription-egress-proxy.test.mjs
@@ -1,0 +1,73 @@
+import { createServer } from "node:http";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import WebSocket, { WebSocketServer } from "ws";
+
+import { startSubscriptionEgressProxy } from "../scripts/subscription-egress-proxy.mjs";
+
+test("subscription egress proxy is capability-gated and relays headers and frames", async () => {
+  const upstreamServer = createServer();
+  const upstreamSockets = new WebSocketServer({ noServer: true });
+  let authorization;
+  upstreamServer.on("upgrade", (request, socket, head) => {
+    authorization = request.headers.authorization;
+    upstreamSockets.handleUpgrade(request, socket, head, (peer) => {
+      peer.on("message", (message, binary) => peer.send(message, { binary }));
+    });
+  });
+  await listen(upstreamServer);
+  const address = upstreamServer.address();
+  assert(address && typeof address !== "string");
+
+  const proxy = await startSubscriptionEgressProxy({
+    upstreamUrl: `ws://127.0.0.1:${address.port}/responses`,
+  });
+  try {
+    const denied = await rejected(proxy.url.replace(/\/v1\/[^/]+$/, "/v1/wrong"));
+    assert.equal(denied, 404);
+
+    const socket = new WebSocket(proxy.url, {
+      headers: {
+        authorization: "Bearer test-only-token",
+        "chatgpt-account-id": "account-1",
+      },
+    });
+    await once(socket, "open");
+    socket.send("hello");
+    const [message] = await once(socket, "message");
+    assert.equal(message.toString(), "hello");
+    assert.equal(authorization, "Bearer test-only-token");
+    socket.close(1000, "done");
+    await once(socket, "close");
+  } finally {
+    await proxy.close();
+    upstreamSockets.clients.forEach((socket) => socket.terminate());
+    await new Promise((resolve, reject) => upstreamServer.close((error) => error ? reject(error) : resolve()));
+  }
+});
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+}
+
+function once(target, event) {
+  return new Promise((resolve, reject) => {
+    target.once(event, (...args) => resolve(args));
+    target.once("error", reject);
+  });
+}
+
+function rejected(url) {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(url, { headers: { authorization: "Bearer nope" } });
+    socket.once("unexpected-response", (_request, response) => {
+      resolve(response.statusCode);
+      socket.terminate();
+    });
+    socket.once("error", reject);
+  });
+}

--- a/examples/cloudflare-workers/test-node/web-assets.test.mjs
+++ b/examples/cloudflare-workers/test-node/web-assets.test.mjs
@@ -1,0 +1,21 @@
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import vm from "node:vm";
+
+import ts from "typescript";
+
+test("the emitted inline browser client is valid JavaScript", async () => {
+  const source = await readFile(new URL("../src/web.ts", import.meta.url), "utf8");
+  const transpiled = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 },
+  }).outputText;
+  const loaded = { exports: {} };
+  vm.runInNewContext(transpiled, {
+    exports: loaded.exports,
+    module: loaded,
+    Response,
+  });
+  const response = loaded.exports.webAsset("/app.js");
+  const app = await response.text();
+  new vm.Script(app, { filename: "app.js" });
+});

--- a/examples/cloudflare-workers/test/env.d.ts
+++ b/examples/cloudflare-workers/test/env.d.ts
@@ -1,0 +1,5 @@
+import type { Env as WorkerEnv } from "../src/index";
+
+declare module "cloudflare:workers" {
+  interface ProvidedEnv extends WorkerEnv {}
+}

--- a/examples/cloudflare-workers/test/worker.test.ts
+++ b/examples/cloudflare-workers/test/worker.test.ts
@@ -12,13 +12,16 @@ describe("Nanocodex Durable Object Worker", () => {
     const page = await SELF.fetch("https://example.test/");
     expect(page.status).toBe(200);
     expect(page.headers.get("content-security-policy")).toContain("connect-src 'self' ws: wss:");
-    expect(await page.text()).toContain("Durable agent, disposable client.");
+    const html = await page.text();
+    expect(html).toContain("Durable agent, disposable client.");
+    expect(html).toContain("Paste the deployment admin token");
 
     const script = await SELF.fetch("https://example.test/app.js");
     const source = await script.text();
     expect(script.headers.get("content-type")).toContain("text/javascript");
     expect(source).toContain("localStorage");
     expect(source).toContain("crypto.randomUUID()");
+    expect(source).toContain("session creation token rejected");
     expect(source).not.toContain("OPENAI_API_KEY");
     expect(source).not.toContain("CHATGPT_ACCESS_TOKEN");
   });

--- a/examples/cloudflare-workers/test/worker.test.ts
+++ b/examples/cloudflare-workers/test/worker.test.ts
@@ -1,0 +1,173 @@
+import { env } from "cloudflare:workers";
+import { evictDurableObject, SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+import type { Env } from "../src/index";
+
+const authorization = { authorization: "Bearer test-admin-token" };
+const workerEnv = env as unknown as Env;
+
+describe("Nanocodex Durable Object Worker", () => {
+  it("protects creation and keeps session state across eviction", async () => {
+    const denied = await SELF.fetch("https://example.test/sessions", { method: "POST" });
+    expect(denied.status).toBe(401);
+
+    const created = await createSession();
+    expect(created.session_id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    expect(created.websocket_url).toBe(`wss://example.test/sessions/${created.session_id}/ws`);
+
+    const before = await SELF.fetch(`https://example.test/sessions/${created.session_id}`);
+    expect(await before.json()).toMatchObject({
+      session_id: created.session_id,
+      has_snapshot: false,
+      completed_turns: 0,
+      agent_loaded: false,
+    });
+
+    const stub = workerEnv.NANOCODEX_SESSIONS.getByName(created.session_id);
+    await evictDurableObject(stub);
+
+    const after = await SELF.fetch(`https://example.test/sessions/${created.session_id}`);
+    expect(await after.json()).toMatchObject({
+      session_id: created.session_id,
+      has_snapshot: false,
+      completed_turns: 0,
+      agent_loaded: false,
+    });
+  });
+
+  it("hibernates client sockets and validates the bounded protocol without loading WASM", async () => {
+    const created = await createSession();
+    const response = await SELF.fetch(created.websocket_url.replace("wss:", "https:"), {
+      headers: { Upgrade: "websocket" },
+    });
+    expect(response.status).toBe(101);
+    const socket = response.webSocket!;
+    socket.accept();
+
+    expect(await nextMessage(socket)).toMatchObject({
+      type: "ready",
+      session_id: created.session_id,
+      restored: false,
+      active_turns: [],
+    });
+    socket.send(JSON.stringify({ type: "ping", nonce: "one" }));
+    expect(await nextMessage(socket)).toEqual({ type: "pong", nonce: "one" });
+
+    const stub = workerEnv.NANOCODEX_SESSIONS.getByName(created.session_id);
+    await evictDurableObject(stub);
+    socket.send(JSON.stringify({ type: "status" }));
+    expect(await nextMessage(socket)).toMatchObject({
+      type: "status",
+      active_turns: [],
+      agent_loaded: false,
+      connected_clients: 1,
+    });
+
+    socket.send("not-json");
+    expect(await nextMessage(socket)).toMatchObject({ type: "error", code: "invalid_json" });
+    socket.send(JSON.stringify({ type: "cancel", id: "missing" }));
+    expect(await nextMessage(socket)).toMatchObject({ type: "error", code: "turn_not_active" });
+    socket.close(1000, "done");
+  });
+
+  it("rejects invalid routes and deletes only the named session", async () => {
+    expect((await SELF.fetch("https://example.test/sessions/not-a-session")).status).toBe(404);
+    const created = await createSession();
+    const deleted = await SELF.fetch(`https://example.test/sessions/${created.session_id}`, {
+      method: "DELETE",
+    });
+    expect(deleted.status).toBe(204);
+    expect((await SELF.fetch(`https://example.test/sessions/${created.session_id}`)).status).toBe(404);
+  });
+
+  it("keeps subscription credentials behind the singleton auth object", async () => {
+    const denied = await SELF.fetch("https://example.test/auth/chatgpt");
+    expect(denied.status).toBe(401);
+
+    const auth = workerEnv.NANOCODEX_AUTH.getByName("subscription");
+    const snapshots = await Promise.all([
+      auth.fetch("https://auth.internal/snapshot", { method: "POST" }),
+      auth.fetch("https://auth.internal/snapshot", { method: "POST" }),
+    ]);
+    expect(await snapshots[0]!.json()).toMatchObject({
+      accountId: "test-account-id",
+      fedramp: false,
+      revision: 1,
+    });
+    expect(await snapshots[1]!.json()).toMatchObject({ revision: 1 });
+
+    const staleRecovery = await auth.fetch("https://auth.internal/recover", {
+      method: "POST",
+      body: JSON.stringify({ revision: 0 }),
+    });
+    expect(await staleRecovery.json()).toMatchObject({ revision: 1 });
+
+    const status = await SELF.fetch("https://example.test/auth/chatgpt", { headers: authorization });
+    expect(await status.json()).toMatchObject({
+      configured: true,
+      account_id: "test-account-id",
+      revision: 1,
+    });
+    const reset = await SELF.fetch("https://example.test/auth/chatgpt", {
+      method: "DELETE",
+      headers: authorization,
+    });
+    expect(reset.status).toBe(204);
+  });
+
+  it("bounds connection amplification and rejects binary and oversized frames", async () => {
+    const created = await createSession();
+    const sockets: WebSocket[] = [];
+    try {
+      for (let index = 0; index < 64; index += 1) {
+        const response = await SELF.fetch(created.websocket_url.replace("wss:", "https:"), {
+          headers: { Upgrade: "websocket" },
+        });
+        expect(response.status).toBe(101);
+        const socket = response.webSocket!;
+        socket.accept();
+        await nextMessage(socket);
+        sockets.push(socket);
+      }
+      const overflow = await SELF.fetch(created.websocket_url.replace("wss:", "https:"), {
+        headers: { Upgrade: "websocket" },
+      });
+      expect(overflow.status).toBe(429);
+
+      sockets[0]!.send(new Uint8Array([1, 2, 3]).buffer);
+      expect(await nextMessage(sockets[0]!)).toMatchObject({
+        type: "error",
+        code: "binary_unsupported",
+      });
+
+      const closed = nextClose(sockets[1]!);
+      sockets[1]!.send("x".repeat(1024 * 1024 + 1));
+      expect(await closed).toMatchObject({ code: 1009 });
+    } finally {
+      for (const socket of sockets) socket.close(1000, "test complete");
+    }
+  });
+});
+
+async function createSession(): Promise<{ session_id: string; websocket_url: string }> {
+  const response = await SELF.fetch("https://example.test/sessions", {
+    method: "POST",
+    headers: authorization,
+  });
+  expect(response.status).toBe(201);
+  return response.json();
+}
+
+function nextMessage(socket: WebSocket): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    socket.addEventListener("message", (event) => {
+      resolve(JSON.parse(String(event.data)) as Record<string, unknown>);
+    }, { once: true });
+    socket.addEventListener("error", () => reject(new Error("WebSocket failed")), { once: true });
+  });
+}
+
+function nextClose(socket: WebSocket): Promise<CloseEvent> {
+  return new Promise((resolve) => socket.addEventListener("close", resolve, { once: true }));
+}

--- a/examples/cloudflare-workers/test/worker.test.ts
+++ b/examples/cloudflare-workers/test/worker.test.ts
@@ -21,6 +21,9 @@ describe("Nanocodex Durable Object Worker", () => {
     expect(script.headers.get("content-type")).toContain("text/javascript");
     expect(source).toContain("localStorage");
     expect(source).toContain("crypto.randomUUID()");
+    expect(source).toContain('window.addEventListener("storage"');
+    expect(source).toContain('kind === "assistant.delta"');
+    expect(source).toContain("message.active_turn_details");
     expect(source).toContain("session creation token rejected");
     expect(source).not.toContain("OPENAI_API_KEY");
     expect(source).not.toContain("CHATGPT_ACCESS_TOKEN");

--- a/examples/cloudflare-workers/test/worker.test.ts
+++ b/examples/cloudflare-workers/test/worker.test.ts
@@ -8,6 +8,21 @@ const authorization = { authorization: "Bearer test-admin-token" };
 const workerEnv = env as unknown as Env;
 
 describe("Nanocodex Durable Object Worker", () => {
+  it("serves a thin resumable browser client without model credentials", async () => {
+    const page = await SELF.fetch("https://example.test/");
+    expect(page.status).toBe(200);
+    expect(page.headers.get("content-security-policy")).toContain("connect-src 'self' ws: wss:");
+    expect(await page.text()).toContain("Durable agent, disposable client.");
+
+    const script = await SELF.fetch("https://example.test/app.js");
+    const source = await script.text();
+    expect(script.headers.get("content-type")).toContain("text/javascript");
+    expect(source).toContain("localStorage");
+    expect(source).toContain("crypto.randomUUID()");
+    expect(source).not.toContain("OPENAI_API_KEY");
+    expect(source).not.toContain("CHATGPT_ACCESS_TOKEN");
+  });
+
   it("protects creation and keeps session state across eviction", async () => {
     const denied = await SELF.fetch("https://example.test/sessions", { method: "POST" });
     expect(denied.status).toBe(401);

--- a/examples/cloudflare-workers/tsconfig.json
+++ b/examples/cloudflare-workers/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "allowJs": false,
+    "lib": ["ESNext"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2024",
+    "types": ["@cloudflare/workers-types", "@cloudflare/vitest-pool-workers/types"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/examples/cloudflare-workers/vitest.config.ts
+++ b/examples/cloudflare-workers/vitest.config.ts
@@ -1,0 +1,51 @@
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+let initialRefreshConsumed = false;
+
+export default defineConfig({
+  plugins: [
+    cloudflareTest({
+      wrangler: { configPath: "./wrangler.jsonc" },
+      miniflare: {
+        bindings: {
+          AGENT_IDLE_TIMEOUT_MS: "1000",
+          CHATGPT_ACCESS_TOKEN: "e30.eyJleHAiOjF9.test",
+          CHATGPT_ACCOUNT_ID: "test-account-id",
+          CHATGPT_REFRESH_TOKEN: "test-refresh-token",
+          CHATGPT_TOKEN_ENDPOINT: "https://auth.test/oauth/token",
+          NANOCODEX_ADMIN_TOKEN: "test-admin-token",
+          NANOCODEX_AUTH_MODE: "api_key",
+          OPENAI_API_KEY: "test-openai-key",
+        },
+        outboundService: async (request) => {
+          const url = new URL(request.url);
+          if (request.method !== "POST" || url.href !== "https://auth.test/oauth/token") {
+            return new Response("not found", { status: 404 });
+          }
+          const payload = await request.json<{ refresh_token?: unknown }>();
+          if (payload.refresh_token !== "test-refresh-token" || initialRefreshConsumed) {
+            return Response.json({ error: { code: "refresh_token_invalidated" } }, { status: 401 });
+          }
+          initialRefreshConsumed = true;
+          await new Promise((resolve) => setTimeout(resolve, 25));
+          return Response.json({
+            access_token: testJwt({ exp: 4_102_444_800 }),
+            refresh_token: "test-rotated-refresh-token",
+            id_token: testJwt({
+              "https://api.openai.com/auth": { chatgpt_account_id: "test-account-id" },
+            }),
+          });
+        },
+      },
+    }),
+  ],
+  test: {
+    testTimeout: 15_000,
+  },
+});
+
+function testJwt(payload: Record<string, unknown>): string {
+  const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "none" })}.${encode(payload)}.test`;
+}

--- a/examples/cloudflare-workers/vitest.config.ts
+++ b/examples/cloudflare-workers/vitest.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
     }),
   ],
   test: {
+    include: ["test/**/*.test.ts"],
     testTimeout: 15_000,
   },
 });

--- a/examples/cloudflare-workers/wrangler.jsonc
+++ b/examples/cloudflare-workers/wrangler.jsonc
@@ -1,0 +1,43 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "nanocodex-durable-agent",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-07-29",
+  "rules": [
+    {
+      "type": "CompiledWasm",
+      "globs": ["src/**/*.wasm"],
+      "fallthrough": true
+    }
+  ],
+  "observability": {
+    "enabled": true,
+    "logs": {
+      "enabled": true,
+      "invocation_logs": true,
+      "persist": true
+    }
+  },
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "NANOCODEX_SESSIONS",
+        "class_name": "NanocodexSession"
+      },
+      {
+        "name": "NANOCODEX_AUTH",
+        "class_name": "NanocodexSubscriptionAuth"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["NanocodexSession", "NanocodexSubscriptionAuth"]
+    }
+  ],
+  "vars": {
+    "AGENT_IDLE_TIMEOUT_MS": "30000",
+    "NANOCODEX_AUTH_MODE": "api_key"
+  }
+}

--- a/examples/cloudflare-workers/wrangler.jsonc
+++ b/examples/cloudflare-workers/wrangler.jsonc
@@ -38,6 +38,6 @@
   ],
   "vars": {
     "AGENT_IDLE_TIMEOUT_MS": "30000",
-    "NANOCODEX_AUTH_MODE": "api_key"
+    "NANOCODEX_AUTH_MODE": "chatgpt"
   }
 }


### PR DESCRIPTION
## Summary

- restore the Cloudflare Durable Object demo that disappeared because #76 was merged into `feat/wasm-host-transport`, not `master`
- retain the subscription-auth Durable Object, resumable browser/REPL, hibernation-safe synchronized WebSockets, and edge hardening
- restore Cloudflare example CI, Justfile, ignore rules, and documentation

This PR is intentionally Cloudflare-only. The cross-platform Cloudflare/Rivet/Vercel sandbox integration is split into a stacked follow-up.

## Validation

- `just build-wasm`
- `npm run check --prefix examples/cloudflare-workers`
- deployed Worker route and Durable Object migrations validated before the split
