### PR TITLE
ci: decouple Harbor from nightly releases

### DIFF
--- a/.github/workflows/harbor-nightly.yml
+++ b/.github/workflows/harbor-nightly.yml
@@ -1,0 +1,146 @@
+name: Harbor Nightly
+run-name: "${{ inputs.pr && format('PR #{0} Harbor artifact', inputs.pr) || 'Harbor Nightly' }}"
+
+permissions: {}
+
+on:
+  schedule:
+    - cron: "15 6 * * *"
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number to build without publishing a release
+        required: false
+        type: string
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ inputs.pr && format('pr-harbor-artifact-{0}', inputs.pr) || 'harbor-nightly' }}
+  cancel-in-progress: ${{ inputs.pr != '' }}
+
+jobs:
+  build:
+    if: github.repository == 'gakonst/nanocodex'
+    name: build Harbor static x86_64 Linux
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ inputs.pr && format('refs/pull/{0}/head', inputs.pr) || github.sha }}
+          persist-credentials: false
+      - name: Record exact source revision
+        shell: bash
+        run: echo "BUILD_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+      - name: Build static Harbor agent
+        shell: bash
+        env:
+          TAG_NAME: ${{ inputs.pr && format('pr-{0}', inputs.pr) || 'harbor-nightly' }}
+        run: |
+          mkdir dist
+          docker build \
+            --platform linux/amd64 \
+            --build-arg CARGO_PROFILE=release \
+            --build-arg TAG_NAME="$TAG_NAME" \
+            --build-arg VERGEN_GIT_SHA="$BUILD_SHA" \
+            --file harbor_adapter/nanocodex.Dockerfile \
+            --target artifact \
+            --output type=local,dest=dist \
+            .
+          mv dist/nanocodex dist/nanocodex-x86_64-unknown-linux-musl
+      - name: Verify the Harbor artifact is portable
+        shell: bash
+        run: |
+          file dist/nanocodex-x86_64-unknown-linux-musl
+          docker run --rm \
+            --volume "$PWD/dist:/dist:ro" \
+            alpine:3.21 \
+            /dist/nanocodex-x86_64-unknown-linux-musl --version
+          docker run --rm \
+            --volume "$PWD/dist:/dist:ro" \
+            ubuntu:22.04 \
+            /dist/nanocodex-x86_64-unknown-linux-musl --version
+      - name: Stage PR provenance and checksum
+        if: github.event_name == 'workflow_dispatch' && inputs.pr != ''
+        shell: bash
+        env:
+          ARTIFACT: nanocodex-x86_64-unknown-linux-musl
+          PR_NUMBER: ${{ inputs.pr }}
+        run: |
+          cd dist
+          sha256sum "$ARTIFACT" > "$ARTIFACT.sha256"
+          printf '{"repository":"%s","pr":%s,"sha":"%s","artifact":"%s","run_id":%s}\n' \
+            "$GITHUB_REPOSITORY" "$PR_NUMBER" "$BUILD_SHA" "$ARTIFACT" \
+            "$GITHUB_RUN_ID" > PR_BUILD.json
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: nanocodex-x86_64-unknown-linux-musl
+          path: dist/*
+          if-no-files-found: error
+          retention-days: ${{ inputs.pr && 7 || 1 }}
+
+  publish:
+    if: >-
+      github.repository == 'gakonst/nanocodex' &&
+      (github.event_name != 'workflow_dispatch' || inputs.pr == '')
+    name: publish immutable and rolling Harbor nightlies
+    needs: build
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: nanocodex-x86_64-unknown-linux-musl
+          path: dist
+      - name: Generate checksum
+        shell: bash
+        run: |
+          cd dist
+          sha256sum nanocodex-x86_64-unknown-linux-musl > SHA256SUMS
+      - name: Publish immutable and rolling Harbor releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          immutable_tag="harbor-nightly-${GITHUB_SHA}"
+          short_sha="${GITHUB_SHA:0:10}"
+          release_name="Nanocodex Harbor Nightly ($(date -u +%Y-%m-%d), ${short_sha})"
+          notes_file=$(mktemp)
+          {
+            printf "Automated Harbor build from [\`%s\`](https://github.com/%s/commit/%s).\n\n" "$short_sha" "$GITHUB_REPOSITORY" "$GITHUB_SHA"
+            printf "This channel is independent from the Nanocodex CLI nightly release.\n"
+          } > "$notes_file"
+
+          if gh release view "$immutable_tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit "$immutable_tag" --repo "$GITHUB_REPOSITORY" \
+              --title "$release_name" --notes-file "$notes_file" --prerelease
+          else
+            gh release create "$immutable_tag" --repo "$GITHUB_REPOSITORY" \
+              --target "$GITHUB_SHA" --title "$release_name" \
+              --notes-file "$notes_file" --prerelease
+          fi
+          gh release upload "$immutable_tag" dist/* --repo "$GITHUB_REPOSITORY" --clobber
+
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/harbor-nightly" >/dev/null 2>&1; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/git/refs/tags/harbor-nightly" \
+              -f sha="$GITHUB_SHA" -F force=true >/dev/null
+          else
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref='refs/tags/harbor-nightly' -f sha="$GITHUB_SHA" >/dev/null
+          fi
+
+          if gh release view harbor-nightly --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release edit harbor-nightly --repo "$GITHUB_REPOSITORY" \
+              --target "$GITHUB_SHA" --title "Nanocodex Harbor Nightly" \
+              --notes-file "$notes_file" --prerelease
+          else
+            gh release create harbor-nightly --repo "$GITHUB_REPOSITORY" \
+              --title "Nanocodex Harbor Nightly" --notes-file "$notes_file" --prerelease
+          fi
+          gh release upload harbor-nightly dist/* --repo "$GITHUB_REPOSITORY" --clobber

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -109,74 +109,12 @@ jobs:
           if-no-files-found: error
           retention-days: ${{ inputs.pr && 7 || 1 }}
 
-  build-harbor:
-    if: github.repository == 'gakonst/nanocodex'
-    name: build Harbor static x86_64 Linux
-    runs-on: ubuntu-22.04
-    timeout-minutes: 45
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          ref: ${{ inputs.pr && format('refs/pull/{0}/head', inputs.pr) || github.sha }}
-          persist-credentials: false
-      - name: Record exact source revision
-        shell: bash
-        run: echo "BUILD_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
-      - name: Build static Harbor agent
-        shell: bash
-        env:
-          TAG_NAME: ${{ inputs.pr && format('pr-{0}', inputs.pr) || 'nightly' }}
-        run: |
-          mkdir dist
-          docker build \
-            --platform linux/amd64 \
-            --build-arg CARGO_PROFILE=release \
-            --build-arg TAG_NAME="$TAG_NAME" \
-            --build-arg VERGEN_GIT_SHA="$BUILD_SHA" \
-            --file harbor_adapter/nanocodex.Dockerfile \
-            --target artifact \
-            --output type=local,dest=dist \
-            .
-          mv dist/nanocodex dist/nanocodex-x86_64-unknown-linux-musl
-      - name: Verify the Harbor artifact is portable
-        shell: bash
-        run: |
-          file dist/nanocodex-x86_64-unknown-linux-musl
-          docker run --rm \
-            --volume "$PWD/dist:/dist:ro" \
-            alpine:3.21 \
-            /dist/nanocodex-x86_64-unknown-linux-musl --version
-          docker run --rm \
-            --volume "$PWD/dist:/dist:ro" \
-            ubuntu:22.04 \
-            /dist/nanocodex-x86_64-unknown-linux-musl --version
-      - name: Stage PR provenance and checksum
-        if: github.event_name == 'workflow_dispatch' && inputs.pr != ''
-        shell: bash
-        env:
-          ARTIFACT: nanocodex-x86_64-unknown-linux-musl
-          PR_NUMBER: ${{ inputs.pr }}
-        run: |
-          cd dist
-          sha256sum "$ARTIFACT" > "$ARTIFACT.sha256"
-          printf '{"repository":"%s","pr":%s,"sha":"%s","artifact":"%s","run_id":%s}\n' \
-            "$GITHUB_REPOSITORY" "$PR_NUMBER" "$BUILD_SHA" "$ARTIFACT" \
-            "$GITHUB_RUN_ID" > PR_BUILD.json
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: nanocodex-x86_64-unknown-linux-musl
-          path: dist/*
-          if-no-files-found: error
-          retention-days: ${{ inputs.pr && 7 || 1 }}
-
   publish:
     if: >-
       github.repository == 'gakonst/nanocodex' &&
       (github.event_name != 'workflow_dispatch' || inputs.pr == '')
     name: publish immutable and rolling nightlies
-    needs: [build, build-harbor]
+    needs: build
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     permissions:

--- a/Justfile
+++ b/Justfile
@@ -10,7 +10,7 @@ hosted_agent_artifact_dir := agent_artifact_dir + "/daytona-amd64"
 hosted_agent_artifact := hosted_agent_artifact_dir + "/nanocodex"
 hosted_agent_checksum := hosted_agent_artifact + ".sha256"
 hosted_agent_pr_provenance := hosted_agent_artifact + ".pr.json"
-hosted_agent_release_tag := env_var_or_default("NANOCODEX_HOSTED_AGENT_RELEASE_TAG", "nightly")
+hosted_agent_release_tag := env_var_or_default("NANOCODEX_HOSTED_AGENT_RELEASE_TAG", "harbor-nightly")
 hosted_agent_url := "https://github.com/gakonst/nanocodex/releases/download/" + hosted_agent_release_tag + "/nanocodex-x86_64-unknown-linux-musl"
 default_eval := "evals/terminal-bench-2.yaml"
 default_fast_eval := "evals/terminal-bench-2-1-fast.yaml"
@@ -277,8 +277,8 @@ download-agent-hosted:
     ./scripts/download-harbor-agent.sh "{{hosted_agent_release_tag}}" "{{hosted_agent_artifact}}"
     @test -f "{{hosted_agent_artifact}}" && test -x "{{hosted_agent_artifact}}" && test -s "{{hosted_agent_checksum}}"
 
-# Ask the existing release workflow to build every binary from the exact head of
-# one open PR. Nothing is built for ordinary pull_request events.
+# Ask the CLI and Harbor artifact workflows to build from the exact head of one
+# open PR. Nothing is built for ordinary pull_request events.
 build-pr-artifacts pr:
     ./scripts/dispatch-pr-artifacts.sh "{{pr}}"
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -11,6 +11,10 @@ Each successful run publishes an immutable `nightly-<full SHA>` prerelease and
 refreshes the rolling `nightly` prerelease with the same binaries and
 `SHA256SUMS`. The rolling tag is what `nanocodex update --nightly` follows.
 
+The independent `Harbor Nightly` workflow builds and verifies the static Harbor
+agent. It publishes `harbor-nightly-<full SHA>` and rolling `harbor-nightly`
+prereleases, so a Harbor build failure cannot block CLI binaries or updates.
+
 The separate `Docker` workflow publishes multi-architecture GHCR images. Tag
 pushes publish the version plus `latest`; scheduled or manually selected
 nightly runs publish `nightly` plus `nightly-<full SHA>`; commit dispatches

--- a/harbor_adapter/nanocodex.Dockerfile
+++ b/harbor_adapter/nanocodex.Dockerfile
@@ -21,6 +21,7 @@ COPY py/bindings/Cargo.toml py/bindings/Cargo.toml
 COPY crates/nanocodex/Cargo.toml crates/nanocodex/Cargo.toml
 COPY crates/nanocodex-agent/Cargo.toml crates/nanocodex-agent/Cargo.toml
 COPY crates/experimental/nanocodex-browser/Cargo.toml crates/experimental/nanocodex-browser/Cargo.toml
+COPY crates/experimental/nanocodex-egress/Cargo.toml crates/experimental/nanocodex-egress/Cargo.toml
 COPY crates/experimental/nanocodex-voice/Cargo.toml crates/experimental/nanocodex-voice/Cargo.toml
 COPY crates/experimental/nanocodex-vm/Cargo.toml crates/experimental/nanocodex-vm/Cargo.toml
 COPY crates/nanocodex-oai-api/Cargo.toml crates/nanocodex-oai-api/Cargo.toml
@@ -41,6 +42,8 @@ RUN mkdir -p bin/nanocodex/src \
         crates/nanocodex-agent/benches \
         crates/experimental/nanocodex-browser/src \
         crates/experimental/nanocodex-browser/benches \
+        crates/experimental/nanocodex-egress/src \
+        crates/experimental/nanocodex-egress/benches \
         crates/experimental/nanocodex-voice/src \
         crates/experimental/nanocodex-vm/src/bin \
         crates/experimental/nanocodex-vm/benches \
@@ -63,6 +66,8 @@ RUN mkdir -p bin/nanocodex/src \
     printf '\n' > crates/experimental/nanocodex-browser/src/lib.rs && \
     printf 'fn main() {}\n' > crates/experimental/nanocodex-browser/benches/browser_protocol.rs && \
     printf 'fn main() {}\n' > crates/experimental/nanocodex-browser/benches/browser_vm.rs && \
+    printf '\n' > crates/experimental/nanocodex-egress/src/lib.rs && \
+    printf 'fn main() {}\n' > crates/experimental/nanocodex-egress/benches/proxy_round_trip.rs && \
     printf '\n' > crates/experimental/nanocodex-voice/src/lib.rs && \
     printf '\n' > crates/experimental/nanocodex-vm/src/lib.rs && \
     printf 'fn main() {}\n' > crates/experimental/nanocodex-vm/src/bin/nanocodex-vm-guest.rs && \
@@ -105,6 +110,8 @@ RUN --mount=type=cache,id=nanocodex-cargo-registry,target=/usr/local/cargo/regis
         crates/nanocodex/src/lib.rs \
         crates/nanocodex-agent/src/lib.rs \
         crates/experimental/nanocodex-browser/src/lib.rs \
+        crates/experimental/nanocodex-egress/src/lib.rs \
+        crates/experimental/nanocodex-egress/benches/proxy_round_trip.rs \
         crates/experimental/nanocodex-voice/src/lib.rs \
         crates/experimental/nanocodex-vm/src/lib.rs \
         crates/nanocodex-oai-api/src/lib.rs \

--- a/scripts/dispatch-pr-artifacts.sh
+++ b/scripts/dispatch-pr-artifacts.sh
@@ -13,7 +13,7 @@ if [[ ! "$pr" =~ ^[1-9][0-9]*$ ]]; then
 fi
 
 repository=${GH_REPO:-gakonst/nanocodex}
-workflow=nightly.yml
+workflows=(nightly.yml harbor-nightly.yml)
 
 command -v gh >/dev/null 2>&1 || {
     echo "gh is required to dispatch PR artifacts" >&2
@@ -46,9 +46,13 @@ else
     workflow_ref=$head_ref
 fi
 
-gh workflow run "$workflow" --repo "$repository" --ref "$workflow_ref" \
-    --field "pr=$pr"
+for workflow in "${workflows[@]}"; do
+    gh workflow run "$workflow" --repo "$repository" --ref "$workflow_ref" \
+        --field "pr=$pr"
+done
 
 printf 'Dispatched PR #%s artifacts for %s.\n' "$pr" "$head_sha"
-printf 'Track it with: gh run list --repo %s --workflow %s --event workflow_dispatch\n' \
-    "$repository" "$workflow"
+for workflow in "${workflows[@]}"; do
+    printf 'Track it with: gh run list --repo %s --workflow %s --event workflow_dispatch\n' \
+        "$repository" "$workflow"
+done

--- a/scripts/download-pr-artifact.sh
+++ b/scripts/download-pr-artifact.sh
@@ -19,7 +19,7 @@ if [[ ! "$artifact" =~ ^[A-Za-z0-9._-]+$ ]]; then
 fi
 
 repository=${GH_REPO:-gakonst/nanocodex}
-workflow=nightly.yml
+workflow=harbor-nightly.yml
 
 command -v gh >/dev/null 2>&1 || {
     echo "gh is required to download PR artifacts" >&2
@@ -47,7 +47,7 @@ runs=$(
         --json conclusion,databaseId,displayTitle,status,url
 )
 run=$(
-    jq -c --arg title "PR #$pr artifacts" \
+    jq -c --arg title "PR #$pr Harbor artifact" \
         'map(select(.displayTitle == $title)) | first // empty' <<<"$runs"
 )
 if [[ -z "$run" ]]; then


### PR DESCRIPTION
## Summary

- remove the Harbor static build from the CLI nightly release workflow
- publish Harbor artifacts through an independent `harbor-nightly` channel
- repair the Harbor Docker manifest cache layer for `nanocodex-egress`
- dispatch and download Harbor PR artifacts through the dedicated workflow

## Validation

- `actionlint .github/workflows/nightly.yml .github/workflows/harbor-nightly.yml`
- `bash -n scripts/dispatch-pr-artifacts.sh scripts/download-pr-artifact.sh`
- `git diff --check`
- `docker build --check --file harbor_adapter/nanocodex.Dockerfile .`
- real Harbor Docker build passed the previously failing manifest layer and entered normal Rust compilation; stopped before completion to avoid waiting on a cold dependency build