### PR TITLE
feat(cli): enable browser tools by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
+- [cli] Enable the private browser and complete desktop-profile cookie import
+  by default, with compact up-front `tools.browser` discovery in Code Mode.
 - [tools] Add bounded MCP pagination, collision-safe Code Mode registration,
   per-tool and per-server exposure policy, and deferred custom-tool wire shapes.
 - [parity] Classify Codex through `7ada37a1` and defer the standalone V8 host.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-- [cli] Enable the private browser and complete desktop-profile cookie import
-  by default, with compact up-front `tools.browser` discovery in Code Mode.
+- [cli] Enable private Brave and complete desktop-profile cookie import by
+  default, with compact up-front `tools.browser` discovery in Code Mode.
 - [tools] Add bounded MCP pagination, collision-safe Code Mode registration,
   per-tool and per-server exposure policy, and deferred custom-tool wire shapes.
 - [parity] Classify Codex through `7ada37a1` and defer the standalone V8 host.

--- a/bin/nanocodex/src/browser.rs
+++ b/bin/nanocodex/src/browser.rs
@@ -12,18 +12,22 @@ enum BrowserKind {
     #[value(alias = "true")]
     Chromium,
     Brave,
+    #[value(alias = "false", alias = "off")]
+    None,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 enum CookieSourceKind {
-    #[value(alias = "true")]
-    Auto,
+    #[value(alias = "auto", alias = "true")]
+    All,
     Brave,
     Chrome,
     Chromium,
     Edge,
     Firefox,
     Safari,
+    #[value(alias = "false", alias = "off")]
+    None,
 }
 
 enum CookieSource {
@@ -31,46 +35,53 @@ enum CookieSource {
     State(BrowserStorageState),
 }
 
-/// Opt-in local browser configuration for normal agent sessions.
-#[derive(Args, Default)]
+/// Local browser configuration for normal agent sessions.
+#[derive(Args)]
 pub(crate) struct BrowserArgs {
-    /// Expose one private browser session to Code Mode as `tools.browser`.
+    /// Select the private browser exposed to Code Mode as `tools.browser`.
     ///
     /// Pass `brave` to use the standard Brave installation. A bare `--browser`
-    /// preserves the private Chromium default.
+    /// preserves the private Chromium default; pass `none` to disable it.
     #[arg(
         long,
         env = "NANOCODEX_BROWSER",
         value_enum,
         num_args = 0..=1,
+        default_value = "chromium",
         default_missing_value = "chromium",
         require_equals = true
     )]
     browser: Option<BrowserKind>,
 
-    /// Copy cookies from a standard desktop browser profile.
+    /// Copy cookies from a standard desktop browser profile into the private session.
     ///
-    /// Pass a browser name to select the source profile. A bare flag or `true`
-    /// automatically selects an installed profile.
+    /// The default `all` copies every cookie from an automatically selected
+    /// installed profile. Pass a browser name to select its profile or `none`
+    /// to start with an empty cookie jar.
     #[arg(
         long,
         env = "NANOCODEX_BROWSER_COOKIES",
         value_enum,
         num_args = 0..=1,
-        default_missing_value = "auto",
-        require_equals = true,
-        requires = "browser"
+        default_value = "all",
+        default_missing_value = "all",
+        require_equals = true
     )]
     cookies: Option<CookieSourceKind>,
 
     /// Chrome or Chromium executable used by the browser tool.
-    #[arg(
-        long,
-        env = "NANOCODEX_BROWSER_EXECUTABLE",
-        value_name = "PATH",
-        requires = "browser"
-    )]
+    #[arg(long, env = "NANOCODEX_BROWSER_EXECUTABLE", value_name = "PATH")]
     browser_executable: Option<PathBuf>,
