### PR TITLE
feat(browser): add pixel-calibrated captures

### DIFF
--- a/crates/experimental/nanocodex-browser/README.md
+++ b/crates/experimental/nanocodex-browser/README.md
@@ -31,11 +31,13 @@ println!("{}", result.final_message());
 # }
 ```
 
-The model reaches the tool as `await tools.browser(...)` inside Code Mode. Its
-full contract is discoverable at runtime through `ALL_TOOLS`, but provider
-registration keeps that contract out of the model-facing tool prefix. A
-runnable version lives at `examples/browser_agent.rs`. Callers that deliberately
-want the eager schema can register the same value with `.tool(browser)`.
+The model reaches the tool as `await tools.browser(...)` inside Code Mode.
+`ALL_TOOLS` discovers the deferred tool without expanding its schema; callers
+can inspect the exact input and output contracts on demand with
+`toolSchema("browser")`. Provider registration therefore keeps the full contract
+out of the model-facing tool prefix. A runnable version lives at
+`examples/browser_agent.rs`. Callers that deliberately want the eager schema
+can register the same value with `.tool(browser)`.
 
 For isolation, one non-cloneable VM owner keeps the disposable browser alive
 and gives the agent a tool handle:
@@ -96,14 +98,47 @@ The browser starts lazily on its first local action. Use `Browser::builder()`
 for deterministic browser context, egress policy, storage state, diagnostics,
 or an explicitly managed CDP endpoint.
 
+Pixel-calibrated captures set both CSS viewport dimensions and device pixel
+ratio, then reuse one semantic or CSS target across screenshots and visual
+comparison:
+
+```no_run
+use nanocodex_browser::{Browser, BrowserAction, BrowserActionResult, BrowserTarget};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let browser = Browser::new()?;
+browser
+    .execute(BrowserAction::SetViewport {
+        width: 1440,
+        height: 1200,
+        device_scale_factor: Some(2.0),
+    })
+    .await?;
+let capture = browser
+    .execute(BrowserAction::Screenshot {
+        full_page: false,
+        annotate: false,
+        target: Some(BrowserTarget::css("#mixer")),
+    })
+    .await?;
+let BrowserActionResult::Screenshot { image: Some(image), .. } = capture else {
+    return Err("browser did not return an image".into());
+};
+println!("{}x{} device pixels", image.width, image.height);
+browser.close().await?;
+# Ok(())
+# }
+```
+
 ## Capabilities
 
 - Chromium navigation and interaction through semantic references, CSS, roles,
   text, labels, frames, tabs, and open shadow roots.
 - Bounded snapshots, DOM/layout/style inspection, console and source-mapped
   errors, network bodies, WebSocket messages, HAR, and React diagnostics.
-- Screenshots, PDF, visual/session/performance traces, video, CPU profiles,
-  coverage, heap inspection, accessibility/axe, Lighthouse, and CrUX actions.
+- Viewport- and element-targeted screenshots, pixel-level visual diffs,
+  PDF, visual/session/performance traces, video, CPU profiles, coverage, heap
+  inspection, accessibility/axe, Lighthouse, and CrUX actions.
 - Harness-owned cookies/storage, virtual passkeys, allowlisted source-browser handoff,
   upload roots, browser egress policy, remote CDP, and libkrun VM composition.
 

--- a/crates/experimental/nanocodex-browser/benches/browser_vm.rs
+++ b/crates/experimental/nanocodex-browser/benches/browser_vm.rs
@@ -118,6 +118,7 @@ fn benchmark_live_vm(criterion: &mut Criterion) {
                 .execute(BrowserAction::Screenshot {
                     full_page: false,
                     annotate: false,
+                    target: None,
                 })
                 .await
                 .expect("warm screenshot");

--- a/crates/experimental/nanocodex-browser/src/lib.rs
+++ b/crates/experimental/nanocodex-browser/src/lib.rs
@@ -84,10 +84,14 @@ pub use features::{
 pub use native::{BrowserBuildError, BrowserError};
 pub use session::{BraveSession, BraveSessionError, BrowserProfileKind};
 
-const TOOL_DESCRIPTION: &str = r"Control one server-managed browser session.
+const TOOL_DESCRIPTION: &str = r#"Control one server-managed browser session.
 
 Call this tool from Code Mode as `await tools.browser({ action: ..., ... })`.
 Each call performs exactly one browser action against the session's active page.
+Before guessing an action's fields, inspect the exact deferred input contract with
+`toolSchema("browser").inputSchema` and filter its `oneOf` variants by the
+single-value `properties.action.enum` discriminator. Keep the inspection inside Code Mode
+and emit only the relevant variant.
 Compose the complete browser investigation in one Code Mode cell whenever
 possible. Do not return to the model after every browser action. Browser actions
 are deliberately ordered within one session; use normal JavaScript loops and
@@ -135,6 +139,10 @@ boundary they also contain `modelImage`; call `image(result.image.modelImage)`
 for a screenshot or baseline, `image(result.diff.modelImage)` for a visual
 diff, or `image(anomaly.modelImage)` for a visual-trace anomaly. Do not include
 the base64-bearing `modelImage` object in subsequent `text(...)` output.
+For pixel calibration, first use `set_viewport` with an explicit
+`device_scale_factor`, then pass the same element `target` to `screenshot`,
+`visual_baseline`, and `visual_diff`. Targeted captures crop to the element's
+rendered border box and cannot be combined with `full_page`.
 Use `visual_baseline` plus `visual_diff` for deterministic before/after
 comparison. Use `visual_trace_start` and `visual_trace_stop` around an
 interaction to detect flashes, blank intermediate frames, and large visual
@@ -190,10 +198,10 @@ A snapshot returns compact accessibility-tree text plus stable `eN` references,
 following a familiar browser-agent convention.
 Use `evaluate` only when the normal snapshot and interaction actions are
 insufficient. The browser is owned by the host: do not launch a browser, connect
-to a debugging port, or manage browser processes yourself.";
+to a debugging port, or manage browser processes yourself."#;
 
 /// One action against the active page of a browser session.
-#[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
 #[serde(tag = "action", rename_all = "snake_case", deny_unknown_fields)]
 pub enum BrowserAction {
     /// Navigate the active page to a URL.
@@ -352,8 +360,13 @@ pub enum BrowserAction {
         /// Paths relative to the browser's configured file root.
         paths: Vec<std::path::PathBuf>,
     },
-    /// Set the active page's viewport in CSS pixels.
-    SetViewport { width: u32, height: u32 },
+    /// Set the active page's viewport in CSS pixels and its output pixel density.
+    SetViewport {
+        width: u32,
+        height: u32,
+        /// Device pixels per CSS pixel. Defaults to 1.0.
+        device_scale_factor: Option<f64>,
+    },
     /// Navigate to the preceding history entry when one exists.
     GoBack,
     /// Navigate to the following history entry when one exists.
@@ -389,6 +402,8 @@ pub enum BrowserAction {
         /// Overlay numbered labels for interactive elements.
         #[serde(default)]
         annotate: bool,
+        /// Crop to one rendered element's border box.
+        target: Option<BrowserTarget>,
     },
     /// Print the active page to a private file-backed PDF artifact.
     Pdf {
@@ -408,6 +423,8 @@ pub enum BrowserAction {
         /// Capture the complete scrollable page.
         #[serde(default)]
         full_page: bool,
+        /// Crop to one rendered element's border box.
+        target: Option<BrowserTarget>,
     },
     /// Compare the current page against a retained visual baseline.
     VisualDiff {
@@ -418,6 +435,8 @@ pub enum BrowserAction {
         /// Capture the complete scrollable page.
         #[serde(default)]
         full_page: bool,
+        /// Crop to one rendered element's border box.
+        target: Option<BrowserTarget>,
     },
     /// Begin a bounded rendered-frame trace for flash and instability detection.
     VisualTraceStart {
@@ -2477,7 +2496,7 @@ async fn persist_trace_artifact(
 }
 
 /// One action retained by [`BrowserRecording`].
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct RecordedBrowserAction {
     pub sequence: u64,

--- a/crates/experimental/nanocodex-browser/src/native.rs
+++ b/crates/experimental/nanocodex-browser/src/native.rs
@@ -33,7 +33,7 @@ use chromiumoxide::{
                 EventDownloadWillBegin, PermissionDescriptor, PermissionSetting,
                 SetDownloadBehaviorBehavior, SetDownloadBehaviorParams, SetPermissionParams,
             },
-            dom::SetFileInputFilesParams,
+            dom::{GetBoxModelParams, SetFileInputFilesParams},
             dom_snapshot::{
                 ArrayOfStrings, CaptureSnapshotParams, CaptureSnapshotReturns, DocumentSnapshot,
                 LayoutTreeSnapshot, RareBooleanData, RareIntegerData, RareStringData, Rectangle,
@@ -59,7 +59,7 @@ use chromiumoxide::{
             page::{
                 AddScriptToEvaluateOnNewDocumentParams, EventJavascriptDialogOpening,
                 GetNavigationHistoryParams, HandleJavaScriptDialogParams,
-                NavigateToHistoryEntryParams,
+                NavigateToHistoryEntryParams, Viewport,
             },
             target::{GetTargetsParams, SetAutoAttachParams, TargetId},
             web_authn::{
@@ -70,7 +70,7 @@ use chromiumoxide::{
         },
         js_protocol::runtime::{
             EvaluateParams, EventConsoleApiCalled, EventExceptionThrown, ExecutionContextId,
-            RemoteObject, StackTrace,
+            ReleaseObjectParams, RemoteObject, StackTrace,
         },
     },
     error::CdpError,
@@ -2783,7 +2783,11 @@ return element.checked;"#
             set_file_input_files(&session.page, &target, paths).await?;
             Ok(action_result(sequence, BrowserActionName::UploadFiles))
         }
-        BrowserAction::SetViewport { width, height } => {
+        BrowserAction::SetViewport {
+            width,
+            height,
+            device_scale_factor,
+        } => {
             if width == 0
                 || height == 0
                 || width > MAX_VIEWPORT_DIMENSION
@@ -2795,12 +2799,18 @@ return element.checked;"#
                     maximum: MAX_VIEWPORT_DIMENSION,
                 });
             }
+            let device_scale_factor = device_scale_factor.unwrap_or(1.0);
+            if !device_scale_factor.is_finite() || device_scale_factor <= 0.0 {
+                return Err(BrowserError::InvalidDeviceScaleFactor {
+                    device_scale_factor,
+                });
+            }
             session
                 .page
                 .execute(SetDeviceMetricsOverrideParams::new(
                     i64::from(width),
                     i64::from(height),
-                    1.0,
+                    device_scale_factor,
                     false,
                 ))
                 .await?;
@@ -2860,6 +2870,7 @@ return element.checked;"#
         BrowserAction::Screenshot {
             full_page,
             annotate,
+            target,
         } => {
             if session.visual_artifacts.len() >= MAX_VISUAL_ARTIFACTS {
                 return Err(BrowserError::VisualArtifactLimit {
@@ -2869,11 +2880,17 @@ return element.checked;"#
             if annotate {
                 install_annotations(session).await?;
             }
+            let clip = capture_clip(session, target.as_ref(), full_page).await;
+            if clip.is_err() && annotate {
+                let _ = evaluate_value(&session.page, REMOVE_ANNOTATIONS_SCRIPT).await;
+            }
+            let clip = clip?;
             let screenshot = artifacts::capture(
                 &session.page,
                 &session.output_dir,
                 format!("screenshot-{sequence}"),
                 full_page,
+                clip,
             )
             .await;
             if annotate {
@@ -2917,17 +2934,19 @@ return element.checked;"#
                 pdf,
             })
         }
-        BrowserAction::VisualBaseline { full_page } => {
+        BrowserAction::VisualBaseline { full_page, target } => {
             if session.visual_artifacts.len() >= MAX_VISUAL_ARTIFACTS {
                 return Err(BrowserError::VisualArtifactLimit {
                     maximum: MAX_VISUAL_ARTIFACTS,
                 });
             }
+            let clip = capture_clip(session, target.as_ref(), full_page).await?;
             let image = artifacts::capture(
                 &session.page,
                 &session.output_dir,
                 format!("visual-{sequence}"),
                 full_page,
+                clip,
             )
             .await?;
             session
@@ -2943,6 +2962,7 @@ return element.checked;"#
             baseline_id,
             threshold,
             full_page,
+            target,
         } => {
             let baseline = session
                 .visual_artifacts
@@ -2956,11 +2976,13 @@ return element.checked;"#
                     maximum: MAX_VISUAL_ARTIFACTS,
                 });
             }
+            let clip = capture_clip(session, target.as_ref(), full_page).await?;
             let current = artifacts::capture(
                 &session.page,
                 &session.output_dir,
                 format!("visual-{sequence}"),
                 full_page,
+                clip,
             )
             .await?;
             let diff = artifacts::compare(&baseline, &current, &session.output_dir, threshold)?;
@@ -5361,6 +5383,100 @@ if (!element) throw new Error("selector did not match an element");
     ))
 }
 
+async fn capture_clip(
+    session: &Session,
+    target: Option<&BrowserTarget>,
+    full_page: bool,
+) -> Result<Option<Viewport>, BrowserError> {
+    let Some(target) = target else {
+        return Ok(None);
+    };
+    if full_page {
+        return Err(BrowserError::TargetWithFullPage);
+    }
+
+    let target = session.target(target).await?;
+    interaction::wait_until_actionable(
+        &session.page,
+        &target,
+        interaction::Actionability::Attached,
+    )
+    .await?;
+    evaluate_typed_in_context::<bool>(
+        &session.page,
+        element_script(
+            &target.query,
+            r#"element.scrollIntoView({ block: "center", inline: "center" });
+return new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve(true))));"#,
+        )?,
+        target.context_id,
+    )
+    .await?;
+
+    let mut params = EvaluateParams::new(element_script(&target.query, "return element;")?);
+    params.context_id = target.context_id;
+    params.return_by_value = Some(false);
+    params.await_promise = Some(true);
+    let result = session.page.evaluate_expression(params).await?;
+    let object_id =
+        result
+            .object()
+            .object_id
+            .clone()
+            .ok_or_else(|| BrowserError::Actionability {
+                selector: target.query.display(),
+                reason: "resolved element did not produce a remote object".to_owned(),
+            })?;
+    let model = session
+        .page
+        .execute(
+            GetBoxModelParams::builder()
+                .object_id(object_id.clone())
+                .build(),
+        )
+        .await;
+    let _ = session
+        .page
+        .execute(ReleaseObjectParams::new(object_id))
+        .await;
+    let border = model?.result.model.border;
+    let coordinates = border.inner();
+    if coordinates.len() != 8 || coordinates.iter().any(|coordinate| !coordinate.is_finite()) {
+        return Err(BrowserError::Actionability {
+            selector: target.query.display(),
+            reason: "element has an invalid rendered border box".to_owned(),
+        });
+    }
+    let mut points = coordinates.chunks_exact(2);
+    let first = points.next().ok_or_else(|| BrowserError::Actionability {
+        selector: target.query.display(),
+        reason: "element has no rendered border box".to_owned(),
+    })?;
+    let (mut left, mut right, mut top, mut bottom) = (first[0], first[0], first[1], first[1]);
+    for point in points {
+        left = left.min(point[0]);
+        right = right.max(point[0]);
+        top = top.min(point[1]);
+        bottom = bottom.max(point[1]);
+    }
+    let width = right - left;
+    let height = bottom - top;
+    if width <= 0.0 || height <= 0.0 {
+        return Err(BrowserError::Actionability {
+            selector: target.query.display(),
+            reason: "element has an empty rendered border box".to_owned(),
+        });
+    }
+    let layout = session.page.layout_metrics().await?;
+    Ok(Some(Viewport {
+        x: left + layout.css_layout_viewport.page_x as f64,
+        y: top + layout.css_layout_viewport.page_y as f64,
+        width,
+        height,
+        scale: 1.0,
+    }))
+}
+
 async fn set_file_input_files(
     page: &Page,
     target: &ElementTarget,
@@ -5953,6 +6069,12 @@ pub enum BrowserError {
         height: u32,
         maximum: u32,
     },
+    #[error(
+        "browser device scale factor must be finite and greater than zero, received {device_scale_factor}"
+    )]
+    InvalidDeviceScaleFactor { device_scale_factor: f64 },
+    #[error("browser element capture cannot be combined with a full-page screenshot")]
+    TargetWithFullPage,
     #[error("browser session could not be initialized")]
     SessionUnavailable,
     #[error("browser session is closed")]

--- a/crates/experimental/nanocodex-browser/src/native/artifacts.rs
+++ b/crates/experimental/nanocodex-browser/src/native/artifacts.rs
@@ -8,7 +8,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use chromiumoxide::{Page, page::ScreenshotParams};
+use chromiumoxide::{Page, cdp::browser_protocol::page::Viewport, page::ScreenshotParams};
 use image::{DynamicImage, ImageBuffer, Rgba};
 use tokio::task::JoinHandle;
 use tracing::warn;
@@ -62,9 +62,14 @@ pub(super) async fn capture(
     output_dir: &Path,
     artifact_id: String,
     full_page: bool,
+    clip: Option<Viewport>,
 ) -> Result<BrowserImageArtifact, BrowserError> {
     let path = output_dir.join(format!("{artifact_id}.png"));
-    let params = ScreenshotParams::builder().full_page(full_page).build();
+    let mut params = ScreenshotParams::builder().full_page(full_page);
+    if let Some(clip) = clip {
+        params = params.clip(clip).capture_beyond_viewport(true);
+    }
+    let params = params.build();
     let bytes = page.screenshot(params).await?;
     let byte_count = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
     if byte_count > MAX_IMAGE_ARTIFACT_BYTES {

--- a/crates/experimental/nanocodex-browser/src/native/session_trace.rs
+++ b/crates/experimental/nanocodex-browser/src/native/session_trace.rs
@@ -70,6 +70,7 @@ impl SessionTraceState {
                 &self.directory,
                 format!("action-{sequence:06}"),
                 false,
+                None,
             )
             .await
             {

--- a/crates/experimental/nanocodex-browser/src/tests.rs
+++ b/crates/experimental/nanocodex-browser/src/tests.rs
@@ -283,6 +283,8 @@ async fn code_mode_description_exposes_browser_action_schema() -> Result<()> {
     assert!(description.contains(r#"action: "get_html""#));
     assert!(description.contains(r#"action: "get_styles""#));
     assert!(description.contains(r#"action: "screenshot""#));
+    assert!(description.contains("device_scale_factor?: number"));
+    assert!(description.contains("target?:"));
     assert!(description.contains(r#"action: "pdf""#));
     assert!(description.contains(r#"action: "session_trace_start""#));
     assert!(description.contains(r#"action: "mouse_move""#));
@@ -360,13 +362,28 @@ if (!metadata) throw new Error("browser metadata missing");
 if (typeof metadata.description !== "string") {
   throw new Error("browser description missing");
 }
-const opened = await tools.browser({
+const schema = toolSchema(metadata.name)?.inputSchema;
+const variants = schema?.oneOf ?? [];
+const screenshot = variants.find((variant) =>
+  variant.properties?.action?.enum?.[0] === "screenshot"
+);
+const viewport = variants.find((variant) =>
+  variant.properties?.action?.enum?.[0] === "set_viewport"
+);
+if (!screenshot?.properties?.target) {
+  throw new Error("targeted screenshot schema missing");
+}
+if (!viewport?.properties?.device_scale_factor) {
+  throw new Error("device scale factor schema missing");
+}
+const opened = await tools[metadata.name]({
   action: "open",
   url: "https://example.com"
 });
 text({
   name: metadata.name,
   hasDescription: metadata.description.length > 0,
+  hasPixelCalibrationSchema: true,
   opened
 });
 "#,
@@ -374,13 +391,100 @@ text({
         )
         .await;
 
-    assert!(execution.success);
+    assert!(execution.success, "{:#?}", execution.output);
     assert_eq!(execution.nested_calls.len(), 1);
     let output: Value = serde_json::from_str(execution_text(&execution.output)?)?;
     assert_eq!(output["name"], "browser");
     assert_eq!(output["hasDescription"], true);
+    assert_eq!(output["hasPixelCalibrationSchema"], true);
     assert_eq!(output["opened"]["action"], "open");
     assert_eq!(recording.actions()?.len(), 1);
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires a local Chrome or Chromium installation"]
+async fn targeted_screenshots_honor_device_pixel_ratio() -> Result<()> {
+    let browser = Browser::new()?;
+    browser
+        .execute(BrowserAction::SetViewport {
+            width: 320,
+            height: 240,
+            device_scale_factor: Some(2.0),
+        })
+        .await?;
+    browser
+        .execute(BrowserAction::Open {
+            url: r#"data:text/html,<body style='margin:0'><div id='target' style='width:120px;height:80px;background:red'></div><iframe style='border:0;width:100px;height:100px' srcdoc="<body style='margin:0'><div id='frame-target' style='width:60px;height:40px;background:green'></div>"></iframe>"#.to_owned(),
+        })
+        .await?;
+    let target = BrowserTarget::css("#target");
+    let screenshot = browser
+        .execute(BrowserAction::Screenshot {
+            full_page: false,
+            annotate: false,
+            target: Some(target.clone()),
+        })
+        .await?;
+    let BrowserActionResult::Screenshot {
+        image: Some(image), ..
+    } = screenshot
+    else {
+        return Err(eyre!("expected targeted screenshot"));
+    };
+    assert_eq!((image.width, image.height), (240, 160));
+    let frame_screenshot = browser
+        .execute(BrowserAction::Screenshot {
+            full_page: false,
+            annotate: false,
+            target: Some(BrowserTarget::css("#frame-target")),
+        })
+        .await?;
+    assert!(matches!(
+        frame_screenshot,
+        BrowserActionResult::Screenshot { image: Some(image), .. }
+            if (image.width, image.height) == (120, 80)
+    ));
+
+    let baseline = browser
+        .execute(BrowserAction::VisualBaseline {
+            full_page: false,
+            target: Some(target.clone()),
+        })
+        .await?;
+    let BrowserActionResult::VisualBaseline { image, .. } = baseline else {
+        return Err(eyre!("expected targeted visual baseline"));
+    };
+    browser
+        .execute(BrowserAction::Evaluate {
+            expression: "document.querySelector('#target').style.background = 'blue'; true"
+                .to_owned(),
+        })
+        .await?;
+    let diff = browser
+        .execute(BrowserAction::VisualDiff {
+            baseline_id: image.artifact_id,
+            threshold: Some(0),
+            full_page: false,
+            target: Some(target.clone()),
+        })
+        .await?;
+    assert!(matches!(
+        diff,
+        BrowserActionResult::VisualDiff { diff, .. }
+            if diff.dimensions_match && diff.changed_pixel_ratio > 0.99
+    ));
+    assert!(matches!(
+        browser
+            .execute(BrowserAction::Screenshot {
+                full_page: true,
+                annotate: false,
+                target: Some(target),
+            })
+            .await,
+        Err(BrowserError::TargetWithFullPage)
+    ));
+    browser.close().await?;
     Ok(())
 }
 
@@ -684,7 +788,10 @@ return true;
     );
 
     let baseline = browser
-        .execute(BrowserAction::VisualBaseline { full_page: false })
+        .execute(BrowserAction::VisualBaseline {
+            full_page: false,
+            target: None,
+        })
         .await?;
     let BrowserActionResult::VisualBaseline { image, .. } = baseline else {
         return Err(eyre!("expected visual baseline"));
@@ -699,6 +806,7 @@ return true;
             baseline_id: image.artifact_id,
             threshold: Some(8),
             full_page: false,
+            target: None,
         })
         .await?;
     let BrowserActionResult::VisualDiff { diff, .. } = diff else {

--- a/crates/experimental/nanocodex-browser/tests/live_vm.rs
+++ b/crates/experimental/nanocodex-browser/tests/live_vm.rs
@@ -77,6 +77,7 @@ async fn headed_browser_vm_runs_typed_actions_and_reaps() {
         .execute(BrowserAction::Screenshot {
             full_page: false,
             annotate: false,
+            target: None,
         })
         .await
         .expect("capture screenshot");

--- a/crates/nanocodex-tools/README.md
+++ b/crates/nanocodex-tools/README.md
@@ -146,7 +146,9 @@ let tools = Tools::builder().provider(mcp).build()?;
 Handshakes and discovery start with the owning runtime. Both exposure policies
 keep the provider-native `tool_search` visible while omitting deferred MCP
 schemas from the initial request. Code Mode lists those deferred tools as
-compact name/description entries in `ALL_TOOLS`. Search results contain
+compact name/description entries in `ALL_TOOLS`; `toolSchema(name)` returns a
+cloned input/output JSON Schema on demand when generated code needs the exact
+payload contract. Search results contain
 loadable MCP namespaces for direct model calls and also activate matching Code
 Mode definitions, keeping large catalogs out of the initial tool list.
 `McpServer::tool_exposure` independently selects `DeferredOnly`,

--- a/crates/nanocodex-tools/src/code_mode/bootstrap.js
+++ b/crates/nanocodex-tools/src/code_mode/bootstrap.js
@@ -254,10 +254,24 @@
         description: tool.description,
       });
     }));
+    function toolSchema(name) {
+      if (typeof name !== "string" || !name) {
+        throw "toolSchema expects a non-empty tool name";
+      }
+      const definition = definitions.find((tool) =>
+        tool.name === name || tool.tool_name === name
+      );
+      if (!definition) return undefined;
+      return cloneValue({
+        inputSchema: definition.input_schema ?? null,
+        outputSchema: definition.output_schema ?? null,
+      });
+    }
     try {
       const script = new AsyncFunction(
         "tools",
         "ALL_TOOLS",
+        "toolSchema",
         "text",
         "image",
         "audio",
@@ -275,6 +289,7 @@
         await script(
           tools,
           allTools,
+          toolSchema,
           text,
           image,
           audio,

--- a/crates/nanocodex-tools/src/code_mode/description.rs
+++ b/crates/nanocodex-tools/src/code_mode/description.rs
@@ -106,6 +106,7 @@ const EXEC_DESCRIPTION: &str = r#"Run JavaScript code to orchestrate/compose too
 - `setTimeout(callback: () => void, delayMs?: number)`: schedules a callback to run later and returns a timeout id. Pending timeouts do not keep `exec` alive by themselves; await an explicit promise if you need to wait for one.
 - `clearTimeout(timeoutId?: number)`: cancels a timeout created by `setTimeout`.
 - `ALL_TOOLS`: metadata for the enabled nested tools as `{ name, description }` entries.
+- `toolSchema(name: string)`: returns cloned `{ inputSchema, outputSchema }` JSON Schemas for one enabled nested tool, or `undefined` when the name is unknown. Use it inside Code Mode to inspect deferred-tool payloads without emitting the complete schema.
 - `yield_control()`: yields the accumulated output to the model immediately while the script keeps running."#;
 
 pub(super) fn exec_description(

--- a/crates/nanocodex-tools/src/code_mode/tests.rs
+++ b/crates/nanocodex-tools/src/code_mode/tests.rs
@@ -353,6 +353,38 @@ text(ALL_TOOLS.map((tool) => ({
 }
 
 #[tokio::test]
+async fn tool_schema_exposes_cloned_schemas_without_expanding_all_tools() -> Result<()> {
+    let workspace = temporary_workspace("tool-schema")?;
+    let tools = test_tools(&workspace);
+    let history = Vec::new();
+    let execution = tools
+        .execute_code(
+            r#"
+const schema = toolSchema("update_plan");
+const missing = toolSchema("missing_tool");
+schema.inputSchema.mutated = true;
+const fresh = toolSchema("update_plan");
+text({
+  hasInputSchema: schema.inputSchema?.type === "object",
+  hasOutputSchema: schema.outputSchema !== undefined,
+  mutationLeaked: fresh.inputSchema.mutated === true,
+  missing: missing === undefined,
+});
+"#,
+            test_context(&history),
+        )
+        .await;
+
+    assert!(execution.success, "{}", execution_output(&execution));
+    assert_eq!(
+        emitted_text(&execution)?,
+        r#"{"hasInputSchema":true,"hasOutputSchema":true,"mutationLeaked":false,"missing":true}"#
+    );
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn function_tools_receive_an_empty_object_when_called_without_arguments() -> Result<()> {
     let workspace = temporary_workspace("empty-function-arguments")?;
     let tools = test_tools(&workspace);


### PR DESCRIPTION
## Summary

- expose exact deferred tool contracts lazily through `toolSchema(name)` without expanding `ALL_TOOLS` or the model-facing tool prefix
- add explicit device-pixel-ratio control to `set_viewport`
- support element-targeted `screenshot`, `visual_baseline`, and `visual_diff` captures using Chromium rendered border boxes across main documents and child frames
- document and test the pixel-calibration workflow

## Validation

- `cargo +1.97.0 test -p nanocodex-tools -p nanocodex-browser`
- `cargo +1.97.0 clippy -p nanocodex-tools -p nanocodex-browser --all-targets -- -D warnings`
- `cargo +1.97.0 test -p nanocodex-browser targeted_screenshots_honor_device_pixel_ratio -- --ignored --nocapture`
- repository crate-boundary, experimental-boundary, rustls-provider, rustfmt, and diff checks