### PR TITLE
feat(model): support GPT-5.6 Terra and routed model IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,17 @@ history, WebSocket, tools, shell sessions, and prompt-cache identity.
 `agent.clone()` is a cheap handle to that same session; the independently
 returned `AgentEvents` stream is the session-wide event firehose.
 
-Nanocodex supports `gpt-5.6-sol` (the default) and `gpt-5.6-luna`. Select the
-model with `.model(Model::Luna)` when creating an agent. The model is fixed for
-that thread: switching later would invalidate the provider checkpoint and
-require an inefficient replay of the complete retained context.
+Nanocodex supports `gpt-5.6-sol` (the default), `gpt-5.6-terra`, and
+`gpt-5.6-luna`. Select a model with `.model(Model::Terra)` or
+`.model(Model::Luna)` when creating an agent. The model is fixed for that
+thread: switching later would invalidate the provider checkpoint and require
+an inefficient replay of the complete retained context.
+
+API-key HTTPS OpenAI routing gateways that namespace model identifiers can set
+`NANOCODEX_MODEL_ID_PREFIX`. For example, a prefix of `openai` sends
+`openai/gpt-5.6-sol` on the wire while preserving Sol's typed behavior,
+pricing, compaction, and snapshot identity inside Nanocodex. This does not add
+an alternate provider or arbitrary-model surface.
 
 ## Voice: devices or Unix pipes
 

--- a/REFACTOR.md
+++ b/REFACTOR.md
@@ -173,9 +173,9 @@ let (agent, events) = Nanocodex::builder(openai)
     .build()?;
 ```
 
-There is one supported model family with a deliberate public Sol/Luna selector.
-`NanocodexBuilder` is a cloneable recipe. Every `build()` creates fresh driver,
-context, transport, tools, and event resources.
+There is one supported model family with a deliberate public Sol/Terra/Luna
+selector. `NanocodexBuilder` is a cloneable recipe. Every `build()` creates
+fresh driver, context, transport, tools, and event resources.
 
 ### Turns
 
@@ -216,11 +216,11 @@ Dropping the event receiver has no lifecycle effect.
 `TurnUsage` aggregates all Responses calls in the logical agent turn.
 It exposes the exact input, cache-read, cache-write, output, and reasoning
 token counts plus a typed estimated USD cost. Nanocodex supports
-`gpt-5.6-sol` and `gpt-5.6-luna`; each model's published standard and priority
-rates are built in and selected from the turn's model and `fast_mode` policy. There is no pricing
-builder, file, environment variable, catalog, or caller-defined rate surface.
-`CostStatus::UsageNotReported` keeps omitted provider accounting distinct from
-a genuine zero-token result.
+`gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`; each model's published
+standard and priority rates are built in and selected from the turn's model and
+`fast_mode` policy. There is no pricing builder, file, environment variable,
+catalog, or caller-defined rate surface. `CostStatus::UsageNotReported` keeps
+omitted provider accounting distinct from a genuine zero-token result.
 
 - `agent.clone()` targets the same driver, session, and command queue.
 - `AgentHandle::spawn()` creates a clean sibling from the same recipe.
@@ -624,8 +624,8 @@ network, VM cold-start, and full eval measurements remain scheduled or release
 gates with retained artifacts.
 
 USD cost is derived from the same authoritative per-call usage retained by the
-trace. The fixed Sol and Luna standard and priority rates come directly from
-OpenAI's API pricing documentation. Agent terminal results, the CLI, and
+trace. The fixed Sol, Terra, and Luna standard and priority rates come directly
+from OpenAI's API pricing documentation. Agent terminal results, the CLI, and
 `nanocodex eval` all project the same aggregate instead of recomputing it
 independently.
 

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -111,9 +111,16 @@ pub(crate) struct AgentArgs {
     #[command(flatten)]
     model_policy: ModelArgs,
 
-    /// GPT-5.6 coding model: gpt-5.6-sol or gpt-5.6-luna.
+    /// GPT-5.6 coding model: gpt-5.6-sol, gpt-5.6-terra, or gpt-5.6-luna.
     #[arg(long, env = "OPENAI_MODEL", default_value_t)]
     model: Model,
+
+    /// Optional namespace prepended to the model identifier on the wire.
+    ///
+    /// OpenAI routing gateways may use `openai`, producing identifiers such as
+    /// `openai/gpt-5.6-sol` without changing Nanocodex's closed model policy.
+    #[arg(long, env = "NANOCODEX_MODEL_ID_PREFIX")]
+    model_id_prefix: Option<String>,
 
     /// Reasoning execution mode: standard or pro.
     #[arg(long, env = "OPENAI_REASONING_MODE", default_value_t)]
@@ -267,6 +274,9 @@ impl AgentArgs {
         let mut openai = OpenAi::builder(auth)
             .transport(responses_transport)
             .websocket_url(direct_websocket_url);
+        if let Some(prefix) = self.model_id_prefix.as_deref() {
+            openai = openai.model_id_prefix(prefix);
+        }
         if mpp_enabled {
             openai = openai.max_attempts(NonZeroU32::MIN);
         }

--- a/crates/nanocodex-oai-api/README.md
+++ b/crates/nanocodex-oai-api/README.md
@@ -36,16 +36,23 @@ if let Some(cost) = completed.estimated_cost() {
 # }
 ```
 
