### PR TITLE
fix(eval): satisfy Linux prepared-host Clippy

### DIFF
--- a/bin/nanocodex/src/eval/run/runtime.rs
+++ b/bin/nanocodex/src/eval/run/runtime.rs
@@ -158,7 +158,7 @@ fn validate_hypervisor_entitlement(vmm: &Path) -> Result<()> {
 }
 
 #[cfg(not(target_os = "macos"))]
-fn validate_hypervisor_entitlement(_vmm: &Path) -> Result<()> {
+const fn validate_hypervisor_entitlement(_vmm: &Path) -> Result<()> {
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- make the non-macOS no-op entitlement validator const
- restore warnings-denied workspace Clippy on Linux after the prepared-host merge

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p nanocodex-bin --all-targets --all-features -- -D warnings` (macOS)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` (`dev-georgios`, Linux)