### PR TITLE
feat(examples): add retained exe.dev agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5195,15 +5195,19 @@ name = "nanocodex-exe-dev"
 version = "0.3.0"
 dependencies = [
  "axum",
+ "chrono",
  "eyre",
  "futures-util",
  "http-body-util",
  "nanocodex",
+ "nix 0.31.3",
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5191,6 +5191,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanocodex-exe-dev"
+version = "0.3.0"
+dependencies = [
+ "axum",
+ "eyre",
+ "futures-util",
+ "http-body-util",
+ "nanocodex",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tower",
+]
+
+[[package]]
 name = "nanocodex-oai-api"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/nanocodex-tools",
     "crates/nanocodex-tools/macros",
     "examples",
+    "examples/exe-dev",
     "js/bindings",
     "py/bindings",
 ]

--- a/crates/nanocodex/src/lib.rs
+++ b/crates/nanocodex/src/lib.rs
@@ -21,9 +21,10 @@ pub mod agent {
     #[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
     pub use nanocodex_agent::rollout;
     pub use nanocodex_agent::{
-        AgentEvents, AgentHandle, AgentSessionContext, CostStatus, EstimatedUsdCost, Nanocodex,
-        NanocodexBuilder, NanocodexError, PromptRoute, Result, ServiceTier, Turn, TurnControl,
-        TurnResult, TurnUsage, UsdAmount, events, input, session, usage,
+        AgentEvents, AgentHandle, AgentSessionContext, CostStatus, EstimatedUsdCost,
+        ExecutionEnvironment, Nanocodex, NanocodexBuilder, NanocodexError, PromptRoute, Result,
+        ServiceTier, Turn, TurnControl, TurnResult, TurnUsage, UsdAmount, events, input, session,
+        usage,
     };
 }
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,6 +21,8 @@ All language consumers live at this repository boundary:
 - Vercel Workflows: `vercel-workflows/` runs Nanocodex as a durable Workflow
   actor with a persistent Vercel Sandbox, replayable state, and synchronized
   native WebSocket clients.
+- exe.dev: `exe-dev/` runs one private native session beside a persistent project
+  workspace, streams typed events over SSE, and resumes completed snapshots.
 
 From the repository root:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,8 +21,8 @@ All language consumers live at this repository boundary:
 - Vercel Workflows: `vercel-workflows/` runs Nanocodex as a durable Workflow
   actor with a persistent Vercel Sandbox, replayable state, and synchronized
   native WebSocket clients.
-- exe.dev: `exe-dev/` runs one private native session beside a persistent project
-  workspace, streams typed events over SSE, and resumes completed snapshots.
+- exe.dev: `exe-dev/` proves both a private retained session inside a persistent
+  VM and an external Nanocodex session using an exe.dev VM as a caller-owned tool.
 
 From the repository root:
 

--- a/examples/exe-dev/Cargo.toml
+++ b/examples/exe-dev/Cargo.toml
@@ -12,16 +12,22 @@ description = "Private native Nanocodex session consumer for exe.dev VMs"
 
 [dependencies]
 axum.workspace = true
+chrono.workspace = true
 eyre.workspace = true
 futures-util.workspace = true
 nanocodex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync"] }
+tempfile.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
+uuid.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+nix.workspace = true
 
 [dev-dependencies]
 http-body-util.workspace = true
-tempfile.workspace = true
 tower.workspace = true
 
 [lints]

--- a/examples/exe-dev/Cargo.toml
+++ b/examples/exe-dev/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "nanocodex-exe-dev"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Private native Nanocodex session consumer for exe.dev VMs"
+
+[dependencies]
+axum.workspace = true
+eyre.workspace = true
+futures-util.workspace = true
+nanocodex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "signal", "sync"] }
+
+[dev-dependencies]
+http-body-util.workspace = true
+tempfile.workspace = true
+tower.workspace = true
+
+[lints]
+workspace = true

--- a/examples/exe-dev/Dockerfile
+++ b/examples/exe-dev/Dockerfile
@@ -5,7 +5,7 @@ COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/src/target \
-    cargo build --locked --release -p nanocodex-exe-dev && \
+    cargo build --locked --release -p nanocodex-exe-dev --bin nanocodex-exe-dev && \
     cp /src/target/release/nanocodex-exe-dev /tmp/nanocodex-exe-dev
 
 FROM scratch AS artifact

--- a/examples/exe-dev/Dockerfile
+++ b/examples/exe-dev/Dockerfile
@@ -1,0 +1,23 @@
+FROM docker.io/library/rust:1.97-bookworm AS builder
+
+WORKDIR /src
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/src/target \
+    cargo build --locked --release -p nanocodex-exe-dev && \
+    cp /src/target/release/nanocodex-exe-dev /tmp/nanocodex-exe-dev
+
+FROM scratch AS artifact
+
+COPY --from=builder /tmp/nanocodex-exe-dev /nanocodex-exe-dev
+
+FROM ghcr.io/boldsoftware/exeuntu:latest
+
+COPY --from=builder /tmp/nanocodex-exe-dev /usr/local/bin/nanocodex-exe-dev
+COPY examples/exe-dev/nanocodex-exe-dev.service /etc/systemd/system/nanocodex-exe-dev.service
+
+RUN install -d -o exedev -g exedev /home/exedev/workspace /home/exedev/.local/state/nanocodex && \
+    systemctl enable nanocodex-exe-dev.service
+
+EXPOSE 8000 9998

--- a/examples/exe-dev/README.md
+++ b/examples/exe-dev/README.md
@@ -1,0 +1,111 @@
+# Nanocodex on exe.dev
+
+This example runs one native, retained Nanocodex session beside a project in an
+exe.dev VM. It is a concrete application consumer, not a generic app-server
+protocol in the stable Nanocodex crates.
+
+The service:
+
+- owns one ordered prompt queue and one native Nanocodex driver;
+- streams the existing typed agent events over SSE without reshaping them;
+- atomically persists the complete unredacted session snapshot after every
+  completed turn;
+- resumes that snapshot when systemd restarts the process; and
+- exposes a small no-build web UI on port 9998.
+
+The snapshot contains the full model-visible conversation and tool activity.
+The image stores it mode `0600` under the `exedev` user's state directory. Do
+not publish, copy, or back it up without applying the same controls as the
+source repository and agent transcript.
+
+## Build and create a VM
+
+Build and publish the image from the repository root:
+
+```sh
+docker build -f examples/exe-dev/Dockerfile \
+  -t ghcr.io/OWNER/nanocodex-exe-dev:latest .
+docker push ghcr.io/OWNER/nanocodex-exe-dev:latest
+```
+
+Create a VM with the exe.dev LLM integration attached directly or through a
+tag:
+
+```sh
+ssh exe.dev integrations setup chatgpt --name nanocodex
+ssh exe.dev \
+  'integrations add llm --name=nanocodex-subscription --openai=chatgpt --openai-account=nanocodex --anthropic=disabled --fireworks=disabled'
+ssh exe.dev \
+  'integrations attach nanocodex-subscription tag:nanocodex'
+ssh exe.dev new \
+  --name=nanocodex-spike \
+  --image=ghcr.io/OWNER/nanocodex-exe-dev:latest \
+  --tag=nanocodex
+```
+
+Open `https://nanocodex-spike.exe.xyz:9998`. Alternate ports are private to VM
+users on exe.dev. Keep port 9998 private: this example deliberately relies on
+exe.dev's authentication boundary and does not implement a second login layer.
+
+Port 8000 remains available for the application Nanocodex builds. To make that
+the VM's ordinary preview URL, install the included preview unit and then map
+the port:
+
+```sh
+scp examples/exe-dev/nanocodex-preview.service nanocodex-spike.exe.xyz:/tmp/
+ssh nanocodex-spike.exe.xyz \
+  'sudo install -m 0644 /tmp/nanocodex-preview.service /etc/systemd/system/ && sudo systemctl daemon-reload && sudo systemctl enable --now nanocodex-preview'
+ssh exe.dev share port nanocodex-spike 8000
+```
+
+Only make the application preview public. Never select port 9998 with
+`share set-public`.
+
+## Model integration spike
+
+The image points Nanocodex's HTTPS transport at the subscription-backed
+exe.dev LLM integration created above:
+
+```text
+https://nanocodex-subscription.int.exe.xyz/v1
+```
+
+The `OPENAI_API_KEY` value in the unit is a non-secret placeholder because the
+integration authenticates the source VM and keeps provider credentials outside
+the guest. The integration currently rejects the Responses WebSocket upgrade
+with HTTP 400, so this application selects Nanocodex's typed HTTPS/SSE path
+with `NANOCODEX_EXE_TRANSPORT=https`. The SDK still owns request encoding,
+stream completion, retries, typed history, tools, and events. Inspect a live
+turn through the journal:
+
+```sh
+ssh nanocodex-spike.exe.xyz journalctl -u nanocodex-exe-dev -f
+```
+
+For a direct OpenAI fallback, add a systemd override with the real API key and
+the standard endpoints, then restart the service:
+
+```ini
+[Service]
+Environment=OPENAI_API_KEY=sk-...
+Environment=NANOCODEX_EXE_API_BASE=
+Environment=NANOCODEX_EXE_TRANSPORT=websocket
+```
+
+## Local validation
+
+```sh
+cargo test -p nanocodex-exe-dev
+cargo clippy -p nanocodex-exe-dev --all-targets -- -D warnings
+OPENAI_API_KEY=sk-... cargo run -p nanocodex-exe-dev
+```
+
+Configuration is intentionally narrow:
+
+- `NANOCODEX_EXE_LISTEN` defaults to `0.0.0.0:9998`;
+- `NANOCODEX_EXE_WORKSPACE` defaults to the current directory;
+- `NANOCODEX_EXE_STATE_FILE` defaults inside that workspace;
+- `NANOCODEX_EXE_INSTRUCTIONS` replaces the stable project-agent instructions;
+- `NANOCODEX_EXE_TRANSPORT` selects `websocket` (default) or `https`;
+- `NANOCODEX_EXE_API_BASE` replaces the OpenAI HTTPS API root; and
+- `NANOCODEX_EXE_WEBSOCKET_URL` replaces the Responses WebSocket endpoint.

