### PR TITLE
feat(cli): default credits to hosted API

### DIFF
--- a/bin/nanocodex/src/credits.rs
+++ b/bin/nanocodex/src/credits.rs
@@ -3,10 +3,11 @@ use std::{path::PathBuf, process::Command, time::Duration};
 use clap::{Args, Subcommand};
 use eyre::{Result, eyre};
 use nanousd::{
-    CreateOrderRequest, CreateOrderResponse, CreditsClient, DEFAULT_API_URL, NANOUSD_DECIMALS,
-    Order, OrderStatus,
+    CreateOrderRequest, CreateOrderResponse, CreditsClient, NANOUSD_DECIMALS, Order, OrderStatus,
 };
 use tempo_alloy::accounts::TempoAccountsStore;
+
+const DEFAULT_CREDITS_API_URL: &str = "https://nanocodex-api.paradigm.xyz";
 
 #[derive(Args)]
 pub(crate) struct Credits {
@@ -18,7 +19,7 @@ pub(crate) struct Credits {
         long,
         global = true,
         env = "NANOCODEX_CREDITS_API_URL",
-        default_value = DEFAULT_API_URL
+        default_value = DEFAULT_CREDITS_API_URL
     )]
     api_url: String,
 
@@ -327,10 +328,9 @@ mod tests {
     }
 
     #[test]
-    fn credits_api_url_defaults_to_loopback() {
+    fn credits_api_url_defaults_to_hosted_service() {
         let cli = TestCli::try_parse_from(["nanocodex-credits", "status"]).unwrap();
 
-        assert_eq!(cli.credits.api_url, DEFAULT_API_URL);
-        assert!(cli.credits.api_url.starts_with("http://127.0.0.1:"));
+        assert_eq!(cli.credits.api_url, DEFAULT_CREDITS_API_URL);
     }
 }

--- a/docs/NANOUSD_CREDITS.md
+++ b/docs/NANOUSD_CREDITS.md
@@ -21,6 +21,10 @@ nanocodex credits buy 25 --json --no-wait
 nanocodex credits wait ord_... --order-token ...
 ```
 
+The CLI defaults to the hosted credits service at
+`https://nanocodex-api.paradigm.xyz`. Override it with `--api-url` or
+`NANOCODEX_CREDITS_API_URL` when running a local service.
+
 In Stripe mode, `credits buy` creates an order and opens the returned hosted
 Stripe Checkout URL in the system browser. `--no-open` prints the URL for SSH
 and other headless environments. The CLI then polls the capability-protected


### PR DESCRIPTION
## Summary

- default `nanocodex credits` to the hosted NanoUSD API
- preserve explicit `--api-url` and environment overrides for local development
- document the hosted default and update the CLI contract test

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p nanocodex-bin --features tempo credits::tests`
- `cargo clippy -p nanocodex-bin --features tempo --bin nanocodex -- -D warnings`