-This crate supports `gpt-5.6-sol` (the default) and `gpt-5.6-luna`. Select a
-client default with `OpenAi::builder(auth).model(Model::Luna)`. A session keeps
-that model for its lifetime, and each replayable attempt retains it across
-retries. Changing models would invalidate the provider checkpoint and require
-an inefficient replay of the complete retained context.
+This crate supports `gpt-5.6-sol` (the default), `gpt-5.6-terra`, and
+`gpt-5.6-luna`. Select a client default with
+`OpenAi::builder(auth).model(Model::Terra)`. A session keeps that model for its
+lifetime, and each replayable attempt retains it across retries. Changing
+models would invalidate the provider checkpoint and require an inefficient
+replay of the complete retained context.
+
+API-key HTTPS OpenAI routing gateways may qualify those same closed model
+identifiers with `OpenAi::builder(auth).model_id_prefix("openai")`. The prefix
+changes only the wire model ID; model-specific reasoning, compaction, pricing,
+and snapshots continue to use the typed [`Model`] value. It does not add an
+alternate provider or arbitrary-model surface.
 
 USD estimates require no pricing configuration. Each model applies its
 published standard rates, or its priority rates when
-[`OpenAiBuilder::fast_mode`] is enabled. Luna usage receives the same complete
-estimate and status treatment as Sol. Provider-omitted usage remains
+[`OpenAiBuilder::fast_mode`] is enabled. Terra and Luna usage receive the same
+complete estimate and status treatment as Sol. Provider-omitted usage remains
 distinguishable as `usage_not_reported`.
 
 ## ChatGPT subscription login

--- a/crates/nanocodex-oai-api/src/lib.rs
+++ b/crates/nanocodex-oai-api/src/lib.rs
@@ -153,6 +153,8 @@ pub enum Model {
     /// GPT-5.6 Sol.
     #[default]
     Sol,
+    /// GPT-5.6 Terra.
+    Terra,
     /// GPT-5.6 Luna.
     Luna,
 }
@@ -163,6 +165,7 @@ impl Model {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Sol => "gpt-5.6-sol",
+            Self::Terra => "gpt-5.6-terra",
             Self::Luna => "gpt-5.6-luna",
         }
     }
@@ -180,15 +183,16 @@ impl FromStr for Model {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
             "gpt-5.6-sol" | "sol" => Ok(Self::Sol),
+            "gpt-5.6-terra" | "terra" => Ok(Self::Terra),
             "gpt-5.6-luna" | "luna" => Ok(Self::Luna),
             _ => Err(format!(
-                "invalid model {value:?}; expected gpt-5.6-sol or gpt-5.6-luna"
+                "invalid model {value:?}; expected gpt-5.6-sol, gpt-5.6-terra, or gpt-5.6-luna"
             )),
         }
     }
 }
 
-/// Context-window size used by both supported Responses Lite model contracts.
+/// Prompt-token budget used by automatic compaction to avoid long-context pricing.
 pub const CONTEXT_WINDOW_TOKENS: u64 = 272_000;
 
 /// User input for one agent turn.