--- a/examples/exe-dev/README.md
+++ b/examples/exe-dev/README.md
@@ -4,6 +4,10 @@ This example runs one native, retained Nanocodex session beside a project in an
 exe.dev VM. It is a concrete application consumer, not a generic app-server
 protocol in the stable Nanocodex crates.
 
+It also includes the inverse experiment: `exe-dev-tool` leaves Nanocodex and
+its model credentials on the host while exposing one exact exe.dev VM through
+narrow caller-defined tools.
+
 The service:
 
 - owns one ordered prompt queue and one native Nanocodex driver;
@@ -92,12 +96,49 @@ Environment=NANOCODEX_EXE_API_BASE=
 Environment=NANOCODEX_EXE_TRANSPORT=websocket
 ```
 
+## exe.dev as an external sandbox tool
+
+`exe-dev-tool` demonstrates the inverse ownership boundary:
+
+```text
+host Nanocodex session
+  -> sandbox_create
+  -> sandbox_exec
+  -> sandbox_info
+       -> one caller-named private exe.dev VM
+```
+
+The model cannot choose a VM name or delete a VM. By default the embedding
+application parses `CODEX_THREAD_ID` and derives a stable
+`nanocodex-<uuid-without-hyphens>` VM name. `NANOCODEX_EXE_SANDBOX` is an
+explicit override for hosts without that Codex identity. The application
+applies `retain` or `delete` cleanup only after the turn finishes. Commands
+travel to the guest over SSH stdin and receive both a local deadline and a
+combined output bound. The tool registry disables host workspace tools, so
+shell work cannot silently fall back to the machine running Nanocodex.
+
+Run it with a Codex-compatible ChatGPT `auth.json` or an OpenAI API key:
+
+```sh
+NANOCODEX_AUTH_FILE="$HOME/.codex/auth.json" \
+NANOCODEX_EXE_CLEANUP=delete \
+cargo run -p nanocodex-exe-dev --bin exe-dev-tool -- \
+  'Create the sandbox, run uname -srm, write and verify ~/proof.txt, then report the result.'
+```
+
+The host must already be authenticated for non-interactive `ssh exe.dev` and
+guest SSH. Set `NANOCODEX_EXE_SANDBOX` when running outside a Codex environment;
+`NANOCODEX_EXE_SSH` may select a different SSH executable. Cleanup defaults to
+`retain`; use `delete` only when the named VM belongs exclusively to this run.
+
 ## Local validation
 
 ```sh
 cargo test -p nanocodex-exe-dev
 cargo clippy -p nanocodex-exe-dev --all-targets -- -D warnings
 OPENAI_API_KEY=sk-... cargo run -p nanocodex-exe-dev
