### PR TITLE
feat(cli): add interactive resume session picker

### DIFF
--- a/bin/nanocodex/src/main.rs
+++ b/bin/nanocodex/src/main.rs
@@ -38,7 +38,7 @@ mod vm;
 use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand, builder::NonEmptyStringValueParser};
-use eyre::{Result, WrapErr};
+use eyre::{Result, WrapErr, eyre};
 use nanocodex::agent::rollout::RolloutConfig;
 
 use config::AgentArgs;
@@ -107,9 +107,9 @@ struct RunCommand {
 
 #[derive(Args)]
 struct ResumeCommand {
-    /// Codex thread UUID to resume.
+    /// Codex thread UUID to resume. Omit it to select from discovered sessions.
     #[arg(value_parser = NonEmptyStringValueParser::new())]
-    thread_id: String,
+    thread_id: Option<String>,
 
     #[command(flatten)]
     agent: AgentArgs,
@@ -154,9 +154,31 @@ async fn run(cli: Cli) -> Result<()> {
         }
         Some(Command::Resume(command)) => {
             let codex_home = config::default_codex_home()?;
-            let session = RolloutConfig::new(&codex_home)
-                .load_session(&command.thread_id)
-                .wrap_err_with(|| format!("failed to load Codex thread {}", command.thread_id))?;
+            let rollouts = RolloutConfig::new(&codex_home);
+            let thread_id = match command.thread_id {
+                Some(thread_id) => thread_id,
+                None => {
+                    let sessions = rollouts.list_sessions().wrap_err_with(|| {
+                        format!(
+                            "failed to discover Codex threads under {}",
+                            codex_home.display()
+                        )
+                    })?;
+                    if sessions.is_empty() {
+                        return Err(eyre!(
+                            "no resumable Codex threads found under {}",
+                            codex_home.display()
+                        ));
+                    }
+                    let Some(thread_id) = tui::select_resume_session(&sessions)? else {
+                        return Ok(());
+                    };
+                    thread_id
+                }
+            };
+            let session = rollouts
+                .load_session(&thread_id)
+                .wrap_err_with(|| format!("failed to load Codex thread {thread_id}"))?;
             let workspace = PathBuf::from(session.workspace());
             let _observability = command.observability.install(true, &workspace)?;
             tui::run(command.agent, command.vm, command.prompt, Some(session)).await
@@ -362,8 +384,22 @@ mod tests {
         let Some(Command::Resume(command)) = cli.command else {
             panic!("resume command was not parsed");
         };
-        assert_eq!(command.thread_id, "019c0d31-c308-7d91-bff4-5dca82d15ac6");
+        assert_eq!(
+            command.thread_id.as_deref(),
+            Some("019c0d31-c308-7d91-bff4-5dca82d15ac6")
+        );
         assert_eq!(command.prompt.as_deref(), Some("continue"));
         assert!(!command.agent.uses_tempo());
+    }
+
+    #[test]
+    fn resume_without_a_thread_id_opens_discovery_path() {
+        let cli = Cli::try_parse_from(["nanocodex", "resume", "--provider.openai"])
+            .expect("resume should accept an omitted thread UUID");
+
+        let Some(Command::Resume(command)) = cli.command else {
+            panic!("resume command was not parsed");
+        };
+        assert!(command.thread_id.is_none());
     }
 }

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -5,6 +5,7 @@ mod diff;
 mod external_editor;
 mod markdown;
 mod notification;
+mod resume_picker;
 mod scheduler;
 mod selection;
 mod telemetry;
@@ -53,6 +54,8 @@ use self::{
     transcript::TranscriptItem,
 };
 use crate::config::AgentArgs;
+
+pub(crate) use resume_picker::select_resume_session;
 
 const BTW_BOUNDARY: &str = r"You are answering an ephemeral BTW side question.
 Treat inherited conversation history only as reference context. Do not resume or complete an

--- a/bin/nanocodex/src/tui/resume_picker.rs
+++ b/bin/nanocodex/src/tui/resume_picker.rs
@@ -1,0 +1,256 @@
+use std::{io, time::SystemTime};
+
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use nanocodex::agent::rollout::RolloutSessionInfo;
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, Paragraph},
+};
+
+use super::terminal::TerminalSession;
+
+pub(crate) fn select_resume_session(sessions: &[RolloutSessionInfo]) -> io::Result<Option<String>> {
+    let mut terminal = TerminalSession::enter()?;
+    let mut picker = ResumePicker::new(sessions.len());
+    loop {
+        terminal.draw(|frame| render(frame, sessions, &mut picker, SystemTime::now()))?;
+        let Event::Key(key) = event::read()? else {
+            continue;
+        };
+        if !matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+            continue;
+        }
+        match picker.handle_key(key) {
+            PickerAction::Continue => {}
+            PickerAction::Select => {
+                return Ok(sessions
+                    .get(picker.selected)
+                    .map(|session| session.thread_id().to_owned()));
+            }
+            PickerAction::Cancel => return Ok(None),
+        }
+    }
+}
+
+struct ResumePicker {
+    selected: usize,
+    session_count: usize,
+    page_size: usize,
+}
+
+impl ResumePicker {
+    const fn new(session_count: usize) -> Self {
+        Self {
+            selected: 0,
+            session_count,
+            page_size: 1,
+        }
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) -> PickerAction {
+        if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
+            return PickerAction::Cancel;
+        }
+        match key.code {
+            KeyCode::Up | KeyCode::Char('k') => self.move_by(-1),
+            KeyCode::Down | KeyCode::Char('j') => self.move_by(1),
+            KeyCode::PageUp => self.move_by(-saturating_isize(self.page_size)),
+            KeyCode::PageDown => self.move_by(saturating_isize(self.page_size)),
+            KeyCode::Home => self.selected = 0,
+            KeyCode::End => self.selected = self.session_count.saturating_sub(1),
+            KeyCode::Enter => return PickerAction::Select,
+            KeyCode::Esc | KeyCode::Char('q') => return PickerAction::Cancel,
+            _ => {}
+        }
+        PickerAction::Continue
+    }
+
+    fn move_by(&mut self, delta: isize) {
+        self.selected = self
+            .selected
+            .saturating_add_signed(delta)
+            .min(self.session_count.saturating_sub(1));
+    }
+
+    fn visible_range(&mut self, page_size: usize) -> std::ops::Range<usize> {
+        self.page_size = page_size.max(1);
+        let max_start = self.session_count.saturating_sub(self.page_size);
+        let start = self
+            .selected
+            .saturating_sub(self.page_size.saturating_sub(1))
+            .min(max_start);
+        start..(start + self.page_size).min(self.session_count)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PickerAction {
+    Continue,
+    Select,
+    Cancel,
+}
+
+fn render(
+    frame: &mut Frame<'_>,
+    sessions: &[RolloutSessionInfo],
+    picker: &mut ResumePicker,
+    now: SystemTime,
+) {
+    let area = frame.area();
+    let block = Block::default()
+        .title(" Resume a thread ")
+        .borders(Borders::ALL);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    let [summary, list, footer] = Layout::vertical([
+        Constraint::Length(2),
+        Constraint::Min(1),
+        Constraint::Length(1),
+    ])
+    .areas(inner);
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::styled(
+                format!("  {} resumable threads", sessions.len()),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Line::styled(
+                "  Newest activity first",
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]),
+        summary,
+    );
+
+    let page_size = usize::from(list.height / 2).max(1);
+    let visible = picker.visible_range(page_size);
+    let items = visible
+        .map(|index| session_item(&sessions[index], index == picker.selected, now))
+        .collect::<Vec<_>>();
+    frame.render_widget(List::new(items), list);
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("  ↑/↓", Style::default().fg(Color::Cyan)),
+            Span::raw(" select · "),
+            Span::styled("enter", Style::default().fg(Color::Cyan)),
+            Span::raw(" resume · "),
+            Span::styled("esc", Style::default().fg(Color::Cyan)),
+            Span::raw(" cancel"),
+        ])),
+        footer,
+    );
+}
+
+fn session_item(
+    session: &RolloutSessionInfo,
+    selected: bool,
+    now: SystemTime,
+) -> ListItem<'static> {
+    let marker = if selected { "›" } else { " " };
+    let style = if selected {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default()
+    };
+    let workspace = session.workspace().unwrap_or("(workspace unavailable)");
+    let location = if session.is_archived() {
+        "archived"
+    } else {
+        "active"
+    };
+    let preview = session.preview().unwrap_or("(prompt unavailable)");
+    ListItem::new(vec![
+        Line::styled(
+            format!(
+                "{marker} {} · {preview}",
+                format_age(session.modified_at(), now)
+            ),
+            style,
+        ),
+        Line::styled(
+            format!("  {workspace} · {location} · {}", session.thread_id()),
+            if selected {
+                style
+            } else {
+                Style::default().fg(Color::DarkGray)
+            },
+        ),
+    ])
+}
+
+fn format_age(modified_at: SystemTime, now: SystemTime) -> String {
+    let Ok(elapsed) = now.duration_since(modified_at) else {
+        return "now".to_owned();
+    };
+    match elapsed.as_secs() {
+        0..60 => "now".to_owned(),
+        seconds @ 60..3_600 => format!("{}m ago", seconds / 60),
+        seconds @ 3_600..86_400 => format!("{}h ago", seconds / 3_600),
+        seconds => format!("{}d ago", seconds / 86_400),
+    }
+}
+
+fn saturating_isize(value: usize) -> isize {
+    isize::try_from(value).unwrap_or(isize::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crossterm::event::KeyEvent;
+
+    use super::*;
+
+    #[test]
+    fn picker_navigation_is_bounded_and_pages_by_the_visible_count() {
+        let mut picker = ResumePicker::new(10);
+        assert_eq!(picker.visible_range(3), 0..3);
+
+        assert_eq!(
+            picker.handle_key(KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE)),
+            PickerAction::Continue
+        );
+        assert_eq!(picker.selected, 3);
+        assert_eq!(picker.visible_range(3), 1..4);
+
+        picker.handle_key(KeyEvent::new(KeyCode::End, KeyModifiers::NONE));
+        assert_eq!(picker.selected, 9);
+        assert_eq!(picker.visible_range(3), 7..10);
+
+        picker.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(picker.selected, 9);
+        picker.handle_key(KeyEvent::new(KeyCode::Home, KeyModifiers::NONE));
+        picker.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        assert_eq!(picker.selected, 0);
+    }
+
+    #[test]
+    fn picker_confirms_and_cancels_with_standard_keys() {
+        let mut picker = ResumePicker::new(1);
+        assert_eq!(
+            picker.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+            PickerAction::Select
+        );
+        assert_eq!(
+            picker.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+            PickerAction::Cancel
+        );
+        assert_eq!(
+            picker.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+            PickerAction::Cancel
+        );
+    }
+
+    #[test]
+    fn age_labels_are_stable_at_display_boundaries() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(100_000);
+        assert_eq!(format_age(now - Duration::from_secs(59), now), "now");
+        assert_eq!(format_age(now - Duration::from_secs(60), now), "1m ago");
+        assert_eq!(format_age(now - Duration::from_secs(3_600), now), "1h ago");
+        assert_eq!(format_age(now - Duration::from_secs(86_400), now), "1d ago");
+    }
+}