@@ -510,6 +514,8 @@ mod tests {
     fn model_parses_short_and_api_names() {
         assert_eq!("sol".parse(), Ok(Model::Sol));
         assert_eq!("gpt-5.6-sol".parse(), Ok(Model::Sol));
+        assert_eq!("terra".parse(), Ok(Model::Terra));
+        assert_eq!("gpt-5.6-terra".parse(), Ok(Model::Terra));
         assert_eq!("luna".parse(), Ok(Model::Luna));
         assert_eq!("gpt-5.6-luna".parse(), Ok(Model::Luna));
         assert_eq!(Model::default().as_str(), "gpt-5.6-sol");

--- a/crates/nanocodex-oai-api/src/openai/config.rs
+++ b/crates/nanocodex-oai-api/src/openai/config.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use crate::{Model, OpenAiAuth, ReasoningMode, ResponsesHistory, ResponsesTransport, Thinking};
 
@@ -15,6 +15,11 @@ const SYSTEM_PROMPT: &str = include_str!("../../prompts/system.md");
 pub struct ModelConfig {
     /// Selected GPT-5.6 coding model.
     pub model: Model,
+    /// Optional namespace prepended to the model identifier on the wire.
+    ///
+    /// This preserves Nanocodex's closed typed model policy while allowing an
+    /// OpenAI routing gateway to require IDs such as `openai/gpt-5.6-sol`.
+    pub model_id_prefix: Option<Arc<str>>,
     /// Authentication source resolved for each transport connection.
     pub auth: OpenAiAuth,
     /// Reasoning execution mode.
@@ -41,6 +46,13 @@ pub struct ModelConfig {
 }
 
 impl ModelConfig {
+    pub(crate) fn wire_model_id(&self, model: Model) -> Cow<'static, str> {
+        match self.model_id_prefix.as_deref() {
+            Some(prefix) => Cow::Owned(format!("{prefix}/{}", model.as_str())),
+            None => Cow::Borrowed(model.as_str()),
+        }
+    }
+
     /// Returns the fixed orchestration mode sent to the supported model.
     #[must_use]
     pub const fn orchestration() -> &'static str {
@@ -64,6 +76,7 @@ impl Default for ModelConfig {
     fn default() -> Self {
         Self {
             model: Model::default(),
+            model_id_prefix: None,
             auth: OpenAiAuth::api_key(String::new()),
             reasoning_mode: ReasoningMode::default(),
             thinking: Thinking::default(),

--- a/crates/nanocodex-oai-api/src/openai/mod.rs
+++ b/crates/nanocodex-oai-api/src/openai/mod.rs
@@ -128,6 +128,21 @@ impl<F> OpenAiBuilder<F> {
         self
     }
 
+    /// Prepends a namespace to supported model identifiers on the wire.
+    ///
+    /// For example, an OpenAI routing gateway may expose Sol as
+    /// `openai/gpt-5.6-sol` while Nanocodex continues to retain `Model::Sol`
+    /// for model-specific behavior, pricing, compaction, and snapshots. This
+    /// changes only the wire identifier for the closed [`Model`] enum; it is
+    /// not an alternate provider or arbitrary-model surface. [`Self::build`]
+    /// rejects malformed prefixes and use outside API-key HTTPS transport.
+    #[must_use]
+    pub fn model_id_prefix(mut self, prefix: impl Into<String>) -> Self {
+        let prefix = prefix.into();
+        self.config.model_id_prefix = Some(Arc::from(prefix.trim()));
+        self
+    }
+
     /// Selects the initial Responses transport policy for new sessions.
     ///
     /// [`ResponsesTransport::WebSocket`] prefers a persistent socket. The
@@ -509,6 +524,30 @@ fn validate(config: &ModelConfig) -> Result<(), OpenAiError> {
             detail: "the OpenAI API base URL must not be empty",
         });
     }
+    if let Some(prefix) = config.model_id_prefix.as_deref() {
+        if prefix.is_empty()
+            || prefix.starts_with('/')
+            || prefix.ends_with('/')
+            || prefix.split('/').any(str::is_empty)
+            || prefix
+                .chars()
+                .any(|character| character.is_whitespace() || character.is_control())
+        {
+            return Err(OpenAiError::InvalidConfiguration {
+                detail: "the model ID prefix must contain non-empty path segments without whitespace",
+            });
+        }
+        if config.auth.mode() != OpenAiAuthMode::ApiKey {
+            return Err(OpenAiError::InvalidConfiguration {
+                detail: "model ID prefixes require API-key authentication",
+            });
+        }
+        if !matches!(config.responses_transport, ResponsesTransport::Https) {
+            return Err(OpenAiError::InvalidConfiguration {
+                detail: "model ID prefixes require the HTTPS Responses transport",
+            });
+        }
+    }
     if config.auth.mode() == OpenAiAuthMode::ChatGpt && config.store_responses {
         return Err(OpenAiError::InvalidConfiguration {
             detail: "ChatGPT subscription authentication does not support store: true",
@@ -602,6 +641,42 @@ mod tests {
             client.config.responses_history,
             ResponsesHistory::Incremental
         );
+    }
+
+    #[test]
+    fn model_id_prefix_is_normalized_and_scoped_to_api_key_https() {
+        let client = OpenAi::builder("test-key")
+            .transport(ResponsesTransport::Https)
+            .model_id_prefix(" openai ")
+            .build()
+            .unwrap();
+
+        assert_eq!(client.config.model_id_prefix.as_deref(), Some("openai"));
+
+        let websocket_error = OpenAi::builder("test-key")
+            .model_id_prefix("openai")
+            .build()
+            .err()
+            .expect("WebSocket prefix should be rejected");
+        assert!(
+            websocket_error
+                .to_string()
+                .contains("require the HTTPS Responses transport")
+        );
+
+        for prefix in [" ", "/openai", "openai/", "openai//routing", "open ai"] {
+            let malformed_error = OpenAi::builder("test-key")
+                .transport(ResponsesTransport::Https)
+                .model_id_prefix(prefix)
+                .build()
+                .err()
+                .expect("malformed prefix should be rejected");
+            assert!(
+                malformed_error
+                    .to_string()
+                    .contains("non-empty path segments")
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/nanocodex-oai-api/src/pricing/estimate.rs
+++ b/crates/nanocodex-oai-api/src/pricing/estimate.rs
@@ -17,6 +17,18 @@ const SOL_PRIORITY: TokenRates = TokenRates {
     cache_write_input: 12_500,
     output: 60_000,
 };
+const TERRA_STANDARD: TokenRates = TokenRates {
+    input: 2_000,
+    cached_input: 200,
+    cache_write_input: 2_500,
+    output: 12_000,
+};
+const TERRA_PRIORITY: TokenRates = TokenRates {
+    input: 4_000,
+    cached_input: 400,
+    cache_write_input: 5_000,
+    output: 24_000,
+};
 const LUNA_STANDARD: TokenRates = TokenRates {
     input: 200,
     cached_input: 20,
@@ -43,6 +55,8 @@ impl TokenRates {
         match (model, service_tier) {
             (Model::Sol, ServiceTier::Standard) => SOL_STANDARD,
             (Model::Sol, ServiceTier::Priority) => SOL_PRIORITY,
+            (Model::Terra, ServiceTier::Standard) => TERRA_STANDARD,
+            (Model::Terra, ServiceTier::Priority) => TERRA_PRIORITY,
             (Model::Luna, ServiceTier::Standard) => LUNA_STANDARD,
             (Model::Luna, ServiceTier::Priority) => LUNA_PRIORITY,
         }
@@ -164,7 +178,7 @@ pub fn estimate(usage: &Usage, service_tier: ServiceTier) -> EstimatedUsdCost {
 /// Estimates one provider operation using the selected model's built-in rates.
 ///
 /// This is the model-aware form of [`estimate`]. Managed sessions use it so
-/// both supported GPT-5.6 models receive an estimate from reported usage.
+/// every supported GPT-5.6 model receives an estimate from reported usage.
 #[must_use]
 pub fn estimate_for_model(
     usage: &Usage,
@@ -302,6 +316,29 @@ mod tests {
         assert_eq!(standard.output().decimal(), "1.2");
         assert_eq!(standard.amount().decimal(), "1.369");
         assert_eq!(priority.amount().decimal(), "2.738");
+    }
+
+    #[test]
+    fn terra_rates_cover_standard_and_priority_usage() {
+        let usage = Usage {
+            input_tokens: 1_000_000,
+            input_tokens_details: Some(InputTokenDetails {
+                cached_tokens: 200_000,
+                cache_write_tokens: 100_000,
+            }),
+            output_tokens: 1_000_000,
+            ..Usage::default()
+        };
+
+        let standard = estimate_for_model(&usage, Model::Terra, ServiceTier::Standard);
+        let priority = estimate_for_model(&usage, Model::Terra, ServiceTier::Priority);
+
+        assert_eq!(standard.input().decimal(), "1.4");
+        assert_eq!(standard.cached_input().decimal(), "0.04");
+        assert_eq!(standard.cache_write_input().decimal(), "0.25");
+        assert_eq!(standard.output().decimal(), "12");
+        assert_eq!(standard.amount().decimal(), "13.69");
+        assert_eq!(priority.amount().decimal(), "27.38");
     }
 
     #[test]

--- a/crates/nanocodex-oai-api/src/pricing/mod.rs
+++ b/crates/nanocodex-oai-api/src/pricing/mod.rs
@@ -1,11 +1,12 @@
 //! Built-in USD estimates for supported GPT-5.6 models.
 //!
-//! Sol and Luna responses are priced automatically from provider-reported
+//! Sol, Terra, and Luna responses are priced automatically from provider-reported
 //! token usage and the selected standard or priority service tier.
 //!
 //! Standard rates and the cache-write multiplier are sourced from the OpenAI
-//! model pages for [Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol)
-//! and [Luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna).
+//! model pages for [Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol),
+//! [Terra](https://developers.openai.com/api/docs/models/gpt-5.6-terra), and
+//! [Luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna).
 //! Fast mode rates are sourced from the
 //! [Fast mode page](https://openai.com/api-fast-mode/). OpenAI continues to
 //! return `priority` as the service-tier name for these models.
@@ -14,6 +15,8 @@
 //! | --- | --- | ---: | ---: | ---: | ---: |
 //! | Sol | Standard | $5.00 | $0.50 | $6.25 | $30.00 |
 //! | Sol | Fast (`priority`) | $10.00 | $1.00 | $12.50 | $60.00 |
+//! | Terra | Standard | $2.00 | $0.20 | $2.50 | $12.00 |
+//! | Terra | Fast (`priority`) | $4.00 | $0.40 | $5.00 | $24.00 |
 //! | Luna | Standard | $0.20 | $0.02 | $0.25 | $1.20 |
 //! | Luna | Fast (`priority`) | $0.40 | $0.04 | $0.50 | $2.40 |
 //!

--- a/crates/nanocodex-oai-api/src/responses/request.rs
+++ b/crates/nanocodex-oai-api/src/responses/request.rs
@@ -1,6 +1,6 @@
 //! Byte-stable request profiles, persistent history, and wire serialization.
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{borrow::Cow, collections::BTreeMap, sync::Arc};
 
 use serde::{Serialize, Serializer, ser::SerializeSeq};
 
@@ -516,7 +516,7 @@ impl Serialize for RequestResponseItem<'_> {
 pub(crate) struct ResponseCreate<'a> {
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     kind: Option<&'static str>,
-    model: &'a str,
+    model: Cow<'static, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     previous_response_id: Option<&'a str>,
     input: RequestInput<'a>,
@@ -593,7 +593,7 @@ impl<'a> ResponseCreate<'a> {
         let websocket = matches!(policy.transport, crate::ResponsesTransport::WebSocket);
         Self {
             kind: websocket.then_some("response.create"),
-            model: policy.model.as_str(),
+            model: config.wire_model_id(policy.model),
             previous_response_id,
             input: RequestInput { input },
             tool_choice: "auto",
@@ -868,12 +868,38 @@ mod tests {
     }
 
     #[test]
-    fn luna_serializes_as_the_selected_model() {
-        let config = ModelConfig::default();
-        let profile = RequestProfile::new("luna-agent", "luna-lineage", Arc::from([]));
+    fn supported_models_serialize_as_selected() {
+        for (model, expected) in [
+            (Model::Sol, "gpt-5.6-sol"),
+            (Model::Terra, "gpt-5.6-terra"),
+            (Model::Luna, "gpt-5.6-luna"),
+        ] {
+            let config = ModelConfig::default();
+            let profile = RequestProfile::new("model-agent", "model-lineage", Arc::from([]));
+            let request = serde_json::to_value(ResponseCreate::warmup(
+                &config,
+                model,
+                Thinking::Medium,
+                false,
+                &profile,
+                None,
+            ))
+            .expect("request should serialize");
+
+            assert_eq!(request["model"], json!(expected));
+        }
+    }
+
+    #[test]
+    fn model_namespace_qualifies_only_the_wire_identifier() {
+        let config = ModelConfig {
+            model_id_prefix: Some(Arc::from("openai")),
+            ..ModelConfig::default()
+        };
+        let profile = RequestProfile::new("gateway-agent", "gateway-lineage", Arc::from([]));
         let request = serde_json::to_value(ResponseCreate::warmup(
             &config,
-            Model::Luna,
+            Model::Terra,
             Thinking::Medium,
             false,
             &profile,
@@ -881,7 +907,7 @@ mod tests {
         ))
         .expect("request should serialize");
 
-        assert_eq!(request["model"], json!("gpt-5.6-luna"));
+        assert_eq!(request["model"], json!("openai/gpt-5.6-terra"));
     }
 
     #[test]

--- a/crates/nanocodex-oai-api/src/session/compaction.rs
+++ b/crates/nanocodex-oai-api/src/session/compaction.rs
@@ -65,7 +65,8 @@ static ORIGINAL_IMAGE_ESTIMATE_CACHE: LazyLock<Mutex<OriginalImageEstimateCache>
 
 #[must_use]
 pub fn auto_compact_token_limit(model: &str) -> Option<u64> {
-    matches!(model, "gpt-5.6-sol" | "gpt-5.6-luna").then_some((CONTEXT_WINDOW_TOKENS * 9) / 10)
+    matches!(model, "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna")
+        .then_some((CONTEXT_WINDOW_TOKENS * 9) / 10)
 }
 
 #[must_use]
@@ -472,8 +473,9 @@ mod tests {
     }
 
     #[test]
-    fn supported_models_compact_at_ninety_percent_of_their_context_window() {
+    fn supported_models_compact_at_ninety_percent_of_the_policy_budget() {
         assert_eq!(auto_compact_token_limit("gpt-5.6-sol"), Some(244_800));
+        assert_eq!(auto_compact_token_limit("gpt-5.6-terra"), Some(244_800));
         assert_eq!(auto_compact_token_limit("gpt-5.6-luna"), Some(244_800));
         assert_eq!(auto_compact_token_limit("unknown-model"), None);
     }

--- a/crates/nanocodex/README.md
+++ b/crates/nanocodex/README.md
@@ -40,17 +40,17 @@ not wait for the turn's optional event stream to be consumed. Follow-on prompts
 reuse the same retained context and transport without asking the caller to
 manage response IDs or history.
 
-`gpt-5.6-sol` is the default; `.model(Model::Luna)` selects
-`gpt-5.6-luna` when creating the agent. The selected model remains fixed for
-the thread so follow-on turns can continue from the provider checkpoint without
-replaying the complete retained context.
+`gpt-5.6-sol` is the default; `.model(Model::Terra)` and `.model(Model::Luna)`
+select the other supported models when creating the agent. The selected model
+remains fixed for the thread so follow-on turns can continue from the provider
+checkpoint without replaying the complete retained context.
 
 ## Usage and USD estimates
 
 Every completed turn reports aggregate provider usage. Cost remains explicit:
 Nanocodex automatically applies the selected model's published standard or
-priority rates. Luna uses its documented Luna rates rather than Sol's higher
-rates.
+priority rates. Terra and Luna use their documented rates rather than Sol's
+higher rates.
 
 ```rust,no_run
 use nanocodex::{Nanocodex, OpenAi};

--- a/docs/CODEX_PARITY.md
+++ b/docs/CODEX_PARITY.md
@@ -379,10 +379,11 @@ WebSocket, while the host owns device-attestation generation.
 
 ### Responses Lite parallel-tool scheduling
 
-For `gpt-5.6-sol` and `gpt-5.6-luna`, Nanocodex matches Codex's Responses Lite
-request contract by sending `parallel_tool_calls: false`. The client still
-accepts multi-call responses and schedules them through Codex's read/write admission gate:
-explicitly safe calls may overlap, while an unsafe call excludes every sibling.
+For `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`, Nanocodex matches
+Codex's Responses Lite request contract by sending `parallel_tool_calls: false`.
+The client still accepts multi-call responses and schedules them through
+Codex's read/write admission gate: explicitly safe calls may overlap, while an
+unsafe call excludes every sibling.
 
 The safe built-ins match Codex: `exec_command`, `write_stdin`, `view_image`,
 provider-native `tool_search`, and web search. MCP tools opt in through

--- a/docs/RESPONSES_TOWER.md
+++ b/docs/RESPONSES_TOWER.md
@@ -5,10 +5,13 @@ Status: implemented.
 ## Ownership and public composition
 
 `OpenAi::new(auth)` creates the standard client recipe with `gpt-5.6-sol`.
-`OpenAi::builder(auth)` exposes the closed Sol/Luna model choice plus transport,
-storage, history, reasoning, and Tower policy. `Nanocodex::builder(openai)`
-then adds agent instructions, tools, workspace, session identity, and lifecycle
-policy while keeping driver mechanics private.
+`OpenAi::builder(auth)` exposes the closed Sol/Terra/Luna model choice plus
+transport, storage, history, reasoning, wire namespace, and Tower policy. The
+optional wire namespace applies only to API-key HTTPS OpenAI routing gateways;
+it changes no provider or model semantics and never expands the typed model
+family. `Nanocodex::builder(openai)` then adds agent instructions, tools,
+workspace, session identity, and lifecycle policy while keeping driver
+mechanics private.
 
 `build()` requires an active Tokio runtime, spawns one stateful driver, and
 returns `(Nanocodex, AgentEvents)`. The driver owns mutable conversation,
@@ -20,7 +23,7 @@ history, code-mode runtime, shell sessions, and prompt-cache identity across
 follow-on turns. A WebSocket policy also reuses its connection. The caller does
 not replay earlier results.
 
-The selected Sol or Luna model is fixed when the thread is created. Upstream
+The selected Sol, Terra, or Luna model is fixed when the thread is created. Upstream
 Codex permits model changes on later turns at commit
 [`acd540f1`](https://github.com/openai/codex/commit/acd540f1581bf30f963fccbcce43ac494102242c):
 

--- a/harbor_adapter/agent.py
+++ b/harbor_adapter/agent.py
@@ -30,7 +30,7 @@ from harbor.utils.trajectory_utils import format_trajectory_json
 
 PROTOCOL_VERSION = 1
 DEFAULT_MODEL = "gpt-5.6-sol"
-SUPPORTED_MODELS = {DEFAULT_MODEL, "gpt-5.6-luna"}
+SUPPORTED_MODELS = {DEFAULT_MODEL, "gpt-5.6-terra", "gpt-5.6-luna"}
 TERMINAL_EVENTS = {"run.completed", "run.failed"}
 RUN_METRIC_FIELDS = (
     "connection_attempts",

--- a/harbor_adapter/test_agent.py
+++ b/harbor_adapter/test_agent.py
@@ -294,16 +294,16 @@ class CliToolInstallContractTests(unittest.TestCase):
 
 
 class ModelContractTests(unittest.TestCase):
-    def test_supported_models_are_exactly_sol_and_luna(self) -> None:
+    def test_supported_models_are_exactly_the_gpt_5_6_family(self) -> None:
         self.assertEqual(
             SUPPORTED_MODELS,
-            {"gpt-5.6-sol", "gpt-5.6-luna"},
+            {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"},
         )
         self.assertEqual(DEFAULT_MODEL, "gpt-5.6-sol")
         self.assertEqual(NanocodexAgent._api_model_name(None), DEFAULT_MODEL)
         self.assertEqual(
-            NanocodexAgent._api_model_name("openai/gpt-5.6-luna"),
-            "gpt-5.6-luna",
+            NanocodexAgent._api_model_name("openai/gpt-5.6-terra"),
+            "gpt-5.6-terra",
         )
 
     def test_run_arguments_forward_the_selected_model(self) -> None:
@@ -336,12 +336,15 @@ class ModelContractTests(unittest.TestCase):
         fast_mode = arguments.index("--fast-mode")
         self.assertEqual(arguments[fast_mode : fast_mode + 2], ["--fast-mode", "false"])
 
-    def test_constructor_rejects_models_outside_the_supported_pair(self) -> None:
+    def test_constructor_rejects_models_outside_the_supported_family(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            with self.assertRaisesRegex(ValueError, "supports only gpt-5.6-luna, gpt-5.6-sol"):
+            with self.assertRaisesRegex(
+                ValueError,
+                "supports only gpt-5.6-luna, gpt-5.6-sol, gpt-5.6-terra",
+            ):
                 NanocodexAgent(
                     logs_dir=Path(directory),
-                    model_name="openai/gpt-5.6-terra",
+                    model_name="openai/gpt-5.5",
                     extra_env={"OPENAI_API_KEY": "test-key"},
                 )
 

--- a/js/bindings/test/types.test-d.mts
+++ b/js/bindings/test/types.test-d.mts
@@ -13,7 +13,7 @@ declare const apiKey: string;
 async function check() {
   const agent = await Agent.create({
     apiKey,
-    model: "gpt-5.6-luna",
+    model: "gpt-5.6-terra",
     thinking: "high",
     fastMode: false,
     workspace: "/workspace",

--- a/js/bindings/types.d.mts
+++ b/js/bindings/types.d.mts
@@ -1,6 +1,6 @@
 export type Thinking = "none" | "low" | "medium" | "high" | "xhigh" | "max";
 export type ReasoningMode = "standard" | "pro";
-export type Model = "gpt-5.6-sol" | "gpt-5.6-luna";
+export type Model = "gpt-5.6-sol" | "gpt-5.6-terra" | "gpt-5.6-luna";
 
 export type PromptItem =
   | { type: "text"; text: string }

--- a/py/bindings/tests/test_binding.py
+++ b/py/bindings/tests/test_binding.py
@@ -23,7 +23,7 @@ class BindingTests(unittest.TestCase):
         secret = "private-test-value"
         agent, events = Nanocodex(
             secret,
-            model="gpt-5.6-luna",
+            model="gpt-5.6-terra",
             thinking="none",
             reasoning_mode="pro",
         )


### PR DESCRIPTION
## Motivation

Nanocodex deliberately supports a small, typed GPT-5.6 model family rather than an arbitrary provider/model catalog. That policy currently leaves two practical gaps:

1. GPT-5.6 Terra is the middle cost/performance tier between Sol and Luna, but callers cannot select it consistently across the Rust API, CLI, language bindings, and Harbor adapter.
2. Some API-key HTTPS routing gateways serve those same OpenAI models under qualified wire identifiers such as `openai/gpt-5.6-terra`. Nanocodex already permits a custom API base URL, but its fixed wire model identifiers prevent those gateways from being used even though the underlying model and its semantics are unchanged.

The goal of this PR is to close both gaps without turning Nanocodex into a generic multi-provider abstraction. Model selection remains the closed `Model::{Sol, Terra, Luna}` enum, and each thread still retains one fixed typed model.

## What changed

- Add `Model::Terra` and expose `gpt-5.6-terra` through the Rust API, CLI, Python and JavaScript bindings, and Harbor adapter.
- Add Terra's published Standard and Fast pricing, including cache-write pricing, to the existing built-in estimator.
- Keep the 272K constant as Nanocodex's automatic-compaction budget so ordinary requests remain below OpenAI's long-context pricing threshold; it is not presented as the models' actual context-window size.
- Add an optional `model_id_prefix` builder setting and `NANOCODEX_MODEL_ID_PREFIX` CLI environment variable. With a custom API base and prefix `openai`, `Model::Terra` serializes as `openai/gpt-5.6-terra` on the wire.
- Restrict namespaced IDs to API-key HTTPS transport. The prefix changes only request serialization; pricing, compaction, snapshots, persistence, reasoning policy, and session identity continue to use the typed model.
- Update the owning architecture, parity, and API documentation. The root changelog remains generated from conventional commits.

Existing configurations are unchanged: without a prefix, Nanocodex sends the ordinary OpenAI model identifier exactly as before.

Pricing sources:

- https://developers.openai.com/api/docs/models/gpt-5.6-terra
- https://openai.com/api-fast-mode/

## Validation

- `cargo +1.97 clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTFLAGS='-C rpath' cargo +1.97 test --workspace --all-features --locked`
- `RUSTDOCFLAGS='-D warnings' cargo +1.97 doc --workspace --all-features --no-deps --locked`
- `RUSTUP_TOOLCHAIN=1.97 ./scripts/check-rustls-provider.sh`
- `./scripts/check-crate-boundaries.sh`
- `./scripts/check-experimental-boundary.sh`
- Harbor model-contract tests
- JavaScript binding typecheck
- Focused pricing and tracing regression tests after the final pricing-source verification
