### PR TITLE
fix(tui): strip quote chrome from copied markdown

### DIFF
--- a/bin/nanocodex/src/tui/markdown.rs
+++ b/bin/nanocodex/src/tui/markdown.rs
@@ -7,6 +7,7 @@ use ratatui::{
 use std::{
     borrow::Cow,
     fmt::Write as _,
+    ops::Range,
     sync::{Arc, OnceLock},
 };
 use syntect::{
@@ -72,7 +73,7 @@ fn render_agent_markdown_inner(
 ) -> RenderedAgentMarkdown {
     let (prepared, formulas) = renderer.map_or_else(
         || (Cow::Borrowed(source), Vec::new()),
-        |_| prepare_display_math(source),
+        |_| prepare_math(source),
     );
     let mut writer = MarkdownWriter::new(width, &formulas, renderer, previous, math_fallback);
     let mut options = Options::empty();
@@ -122,15 +123,36 @@ pub(super) struct MarkdownFormula {
     pub(super) full_source: Arc<str>,
     pub(super) line: usize,
     pub(super) column: u16,
+    pub(super) source_column: u16,
+    pub(super) block: bool,
 }
 
-struct DisplayFormula {
+struct MarkdownMath {
     source: String,
     full_source: String,
+    display: bool,
 }
 
-fn prepare_display_math(source: &str) -> (Cow<'_, str>, Vec<DisplayFormula>) {
-    let regions = ratatex::display_math(source);
+struct MathRegion<'a> {
+    source: &'a str,
+    full_source: &'a str,
+    range: Range<usize>,
+    display: bool,
+}
+
+fn prepare_math(source: &str) -> (Cow<'_, str>, Vec<MarkdownMath>) {
+    let display = ratatex::display_math(source);
+    let mut regions = display
+        .iter()
+        .map(|region| MathRegion {
+            source: region.source(),
+            full_source: region.full_source(),
+            range: region.range(),
+            display: true,
+        })
+        .collect::<Vec<_>>();
+    regions.extend(inline_math(source, &display));
+    regions.sort_unstable_by_key(|region| region.range.start);
     if regions.is_empty() {
         return (Cow::Borrowed(source), Vec::new());
     }
@@ -138,13 +160,18 @@ fn prepare_display_math(source: &str) -> (Cow<'_, str>, Vec<DisplayFormula>) {
     let mut formulas = Vec::with_capacity(regions.len());
     let mut cursor = 0;
     for region in regions {
-        let range = region.range();
+        let range = region.range;
         prepared.push_str(&source[cursor..range.start]);
         let index = formulas.len();
-        let _ = write!(prepared, "\n\n<!--ratatex-display:{index}-->\n\n");
-        formulas.push(DisplayFormula {
-            source: region.source().to_owned(),
-            full_source: region.full_source().to_owned(),
+        if region.display {
+            let _ = write!(prepared, "\n\n<!--ratatex-display:{index}-->\n\n");
+        } else {
+            let _ = write!(prepared, "<!--ratatex-inline:{index}-->");
+        }
+        formulas.push(MarkdownMath {
+            source: region.source.to_owned(),
+            full_source: region.full_source.to_owned(),
+            display: region.display,
         });
         cursor = range.end;
     }
@@ -152,12 +179,97 @@ fn prepare_display_math(source: &str) -> (Cow<'_, str>, Vec<DisplayFormula>) {
     (Cow::Owned(prepared), formulas)
 }
 
-fn display_math_marker(html: &str) -> Option<usize> {
-    html.trim()
-        .strip_prefix("<!--ratatex-display:")?
-        .strip_suffix("-->")?
+fn inline_math<'a>(source: &'a str, display: &[ratatex::DisplayMath<'a>]) -> Vec<MathRegion<'a>> {
+    let mut protected = display
+        .iter()
+        .map(ratatex::DisplayMath::range)
+        .collect::<Vec<_>>();
+    let mut code_block_start = None;
+    for (event, range) in Parser::new(source).into_offset_iter() {
+        match event {
+            Event::Start(Tag::CodeBlock(_)) => code_block_start = Some(range.start),
+            Event::End(TagEnd::CodeBlock) => {
+                if let Some(start) = code_block_start.take() {
+                    protected.push(start..range.end);
+                }
+            }
+            Event::Code(_) => protected.push(range),
+            _ => {}
+        }
+    }
+    protected.sort_unstable_by_key(|range| range.start);
+
+    let mut regions = Vec::new();
+    let mut cursor = 0;
+    let mut protected_index = 0;
+    while cursor < source.len() {
+        if let Some(range) = protected.get(protected_index) {
+            if cursor >= range.end {
+                protected_index += 1;
+                continue;
+            }
+            if range.contains(&cursor) {
+                cursor = range.end;
+                continue;
+            }
+        }
+        if source[cursor..].starts_with(r"\(")
+            && !is_escaped_at(source, cursor)
+            && let Some(end_start) = find_inline_math_end(source, cursor + 2)
+        {
+            let end = end_start + 2;
+            let body = &source[cursor + 2..end_start];
+            if !body.trim().is_empty() && !body.contains('\n') {
+                regions.push(MathRegion {
+                    source: body.trim(),
+                    full_source: &source[cursor..end],
+                    range: cursor..end,
+                    display: false,
+                });
+                cursor = end;
+                continue;
+            }
+        }
+        cursor += source[cursor..].chars().next().map_or(1, char::len_utf8);
+    }
+    regions
+}
+
+fn find_inline_math_end(source: &str, mut cursor: usize) -> Option<usize> {
+    while cursor < source.len() {
+        if source[cursor..].starts_with(r"\)") && !is_escaped_at(source, cursor) {
+            return Some(cursor);
+        }
+        cursor += source[cursor..].chars().next().map_or(1, char::len_utf8);
+    }
+    None
+}
+
+fn is_escaped_at(source: &str, index: usize) -> bool {
+    source[..index]
+        .bytes()
+        .rev()
+        .take_while(|byte| *byte == b'\\')
+        .count()
+        % 2
+        == 1
+}
+
+enum MathMarker {
+    Display(usize),
+    Inline(usize),
+}
+
+fn math_marker(html: &str) -> Option<MathMarker> {
+    let marker = html.trim().strip_suffix("-->")?;
+    if let Some(index) = marker.strip_prefix("<!--ratatex-display:") {
+        return index.parse().ok().map(MathMarker::Display);
+    }
+    marker
+        .strip_prefix("<!--ratatex-inline:")?
         .parse()
         .ok()
+        .map(MathMarker::Inline)
 }
 
 #[cfg(test)]
@@ -779,7 +891,7 @@ struct MarkdownWriter<'a> {
     code_block: Option<CodeBlock>,
     table: Option<TableState>,
     image: Option<MarkdownImage>,
-    formulas: &'a [DisplayFormula],
+    formulas: &'a [MarkdownMath],
     renderer: Option<&'a Ratatex>,
     previous_formulas: &'a [StreamingFormulaFrame],
     math_fallback: MathFallback,
@@ -812,7 +924,7 @@ struct TableState {
 impl<'a> MarkdownWriter<'a> {
     fn new(
         width: u16,
-        formulas: &'a [DisplayFormula],
+        formulas: &'a [MarkdownMath],
         renderer: Option<&'a Ratatex>,
         previous_formulas: &'a [StreamingFormulaFrame],
         math_fallback: MathFallback,
@@ -976,16 +1088,16 @@ impl<'a> MarkdownWriter<'a> {
             Event::TaskListMarker(checked) => {
                 self.append_text(if checked { "[✓] " } else { "[ ] " });
             }
-            Event::Html(html) | Event::InlineHtml(html) => {
-                if let Some(index) = display_math_marker(&html) {
-                    self.append_display_math(index);
-                } else {
+            Event::Html(html) | Event::InlineHtml(html) => match math_marker(&html) {
+                Some(MathMarker::Display(index)) => self.append_display_math(index),
+                Some(MathMarker::Inline(index)) => self.append_inline_math(index),
+                None => {
                     let plain = strip_html(&html);
                     if !plain.is_empty() {
                         self.append_text(&plain);
                     }
                 }
-            }
+            },
             Event::FootnoteReference(label) => self.append_text(&format!("[{label}]")),
             Event::Start(Tag::Table(_)) => self.table = Some(TableState::default()),
             Event::Start(
@@ -1058,6 +1170,7 @@ impl<'a> MarkdownWriter<'a> {
         let Some(formula) = self.formulas.get(index) else {
             return;
         };
+        debug_assert!(formula.display);
         let source = formula.source.clone();
         let full_source = formula.full_source.clone();
         self.flush_current();
@@ -1074,11 +1187,11 @@ impl<'a> MarkdownWriter<'a> {
         });
         match state {
             FormulaState::Ready(formula) => {
-                self.append_ready_formula(index, formula, full_source, column);
+                self.append_ready_display_formula(index, formula, full_source, column);
             }
             FormulaState::Pending => {
                 if let Some(previous) = self.previous_formula(index, &source, max_columns) {
-                    self.append_ready_formula(index, previous, full_source, column);
+                    self.append_ready_display_formula(index, previous, full_source, column);
                 } else if self.math_fallback.hides_pending() {
                     self.append_hidden_formula();
                 } else {
@@ -1087,7 +1200,7 @@ impl<'a> MarkdownWriter<'a> {
             }
             FormulaState::Failed(_) if self.math_fallback.hides_failed() => {
                 if let Some(previous) = self.previous_formula(index, &source, max_columns) {
-                    self.append_ready_formula(index, previous, full_source, column);
+                    self.append_ready_display_formula(index, previous, full_source, column);
                 } else {
                     self.append_hidden_formula();
                 }
@@ -1096,6 +1209,50 @@ impl<'a> MarkdownWriter<'a> {
                 self.append_formula_source(&full_source);
             }
         }
+    }
+
+    fn append_inline_math(&mut self, index: usize) {
+        let Some(formula) = self.formulas.get(index) else {
+            return;
+        };
+        debug_assert!(!formula.display);
+        let source = formula.source.clone();
+        let full_source = formula.full_source.clone();
+        self.ensure_prefix();
+        let column = self.current_width();
+        let max_columns = self.width.saturating_sub(column).max(1);
+        let state = self.renderer.map_or(FormulaState::Unsupported, |renderer| {
+            renderer.request(&source, max_columns)
+        });
+        let ready = match state {
+            FormulaState::Ready(formula) => Some(formula),
+            FormulaState::Pending => self.previous_formula(index, &source, max_columns),
+            FormulaState::Failed(_) | FormulaState::Unsupported => None,
+        };
+        if let Some(formula) = ready
+            && formula.rows() == 1
+        {
+            let source_width =
+                UnicodeWidthStr::width(full_source.as_str()).min(usize::from(u16::MAX)) as u16;
+            let reserved = formula.columns().max(source_width);
+            if reserved <= self.width.saturating_sub(column) {
+                let formula_column =
+                    column.saturating_add(reserved.saturating_sub(formula.columns()) / 2);
+                self.current
+                    .push(Span::raw(" ".repeat(usize::from(reserved))));
+                self.rendered_formulas.push(MarkdownFormula {
+                    index,
+                    formula,
+                    full_source: full_source.into(),
+                    line: self.lines.len(),
+                    column: formula_column,
+                    source_column: column,
+                    block: false,
+                });
+                return;
+            }
+        }
+        self.append_text(&full_source);
     }
 
     fn previous_formula(
@@ -1122,14 +1279,16 @@ impl<'a> MarkdownWriter<'a> {
             .cloned()
     }
 
-    fn append_ready_formula(
+    fn append_ready_display_formula(
         &mut self,
         index: usize,
         formula: Arc<Formula>,
         full_source: String,
-        column: u16,
+        content_column: u16,
     ) {
         self.current.clear();
+        let available = self.width.saturating_sub(content_column);
+        let column = content_column.saturating_add(available.saturating_sub(formula.columns()) / 2);
         let line = self.lines.len();
         self.lines
             .extend((0..formula.rows()).map(|_| Line::raw(" ")));
@@ -1139,6 +1298,8 @@ impl<'a> MarkdownWriter<'a> {
             full_source: full_source.into(),
             line,
             column,
+            source_column: column,
+            block: true,
         });
     }
 
@@ -1170,6 +1331,14 @@ impl<'a> MarkdownWriter<'a> {
             self.current
                 .push(Span::styled(prefix, Style::default().fg(Color::Green)));
         }
+    }
+
+    fn current_width(&self) -> u16 {
+        self.current
+            .iter()
+            .map(|span| UnicodeWidthStr::width(span.content.as_ref()))
+            .sum::<usize>()
+            .min(usize::from(u16::MAX)) as u16
     }
 
     fn flush_current(&mut self) {
@@ -1510,6 +1679,69 @@ mod tests {
     }
 
     #[test]
+    fn unsupported_graphics_preserves_inline_math_as_text() {
+        let renderer = Ratatex::builder(TerminalProfile::unsupported(PixelSize::default()))
+            .build()
+            .unwrap();
+        let rendered = render_agent_markdown_with_math(
+            r"The bound \(d\le P(n)^2\) is sufficient.",
+            60,
+            &renderer,
+        );
+        let text = rendered
+            .text
+            .lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+
+        assert!(text.contains(r"The bound \(d\le P(n)^2\) is sufficient."));
+        assert!(rendered.formulas.is_empty());
+        renderer.shutdown();
+    }
+
+    #[test]
+    fn inline_math_renders_inside_the_surrounding_markdown_line() {
+        let (wake_tx, wake_rx) = mpsc::sync_channel(1);
+        let cache = tempfile::tempdir().unwrap();
+        let renderer = Ratatex::builder(TerminalProfile::kitty(PixelSize::new(10, 40), false))
+            .cache_dir(cache.path())
+            .on_update(move || {
+                let _ = wake_tx.try_send(());
+            })
+            .build()
+            .unwrap();
+        let source = r"- The bound \(d\le P(n)^2\) for boundary obstructions.";
+
+        let pending = render_agent_markdown_with_math(source, 80, &renderer);
+        let pending_text = pending
+            .text
+            .lines
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+        assert!(pending_text.contains(r"\(d\le P(n)^2\)"));
+        wake_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+
+        let rendered = render_agent_markdown_with_math(source, 80, &renderer);
+        assert_eq!(rendered.formulas.len(), 1);
+        let formula = &rendered.formulas[0];
+        assert!(!formula.block);
+        assert_eq!(formula.formula.rows(), 1);
+        let line = rendered.text.lines[formula.line]
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+        assert!(line.contains("• The bound "));
+        assert!(line.contains(" for boundary obstructions."));
+        assert!(!line.contains(r"\le"));
+        renderer.shutdown();
+    }
+
+    #[test]
     fn display_math_becomes_placeholder_rows() {
         let (wake_tx, wake_rx) = mpsc::sync_channel(1);
         let cache = tempfile::tempdir().unwrap();
@@ -1585,6 +1817,10 @@ After";
 
         assert_eq!(formula.line, maxwell + 2);
         assert_eq!(next, formula.line + usize::from(formula.formula.rows()));
+        assert_eq!(
+            formula.column,
+            2 + (78_u16.saturating_sub(formula.formula.columns())) / 2
+        );
         renderer.shutdown();
     }
 

--- a/bin/nanocodex/src/tui/markdown.rs
+++ b/bin/nanocodex/src/tui/markdown.rs
@@ -240,6 +240,13 @@ impl LogicalMarkdown {
     }
 
     pub(super) fn copy_range(&self, selected: &str) -> Option<String> {
+        self.copy_range_exact(selected).or_else(|| {
+            let stripped = strip_rendered_markdown_chrome(selected)?;
+            self.copy_range_exact(&stripped)
+        })
+    }
+
+    fn copy_range_exact(&self, selected: &str) -> Option<String> {
         let selected_key = compact_whitespace(selected);
         if selected_key.is_empty() {
             return None;
@@ -370,6 +377,29 @@ fn strip_code_gutters(selected: &str) -> Option<String> {
             };
             stripped_any = true;
             body.strip_prefix(' ').unwrap_or(body)
+        })
+        .collect::<Vec<_>>();
+    stripped_any.then(|| lines.join("\n"))
+}
+
+fn strip_rendered_markdown_chrome(selected: &str) -> Option<String> {
+    let mut stripped_any = false;
+    let lines = selected
+        .split('\n')
+        .enumerate()
+        .map(|(index, line)| {
+            if index == 0 && line.trim_start_matches(' ') == "● Nanocodex" {
+                stripped_any = true;
+                return "";
+            }
+            let mut body = line.trim_start_matches(' ');
+            let mut stripped_line = false;
+            while let Some(rest) = body.strip_prefix('│') {
+                stripped_any = true;
+                stripped_line = true;
+                body = rest.strip_prefix(' ').unwrap_or(rest);
+            }
+            if stripped_line { body } else { line }
         })
         .collect::<Vec<_>>();
     stripped_any.then(|| lines.join("\n"))
@@ -1645,6 +1675,49 @@ After";
         assert_eq!(
             restore_markdown_links(selected.to_owned(), source),
             "const first = 1;\nconst second = 2;"
+        );
+    }
+
+    #[test]
+    fn semantic_copy_strips_rendered_block_quote_gutters() {
+        let source = "Intro\n\n> got an awesome group speaking\n>\n> @rauch (Vercel)\n> @sqs (Amp)\n>\n> october 12-14";
+        let selected = "Intro\n\n  │ got an awesome group speaking\n\n  │ @rauch (Vercel)\n  │ @sqs (Amp)\n\n  │ october 12-14";
+
+        assert_eq!(
+            restore_markdown_links(selected.to_owned(), source),
+            "Intro\ngot an awesome group speaking\n@rauch (Vercel)\n@sqs (Amp)\noctober 12-14"
+        );
+    }
+
+    #[test]
+    fn semantic_copy_of_a_whole_rendered_quote_drops_the_header_and_gutters() {
+        let source = "Intro\n\n> got an awesome group speaking\n>\n> @rauch (Vercel)\n> @sqs (Amp)\n>\n> october 12-14";
+        let selected = render_agent_markdown(source, 120)
+            .lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert_eq!(
+            restore_markdown_links(selected, source),
+            "Intro\ngot an awesome group speaking\n@rauch (Vercel)\n@sqs (Amp)\noctober 12-14"
+        );
+    }
+
+    #[test]
+    fn semantic_copy_prefers_a_literal_vertical_bar_over_gutter_stripping() {
+        assert_eq!(
+            restore_markdown_links(
+                "│ literal text".to_owned(),
+                "│ literal text\n\nliteral text"
+            ),
+            "│ literal text"
         );
     }
 

--- a/bin/nanocodex/src/tui/transcript.rs
+++ b/bin/nanocodex/src/tui/transcript.rs
@@ -889,6 +889,7 @@ struct RenderedFormula {
     full_source: Arc<str>,
     visual_top: usize,
     column: u16,
+    source_column: u16,
 }
 
 #[derive(Clone)]
@@ -2154,6 +2155,9 @@ impl RenderedText {
     fn with_formulas(text: Text<'static>, width: u16, formulas: Vec<MarkdownFormula>) -> Self {
         let mut formula_rows = vec![false; text.lines.len()];
         for formula in &formulas {
+            if !formula.block {
+                continue;
+            }
             let end = formula
                 .line
                 .saturating_add(usize::from(formula.formula.rows()))
@@ -2181,6 +2185,7 @@ impl RenderedText {
                 formula: formula.formula,
                 full_source: formula.full_source,
                 column: formula.column,
+                source_column: formula.source_column,
             })
             .collect();
         Self {
@@ -2347,12 +2352,17 @@ impl RenderedText {
             if formula_bottom <= scroll || formula.visual_top >= viewport_bottom {
                 continue;
             }
-            let x = i32::from(formula.column);
+            let source_fallback = math_fallback || selected;
+            let x = i32::from(if source_fallback {
+                formula.source_column
+            } else {
+                formula.column
+            });
             let y = i32::try_from(formula.visual_top)
                 .unwrap_or(i32::MAX)
                 .saturating_sub(i32::try_from(scroll).unwrap_or(i32::MAX));
             let widget = FormulaWidget::new(&formula.formula).position(SignedPosition::new(x, y));
-            if math_fallback || selected {
+            if source_fallback {
                 widget
                     .compact_source_fallback(formula.full_source.as_ref())
                     .source_fallback_style(Style::default())
@@ -2935,6 +2945,66 @@ with $\mathbf{u}$ denoting velocity."
                 .iter()
                 .all(|cell| !cell.symbol().starts_with('\u{10eeee}'))
         );
+        renderer.shutdown();
+    }
+
+    #[test]
+    fn inline_formula_shares_a_transcript_row_with_prose() {
+        let (wake_tx, wake_rx) = mpsc::sync_channel(1);
+        let cache = tempfile::tempdir().unwrap();
+        let renderer = Ratatex::builder(TerminalProfile::kitty(PixelSize::new(10, 40), false))
+            .cache_dir(cache.path())
+            .on_update(move || {
+                let _ = wake_tx.try_send(());
+            })
+            .build()
+            .unwrap();
+        let mut transcript = Transcript::default();
+        transcript.set_math_renderer(renderer.clone());
+        transcript.push(TranscriptItem::Assistant(
+            r"The bound \(d\le P(n)^2\) controls boundary obstructions.".to_owned(),
+        ));
+
+        let _ = transcript.height_from(0, 80);
+        wait_for_math_render(&wake_rx);
+        transcript.invalidate_math_layouts();
+
+        let mut terminal = Terminal::new(TestBackend::new(80, 5)).unwrap();
+        terminal
+            .draw(|frame| {
+                frame.render_widget(transcript.widget(0, None, None, "empty"), frame.area());
+            })
+            .unwrap();
+        let formula_row = terminal
+            .backend()
+            .buffer()
+            .content
+            .chunks(80)
+            .position(|row| {
+                row.iter()
+                    .any(|cell| cell.symbol().starts_with('\u{10eeee}'))
+            })
+            .unwrap();
+        let row = terminal.backend().buffer().content[formula_row * 80..(formula_row + 1) * 80]
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect::<String>();
+        assert!(row.contains("The bound "));
+        assert!(row.contains(" controls boundary obstructions."));
+
+        terminal
+            .draw(|frame| {
+                frame.render_widget(
+                    transcript
+                        .widget(0, None, None, "empty")
+                        .math_fallback(true),
+                    frame.area(),
+                );
+            })
+            .unwrap();
+        let fallback = terminal.backend().to_string();
+        assert!(fallback.contains(r"\(d\le P(n)^2\)"));
+        assert!(fallback.contains(" controls boundary obstructions."));
         renderer.shutdown();
     }
 


### PR DESCRIPTION
## Summary

- strip rendered blockquote gutters from semantic clipboard copies
- omit the Nanocodex presentation header when copying a whole response
- preserve literal vertical-bar content by preferring exact source matches

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p nanocodex-bin`