--- a/bin/nanocodex/src/tui/resume_picker.rs
+++ b/bin/nanocodex/src/tui/resume_picker.rs
@@ -1,4 +1,4 @@
-use std::{io, time::SystemTime};
+use std::{borrow::Cow, io, time::SystemTime};
 
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use nanocodex::agent::rollout::RolloutSessionInfo;
@@ -155,13 +155,14 @@ fn session_item(
     } else {
         Style::default()
     };
-    let workspace = session.workspace().unwrap_or("(workspace unavailable)");
+    let workspace =
+        sanitized_terminal_text(session.workspace().unwrap_or("(workspace unavailable)"));
     let location = if session.is_archived() {
         "archived"
     } else {
         "active"
     };
-    let preview = session.preview().unwrap_or("(prompt unavailable)");
+    let preview = sanitized_terminal_text(session.preview().unwrap_or("(prompt unavailable)"));
     ListItem::new(vec![
         Line::styled(
             format!(
@@ -179,6 +180,19 @@ fn session_item(
             },
         ),
     ])
+}
+
+fn sanitized_terminal_text(value: &str) -> Cow<'_, str> {
+    if value.chars().any(char::is_control) {
+        Cow::Owned(
+            value
+                .chars()
+                .filter(|character| !character.is_control())
+                .collect(),
+        )
+    } else {
+        Cow::Borrowed(value)
+    }
 }
 
 fn format_age(modified_at: SystemTime, now: SystemTime) -> String {
@@ -252,5 +266,17 @@ mod tests {
         assert_eq!(format_age(now - Duration::from_secs(60), now), "1m ago");
         assert_eq!(format_age(now - Duration::from_secs(3_600), now), "1h ago");
         assert_eq!(format_age(now - Duration::from_secs(86_400), now), "1d ago");
+    }
+
+    #[test]
+    fn terminal_text_strips_control_sequences_without_allocating_normal_text() {
+        assert!(matches!(
+            sanitized_terminal_text("normal text"),
+            Cow::Borrowed("normal text")
+        ));
+        assert_eq!(
+            sanitized_terminal_text("/tmp/\u{1b}]52;c;payload\u{7}\nworkspace"),
+            "/tmp/]52;c;payloadworkspace"
+        );
     }
 }

