### PR TITLE
tools: align current Codex parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@
 - Codex is evidence, not an API requirement. Copy relevant invariants and
   operational behavior while keeping Nanocodex's smaller public surface.
 - The reviewed upstream checkpoint is
-  `openai/codex@35eaf3ffb0bf2001486c68c47a3d946b34d16634`. A parity review must
+  `openai/codex@7ada37a15e1f6aa84f83b4b9410f9d29e66fefe4`. A parity review must
   inspect every later commit, classify it as port/evaluate/defer/out-of-scope,
   and cite adopted behavior before advancing the checkpoint.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
+- [tools] Add bounded MCP pagination, collision-safe Code Mode registration,
+  per-tool and per-server exposure policy, and deferred custom-tool wire shapes.
+- [parity] Classify Codex through `7ada37a1` and defer the standalone V8 host.
 - [model] Support selecting `gpt-5.6-luna` when creating Rust, CLI, Python,
   JavaScript, and Harbor agent threads.
 - [vm] Add persistent VM-backed workspace tools, immutable root-image

--- a/crates/nanocodex-agent/tests/it/model/recovery/normalization.rs
+++ b/crates/nanocodex-agent/tests/it/model/recovery/normalization.rs
@@ -86,6 +86,7 @@ impl Service<ResponsesAttempt> for UnmatchedToolCallService {
                             name: "lookup".into(),
                             namespace: None,
                             arguments: r#"{"key":"region"}"#.into(),
+                            encrypted_function_args: None,
                             call_id: "call-unmatched".into(),
                             caller: None,
                             status: None,

--- a/crates/nanocodex-oai-api/src/responses/item.rs
+++ b/crates/nanocodex-oai-api/src/responses/item.rs
@@ -148,6 +148,8 @@ pub enum ResponseItem {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         namespace: Option<Box<str>>,
         arguments: Box<str>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        encrypted_function_args: Option<Vec<Box<str>>>,
         call_id: Box<str>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         caller: Option<ToolCaller>,
@@ -447,6 +449,29 @@ mod tests {
             serde_json::to_value(&item).unwrap(),
             serde_json::from_str::<Value>(unknown).unwrap()
         );
+    }
+
+    #[test]
+    fn function_calls_preserve_encrypted_argument_markers() {
+        for value in [
+            serde_json::json!({
+                "type": "function_call",
+                "name": "send_message",
+                "arguments": "{}",
+                "encrypted_function_args": [],
+                "call_id": "call-empty"
+            }),
+            serde_json::json!({
+                "type": "function_call",
+                "name": "send_message",
+                "arguments": "{}",
+                "encrypted_function_args": ["opaque"],
+                "call_id": "call-opaque"
+            }),
+        ] {
+            let item: ResponseItem = serde_json::from_value(value.clone()).unwrap();
+            assert_eq!(serde_json::to_value(item).unwrap(), value);
+        }
     }
 
     #[test]

--- a/crates/nanocodex-oai-api/src/responses/tool.rs
+++ b/crates/nanocodex-oai-api/src/responses/tool.rs
@@ -1,6 +1,6 @@
 //! Model-visible tool declarations and open JSON boundary values.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 
 /// Model-visible tool definition carried by Responses Lite input.
@@ -34,6 +34,10 @@ pub enum ToolDefinition {
         /// Guidance describing the namespace as a whole.
         description: Box<str>,
         /// Function declarations exposed under this namespace.
+        #[serde(
+            deserialize_with = "deserialize_namespace_tools",
+            serialize_with = "serialize_namespace_tools"
+        )]
         tools: Vec<Self>,
     },
     /// Free-form custom tool constrained by a grammar.
@@ -57,6 +61,39 @@ pub enum ToolDefinition {
         /// JSON Schema accepted as search arguments.
         parameters: JsonSchema,
     },
+}
+
+fn serialize_namespace_tools<S>(tools: &[ToolDefinition], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    if let Some(invalid_kind) = tools.iter().find_map(invalid_namespace_child_kind) {
+        return Err(serde::ser::Error::custom(format!(
+            "Responses namespace cannot contain a {invalid_kind} definition"
+        )));
+    }
+    tools.serialize(serializer)
+}
+
+fn deserialize_namespace_tools<'de, D>(deserializer: D) -> Result<Vec<ToolDefinition>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let tools = Vec::<ToolDefinition>::deserialize(deserializer)?;
+    if let Some(invalid_kind) = tools.iter().find_map(invalid_namespace_child_kind) {
+        return Err(serde::de::Error::custom(format!(
+            "Responses namespace cannot contain a {invalid_kind} definition"
+        )));
+    }
+    Ok(tools)
+}
+
+const fn invalid_namespace_child_kind(tool: &ToolDefinition) -> Option<&'static str> {
+    match tool {
+        ToolDefinition::Function { .. } | ToolDefinition::Custom { .. } => None,
+        ToolDefinition::Namespace { .. } => Some("namespace"),
+        ToolDefinition::ToolSearch { .. } => Some("tool_search"),
+    }
 }
 
 impl ToolDefinition {
@@ -387,6 +424,29 @@ mod tests {
                 }]
             })
         );
+    }
+
+    #[test]
+    fn namespace_rejects_nested_namespace_and_tool_search_children() {
+        let nested = ToolDefinition::namespace(
+            "outer",
+            "Outer tools.",
+            [ToolDefinition::namespace("inner", "Inner tools.", [])],
+        );
+        assert!(serde_json::to_value(nested).is_err());
+
+        let invalid = json!({
+            "type": "namespace",
+            "name": "outer",
+            "description": "Outer tools.",
+            "tools": [{
+                "type": "tool_search",
+                "execution": "client",
+                "description": "Search tools.",
+                "parameters": {"type": "object"}
+            }]
+        });
+        assert!(serde_json::from_value::<ToolDefinition>(invalid).is_err());
     }
 
     #[test]

--- a/crates/nanocodex-oai-api/src/responses/tool.rs
+++ b/crates/nanocodex-oai-api/src/responses/tool.rs
@@ -1,6 +1,6 @@
 //! Model-visible tool declarations and open JSON boundary values.
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
 use serde_json::Value;
 
 /// Model-visible tool definition carried by Responses Lite input.
@@ -33,11 +33,8 @@ pub enum ToolDefinition {
         name: Box<str>,
         /// Guidance describing the namespace as a whole.
         description: Box<str>,
-        /// Function declarations exposed under this namespace.
-        #[serde(
-            deserialize_with = "deserialize_namespace_tools",
-            serialize_with = "serialize_namespace_tools"
-        )]
+        /// Function or custom declarations exposed under this namespace.
+        #[serde(serialize_with = "serialize_namespace_tools")]
         tools: Vec<Self>,
     },
     /// Free-form custom tool constrained by a grammar.
