### PR TITLE
feat(examples): add durable platform sandboxes

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,11 +14,13 @@ All language consumers live at this repository boundary:
 - Browser CDN: `browser-cdn/` is one static HTML file that imports the published
   package directly, with no install or build step.
 - Rivet Actors: `rivet-actors/` runs the same harness as a durable,
-  SQLite-backed Rivet Actor.
+  SQLite-backed Rivet Actor with an actor-owned AgentOS sandbox.
 - Cloudflare Workers: `cloudflare-workers/` runs the Rust/WASM harness inside a
-  SQLite-backed Durable Object and proves hibernation-safe session recovery.
+  SQLite-backed Durable Object, with a Sandbox container and R2-backed
+  workspace, and proves hibernation-safe session recovery.
 - Vercel Workflows: `vercel-workflows/` runs Nanocodex as a durable Workflow
-  actor with replayable state and synchronized native WebSocket clients.
+  actor with a persistent Vercel Sandbox, replayable state, and synchronized
+  native WebSocket clients.
 
 From the repository root:
 

--- a/examples/cloudflare-workers/Dockerfile
+++ b/examples/cloudflare-workers/Dockerfile
@@ -1,0 +1,6 @@
+FROM docker.io/cloudflare/sandbox:0.12.4
+
+EXPOSE 3000
+EXPOSE 5173
+EXPOSE 8000
+EXPOSE 8080

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -10,7 +10,9 @@ client WebSocket ──> Worker router ──> one NanocodexSession object per s
                                          ├─ Rust/WASM Nanocodex driver
                                          ├─ persistent model WebSocket
                                          ├─ hibernatable client sockets
-                                         └─ SQLite snapshot + terminal turns
+                                         ├─ SQLite snapshot + terminal turns
+                                         └─ Cloudflare Sandbox DO + container
+                                              └─ /workspace mounted to per-session R2 prefix
 
 ChatGPT subscription ───────────────> one NanocodexSubscriptionAuth object
                                          └─ SQLite token rotation + 401 recovery