--- a/crates/nanocodex-agent/src/rollout/load.rs
+++ b/crates/nanocodex-agent/src/rollout/load.rs
@@ -285,6 +285,9 @@ pub(super) fn prompt_preview(prompt: &str) -> Option<String> {
             pending_space = !preview.is_empty();
             continue;
         }
+        if character.is_control() {
+            continue;
+        }
         if pending_space && chars < MAX_CHARS {
             preview.push(' ');
             chars += 1;

--- a/crates/nanocodex-agent/src/rollout/load.rs
+++ b/crates/nanocodex-agent/src/rollout/load.rs
@@ -1,4 +1,47 @@
 use super::*;
+use std::{collections::HashMap, time::SystemTime};
+
+/// Lightweight metadata for one resumable Codex-compatible rollout.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RolloutSessionInfo {
+    thread_id: String,
+    workspace: Option<String>,
+    preview: Option<String>,
+    modified_at: SystemTime,
+    archived: bool,
+}
+
+impl RolloutSessionInfo {
+    /// Returns the stable thread UUID accepted by [`RolloutConfig::load_session`].
+    #[must_use]
+    pub fn thread_id(&self) -> &str {
+        &self.thread_id
+    }
+
+    /// Returns the workspace recorded in the rollout metadata, when available.
+    #[must_use]
+    pub fn workspace(&self) -> Option<&str> {
+        self.workspace.as_deref()
+    }
+
+    /// Returns a bounded single-line preview of the first user prompt.
+    #[must_use]
+    pub fn preview(&self) -> Option<&str> {
+        self.preview.as_deref()
+    }
+
+    /// Returns the rollout file's last modification time.
+    #[must_use]
+    pub const fn modified_at(&self) -> SystemTime {
+        self.modified_at
+    }
+
+    /// Returns whether the rollout was found below `archived_sessions`.
+    #[must_use]
+    pub const fn is_archived(&self) -> bool {
+        self.archived
+    }
+}
 
 /// A completed model boundary materialized from a Codex-compatible rollout.
 ///