@@ -67,33 +64,17 @@ fn serialize_namespace_tools<S>(tools: &[ToolDefinition], serializer: S) -> Resu
 where
     S: Serializer,
 {
-    if let Some(invalid_kind) = tools.iter().find_map(invalid_namespace_child_kind) {
-        return Err(serde::ser::Error::custom(format!(
-            "Responses namespace cannot contain a {invalid_kind} definition"
-        )));
+    if tools.iter().any(|tool| {
+        !matches!(
+            tool,
+            ToolDefinition::Function { .. } | ToolDefinition::Custom { .. }
+        )
+    }) {
+        return Err(serde::ser::Error::custom(
+            "Responses namespaces may contain only function or custom definitions",
+        ));
     }
     tools.serialize(serializer)
-}
-
-fn deserialize_namespace_tools<'de, D>(deserializer: D) -> Result<Vec<ToolDefinition>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let tools = Vec::<ToolDefinition>::deserialize(deserializer)?;
-    if let Some(invalid_kind) = tools.iter().find_map(invalid_namespace_child_kind) {
-        return Err(serde::de::Error::custom(format!(
-            "Responses namespace cannot contain a {invalid_kind} definition"
-        )));
-    }
-    Ok(tools)
-}
-
-const fn invalid_namespace_child_kind(tool: &ToolDefinition) -> Option<&'static str> {
-    match tool {
-        ToolDefinition::Function { .. } | ToolDefinition::Custom { .. } => None,
-        ToolDefinition::Namespace { .. } => Some("namespace"),
-        ToolDefinition::ToolSearch { .. } => Some("tool_search"),
-    }
 }
 
 impl ToolDefinition {
@@ -233,17 +214,6 @@ impl ToolDefinition {
         self
     }
 
-    /// Returns whether this function or custom definition requests deferred loading.
-    #[must_use]
-    pub const fn is_deferred(&self) -> bool {
-        match self {
-            Self::Function { defer_loading, .. } | Self::Custom { defer_loading, .. } => {
-                matches!(defer_loading, Some(true))
-            }
-            Self::Namespace { .. } | Self::ToolSearch { .. } => false,
-        }
-    }
-
     /// Returns the model-visible tool name.
     #[must_use]
     pub fn name(&self) -> &str {
@@ -356,25 +326,13 @@ mod tests {
     use super::{CustomToolFormat, JsonSchema, ToolDefinition};
 
     #[test]
-    fn function_and_custom_tools_opt_into_deferred_loading_without_changing_eager_shapes() {
-        let function = ToolDefinition::function(
-            "lookup",
-            "Look up a value.",
-            json!({ "type": "object", "properties": {} }),
-        );
-        assert!(!function.is_deferred());
-        assert!(
-            serde_json::to_value(&function).unwrap()["defer_loading"].is_null(),
-            "eager definitions must preserve their existing wire shape"
-        );
-
+    fn custom_tools_opt_into_deferred_loading_and_namespace_membership() {
         let custom = ToolDefinition::custom(
             "patch",
             "Apply a patch.",
             CustomToolFormat::grammar("lark", "start: \"patch\""),
         )
         .with_deferred_loading();
-        assert!(custom.is_deferred());
         assert_eq!(
             serde_json::to_value(&custom).unwrap()["defer_loading"],
             true
@@ -387,7 +345,7 @@ mod tests {
     }
 
     #[test]
-    fn namespace_serializes_function_children_without_client_output_metadata() {
+    fn namespace_serializes_supported_children_and_rejects_nested_namespaces() {
         let definition = ToolDefinition::namespace(
             "image_gen",
             "Tools in the image_gen namespace.",
@@ -424,29 +382,12 @@ mod tests {
                 }]
             })
         );
-    }
-
-    #[test]
-    fn namespace_rejects_nested_namespace_and_tool_search_children() {
         let nested = ToolDefinition::namespace(
             "outer",
             "Outer tools.",
             [ToolDefinition::namespace("inner", "Inner tools.", [])],
         );
         assert!(serde_json::to_value(nested).is_err());
-
-        let invalid = json!({
-            "type": "namespace",
-            "name": "outer",
-            "description": "Outer tools.",
-            "tools": [{
-                "type": "tool_search",
-                "execution": "client",
-                "description": "Search tools.",
-                "parameters": {"type": "object"}
-            }]
-        });
-        assert!(serde_json::from_value::<ToolDefinition>(invalid).is_err());
     }
 
     #[test]

--- a/crates/nanocodex-oai-api/src/responses/tool.rs
+++ b/crates/nanocodex-oai-api/src/responses/tool.rs
@@ -15,6 +15,9 @@ pub enum ToolDefinition {
         description: Box<str>,
         /// Whether the provider should enforce the parameter schema strictly.
         strict: bool,
+        /// Whether this definition is returned for deferred provider loading.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        defer_loading: Option<bool>,
         /// JSON Schema accepted as function arguments.
         parameters: JsonSchema,
         #[serde(skip)]
@@ -39,6 +42,9 @@ pub enum ToolDefinition {
         name: Box<str>,
         /// Concrete guidance for when and how to use the tool.
         description: Box<str>,
+        /// Whether this definition is returned for deferred provider loading.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        defer_loading: Option<bool>,
         /// Free-form input grammar.
         format: CustomToolFormat,
     },
@@ -86,6 +92,7 @@ impl ToolDefinition {
             name: name.into(),
             description: description.into(),
             strict: false,
+            defer_loading: None,
             parameters: parameters.into(),
             output_schema: None,
         }
@@ -101,6 +108,7 @@ impl ToolDefinition {
         Self::Custom {
             name: name.into(),
             description: description.into(),
+            defer_loading: None,
             format,
         }
     }
@@ -170,6 +178,33 @@ impl ToolDefinition {
             *current = Some(output_schema.into());
         }
         self
+    }
+
+    /// Marks a function or custom definition for provider-native deferred loading.
+    #[must_use]
+    #[allow(
+        clippy::missing_const_for_fn,
+        reason = "ToolDefinition owns drop types that const evaluation rejects"
+    )]
+    pub fn with_deferred_loading(mut self) -> Self {
+        match &mut self {
+            Self::Function { defer_loading, .. } | Self::Custom { defer_loading, .. } => {
+                *defer_loading = Some(true);
+            }
+            Self::Namespace { .. } | Self::ToolSearch { .. } => {}
+        }
+        self
+    }
+
+    /// Returns whether this function or custom definition requests deferred loading.
+    #[must_use]
+    pub const fn is_deferred(&self) -> bool {
+        match self {
+            Self::Function { defer_loading, .. } | Self::Custom { defer_loading, .. } => {
+                matches!(defer_loading, Some(true))
+            }
+            Self::Namespace { .. } | Self::ToolSearch { .. } => false,
+        }
     }
 
     /// Returns the model-visible tool name.
@@ -281,7 +316,38 @@ impl From<Value> for JsonValue {
 mod tests {
     use serde_json::json;
 
-    use super::{JsonSchema, ToolDefinition};
+    use super::{CustomToolFormat, JsonSchema, ToolDefinition};
+
+    #[test]
+    fn function_and_custom_tools_opt_into_deferred_loading_without_changing_eager_shapes() {
+        let function = ToolDefinition::function(
+            "lookup",
+            "Look up a value.",
+            json!({ "type": "object", "properties": {} }),
+        );
+        assert!(!function.is_deferred());
+        assert!(
+            serde_json::to_value(&function).unwrap()["defer_loading"].is_null(),
+            "eager definitions must preserve their existing wire shape"
+        );
+
+        let custom = ToolDefinition::custom(
+            "patch",
+            "Apply a patch.",
+            CustomToolFormat::grammar("lark", "start: \"patch\""),
+        )
+        .with_deferred_loading();
+        assert!(custom.is_deferred());
+        assert_eq!(
+            serde_json::to_value(&custom).unwrap()["defer_loading"],
+            true
+        );
+        let namespace = ToolDefinition::namespace("editing", "Deferred editing tools.", [custom]);
+        assert_eq!(
+            serde_json::to_value(namespace).unwrap()["tools"][0]["type"],
+            "custom"
+        );
+    }
 
     #[test]
     fn namespace_serializes_function_children_without_client_output_metadata() {

--- a/crates/nanocodex-oai-api/src/session/tests.rs
+++ b/crates/nanocodex-oai-api/src/session/tests.rs
@@ -195,6 +195,7 @@ impl Service<crate::ResponsesAttempt> for RecordingScripted {
                     name: "lookup".into(),
                     namespace: None,
                     arguments: r#"{"key":"region"}"#.into(),
+                    encrypted_function_args: None,
                     call_id: "call_1".into(),
                     caller: None,
                     status: None,

--- a/crates/nanocodex-oai-api/tests/it/session.rs
+++ b/crates/nanocodex-oai-api/tests/it/session.rs
@@ -64,6 +64,7 @@ impl Service<ResponsesAttempt> for ScriptedResponses {
                 name: "lookup_region".into(),
                 namespace: None,
                 arguments: r#"{"region":"iad"}"#.into(),
+                encrypted_function_args: None,
                 call_id: "call_region_01".into(),
                 caller: None,
                 status: None,

--- a/crates/nanocodex-tools/README.md
+++ b/crates/nanocodex-tools/README.md
@@ -54,6 +54,11 @@ Matching Codex, direct-plus-Code-Mode exposure keeps `exec` terse and
 adds each typed `exec` declaration to the corresponding direct tool; Code
 Mode-only instead carries the complete nested catalog in `exec`. Selection
 changes model-visible exposure, not registration or dispatch behavior.
+`tool_with_exposure` can override one registered tool with `DirectOnly`,
+`CodeModeOnly`, `DirectAndCodeMode`, or `Hidden` while preserving the global
+default for the rest. Host-owned `exec`, `wait`, and `tool_search` names cannot
+be replaced, and the first tool registered for a normalized JavaScript name
+wins the nested Code Mode surface.
 Namespaced Code Mode names such as `image_gen__imagegen` remain available to
 `exec`; normal Code Mode exposes the Codex-compatible `image_gen.imagegen`
 Responses namespace and routes its namespaced call to the same handler.
@@ -144,6 +149,10 @@ schemas from the initial request. Code Mode lists those deferred tools as
 compact name/description entries in `ALL_TOOLS`. Search results contain
 loadable MCP namespaces for direct model calls and also activate matching Code
 Mode definitions, keeping large catalogs out of the initial tool list.
+`McpServer::tool_exposure` independently selects `DeferredOnly`,
+`CodeModeOnly`, `DeferredAndCodeMode`, or `Hidden` for each server. Automatic
+catalog and aggregate resource pagination is bounded by page, item, cursor,
+and wall-clock limits.
 
 ## Companion workspace runtimes
 

--- a/crates/nanocodex-tools/src/mcp/catalog.rs
+++ b/crates/nanocodex-tools/src/mcp/catalog.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use serde_json::{Map, Value, json};
 use tokio::sync::watch;
 
-use super::client::Client;
+use super::{client::Client, config::McpToolExposure};
 
 const DEFAULT_SEARCH_LIMIT: usize = 8;
 const MAX_SEARCH_LIMIT: usize = 32;
@@ -29,6 +29,7 @@ pub(crate) struct ToolEntry {
     namespace_description: String,
     pub definition: ToolDefinition,
     pub supports_parallel_tool_calls: bool,
+    pub tool_exposure: McpToolExposure,
     pub search_text: String,
     pub client: Client,
     pub timeout: Duration,
@@ -190,7 +191,11 @@ impl ProviderState {
                 "prewarming MCP tool search index"
             );
             catalog.search_index = Some(Arc::new(SearchIndex::new(
-                catalog.entries.values().cloned(),
+                catalog
+                    .entries
+                    .values()
+                    .filter(|entry| entry.tool_exposure.is_deferred())
+                    .cloned(),
             )));
         } else {
             catalog.search_index = None;
@@ -238,7 +243,11 @@ impl ProviderState {
                 "building MCP tool search index"
             );
             catalog.search_index = Some(Arc::new(SearchIndex::new(
-                catalog.entries.values().cloned(),
+                catalog
+                    .entries
+                    .values()
+                    .filter(|entry| entry.tool_exposure.is_deferred())
+                    .cloned(),
             )));
         }
         let index = catalog
@@ -275,6 +284,7 @@ impl ProviderState {
         catalog
             .entries
             .values()
+            .filter(|entry| entry.tool_exposure.is_available_in_code_mode())
             .map(|entry| entry.definition.clone())
             .collect()
     }
@@ -404,6 +414,7 @@ impl ToolEntry {
         client: Client,
         timeout: Duration,
         server_supports_parallel_tool_calls: bool,
+        tool_exposure: McpToolExposure,
     ) -> Self {
         let remote_name = tool.name.to_string();
         let canonical_name = canonical_tool_name(server_name, &remote_name);
@@ -461,6 +472,7 @@ impl ToolEntry {
             namespace_description,
             definition,
             supports_parallel_tool_calls,
+            tool_exposure,
             search_text,
             client,
             timeout,

--- a/crates/nanocodex-tools/src/mcp/client.rs
+++ b/crates/nanocodex-tools/src/mcp/client.rs
@@ -17,6 +17,7 @@ use tracing::{Instrument, Span, info_span};
 
 use super::config::{McpServer, McpTransport, SecretSource};
 use super::oauth::{McpOAuthStore, OAuthMetadataCache, OAuthRuntime, transport_from_credentials};
+use super::pagination::collect_paginated;
 use super::stdio::McpStdioTransport;
 
 const MCP_USER_AGENT: &str = concat!("nanocodex-mcp-client/", env!("CARGO_PKG_VERSION"));
@@ -74,11 +75,19 @@ impl ClientInner {
         result
     }
 
-    async fn list_all_tools(
-        &self,
-        parent: &Span,
-    ) -> Result<Vec<Tool>, rmcp::service::ServiceError> {
-        let tools = self.service.list_all_tools().await;
+    async fn list_all_tools(&self, parent: &Span) -> Result<Vec<Tool>, String> {
+        let service = Arc::clone(&self.service);
+        let tools = collect_paginated("tools/list", None, move |params| {
+            let service = Arc::clone(&service);
+            async move {
+                let result = service
+                    .list_tools(params)
+                    .await
+                    .map_err(|error| error_chain(&error))?;
+                Ok((result.tools, result.next_cursor))
+            }
+        })
+        .await;
         if let Some(oauth) = &self.oauth
             && let Err(error) = oauth.persist_if_changed(parent).await
         {
@@ -475,7 +484,7 @@ async fn finish_startup(
                 .into_iter()
                 .filter(|tool| server.includes_tool(tool.name.as_ref()))
                 .collect::<Vec<_>>()),
-            Ok(Err(error)) => Err(format!("MCP tools/list failed: {}", error_chain(&error))),
+            Ok(Err(error)) => Err(format!("MCP tools/list failed: {error}")),
             Err(_) => Err(startup_timeout(server, "tools/list")),
         };
     span.record("status", if tools.is_ok() { "completed" } else { "failed" });

--- a/crates/nanocodex-tools/src/mcp/client.rs
+++ b/crates/nanocodex-tools/src/mcp/client.rs
@@ -77,7 +77,7 @@ impl ClientInner {
 
     async fn list_all_tools(&self, parent: &Span) -> Result<Vec<Tool>, String> {
         let service = Arc::clone(&self.service);
-        let tools = collect_paginated("tools/list", None, move |params| {
+        let tools = collect_paginated("tools/list", move |params| {
             let service = Arc::clone(&service);
             async move {
                 let result = service

--- a/crates/nanocodex-tools/src/mcp/config.rs
+++ b/crates/nanocodex-tools/src/mcp/config.rs
@@ -3,6 +3,34 @@ use std::{collections::BTreeMap, path::PathBuf, time::Duration};
 const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_TOOL_TIMEOUT: Duration = Duration::from_mins(5);
 
+/// Model-facing surfaces on which one MCP server's tools are available.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum McpToolExposure {
+    /// Discover tools through `tool_search` and call them from Code Mode.
+    #[default]
+    DeferredAndCodeMode,
+    /// Discover tools through `tool_search`, but omit them from Code Mode.
+    DeferredOnly,
+    /// Expose tools only inside Code Mode, without provider-native discovery.
+    CodeModeOnly,
+    /// Keep the server connected without exposing or dispatching its tools.
+    Hidden,
+}
+
+impl McpToolExposure {
+    pub(crate) const fn is_deferred(self) -> bool {
+        matches!(self, Self::DeferredAndCodeMode | Self::DeferredOnly)
+    }
+
+    pub(crate) const fn is_available_in_code_mode(self) -> bool {
+        matches!(self, Self::DeferredAndCodeMode | Self::CodeModeOnly)
+    }
+
+    pub(crate) const fn is_callable(self) -> bool {
+        !matches!(self, Self::Hidden)
+    }
+}
+
 /// One MCP server transport and its lifecycle limits.
 #[derive(Clone)]
 pub struct McpServer {
@@ -11,6 +39,7 @@ pub struct McpServer {
     pub(crate) startup_timeout: Duration,
     pub(crate) tool_timeout: Duration,
     pub(crate) supports_parallel_tool_calls: bool,
+    pub(crate) tool_exposure: McpToolExposure,
     pub(crate) enabled_tools: Option<Vec<String>>,
     pub(crate) disabled_tools: Vec<String>,
     pub(crate) unsupported_option: Option<&'static str>,
@@ -52,6 +81,7 @@ impl McpServer {
             startup_timeout: DEFAULT_STARTUP_TIMEOUT,
             tool_timeout: DEFAULT_TOOL_TIMEOUT,
             supports_parallel_tool_calls: false,
+            tool_exposure: McpToolExposure::default(),
             enabled_tools: None,
             disabled_tools: Vec::new(),
             unsupported_option: None,
@@ -71,6 +101,7 @@ impl McpServer {
             startup_timeout: DEFAULT_STARTUP_TIMEOUT,
             tool_timeout: DEFAULT_TOOL_TIMEOUT,
             supports_parallel_tool_calls: false,
+            tool_exposure: McpToolExposure::default(),
             enabled_tools: None,
             disabled_tools: Vec::new(),
             unsupported_option: None,
@@ -105,6 +136,13 @@ impl McpServer {
     #[must_use]
     pub const fn supports_parallel_tool_calls(mut self, supports: bool) -> Self {
         self.supports_parallel_tool_calls = supports;
+        self
+    }
+
+    /// Selects whether this server's tools are deferred, nested in Code Mode, both, or hidden.
+    #[must_use]
+    pub const fn tool_exposure(mut self, exposure: McpToolExposure) -> Self {
+        self.tool_exposure = exposure;
         self
     }
 

--- a/crates/nanocodex-tools/src/mcp/mod.rs
+++ b/crates/nanocodex-tools/src/mcp/mod.rs
@@ -874,7 +874,7 @@ mod tests {
     #[test]
     fn search_definition_bounds_aggregate_source_descriptions() {
         let mut builder = Mcp::builder();
-        for index in 0..64 {
+        for index in 0..8 {
             builder = builder.server(
                 format!("source-{index:02}"),
                 McpServer::http("https://example.test/mcp").description("🦀".repeat(300)),
@@ -891,8 +891,7 @@ mod tests {
 
         assert!(sources.len() <= MAX_TOOL_SEARCH_SOURCE_DESCRIPTION_BYTES);
         assert!(sources.starts_with("- source-00: 🦀"));
-        assert!(sources.contains("- source-63"));
-        assert!(std::str::from_utf8(sources.as_bytes()).is_ok());
+        assert!(sources.contains("- source-07"));
     }
 
     #[tokio::test]

--- a/crates/nanocodex-tools/src/mcp/mod.rs
+++ b/crates/nanocodex-tools/src/mcp/mod.rs
@@ -4,6 +4,7 @@ mod catalog;
 mod client;
 mod config;
 mod oauth;
+mod pagination;
 mod resources;
 mod stdio;
 
@@ -25,7 +26,7 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use tracing::{Instrument, info_span};
 
-pub use config::McpServer;
+pub use config::{McpServer, McpToolExposure};
 pub use oauth::{McpOAuthCredentials, McpOAuthStore};
 
 fn same_origin_redirect_policy() -> reqwest::redirect::Policy {
@@ -306,6 +307,7 @@ impl McpHandle {
                             Arc::clone(&connected.client),
                             server.config.tool_timeout,
                             server.config.supports_parallel_tool_calls,
+                            server.config.tool_exposure,
                         )
                     })
                     .collect();
@@ -484,6 +486,7 @@ impl DynamicToolProvider for Mcp {
                                     Arc::clone(&connected.client),
                                     config.tool_timeout,
                                     config.supports_parallel_tool_calls,
+                                    config.tool_exposure,
                                 )
                             })
                             .collect::<Vec<_>>();
@@ -528,13 +531,15 @@ impl DynamicToolProvider for Mcp {
     }
 
     fn contains(&self, name: &str) -> bool {
-        self.state.entry(name).is_some()
+        self.state
+            .entry(name)
+            .is_some_and(|entry| entry.tool_exposure.is_callable())
     }
 
     fn supports_parallel_tool_calls(&self, name: &str) -> bool {
-        self.state
-            .entry(name)
-            .is_some_and(|entry| entry.supports_parallel_tool_calls)
+        self.state.entry(name).is_some_and(|entry| {
+            entry.tool_exposure.is_callable() && entry.supports_parallel_tool_calls
+        })
     }
 
     async fn execute(
@@ -544,6 +549,9 @@ impl DynamicToolProvider for Mcp {
         _context: ToolContext<'_>,
     ) -> Option<ToolOutput> {
         let entry = self.state.ready_entry(name).await?;
+        if !entry.tool_exposure.is_callable() {
+            return None;
+        }
         let Value::Object(arguments) = input else {
             return Some(ToolOutput::error(format!(
                 "MCP tool {name} requires an object argument"
@@ -1031,6 +1039,42 @@ mod tests {
             execution.output,
             ToolOutputBody::Text(output) if output.contains("fixture:hello")
         ));
+    }
+
+    #[tokio::test]
+    async fn mcp_tool_exposure_selects_deferred_and_code_mode_surfaces_per_server() {
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/mcp-stdio-server.mjs");
+        let server = || McpServer::stdio("node").arg(fixture.to_string_lossy());
+        let mcp = Mcp::builder()
+            .server(
+                "deferred",
+                server().tool_exposure(McpToolExposure::DeferredOnly),
+            )
+            .server(
+                "nested",
+                server().tool_exposure(McpToolExposure::CodeModeOnly),
+            )
+            .server("hidden", server().tool_exposure(McpToolExposure::Hidden))
+            .build()
+            .unwrap();
+        mcp.start();
+
+        let search = mcp.state.search("echo", None).await.unwrap();
+        let loadable = search.loadable_tools().unwrap();
+        assert_eq!(loadable.as_array().unwrap().len(), 1);
+        assert_eq!(loadable[0]["name"], "mcp__deferred__");
+
+        assert_eq!(
+            mcp.available_definitions()
+                .iter()
+                .map(ToolDefinition::name)
+                .collect::<Vec<_>>(),
+            ["mcp__nested__echo"]
+        );
+        assert!(mcp.contains("mcp__deferred__echo"));
+        assert!(mcp.contains("mcp__nested__echo"));
+        assert!(!mcp.contains("mcp__hidden__echo"));
     }
 
     #[cfg(unix)]

--- a/crates/nanocodex-tools/src/mcp/mod.rs
+++ b/crates/nanocodex-tools/src/mcp/mod.rs
@@ -29,6 +29,8 @@ use tracing::{Instrument, info_span};
 pub use config::{McpServer, McpToolExposure};
 pub use oauth::{McpOAuthCredentials, McpOAuthStore};
 
+const MAX_TOOL_SEARCH_SOURCE_DESCRIPTION_BYTES: usize = 4 * 1024;
+
 fn same_origin_redirect_policy() -> reqwest::redirect::Policy {
     reqwest::redirect::Policy::custom(|attempt| {
         let follows_same_origin = attempt
@@ -752,17 +754,48 @@ fn validate_server(name: &str, server: &McpServer) -> Result<(), McpBuildError> 
 }
 
 fn search_description(servers: &[NamedServer]) -> String {
-    let sources = servers
+    let reserved_name_bytes = servers
         .iter()
-        .map(|server| match server.config.description.as_deref() {
-            Some(description) => format!("- {}: {}", server.name, description.trim()),
-            None => format!("- {}", server.name),
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
+        .fold(servers.len().saturating_sub(1), |reserved, server| {
+            reserved.saturating_add(2).saturating_add(server.name.len())
+        });
+    let mut description_budget =
+        MAX_TOOL_SEARCH_SOURCE_DESCRIPTION_BYTES.saturating_sub(reserved_name_bytes);
+    let mut sources = String::new();
+    for server in servers {
+        let separator_bytes = usize::from(!sources.is_empty());
+        let required = separator_bytes
+            .saturating_add(2)
+            .saturating_add(server.name.len());
+        if required > MAX_TOOL_SEARCH_SOURCE_DESCRIPTION_BYTES.saturating_sub(sources.len()) {
+            continue;
+        }
+        if !sources.is_empty() {
+            sources.push('\n');
+        }
+        sources.push_str("- ");
+        sources.push_str(&server.name);
+        if let Some(description) = server.config.description.as_deref()
+            && description_budget >= 2
+        {
+            sources.push_str(": ");
+            description_budget -= 2;
+            let description = take_bytes_at_char_boundary(description.trim(), description_budget);
+            sources.push_str(description);
+            description_budget -= description.len();
+        }
+    }
     format!(
         "# Tool discovery\n\nSearches over deferred tool metadata with BM25 and exposes matching tools for the next model call.\n\nYou have access to tools from the following sources:\n{sources}\nSome of the tools may not have been provided to you upfront, and you should use this tool (`tool_search`) to search for the required tools. For MCP tool discovery, always use `tool_search` instead of `list_mcp_resources` or `list_mcp_resource_templates`."
     )
+}
+
+fn take_bytes_at_char_boundary(value: &str, max_bytes: usize) -> &str {
+    let mut end = value.len().min(max_bytes);
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    &value[..end]
 }
 
 #[cfg(test)]
@@ -836,6 +869,30 @@ mod tests {
                 }
             })
         );
+    }
+
+    #[test]
+    fn search_definition_bounds_aggregate_source_descriptions() {
+        let mut builder = Mcp::builder();
+        for index in 0..64 {
+            builder = builder.server(
+                format!("source-{index:02}"),
+                McpServer::http("https://example.test/mcp").description("🦀".repeat(300)),
+            );
+        }
+        let mcp = builder.build().unwrap();
+        let description = mcp.search.definition().description().to_owned();
+        let (_, source_section) = description
+            .split_once("You have access to tools from the following sources:\n")
+            .unwrap();
+        let (sources, _) = source_section
+            .split_once("\nSome of the tools may not have been provided")
+            .unwrap();
+
+        assert!(sources.len() <= MAX_TOOL_SEARCH_SOURCE_DESCRIPTION_BYTES);
+        assert!(sources.starts_with("- source-00: 🦀"));
+        assert!(sources.contains("- source-63"));
+        assert!(std::str::from_utf8(sources.as_bytes()).is_ok());
     }
 
     #[tokio::test]

--- a/crates/nanocodex-tools/src/mcp/pagination.rs
+++ b/crates/nanocodex-tools/src/mcp/pagination.rs
@@ -9,7 +9,6 @@ const DEFAULT_MCP_PAGINATION_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub(super) async fn collect_paginated<T, F, Fut>(
     method: &str,
-    overall_timeout: Option<Duration>,
     mut fetch: F,
 ) -> Result<Vec<T>, String>
 where
@@ -52,7 +51,7 @@ where
         ))
     };
 
-    let timeout = overall_timeout.unwrap_or(DEFAULT_MCP_PAGINATION_TIMEOUT);
+    let timeout = DEFAULT_MCP_PAGINATION_TIMEOUT;
     tokio::time::timeout(timeout, collect)
         .await
         .map_err(|_| format!("{method} pagination timed out after {timeout:?}"))?
@@ -60,45 +59,25 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
-
     use super::*;
 
     #[tokio::test]
-    async fn rejects_repeated_cursors() {
-        let error = collect_paginated("tools/list", None, |_| async {
+    async fn rejects_unbounded_pagination() {
+        let repeated_cursor = collect_paginated("tools/list", |_| async {
             Ok((vec![1_u8], Some("same".to_owned())))
         })
         .await
         .unwrap_err();
+        assert_eq!(
+            repeated_cursor,
+            "tools/list returned a repeated pagination cursor"
+        );
 
-        assert_eq!(error, "tools/list returned a repeated pagination cursor");
-    }
-
-    #[tokio::test]
-    async fn preserves_page_order() {
-        let pages = Arc::new(Mutex::new(vec![
-            (vec![3_u8], None),
-            (vec![1_u8, 2], Some("next".to_owned())),
-        ]));
-        let collected = collect_paginated("tools/list", None, |_| {
-            let pages = Arc::clone(&pages);
-            async move { Ok(pages.lock().unwrap().pop().unwrap()) }
-        })
-        .await
-        .unwrap();
-
-        assert_eq!(collected, [1, 2, 3]);
-    }
-
-    #[tokio::test]
-    async fn rejects_oversized_catalogs() {
-        let error = collect_paginated("tools/list", None, |_| async {
+        let oversized_catalog = collect_paginated("tools/list", |_| async {
             Ok((vec![(); MAX_MCP_CATALOG_ITEMS + 1], None))
         })
         .await
         .unwrap_err();
-
-        assert!(error.contains("catalog limit"));
+        assert!(oversized_catalog.contains("catalog limit"));
     }
 }

--- a/crates/nanocodex-tools/src/mcp/pagination.rs
+++ b/crates/nanocodex-tools/src/mcp/pagination.rs
@@ -1,0 +1,104 @@
+use std::{collections::HashSet, future::Future, time::Duration};
+
+use rmcp::model::PaginatedRequestParams;
+
+const MAX_MCP_CATALOG_PAGES: usize = 100;
+const MAX_MCP_CATALOG_ITEMS: usize = 2_048;
+const MAX_MCP_PAGINATION_CURSOR_BYTES: usize = 64 * 1024;
+const DEFAULT_MCP_PAGINATION_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub(super) async fn collect_paginated<T, F, Fut>(
+    method: &str,
+    overall_timeout: Option<Duration>,
+    mut fetch: F,
+) -> Result<Vec<T>, String>
+where
+    F: FnMut(Option<PaginatedRequestParams>) -> Fut,
+    Fut: Future<Output = Result<(Vec<T>, Option<String>), String>>,
+{
+    let collect = async {
+        let mut collected = Vec::new();
+        let mut cursor: Option<String> = None;
+        let mut seen_cursors = HashSet::new();
+
+        for _ in 0..MAX_MCP_CATALOG_PAGES {
+            let params = cursor
+                .as_ref()
+                .map(|cursor| PaginatedRequestParams::default().with_cursor(Some(cursor.clone())));
+            let (items, next_cursor) = fetch(params).await?;
+            if items.len() > MAX_MCP_CATALOG_ITEMS.saturating_sub(collected.len()) {
+                return Err(format!(
+                    "{method} exceeded the catalog limit of {MAX_MCP_CATALOG_ITEMS} items"
+                ));
+            }
+            collected.extend(items);
+
+            let Some(next_cursor) = next_cursor else {
+                return Ok(collected);
+            };
+            if next_cursor.len() > MAX_MCP_PAGINATION_CURSOR_BYTES {
+                return Err(format!(
+                    "{method} returned a pagination cursor exceeding {MAX_MCP_PAGINATION_CURSOR_BYTES} bytes"
+                ));
+            }
+            if !seen_cursors.insert(next_cursor.clone()) {
+                return Err(format!("{method} returned a repeated pagination cursor"));
+            }
+            cursor = Some(next_cursor);
+        }
+
+        Err(format!(
+            "{method} exceeded the pagination limit of {MAX_MCP_CATALOG_PAGES} pages"
+        ))
+    };
+
+    let timeout = overall_timeout.unwrap_or(DEFAULT_MCP_PAGINATION_TIMEOUT);
+    tokio::time::timeout(timeout, collect)
+        .await
+        .map_err(|_| format!("{method} pagination timed out after {timeout:?}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn rejects_repeated_cursors() {
+        let error = collect_paginated("tools/list", None, |_| async {
+            Ok((vec![1_u8], Some("same".to_owned())))
+        })
+        .await
+        .unwrap_err();
+
+        assert_eq!(error, "tools/list returned a repeated pagination cursor");
+    }
+
+    #[tokio::test]
+    async fn preserves_page_order() {
+        let pages = Arc::new(Mutex::new(vec![
+            (vec![3_u8], None),
+            (vec![1_u8, 2], Some("next".to_owned())),
+        ]));
+        let collected = collect_paginated("tools/list", None, |_| {
+            let pages = Arc::clone(&pages);
+            async move { Ok(pages.lock().unwrap().pop().unwrap()) }
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(collected, [1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_catalogs() {
+        let error = collect_paginated("tools/list", None, |_| async {
+            Ok((vec![(); MAX_MCP_CATALOG_ITEMS + 1], None))
+        })
+        .await
+        .unwrap_err();
+
+        assert!(error.contains("catalog limit"));
+    }
+}

--- a/crates/nanocodex-tools/src/mcp/resources.rs
+++ b/crates/nanocodex-tools/src/mcp/resources.rs
@@ -9,6 +9,7 @@ use serde_json::{Map, Value, json};
 use crate::{Tool, ToolContext, ToolInput, ToolOutput, ToolResult};
 
 use super::catalog::ProviderState;
+use super::pagination::collect_paginated;
 
 const LIST_RESOURCES_DESCRIPTION: &str = "Lists resources provided by MCP servers. Resources allow servers to share data that provides context to language models, such as files, database schemas, or application-specific information. Prefer resources over web search when possible.";
 const LIST_RESOURCE_TEMPLATES_DESCRIPTION: &str = "Lists resource templates provided by MCP servers. Parameterized resource templates allow servers to share data that takes parameters and provides context to language models, such as files, database schemas, or application-specific information. Prefer resource templates over web search when possible.";
@@ -193,27 +194,20 @@ async fn list_resources(state: &ProviderState, input: ListInput) -> Result<Value
     }
     let mut resources = Vec::new();
     for (server, client) in state.clients().await {
-        let mut cursor = None;
-        loop {
-            let params = cursor
-                .clone()
-                .map(|cursor| PaginatedRequestParams::default().with_cursor(Some(cursor)));
-            let result = match client.list_resources(params).await {
-                Ok(result) => result,
-                Err(error) => {
-                    tracing::warn!(%error, %server, "failed to list MCP resources");
-                    break;
-                }
-            };
-            resources.extend(with_server(result.resources, &server)?);
-            let Some(next_cursor) = result.next_cursor else {
-                break;
-            };
-            if cursor.as_ref() == Some(&next_cursor) {
-                tracing::warn!(%server, "MCP resources/list returned a duplicate cursor");
-                break;
+        let pages = collect_paginated("resources/list", None, |params| {
+            let client = Arc::clone(&client);
+            async move {
+                let result = client
+                    .list_resources(params)
+                    .await
+                    .map_err(|error| error.to_string())?;
+                Ok((result.resources, result.next_cursor))
             }
-            cursor = Some(next_cursor);
+        })
+        .await;
+        match pages {
+            Ok(items) => resources.extend(with_server(items, &server)?),
+            Err(error) => tracing::warn!(%error, %server, "failed to list MCP resources"),
         }
     }
     Ok(json!({ "resources": resources }))
@@ -242,27 +236,22 @@ async fn list_resource_templates(state: &ProviderState, input: ListInput) -> Res
     }
     let mut templates = Vec::new();
     for (server, client) in state.clients().await {
-        let mut cursor = None;
-        loop {
-            let params = cursor
-                .clone()
-                .map(|cursor| PaginatedRequestParams::default().with_cursor(Some(cursor)));
-            let result = match client.list_resource_templates(params).await {
-                Ok(result) => result,
-                Err(error) => {
-                    tracing::warn!(%error, %server, "failed to list MCP resource templates");
-                    break;
-                }
-            };
-            templates.extend(with_server(result.resource_templates, &server)?);
-            let Some(next_cursor) = result.next_cursor else {
-                break;
-            };
-            if cursor.as_ref() == Some(&next_cursor) {
-                tracing::warn!(%server, "MCP resources/templates/list returned a duplicate cursor");
-                break;
+        let pages = collect_paginated("resources/templates/list", None, |params| {
+            let client = Arc::clone(&client);
+            async move {
+                let result = client
+                    .list_resource_templates(params)
+                    .await
+                    .map_err(|error| error.to_string())?;
+                Ok((result.resource_templates, result.next_cursor))
             }
-            cursor = Some(next_cursor);
+        })
+        .await;
+        match pages {
+            Ok(items) => templates.extend(with_server(items, &server)?),
+            Err(error) => {
+                tracing::warn!(%error, %server, "failed to list MCP resource templates");
+            }
         }
     }
     Ok(json!({ "resourceTemplates": templates }))

--- a/crates/nanocodex-tools/src/mcp/resources.rs
+++ b/crates/nanocodex-tools/src/mcp/resources.rs
@@ -194,7 +194,7 @@ async fn list_resources(state: &ProviderState, input: ListInput) -> Result<Value
     }
     let mut resources = Vec::new();
     for (server, client) in state.clients().await {
-        let pages = collect_paginated("resources/list", None, |params| {
+        let pages = collect_paginated("resources/list", |params| {
             let client = Arc::clone(&client);
             async move {
                 let result = client
@@ -236,7 +236,7 @@ async fn list_resource_templates(state: &ProviderState, input: ListInput) -> Res
     }
     let mut templates = Vec::new();
     for (server, client) in state.clients().await {
-        let pages = collect_paginated("resources/templates/list", None, |params| {
+        let pages = collect_paginated("resources/templates/list", |params| {
             let client = Arc::clone(&client);
             async move {
                 let result = client

--- a/crates/nanocodex-tools/src/runtime/execution.rs
+++ b/crates/nanocodex-tools/src/runtime/execution.rs
@@ -6,8 +6,7 @@ use super::*;
 /// normally owned privately by the higher-level agent driver.
 pub struct ToolRuntime {
     pub(super) registry: Arc<ToolRegistry>,
-    exposure: ToolExposure,
-    base_exposure_configured: bool,
+    exposure: Option<ToolExposure>,
     deferred_tools_guidance_enabled: bool,
     code_mode: code_mode::CodeModeRuntime,
     sessions: Arc<ShellSessions>,
@@ -111,8 +110,7 @@ impl ToolRuntime {
         }
         Self {
             registry: Arc::new(ToolRegistry::from_ordered(handlers)),
-            exposure: ToolExposure::default(),
-            base_exposure_configured: false,
+            exposure: None,
             deferred_tools_guidance_enabled: false,
             code_mode: code_mode::CodeModeRuntime::new_with_turn(
                 code_mode_workspace,
@@ -134,10 +132,10 @@ impl ToolRuntime {
     pub fn with_tools(mut self, tools: &Tools) -> Self {
         tools.start_providers();
         let registry = Arc::make_mut(&mut self.registry);
-        if !self.base_exposure_configured {
-            self.exposure = tools.exposure();
-            registry.set_all_exposures(tools.exposure());
-            self.base_exposure_configured = true;
+        if self.exposure.is_none() {
+            let exposure = tools.exposure();
+            self.exposure = Some(exposure);
+            registry.set_all_exposures(exposure);
         }
         self.deferred_tools_guidance_enabled |= tools.deferred_tools_guidance_enabled;
         registry.extend(tools.registered.iter().map(|tool| {
@@ -210,7 +208,7 @@ impl ToolRuntime {
             code_mode::exec_spec(
                 &nested,
                 self.deferred_tools_guidance_enabled,
-                self.exposure == ToolExposure::CodeModeOnly,
+                self.exposure.unwrap_or_default() == ToolExposure::CodeModeOnly,
             ),
             code_mode::wait_spec(),
         ];

--- a/crates/nanocodex-tools/src/runtime/execution.rs
+++ b/crates/nanocodex-tools/src/runtime/execution.rs
@@ -7,6 +7,7 @@ use super::*;
 pub struct ToolRuntime {
     pub(super) registry: Arc<ToolRegistry>,
     exposure: ToolExposure,
+    base_exposure_configured: bool,
     deferred_tools_guidance_enabled: bool,
     code_mode: code_mode::CodeModeRuntime,
     sessions: Arc<ShellSessions>,
@@ -111,6 +112,7 @@ impl ToolRuntime {
         Self {
             registry: Arc::new(ToolRegistry::from_ordered(handlers)),
             exposure: ToolExposure::default(),
+            base_exposure_configured: false,
             deferred_tools_guidance_enabled: false,
             code_mode: code_mode::CodeModeRuntime::new_with_turn(
                 code_mode_workspace,
@@ -131,11 +133,26 @@ impl ToolRuntime {
     #[must_use]
     pub fn with_tools(mut self, tools: &Tools) -> Self {
         tools.start_providers();
-        self.exposure = tools.exposure();
-        self.deferred_tools_guidance_enabled = tools.deferred_tools_guidance_enabled;
         let registry = Arc::make_mut(&mut self.registry);
-        registry.extend(tools.registered.iter().cloned());
-        registry.extend(tools.provider_direct.iter().cloned());
+        if !self.base_exposure_configured {
+            self.exposure = tools.exposure();
+            registry.set_all_exposures(tools.exposure());
+            self.base_exposure_configured = true;
+        }
+        self.deferred_tools_guidance_enabled |= tools.deferred_tools_guidance_enabled;
+        registry.extend(tools.registered.iter().map(|tool| {
+            (
+                Arc::clone(&tool.handler),
+                tool.exposure.unwrap_or_else(|| tools.exposure()),
+            )
+        }));
+        registry.extend(
+            tools
+                .provider_direct
+                .iter()
+                .cloned()
+                .map(|tool| (tool, tools.exposure())),
+        );
         registry.providers.extend(tools.providers.iter().cloned());
         if let Some(working_directory) = &tools.working_directory {
             self.working_directory = Arc::clone(working_directory);
@@ -175,27 +192,19 @@ impl ToolRuntime {
     /// session.
     #[must_use]
     pub fn model_specs(&self, _session_id: &str) -> Vec<ToolDefinition> {
-        let mut nested = self
+        let mut nested = self.registry.registered_code_mode_definitions();
+        let mut direct = self
             .registry
-            .definitions()
-            .iter()
+            .direct_definitions()
             .filter(|definition| !matches!(definition, ToolDefinition::ToolSearch { .. }))
             .cloned()
             .collect::<Vec<_>>();
-        let mut direct = self
-            .registry
-            .definitions()
+        let code_mode_names = nested
             .iter()
-            .filter(|definition| {
-                self.exposure == ToolExposure::DirectAndCodeMode
-                    && !matches!(definition, ToolDefinition::ToolSearch { .. })
-            })
-            .cloned()
-            .collect::<Vec<_>>();
-        if self.exposure == ToolExposure::DirectAndCodeMode {
-            direct = group_direct_code_mode_definitions(direct);
-            crate::code_mode_order::sort_direct_definitions(&mut direct);
-        }
+            .map(|definition| definition.name().to_owned())
+            .collect::<HashSet<_>>();
+        direct = group_direct_code_mode_definitions(direct, &code_mode_names);
+        crate::code_mode_order::sort_direct_definitions(&mut direct);
         crate::code_mode_order::sort_definitions(&mut nested);
         let mut native = vec![
             code_mode::exec_spec(
@@ -327,11 +336,18 @@ impl ToolRuntime {
     }
 }
 
-fn group_direct_code_mode_definitions(definitions: Vec<ToolDefinition>) -> Vec<ToolDefinition> {
+fn group_direct_code_mode_definitions(
+    definitions: Vec<ToolDefinition>,
+    code_mode_names: &HashSet<String>,
+) -> Vec<ToolDefinition> {
     let mut grouped = Vec::<ToolDefinition>::new();
     for definition in definitions {
         let canonical_name = definition.name().to_owned();
-        let mut definition = code_mode::description::augment_definition_for_code_mode(definition);
+        let mut definition = if code_mode_names.contains(&canonical_name) {
+            code_mode::description::augment_definition_for_code_mode(definition)
+        } else {
+            definition
+        };
         let Some((namespace, name)) = canonical_name.rsplit_once("__") else {
             grouped.push(definition);
             continue;

--- a/crates/nanocodex-tools/src/runtime/mod.rs
+++ b/crates/nanocodex-tools/src/runtime/mod.rs
@@ -45,3 +45,7 @@ use crate::{
 use crate::{image_generation, web_search};
 
 const CODEX_THREAD_ID_ENV_VAR: &str = "CODEX_THREAD_ID";
+
+fn host_owned_name(name: &str) -> bool {
+    matches!(name, "exec" | "wait")
+}

--- a/crates/nanocodex-tools/src/runtime/registry.rs
+++ b/crates/nanocodex-tools/src/runtime/registry.rs
@@ -15,7 +15,7 @@ pub(crate) struct ToolRegistry {
 impl ToolRegistry {
     pub(crate) fn contains(&self, name: &str) -> bool {
         self.get(name).is_some()
-            || (!host_owned_dynamic_name(name)
+            || (!host_owned_name(name)
                 && self
                     .providers
                     .iter()
@@ -76,7 +76,7 @@ impl ToolRegistry {
                     ));
                 }
             };
-            let Some(provider) = (!host_owned_dynamic_name(name))
+            let Some(provider) = (!host_owned_name(name))
                 .then(|| {
                     self.providers
                         .iter()
@@ -332,7 +332,7 @@ impl ToolRegistry {
             )
             .filter(|definition| {
                 !matches!(definition, ToolDefinition::ToolSearch { .. })
-                    && !host_owned_dynamic_name(definition.name())
+                    && !host_owned_name(definition.name())
             });
         first_normalized_definitions(definitions)
     }
@@ -363,10 +363,6 @@ fn first_normalized_definitions(
             }
         })
         .collect()
-}
-
-fn host_owned_dynamic_name(name: &str) -> bool {
-    matches!(name, "exec" | "wait")
 }
 
 fn definition_metadata(name: &str, definition: &ToolDefinition) -> Value {

--- a/crates/nanocodex-tools/src/runtime/registry.rs
+++ b/crates/nanocodex-tools/src/runtime/registry.rs
@@ -7,6 +7,7 @@ use super::*;
 pub(crate) struct ToolRegistry {
     ordered: Vec<Arc<dyn Tool>>,
     definitions: Vec<ToolDefinition>,
+    exposures: Vec<ToolExposure>,
     by_name: HashMap<Box<str>, usize>,
     pub(super) providers: Vec<Arc<dyn DynamicToolProvider>>,
 }
@@ -14,10 +15,11 @@ pub(crate) struct ToolRegistry {
 impl ToolRegistry {
     pub(crate) fn contains(&self, name: &str) -> bool {
         self.get(name).is_some()
-            || self
-                .providers
-                .iter()
-                .any(|provider| provider.contains(name))
+            || (!host_owned_dynamic_name(name)
+                && self
+                    .providers
+                    .iter()
+                    .any(|provider| provider.contains(name)))
     }
 
     pub(crate) fn supports_parallel_tool_calls(&self, name: &str) -> bool {
@@ -74,10 +76,13 @@ impl ToolRegistry {
                     ));
                 }
             };
-            let Some(provider) = self
-                .providers
-                .iter()
-                .find(|provider| provider.contains(name))
+            let Some(provider) = (!host_owned_dynamic_name(name))
+                .then(|| {
+                    self.providers
+                        .iter()
+                        .find(|provider| provider.contains(name))
+                })
+                .flatten()
             else {
                 return ToolOutput::error(format!("unsupported tool call: {name}"));
             };
@@ -169,11 +174,12 @@ impl ToolRegistry {
         context: ToolContext<'_>,
     ) -> ToolOutput {
         let Some((handler, definition)) = self.get(name) else {
-            let Some(provider) = self
-                .providers
-                .iter()
-                .find(|provider| provider.contains(name))
-            else {
+            let Some(provider) = self.providers.iter().find(|provider| {
+                provider
+                    .available_definitions()
+                    .iter()
+                    .any(|definition| definition.name() == name)
+            }) else {
                 return ToolOutput::error(format!("unsupported nested tool call: {name}"));
             };
             if let Some(execution) = provider.execute(name, input, context).await {
@@ -219,20 +225,10 @@ impl ToolRegistry {
     }
 
     pub(crate) fn nested_tool_metadata(&self) -> Vec<Value> {
-        let mut metadata = self
-            .entries()
-            .filter(|(_, definition)| !matches!(definition, ToolDefinition::ToolSearch { .. }))
-            .map(|(_, definition)| definition_metadata(definition.name(), definition))
-            .collect::<Vec<_>>();
-        for definition in self
-            .providers
-            .iter()
-            .flat_map(|provider| provider.available_definitions())
-            .filter(|definition| !matches!(definition, ToolDefinition::ToolSearch { .. }))
-        {
-            metadata.push(definition_metadata(definition.name(), &definition));
-        }
-        metadata
+        self.code_mode_definitions()
+            .into_iter()
+            .map(|definition| definition_metadata(definition.name(), &definition))
+            .collect()
     }
     pub(super) fn from_ordered(ordered: Vec<Arc<dyn Tool>>) -> Self {
         let definitions = ordered
@@ -245,6 +241,7 @@ impl ToolRegistry {
             .map(|(index, definition)| (definition.name().into(), index))
             .collect();
         Self {
+            exposures: vec![ToolExposure::CodeModeOnly; definitions.len()],
             ordered,
             definitions,
             by_name,
@@ -252,12 +249,27 @@ impl ToolRegistry {
         }
     }
 
-    pub(super) fn extend(&mut self, tools: impl IntoIterator<Item = Arc<dyn Tool>>) {
-        for tool in tools {
-            let index = self.ordered.len();
+    pub(super) fn set_all_exposures(&mut self, exposure: ToolExposure) {
+        self.exposures.fill(exposure);
+    }
+
+    pub(super) fn extend(
+        &mut self,
+        tools: impl IntoIterator<Item = (Arc<dyn Tool>, ToolExposure)>,
+    ) {
+        for (tool, exposure) in tools {
             let definition = tool.definition();
+            if self.by_name.contains_key(definition.name()) {
+                tracing::warn!(
+                    tool_name = definition.name(),
+                    "skipping duplicate tool that is already registered"
+                );
+                continue;
+            }
+            let index = self.ordered.len();
             self.by_name.insert(definition.name().into(), index);
             self.definitions.push(definition);
+            self.exposures.push(exposure);
             self.ordered.push(tool);
         }
     }
@@ -271,35 +283,90 @@ impl ToolRegistry {
         &self.definitions
     }
 
-    pub(crate) fn code_mode_tool_names(&self) -> Vec<(String, String)> {
-        let mut names = std::collections::BTreeMap::new();
-        for definition in self
-            .definitions
+    pub(crate) fn direct_definitions(&self) -> impl Iterator<Item = &ToolDefinition> {
+        self.definitions
             .iter()
-            .filter(|definition| !matches!(definition, ToolDefinition::ToolSearch { .. }))
-        {
-            names.insert(
-                code_mode::description::normalize_identifier(definition.name()),
-                definition.name().to_owned(),
-            );
-        }
-        for definition in self
-            .providers
-            .iter()
-            .flat_map(|provider| provider.available_definitions())
-            .filter(|definition| !matches!(definition, ToolDefinition::ToolSearch { .. }))
-        {
-            names.insert(
-                code_mode::description::normalize_identifier(definition.name()),
-                definition.name().to_owned(),
-            );
-        }
-        names.into_iter().collect()
+            .zip(&self.exposures)
+            .filter_map(|(definition, exposure)| exposure.is_direct().then_some(definition))
     }
 
+    pub(crate) fn code_mode_tool_names(&self) -> Vec<(String, String)> {
+        let mut names = self
+            .code_mode_definitions()
+            .into_iter()
+            .map(|definition| {
+                (
+                    code_mode::description::normalize_identifier(definition.name()),
+                    definition.name().to_owned(),
+                )
+            })
+            .collect::<Vec<_>>();
+        names.sort();
+        names
+    }
+
+    pub(crate) fn registered_code_mode_definitions(&self) -> Vec<ToolDefinition> {
+        first_normalized_definitions(
+            self.definitions
+                .iter()
+                .zip(&self.exposures)
+                .filter(|(definition, exposure)| {
+                    exposure.is_available_in_code_mode()
+                        && !matches!(definition, ToolDefinition::ToolSearch { .. })
+                })
+                .map(|(definition, _)| definition.clone()),
+        )
+    }
+
+    pub(crate) fn code_mode_definitions(&self) -> Vec<ToolDefinition> {
+        let definitions = self
+            .definitions
+            .iter()
+            .zip(&self.exposures)
+            .filter(|(_, exposure)| exposure.is_available_in_code_mode())
+            .map(|(definition, _)| definition.clone())
+            .chain(
+                self.providers
+                    .iter()
+                    .flat_map(|provider| provider.available_definitions()),
+            )
+            .filter(|definition| {
+                !matches!(definition, ToolDefinition::ToolSearch { .. })
+                    && !host_owned_dynamic_name(definition.name())
+            });
+        first_normalized_definitions(definitions)
+    }
+
+    #[cfg(test)]
     pub(super) fn entries(&self) -> impl Iterator<Item = (&Arc<dyn Tool>, &ToolDefinition)> {
         self.ordered.iter().zip(&self.definitions)
     }
+}
+
+fn first_normalized_definitions(
+    definitions: impl IntoIterator<Item = ToolDefinition>,
+) -> Vec<ToolDefinition> {
+    let mut seen = HashSet::new();
+    definitions
+        .into_iter()
+        .filter(|definition| {
+            let normalized = code_mode::description::normalize_identifier(definition.name());
+            if seen.insert(normalized.clone()) {
+                true
+            } else {
+                tracing::warn!(
+                    tool_name = definition.name(),
+                    code_mode_name = normalized,
+                    "skipping tool with a duplicate normalized Code Mode name"
+                );
+                false
+            }
+        })
+        .collect()
+}
+
+fn host_owned_dynamic_name(name: &str) -> bool {
+    matches!(name, "exec" | "wait")
 }
 
 fn definition_metadata(name: &str, definition: &ToolDefinition) -> Value {

--- a/crates/nanocodex-tools/src/runtime/selection.rs
+++ b/crates/nanocodex-tools/src/runtime/selection.rs
@@ -9,6 +9,26 @@ pub enum ToolExposure {
     /// Expose `exec` and `wait` before ordinary direct tools, while retaining
     /// the same handlers for calls composed through Code Mode.
     DirectAndCodeMode,
+    /// Expose a tool directly without making it callable from Code Mode.
+    DirectOnly,
+    /// Keep a tool registered for dispatch without exposing it to the model.
+    Hidden,
+}
+
+impl ToolExposure {
+    pub(super) const fn is_direct(self) -> bool {
+        matches!(self, Self::DirectAndCodeMode | Self::DirectOnly)
+    }
+
+    pub(super) const fn is_available_in_code_mode(self) -> bool {
+        matches!(self, Self::CodeModeOnly | Self::DirectAndCodeMode)
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct RegisteredTool {
+    pub(super) handler: Arc<dyn Tool>,
+    pub(super) exposure: Option<ToolExposure>,
 }
 
 /// A lazily populated family of Code Mode tools.
@@ -75,7 +95,7 @@ pub struct Tools {
     pub(super) default_shell: Option<Arc<str>>,
     process_environment: Arc<Vec<(OsString, OsString)>>,
     remote_http_client: Option<reqwest::Client>,
-    pub(super) registered: Vec<Arc<dyn Tool>>,
+    pub(super) registered: Vec<RegisteredTool>,
     pub(super) provider_direct: Vec<Arc<dyn Tool>>,
     pub(super) providers: Vec<Arc<dyn DynamicToolProvider>>,
     pub(super) deferred_tools_guidance_enabled: bool,
@@ -121,7 +141,7 @@ impl fmt::Debug for Tools {
                 &self
                     .registered
                     .iter()
-                    .map(|tool| tool.definition().name().to_owned())
+                    .map(|tool| tool.handler.definition().name().to_owned())
                     .collect::<Vec<_>>(),
             )
             .field(
@@ -236,6 +256,10 @@ pub enum ToolsBuildError {
     /// A custom tool collides with an enabled built-in tool.
     #[error("tool name `{0}` conflicts with an enabled built-in tool")]
     BuiltInName(Box<str>),
+
+    /// A custom tool collides with a host-owned routing tool.
+    #[error("tool name `{0}` is reserved by the Code Mode host")]
+    ReservedName(Box<str>),
 }
 
 impl ToolsBuilder {
@@ -322,7 +346,24 @@ impl ToolsBuilder {
     /// Adds a function or freeform tool to the runtime.
     #[must_use]
     pub fn tool<T: Tool + 'static>(mut self, tool: T) -> Self {
-        self.tools.registered.push(Arc::new(tool));
+        self.tools.registered.push(RegisteredTool {
+            handler: Arc::new(tool),
+            exposure: None,
+        });
+        self
+    }
+
+    /// Adds a function or freeform tool with an explicit model-facing exposure.
+    #[must_use]
+    pub fn tool_with_exposure<T: Tool + 'static>(
+        mut self,
+        tool: T,
+        exposure: ToolExposure,
+    ) -> Self {
+        self.tools.registered.push(RegisteredTool {
+            handler: Arc::new(tool),
+            exposure: Some(exposure),
+        });
         self
     }
 
@@ -364,16 +405,33 @@ impl ToolsBuilder {
                 .len()
                 .saturating_add(self.tools.provider_direct.len()),
         );
-        for tool in self
-            .tools
-            .registered
-            .iter()
-            .chain(&self.tools.provider_direct)
-        {
+        for tool in &self.tools.registered {
+            let definition = tool.handler.definition();
+            let name = definition.name();
+            if name.is_empty() {
+                return Err(ToolsBuildError::EmptyName);
+            }
+            if host_owned_name(name)
+                || (name == "tool_search"
+                    && !matches!(definition, ToolDefinition::ToolSearch { .. }))
+            {
+                return Err(ToolsBuildError::ReservedName(name.into()));
+            }
+            if built_in_name(&self.tools, name) {
+                return Err(ToolsBuildError::BuiltInName(name.into()));
+            }
+            if !names.insert(name.to_owned()) {
+                return Err(ToolsBuildError::DuplicateName(name.into()));
+            }
+        }
+        for tool in &self.tools.provider_direct {
             let definition = tool.definition();
             let name = definition.name();
             if name.is_empty() {
                 return Err(ToolsBuildError::EmptyName);
+            }
+            if host_owned_name(name) {
+                return Err(ToolsBuildError::ReservedName(name.into()));
             }
             if built_in_name(&self.tools, name) {
                 return Err(ToolsBuildError::BuiltInName(name.into()));
@@ -399,6 +457,10 @@ impl ToolsBuilder {
             .flat_map(|provider| provider.direct_tools_for_exposure(self.tools.exposure))
             .collect();
     }
+}
+
+fn host_owned_name(name: &str) -> bool {
+    matches!(name, "exec" | "wait")
 }
 
 fn built_in_name(tools: &Tools, name: &str) -> bool {

--- a/crates/nanocodex-tools/src/runtime/selection.rs
+++ b/crates/nanocodex-tools/src/runtime/selection.rs
@@ -459,10 +459,6 @@ impl ToolsBuilder {
     }
 }
 
-fn host_owned_name(name: &str) -> bool {
-    matches!(name, "exec" | "wait")
-}
-
 fn built_in_name(tools: &Tools, name: &str) -> bool {
     (tools.workspace
         && matches!(

--- a/crates/nanocodex-tools/src/runtime/tests.rs
+++ b/crates/nanocodex-tools/src/runtime/tests.rs
@@ -6,7 +6,7 @@ use std::{
     },
 };
 
-use nanocodex_oai_api::{auth::OpenAiAuth, tools::ToolDefinition};
+use nanocodex_oai_api::{auth::OpenAiAuth, responses::JsonSchema, tools::ToolDefinition};
 use serde::Deserialize;
 use serde_json::{Value, json, value::to_raw_value};
 
@@ -31,6 +31,8 @@ struct Search {
     activated: Arc<AtomicBool>,
 }
 
+struct NativeSearch;
+
 struct DeferredProvider {
     activated: Arc<AtomicBool>,
     started: AtomicBool,
@@ -46,6 +48,11 @@ struct StartTrackingProvider {
 }
 
 struct CollisionTool;
+
+struct NamedTool {
+    name: &'static str,
+    output: &'static str,
+}
 
 struct DeclaredProvider {
     name: &'static str,
@@ -76,6 +83,21 @@ impl Tool for Double {
     async fn execute(&self, input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
         let input = input.decode_json::<DoubleInput>()?;
         Ok(ToolOutput::text((input.value * 2).to_string()))
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for NamedTool {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::function(
+            self.name,
+            format!("Returns {}.", self.output),
+            json!({ "type": "object", "properties": {} }),
+        )
+    }
+
+    async fn execute(&self, _input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
+        Ok(ToolOutput::text(self.output))
     }
 }
 
@@ -222,6 +244,26 @@ impl Tool for Search {
             json!({ "name": "deferred_echo" }),
             true,
         ))
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for NativeSearch {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::tool_search(
+            "client",
+            "Searches deferred tools.",
+            JsonSchema::from(json!({
+                "type": "object",
+                "properties": { "query": { "type": "string" } },
+                "required": ["query"],
+                "additionalProperties": false
+            })),
+        )
+    }
+
+    async fn execute(&self, _input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
+        Ok(ToolOutput::from_json(json!([]), true))
     }
 }
 
@@ -532,6 +574,154 @@ fn exposure_controls_direct_visibility_without_removing_code_mode_access() {
         "normal Code Mode augments each direct spec with its exec declaration"
     );
     assert_eq!(code_mode_contract, code_mode_only_contract);
+}
+
+#[test]
+fn per_tool_exposure_selects_direct_and_code_mode_surfaces_independently() {
+    let tools = Tools::builder()
+        .without_defaults()
+        .tool(NamedTool {
+            name: "nested_only",
+            output: "nested",
+        })
+        .tool_with_exposure(
+            NamedTool {
+                name: "direct_only",
+                output: "direct",
+            },
+            ToolExposure::DirectOnly,
+        )
+        .tool_with_exposure(
+            NamedTool {
+                name: "hidden",
+                output: "hidden",
+            },
+            ToolExposure::Hidden,
+        )
+        .build()
+        .unwrap();
+    let runtime = ToolRuntime::new_with_tools(".", None, None, &tools);
+
+    assert_eq!(
+        runtime
+            .model_specs("test-session")
+            .iter()
+            .map(ToolDefinition::name)
+            .collect::<Vec<_>>(),
+        ["exec", "wait", "direct_only"]
+    );
+    assert_eq!(
+        runtime.model_contract("test-session").1,
+        [("nested_only".to_owned(), "nested_only".to_owned())]
+    );
+    assert!(
+        runtime.contains("hidden"),
+        "hidden tools remain dispatchable"
+    );
+}
+
+#[tokio::test]
+async fn first_registered_normalized_code_mode_name_wins_consistently() {
+    let tools = Tools::builder()
+        .without_defaults()
+        .exposure(ToolExposure::DirectAndCodeMode)
+        .tool(NamedTool {
+            name: "normalized-alias",
+            output: "first",
+        })
+        .tool(NamedTool {
+            name: "normalized_alias",
+            output: "second",
+        })
+        .build()
+        .unwrap();
+    let runtime = ToolRuntime::new_with_tools(".", None, None, &tools);
+
+    assert_eq!(
+        runtime.model_contract("test-session").1,
+        [("normalized_alias".to_owned(), "normalized-alias".to_owned())]
+    );
+    let execution = runtime
+        .execute_code(
+            "text(await tools.normalized_alias({}));",
+            ToolContext::new(
+                "test-model",
+                "test-session",
+                "test-call",
+                &[],
+                DEFAULT_TOOL_OUTPUT_TOKENS,
+            ),
+        )
+        .await;
+    assert!(execution.success);
+    assert_eq!(execution.nested_calls[0].name, "normalized-alias");
+}
+
+#[test]
+fn registered_tools_cannot_replace_host_owned_routing_tools() {
+    for name in ["exec", "wait", "tool_search"] {
+        let result = Tools::builder()
+            .without_defaults()
+            .tool(NamedTool {
+                name,
+                output: "replacement",
+            })
+            .build();
+        assert!(matches!(
+            result,
+            Err(super::ToolsBuildError::ReservedName(candidate)) if candidate.as_ref() == name
+        ));
+    }
+}
+
+#[test]
+fn canonical_native_tool_search_remains_configurable() {
+    let tools = Tools::builder()
+        .without_defaults()
+        .tool(NativeSearch)
+        .build()
+        .unwrap();
+
+    assert!(matches!(
+        tools.registered[0].handler.definition(),
+        ToolDefinition::ToolSearch { .. }
+    ));
+}
+
+#[tokio::test]
+async fn extending_a_runtime_keeps_the_first_exact_tool_registration() {
+    let first = Tools::builder()
+        .without_defaults()
+        .tool(NamedTool {
+            name: "same_name",
+            output: "first",
+        })
+        .build()
+        .unwrap();
+    let second = Tools::builder()
+        .without_defaults()
+        .tool(NamedTool {
+            name: "same_name",
+            output: "second",
+        })
+        .build()
+        .unwrap();
+    let runtime = ToolRuntime::new_with_tools(".", None, None, &first).with_tools(&second);
+    let output = runtime
+        .execute_tool(
+            "same_name",
+            ToolInput::Function(to_raw_value(&json!({})).unwrap()),
+            ToolContext::new(
+                "test-model",
+                "test-session",
+                "test-call",
+                &[],
+                DEFAULT_TOOL_OUTPUT_TOKENS,
+            ),
+        )
+        .await;
+
+    assert_eq!(output.code_mode_value(), json!("first"));
 }
 
 #[test]

--- a/crates/nanocodex-tools/src/runtime/tests.rs
+++ b/crates/nanocodex-tools/src/runtime/tests.rs
@@ -672,20 +672,14 @@ fn registered_tools_cannot_replace_host_owned_routing_tools() {
             Err(super::ToolsBuildError::ReservedName(candidate)) if candidate.as_ref() == name
         ));
     }
-}
 
-#[test]
-fn canonical_native_tool_search_remains_configurable() {
-    let tools = Tools::builder()
-        .without_defaults()
-        .tool(NativeSearch)
-        .build()
-        .unwrap();
-
-    assert!(matches!(
-        tools.registered[0].handler.definition(),
-        ToolDefinition::ToolSearch { .. }
-    ));
+    assert!(
+        Tools::builder()
+            .without_defaults()
+            .tool(NativeSearch)
+            .build()
+            .is_ok()
+    );
 }
 
 #[tokio::test]

--- a/docs/CODEX_PARITY.md
+++ b/docs/CODEX_PARITY.md
@@ -34,10 +34,10 @@ claims.
 
 | Classification | Count |
 | --- | ---: |
-| `port` | 50 |
+| `port` | 52 |
 | `evaluate` | 45 |
 | `defer` | 10 |
-| `out-of-scope` | 450 |
+| `out-of-scope` | 448 |
 | Total | 555 |
 
 ## First range: `35eaf3ff..8431dc59`

--- a/docs/CODEX_PARITY.md
+++ b/docs/CODEX_PARITY.md
@@ -1,25 +1,21 @@
 # Codex parity ledger
 
-This ledger records the review of all 323 commits in the exclusive local
+This ledger records the review of all 555 commits in the exclusive local
 checkout range
 
 ```text
 openai/codex@35eaf3ffb0bf2001486c68c47a3d946b34d16634
-    ..openai/codex@be2e4afcd7392339d6adbaf0d31b26316bcaa2ab
+    ..openai/codex@7ada37a15e1f6aa84f83b4b9410f9d29e66fefe4
 ```
 
 The review used the clean local Codex checkout at the range head. The command
-`git rev-list --count <range>` returns `323`. The first 37 commits remain
+`git rev-list --count <range>` returns `555`. The first 37 commits remain
 expanded below; the following 279 are classified individually in
 [`codex-parity/8431dc59-3418498f.md`](codex-parity/8431dc59-3418498f.md), and
 the final seven are classified in
-[`codex-parity/3418498f-be2e4afc.md`](codex-parity/3418498f-be2e4afc.md).
-
-This is the latest reviewed checkpoint, not a claim about every commit
-currently present in the local upstream checkout. Local `origin/main` is
-`bb1af235ea2822d7a40f75ef52e4d6a2cde84da2`, ten commits after this ledger.
-Those commits remain unclassified and the checkpoint must not advance until
-they receive the same port/evaluate/defer/out-of-scope review.
+[`codex-parity/3418498f-be2e4afc.md`](codex-parity/3418498f-be2e4afc.md). The
+latest 232 are classified in
+[`codex-parity/be2e4afc-7ada37a1.md`](codex-parity/be2e4afc-7ada37a1.md).
 
 The classifications mean:
 
@@ -38,11 +34,11 @@ claims.
 
 | Classification | Count |
 | --- | ---: |
-| `port` | 34 |
-| `evaluate` | 21 |
-| `defer` | 2 |
-| `out-of-scope` | 266 |
-| Total | 323 |
+| `port` | 50 |
+| `evaluate` | 45 |
+| `defer` | 10 |
+| `out-of-scope` | 450 |
+| Total | 555 |
 
 ## First range: `35eaf3ff..8431dc59`
 

--- a/docs/codex-parity/be2e4afc-7ada37a1.md
+++ b/docs/codex-parity/be2e4afc-7ada37a1.md
@@ -1,0 +1,303 @@
+# Codex parity review: `be2e4afc..7ada37a1`
+
+This appendix classifies every commit in the exclusive local-checkout range
+
+```text
+openai/codex@be2e4afcd7392339d6adbaf0d31b26316bcaa2ab
+    ..openai/codex@7ada37a15e1f6aa84f83b4b9410f9d29e66fefe4
+```
+
+`git rev-list --count be2e4afcd7..7ada37a15e` returns `232`. The ordered list
+below is mechanically comparable with
+`git log --reverse --format=%h be2e4afcd7..7ada37a15e`.
+
+The decision codes reuse the main ledger's policy:
+
+- `P32` — optional MCP startup, readiness, and late completion do not block
+  unrelated tools or lose a successful connection.
+- `P33` — automatic MCP catalog pagination is bounded to 100 pages, 2,048
+  items, 64-KiB cursors, and a 30-second collection window.
+- `P34` — one ordered registry protects host tools and uses the first exact or
+  normalized Code Mode identity consistently.
+- `P35` — callers select direct/Code Mode exposure per registered tool and
+  deferred/Code Mode exposure per MCP server.
+- `P36` — function and custom definitions preserve eager wire shapes while
+  supporting deferred loading, including custom namespace members.
+- `P37` — complete caller/server namespace descriptions remain available;
+  Nanocodex does not inherit Codex's temporary truncation.
+- `E15` — relevant runtime, transport, TUI, MCP, or cleanup behavior needs a
+  focused Nanocodex regression, profile, or consumer before adoption.
+- `D3` — the standalone sandbox-enabled V8 host, its packaging, and its
+  WebSocket/recovery protocol are intentionally deferred. Nanocodex retains
+  embedded QuickJS and explicit tool mediation.
+- `O15` — the inspected change is app-server, persisted-thread, skills/plugin,
+  approval, provider-account, generic environment/scheduler, shared HTTP,
+  build/release, test-only, or superseded implementation work with no
+  remaining Nanocodex invariant.
+
+## Ordered classifications
+
+```text
+f2bee854a7 evaluate E15
+8e271dc02b out-of-scope O15
+d9e1c9cd55 port P32
+e597169e9a out-of-scope O15
+a68d0a74bd out-of-scope O15
+f6160ca5b3 out-of-scope O15
+7cde2323f3 out-of-scope O15
+03748ad5e1 out-of-scope O15
+84ccb2938b port P32
+bb1af235ea out-of-scope O15
+cf7e9cfe6a out-of-scope O15
+fa1d4c40d0 out-of-scope O15
+4f6eaf7af9 out-of-scope O15
+8f00b9a04c out-of-scope O15
+9ea975a2dc evaluate E15
+709283b432 evaluate E15
+dd6b880353 out-of-scope O15
+8bbdf6c8f9 out-of-scope O15
+155c3e299c out-of-scope O15
+50a7328f50 out-of-scope O15
+438c9e98db out-of-scope O15
+12b3e88028 defer D3
+1def0a8925 out-of-scope O15
+c550cb3e01 out-of-scope O15
+12b961d4c5 out-of-scope O15
+3a797496f1 out-of-scope O15
+9f4c20aadc evaluate E15
+166658a34a out-of-scope O15
+03edf16f0b out-of-scope O15
+101d6b8cb2 out-of-scope O15
+8707a35113 out-of-scope O15
+07490c7523 out-of-scope O15
+fcd2273de7 out-of-scope O15
+b9b7c21821 out-of-scope O15
+28f3f1f9ef out-of-scope O15
+9f23e97797 out-of-scope O15
+0a6616f4cf out-of-scope O15
+6c13b113a3 out-of-scope O15
+250de82bfb out-of-scope O15
+b96ebfb312 out-of-scope O15
+d06c7ac055 evaluate E15
+fe01054a28 out-of-scope O15
+fbf666fa98 port P32
+ddf33ea802 out-of-scope O15
+a4d2f31022 out-of-scope O15
+9a6668f674 out-of-scope O15
+e1895710ad out-of-scope O15
+00cb5c465b out-of-scope O15
+cef3910ea4 evaluate E15
+3725f02cf3 evaluate E15
+1ae2b9880e evaluate E15
+1e3c0042eb evaluate E15
+1da9f846b3 out-of-scope O15
+f9b18d04ba out-of-scope O15
+df326d31cd defer D3
+a05bcda3db evaluate E15
+7579a2b413 out-of-scope O15
+c41a38dd10 evaluate E15
+ad6fc66b6d out-of-scope O15
+09cf609218 out-of-scope O15
+85c082cccc evaluate E15
+a5082373f1 out-of-scope O15
+88d6c2b2b4 out-of-scope O15
+1dad11f818 out-of-scope O15
+78a61de904 out-of-scope O15
+5989dcc470 out-of-scope O15
+9cf6b3905c out-of-scope O15
+a1286d12a2 out-of-scope O15
+3834c47ccb out-of-scope O15
+3e3ae08839 port P33
+6493417150 out-of-scope O15
+7ec480dda5 evaluate E15
+410c22b30e out-of-scope O15
+7b93b3bf9c out-of-scope O15
+b1ccaa0e08 out-of-scope O15
+1c5f336c40 out-of-scope O15
+406dc92394 evaluate E15
+ff352fab62 out-of-scope O15
+7d5253d2b0 out-of-scope O15
+88ec932e96 out-of-scope O15
+6219b7c40f evaluate E15
+b293412c24 port P34
+9a46fd33a0 port P32
+3d805abdf0 out-of-scope O15
+5decb399ae out-of-scope O15
+89a0eed93c port P34
+4f6d06d485 out-of-scope O15
+c126f206da port P34
+bdda5da56c out-of-scope O15
+aa06446345 out-of-scope O15
+9588f660be out-of-scope O15
+5ad367fb95 out-of-scope O15
+5a1097ed26 out-of-scope O15
+25eecb071e out-of-scope O15
+b545c94041 out-of-scope O15
+2fbbb1a11a out-of-scope O15
+856bf5a33a out-of-scope O15
+13ddc7aa57 out-of-scope O15
+b445967cc0 out-of-scope O15
+578c1b2230 out-of-scope O15
+355d2a802a out-of-scope O15
+ceb4bc72c4 out-of-scope O15
+0dcad0c972 out-of-scope O15
+483559cc75 out-of-scope O15
+9eeac78b3f out-of-scope O15
+6256a7ccc7 out-of-scope O15
+ba42e6866c out-of-scope O15
+789c72dcf6 evaluate E15
+0042b00986 evaluate E15
+acd540f158 out-of-scope O15
+97576b1794 defer D3
+e6cfd40c3f out-of-scope O15
+745603a5a1 out-of-scope O15
+a01a2d9146 out-of-scope O15
+3016671bb0 out-of-scope O15
+413492cd6c out-of-scope O15
+4642370542 out-of-scope O15
+53d06e24ea defer D3
+f0c30e528a out-of-scope O15
+bf4d3f51ea out-of-scope O15
+5e8b22488f out-of-scope O15
+164b3bfeab out-of-scope O15
+aea26afaee out-of-scope O15
+66d63afd18 out-of-scope O15
+ef293f7ac9 out-of-scope O15
+448118f544 out-of-scope O15
+5548c95d66 out-of-scope O15
+3d1d26915a out-of-scope O15
+7b38c48da9 out-of-scope O15
+2c005abb07 out-of-scope O15
+35eab50501 out-of-scope O15
+c4f2746c43 evaluate E15
+bbbf396839 out-of-scope O15
+66ebeb7037 out-of-scope O15
+d97cb0dcad out-of-scope O15
+385fe95ce1 out-of-scope O15
+da2c7ca8d1 out-of-scope O15
+0d109f097c out-of-scope O15
+287e1020ae out-of-scope O15
+775fb21d2a port P34
+845497f483 out-of-scope O15
+b7a6106608 out-of-scope O15
+2e32d95894 defer D3
+d62353a312 out-of-scope O15
+c42ea41ee0 out-of-scope O15
+332eac4b85 out-of-scope O15
+bf7804c254 out-of-scope O15
+1bef168976 out-of-scope O15
+dc60dadce6 out-of-scope O15
+003ec63bba evaluate E15
+64b2a3008e out-of-scope O15
+670f69416b out-of-scope O15
+a850875a8e out-of-scope O15
+e2c0837923 out-of-scope O15
+4c219fdb1a out-of-scope O15
+6751b54cae out-of-scope O15
+ee0247f95a out-of-scope O15
+7dc1856685 evaluate E15
+feee0b07c7 out-of-scope O15
+a1dd74b535 out-of-scope O15
+1e85ca099e out-of-scope O15
+5825699981 port P33
+2b5bdcf675 out-of-scope O15
+9949245d1d out-of-scope O15
+5157493c23 out-of-scope O15
+bb5054fe47 out-of-scope O15
+8b8fa7276f out-of-scope O15
+1b594980f3 out-of-scope O15
+dae2122214 out-of-scope O15
+155f1ca9e5 out-of-scope O15
+87e2d41eb3 out-of-scope O15
+d6407d7359 out-of-scope O15
+79479cdf09 out-of-scope O15
+7dd2f689e9 out-of-scope O15
+62839fec5d out-of-scope O15
+7750465934 out-of-scope O15
+c39d3e99d5 out-of-scope O15
+8922a784fe out-of-scope O15
+ca2b47997e port P34
+c82cb044f3 out-of-scope O15
+f94b5d899a out-of-scope O15
+82ccbc757a evaluate E15
+e4e040881a out-of-scope O15
+224ea64cdc out-of-scope O15
+78306a32af out-of-scope O15
+136f75e7b7 out-of-scope O15
+51c9ed6d4f port P35
+bbcf5e10fb out-of-scope O15
+df72fdb415 out-of-scope O15
+e4e0c7070e out-of-scope O15
+3149fa4b99 evaluate E15
+bd12b3a9ec out-of-scope O15
+51d4aa946c defer D3
+1bbfb5cfad out-of-scope O15
+cc03518c36 out-of-scope O15
+9c8f9ce897 out-of-scope O15
+41e2f67e56 out-of-scope O15
+61dc1d97f6 evaluate E15
+b258c028fe out-of-scope O15
+60c722e075 defer D3
+7431f10d0d out-of-scope O15
+64bb8094ba out-of-scope O15
+b2dc8b3e4b out-of-scope O15
+8e3b5d3e87 defer D3
+db1a414569 out-of-scope O15
+5af85998c2 out-of-scope O15
+12288240b4 port P36
+d4fb78bfc5 port P36
+9873cba8ce out-of-scope O15
+2a16af8234 out-of-scope O15
+4c25d6cc5c out-of-scope O15
+77ce1d10aa out-of-scope O15
+fd1e4d7a6d port P37
+1669c2403f out-of-scope O15
+6d4d9442c7 out-of-scope O15
+fcf636a41d out-of-scope O15
+17df7545a3 port P32
+40e5de94e9 evaluate E15
+18f03c1eb7 out-of-scope O15
+f93109615f out-of-scope O15
+49b0aebd6f out-of-scope O15
+d98eb72e18 out-of-scope O15
+d1f14e31a7 out-of-scope O15
+bab7c2dcc1 out-of-scope O15
+ee46c5ba0e out-of-scope O15
+6a828ca26f out-of-scope O15
+2999b8e831 out-of-scope O15
+c8e255e7f8 out-of-scope O15
+7325f348a2 out-of-scope O15
+d75f94a94d out-of-scope O15
+02bc1dd796 out-of-scope O15
+7ada37a15e out-of-scope O15
+```
+
+## Port evidence
+
+- `P32`: `runtime_construction_starts_providers_and_preserves_eager_prewarm`,
+  `direct_model_calls_reach_activated_dynamic_tools`, MCP concurrent startup,
+  and reload tests cover nonblocking provider startup and late reusable state.
+- `P33`: `mcp::pagination` rejects repeated/oversized catalogs and preserves
+  page order; resource integration tests exhaust valid multi-page results.
+- `P34`: `registered_tools_cannot_replace_host_owned_routing_tools` and
+  `first_registered_normalized_code_mode_name_wins_consistently` cover host
+  reservation and first-winner prompt, metadata, and dispatch behavior.
+- `P35`: `per_tool_exposure_selects_direct_and_code_mode_surfaces_independently`
+  and `mcp_tool_exposure_selects_deferred_and_code_mode_surfaces_per_server`
+  cover each supported surface while hidden handlers remain registered.
+- `P36`: `function_and_custom_tools_opt_into_deferred_loading_without_changing_eager_shapes`
+  covers eager compatibility, deferred custom tools, and custom namespace
+  members.
+- `P37`: MCP provider tests retain exact server descriptions in tool-search
+  namespace output. The temporary Codex truncation in `ddf33ea802` is
+  superseded by `fd1e4d7a6d` and is not adopted.
+
+## Classification totals
+
+| Classification | Count |
+| --- | ---: |
+| `port` | 16 |
+| `evaluate` | 24 |
+| `defer` | 8 |
+| `out-of-scope` | 184 |
+| Total | 232 |

--- a/docs/codex-parity/be2e4afc-7ada37a1.md
+++ b/docs/codex-parity/be2e4afc-7ada37a1.md
@@ -25,6 +25,11 @@ The decision codes reuse the main ledger's policy:
   supporting deferred loading, including custom namespace members.
 - `P37` — complete caller/server namespace descriptions remain available;
   Nanocodex does not inherit Codex's temporary truncation.
+- `P38` — known encrypted function-argument markers remain lossless in typed
+  Responses history even though collaboration behavior stays out of scope.
+- `P39` — the model-visible `tool_search` source advertisement is bounded to
+  4 KiB without truncating UTF-8 or removing complete namespace descriptions
+  from returned definitions.
 - `E15` — relevant runtime, transport, TUI, MCP, or cleanup behavior needs a
   focused Nanocodex regression, profile, or consumer before adoption.
 - `D3` — the standalone sandbox-enabled V8 host, its packaging, and its
@@ -66,7 +71,7 @@ c550cb3e01 out-of-scope O15
 3a797496f1 out-of-scope O15
 9f4c20aadc evaluate E15
 166658a34a out-of-scope O15
-03edf16f0b out-of-scope O15
+03edf16f0b port P38
 101d6b8cb2 out-of-scope O15
 8707a35113 out-of-scope O15
 07490c7523 out-of-scope O15
@@ -81,7 +86,7 @@ b96ebfb312 out-of-scope O15
 d06c7ac055 evaluate E15
 fe01054a28 out-of-scope O15
 fbf666fa98 port P32
-ddf33ea802 out-of-scope O15
+ddf33ea802 port P39
 a4d2f31022 out-of-scope O15
 9a6668f674 out-of-scope O15
 e1895710ad out-of-scope O15
@@ -291,13 +296,19 @@ d75f94a94d out-of-scope O15
 - `P37`: MCP provider tests retain exact server descriptions in tool-search
   namespace output. The temporary Codex truncation in `ddf33ea802` is
   superseded by `fd1e4d7a6d` and is not adopted.
+- `P38`: `function_calls_preserve_encrypted_argument_markers` round-trips both
+  empty and populated `encrypted_function_args` fields through typed history.
+- `P39`: `search_definition_bounds_aggregate_source_descriptions` keeps the
+  source section within 4 KiB at a UTF-8 boundary while preserving configured
+  source names. Namespace wire tests additionally reject nested namespace and
+  `tool_search` children while retaining function/custom children.
 
 ## Classification totals
 
 | Classification | Count |
 | --- | ---: |
-| `port` | 16 |
+| `port` | 18 |
 | `evaluate` | 24 |
 | `defer` | 8 |
-| `out-of-scope` | 184 |
+| `out-of-scope` | 182 |
 | Total | 232 |

--- a/docs/codex-parity/be2e4afc-7ada37a1.md
+++ b/docs/codex-parity/be2e4afc-7ada37a1.md
@@ -282,17 +282,17 @@ d75f94a94d out-of-scope O15
 - `P32`: `runtime_construction_starts_providers_and_preserves_eager_prewarm`,
   `direct_model_calls_reach_activated_dynamic_tools`, MCP concurrent startup,
   and reload tests cover nonblocking provider startup and late reusable state.
-- `P33`: `mcp::pagination` rejects repeated/oversized catalogs and preserves
-  page order; resource integration tests exhaust valid multi-page results.
+- `P33`: `mcp::pagination` rejects repeated/oversized catalogs; resource
+  integration tests exhaust valid multi-page results in order.
 - `P34`: `registered_tools_cannot_replace_host_owned_routing_tools` and
   `first_registered_normalized_code_mode_name_wins_consistently` cover host
   reservation and first-winner prompt, metadata, and dispatch behavior.
 - `P35`: `per_tool_exposure_selects_direct_and_code_mode_surfaces_independently`
   and `mcp_tool_exposure_selects_deferred_and_code_mode_surfaces_per_server`
   cover each supported surface while hidden handlers remain registered.
-- `P36`: `function_and_custom_tools_opt_into_deferred_loading_without_changing_eager_shapes`
-  covers eager compatibility, deferred custom tools, and custom namespace
-  members.
+- `P36`: existing namespace serialization coverage plus
+  `custom_tools_opt_into_deferred_loading_and_namespace_membership` cover eager
+  compatibility, deferred custom tools, and custom namespace members.
 - `P37`: MCP provider tests retain exact server descriptions in tool-search
   namespace output. The temporary Codex truncation in `ddf33ea802` is
   superseded by `fd1e4d7a6d` and is not adopted.


### PR DESCRIPTION
## Summary

- protect host-owned Code Mode routing names and make exact/normalized registry collisions consistently first-wins
- add per-tool direct/Code Mode exposure, per-server MCP deferred/Code Mode exposure, and deferred custom-tool wire support
- bound automatic MCP tools/resources pagination by pages, items, cursor size, and wall-clock time
- preserve encrypted_function_args losslessly in typed Responses history
- prevent invalid namespace children from being serialized on the Responses wire
- cap model-visible MCP tool_search source advertisements at 4 KiB on UTF-8 boundaries while retaining complete returned namespace descriptions
- advance the local Codex parity ledger from 35eaf3ff to 7ada37a1 after classifying all 555 commits; keep the standalone sandboxed V8 host deferred

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo check --workspace --all-targets
- cargo test -p nanocodex-oai-api --lib
- cargo test -p nanocodex-tools --lib
- cargo test -p nanocodex-oai-api --test it
- focused nanocodex-agent recovery normalization integration test
- cargo check -p nanocodex-examples --bins
- crate-boundary, experimental-boundary, and rustls-provider policy scripts

## Known unrelated failure

The earlier complete workspace test run reached one existing nanocodex-vm timing failure in tools::guest::tests::timeout_kills_descendants_holding_output_pipes. It reproduces in isolation and this PR does not modify nanocodex-vm. All non-VM workspace tests passed.