+NANOCODEX_EXE_SANDBOX=nanocodex-tool-local cargo run \
+  -p nanocodex-exe-dev --bin exe-dev-tool
 ```
 
 Configuration is intentionally narrow:

--- a/examples/exe-dev/nanocodex-exe-dev.service
+++ b/examples/exe-dev/nanocodex-exe-dev.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Nanocodex private project agent
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=exedev
+Group=exedev
+WorkingDirectory=/home/exedev/workspace
+Environment=OPENAI_API_KEY=exe-integration-placeholder
+Environment=NANOCODEX_EXE_API_BASE=https://nanocodex-subscription.int.exe.xyz/v1
+Environment=NANOCODEX_EXE_TRANSPORT=https
+Environment=NANOCODEX_EXE_LISTEN=0.0.0.0:9998
+Environment=NANOCODEX_EXE_WORKSPACE=/home/exedev/workspace
+Environment=NANOCODEX_EXE_STATE_FILE=/home/exedev/.local/state/nanocodex/session.json
+ExecStart=/usr/local/bin/nanocodex-exe-dev
+Restart=on-failure
+RestartSec=2s
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/exe-dev/nanocodex-preview.service
+++ b/examples/exe-dev/nanocodex-preview.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Nanocodex workspace preview
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=exedev
+Group=exedev
+WorkingDirectory=/home/exedev/workspace
+ExecStart=/usr/bin/python3 -m http.server 8000 --bind 0.0.0.0
+Restart=on-failure
+RestartSec=2s
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/exe-dev/src/bin/exe-dev-tool.rs
+++ b/examples/exe-dev/src/bin/exe-dev-tool.rs
@@ -1,0 +1,169 @@
+//! Runs Nanocodex on the host with one caller-owned exe.dev VM as its tool.
+
+use std::{env, path::PathBuf};
+
+use chrono::Utc;
+use eyre::{Result, WrapErr, bail};
+use nanocodex::{
+    Nanocodex, OpenAi, Thinking,
+    agent::ExecutionEnvironment,
+    oai::auth::{OpenAiAuth, load_chatgpt_auth},
+};
+use nanocodex_exe_dev::sandbox::{ExeDevSandbox, SandboxCleanup, SandboxConfig};
+use uuid::Uuid;
+
+const DEFAULT_PROMPT: &str = "Create the remote sandbox, use it to report `uname -srm`, write the exact text `created by external nanocodex` to `~/nanocodex-proof.txt`, verify the file, and report the sandbox name and private preview URL.";
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let name = sandbox_name()?;
+    let cleanup = cleanup_policy()?;
+    let mut config = SandboxConfig::new(name)?;
+    if let Some(binary) = env::var_os("NANOCODEX_EXE_SSH") {
+        config.ssh_binary = PathBuf::from(binary);
+    }
+    let sandbox = ExeDevSandbox::new(config)?;
+    let result = run_agent(
+        &sandbox,
+        env::args()
+            .nth(1)
+            .unwrap_or_else(|| DEFAULT_PROMPT.to_owned()),
+    )
+    .await;
+    let cleanup_result = sandbox.cleanup(cleanup).await;
+
+    match cleanup_result {
+        Ok(Some(operation)) if operation.exit_code == Some(0) => {
+            eprintln!("deleted caller-owned sandbox {}", sandbox.name());
+        }
+        Ok(Some(operation)) => {
+            bail!(
+                "failed to delete sandbox {}: exit={:?}, stderr={}",
+                sandbox.name(),
+                operation.exit_code,
+                operation.stderr.trim()
+            );
+        }
+        Ok(None) if cleanup == SandboxCleanup::Retain => {
+            eprintln!(
+                "retained caller-owned sandbox {} at https://{}.exe.xyz",
+                sandbox.name(),
+                sandbox.name()
+            );
+        }
+        Ok(None) => {}
+        Err(error) => return Err(error).wrap_err("sandbox cleanup failed"),
+    }
+
+    println!("{}", result?);
+    Ok(())
+}
+
+fn sandbox_name() -> Result<String> {
+    select_sandbox_name(
+        env::var("NANOCODEX_EXE_SANDBOX").ok(),
+        env::var("CODEX_THREAD_ID").ok(),
+    )
+}
+
+fn select_sandbox_name(explicit: Option<String>, thread_id: Option<String>) -> Result<String> {
+    if let Some(explicit) = explicit {
+        return Ok(explicit);
+    }
+    let thread_id = thread_id.ok_or_else(|| {
+        eyre::eyre!("set CODEX_THREAD_ID or the explicit NANOCODEX_EXE_SANDBOX override")
+    })?;
+    let thread_id = Uuid::parse_str(&thread_id)
+        .wrap_err("CODEX_THREAD_ID must be a UUID when used for an exe.dev sandbox name")?;
+    Ok(format!("nanocodex-{}", thread_id.simple()))
+}
+
+async fn run_agent(sandbox: &ExeDevSandbox, prompt: String) -> Result<String> {
+    let auth = model_auth()?;
+    let openai = OpenAi::new(auth).wrap_err("failed to configure OpenAI")?;
+    let tools = sandbox.tools()?;
+    let (agent, events) = Nanocodex::builder(openai)
+        .instructions(
+            "You operate exactly one caller-owned remote exe.dev sandbox. Call sandbox_create before sandbox_exec. Execute all shell work through sandbox_exec; host workspace tools are unavailable. The sandbox name and deletion policy are fixed by the caller. Never claim a command succeeded unless its structured result reports exit_code 0.",
+        )
+        .thinking(Thinking::Low)
+        .tools(tools)
+        .execution_environment(ExecutionEnvironment::new(
+            Utc::now().date_naive().to_string(),
+            "Etc/UTC",
+        ))
+        .build()?;
+    drop(events);
+
+    let result = agent.prompt(prompt).await?.result().await;
+    let shutdown = agent.shutdown().await;
+    shutdown.wrap_err("failed to shut down the external Nanocodex session")?;
+    result
+        .map(|result| result.into_final_message())
+        .wrap_err("external Nanocodex turn failed")
+}
+
+fn model_auth() -> Result<OpenAiAuth> {
+    if let Ok(api_key) = env::var("OPENAI_API_KEY")
+        && !api_key.trim().is_empty()
+    {
+        return Ok(OpenAiAuth::api_key(api_key));
+    }
+    let auth_file = env::var_os("NANOCODEX_AUTH_FILE")
+        .map(PathBuf::from)
+        .or_else(|| env::var_os("CODEX_HOME").map(|root| PathBuf::from(root).join("auth.json")))
+        .or_else(|| env::var_os("HOME").map(|root| PathBuf::from(root).join(".codex/auth.json")))
+        .ok_or_else(|| eyre::eyre!("set OPENAI_API_KEY or NANOCODEX_AUTH_FILE"))?;
+    load_chatgpt_auth(&auth_file).wrap_err_with(|| {
+        format!(
+            "failed to load ChatGPT authorization from {}",
+            auth_file.display()
+        )
+    })
+}
+
+fn cleanup_policy() -> Result<SandboxCleanup> {
+    match env::var("NANOCODEX_EXE_CLEANUP")
+        .unwrap_or_else(|_| "retain".to_owned())
+        .as_str()
+    {
+        "retain" => Ok(SandboxCleanup::Retain),
+        "delete" => Ok(SandboxCleanup::Delete),
+        value => bail!("NANOCODEX_EXE_CLEANUP must be `retain` or `delete`, got `{value}`"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_name_overrides_the_host_thread() {
+        assert_eq!(
+            select_sandbox_name(
+                Some("named-by-caller".to_owned()),
+                Some("not-a-uuid".to_owned())
+            )
+            .unwrap(),
+            "named-by-caller"
+        );
+    }
+
+    #[test]
+    fn codex_thread_id_becomes_a_stable_valid_vm_name() {
+        assert_eq!(
+            select_sandbox_name(
+                None,
+                Some("019fc99b-15d2-7470-9ce5-d14ce353d2f8".to_owned())
+            )
+            .unwrap(),
+            "nanocodex-019fc99b15d274709ce5d14ce353d2f8"
+        );
+    }
+
+    #[test]
+    fn missing_or_invalid_thread_identity_fails_closed() {
+        assert!(select_sandbox_name(None, None).is_err());
+        assert!(select_sandbox_name(None, Some("process-42".to_owned())).is_err());
+    }
+}

--- a/examples/exe-dev/src/lib.rs
+++ b/examples/exe-dev/src/lib.rs
@@ -1,5 +1,7 @@
 //! A deliberately small native Nanocodex consumer for one private exe.dev VM.
 
+pub mod sandbox;
+
 use std::{
     convert::Infallible,
     env,

--- a/examples/exe-dev/src/lib.rs
+++ b/examples/exe-dev/src/lib.rs
@@ -1,0 +1,633 @@
+//! A deliberately small native Nanocodex consumer for one private exe.dev VM.
+
+use std::{
+    convert::Infallible,
+    env,
+    net::SocketAddr,
+    path::{Path, PathBuf},
+};
+
+use axum::{
+    Json, Router,
+    extract::{DefaultBodyLimit, State},
+    http::StatusCode,
+    response::{Html, IntoResponse, Response, Sse, sse::Event},
+    routing::{get, post},
+};
+use eyre::{Result, WrapErr, bail};
+use futures_util::{Stream, stream};
+use nanocodex::{
+    AgentEvents, Nanocodex, OpenAi,
+    agent::{events::AgentEvent, session::SessionSnapshot},
+    oai::transport::ResponsesTransport,
+};
+use serde::{Deserialize, Serialize};
+use tokio::{
+    io::AsyncWriteExt,
+    sync::{broadcast, mpsc, oneshot},
+    task::JoinHandle,
+};
+
+const DEFAULT_LISTEN: &str = "0.0.0.0:9998";
+const DEFAULT_INSTRUCTIONS: &str = "You are the coding agent for this project. Inspect the workspace carefully, preserve unrelated work, and verify changes before finishing.";
+const PROMPT_BODY_LIMIT: usize = 64 * 1024;
+const PROMPT_QUEUE_CAPACITY: usize = 32;
+const EVENT_CAPACITY: usize = 1_024;
+
+/// Process configuration owned by the exe.dev application consumer.
+#[derive(Clone)]
+pub struct Config {
+    /// Address exposed through exe.dev's private alternate-port proxy.
+    pub listen: SocketAddr,
+    /// Project root affected by model-callable workspace tools.
+    pub workspace: PathBuf,
+    /// Durable completed-turn snapshot.
+    pub state_file: PathBuf,
+    /// Stable model instructions used for both fresh and resumed sessions.
+    pub instructions: String,
+    api_key: String,
+    api_base: Option<String>,
+    websocket_url: Option<String>,
+    transport: ResponsesTransport,
+}
+
+impl Config {
+    /// Reads the small deployment policy from environment variables.
+    pub fn from_env() -> Result<Self> {
+        let listen = env::var("NANOCODEX_EXE_LISTEN")
+            .unwrap_or_else(|_| DEFAULT_LISTEN.to_owned())
+            .parse()
+            .wrap_err("NANOCODEX_EXE_LISTEN must be a socket address")?;
+        let workspace = match env::var_os("NANOCODEX_EXE_WORKSPACE") {
+            Some(path) => PathBuf::from(path),
+            None => env::current_dir().wrap_err("failed to resolve the current workspace")?,
+        };
+        let workspace = workspace
+            .canonicalize()
+            .wrap_err_with(|| format!("failed to resolve workspace {}", workspace.display()))?;
+        if !workspace.is_dir() {
+            bail!("workspace is not a directory: {}", workspace.display());
+        }
+        let state_file = env::var_os("NANOCODEX_EXE_STATE_FILE")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| workspace.join(".nanocodex/exe-dev/session.json"));
+        let instructions = env::var("NANOCODEX_EXE_INSTRUCTIONS")
+            .unwrap_or_else(|_| DEFAULT_INSTRUCTIONS.to_owned());
+        let api_key = env::var("OPENAI_API_KEY")
+            .wrap_err("OPENAI_API_KEY is required (the exe.dev image supplies a harmless integration placeholder)")?;
+        if api_key.is_empty() {
+            bail!("OPENAI_API_KEY must not be empty");
+        }
+
+        let transport = env::var("NANOCODEX_EXE_TRANSPORT")
+            .unwrap_or_else(|_| "websocket".to_owned())
+            .parse::<ResponsesTransport>()
+            .map_err(|error| eyre::eyre!(error))?;
+        let api_base = nonempty_env("NANOCODEX_EXE_API_BASE");
+        let websocket_url = nonempty_env("NANOCODEX_EXE_WEBSOCKET_URL");
+        validate_endpoint_policy(transport, api_base.as_deref(), websocket_url.as_deref())?;
+
+        Ok(Self {
+            listen,
+            workspace,
+            state_file,
+            instructions,
+            api_key,
+            api_base,
+            websocket_url,
+            transport,
+        })
+    }
+
+    #[cfg(test)]
+    fn for_test(workspace: PathBuf) -> Self {
+        Self {
+            listen: DEFAULT_LISTEN.parse().expect("valid test address"),
+            state_file: workspace.join("session.json"),
+            workspace,
+            instructions: DEFAULT_INSTRUCTIONS.to_owned(),
+            api_key: "test-key".to_owned(),
+            api_base: None,
+            websocket_url: None,
+            transport: ResponsesTransport::WebSocket,
+        }
+    }
+}
+
+fn nonempty_env(name: &str) -> Option<String> {
+    env::var(name).ok().filter(|value| !value.trim().is_empty())
+}
+
+fn validate_endpoint_policy(
+    transport: ResponsesTransport,
+    api_base: Option<&str>,
+    websocket_url: Option<&str>,
+) -> Result<()> {
+    if websocket_url.is_some() && api_base.is_none() {
+        bail!("NANOCODEX_EXE_WEBSOCKET_URL requires NANOCODEX_EXE_API_BASE");
+    }
+    if matches!(transport, ResponsesTransport::WebSocket)
+        && api_base.is_some()
+        && websocket_url.is_none()
+    {
+        bail!(
+            "WebSocket transport with NANOCODEX_EXE_API_BASE also requires NANOCODEX_EXE_WEBSOCKET_URL"
+        );
+    }
+    Ok(())
+}
+
+/// Builds one retained native session, resuming its last completed boundary when present.
+pub fn build_agent(config: &Config) -> Result<(Nanocodex, AgentEvents)> {
+    let mut openai = OpenAi::builder(config.api_key.clone()).transport(config.transport);
+    if let Some(api_base) = &config.api_base {
+        openai = openai.api_base_url(api_base);
+    }
+    if let Some(websocket_url) = &config.websocket_url {
+        openai = openai.websocket_url(websocket_url);
+    }
+    let openai = openai.build().wrap_err("failed to configure OpenAI")?;
+
+    let mut builder = Nanocodex::builder(openai)
+        .instructions(config.instructions.clone())
+        .workspace(&config.workspace);
+    if let Some(snapshot) = load_snapshot(&config.state_file)? {
+        builder = builder.resume(snapshot);
+    }
+    builder
+        .build()
+        .wrap_err("failed to build Nanocodex session")
+}
+
+fn load_snapshot(path: &Path) -> Result<Option<SessionSnapshot>> {
+    let bytes = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error).wrap_err_with(|| format!("failed to read {}", path.display()));
+        }
+    };
+    serde_json::from_slice(&bytes)
+        .wrap_err_with(|| format!("failed to decode {}", path.display()))
+        .map(Some)
+}
+
+/// Running application tasks and the Nanocodex shutdown capability.
+pub struct Runtime {
+    agent: Nanocodex,
+    prompt_task: JoinHandle<()>,
+    event_task: JoinHandle<()>,
+}
+
+impl Runtime {
+    /// Gracefully closes the model, tools, and event stream.
+    pub async fn shutdown(self) -> Result<()> {
+        let result = self.agent.shutdown().await;
+        self.prompt_task.abort();
+        self.event_task.abort();
+        let _ = self.prompt_task.await;
+        let _ = self.event_task.await;
+        result.wrap_err("failed to shut down Nanocodex")
+    }
+}
+
+#[derive(Clone)]
+struct AppState {
+    info: ServiceInfo,
+    prompts: mpsc::Sender<PromptCommand>,
+    events: broadcast::Sender<AgentEvent>,
+}
+
+#[derive(Clone, Serialize)]
+struct ServiceInfo {
+    status: &'static str,
+    session_id: String,
+    workspace: String,
+}
+
+struct PromptCommand {
+    prompt: String,
+    result: oneshot::Sender<std::result::Result<PromptResponse, String>>,
+}
+
+/// Successful completed-turn response.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PromptResponse {
+    /// Complete final assistant message.
+    pub final_message: String,
+}
+
+#[derive(Deserialize)]
+struct PromptRequest {
+    prompt: String,
+}
+
+/// Starts the application-owned prompt queue and event projection.
+pub fn application(agent: Nanocodex, events: AgentEvents, config: &Config) -> (Router, Runtime) {
+    let (prompt_tx, prompt_rx) = mpsc::channel(PROMPT_QUEUE_CAPACITY);
+    let (event_tx, _) = broadcast::channel(EVENT_CAPACITY);
+    let state = AppState {
+        info: ServiceInfo {
+            status: "ok",
+            session_id: agent.session_id().to_string(),
+            workspace: config.workspace.display().to_string(),
+        },
+        prompts: prompt_tx,
+        events: event_tx.clone(),
+    };
+    let prompt_task = tokio::spawn(prompt_loop(
+        agent.clone(),
+        config.state_file.clone(),
+        prompt_rx,
+    ));
+    let event_task = tokio::spawn(event_loop(events, event_tx));
+    let router = router(state);
+    (
+        router,
+        Runtime {
+            agent,
+            prompt_task,
+            event_task,
+        },
+    )
+}
+
+fn router(state: AppState) -> Router {
+    Router::new()
+        .route("/", get(index))
+        .route("/healthz", get(health))
+        .route("/api/prompt", post(prompt))
+        .route("/api/events", get(event_stream))
+        .layer(DefaultBodyLimit::max(PROMPT_BODY_LIMIT))
+        .with_state(state)
+}
+
+async fn index() -> Html<&'static str> {
+    Html(INDEX_HTML)
+}
+
+async fn health(State(state): State<AppState>) -> Json<ServiceInfo> {
+    Json(state.info)
+}
+
+async fn prompt(
+    State(state): State<AppState>,
+    Json(request): Json<PromptRequest>,
+) -> std::result::Result<Json<PromptResponse>, ApiError> {
+    if request.prompt.trim().is_empty() {
+        return Err(ApiError::new(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "prompt must not be empty",
+        ));
+    }
+    let (result, receiver) = oneshot::channel();
+    state
+        .prompts
+        .send(PromptCommand {
+            prompt: request.prompt,
+            result,
+        })
+        .await
+        .map_err(|_| ApiError::unavailable())?;
+    receiver
+        .await
+        .map_err(|_| ApiError::unavailable())?
+        .map(Json)
+        .map_err(|message| ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, message))
+}
+
+async fn event_stream(
+    State(state): State<AppState>,
+) -> Sse<impl Stream<Item = std::result::Result<Event, Infallible>>> {
+    let receiver = state.events.subscribe();
+    let stream = stream::unfold(receiver, |mut receiver| async move {
+        match receiver.recv().await {
+            Ok(event) => {
+                let data = serde_json::to_string(&event).unwrap_or_else(|error| {
+                    serde_json::json!({"error": error.to_string()}).to_string()
+                });
+                let item = Event::default()
+                    .event("agent")
+                    .id(event.seq.to_string())
+                    .data(data);
+                Some((Ok(item), receiver))
+            }
+            Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                let item = Event::default()
+                    .event("lagged")
+                    .data(format!(r#"{{"skipped":{skipped}}}"#));
+                Some((Ok(item), receiver))
+            }
+            Err(broadcast::error::RecvError::Closed) => None,
+        }
+    });
+    Sse::new(stream).keep_alive(axum::response::sse::KeepAlive::default())
+}
+
+async fn prompt_loop(
+    agent: Nanocodex,
+    state_file: PathBuf,
+    mut commands: mpsc::Receiver<PromptCommand>,
+) {
+    while let Some(command) = commands.recv().await {
+        let result = run_prompt(&agent, &state_file, command.prompt).await;
+        let result = result.map_err(|error| format!("{error:#}"));
+        let _ = command.result.send(result);
+    }
+}
+
+async fn run_prompt(
+    agent: &Nanocodex,
+    state_file: &Path,
+    prompt: String,
+) -> Result<PromptResponse> {
+    let result = agent
+        .prompt(prompt)
+        .await
+        .wrap_err("agent rejected the prompt")?
+        .result()
+        .await
+        .wrap_err("agent turn failed")?;
+    persist_snapshot(state_file, &result.snapshot()).await?;
+    Ok(PromptResponse {
+        final_message: result.into_final_message(),
+    })
+}
+
+async fn persist_snapshot(path: &Path, snapshot: &SessionSnapshot) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| eyre::eyre!("snapshot path has no parent: {}", path.display()))?;
+    tokio::fs::create_dir_all(parent)
+        .await
+        .wrap_err_with(|| format!("failed to create {}", parent.display()))?;
+    let bytes = serde_json::to_vec(snapshot).wrap_err("failed to encode session snapshot")?;
+    let temporary = path.with_extension(format!("tmp-{}", std::process::id()));
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create(true).write(true).truncate(true);
+    #[cfg(unix)]
+    {
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(&temporary)
+        .await
+        .wrap_err_with(|| format!("failed to open {}", temporary.display()))?;
+    file.write_all(&bytes)
+        .await
+        .wrap_err_with(|| format!("failed to write {}", temporary.display()))?;
+    file.sync_all()
+        .await
+        .wrap_err_with(|| format!("failed to sync {}", temporary.display()))?;
+    drop(file);
+    tokio::fs::rename(&temporary, path)
+        .await
+        .wrap_err_with(|| format!("failed to publish {}", path.display()))?;
+    Ok(())
+}
+
+async fn event_loop(mut events: AgentEvents, sender: broadcast::Sender<AgentEvent>) {
+    while let Some(event) = events.recv().await {
+        let _ = sender.send(event);
+    }
+}
+
+#[derive(Serialize)]
+struct ErrorBody<'a> {
+    error: &'a str,
+}
+
+struct ApiError {
+    status: StatusCode,
+    message: String,
+}
+
+impl ApiError {
+    fn new(status: StatusCode, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            message: message.into(),
+        }
+    }
+
+    fn unavailable() -> Self {
+        Self::new(StatusCode::SERVICE_UNAVAILABLE, "agent is unavailable")
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        (
+            self.status,
+            Json(ErrorBody {
+                error: &self.message,
+            }),
+        )
+            .into_response()
+    }
+}
+
+const INDEX_HTML: &str = r#"<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Nanocodex on exe.dev</title>
+<style>
+  :root { color-scheme: dark; font: 16px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
+  body { max-width: 900px; margin: 0 auto; padding: 32px 20px; background: #0b0d10; color: #e7e9ec; }
+  h1 { font: 600 28px/1.2 system-ui, sans-serif; }
+  textarea, button { box-sizing: border-box; border: 1px solid #353a43; border-radius: 8px; background: #15181d; color: inherit; }
+  textarea { width: 100%; min-height: 120px; padding: 12px; resize: vertical; }
+  button { margin-top: 10px; padding: 9px 14px; cursor: pointer; }
+  button:disabled { opacity: .5; cursor: wait; }
+  pre { min-height: 180px; padding: 16px; border: 1px solid #272b32; border-radius: 8px; white-space: pre-wrap; background: #101216; }
+  #status { color: #99a1ad; }
+</style>
+<h1>Nanocodex on exe.dev</h1>
+<p id="status">Connecting to the private agent…</p>
+<form id="prompt-form">
+  <textarea id="prompt" placeholder="Ask Nanocodex to inspect or change this project"></textarea>
+  <button id="submit" type="submit">Run</button>
+</form>
+<h2>Result</h2>
+<pre id="result"></pre>
+<h2>Events</h2>
+<pre id="events"></pre>
+<script>
+const status = document.querySelector('#status');
+const result = document.querySelector('#result');
+const events = document.querySelector('#events');
+const submit = document.querySelector('#submit');
+fetch('/healthz').then(r => r.json()).then(info => {
+  status.textContent = `session ${info.session_id} · ${info.workspace}`;
+}).catch(error => { status.textContent = `health check failed: ${error}`; });
+const source = new EventSource('/api/events');
+source.addEventListener('agent', message => {
+  const event = JSON.parse(message.data);
+  events.textContent += `${event.seq} ${event.type}\n`;
+  events.scrollTop = events.scrollHeight;
+});
+source.addEventListener('lagged', message => {
+  events.textContent += `event stream lagged: ${message.data}\n`;
+});
+document.querySelector('#prompt-form').addEventListener('submit', async event => {
+  event.preventDefault();
+  const prompt = document.querySelector('#prompt').value;
+  submit.disabled = true;
+  result.textContent = 'Working…';
+  try {
+    const response = await fetch('/api/prompt', {
+      method: 'POST', headers: {'content-type': 'application/json'}, body: JSON.stringify({prompt})
+    });
+    const body = await response.json();
+    if (!response.ok) throw new Error(body.error || `HTTP ${response.status}`);
+    result.textContent = body.final_message;
+  } catch (error) {
+    result.textContent = String(error);
+  } finally {
+    submit.disabled = false;
+  }
+});
+</script>
+</html>
+"#;
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use http_body_util::BodyExt;
+    use tempfile::tempdir;
+    use tower::ServiceExt;
+
+    use super::*;
+
+    fn test_state() -> (AppState, mpsc::Receiver<PromptCommand>) {
+        let (prompts, receiver) = mpsc::channel(1);
+        let (events, _) = broadcast::channel(4);
+        (
+            AppState {
+                info: ServiceInfo {
+                    status: "ok",
+                    session_id: "session-test".to_owned(),
+                    workspace: "/workspace".to_owned(),
+                },
+                prompts,
+                events,
+            },
+            receiver,
+        )
+    }
+
+    #[tokio::test]
+    async fn health_exposes_only_structural_session_information() {
+        let (state, _receiver) = test_state();
+        let response = router(state)
+            .oneshot(Request::get("/healthz").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&body).unwrap(),
+            serde_json::json!({
+                "status": "ok",
+                "session_id": "session-test",
+                "workspace": "/workspace"
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn prompt_endpoint_waits_for_the_owned_session_result() {
+        let (state, mut receiver) = test_state();
+        let responder = tokio::spawn(async move {
+            let command = receiver.recv().await.unwrap();
+            assert_eq!(command.prompt, "inspect the project");
+            command
+                .result
+                .send(Ok(PromptResponse {
+                    final_message: "done".to_owned(),
+                }))
+                .unwrap();
+        });
+        let response = router(state)
+            .oneshot(
+                Request::post("/api/prompt")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"prompt":"inspect the project"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        responder.await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&body).unwrap(),
+            serde_json::json!({"final_message": "done"})
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_prompts_do_not_enter_the_agent_queue() {
+        let (state, mut receiver) = test_state();
+        let response = router(state)
+            .oneshot(
+                Request::post("/api/prompt")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"prompt":"  "}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn test_config_keeps_state_inside_the_selected_workspace() {
+        let directory = tempdir().unwrap();
+        let config = Config::for_test(directory.path().to_path_buf());
+        assert_eq!(config.state_file, directory.path().join("session.json"));
+    }
+
+    #[test]
+    fn custom_model_endpoints_are_atomic_policy() {
+        assert!(validate_endpoint_policy(ResponsesTransport::WebSocket, None, None).is_ok());
+        assert!(
+            validate_endpoint_policy(
+                ResponsesTransport::WebSocket,
+                Some("https://llm.int.exe.xyz/v1"),
+                Some("wss://llm.int.exe.xyz/v1/responses")
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_endpoint_policy(
+                ResponsesTransport::WebSocket,
+                Some("https://example.invalid/v1"),
+                None
+            )
+            .is_err()
+        );
+        assert!(
+            validate_endpoint_policy(
+                ResponsesTransport::Https,
+                Some("https://llm.int.exe.xyz/v1"),
+                None
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_endpoint_policy(
+                ResponsesTransport::Https,
+                None,
+                Some("wss://example.invalid/v1/responses")
+            )
+            .is_err()
+        );
+    }
+}

--- a/examples/exe-dev/src/main.rs
+++ b/examples/exe-dev/src/main.rs
@@ -1,0 +1,46 @@
+use eyre::{Result, WrapErr};
+use nanocodex_exe_dev::{Config, application, build_agent};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let config = Config::from_env()?;
+    let (agent, events) = build_agent(&config)?;
+    let (app, runtime) = application(agent, events, &config);
+    let listener = tokio::net::TcpListener::bind(config.listen)
+        .await
+        .wrap_err_with(|| format!("failed to listen on {}", config.listen))?;
+    eprintln!(
+        "nanocodex exe.dev session listening on http://{} for workspace {}",
+        config.listen,
+        config.workspace.display()
+    );
+
+    let server = axum::serve(listener, app).with_graceful_shutdown(shutdown_signal());
+    let server_result = server.await;
+    let shutdown_result = runtime.shutdown().await;
+    server_result.wrap_err("exe.dev HTTP server failed")?;
+    shutdown_result
+}
+
+async fn shutdown_signal() {
+    let interrupt = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl-C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = interrupt => {},
+        () = terminate => {},
+    }
+}

--- a/examples/exe-dev/src/sandbox.rs
+++ b/examples/exe-dev/src/sandbox.rs
@@ -1,0 +1,843 @@
+//! Caller-owned exe.dev sandbox tools for an agent running outside the guest.
+
+use std::{
+    path::PathBuf,
+    process::{ExitStatus, Stdio},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::{Duration, Instant},
+};
+
+use nanocodex::{
+    Tool, Tools,
+    tools::{
+        ToolContext, ToolDefinition, ToolExposure, ToolInput, ToolOutput, ToolResult,
+        ToolsBuildError, contract::async_trait,
+    },
+};
+#[cfg(unix)]
+use nix::{
+    errno::Errno,
+    sys::signal::{Signal, killpg},
+    unistd::Pid,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWriteExt},
+    process::{Child, Command},
+    sync::{Mutex, mpsc},
+};
+
+const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(120);
+const DEFAULT_OUTPUT_LIMIT: usize = 128 * 1024;
+const MAX_SCRIPT_BYTES: usize = 32 * 1024;
+const REMOTE_COMMAND_TIMEOUT_SECONDS: u64 = 120;
+
+/// Caller-selected cleanup policy for one owned remote sandbox.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SandboxCleanup {
+    /// Leave the VM running for follow-up work.
+    Retain,
+    /// Delete the exact VM created by this sandbox handle.
+    Delete,
+}
+
+/// Configuration for one application-owned exe.dev VM.
+#[derive(Clone, Debug)]
+pub struct SandboxConfig {
+    /// Exact VM name unavailable for model selection.
+    pub name: String,
+    /// SSH executable used for both lobby and guest calls.
+    pub ssh_binary: PathBuf,
+    /// Deadline for each local SSH process.
+    pub command_timeout: Duration,
+    /// Combined retained stdout and stderr limit per call.
+    pub output_limit: usize,
+}
+
+impl SandboxConfig {
+    /// Creates conservative defaults around one exact VM name.
+    pub fn new(name: impl Into<String>) -> Result<Self, SandboxError> {
+        let name = name.into();
+        validate_vm_name(&name)?;
+        Ok(Self {
+            name,
+            ssh_binary: PathBuf::from("ssh"),
+            command_timeout: DEFAULT_COMMAND_TIMEOUT,
+            output_limit: DEFAULT_OUTPUT_LIMIT,
+        })
+    }
+}
+
+/// Invalid policy or failed exe.dev control operation.
+#[derive(Debug, thiserror::Error)]
+pub enum SandboxError {
+    /// VM names are restricted before they enter an SSH argument.
+    #[error("invalid exe.dev VM name `{0}`")]
+    InvalidName(String),
+    /// A process-backed operation could not be started or observed.
+    #[error("exe.dev SSH operation failed: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// One retained, application-owned exe.dev sandbox exposed through narrow tools.
+#[derive(Clone)]
+pub struct ExeDevSandbox {
+    inner: Arc<SandboxInner>,
+}
+
+struct SandboxInner {
+    name: String,
+    transport: Arc<dyn SandboxTransport>,
+    state: Mutex<SandboxState>,
+}
+
+#[derive(Default)]
+struct SandboxState {
+    created: bool,
+}
+
+impl ExeDevSandbox {
+    /// Builds a sandbox handle without creating its VM.
+    pub fn new(config: SandboxConfig) -> Result<Self, SandboxError> {
+        validate_vm_name(&config.name)?;
+        let transport = SshTransport {
+            binary: config.ssh_binary,
+            timeout: config.command_timeout,
+            output_limit: config.output_limit,
+            known_hosts: tempfile::NamedTempFile::new()?.into_temp_path(),
+        };
+        Ok(Self::with_transport(config.name, Arc::new(transport)))
+    }
+
+    fn with_transport(name: String, transport: Arc<dyn SandboxTransport>) -> Self {
+        Self {
+            inner: Arc::new(SandboxInner {
+                name,
+                transport,
+                state: Mutex::new(SandboxState::default()),
+            }),
+        }
+    }
+
+    /// Returns the exact caller-owned VM name.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.inner.name
+    }
+
+    /// Builds the three model-callable tools without host workspace access.
+    pub fn tools(&self) -> Result<Tools, ToolsBuildError> {
+        Tools::builder()
+            .without_defaults()
+            .exposure(ToolExposure::DirectAndCodeMode)
+            .tool(CreateSandbox(self.clone()))
+            .tool(ExecSandbox(self.clone()))
+            .tool(SandboxInfo(self.clone()))
+            .build()
+    }
+
+    /// Applies caller-owned cleanup after the agent turn has finished.
+    pub async fn cleanup(
+        &self,
+        policy: SandboxCleanup,
+    ) -> Result<Option<SandboxOperation>, SandboxError> {
+        if policy == SandboxCleanup::Retain {
+            return Ok(None);
+        }
+        let mut state = self.inner.state.lock().await;
+        if !state.created {
+            return Ok(None);
+        }
+        let output = self
+            .inner
+            .transport
+            .lobby(vec![
+                "rm".to_owned(),
+                self.inner.name.clone(),
+                "--json".to_owned(),
+            ])
+            .await?;
+        let success = output.success();
+        if success {
+            state.created = false;
+        }
+        Ok(Some(SandboxOperation::from_process(
+            self.info(state.created),
+            output,
+        )))
+    }
+
+    fn info(&self, created: bool) -> SandboxIdentity {
+        SandboxIdentity {
+            name: self.inner.name.clone(),
+            ssh_destination: format!("{}.exe.xyz", self.inner.name),
+            preview_url: format!("https://{}.exe.xyz", self.inner.name),
+            created,
+        }
+    }
+
+    async fn create(&self) -> Result<SandboxOperation, SandboxError> {
+        let mut state = self.inner.state.lock().await;
+        if state.created {
+            return Ok(SandboxOperation {
+                sandbox: self.info(true),
+                exit_code: Some(0),
+                stdout: "sandbox already created by this agent session".to_owned(),
+                stderr: String::new(),
+                timed_out: false,
+                output_limit_exceeded: false,
+                wall_time_seconds: 0.0,
+            });
+        }
+        let output = self
+            .inner
+            .transport
+            .lobby(vec![
+                "new".to_owned(),
+                format!("--name={}", self.inner.name),
+                "--tag=nanocodex-tool".to_owned(),
+                "--no-email".to_owned(),
+                "--json".to_owned(),
+            ])
+            .await?;
+        state.created = output.success();
+        Ok(SandboxOperation::from_process(
+            self.info(state.created),
+            output,
+        ))
+    }
+
+    async fn execute(&self, script: String) -> Result<SandboxOperation, SandboxError> {
+        if script.trim().is_empty() || script.len() > MAX_SCRIPT_BYTES {
+            return Err(SandboxError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("command must contain 1..={MAX_SCRIPT_BYTES} bytes"),
+            )));
+        }
+        let created = self.inner.state.lock().await.created;
+        if !created {
+            return Err(SandboxError::Io(std::io::Error::other(
+                "sandbox has not been created; call sandbox_create first",
+            )));
+        }
+        let output = self
+            .inner
+            .transport
+            .guest(&format!("{}.exe.xyz", self.inner.name), script)
+            .await?;
+        Ok(SandboxOperation::from_process(self.info(true), output))
+    }
+}
+
+/// Stable identity and private preview for the caller-owned VM.
+#[derive(Clone, Debug, Serialize)]
+pub struct SandboxIdentity {
+    /// Exact application-selected name.
+    pub name: String,
+    /// SSH destination derived from the validated name.
+    pub ssh_destination: String,
+    /// Private exe.dev HTTPS endpoint on port 8000.
+    pub preview_url: String,
+    /// Whether this handle successfully created the VM.
+    pub created: bool,
+}
+
+/// Structured result returned by create, execute, and cleanup operations.
+#[derive(Debug, Serialize)]
+pub struct SandboxOperation {
+    /// Stable sandbox identity.
+    pub sandbox: SandboxIdentity,
+    /// SSH process exit code, absent after timeout or signal termination.
+    pub exit_code: Option<i32>,
+    /// Bounded standard output.
+    pub stdout: String,
+    /// Bounded standard error.
+    pub stderr: String,
+    /// Whether the local operation reached its deadline.
+    pub timed_out: bool,
+    /// Whether combined output crossed the configured bound.
+    pub output_limit_exceeded: bool,
+    /// Local wall-clock duration.
+    pub wall_time_seconds: f64,
+}
+
+impl SandboxOperation {
+    fn from_process(sandbox: SandboxIdentity, output: ProcessOutput) -> Self {
+        Self {
+            sandbox,
+            exit_code: output.exit_code,
+            stdout: output.stdout,
+            stderr: output.stderr,
+            timed_out: output.timed_out,
+            output_limit_exceeded: output.output_limit_exceeded,
+            wall_time_seconds: output.wall_time_seconds,
+        }
+    }
+
+    fn success(&self) -> bool {
+        self.exit_code == Some(0) && !self.timed_out && !self.output_limit_exceeded
+    }
+
+    fn tool_output(&self) -> ToolOutput {
+        ToolOutput::from_json(
+            serde_json::to_value(self).unwrap_or_else(
+                |error| json!({"error": format!("failed to encode sandbox result: {error}")}),
+            ),
+            self.success(),
+        )
+        .with_process_trace(
+            self.exit_code,
+            None,
+            None,
+            self.stdout.len().saturating_add(self.stderr.len()),
+            self.wall_time_seconds,
+        )
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EmptyInput {}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExecInput {
+    command: String,
+}
+
+struct CreateSandbox(ExeDevSandbox);
+
+#[async_trait]
+impl Tool for CreateSandbox {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::function(
+            "sandbox_create",
+            "Create the one caller-named private exe.dev VM owned by this session. This is idempotent within the session and must run before sandbox_exec.",
+            empty_schema(),
+        )
+    }
+
+    async fn execute(&self, input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
+        let EmptyInput {} = input.decode_json()?;
+        Ok(self.0.create().await?.tool_output())
+    }
+}
+
+struct ExecSandbox(ExeDevSandbox);
+
+#[async_trait]
+impl Tool for ExecSandbox {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::function(
+            "sandbox_exec",
+            "Run a non-interactive bash script inside the caller-owned exe.dev VM. The command is sent over SSH stdin, never run on the Nanocodex host, and has bounded time and output.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": MAX_SCRIPT_BYTES,
+                        "description": "Complete bash script to execute in the remote VM."
+                    }
+                },
+                "required": ["command"],
+                "additionalProperties": false
+            }),
+        )
+    }
+
+    async fn execute(&self, input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
+        let ExecInput { command } = input.decode_json()?;
+        Ok(self.0.execute(command).await?.tool_output())
+    }
+}
+
+struct SandboxInfo(ExeDevSandbox);
+
+#[async_trait]
+impl Tool for SandboxInfo {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::function(
+            "sandbox_info",
+            "Return the fixed identity, private preview URL, and creation state of the caller-owned exe.dev VM without changing it.",
+            empty_schema(),
+        )
+    }
+
+    async fn execute(&self, input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
+        let EmptyInput {} = input.decode_json()?;
+        let created = self.0.inner.state.lock().await.created;
+        Ok(ToolOutput::json(&self.0.info(created)))
+    }
+}
+
+fn empty_schema() -> serde_json::Value {
+    json!({
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+    })
+}
+
+fn validate_vm_name(name: &str) -> Result<(), SandboxError> {
+    let valid = (3..=63).contains(&name.len())
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        && name
+            .as_bytes()
+            .first()
+            .is_some_and(u8::is_ascii_alphanumeric)
+        && name
+            .as_bytes()
+            .last()
+            .is_some_and(u8::is_ascii_alphanumeric);
+    if valid {
+        Ok(())
+    } else {
+        Err(SandboxError::InvalidName(name.to_owned()))
+    }
+}
+
+#[async_trait]
+trait SandboxTransport: Send + Sync {
+    async fn lobby(&self, arguments: Vec<String>) -> std::io::Result<ProcessOutput>;
+    async fn guest(&self, destination: &str, script: String) -> std::io::Result<ProcessOutput>;
+}
+
+struct SshTransport {
+    binary: PathBuf,
+    timeout: Duration,
+    output_limit: usize,
+    known_hosts: tempfile::TempPath,
+}
+
+#[async_trait]
+impl SandboxTransport for SshTransport {
+    async fn lobby(&self, arguments: Vec<String>) -> std::io::Result<ProcessOutput> {
+        self.run("exe.dev", arguments, None, false).await
+    }
+
+    async fn guest(&self, destination: &str, script: String) -> std::io::Result<ProcessOutput> {
+        self.run(
+            destination,
+            vec![
+                "timeout".to_owned(),
+                "--signal=TERM".to_owned(),
+                "--kill-after=5s".to_owned(),
+                format!("{REMOTE_COMMAND_TIMEOUT_SECONDS}s"),
+                "bash".to_owned(),
+                "-se".to_owned(),
+            ],
+            Some(script.into_bytes()),
+            true,
+        )
+        .await
+    }
+}
+
+impl SshTransport {
+    async fn run(
+        &self,
+        destination: &str,
+        arguments: Vec<String>,
+        input: Option<Vec<u8>>,
+        accept_new_host: bool,
+    ) -> std::io::Result<ProcessOutput> {
+        let mut command = Command::new(&self.binary);
+        command
+            .arg("-o")
+            .arg("BatchMode=yes")
+            .arg("-o")
+            .arg("ConnectTimeout=10")
+            .arg("-o")
+            .arg("ConnectionAttempts=6");
+        if accept_new_host {
+            command
+                .arg("-o")
+                .arg("StrictHostKeyChecking=accept-new")
+                .arg("-o")
+                .arg(format!("UserKnownHostsFile={}", self.known_hosts.display()));
+        }
+        command
+            .arg(destination)
+            .args(arguments)
+            .stdin(if input.is_some() {
+                Stdio::piped()
+            } else {
+                Stdio::null()
+            })
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        #[cfg(unix)]
+        command.process_group(0);
+        bounded_output(command, input, self.timeout, self.output_limit).await
+    }
+}
+
+struct ProcessOutput {
+    exit_code: Option<i32>,
+    stdout: String,
+    stderr: String,
+    timed_out: bool,
+    output_limit_exceeded: bool,
+    wall_time_seconds: f64,
+}
+
+impl ProcessOutput {
+    fn success(&self) -> bool {
+        self.exit_code == Some(0) && !self.timed_out && !self.output_limit_exceeded
+    }
+}
+
+async fn bounded_output(
+    mut command: Command,
+    input: Option<Vec<u8>>,
+    timeout: Duration,
+    output_limit: usize,
+) -> std::io::Result<ProcessOutput> {
+    let started = Instant::now();
+    let mut child = command.spawn()?;
+    let process_group = process_group_value(&child);
+    #[cfg(unix)]
+    let mut process_group_guard = ProcessGroupGuard(process_group);
+
+    if let Some(input) = input {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| std::io::Error::other("SSH stdin was not piped"))?;
+        stdin.write_all(&input).await?;
+        stdin.shutdown().await?;
+    }
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| std::io::Error::other("SSH stdout was not piped"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| std::io::Error::other("SSH stderr was not piped"))?;
+    let retained = Arc::new(AtomicUsize::new(0));
+    let (limit_sender, mut limit_receiver) = mpsc::channel(1);
+    let mut stdout_task = tokio::spawn(read_bounded(
+        stdout,
+        Arc::clone(&retained),
+        output_limit,
+        limit_sender.clone(),
+    ));
+    let mut stderr_task = tokio::spawn(read_bounded(
+        stderr,
+        Arc::clone(&retained),
+        output_limit,
+        limit_sender,
+    ));
+    let deadline = tokio::time::sleep(timeout);
+    tokio::pin!(deadline);
+
+    let outcome = tokio::select! {
+        status = child.wait() => WaitOutcome::Exited(status?),
+        () = &mut deadline => WaitOutcome::TimedOut,
+        Some(()) = limit_receiver.recv() => WaitOutcome::OutputLimitExceeded,
+    };
+    if !matches!(outcome, WaitOutcome::Exited(_)) {
+        kill_child(&mut child, process_group)?;
+        child.wait().await?;
+    }
+    let (stdout, stderr) = tokio::time::timeout(Duration::from_secs(1), async {
+        let stdout = (&mut stdout_task).await.map_err(std::io::Error::other)??;
+        let stderr = (&mut stderr_task).await.map_err(std::io::Error::other)??;
+        Ok::<_, std::io::Error>((stdout, stderr))
+    })
+    .await
+    .map_err(|_| std::io::Error::other("SSH descendants kept output pipes open"))??;
+    #[cfg(unix)]
+    process_group_guard.disarm();
+
+    let output_limit_exceeded = matches!(outcome, WaitOutcome::OutputLimitExceeded)
+        || retained.load(Ordering::Relaxed) > output_limit;
+    Ok(ProcessOutput {
+        exit_code: match outcome {
+            WaitOutcome::Exited(status) => status.code(),
+            WaitOutcome::TimedOut | WaitOutcome::OutputLimitExceeded => None,
+        },
+        stdout: String::from_utf8_lossy(&stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&stderr).into_owned(),
+        timed_out: matches!(outcome, WaitOutcome::TimedOut),
+        output_limit_exceeded,
+        wall_time_seconds: started.elapsed().as_secs_f64(),
+    })
+}
+
+enum WaitOutcome {
+    Exited(ExitStatus),
+    TimedOut,
+    OutputLimitExceeded,
+}
+
+async fn read_bounded(
+    mut reader: impl AsyncRead + Unpin,
+    retained: Arc<AtomicUsize>,
+    limit: usize,
+    limit_sender: mpsc::Sender<()>,
+) -> std::io::Result<Vec<u8>> {
+    let mut output = Vec::new();
+    let mut buffer = [0_u8; 8 * 1024];
+    let mut reported = false;
+    loop {
+        let read = reader.read(&mut buffer).await?;
+        if read == 0 {
+            return Ok(output);
+        }
+        let previous = retained.fetch_add(read, Ordering::Relaxed);
+        let available = limit.saturating_sub(previous);
+        output.extend_from_slice(&buffer[..read.min(available)]);
+        if previous.saturating_add(read) > limit && !reported {
+            reported = true;
+            let _ = limit_sender.try_send(());
+        }
+    }
+}
+
+#[cfg(unix)]
+fn process_group_value(child: &Child) -> Option<Pid> {
+    child
+        .id()
+        .and_then(|id| i32::try_from(id).ok())
+        .map(Pid::from_raw)
+}
+
+#[cfg(not(unix))]
+fn process_group_value(_child: &Child) -> Option<()> {
+    None
+}
+
+#[cfg(unix)]
+fn kill_child(child: &mut Child, process_group: Option<Pid>) -> std::io::Result<()> {
+    let child_kill = child.start_kill();
+    if let Some(process_group) = process_group {
+        match killpg(process_group, Signal::SIGKILL) {
+            Ok(()) | Err(Errno::ESRCH) => Ok(()),
+            Err(Errno::EPERM) => child_kill.or(Ok(())),
+            Err(error) => Err(std::io::Error::other(error)),
+        }
+    } else {
+        child_kill
+    }
+}
+
+#[cfg(not(unix))]
+fn kill_child(child: &mut Child, _process_group: Option<()>) -> std::io::Result<()> {
+    child.start_kill()
+}
+
+#[cfg(unix)]
+struct ProcessGroupGuard(Option<Pid>);
+
+#[cfg(unix)]
+impl ProcessGroupGuard {
+    const fn disarm(&mut self) {
+        self.0 = None;
+    }
+}
+
+#[cfg(unix)]
+impl Drop for ProcessGroupGuard {
+    fn drop(&mut self) {
+        if let Some(process_group) = self.0 {
+            let _ = killpg(process_group, Signal::SIGKILL);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::VecDeque, sync::Mutex as StdMutex};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeTransport {
+        calls: StdMutex<Vec<String>>,
+        outputs: StdMutex<VecDeque<ProcessOutput>>,
+    }
+
+    impl FakeTransport {
+        fn successful() -> ProcessOutput {
+            ProcessOutput {
+                exit_code: Some(0),
+                stdout: "ok".to_owned(),
+                stderr: String::new(),
+                timed_out: false,
+                output_limit_exceeded: false,
+                wall_time_seconds: 0.01,
+            }
+        }
+
+        fn push(&self, output: ProcessOutput) {
+            self.outputs.lock().unwrap().push_back(output);
+        }
+    }
+
+    #[async_trait]
+    impl SandboxTransport for FakeTransport {
+        async fn lobby(&self, arguments: Vec<String>) -> std::io::Result<ProcessOutput> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("lobby {}", arguments.join(" ")));
+            self.outputs
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or_else(|| std::io::Error::other("missing fake output"))
+        }
+
+        async fn guest(&self, destination: &str, script: String) -> std::io::Result<ProcessOutput> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(format!("guest {destination} {script}"));
+            self.outputs
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or_else(|| std::io::Error::other("missing fake output"))
+        }
+    }
+
+    fn sandbox(transport: Arc<FakeTransport>) -> ExeDevSandbox {
+        ExeDevSandbox::with_transport("nanocodex-test".to_owned(), transport)
+    }
+
+    #[test]
+    fn names_are_validated_before_entering_ssh_arguments() {
+        assert!(SandboxConfig::new("nanocodex-test").is_ok());
+        assert!(SandboxConfig::new("UPPER").is_err());
+        assert!(SandboxConfig::new("-leading").is_err());
+        assert!(SandboxConfig::new("two words").is_err());
+    }
+
+    #[tokio::test]
+    async fn create_is_idempotent_and_targets_one_owned_name() {
+        let transport = Arc::new(FakeTransport::default());
+        transport.push(FakeTransport::successful());
+        let sandbox = sandbox(transport.clone());
+
+        let first = sandbox.create().await.unwrap();
+        let second = sandbox.create().await.unwrap();
+
+        assert!(first.success());
+        assert!(second.success());
+        assert_eq!(
+            transport.calls.lock().unwrap().as_slice(),
+            ["lobby new --name=nanocodex-test --tag=nanocodex-tool --no-email --json"]
+        );
+    }
+
+    #[tokio::test]
+    async fn command_never_runs_before_successful_creation() {
+        let transport = Arc::new(FakeTransport::default());
+        let sandbox = sandbox(transport.clone());
+
+        let error = sandbox.execute("uname -a".to_owned()).await.unwrap_err();
+
+        assert!(error.to_string().contains("has not been created"));
+        assert!(transport.calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn command_is_sent_only_to_the_owned_guest() {
+        let transport = Arc::new(FakeTransport::default());
+        transport.push(FakeTransport::successful());
+        transport.push(FakeTransport::successful());
+        let sandbox = sandbox(transport.clone());
+        sandbox.create().await.unwrap();
+
+        let output = sandbox.execute("printf proof".to_owned()).await.unwrap();
+
+        assert!(output.success());
+        assert_eq!(
+            transport.calls.lock().unwrap().last().unwrap(),
+            "guest nanocodex-test.exe.xyz printf proof"
+        );
+    }
+
+    #[tokio::test]
+    async fn deletion_is_caller_owned_and_exact() {
+        let transport = Arc::new(FakeTransport::default());
+        transport.push(FakeTransport::successful());
+        transport.push(FakeTransport::successful());
+        let sandbox = sandbox(transport.clone());
+        sandbox.create().await.unwrap();
+
+        assert!(
+            sandbox
+                .cleanup(SandboxCleanup::Retain)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        let deleted = sandbox
+            .cleanup(SandboxCleanup::Delete)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(deleted.success());
+        assert_eq!(
+            transport.calls.lock().unwrap().last().unwrap(),
+            "lobby rm nanocodex-test --json"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn process_output_is_bounded_while_produced() {
+        let mut command = Command::new("/bin/sh");
+        command
+            .arg("-c")
+            .arg("while :; do printf 1234567890; done")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        command.process_group(0);
+
+        let output = bounded_output(command, None, Duration::from_secs(5), 32)
+            .await
+            .unwrap();
+
+        assert!(output.output_limit_exceeded);
+        assert!(!output.timed_out);
+        assert!(output.stdout.len().saturating_add(output.stderr.len()) <= 32);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn process_deadline_terminates_the_local_ssh_group() {
+        let mut command = Command::new("/bin/sh");
+        command
+            .arg("-c")
+            .arg("sleep 30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        command.process_group(0);
+
+        let output = bounded_output(command, None, Duration::from_millis(50), 1024)
+            .await
+            .unwrap();
+
+        assert!(output.timed_out);
+        assert_eq!(output.exit_code, None);
+        assert!(output.wall_time_seconds < 2.0);
+    }
+}


### PR DESCRIPTION
## Summary

This draft now proves both exe.dev ownership topologies:

1. **Agent inside the sandbox:** one native Nanocodex session runs beside a persistent project workspace in an exe.dev VM.
2. **Sandbox as a tool:** Nanocodex and its ChatGPT credential remain on the host while one exact exe.dev VM is exposed through caller-defined `sandbox_create`, `sandbox_exec`, and `sandbox_info` tools.

The change also:

- projects typed agent events over SSE and atomically persists completed-turn snapshots with mode 0600
- includes a small private web consumer, Docker image, and boot-persistent systemd units
- bounds external SSH command time and output while terminating the local process group on timeout
- keeps VM deletion outside model authority as explicit caller policy
- derives the default external VM name from `CODEX_THREAD_ID`, with `NANOCODEX_EXE_SANDBOX` as an explicit override
- re-exports `ExecutionEnvironment` through the facade's canonical `agent` module so remote tools do not inherit host context accidentally

## Experiment log

### Retained agent inside exe.dev

Deployed to the private `nanocodex-spike` VM through the ChatGPT-backed `nanocodex-subscription` integration.

- a subscription-backed text turn completed
- a retained follow-up called workspace tools, created and verified `/home/exedev/workspace/index.html`, and committed its snapshot
- the snapshot was mode `0600`
- the private agent and preview services survived systemd restart and are enabled across VM reboots
- an explicit `linux/amd64` release image ran successfully

The exe.dev integration rejected the Responses WebSocket upgrade with HTTP 400, so this topology uses Nanocodex's typed HTTPS/SSE transport.

### exe.dev as an external sandbox tool

The external binary loaded the existing Codex-compatible ChatGPT `auth.json`; model credentials never entered the guest.

- the first run created `nanocodex-tool-spike`, observed SSH exit 255 from first-use host-key verification, refused to claim the remote work succeeded, and caller cleanup deleted the VM
- guest SSH now uses an isolated ephemeral `known_hosts` file with `StrictHostKeyChecking=accept-new`; the exe.dev lobby continues using the user's normal trust store
- the next run created `nanocodex-tool-spike2`, executed inside Linux 6.12.93 x86_64, wrote and verified the exact proof file, and deleted the exact VM
- the final rebased run omitted `NANOCODEX_EXE_SANDBOX`; `CODEX_THREAD_ID=019fc99b-15d2-7470-9ce5-d14ce353d2f8` deterministically selected `nanocodex-019fc99b15d274709ce5d14ce353d2f8`
- `sandbox_exec` returned exit code 0 with `external-sandbox-ok` and `Linux 6.12.93 x86_64`; caller cleanup then deleted that exact VM
- no external experiment VM remains

This was rebased after the hosted-platform sandbox examples landed and uses their model-facing `sandbox_*` naming while keeping exe.dev lifecycle and credential policy in the application.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --locked -p nanocodex-exe-dev`
- `cargo clippy -p nanocodex-exe-dev --all-targets -- -D warnings`
- `cargo test -p nanocodex-exe-dev` (15 tests across the library and external binary)
- `cargo doc -p nanocodex --no-deps`
- `scripts/check-crate-boundaries.sh`
- release Docker build for `linux/amd64`
- live health, model, tool, snapshot, external sandbox, cleanup, and private-preview smoke tests

## Ongoing work

This remains a draft PR and the running record for the exe.dev experiments.

- [x] prove a retained Nanocodex session inside an exe.dev VM
- [x] prototype Nanocodex outside the sandbox with exe.dev as caller-defined tools
- [x] bind the default external VM identity to `CODEX_THREAD_ID`
- [x] verify explicit caller-owned deletion after both failed and successful model turns
- [ ] investigate whether the exe.dev Responses WebSocket path can be supported
- [ ] decide which deployment and external-tool pieces should remain together for merge