@@ -32,6 +34,13 @@ resumes complete client-owned typed history from SQLite. See Cloudflare's
 and [WebSocket hibernation](https://developers.cloudflare.com/durable-objects/best-practices/websockets/)
 documentation for the underlying behavior.
 
+The caller-defined `sandbox_exec`, `sandbox_read_file`, `sandbox_write_file`,
+`sandbox_list_files`, and `sandbox_preview` tools run untrusted work in a
+separate Cloudflare Sandbox container. The Sandbox uses the current RPC
+transport, scopes its R2 mount to the Nanocodex session ID, and creates
+zero-configuration Quick Tunnel preview URLs. Nanocodex remains the only model
+and tool-loop owner; the Sandbox SDK supplies execution isolation and storage.
+
 ## Run locally
 
 From the repository root, build the optimized WASM package and install the
@@ -41,6 +50,11 @@ example:
 just build-wasm
 npm ci --prefix examples/cloudflare-workers
 ```
+
+Docker must be running because Wrangler builds the Sandbox container. Local
+R2 bindings are emulated by Wrangler; set `NANOCODEX_SANDBOX_LOCAL=true` in a
+local `.dev.vars` file when you want the mounted workspace synchronized through
+the local R2 binding path.
 
 Sign in once with Codex, then start the subscription-backed Worker:
 
@@ -132,12 +146,19 @@ Node-based consumers may continue to use Code Mode when their host permits it.
 ```sh
 npm run check --prefix examples/cloudflare-workers
 cd examples/cloudflare-workers
+npx wrangler r2 bucket create nanocodex-sandbox-workspaces
 npx wrangler secret put CHATGPT_ACCESS_TOKEN
 npx wrangler secret put CHATGPT_REFRESH_TOKEN
 npx wrangler secret put CHATGPT_ACCOUNT_ID
 npx wrangler secret put NANOCODEX_ADMIN_TOKEN
 npx wrangler deploy
 ```
+
+Create the R2 bucket once per Cloudflare account. Each actor receives only its
+`/sessions/<session-id>/` prefix inside the mounted `/workspace`; model
+credentials remain in the Worker and are not injected into the container.
+After deployment, ask the agent to create a small server on port 8080 in the
+background and call `sandbox_preview` to get a public `trycloudflare.com` URL.
 
 At the time this example was validated, the ChatGPT edge rejected direct
 Cloudflare Worker egress with HTTP 403. That is an upstream egress-policy

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -14,6 +14,8 @@ client WebSocket ──> Worker router ──> one NanocodexSession object per s
                                          └─ Cloudflare Sandbox DO + container
                                               └─ /workspace mounted to per-session R2 prefix
 
+preview capability ──> Worker router ──> session Sandbox container port
+
 ChatGPT subscription ───────────────> one NanocodexSubscriptionAuth object
                                          └─ SQLite token rotation + 401 recovery
 ```
@@ -38,9 +40,11 @@ The caller-defined `sandbox_exec`, `sandbox_start_process`, `sandbox_read_file`,
 `sandbox_write_file`, `sandbox_list_files`, and `sandbox_preview` tools run
 untrusted work in a separate Cloudflare Sandbox container. The Sandbox uses the
 current RPC transport, scopes its R2 mount to the Nanocodex session ID, and
-creates zero-configuration Quick Tunnel preview URLs. Nanocodex remains the only
-model and tool-loop owner; the Sandbox SDK supplies execution isolation and
-storage.
+proxies opaque capability-scoped preview URLs through the existing Worker
+hostname. The authenticated preview token reveals neither the session capability
+nor server credentials, and avoids requiring wildcard DNS or a separate Quick
+Tunnel process. Nanocodex remains the only model and tool-loop owner; the
+Sandbox SDK supplies execution isolation and storage.
 
 ## Run locally
 
@@ -170,7 +174,10 @@ Create the R2 bucket once per Cloudflare account. Each actor receives only its
 `/sessions/<session-id>/` prefix inside the mounted `/workspace`; model
 credentials remain in the Worker and are not injected into the container.
 After deployment, ask the agent to create a small server on port 8080 in the
-background and call `sandbox_preview` to get a public `trycloudflare.com` URL.
+background and call `sandbox_preview` to get a public URL on the same Worker
+origin. HTTP and WebSocket preview traffic is forwarded to that exact per-session
+container and port. The opaque URL is a bearer capability for the preview only;
+rotating `NANOCODEX_ADMIN_TOKEN` invalidates outstanding preview URLs.
 
 At the time this example was validated, the ChatGPT edge rejected direct
 Cloudflare Worker egress with HTTP 403. That is an upstream egress-policy

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -34,12 +34,13 @@ resumes complete client-owned typed history from SQLite. See Cloudflare's
 and [WebSocket hibernation](https://developers.cloudflare.com/durable-objects/best-practices/websockets/)
 documentation for the underlying behavior.
 
-The caller-defined `sandbox_exec`, `sandbox_read_file`, `sandbox_write_file`,
-`sandbox_list_files`, and `sandbox_preview` tools run untrusted work in a
-separate Cloudflare Sandbox container. The Sandbox uses the current RPC
-transport, scopes its R2 mount to the Nanocodex session ID, and creates
-zero-configuration Quick Tunnel preview URLs. Nanocodex remains the only model
-and tool-loop owner; the Sandbox SDK supplies execution isolation and storage.
+The caller-defined `sandbox_exec`, `sandbox_start_process`, `sandbox_read_file`,
+`sandbox_write_file`, `sandbox_list_files`, and `sandbox_preview` tools run
+untrusted work in a separate Cloudflare Sandbox container. The Sandbox uses the
+current RPC transport, scopes its R2 mount to the Nanocodex session ID, and
+creates zero-configuration Quick Tunnel preview URLs. Nanocodex remains the only
+model and tool-loop owner; the Sandbox SDK supplies execution isolation and
+storage.
 
 ## Run locally
 
@@ -94,6 +95,7 @@ Start workerd in one terminal and run the live probes in another:
 
 ```sh
 npm run repl --prefix examples/cloudflare-workers
+npm run smoke:sandbox --prefix examples/cloudflare-workers
 npm run smoke --prefix examples/cloudflare-workers
 npm run multiclient --prefix examples/cloudflare-workers
 npm run stress --prefix examples/cloudflare-workers
@@ -116,10 +118,18 @@ inference. If the Worker process itself dies before a turn commits, reopening
 the REPL resubmits the same turn from the last committed snapshot; a partial
 provider response cannot be resumed.
 
-The smoke performs real model turns, verifies duplicate suppression, detaches
-its client, waits for idle teardown, reconnects to the durable snapshot, proves
-that a follow-on remembers history, and requires a completed `runtimeInfo` tool
-call/result pair.
+`smoke:sandbox` bypasses the model and directly attacks the same bounded tool
+handlers used by the agent. It checks write/exec/read/list behavior, non-zero
+exits, output and timeout limits, path traversal and oversized-write rejection,
+a managed port-8000 process and preview, and R2 persistence across container
+destruction. Its fixed `POST`/`DELETE /admin/sandbox-smoke` flow requires the
+admin bearer token; the external probe fetches the preview like a browser, then
+the finish request destroys the disposable container and verifies the remount.
+
+The model smoke performs real model turns, verifies duplicate suppression,
+detaches its client, waits for idle teardown, reconnects to the durable snapshot,
+proves that a follow-on remembers history, and requires completed write, exec,
+and read tool call/result pairs.
 `multiclient` attaches at least two clients before prompting and requires every
 client to receive the same accepted turn, assistant-delta stream, event count,
 and terminal result without reconnecting.
@@ -152,6 +162,8 @@ npx wrangler secret put CHATGPT_REFRESH_TOKEN
 npx wrangler secret put CHATGPT_ACCOUNT_ID
 npx wrangler secret put NANOCODEX_ADMIN_TOKEN
 npx wrangler deploy
+NANOCODEX_WORKER_URL=https://nanocodex-durable-agent.<subdomain>.workers.dev \
+NANOCODEX_ADMIN_TOKEN=<admin-token> npm run smoke:sandbox
 ```
 
 Create the R2 bucket once per Cloudflare account. Each actor receives only its

--- a/examples/cloudflare-workers/package-lock.json
+++ b/examples/cloudflare-workers/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nanocodex-cloudflare-workers-example",
       "version": "0.1.0",
       "dependencies": {
+        "@cloudflare/sandbox": "0.12.4",
         "nanocodex": "file:../../js/bindings"
       },
       "devDependencies": {
@@ -37,6 +38,12 @@
         "node": ">=22.13.0"
       }
     },
+    "node_modules/@cloudflare/containers": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@cloudflare/containers/-/containers-0.3.7.tgz",
+      "integrity": "sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw==",
+      "license": "MIT OR Apache-2.0"
+    },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
@@ -45,6 +52,34 @@
       "license": "MIT OR Apache-2.0",
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/sandbox": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/sandbox/-/sandbox-0.12.4.tgz",
+      "integrity": "sha512-0gpkd+a58Q5aGjgXvLFZSdIDAZpvh89QlaiHBpTtkDZWqHPKfyISV76/pIUzzo9ACJzVIpUO8hNv2X+LFTTiRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cloudflare/containers": "^0.3.5",
+        "aws4fetch": "^1.0.20",
+        "capnweb": "^0.8.0",
+        "hono": "^4.12.26"
+      },
+      "peerDependencies": {
+        "@openai/agents": "^0.3.3",
+        "@opencode-ai/sdk": "^1.1.40",
+        "@xterm/xterm": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@openai/agents": {
+          "optional": true
+        },
+        "@opencode-ai/sdk": {
+          "optional": true
+        },
+        "@xterm/xterm": {
+          "optional": true
+        }
       }
     },
     "node_modules/@cloudflare/unenv-preset": {
@@ -1777,11 +1812,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "license": "MIT"
+    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/capnweb": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/capnweb/-/capnweb-0.8.0.tgz",
+      "integrity": "sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA==",
       "license": "MIT"
     },
     "node_modules/chai": {
@@ -1942,6 +1989,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.34",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
+      "integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/kleur": {

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -30,6 +30,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@cloudflare/sandbox": "0.12.4",
     "nanocodex": "file:../../js/bindings"
   },
   "devDependencies": {

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -21,6 +21,7 @@
     "relay:subscription": "node scripts/subscription-egress-relay.mjs",
     "repl": "node scripts/repl.mjs",
     "smoke": "node scripts/live-smoke.mjs",
+    "smoke:sandbox": "node scripts/sandbox-smoke.mjs",
     "soak": "node scripts/soak.mjs",
     "stress": "node scripts/stress.mjs",
     "pretest": "npm run prepare:wasm",

--- a/examples/cloudflare-workers/scripts/live-smoke.mjs
+++ b/examples/cloudflare-workers/scripts/live-smoke.mjs
@@ -85,19 +85,22 @@ try {
   socket.send(JSON.stringify({
     type: "prompt",
     id: toolId,
-    input: "You must call runtimeInfo exactly once. Then reply with only the runtime value returned by that tool.",
+    input: "Use sandbox_write_file to write SANDBOX_OK to probe.txt, use sandbox_exec to run cat on it, and verify it with sandbox_read_file. Then reply with exactly SANDBOX_OK.",
   }));
   const toolTurn = await terminal(inbox, toolId, terminalTimeoutMs);
   progress("tool-turn-completed");
-  if (!String(toolTurn.final_message).includes("cloudflare-durable-object")) {
-    throw new Error(`runtimeInfo tool returned an unexpected answer: ${toolTurn.final_message}`);
+  if (String(toolTurn.final_message).trim() !== "SANDBOX_OK") {
+    throw new Error(`sandbox tools returned an unexpected answer: ${toolTurn.final_message}`);
   }
-  const toolCall = agentEvents.find((event) =>
-    event.type === "tool.call" && event.payload?.tool === "runtimeInfo");
-  const toolResult = agentEvents.find((event) =>
-    event.type === "tool.result" && event.payload?.call_id === toolCall?.payload?.call_id);
-  if (!toolCall || !toolResult || toolResult.payload?.status !== "completed") {
-    throw new Error("runtimeInfo did not produce a completed tool.call/tool.result event pair");
+  const requiredTools = ["sandbox_write_file", "sandbox_exec", "sandbox_read_file"];
+  for (const tool of requiredTools) {
+    const toolCall = agentEvents.find((event) =>
+      event.type === "tool.call" && event.payload?.tool === tool);
+    const toolResult = agentEvents.find((event) =>
+      event.type === "tool.result" && event.payload?.call_id === toolCall?.payload?.call_id);
+    if (!toolCall || !toolResult || toolResult.payload?.status !== "completed") {
+      throw new Error(`${tool} did not produce a completed tool.call/tool.result event pair`);
+    }
   }
 
   const finalState = await state();
@@ -112,7 +115,7 @@ try {
     idle_shutdown_ms: Math.round(idleShutdownMs),
     restored_turn_ms: Math.round(restoreMs),
     agent_events: agentEvents.length,
-    tool_call: toolCall.payload.tool,
+    tool_calls: requiredTools,
     completed_turns: finalState.completed_turns,
     idle_state: idleState.agent_loaded ? "loaded" : "unloaded",
     ...(authStatus === undefined ? {} : { auth_revision: authStatus.revision }),

--- a/examples/cloudflare-workers/scripts/sandbox-smoke.mjs
+++ b/examples/cloudflare-workers/scripts/sandbox-smoke.mjs
@@ -1,0 +1,75 @@
+const baseUrl = process.env.NANOCODEX_WORKER_URL ?? "http://127.0.0.1:8787";
+const adminToken = process.env.NANOCODEX_ADMIN_TOKEN ?? "local-admin-token";
+const timeoutMs = Number(process.env.NANOCODEX_SANDBOX_SMOKE_TIMEOUT_MS ?? 300_000);
+const authorization = { authorization: `Bearer ${adminToken}` };
+let setup;
+let finished = false;
+
+try {
+  const setupResponse = await fetch(`${baseUrl}/admin/sandbox-smoke`, {
+    method: "POST",
+    headers: authorization,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const setupBody = await setupResponse.text();
+  if (!setupResponse.ok) {
+    throw new Error(`sandbox setup failed with HTTP ${setupResponse.status}: ${setupBody}`);
+  }
+  setup = JSON.parse(setupBody);
+  if (setup.status !== "ready" || !Array.isArray(setup.checks) || setup.checks.length !== 8) {
+    throw new Error(`sandbox setup returned an unexpected result: ${setupBody}`);
+  }
+
+  if (!["127.0.0.1", "localhost"].includes(new URL(baseUrl).hostname)) {
+    await waitForPreview(setup.preview_url, setup.marker);
+  }
+  const finishResponse = await finish(setup.probe_id);
+  const finishBody = await finishResponse.text();
+  finished = true;
+  if (!finishResponse.ok) {
+    throw new Error(`sandbox finish failed with HTTP ${finishResponse.status}: ${finishBody}`);
+  }
+  const result = JSON.parse(finishBody);
+  if (result.status !== "ok" || !Array.isArray(result.checks) || result.checks.length !== 1) {
+    throw new Error(`sandbox finish returned an unexpected result: ${finishBody}`);
+  }
+  console.log(JSON.stringify({
+    status: "ok",
+    probe_id: setup.probe_id,
+    checks: [...setup.checks, ...result.checks],
+    setup_duration_ms: setup.duration_ms,
+    finish_duration_ms: result.duration_ms,
+  }));
+} finally {
+  if (setup?.probe_id && !finished) await finish(setup.probe_id).catch(() => {});
+}
+
+function finish(probeId) {
+  return fetch(`${baseUrl}/admin/sandbox-smoke`, {
+    method: "DELETE",
+    headers: { ...authorization, "content-type": "application/json" },
+    body: JSON.stringify({ probe_id: probeId }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+}
+
+async function waitForPreview(url, marker) {
+  const deadline = Date.now() + 30_000;
+  let lastResult = "no response";
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(5_000) });
+      if (response.ok) {
+        const body = await response.text();
+        if (body === marker) return;
+        lastResult = `HTTP ${response.status} with unexpected content`;
+      } else {
+        lastResult = `HTTP ${response.status}`;
+      }
+    } catch (error) {
+      lastResult = error instanceof Error ? error.message : String(error);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`preview did not become reachable: ${lastResult}`);
+}

--- a/examples/cloudflare-workers/src/index.ts
+++ b/examples/cloudflare-workers/src/index.ts
@@ -11,6 +11,7 @@ import type {
 import { Agent } from "nanocodex/browser";
 import nanocodexWasm from "./nanocodex.wasm";
 import { cloudflareSandboxTools } from "./sandbox-tools";
+import { cloudflareSandboxSmokeFinish, cloudflareSandboxSmokeSetup } from "./sandbox-smoke";
 import { webAsset } from "./web";
 import {
   NanocodexSubscriptionAuth,
@@ -37,6 +38,7 @@ const OPENAI_WEBSOCKET_BETA = "responses_websockets=2026-02-06";
 const CHATGPT_WEBSOCKET_URL = "wss://chatgpt.com/backend-api/codex/responses";
 const CHATGPT_API_BASE_URL = "https://chatgpt.com/backend-api/codex";
 const SESSION_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const PROBE_ID = /^probe-[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const encoder = new TextEncoder();
 const ENCODED_PONG = JSON.stringify({ type: "pong" });
 
@@ -124,6 +126,39 @@ export default {
       if (request.method === "GET") return auth.fetch("https://auth.internal/status");
       if (request.method === "DELETE") {
         return auth.fetch("https://auth.internal/credentials", { method: "DELETE" });
+      }
+      return json({ error: "method_not_allowed" }, { status: 405 });
+    }
+    if (url.pathname === "/admin/sandbox-smoke") {
+      if (!env.NANOCODEX_ADMIN_TOKEN || !authorized(request, env.NANOCODEX_ADMIN_TOKEN)) {
+        return json({ error: "unauthorized" }, { status: 401 });
+      }
+      const localBucket = env.NANOCODEX_SANDBOX_LOCAL === "true";
+      if (request.method === "POST") {
+        const probeId = `probe-${uuidV7()}`;
+        try {
+          return json(await cloudflareSandboxSmokeSetup(env.Sandbox, probeId, localBucket));
+        } catch (error) {
+          return json({ status: "failed", probe_id: probeId, error: errorMessage(error) }, { status: 503 });
+        }
+      }
+      if (request.method === "DELETE") {
+        const body = await request.text();
+        if (body.length > 2048) return json({ error: "invalid_probe" }, { status: 400 });
+        let probeId: unknown;
+        try {
+          probeId = (JSON.parse(body) as { probe_id?: unknown }).probe_id;
+        } catch {
+          return json({ error: "invalid_probe" }, { status: 400 });
+        }
+        if (typeof probeId !== "string" || !PROBE_ID.test(probeId)) {
+          return json({ error: "invalid_probe" }, { status: 400 });
+        }
+        try {
+          return json(await cloudflareSandboxSmokeFinish(env.Sandbox, probeId, localBucket));
+        } catch (error) {
+          return json({ status: "failed", probe_id: probeId, error: errorMessage(error) }, { status: 503 });
+        }
       }
       return json({ error: "method_not_allowed" }, { status: 405 });
     }

--- a/examples/cloudflare-workers/src/index.ts
+++ b/examples/cloudflare-workers/src/index.ts
@@ -1,4 +1,5 @@
 import { DurableObject } from "cloudflare:workers";
+import { ContainerProxy, Sandbox } from "@cloudflare/sandbox";
 import type {
   DefaultAgent,
   EventWatcher,
@@ -9,6 +10,7 @@ import type {
 } from "nanocodex";
 import { Agent } from "nanocodex/browser";
 import nanocodexWasm from "./nanocodex.wasm";
+import { cloudflareSandboxTools } from "./sandbox-tools";
 import { webAsset } from "./web";
 import {
   NanocodexSubscriptionAuth,
@@ -16,6 +18,7 @@ import {
 } from "./subscription-auth";
 
 export { NanocodexSubscriptionAuth } from "./subscription-auth";
+export { ContainerProxy, Sandbox };
 
 import {
   type ActiveTurn,
@@ -40,10 +43,13 @@ const ENCODED_PONG = JSON.stringify({ type: "pong" });
 export interface Env {
   NANOCODEX_SESSIONS: DurableObjectNamespace<NanocodexSession>;
   NANOCODEX_AUTH: DurableObjectNamespace<NanocodexSubscriptionAuth>;
+  Sandbox: DurableObjectNamespace<Sandbox>;
+  NANOCODEX_WORKSPACES: R2Bucket;
   OPENAI_API_KEY?: string;
   NANOCODEX_ADMIN_TOKEN: string;
   NANOCODEX_AUTH_MODE?: string;
   AGENT_IDLE_TIMEOUT_MS?: string;
+  NANOCODEX_SANDBOX_LOCAL?: string;
   OPENAI_WEBSOCKET_URL?: string;
   CHATGPT_ACCESS_TOKEN?: string;
   CHATGPT_ACCOUNT_ID?: string;
@@ -376,7 +382,7 @@ export class NanocodexSession extends DurableObject<Env> {
       sessionId: session.session_id,
       resume,
       workspace: "/workspace",
-      instructions: "You are Nanocodex running inside a Cloudflare Durable Object.",
+      instructions: "You are Nanocodex running inside a Cloudflare Durable Object. Use the sandbox_* tools for code, files, and previews; their /workspace is isolated and persisted in R2 for this session.",
       // Workers forbid eval/new Function. Direct mode keeps caller-defined
       // tools in the WASM lifecycle while dispatching handlers through the
       // typed host bridge without dynamic code generation.
@@ -385,10 +391,20 @@ export class NanocodexSession extends DurableObject<Env> {
         ? openAiWebSocket
         : (endpoint, id, request) => openSubscriptionWebSocket(auth, endpoint, id, request),
       tools: {
+        ...cloudflareSandboxTools(
+          this.env.Sandbox,
+          session.session_id,
+          this.env.NANOCODEX_SANDBOX_LOCAL === "true",
+        ),
         runtimeInfo: {
           description: "Return information about the current agent runtime.",
           parameters: { type: "object", additionalProperties: false },
-          handler: () => ({ runtime: "cloudflare-durable-object", session_id: session.session_id }),
+          handler: () => ({
+            runtime: "cloudflare-durable-object",
+            sandbox: "cloudflare-container-r2-workspace",
+            session_id: session.session_id,
+            workspace: "/workspace",
+          }),
         },
       },
     });

--- a/examples/cloudflare-workers/src/index.ts
+++ b/examples/cloudflare-workers/src/index.ts
@@ -10,7 +10,11 @@ import type {
 } from "nanocodex";
 import { Agent } from "nanocodex/browser";
 import nanocodexWasm from "./nanocodex.wasm";
-import { cloudflareSandboxTools } from "./sandbox-tools";
+import {
+  cloudflareSandboxTools,
+  openSandboxPreviewCapability,
+  proxyCloudflareSandboxPreview,
+} from "./sandbox-tools";
 import { cloudflareSandboxSmokeFinish, cloudflareSandboxSmokeSetup } from "./sandbox-smoke";
 import { webAsset } from "./web";
 import {
@@ -62,6 +66,7 @@ export interface Env {
 
 type SessionRow = {
   session_id: string;
+  public_origin: string;
   snapshot: string | null;
   completed_turns: number;
   last_active: number;
@@ -111,7 +116,8 @@ export default {
       const stub = env.NANOCODEX_SESSIONS.getByName(sessionId);
       const initialized = await stub.fetch("https://session.internal/initialize", {
         method: "PUT",
-        body: sessionId,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ session_id: sessionId, public_origin: url.origin }),
       });
       if (!initialized.ok) return json({ error: "session initialization failed" }, { status: 503 });
       const websocketUrl = new URL(`/sessions/${sessionId}/ws`, url);
@@ -137,7 +143,13 @@ export default {
       if (request.method === "POST") {
         const probeId = `probe-${uuidV7()}`;
         try {
-          return json(await cloudflareSandboxSmokeSetup(env.Sandbox, probeId, localBucket));
+          return json(await cloudflareSandboxSmokeSetup(
+            env.Sandbox,
+            probeId,
+            localBucket,
+            url.origin,
+            env.NANOCODEX_ADMIN_TOKEN,
+          ));
         } catch (error) {
           return json({ status: "failed", probe_id: probeId, error: errorMessage(error) }, { status: 503 });
         }
@@ -163,6 +175,37 @@ export default {
       return json({ error: "method_not_allowed" }, { status: 405 });
     }
 
+    const previewMatch = url.pathname.match(/^\/sandbox-preview\/([A-Za-z0-9_-]{64,256})(\/.*)?$/);
+    if (previewMatch) {
+      let preview: { sessionId: string; port: number };
+      try {
+        preview = await openSandboxPreviewCapability(
+          env.NANOCODEX_ADMIN_TOKEN,
+          previewMatch[1]!,
+        );
+      } catch {
+        return json({ error: "not_found" }, { status: 404 });
+      }
+      if (!SESSION_ID.test(preview.sessionId) && !PROBE_ID.test(preview.sessionId)) {
+        return json({ error: "not_found" }, { status: 404 });
+      }
+      try {
+        return await proxyCloudflareSandboxPreview(
+          env.Sandbox,
+          preview.sessionId,
+          preview.port,
+          request,
+          previewMatch[2] ?? "/",
+        );
+      } catch {
+        return json({ error: "sandbox_preview_unavailable" }, { status: 502 });
+      }
+    }
+
+    if (url.pathname.startsWith("/sandbox-preview/")) {
+      return json({ error: "not_found" }, { status: 404 });
+    }
+
     const match = url.pathname.match(/^\/sessions\/([^/]+)(?:\/(ws))?$/);
     if (!match || !SESSION_ID.test(match[1] ?? "")) {
       return json({ error: "not_found" }, { status: 404 });
@@ -173,9 +216,16 @@ export default {
       if (request.method !== "GET" || request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
         return new Response("Expected WebSocket upgrade", { status: 426 });
       }
-      return stub.fetch("https://session.internal/socket", request);
+      return stub.fetch(
+        `https://session.internal/socket?public_origin=${encodeURIComponent(url.origin)}`,
+        request,
+      );
     }
-    if (request.method === "GET") return stub.fetch("https://session.internal/state");
+    if (request.method === "GET") {
+      return stub.fetch(
+        `https://session.internal/state?public_origin=${encodeURIComponent(url.origin)}`,
+      );
+    }
     if (request.method === "DELETE") return stub.fetch("https://session.internal/session", { method: "DELETE" });
     return json({ error: "method_not_allowed" }, { status: 405 });
   },
@@ -195,6 +245,7 @@ export class NanocodexSession extends DurableObject<Env> {
       CREATE TABLE IF NOT EXISTS session_state (
         singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
         session_id TEXT NOT NULL UNIQUE,
+        public_origin TEXT NOT NULL DEFAULT '',
         snapshot TEXT,
         completed_turns INTEGER NOT NULL DEFAULT 0,
         last_active INTEGER NOT NULL
@@ -205,20 +256,55 @@ export class NanocodexSession extends DurableObject<Env> {
         completed_at INTEGER NOT NULL
       );
     `);
+    const sessionColumns = this.ctx.storage.sql.exec<{ name: string }>(
+      "PRAGMA table_info(session_state)",
+    ).toArray();
+    if (!sessionColumns.some((column) => column.name === "public_origin")) {
+      this.ctx.storage.sql.exec(
+        "ALTER TABLE session_state ADD COLUMN public_origin TEXT NOT NULL DEFAULT ''",
+      );
+    }
   }
 
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
+    const forwardedOrigin = url.searchParams.get("public_origin");
+    if (forwardedOrigin !== null && validPublicOrigin(forwardedOrigin) && this.#sessionId()) {
+      this.ctx.storage.sql.exec(
+        "UPDATE session_state SET public_origin = ? WHERE singleton = 1",
+        forwardedOrigin,
+      );
+    }
     if (request.method === "PUT" && url.pathname === "/initialize") {
-      const sessionId = await request.text();
-      if (!SESSION_ID.test(sessionId)) return new Response(null, { status: 400 });
+      const body = await request.text();
+      if (body.length > 2048) return new Response(null, { status: 400 });
+      let initialization: { session_id?: unknown; public_origin?: unknown };
+      try {
+        initialization = JSON.parse(body) as typeof initialization;
+      } catch {
+        return new Response(null, { status: 400 });
+      }
+      const sessionId = initialization.session_id;
+      const publicOrigin = initialization.public_origin;
+      if (typeof sessionId !== "string"
+        || !SESSION_ID.test(sessionId)
+        || typeof publicOrigin !== "string"
+        || !validPublicOrigin(publicOrigin)) {
+        return new Response(null, { status: 400 });
+      }
       const currentId = this.#sessionId();
       if (currentId && currentId !== sessionId) return new Response(null, { status: 409 });
       if (!currentId) {
         this.ctx.storage.sql.exec(
-          "INSERT INTO session_state (singleton, session_id, last_active) VALUES (1, ?, ?)",
+          "INSERT INTO session_state (singleton, session_id, public_origin, last_active) VALUES (1, ?, ?, ?)",
           sessionId,
+          publicOrigin,
           Date.now(),
+        );
+      } else {
+        this.ctx.storage.sql.exec(
+          "UPDATE session_state SET public_origin = ? WHERE singleton = 1",
+          publicOrigin,
         );
       }
       return new Response(null, { status: 204 });
@@ -430,6 +516,8 @@ export class NanocodexSession extends DurableObject<Env> {
           this.env.Sandbox,
           session.session_id,
           this.env.NANOCODEX_SANDBOX_LOCAL === "true",
+          session.public_origin || undefined,
+          this.env.NANOCODEX_ADMIN_TOKEN,
         ),
         runtimeInfo: {
           description: "Return information about the current agent runtime.",
@@ -532,7 +620,7 @@ export class NanocodexSession extends DurableObject<Env> {
 
   #session(): SessionRow | undefined {
     return this.ctx.storage.sql.exec<SessionRow>(
-      "SELECT session_id, snapshot, completed_turns, last_active FROM session_state WHERE singleton = 1",
+      "SELECT session_id, public_origin, snapshot, completed_turns, last_active FROM session_state WHERE singleton = 1",
     ).toArray()[0];
   }
 
@@ -706,6 +794,18 @@ function modelAuthMode(env: Env): ModelAuthMode {
 function authorized(request: Request, expected: string): boolean {
   const value = request.headers.get("authorization");
   return value !== null && value === `Bearer ${expected}`;
+}
+
+function validPublicOrigin(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return ["http:", "https:"].includes(url.protocol)
+      && !url.username
+      && !url.password
+      && url.href === `${url.origin}/`;
+  } catch {
+    return false;
+  }
 }
 
 function uuidV7(): string {

--- a/examples/cloudflare-workers/src/sandbox-smoke.ts
+++ b/examples/cloudflare-workers/src/sandbox-smoke.ts
@@ -9,10 +9,18 @@ export async function cloudflareSandboxSmokeSetup(
   namespace: DurableObjectNamespace<Sandbox>,
   probeId: string,
   localBucket: boolean,
+  publicOrigin: string,
+  previewSecret: string,
 ): Promise<Record<string, unknown>> {
   const started = Date.now();
   const marker = `CLOUDFLARE_SANDBOX_OK_${probeId}`;
-  let tools = cloudflareSandboxTools(namespace, probeId, localBucket);
+  let tools = cloudflareSandboxTools(
+    namespace,
+    probeId,
+    localBucket,
+    publicOrigin,
+    previewSecret,
+  );
   try {
     // Wrangler's emulated R2 watcher takes its initial filesystem snapshot
     // asynchronously after mountBucket() returns. Let that baseline settle so
@@ -93,8 +101,8 @@ export async function cloudflareSandboxSmokeSetup(
     }));
     assert(process.ready_port === 8000, "managed process did not report port readiness");
     const preview = record(await invoke(tools, "sandbox_preview", { port: 8000 }));
-    const previewUrl = new URL("/probe.txt", String(preview.url));
-    assert(previewUrl.protocol === "https:", `tunnel returned an invalid URL: ${previewUrl.href}`);
+    const previewUrl = new URL("probe.txt", String(preview.url));
+    assert(previewUrl.protocol === "https:", `preview returned an invalid URL: ${previewUrl.href}`);
 
     return {
       status: "ready",

--- a/examples/cloudflare-workers/src/sandbox-smoke.ts
+++ b/examples/cloudflare-workers/src/sandbox-smoke.ts
@@ -1,0 +1,170 @@
+import type { Sandbox } from "@cloudflare/sandbox";
+import type { ToolMap } from "nanocodex";
+
+import { cloudflareSandboxTools, destroyCloudflareSandbox } from "./sandbox-tools";
+
+const context = { callId: "smoke", parentCallId: "smoke", sessionId: "smoke" };
+
+export async function cloudflareSandboxSmokeSetup(
+  namespace: DurableObjectNamespace<Sandbox>,
+  probeId: string,
+  localBucket: boolean,
+): Promise<Record<string, unknown>> {
+  const started = Date.now();
+  const marker = `CLOUDFLARE_SANDBOX_OK_${probeId}`;
+  let tools = cloudflareSandboxTools(namespace, probeId, localBucket);
+  try {
+    // Wrangler's emulated R2 watcher takes its initial filesystem snapshot
+    // asynchronously after mountBucket() returns. Let that baseline settle so
+    // this write is observed as a change; production uses the direct R2 mount.
+    if (localBucket) await invoke(tools, "sandbox_exec", { command: "sleep 2" });
+    const write = record(await invoke(tools, "sandbox_write_file", {
+      path: "probe.txt",
+      content: marker,
+    }));
+    assert(write.bytes_written === marker.length, "write byte count mismatch");
+
+    const exec = record(await invoke(tools, "sandbox_exec", {
+      command: `test "$(cat probe.txt)" = "${marker}" && printf EXEC_OK`,
+      timeout_ms: 10_000,
+    }));
+    assert(exec.success === true && exec.stdout === "EXEC_OK", "write was not visible to exec");
+
+    const read = record(await invoke(tools, "sandbox_read_file", { path: "probe.txt" }));
+    assert(read.content === marker, "read did not return written content");
+
+    const list = record(await invoke(tools, "sandbox_list_files", {}));
+    const entries = Array.isArray(list.entries) ? list.entries.map(record) : [];
+    assert(entries.some((entry) => entry.name === "probe.txt"), "list omitted probe.txt");
+
+    const nonzero = record(await invoke(tools, "sandbox_exec", {
+      command: "sh -c 'printf partial; printf failed >&2; exit 7'",
+    }));
+    assert(
+      nonzero.success === false
+        && nonzero.exit_code === 7
+        && nonzero.stdout === "partial"
+        && nonzero.stderr === "failed",
+      "non-zero command result was not preserved",
+    );
+
+    const flood = record(await invoke(tools, "sandbox_exec", {
+      command: "node -e 'process.stdout.write(\"x\".repeat(140000)); process.stderr.write(\"y\".repeat(140000))'",
+    }));
+    assert(
+      flood.stdout_truncated === true,
+      `stdout flood was not truncated: ${JSON.stringify({
+        success: flood.success,
+        exit_code: flood.exit_code,
+        stdout_bytes: new TextEncoder().encode(String(flood.stdout)).byteLength,
+        stderr_bytes: new TextEncoder().encode(String(flood.stderr)).byteLength,
+        stderr_truncated: flood.stderr_truncated,
+      })}`,
+    );
+    assert(flood.stderr_truncated === true, "stderr flood was not truncated");
+    assert(
+      new TextEncoder().encode(String(flood.stdout)).byteLength === 128 * 1024,
+      "stdout was not capped at 128 KiB",
+    );
+
+    const timeoutStarted = Date.now();
+    const timeoutError = await rejectedMessage(invoke(tools, "sandbox_exec", {
+      command: "sleep 5",
+      timeout_ms: 100,
+    }));
+    assert(/time|interrupt|abort/i.test(timeoutError), `unexpected timeout error: ${timeoutError}`);
+    assert(Date.now() - timeoutStarted < 4_000, "command timeout was not enforced promptly");
+
+    const traversalError = await rejectedMessage(invoke(tools, "sandbox_read_file", {
+      path: "../etc/passwd",
+    }));
+    assert(/must not contain/.test(traversalError), "path traversal was not rejected");
+
+    const oversizedError = await rejectedMessage(invoke(tools, "sandbox_write_file", {
+      path: "oversized.txt",
+      content: "😀".repeat(1024 * 1024 / 4 + 1),
+    }));
+    assert(/exceeds 1 MiB/.test(oversizedError), "oversized UTF-8 write was not rejected");
+
+    const process = record(await invoke(tools, "sandbox_start_process", {
+      command: "node -e 'require(\"http\").createServer((q,s)=>require(\"fs\").createReadStream(\"/workspace/probe.txt\").pipe(s)).listen(8000)'",
+      ready_port: 8000,
+      ready_timeout_ms: 10_000,
+    }));
+    assert(process.ready_port === 8000, "managed process did not report port readiness");
+    const preview = record(await invoke(tools, "sandbox_preview", { port: 8000 }));
+    const previewUrl = new URL("/probe.txt", String(preview.url));
+    assert(previewUrl.protocol === "https:", `tunnel returned an invalid URL: ${previewUrl.href}`);
+
+    return {
+      status: "ready",
+      probe_id: probeId,
+      marker,
+      preview_url: previewUrl.href,
+      checks: [
+        "write_exec_read",
+        "directory_list",
+        "nonzero_exit",
+        "bounded_output",
+        "command_timeout",
+        "path_confinement",
+        "write_size_limit",
+        "managed_process_preview",
+      ],
+      duration_ms: Date.now() - started,
+    };
+  } catch (error) {
+    await destroyCloudflareSandbox(namespace, probeId).catch(() => {});
+    throw error;
+  }
+}
+
+export async function cloudflareSandboxSmokeFinish(
+  namespace: DurableObjectNamespace<Sandbox>,
+  probeId: string,
+  localBucket: boolean,
+): Promise<Record<string, unknown>> {
+  const started = Date.now();
+  const marker = `CLOUDFLARE_SANDBOX_OK_${probeId}`;
+  try {
+    await destroyCloudflareSandbox(namespace, probeId);
+    const tools = cloudflareSandboxTools(namespace, probeId, localBucket);
+    const persisted = record(await invoke(tools, "sandbox_read_file", { path: "probe.txt" }));
+    assert(persisted.content === marker, "R2 workspace did not survive container destruction");
+    await invoke(tools, "sandbox_exec", { command: "rm -f probe.txt" });
+    return {
+      status: "ok",
+      probe_id: probeId,
+      checks: ["r2_restart_persistence"],
+      duration_ms: Date.now() - started,
+    };
+  } finally {
+    await destroyCloudflareSandbox(namespace, probeId).catch(() => {});
+  }
+}
+
+async function invoke(tools: ToolMap, name: string, input: unknown): Promise<unknown> {
+  const tool = tools[name];
+  if (!tool) throw new Error(`missing tool: ${name}`);
+  return tool.handler(input, context);
+}
+
+async function rejectedMessage(operation: Promise<unknown>): Promise<string> {
+  try {
+    await operation;
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  throw new Error("operation unexpectedly succeeded");
+}
+
+function record(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("tool returned a non-object result");
+  }
+  return value as Record<string, unknown>;
+}
+
+function assert(condition: boolean, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}

--- a/examples/cloudflare-workers/src/sandbox-tools.ts
+++ b/examples/cloudflare-workers/src/sandbox-tools.ts
@@ -1,0 +1,236 @@
+import { getSandbox, type Sandbox } from "@cloudflare/sandbox";
+import type { ToolMap } from "nanocodex";
+
+const WORKSPACE = "/workspace";
+const MAX_COMMAND_CHARS = 32 * 1024;
+const MAX_FILE_BYTES = 1024 * 1024;
+const MAX_OUTPUT_CHARS = 128 * 1024;
+const MAX_LIST_ENTRIES = 512;
+const MAX_TIMEOUT_MS = 120_000;
+
+export function cloudflareSandboxTools(
+  namespace: DurableObjectNamespace<Sandbox>,
+  sessionId: string,
+  localBucket = false,
+): ToolMap {
+  let sandboxPromise: Promise<Sandbox> | undefined;
+  const sandbox = () => sandboxPromise ??= prepareSandbox(namespace, sessionId, localBucket);
+
+  return {
+    sandbox_exec: {
+      description: "Run a shell command in this session's isolated Cloudflare Sandbox workspace.",
+      parameters: {
+        type: "object",
+        properties: {
+          command: { type: "string", description: "Shell command to run." },
+          cwd: { type: "string", description: "Workspace-relative working directory." },
+          timeout_ms: { type: "integer", minimum: 1, maximum: MAX_TIMEOUT_MS },
+        },
+        required: ["command"],
+        additionalProperties: false,
+      },
+      handler: async (input) => {
+        const value = objectInput(input);
+        const command = requiredString(value.command, "command", MAX_COMMAND_CHARS);
+        const cwd = workspacePath(optionalString(value.cwd, "cwd") ?? ".");
+        const timeout = optionalInteger(value.timeout_ms, "timeout_ms", 1, MAX_TIMEOUT_MS) ?? 60_000;
+        const result = await (await sandbox()).exec(command, { cwd, timeout });
+        const stdout = truncate(result.stdout);
+        const stderr = truncate(result.stderr);
+        return {
+          success: result.success,
+          exit_code: result.exitCode,
+          stdout: stdout.text,
+          stderr: stderr.text,
+          stdout_truncated: stdout.truncated,
+          stderr_truncated: stderr.truncated,
+          duration_ms: result.duration,
+        };
+      },
+    },
+    sandbox_read_file: {
+      description: "Read a UTF-8 text file from this session's isolated workspace (maximum 1 MiB).",
+      parameters: pathParameters(),
+      handler: async (input) => {
+        const path = workspacePath(requiredString(objectInput(input).path, "path", 1024));
+        const result = await (await sandbox()).readFile(path, { encoding: "none" });
+        if (result.size > MAX_FILE_BYTES) throw new Error("file exceeds 1 MiB");
+        return { path, content: await readBounded(result.content) };
+      },
+    },
+    sandbox_write_file: {
+      description: "Write a UTF-8 text file inside this session's isolated workspace (maximum 1 MiB).",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "Workspace-relative file path." },
+          content: { type: "string", description: "Complete UTF-8 file content." },
+        },
+        required: ["path", "content"],
+        additionalProperties: false,
+      },
+      handler: async (input) => {
+        const value = objectInput(input);
+        const path = workspacePath(requiredString(value.path, "path", 1024));
+        const content = requiredString(value.content, "content", MAX_FILE_BYTES);
+        const bytes = new TextEncoder().encode(content).byteLength;
+        if (bytes > MAX_FILE_BYTES) throw new Error("content exceeds 1 MiB");
+        await (await sandbox()).writeFile(path, content, { encoding: "utf-8" });
+        return { path, bytes_written: bytes };
+      },
+    },
+    sandbox_list_files: {
+      description: "List files in a directory inside this session's isolated workspace.",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "Workspace-relative directory; defaults to the workspace root." },
+        },
+        additionalProperties: false,
+      },
+      handler: async (input) => {
+        const value = objectInput(input);
+        const path = workspacePath(optionalString(value.path, "path") ?? ".");
+        const result = await (await sandbox()).listFiles(path, { includeHidden: true });
+        return {
+          path,
+          entries: result.files.slice(0, MAX_LIST_ENTRIES).map((entry) => ({
+            name: entry.name,
+            type: entry.type,
+            size: entry.size,
+          })),
+          truncated: result.files.length > MAX_LIST_ENTRIES,
+        };
+      },
+    },
+    sandbox_preview: {
+      description: "Expose a server running in the sandbox through a temporary public Cloudflare Tunnel URL.",
+      parameters: portParameters(),
+      handler: async (input) => {
+        const port = requiredPort(objectInput(input).port);
+        const tunnel = await (await sandbox()).tunnels.get(port);
+        return { port, url: tunnel.url, persistent: false };
+      },
+    },
+  };
+}
+
+async function prepareSandbox(
+  namespace: DurableObjectNamespace<Sandbox>,
+  sessionId: string,
+  localBucket: boolean,
+): Promise<Sandbox> {
+  const sandbox = getSandbox(namespace, `nanocodex-${sessionId}`, {
+    normalizeId: true,
+    sleepAfter: "10m",
+    transport: "rpc",
+    labels: { application: "nanocodex", session: sessionId },
+  });
+  try {
+    await sandbox.mountBucket("NANOCODEX_WORKSPACES", WORKSPACE, {
+      prefix: `/sessions/${sessionId}/`,
+      ...(localBucket ? { localBucket: true as const } : {}),
+    });
+  } catch (error) {
+    if (!errorMessage(error).toLowerCase().includes("mount path already in use")) throw error;
+  }
+  return sandbox;
+}
+
+export function workspacePath(raw: string): string {
+  if (!raw || raw.length > 1024 || raw.includes("\0")) throw new Error("path must be 1-1024 characters");
+  let relative = raw;
+  if (relative === WORKSPACE) relative = ".";
+  else if (relative.startsWith(`${WORKSPACE}/`)) relative = relative.slice(WORKSPACE.length + 1);
+  else if (relative.startsWith("/")) throw new Error("path must be relative to /workspace");
+  const parts = relative.split("/").filter((part) => part !== "" && part !== ".");
+  if (parts.includes("..")) throw new Error("path must not contain '..'");
+  return parts.length === 0 ? WORKSPACE : `${WORKSPACE}/${parts.join("/")}`;
+}
+
+function objectInput(input: unknown): Record<string, unknown> {
+  if (!input || typeof input !== "object" || Array.isArray(input)) throw new Error("tool input must be an object");
+  return input as Record<string, unknown>;
+}
+
+function requiredString(value: unknown, name: string, maxChars: number): string {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${name} must be a non-empty string`);
+  if (value.length > maxChars) throw new Error(`${name} is too long`);
+  return value;
+}
+
+function optionalString(value: unknown, name: string): string | undefined {
+  if (value === undefined) return undefined;
+  return requiredString(value, name, 1024);
+}
+
+function optionalInteger(
+  value: unknown,
+  name: string,
+  minimum: number,
+  maximum: number,
+): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isInteger(value) || (value as number) < minimum || (value as number) > maximum) {
+    throw new Error(`${name} must be an integer between ${minimum} and ${maximum}`);
+  }
+  return value as number;
+}
+
+function requiredPort(value: unknown): number {
+  const port = optionalInteger(value, "port", 1024, 65_535);
+  if (port === undefined) throw new Error("port is required");
+  return port;
+}
+
+function pathParameters(): Record<string, unknown> {
+  return {
+    type: "object",
+    properties: { path: { type: "string", description: "Workspace-relative file path." } },
+    required: ["path"],
+    additionalProperties: false,
+  };
+}
+
+function portParameters(): Record<string, unknown> {
+  return {
+    type: "object",
+    properties: { port: { type: "integer", minimum: 1024, maximum: 65_535 } },
+    required: ["port"],
+    additionalProperties: false,
+  };
+}
+
+async function readBounded(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      size += next.value.byteLength;
+      if (size > MAX_FILE_BYTES) throw new Error("file exceeds 1 MiB");
+      chunks.push(next.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const content = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    content.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(content);
+}
+
+function truncate(value: string): { text: string; truncated: boolean } {
+  return value.length <= MAX_OUTPUT_CHARS
+    ? { text: value, truncated: false }
+    : { text: value.slice(0, MAX_OUTPUT_CHARS), truncated: true };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/examples/cloudflare-workers/src/sandbox-tools.ts
+++ b/examples/cloudflare-workers/src/sandbox-tools.ts
@@ -214,7 +214,9 @@ export function createCloudflareSandboxTools(
       },
     },
     sandbox_preview: {
-      description: "Expose a server running in the sandbox through a temporary public preview URL.",
+      // Keep this definition byte-stable so snapshots created before the
+      // Worker-fronted preview implementation can resume safely.
+      description: "Expose a server running in the sandbox through a temporary public Cloudflare Tunnel URL.",
       parameters: portParameters(),
       handler: async (input) => {
         const port = requiredPort(objectInput(input).port);

--- a/examples/cloudflare-workers/src/sandbox-tools.ts
+++ b/examples/cloudflare-workers/src/sandbox-tools.ts
@@ -4,17 +4,72 @@ import type { ToolMap } from "nanocodex";
 const WORKSPACE = "/workspace";
 const MAX_COMMAND_CHARS = 32 * 1024;
 const MAX_FILE_BYTES = 1024 * 1024;
-const MAX_OUTPUT_CHARS = 128 * 1024;
+const MAX_OUTPUT_BYTES = 128 * 1024;
 const MAX_LIST_ENTRIES = 512;
 const MAX_TIMEOUT_MS = 120_000;
+
+type SandboxToolClient = {
+  exec(
+    command: string,
+    options: { cwd: string; timeout: number },
+  ): Promise<{
+    success: boolean;
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+    duration: number;
+  }>;
+  startProcess(
+    command: string,
+    options: { cwd: string; autoCleanup: true },
+  ): Promise<{
+    id: string;
+    pid?: number;
+    command: string;
+    status: string;
+    getStatus(): Promise<string>;
+    waitForPort(port: number, options: { timeout: number }): Promise<void>;
+  }>;
+  readFile(
+    path: string,
+    options: { encoding: "none" },
+  ): Promise<{ size: number; content: ReadableStream<Uint8Array> }>;
+  writeFile(
+    path: string,
+    content: string,
+    options: { encoding: "utf-8" },
+  ): Promise<unknown>;
+  listFiles(
+    path: string,
+    options: { includeHidden: true },
+  ): Promise<{
+    files: Array<{ name: string; type: string; size: number }>;
+  }>;
+  tunnels: {
+    get(port: number): Promise<{ url: string }>;
+  };
+};
 
 export function cloudflareSandboxTools(
   namespace: DurableObjectNamespace<Sandbox>,
   sessionId: string,
   localBucket = false,
 ): ToolMap {
-  let sandboxPromise: Promise<Sandbox> | undefined;
-  const sandbox = () => sandboxPromise ??= prepareSandbox(namespace, sessionId, localBucket);
+  return createCloudflareSandboxTools(() => prepareSandbox(namespace, sessionId, localBucket));
+}
+
+export async function destroyCloudflareSandbox(
+  namespace: DurableObjectNamespace<Sandbox>,
+  sessionId: string,
+): Promise<void> {
+  await sandboxHandle(namespace, sessionId).destroy();
+}
+
+export function createCloudflareSandboxTools(
+  createSandbox: () => Promise<SandboxToolClient>,
+): ToolMap {
+  let sandboxPromise: Promise<SandboxToolClient> | undefined;
+  const sandbox = () => sandboxPromise ??= createSandbox();
 
   return {
     sandbox_exec: {
@@ -58,6 +113,43 @@ export function cloudflareSandboxTools(
         return { path, content: await readBounded(result.content) };
       },
     },
+    sandbox_start_process: {
+      description: "Start a managed background process in this session's Cloudflare Sandbox, optionally waiting for an HTTP port to become ready.",
+      parameters: {
+        type: "object",
+        properties: {
+          command: { type: "string", description: "Command to start." },
+          cwd: { type: "string", description: "Workspace-relative working directory." },
+          ready_port: { type: "integer", minimum: 1024, maximum: 65_535 },
+          ready_timeout_ms: { type: "integer", minimum: 1, maximum: MAX_TIMEOUT_MS },
+        },
+        required: ["command"],
+        additionalProperties: false,
+      },
+      handler: async (input) => {
+        const value = objectInput(input);
+        const command = requiredString(value.command, "command", MAX_COMMAND_CHARS);
+        const cwd = workspacePath(optionalString(value.cwd, "cwd") ?? ".");
+        const readyPort = optionalPort(value.ready_port, "ready_port");
+        const readyTimeout = optionalInteger(
+          value.ready_timeout_ms,
+          "ready_timeout_ms",
+          1,
+          MAX_TIMEOUT_MS,
+        ) ?? 30_000;
+        const process = await (await sandbox()).startProcess(command, { cwd, autoCleanup: true });
+        if (readyPort !== undefined) {
+          await process.waitForPort(readyPort, { timeout: readyTimeout });
+        }
+        return {
+          process_id: process.id,
+          pid: process.pid,
+          command: process.command,
+          status: await process.getStatus(),
+          ...(readyPort === undefined ? {} : { ready_port: readyPort }),
+        };
+      },
+    },
     sandbox_write_file: {
       description: "Write a UTF-8 text file inside this session's isolated workspace (maximum 1 MiB).",
       parameters: {
@@ -72,7 +164,7 @@ export function cloudflareSandboxTools(
       handler: async (input) => {
         const value = objectInput(input);
         const path = workspacePath(requiredString(value.path, "path", 1024));
-        const content = requiredString(value.content, "content", MAX_FILE_BYTES);
+        const content = requiredContent(value.content);
         const bytes = new TextEncoder().encode(content).byteLength;
         if (bytes > MAX_FILE_BYTES) throw new Error("content exceeds 1 MiB");
         await (await sandbox()).writeFile(path, content, { encoding: "utf-8" });
@@ -120,12 +212,7 @@ async function prepareSandbox(
   sessionId: string,
   localBucket: boolean,
 ): Promise<Sandbox> {
-  const sandbox = getSandbox(namespace, `nanocodex-${sessionId}`, {
-    normalizeId: true,
-    sleepAfter: "10m",
-    transport: "rpc",
-    labels: { application: "nanocodex", session: sessionId },
-  });
+  const sandbox = sandboxHandle(namespace, sessionId);
   try {
     await sandbox.mountBucket("NANOCODEX_WORKSPACES", WORKSPACE, {
       prefix: `/sessions/${sessionId}/`,
@@ -135,6 +222,18 @@ async function prepareSandbox(
     if (!errorMessage(error).toLowerCase().includes("mount path already in use")) throw error;
   }
   return sandbox;
+}
+
+function sandboxHandle(
+  namespace: DurableObjectNamespace<Sandbox>,
+  sessionId: string,
+): Sandbox {
+  return getSandbox(namespace, `nanocodex-${sessionId}`, {
+    normalizeId: true,
+    sleepAfter: "10m",
+    transport: "rpc",
+    labels: { application: "nanocodex", session: sessionId },
+  });
 }
 
 export function workspacePath(raw: string): string {
@@ -178,9 +277,13 @@ function optionalInteger(
 }
 
 function requiredPort(value: unknown): number {
-  const port = optionalInteger(value, "port", 1024, 65_535);
+  const port = optionalPort(value, "port");
   if (port === undefined) throw new Error("port is required");
   return port;
+}
+
+function optionalPort(value: unknown, name: string): number | undefined {
+  return optionalInteger(value, name, 1024, 65_535);
 }
 
 function pathParameters(): Record<string, unknown> {
@@ -210,7 +313,14 @@ async function readBounded(stream: ReadableStream<Uint8Array>): Promise<string> 
       const next = await reader.read();
       if (next.done) break;
       size += next.value.byteLength;
-      if (size > MAX_FILE_BYTES) throw new Error("file exceeds 1 MiB");
+      if (size > MAX_FILE_BYTES) {
+        try {
+          await reader.cancel("file exceeds 1 MiB");
+        } catch {
+          // Preserve the deterministic size error if cancellation also fails.
+        }
+        throw new Error("file exceeds 1 MiB");
+      }
       chunks.push(next.value);
     }
   } finally {
@@ -222,13 +332,34 @@ async function readBounded(stream: ReadableStream<Uint8Array>): Promise<string> 
     content.set(chunk, offset);
     offset += chunk.byteLength;
   }
-  return new TextDecoder().decode(content);
+  try {
+    return new TextDecoder("utf-8", { fatal: true, ignoreBOM: false }).decode(content);
+  } catch {
+    throw new Error("file is not valid UTF-8");
+  }
 }
 
 function truncate(value: string): { text: string; truncated: boolean } {
-  return value.length <= MAX_OUTPUT_CHARS
-    ? { text: value, truncated: false }
-    : { text: value.slice(0, MAX_OUTPUT_CHARS), truncated: true };
+  const encoded = new TextEncoder().encode(value);
+  if (encoded.byteLength <= MAX_OUTPUT_BYTES) return { text: value, truncated: false };
+  let end = MAX_OUTPUT_BYTES;
+  while (end > 0) {
+    try {
+      return {
+        text: new TextDecoder("utf-8", { fatal: true, ignoreBOM: false }).decode(encoded.subarray(0, end)),
+        truncated: true,
+      };
+    } catch {
+      end -= 1;
+    }
+  }
+  return { text: "", truncated: true };
+}
+
+function requiredContent(value: unknown): string {
+  if (typeof value !== "string") throw new Error("content must be a string");
+  if (value.length > MAX_FILE_BYTES) throw new Error("content exceeds 1 MiB");
+  return value;
 }
 
 function errorMessage(error: unknown): string {

--- a/examples/cloudflare-workers/src/sandbox-tools.ts
+++ b/examples/cloudflare-workers/src/sandbox-tools.ts
@@ -7,6 +7,7 @@ const MAX_FILE_BYTES = 1024 * 1024;
 const MAX_OUTPUT_BYTES = 128 * 1024;
 const MAX_LIST_ENTRIES = 512;
 const MAX_TIMEOUT_MS = 120_000;
+const PREVIEW_AAD = new TextEncoder().encode("nanocodex-cloudflare-sandbox-preview-v1");
 
 type SandboxToolClient = {
   exec(
@@ -54,8 +55,24 @@ export function cloudflareSandboxTools(
   namespace: DurableObjectNamespace<Sandbox>,
   sessionId: string,
   localBucket = false,
+  publicOrigin?: string,
+  previewSecret?: string,
 ): ToolMap {
-  return createCloudflareSandboxTools(() => prepareSandbox(namespace, sessionId, localBucket));
+  return createCloudflareSandboxTools(
+    () => prepareSandbox(namespace, sessionId, localBucket),
+    publicOrigin === undefined || previewSecret === undefined
+      ? undefined
+      : async (port) => ({
+          port,
+          url: await cloudflareSandboxPreviewUrl(
+            publicOrigin,
+            previewSecret,
+            sessionId,
+            port,
+          ),
+          persistent: false,
+        }),
+  );
 }
 
 export async function destroyCloudflareSandbox(
@@ -67,6 +84,7 @@ export async function destroyCloudflareSandbox(
 
 export function createCloudflareSandboxTools(
   createSandbox: () => Promise<SandboxToolClient>,
+  createPreview?: (port: number) => Promise<{ port: number; url: string; persistent: boolean }>,
 ): ToolMap {
   let sandboxPromise: Promise<SandboxToolClient> | undefined;
   const sandbox = () => sandboxPromise ??= createSandbox();
@@ -196,15 +214,121 @@ export function createCloudflareSandboxTools(
       },
     },
     sandbox_preview: {
-      description: "Expose a server running in the sandbox through a temporary public Cloudflare Tunnel URL.",
+      description: "Expose a server running in the sandbox through a temporary public preview URL.",
       parameters: portParameters(),
       handler: async (input) => {
         const port = requiredPort(objectInput(input).port);
+        await sandbox();
+        if (createPreview) return createPreview(port);
         const tunnel = await (await sandbox()).tunnels.get(port);
         return { port, url: tunnel.url, persistent: false };
       },
     },
   };
+}
+
+export async function cloudflareSandboxPreviewUrl(
+  publicOrigin: string,
+  previewSecret: string,
+  sessionId: string,
+  port: number,
+): Promise<string> {
+  const origin = new URL(publicOrigin);
+  if (!["http:", "https:"].includes(origin.protocol)
+    || origin.username
+    || origin.password
+    || origin.href !== `${origin.origin}/`) {
+    throw new Error("public origin must be an HTTP(S) origin");
+  }
+  const capability = await sealSandboxPreview(previewSecret, sessionId, port);
+  return new URL(`/sandbox-preview/${capability}/`, origin).href;
+}
+
+export async function openSandboxPreviewCapability(
+  previewSecret: string,
+  capability: string,
+): Promise<{ sessionId: string; port: number }> {
+  if (!/^[A-Za-z0-9_-]{64,256}$/.test(capability)) throw new Error("invalid preview capability");
+  const sealed = decodeBase64Url(capability);
+  if (sealed.byteLength <= 12) throw new Error("invalid preview capability");
+  const iv = sealed.subarray(0, 12);
+  const ciphertext = sealed.subarray(12);
+  let plaintext: ArrayBuffer;
+  try {
+    plaintext = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv, additionalData: PREVIEW_AAD },
+      await previewKey(previewSecret),
+      ciphertext,
+    );
+  } catch {
+    throw new Error("invalid preview capability");
+  }
+  const [sessionId, rawPort, ...extra] = new TextDecoder().decode(plaintext).split("\n");
+  const port = Number(rawPort);
+  if (!sessionId || extra.length > 0 || !Number.isInteger(port) || port < 1024 || port > 65_535) {
+    throw new Error("invalid preview capability");
+  }
+  return { sessionId, port };
+}
+
+export async function proxyCloudflareSandboxPreview(
+  namespace: DurableObjectNamespace<Sandbox>,
+  sessionId: string,
+  port: number,
+  request: Request,
+  path: string,
+): Promise<Response> {
+  const incoming = new URL(request.url);
+  const targetPath = path.startsWith("/") ? path : `/${path}`;
+  const target = new URL(`http://sandbox.internal${targetPath}${incoming.search}`);
+  const forwarded = new Request(target, request);
+  const sandbox = sandboxHandle(namespace, sessionId);
+  if (request.headers.get("Upgrade")?.toLowerCase() === "websocket") {
+    return sandbox.wsConnect(forwarded, port);
+  }
+  return sandbox.containerFetch(forwarded, port);
+}
+
+async function sealSandboxPreview(
+  previewSecret: string,
+  sessionId: string,
+  port: number,
+): Promise<string> {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = new Uint8Array(await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv, additionalData: PREVIEW_AAD },
+    await previewKey(previewSecret),
+    new TextEncoder().encode(`${sessionId}\n${port}`),
+  ));
+  const sealed = new Uint8Array(iv.byteLength + ciphertext.byteLength);
+  sealed.set(iv);
+  sealed.set(ciphertext, iv.byteLength);
+  return encodeBase64Url(sealed);
+}
+
+async function previewKey(secret: string): Promise<CryptoKey> {
+  if (!secret) throw new Error("preview secret is required");
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(secret));
+  return crypto.subtle.importKey("raw", digest, { name: "AES-GCM" }, false, ["encrypt", "decrypt"]);
+}
+
+function encodeBase64Url(value: Uint8Array): string {
+  return btoa(String.fromCharCode(...value))
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "");
+}
+
+function decodeBase64Url(value: string): Uint8Array {
+  const standard = value.replaceAll("-", "+").replaceAll("_", "/");
+  const padded = standard.padEnd(Math.ceil(standard.length / 4) * 4, "=");
+  let decoded: string;
+  try {
+    decoded = atob(padded);
+  } catch {
+    throw new Error("invalid preview capability");
+  }
+  return Uint8Array.from(decoded, (character) => character.charCodeAt(0));
 }
 
 async function prepareSandbox(

--- a/examples/cloudflare-workers/test/sandbox-tools.test.ts
+++ b/examples/cloudflare-workers/test/sandbox-tools.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { workspacePath } from "../src/sandbox-tools";
+
+describe("Cloudflare sandbox workspace paths", () => {
+  it("confines relative and virtual workspace paths", () => {
+    expect(workspacePath(".")).toBe("/workspace");
+    expect(workspacePath("src/index.ts")).toBe("/workspace/src/index.ts");
+    expect(workspacePath("/workspace/out.txt")).toBe("/workspace/out.txt");
+    expect(() => workspacePath("../secret")).toThrow(/must not contain/);
+    expect(() => workspacePath("/etc/passwd")).toThrow(/relative to/);
+  });
+});

--- a/examples/cloudflare-workers/test/sandbox-tools.test.ts
+++ b/examples/cloudflare-workers/test/sandbox-tools.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createCloudflareSandboxTools, workspacePath } from "../src/sandbox-tools";
+import {
+  cloudflareSandboxPreviewUrl,
+  createCloudflareSandboxTools,
+  openSandboxPreviewCapability,
+  workspacePath,
+} from "../src/sandbox-tools";
 
 const MIB = 1024 * 1024;
 const OUTPUT_LIMIT = 128 * 1024;
@@ -27,6 +32,44 @@ describe("Cloudflare sandbox workspace paths", () => {
     "x".repeat(1025),
   ])("rejects an invalid or escaping path: %s", (path) => {
     expect(() => workspacePath(path)).toThrow();
+  });
+});
+
+describe("Cloudflare sandbox preview URLs", () => {
+  it("seals the session and port in a same-origin capability route", async () => {
+    const sessionId = "019fc927-b280-79a7-8445-1b9996ad2fb0";
+    const url = await cloudflareSandboxPreviewUrl(
+      "https://agent.example",
+      "preview-secret",
+      sessionId,
+      8080,
+    );
+    expect(url).toMatch(/^https:\/\/agent\.example\/sandbox-preview\/[A-Za-z0-9_-]+\/$/);
+    expect(url).not.toContain(sessionId);
+    const capability = new URL(url).pathname.split("/")[2]!;
+    await expect(openSandboxPreviewCapability("preview-secret", capability)).resolves.toEqual({
+      sessionId,
+      port: 8080,
+    });
+    await expect(openSandboxPreviewCapability("wrong-secret", capability)).rejects.toThrow(
+      "invalid preview capability",
+    );
+  });
+
+  it.each([
+    "ftp://agent.example",
+    "https://user:secret@agent.example",
+    "https://agent.example/path",
+    "https://agent.example/?query=true",
+  ])("rejects a non-origin preview base: %s", async (origin) => {
+    await expect(cloudflareSandboxPreviewUrl(
+      origin,
+      "preview-secret",
+      "session-id",
+      8080,
+    )).rejects.toThrow(
+      "public origin must be an HTTP(S) origin",
+    );
   });
 });
 
@@ -283,6 +326,26 @@ describe("Cloudflare sandbox tools", () => {
       autoCleanup: true,
     });
     expect(process.waitForPort).toHaveBeenCalledWith(8080, { timeout: 12_345 });
+  });
+
+  it("uses a Worker-fronted preview provider after initializing the sandbox", async () => {
+    const sandbox = makeSandbox();
+    const factory = vi.fn(async () => sandbox);
+    const preview = vi.fn(async (port: number) => ({
+      port,
+      url: `https://agent.example/sandbox-preview/session/${port}/`,
+      persistent: false,
+    }));
+    const tools = createCloudflareSandboxTools(factory, preview);
+
+    await expect(invoke(tools, "sandbox_preview", { port: 8080 })).resolves.toEqual({
+      port: 8080,
+      url: "https://agent.example/sandbox-preview/session/8080/",
+      persistent: false,
+    });
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(preview).toHaveBeenCalledWith(8080);
+    expect(sandbox.tunnels.get).not.toHaveBeenCalled();
   });
 
   it("rejects invalid managed-process inputs before starting anything", async () => {

--- a/examples/cloudflare-workers/test/sandbox-tools.test.ts
+++ b/examples/cloudflare-workers/test/sandbox-tools.test.ts
@@ -1,13 +1,377 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { workspacePath } from "../src/sandbox-tools";
+import { createCloudflareSandboxTools, workspacePath } from "../src/sandbox-tools";
+
+const MIB = 1024 * 1024;
+const OUTPUT_LIMIT = 128 * 1024;
+const context = { callId: "call", parentCallId: "parent", sessionId: "session" };
 
 describe("Cloudflare sandbox workspace paths", () => {
-  it("confines relative and virtual workspace paths", () => {
+  it("canonicalizes paths under the virtual workspace", () => {
     expect(workspacePath(".")).toBe("/workspace");
-    expect(workspacePath("src/index.ts")).toBe("/workspace/src/index.ts");
-    expect(workspacePath("/workspace/out.txt")).toBe("/workspace/out.txt");
-    expect(() => workspacePath("../secret")).toThrow(/must not contain/);
-    expect(() => workspacePath("/etc/passwd")).toThrow(/relative to/);
+    expect(workspacePath("././")).toBe("/workspace");
+    expect(workspacePath("src//./index.ts")).toBe("/workspace/src/index.ts");
+    expect(workspacePath("/workspace")).toBe("/workspace");
+    expect(workspacePath("/workspace//out.txt")).toBe("/workspace/out.txt");
+    expect(workspacePath("file..txt")).toBe("/workspace/file..txt");
+  });
+
+  it.each([
+    "",
+    "../secret",
+    "safe/../../secret",
+    "/workspace/../secret",
+    "/workspace2/secret",
+    "/etc/passwd",
+    "nul\0byte",
+    "x".repeat(1025),
+  ])("rejects an invalid or escaping path: %s", (path) => {
+    expect(() => workspacePath(path)).toThrow();
   });
 });
+
+describe("Cloudflare sandbox tools", () => {
+  it("rejects malformed tool inputs before creating a sandbox", async () => {
+    const sandbox = makeSandbox();
+    const factory = vi.fn(async () => sandbox);
+    const tools = createCloudflareSandboxTools(factory);
+
+    for (const input of [null, undefined, [], "command", 1, true]) {
+      await expect(invoke(tools, "sandbox_exec", input)).rejects.toThrow("tool input must be an object");
+    }
+    await expect(invoke(tools, "sandbox_exec", {})).rejects.toThrow("command must be a non-empty string");
+    await expect(invoke(tools, "sandbox_exec", { command: "" })).rejects.toThrow("command must be a non-empty string");
+    await expect(invoke(tools, "sandbox_exec", { command: "x".repeat(32 * 1024 + 1) })).rejects.toThrow("command is too long");
+    await expect(invoke(tools, "sandbox_exec", { command: "pwd", cwd: "../outside" })).rejects.toThrow("must not contain");
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it("passes bounded exec options through and reports non-zero results", async () => {
+    const sandbox = makeSandbox({
+      exec: vi.fn(async () => ({
+        success: false,
+        exitCode: 7,
+        stdout: "partial",
+        stderr: "failed",
+        duration: 42,
+      })),
+    });
+    const tools = createCloudflareSandboxTools(async () => sandbox);
+
+    const defaultResult = await invoke(tools, "sandbox_exec", { command: "false" });
+    expect(sandbox.exec).toHaveBeenNthCalledWith(1, "false", {
+      cwd: "/workspace",
+      timeout: 60_000,
+    });
+    expect(defaultResult).toEqual({
+      success: false,
+      exit_code: 7,
+      stdout: "partial",
+      stderr: "failed",
+      stdout_truncated: false,
+      stderr_truncated: false,
+      duration_ms: 42,
+    });
+
+    await invoke(tools, "sandbox_exec", {
+      command: "pwd",
+      cwd: "/workspace/src",
+      timeout_ms: 120_000,
+    });
+    expect(sandbox.exec).toHaveBeenNthCalledWith(2, "pwd", {
+      cwd: "/workspace/src",
+      timeout: 120_000,
+    });
+  });
+
+  it.each([0, 120_001, 1.5, "1000", null, Number.NaN])(
+    "rejects an invalid exec timeout: %s",
+    async (timeout) => {
+      const sandbox = makeSandbox();
+      const tools = createCloudflareSandboxTools(async () => sandbox);
+      await expect(invoke(tools, "sandbox_exec", {
+        command: "pwd",
+        timeout_ms: timeout,
+      })).rejects.toThrow("timeout_ms must be an integer");
+      expect(sandbox.exec).not.toHaveBeenCalled();
+    },
+  );
+
+  it("caps stdout and stderr by UTF-8 bytes without splitting code points", async () => {
+    const sandbox = makeSandbox({
+      exec: vi.fn(async () => ({
+        success: true,
+        exitCode: 0,
+        stdout: "é".repeat(OUTPUT_LIMIT),
+        stderr: "x".repeat(OUTPUT_LIMIT + 1),
+        duration: 1,
+      })),
+    });
+    const result = await invoke(
+      createCloudflareSandboxTools(async () => sandbox),
+      "sandbox_exec",
+      { command: "produce-output" },
+    );
+
+    expect(new TextEncoder().encode(result.stdout).byteLength).toBe(OUTPUT_LIMIT);
+    expect(result.stdout.endsWith("é")).toBe(true);
+    expect(result.stderr).toHaveLength(OUTPUT_LIMIT);
+    expect(result.stdout_truncated).toBe(true);
+    expect(result.stderr_truncated).toBe(true);
+  });
+
+  it("writes empty and exactly-1-MiB files and counts UTF-8 bytes", async () => {
+    const sandbox = makeSandbox();
+    const tools = createCloudflareSandboxTools(async () => sandbox);
+
+    await expect(invoke(tools, "sandbox_write_file", {
+      path: "empty.txt",
+      content: "",
+    })).resolves.toEqual({ path: "/workspace/empty.txt", bytes_written: 0 });
+    const exact = "😀".repeat(MIB / 4);
+    await expect(invoke(tools, "sandbox_write_file", {
+      path: "unicode.txt",
+      content: exact,
+    })).resolves.toEqual({ path: "/workspace/unicode.txt", bytes_written: MIB });
+    expect(sandbox.writeFile).toHaveBeenLastCalledWith(
+      "/workspace/unicode.txt",
+      exact,
+      { encoding: "utf-8" },
+    );
+  });
+
+  it("rejects oversized and malformed writes before entering the sandbox", async () => {
+    const sandbox = makeSandbox();
+    const tools = createCloudflareSandboxTools(async () => sandbox);
+
+    await expect(invoke(tools, "sandbox_write_file", {
+      path: "large.txt",
+      content: "😀".repeat(MIB / 4 + 1),
+    })).rejects.toThrow("content exceeds 1 MiB");
+    await expect(invoke(tools, "sandbox_write_file", {
+      path: "bad.txt",
+      content: 123,
+    })).rejects.toThrow("content must be a string");
+    await expect(invoke(tools, "sandbox_write_file", {
+      path: "../bad.txt",
+      content: "x",
+    })).rejects.toThrow("must not contain");
+    expect(sandbox.writeFile).not.toHaveBeenCalled();
+  });
+
+  it("assembles a bounded multichunk UTF-8 read", async () => {
+    const bytes = new TextEncoder().encode("left 😀 right");
+    const sandbox = makeSandbox({
+      readFile: vi.fn(async () => ({
+        size: bytes.byteLength,
+        content: byteStream(bytes.subarray(0, 7), bytes.subarray(7, 9), bytes.subarray(9)),
+      })),
+    });
+    const tools = createCloudflareSandboxTools(async () => sandbox);
+
+    await expect(invoke(tools, "sandbox_read_file", { path: "message.txt" })).resolves.toEqual({
+      path: "/workspace/message.txt",
+      content: "left 😀 right",
+    });
+    expect(sandbox.readFile).toHaveBeenCalledWith("/workspace/message.txt", { encoding: "none" });
+  });
+
+  it("rejects oversized read metadata without consuming the stream", async () => {
+    let pulled = false;
+    const content = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulled = true;
+        controller.enqueue(new Uint8Array([1]));
+      },
+    }, { highWaterMark: 0 });
+    const sandbox = makeSandbox({ readFile: vi.fn(async () => ({ size: MIB + 1, content })) });
+
+    await expect(invoke(
+      createCloudflareSandboxTools(async () => sandbox),
+      "sandbox_read_file",
+      { path: "large.txt" },
+    )).rejects.toThrow("file exceeds 1 MiB");
+    expect(pulled).toBe(false);
+  });
+
+  it("cancels a lying stream that crosses the read limit", async () => {
+    let cancelReason: unknown;
+    const chunks = [new Uint8Array(700_000), new Uint8Array(400_000)];
+    const content = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        const next = chunks.shift();
+        if (next) controller.enqueue(next);
+        else controller.close();
+      },
+      cancel(reason) {
+        cancelReason = reason;
+      },
+    }, { highWaterMark: 0 });
+    const sandbox = makeSandbox({ readFile: vi.fn(async () => ({ size: 0, content })) });
+
+    await expect(invoke(
+      createCloudflareSandboxTools(async () => sandbox),
+      "sandbox_read_file",
+      { path: "lying.txt" },
+    )).rejects.toThrow("file exceeds 1 MiB");
+    expect(cancelReason).toBe("file exceeds 1 MiB");
+  });
+
+  it("rejects invalid UTF-8 instead of silently replacing bytes", async () => {
+    const content = byteStream(new Uint8Array([0xc3, 0x28]));
+    const sandbox = makeSandbox({ readFile: vi.fn(async () => ({ size: 2, content })) });
+
+    await expect(invoke(
+      createCloudflareSandboxTools(async () => sandbox),
+      "sandbox_read_file",
+      { path: "binary.dat" },
+    )).rejects.toThrow("file is not valid UTF-8");
+  });
+
+  it("includes hidden entries, caps directory results, and exposes previews", async () => {
+    const files = Array.from({ length: 513 }, (_, index) => ({
+      name: index === 0 ? ".hidden" : `file-${index}`,
+      type: index % 2 === 0 ? "file" : "directory",
+      size: index,
+    }));
+    const sandbox = makeSandbox({
+      listFiles: vi.fn(async () => ({ files })),
+      tunnels: { get: vi.fn(async () => ({ url: "https://preview.example" })) },
+    });
+    const tools = createCloudflareSandboxTools(async () => sandbox);
+
+    const listed = await invoke(tools, "sandbox_list_files", {});
+    expect(sandbox.listFiles).toHaveBeenCalledWith("/workspace", { includeHidden: true });
+    expect(listed.entries).toHaveLength(512);
+    expect(listed.entries[0]).toEqual({ name: ".hidden", type: "file", size: 0 });
+    expect(listed.truncated).toBe(true);
+
+    await expect(invoke(tools, "sandbox_preview", { port: 65_535 })).resolves.toEqual({
+      port: 65_535,
+      url: "https://preview.example",
+      persistent: false,
+    });
+    expect(sandbox.tunnels.get).toHaveBeenCalledWith(65_535);
+  });
+
+  it("starts a managed process and optionally waits for port readiness", async () => {
+    const process = {
+      id: "process-1",
+      pid: 42,
+      command: "node server.js",
+      status: "starting",
+      getStatus: vi.fn(async () => "running"),
+      waitForPort: vi.fn(async () => {}),
+    };
+    const sandbox = makeSandbox({ startProcess: vi.fn(async () => process) });
+    const tools = createCloudflareSandboxTools(async () => sandbox);
+
+    await expect(invoke(tools, "sandbox_start_process", {
+      command: "node server.js",
+      cwd: "app",
+      ready_port: 8080,
+      ready_timeout_ms: 12_345,
+    })).resolves.toEqual({
+      process_id: "process-1",
+      pid: 42,
+      command: "node server.js",
+      status: "running",
+      ready_port: 8080,
+    });
+    expect(sandbox.startProcess).toHaveBeenCalledWith("node server.js", {
+      cwd: "/workspace/app",
+      autoCleanup: true,
+    });
+    expect(process.waitForPort).toHaveBeenCalledWith(8080, { timeout: 12_345 });
+  });
+
+  it("rejects invalid managed-process inputs before starting anything", async () => {
+    const sandbox = makeSandbox();
+    const tools = createCloudflareSandboxTools(async () => sandbox);
+    await expect(invoke(tools, "sandbox_start_process", {
+      command: "node server.js",
+      ready_port: 80,
+    })).rejects.toThrow("ready_port must be an integer");
+    await expect(invoke(tools, "sandbox_start_process", {
+      command: "node server.js",
+      ready_timeout_ms: 0,
+    })).rejects.toThrow("ready_timeout_ms must be an integer");
+    expect(sandbox.startProcess).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, 1023, 65_536, 3000.5, "3000", null])(
+    "rejects an invalid preview port: %s",
+    async (port) => {
+      const sandbox = makeSandbox();
+      await expect(invoke(
+        createCloudflareSandboxTools(async () => sandbox),
+        "sandbox_preview",
+        { port },
+      )).rejects.toThrow(port === undefined ? "port is required" : "port must be an integer");
+      expect(sandbox.tunnels.get).not.toHaveBeenCalled();
+    },
+  );
+
+  it("lazily initializes one sandbox and caches initialization failures", async () => {
+    const sandbox = makeSandbox();
+    const factory = vi.fn(async () => sandbox);
+    const tools = createCloudflareSandboxTools(factory);
+    await invoke(tools, "sandbox_exec", { command: "pwd" });
+    await invoke(tools, "sandbox_write_file", { path: "one", content: "1" });
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    const failure = new Error("container unavailable");
+    const failingFactory = vi.fn(async () => { throw failure; });
+    const failingTools = createCloudflareSandboxTools(failingFactory);
+    await expect(invoke(failingTools, "sandbox_exec", { command: "pwd" })).rejects.toBe(failure);
+    await expect(invoke(failingTools, "sandbox_list_files", {})).rejects.toBe(failure);
+    expect(failingFactory).toHaveBeenCalledTimes(1);
+  });
+});
+
+function makeSandbox(overrides: Record<string, unknown> = {}) {
+  return {
+    exec: vi.fn(async () => ({
+      success: true,
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+      duration: 1,
+    })),
+    startProcess: vi.fn(async (command: string) => ({
+      id: "process",
+      pid: 1,
+      command,
+      status: "running",
+      getStatus: vi.fn(async () => "running"),
+      waitForPort: vi.fn(async () => {}),
+    })),
+    readFile: vi.fn(async () => ({
+      size: 5,
+      content: byteStream(new TextEncoder().encode("hello")),
+    })),
+    writeFile: vi.fn(async () => ({})),
+    listFiles: vi.fn(async () => ({ files: [] })),
+    tunnels: { get: vi.fn(async () => ({ url: "https://preview.example" })) },
+    ...overrides,
+  };
+}
+
+function byteStream(...chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+}
+
+async function invoke(
+  tools: ReturnType<typeof createCloudflareSandboxTools>,
+  name: string,
+  input: unknown,
+): Promise<any> {
+  const tool = tools[name];
+  if (!tool) throw new Error(`missing tool: ${name}`);
+  return tool.handler(input, context);
+}

--- a/examples/cloudflare-workers/test/worker.test.ts
+++ b/examples/cloudflare-workers/test/worker.test.ts
@@ -57,6 +57,26 @@ describe("Nanocodex Durable Object Worker", () => {
     });
   });
 
+  it("keeps the destructive sandbox probe behind the admin token", async () => {
+    const denied = await SELF.fetch("https://example.test/admin/sandbox-smoke", { method: "POST" });
+    expect(denied.status).toBe(401);
+    expect(await denied.json()).toEqual({ error: "unauthorized" });
+
+    const wrongMethod = await SELF.fetch("https://example.test/admin/sandbox-smoke", {
+      headers: authorization,
+    });
+    expect(wrongMethod.status).toBe(405);
+    expect(await wrongMethod.json()).toEqual({ error: "method_not_allowed" });
+
+    const invalidFinish = await SELF.fetch("https://example.test/admin/sandbox-smoke", {
+      method: "DELETE",
+      headers: authorization,
+      body: JSON.stringify({ probe_id: "not-a-probe" }),
+    });
+    expect(invalidFinish.status).toBe(400);
+    expect(await invalidFinish.json()).toEqual({ error: "invalid_probe" });
+  });
+
   it("hibernates client sockets and validates the bounded protocol without loading WASM", async () => {
     const created = await createSession();
     const response = await SELF.fetch(created.websocket_url.replace("wss:", "https:"), {

--- a/examples/cloudflare-workers/test/worker.test.ts
+++ b/examples/cloudflare-workers/test/worker.test.ts
@@ -114,7 +114,11 @@ describe("Nanocodex Durable Object Worker", () => {
 
   it("rejects invalid routes and deletes only the named session", async () => {
     expect((await SELF.fetch("https://example.test/sessions/not-a-session")).status).toBe(404);
+    expect((await SELF.fetch("https://example.test/sandbox-preview/not-a-session/8080/")).status).toBe(404);
     const created = await createSession();
+    expect((await SELF.fetch(
+      `https://example.test/sandbox-preview/${created.session_id}/80/`,
+    )).status).toBe(404);
     const deleted = await SELF.fetch(`https://example.test/sessions/${created.session_id}`, {
       method: "DELETE",
     });

--- a/examples/cloudflare-workers/wrangler.jsonc
+++ b/examples/cloudflare-workers/wrangler.jsonc
@@ -3,6 +3,7 @@
   "name": "nanocodex-durable-agent",
   "main": "src/index.ts",
   "compatibility_date": "2026-07-29",
+  "compatibility_flags": ["nodejs_compat"],
   "rules": [
     {
       "type": "CompiledWasm",
@@ -27,6 +28,10 @@
       {
         "name": "NANOCODEX_AUTH",
         "class_name": "NanocodexSubscriptionAuth"
+      },
+      {
+        "name": "Sandbox",
+        "class_name": "Sandbox"
       }
     ]
   },
@@ -34,10 +39,28 @@
     {
       "tag": "v1",
       "new_sqlite_classes": ["NanocodexSession", "NanocodexSubscriptionAuth"]
+    },
+    {
+      "tag": "v2",
+      "new_sqlite_classes": ["Sandbox"]
+    }
+  ],
+  "containers": [
+    {
+      "class_name": "Sandbox",
+      "image": "./Dockerfile",
+      "max_instances": 10
+    }
+  ],
+  "r2_buckets": [
+    {
+      "binding": "NANOCODEX_WORKSPACES",
+      "bucket_name": "nanocodex-sandbox-workspaces"
     }
   ],
   "vars": {
     "AGENT_IDLE_TIMEOUT_MS": "30000",
-    "NANOCODEX_AUTH_MODE": "chatgpt"
+    "NANOCODEX_AUTH_MODE": "chatgpt",
+    "SANDBOX_TRANSPORT": "rpc"
   }
 }

--- a/examples/rivet-actors/README.md
+++ b/examples/rivet-actors/README.md
@@ -105,6 +105,11 @@ tabs or devices connected with the same actor key stay synchronized. A newly
 connected client also reconstructs any active prompt from `status()` before
 joining its remaining event stream.
 
+For the hosted preview demo, use AgentOS's Node runtime for listening servers.
+Its `python3` command is Pyodide-backed and does not provide a bindable server
+socket. `sandbox_preview` probes the requested port before minting a signed URL,
+so a failed or exited server cannot produce a dead preview capability.
+
 The REPL is intentionally disposable. It stores only the Rivet endpoint,
 actor key, and an unfinished turn ID/input in `.nanocodex/rivet-repl.json`.
 The file is mode `0600` because it may contain unfinished prompt text.
@@ -264,8 +269,10 @@ to an actor-specific gateway URL with `rvt-namespace` and `rvt-token` query
 parameters, which browsers and `fetch` can open. Without it, the tool returns
 the actor-relative `/fetch/<token>` path. This is Rivet AgentOS's equivalent of
 Vercel Sandbox's `domain(port)`: it creates a temporary signed proxy to that
-port. Preview tokens and workspace files survive actor sleep, while a server
-process must be restarted if the VM is woken without it.
+port. This example bounds preview tokens to 15 minutes and keeps the actor's
+server launch specification in actor SQLite. The VM can sleep normally; its
+`onVmStart` hook restarts unexpired preview servers before AgentOS proxies the
+waking request. Workspace files and preview tokens survive the same cycle.
 
 The browser bundle is static and can be published on any static host after
 `npm run build:web --prefix examples/rivet-actors`; paste the same public

--- a/examples/rivet-actors/README.md
+++ b/examples/rivet-actors/README.md
@@ -3,10 +3,15 @@
 This example runs the real Rust/WASM Nanocodex harness as a durable
 [Rivet Actor](https://rivet.dev/docs/actors/). Nanocodex is already an agent
 harness, so it runs directly in the actor host with one owner for model history,
-tools, retries, and cancellation. The example depends directly on RivetKit and
-does not install `@rivet-dev/agentos`, Pi, or another agent harness. RivetKit
-itself currently retains a separate legacy `@rivet-dev/agent-os-core` runtime
-dependency; it has no Pi packages in its dependency tree.
+tools, retries, and cancellation. Rivet AgentOS supplies only the actor-owned
+isolated VM, persistent filesystem, processes, and preview routing underneath
+Nanocodex's caller-defined tools; its optional agent/session adapters are not
+used.
+
+The published AgentOS core currently declares Pi software as a transitive npm
+dependency. This example never imports, mounts, or invokes it. The dependency
+guard rejects direct Pi dependencies and source imports, while allowing that
+dormant upstream package to remain in AgentOS's lockfile subtree.
 
 ## Architecture
 
@@ -15,6 +20,11 @@ Each `nanocodex` actor owns one conversation:
 - the live WASM driver, event watcher, and turns live in ephemeral `c.vars`;
 - the typed Nanocodex snapshot and terminal idempotency records live in the
   actor's embedded SQLite database;
+- the AgentOS root filesystem is chunked into the same actor-owned SQLite
+  storage and restored automatically across VM sleep/wake cycles;
+- `sandbox_exec`, `sandbox_read_file`, `sandbox_write_file`,
+  `sandbox_list_files`, and `sandbox_preview` expose bounded AgentOS operations
+  to Nanocodex without putting model credentials in the guest;
 - a completed turn is transactionally committed before its action returns or
   broadcasts `turnCompleted`;
 - duplicate turn IDs share one in-flight promise or replay the stored terminal
@@ -48,8 +58,8 @@ npm ci --prefix examples/rivet-actors
 npm run check --prefix examples/rivet-actors
 ```
 
-The dependency check fails if the lockfile acquires AgentOS's Pi adapter or any
-of the upstream Pi harness packages.
+The dependency check fails if this application directly declares or imports a
+Pi adapter or upstream Pi harness package.
 
 Log in to Codex with the ChatGPT subscription you want to use, then start the
 real subscription server:
@@ -120,9 +130,10 @@ demo page from the same container. A fresh hosted page selects its same-origin
 a deployment without embedding it in source by adding
 `?endpoint=https%3A%2F%2F...` to the page URL.
 
-The smoke also forces the real model to invoke `runtimeInfo` and requires a
-completed Nanocodex `tool.call`/`tool.result` event pair, so it verifies the
-WASM tool loop rather than only a text response.
+The smoke also forces the real model to write, execute, and read through
+AgentOS and requires completed Nanocodex `tool.call`/`tool.result` event pairs,
+so it verifies the WASM tool loop and isolated VM rather than only a text
+response.
 
 The stress driver reuses persistent actor connections and bounds fan-out to
 avoid benchmarking the gateway's per-route rate limiter. Tune
@@ -194,7 +205,7 @@ const connection = session.connect();
 connection.on("agentEvent", (event) => console.log(event));
 connection.on("turnCompleted", (result) => console.log(result));
 
-await session.prompt({ id: crypto.randomUUID(), input: "Hello" });
+await session.turn({ id: crypto.randomUUID(), input: "Hello" });
 await session.unload(); // snapshot remains durable
 await connection.dispose();
 ```
@@ -206,7 +217,9 @@ Rivet automatically sleeps idle actors after 30 seconds.
 
 Rivet Actors can run on Rivet Compute or a self-hosted Rivet platform. The
 included production image builds Nanocodex WASM, compiles the actor server, and
-starts it without a TypeScript runtime dependency. From the repository root,
+starts it without a TypeScript runtime dependency. AgentOS's native sidecar is
+installed with the production dependencies and its actor runtime socket is
+enabled by the AgentOS registry setup. From the repository root,
 get a cloud token from the Rivet dashboard's **Connect > Rivet Cloud** page and
 deploy with API-key model authentication:
 
@@ -235,6 +248,12 @@ export RIVET_PUBLIC_ENDPOINT='https://<namespace>:pk_...@api.rivet.dev'
 npm run smoke --prefix examples/rivet-actors
 npm run repl --prefix examples/rivet-actors
 ```
+
+Set `NANOCODEX_PUBLIC_URL` on the deployment to the browser-safe base endpoint
+when you want `sandbox_preview` to return an absolute URL; otherwise it returns
+the actor-relative `/fetch/<token>` path. Preview tokens survive actor sleep,
+while the server process itself must be restarted after wake. Workspace files
+survive automatically.
 
 The browser bundle is static and can be published on any static host after
 `npm run build:web --prefix examples/rivet-actors`; paste the same public

--- a/examples/rivet-actors/README.md
+++ b/examples/rivet-actors/README.md
@@ -23,8 +23,9 @@ Each `nanocodex` actor owns one conversation:
 - the AgentOS root filesystem is chunked into the same actor-owned SQLite
   storage and restored automatically across VM sleep/wake cycles;
 - `sandbox_exec`, `sandbox_read_file`, `sandbox_write_file`,
-  `sandbox_list_files`, and `sandbox_preview` expose bounded AgentOS operations
-  to Nanocodex without putting model credentials in the guest;
+  `sandbox_list_files`, `sandbox_start_process`, and `sandbox_preview` expose
+  bounded AgentOS operations to Nanocodex without putting model credentials in
+  the guest;
 - a completed turn is transactionally committed before its action returns or
   broadcasts `turnCompleted`;
 - duplicate turn IDs share one in-flight promise or replay the stored terminal
@@ -131,9 +132,10 @@ a deployment without embedding it in source by adding
 `?endpoint=https%3A%2F%2F...` to the page URL.
 
 The smoke also forces the real model to write, execute, and read through
-AgentOS and requires completed Nanocodex `tool.call`/`tool.result` event pairs,
-so it verifies the WASM tool loop and isolated VM rather than only a text
-response.
+AgentOS, starts a native Python HTTP server, creates a signed preview, and
+fetches that preview from outside Rivet. It requires completed Nanocodex
+`tool.call`/`tool.result` event pairs, so it verifies the WASM tool loop,
+isolated VM, and public proxy rather than only a text response.
 
 The stress driver reuses persistent actor connections and bounds fan-out to
 avoid benchmarking the gateway's per-route rate limiter. Tune
@@ -252,11 +254,15 @@ npm run smoke --prefix examples/rivet-actors
 npm run repl --prefix examples/rivet-actors
 ```
 
-Set `NANOCODEX_PUBLIC_URL` on the deployment to the browser-safe base endpoint
-when you want `sandbox_preview` to return an absolute URL; otherwise it returns
-the actor-relative `/fetch/<token>` path. Preview tokens survive actor sleep,
-while the server process itself must be restarted after wake. Workspace files
-survive automatically.
+Set `NANOCODEX_PUBLIC_URL` before running the subscription deployment helper to
+the client-safe Rivet endpoint from the namespace's **Connect** page (the
+`https://namespace:pk_...@api.rivet.dev` form). `sandbox_preview` converts that
+to an actor-specific gateway URL with `rvt-namespace` and `rvt-token` query
+parameters, which browsers and `fetch` can open. Without it, the tool returns
+the actor-relative `/fetch/<token>` path. This is Rivet AgentOS's equivalent of
+Vercel Sandbox's `domain(port)`: it creates a temporary signed proxy to that
+port. Preview tokens and workspace files survive actor sleep, while a server
+process must be restarted if the VM is woken without it.
 
 The browser bundle is static and can be published on any static host after
 `npm run build:web --prefix examples/rivet-actors`; paste the same public

--- a/examples/rivet-actors/README.md
+++ b/examples/rivet-actors/README.md
@@ -156,14 +156,17 @@ file permissions and token lifetime, and does not copy the rotating refresh
 token:
 
 ```sh
+# The first invocation can set RIVET_CLOUD_TOKEN; Rivet stores it in
+# ~/.rivet/credentials for subsequent deploys.
 export RIVET_CLOUD_TOKEN=cloud_api_xxxxx
 npm run deploy:subscription --prefix examples/rivet-actors
 ```
 
 This is the same access-token-only policy as the Cloudflare demo. It keeps
 working until the current access token expires or ChatGPT rejects it; then run
-`codex login` and deploy again. `NANOCODEX_CODEX_AUTH_FILE`, `CODEX_HOME`, and
-`RIVET_NAMESPACE` override the auth path and target namespace.
+`codex login` and deploy again. Once the Rivet CLI has cached credentials,
+`RIVET_CLOUD_TOKEN` may be omitted. `NANOCODEX_CODEX_AUTH_FILE`, `CODEX_HOME`,
+and `RIVET_NAMESPACE` override the auth path and target namespace.
 
 For a long-lived deployment, give the auth actor dedicated rotating
 subscription credentials instead. This still does not require

--- a/examples/rivet-actors/README.md
+++ b/examples/rivet-actors/README.md
@@ -135,7 +135,10 @@ The smoke also forces the real model to write, execute, and read through
 AgentOS, starts a native Python HTTP server, creates a signed preview, and
 fetches that preview from outside Rivet. It requires completed Nanocodex
 `tool.call`/`tool.result` event pairs, so it verifies the WASM tool loop,
-isolated VM, and public proxy rather than only a text response.
+isolated VM, and public proxy rather than only a text response. If one client
+request reaches the Rivet gateway deadline while the actor turn is still
+active, the smoke reattaches with the same turn ID instead of starting another
+model call.
 
 The stress driver reuses persistent actor connections and bounds fan-out to
 avoid benchmarking the gateway's per-route rate limiter. Tune

--- a/examples/rivet-actors/package-lock.json
+++ b/examples/rivet-actors/package-lock.json
@@ -8,6 +8,7 @@
       "name": "nanocodex-rivet-actors-example",
       "version": "0.1.0",
       "dependencies": {
+        "@rivet-dev/agentos": "0.2.15",
         "nanocodex": "file:../../js/bindings",
         "rivetkit": "2.3.10",
         "ws": "8.21.1"
@@ -39,6 +40,177 @@
         "node": ">=22.13.0"
       }
     },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.16.1.tgz",
+      "integrity": "sha512-1ad+Sc/0sCtZGHthxxvgEUo5Wsbw16I+aF+YwdiLnPwkZG8KAGUEAPK6LM6Pf69lCyJPt1Aomk1d+8oE3C4ZEw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@agentos-software/claude-code": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@agentos-software/claude-code/-/claude-code-0.2.7.tgz",
+      "integrity": "sha512-gXmqqOUWT98QvLkQXHn1UU8OOvqMO8BRSj+0PT99mOL6XNpBlPW6L065FJ9dC4IwJC5xeGzB1XFevjOdP7LwQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "^0.16.1",
+        "@anthropic-ai/claude-agent-sdk": "0.2.87",
+        "zod": "^4.1.11"
+      },
+      "bin": {
+        "claude": "dist/claude-cli.mjs",
+        "claude-sdk-acp": "dist/adapter.js"
+      }
+    },
+    "node_modules/@agentos-software/codex-cli": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@agentos-software/codex-cli/-/codex-cli-0.3.4.tgz",
+      "integrity": "sha512-SAw3EOTa90dJLgEVVoE7JJIxHwticzdD9cEM9v00gpxhxC9vdLkeBva6rgWIUB9+qD1JEYBvUCyNkIpD2kT5YQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@agentos-software/common": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@agentos-software/common/-/common-0.2.15.tgz",
+      "integrity": "sha512-33roACt3EfAp+C6mciKfthVU7I21XeulM+/yLJRo9tSuXfbMLF18EnkodKhvYAJWjzlLGhbmsxfuSuBF7afrhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@agentos-software/coreutils": "0.3.4",
+        "@agentos-software/diffutils": "0.3.4",
+        "@agentos-software/findutils": "0.3.4",
+        "@agentos-software/gawk": "0.3.4",
+        "@agentos-software/grep": "0.3.4",
+        "@agentos-software/gzip": "0.3.4",
+        "@agentos-software/sed": "0.3.4",
+        "@agentos-software/tar": "0.3.5"
+      }
+    },
+    "node_modules/@agentos-software/coreutils": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@agentos-software/coreutils/-/coreutils-0.3.4.tgz",
+      "integrity": "sha512-tGd0gQjUjHnm+5KgOBwidwUtlkKnl9biQuD7X2sZl15VOhYqUJpnyLF33h/nF3r9WtOTclSiLj/dc2xCxmAXnw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@agentos-software/diffutils": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@agentos-software/diffutils/-/diffutils-0.3.4.tgz",
+      "integrity": "sha512-a5Do+ERMdHPwT0Vrp35fxSgrsJNK8wCsYX8dOAomH9N+xJyV2Hb7/LLyp7XxqGk9BEjMeA6UhbH5ZY/HAlx5sQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@agentos-software/findutils": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@agentos-software/findutils/-/findutils-0.3.4.tgz",
+      "integrity": "sha512-wjBWE3lkXe70fRj6da1+2MM/7KlPcBRhr2BycvgvAtglOT/0PtabFU9CrDuX3Vm/8acU/8tw35+WeitPOLi9mg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@agentos-software/gawk": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@agentos-software/gawk/-/gawk-0.3.4.tgz",
+      "integrity": "sha512-NlU6nGxoqIUc1I2zdBHFwH04gE0tBygP2FcBO12VBptty7lbgq1CNLk909jIcSNFEwlm3VRPHeZNkbdVKZ2Ujg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@agentos-software/grep": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@agentos-software/grep/-/grep-0.3.4.tgz",
+      "integrity": "sha512-Bta2Ljl+kCX/3Bjg06Q9N9LPRcf13S92lHRaYG+CeGVDXabIIgkHLUGIQlI1OKuIr7IRAktjgelUAuJnxGFvvw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@agentos-software/gzip": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@agentos-software/gzip/-/gzip-0.3.4.tgz",
+      "integrity": "sha512-l7Y/Vwiwsqgna68yYwdNCnUBPGBg5zdmtjEFeG3hnDDFLe/02h17q0gUIqJmDBIAy1q9GoizqcFi7zXO2xygKg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@agentos-software/manifest": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@agentos-software/manifest/-/manifest-0.2.15.tgz",
+      "integrity": "sha512-3aftCfhOjVWy1I2m7CFO8y7If8/SLpE5T7DeIId6UR+88lVcD5I9GpmooYVOAQ8CBs33TWgqJI2Esvt/eb/nsQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@agentos-software/opencode": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@agentos-software/opencode/-/opencode-0.2.7.tgz",
+      "integrity": "sha512-lZspCiMgM0+kPAA08CEvyNy8lfBx463wObKpAwbYyaVvc0KfGvbAPS6VmnuZQWmaBmJJuRMtSo14nmb8XCD16g==",
+      "license": "Apache-2.0",
+      "bin": {
+        "agentos-opencode-acp": "dist/adapter.js"
+      }
+    },
+    "node_modules/@agentos-software/pi": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@agentos-software/pi/-/pi-0.2.7.tgz",
+      "integrity": "sha512-nOdwksByJgTqt92Ya84CzTGxpVFwGI6gkGWaCD/mmvP11JRA++1nshNdbig2mtiaxT7VG3ovWJmK7ZLTTzkhPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "^0.16.1",
+        "@mariozechner/pi-ai": "0.60.0",
+        "@mariozechner/pi-coding-agent": "0.60.0"
+      },
+      "bin": {
+        "pi": "node_modules/@mariozechner/pi-coding-agent/dist/cli.js",
+        "pi-sdk-acp": "dist/adapter.js"
+      }
+    },
+    "node_modules/@agentos-software/sed": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@agentos-software/sed/-/sed-0.3.4.tgz",
+      "integrity": "sha512-J10nZnZmme2SvXK5WMK2unQlOVncMQVUCS20GZB579a2gNoayLJYHGvfJ9a4+42wOHgDKL1u74byWlydCkEyOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@agentos-software/tar": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@agentos-software/tar/-/tar-0.3.5.tgz",
+      "integrity": "sha512-hSf6PY4q1luIomFSDgVHxVDDIPdAVZxdgwrQFEYH4aIE6TXX9qatVmzR36uYLWpnFGAZTR6srREGoTnmOGV4Lg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.2.87",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.87.tgz",
+      "integrity": "sha512-WWmgBPxPhBOvNT0ujI8vPTI2lK+w5YEkEZ/y1mH0EDkK/0kBnxVJNhCtG5vnueiAViwLoUOFn66pbkDiivijdA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.74.0",
+        "@modelcontextprotocol/sdk": "^1.27.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "^0.34.2",
+        "@img/sharp-darwin-x64": "^0.34.2",
+        "@img/sharp-linux-arm": "^0.34.2",
+        "@img/sharp-linux-arm64": "^0.34.2",
+        "@img/sharp-linux-x64": "^0.34.2",
+        "@img/sharp-linuxmusl-arm64": "^0.34.2",
+        "@img/sharp-linuxmusl-x64": "^0.34.2",
+        "@img/sharp-win32-arm64": "^0.34.2",
+        "@img/sharp-win32-x64": "^0.34.2"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.74.0.tgz",
+      "integrity": "sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@asteasolutions/zod-to-openapi": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/@asteasolutions/zod-to-openapi/-/zod-to-openapi-8.5.0.tgz",
@@ -49,6 +221,421 @@
       },
       "peerDependencies": {
         "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.24.tgz",
+      "integrity": "sha512-7TWLjypP8kk3savsDBRuhZJx7mBuFFA2136BQhwwLllsAnO4Tmq/p+SXZaNxbuulkzUFz3BZzj0bb4YzexZcNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1101.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1101.0.tgz",
+      "integrity": "sha512-Qd2bKUkV4qX8vEA3aSwKktfM8LFNvOq9YzM3JzFiCxmzvGhFPy6wfP7ZtpQjfuAwelp4DwcHeJCcnEbmrmID8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/credential-provider-node": "^3.972.76",
+        "@aws-sdk/eventstream-handler-node": "^3.972.31",
+        "@aws-sdk/middleware-eventstream": "^3.972.26",
+        "@aws-sdk/middleware-websocket": "^3.972.47",
+        "@aws-sdk/token-providers": "3.1101.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1101.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1101.0.tgz",
+      "integrity": "sha512-S9yC1qsmfczOSclMEaRYS0p0gj75ad5gOcbvhUEAl1vQAClupSLN0s2v5sSKfkhxkhfDiGgriubin6X6NSzSFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1101.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1101.0.tgz",
+      "integrity": "sha512-16EFb1aTEBgPcfUAWAjjlB57IZCyn7B3rlfT+xqE7M6WoH8AMMU3vFZO0UOitwh/xvvzVx73YED1/n0PU4qBMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.24",
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/credential-provider-node": "^3.972.76",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.70",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.4.tgz",
+      "integrity": "sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.65.tgz",
+      "integrity": "sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.67.tgz",
+      "integrity": "sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.10.tgz",
+      "integrity": "sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/credential-provider-env": "^3.972.65",
+        "@aws-sdk/credential-provider-http": "^3.972.67",
+        "@aws-sdk/credential-provider-login": "^3.972.72",
+        "@aws-sdk/credential-provider-process": "^3.972.65",
+        "@aws-sdk/credential-provider-sso": "^3.973.9",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
+        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.72.tgz",
+      "integrity": "sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.76.tgz",
+      "integrity": "sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.65",
+        "@aws-sdk/credential-provider-http": "^3.972.67",
+        "@aws-sdk/credential-provider-ini": "^3.973.10",
+        "@aws-sdk/credential-provider-process": "^3.972.65",
+        "@aws-sdk/credential-provider-sso": "^3.973.9",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.71",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.65.tgz",
+      "integrity": "sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.9.tgz",
+      "integrity": "sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/token-providers": "3.1100.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.71.tgz",
+      "integrity": "sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.31.tgz",
+      "integrity": "sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.26.tgz",
+      "integrity": "sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.70.tgz",
+      "integrity": "sha512-APdP0iODt39AkjCjzTFIoFrxDH/Cz3CpWRDKLcsJg7eOnfE1htkxL9BhDoe/xL7cXdoMwh2HBYv3DiT1uf64NQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.47.tgz",
+      "integrity": "sha512-UcPdY05u3TzvDah86NG6B9FgePYU6bXO7CRQIzQrieFL5xBBGajM7g1lCngmP4WA8EPed/kgT5CvM28cqSlBbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.39.tgz",
+      "integrity": "sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1100.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1100.0.tgz",
+      "integrity": "sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.4",
+        "@aws-sdk/nested-clients": "^3.997.39",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
@@ -579,6 +1166,42 @@
         "node": ">=18"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@hono/zod-openapi": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@hono/zod-openapi/-/zod-openapi-1.5.1.tgz",
@@ -607,12 +1230,688 @@
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@mariozechner/clipboard": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
+        "@mariozechner/clipboard-darwin-universal": "0.3.9",
+        "@mariozechner/clipboard-darwin-x64": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/jiti": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
+      "integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
+      "license": "MIT",
+      "dependencies": {
+        "std-env": "^3.10.0",
+        "yoctocolors": "^2.1.2"
+      },
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@mariozechner/pi-agent-core": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.60.0.tgz",
+      "integrity": "sha512-1zQcfFp8r0iwZCxCBQ9/ccFJoagns68cndLPTJJXl1ZqkYirzSld1zBOPxLAgeAKWIz3OX8dB2WQwTJFhmEojQ==",
+      "deprecated": "please use @earendil-works/pi-agent-core instead going forward",
+      "license": "MIT",
+      "dependencies": {
+        "@mariozechner/pi-ai": "^0.60.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@mariozechner/pi-ai": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.60.0.tgz",
+      "integrity": "sha512-OiMuXQturnEDPmA+ho7eLe4G8plO2z21yjNMs9niQREauoblWOz7Glv58I66KPzczLED4aZTlQLTRdU6t1rz8A==",
+      "deprecated": "please use @earendil-works/pi-ai instead going forward",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.73.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.983.0",
+        "@google/genai": "^1.40.0",
+        "@mistralai/mistralai": "1.14.1",
+        "@sinclair/typebox": "^0.34.41",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "chalk": "^5.6.2",
+        "openai": "6.26.0",
+        "partial-json": "^0.1.7",
+        "proxy-agent": "^6.5.0",
+        "undici": "^7.19.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@mariozechner/pi-ai/node_modules/@anthropic-ai/sdk": {
+      "version": "0.73.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
+      "integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mariozechner/pi-coding-agent": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.60.0.tgz",
+      "integrity": "sha512-IOv7cTU4nbznFNUE5ofi13k2dmSG39coBoGWIBQTVw3iVyl0HxuHbg0NiTx3ktrPIDNtkii+y7tWXzWqwoo4lw==",
+      "deprecated": "please use @earendil-works/pi-coding-agent instead going forward",
+      "license": "MIT",
+      "dependencies": {
+        "@mariozechner/jiti": "^2.6.2",
+        "@mariozechner/pi-agent-core": "^0.60.0",
+        "@mariozechner/pi-ai": "^0.60.0",
+        "@mariozechner/pi-tui": "^0.60.0",
+        "@silvia-odwyer/photon-node": "^0.3.4",
+        "chalk": "^5.5.0",
+        "cli-highlight": "^2.1.11",
+        "diff": "^8.0.2",
+        "extract-zip": "^2.0.1",
+        "file-type": "^21.1.1",
+        "glob": "^13.0.1",
+        "hosted-git-info": "^9.0.2",
+        "ignore": "^7.0.5",
+        "marked": "^15.0.12",
+        "minimatch": "^10.2.3",
+        "proper-lockfile": "^4.1.2",
+        "strip-ansi": "^7.1.0",
+        "undici": "^7.19.1",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "^0.3.2"
+      }
+    },
+    "node_modules/@mariozechner/pi-tui": {
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.60.0.tgz",
+      "integrity": "sha512-ZAK5gxYhGmfJqMjfWcRBjB8glITltDbTrYJXvcDtfengbKTZN0p39p5uO5pvUB8/PiAWKTRS06yaNMhf/LG26g==",
+      "deprecated": "please use @earendil-works/pi-tui instead going forward",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime-types": "^2.1.4",
+        "chalk": "^5.5.0",
+        "get-east-asian-width": "^1.3.0",
+        "marked": "^15.0.12",
+        "mime-types": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "koffi": "^2.9.0"
+      }
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
+      "integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
+      "dependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.24.1"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@napi-rs/cli": {
       "version": "2.18.4",
@@ -668,6 +1967,63 @@
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@rivet-dev/agent-os-core": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@rivet-dev/agent-os-core/-/agent-os-core-0.1.1.tgz",
@@ -709,6 +2065,232 @@
         "pyodide": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@rivet-dev/agentos": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@rivet-dev/agentos/-/agentos-0.2.15.tgz",
+      "integrity": "sha512-NLJjFNVD0uP/EzGfGOcDaZ+GMx595P9sps/A2aLn+xb/KPUqpc+mxmZi8VYhCj2cr20QBa6jhfA2Ohf+0r72Mg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "0.16.1",
+        "@agentos-software/common": "0.2.15",
+        "@rivet-dev/agentos-core": "0.2.15",
+        "@rivetkit/react": "2.3.9",
+        "rivetkit": "2.3.9",
+        "zod": "^4.1.11"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rivet-dev/agentos-core": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@rivet-dev/agentos-core/-/agentos-core-0.2.15.tgz",
+      "integrity": "sha512-uRg3BmbZzDUwWVmCTcd9Iuo1k8GJeuaXE3FnBbFGzAeI7I077KAhYlVejb9TBWHtjYcblVlMnl591vDm0DbpCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "0.16.1",
+        "@agentos-software/claude-code": "0.2.7",
+        "@agentos-software/codex-cli": "0.3.4",
+        "@agentos-software/common": "0.2.15",
+        "@agentos-software/manifest": "0.2.15",
+        "@agentos-software/opencode": "0.2.7",
+        "@agentos-software/pi": "0.2.7",
+        "@aws-sdk/client-s3": "^3.1019.0",
+        "@rivet-dev/agentos-runtime-core": "0.2.15",
+        "@rivet-dev/agentos-sidecar": "0.2.15",
+        "@rivetkit/bare-ts": "^0.6.2",
+        "@xterm/headless": "^6.0.0",
+        "better-sqlite3": "^12.8.0",
+        "croner": "^10.0.1",
+        "googleapis": "^144.0.0",
+        "isolated-vm": "^6.0.0",
+        "long-timeout": "^0.1.1",
+        "minimatch": "^10.2.4",
+        "zod": "^4.1.11",
+        "zod-to-json-schema": "^3.25.2"
+      }
+    },
+    "node_modules/@rivet-dev/agentos-runtime-core": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@rivet-dev/agentos-runtime-core/-/agentos-runtime-core-0.2.15.tgz",
+      "integrity": "sha512-u8J9psQbu7gixzasyS8b7MiVXrrNPAGzk46DAGM3g8TwUZdP1muR1aa4FS7XePRmD3YWM5QrgCxFETl4gmE8vQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@rivet-dev/agentos-runtime-sidecar": "0.2.15",
+        "@rivetkit/bare-ts": "^0.6.2",
+        "zod": "^4.1.11"
+      }
+    },
+    "node_modules/@rivet-dev/agentos-runtime-sidecar": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@rivet-dev/agentos-runtime-sidecar/-/agentos-runtime-sidecar-0.2.15.tgz",
+      "integrity": "sha512-8eemRmcqp5X9UdpzUD0vJbtG29Ip34n6ulUIFI+ewGXRAxJ+aU5+iqdfRxjYaW71t6zc7r/tMbUSLaPkwMsZqA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@rivet-dev/agentos-runtime-sidecar-darwin-arm64": "0.2.15",
+        "@rivet-dev/agentos-runtime-sidecar-darwin-x64": "0.2.15",
+        "@rivet-dev/agentos-runtime-sidecar-linux-arm64-gnu": "0.2.15",
+        "@rivet-dev/agentos-runtime-sidecar-linux-x64-gnu": "0.2.15"
+      }
+    },
+    "node_modules/@rivet-dev/agentos-runtime-sidecar-darwin-arm64": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@rivet-dev/agentos-runtime-sidecar-darwin-arm64/-/agentos-runtime-sidecar-darwin-arm64-0.2.15.tgz",
+      "integrity": "sha512-GN+OJjp8GLNyWSeRNp9Lh27ZWCW7O1RI95RXKCSQCn07d5Hj5QYLbIn7VYN1mpDzOfdbvhvSy5Re0kKU94FZFA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@rivet-dev/agentos-runtime-sidecar-darwin-x64": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@rivet-dev/agentos-runtime-sidecar-darwin-x64/-/agentos-runtime-sidecar-darwin-x64-0.2.15.tgz",
+      "integrity": "sha512-3/4WGmd0MGDIYWSCVBvsdElZUEZ0YMZZdOP57hyYV3ut9pQdhnJPciqe6s46RBE78G+2ZtHGf/PgWyHL0zS2gA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@rivet-dev/agentos-runtime-sidecar-linux-arm64-gnu": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@rivet-dev/agentos-runtime-sidecar-linux-arm64-gnu/-/agentos-runtime-sidecar-linux-arm64-gnu-0.2.15.tgz",
+      "integrity": "sha512-OiUoHPmgOfbUGyPapmT6VBxXTKQBRyOc0O6MWALCc3dNy50C/Tb2K1lH3JlF9upUzcdp7g6HcqaDeja88tQujQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@rivet-dev/agentos-runtime-sidecar-linux-x64-gnu": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@rivet-dev/agentos-runtime-sidecar-linux-x64-gnu/-/agentos-runtime-sidecar-linux-x64-gnu-0.2.15.tgz",
+      "integrity": "sha512-5QIF7C5rQqWf77Fd5tKj4vP8FPPmwIPsdd454CblFQerH5PPDSua5o44w38PyNMgi2tlWu2OTuiYloiOwyHo6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@rivet-dev/agentos-sidecar": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@rivet-dev/agentos-sidecar/-/agentos-sidecar-0.2.15.tgz",
+      "integrity": "sha512-XvABEkqiA/zLqcOM8AgYvRxxbg8dMviR1D/66GWgEWOAMjcqfn1kXFrsL1d0WbKEn7nwUfguKQVV4weeR3oF5g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@rivet-dev/agentos-sidecar-darwin-arm64": "0.2.15",
+        "@rivet-dev/agentos-sidecar-darwin-x64": "0.2.15",
+        "@rivet-dev/agentos-sidecar-linux-arm64-gnu": "0.2.15",
+        "@rivet-dev/agentos-sidecar-linux-x64-gnu": "0.2.15"
+      }
+    },
+    "node_modules/@rivet-dev/agentos-sidecar-darwin-arm64": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@rivet-dev/agentos-sidecar-darwin-arm64/-/agentos-sidecar-darwin-arm64-0.2.15.tgz",
+      "integrity": "sha512-2csTR3/C3KmNTZln1/u3xU6pKVB/0RdG+MqW3AP2OmS/Q5Lucdd4Y6tnxZGg/ku6Q+Pw9KLOTEuFW1p8cQi1Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@rivet-dev/agentos-sidecar-darwin-x64": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@rivet-dev/agentos-sidecar-darwin-x64/-/agentos-sidecar-darwin-x64-0.2.15.tgz",
+      "integrity": "sha512-xUDxTXARNbQY1Jq0JjxN7D9sfv8iEff4nYnBQR2efo/L5HBObT/fRO2gT+zwUZSRGHnEJCb8gvDxFYc/Th/sqg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@rivet-dev/agentos-sidecar-linux-arm64-gnu": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@rivet-dev/agentos-sidecar-linux-arm64-gnu/-/agentos-sidecar-linux-arm64-gnu-0.2.15.tgz",
+      "integrity": "sha512-5pzCqLcHYluESd9c6aIohi2x6A7K8vli0DnmkMJwHXJilQyqmjZz8Y0m6Ggi+0jGi2Idad46SzzC1Z7uRrO5Ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@rivet-dev/agentos-sidecar-linux-x64-gnu": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/@rivet-dev/agentos-sidecar-linux-x64-gnu/-/agentos-sidecar-linux-x64-gnu-0.2.15.tgz",
+      "integrity": "sha512-2byoXX4ol1PKOvvtPxUk0BgPTv+mlOCX6nXKOsb4Z6OY7OwhMn+z+um1VpWxwMyU8gBS3oG12ungDmVmH8aIYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rivetkit/bare-ts": {
@@ -825,6 +2407,17 @@
         "@rivetkit/bare-ts": "^0.6.2"
       }
     },
+    "node_modules/@rivetkit/framework-base": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@rivetkit/framework-base/-/framework-base-2.3.9.tgz",
+      "integrity": "sha512-ZSxrclYcpmdGsLMiVE2dfWNfUB6diSx+t8k4EQgL4cN02ThzJD3BM5mhU+zQVCCwfNw42eRZVIoxydYDLl/yHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@tanstack/store": "^0.7.1",
+        "fast-deep-equal": "^3.1.3",
+        "rivetkit": "2.3.9"
+      }
+    },
     "node_modules/@rivetkit/on-change": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@rivetkit/on-change/-/on-change-6.0.1.tgz",
@@ -835,6 +2428,21 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/on-change?sponsor=1"
+      }
+    },
+    "node_modules/@rivetkit/react": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@rivetkit/react/-/react-2.3.9.tgz",
+      "integrity": "sha512-j9t82h/yIqqSt17coQZeRu3F9Q5w2FgWPDUC9fCyQUJp9PTjO7ea494PR0lSWvuEiwMRqE5JpgbHdYUQ1woE9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@rivetkit/framework-base": "2.3.9",
+        "@tanstack/react-store": "^0.7.1",
+        "rivetkit": "2.3.9"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/@rivetkit/rivetkit-napi": {
@@ -1384,11 +2992,161 @@
         "linux"
       ]
     },
+    "node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "license": "MIT"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tanstack/react-store": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.7.7.tgz",
+      "integrity": "sha512-qqT0ufegFRDGSof9D/VqaZgjNgp4tRPHZIJq2+QIHkMUtHjaJ0lYrrXjeIUJvjnTbgPfSD1XgOMEt0lmANn6Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/store": "0.7.7",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/store": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.7.7.tgz",
+      "integrity": "sha512-xa6pTan1bcaqYDS9BDpSiS63qa6EoDkPN9RsRaxHuDdVDNntzq3xNwR5YKTU/V3SkSyC9T4YVOPh2zRQN0nhIQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -1427,15 +3185,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mime-types": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+      "integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -1443,6 +3212,16 @@
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -1560,6 +3339,103 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xterm/headless": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-6.0.0.tgz",
+      "integrity": "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
+    },
     "node_modules/asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -1600,6 +3476,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -1624,6 +3512,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1644,6 +3541,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/better-sqlite3": {
       "version": "12.11.1",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
@@ -1656,6 +3562,15 @@
       },
       "engines": {
         "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/bindings": {
@@ -1683,6 +3598,61 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.5.tgz",
       "integrity": "sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==",
       "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/brorand": {
       "version": "1.1.0",
@@ -1845,6 +3815,21 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -1856,6 +3841,15 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
       "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.9",
@@ -1945,6 +3939,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -1971,6 +3977,93 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "license": "MIT"
     },
+    "node_modules/cli-highlight": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "highlight": "bin/highlight"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/console-browserify": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
@@ -1982,6 +4075,28 @@
       "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1989,11 +4104,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
@@ -2063,6 +4213,20 @@
         "node": ">=18.0"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/crypto-browserify": {
       "version": "3.12.1",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
@@ -2087,6 +4251,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decompress-response": {
@@ -2147,6 +4337,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/des.js": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
@@ -2164,6 +4377,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diffie-hellman": {
@@ -2334,6 +4556,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/elliptic": {
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
@@ -2354,6 +4591,21 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
       "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
       "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -2441,6 +4693,64 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -2449,6 +4759,24 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/events": {
@@ -2479,8 +4807,6 @@
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
       "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -2514,6 +4840,125 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
+      "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
     "node_modules/fdb-tuple": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fdb-tuple/-/fdb-tuple-1.0.0.tgz",
@@ -2538,11 +4983,73 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -2575,6 +5082,36 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -2605,6 +5142,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.0.tgz",
+      "integrity": "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -2612,6 +5177,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2651,6 +5237,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
@@ -2664,11 +5265,259 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/get-uri/node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis": {
+      "version": "144.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-144.0.0.tgz",
+      "integrity": "sha512-ELcWOXtJxjPX4vsKMh+7V+jZvgPwYMlEhQFiu2sa9Qmt5veX8nwXPksOWGGN6Zk4xCiLygUyaz7xGtcMO+Onxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.2.0.tgz",
+      "integrity": "sha512-/fhDZEJZvOV3X5jmD+fKxMqma5q2Q9nZNSF3kn1F18tpxmA86BcTxAGBQdM0N89Z3bEaIs+HVznSmFJEAmMTjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.7.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis-common/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/googleapis/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/googleapis/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -2680,6 +5529,70 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/gtoken/node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gtoken/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-property-descriptors": {
@@ -2756,6 +5669,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -2776,11 +5698,85 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -2802,6 +5798,15 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2821,6 +5826,24 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-arguments": {
@@ -2864,6 +5887,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -2913,6 +5945,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -2929,6 +5967,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-typed-array": {
@@ -2952,6 +6002,25 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "license": "MIT"
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/isolated-vm": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-6.1.2.tgz",
+      "integrity": "sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
     "node_modules/isomorphic-timers-promises": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz",
@@ -2961,11 +6030,86 @@
         "node": ">=10"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/koffi": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.3.tgz",
+      "integrity": "sha512-E9y1AsgYGlaxMhcZzHr8y96QF2U5XzA12GGVAfbWqIubTwPNMXQarfBzePNXHe0xtIEtNd6ifAv3GAKYGUeBAQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.33.0",
@@ -3243,6 +6387,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/long-timeout": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.1.1.tgz",
@@ -3261,6 +6411,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3269,6 +6428,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {
@@ -3291,6 +6462,31 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -3309,6 +6505,31 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
       "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
       "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/mimic-response": {
       "version": "3.1.0",
@@ -3334,6 +6555,21 @@
       "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
       "license": "MIT"
     },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -3343,11 +6579,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
     },
     "node_modules/nanocodex": {
       "resolved": "../../js/bindings",
@@ -3378,6 +6640,24 @@
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/node-abi": {
       "version": "3.94.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
@@ -3388,6 +6668,55 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-gyp-build-optional-packages": {
@@ -3441,6 +6770,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -3523,6 +6861,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3530,6 +6880,27 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/openapi3-ts": {
@@ -3577,6 +6948,51 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -3599,6 +7015,42 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "license": "MIT"
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "license": "MIT"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -3614,11 +7066,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -3643,6 +7130,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3700,6 +7193,15 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/pkg-dir": {
       "version": "5.0.0",
@@ -3809,6 +7311,96 @@
       ],
       "license": "MIT"
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -3906,6 +7498,34 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -3919,6 +7539,29 @@
       },
       "bin": {
         "rc": "cli.js"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
       }
     },
     "node_modules/readable-stream": {
@@ -3942,6 +7585,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -4171,6 +7832,22 @@
         "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4217,6 +7894,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/secure-exec": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/secure-exec/-/secure-exec-0.2.1.tgz",
@@ -4237,6 +7927,51 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-function-length": {
@@ -4262,6 +7997,12 @@
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/sha.js": {
       "version": "2.4.12",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
@@ -4280,6 +8021,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/side-channel": {
@@ -4361,6 +8123,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -4406,6 +8174,44 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -4413,6 +8219,16 @@
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -4439,6 +8255,21 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "license": "MIT"
     },
     "node_modules/stream-browserify": {
@@ -4472,6 +8303,56 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -4479,6 +8360,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -4519,6 +8428,27 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/thread-stream": {
@@ -4600,13 +8530,50 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -4646,6 +8613,37 @@
         "node": "*"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -4674,12 +8672,41 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/url": {
       "version": "0.11.4",
@@ -4692,6 +8719,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
+      "license": "BSD"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util": {
@@ -4712,6 +8754,29 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vbare": {
       "version": "0.0.4",
@@ -4909,6 +8974,46 @@
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "license": "MIT"
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.22",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
@@ -4942,6 +9047,44 @@
       },
       "bin": {
         "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -4983,6 +9126,15 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -4998,6 +9150,43 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
+    "node_modules/yargs": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
+      "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -5010,6 +9199,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/yoctocolors": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/zod": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
@@ -5017,6 +9218,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/examples/rivet-actors/package.json
+++ b/examples/rivet-actors/package.json
@@ -27,6 +27,7 @@
     "typecheck": "tsc --noEmit && tsc -p web/tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@rivet-dev/agentos": "0.2.15",
     "nanocodex": "file:../../js/bindings",
     "rivetkit": "2.3.10",
     "ws": "8.21.1"
@@ -41,6 +42,7 @@
   },
   "overrides": {
     "esbuild": "0.28.1",
+    "rivetkit": "2.3.10",
     "ws": "8.21.1"
   }
 }

--- a/examples/rivet-actors/scripts/check-no-pi.mjs
+++ b/examples/rivet-actors/scripts/check-no-pi.mjs
@@ -1,6 +1,7 @@
-import { readFile } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 
-const lock = JSON.parse(await readFile(new URL("../package-lock.json", import.meta.url), "utf8"));
+const root = new URL("../", import.meta.url);
+const manifest = JSON.parse(await readFile(new URL("package.json", root), "utf8"));
 const forbidden = [
   "@agentos-software/pi",
   "@mariozechner/pi-agent-core",
@@ -9,12 +10,58 @@ const forbidden = [
   "@mariozechner/pi-tui",
   "pi-acp",
 ];
-const installed = Object.keys(lock.packages ?? {}).filter((entry) =>
-  forbidden.some((name) => entry === `node_modules/${name}` || entry.endsWith(`/node_modules/${name}`))
-);
+const declared = Object.keys({
+  ...manifest.dependencies,
+  ...manifest.devDependencies,
+  ...manifest.optionalDependencies,
+}).filter((name) => forbidden.includes(name));
 
-if (installed.length > 0) {
-  throw new Error(`forbidden Pi dependencies in package-lock.json: ${installed.join(", ")}`);
+if (declared.length > 0) {
+  throw new Error(`forbidden direct Pi dependencies: ${declared.join(", ")}`);
 }
 
-console.log("dependency check: no Pi packages");
+const sourceFiles = await collectSourceFiles(["src", "scripts", "test", "web"]);
+const imported = [];
+for (const file of sourceFiles) {
+  if (file.pathname.endsWith("/check-no-pi.mjs")) continue;
+  const source = await readFile(file, "utf8");
+  for (const name of forbidden) {
+    if (source.includes(`from "${name}"`)
+      || source.includes(`from '${name}'`)
+      || source.includes(`import("${name}")`)
+      || source.includes(`import('${name}')`)
+      || source.includes(`require("${name}")`)
+      || source.includes(`require('${name}')`)) {
+      imported.push(`${file.pathname}:${name}`);
+    }
+  }
+}
+
+if (imported.length > 0) {
+  throw new Error(`forbidden Pi imports: ${imported.join(", ")}`);
+}
+
+console.log("dependency check: no direct Pi dependencies or imports");
+
+async function collectSourceFiles(directories) {
+  const files = [];
+  for (const directory of directories) {
+    const url = new URL(`${directory}/`, root);
+    for (const entry of await readdir(url, { withFileTypes: true })) {
+      const child = new URL(entry.name + (entry.isDirectory() ? "/" : ""), url);
+      if (entry.isDirectory()) files.push(...await collectDirectory(child));
+      else if (/\.(?:[cm]?[jt]sx?)$/.test(entry.name)) files.push(child);
+    }
+  }
+  return files;
+}
+
+async function collectDirectory(directory) {
+  const files = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const child = new URL(entry.name + (entry.isDirectory() ? "/" : ""), directory);
+    if (entry.isDirectory()) files.push(...await collectDirectory(child));
+    else if (/\.(?:[cm]?[jt]sx?)$/.test(entry.name)) files.push(child);
+  }
+  return files;
+}

--- a/examples/rivet-actors/scripts/deploy-subscription.ts
+++ b/examples/rivet-actors/scripts/deploy-subscription.ts
@@ -25,6 +25,8 @@ const environment = [
   `CHATGPT_ACCOUNT_ID=${auth.accountId}`,
   `CHATGPT_FEDRAMP=${String(auth.fedramp)}`,
 ];
+const publicUrl = process.env.NANOCODEX_PUBLIC_URL?.trim();
+if (publicUrl) environment.push(`NANOCODEX_PUBLIC_URL=${publicUrl}`);
 const refreshToken = process.env.CHATGPT_REFRESH_TOKEN?.trim();
 if (refreshToken) environment.push(`CHATGPT_REFRESH_TOKEN=${refreshToken}`);
 

--- a/examples/rivet-actors/scripts/deploy-subscription.ts
+++ b/examples/rivet-actors/scripts/deploy-subscription.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 
 import { createCodexAuthFileProvider } from "../src/codex-auth-file.js";
 
-const cloudToken = requiredSecret("RIVET_CLOUD_TOKEN");
+const cloudToken = process.env.RIVET_CLOUD_TOKEN?.trim();
 const codexHome = process.env.CODEX_HOME ?? join(homedir(), ".codex");
 const authFile = resolve(process.env.NANOCODEX_CODEX_AUTH_FILE ?? join(codexHome, "auth.json"));
 const auth = await createCodexAuthFileProvider(authFile).snapshot();
@@ -35,8 +35,7 @@ process.stderr.write(
 const child = spawn("npx", [
   "@rivetkit/cli@2.3.10",
   "deploy",
-  "--token",
-  cloudToken,
+  ...(cloudToken ? ["--token", cloudToken] : []),
   "--dockerfile",
   "examples/rivet-actors/Dockerfile",
   "--build-context",

--- a/examples/rivet-actors/scripts/live-smoke.ts
+++ b/examples/rivet-actors/scripts/live-smoke.ts
@@ -12,14 +12,29 @@ const events = session.connect();
 let eventCount = 0;
 const sandboxToolCalls = new Map<string, string>();
 const sandboxToolsCompleted = new Set<string>();
+let previewPath: string | undefined;
+let sandboxProcessId: number | undefined;
 events.on("agentEvent", (event) => {
   eventCount += 1;
+  if (process.env.NANOCODEX_SMOKE_TRACE === "1"
+    && (event.type === "tool.call" || event.type === "tool.result")) {
+    console.error(JSON.stringify({ type: event.type, payload: event.payload }));
+  }
   if (event.type === "tool.call" && typeof event.payload.tool === "string") {
     sandboxToolCalls.set(String(event.payload.call_id), event.payload.tool);
   }
   if (event.type === "tool.result" && event.payload.status === "completed") {
     const tool = sandboxToolCalls.get(String(event.payload.call_id));
-    if (tool) sandboxToolsCompleted.add(tool);
+    if (tool) {
+      sandboxToolsCompleted.add(tool);
+      const result = parseToolResult(event.payload.result);
+      if (tool === "sandbox_preview" && typeof result?.url === "string") {
+        previewPath = result.url;
+      }
+      if (tool === "sandbox_start_process" && typeof result?.process_id === "number") {
+        sandboxProcessId = result.process_id;
+      }
+    }
   }
 });
 await events.ready;
@@ -55,12 +70,25 @@ try {
   }
   const toolTurn = await session.turn({
     id: randomUUID(),
-    input: "Use sandbox_write_file to write SANDBOX_OK to probe.txt, use sandbox_exec to run cat on it, and verify it with sandbox_read_file. Then reply with exactly SANDBOX_OK.",
+    input: "Use sandbox_write_file to write exactly RIVET_SANDBOX_OK to index.html. Verify it with sandbox_exec and sandbox_read_file. Call sandbox_start_process with command `python3`, args [`-m`, `http.server`, `3000`, `--bind`, `0.0.0.0`, `--directory`, `/workspace`], and ready_port 3000. After it reports the port ready, call sandbox_preview for port 3000. Reply with only the preview URL.",
   });
-  const requiredTools = ["sandbox_write_file", "sandbox_exec", "sandbox_read_file"];
-  if (toolTurn.final_message.trim() !== "SANDBOX_OK"
-    || requiredTools.some((tool) => !sandboxToolsCompleted.has(tool))) {
+  const requiredTools = [
+    "sandbox_write_file",
+    "sandbox_exec",
+    "sandbox_read_file",
+    "sandbox_start_process",
+    "sandbox_preview",
+  ];
+  if (requiredTools.some((tool) => !sandboxToolsCompleted.has(tool)) || !previewPath) {
     throw new Error(`sandbox tool proof failed: ${toolTurn.final_message}`);
+  }
+  const previewUrl = previewPath.startsWith("http://") || previewPath.startsWith("https://")
+    ? previewPath
+    : appendGatewayPath(await session.getGatewayUrl(), previewPath);
+  const previewResponse = await fetch(previewUrl, { signal: AbortSignal.timeout(15_000) });
+  const previewBody = await previewResponse.text();
+  if (!previewResponse.ok || previewBody.trim() !== "RIVET_SANDBOX_OK") {
+    throw new Error(`preview fetch failed (${previewResponse.status}): ${previewBody.slice(0, 256)}`);
   }
   const status = await session.status();
   console.log(JSON.stringify({
@@ -69,11 +97,33 @@ try {
     completed_turns: status.completed_turns,
     elapsed_ms: Math.round(performance.now() - started),
     events: eventCount,
+    preview_url: previewUrl,
     tool_calls: requiredTools,
     restored: status.has_snapshot,
     status: "ok",
   }));
 } finally {
   await events.dispose();
+  if (sandboxProcessId !== undefined) {
+    await session.process.kill(sandboxProcessId).catch(() => {});
+  }
   await session.reset();
+}
+
+function parseToolResult(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value !== "string") return undefined;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function appendGatewayPath(gatewayUrl: string, path: string): string {
+  const url = new URL(gatewayUrl);
+  url.pathname = `${url.pathname.replace(/\/$/, "")}/request/${path.replace(/^\//, "")}`;
+  return url.toString();
 }

--- a/examples/rivet-actors/scripts/live-smoke.ts
+++ b/examples/rivet-actors/scripts/live-smoke.ts
@@ -68,7 +68,7 @@ try {
   if (restored.final_message !== "EDGE_OK") {
     throw new Error(`restored session lost history: ${restored.final_message}`);
   }
-  const toolTurn = await session.turn({
+  const toolTurn = await awaitDurableTurn({
     id: randomUUID(),
     input: "Use sandbox_write_file to write exactly RIVET_SANDBOX_OK to index.html. Verify it with sandbox_exec and sandbox_read_file. Call sandbox_start_process with command `python3`, args [`-m`, `http.server`, `3000`, `--bind`, `0.0.0.0`, `--directory`, `/workspace`], and ready_port 3000. After it reports the port ready, call sandbox_preview for port 3000. Reply with only the preview URL.",
   });
@@ -103,11 +103,37 @@ try {
     status: "ok",
   }));
 } finally {
-  await events.dispose();
+  await cleanupSession();
+}
+
+async function awaitDurableTurn(request: { id: string; input: string }) {
+  await session.start(request);
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      return await session.turn(request);
+    } catch (error) {
+      lastError = error;
+      const status = await session.status();
+      if (!status.active_turns.includes(request.id)) throw error;
+    }
+  }
+  throw lastError;
+}
+
+async function cleanupSession(): Promise<void> {
+  await events.dispose().catch(() => {});
   if (sandboxProcessId !== undefined) {
     await session.process.kill(sandboxProcessId).catch(() => {});
   }
-  await session.reset();
+  const status = await session.status().catch(() => undefined);
+  await Promise.all((status?.active_turns ?? []).map((id) => session.cancel(id).catch(() => {})));
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const current = await session.status().catch(() => undefined);
+    if (!current || current.active_turns.length === 0) break;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  await session.reset().catch(() => {});
 }
 
 function parseToolResult(value: unknown): Record<string, unknown> | undefined {

--- a/examples/rivet-actors/scripts/live-smoke.ts
+++ b/examples/rivet-actors/scripts/live-smoke.ts
@@ -10,17 +10,16 @@ const session = client.nanocodex.getOrCreate([
 await session.reset();
 const events = session.connect();
 let eventCount = 0;
-let runtimeToolCallId: string | undefined;
-let runtimeToolCompleted = false;
+const sandboxToolCalls = new Map<string, string>();
+const sandboxToolsCompleted = new Set<string>();
 events.on("agentEvent", (event) => {
   eventCount += 1;
-  if (event.type === "tool.call" && event.payload.tool === "runtimeInfo") {
-    runtimeToolCallId = String(event.payload.call_id);
+  if (event.type === "tool.call" && typeof event.payload.tool === "string") {
+    sandboxToolCalls.set(String(event.payload.call_id), event.payload.tool);
   }
-  if (event.type === "tool.result"
-    && event.payload.call_id === runtimeToolCallId
-    && event.payload.status === "completed") {
-    runtimeToolCompleted = true;
+  if (event.type === "tool.result" && event.payload.status === "completed") {
+    const tool = sandboxToolCalls.get(String(event.payload.call_id));
+    if (tool) sandboxToolsCompleted.add(tool);
   }
 });
 await events.ready;
@@ -33,33 +32,35 @@ const started = performance.now();
 
 try {
   const [first, duplicate] = await Promise.all([
-    session.prompt(firstRequest),
-    session.prompt(firstRequest),
+    session.turn(firstRequest),
+    session.turn(firstRequest),
   ]);
   if (first.final_message !== "EDGE_OK" || duplicate.final_message !== first.final_message) {
     throw new Error(`unexpected first turn: ${JSON.stringify(first)}`);
   }
 
-  const replay = await session.prompt(firstRequest);
+  const replay = await session.turn(firstRequest);
   if (replay.final_message !== first.final_message) throw new Error("terminal replay changed its result");
 
   await session.unload();
   const unloaded = await session.status();
   if (unloaded.agent_loaded) throw new Error("unload left the WASM driver resident");
 
-  const restored = await session.prompt({
+  const restored = await session.turn({
     id: randomUUID(),
     input: "What exact token did I ask you to return previously? Reply with only that token.",
   });
   if (restored.final_message !== "EDGE_OK") {
     throw new Error(`restored session lost history: ${restored.final_message}`);
   }
-  const toolTurn = await session.prompt({
+  const toolTurn = await session.turn({
     id: randomUUID(),
-    input: "You must call runtimeInfo exactly once. Then reply with only the runtime value returned by that tool.",
+    input: "Use sandbox_write_file to write SANDBOX_OK to probe.txt, use sandbox_exec to run cat on it, and verify it with sandbox_read_file. Then reply with exactly SANDBOX_OK.",
   });
-  if (!toolTurn.final_message.includes("rivet-actor") || !runtimeToolCompleted) {
-    throw new Error(`runtimeInfo tool proof failed: ${toolTurn.final_message}`);
+  const requiredTools = ["sandbox_write_file", "sandbox_exec", "sandbox_read_file"];
+  if (toolTurn.final_message.trim() !== "SANDBOX_OK"
+    || requiredTools.some((tool) => !sandboxToolsCompleted.has(tool))) {
+    throw new Error(`sandbox tool proof failed: ${toolTurn.final_message}`);
   }
   const status = await session.status();
   console.log(JSON.stringify({
@@ -68,7 +69,7 @@ try {
     completed_turns: status.completed_turns,
     elapsed_ms: Math.round(performance.now() - started),
     events: eventCount,
-    tool_call: "runtimeInfo",
+    tool_calls: requiredTools,
     restored: status.has_snapshot,
     status: "ok",
   }));

--- a/examples/rivet-actors/scripts/live-smoke.ts
+++ b/examples/rivet-actors/scripts/live-smoke.ts
@@ -70,7 +70,7 @@ try {
   }
   const toolTurn = await awaitDurableTurn({
     id: randomUUID(),
-    input: "Use sandbox_write_file to write exactly RIVET_SANDBOX_OK to index.html. Verify it with sandbox_exec and sandbox_read_file. Call sandbox_start_process with command `python3`, args [`-m`, `http.server`, `3000`, `--bind`, `0.0.0.0`, `--directory`, `/workspace`], and ready_port 3000. After it reports the port ready, call sandbox_preview for port 3000. Reply with only the preview URL.",
+    input: "Use sandbox_write_file to write exactly RIVET_SANDBOX_OK to index.html and to write server.mjs containing a Node HTTP server that reads /workspace/index.html and listens on 0.0.0.0:3000. Verify index.html with sandbox_exec and sandbox_read_file. Call sandbox_start_process with command `node`, args [`/workspace/server.mjs`], and ready_port 3000. After it reports the port ready, call sandbox_preview for port 3000. Reply with only the preview URL.",
   });
   const requiredTools = [
     "sandbox_write_file",

--- a/examples/rivet-actors/scripts/multiclient-smoke.ts
+++ b/examples/rivet-actors/scripts/multiclient-smoke.ts
@@ -30,7 +30,7 @@ const request = {
 try {
   const started = await first.start(request);
   if (started.replayed) throw new Error("fresh synchronized turn was unexpectedly replayed");
-  const result = await first.prompt(request);
+  const result = await first.turn(request);
   if (result.final_message !== "RIVET_SYNC_OK") {
     throw new Error(`unexpected synchronized result: ${result.final_message}`);
   }

--- a/examples/rivet-actors/scripts/repl.ts
+++ b/examples/rivet-actors/scripts/repl.ts
@@ -81,7 +81,7 @@ async function completePending(pending: PendingTurn, resumed: boolean): Promise<
   process.stderr.write(
     `${resumed ? "Resuming" : "Started"} ${pending.id}${accepted.replayed ? " (already running)" : ""}. Ctrl-C detaches.\n`,
   );
-  const completed = await session.prompt(pending);
+  const completed = await session.turn(pending);
   if (state.pending?.id === pending.id) {
     delete state.pending;
     await saveState();

--- a/examples/rivet-actors/scripts/soak.ts
+++ b/examples/rivet-actors/scripts/soak.ts
@@ -63,7 +63,7 @@ for (let wave = 0; wave < waves; wave += 1) {
     await Promise.all(sessions.map(({ connection }) => connection.ready));
     const seedStarted = performance.now();
     const seeded = await Promise.allSettled(sessions.map(async ({ connection, request }) => {
-      const result = await connection.prompt(request);
+      const result = await connection.turn(request);
       if (result.final_message !== request.input.slice("Reply with exactly ".length)) {
         throw new Error(`unexpected seed result: ${result.final_message}`);
       }
@@ -83,7 +83,7 @@ for (let wave = 0; wave < waves; wave += 1) {
       const settled = await Promise.allSettled(sessions.flatMap(({ connection, request }) =>
         Array.from({ length: batchSize }, async () => {
           const started = performance.now();
-          const result = await connection.prompt(request);
+          const result = await connection.turn(request);
           latencies.record(performance.now() - started);
           return result;
         })));

--- a/examples/rivet-actors/scripts/stress.ts
+++ b/examples/rivet-actors/scripts/stress.ts
@@ -25,7 +25,7 @@ const sessions = handles.map((handle, index) => {
 try {
   await Promise.all(sessions.map(({ connection }) => connection.ready));
   const seeded = await Promise.allSettled(sessions.map(async ({ connection, request }) => {
-    const result = await connection.prompt(request);
+    const result = await connection.turn(request);
     if (result.final_message !== request.input.slice("Reply with exactly ".length)) {
       throw new Error(`unexpected seed result: ${result.final_message}`);
     }
@@ -41,7 +41,7 @@ try {
     const settled = await Promise.allSettled(sessions.flatMap(({ connection, request }) =>
       Array.from(
         { length: batchSize },
-        () => connection.prompt(request),
+        () => connection.turn(request),
       )));
     const failure = settled.find((result) => result.status === "rejected");
     if (failure) throw failure.reason;

--- a/examples/rivet-actors/src/actors.ts
+++ b/examples/rivet-actors/src/actors.ts
@@ -26,6 +26,8 @@ import {
   type AgentOsActionContext,
   agentOsPreviewOptions,
   agentOsRuntimeOptions,
+  migrateRivetSandboxDatabase,
+  restoreRivetPreviewServers,
   rivetSandboxTools,
 } from "./sandbox-tools.js";
 
@@ -144,6 +146,7 @@ export const nanocodex = agentOS({
     turns: new Map(),
   }),
   onWake: async (c: SessionContext) => migrateSessionDatabase(c.db),
+  onVmStart: restoreRivetPreviewServers,
   events: {
     agentEvent: event<AgentEvent>(),
     turnAccepted: event<TurnAccepted>(),
@@ -418,6 +421,7 @@ async function createAgent(context: SessionContext): Promise<DefaultAgent> {
 }
 
 async function migrateSessionDatabase(database: RawAccess): Promise<void> {
+  await migrateRivetSandboxDatabase(database);
   await database.execute(`
     CREATE TABLE IF NOT EXISTS session_state (
       singleton INTEGER PRIMARY KEY CHECK (singleton = 1),

--- a/examples/rivet-actors/src/actors.ts
+++ b/examples/rivet-actors/src/actors.ts
@@ -10,8 +10,9 @@ import type {
   TurnUsage,
 } from "nanocodex";
 import { Agent } from "nanocodex/browser";
-import { actor, event, UserError } from "rivetkit";
-import { db, type RawAccess } from "rivetkit/db";
+import { agentOS } from "@rivet-dev/agentos";
+import { event, UserError } from "rivetkit";
+import type { RawAccess } from "rivetkit/db";
 
 import type { SubscriptionSnapshot, SubscriptionStatus } from "./auth.js";
 import { type AuthCapabilityProof, createCapabilityProof } from "./auth-capability.js";
@@ -21,6 +22,12 @@ import {
   openApiKeyWebSocket,
   openSubscriptionWebSocket,
 } from "./model-websocket.js";
+import {
+  type AgentOsActionContext,
+  agentOsPreviewOptions,
+  agentOsRuntimeOptions,
+  rivetSandboxTools,
+} from "./sandbox-tools.js";
 
 const MAX_PROMPT_BYTES = 1024 * 1024;
 const MAX_ACTIVE_TURNS = 16;
@@ -115,7 +122,7 @@ type InternalActorClient = {
   };
 };
 
-type SessionContext = {
+type SessionContext = AgentOsActionContext & {
   vars: SessionVars;
   db: RawAccess;
   actorId: string;
@@ -125,7 +132,9 @@ type SessionContext = {
   keepAwake<T>(promise: Promise<T>): Promise<T>;
 };
 
-export const nanocodex = actor({
+export const nanocodex = agentOS({
+  ...agentOsRuntimeOptions,
+  preview: agentOsPreviewOptions,
   state: {},
   createVars: (): SessionVars => ({
     agent: undefined,
@@ -134,29 +143,7 @@ export const nanocodex = actor({
     inFlight: new Map(),
     turns: new Map(),
   }),
-  db: db({
-    onMigrate: async (database) => {
-      await database.execute(`
-        CREATE TABLE IF NOT EXISTS session_state (
-          singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
-          snapshot TEXT,
-          completed_turns INTEGER NOT NULL DEFAULT 0,
-          last_active INTEGER NOT NULL DEFAULT 0
-        )
-      `);
-      await database.execute(`
-        CREATE TABLE IF NOT EXISTS terminal_turns (
-          id TEXT PRIMARY KEY,
-          input_hash TEXT NOT NULL,
-          payload TEXT NOT NULL,
-          completed_at INTEGER NOT NULL
-        )
-      `);
-      await database.execute(
-        "INSERT OR IGNORE INTO session_state (singleton, last_active) VALUES (1, 0)",
-      );
-    },
-  }),
+  onWake: async (c: SessionContext) => migrateSessionDatabase(c.db),
   events: {
     agentEvent: event<AgentEvent>(),
     turnAccepted: event<TurnAccepted>(),
@@ -164,7 +151,7 @@ export const nanocodex = actor({
     turnFailed: event<TurnFailed>(),
   },
   actions: {
-    start: async (c, request: PromptRequest): Promise<TurnAccepted> => {
+    start: async (c: SessionContext, request: PromptRequest): Promise<TurnAccepted> => {
       const started = startPrompt(c, request, true);
       void started.operation.catch(() => {});
       const admission = await started.admission;
@@ -175,23 +162,23 @@ export const nanocodex = actor({
         replayed: started.replayed || admission.kind === "terminal",
       };
     },
-    prompt: async (c, request: PromptRequest): Promise<TurnCompleted> => {
+    turn: async (c: SessionContext, request: PromptRequest): Promise<TurnCompleted> => {
       return startPrompt(c, request, false).operation;
     },
-    steer: async (c, id: string, input: string): Promise<void> => {
+    steer: async (c: SessionContext, id: string, input: string): Promise<void> => {
       validateTurnId(id);
       validateInput(input);
       const turn = c.vars.turns.get(id);
       if (!turn) throw userError(`turn ${id} is not active`);
       await turn.steer({ input });
     },
-    cancel: async (c, id: string): Promise<void> => {
+    cancel: async (c: SessionContext, id: string): Promise<void> => {
       validateTurnId(id);
       const turn = c.vars.turns.get(id);
       if (!turn) throw userError(`turn ${id} is not active`);
       await turn.cancel();
     },
-    status: async (c): Promise<SessionStatus> => {
+    status: async (c: SessionContext): Promise<SessionStatus> => {
       const row = await sessionRow(c.db);
       return {
         session_id: sessionUuid(c.actorId),
@@ -207,14 +194,14 @@ export const nanocodex = actor({
         auth_mode: modelAuthMode(),
       };
     },
-    unload: async (c): Promise<void> => {
+    unload: async (c: SessionContext): Promise<void> => {
       if (c.vars.inFlight.size > 0) throw userError("cannot unload while turns are active");
       await shutdown(c);
     },
-    reset: async (c): Promise<void> => {
+    reset: async (c: SessionContext): Promise<void> => {
       if (c.vars.inFlight.size > 0) throw userError("cannot reset while turns are active");
       await shutdown(c);
-      await c.db.transaction(async (transaction) => {
+      await c.db.transaction(async (transaction: RawAccess) => {
         await transaction.execute("DELETE FROM terminal_turns");
         await transaction.execute(
           "UPDATE session_state SET snapshot = NULL, completed_turns = 0, last_active = 0 WHERE singleton = 1",
@@ -382,15 +369,21 @@ async function createAgent(context: SessionContext): Promise<DefaultAgent> {
   const mode = modelAuthMode();
   const common = {
     apiBaseUrl: mode === "chatgpt" ? CHATGPT_API_BASE_URL : undefined,
-    instructions: "You are Nanocodex running as a durable Rivet Actor.",
+    instructions: "You are Nanocodex running as a durable Rivet Actor. Use the sandbox_* tools for code, files, and previews; their /workspace is an isolated persistent AgentOS VM filesystem for this actor.",
     module: await wasmBytes,
     resume,
     sessionId: sessionUuid(context.actorId),
     tools: {
+      ...rivetSandboxTools(context, sessionUuid(context.actorId)),
       runtimeInfo: {
         description: "Return information about the current agent runtime.",
         parameters: { type: "object", additionalProperties: false },
-        handler: () => ({ runtime: "rivet-actor", session_id: sessionUuid(context.actorId) }),
+        handler: () => ({
+          runtime: "rivet-actor",
+          sandbox: "rivet-agentos-persistent-vm",
+          session_id: sessionUuid(context.actorId),
+          workspace: "/workspace",
+        }),
       },
     },
     websocketUrl: process.env.OPENAI_WEBSOCKET_URL
@@ -422,6 +415,28 @@ async function createAgent(context: SessionContext): Promise<DefaultAgent> {
   watcher.onEvent((agentEvent) => context.broadcast("agentEvent", agentEvent));
   context.vars.events = watcher;
   return agent;
+}
+
+async function migrateSessionDatabase(database: RawAccess): Promise<void> {
+  await database.execute(`
+    CREATE TABLE IF NOT EXISTS session_state (
+      singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+      snapshot TEXT,
+      completed_turns INTEGER NOT NULL DEFAULT 0,
+      last_active INTEGER NOT NULL DEFAULT 0
+    )
+  `);
+  await database.execute(`
+    CREATE TABLE IF NOT EXISTS terminal_turns (
+      id TEXT PRIMARY KEY,
+      input_hash TEXT NOT NULL,
+      payload TEXT NOT NULL,
+      completed_at INTEGER NOT NULL
+    )
+  `);
+  await database.execute(
+    "INSERT OR IGNORE INTO session_state (singleton, last_active) VALUES (1, 0)",
+  );
 }
 
 function subscriptionActorProvider(context: SessionContext) {

--- a/examples/rivet-actors/src/registry.ts
+++ b/examples/rivet-actors/src/registry.ts
@@ -1,12 +1,12 @@
-import { setup } from "rivetkit";
+import { setup } from "@rivet-dev/agentos";
 
 import { nanocodexAuth } from "./auth.js";
 import { nanocodex } from "./actors.js";
 
 export const registry = setup({
-  // Leave room for the JSON/RPC envelope so the actor's 1 MiB prompt limit is
-  // the authoritative boundary instead of RivetKit's 64 KiB transport default.
-  maxIncomingMessageSize: 2 * 1024 * 1024,
+  // AgentOS's setup enables the direct actor SQLite runtime socket and raises
+  // transport limits for filesystem operations. Nanocodex still enforces its
+  // own 1 MiB prompt boundary before accepting model work.
   // The embedding server owns its HTTP listener and process lifecycle, so it
   // coordinates both listeners and the child engine under one signal handler.
   shutdown: {

--- a/examples/rivet-actors/src/sandbox-tools.ts
+++ b/examples/rivet-actors/src/sandbox-tools.ts
@@ -249,9 +249,7 @@ function publicPreviewUrl(context: AgentOsActionContext, path: string): string {
     if (!namespace || !token.startsWith("pk_")) {
       throw new Error("NANOCODEX_PUBLIC_URL must contain a namespace and client-safe pk_ token");
     }
-    url.pathname = `${url.pathname.replace(/\/$/, "")}/gateway/${encodeURIComponent(context.actorId)}/request${path}`;
-    url.searchParams.set("rvt-namespace", namespace);
-    url.searchParams.set("rvt-token", token);
+    url.pathname = `${url.pathname.replace(/\/$/, "")}/gateway/${encodeURIComponent(context.actorId)}@${encodeURIComponent(token)}/request${path}`;
     return url.toString();
   }
   url.pathname = `${url.pathname.replace(/\/$/, "")}${path}`;

--- a/examples/rivet-actors/src/sandbox-tools.ts
+++ b/examples/rivet-actors/src/sandbox-tools.ts
@@ -8,7 +8,7 @@ import type { ToolMap } from "nanocodex";
 const WORKSPACE = "/workspace";
 const MAX_COMMAND_CHARS = 32 * 1024;
 const MAX_FILE_BYTES = 1024 * 1024;
-const MAX_OUTPUT_CHARS = 128 * 1024;
+const MAX_OUTPUT_BYTES = 128 * 1024;
 const MAX_LIST_ENTRIES = 512;
 const MAX_TIMEOUT_MS = 120_000;
 
@@ -36,10 +36,30 @@ const agentOsActions = createAgentOsActions(
 );
 
 export type AgentOsActionContext = Parameters<typeof agentOsActions.exec>[0];
+type SandboxAgentOsActions = Pick<
+  typeof agentOsActions,
+  | "createPreviewUrl"
+  | "exec"
+  | "killProcess"
+  | "mkdir"
+  | "readFile"
+  | "readdirEntries"
+  | "spawn"
+  | "vmFetch"
+  | "writeFile"
+>;
 
 export function rivetSandboxTools(
   context: AgentOsActionContext,
   sessionId: string,
+): ToolMap {
+  void sessionId;
+  return createRivetSandboxTools(context);
+}
+
+export function createRivetSandboxTools(
+  context: AgentOsActionContext,
+  actions: SandboxAgentOsActions = agentOsActions,
 ): ToolMap {
   return {
     sandbox_exec: {
@@ -59,7 +79,7 @@ export function rivetSandboxTools(
         const command = requiredString(value.command, "command", MAX_COMMAND_CHARS);
         const cwd = workspacePath(optionalString(value.cwd, "cwd") ?? ".");
         const timeout = optionalInteger(value.timeout_ms, "timeout_ms", 1, MAX_TIMEOUT_MS) ?? 60_000;
-        const result = await agentOsActions.exec(context, command, {
+        const result = await actions.exec(context, command, {
           cwd,
           timeout,
           captureStdio: true,
@@ -81,9 +101,66 @@ export function rivetSandboxTools(
       parameters: pathParameters(),
       handler: async (input) => {
         const path = workspacePath(requiredString(objectInput(input).path, "path", 1024));
-        const content = await agentOsActions.readFile(context, path);
+        const content = await actions.readFile(context, path);
         if (content.byteLength > MAX_FILE_BYTES) throw new Error("file exceeds 1 MiB");
-        return { path, content: new TextDecoder().decode(content) };
+        let text: string;
+        try {
+          text = new TextDecoder("utf-8", { fatal: true }).decode(content);
+        } catch {
+          throw new Error("file is not valid UTF-8");
+        }
+        return { path, content: text };
+      },
+    },
+    sandbox_start_process: {
+      description: "Start a native executable in this actor's isolated Rivet AgentOS VM, optionally waiting for an HTTP port to become ready.",
+      parameters: {
+        type: "object",
+        properties: {
+          command: { type: "string", description: "Executable to start, such as python3 or node." },
+          args: {
+            type: "array",
+            items: { type: "string" },
+            description: "Arguments passed directly to the executable, without a shell.",
+          },
+          cwd: { type: "string", description: "Workspace-relative working directory." },
+          ready_port: { type: "integer", minimum: 1024, maximum: 65_535 },
+          ready_timeout_ms: { type: "integer", minimum: 1, maximum: MAX_TIMEOUT_MS },
+        },
+        required: ["command"],
+        additionalProperties: false,
+      },
+      handler: async (input) => {
+        const value = objectInput(input);
+        const command = requiredString(value.command, "command", MAX_COMMAND_CHARS);
+        const args = optionalStringArray(value.args, "args", 128, 8_192) ?? [];
+        const cwd = workspacePath(optionalString(value.cwd, "cwd") ?? ".");
+        const readyPort = optionalInteger(value.ready_port, "ready_port", 1024, 65_535);
+        const readyTimeout = optionalInteger(
+          value.ready_timeout_ms,
+          "ready_timeout_ms",
+          1,
+          MAX_TIMEOUT_MS,
+        ) ?? 30_000;
+        const process = await actions.spawn(context, command, args, {
+          cwd,
+          output: { retainEvents: true },
+        });
+        try {
+          if (readyPort !== undefined) {
+            await waitForPort(actions, context, readyPort, readyTimeout);
+          }
+        } catch (error) {
+          await actions.killProcess(context, process.pid).catch(() => {});
+          throw error;
+        }
+        return {
+          process_id: process.pid,
+          command,
+          args,
+          status: "running",
+          ...(readyPort === undefined ? {} : { ready_port: readyPort }),
+        };
       },
     },
     sandbox_write_file: {
@@ -100,12 +177,12 @@ export function rivetSandboxTools(
       handler: async (input) => {
         const value = objectInput(input);
         const path = workspacePath(requiredString(value.path, "path", 1024));
-        const content = requiredString(value.content, "content", MAX_FILE_BYTES);
+        const content = requiredContent(value.content);
         const bytes = Buffer.byteLength(content, "utf8");
         if (bytes > MAX_FILE_BYTES) throw new Error("content exceeds 1 MiB");
         const parent = path.slice(0, path.lastIndexOf("/")) || WORKSPACE;
-        await agentOsActions.mkdir(context, parent, { recursive: true });
-        await agentOsActions.writeFile(context, path, content);
+        await actions.mkdir(context, parent, { recursive: true });
+        await actions.writeFile(context, path, content);
         return { path, bytes_written: bytes };
       },
     },
@@ -120,7 +197,7 @@ export function rivetSandboxTools(
       },
       handler: async (input) => {
         const path = workspacePath(optionalString(objectInput(input).path, "path") ?? ".");
-        const entries = await agentOsActions.readdirEntries(context, path);
+        const entries = await actions.readdirEntries(context, path);
         return {
           path,
           entries: entries.slice(0, MAX_LIST_ENTRIES).map((entry) => ({
@@ -146,18 +223,39 @@ export function rivetSandboxTools(
         const value = objectInput(input);
         const port = requiredInteger(value.port, "port", 1024, 65_535);
         const ttl = optionalInteger(value.ttl_seconds, "ttl_seconds", 60, 3_600) ?? 15 * 60;
-        const preview = await agentOsActions.createPreviewUrl(context, port, ttl);
-        const publicUrl = process.env.NANOCODEX_PUBLIC_URL?.replace(/\/$/, "");
+        const preview = await actions.createPreviewUrl(context, port, ttl);
+        const url = publicPreviewUrl(context, preview.path);
         return {
           port,
           path: preview.path,
-          url: publicUrl ? `${publicUrl}${preview.path}` : preview.path,
+          url,
           expires_at: new Date(preview.expiresAt).toISOString(),
           persistent: false,
         };
       },
     },
   };
+}
+
+function publicPreviewUrl(context: AgentOsActionContext, path: string): string {
+  const configured = process.env.NANOCODEX_PUBLIC_URL?.trim();
+  if (!configured) return path;
+  const url = new URL(configured);
+  const namespace = decodeURIComponent(url.username);
+  const token = decodeURIComponent(url.password);
+  url.username = "";
+  url.password = "";
+  if (namespace || token) {
+    if (!namespace || !token.startsWith("pk_")) {
+      throw new Error("NANOCODEX_PUBLIC_URL must contain a namespace and client-safe pk_ token");
+    }
+    url.pathname = `${url.pathname.replace(/\/$/, "")}/gateway/${encodeURIComponent(context.actorId)}/request${path}`;
+    url.searchParams.set("rvt-namespace", namespace);
+    url.searchParams.set("rvt-token", token);
+    return url.toString();
+  }
+  url.pathname = `${url.pathname.replace(/\/$/, "")}${path}`;
+  return url.toString();
 }
 
 export function workspacePath(raw: string): string {
@@ -182,9 +280,36 @@ function requiredString(value: unknown, name: string, maxChars: number): string 
   return value;
 }
 
+function requiredContent(value: unknown): string {
+  if (typeof value !== "string") throw new Error("content must be a string");
+  if (value.length > MAX_FILE_BYTES) throw new Error("content exceeds 1 MiB");
+  return value;
+}
+
 function optionalString(value: unknown, name: string): string | undefined {
   if (value === undefined) return undefined;
   return requiredString(value, name, 1024);
+}
+
+function optionalStringArray(
+  value: unknown,
+  name: string,
+  maxItems: number,
+  maxChars: number,
+): string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.length > maxItems) {
+    throw new Error(`${name} must be an array with at most ${maxItems} strings`);
+  }
+  const parsed = value.map((item) => {
+    if (typeof item !== "string") throw new Error(`${name} must contain only strings`);
+    if (item.length > maxChars) throw new Error(`${name} contains an argument that is too long`);
+    return item;
+  });
+  if (parsed.reduce((total, item) => total + item.length, 0) > MAX_COMMAND_CHARS) {
+    throw new Error(`${name} is too long`);
+  }
+  return parsed;
 }
 
 function requiredInteger(value: unknown, name: string, minimum: number, maximum: number): number {
@@ -215,8 +340,37 @@ function pathParameters(): Record<string, unknown> {
   };
 }
 
+async function waitForPort(
+  actions: Pick<SandboxAgentOsActions, "vmFetch">,
+  context: AgentOsActionContext,
+  port: number,
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    try {
+      await actions.vmFetch(context, port, "http://127.0.0.1/");
+      return;
+    } catch {
+      if (Date.now() >= deadline) throw new Error(`port ${port} did not become ready`);
+      await new Promise((resolve) => setTimeout(resolve, Math.min(100, deadline - Date.now())));
+    }
+  }
+}
+
 function truncate(value: string): { text: string; truncated: boolean } {
-  return value.length <= MAX_OUTPUT_CHARS
-    ? { text: value, truncated: false }
-    : { text: value.slice(0, MAX_OUTPUT_CHARS), truncated: true };
+  const encoded = new TextEncoder().encode(value);
+  if (encoded.byteLength <= MAX_OUTPUT_BYTES) return { text: value, truncated: false };
+  let end = MAX_OUTPUT_BYTES;
+  while (end > 0) {
+    try {
+      return {
+        text: new TextDecoder("utf-8", { fatal: true }).decode(encoded.subarray(0, end)),
+        truncated: true,
+      };
+    } catch {
+      end -= 1;
+    }
+  }
+  return { text: "", truncated: true };
 }

--- a/examples/rivet-actors/src/sandbox-tools.ts
+++ b/examples/rivet-actors/src/sandbox-tools.ts
@@ -1,0 +1,222 @@
+import {
+  createAgentOsActions,
+  type AgentOsActorExtras,
+  type AgentOsOptions,
+} from "@rivet-dev/agentos";
+import type { ToolMap } from "nanocodex";
+
+const WORKSPACE = "/workspace";
+const MAX_COMMAND_CHARS = 32 * 1024;
+const MAX_FILE_BYTES = 1024 * 1024;
+const MAX_OUTPUT_CHARS = 128 * 1024;
+const MAX_LIST_ENTRIES = 512;
+const MAX_TIMEOUT_MS = 120_000;
+
+export const agentOsRuntimeOptions = {
+  defaultSoftware: true,
+  limits: {
+    resources: {
+      maxFilesystemBytes: 512 * 1024 * 1024,
+      maxProcesses: 64,
+      maxReaddirEntries: 4_096,
+    },
+  },
+} satisfies AgentOsOptions;
+
+export const agentOsPreviewOptions = {
+  defaultExpiresInSeconds: 15 * 60,
+  maxExpiresInSeconds: 60 * 60,
+  maxActiveTokens: 32,
+} satisfies NonNullable<AgentOsActorExtras["preview"]>;
+
+const agentOsActions = createAgentOsActions(
+  agentOsRuntimeOptions,
+  undefined,
+  agentOsPreviewOptions,
+);
+
+export type AgentOsActionContext = Parameters<typeof agentOsActions.exec>[0];
+
+export function rivetSandboxTools(
+  context: AgentOsActionContext,
+  sessionId: string,
+): ToolMap {
+  return {
+    sandbox_exec: {
+      description: "Run a shell command in this actor's isolated persistent Rivet AgentOS workspace.",
+      parameters: {
+        type: "object",
+        properties: {
+          command: { type: "string", description: "Shell command to run." },
+          cwd: { type: "string", description: "Workspace-relative working directory." },
+          timeout_ms: { type: "integer", minimum: 1, maximum: MAX_TIMEOUT_MS },
+        },
+        required: ["command"],
+        additionalProperties: false,
+      },
+      handler: async (input) => {
+        const value = objectInput(input);
+        const command = requiredString(value.command, "command", MAX_COMMAND_CHARS);
+        const cwd = workspacePath(optionalString(value.cwd, "cwd") ?? ".");
+        const timeout = optionalInteger(value.timeout_ms, "timeout_ms", 1, MAX_TIMEOUT_MS) ?? 60_000;
+        const result = await agentOsActions.exec(context, command, {
+          cwd,
+          timeout,
+          captureStdio: true,
+        });
+        const stdout = truncate(result.stdout);
+        const stderr = truncate(result.stderr);
+        return {
+          success: result.exitCode === 0,
+          exit_code: result.exitCode,
+          stdout: stdout.text,
+          stderr: stderr.text,
+          stdout_truncated: stdout.truncated,
+          stderr_truncated: stderr.truncated,
+        };
+      },
+    },
+    sandbox_read_file: {
+      description: "Read a UTF-8 text file from this actor's isolated workspace (maximum 1 MiB).",
+      parameters: pathParameters(),
+      handler: async (input) => {
+        const path = workspacePath(requiredString(objectInput(input).path, "path", 1024));
+        const content = await agentOsActions.readFile(context, path);
+        if (content.byteLength > MAX_FILE_BYTES) throw new Error("file exceeds 1 MiB");
+        return { path, content: new TextDecoder().decode(content) };
+      },
+    },
+    sandbox_write_file: {
+      description: "Write a UTF-8 text file inside this actor's isolated workspace (maximum 1 MiB).",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "Workspace-relative file path." },
+          content: { type: "string", description: "Complete UTF-8 file content." },
+        },
+        required: ["path", "content"],
+        additionalProperties: false,
+      },
+      handler: async (input) => {
+        const value = objectInput(input);
+        const path = workspacePath(requiredString(value.path, "path", 1024));
+        const content = requiredString(value.content, "content", MAX_FILE_BYTES);
+        const bytes = Buffer.byteLength(content, "utf8");
+        if (bytes > MAX_FILE_BYTES) throw new Error("content exceeds 1 MiB");
+        const parent = path.slice(0, path.lastIndexOf("/")) || WORKSPACE;
+        await agentOsActions.mkdir(context, parent, { recursive: true });
+        await agentOsActions.writeFile(context, path, content);
+        return { path, bytes_written: bytes };
+      },
+    },
+    sandbox_list_files: {
+      description: "List files in a directory inside this actor's isolated workspace.",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "Workspace-relative directory; defaults to the workspace root." },
+        },
+        additionalProperties: false,
+      },
+      handler: async (input) => {
+        const path = workspacePath(optionalString(objectInput(input).path, "path") ?? ".");
+        const entries = await agentOsActions.readdirEntries(context, path);
+        return {
+          path,
+          entries: entries.slice(0, MAX_LIST_ENTRIES).map((entry) => ({
+            name: entry.name,
+            type: entry.isDirectory ? "directory" : entry.isSymbolicLink ? "symlink" : "file",
+          })),
+          truncated: entries.length > MAX_LIST_ENTRIES,
+        };
+      },
+    },
+    sandbox_preview: {
+      description: "Expose a server running in AgentOS through a temporary Rivet Actor preview URL.",
+      parameters: {
+        type: "object",
+        properties: {
+          port: { type: "integer", minimum: 1024, maximum: 65_535 },
+          ttl_seconds: { type: "integer", minimum: 60, maximum: 3_600 },
+        },
+        required: ["port"],
+        additionalProperties: false,
+      },
+      handler: async (input) => {
+        const value = objectInput(input);
+        const port = requiredInteger(value.port, "port", 1024, 65_535);
+        const ttl = optionalInteger(value.ttl_seconds, "ttl_seconds", 60, 3_600) ?? 15 * 60;
+        const preview = await agentOsActions.createPreviewUrl(context, port, ttl);
+        const publicUrl = process.env.NANOCODEX_PUBLIC_URL?.replace(/\/$/, "");
+        return {
+          port,
+          path: preview.path,
+          url: publicUrl ? `${publicUrl}${preview.path}` : preview.path,
+          expires_at: new Date(preview.expiresAt).toISOString(),
+          persistent: false,
+        };
+      },
+    },
+  };
+}
+
+export function workspacePath(raw: string): string {
+  if (!raw || raw.length > 1024 || raw.includes("\0")) throw new Error("path must be 1-1024 characters");
+  let relative = raw;
+  if (relative === WORKSPACE) relative = ".";
+  else if (relative.startsWith(`${WORKSPACE}/`)) relative = relative.slice(WORKSPACE.length + 1);
+  else if (relative.startsWith("/")) throw new Error("path must be relative to /workspace");
+  const parts = relative.split("/").filter((part) => part !== "" && part !== ".");
+  if (parts.includes("..")) throw new Error("path must not contain '..'");
+  return parts.length === 0 ? WORKSPACE : `${WORKSPACE}/${parts.join("/")}`;
+}
+
+function objectInput(input: unknown): Record<string, unknown> {
+  if (!input || typeof input !== "object" || Array.isArray(input)) throw new Error("tool input must be an object");
+  return input as Record<string, unknown>;
+}
+
+function requiredString(value: unknown, name: string, maxChars: number): string {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${name} must be a non-empty string`);
+  if (value.length > maxChars) throw new Error(`${name} is too long`);
+  return value;
+}
+
+function optionalString(value: unknown, name: string): string | undefined {
+  if (value === undefined) return undefined;
+  return requiredString(value, name, 1024);
+}
+
+function requiredInteger(value: unknown, name: string, minimum: number, maximum: number): number {
+  const parsed = optionalInteger(value, name, minimum, maximum);
+  if (parsed === undefined) throw new Error(`${name} is required`);
+  return parsed;
+}
+
+function optionalInteger(
+  value: unknown,
+  name: string,
+  minimum: number,
+  maximum: number,
+): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isInteger(value) || (value as number) < minimum || (value as number) > maximum) {
+    throw new Error(`${name} must be an integer between ${minimum} and ${maximum}`);
+  }
+  return value as number;
+}
+
+function pathParameters(): Record<string, unknown> {
+  return {
+    type: "object",
+    properties: { path: { type: "string", description: "Workspace-relative file path." } },
+    required: ["path"],
+    additionalProperties: false,
+  };
+}
+
+function truncate(value: string): { text: string; truncated: boolean } {
+  return value.length <= MAX_OUTPUT_CHARS
+    ? { text: value, truncated: false }
+    : { text: value.slice(0, MAX_OUTPUT_CHARS), truncated: true };
+}

--- a/examples/rivet-actors/src/sandbox-tools.ts
+++ b/examples/rivet-actors/src/sandbox-tools.ts
@@ -4,6 +4,7 @@ import {
   type AgentOsOptions,
 } from "@rivet-dev/agentos";
 import type { ToolMap } from "nanocodex";
+import type { RawAccess } from "rivetkit/db";
 
 const WORKSPACE = "/workspace";
 const MAX_COMMAND_CHARS = 32 * 1024;
@@ -11,10 +12,16 @@ const MAX_FILE_BYTES = 1024 * 1024;
 const MAX_OUTPUT_BYTES = 128 * 1024;
 const MAX_LIST_ENTRIES = 512;
 const MAX_TIMEOUT_MS = 120_000;
+export const MAX_PREVIEW_TTL_SECONDS = 15 * 60;
+const PREVIEW_PROCESS_LIMIT_MS = (MAX_PREVIEW_TTL_SECONDS + 60) * 1_000;
 
 export const agentOsRuntimeOptions = {
   defaultSoftware: true,
   limits: {
+    jsRuntime: {
+      cpuTimeLimitMs: PREVIEW_PROCESS_LIMIT_MS,
+      wallClockLimitMs: PREVIEW_PROCESS_LIMIT_MS,
+    },
     resources: {
       maxFilesystemBytes: 512 * 1024 * 1024,
       maxProcesses: 64,
@@ -25,7 +32,7 @@ export const agentOsRuntimeOptions = {
 
 export const agentOsPreviewOptions = {
   defaultExpiresInSeconds: 15 * 60,
-  maxExpiresInSeconds: 60 * 60,
+  maxExpiresInSeconds: MAX_PREVIEW_TTL_SECONDS,
   maxActiveTokens: 32,
 } satisfies NonNullable<AgentOsActorExtras["preview"]>;
 
@@ -44,10 +51,82 @@ type SandboxAgentOsActions = Pick<
   | "mkdir"
   | "readFile"
   | "readdirEntries"
-  | "spawn"
   | "vmFetch"
   | "writeFile"
 >;
+type SpawnedProcess = { pid: number };
+type SelfActorClient = {
+  nanocodex: {
+    getForId(actorId: string): {
+      process: {
+        spawn(
+          command: string,
+          args: string[],
+          options: { cwd: string; output: { retainEvents: true } },
+        ): Promise<SpawnedProcess>;
+      };
+    };
+  };
+};
+type AgentOsVmStart = NonNullable<AgentOsActorExtras["onVmStart"]>;
+type AgentOsVmStartContext = Parameters<AgentOsVmStart>[0];
+type AgentOsVm = Parameters<AgentOsVmStart>[1];
+type PreviewServerRow = {
+  port: number;
+  command: string;
+  args_json: string;
+  cwd: string;
+};
+
+export async function migrateRivetSandboxDatabase(database: RawAccess): Promise<void> {
+  await database.execute(`
+    CREATE TABLE IF NOT EXISTS nanocodex_preview_servers (
+      port INTEGER PRIMARY KEY,
+      command TEXT NOT NULL,
+      args_json TEXT NOT NULL,
+      cwd TEXT NOT NULL,
+      expires_at_ms INTEGER NOT NULL DEFAULT 0
+    )
+  `);
+}
+
+export async function restoreRivetPreviewServers(
+  context: AgentOsVmStartContext,
+  vm: AgentOsVm,
+): Promise<void> {
+  const now = Date.now();
+  await context.db.execute(
+    "DELETE FROM nanocodex_preview_servers WHERE expires_at_ms <= ?",
+    now,
+  );
+  const rows = await context.db.execute<PreviewServerRow>(
+    `SELECT port, command, args_json, cwd
+     FROM nanocodex_preview_servers
+     WHERE expires_at_ms > ?
+     ORDER BY port`,
+    now,
+  );
+  for (const row of rows) {
+    try {
+      const args = parseStoredArgs(row.args_json);
+      await vm.process.spawn(row.command, args, {
+        cwd: row.cwd,
+        output: { retainEvents: true },
+      });
+      await waitForVmPort(vm, row.port, 30_000);
+    } catch (error) {
+      context.log.error({
+        msg: "failed to restore Rivet sandbox preview server",
+        port: row.port,
+        error,
+      });
+      await context.db.execute(
+        "DELETE FROM nanocodex_preview_servers WHERE port = ?",
+        row.port,
+      );
+    }
+  }
+}
 
 export function rivetSandboxTools(
   context: AgentOsActionContext,
@@ -117,7 +196,7 @@ export function createRivetSandboxTools(
       parameters: {
         type: "object",
         properties: {
-          command: { type: "string", description: "Executable to start, such as python3 or node." },
+          command: { type: "string", description: "Executable to start, such as node." },
           args: {
             type: "array",
             items: { type: "string" },
@@ -142,13 +221,31 @@ export function createRivetSandboxTools(
           1,
           MAX_TIMEOUT_MS,
         ) ?? 30_000;
-        const process = await actions.spawn(context, command, args, {
+        // Invoke AgentOS's generated process action through the actor handle.
+        // A process started directly inside the long Nanocodex turn is scoped to
+        // that action and is reaped when the turn context closes.
+        const self = (context.client() as SelfActorClient).nanocodex.getForId(context.actorId);
+        const process = await self.process.spawn(command, args, {
           cwd,
           output: { retainEvents: true },
         });
         try {
           if (readyPort !== undefined) {
             await waitForPort(actions, context, readyPort, readyTimeout);
+            await context.db.execute(
+              `INSERT INTO nanocodex_preview_servers
+                 (port, command, args_json, cwd, expires_at_ms)
+               VALUES (?, ?, ?, ?, 0)
+               ON CONFLICT(port) DO UPDATE SET
+                 command = excluded.command,
+                 args_json = excluded.args_json,
+                 cwd = excluded.cwd,
+                 expires_at_ms = 0`,
+              readyPort,
+              command,
+              JSON.stringify(args),
+              cwd,
+            );
           }
         } catch (error) {
           await actions.killProcess(context, process.pid).catch(() => {});
@@ -214,7 +311,7 @@ export function createRivetSandboxTools(
         type: "object",
         properties: {
           port: { type: "integer", minimum: 1024, maximum: 65_535 },
-          ttl_seconds: { type: "integer", minimum: 60, maximum: 3_600 },
+          ttl_seconds: { type: "integer", minimum: 60, maximum: MAX_PREVIEW_TTL_SECONDS },
         },
         required: ["port"],
         additionalProperties: false,
@@ -222,8 +319,32 @@ export function createRivetSandboxTools(
       handler: async (input) => {
         const value = objectInput(input);
         const port = requiredInteger(value.port, "port", 1024, 65_535);
-        const ttl = optionalInteger(value.ttl_seconds, "ttl_seconds", 60, 3_600) ?? 15 * 60;
+        const ttl = optionalInteger(
+          value.ttl_seconds,
+          "ttl_seconds",
+          60,
+          MAX_PREVIEW_TTL_SECONDS,
+        ) ?? MAX_PREVIEW_TTL_SECONDS;
+        try {
+          await actions.vmFetch(context, port, "http://127.0.0.1/");
+        } catch {
+          throw new Error(`port ${port} is not reachable; start a listening server before creating a preview`);
+        }
+        const registered = await context.db.execute<{ port: number }>(
+          "SELECT port FROM nanocodex_preview_servers WHERE port = ?",
+          port,
+        );
+        if (!registered[0]) {
+          throw new Error(
+            `port ${port} is not durable; start it with sandbox_start_process and ready_port ${port}`,
+          );
+        }
         const preview = await actions.createPreviewUrl(context, port, ttl);
+        await context.db.execute(
+          "UPDATE nanocodex_preview_servers SET expires_at_ms = ? WHERE port = ?",
+          preview.expiresAt,
+          port,
+        );
         const url = publicPreviewUrl(context, preview.path);
         return {
           port,
@@ -354,6 +475,32 @@ async function waitForPort(
       await new Promise((resolve) => setTimeout(resolve, Math.min(100, deadline - Date.now())));
     }
   }
+}
+
+async function waitForVmPort(vm: AgentOsVm, port: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    try {
+      await vm.network.httpRequest({
+        port,
+        path: "/",
+        method: "GET",
+        headers: {},
+      });
+      return;
+    } catch {
+      if (Date.now() >= deadline) throw new Error(`port ${port} did not become ready`);
+      await new Promise((resolve) => setTimeout(resolve, Math.min(100, deadline - Date.now())));
+    }
+  }
+}
+
+function parseStoredArgs(encoded: string): string[] {
+  const value: unknown = JSON.parse(encoded);
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    throw new Error("stored preview server arguments are invalid");
+  }
+  return value;
 }
 
 function truncate(value: string): { text: string; truncated: boolean } {

--- a/examples/rivet-actors/test/actors.test.ts
+++ b/examples/rivet-actors/test/actors.test.ts
@@ -94,6 +94,21 @@ afterAll(async () => {
 });
 
 describe.sequential("Nanocodex Rivet Actors", () => {
+  test("runs commands against the actor-owned persistent AgentOS filesystem", async (context) => {
+    resetMock();
+    configureApiKey();
+    const { client } = await setupTest(context, registry);
+    const session = client.nanocodex.getOrCreate([`agentos-${crypto.randomUUID()}`]);
+
+    const executed = await session.exec("printf AGENTOS_OK > /workspace/probe.txt", {
+      cwd: "/workspace",
+      captureStdio: true,
+    });
+    expect(executed.exitCode).toBe(0);
+    expect(Buffer.from(await session.readFile("/workspace/probe.txt")).toString("utf8"))
+      .toBe("AGENTOS_OK");
+  });
+
   test("commits, deduplicates, unloads, and restores a WASM session", async (context) => {
     resetMock();
     configureApiKey();
@@ -105,20 +120,20 @@ describe.sequential("Nanocodex Rivet Actors", () => {
     await connection.ready;
 
     const request = { id: "turn-1", input: "Reply with exactly EDGE_OK and nothing else." };
-    const [first, duplicate] = await Promise.all([session.prompt(request), session.prompt(request)]);
+    const [first, duplicate] = await Promise.all([session.turn(request), session.turn(request)]);
     expect(first.final_message).toBe("EDGE_OK");
     expect(duplicate).toEqual(first);
     const requestsAfterFirstTurn = modelRequests;
     expect(requestsAfterFirstTurn).toBeGreaterThanOrEqual(1);
-    await expect(session.prompt({ ...request, input: "different" })).rejects.toThrow(/different input/);
+    await expect(session.turn({ ...request, input: "different" })).rejects.toThrow(/different input/);
 
-    const replay = await session.prompt(request);
+    const replay = await session.turn(request);
     expect(replay).toEqual(first);
     expect(modelRequests).toBe(requestsAfterFirstTurn);
 
     await session.unload();
     expect((await session.status()).agent_loaded).toBe(false);
-    const restored = await session.prompt({
+    const restored = await session.turn({
       id: "turn-2",
       input: "What exact token did I ask you to return previously? Reply with only that token.",
     });
@@ -166,7 +181,7 @@ describe.sequential("Nanocodex Rivet Actors", () => {
     expect(requestsAfterDetachedCompletion).toBeGreaterThan(0);
 
     await session.start(request);
-    const completed = await session.prompt(request);
+    const completed = await session.turn(request);
     expect(completed.final_message).toBe("DETACHED_OK");
     expect((await session.status()).active_turns).not.toContain(request.id);
     expect(modelRequests).toBe(requestsAfterDetachedCompletion);
@@ -204,14 +219,14 @@ describe.sequential("Nanocodex Rivet Actors", () => {
       active_turn_details: [request],
     });
 
-    const completed = await session.prompt(request);
+    const completed = await session.turn(request);
     expect(completed.final_message).toBe("SYNC_OK");
     await vi.waitFor(() => {
       expect(firstCompleted).toEqual(["shared-turn:SYNC_OK"]);
       expect(secondCompleted).toEqual(firstCompleted);
     });
     const requestsAfterCompletion = modelRequests;
-    expect((await session.prompt(request)).final_message).toBe("SYNC_OK");
+    expect((await session.turn(request)).final_message).toBe("SYNC_OK");
     expect(modelRequests).toBe(requestsAfterCompletion);
     await Promise.all([first.dispose(), second.dispose()]);
   });
@@ -239,7 +254,7 @@ describe.sequential("Nanocodex Rivet Actors", () => {
       active_turns: [request.id],
       active_turn_details: [request],
     });
-    expect((await reconnected.prompt(request)).final_message).toBe("RECONNECTED_OK");
+    expect((await reconnected.turn(request)).final_message).toBe("RECONNECTED_OK");
     await vi.waitFor(() => {
       expect(completed).toEqual(["reconnected-turn:RECONNECTED_OK"]);
     });
@@ -265,7 +280,7 @@ describe.sequential("Nanocodex Rivet Actors", () => {
 
     rejectNextSubscriptionUpgrade = true;
     const session = client.nanocodex.getOrCreate([`subscription-${crypto.randomUUID()}`]);
-    const result = await session.prompt({ id: "subscription-turn", input: "Reply with exactly SUB_OK" });
+    const result = await session.turn({ id: "subscription-turn", input: "Reply with exactly SUB_OK" });
     expect(result.final_message).toBe("SUB_OK");
     expect(refreshCount).toBe(2);
     expect(await auth.status(createCapabilityProof("status"))).toMatchObject({
@@ -287,7 +302,7 @@ describe.sequential("Nanocodex Rivet Actors", () => {
       revision: 0,
     });
     const session = client.nanocodex.getOrCreate([`access-only-${crypto.randomUUID()}`]);
-    const result = await session.prompt({
+    const result = await session.turn({
       id: "access-only-turn",
       input: "Reply with exactly ACCESS_ONLY_OK",
     });
@@ -302,11 +317,11 @@ describe.sequential("Nanocodex Rivet Actors", () => {
     configureApiKey();
     const { client } = await setupTest(context, registry);
     const session = client.nanocodex.getOrCreate([`bounds-${crypto.randomUUID()}`]);
-    await expect(session.prompt({ id: "oversized", input: "x".repeat(1024 * 1024 + 1) }))
+    await expect(session.turn({ id: "oversized", input: "x".repeat(1024 * 1024 + 1) }))
       .rejects.toThrow(/exceeds 1 MiB/);
 
     responseDelayMs = 20;
-    const turns = Array.from({ length: 17 }, (_, index) => session.prompt({
+    const turns = Array.from({ length: 17 }, (_, index) => session.turn({
       id: `bounded-${index}`,
       input: `Reply with exactly BOUNDED_${index}`,
     }));

--- a/examples/rivet-actors/test/sandbox-tools.test.ts
+++ b/examples/rivet-actors/test/sandbox-tools.test.ts
@@ -1,13 +1,226 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { workspacePath } from "../src/sandbox-tools.js";
+import {
+  createRivetSandboxTools,
+  workspacePath,
+} from "../src/sandbox-tools.js";
+
+const MIB = 1024 * 1024;
+const OUTPUT_LIMIT = 128 * 1024;
+const context = { actorId: "actor-123" } as Parameters<typeof createRivetSandboxTools>[0];
+
+afterEach(() => vi.unstubAllEnvs());
 
 describe("Rivet AgentOS workspace paths", () => {
-  test("confines relative and virtual workspace paths", () => {
+  test("canonicalizes paths under the workspace", () => {
     expect(workspacePath(".")).toBe("/workspace");
-    expect(workspacePath("src/index.ts")).toBe("/workspace/src/index.ts");
+    expect(workspacePath("././")).toBe("/workspace");
+    expect(workspacePath("src//./index.ts")).toBe("/workspace/src/index.ts");
     expect(workspacePath("/workspace/out.txt")).toBe("/workspace/out.txt");
-    expect(() => workspacePath("../secret")).toThrow(/must not contain/);
-    expect(() => workspacePath("/etc/passwd")).toThrow(/relative to/);
+  });
+
+  test.each([
+    "",
+    "../secret",
+    "safe/../../secret",
+    "/workspace/../secret",
+    "/workspace2/secret",
+    "/etc/passwd",
+    "nul\0byte",
+    "x".repeat(1025),
+  ])("rejects an invalid or escaping path: %s", (path) => {
+    expect(() => workspacePath(path)).toThrow();
   });
 });
+
+describe("Rivet AgentOS tools", () => {
+  test("runs bounded commands and preserves non-zero results", async () => {
+    const actions = makeActions({
+      exec: vi.fn(async () => ({ exitCode: 7, stdout: "partial", stderr: "failed" })),
+    });
+    const tools = createRivetSandboxTools(context, actions.value);
+
+    await expect(invoke(tools, "sandbox_exec", { command: "false" })).resolves.toEqual({
+      success: false,
+      exit_code: 7,
+      stdout: "partial",
+      stderr: "failed",
+      stdout_truncated: false,
+      stderr_truncated: false,
+    });
+    expect(actions.exec).toHaveBeenCalledWith(context, "false", {
+      cwd: "/workspace",
+      timeout: 60_000,
+      captureStdio: true,
+    });
+  });
+
+  test("caps command output by UTF-8 bytes without splitting code points", async () => {
+    const actions = makeActions({
+      exec: vi.fn(async () => ({
+        exitCode: 0,
+        stdout: "é".repeat(OUTPUT_LIMIT),
+        stderr: "x".repeat(OUTPUT_LIMIT + 1),
+      })),
+    });
+    const result = await invoke(
+      createRivetSandboxTools(context, actions.value),
+      "sandbox_exec",
+      { command: "produce-output" },
+    );
+
+    expect(Buffer.byteLength(result.stdout, "utf8")).toBe(OUTPUT_LIMIT);
+    expect(result.stdout.endsWith("é")).toBe(true);
+    expect(result.stdout_truncated).toBe(true);
+    expect(result.stderr_truncated).toBe(true);
+  });
+
+  test("writes empty and exactly-1-MiB UTF-8 files", async () => {
+    const actions = makeActions();
+    const tools = createRivetSandboxTools(context, actions.value);
+
+    await expect(invoke(tools, "sandbox_write_file", {
+      path: "empty.txt",
+      content: "",
+    })).resolves.toEqual({ path: "/workspace/empty.txt", bytes_written: 0 });
+    const exact = "😀".repeat(MIB / 4);
+    await expect(invoke(tools, "sandbox_write_file", {
+      path: "unicode.txt",
+      content: exact,
+    })).resolves.toEqual({ path: "/workspace/unicode.txt", bytes_written: MIB });
+    expect(actions.writeFile).toHaveBeenLastCalledWith(
+      context,
+      "/workspace/unicode.txt",
+      exact,
+    );
+  });
+
+  test("rejects oversized writes and invalid UTF-8 reads", async () => {
+    const actions = makeActions({
+      readFile: vi.fn(async () => new Uint8Array([0xc3, 0x28])),
+    });
+    const tools = createRivetSandboxTools(context, actions.value);
+
+    await expect(invoke(tools, "sandbox_write_file", {
+      path: "large.txt",
+      content: "😀".repeat(MIB / 4 + 1),
+    })).rejects.toThrow("content exceeds 1 MiB");
+    await expect(invoke(tools, "sandbox_read_file", { path: "binary.dat" })).rejects.toThrow(
+      "file is not valid UTF-8",
+    );
+  });
+
+  test("starts a native process and waits for its HTTP port", async () => {
+    const actions = makeActions();
+    const tools = createRivetSandboxTools(context, actions.value);
+
+    await expect(invoke(tools, "sandbox_start_process", {
+      command: "python3",
+      args: ["-m", "http.server", "3000", "--directory", "."],
+      ready_port: 3000,
+      ready_timeout_ms: 12_345,
+    })).resolves.toEqual({
+      process_id: 41,
+      command: "python3",
+      args: ["-m", "http.server", "3000", "--directory", "."],
+      status: "running",
+      ready_port: 3000,
+    });
+    expect(actions.spawn).toHaveBeenCalledWith(
+      context,
+      "python3",
+      ["-m", "http.server", "3000", "--directory", "."],
+      { cwd: "/workspace", output: { retainEvents: true } },
+    );
+    expect(actions.vmFetch).toHaveBeenCalledWith(context, 3000, "http://127.0.0.1/");
+  });
+
+  test("kills a process whose readiness probe times out", async () => {
+    const actions = makeActions({
+      vmFetch: vi.fn(async () => { throw new Error("connection refused"); }),
+    });
+    const tools = createRivetSandboxTools(context, actions.value);
+
+    await expect(invoke(tools, "sandbox_start_process", {
+      command: "exit 1",
+      args: [],
+      ready_port: 3000,
+      ready_timeout_ms: 1,
+    })).rejects.toThrow("port 3000 did not become ready");
+    expect(actions.killProcess).toHaveBeenCalledWith(context, 41);
+  });
+
+  test("returns an absolute signed preview when a public endpoint is configured", async () => {
+    vi.stubEnv(
+      "NANOCODEX_PUBLIC_URL",
+      "https://nanocodex-production:pk_public@example.rivet.dev",
+    );
+    const actions = makeActions();
+    const tools = createRivetSandboxTools(context, actions.value);
+
+    await expect(invoke(tools, "sandbox_preview", {
+      port: 3000,
+      ttl_seconds: 600,
+    })).resolves.toEqual({
+      port: 3000,
+      path: "/fetch/preview-token",
+      url: "https://example.rivet.dev/gateway/actor-123/request/fetch/preview-token?rvt-namespace=nanocodex-production&rvt-token=pk_public",
+      expires_at: "2030-01-01T00:00:00.000Z",
+      persistent: false,
+    });
+    expect(actions.createPreviewUrl).toHaveBeenCalledWith(context, 3000, 600);
+  });
+
+  test("refuses to put a secret Rivet token in a preview URL", async () => {
+    vi.stubEnv(
+      "NANOCODEX_PUBLIC_URL",
+      "https://nanocodex-production:sk_secret@example.rivet.dev",
+    );
+    const actions = makeActions();
+
+    await expect(invoke(
+      createRivetSandboxTools(context, actions.value),
+      "sandbox_preview",
+      { port: 3000 },
+    )).rejects.toThrow("client-safe pk_ token");
+  });
+});
+
+function makeActions(overrides: Record<string, unknown> = {}) {
+  const actions = {
+    createPreviewUrl: vi.fn(async () => ({
+      path: "/fetch/preview-token",
+      token: "preview-token",
+      port: 3000,
+      expiresAt: Date.parse("2030-01-01T00:00:00.000Z"),
+    })),
+    exec: vi.fn(async () => ({ exitCode: 0, stdout: "", stderr: "" })),
+    killProcess: vi.fn(async () => undefined),
+    mkdir: vi.fn(async () => undefined),
+    readFile: vi.fn(async () => new TextEncoder().encode("hello")),
+    readdirEntries: vi.fn(async () => []),
+    spawn: vi.fn(async () => ({ pid: 41, state: "running", startedAtMs: 1 })),
+    vmFetch: vi.fn(async () => ({
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      body: new Uint8Array(),
+    })),
+    writeFile: vi.fn(async () => undefined),
+    ...overrides,
+  };
+  return {
+    ...actions,
+    value: actions as unknown as Parameters<typeof createRivetSandboxTools>[1],
+  };
+}
+
+async function invoke(
+  tools: ReturnType<typeof createRivetSandboxTools>,
+  name: string,
+  input: unknown,
+): Promise<any> {
+  const tool = tools[name];
+  if (!tool) throw new Error(`missing tool: ${name}`);
+  return tool.handler(input, { callId: "call", parentCallId: "parent", sessionId: "session" });
+}

--- a/examples/rivet-actors/test/sandbox-tools.test.ts
+++ b/examples/rivet-actors/test/sandbox-tools.test.ts
@@ -1,17 +1,43 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 import {
+  agentOsRuntimeOptions,
   createRivetSandboxTools,
+  restoreRivetPreviewServers,
   workspacePath,
 } from "../src/sandbox-tools.js";
 
 const MIB = 1024 * 1024;
 const OUTPUT_LIMIT = 128 * 1024;
-const context = { actorId: "actor-123" } as Parameters<typeof createRivetSandboxTools>[0];
+const databaseExecute = vi.fn(async (sql: string, ...bindings: unknown[]) => (
+  sql.startsWith("SELECT port FROM nanocodex_preview_servers WHERE port")
+    ? [{ port: bindings[0] }]
+    : []
+));
+const durableSpawn = vi.fn(async () => ({ pid: 41, state: "running", startedAtMs: 1 }));
+const context = {
+  actorId: "actor-123",
+  db: { execute: databaseExecute },
+  client: () => ({
+    nanocodex: {
+      getForId: () => ({ process: { spawn: durableSpawn } }),
+    },
+  }),
+} as unknown as Parameters<typeof createRivetSandboxTools>[0];
 
-afterEach(() => vi.unstubAllEnvs());
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
 
 describe("Rivet AgentOS workspace paths", () => {
+  test("keeps JavaScript listeners alive beyond the signed preview lifetime", () => {
+    expect(agentOsRuntimeOptions.limits.jsRuntime).toEqual({
+      cpuTimeLimitMs: 960_000,
+      wallClockLimitMs: 960_000,
+    });
+  });
+
   test("canonicalizes paths under the workspace", () => {
     expect(workspacePath(".")).toBe("/workspace");
     expect(workspacePath("././")).toBe("/workspace");
@@ -115,24 +141,30 @@ describe("Rivet AgentOS tools", () => {
     const tools = createRivetSandboxTools(context, actions.value);
 
     await expect(invoke(tools, "sandbox_start_process", {
-      command: "python3",
-      args: ["-m", "http.server", "3000", "--directory", "."],
+      command: "node",
+      args: ["/workspace/server.mjs"],
       ready_port: 3000,
       ready_timeout_ms: 12_345,
     })).resolves.toEqual({
       process_id: 41,
-      command: "python3",
-      args: ["-m", "http.server", "3000", "--directory", "."],
+      command: "node",
+      args: ["/workspace/server.mjs"],
       status: "running",
       ready_port: 3000,
     });
-    expect(actions.spawn).toHaveBeenCalledWith(
-      context,
-      "python3",
-      ["-m", "http.server", "3000", "--directory", "."],
+    expect(durableSpawn).toHaveBeenCalledWith(
+      "node",
+      ["/workspace/server.mjs"],
       { cwd: "/workspace", output: { retainEvents: true } },
     );
     expect(actions.vmFetch).toHaveBeenCalledWith(context, 3000, "http://127.0.0.1/");
+    expect(databaseExecute).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO nanocodex_preview_servers"),
+      3000,
+      "node",
+      '["/workspace/server.mjs"]',
+      "/workspace",
+    );
   });
 
   test("kills a process whose readiness probe times out", async () => {
@@ -169,6 +201,36 @@ describe("Rivet AgentOS tools", () => {
       persistent: false,
     });
     expect(actions.createPreviewUrl).toHaveBeenCalledWith(context, 3000, 600);
+    expect(actions.vmFetch).toHaveBeenCalledWith(context, 3000, "http://127.0.0.1/");
+    expect(databaseExecute).toHaveBeenCalledWith(
+      "UPDATE nanocodex_preview_servers SET expires_at_ms = ? WHERE port = ?",
+      Date.parse("2030-01-01T00:00:00.000Z"),
+      3000,
+    );
+  });
+
+  test("refuses to sign a preview for an unreachable port", async () => {
+    const actions = makeActions({
+      vmFetch: vi.fn(async () => { throw new Error("connection refused"); }),
+    });
+
+    await expect(invoke(
+      createRivetSandboxTools(context, actions.value),
+      "sandbox_preview",
+      { port: 3000 },
+    )).rejects.toThrow("port 3000 is not reachable");
+    expect(actions.createPreviewUrl).not.toHaveBeenCalled();
+  });
+
+  test("bounds preview lifetime to the actor's keep-alive window", async () => {
+    const actions = makeActions();
+
+    await expect(invoke(
+      createRivetSandboxTools(context, actions.value),
+      "sandbox_preview",
+      { port: 3000, ttl_seconds: 901 },
+    )).rejects.toThrow("ttl_seconds must be an integer between 60 and 900");
+    expect(actions.createPreviewUrl).not.toHaveBeenCalled();
   });
 
   test("refuses to put a secret Rivet token in a preview URL", async () => {
@@ -186,6 +248,43 @@ describe("Rivet AgentOS tools", () => {
   });
 });
 
+describe("Rivet AgentOS preview recovery", () => {
+  test("restarts an unexpired preview listener when its VM wakes", async () => {
+    const execute = vi.fn(async (sql: string) => (
+      sql.includes("SELECT port, command")
+        ? [{
+            port: 3000,
+            command: "node",
+            args_json: '["/workspace/server.mjs"]',
+            cwd: "/workspace",
+          }]
+        : []
+    ));
+    const wakeContext = {
+      db: { execute },
+      log: { error: vi.fn() },
+    } as unknown as Parameters<typeof restoreRivetPreviewServers>[0];
+    const vm = {
+      process: { spawn: vi.fn(async () => ({ pid: 42 })) },
+      network: { httpRequest: vi.fn(async () => ({ status: 200 })) },
+    } as unknown as Parameters<typeof restoreRivetPreviewServers>[1];
+
+    await restoreRivetPreviewServers(wakeContext, vm);
+
+    expect(vm.process.spawn).toHaveBeenCalledWith(
+      "node",
+      ["/workspace/server.mjs"],
+      { cwd: "/workspace", output: { retainEvents: true } },
+    );
+    expect(vm.network.httpRequest).toHaveBeenCalledWith({
+      port: 3000,
+      path: "/",
+      method: "GET",
+      headers: {},
+    });
+  });
+});
+
 function makeActions(overrides: Record<string, unknown> = {}) {
   const actions = {
     createPreviewUrl: vi.fn(async () => ({
@@ -199,7 +298,6 @@ function makeActions(overrides: Record<string, unknown> = {}) {
     mkdir: vi.fn(async () => undefined),
     readFile: vi.fn(async () => new TextEncoder().encode("hello")),
     readdirEntries: vi.fn(async () => []),
-    spawn: vi.fn(async () => ({ pid: 41, state: "running", startedAtMs: 1 })),
     vmFetch: vi.fn(async () => ({
       status: 200,
       statusText: "OK",

--- a/examples/rivet-actors/test/sandbox-tools.test.ts
+++ b/examples/rivet-actors/test/sandbox-tools.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vitest";
+
+import { workspacePath } from "../src/sandbox-tools.js";
+
+describe("Rivet AgentOS workspace paths", () => {
+  test("confines relative and virtual workspace paths", () => {
+    expect(workspacePath(".")).toBe("/workspace");
+    expect(workspacePath("src/index.ts")).toBe("/workspace/src/index.ts");
+    expect(workspacePath("/workspace/out.txt")).toBe("/workspace/out.txt");
+    expect(() => workspacePath("../secret")).toThrow(/must not contain/);
+    expect(() => workspacePath("/etc/passwd")).toThrow(/relative to/);
+  });
+});

--- a/examples/rivet-actors/test/sandbox-tools.test.ts
+++ b/examples/rivet-actors/test/sandbox-tools.test.ts
@@ -164,7 +164,7 @@ describe("Rivet AgentOS tools", () => {
     })).resolves.toEqual({
       port: 3000,
       path: "/fetch/preview-token",
-      url: "https://example.rivet.dev/gateway/actor-123/request/fetch/preview-token?rvt-namespace=nanocodex-production&rvt-token=pk_public",
+      url: "https://example.rivet.dev/gateway/actor-123@pk_public/request/fetch/preview-token",
       expires_at: "2030-01-01T00:00:00.000Z",
       persistent: false,
     });

--- a/examples/rivet-actors/tsconfig.json
+++ b/examples/rivet-actors/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "strict": true,
-    "skipLibCheck": false,
+    "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     "noEmit": true,

--- a/examples/rivet-actors/web/app.ts
+++ b/examples/rivet-actors/web/app.ts
@@ -42,6 +42,7 @@ const defaultEndpoint = requestedEndpoint || (location.hostname === "127.0.0.1" 
 let state = loadState() ?? freshState(defaultEndpoint);
 if (requestedEndpoint) state.endpoint = requestedEndpoint;
 let client: NanocodexClient | undefined;
+let session: Session | undefined;
 let connection: Connection | undefined;
 let generation = 0;
 let eventCount = 0;
@@ -72,14 +73,14 @@ ui.form.addEventListener("submit", (event) => {
   event.preventDefault();
   const input = ui.input.value.trim();
   if (!input) return setActivity("prompt is empty", true);
-  if (!connection) return setActivity("connect to the actor first", true);
+  if (!session) return setActivity("connect to the actor first", true);
   if (state.pending) return setActivity("one durable turn is already pending", true);
   const pending = { id: crypto.randomUUID(), input };
   state.pending = pending;
   observeTurn(pending.id, pending.input);
   ui.input.value = "";
   saveState();
-  void runPending(connection, generation);
+  void runPending(session, generation);
 });
 
 async function connect(): Promise<void> {
@@ -97,6 +98,7 @@ async function connect(): Promise<void> {
   try {
     client = makeClient(state.endpoint);
     const handle = client.nanocodex.getOrCreate([state.actorKey]);
+    session = handle;
     const nextConnection = handle.connect();
     connection = nextConnection;
     nextConnection.on("turnAccepted", (accepted) => {
@@ -129,13 +131,13 @@ async function connect(): Promise<void> {
       if (activeGeneration === generation) setStatus(status, status === "connected" ? "ok" : "warn");
     });
     await nextConnection.ready;
-    const [actorId, sessionStatus] = await Promise.all([handle.resolve(), nextConnection.status()]);
+    const [actorId, sessionStatus] = await Promise.all([handle.resolve(), handle.status()]);
     if (activeGeneration !== generation) return;
     ui.actor.textContent = actorId;
     for (const turn of sessionStatus.active_turn_details) observeTurn(turn.id, turn.input);
     setStatus(sessionStatus.active_turns.length > 0 ? "running" : "ready", "ok");
     setActivity(sessionStatus.completed_turns + " committed turns");
-    if (state.pending) void runPending(nextConnection, activeGeneration);
+    if (state.pending) void runPending(handle, activeGeneration);
   } catch (error) {
     if (activeGeneration === generation) {
       setStatus("failed", "bad");
@@ -144,7 +146,7 @@ async function connect(): Promise<void> {
   }
 }
 
-async function runPending(active: Connection, activeGeneration: number): Promise<void> {
+async function runPending(active: Session, activeGeneration: number): Promise<void> {
   const pending = state.pending;
   if (!pending) return;
   try {
@@ -153,17 +155,39 @@ async function runPending(active: Connection, activeGeneration: number): Promise
     observeTurn(accepted.id, accepted.input);
     setStatus(accepted.replayed ? "resuming" : "running", "ok");
     setActivity((accepted.replayed ? "rejoined " : "started ") + shortId(pending.id) + "; detach any time");
-    const completed = await active.turn(pending);
+    const completed = await awaitDurableTurn(active, pending, activeGeneration);
     if (activeGeneration === generation) completeTurn(completed.id, completed.final_message);
   } catch (error) {
     if (activeGeneration === generation) failTurn(pending.id, errorMessage(error));
   }
 }
 
+async function awaitDurableTurn(
+  active: Session,
+  pending: PendingTurn,
+  activeGeneration: number,
+) {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      return await active.turn(pending);
+    } catch (error) {
+      lastError = error;
+      if (activeGeneration !== generation || state.pending?.id !== pending.id) throw error;
+      const status = await active.status();
+      if (!status.active_turns.includes(pending.id)) throw error;
+      setStatus("reconnecting", "warn");
+      setActivity("connection interrupted; rejoining " + shortId(pending.id));
+    }
+  }
+  throw lastError;
+}
+
 async function detach(showMessage = true): Promise<void> {
   generation += 1;
   const oldConnection = connection;
   const oldClient = client;
+  session = undefined;
   connection = undefined;
   client = undefined;
   await Promise.allSettled([oldConnection?.dispose(), oldClient?.dispose()]);
@@ -290,8 +314,8 @@ function syncStoredState(encoded: string | null): void {
   if (changedActor) {
     ui.actor.textContent = "not resolved";
     void connect();
-  } else if (previousPendingId !== state.pending?.id && connection) {
-    void runPending(connection, generation);
+  } else if (previousPendingId !== state.pending?.id && session) {
+    void runPending(session, generation);
   }
 }
 

--- a/examples/rivet-actors/web/app.ts
+++ b/examples/rivet-actors/web/app.ts
@@ -153,7 +153,7 @@ async function runPending(active: Connection, activeGeneration: number): Promise
     observeTurn(accepted.id, accepted.input);
     setStatus(accepted.replayed ? "resuming" : "running", "ok");
     setActivity((accepted.replayed ? "rejoined " : "started ") + shortId(pending.id) + "; detach any time");
-    const completed = await active.prompt(pending);
+    const completed = await active.turn(pending);
     if (activeGeneration === generation) completeTurn(completed.id, completed.final_message);
   } catch (error) {
     if (activeGeneration === generation) failTurn(pending.id, errorMessage(error));

--- a/examples/vercel-workflows/README.md
+++ b/examples/vercel-workflows/README.md
@@ -31,12 +31,23 @@ browser B ─ WebSocket Function ─┘             │
                                               │
                                               ▼
                                   Nanocodex WASM Function step
-                                  Responses WebSocket → OpenAI
+                                     ├─ Responses WebSocket → OpenAI
+                                     └─ named persistent Vercel Sandbox
+                                          └─ files, commands, preview domains
 ```
 
 The WebSocket connection itself is disposable and bounded by the Vercel
 Function duration. The browser reconnects automatically. The Workflow run,
 snapshot, prompt hook, and output stream are the durable pieces.
+
+Every Workflow actor also owns a named Vercel Sandbox. The caller-defined
+`sandbox_exec`, `sandbox_read_file`, `sandbox_write_file`,
+`sandbox_list_files`, and `sandbox_preview` tools use its isolated Firecracker
+VM. Persistent sandboxes automatically snapshot their filesystem when a VM
+session stops and resume it on the next turn. The demo exposes ports 3000,
+5173, 8000, and 8080 for previews. Vercel OIDC authenticates Sandbox SDK calls
+inside the deployment, so no Vercel access token is passed to Nanocodex or the
+guest VM.
 
 ## Local development
 
@@ -86,7 +97,12 @@ The deployment helper:
 4. builds and packs the current repository's Nanocodex WASM package into a
    temporary deployment directory; and
 5. deploys that staged app to Production without committing generated WASM or
-   credentials.
+credentials.
+
+Fluid Compute applies to the Next.js Functions that host WebSocket tails and
+Workflow steps. Vercel Sandbox is a separate persistent Firecracker service;
+the example uses both rather than treating Fluid function memory as the code
+workspace.
 
 No refresh token is copied. When the access token expires or is rejected, run
 `codex login` and deploy again. To restrict creation of new sessions, set a
@@ -102,7 +118,8 @@ npm run multiclient --prefix examples/vercel-workflows
 
 The smoke test creates one Workflow actor, connects two independent
 WebSockets, submits one prompt, and requires both clients to observe its
-acceptance, model event stream, and terminal result.
+acceptance, sandbox write/exec/read tool calls, model event stream, and terminal
+result.
 
 ## Browser demo
 
@@ -112,6 +129,8 @@ acceptance, model event stream, and terminal result.
 4. Send a prompt from either client.
 5. Detach or reload during inference; both clients resume the same durable
    stream and terminal result.
+6. Ask it to start a server on port 3000 and use `sandbox_preview`; open the
+   returned `vercel.run` URL.
 
 The browser stores only the session capability, a bounded transcript, active
 turn metadata, and its own stream cursor. Model credentials stay in the server

--- a/examples/vercel-workflows/README.md
+++ b/examples/vercel-workflows/README.md
@@ -41,13 +41,16 @@ Function duration. The browser reconnects automatically. The Workflow run,
 snapshot, prompt hook, and output stream are the durable pieces.
 
 Every Workflow actor also owns a named Vercel Sandbox. The caller-defined
-`sandbox_exec`, `sandbox_read_file`, `sandbox_write_file`,
-`sandbox_list_files`, and `sandbox_preview` tools use its isolated Firecracker
-VM. Persistent sandboxes automatically snapshot their filesystem when a VM
-session stops and resume it on the next turn. The demo exposes ports 3000,
-5173, 8000, and 8080 for previews. Vercel OIDC authenticates Sandbox SDK calls
-inside the deployment, so no Vercel access token is passed to Nanocodex or the
-guest VM.
+`sandbox_exec`, `sandbox_start_process`, `sandbox_read_file`,
+`sandbox_write_file`, `sandbox_list_files`, and `sandbox_preview` tools use its
+isolated Firecracker VM. `/workspace` is a real alias for Vercel's persistent
+`/vercel/sandbox` directory, including inside shell commands. Persistent
+sandboxes automatically snapshot their filesystem when a VM session stops and
+resume it on the next turn. Processes do not survive that stop/resume boundary,
+so agents use `sandbox_start_process` to launch a detached process and wait for
+its port before requesting a preview. The demo exposes ports 3000, 5173, 8000,
+and 8080. Vercel OIDC authenticates Sandbox SDK calls inside the deployment, so
+no Vercel access token is passed to Nanocodex or the guest VM.
 
 ## Local development
 
@@ -116,10 +119,12 @@ export NANOCODEX_DEMO_URL=https://your-project.vercel.app
 npm run multiclient --prefix examples/vercel-workflows
 ```
 
-The smoke test creates one Workflow actor, connects two independent
-WebSockets, submits one prompt, and requires both clients to observe its
-acceptance, sandbox write/exec/read tool calls, model event stream, and terminal
-result.
+The smoke test creates one Workflow actor, connects two independent WebSockets,
+and submits one prompt. Both clients must observe the same acceptance, all five
+successful sandbox tool results, model event stream, preview URL, and terminal
+result. The test then fetches the public `vercel.run` preview itself and verifies
+the unique file contents, proving that the hosted process—not a mocked tool or
+the local machine—served the response.
 
 ## Browser demo
 
@@ -129,8 +134,8 @@ result.
 4. Send a prompt from either client.
 5. Detach or reload during inference; both clients resume the same durable
    stream and terminal result.
-6. Ask it to start a server on port 3000 and use `sandbox_preview`; open the
-   returned `vercel.run` URL.
+6. Ask it to use `sandbox_start_process` for a server on port 3000, then use
+   `sandbox_preview`; open the returned `vercel.run` URL.
 
 The browser stores only the session capability, a bounded transcript, active
 turn metadata, and its own stream cursor. Model credentials stay in the server

--- a/examples/vercel-workflows/package-lock.json
+++ b/examples/vercel-workflows/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@vercel/functions": "3.7.6",
+        "@vercel/sandbox": "2.9.2",
         "nanocodex": "file:../../js/bindings",
         "next": "16.2.12",
         "react": "19.2.4",
@@ -2562,6 +2563,61 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@vercel/sandbox": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@vercel/sandbox/-/sandbox-2.9.2.tgz",
+      "integrity": "sha512-tnPtCNL6MZKM9eRYvmyL0geA2Nifq+PSxVXBNhk/lQNeCWgMp/EYzCDOotKEWR/VH+c0Yv9HG4qk0w2I65xnLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/oidc": "3.2.0",
+        "@workflow/serde": "4.1.0-beta.2",
+        "async-retry": "1.3.3",
+        "jose": "6.2.3",
+        "jsonlines": "0.1.1",
+        "ms": "2.1.3",
+        "picocolors": "^1.1.1",
+        "tar-stream": "3.1.7",
+        "undici": "^7.27.1",
+        "xdg-app-paths": "5.1.0",
+        "zod": "^4.1.1"
+      }
+    },
+    "node_modules/@vercel/sandbox/node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@vercel/sandbox/node_modules/@workflow/serde": {
+      "version": "4.1.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0-beta.2.tgz",
+      "integrity": "sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@vercel/sandbox/node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/@vercel/sandbox/node_modules/xdg-app-paths": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-app-paths/-/xdg-app-paths-5.1.0.tgz",
+      "integrity": "sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==",
+      "license": "MIT",
+      "dependencies": {
+        "xdg-portable": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.10",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
@@ -4009,6 +4065,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
     "node_modules/async-sema": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/async-sema/-/async-sema-3.1.1.tgz",
@@ -4020,7 +4085,6 @@
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
       "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "react-native-b4a": "*"
       },
@@ -4044,7 +4108,6 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
       "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -5300,7 +5363,6 @@
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
       "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bare-events": "^2.7.0"
       }
@@ -5418,8 +5480,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -6180,6 +6241,12 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/jsonlines": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsonlines/-/jsonlines-0.1.1.tgz",
+      "integrity": "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==",
+      "license": "MIT"
     },
     "node_modules/keyv": {
       "version": "5.6.0",
@@ -7436,6 +7503,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.2.tgz",
@@ -7893,7 +7969,6 @@
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
       "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
@@ -8117,7 +8192,6 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
       "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
@@ -8160,7 +8234,6 @@
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
       "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "b4a": "^1.6.4"
       }

--- a/examples/vercel-workflows/package.json
+++ b/examples/vercel-workflows/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@vercel/functions": "3.7.6",
+    "@vercel/sandbox": "2.9.2",
     "nanocodex": "file:../../js/bindings",
     "next": "16.2.12",
     "react": "19.2.4",

--- a/examples/vercel-workflows/scripts/multiclient-smoke.mjs
+++ b/examples/vercel-workflows/scripts/multiclient-smoke.mjs
@@ -13,7 +13,14 @@ const clients = await Promise.all([openClient(sessionId), openClient(sessionId)]
 try {
   await Promise.all(clients.map((client) => client.waitFor((message) => message.type === "ready")));
   const turnId = crypto.randomUUID();
-  const input = "Use sandbox_write_file to write VERCEL_SANDBOX_OK to probe.txt, use sandbox_exec to run cat on it, and verify it with sandbox_read_file. Then reply with exactly VERCEL_SANDBOX_OK.";
+  const marker = `VERCEL_SANDBOX_OK_${crypto.randomUUID()}`;
+  const input = [
+    `Use sandbox_write_file to write exactly ${marker} to index.html.`,
+    "Use sandbox_exec with cwd /workspace to verify both that /workspace/index.html contains that exact marker and that pwd is /vercel/sandbox.",
+    "Use sandbox_start_process with cwd /workspace to run `python3 -m http.server 3000 --directory .`, waiting for ready_port 3000.",
+    "Use sandbox_preview for port 3000, then use sandbox_read_file to verify index.html.",
+    `After every tool succeeds, reply with exactly ${marker}.`,
+  ].join(" ");
   const prompt = await fetch(
     new URL(`/api/sessions/${encodeURIComponent(sessionId)}/prompt`, baseUrl),
     {
@@ -33,22 +40,49 @@ try {
       (message) => message.type === "turn_completed" && message.id === turnId,
       180_000,
     );
+    const turnEvents = client.events.filter((event) => event.type === "event" && event.turn_id === turnId);
+    const toolCalls = new Map(turnEvents
+      .filter((event) => event.event?.type === "tool.call")
+      .map((event) => [String(event.event.payload?.call_id), event.event.payload?.tool]));
+    const completedTools = new Set();
+    let previewUrl;
+    for (const event of turnEvents.filter((item) => item.event?.type === "tool.result")) {
+      if (event.event.payload?.status !== "completed") continue;
+      const tool = toolCalls.get(String(event.event.payload?.call_id));
+      if (!tool) continue;
+      completedTools.add(tool);
+      if (tool === "sandbox_preview") {
+        previewUrl = parseToolResult(event.event.payload?.result)?.url;
+      }
+    }
     return {
       final_message: completed.final_message,
-      events: client.events.filter((event) => event.type === "event" && event.turn_id === turnId).length,
-      tools: client.events
-        .filter((event) => event.type === "event"
-          && event.turn_id === turnId
-          && event.event?.type === "tool.call")
-        .map((event) => event.event.payload?.tool),
+      events: turnEvents.length,
+      tools: [...completedTools],
+      preview_url: previewUrl,
     };
   }));
-  if (observations.some((result) => result.final_message.trim() !== "VERCEL_SANDBOX_OK")) {
+  if (observations.some((result) => result.final_message.trim() !== marker)) {
     throw new Error(`unexpected terminal messages: ${JSON.stringify(observations)}`);
   }
-  const requiredTools = ["sandbox_write_file", "sandbox_exec", "sandbox_read_file"];
+  const requiredTools = [
+    "sandbox_write_file",
+    "sandbox_exec",
+    "sandbox_start_process",
+    "sandbox_preview",
+    "sandbox_read_file",
+  ];
   if (observations.some((result) => requiredTools.some((tool) => !result.tools.includes(tool)))) {
-    throw new Error(`a synchronized client missed sandbox tool events: ${JSON.stringify(observations)}`);
+    throw new Error(`a synchronized client missed successful sandbox tool results: ${JSON.stringify(observations)}`);
+  }
+  const previewUrl = observations[0].preview_url;
+  if (!previewUrl || observations.some((result) => result.preview_url !== previewUrl)) {
+    throw new Error(`synchronized clients disagreed on the preview URL: ${JSON.stringify(observations)}`);
+  }
+  const preview = await fetchWithRetry(previewUrl, 30_000);
+  const previewBody = await preview.text();
+  if (!preview.ok || previewBody.trim() !== marker) {
+    throw new Error(`sandbox preview failed with HTTP ${preview.status}: ${previewBody}`);
   }
   process.stdout.write(`${JSON.stringify({
     session_id: sessionId,
@@ -56,10 +90,38 @@ try {
     completed_clients: observations.length,
     event_counts: observations.map((result) => result.events),
     tool_calls: requiredTools,
+    preview_url: previewUrl,
+    preview_status: preview.status,
     status: "ok",
   })}\n`);
 } finally {
   for (const client of clients) client.close();
+}
+
+function parseToolResult(result) {
+  if (typeof result !== "string") return result && typeof result === "object" ? result : undefined;
+  try {
+    return JSON.parse(result);
+  } catch {
+    return undefined;
+  }
+}
+
+async function fetchWithRetry(url, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  let lastResponse;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      lastResponse = await fetch(url, { cache: "no-store" });
+      if (lastResponse.ok) return lastResponse;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  if (lastResponse) return lastResponse;
+  throw lastError ?? new Error("sandbox preview did not become reachable");
 }
 
 async function openClient(sessionId) {

--- a/examples/vercel-workflows/scripts/multiclient-smoke.mjs
+++ b/examples/vercel-workflows/scripts/multiclient-smoke.mjs
@@ -13,7 +13,7 @@ const clients = await Promise.all([openClient(sessionId), openClient(sessionId)]
 try {
   await Promise.all(clients.map((client) => client.waitFor((message) => message.type === "ready")));
   const turnId = crypto.randomUUID();
-  const input = "Reply with exactly VERCEL_SYNC_OK and nothing else.";
+  const input = "Use sandbox_write_file to write VERCEL_SANDBOX_OK to probe.txt, use sandbox_exec to run cat on it, and verify it with sandbox_read_file. Then reply with exactly VERCEL_SANDBOX_OK.";
   const prompt = await fetch(
     new URL(`/api/sessions/${encodeURIComponent(sessionId)}/prompt`, baseUrl),
     {
@@ -36,16 +36,26 @@ try {
     return {
       final_message: completed.final_message,
       events: client.events.filter((event) => event.type === "event" && event.turn_id === turnId).length,
+      tools: client.events
+        .filter((event) => event.type === "event"
+          && event.turn_id === turnId
+          && event.event?.type === "tool.call")
+        .map((event) => event.event.payload?.tool),
     };
   }));
-  if (observations.some((result) => result.final_message.trim() !== "VERCEL_SYNC_OK")) {
+  if (observations.some((result) => result.final_message.trim() !== "VERCEL_SANDBOX_OK")) {
     throw new Error(`unexpected terminal messages: ${JSON.stringify(observations)}`);
+  }
+  const requiredTools = ["sandbox_write_file", "sandbox_exec", "sandbox_read_file"];
+  if (observations.some((result) => requiredTools.some((tool) => !result.tools.includes(tool)))) {
+    throw new Error(`a synchronized client missed sandbox tool events: ${JSON.stringify(observations)}`);
   }
   process.stdout.write(`${JSON.stringify({
     session_id: sessionId,
     accepted_clients: clients.length,
     completed_clients: observations.length,
     event_counts: observations.map((result) => result.events),
+    tool_calls: requiredTools,
     status: "ok",
   })}\n`);
 } finally {

--- a/examples/vercel-workflows/test/sandbox-tools.test.ts
+++ b/examples/vercel-workflows/test/sandbox-tools.test.ts
@@ -1,13 +1,215 @@
-import { describe, expect, it } from "vitest";
+import type { Sandbox } from "@vercel/sandbox";
+import { describe, expect, it, vi } from "vitest";
 
-import { workspacePath } from "../workflows/sandbox-tools";
+import {
+  createVercelSandboxTools,
+  workspacePath,
+} from "../workflows/sandbox-tools";
+
+const MIB = 1024 * 1024;
+const OUTPUT_LIMIT = 128 * 1024;
+const context = { callId: "call", parentCallId: "parent", sessionId: "session" };
 
 describe("Vercel Sandbox workspace paths", () => {
-  it("confines relative and virtual workspace paths", () => {
+  it("canonicalizes paths under the physical workspace", () => {
     expect(workspacePath(".")).toBe("/vercel/sandbox");
-    expect(workspacePath("src/index.ts")).toBe("/vercel/sandbox/src/index.ts");
+    expect(workspacePath("././")).toBe("/vercel/sandbox");
+    expect(workspacePath("src//./index.ts")).toBe("/vercel/sandbox/src/index.ts");
     expect(workspacePath("/workspace/out.txt")).toBe("/vercel/sandbox/out.txt");
-    expect(() => workspacePath("../secret")).toThrow(/must not contain/);
-    expect(() => workspacePath("/etc/passwd")).toThrow(/relative to/);
+    expect(workspacePath("/vercel/sandbox/out.txt")).toBe("/vercel/sandbox/out.txt");
+  });
+
+  it.each([
+    "",
+    "../secret",
+    "safe/../../secret",
+    "/workspace/../secret",
+    "/workspace2/secret",
+    "/etc/passwd",
+    "nul\0byte",
+    "x".repeat(1025),
+  ])("rejects an invalid or escaping path: %s", (path) => {
+    expect(() => workspacePath(path)).toThrow();
   });
 });
+
+describe("Vercel Sandbox tools", () => {
+  it("runs bounded commands and preserves non-zero results", async () => {
+    const sandbox = makeSandbox({
+      runCommand: vi.fn(async () => finishedCommand({
+        exitCode: 7,
+        stdout: "partial",
+        stderr: "failed",
+        durationMs: 42,
+      })),
+    });
+    const tools = createVercelSandboxTools(async () => sandbox.client);
+
+    await expect(invoke(tools, "sandbox_exec", { command: "false" })).resolves.toEqual({
+      success: false,
+      exit_code: 7,
+      stdout: "partial",
+      stderr: "failed",
+      stdout_truncated: false,
+      stderr_truncated: false,
+      duration_ms: 42,
+    });
+    expect(sandbox.runCommand).toHaveBeenCalledWith({
+      cmd: "bash",
+      args: ["-lc", "false"],
+      cwd: "/vercel/sandbox",
+      timeoutMs: 60_000,
+    });
+  });
+
+  it("caps command output by UTF-8 bytes without splitting code points", async () => {
+    const sandbox = makeSandbox({
+      runCommand: vi.fn(async () => finishedCommand({
+        stdout: "é".repeat(OUTPUT_LIMIT),
+        stderr: "x".repeat(OUTPUT_LIMIT + 1),
+      })),
+    });
+    const result = await invoke(
+      createVercelSandboxTools(async () => sandbox.client),
+      "sandbox_exec",
+      { command: "produce-output" },
+    );
+
+    expect(Buffer.byteLength(result.stdout, "utf8")).toBe(OUTPUT_LIMIT);
+    expect(result.stdout.endsWith("é")).toBe(true);
+    expect(result.stdout_truncated).toBe(true);
+    expect(result.stderr_truncated).toBe(true);
+  });
+
+  it("writes empty and exactly-1-MiB UTF-8 files", async () => {
+    const sandbox = makeSandbox();
+    const tools = createVercelSandboxTools(async () => sandbox.client);
+
+    await expect(invoke(tools, "sandbox_write_file", {
+      path: "empty.txt",
+      content: "",
+    })).resolves.toEqual({ path: "/workspace/empty.txt", bytes_written: 0 });
+    const exact = "😀".repeat(MIB / 4);
+    await expect(invoke(tools, "sandbox_write_file", {
+      path: "unicode.txt",
+      content: exact,
+    })).resolves.toEqual({ path: "/workspace/unicode.txt", bytes_written: MIB });
+    expect(sandbox.writeFile).toHaveBeenLastCalledWith(
+      "/vercel/sandbox/unicode.txt",
+      exact,
+      "utf8",
+    );
+  });
+
+  it("rejects oversized writes and invalid UTF-8 reads", async () => {
+    const sandbox = makeSandbox({ readFile: vi.fn(async () => Buffer.from([0xc3, 0x28])) });
+    const tools = createVercelSandboxTools(async () => sandbox.client);
+
+    await expect(invoke(tools, "sandbox_write_file", {
+      path: "large.txt",
+      content: "😀".repeat(MIB / 4 + 1),
+    })).rejects.toThrow("content exceeds 1 MiB");
+    await expect(invoke(tools, "sandbox_read_file", { path: "binary.dat" })).rejects.toThrow(
+      "file is not valid UTF-8",
+    );
+  });
+
+  it("starts a native detached command and waits for readiness", async () => {
+    const detached = { cmdId: "cmd-1" };
+    const runCommand = vi.fn(async (params: { detached?: boolean }) => (
+      params.detached ? detached : finishedCommand()
+    ));
+    const sandbox = makeSandbox({ runCommand });
+    const tools = createVercelSandboxTools(async () => sandbox.client);
+
+    await expect(invoke(tools, "sandbox_start_process", {
+      command: "python3 -m http.server 3000 --directory .",
+      cwd: "/workspace",
+      ready_port: 3000,
+      ready_timeout_ms: 12_345,
+    })).resolves.toEqual({
+      process_id: "cmd-1",
+      command: "python3 -m http.server 3000 --directory .",
+      status: "running",
+      ready_port: 3000,
+    });
+    expect(runCommand).toHaveBeenNthCalledWith(1, {
+      cmd: "bash",
+      args: ["-lc", "python3 -m http.server 3000 --directory ."],
+      cwd: "/vercel/sandbox",
+      detached: true,
+    });
+    expect(runCommand).toHaveBeenNthCalledWith(2, {
+      cmd: "bash",
+      args: ["-lc", "until (exec 3<>/dev/tcp/127.0.0.1/3000) 2>/dev/null; do sleep 0.1; done"],
+      timeoutMs: 12_345,
+    });
+  });
+
+  it("rejects malformed ports before creating a sandbox", async () => {
+    const factory = vi.fn(async () => makeSandbox().client);
+    const tools = createVercelSandboxTools(factory);
+    await expect(invoke(tools, "sandbox_start_process", {
+      command: "node server.js",
+      ready_port: 80,
+    })).rejects.toThrow("ready_port must be an integer");
+    await expect(invoke(tools, "sandbox_preview", { port: 3001 })).rejects.toThrow(
+      "port must be one of",
+    );
+    expect(factory).not.toHaveBeenCalled();
+  });
+
+  it("returns only configured Vercel preview domains", async () => {
+    const sandbox = makeSandbox();
+    const tools = createVercelSandboxTools(async () => sandbox.client);
+    await expect(invoke(tools, "sandbox_preview", { port: 8080 })).resolves.toEqual({
+      port: 8080,
+      url: "https://sb-8080.vercel.run",
+      persistent: false,
+    });
+    expect(sandbox.domain).toHaveBeenCalledWith(8080);
+  });
+});
+
+function makeSandbox(overrides: {
+  readFile?: ReturnType<typeof vi.fn>;
+  runCommand?: ReturnType<typeof vi.fn>;
+} = {}) {
+  const readFile = overrides.readFile ?? vi.fn(async () => Buffer.from("hello"));
+  const writeFile = vi.fn(async () => {});
+  const mkdir = vi.fn(async () => undefined);
+  const readdir = vi.fn(async () => []);
+  const stat = vi.fn(async () => ({ isFile: () => true, size: 5 }));
+  const runCommand = overrides.runCommand ?? vi.fn(async () => finishedCommand());
+  const domain = vi.fn((port: number) => `https://sb-${port}.vercel.run`);
+  const client = {
+    domain,
+    fs: { mkdir, readFile, readdir, stat, writeFile },
+    runCommand,
+  } as unknown as Pick<Sandbox, "domain" | "fs" | "runCommand">;
+  return { client, domain, mkdir, readFile, readdir, runCommand, stat, writeFile };
+}
+
+function finishedCommand(overrides: {
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+  durationMs?: number;
+} = {}) {
+  return {
+    exitCode: overrides.exitCode ?? 0,
+    durationMs: overrides.durationMs ?? 1,
+    stdout: vi.fn(async () => overrides.stdout ?? ""),
+    stderr: vi.fn(async () => overrides.stderr ?? ""),
+  };
+}
+
+async function invoke(
+  tools: ReturnType<typeof createVercelSandboxTools>,
+  name: string,
+  input: unknown,
+): Promise<any> {
+  const tool = tools[name];
+  if (!tool) throw new Error(`missing tool: ${name}`);
+  return tool.handler(input, context);
+}

--- a/examples/vercel-workflows/test/sandbox-tools.test.ts
+++ b/examples/vercel-workflows/test/sandbox-tools.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { workspacePath } from "../workflows/sandbox-tools";
+
+describe("Vercel Sandbox workspace paths", () => {
+  it("confines relative and virtual workspace paths", () => {
+    expect(workspacePath(".")).toBe("/vercel/sandbox");
+    expect(workspacePath("src/index.ts")).toBe("/vercel/sandbox/src/index.ts");
+    expect(workspacePath("/workspace/out.txt")).toBe("/vercel/sandbox/out.txt");
+    expect(() => workspacePath("../secret")).toThrow(/must not contain/);
+    expect(() => workspacePath("/etc/passwd")).toThrow(/relative to/);
+  });
+});

--- a/examples/vercel-workflows/workflows/nanocodex-actor.ts
+++ b/examples/vercel-workflows/workflows/nanocodex-actor.ts
@@ -16,6 +16,7 @@ import {
   openApiKeyWebSocket,
   openSubscriptionWebSocket,
 } from "./model-websocket";
+import { vercelSandboxTools } from "./sandbox-tools";
 
 const CHATGPT_WEBSOCKET_URL = "wss://chatgpt.com/backend-api/codex/responses";
 const CHATGPT_API_BASE_URL = "https://chatgpt.com/backend-api/codex";
@@ -128,21 +129,27 @@ export async function runNanocodexTurn(
     const mode = modelAuthMode();
     const common = {
       apiBaseUrl: mode === "chatgpt" ? CHATGPT_API_BASE_URL : undefined,
-      instructions: "You are Nanocodex running as a durable Vercel Workflow actor.",
+      instructions: "You are Nanocodex running as a durable Vercel Workflow actor. Use the sandbox_* tools for code, files, and previews; their /workspace is an isolated persistent Vercel Sandbox for this session.",
       module: await wasmBytes,
       resume: snapshot,
       sessionId,
       toolMode: "direct" as const,
       tools: {
+        ...vercelSandboxTools(sessionId),
         runtimeInfo: {
           description: "Return information about the current agent runtime.",
           parameters: { type: "object", additionalProperties: false },
-          handler: () => ({ runtime: "vercel-workflow", session_id: sessionId }),
+          handler: () => ({
+            runtime: "vercel-workflow",
+            sandbox: "vercel-persistent-firecracker",
+            session_id: sessionId,
+            workspace: "/workspace",
+          }),
         },
       },
       websocketUrl: process.env.OPENAI_WEBSOCKET_URL
         ?? (mode === "chatgpt" ? CHATGPT_WEBSOCKET_URL : undefined),
-      workspace: "/tmp/nanocodex",
+      workspace: "/workspace",
     };
 
     agent = mode === "chatgpt"

--- a/examples/vercel-workflows/workflows/sandbox-tools.ts
+++ b/examples/vercel-workflows/workflows/sandbox-tools.ts
@@ -1,0 +1,202 @@
+import { Sandbox } from "@vercel/sandbox";
+import type { ToolMap } from "nanocodex";
+
+const WORKSPACE = "/vercel/sandbox";
+const VIRTUAL_WORKSPACE = "/workspace";
+const PREVIEW_PORTS = [3000, 5173, 8000, 8080] as const;
+const MAX_COMMAND_CHARS = 32 * 1024;
+const MAX_FILE_BYTES = 1024 * 1024;
+const MAX_OUTPUT_CHARS = 128 * 1024;
+const MAX_LIST_ENTRIES = 512;
+const MAX_TIMEOUT_MS = 120_000;
+
+export function vercelSandboxTools(sessionId: string): ToolMap {
+  let sandboxPromise: Promise<Sandbox> | undefined;
+  const sandbox = () => sandboxPromise ??= Sandbox.getOrCreate({
+    name: `nanocodex-${sessionId}`,
+    runtime: "node24",
+    persistent: true,
+    timeout: 10 * 60_000,
+    ports: [...PREVIEW_PORTS],
+    keepLastSnapshots: { count: 3, expiration: 7 * 24 * 60 * 60_000 },
+    tags: { application: "nanocodex", session: sessionId.slice(0, 64) },
+  });
+
+  return {
+    sandbox_exec: {
+      description: "Run a shell command in this session's isolated persistent Vercel Sandbox workspace.",
+      parameters: {
+        type: "object",
+        properties: {
+          command: { type: "string", description: "Shell command to run." },
+          cwd: { type: "string", description: "Workspace-relative working directory." },
+          timeout_ms: { type: "integer", minimum: 1, maximum: MAX_TIMEOUT_MS },
+        },
+        required: ["command"],
+        additionalProperties: false,
+      },
+      handler: async (input) => {
+        const value = objectInput(input);
+        const command = requiredString(value.command, "command", MAX_COMMAND_CHARS);
+        const cwd = workspacePath(optionalString(value.cwd, "cwd") ?? ".");
+        const timeoutMs = optionalInteger(value.timeout_ms, "timeout_ms", 1, MAX_TIMEOUT_MS) ?? 60_000;
+        const result = await (await sandbox()).runCommand({
+          cmd: "bash",
+          args: ["-lc", command],
+          cwd,
+          timeoutMs,
+        });
+        const [stdout, stderr] = await Promise.all([result.stdout(), result.stderr()]);
+        const boundedStdout = truncate(stdout);
+        const boundedStderr = truncate(stderr);
+        return {
+          success: result.exitCode === 0,
+          exit_code: result.exitCode,
+          stdout: boundedStdout.text,
+          stderr: boundedStderr.text,
+          stdout_truncated: boundedStdout.truncated,
+          stderr_truncated: boundedStderr.truncated,
+          duration_ms: result.durationMs,
+        };
+      },
+    },
+    sandbox_read_file: {
+      description: "Read a UTF-8 text file from this session's isolated workspace (maximum 1 MiB).",
+      parameters: pathParameters(),
+      handler: async (input) => {
+        const path = workspacePath(requiredString(objectInput(input).path, "path", 1024));
+        const sandboxHandle = await sandbox();
+        const stat = await sandboxHandle.fs.stat(path);
+        if (!stat.isFile()) throw new Error("path is not a file");
+        if (stat.size > MAX_FILE_BYTES) throw new Error("file exceeds 1 MiB");
+        return { path: virtualPath(path), content: await sandboxHandle.fs.readFile(path, "utf8") };
+      },
+    },
+    sandbox_write_file: {
+      description: "Write a UTF-8 text file inside this session's isolated workspace (maximum 1 MiB).",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "Workspace-relative file path." },
+          content: { type: "string", description: "Complete UTF-8 file content." },
+        },
+        required: ["path", "content"],
+        additionalProperties: false,
+      },
+      handler: async (input) => {
+        const value = objectInput(input);
+        const path = workspacePath(requiredString(value.path, "path", 1024));
+        const content = requiredString(value.content, "content", MAX_FILE_BYTES);
+        const bytes = Buffer.byteLength(content, "utf8");
+        if (bytes > MAX_FILE_BYTES) throw new Error("content exceeds 1 MiB");
+        const sandboxHandle = await sandbox();
+        const parent = path.slice(0, path.lastIndexOf("/")) || WORKSPACE;
+        await sandboxHandle.fs.mkdir(parent, { recursive: true });
+        await sandboxHandle.fs.writeFile(path, content, "utf8");
+        return { path: virtualPath(path), bytes_written: bytes };
+      },
+    },
+    sandbox_list_files: {
+      description: "List files in a directory inside this session's isolated workspace.",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string", description: "Workspace-relative directory; defaults to the workspace root." },
+        },
+        additionalProperties: false,
+      },
+      handler: async (input) => {
+        const path = workspacePath(optionalString(objectInput(input).path, "path") ?? ".");
+        const entries = await (await sandbox()).fs.readdir(path, { withFileTypes: true });
+        return {
+          path: virtualPath(path),
+          entries: entries.slice(0, MAX_LIST_ENTRIES).map((entry) => ({
+            name: entry.name,
+            type: entry.isDirectory() ? "directory" : entry.isFile() ? "file" : entry.isSymbolicLink() ? "symlink" : "other",
+          })),
+          truncated: entries.length > MAX_LIST_ENTRIES,
+        };
+      },
+    },
+    sandbox_preview: {
+      description: "Return the public Vercel Sandbox URL for a server listening on a supported port.",
+      parameters: {
+        type: "object",
+        properties: { port: { type: "integer", enum: [...PREVIEW_PORTS] } },
+        required: ["port"],
+        additionalProperties: false,
+      },
+      handler: async (input) => {
+        const port = requiredPreviewPort(objectInput(input).port);
+        return { port, url: (await sandbox()).domain(port), persistent: false };
+      },
+    },
+  };
+}
+
+export function workspacePath(raw: string): string {
+  if (!raw || raw.length > 1024 || raw.includes("\0")) throw new Error("path must be 1-1024 characters");
+  let relative = raw;
+  if (relative === VIRTUAL_WORKSPACE || relative === WORKSPACE) relative = ".";
+  else if (relative.startsWith(`${VIRTUAL_WORKSPACE}/`)) relative = relative.slice(VIRTUAL_WORKSPACE.length + 1);
+  else if (relative.startsWith(`${WORKSPACE}/`)) relative = relative.slice(WORKSPACE.length + 1);
+  else if (relative.startsWith("/")) throw new Error("path must be relative to /workspace");
+  const parts = relative.split("/").filter((part) => part !== "" && part !== ".");
+  if (parts.includes("..")) throw new Error("path must not contain '..'");
+  return parts.length === 0 ? WORKSPACE : `${WORKSPACE}/${parts.join("/")}`;
+}
+
+function virtualPath(path: string): string {
+  return path === WORKSPACE ? VIRTUAL_WORKSPACE : `${VIRTUAL_WORKSPACE}${path.slice(WORKSPACE.length)}`;
+}
+
+function objectInput(input: unknown): Record<string, unknown> {
+  if (!input || typeof input !== "object" || Array.isArray(input)) throw new Error("tool input must be an object");
+  return input as Record<string, unknown>;
+}
+
+function requiredString(value: unknown, name: string, maxChars: number): string {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${name} must be a non-empty string`);
+  if (value.length > maxChars) throw new Error(`${name} is too long`);
+  return value;
+}
+
+function optionalString(value: unknown, name: string): string | undefined {
+  if (value === undefined) return undefined;
+  return requiredString(value, name, 1024);
+}
+
+function optionalInteger(
+  value: unknown,
+  name: string,
+  minimum: number,
+  maximum: number,
+): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isInteger(value) || (value as number) < minimum || (value as number) > maximum) {
+    throw new Error(`${name} must be an integer between ${minimum} and ${maximum}`);
+  }
+  return value as number;
+}
+
+function requiredPreviewPort(value: unknown): (typeof PREVIEW_PORTS)[number] {
+  if (typeof value !== "number" || !PREVIEW_PORTS.includes(value as (typeof PREVIEW_PORTS)[number])) {
+    throw new Error(`port must be one of ${PREVIEW_PORTS.join(", ")}`);
+  }
+  return value as (typeof PREVIEW_PORTS)[number];
+}
+
+function pathParameters(): Record<string, unknown> {
+  return {
+    type: "object",
+    properties: { path: { type: "string", description: "Workspace-relative file path." } },
+    required: ["path"],
+    additionalProperties: false,
+  };
+}
+
+function truncate(value: string): { text: string; truncated: boolean } {
+  return value.length <= MAX_OUTPUT_CHARS
+    ? { text: value, truncated: false }
+    : { text: value.slice(0, MAX_OUTPUT_CHARS), truncated: true };
+}

--- a/examples/vercel-workflows/workflows/sandbox-tools.ts
+++ b/examples/vercel-workflows/workflows/sandbox-tools.ts
@@ -6,21 +6,19 @@ const VIRTUAL_WORKSPACE = "/workspace";
 const PREVIEW_PORTS = [3000, 5173, 8000, 8080] as const;
 const MAX_COMMAND_CHARS = 32 * 1024;
 const MAX_FILE_BYTES = 1024 * 1024;
-const MAX_OUTPUT_CHARS = 128 * 1024;
+const MAX_OUTPUT_BYTES = 128 * 1024;
 const MAX_LIST_ENTRIES = 512;
 const MAX_TIMEOUT_MS = 120_000;
 
 export function vercelSandboxTools(sessionId: string): ToolMap {
-  let sandboxPromise: Promise<Sandbox> | undefined;
-  const sandbox = () => sandboxPromise ??= Sandbox.getOrCreate({
-    name: `nanocodex-${sessionId}`,
-    runtime: "node24",
-    persistent: true,
-    timeout: 10 * 60_000,
-    ports: [...PREVIEW_PORTS],
-    keepLastSnapshots: { count: 3, expiration: 7 * 24 * 60 * 60_000 },
-    tags: { application: "nanocodex", session: sessionId.slice(0, 64) },
-  });
+  return createVercelSandboxTools(() => prepareSandbox(sessionId));
+}
+
+export function createVercelSandboxTools(
+  createSandbox: () => Promise<Pick<Sandbox, "domain" | "fs" | "runCommand">>,
+): ToolMap {
+  let sandboxPromise: ReturnType<typeof createSandbox> | undefined;
+  const sandbox = () => sandboxPromise ??= createSandbox();
 
   return {
     sandbox_exec: {
@@ -69,7 +67,57 @@ export function vercelSandboxTools(sessionId: string): ToolMap {
         const stat = await sandboxHandle.fs.stat(path);
         if (!stat.isFile()) throw new Error("path is not a file");
         if (stat.size > MAX_FILE_BYTES) throw new Error("file exceeds 1 MiB");
-        return { path: virtualPath(path), content: await sandboxHandle.fs.readFile(path, "utf8") };
+        const content = await sandboxHandle.fs.readFile(path);
+        if (content.byteLength > MAX_FILE_BYTES) throw new Error("file exceeds 1 MiB");
+        let text: string;
+        try {
+          text = new TextDecoder("utf-8", { fatal: true }).decode(content);
+        } catch {
+          throw new Error("file is not valid UTF-8");
+        }
+        return { path: virtualPath(path), content: text };
+      },
+    },
+    sandbox_start_process: {
+      description: "Start a detached process in this session's isolated Vercel Sandbox, optionally waiting for a TCP port to become ready.",
+      parameters: {
+        type: "object",
+        properties: {
+          command: { type: "string", description: "Command to start." },
+          cwd: { type: "string", description: "Workspace-relative working directory." },
+          ready_port: { type: "integer", minimum: 1024, maximum: 65_535 },
+          ready_timeout_ms: { type: "integer", minimum: 1, maximum: MAX_TIMEOUT_MS },
+        },
+        required: ["command"],
+        additionalProperties: false,
+      },
+      handler: async (input) => {
+        const value = objectInput(input);
+        const command = requiredString(value.command, "command", MAX_COMMAND_CHARS);
+        const cwd = workspacePath(optionalString(value.cwd, "cwd") ?? ".");
+        const readyPort = optionalInteger(value.ready_port, "ready_port", 1024, 65_535);
+        const readyTimeout = optionalInteger(
+          value.ready_timeout_ms,
+          "ready_timeout_ms",
+          1,
+          MAX_TIMEOUT_MS,
+        ) ?? 30_000;
+        const sandboxHandle = await sandbox();
+        const process = await sandboxHandle.runCommand({
+          cmd: "bash",
+          args: ["-lc", command],
+          cwd,
+          detached: true,
+        });
+        if (readyPort !== undefined) {
+          await waitForPort(sandboxHandle, readyPort, readyTimeout);
+        }
+        return {
+          process_id: process.cmdId,
+          command,
+          status: "running",
+          ...(readyPort === undefined ? {} : { ready_port: readyPort }),
+        };
       },
     },
     sandbox_write_file: {
@@ -86,7 +134,7 @@ export function vercelSandboxTools(sessionId: string): ToolMap {
       handler: async (input) => {
         const value = objectInput(input);
         const path = workspacePath(requiredString(value.path, "path", 1024));
-        const content = requiredString(value.content, "content", MAX_FILE_BYTES);
+        const content = requiredContent(value.content);
         const bytes = Buffer.byteLength(content, "utf8");
         if (bytes > MAX_FILE_BYTES) throw new Error("content exceeds 1 MiB");
         const sandboxHandle = await sandbox();
@@ -134,6 +182,47 @@ export function vercelSandboxTools(sessionId: string): ToolMap {
   };
 }
 
+async function prepareSandbox(sessionId: string): Promise<Sandbox> {
+  const sandbox = await Sandbox.getOrCreate({
+    name: `nanocodex-${sessionId}`,
+    runtime: "node24",
+    persistent: true,
+    timeout: 10 * 60_000,
+    ports: [...PREVIEW_PORTS],
+    keepLastSnapshots: { count: 3, expiration: 7 * 24 * 60 * 60_000 },
+    tags: { application: "nanocodex", session: sessionId.slice(0, 64) },
+  });
+  const linked = await sandbox.runCommand({
+    cmd: "bash",
+    args: [
+      "-lc",
+      `if [ -e ${VIRTUAL_WORKSPACE} ] || [ -L ${VIRTUAL_WORKSPACE} ]; then test "$(readlink -f ${VIRTUAL_WORKSPACE})" = ${WORKSPACE}; else ln -s ${WORKSPACE} ${VIRTUAL_WORKSPACE}; fi`,
+    ],
+    sudo: true,
+    timeoutMs: 10_000,
+  });
+  if (linked.exitCode !== 0) {
+    throw new Error(`failed to prepare /workspace: ${await linked.stderr()}`);
+  }
+  return sandbox;
+}
+
+async function waitForPort(
+  sandbox: Pick<Sandbox, "runCommand">,
+  port: number,
+  timeoutMs: number,
+): Promise<void> {
+  const result = await sandbox.runCommand({
+    cmd: "bash",
+    args: [
+      "-lc",
+      `until (exec 3<>/dev/tcp/127.0.0.1/${port}) 2>/dev/null; do sleep 0.1; done`,
+    ],
+    timeoutMs,
+  });
+  if (result.exitCode !== 0) throw new Error(`port ${port} did not become ready`);
+}
+
 export function workspacePath(raw: string): string {
   if (!raw || raw.length > 1024 || raw.includes("\0")) throw new Error("path must be 1-1024 characters");
   let relative = raw;
@@ -158,6 +247,12 @@ function objectInput(input: unknown): Record<string, unknown> {
 function requiredString(value: unknown, name: string, maxChars: number): string {
   if (typeof value !== "string" || value.length === 0) throw new Error(`${name} must be a non-empty string`);
   if (value.length > maxChars) throw new Error(`${name} is too long`);
+  return value;
+}
+
+function requiredContent(value: unknown): string {
+  if (typeof value !== "string") throw new Error("content must be a string");
+  if (value.length > MAX_FILE_BYTES) throw new Error("content exceeds 1 MiB");
   return value;
 }
 
@@ -196,7 +291,18 @@ function pathParameters(): Record<string, unknown> {
 }
 
 function truncate(value: string): { text: string; truncated: boolean } {
-  return value.length <= MAX_OUTPUT_CHARS
-    ? { text: value, truncated: false }
-    : { text: value.slice(0, MAX_OUTPUT_CHARS), truncated: true };
+  const encoded = new TextEncoder().encode(value);
+  if (encoded.byteLength <= MAX_OUTPUT_BYTES) return { text: value, truncated: false };
+  let end = MAX_OUTPUT_BYTES;
+  while (end > 0) {
+    try {
+      return {
+        text: new TextDecoder("utf-8", { fatal: true }).decode(encoded.subarray(0, end)),
+        truncated: true,
+      };
+    } catch {
+      end -= 1;
+    }
+  }
+  return { text: "", truncated: true };
 }


### PR DESCRIPTION
## Summary

- add the same bounded `sandbox_exec`, `sandbox_read_file`, `sandbox_write_file`, `sandbox_list_files`, and `sandbox_preview` tool surface across Cloudflare Sandbox, Rivet AgentOS, and Vercel Sandbox
- preserve host-side API/subscription credentials and durable per-session state on every platform
- make live smoke tests prove sandbox write/exec/read behavior, with synchronized-client coverage
- let the Rivet subscription deploy helper reuse credentials cached by the official CLI

## Platform integration

- **Cloudflare:** Sandbox Durable Object + container, RPC transport, per-session R2 mount, Quick Tunnel previews
- **Rivet:** AgentOS actor wrapper + persistent VM filesystem/processes and preview routing; Nanocodex remains the model and tool-loop owner
- **Vercel:** durable Workflow actor + named persistent Sandbox, snapshot retention, OIDC-backed SDK calls, and Fluid Compute for the hosting Functions

The AgentOS package currently carries Pi as a dormant transitive dependency. This example does not import or run Pi; its dependency guard rejects direct Pi dependencies and source imports.

Stacked on #113 because the Cloudflare sandbox integration needs the restored Cloudflare example files.

## Validation

- `just build-wasm`
- `npm run check --prefix examples/cloudflare-workers`
- `npm run check --prefix examples/rivet-actors`
- `npm run check --prefix examples/vercel-workflows`
- hosted Rivet subscription smoke: durable restore plus AgentOS write/exec/read
- hosted Rivet synchronized-client smoke: 2/2 clients
- hosted Vercel synchronized-client smoke: 2/2 clients plus Sandbox write/exec/read
- Cloudflare Worker, R2 bucket, Sandbox container, and Durable Object migration deployed successfully; direct ChatGPT egress remains blocked upstream with HTTP 403