+}
+
+impl Default for BrowserArgs {
+    fn default() -> Self {
+        Self {
+            browser: Some(BrowserKind::Chromium),
+            cookies: Some(CookieSourceKind::All),
+            browser_executable: None,
+        }
+    }
 }
 
 pub(crate) struct ConfiguredBrowser {
@@ -80,13 +91,30 @@ pub(crate) struct ConfiguredBrowser {
 impl BrowserArgs {
     #[cfg(test)]
     pub(crate) const fn is_enabled(&self) -> bool {
-        self.browser.is_some()
+        !matches!(self.browser, None | Some(BrowserKind::None))
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn copies_all_cookies(&self) -> bool {
+        matches!(self.cookies, Some(CookieSourceKind::All))
     }
 
     pub(crate) fn configure(&self, workspace: &Path) -> Result<Option<ConfiguredBrowser>> {
         let Some(kind) = self.browser else {
             return Ok(None);
         };
+        if kind == BrowserKind::None {
+            if self
+                .cookies
+                .is_some_and(|source| source != CookieSourceKind::All)
+            {
+                return Err(eyre!("--cookies requires an enabled browser"));
+            }
+            if self.browser_executable.is_some() {
+                return Err(eyre!("--browser-executable requires an enabled browser"));
+            }
+            return Ok(None);
+        }
         let mut builder = Browser::builder().file_root(workspace);
         match kind {
             BrowserKind::Chromium => {
@@ -104,8 +132,12 @@ impl BrowserArgs {
                     .wrap_err("failed to locate the standard Brave profile")?;
                 builder = builder.executable(brave.executable().to_path_buf());
             }
+            BrowserKind::None => unreachable!("disabled browsers return before configuration"),
         }
-        if let Some(source) = self.cookies {
+        if let Some(source) = self
+            .cookies
+            .filter(|source| *source != CookieSourceKind::None)
+        {
             builder = match cookie_source(source, kind)? {
                 CookieSource::Chromium(source) => builder.cookie_source(source.copy_all_cookies()),
                 CookieSource::State(state) => builder.storage_state(state),
@@ -135,12 +167,12 @@ fn cookie_source(source: CookieSourceKind, target: BrowserKind) -> Result<Cookie
         _ => {}
     }
     let explicit = match source {
-        CookieSourceKind::Auto => None,
+        CookieSourceKind::All => None,
         CookieSourceKind::Brave => Some(BrowserProfileKind::Brave),
         CookieSourceKind::Chrome => Some(BrowserProfileKind::Chrome),
         CookieSourceKind::Chromium => Some(BrowserProfileKind::Chromium),
         CookieSourceKind::Edge => Some(BrowserProfileKind::Edge),
-        CookieSourceKind::Firefox | CookieSourceKind::Safari => None,
+        CookieSourceKind::Firefox | CookieSourceKind::Safari | CookieSourceKind::None => None,
     };
     if let Some(source) = explicit {
         return BraveSession::standard_for(source)
@@ -161,6 +193,7 @@ fn cookie_source(source: CookieSourceKind, target: BrowserKind) -> Result<Cookie
             BrowserProfileKind::Brave,
             BrowserProfileKind::Edge,
         ],
+        BrowserKind::None => unreachable!("disabled browsers have no cookie source"),
     };
     preferences
         .into_iter()
@@ -220,13 +253,41 @@ mod tests {
         let definitions = runtime.model_specs("browser-tui-test");
         let serialized = serde_json::to_string(&definitions).unwrap();
 
-        assert_eq!(
-            serde_json::to_vec(&definitions).unwrap(),
-            serde_json::to_vec(&baseline).unwrap(),
-            "enabling browser must not add any model-input schema bytes"
-        );
-        assert!(!serialized.contains("browser"));
+        let baseline_bytes = serde_json::to_vec(&baseline).unwrap();
+        let definition_bytes = serde_json::to_vec(&definitions).unwrap();
+        assert_ne!(definition_bytes, baseline_bytes);
+        assert!(serialized.contains("tools.browser"));
+        assert!(serialized.contains("host-managed browser session"));
+        assert!(!serialized.contains("detect_gate"));
+        assert!(definition_bytes.len() - baseline_bytes.len() < 512);
         assert!(runtime.contains("browser"));
         browser.shutdown().await.unwrap();
+    }
+
+    #[test]
+    fn disabled_browser_rejects_nondefault_browser_configuration() {
+        let workspace = tempfile::tempdir().unwrap();
+        let cookies = BrowserArgs {
+            browser: Some(super::BrowserKind::None),
+            cookies: Some(super::CookieSourceKind::Chrome),
+            browser_executable: None,
+        }
+        .configure(workspace.path())
+        .err()
+        .unwrap();
+        assert_eq!(cookies.to_string(), "--cookies requires an enabled browser");
+
+        let executable = BrowserArgs {
+            browser: Some(super::BrowserKind::None),
+            cookies: Some(super::CookieSourceKind::All),
+            browser_executable: Some("/tmp/chromium".into()),
+        }
+        .configure(workspace.path())
+        .err()
+        .unwrap();
+        assert_eq!(
+            executable.to_string(),
+            "--browser-executable requires an enabled browser"
+        );
     }
 }

--- a/bin/nanocodex/src/browser.rs
+++ b/bin/nanocodex/src/browser.rs
@@ -9,8 +9,8 @@ use nanocodex_browser::{
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 enum BrowserKind {
-    #[value(alias = "true")]
     Chromium,
+    #[value(alias = "true")]
     Brave,
     #[value(alias = "false", alias = "off")]
     None,
@@ -40,15 +40,15 @@ enum CookieSource {
 pub(crate) struct BrowserArgs {
     /// Select the private browser exposed to Code Mode as `tools.browser`.
     ///
-    /// Pass `brave` to use the standard Brave installation. A bare `--browser`
-    /// preserves the private Chromium default; pass `none` to disable it.
+    /// Brave is the default. Pass `chromium` to use private Chromium or `none`
+    /// to disable browser tools.
     #[arg(
         long,
         env = "NANOCODEX_BROWSER",
         value_enum,
         num_args = 0..=1,
-        default_value = "chromium",
-        default_missing_value = "chromium",
+        default_value = "brave",
+        default_missing_value = "brave",
         require_equals = true
     )]
     browser: Option<BrowserKind>,
@@ -77,7 +77,7 @@ pub(crate) struct BrowserArgs {
 impl Default for BrowserArgs {
     fn default() -> Self {
         Self {
-            browser: Some(BrowserKind::Chromium),
+            browser: Some(BrowserKind::Brave),
             cookies: Some(CookieSourceKind::All),
             browser_executable: None,
         }
@@ -97,6 +97,11 @@ impl BrowserArgs {
     #[cfg(test)]
     pub(crate) const fn copies_all_cookies(&self) -> bool {
         matches!(self.cookies, Some(CookieSourceKind::All))
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn uses_brave(&self) -> bool {
+        matches!(self.browser, Some(BrowserKind::Brave))
     }
 
     pub(crate) fn configure(&self, workspace: &Path) -> Result<Option<ConfiguredBrowser>> {

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -215,6 +215,11 @@ impl AgentArgs {
         self.browser.copies_all_cookies()
     }
 
+    #[cfg(test)]
+    pub(crate) const fn uses_brave_browser(&self) -> bool {
+        self.browser.uses_brave()
+    }
+
     pub(crate) fn thinking(&self) -> Thinking {
         self.model_policy.thinking.unwrap_or_default()
     }

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -210,6 +210,11 @@ impl AgentArgs {
         self.browser.is_enabled()
     }
 
+    #[cfg(test)]
+    pub(crate) const fn copies_all_browser_cookies(&self) -> bool {
+        self.browser.copies_all_cookies()
+    }
+
     pub(crate) fn thinking(&self) -> Thinking {
         self.model_policy.thinking.unwrap_or_default()
     }

--- a/bin/nanocodex/src/main.rs
+++ b/bin/nanocodex/src/main.rs
@@ -273,9 +273,10 @@ mod tests {
     }
 
     #[test]
-    fn browser_tool_is_opt_in_for_tui_and_one_shot_runs() {
+    fn browser_tool_and_all_cookies_are_enabled_by_default() {
         let tui = Cli::try_parse_from(["nanocodex"]).unwrap();
-        assert!(!tui.agent.browser_enabled());
+        assert!(tui.agent.browser_enabled());
+        assert!(tui.agent.copies_all_browser_cookies());
 
         let tui = Cli::try_parse_from(["nanocodex", "--browser"]).unwrap();
         assert!(tui.agent.browser_enabled());
@@ -286,6 +287,13 @@ mod tests {
 
         let chromium = Cli::try_parse_from(["nanocodex", "--browser", "--cookies=true"]).unwrap();
         assert!(chromium.agent.browser_enabled());
+
+        let all_cookies = Cli::try_parse_from(["nanocodex", "--cookies=all"]).unwrap();
+        assert!(all_cookies.agent.browser_enabled());
+
+        let no_cookies = Cli::try_parse_from(["nanocodex", "--cookies=none"]).unwrap();
+        assert!(no_cookies.agent.browser_enabled());
+        assert!(!no_cookies.agent.copies_all_browser_cookies());
 
         let chrome_source =
             Cli::try_parse_from(["nanocodex", "--browser=brave", "--cookies=chrome"]).unwrap();
@@ -299,40 +307,15 @@ mod tests {
             Cli::try_parse_from(["nanocodex", "--browser", "--cookies=safari"]).unwrap();
         assert!(safari_source.agent.browser_enabled());
 
-        let run =
-            Cli::try_parse_from(["nanocodex", "run", "inspect example.com", "--browser"]).unwrap();
+        let run = Cli::try_parse_from(["nanocodex", "run", "inspect example.com"]).unwrap();
         let Some(Command::Run(run)) = run.command else {
             panic!("run command was not parsed");
         };
         assert!(run.agent.browser_enabled());
-    }
 
-    #[test]
-    fn browser_cookies_require_an_opted_in_browser() {
-        let error = Cli::try_parse_from(["nanocodex", "--cookies=true"])
-            .err()
-            .unwrap();
-
-        assert_eq!(
-            error.kind(),
-            clap::error::ErrorKind::MissingRequiredArgument
-        );
-    }
-
-    #[test]
-    fn browser_executable_requires_the_opt_in() {
-        let error = Cli::try_parse_from([
-            "nanocodex",
-            "--browser-executable",
-            "/Applications/Chromium.app/Contents/MacOS/Chromium",
-        ])
-        .err()
-        .unwrap();
-
-        assert_eq!(
-            error.kind(),
-            clap::error::ErrorKind::MissingRequiredArgument
-        );
+        let disabled =
+            Cli::try_parse_from(["nanocodex", "--browser=none", "--cookies=none"]).unwrap();
+        assert!(!disabled.agent.browser_enabled());
     }
 
     #[test]

--- a/bin/nanocodex/src/main.rs
+++ b/bin/nanocodex/src/main.rs
@@ -273,20 +273,25 @@ mod tests {
     }
 
     #[test]
-    fn browser_tool_and_all_cookies_are_enabled_by_default() {
+    fn brave_browser_tool_and_all_cookies_are_enabled_by_default() {
         let tui = Cli::try_parse_from(["nanocodex"]).unwrap();
         assert!(tui.agent.browser_enabled());
         assert!(tui.agent.copies_all_browser_cookies());
+        assert!(tui.agent.uses_brave_browser());
 
         let tui = Cli::try_parse_from(["nanocodex", "--browser"]).unwrap();
         assert!(tui.agent.browser_enabled());
+        assert!(tui.agent.uses_brave_browser());
 
         let brave =
             Cli::try_parse_from(["nanocodex", "--browser=brave", "--cookies=true"]).unwrap();
         assert!(brave.agent.browser_enabled());
+        assert!(brave.agent.uses_brave_browser());
 
-        let chromium = Cli::try_parse_from(["nanocodex", "--browser", "--cookies=true"]).unwrap();
+        let chromium =
+            Cli::try_parse_from(["nanocodex", "--browser=chromium", "--cookies=true"]).unwrap();
         assert!(chromium.agent.browser_enabled());
+        assert!(!chromium.agent.uses_brave_browser());
 
         let all_cookies = Cli::try_parse_from(["nanocodex", "--cookies=all"]).unwrap();
         assert!(all_cookies.agent.browser_enabled());

--- a/crates/experimental/nanocodex-browser/README.md
+++ b/crates/experimental/nanocodex-browser/README.md
@@ -107,8 +107,8 @@ or an explicitly managed CDP endpoint.
 - Harness-owned cookies/storage, virtual passkeys, allowlisted source-browser handoff,
   upload roots, browser egress policy, remote CDP, and libkrun VM composition.
 
-The Nanocodex CLI exposes a private Chromium session and copies a standard
-desktop browser profile's complete cookie database into it by default. `all`
+The Nanocodex CLI exposes a private Brave session and copies a standard desktop
+browser profile's complete cookie database into it by default. `all`
 auto-detects the source; `brave`, `chrome`, `chromium`, `edge`, `firefox`, and
 `safari` select it explicitly. Pass `none` to either option to disable that
 default:
@@ -117,7 +117,7 @@ default:
 nanocodex
 nanocodex --browser=none --cookies=none
 nanocodex --cookies=none
-nanocodex --browser=brave --cookies=all
+nanocodex --browser=chromium --cookies=all
 nanocodex --browser --cookies=chrome
 nanocodex --browser=brave --cookies=edge
 nanocodex --browser --cookies=firefox

--- a/crates/experimental/nanocodex-browser/README.md
+++ b/crates/experimental/nanocodex-browser/README.md
@@ -107,13 +107,17 @@ or an explicitly managed CDP endpoint.
 - Harness-owned cookies/storage, virtual passkeys, allowlisted source-browser handoff,
   upload roots, browser egress policy, remote CDP, and libkrun VM composition.
 
-The Nanocodex CLI can copy a standard desktop browser profile's complete cookie
-database into either supported session-private browser. A bare cookie flag
-auto-detects a source; `brave`, `chrome`, `chromium`, `edge`, `firefox`, and
-`safari` select it explicitly:
+The Nanocodex CLI exposes a private Chromium session and copies a standard
+desktop browser profile's complete cookie database into it by default. `all`
+auto-detects the source; `brave`, `chrome`, `chromium`, `edge`, `firefox`, and
+`safari` select it explicitly. Pass `none` to either option to disable that
+default:
 
 ```console
-nanocodex --browser --cookies
+nanocodex
+nanocodex --browser=none --cookies=none
+nanocodex --cookies=none
+nanocodex --browser=brave --cookies=all
 nanocodex --browser --cookies=chrome
 nanocodex --browser=brave --cookies=edge
 nanocodex --browser --cookies=firefox
@@ -123,11 +127,12 @@ nanocodex --browser --cookies=safari
 Chromium-family sources use their own executable as a short-lived decryption
 broker. Firefox is copied with SQLite's online backup API. Safari's bounded
 binary-cookie decoder may require granting the Nanocodex process macOS access
-to Safari's sandboxed profile. Source profiles are never mutated.
-
-The source profile is never mutated, and cookie values remain outside the
-model-callable browser schema. This mode deliberately gives the agent
-authenticated access to every site represented in the selected profile.
+to Safari's sandboxed profile. Source profiles are never mutated, and cookie
+values remain outside the model-callable browser schema. The `exec` contract
+advertises `tools.browser` with a compact summary; its complete action guidance
+remains runtime-only in `ALL_TOOLS`. The default cookie mode deliberately gives
+the agent authenticated access to every site represented in the selected
+profile.
 
 ## Current boundaries
 

--- a/crates/experimental/nanocodex-browser/src/lib.rs
+++ b/crates/experimental/nanocodex-browser/src/lib.rs
@@ -3797,6 +3797,13 @@ impl DynamicToolProvider for BrowserTool {
         vec![browser_tool_definition()]
     }
 
+    fn code_mode_tool_summaries(&self) -> Vec<(String, String)> {
+        vec![(
+            "browser".to_owned(),
+            "Control the host-managed browser session one typed action at a time.".to_owned(),
+        )]
+    }
+
     fn contains(&self, name: &str) -> bool {
         name == "browser"
     }

--- a/crates/experimental/nanocodex-browser/src/tests.rs
+++ b/crates/experimental/nanocodex-browser/src/tests.rs
@@ -331,7 +331,7 @@ async fn code_mode_description_exposes_browser_action_schema() -> Result<()> {
 }
 
 #[tokio::test]
-async fn deferred_browser_is_discoverable_without_model_schema_bytes() -> Result<()> {
+async fn deferred_browser_is_advertised_without_action_schema_bytes() -> Result<()> {
     let baseline_tools = Tools::builder().without_defaults().build()?;
     let baseline =
         ToolRuntime::new_with_tools(".", None, None, &baseline_tools).model_specs("test-session");
@@ -343,28 +343,30 @@ async fn deferred_browser_is_discoverable_without_model_schema_bytes() -> Result
     let runtime = ToolRuntime::new_with_tools(".", None, None, &tools);
     let specs = runtime.model_specs("test-session");
 
-    assert_eq!(
-        serde_json::to_vec(&specs)?,
-        serde_json::to_vec(&baseline)?,
-        "deferred browser registration must not change the model-facing tool prefix"
-    );
+    let baseline = serde_json::to_vec(&baseline)?;
+    let serialized = serde_json::to_vec(&specs)?;
+    let model_contract = String::from_utf8(serialized.clone())?;
+    assert!(model_contract.contains("tools.browser"));
+    assert!(model_contract.contains("host-managed browser session"));
+    assert!(!model_contract.contains("detect_gate"));
+    assert!(serialized.len() - baseline.len() < 512);
     assert!(runtime.contains("browser"));
 
     let execution = runtime
         .execute_code(
             r#"
-const browser = ALL_TOOLS.find((tool) => tool.name === "browser");
-if (!browser) throw new Error("browser metadata missing");
-if (typeof browser.description !== "string") {
+const metadata = ALL_TOOLS.find((tool) => tool.name === "browser");
+if (!metadata) throw new Error("browser metadata missing");
+if (typeof metadata.description !== "string") {
   throw new Error("browser description missing");
 }
-const opened = await tools[browser.name]({
+const opened = await tools.browser({
   action: "open",
   url: "https://example.com"
 });
 text({
-  name: browser.name,
-  hasDescription: browser.description.length > 0,
+  name: metadata.name,
+  hasDescription: metadata.description.length > 0,
   opened
 });
 "#,

--- a/crates/nanocodex-tools/src/code_mode/description.rs
+++ b/crates/nanocodex-tools/src/code_mode/description.rs
@@ -110,10 +110,20 @@ const EXEC_DESCRIPTION: &str = r#"Run JavaScript code to orchestrate/compose too
 
 pub(super) fn exec_description(
     definitions: &[ToolDefinition],
+    provider_summaries: &[(String, String)],
     has_deferred_tools: bool,
     code_mode_only: bool,
 ) -> String {
     let mut description = EXEC_DESCRIPTION.to_owned();
+    if !provider_summaries.is_empty() {
+        description.push_str("\n\nAdditional runtime-provided nested tools:");
+        for (name, summary) in provider_summaries {
+            let _ = write!(description, "\n- `tools.{name}`: {}", summary.trim());
+        }
+        description.push_str(
+            "\nInspect the matching `ALL_TOOLS` entry for complete guidance before using an unfamiliar runtime-provided tool.",
+        );
+    }
     if has_deferred_tools {
         let _ = write!(description, "\n\n{DEFERRED_NESTED_TOOLS_GUIDANCE}");
     }
@@ -484,7 +494,7 @@ mod tests {
             ["apply_patch", "write_stdin", "image_gen__imagegen"]
         );
 
-        let description = exec_description(&definitions, false, true);
+        let description = exec_description(&definitions, &[], false, true);
         let namespace = description
             .find("## image_gen\nTools in the image_gen namespace.")
             .unwrap();
@@ -500,7 +510,7 @@ mod tests {
             json!({"type": "object"}),
         )];
 
-        let description = exec_description(&definitions, false, false);
+        let description = exec_description(&definitions, &[], false, false);
 
         assert!(
             description.contains(
@@ -512,5 +522,19 @@ mod tests {
         ));
         assert!(!description.contains("### `update_plan`"));
         assert!(!description.contains("declare const tools"));
+    }
+
+    #[test]
+    fn runtime_provider_summaries_are_visible_without_their_schemas() {
+        let summaries = vec![(
+            "browser".to_owned(),
+            "Control the host-managed browser session.".to_owned(),
+        )];
+
+        let description = exec_description(&[], &summaries, false, true);
+
+        assert!(description.contains("`tools.browser`: Control the host-managed browser session."));
+        assert!(description.contains("Inspect the matching `ALL_TOOLS` entry"));
+        assert!(!description.contains("declare const tools: { browser"));
     }
 }

--- a/crates/nanocodex-tools/src/code_mode/spec.rs
+++ b/crates/nanocodex-tools/src/code_mode/spec.rs
@@ -15,12 +15,18 @@ SOURCE: /[\s\S]+/
 
 pub(crate) fn exec_spec(
     definitions: &[ToolDefinition],
+    provider_summaries: &[(String, String)],
     has_deferred_tools: bool,
     code_mode_only: bool,
 ) -> ToolDefinition {
     ToolDefinition::custom(
         "exec",
-        description::exec_description(definitions, has_deferred_tools, code_mode_only),
+        description::exec_description(
+            definitions,
+            provider_summaries,
+            has_deferred_tools,
+            code_mode_only,
+        ),
         CustomToolFormat::grammar("lark", GRAMMAR),
     )
 }

--- a/crates/nanocodex-tools/src/runtime/execution.rs
+++ b/crates/nanocodex-tools/src/runtime/execution.rs
@@ -191,6 +191,7 @@ impl ToolRuntime {
     #[must_use]
     pub fn model_specs(&self, _session_id: &str) -> Vec<ToolDefinition> {
         let mut nested = self.registry.registered_code_mode_definitions();
+        let provider_summaries = self.registry.code_mode_tool_summaries();
         let mut direct = self
             .registry
             .direct_definitions()
@@ -207,6 +208,7 @@ impl ToolRuntime {
         let mut native = vec![
             code_mode::exec_spec(
                 &nested,
+                &provider_summaries,
                 self.deferred_tools_guidance_enabled,
                 self.exposure.unwrap_or_default() == ToolExposure::CodeModeOnly,
             ),

--- a/crates/nanocodex-tools/src/runtime/registry.rs
+++ b/crates/nanocodex-tools/src/runtime/registry.rs
@@ -318,6 +318,26 @@ impl ToolRegistry {
         )
     }
 
+    pub(crate) fn code_mode_tool_summaries(&self) -> Vec<(String, String)> {
+        let mut seen = self
+            .registered_code_mode_definitions()
+            .into_iter()
+            .map(|definition| code_mode::description::normalize_identifier(definition.name()))
+            .collect::<HashSet<_>>();
+        let mut summaries = self
+            .providers
+            .iter()
+            .flat_map(|provider| provider.code_mode_tool_summaries())
+            .filter_map(|(name, description)| {
+                let normalized = code_mode::description::normalize_identifier(&name);
+                (!host_owned_name(&name) && seen.insert(normalized.clone()))
+                    .then_some((normalized, description))
+            })
+            .collect::<Vec<_>>();
+        summaries.sort_by(|left, right| left.0.cmp(&right.0));
+        summaries
+    }
+
     pub(crate) fn code_mode_definitions(&self) -> Vec<ToolDefinition> {
         let definitions = self
             .definitions

--- a/crates/nanocodex-tools/src/runtime/selection.rs
+++ b/crates/nanocodex-tools/src/runtime/selection.rs
@@ -55,6 +55,16 @@ pub trait DynamicToolProvider: Send + Sync {
     /// Returns deferred tools currently callable from new Code Mode cells.
     fn available_definitions(&self) -> Vec<ToolDefinition>;
 
+    /// Returns compact, stable guidance for provider tools that should be
+    /// discoverable before the model starts its first Code Mode cell.
+    ///
+    /// The complete definitions remain runtime-only and available through
+    /// `ALL_TOOLS`; summaries keep large dynamic schemas out of the model
+    /// request prefix.
+    fn code_mode_tool_summaries(&self) -> Vec<(String, String)> {
+        Vec::new()
+    }
+
     /// Returns whether this provider currently exposes `name`.
     fn contains(&self, name: &str) -> bool {
         self.available_definitions()

--- a/examples/tests/browser_agent.rs
+++ b/examples/tests/browser_agent.rs
@@ -55,11 +55,14 @@ async fn run_agent(browser: BrowserTool) -> Result<Value> {
             .as_array()
             .and_then(|tools| tools.iter().find(|tool| tool["name"] == "exec"))
             .ok_or_else(|| eyre!("warmup did not expose Code Mode"))?;
+        let description = exec["description"]
+            .as_str()
+            .ok_or_else(|| eyre!("Code Mode description was not text"))?;
+        assert!(description.contains("tools.browser"));
+        assert!(description.contains("host-managed browser session"));
         assert!(
-            exec["description"]
-                .as_str()
-                .is_some_and(|description| !description.contains("tools.browser")),
-            "warmup unexpectedly included the browser schema: {exec}"
+            !description.contains("detect_gate"),
+            "warmup unexpectedly included the browser action schema: {exec}"
         );
         send_completed(&mut socket, "resp-warmup", &[], None).await?;
 


### PR DESCRIPTION
## Summary

- enable the private Chromium browser and complete desktop-profile cookie import by default
- add explicit browser and cookie opt-outs with --browser=none and --cookies=none
- advertise tools.browser compactly before the first Code Mode cell while keeping its large action schema runtime-only
- update CLI, runtime, browser, and public example coverage for the new contract

## Validation

- ./scripts/check-crate-boundaries.sh
- ./scripts/check-experimental-boundary.sh
- ./scripts/check-rustls-provider.sh
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace
- .venv/bin/python -m unittest discover -s harbor_adapter -p test_*.py
- .venv/bin/python -m compileall -q harbor_adapter
- .venv/bin/harbor run --config evals/terminal-bench-2.yaml --print-config