@@ -114,6 +157,164 @@ pub enum RolloutTranscriptItem {
         /// Serialized tool arguments sent by the model.
         arguments: String,
     },
+}
+
+pub(super) fn list_sessions(codex_home: &Path) -> io::Result<Vec<RolloutSessionInfo>> {
+    let mut sessions = HashMap::<String, RolloutSessionInfo>::new();
+    for (root, archived) in [
+        (codex_home.join("sessions"), false),
+        (codex_home.join("archived_sessions"), true),
+    ] {
+        let mut directories = vec![root];
+        while let Some(directory) = directories.pop() {
+            let entries = match std::fs::read_dir(&directory) {
+                Ok(entries) => entries,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error),
+            };
+            for entry in entries {
+                let entry = entry?;
+                let file_type = entry.file_type()?;
+                if file_type.is_dir() {
+                    directories.push(entry.path());
+                    continue;
+                }
+                if !file_type.is_file() {
+                    continue;
+                }
+                let Some(thread_id) = rollout_thread_id(&entry.file_name()) else {
+                    continue;
+                };
+                let Some(candidate) = rollout_session_info(&entry.path(), thread_id, archived)
+                else {
+                    continue;
+                };
+                match sessions.entry(candidate.thread_id.clone()) {
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        entry.insert(candidate);
+                    }
+                    std::collections::hash_map::Entry::Occupied(mut entry)
+                        if prefer_session(&candidate, entry.get()) =>
+                    {
+                        entry.insert(candidate);
+                    }
+                    std::collections::hash_map::Entry::Occupied(_) => {}
+                }
+            }
+        }
+    }
+    let mut sessions = sessions.into_values().collect::<Vec<_>>();
+    sort_sessions(&mut sessions);
+    Ok(sessions)
+}
+
+fn rollout_thread_id(file_name: &std::ffi::OsStr) -> Option<String> {
+    let stem = file_name.to_str()?.strip_suffix(".jsonl")?;
+    let start = stem.len().checked_sub(36)?;
+    let suffix = stem.get(start..)?;
+    (start > 0 && stem.as_bytes().get(start - 1) == Some(&b'-'))
+        .then(|| uuid::Uuid::parse_str(suffix).ok())
+        .flatten()
+        .map(|id| id.to_string())
+}
+
+fn rollout_session_info(
+    path: &Path,
+    thread_id: String,
+    archived: bool,
+) -> Option<RolloutSessionInfo> {
+    let expected_id = uuid::Uuid::parse_str(&thread_id).ok()?;
+    let modified_at = path.metadata().ok()?.modified().ok()?;
+    let mut workspace = None;
+    let mut preview = None;
+    for line in BufReader::new(File::open(path).ok()?).lines() {
+        let Ok(line) = line else {
+            return None;
+        };
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        match value.get("type").and_then(serde_json::Value::as_str) {
+            Some("session_meta") if workspace.is_none() => {
+                let payload = value.get("payload")?;
+                validate_legacy_history_mode(payload).ok()?;
+                let stored_id = payload
+                    .get("id")
+                    .and_then(serde_json::Value::as_str)
+                    .and_then(|id| uuid::Uuid::parse_str(id).ok())?;
+                if stored_id != expected_id {
+                    return None;
+                }
+                workspace = payload
+                    .get("cwd")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned);
+            }
+            Some("event_msg") if preview.is_none() => {
+                let payload = value.get("payload")?;
+                if payload.get("type").and_then(serde_json::Value::as_str) == Some("user_message") {
+                    preview = payload
+                        .get("message")
+                        .and_then(serde_json::Value::as_str)
+                        .and_then(prompt_preview);
+                }
+            }
+            Some("response_item" | "compacted") if workspace.is_some() => {
+                return Some(RolloutSessionInfo {
+                    thread_id,
+                    workspace,
+                    preview,
+                    modified_at,
+                    archived,
+                });
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+pub(super) fn prompt_preview(prompt: &str) -> Option<String> {
+    const MAX_CHARS: usize = 160;
+
+    let mut preview = String::new();
+    let mut chars = 0;
+    let mut pending_space = false;
+    for character in prompt.chars() {
+        if character.is_whitespace() {
+            pending_space = !preview.is_empty();
+            continue;
+        }
+        if pending_space && chars < MAX_CHARS {
+            preview.push(' ');
+            chars += 1;
+        }
+        pending_space = false;
+        if chars == MAX_CHARS {
+            break;
+        }
+        preview.push(character);
+        chars += 1;
+    }
+    (!preview.is_empty()).then_some(preview)
+}
+
+fn prefer_session(candidate: &RolloutSessionInfo, current: &RolloutSessionInfo) -> bool {
+    match (candidate.archived, current.archived) {
+        (false, true) => true,
+        (true, false) => false,
+        _ => candidate.modified_at > current.modified_at,
+    }
+}
+
+fn sort_sessions(sessions: &mut [RolloutSessionInfo]) {
+    sessions.sort_by(|left, right| {
+        right
+            .modified_at
+            .cmp(&left.modified_at)
+            .then_with(|| left.archived.cmp(&right.archived))
+            .then_with(|| left.thread_id.cmp(&right.thread_id))
+    });
 }
 
 fn find_rollout_path(codex_home: &Path, thread_id: &str) -> io::Result<Option<PathBuf>> {

--- a/crates/nanocodex-agent/src/rollout/mod.rs
+++ b/crates/nanocodex-agent/src/rollout/mod.rs
@@ -5,7 +5,7 @@ mod wire;
 #[cfg(test)]
 mod tests;
 
-pub use load::{DurableSession, RolloutTranscriptItem};
+pub use load::{DurableSession, RolloutSessionInfo, RolloutTranscriptItem};
 pub use store::RolloutInfo;
 pub(crate) use store::{RolloutOrigin, RolloutRecorder, RolloutTurn};
 
@@ -67,6 +67,19 @@ impl RolloutConfig {
     /// exist, or its rollout is malformed or incompatible.
     pub fn load_session(&self, thread_id: &str) -> io::Result<DurableSession> {
         DurableSession::load(&self.codex_home, thread_id)
+    }
+
+    /// Lists resumable Codex and Nanocodex sessions beneath this Codex home.
+    ///
+    /// Active and archived uncompressed JSONL rollouts are returned newest
+    /// first. Files without recognizable session metadata are ignored so a
+    /// stale or partially written unrelated file cannot prevent discovery.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when a session directory exists but cannot be read.
+    pub fn list_sessions(&self) -> io::Result<Vec<RolloutSessionInfo>> {
+        load::list_sessions(&self.codex_home)
     }
 
     pub(crate) fn resumed(mut self, rollout_path: PathBuf) -> Self {

--- a/crates/nanocodex-agent/src/rollout/tests.rs
+++ b/crates/nanocodex-agent/src/rollout/tests.rs
@@ -161,6 +161,10 @@ fn prompt_previews_are_single_line_and_bounded() {
         160
     );
     assert_eq!(load::prompt_preview(" \n\t "), None);
+    assert_eq!(
+        load::prompt_preview("safe\u{1b}]52;c;payload\u{7} text"),
+        Some("safe]52;c;payload text".to_owned())
+    );
 }
 
 fn set_modified(path: &Path, seconds: u64) {

--- a/crates/nanocodex-agent/src/rollout/tests.rs
+++ b/crates/nanocodex-agent/src/rollout/tests.rs
@@ -1,4 +1,7 @@
-use std::io::{BufRead, BufReader, Read};
+use std::{
+    io::{BufRead, BufReader, Read},
+    time::Duration,
+};
 
 use nanocodex_oai_api::responses::{ContentItem, MessageRole};
 use serde_json::Value;
@@ -36,6 +39,140 @@ fn child_rollout_policy_does_not_inherit_a_resume_path() {
 
     assert_eq!(child.codex_home(), Path::new("/codex"));
     assert!(child.resume_path.is_none());
+}
+
+#[test]
+fn discovers_active_and_archived_rollouts_newest_first() {
+    let home = tempdir().expect("temporary Codex home");
+    let active_id = "019c0d31-c308-7d91-bff4-5dca82d15ac6";
+    let archived_id = "019c0d31-c308-7d91-bff4-5dca82d15ac5";
+    let ignored_id = "019c0d31-c308-7d91-bff4-5dca82d15ac4";
+    let active = write_discoverable_rollout(home.path(), "sessions/2026/08/04", active_id);
+    let archived =
+        write_discoverable_rollout(home.path(), "archived_sessions/2026/08/03", archived_id);
+    let ignored_directory = home.path().join("sessions/2026/08/02");
+    std::fs::create_dir_all(&ignored_directory).expect("create ignored rollout directory");
+    std::fs::write(
+        ignored_directory.join(format!("rollout-2026-08-02T12-00-00-{ignored_id}.jsonl")),
+        "not json\n",
+    )
+    .expect("write malformed rollout");
+    std::fs::write(
+        ignored_directory.join(format!(
+            "rollout-2026-08-02T12-00-00-{ignored_id}.jsonl.zst"
+        )),
+        "compressed",
+    )
+    .expect("write unsupported compressed rollout");
+
+    set_modified(&archived, 10);
+    set_modified(&active, 20);
+    let sessions = RolloutConfig::new(home.path())
+        .list_sessions()
+        .expect("discover rollouts");
+
+    assert_eq!(sessions.len(), 2);
+    assert_eq!(sessions[0].thread_id(), active_id);
+    assert_eq!(sessions[0].workspace(), home.path().to_str());
+    assert_eq!(sessions[0].preview(), Some("resume me"));
+    assert!(!sessions[0].is_archived());
+    assert_eq!(sessions[1].thread_id(), archived_id);
+    assert!(sessions[1].is_archived());
+}
+
+#[test]
+fn discovery_prefers_an_active_copy_of_a_duplicate_thread() {
+    let home = tempdir().expect("temporary Codex home");
+    let thread_id = "019c0d31-c308-7d91-bff4-5dca82d15ac6";
+    let active = write_discoverable_rollout(home.path(), "sessions/2026/08/04", thread_id);
+    let archived =
+        write_discoverable_rollout(home.path(), "archived_sessions/2026/08/05", thread_id);
+    set_modified(&active, 10);
+    set_modified(&archived, 20);
+
+    let sessions = RolloutConfig::new(home.path())
+        .list_sessions()
+        .expect("discover deduplicated rollouts");
+
+    assert_eq!(sessions.len(), 1);
+    assert!(!sessions[0].is_archived());
+}
+
+fn write_discoverable_rollout(home: &Path, relative: &str, thread_id: &str) -> PathBuf {
+    let directory = home.join(relative);
+    std::fs::create_dir_all(&directory).expect("create rollout directory");
+    let path = directory.join(format!("rollout-2026-08-04T12-00-00-{thread_id}.jsonl"));
+    let mut file = File::create(&path).expect("create discoverable rollout");
+    write_line(
+        &mut file,
+        &serde_json::json!({
+            "timestamp": "2026-08-04T12:00:00Z",
+            "type": "session_meta",
+            "payload": {
+                "id": thread_id,
+                "cwd": home,
+                "history_mode": "legacy",
+                "context_window": {"window_id": "window-1"}
+            }
+        }),
+    )
+    .expect("write session metadata");
+    write_line(
+        &mut file,
+        &serde_json::json!({
+            "timestamp": "2026-08-04T12:00:01Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "user_message",
+                "message": "resume\n  me"
+            }
+        }),
+    )
+    .expect("write user preview");
+    write_line(
+        &mut file,
+        &serde_json::json!({
+            "timestamp": "2026-08-04T12:00:02Z",
+            "type": "response_item",
+            "payload": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "resume me"}]
+            }
+        }),
+    )
+    .expect("write committed history");
+    file.flush().expect("flush discoverable rollout");
+    path
+}
+
+#[test]
+fn prompt_previews_are_single_line_and_bounded() {
+    assert_eq!(
+        load::prompt_preview("  first\n\tsecond  "),
+        Some("first second".to_owned())
+    );
+    let long = "x".repeat(200);
+    assert_eq!(
+        load::prompt_preview(&long)
+            .expect("non-empty preview")
+            .chars()
+            .count(),
+        160
+    );
+    assert_eq!(load::prompt_preview(" \n\t "), None);
+}
+
+fn set_modified(path: &Path, seconds: u64) {
+    File::options()
+        .write(true)
+        .open(path)
+        .expect("open rollout to set modification time")
+        .set_times(
+            std::fs::FileTimes::new()
+                .set_modified(std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(seconds)),
+        )
+        .expect("set rollout modification time");
 }
 
 fn recorder(home: &Path) -> RolloutRecorder {


### PR DESCRIPTION
## Summary

This adds an interactive thread selector for the CLI resume path. Running `nanocodex resume` without a positional thread UUID now discovers compatible Codex and Nanocodex rollouts beneath the configured Codex home and opens a Ratatui picker. Supplying `nanocodex resume THREAD_ID` preserves the existing direct-resume behavior.

The selector presents the information needed to distinguish real histories:

- a bounded, single-line preview of the first user prompt;
- relative last-modified age;
- original workspace;
- active versus archived status; and
- the stable thread UUID.

Sessions are ordered by newest activity. Arrow keys and `j`/`k` move one row, Page Up and Page Down move by a viewport, Home and End jump to the boundaries, Enter resumes, and Escape, `q`, or Ctrl-C cancel without starting an agent.

## Why this is needed

The existing CLI required callers to already know a thread UUID. Rollouts are retained under date-partitioned `$CODEX_HOME/sessions` and `$CODEX_HOME/archived_sessions` directories, so finding and copying an identifier manually is cumbersome and error-prone. This is especially visible on a real Codex home with many retained sessions and repeated workspaces.

The library already owns Codex-compatible rollout loading, and the CLI already owns the interactive Ratatui consumer. This change adds one concrete vertical slice across those existing boundaries: the agent crate provides lightweight rollout discovery metadata, while the CLI remains responsible for selection policy and terminal presentation.

## Implementation details

### Rollout discovery API

`RolloutConfig::list_sessions` returns lightweight `RolloutSessionInfo` values containing the thread UUID, workspace, bounded prompt preview, filesystem modification time, and archive status.

Discovery:

1. recursively scans both active and archived rollout roots;
2. accepts uncompressed `.jsonl` rollout filenames ending in a valid UUID;
3. validates canonical session metadata, supported legacy history mode, and agreement between the filename UUID and stored session UUID;
4. requires a committed response or compaction boundary before advertising a candidate;
5. ignores unrelated, unsupported compressed, and unrecognizable files;
6. deduplicates repeated UUIDs, preferring an active copy over an archived copy and otherwise preferring the newer file; and
7. returns deterministic newest-first ordering with stable tie breakers.

The complete existing `load_session` path remains authoritative when the user chooses a thread. No transport response IDs or mutable rollout internals are exposed.

### Prompt previews

The first recorded `user_message` event supplies a Codex-style description. Preview derivation collapses whitespace, removes non-whitespace control characters, and retains at most 160 Unicode scalar values. Empty or unavailable prompts use a neutral fallback in the UI.

### Terminal safety

Rollout content is local data but is not assumed safe to emit as terminal commands. Control characters are removed at two boundaries:

- while deriving the stored prompt preview; and
- immediately before rendering both prompt and workspace metadata.

The renderer uses `Cow<str>`, so ordinary text remains borrowed and does not allocate. Regression coverage includes ESC, OSC-style payload text, BEL, and newline characters. Removing the actual control bytes prevents rollout metadata from injecting terminal control sequences when the picker opens.

### CLI behavior

The Clap positional thread argument is now optional. With a UUID, the command follows the previous loading path. Without one, it discovers sessions and opens the picker. An empty catalog returns a contextual error identifying the searched Codex home, while a user cancellation exits successfully.

The picker reuses the existing `TerminalSession`, including terminal capability checks, alternate-screen setup, panic restoration, raw-mode cleanup, and synchronized drawing. No dependency was added.

## Design decisions and tradeoffs

- Discovery is implemented beside rollout loading because that crate owns the Codex directory and compatibility rules. The Ratatui picker itself stays application-owned under `bin/nanocodex`.
- Only uncompressed JSONL files are listed because compressed rollouts are not currently loadable. Advertising them would produce a selector entry that cannot succeed.
- Filesystem modification time is used for activity ordering because it reflects appended rollout activity across both Codex and Nanocodex writers.
- Active copies win duplicate resolution to match the loader search order and avoid presenting duplicate UUIDs.
- The picker deliberately starts with navigation rather than adding a new fuzzy-search dependency. Incremental filtering across prompt, workspace, and UUID is a useful follow-up for very large catalogs.
- Discovery performs lightweight prefix inspection, while full materialization remains deferred until selection. A malformed trailing record can therefore still produce a candidate that later fails with the existing contextual load error. Unifying catalog validation with full loading without scanning every complete retained trace is a separate follow-up.
- The new `RolloutSessionInfo` API is intentionally metadata-only. Queueing, replay state, paths, and writer mechanics remain private.

## Testing performed

All validation used Rust 1.97, matching the workspace rust-version requirement.

- `cargo +1.97 fmt --all --check`
- `git diff --check`
- `cargo +1.97 clippy -p nanocodex-agent --lib -- -D warnings`
- `cargo +1.97 clippy -p nanocodex-bin --bin nanocodex -- -D warnings`
- `cargo +1.97 test -p nanocodex-agent --lib`
  - 35 passed
- `cargo +1.97 test -p nanocodex-bin --bin nanocodex`
  - 308 passed
  - 2 intentionally ignored manual live MCP tests
- `cargo +1.97 test -p nanocodex-agent --doc`
  - 4 passed
- `cargo +1.97 build -p nanocodex-bin --bin nanocodex`

Focused regressions cover active and archived discovery, newest-first ordering, duplicate resolution, malformed and compressed file exclusion, prompt normalization and bounds, control-character removal, bounded navigation, paging, selection and cancellation keys, and relative-age display boundaries.

A live read-only smoke against the configured Codex home discovered 165 resumable threads, rendered their real first-prompt descriptions, navigated the selector, and restored the terminal cleanly after Escape.

## Risks

- Large Codex homes require recursive directory traversal and opening each candidate far enough to read metadata and the first committed boundary. The current retained corpus behaved interactively, but this PR does not claim a formal discovery-latency benchmark.
- The lightweight catalog check and strict full loader can disagree on corruption after the inspected prefix, as described above.
- Prompt previews and workspace labels may be clipped by Ratatui on narrow terminals. The underlying UUID and metadata are unchanged, and normal terminal widths retain the useful prompt-first ordering.
- The local macOS debug link emits the existing non-fatal `__eh_frame section too large` linker warning. The executable is produced successfully; this change does not alter unwind configuration.

## Scope and follow-up

This PR does not change model policy, transport behavior, retained history semantics, response chaining, tool execution, or the direct UUID resume contract. It adds no dependencies and does not modify `PLAN.md`.

Likely follow-ups are:

1. incremental search and current-workspace filtering for large catalogs;
2. aligning catalog validity and full-loader validity without imposing an unbounded startup scan; and
3. deterministic TestBackend rendering snapshots at narrow, normal, and wide terminal sizes.