### PR TITLE
feat(eval): make SQLite own durable benchmark work

### DIFF
--- a/bin/nanocodex/src/benchmark.rs
+++ b/bin/nanocodex/src/benchmark.rs
@@ -6,7 +6,7 @@ pub(crate) fn prompt(
     state_dir: Option<&Path>,
     coordinator: Option<&str>,
 ) -> String {
-    let selected = profile.unwrap_or("the selected SQLite workset");
+    let selected = profile.unwrap_or("the selected SQLite profile");
     let profile_argument =
         profile.map_or_else(String::new, |profile| format!(" {}", shell_quote(profile)));
     let state_argument = state_dir.map_or_else(String::new, |directory| {
@@ -17,7 +17,7 @@ pub(crate) fn prompt(
     });
     let config_argument = shell_quote(&config.to_string_lossy());
     format!(
-        r#"Drive the Nanocodex SQLite workset {selected} to durable completion.
+        r#"Drive the Nanocodex SQLite profile {selected} to durable completion.
 
 The desired amount of work is already materialized in SQLite. Do not infer it from `{config}` or add ad-hoc work during this workflow. Inspect the durable ledger with:
 

--- a/bin/nanocodex/src/benchmark.rs
+++ b/bin/nanocodex/src/benchmark.rs
@@ -37,7 +37,7 @@ This is an operations loop, not a software-development task. Do not inspect repo
 
 The desired amount of work is already materialized in {ledger}. Do not infer it from `{config}` or add ad-hoc work during this workflow. Inspect the durable ledger with:
 
-    {executable} eval status{profile_argument}{state_argument}{coordinator_argument} --json
+    {executable} eval status{profile_argument}{state_argument}{coordinator_argument} --json --family-limit 32
 
 You own execution strategy. Read the family records, choose an exact pending task and harness treatment, and invoke one repetition with `{executable} eval run{profile_argument} --config {config_argument}{state_argument}{coordinator_argument}{worker_argument} --task <exact-profile-selector>` plus `--harness`, model, or thinking selectors required to identify that profile family. Omit `--harness` for built-in Nanocodex. The CLI allocates the internal repetition; never pass or invent a trial number.
 
@@ -104,6 +104,7 @@ mod tests {
         );
 
         assert!(prompt.contains("status 'release' --coordinator 'http://127.0.0.1:8789'"));
+        assert!(prompt.contains("--json --family-limit 32"));
         assert!(prompt.contains(
             "'/opt/nanocodex/bin/nanocodex' eval run 'release' --config 'nanocodex.toml' --coordinator 'http://127.0.0.1:8789' --worker 'dev-georgios-01' --task"
         ));

--- a/bin/nanocodex/src/benchmark.rs
+++ b/bin/nanocodex/src/benchmark.rs
@@ -5,6 +5,7 @@ pub(crate) fn prompt(
     config: &Path,
     state_dir: Option<&Path>,
     coordinator: Option<&str>,
+    worker: Option<&str>,
 ) -> String {
     let selected = profile.unwrap_or("the selected SQLite profile");
     let profile_argument =
@@ -14,6 +15,9 @@ pub(crate) fn prompt(
     });
     let coordinator_argument = coordinator.map_or_else(String::new, |coordinator| {
         format!(" --coordinator {}", shell_quote(coordinator))
+    });
+    let worker_argument = worker.map_or_else(String::new, |worker| {
+        format!(" --worker {}", shell_quote(worker))
     });
     let config_argument = shell_quote(&config.to_string_lossy());
     let ledger = if coordinator.is_some() {
@@ -28,7 +32,7 @@ The desired amount of work is already materialized in {ledger}. Do not infer it 
 
     nanocodex eval status{profile_argument}{state_argument}{coordinator_argument} --json
 
-You own execution strategy. Read the family records, choose an exact pending task and harness treatment, and invoke one repetition with `nanocodex eval run{profile_argument} --config {config_argument}{state_argument}{coordinator_argument} --task <exact-profile-selector>` plus `--harness`, model, or thinking selectors required to identify that profile family. Omit `--harness` for built-in Nanocodex. The CLI allocates the internal repetition; never pass or invent a trial number.
+You own execution strategy. Read the family records, choose an exact pending task and harness treatment, and invoke one repetition with `nanocodex eval run{profile_argument} --config {config_argument}{state_argument}{coordinator_argument}{worker_argument} --task <exact-profile-selector>` plus `--harness`, model, or thinking selectors required to identify that profile family. Omit `--harness` for built-in Nanocodex. The CLI allocates the internal repetition; never pass or invent a trial number.
 
 Decide how many run processes to launch concurrently and which tasks to prioritize. You may adjust fan-out based on memory, preparation contention, failures, and observed throughput. There is deliberately no run-all command, next-work command, scheduler, or host-saturation loop in the evaluator.
 
@@ -54,6 +58,7 @@ mod tests {
             Path::new("nanocodex.toml"),
             Some(Path::new("/mnt/evals")),
             None,
+            None,
         );
 
         assert!(prompt.contains("choose an exact pending task and harness treatment"));
@@ -71,6 +76,7 @@ mod tests {
             Path::new("configs/eval profile.toml"),
             Some(Path::new("/mnt/eval state")),
             None,
+            None,
         );
 
         assert!(prompt.contains("status 'release candidate' --state-dir '/mnt/eval state'"));
@@ -84,11 +90,12 @@ mod tests {
             Path::new("nanocodex.toml"),
             None,
             Some("http://127.0.0.1:8789"),
+            Some("dev-georgios-01"),
         );
 
         assert!(prompt.contains("status 'release' --coordinator 'http://127.0.0.1:8789'"));
         assert!(prompt.contains(
-            "run 'release' --config 'nanocodex.toml' --coordinator 'http://127.0.0.1:8789' --task"
+            "run 'release' --config 'nanocodex.toml' --coordinator 'http://127.0.0.1:8789' --worker 'dev-georgios-01' --task"
         ));
         assert!(prompt.contains("do not open SQLite directly"));
         assert!(!prompt.contains("--state-dir"));

--- a/bin/nanocodex/src/benchmark.rs
+++ b/bin/nanocodex/src/benchmark.rs
@@ -6,6 +6,7 @@ pub(crate) fn prompt(
     state_dir: Option<&Path>,
     coordinator: Option<&str>,
     worker: Option<&str>,
+    executable: Option<&Path>,
 ) -> String {
     let selected = profile.unwrap_or("the selected SQLite profile");
     let profile_argument =
@@ -20,6 +21,10 @@ pub(crate) fn prompt(
         format!(" --worker {}", shell_quote(worker))
     });
     let config_argument = shell_quote(&config.to_string_lossy());
+    let executable = executable.map_or_else(
+        || "nanocodex".to_owned(),
+        |executable| shell_quote(&executable.to_string_lossy()),
+    );
     let ledger = if coordinator.is_some() {
         "the coordinator-backed SQLite ledger; do not open SQLite directly"
     } else {
@@ -28,11 +33,13 @@ pub(crate) fn prompt(
     format!(
         r#"Drive the Nanocodex evaluation profile {selected} to durable completion.
 
+This is an operations loop, not a software-development task. Do not inspect repository source, plans, documentation, or configuration. Do not edit files. Begin with the status command below, then immediately launch a wave of pending work.
+
 The desired amount of work is already materialized in {ledger}. Do not infer it from `{config}` or add ad-hoc work during this workflow. Inspect the durable ledger with:
 
-    nanocodex eval status{profile_argument}{state_argument}{coordinator_argument} --json
+    {executable} eval status{profile_argument}{state_argument}{coordinator_argument} --json
 
-You own execution strategy. Read the family records, choose an exact pending task and harness treatment, and invoke one repetition with `nanocodex eval run{profile_argument} --config {config_argument}{state_argument}{coordinator_argument}{worker_argument} --task <exact-profile-selector>` plus `--harness`, model, or thinking selectors required to identify that profile family. Omit `--harness` for built-in Nanocodex. The CLI allocates the internal repetition; never pass or invent a trial number.
+You own execution strategy. Read the family records, choose an exact pending task and harness treatment, and invoke one repetition with `{executable} eval run{profile_argument} --config {config_argument}{state_argument}{coordinator_argument}{worker_argument} --task <exact-profile-selector>` plus `--harness`, model, or thinking selectors required to identify that profile family. Omit `--harness` for built-in Nanocodex. The CLI allocates the internal repetition; never pass or invent a trial number.
 
 Decide how many run processes to launch concurrently and which tasks to prioritize. You may adjust fan-out based on memory, preparation contention, failures, and observed throughput. There is deliberately no run-all command, next-work command, scheduler, or host-saturation loop in the evaluator.
 
@@ -59,6 +66,7 @@ mod tests {
             Some(Path::new("/mnt/evals")),
             None,
             None,
+            None,
         );
 
         assert!(prompt.contains("choose an exact pending task and harness treatment"));
@@ -77,6 +85,7 @@ mod tests {
             Some(Path::new("/mnt/eval state")),
             None,
             None,
+            None,
         );
 
         assert!(prompt.contains("status 'release candidate' --state-dir '/mnt/eval state'"));
@@ -91,13 +100,15 @@ mod tests {
             None,
             Some("http://127.0.0.1:8789"),
             Some("dev-georgios-01"),
+            Some(Path::new("/opt/nanocodex/bin/nanocodex")),
         );
 
         assert!(prompt.contains("status 'release' --coordinator 'http://127.0.0.1:8789'"));
         assert!(prompt.contains(
-            "run 'release' --config 'nanocodex.toml' --coordinator 'http://127.0.0.1:8789' --worker 'dev-georgios-01' --task"
+            "'/opt/nanocodex/bin/nanocodex' eval run 'release' --config 'nanocodex.toml' --coordinator 'http://127.0.0.1:8789' --worker 'dev-georgios-01' --task"
         ));
         assert!(prompt.contains("do not open SQLite directly"));
+        assert!(prompt.contains("not a software-development task"));
         assert!(!prompt.contains("--state-dir"));
     }
 }

--- a/bin/nanocodex/src/benchmark.rs
+++ b/bin/nanocodex/src/benchmark.rs
@@ -16,10 +16,15 @@ pub(crate) fn prompt(
         format!(" --coordinator {}", shell_quote(coordinator))
     });
     let config_argument = shell_quote(&config.to_string_lossy());
+    let ledger = if coordinator.is_some() {
+        "the coordinator-backed SQLite ledger; do not open SQLite directly"
+    } else {
+        "SQLite"
+    };
     format!(
-        r#"Drive the Nanocodex SQLite profile {selected} to durable completion.
+        r#"Drive the Nanocodex evaluation profile {selected} to durable completion.
 
-The desired amount of work is already materialized in SQLite. Do not infer it from `{config}` or add ad-hoc work during this workflow. Inspect the durable ledger with:
+The desired amount of work is already materialized in {ledger}. Do not infer it from `{config}` or add ad-hoc work during this workflow. Inspect the durable ledger with:
 
     nanocodex eval status{profile_argument}{state_argument}{coordinator_argument} --json
 
@@ -85,6 +90,7 @@ mod tests {
         assert!(prompt.contains(
             "run 'release' --config 'nanocodex.toml' --coordinator 'http://127.0.0.1:8789' --task"
         ));
+        assert!(prompt.contains("do not open SQLite directly"));
         assert!(!prompt.contains("--state-dir"));
     }
 }

--- a/bin/nanocodex/src/benchmark.rs
+++ b/bin/nanocodex/src/benchmark.rs
@@ -6,7 +6,7 @@ pub(crate) fn prompt(
     state_dir: Option<&Path>,
     coordinator: Option<&str>,
 ) -> String {
-    let selected = profile.unwrap_or("the manifest default profile");
+    let selected = profile.unwrap_or("the selected SQLite workset");
     let profile_argument =
         profile.map_or_else(String::new, |profile| format!(" {}", shell_quote(profile)));
     let state_argument = state_dir.map_or_else(String::new, |directory| {
@@ -17,11 +17,11 @@ pub(crate) fn prompt(
     });
     let config_argument = shell_quote(&config.to_string_lossy());
     format!(
-        r#"Drive the closed Nanocodex evaluation profile {selected} to durable completion.
+        r#"Drive the Nanocodex SQLite workset {selected} to durable completion.
 
-The desired amount of work is defined only by `{config}`. Never add an ad-hoc task, treatment, model, reasoning effort, or trial. Materialize and inspect its durable SQLite ledger with:
+The desired amount of work is already materialized in SQLite. Do not infer it from `{config}` or add ad-hoc work during this workflow. Inspect the durable ledger with:
 
-    nanocodex eval status{profile_argument} --config {config_argument}{state_argument}{coordinator_argument} --json
+    nanocodex eval status{profile_argument}{state_argument}{coordinator_argument} --json
 
 You own execution strategy. Read the family records, choose an exact pending task and harness treatment, and invoke one repetition with `nanocodex eval run{profile_argument} --config {config_argument}{state_argument}{coordinator_argument} --task <exact-profile-selector>` plus `--harness`, model, or thinking selectors required to identify that profile family. Omit `--harness` for built-in Nanocodex. The CLI allocates the internal repetition; never pass or invent a trial number.
 
@@ -68,7 +68,7 @@ mod tests {
             None,
         );
 
-        assert!(prompt.contains("status 'release candidate' --config 'configs/eval profile.toml'"));
+        assert!(prompt.contains("status 'release candidate' --state-dir '/mnt/eval state'"));
         assert!(prompt.contains("--state-dir '/mnt/eval state'"));
     }
 
@@ -81,9 +81,7 @@ mod tests {
             Some("http://127.0.0.1:8789"),
         );
 
-        assert!(prompt.contains(
-            "status 'release' --config 'nanocodex.toml' --coordinator 'http://127.0.0.1:8789'"
-        ));
+        assert!(prompt.contains("status 'release' --coordinator 'http://127.0.0.1:8789'"));
         assert!(prompt.contains(
             "run 'release' --config 'nanocodex.toml' --coordinator 'http://127.0.0.1:8789' --task"
         ));

--- a/bin/nanocodex/src/eval/benchmark.rs
+++ b/bin/nanocodex/src/eval/benchmark.rs
@@ -51,6 +51,14 @@ pub(super) struct Benchmark {
     #[arg(long)]
     systemd: bool,
 
+    /// Host-local cache and temporary workspace for the supervised benchmark.
+    ///
+    /// The systemd unit exports this as `NANOCODEX_HOME` and places `TMPDIR`
+    /// beneath it so VM images and transient build contexts stay off the root
+    /// filesystem.
+    #[arg(long, value_name = "DIRECTORY", requires = "systemd")]
+    runtime_dir: Option<PathBuf>,
+
     #[command(flatten)]
     agent: AgentArgs,
 
@@ -71,6 +79,7 @@ impl Benchmark {
             worker,
             headless,
             systemd,
+            runtime_dir,
             agent,
             observability,
             vm,
@@ -81,6 +90,7 @@ impl Benchmark {
                 &config,
                 state_dir.as_deref(),
                 coordinator.as_deref(),
+                runtime_dir.as_deref(),
             );
         }
         let executable =

--- a/bin/nanocodex/src/eval/benchmark.rs
+++ b/bin/nanocodex/src/eval/benchmark.rs
@@ -35,7 +35,10 @@ pub(super) struct Benchmark {
     headless: bool,
 
     /// Install and start this benchmark as a durable user systemd service.
-    #[arg(long, conflicts_with = "coordinator")]
+    ///
+    /// When `--coordinator` is present, the supervised agent and every run it
+    /// launches use that coordinator instead of opening SQLite directly.
+    #[arg(long)]
     systemd: bool,
 
     #[command(flatten)]
@@ -62,7 +65,12 @@ impl Benchmark {
             vm,
         } = self;
         if systemd {
-            return systemd::install(&profile, &config, state_dir.as_deref());
+            return systemd::install(
+                &profile,
+                &config,
+                state_dir.as_deref(),
+                coordinator.as_deref(),
+            );
         }
         let prompt = benchmark::prompt(
             Some(profile.as_str()),

--- a/bin/nanocodex/src/eval/benchmark.rs
+++ b/bin/nanocodex/src/eval/benchmark.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::Args;
+use clap::{Args, builder::NonEmptyStringValueParser};
 use eyre::{Result, WrapErr as _};
 use nanocodex_eval::{Evaluation, EvaluationStatus, coordinator::CoordinatorClient};
 use serde::Deserialize;
@@ -30,6 +30,16 @@ pub(super) struct Benchmark {
     #[arg(long, value_name = "URL", conflicts_with = "state_dir")]
     coordinator: Option<String>,
 
+    /// Stable host identity used for coordinator task affinity.
+    #[arg(
+        long,
+        env = "NANOCODEX_WORKER_NAME",
+        value_name = "NAME",
+        value_parser = NonEmptyStringValueParser::new(),
+        requires = "coordinator"
+    )]
+    worker: Option<String>,
+
     /// Run the same benchmark workflow as flushed JSONL without a TUI.
     #[arg(long)]
     headless: bool,
@@ -58,6 +68,7 @@ impl Benchmark {
             config,
             state_dir,
             coordinator,
+            worker,
             headless,
             systemd,
             agent,
@@ -77,6 +88,7 @@ impl Benchmark {
             &config,
             state_dir.as_deref(),
             coordinator.as_deref(),
+            worker.as_deref(),
         );
         let initial = BoardStatus::load(
             &profile,

--- a/bin/nanocodex/src/eval/benchmark.rs
+++ b/bin/nanocodex/src/eval/benchmark.rs
@@ -1,9 +1,15 @@
 use std::path::PathBuf;
 
 use clap::Args;
-use eyre::Result;
+use eyre::{Result, WrapErr as _};
+use nanocodex_eval::{Evaluation, EvaluationStatus, coordinator::CoordinatorClient};
+use serde::Deserialize;
 
-use crate::{benchmark, config::AgentArgs, observability::ObservabilityArgs, run, tui, vm::VmArgs};
+use super::{profile::default_state_dir, systemd};
+use crate::{
+    RetryableProcessExit, benchmark, config::AgentArgs, observability::ObservabilityArgs, run, tui,
+    vm::VmArgs,
+};
 
 #[derive(Args)]
 pub(super) struct Benchmark {
@@ -28,6 +34,10 @@ pub(super) struct Benchmark {
     #[arg(long)]
     headless: bool,
 
+    /// Install and start this benchmark as a durable user systemd service.
+    #[arg(long, conflicts_with = "coordinator")]
+    systemd: bool,
+
     #[command(flatten)]
     agent: AgentArgs,
 
@@ -40,28 +50,226 @@ pub(super) struct Benchmark {
 
 impl Benchmark {
     pub(super) async fn run(self) -> Result<()> {
+        let Self {
+            profile,
+            config,
+            state_dir,
+            coordinator,
+            headless,
+            systemd,
+            agent,
+            observability,
+            vm,
+        } = self;
+        if systemd {
+            return systemd::install(profile.as_deref(), &config, state_dir.as_deref());
+        }
         let prompt = benchmark::prompt(
-            self.profile.as_deref(),
-            &self.config,
-            self.state_dir.as_deref(),
-            self.coordinator.as_deref(),
+            profile.as_deref(),
+            &config,
+            state_dir.as_deref(),
+            coordinator.as_deref(),
         );
-        if self.headless {
-            let _observability = self.observability.install(false, self.agent.cwd())?;
-            run::run_prompt(prompt, self.agent, self.vm).await
+        let initial = BoardStatus::load(
+            profile.as_deref(),
+            &config,
+            state_dir.as_deref(),
+            coordinator.as_deref(),
+        )
+        .await?;
+        if initial.is_complete() {
+            return Ok(());
+        }
+        let workflow = if headless {
+            let _observability = observability.install(false, agent.cwd())?;
+            run::run_prompt(prompt, agent, vm).await
         } else {
-            let _observability = self.observability.install(true, self.agent.cwd())?;
-            let display = self.profile.as_ref().map_or_else(
+            let _observability = observability.install(true, agent.cwd())?;
+            let display = profile.as_ref().map_or_else(
                 || "/benchmark".to_owned(),
                 |profile| format!("/benchmark {profile}"),
             );
             tui::run(
-                self.agent,
-                self.vm,
+                agent,
+                vm,
                 Some(tui::InitialPrompt::workflow(display, prompt)),
                 None,
             )
             .await
+        };
+        let board = BoardStatus::load(
+            profile.as_deref(),
+            &config,
+            state_dir.as_deref(),
+            coordinator.as_deref(),
+        )
+        .await?;
+        board.require_complete(workflow.as_ref().err())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+struct BoardCounts {
+    pending: i64,
+    running: i64,
+    complete: i64,
+}
+
+impl BoardCounts {
+    const fn total(self) -> i64 {
+        self.pending + self.running + self.complete
+    }
+
+    const fn is_complete(self) -> bool {
+        self.pending == 0 && self.running == 0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+struct BoardStatus {
+    preparation: BoardCounts,
+    coordinates: BoardCounts,
+}
+
+impl BoardStatus {
+    async fn load(
+        profile: Option<&str>,
+        config: &std::path::Path,
+        state_dir: Option<&std::path::Path>,
+        coordinator: Option<&str>,
+    ) -> Result<Self> {
+        if let Some(coordinator) = coordinator {
+            let status = CoordinatorClient::new(coordinator)?.status().await?;
+            return serde_json::from_value(status)
+                .wrap_err("coordinator returned an invalid benchmark board status");
         }
+        let state_dir = state_dir.map_or_else(default_state_dir, |path| Ok(path.to_path_buf()))?;
+        let evaluation = Evaluation::open(config, profile, state_dir)?;
+        Ok(evaluation.status()?.into())
+    }
+
+    const fn is_complete(self) -> bool {
+        self.preparation.is_complete() && self.coordinates.is_complete()
+    }
+
+    fn require_complete(self, workflow_error: Option<&eyre::Report>) -> Result<()> {
+        if self.is_complete() {
+            return Ok(());
+        }
+        let workflow_error = workflow_error.map_or_else(String::new, |error| {
+            format!("; agent workflow ended with: {error:#}")
+        });
+        Err(RetryableProcessExit::new(format!(
+            "benchmark board remains incomplete: preparation {}/{} ready ({} pending, {} running); coordinates {}/{} terminal ({} pending, {} running){workflow_error}",
+            self.preparation.complete,
+            self.preparation.total(),
+            self.preparation.pending,
+            self.preparation.running,
+            self.coordinates.complete,
+            self.coordinates.total(),
+            self.coordinates.pending,
+            self.coordinates.running,
+        ))
+        .into())
+    }
+}
+
+impl From<EvaluationStatus> for BoardStatus {
+    fn from(status: EvaluationStatus) -> Self {
+        Self {
+            preparation: BoardCounts {
+                pending: status.preparation.pending,
+                running: status.preparation.running,
+                complete: status.preparation.complete,
+            },
+            coordinates: BoardCounts {
+                pending: status.coordinates.pending,
+                running: status.coordinates.running,
+                complete: status.coordinates.complete,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BoardCounts, BoardStatus};
+    use crate::{RETRYABLE_EXIT_CODE, process_exit_code};
+
+    #[test]
+    fn benchmark_succeeds_only_when_the_entire_board_is_terminal() {
+        let complete = BoardStatus {
+            preparation: BoardCounts {
+                pending: 0,
+                running: 0,
+                complete: 3,
+            },
+            coordinates: BoardCounts {
+                pending: 0,
+                running: 0,
+                complete: 30,
+            },
+        };
+        assert!(complete.require_complete(None).is_ok());
+
+        for incomplete in [
+            BoardStatus {
+                coordinates: BoardCounts {
+                    pending: 1,
+                    ..complete.coordinates
+                },
+                ..complete
+            },
+            BoardStatus {
+                coordinates: BoardCounts {
+                    running: 1,
+                    ..complete.coordinates
+                },
+                ..complete
+            },
+            BoardStatus {
+                preparation: BoardCounts {
+                    running: 1,
+                    ..complete.preparation
+                },
+                ..complete
+            },
+        ] {
+            let error = incomplete.require_complete(None).unwrap_err();
+            assert_eq!(process_exit_code(&error), RETRYABLE_EXIT_CODE);
+        }
+    }
+
+    #[test]
+    fn remote_status_uses_the_same_completion_contract() {
+        let board: BoardStatus = serde_json::from_value(serde_json::json!({
+            "profile": "release",
+            "digest": "abc",
+            "preparation": { "pending": 0, "running": 0, "complete": 2 },
+            "coordinates": { "pending": 0, "running": 0, "complete": 20 },
+            "families": [],
+        }))
+        .unwrap();
+        assert!(board.require_complete(None).is_ok());
+    }
+
+    #[test]
+    fn agent_failure_is_retryable_while_the_board_remains_incomplete() {
+        let board = BoardStatus {
+            preparation: BoardCounts {
+                pending: 0,
+                running: 0,
+                complete: 2,
+            },
+            coordinates: BoardCounts {
+                pending: 1,
+                running: 0,
+                complete: 19,
+            },
+        };
+        let workflow_error = eyre::eyre!("connection closed");
+        let error = board.require_complete(Some(&workflow_error)).unwrap_err();
+        assert_eq!(process_exit_code(&error), RETRYABLE_EXIT_CODE);
+        assert!(error.to_string().contains("connection closed"));
     }
 }

--- a/bin/nanocodex/src/eval/benchmark.rs
+++ b/bin/nanocodex/src/eval/benchmark.rs
@@ -13,8 +13,8 @@ use crate::{
 
 #[derive(Args)]
 pub(super) struct Benchmark {
-    /// Named durable workset to drive to completion.
-    workset: String,
+    /// Named durable profile to drive to completion.
+    profile: String,
 
     /// Runtime harness helper configuration passed to workers.
     #[arg(long, default_value = "nanocodex.toml")]
@@ -51,7 +51,7 @@ pub(super) struct Benchmark {
 impl Benchmark {
     pub(super) async fn run(self) -> Result<()> {
         let Self {
-            workset,
+            profile,
             config,
             state_dir,
             coordinator,
@@ -62,16 +62,16 @@ impl Benchmark {
             vm,
         } = self;
         if systemd {
-            return systemd::install(&workset, &config, state_dir.as_deref());
+            return systemd::install(&profile, &config, state_dir.as_deref());
         }
         let prompt = benchmark::prompt(
-            Some(workset.as_str()),
+            Some(profile.as_str()),
             &config,
             state_dir.as_deref(),
             coordinator.as_deref(),
         );
         let initial = BoardStatus::load(
-            &workset,
+            &profile,
             &config,
             state_dir.as_deref(),
             coordinator.as_deref(),
@@ -85,7 +85,7 @@ impl Benchmark {
             run::run_prompt(prompt, agent, vm).await
         } else {
             let _observability = observability.install(true, agent.cwd())?;
-            let display = format!("/benchmark {workset}");
+            let display = format!("/benchmark {profile}");
             tui::run(
                 agent,
                 vm,
@@ -95,7 +95,7 @@ impl Benchmark {
             .await
         };
         let board = BoardStatus::load(
-            &workset,
+            &profile,
             &config,
             state_dir.as_deref(),
             coordinator.as_deref(),
@@ -241,7 +241,7 @@ mod tests {
     fn remote_status_uses_the_same_completion_contract() {
         let board: BoardStatus = serde_json::from_value(serde_json::json!({
             "profile": "release",
-            "digest": "abc",
+            "generation": "abc",
             "preparation": { "pending": 0, "running": 0, "complete": 2 },
             "coordinates": { "pending": 0, "running": 0, "complete": 20 },
             "families": [],

--- a/bin/nanocodex/src/eval/benchmark.rs
+++ b/bin/nanocodex/src/eval/benchmark.rs
@@ -13,10 +13,10 @@ use crate::{
 
 #[derive(Args)]
 pub(super) struct Benchmark {
-    /// Evaluation profile. Uses nanocodex.toml's default when omitted.
-    profile: Option<String>,
+    /// Named durable workset to drive to completion.
+    workset: String,
 
-    /// Closed evaluation manifest.
+    /// Runtime harness helper configuration passed to workers.
     #[arg(long, default_value = "nanocodex.toml")]
     config: PathBuf,
 
@@ -51,7 +51,7 @@ pub(super) struct Benchmark {
 impl Benchmark {
     pub(super) async fn run(self) -> Result<()> {
         let Self {
-            profile,
+            workset,
             config,
             state_dir,
             coordinator,
@@ -62,16 +62,16 @@ impl Benchmark {
             vm,
         } = self;
         if systemd {
-            return systemd::install(profile.as_deref(), &config, state_dir.as_deref());
+            return systemd::install(&workset, &config, state_dir.as_deref());
         }
         let prompt = benchmark::prompt(
-            profile.as_deref(),
+            Some(workset.as_str()),
             &config,
             state_dir.as_deref(),
             coordinator.as_deref(),
         );
         let initial = BoardStatus::load(
-            profile.as_deref(),
+            &workset,
             &config,
             state_dir.as_deref(),
             coordinator.as_deref(),
@@ -85,10 +85,7 @@ impl Benchmark {
             run::run_prompt(prompt, agent, vm).await
         } else {
             let _observability = observability.install(true, agent.cwd())?;
-            let display = profile.as_ref().map_or_else(
-                || "/benchmark".to_owned(),
-                |profile| format!("/benchmark {profile}"),
-            );
+            let display = format!("/benchmark {workset}");
             tui::run(
                 agent,
                 vm,
@@ -98,7 +95,7 @@ impl Benchmark {
             .await
         };
         let board = BoardStatus::load(
-            profile.as_deref(),
+            &workset,
             &config,
             state_dir.as_deref(),
             coordinator.as_deref(),
@@ -133,7 +130,7 @@ struct BoardStatus {
 
 impl BoardStatus {
     async fn load(
-        profile: Option<&str>,
+        profile: &str,
         config: &std::path::Path,
         state_dir: Option<&std::path::Path>,
         coordinator: Option<&str>,

--- a/bin/nanocodex/src/eval/benchmark.rs
+++ b/bin/nanocodex/src/eval/benchmark.rs
@@ -83,12 +83,15 @@ impl Benchmark {
                 coordinator.as_deref(),
             );
         }
+        let executable =
+            std::env::current_exe().wrap_err("failed to resolve nanocodex executable")?;
         let prompt = benchmark::prompt(
             Some(profile.as_str()),
             &config,
             state_dir.as_deref(),
             coordinator.as_deref(),
             worker.as_deref(),
+            Some(&executable),
         );
         let initial = BoardStatus::load(
             &profile,

--- a/bin/nanocodex/src/eval/coordinator.rs
+++ b/bin/nanocodex/src/eval/coordinator.rs
@@ -9,10 +9,10 @@ use super::profile::default_state_dir;
 
 #[derive(Args)]
 pub(super) struct Coordinator {
-    /// Evaluation profile. Uses the manifest's top-level default when omitted.
-    profile: Option<String>,
+    /// Named durable workset served from SQLite.
+    workset: String,
 
-    /// Evaluation manifest containing the closed desired work bundle.
+    /// Runtime harness helper configuration.
     #[arg(long, default_value = "nanocodex.toml")]
     config: PathBuf,
 
@@ -28,7 +28,7 @@ pub(super) struct Coordinator {
 impl Coordinator {
     pub(super) async fn run(self) -> Result<()> {
         let state = self.state_dir.map_or_else(default_state_dir, Ok)?;
-        let evaluation = Evaluation::open(&self.config, self.profile.as_deref(), state)?;
+        let evaluation = Evaluation::open(&self.config, &self.workset, state)?;
         let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, self.port))
             .await
             .wrap_err("failed to bind the evaluation coordinator")?;

--- a/bin/nanocodex/src/eval/coordinator.rs
+++ b/bin/nanocodex/src/eval/coordinator.rs
@@ -9,8 +9,8 @@ use super::profile::default_state_dir;
 
 #[derive(Args)]
 pub(super) struct Coordinator {
-    /// Named durable workset served from SQLite.
-    workset: String,
+    /// Named durable profile served from SQLite.
+    profile: String,
 
     /// Runtime harness helper configuration.
     #[arg(long, default_value = "nanocodex.toml")]
@@ -28,7 +28,7 @@ pub(super) struct Coordinator {
 impl Coordinator {
     pub(super) async fn run(self) -> Result<()> {
         let state = self.state_dir.map_or_else(default_state_dir, Ok)?;
-        let evaluation = Evaluation::open(&self.config, &self.workset, state)?;
+        let evaluation = Evaluation::open(&self.config, &self.profile, state)?;
         let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, self.port))
             .await
             .wrap_err("failed to bind the evaluation coordinator")?;

--- a/bin/nanocodex/src/eval/mod.rs
+++ b/bin/nanocodex/src/eval/mod.rs
@@ -15,7 +15,7 @@ pub(crate) struct Eval {
 
 #[derive(Subcommand)]
 enum EvalCommand {
-    /// Add concrete tasks and treatments to a durable SQLite profile.
+    /// Add concrete tasks and treatments to a durable evaluation profile.
     Add(profile::Add),
 
     /// Launch the agent-owned benchmark workflow in the TUI or headlessly.

--- a/bin/nanocodex/src/eval/mod.rs
+++ b/bin/nanocodex/src/eval/mod.rs
@@ -2,6 +2,7 @@ mod benchmark;
 mod coordinator;
 mod profile;
 mod run;
+mod systemd;
 
 use clap::{Args, Subcommand};
 use eyre::Result;
@@ -68,6 +69,7 @@ mod tests {
             ],
             vec!["nanocodex", "eval", "status", "local-smoke"],
             vec!["nanocodex", "eval", "benchmark", "local-smoke"],
+            vec!["nanocodex", "eval", "benchmark", "local-smoke", "--systemd"],
             vec!["nanocodex", "eval", "coordinator", "local-smoke"],
         ] {
             Cli::try_parse_from(arguments).expect("supported eval command must parse");

--- a/bin/nanocodex/src/eval/mod.rs
+++ b/bin/nanocodex/src/eval/mod.rs
@@ -15,7 +15,7 @@ pub(crate) struct Eval {
 
 #[derive(Subcommand)]
 enum EvalCommand {
-    /// Add concrete tasks and treatments to a durable SQLite workset.
+    /// Add concrete tasks and treatments to a durable SQLite profile.
     Add(profile::Add),
 
     /// Launch the agent-owned benchmark workflow in the TUI or headlessly.
@@ -24,10 +24,10 @@ enum EvalCommand {
     /// Own one SQLite ledger for pull workers on this machine.
     Coordinator(coordinator::Coordinator),
 
-    /// Inspect one named SQLite workset and its durable progress.
+    /// Inspect one named SQLite profile and its durable progress.
     Status(profile::Status),
 
-    /// Durably execute one selected task treatment from a SQLite workset.
+    /// Durably execute one selected task treatment from a SQLite profile.
     Run(profile::Run),
 }
 

--- a/bin/nanocodex/src/eval/mod.rs
+++ b/bin/nanocodex/src/eval/mod.rs
@@ -86,6 +86,17 @@ mod tests {
             vec!["nanocodex", "eval", "status", "local-smoke"],
             vec!["nanocodex", "eval", "benchmark", "local-smoke"],
             vec!["nanocodex", "eval", "benchmark", "local-smoke", "--systemd"],
+            vec![
+                "nanocodex",
+                "eval",
+                "benchmark",
+                "local-smoke",
+                "--coordinator",
+                "http://127.0.0.1:8788",
+                "--worker",
+                "dev-one",
+                "--systemd",
+            ],
             vec!["nanocodex", "eval", "coordinator", "local-smoke"],
         ] {
             Cli::try_parse_from(arguments).expect("supported eval command must parse");

--- a/bin/nanocodex/src/eval/mod.rs
+++ b/bin/nanocodex/src/eval/mod.rs
@@ -15,16 +15,19 @@ pub(crate) struct Eval {
 
 #[derive(Subcommand)]
 enum EvalCommand {
+    /// Add concrete tasks and treatments to a durable SQLite workset.
+    Add(profile::Add),
+
     /// Launch the agent-owned benchmark workflow in the TUI or headlessly.
     Benchmark(benchmark::Benchmark),
 
     /// Own one SQLite ledger for pull workers on this machine.
     Coordinator(coordinator::Coordinator),
 
-    /// Inspect one immutable profile revision and its durable progress.
+    /// Inspect one named SQLite workset and its durable progress.
     Status(profile::Status),
 
-    /// Durably execute one agent-selected task repetition from a profile.
+    /// Durably execute one selected task treatment from a SQLite workset.
     Run(profile::Run),
 }
 
@@ -42,6 +45,7 @@ fn enable_paint() {
 
 async fn run(eval: Eval) -> Result<()> {
     match eval.command {
+        EvalCommand::Add(command) => command.run().await?,
         EvalCommand::Benchmark(command) => command.run().await?,
         EvalCommand::Coordinator(command) => command.run().await?,
         EvalCommand::Status(command) => command.run().await?,
@@ -59,6 +63,18 @@ mod tests {
     #[test]
     fn complete_eval_surface_is_nested_under_nanocodex() {
         for arguments in [
+            vec![
+                "nanocodex",
+                "eval",
+                "add",
+                "local-smoke",
+                "--task",
+                "tasks/write-greeting",
+                "--harness",
+                "codex",
+                "--trials",
+                "5",
+            ],
             vec![
                 "nanocodex",
                 "eval",
@@ -114,6 +130,21 @@ mod tests {
                 "local-smoke",
                 "--bind",
                 "100.64.0.1",
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn status_reads_only_the_sqlite_workset() {
+        assert!(
+            Cli::try_parse_from([
+                "nanocodex",
+                "eval",
+                "status",
+                "local-smoke",
+                "--config",
+                "nanocodex.toml",
             ])
             .is_err()
         );

--- a/bin/nanocodex/src/eval/profile.rs
+++ b/bin/nanocodex/src/eval/profile.rs
@@ -10,7 +10,7 @@ use nanocodex_eval::{
     EvalAttemptOutcome, EvalEventKind, EvalEventStream, EvalOutcome, Evaluation, EvaluationClaim,
     EvaluationSelector, EvaluationWork, Evaluator, ResolvedHarness, Task,
     atif::AtifBuilder,
-    coordinator::{CoordinatorClient, RemoteClaim, RemoteLease},
+    coordinator::{CoordinatorAddRequest, CoordinatorClient, RemoteClaim, RemoteLease},
     harness::{Harness, HarnessAuth},
     vm::{CachePolicy, VmBackend, VmResources},
 };
@@ -79,13 +79,19 @@ pub(super) struct Add {
     #[arg(long)]
     new: bool,
 
-    /// Optional profile recipes and runtime harness helpers.
+    /// Optional local profile recipes and runtime harness helpers.
+    ///
+    /// A remote coordinator resolves recipes from its own configured file.
     #[arg(long, default_value = CONFIG_FILE)]
     config: PathBuf,
 
-    /// Durable SQLite ledger and retained artifacts.
+    /// Local durable SQLite ledger and retained artifacts.
     #[arg(long, value_name = "DIRECTORY")]
     state_dir: Option<PathBuf>,
+
+    /// Add work through a remote coordinator instead of opening SQLite directly.
+    #[arg(long, value_name = "URL", conflicts_with = "state_dir")]
+    coordinator: Option<String>,
 }
 
 #[derive(Args)]
@@ -144,6 +150,42 @@ pub(super) struct Run {
 
 impl Add {
     pub(super) async fn run(self) -> Result<()> {
+        if let Some(coordinator) = &self.coordinator {
+            for task in &self.task {
+                if !task.is_absolute() {
+                    return Err(eyre!(
+                        "remote task paths must be absolute coordinator-host paths: {}",
+                        task.display()
+                    ));
+                }
+            }
+            let request = CoordinatorAddRequest {
+                profile: self.profile,
+                recipe: self.recipe,
+                tasks: self
+                    .task
+                    .into_iter()
+                    .map(|task| task.to_string_lossy().into_owned())
+                    .collect(),
+                harnesses: self.harness,
+                models: self
+                    .model
+                    .into_iter()
+                    .map(|model| model.as_str().to_owned())
+                    .collect(),
+                thinking: self
+                    .thinking
+                    .into_iter()
+                    .map(|thinking| thinking.as_str().to_owned())
+                    .collect(),
+                trials: self.trials,
+                web_search: self.web_search,
+                new_generation: self.new,
+            };
+            let status = CoordinatorClient::new(coordinator)?.add(&request).await?;
+            print_added_remote_status(&status);
+            return Ok(());
+        }
         let state = self.state_dir.map_or_else(default_state_dir, Ok)?;
         if let Some(recipe) = self.recipe.as_deref() {
             if !self.task.is_empty()
@@ -209,6 +251,19 @@ impl Add {
         );
         Ok(())
     }
+}
+
+fn print_added_remote_status(status: &serde_json::Value) {
+    let profile = status["profile"].as_str().unwrap_or("unknown");
+    let generation = status["generation"].as_str().unwrap_or("unknown");
+    let generation = generation.get(..12).unwrap_or(generation);
+    println!(
+        "{} {} · {} tasks · {} coordinate(s)",
+        profile,
+        generation,
+        count_total(&status["preparation"]),
+        count_total(&status["coordinates"]),
+    );
 }
 
 #[derive(Serialize)]
@@ -820,6 +875,47 @@ mod tests {
         };
         assert_eq!(run.task, "terminal/fix-git");
         assert_eq!(run.worker.as_deref(), Some("dev-one"));
+    }
+
+    #[test]
+    fn add_accepts_remote_coordinator_and_rejects_direct_sqlite_combination() {
+        let cli = Cli::try_parse_from([
+            "nanocodex",
+            "eval",
+            "add",
+            "release",
+            "--coordinator",
+            "http://127.0.0.1:8788",
+            "--task",
+            "/mnt/tasks/fix-git",
+            "--trials",
+            "3",
+        ])
+        .unwrap();
+        let Some(Command::Eval(eval)) = cli.command else {
+            panic!("expected eval command");
+        };
+        let EvalCommand::Add(add) = eval.command else {
+            panic!("expected profile add");
+        };
+        assert_eq!(add.coordinator.as_deref(), Some("http://127.0.0.1:8788"));
+        assert_eq!(add.task, [Path::new("/mnt/tasks/fix-git")]);
+
+        assert!(
+            Cli::try_parse_from([
+                "nanocodex",
+                "eval",
+                "add",
+                "release",
+                "--coordinator",
+                "http://127.0.0.1:8788",
+                "--state-dir",
+                "/mnt/evals",
+                "--task",
+                "/mnt/tasks/fix-git",
+            ])
+            .is_err()
+        );
     }
 
     #[test]

--- a/bin/nanocodex/src/eval/profile.rs
+++ b/bin/nanocodex/src/eval/profile.rs
@@ -28,8 +28,8 @@ const LEASE_DURATION: Duration = Duration::from_secs(5 * 60);
 
 #[derive(Clone, Debug, Args)]
 pub(super) struct WorksetTarget {
-    /// Named durable workset stored in SQLite.
-    workset: String,
+    /// Named durable profile stored in SQLite. Uses its latest generation.
+    profile: String,
 
     /// Durable SQLite ledger and retained artifacts.
     ///
@@ -44,12 +44,12 @@ pub(super) struct WorksetTarget {
 
 #[derive(Args)]
 pub(super) struct Add {
-    /// Named durable workset to create or extend.
-    workset: String,
+    /// Named durable profile to create or extend.
+    profile: String,
 
-    /// Expand this optional nanocodex.toml profile recipe into SQLite.
+    /// Expand this optional nanocodex.toml recipe into SQLite.
     #[arg(long, value_name = "NAME")]
-    profile: Option<String>,
+    recipe: Option<String>,
 
     /// Task package to add. Repeat to add multiple task packages.
     #[arg(long, value_name = "PATH")]
@@ -75,7 +75,7 @@ pub(super) struct Add {
     #[arg(long)]
     web_search: bool,
 
-    /// Start a fresh generation instead of extending the newest board.
+    /// Start a new profile generation. By default, extends the latest generation.
     #[arg(long)]
     new: bool,
 
@@ -93,7 +93,7 @@ pub(super) struct Status {
     #[command(flatten)]
     target: WorksetTarget,
 
-    /// Print the complete machine-readable workset ledger.
+    /// Print the complete machine-readable profile ledger.
     #[arg(long)]
     json: bool,
 }
@@ -107,11 +107,14 @@ pub(super) struct Run {
     #[arg(long, default_value = CONFIG_FILE)]
     config: PathBuf,
 
-    /// Exact task selector already stored in the workset.
+    /// Exact SQLite task selector and locally loadable task package path.
+    ///
+    /// Remote workers need this local task package, but never the profile that
+    /// originally added it to the coordinator.
     #[arg(long, value_name = "TASK", required = true)]
     task: String,
 
-    /// Select one model when the workset contains a model matrix.
+    /// Select one model when the profile contains a model matrix.
     #[arg(long)]
     model: Option<Model>,
 
@@ -133,7 +136,7 @@ pub(super) struct Run {
 impl Add {
     pub(super) async fn run(self) -> Result<()> {
         let state = self.state_dir.map_or_else(default_state_dir, Ok)?;
-        if let Some(recipe) = self.profile.as_deref() {
+        if let Some(recipe) = self.recipe.as_deref() {
             if !self.task.is_empty()
                 || !self.harness.is_empty()
                 || !self.model.is_empty()
@@ -142,13 +145,13 @@ impl Add {
                 || self.web_search
             {
                 return Err(eyre!(
-                    "--profile is a complete recipe; use either --profile or explicit work knobs"
+                    "--recipe is complete; use either --recipe or explicit work knobs"
                 ));
             }
-            Evaluation::add_profile(&self.config, Some(recipe), &state, &self.workset, self.new)?;
+            Evaluation::add_profile(&self.config, Some(recipe), &state, &self.profile, self.new)?;
         } else {
             if self.task.is_empty() {
-                return Err(eyre!("at least one --task or --profile is required"));
+                return Err(eyre!("at least one --task or --recipe is required"));
             }
             let trials = self.trials.unwrap_or(1);
             let harnesses = if self.harness.is_empty() {
@@ -185,12 +188,13 @@ impl Add {
                     }
                 }
             }
-            Evaluation::add(&state, &self.workset, &work, self.new)?;
+            Evaluation::add(&state, &self.profile, &work, self.new)?;
         }
-        let status = Evaluation::open(&self.config, &self.workset, state)?.status()?;
+        let status = Evaluation::open(&self.config, &self.profile, state)?.status()?;
         println!(
-            "{} · {} tasks · {} coordinate(s)",
+            "{} {} · {} tasks · {} coordinate(s)",
             status.profile,
+            &status.generation[..12],
             status.preparation.pending + status.preparation.running + status.preparation.complete,
             status.coordinates.pending + status.coordinates.running + status.coordinates.complete,
         );
@@ -240,7 +244,7 @@ impl Status {
             println!(
                 "{} {} · preparation {}/{} ready · coordinates {}/{} terminal, {} running",
                 status.profile,
-                &status.digest[..12],
+                &status.generation[..12],
                 status.preparation.complete,
                 status.preparation.pending
                     + status.preparation.running
@@ -280,7 +284,7 @@ impl Run {
             return run_remote(
                 coordinator,
                 selector,
-                &self.target.workset,
+                &self.target.profile,
                 task,
                 &self.config,
                 &self.task,
@@ -377,7 +381,7 @@ impl Run {
 async fn run_remote(
     coordinator: CoordinatorClient,
     selector: EvaluationSelector,
-    workset: &str,
+    profile: &str,
     task: Task,
     config: &Path,
     task_selector: &str,
@@ -441,7 +445,7 @@ async fn run_remote(
                         heartbeat.abort();
                         finish?;
                         write_json(&RunOutput::Completed {
-                            profile: workset,
+                            profile,
                             task: task_selector,
                             repetition,
                             evidence: "coordinator",
@@ -475,7 +479,7 @@ async fn run_remote(
                 retry_after_ms,
             } => {
                 write_json(&RunOutput::TemporarilyUnavailable {
-                    profile: workset,
+                    profile,
                     task: task_selector,
                     reason: &reason,
                     retry_after_ms,
@@ -486,7 +490,7 @@ async fn run_remote(
             }
             RemoteClaim::Complete => {
                 write_json(&RunOutput::AlreadyComplete {
-                    profile: workset,
+                    profile,
                     task: task_selector,
                 })?;
                 return Ok(());
@@ -514,7 +518,7 @@ fn remote_heartbeat(
 impl WorksetTarget {
     fn open(&self, config: &Path) -> Result<Evaluation> {
         let state_directory = self.state_dir.clone().map_or_else(default_state_dir, Ok)?;
-        Ok(Evaluation::open(config, &self.workset, state_directory)?)
+        Ok(Evaluation::open(config, &self.profile, state_directory)?)
     }
 }
 
@@ -713,13 +717,13 @@ pub(super) fn default_state_dir() -> Result<PathBuf> {
 
 fn print_remote_status(status: &serde_json::Value) {
     let profile = status["profile"].as_str().unwrap_or("unknown");
-    let digest = status["digest"].as_str().unwrap_or("unknown");
+    let generation = status["generation"].as_str().unwrap_or("unknown");
     let preparation = &status["preparation"];
     let coordinates = &status["coordinates"];
     println!(
         "{} {} · preparation {}/{} ready · coordinates {}/{} terminal, {} running",
         profile,
-        &digest[..digest.len().min(12)],
+        &generation[..generation.len().min(12)],
         preparation["complete"].as_u64().unwrap_or(0),
         count_total(preparation),
         coordinates["complete"].as_u64().unwrap_or(0),

--- a/bin/nanocodex/src/eval/profile.rs
+++ b/bin/nanocodex/src/eval/profile.rs
@@ -5,10 +5,10 @@ use std::{
 
 use clap::Args;
 use eyre::{Result, WrapErr as _, eyre};
-use nanocodex::Model;
+use nanocodex::{Model, Thinking};
 use nanocodex_eval::{
     EvalAttemptOutcome, EvalEventKind, EvalEventStream, EvalOutcome, Evaluation, EvaluationClaim,
-    EvaluationSelection, EvaluationSelector, Evaluator, ResolvedHarness, Task,
+    EvaluationSelector, EvaluationWork, Evaluator, ResolvedHarness, Task,
     atif::AtifBuilder,
     coordinator::{CoordinatorClient, RemoteClaim, RemoteLease},
     harness::{Harness, HarnessAuth},
@@ -27,13 +27,9 @@ const CONFIG_FILE: &str = "nanocodex.toml";
 const LEASE_DURATION: Duration = Duration::from_secs(5 * 60);
 
 #[derive(Clone, Debug, Args)]
-pub(super) struct ProfileTarget {
-    /// Evaluation profile. Uses the manifest's top-level default when omitted.
-    profile: Option<String>,
-
-    /// Evaluation manifest containing the closed desired work bundle.
-    #[arg(long, default_value = CONFIG_FILE)]
-    config: PathBuf,
+pub(super) struct WorksetTarget {
+    /// Named durable workset stored in SQLite.
+    workset: String,
 
     /// Durable SQLite ledger and retained artifacts.
     ///
@@ -47,11 +43,57 @@ pub(super) struct ProfileTarget {
 }
 
 #[derive(Args)]
+pub(super) struct Add {
+    /// Named durable workset to create or extend.
+    workset: String,
+
+    /// Expand this optional nanocodex.toml profile recipe into SQLite.
+    #[arg(long, value_name = "NAME")]
+    profile: Option<String>,
+
+    /// Task package to add. Repeat to add multiple task packages.
+    #[arg(long, value_name = "PATH")]
+    task: Vec<PathBuf>,
+
+    /// Harness name to store. Repeat to create a matrix.
+    #[arg(long, value_name = "NAME")]
+    harness: Vec<String>,
+
+    /// Model to store. Repeat to create a matrix.
+    #[arg(long)]
+    model: Vec<Model>,
+
+    /// Reasoning effort to store. Repeat to create a matrix.
+    #[arg(long)]
+    thinking: Vec<Thinking>,
+
+    /// Desired repetitions for every added treatment.
+    #[arg(long)]
+    trials: Option<u16>,
+
+    /// Enable model-facing web search for the added treatments.
+    #[arg(long)]
+    web_search: bool,
+
+    /// Start a fresh generation instead of extending the newest board.
+    #[arg(long)]
+    new: bool,
+
+    /// Optional profile recipes and runtime harness helpers.
+    #[arg(long, default_value = CONFIG_FILE)]
+    config: PathBuf,
+
+    /// Durable SQLite ledger and retained artifacts.
+    #[arg(long, value_name = "DIRECTORY")]
+    state_dir: Option<PathBuf>,
+}
+
+#[derive(Args)]
 pub(super) struct Status {
     #[command(flatten)]
-    target: ProfileTarget,
+    target: WorksetTarget,
 
-    /// Print the complete machine-readable profile ledger.
+    /// Print the complete machine-readable workset ledger.
     #[arg(long)]
     json: bool,
 }
@@ -59,13 +101,17 @@ pub(super) struct Status {
 #[derive(Args)]
 pub(super) struct Run {
     #[command(flatten)]
-    target: ProfileTarget,
+    target: WorksetTarget,
 
-    /// Exact task selector from the configured profile.
+    /// Runtime harness helper configuration.
+    #[arg(long, default_value = CONFIG_FILE)]
+    config: PathBuf,
+
+    /// Exact task selector already stored in the workset.
     #[arg(long, value_name = "TASK", required = true)]
     task: String,
 
-    /// Select one model when the profile contains a model matrix.
+    /// Select one model when the workset contains a model matrix.
     #[arg(long)]
     model: Option<Model>,
 
@@ -82,6 +128,74 @@ pub(super) struct Run {
 
     #[command(flatten)]
     agent: EvalAgentArgs,
+}
+
+impl Add {
+    pub(super) async fn run(self) -> Result<()> {
+        let state = self.state_dir.map_or_else(default_state_dir, Ok)?;
+        if let Some(recipe) = self.profile.as_deref() {
+            if !self.task.is_empty()
+                || !self.harness.is_empty()
+                || !self.model.is_empty()
+                || !self.thinking.is_empty()
+                || self.trials.is_some()
+                || self.web_search
+            {
+                return Err(eyre!(
+                    "--profile is a complete recipe; use either --profile or explicit work knobs"
+                ));
+            }
+            Evaluation::add_profile(&self.config, Some(recipe), &state, &self.workset, self.new)?;
+        } else {
+            if self.task.is_empty() {
+                return Err(eyre!("at least one --task or --profile is required"));
+            }
+            let trials = self.trials.unwrap_or(1);
+            let harnesses = if self.harness.is_empty() {
+                vec!["nanocodex".to_owned()]
+            } else {
+                self.harness
+            };
+            let models = if self.model.is_empty() {
+                vec![Model::default()]
+            } else {
+                self.model
+            };
+            let thinking = if self.thinking.is_empty() {
+                vec![Thinking::default()]
+            } else {
+                self.thinking
+            };
+            let mut work = Vec::new();
+            for path in self.task {
+                let selector = path.to_string_lossy().into_owned();
+                let task = Task::load(&path)?;
+                for harness in &harnesses {
+                    for model in &models {
+                        for thinking in &thinking {
+                            work.push(
+                                EvaluationWork::new(&selector, task.clone())
+                                    .harness(harness)
+                                    .model(*model)
+                                    .thinking(*thinking)
+                                    .web_search(self.web_search)
+                                    .trials(trials),
+                            );
+                        }
+                    }
+                }
+            }
+            Evaluation::add(&state, &self.workset, &work, self.new)?;
+        }
+        let status = Evaluation::open(&self.config, &self.workset, state)?.status()?;
+        println!(
+            "{} · {} tasks · {} coordinate(s)",
+            status.profile,
+            status.preparation.pending + status.preparation.running + status.preparation.complete,
+            status.coordinates.pending + status.coordinates.running + status.coordinates.complete,
+        );
+        Ok(())
+    }
 }
 
 #[derive(Serialize)]
@@ -117,7 +231,7 @@ impl Status {
             }
             return Ok(());
         }
-        let evaluation = self.target.open()?;
+        let evaluation = self.target.open(Path::new(CONFIG_FILE))?;
         let status = evaluation.status()?;
         if self.json {
             serde_json::to_writer_pretty(std::io::stdout().lock(), &status)?;
@@ -155,22 +269,26 @@ impl Run {
         let selector = EvaluationSelector::new(&self.task)
             .harness(self.harness)
             .model(self.model)
-            .thinking(requested_thinking);
+            .thinking(requested_thinking)
+            .web_search(self.agent.web_search());
         if let Some(coordinator) = &self.target.coordinator {
-            let selection = EvaluationSelection::load(
-                &self.target.config,
-                self.target.profile.as_deref(),
-                &selector,
-            )?;
-            validate_web_search(&self.agent, selection.profile(), selection.web_search())?;
+            let task = Task::load(&self.task)?;
             let mut coordinator = CoordinatorClient::new(coordinator)?;
             if let Some(worker) = self.worker {
                 coordinator = coordinator.worker(worker);
             }
-            return run_remote(coordinator, selection, &self.task, self.agent).await;
+            return run_remote(
+                coordinator,
+                selector,
+                &self.target.workset,
+                task,
+                &self.config,
+                &self.task,
+                self.agent,
+            )
+            .await;
         }
-        let evaluation = self.target.open()?;
-        validate_web_search(&self.agent, evaluation.name(), evaluation.web_search())?;
+        let evaluation = self.target.open(&self.config)?;
         let mut prepared = None;
         loop {
             match evaluation.claim(&selector, LEASE_DURATION)? {
@@ -258,16 +376,21 @@ impl Run {
 
 async fn run_remote(
     coordinator: CoordinatorClient,
-    selection: EvaluationSelection,
+    selector: EvaluationSelector,
+    workset: &str,
+    task: Task,
+    config: &Path,
     task_selector: &str,
     agent: EvalAgentArgs,
 ) -> Result<()> {
     let mut prepared = None;
     loop {
-        match coordinator.claim(&selection).await? {
-            RemoteClaim::Prepare(lease) => {
+        match coordinator.claim(&selector).await? {
+            RemoteClaim::Prepare { lease, treatment } => {
+                let harness = Evaluation::resolve_harness(config, &treatment.harness)?;
+                let harnesses = harness.iter().cloned().collect::<Vec<_>>();
                 let heartbeat = remote_heartbeat(coordinator.clone(), lease.clone());
-                let result = prepare_resources(selection.task(), selection.harnesses()).await;
+                let result = prepare_resources(&task, &harnesses).await;
                 match result {
                     Ok(resources) => {
                         let finish = coordinator.prepared(&lease).await;
@@ -283,7 +406,13 @@ async fn run_remote(
                     }
                 }
             }
-            RemoteClaim::Run { lease, repetition } => {
+            RemoteClaim::Run {
+                lease,
+                repetition,
+                treatment,
+            } => {
+                let harness = Evaluation::resolve_harness(config, &treatment.harness)?;
+                let harnesses = harness.iter().cloned().collect::<Vec<_>>();
                 let host = run::PreparedVmHost::open()?;
                 let output = tempfile::Builder::new()
                     .prefix("nanocodex-eval-worker-")
@@ -292,16 +421,13 @@ async fn run_remote(
                 let result = async {
                     let resources = match prepared.take() {
                         Some(resources) => resources,
-                        None => {
-                            prepare_resources_from(selection.task(), selection.harnesses(), &host)
-                                .await?
-                        }
+                        None => prepare_resources_from(&task, &harnesses, &host).await?,
                     };
                     execute_coordinate(
-                        selection.task().clone(),
-                        selection.treatment().clone(),
-                        selection.web_search(),
-                        selection.harness().cloned(),
+                        task.clone(),
+                        treatment.clone(),
+                        treatment.web_search,
+                        harness,
                         output.path().to_path_buf(),
                         resources,
                         agent,
@@ -315,7 +441,7 @@ async fn run_remote(
                         heartbeat.abort();
                         finish?;
                         write_json(&RunOutput::Completed {
-                            profile: selection.profile(),
+                            profile: workset,
                             task: task_selector,
                             repetition,
                             evidence: "coordinator",
@@ -349,7 +475,7 @@ async fn run_remote(
                 retry_after_ms,
             } => {
                 write_json(&RunOutput::TemporarilyUnavailable {
-                    profile: selection.profile(),
+                    profile: workset,
                     task: task_selector,
                     reason: &reason,
                     retry_after_ms,
@@ -360,7 +486,7 @@ async fn run_remote(
             }
             RemoteClaim::Complete => {
                 write_json(&RunOutput::AlreadyComplete {
-                    profile: selection.profile(),
+                    profile: workset,
                     task: task_selector,
                 })?;
                 return Ok(());
@@ -385,26 +511,10 @@ fn remote_heartbeat(
     })
 }
 
-fn validate_web_search(agent: &EvalAgentArgs, profile: &str, web_search: bool) -> Result<()> {
-    if agent
-        .web_search()
-        .is_some_and(|requested| requested != web_search)
-    {
-        return Err(eyre!(
-            "--web-search cannot override profile `{profile}`; the profile fixes web_search={web_search}"
-        ));
-    }
-    Ok(())
-}
-
-impl ProfileTarget {
-    fn open(&self) -> Result<Evaluation> {
+impl WorksetTarget {
+    fn open(&self, config: &Path) -> Result<Evaluation> {
         let state_directory = self.state_dir.clone().map_or_else(default_state_dir, Ok)?;
-        Ok(Evaluation::open(
-            &self.config,
-            self.profile.as_deref(),
-            state_directory,
-        )?)
+        Ok(Evaluation::open(config, &self.workset, state_directory)?)
     }
 }
 

--- a/bin/nanocodex/src/eval/profile.rs
+++ b/bin/nanocodex/src/eval/profile.rs
@@ -596,9 +596,6 @@ async fn retain_native_trajectory(
 }
 
 pub(super) fn default_state_dir() -> Result<PathBuf> {
-    if let Some(home) = std::env::var_os("NANOCODEX_HOME") {
-        return Ok(PathBuf::from(home).join("evals"));
-    }
     let home = std::env::var_os("HOME")
         .ok_or_else(|| eyre!("HOME is not set; pass --state-dir for durable eval state"))?;
     Ok(PathBuf::from(home).join(".nanocodex/evals"))
@@ -726,7 +723,7 @@ mod tests {
     }
 
     #[test]
-    fn nanocodex_home_owns_the_default_eval_directory() {
+    fn home_owns_the_default_eval_directory() {
         let path = default_state_dir().unwrap();
         assert_eq!(
             path.file_name().and_then(|name| name.to_str()),

--- a/bin/nanocodex/src/eval/profile.rs
+++ b/bin/nanocodex/src/eval/profile.rs
@@ -3,7 +3,7 @@ use std::{
     time::Duration,
 };
 
-use clap::Args;
+use clap::{Args, builder::NonEmptyStringValueParser};
 use eyre::{Result, WrapErr as _, eyre};
 use nanocodex::{Model, Thinking};
 use nanocodex_eval::{
@@ -123,7 +123,12 @@ pub(super) struct Run {
     harness: Option<String>,
 
     /// Advisory stable name used for coordinator task affinity and status.
-    #[arg(long, env = "NANOCODEX_WORKER_NAME", value_name = "NAME")]
+    #[arg(
+        long,
+        env = "NANOCODEX_WORKER_NAME",
+        value_name = "NAME",
+        value_parser = NonEmptyStringValueParser::new()
+    )]
     worker: Option<String>,
 
     #[command(flatten)]

--- a/bin/nanocodex/src/eval/profile.rs
+++ b/bin/nanocodex/src/eval/profile.rs
@@ -96,6 +96,10 @@ pub(super) struct Status {
     /// Print the complete machine-readable profile ledger.
     #[arg(long)]
     json: bool,
+
+    /// Return at most this many nonterminal family records while preserving exact totals.
+    #[arg(long, value_name = "COUNT", value_parser = clap::value_parser!(u16).range(1..))]
+    family_limit: Option<u16>,
 }
 
 #[derive(Args)]
@@ -231,7 +235,8 @@ enum RunOutput<'a> {
 impl Status {
     pub(super) async fn run(self) -> Result<()> {
         if let Some(coordinator) = &self.target.coordinator {
-            let status = CoordinatorClient::new(coordinator)?.status().await?;
+            let mut status = CoordinatorClient::new(coordinator)?.status().await?;
+            limit_remote_families(&mut status, self.family_limit);
             if self.json {
                 serde_json::to_writer_pretty(std::io::stdout().lock(), &status)?;
                 println!();
@@ -241,7 +246,13 @@ impl Status {
             return Ok(());
         }
         let evaluation = self.target.open(Path::new(CONFIG_FILE))?;
-        let status = evaluation.status()?;
+        let mut status = evaluation.status()?;
+        if let Some(limit) = self.family_limit {
+            status
+                .families
+                .retain(|family| family.pending > 0 || family.running > 0);
+            status.families.truncate(usize::from(limit));
+        }
         if self.json {
             serde_json::to_writer_pretty(std::io::stdout().lock(), &status)?;
             println!();
@@ -269,6 +280,23 @@ impl Status {
         }
         Ok(())
     }
+}
+
+fn limit_remote_families(status: &mut serde_json::Value, limit: Option<u16>) {
+    let Some(limit) = limit else {
+        return;
+    };
+    let Some(families) = status
+        .get_mut("families")
+        .and_then(serde_json::Value::as_array_mut)
+    else {
+        return;
+    };
+    families.retain(|family| {
+        family.get("pending").and_then(serde_json::Value::as_u64) > Some(0)
+            || family.get("running").and_then(serde_json::Value::as_u64) > Some(0)
+    });
+    families.truncate(usize::from(limit));
 }
 
 impl Run {
@@ -766,7 +794,7 @@ mod tests {
 
     use clap::Parser as _;
 
-    use super::default_state_dir;
+    use super::{default_state_dir, limit_remote_families};
     use crate::{Cli, Command, eval::EvalCommand};
 
     #[test]
@@ -792,6 +820,22 @@ mod tests {
         };
         assert_eq!(run.task, "terminal/fix-git");
         assert_eq!(run.worker.as_deref(), Some("dev-one"));
+    }
+
+    #[test]
+    fn status_family_limit_keeps_exact_totals_and_only_nonterminal_rows() {
+        let mut status = serde_json::json!({
+            "coordinates": { "complete": 10, "pending": 20, "running": 2 },
+            "families": [
+                { "id": "done", "pending": 0, "running": 0 },
+                { "id": "one", "pending": 1, "running": 0 },
+                { "id": "two", "pending": 0, "running": 1 },
+            ],
+        });
+        limit_remote_families(&mut status, Some(1));
+        assert_eq!(status["coordinates"]["pending"], 20);
+        assert_eq!(status["families"].as_array().unwrap().len(), 1);
+        assert_eq!(status["families"][0]["id"], "one");
     }
 
     #[test]

--- a/bin/nanocodex/src/eval/systemd.rs
+++ b/bin/nanocodex/src/eval/systemd.rs
@@ -16,17 +16,13 @@ use super::profile::default_state_dir;
 
 const RESTART_DELAY: &str = "30s";
 
-pub(super) fn install(
-    profile: Option<&str>,
-    config: &Path,
-    state_dir: Option<&Path>,
-) -> Result<()> {
+pub(super) fn install(profile: &str, config: &Path, state_dir: Option<&Path>) -> Result<()> {
     if !cfg!(target_os = "linux") {
         bail!("--systemd is supported only on Linux");
     }
 
     let working_directory = env::current_dir().wrap_err("failed to resolve current directory")?;
-    let config = absolute_existing(config, &working_directory, "evaluation manifest")?;
+    let config = absolute_existing(config, &working_directory, "runtime helper config")?;
     let state_dir = state_dir.map_or_else(default_state_dir, |path| Ok(path.to_path_buf()))?;
     let state_dir = absolute(&state_dir, &working_directory);
     let evaluation = Evaluation::open(&config, profile, &state_dir)?;

--- a/bin/nanocodex/src/eval/systemd.rs
+++ b/bin/nanocodex/src/eval/systemd.rs
@@ -21,6 +21,7 @@ pub(super) fn install(
     config: &Path,
     state_dir: Option<&Path>,
     coordinator: Option<&str>,
+    runtime_dir: Option<&Path>,
 ) -> Result<()> {
     if !cfg!(target_os = "linux") {
         bail!("--systemd is supported only on Linux");
@@ -32,6 +33,24 @@ pub(super) fn install(
     let working_directory = config
         .parent()
         .ok_or_else(|| eyre!("runtime helper config has no parent directory"))?;
+    let runtime_dir = runtime_dir.map_or_else(
+        || working_directory.join(".nanocodex-runtime"),
+        |runtime_dir| absolute(runtime_dir, &invocation_directory),
+    );
+    let temporary_directory = runtime_dir.join("tmp");
+    fs::create_dir_all(&temporary_directory).wrap_err_with(|| {
+        format!(
+            "failed to create benchmark runtime directory {}",
+            temporary_directory.display()
+        )
+    })?;
+    let runtime_dir = runtime_dir.canonicalize().wrap_err_with(|| {
+        format!(
+            "failed to resolve benchmark runtime directory {}",
+            runtime_dir.display()
+        )
+    })?;
+    let temporary_directory = runtime_dir.join("tmp");
     if let Some(coordinator) = coordinator {
         CoordinatorClient::new(coordinator)?;
     }
@@ -52,7 +71,13 @@ pub(super) fn install(
         .or_else(|| state_dir.as_deref().map(Path::as_os_str))
         .ok_or_else(|| eyre!("benchmark service target is absent"))?;
     let unit_name = unit_name(profile, &config, target);
-    let unit = render_unit(&executable, &arguments, working_directory)?;
+    let unit = render_unit(
+        &executable,
+        &arguments,
+        working_directory,
+        &runtime_dir,
+        &temporary_directory,
+    )?;
     let unit_path = user_unit_directory()?.join(&unit_name);
 
     fs::create_dir_all(
@@ -87,6 +112,7 @@ fn normalize_service_arguments(
     state_dir: Option<&Path>,
 ) -> Vec<OsString> {
     arguments.retain(|argument| argument != "--systemd");
+    remove_option(&mut arguments, "--runtime-dir");
     replace_option(&mut arguments, "--config", config.as_os_str());
     if let Some(state_dir) = state_dir {
         replace_option(&mut arguments, "--state-dir", state_dir.as_os_str());
@@ -95,6 +121,28 @@ fn normalize_service_arguments(
         arguments.push(OsString::from("--headless"));
     }
     arguments
+}
+
+fn remove_option(arguments: &mut Vec<OsString>, option: &str) {
+    let with_equals = format!("{option}=");
+    let mut index = 0;
+    while index < arguments.len() {
+        if arguments[index] == option {
+            arguments.remove(index);
+            if index < arguments.len() {
+                arguments.remove(index);
+            }
+            continue;
+        }
+        if arguments[index]
+            .to_str()
+            .is_some_and(|argument| argument.starts_with(&with_equals))
+        {
+            arguments.remove(index);
+            continue;
+        }
+        index += 1;
+    }
 }
 
 fn replace_option(arguments: &mut Vec<OsString>, option: &str, value: &OsStr) {
@@ -126,6 +174,8 @@ fn render_unit(
     executable: &Path,
     arguments: &[OsString],
     working_directory: &Path,
+    runtime_directory: &Path,
+    temporary_directory: &Path,
 ) -> Result<String> {
     let mut command = quote(executable.as_os_str())?;
     for argument in arguments {
@@ -140,6 +190,8 @@ fn render_unit(
          [Service]\n\
          Type=simple\n\
          WorkingDirectory={}\n\
+         Environment={}\n\
+         Environment={}\n\
          ExecStart={command}\n\
          Restart=on-failure\n\
          RestartSec={RESTART_DELAY}\n\
@@ -148,6 +200,10 @@ fn render_unit(
          [Install]\n\
          WantedBy=default.target\n",
         escape_path(working_directory.as_os_str())?,
+        quote(
+            OsString::from(format!("NANOCODEX_HOME={}", runtime_directory.display())).as_os_str()
+        )?,
+        quote(OsString::from(format!("TMPDIR={}", temporary_directory.display())).as_os_str())?,
     ))
 }
 
@@ -311,12 +367,16 @@ mod tests {
                 OsString::from("--headless"),
             ],
             "/srv/evals".as_ref(),
+            "/mnt/eval-runtime".as_ref(),
+            "/mnt/eval-runtime/tmp".as_ref(),
         )
         .unwrap();
         assert!(unit.contains(
             "ExecStart=\"/opt/nanocodex/bin/nanocodex\" \"eval\" \"benchmark\" \"terminal bench\" \"--headless\""
         ));
         assert!(unit.contains("WorkingDirectory=/srv/evals"));
+        assert!(unit.contains("Environment=\"NANOCODEX_HOME=/mnt/eval-runtime\""));
+        assert!(unit.contains("Environment=\"TMPDIR=/mnt/eval-runtime/tmp\""));
         assert!(unit.contains("Restart=on-failure"));
         assert!(!unit.contains("RestartPreventExitStatus"));
     }
@@ -358,6 +418,7 @@ mod tests {
                 "http://127.0.0.1:8788",
                 "--worker",
                 "dev-georgios-01",
+                "--runtime-dir=/mnt/eval-runtime",
                 "--systemd",
             ]
             .map(OsString::from)
@@ -383,6 +444,11 @@ mod tests {
             .map(OsString::from)
         );
         assert!(!arguments.iter().any(|argument| argument == "--state-dir"));
+        assert!(!arguments.iter().any(|argument| {
+            argument
+                .to_str()
+                .is_some_and(|argument| argument.starts_with("--runtime-dir"))
+        }));
     }
 
     #[test]

--- a/bin/nanocodex/src/eval/systemd.rs
+++ b/bin/nanocodex/src/eval/systemd.rs
@@ -352,6 +352,8 @@ mod tests {
                 "relative.toml",
                 "--coordinator",
                 "http://127.0.0.1:8788",
+                "--worker",
+                "dev-georgios-01",
                 "--systemd",
             ]
             .map(OsString::from)
@@ -370,6 +372,8 @@ mod tests {
                 "/srv/nanocodex.toml",
                 "--coordinator",
                 "http://127.0.0.1:8788",
+                "--worker",
+                "dev-georgios-01",
                 "--headless",
             ]
             .map(OsString::from)

--- a/bin/nanocodex/src/eval/systemd.rs
+++ b/bin/nanocodex/src/eval/systemd.rs
@@ -9,29 +9,45 @@ use std::{
 };
 
 use eyre::{Result, WrapErr as _, bail, eyre};
-use nanocodex_eval::Evaluation;
+use nanocodex_eval::{Evaluation, coordinator::CoordinatorClient};
 use sha2::{Digest as _, Sha256};
 
 use super::profile::default_state_dir;
 
 const RESTART_DELAY: &str = "30s";
 
-pub(super) fn install(profile: &str, config: &Path, state_dir: Option<&Path>) -> Result<()> {
+pub(super) fn install(
+    profile: &str,
+    config: &Path,
+    state_dir: Option<&Path>,
+    coordinator: Option<&str>,
+) -> Result<()> {
     if !cfg!(target_os = "linux") {
         bail!("--systemd is supported only on Linux");
     }
 
     let working_directory = env::current_dir().wrap_err("failed to resolve current directory")?;
     let config = absolute_existing(config, &working_directory, "runtime helper config")?;
-    let state_dir = state_dir.map_or_else(default_state_dir, |path| Ok(path.to_path_buf()))?;
-    let state_dir = absolute(&state_dir, &working_directory);
-    let evaluation = Evaluation::open(&config, profile, &state_dir)?;
-    let state_dir = state_dir
-        .canonicalize()
-        .wrap_err_with(|| format!("failed to resolve state directory {}", state_dir.display()))?;
+    if let Some(coordinator) = coordinator {
+        CoordinatorClient::new(coordinator)?;
+    }
+    let state_dir = if coordinator.is_some() {
+        None
+    } else {
+        let state_dir = state_dir.map_or_else(default_state_dir, |path| Ok(path.to_path_buf()))?;
+        let state_dir = absolute(&state_dir, &working_directory);
+        Evaluation::open(&config, profile, &state_dir)?;
+        Some(state_dir.canonicalize().wrap_err_with(|| {
+            format!("failed to resolve state directory {}", state_dir.display())
+        })?)
+    };
     let executable = env::current_exe().wrap_err("failed to resolve the nanocodex executable")?;
-    let arguments = service_arguments(&config, &state_dir)?;
-    let unit_name = unit_name(evaluation.name(), &config, &state_dir);
+    let arguments = service_arguments(&config, state_dir.as_deref())?;
+    let target = coordinator
+        .map(OsStr::new)
+        .or_else(|| state_dir.as_deref().map(Path::as_os_str))
+        .ok_or_else(|| eyre!("benchmark service target is absent"))?;
+    let unit_name = unit_name(profile, &config, target);
     let unit = render_unit(&executable, &arguments, &working_directory)?;
     let unit_path = user_unit_directory()?.join(&unit_name);
 
@@ -53,15 +69,28 @@ pub(super) fn install(profile: &str, config: &Path, state_dir: Option<&Path>) ->
     Ok(())
 }
 
-fn service_arguments(config: &Path, state_dir: &Path) -> Result<Vec<OsString>> {
-    let mut arguments = env::args_os().skip(1).collect::<Vec<_>>();
+fn service_arguments(config: &Path, state_dir: Option<&Path>) -> Result<Vec<OsString>> {
+    Ok(normalize_service_arguments(
+        env::args_os().skip(1).collect(),
+        config,
+        state_dir,
+    ))
+}
+
+fn normalize_service_arguments(
+    mut arguments: Vec<OsString>,
+    config: &Path,
+    state_dir: Option<&Path>,
+) -> Vec<OsString> {
     arguments.retain(|argument| argument != "--systemd");
     replace_option(&mut arguments, "--config", config.as_os_str());
-    replace_option(&mut arguments, "--state-dir", state_dir.as_os_str());
+    if let Some(state_dir) = state_dir {
+        replace_option(&mut arguments, "--state-dir", state_dir.as_os_str());
+    }
     if !arguments.iter().any(|argument| argument == "--headless") {
         arguments.push(OsString::from("--headless"));
     }
-    Ok(arguments)
+    arguments
 }
 
 fn replace_option(arguments: &mut Vec<OsString>, option: &str, value: &OsStr) {
@@ -157,11 +186,11 @@ fn quote(value: &OsStr) -> Result<String> {
     Ok(quoted)
 }
 
-fn unit_name(profile: &str, config: &Path, state_dir: &Path) -> String {
+fn unit_name(profile: &str, config: &Path, target: &OsStr) -> String {
     let mut digest = Sha256::new();
     digest.update(config.as_os_str().as_encoded_bytes());
     digest.update([0]);
-    digest.update(state_dir.as_os_str().as_encoded_bytes());
+    digest.update(target.as_encoded_bytes());
     digest.update([0]);
     digest.update(profile.as_bytes());
     let digest = hex::encode(digest.finalize());
@@ -260,9 +289,12 @@ fn print_linger_hint() {
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::OsString;
+    use std::{
+        ffi::{OsStr, OsString},
+        path::Path,
+    };
 
-    use super::{render_unit, replace_option, unit_name};
+    use super::{normalize_service_arguments, render_unit, replace_option, unit_name};
 
     #[test]
     fn unit_runs_the_plain_headless_benchmark_and_restarts_failures() {
@@ -310,26 +342,75 @@ mod tests {
     }
 
     #[test]
+    fn coordinator_backed_service_keeps_remote_routing_without_sqlite_state() {
+        let arguments = normalize_service_arguments(
+            [
+                "eval",
+                "benchmark",
+                "release",
+                "--config",
+                "relative.toml",
+                "--coordinator",
+                "http://127.0.0.1:8788",
+                "--systemd",
+            ]
+            .map(OsString::from)
+            .into(),
+            Path::new("/srv/nanocodex.toml"),
+            None,
+        );
+
+        assert_eq!(
+            arguments,
+            [
+                "eval",
+                "benchmark",
+                "release",
+                "--config",
+                "/srv/nanocodex.toml",
+                "--coordinator",
+                "http://127.0.0.1:8788",
+                "--headless",
+            ]
+            .map(OsString::from)
+        );
+        assert!(!arguments.iter().any(|argument| argument == "--state-dir"));
+    }
+
+    #[test]
     fn unit_identity_is_stable_and_safe() {
         assert_eq!(
             unit_name(
                 "Terminal Bench / k=5",
                 "/srv/nanocodex.toml".as_ref(),
-                "/srv/state".as_ref(),
+                OsStr::new("/srv/state"),
             ),
             unit_name(
                 "Terminal Bench / k=5",
                 "/srv/nanocodex.toml".as_ref(),
-                "/srv/state".as_ref(),
+                OsStr::new("/srv/state"),
             )
         );
         assert!(
             unit_name(
                 "Terminal Bench / k=5",
                 "/srv/nanocodex.toml".as_ref(),
-                "/srv/state".as_ref(),
+                OsStr::new("/srv/state"),
             )
             .starts_with("nanocodex-benchmark-terminal-bench---k-5-")
+        );
+
+        assert_ne!(
+            unit_name(
+                "Terminal Bench / k=5",
+                "/srv/nanocodex.toml".as_ref(),
+                OsStr::new("/srv/state"),
+            ),
+            unit_name(
+                "Terminal Bench / k=5",
+                "/srv/nanocodex.toml".as_ref(),
+                OsStr::new("http://127.0.0.1:8788"),
+            )
         );
     }
 }

--- a/bin/nanocodex/src/eval/systemd.rs
+++ b/bin/nanocodex/src/eval/systemd.rs
@@ -1,0 +1,339 @@
+use std::{
+    env,
+    ffi::{OsStr, OsString},
+    fmt::Write as _,
+    fs,
+    io::Write as _,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+use eyre::{Result, WrapErr as _, bail, eyre};
+use nanocodex_eval::Evaluation;
+use sha2::{Digest as _, Sha256};
+
+use super::profile::default_state_dir;
+
+const RESTART_DELAY: &str = "30s";
+
+pub(super) fn install(
+    profile: Option<&str>,
+    config: &Path,
+    state_dir: Option<&Path>,
+) -> Result<()> {
+    if !cfg!(target_os = "linux") {
+        bail!("--systemd is supported only on Linux");
+    }
+
+    let working_directory = env::current_dir().wrap_err("failed to resolve current directory")?;
+    let config = absolute_existing(config, &working_directory, "evaluation manifest")?;
+    let state_dir = state_dir.map_or_else(default_state_dir, |path| Ok(path.to_path_buf()))?;
+    let state_dir = absolute(&state_dir, &working_directory);
+    let evaluation = Evaluation::open(&config, profile, &state_dir)?;
+    let state_dir = state_dir
+        .canonicalize()
+        .wrap_err_with(|| format!("failed to resolve state directory {}", state_dir.display()))?;
+    let executable = env::current_exe().wrap_err("failed to resolve the nanocodex executable")?;
+    let arguments = service_arguments(&config, &state_dir)?;
+    let unit_name = unit_name(evaluation.name(), &config, &state_dir);
+    let unit = render_unit(&executable, &arguments, &working_directory)?;
+    let unit_path = user_unit_directory()?.join(&unit_name);
+
+    fs::create_dir_all(
+        unit_path
+            .parent()
+            .ok_or_else(|| eyre!("systemd unit path has no parent"))?,
+    )
+    .wrap_err_with(|| format!("failed to create user systemd directory for {unit_name}"))?;
+    write_atomic(&unit_path, unit.as_bytes())?;
+    systemctl(["daemon-reload"])?;
+    systemctl(["enable", unit_name.as_str()])?;
+    systemctl(["restart", unit_name.as_str()])?;
+
+    println!("Installed and started {unit_name}");
+    println!("  systemctl --user status {unit_name}");
+    println!("  journalctl --user --unit {unit_name} --follow");
+    print_linger_hint();
+    Ok(())
+}
+
+fn service_arguments(config: &Path, state_dir: &Path) -> Result<Vec<OsString>> {
+    let mut arguments = env::args_os().skip(1).collect::<Vec<_>>();
+    arguments.retain(|argument| argument != "--systemd");
+    replace_option(&mut arguments, "--config", config.as_os_str());
+    replace_option(&mut arguments, "--state-dir", state_dir.as_os_str());
+    if !arguments.iter().any(|argument| argument == "--headless") {
+        arguments.push(OsString::from("--headless"));
+    }
+    Ok(arguments)
+}
+
+fn replace_option(arguments: &mut Vec<OsString>, option: &str, value: &OsStr) {
+    let with_equals = format!("{option}=");
+    let mut index = 0;
+    while index < arguments.len() {
+        if arguments[index] == option {
+            if index + 1 < arguments.len() {
+                arguments[index + 1] = value.to_os_string();
+            } else {
+                arguments.push(value.to_os_string());
+            }
+            return;
+        }
+        if arguments[index]
+            .to_str()
+            .is_some_and(|argument| argument.starts_with(&with_equals))
+        {
+            arguments[index] = OsString::from(format!("{option}={}", value.to_string_lossy()));
+            return;
+        }
+        index += 1;
+    }
+    arguments.push(OsString::from(option));
+    arguments.push(value.to_os_string());
+}
+
+fn render_unit(
+    executable: &Path,
+    arguments: &[OsString],
+    working_directory: &Path,
+) -> Result<String> {
+    let mut command = quote(executable.as_os_str())?;
+    for argument in arguments {
+        write!(command, " {}", quote(argument)?)?;
+    }
+    Ok(format!(
+        "[Unit]\n\
+         Description=Nanocodex benchmark\n\
+         Wants=network-online.target\n\
+         After=network-online.target\n\
+         \n\
+         [Service]\n\
+         Type=simple\n\
+         WorkingDirectory={}\n\
+         ExecStart={command}\n\
+         Restart=on-failure\n\
+         RestartSec={RESTART_DELAY}\n\
+         KillMode=control-group\n\
+         \n\
+         [Install]\n\
+         WantedBy=default.target\n",
+        escape_path(working_directory.as_os_str())?,
+    ))
+}
+
+fn escape_path(value: &OsStr) -> Result<String> {
+    let value = value
+        .to_str()
+        .ok_or_else(|| eyre!("systemd paths must be valid UTF-8"))?;
+    let mut escaped = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'/' | b'0'..=b'9' | b'A'..=b'Z' | b'a'..=b'z' | b':' | b'_' | b'.' | b'-' => {
+                escaped.push(char::from(byte));
+            }
+            b'%' => escaped.push_str("%%"),
+            byte => write!(escaped, "\\x{byte:02x}")?,
+        }
+    }
+    Ok(escaped)
+}
+
+fn quote(value: &OsStr) -> Result<String> {
+    let value = value
+        .to_str()
+        .ok_or_else(|| eyre!("systemd arguments must be valid UTF-8"))?;
+    let mut quoted = String::with_capacity(value.len() + 2);
+    quoted.push('"');
+    for character in value.chars() {
+        match character {
+            '\\' => quoted.push_str("\\\\"),
+            '"' => quoted.push_str("\\\""),
+            '\n' => quoted.push_str("\\n"),
+            '\r' => quoted.push_str("\\r"),
+            '\t' => quoted.push_str("\\t"),
+            '%' => quoted.push_str("%%"),
+            '$' => quoted.push_str("$$"),
+            character => quoted.push(character),
+        }
+    }
+    quoted.push('"');
+    Ok(quoted)
+}
+
+fn unit_name(profile: &str, config: &Path, state_dir: &Path) -> String {
+    let mut digest = Sha256::new();
+    digest.update(config.as_os_str().as_encoded_bytes());
+    digest.update([0]);
+    digest.update(state_dir.as_os_str().as_encoded_bytes());
+    digest.update([0]);
+    digest.update(profile.as_bytes());
+    let digest = hex::encode(digest.finalize());
+    let profile = profile
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || character == '-' {
+                character.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    format!(
+        "nanocodex-benchmark-{}-{}.service",
+        profile.trim_matches('-'),
+        &digest[..12]
+    )
+}
+
+fn user_unit_directory() -> Result<PathBuf> {
+    if let Some(config_home) = env::var_os("XDG_CONFIG_HOME") {
+        return Ok(PathBuf::from(config_home).join("systemd/user"));
+    }
+    let home = env::var_os("HOME")
+        .ok_or_else(|| eyre!("HOME is not set; cannot install a user systemd service"))?;
+    Ok(PathBuf::from(home).join(".config/systemd/user"))
+}
+
+fn absolute_existing(path: &Path, cwd: &Path, description: &str) -> Result<PathBuf> {
+    absolute(path, cwd)
+        .canonicalize()
+        .wrap_err_with(|| format!("failed to resolve {description} {}", path.display()))
+}
+
+fn absolute(path: &Path, cwd: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }
+}
+
+fn write_atomic(path: &Path, contents: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| eyre!("systemd unit path has no parent"))?;
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)
+        .wrap_err_with(|| format!("failed to create temporary unit beside {}", path.display()))?;
+    temporary.write_all(contents)?;
+    temporary.as_file_mut().sync_all()?;
+    temporary
+        .persist(path)
+        .map_err(|error| error.error)
+        .wrap_err_with(|| format!("failed to install systemd unit {}", path.display()))?;
+    Ok(())
+}
+
+fn systemctl<const N: usize>(arguments: [&str; N]) -> Result<Output> {
+    let output = Command::new("systemctl")
+        .arg("--user")
+        .args(arguments)
+        .output()
+        .wrap_err("failed to execute systemctl --user")?;
+    if !output.status.success() {
+        bail!(
+            "systemctl --user failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(output)
+}
+
+fn print_linger_hint() {
+    let Some(user) = env::var_os("USER") else {
+        return;
+    };
+    let output = Command::new("loginctl")
+        .args([
+            "show-user",
+            &user.to_string_lossy(),
+            "--property=Linger",
+            "--value",
+        ])
+        .output();
+    if output.ok().is_some_and(|output| {
+        output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "yes"
+    }) {
+        return;
+    }
+    eprintln!(
+        "To keep this service running after logout, run once:\n  sudo loginctl enable-linger {}",
+        user.to_string_lossy()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use super::{render_unit, replace_option, unit_name};
+
+    #[test]
+    fn unit_runs_the_plain_headless_benchmark_and_restarts_failures() {
+        let unit = render_unit(
+            "/opt/nanocodex/bin/nanocodex".as_ref(),
+            &[
+                OsString::from("eval"),
+                OsString::from("benchmark"),
+                OsString::from("terminal bench"),
+                OsString::from("--headless"),
+            ],
+            "/srv/evals".as_ref(),
+        )
+        .unwrap();
+        assert!(unit.contains(
+            "ExecStart=\"/opt/nanocodex/bin/nanocodex\" \"eval\" \"benchmark\" \"terminal bench\" \"--headless\""
+        ));
+        assert!(unit.contains("WorkingDirectory=/srv/evals"));
+        assert!(unit.contains("Restart=on-failure"));
+        assert!(!unit.contains("RestartPreventExitStatus"));
+    }
+
+    #[test]
+    fn absolute_paths_replace_user_supplied_service_arguments() {
+        let mut arguments = vec![
+            OsString::from("eval"),
+            OsString::from("benchmark"),
+            OsString::from("release"),
+            OsString::from("--config=relative.toml"),
+        ];
+        replace_option(&mut arguments, "--config", "/srv/nanocodex.toml".as_ref());
+        replace_option(&mut arguments, "--state-dir", "/srv/state".as_ref());
+        assert_eq!(
+            arguments,
+            [
+                "eval",
+                "benchmark",
+                "release",
+                "--config=/srv/nanocodex.toml",
+                "--state-dir",
+                "/srv/state",
+            ]
+            .map(OsString::from)
+        );
+    }
+
+    #[test]
+    fn unit_identity_is_stable_and_safe() {
+        assert_eq!(
+            unit_name(
+                "Terminal Bench / k=5",
+                "/srv/nanocodex.toml".as_ref(),
+                "/srv/state".as_ref(),
+            ),
+            unit_name(
+                "Terminal Bench / k=5",
+                "/srv/nanocodex.toml".as_ref(),
+                "/srv/state".as_ref(),
+            )
+        );
+        assert!(
+            unit_name(
+                "Terminal Bench / k=5",
+                "/srv/nanocodex.toml".as_ref(),
+                "/srv/state".as_ref(),
+            )
+            .starts_with("nanocodex-benchmark-terminal-bench---k-5-")
+        );
+    }
+}

--- a/bin/nanocodex/src/eval/systemd.rs
+++ b/bin/nanocodex/src/eval/systemd.rs
@@ -26,8 +26,12 @@ pub(super) fn install(
         bail!("--systemd is supported only on Linux");
     }
 
-    let working_directory = env::current_dir().wrap_err("failed to resolve current directory")?;
-    let config = absolute_existing(config, &working_directory, "runtime helper config")?;
+    let invocation_directory =
+        env::current_dir().wrap_err("failed to resolve current directory")?;
+    let config = absolute_existing(config, &invocation_directory, "runtime helper config")?;
+    let working_directory = config
+        .parent()
+        .ok_or_else(|| eyre!("runtime helper config has no parent directory"))?;
     if let Some(coordinator) = coordinator {
         CoordinatorClient::new(coordinator)?;
     }
@@ -35,7 +39,7 @@ pub(super) fn install(
         None
     } else {
         let state_dir = state_dir.map_or_else(default_state_dir, |path| Ok(path.to_path_buf()))?;
-        let state_dir = absolute(&state_dir, &working_directory);
+        let state_dir = absolute(&state_dir, &invocation_directory);
         Evaluation::open(&config, profile, &state_dir)?;
         Some(state_dir.canonicalize().wrap_err_with(|| {
             format!("failed to resolve state directory {}", state_dir.display())
@@ -48,7 +52,7 @@ pub(super) fn install(
         .or_else(|| state_dir.as_deref().map(Path::as_os_str))
         .ok_or_else(|| eyre!("benchmark service target is absent"))?;
     let unit_name = unit_name(profile, &config, target);
-    let unit = render_unit(&executable, &arguments, &working_directory)?;
+    let unit = render_unit(&executable, &arguments, working_directory)?;
     let unit_path = user_unit_directory()?.join(&unit_name);
 
     fs::create_dir_all(

--- a/bin/nanocodex/src/main.rs
+++ b/bin/nanocodex/src/main.rs
@@ -36,7 +36,7 @@ mod vm;
 #[path = "vm_unsupported.rs"]
 mod vm;
 
-use std::path::PathBuf;
+use std::{path::PathBuf, process::ExitCode};
 
 use clap::{Args, Parser, Subcommand, builder::NonEmptyStringValueParser};
 use eyre::{Result, WrapErr, eyre};
@@ -44,6 +44,22 @@ use nanocodex::agent::rollout::RolloutConfig;
 
 use config::AgentArgs;
 use observability::ObservabilityArgs;
+
+const RETRYABLE_EXIT_CODE: u8 = 75;
+
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
+struct RetryableProcessExit {
+    message: String,
+}
+
+impl RetryableProcessExit {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
 
 #[derive(Parser)]
 #[command(
@@ -126,7 +142,17 @@ struct ResumeCommand {
     prompt: Option<String>,
 }
 
-fn main() -> Result<()> {
+fn main() -> ExitCode {
+    match try_main() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("Error: {error:?}");
+            ExitCode::from(process_exit_code(&error))
+        }
+    }
+}
+
+fn try_main() -> Result<()> {
     nanocodex::oai::transport::install_default_rustls_crypto_provider();
     // Keep direct `cargo run` behavior consistent with the Justfile without
     // requiring shell-specific syntax to load the repository's `.env` file.
@@ -140,6 +166,14 @@ fn main() -> Result<()> {
         .enable_all()
         .build()?
         .block_on(run(cli))
+}
+
+fn process_exit_code(error: &eyre::Report) -> u8 {
+    if error.downcast_ref::<RetryableProcessExit>().is_some() {
+        RETRYABLE_EXIT_CODE
+    } else {
+        1
+    }
 }
 
 async fn run(cli: Cli) -> Result<()> {

--- a/bin/nanocodex/src/run.rs
+++ b/bin/nanocodex/src/run.rs
@@ -35,7 +35,7 @@ impl Run {
                 tokio::pin!(completion);
                 tokio::select! {
                     result = &mut completion => result?,
-                    signal = tokio::signal::ctrl_c() => {
+                    signal = interrupt_signal() => {
                         signal?;
                         // The driver may have completed while JSONL was still
                         // backpressured. A late cancellation rejection must not
@@ -76,6 +76,28 @@ impl Run {
         browser_shutdown_result?;
         vm_shutdown_result?;
         shutdown_result
+    }
+}
+
+async fn interrupt_signal() -> Result<()> {
+    #[cfg(unix)]
+    {
+        let mut terminate =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+        tokio::select! {
+            result = tokio::signal::ctrl_c() => result?,
+            signal = terminate.recv() => {
+                if signal.is_none() {
+                    return Err(eyre!("SIGTERM listener closed"));
+                }
+            }
+        }
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    {
+        tokio::signal::ctrl_c().await?;
+        Ok(())
     }
 }
 

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -2785,8 +2785,13 @@ fn classify_submission(input: impl Into<SubmittedPrompt>) -> Submission {
         if argument.is_some_and(|argument| argument.split_whitespace().count() != 1) {
             return Submission::InvalidCommand("Usage: /benchmark [profile]".to_owned());
         }
-        let instruction =
-            crate::benchmark::prompt(argument, std::path::Path::new("nanocodex.toml"), None, None);
+        let instruction = crate::benchmark::prompt(
+            argument,
+            std::path::Path::new("nanocodex.toml"),
+            None,
+            None,
+            None,
+        );
         input.set_display(display);
         input.set_instruction(instruction);
         return Submission::Prompt(input);

--- a/bin/nanocodex/src/tui/mod.rs
+++ b/bin/nanocodex/src/tui/mod.rs
@@ -2791,6 +2791,7 @@ fn classify_submission(input: impl Into<SubmittedPrompt>) -> Submission {
             None,
             None,
             None,
+            None,
         );
         input.set_display(display);
         input.set_instruction(instruction);

--- a/bin/nanocodex/tests/it/run_interrupt.rs
+++ b/bin/nanocodex/tests/it/run_interrupt.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, process::Stdio, time::Duration};
+use std::{process::Stdio, time::Duration};
 
 use eyre::{Result, eyre};
 use futures_util::{SinkExt, StreamExt};
@@ -21,9 +21,9 @@ async fn assert_signal_after_completion(signal_name: &str) -> Result<()> {
     let endpoint = format!("ws://{}", listener.local_addr()?);
     let (completed_tx, completed_rx) = oneshot::channel();
     let server = tokio::spawn(serve_completed_response(listener, completed_tx));
-    let workspace = temporary_workspace()?;
+    let workspace = tempfile::tempdir()?;
     let child = Command::new(env!("CARGO_BIN_EXE_nanocodex"))
-        .current_dir(&workspace)
+        .current_dir(workspace.path())
         .env_remove("OPENAI_API_KEY")
         .arg("run")
         .arg("--browser=none")
@@ -33,7 +33,7 @@ async fn assert_signal_after_completion(signal_name: &str) -> Result<()> {
         .arg("--websocket-url")
         .arg(endpoint)
         .arg("--cwd")
-        .arg(&workspace)
+        .arg(workspace.path())
         .arg("--rollouts")
         .arg("false")
         .arg("--mcp-defaults")
@@ -77,8 +77,6 @@ async fn assert_signal_after_completion(signal_name: &str) -> Result<()> {
         .iter()
         .filter(|event| matches!(event["type"].as_str(), Some("run.completed" | "run.failed")))
         .count();
-    std::fs::remove_dir_all(workspace)?;
-
     assert!(
         !output.status.success(),
         "SIG{signal_name} unexpectedly returned success"
@@ -174,16 +172,4 @@ where
         ))
         .await?;
     Ok(())
-}
-
-fn temporary_workspace() -> Result<PathBuf> {
-    let path = std::env::temp_dir().join(format!(
-        "nanocodex-run-interrupt-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)?
-            .as_nanos()
-    ));
-    std::fs::create_dir_all(&path)?;
-    Ok(path)
 }

--- a/bin/nanocodex/tests/it/run_interrupt.rs
+++ b/bin/nanocodex/tests/it/run_interrupt.rs
@@ -8,6 +8,15 @@ use tokio_tungstenite::{WebSocketStream, accept_async, tungstenite::Message};
 
 #[tokio::test]
 async fn interrupt_after_completion_still_flushes_one_terminal_event() -> Result<()> {
+    assert_signal_after_completion("INT").await
+}
+
+#[tokio::test]
+async fn terminate_after_completion_still_returns_failure() -> Result<()> {
+    assert_signal_after_completion("TERM").await
+}
+
+async fn assert_signal_after_completion(signal_name: &str) -> Result<()> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let endpoint = format!("ws://{}", listener.local_addr()?);
     let (completed_tx, completed_rx) = oneshot::channel();
@@ -47,10 +56,10 @@ async fn interrupt_after_completion_still_flushes_one_terminal_event() -> Result
     tokio::time::sleep(Duration::from_millis(250)).await;
     let pid = child.id().ok_or_else(|| eyre!("CLI had no process ID"))?;
     let signal = Command::new("kill")
-        .args(["-INT", &pid.to_string()])
+        .args([format!("-{signal_name}"), pid.to_string()])
         .status()
         .await?;
-    assert!(signal.success(), "failed to send SIGINT to CLI");
+    assert!(signal.success(), "failed to send SIG{signal_name} to CLI");
     tokio::time::sleep(Duration::from_millis(250)).await;
 
     let output = timeout(Duration::from_secs(10), child.wait_with_output())
@@ -72,7 +81,7 @@ async fn interrupt_after_completion_still_flushes_one_terminal_event() -> Result
 
     assert!(
         !output.status.success(),
-        "SIGINT unexpectedly returned success"
+        "SIG{signal_name} unexpectedly returned success"
     );
     assert_eq!(
         terminals, 1,

--- a/crates/experimental/nanocodex-eval/src/api.rs
+++ b/crates/experimental/nanocodex-eval/src/api.rs
@@ -1,0 +1,943 @@
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{BufRead as _, BufReader, Read as _, Seek as _, SeekFrom},
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use rusqlite::{Connection, OpenFlags, OptionalExtension as _};
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest as _, Sha256};
+
+const LEDGER_FILE: &str = "state.sqlite3";
+const MAX_EVENT_LINE_BYTES: usize = 8 * 1024 * 1024;
+const OUTCOME_TAIL_BYTES: u64 = 512 * 1024;
+
+#[derive(Clone)]
+pub(crate) struct EvalApi {
+    ledger: PathBuf,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct EvalSummary {
+    total: u64,
+    completed: u64,
+    running: u64,
+    retrying: u64,
+    queued: u64,
+    stale: u64,
+    passed: u64,
+    failed: u64,
+    errors: u64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct EvalOverview {
+    schema_version: u32,
+    observed_at_ms: i64,
+    summary: EvalSummary,
+    worksets: Vec<WorksetOverview>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WorksetOverview {
+    id: String,
+    profile: String,
+    digest: String,
+    created_at_ms: i64,
+    task_count: u64,
+    summary: EvalSummary,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WorksetDetail {
+    schema_version: u32,
+    observed_at_ms: i64,
+    workset: WorksetOverview,
+    tasks: Vec<TaskOverview>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TaskOverview {
+    id: String,
+    name: String,
+    label: String,
+    digest: String,
+    treatment_count: u64,
+    summary: EvalSummary,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TaskDetail {
+    schema_version: u32,
+    observed_at_ms: i64,
+    workset_id: String,
+    task: TaskMatrix,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TaskOutcomesPage {
+    schema_version: u32,
+    observed_at_ms: i64,
+    workset_id: String,
+    task_id: String,
+    total: usize,
+    next_cursor: Option<usize>,
+    outcomes: Vec<CoordinateOutcome>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CoordinateOutcome {
+    id: String,
+    status: Option<String>,
+    outcome: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TaskMatrix {
+    id: String,
+    name: String,
+    label: String,
+    digest: String,
+    treatments: Vec<TreatmentDetail>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TreatmentDetail {
+    id: String,
+    label: String,
+    harness: String,
+    model: String,
+    thinking: String,
+    cells: Vec<CoordinateDetail>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CoordinateDetail {
+    id: String,
+    repetition: u16,
+    state: &'static str,
+    attempts: usize,
+    status: Option<String>,
+    outcome: Option<String>,
+    updated_at_ms: Option<i64>,
+    duration_ms: Option<i64>,
+    message: Option<&'static str>,
+    detail_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CaseEvidence {
+    schema_version: u32,
+    task_name: Option<String>,
+    prompt: Option<String>,
+    status: Option<String>,
+    outcome: Option<String>,
+    environment: Option<String>,
+    model: Option<String>,
+    effort: Option<String>,
+    final_message: Option<String>,
+    tool_calls: Option<u64>,
+    usage: Option<Value>,
+    verifier: Option<Value>,
+    exception: Option<Value>,
+    timing: Option<Value>,
+    verifier_stdout: Option<String>,
+    verifier_stderr: Option<String>,
+}
+
+#[derive(Debug)]
+struct WorksetRow {
+    id: i64,
+    profile: String,
+    digest: String,
+    created_at_ms: i64,
+}
+
+#[derive(Debug)]
+struct TaskRow {
+    id: i64,
+    name: String,
+    digest: String,
+}
+
+#[derive(Debug)]
+struct CoordinateRow {
+    id: i64,
+    family_key: String,
+    treatment: String,
+    repetition: u16,
+    state: String,
+    lease_expires_at_ms: Option<i64>,
+    result_path: Option<PathBuf>,
+    task_name: String,
+    task_digest: String,
+    attempts: Vec<ExecutionRow>,
+}
+
+#[derive(Debug)]
+struct ExecutionRow {
+    state: String,
+    started_at_ms: i64,
+    finished_at_ms: Option<i64>,
+    result_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Default)]
+struct Treatment {
+    harness: String,
+    mode: String,
+    model: String,
+    thinking: String,
+    nanocodex_tool_mode: String,
+    codex_tool_mode: String,
+}
+
+impl EvalApi {
+    pub(crate) fn new(state_directory: &Path) -> Self {
+        Self {
+            ledger: state_directory.join(LEDGER_FILE),
+        }
+    }
+
+    pub(crate) fn overview(&self) -> Result<EvalOverview, String> {
+        let connection = self.connection()?;
+        let now = now_ms()?;
+        let worksets = read_worksets(&connection)?;
+        let mut total = EvalSummary::default();
+        let mut overview = Vec::with_capacity(worksets.len());
+        for workset in worksets {
+            let coordinates = read_coordinates(&connection, workset.id, None)?;
+            let summary = summarize(&coordinates, now)?;
+            add_summary(&mut total, &summary);
+            let task_count = u64::try_from(
+                connection
+                    .query_row(
+                        "SELECT COUNT(*) FROM tasks WHERE workset_id = ?1",
+                        [workset.id],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .map_err(|error| error.to_string())?,
+            )
+            .map_err(|error| error.to_string())?;
+            overview.push(WorksetOverview {
+                id: workset.digest.clone(),
+                profile: workset.profile,
+                digest: workset.digest,
+                created_at_ms: workset.created_at_ms,
+                task_count,
+                summary,
+            });
+        }
+        Ok(EvalOverview {
+            schema_version: 1,
+            observed_at_ms: now,
+            summary: total,
+            worksets: overview,
+        })
+    }
+
+    pub(crate) fn workset(&self, digest: &str) -> Result<Option<WorksetDetail>, String> {
+        let connection = self.connection()?;
+        let Some(workset) = find_workset(&connection, digest)? else {
+            return Ok(None);
+        };
+        let now = now_ms()?;
+        let coordinates = read_coordinates(&connection, workset.id, None)?;
+        let summary = summarize(&coordinates, now)?;
+        let task_count = coordinates
+            .iter()
+            .map(|coordinate| coordinate.task_name.as_str())
+            .collect::<std::collections::HashSet<_>>()
+            .len();
+        let workset_overview = WorksetOverview {
+            id: workset.digest.clone(),
+            profile: workset.profile,
+            digest: workset.digest.clone(),
+            created_at_ms: workset.created_at_ms,
+            task_count: u64::try_from(task_count).map_err(|error| error.to_string())?,
+            summary,
+        };
+        let mut grouped = HashMap::<String, Vec<CoordinateRow>>::new();
+        for coordinate in coordinates {
+            grouped
+                .entry(coordinate.task_name.clone())
+                .or_default()
+                .push(coordinate);
+        }
+        let mut tasks = grouped
+            .into_iter()
+            .map(|(name, coordinates)| {
+                let digest = coordinates[0].task_digest.clone();
+                let treatment_count = coordinates
+                    .iter()
+                    .map(|coordinate| coordinate.family_key.as_str())
+                    .collect::<std::collections::HashSet<_>>()
+                    .len();
+                Ok(TaskOverview {
+                    id: public_id(&[&workset.digest, &name]),
+                    label: short_name(&name).to_owned(),
+                    name,
+                    digest,
+                    treatment_count: u64::try_from(treatment_count)
+                        .map_err(|error| error.to_string())?,
+                    summary: summarize(&coordinates, now)?,
+                })
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        tasks.sort_by(|left, right| left.name.cmp(&right.name));
+        Ok(Some(WorksetDetail {
+            schema_version: 1,
+            observed_at_ms: now,
+            workset: workset_overview,
+            tasks,
+        }))
+    }
+
+    pub(crate) fn task(
+        &self,
+        workset_digest: &str,
+        task_id: &str,
+    ) -> Result<Option<TaskDetail>, String> {
+        let connection = self.connection()?;
+        let Some(workset) = find_workset(&connection, workset_digest)? else {
+            return Ok(None);
+        };
+        let Some(task) = find_task(&connection, workset.id, workset_digest, task_id)? else {
+            return Ok(None);
+        };
+        let now = now_ms()?;
+        let mut coordinates = read_coordinates(&connection, workset.id, Some(task.id))?;
+        let mut treatments = Vec::<TreatmentDetail>::new();
+        for coordinate in coordinates.drain(..) {
+            let treatment = parse_treatment(&coordinate.treatment);
+            let latest = coordinate.attempts.last();
+            let expired = coordinate.state == "running"
+                && coordinate
+                    .lease_expires_at_ms
+                    .is_some_and(|expiry| expiry <= now);
+            let state = coordinate_state(&coordinate, expired);
+            let cell = CoordinateDetail {
+                id: case_id(workset_digest, coordinate.id),
+                repetition: coordinate.repetition,
+                state,
+                attempts: coordinate.attempts.len(),
+                status: None,
+                outcome: None,
+                updated_at_ms: latest
+                    .and_then(|attempt| attempt.finished_at_ms)
+                    .or_else(|| latest.map(|attempt| attempt.started_at_ms)),
+                duration_ms: latest.and_then(|attempt| {
+                    attempt
+                        .finished_at_ms
+                        .map(|finished| finished.saturating_sub(attempt.started_at_ms))
+                }),
+                message: match state {
+                    "stale" => Some("The execution lease expired and can be reclaimed"),
+                    "retrying" => Some("The previous attempt remains retryable"),
+                    _ => None,
+                },
+                detail_id: result_path(&coordinate).map(|_| case_id(workset_digest, coordinate.id)),
+            };
+            let treatment_id = public_id(&[workset_digest, &coordinate.family_key]);
+            if let Some(row) = treatments.iter_mut().find(|row| row.id == treatment_id) {
+                row.cells.push(cell);
+            } else {
+                treatments.push(TreatmentDetail {
+                    id: treatment_id,
+                    label: treatment_label(&treatment),
+                    harness: treatment_harness(&treatment),
+                    model: treatment.model,
+                    thinking: treatment.thinking,
+                    cells: vec![cell],
+                });
+            }
+        }
+        treatments.sort_by(|left, right| left.label.cmp(&right.label));
+        for treatment in &mut treatments {
+            treatment.cells.sort_by_key(|cell| cell.repetition);
+        }
+        Ok(Some(TaskDetail {
+            schema_version: 1,
+            observed_at_ms: now,
+            workset_id: workset.digest,
+            task: TaskMatrix {
+                id: task_id.to_owned(),
+                label: short_name(&task.name).to_owned(),
+                name: task.name,
+                digest: task.digest,
+                treatments,
+            },
+        }))
+    }
+
+    pub(crate) fn task_outcomes(
+        &self,
+        workset_digest: &str,
+        task_id: &str,
+        cursor: usize,
+        limit: usize,
+    ) -> Result<Option<TaskOutcomesPage>, String> {
+        let connection = self.connection()?;
+        let Some(workset) = find_workset(&connection, workset_digest)? else {
+            return Ok(None);
+        };
+        let Some(task) = find_task(&connection, workset.id, workset_digest, task_id)? else {
+            return Ok(None);
+        };
+        let coordinates = read_coordinates(&connection, workset.id, Some(task.id))?
+            .into_iter()
+            .filter(|coordinate| {
+                coordinate.state == "terminal" && result_path(coordinate).is_some()
+            })
+            .collect::<Vec<_>>();
+        let total = coordinates.len();
+        let mut outcomes = Vec::with_capacity(limit.min(total.saturating_sub(cursor)));
+        for coordinate in coordinates.into_iter().skip(cursor).take(limit) {
+            let evidence = self.outcome_for(&coordinate)?;
+            outcomes.push(CoordinateOutcome {
+                id: case_id(workset_digest, coordinate.id),
+                status: evidence.as_ref().and_then(|value| value.status.clone()),
+                outcome: evidence.and_then(|value| value.outcome),
+            });
+        }
+        let loaded = cursor.saturating_add(outcomes.len());
+        Ok(Some(TaskOutcomesPage {
+            schema_version: 1,
+            observed_at_ms: now_ms()?,
+            workset_id: workset.digest,
+            task_id: task_id.to_owned(),
+            total,
+            next_cursor: (loaded < total).then_some(loaded),
+            outcomes,
+        }))
+    }
+
+    pub(crate) fn case(&self, id: &str) -> Result<Option<CaseEvidence>, String> {
+        let connection = self.connection()?;
+        for workset in read_worksets(&connection)? {
+            for coordinate in read_coordinates(&connection, workset.id, None)? {
+                if case_id(&workset.digest, coordinate.id) == id {
+                    return self.evidence_for(&coordinate);
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    fn connection(&self) -> Result<Connection, String> {
+        let connection = Connection::open_with_flags(
+            &self.ledger,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .map_err(|error| error.to_string())?;
+        connection
+            .busy_timeout(std::time::Duration::from_secs(5))
+            .map_err(|error| error.to_string())?;
+        Ok(connection)
+    }
+
+    fn evidence_for(&self, coordinate: &CoordinateRow) -> Result<Option<CaseEvidence>, String> {
+        let Some(result_path) = result_path(coordinate) else {
+            return Ok(None);
+        };
+        let result = match result_path.canonicalize() {
+            Ok(result) => result,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error.to_string()),
+        };
+        read_evidence(&result)
+    }
+
+    fn outcome_for(&self, coordinate: &CoordinateRow) -> Result<Option<CaseEvidence>, String> {
+        let Some(result_path) = result_path(coordinate) else {
+            return Ok(None);
+        };
+        let result = match result_path.canonicalize() {
+            Ok(result) => result,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error.to_string()),
+        };
+        read_outcome(&result)
+    }
+}
+
+fn result_path(coordinate: &CoordinateRow) -> Option<&PathBuf> {
+    coordinate.result_path.as_ref().or_else(|| {
+        coordinate
+            .attempts
+            .iter()
+            .rev()
+            .find_map(|attempt| attempt.result_path.as_ref())
+    })
+}
+
+fn summarize(coordinates: &[CoordinateRow], now: i64) -> Result<EvalSummary, String> {
+    let mut summary = EvalSummary {
+        total: u64::try_from(coordinates.len()).map_err(|error| error.to_string())?,
+        ..EvalSummary::default()
+    };
+    for coordinate in coordinates {
+        let expired = coordinate.state == "running"
+            && coordinate
+                .lease_expires_at_ms
+                .is_some_and(|expiry| expiry <= now);
+        match coordinate_state(coordinate, expired) {
+            "completed" => summary.completed += 1,
+            "running" => summary.running += 1,
+            "retrying" => summary.retrying += 1,
+            "stale" => summary.stale += 1,
+            _ => summary.queued += 1,
+        }
+    }
+    Ok(summary)
+}
+
+fn read_worksets(connection: &Connection) -> Result<Vec<WorksetRow>, String> {
+    let mut statement = connection
+        .prepare(
+            "SELECT id, name, generation, created_at_ms FROM worksets \
+             ORDER BY created_at_ms DESC, id DESC",
+        )
+        .map_err(|error| error.to_string())?;
+    statement
+        .query_map([], |row| {
+            Ok(WorksetRow {
+                id: row.get(0)?,
+                profile: row.get(1)?,
+                digest: row.get(2)?,
+                created_at_ms: row.get(3)?,
+            })
+        })
+        .map_err(|error| error.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| error.to_string())
+}
+
+fn find_workset(connection: &Connection, digest: &str) -> Result<Option<WorksetRow>, String> {
+    connection
+        .query_row(
+            "SELECT id, name, generation, created_at_ms FROM worksets WHERE generation = ?1",
+            [digest],
+            |row| {
+                Ok(WorksetRow {
+                    id: row.get(0)?,
+                    profile: row.get(1)?,
+                    digest: row.get(2)?,
+                    created_at_ms: row.get(3)?,
+                })
+            },
+        )
+        .optional()
+        .map_err(|error| error.to_string())
+}
+
+fn find_task(
+    connection: &Connection,
+    workset_id: i64,
+    workset_digest: &str,
+    public_task_id: &str,
+) -> Result<Option<TaskRow>, String> {
+    let mut statement = connection
+        .prepare("SELECT id, name, digest FROM tasks WHERE workset_id = ?1 ORDER BY id")
+        .map_err(|error| error.to_string())?;
+    let rows = statement
+        .query_map([workset_id], |row| {
+            Ok(TaskRow {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                digest: row.get(2)?,
+            })
+        })
+        .map_err(|error| error.to_string())?;
+    for row in rows {
+        let task = row.map_err(|error| error.to_string())?;
+        if public_id(&[workset_digest, &task.name]) == public_task_id {
+            return Ok(Some(task));
+        }
+    }
+    Ok(None)
+}
+
+fn read_coordinates(
+    connection: &Connection,
+    workset_id: i64,
+    task_id: Option<i64>,
+) -> Result<Vec<CoordinateRow>, String> {
+    let mut statement = connection
+        .prepare(
+            "SELECT c.id, c.family_key, c.treatment, c.repetition, c.state, \
+                    c.lease_expires_at_ms, c.result_path, t.name, t.digest \
+             FROM coordinates c JOIN tasks t ON t.id = c.task_id \
+             WHERE c.workset_id = ?1 AND (?2 IS NULL OR c.task_id = ?2) \
+             ORDER BY t.name, c.family_key, c.repetition",
+        )
+        .map_err(|error| error.to_string())?;
+    let mut coordinates = statement
+        .query_map((workset_id, task_id), |row| {
+            Ok(CoordinateRow {
+                id: row.get(0)?,
+                family_key: row.get(1)?,
+                treatment: row.get(2)?,
+                repetition: row.get(3)?,
+                state: row.get(4)?,
+                lease_expires_at_ms: row.get(5)?,
+                result_path: row.get::<_, Option<String>>(6)?.map(PathBuf::from),
+                task_name: row.get(7)?,
+                task_digest: row.get(8)?,
+                attempts: Vec::new(),
+            })
+        })
+        .map_err(|error| error.to_string())?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| error.to_string())?;
+    let mut indices = coordinates
+        .iter()
+        .enumerate()
+        .map(|(index, coordinate)| (coordinate.id, index))
+        .collect::<HashMap<_, _>>();
+    let mut attempts = connection
+        .prepare(
+            "SELECT e.coordinate_id, e.state, e.started_at_ms, e.finished_at_ms, e.result_path \
+             FROM executions e JOIN coordinates c ON c.id = e.coordinate_id \
+             WHERE c.workset_id = ?1 AND (?2 IS NULL OR c.task_id = ?2) \
+             ORDER BY e.coordinate_id, e.generation",
+        )
+        .map_err(|error| error.to_string())?;
+    let rows = attempts
+        .query_map((workset_id, task_id), |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                ExecutionRow {
+                    state: row.get(1)?,
+                    started_at_ms: row.get(2)?,
+                    finished_at_ms: row.get(3)?,
+                    result_path: row.get::<_, Option<String>>(4)?.map(PathBuf::from),
+                },
+            ))
+        })
+        .map_err(|error| error.to_string())?;
+    for row in rows {
+        let (coordinate_id, execution) = row.map_err(|error| error.to_string())?;
+        if let Some(index) = indices.remove(&coordinate_id).or_else(|| {
+            coordinates
+                .iter()
+                .position(|coordinate| coordinate.id == coordinate_id)
+        }) {
+            coordinates[index].attempts.push(execution);
+            indices.insert(coordinate_id, index);
+        }
+    }
+    Ok(coordinates)
+}
+
+fn coordinate_state(coordinate: &CoordinateRow, expired: bool) -> &'static str {
+    if coordinate.state == "terminal" {
+        "completed"
+    } else if expired {
+        "stale"
+    } else if coordinate.state == "running" {
+        "running"
+    } else if coordinate
+        .attempts
+        .last()
+        .is_some_and(|attempt| attempt.state == "retryable")
+    {
+        "retrying"
+    } else {
+        "queued"
+    }
+}
+
+fn read_evidence(result: &Path) -> Result<Option<CaseEvidence>, String> {
+    let Some(events) = events_path(result) else {
+        return Ok(None);
+    };
+    let file = match File::open(events) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.to_string()),
+    };
+    let mut evidence = empty_evidence();
+    for line in BufReader::new(file).lines() {
+        let line = line.map_err(|error| error.to_string())?;
+        if line.len() > MAX_EVENT_LINE_BYTES {
+            return Err("retained evaluation event exceeded the API limit".to_owned());
+        }
+        let event: Value = serde_json::from_str(&line).map_err(|error| error.to_string())?;
+        match event.get("type").and_then(Value::as_str) {
+            Some("attempt_started") => {
+                evidence.task_name = event
+                    .pointer("/attempt/task_name")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned);
+                evidence.prompt = event
+                    .pointer("/payload/prompt")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned);
+            }
+            Some("verifier_output") => {
+                evidence.verifier_stdout = event
+                    .pointer("/payload/stdout")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned);
+                evidence.verifier_stderr = event
+                    .pointer("/payload/stderr")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned);
+            }
+            Some("completed") => apply_terminal_payload(&mut evidence, &event["payload"]),
+            Some("failed") => apply_terminal_payload(&mut evidence, &event["payload"]),
+            _ => {}
+        }
+    }
+    Ok((evidence.status.is_some() || evidence.outcome.is_some()).then_some(evidence))
+}
+
+fn read_outcome(result: &Path) -> Result<Option<CaseEvidence>, String> {
+    let Some(events) = events_path(result) else {
+        return Ok(None);
+    };
+    let mut file = match File::open(&events) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.to_string()),
+    };
+    let length = file.metadata().map_err(|error| error.to_string())?.len();
+    let start = length.saturating_sub(OUTCOME_TAIL_BYTES);
+    file.seek(SeekFrom::Start(start))
+        .map_err(|error| error.to_string())?;
+    let mut tail = Vec::with_capacity(
+        usize::try_from(length.saturating_sub(start)).map_err(|error| error.to_string())?,
+    );
+    file.read_to_end(&mut tail)
+        .map_err(|error| error.to_string())?;
+    let first_complete_line = if start == 0 {
+        0
+    } else {
+        tail.iter()
+            .position(|byte| *byte == b'\n')
+            .map_or(tail.len(), |position| position + 1)
+    };
+    for line in tail[first_complete_line..]
+        .split(|byte| *byte == b'\n')
+        .rev()
+        .filter(|line| !line.is_empty())
+    {
+        if line.len() > MAX_EVENT_LINE_BYTES {
+            return Err("retained evaluation event exceeded the API limit".to_owned());
+        }
+        let event: Value = serde_json::from_slice(line).map_err(|error| error.to_string())?;
+        if matches!(
+            event.get("type").and_then(Value::as_str),
+            Some("completed" | "failed")
+        ) {
+            let mut evidence = empty_evidence();
+            apply_terminal_payload(&mut evidence, &event["payload"]);
+            return Ok(Some(evidence));
+        }
+    }
+    read_evidence(result)
+}
+
+fn events_path(result: &Path) -> Option<PathBuf> {
+    if result.is_dir() {
+        Some(result.join("events.jsonl"))
+    } else if result
+        .file_name()
+        .is_some_and(|name| name == "events.jsonl")
+    {
+        Some(result.to_path_buf())
+    } else if result.is_file() {
+        result.parent().map(|parent| parent.join("events.jsonl"))
+    } else {
+        None
+    }
+}
+
+const fn empty_evidence() -> CaseEvidence {
+    CaseEvidence {
+        schema_version: 1,
+        task_name: None,
+        prompt: None,
+        status: None,
+        outcome: None,
+        environment: None,
+        model: None,
+        effort: None,
+        final_message: None,
+        tool_calls: None,
+        usage: None,
+        verifier: None,
+        exception: None,
+        timing: None,
+        verifier_stdout: None,
+        verifier_stderr: None,
+    }
+}
+
+fn apply_terminal_payload(evidence: &mut CaseEvidence, payload: &Value) {
+    evidence.task_name = payload
+        .get("task_name")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .or_else(|| evidence.task_name.take());
+    evidence.status = payload
+        .get("status")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    evidence.outcome = payload
+        .get("outcome")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    evidence.environment = payload
+        .get("environment")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let agent = payload.get("agent").filter(|value| value.is_object());
+    evidence.model = agent
+        .and_then(|value| value.get("model"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .or_else(|| {
+            payload
+                .get("model")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        });
+    evidence.effort = agent
+        .and_then(|value| value.get("effort"))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .or_else(|| {
+            payload
+                .get("effort")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        });
+    evidence.final_message = agent
+        .and_then(|value| value.get("final_message"))
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    evidence.tool_calls = agent
+        .and_then(|value| value.get("tool_calls"))
+        .and_then(Value::as_u64);
+    evidence.usage = agent.and_then(|value| value.get("usage")).cloned();
+    evidence.verifier = payload
+        .get("verifier")
+        .filter(|value| value.is_object())
+        .cloned();
+    evidence.exception = payload
+        .get("exception")
+        .filter(|value| !value.is_null())
+        .cloned();
+    evidence.timing = payload
+        .get("timing")
+        .filter(|value| value.is_object())
+        .cloned();
+}
+
+fn parse_treatment(raw: &str) -> Treatment {
+    let value = serde_json::from_str::<Value>(raw).unwrap_or(Value::Null);
+    let string = |key: &str| {
+        value
+            .get(key)
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned()
+    };
+    Treatment {
+        harness: string("harness"),
+        mode: string("mode"),
+        model: string("model"),
+        thinking: string("thinking"),
+        nanocodex_tool_mode: string("nanocodex_tool_mode"),
+        codex_tool_mode: string("codex_tool_mode"),
+    }
+}
+
+fn treatment_harness(treatment: &Treatment) -> String {
+    if !treatment.harness.is_empty() {
+        treatment.harness.clone()
+    } else if !treatment.mode.is_empty() {
+        treatment.mode.clone()
+    } else {
+        "unknown".to_owned()
+    }
+}
+
+fn treatment_label(treatment: &Treatment) -> String {
+    let mut parts = [
+        treatment_harness(treatment),
+        treatment.model.clone(),
+        treatment.thinking.clone(),
+    ]
+    .into_iter()
+    .filter(|part| !part.is_empty())
+    .collect::<Vec<_>>();
+    if !treatment.nanocodex_tool_mode.is_empty() || !treatment.codex_tool_mode.is_empty() {
+        let tools = if treatment.nanocodex_tool_mode == treatment.codex_tool_mode {
+            treatment.nanocodex_tool_mode.clone()
+        } else {
+            format!(
+                "N:{} / C:{}",
+                treatment.nanocodex_tool_mode, treatment.codex_tool_mode
+            )
+        };
+        if !tools.is_empty() {
+            parts.push(tools);
+        }
+    }
+    parts.join(" · ")
+}
+
+const fn add_summary(total: &mut EvalSummary, summary: &EvalSummary) {
+    total.total += summary.total;
+    total.completed += summary.completed;
+    total.running += summary.running;
+    total.retrying += summary.retrying;
+    total.queued += summary.queued;
+    total.stale += summary.stale;
+    total.passed += summary.passed;
+    total.failed += summary.failed;
+    total.errors += summary.errors;
+}
+
+fn short_name(name: &str) -> &str {
+    name.rsplit('/').next().unwrap_or(name)
+}
+
+fn case_id(workset_digest: &str, coordinate_id: i64) -> String {
+    public_id(&[workset_digest, &coordinate_id.to_string()])
+}
+
+fn public_id(parts: &[&str]) -> String {
+    let mut digest = Sha256::new();
+    for part in parts {
+        digest.update(part.as_bytes());
+        digest.update([0]);
+    }
+    hex::encode(digest.finalize())[..24].to_owned()
+}
+
+fn now_ms() -> Result<i64, String> {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| error.to_string())?
+        .as_millis();
+    i64::try_from(millis).map_err(|error| error.to_string())
+}

--- a/crates/experimental/nanocodex-eval/src/api.rs
+++ b/crates/experimental/nanocodex-eval/src/api.rs
@@ -221,7 +221,7 @@ impl EvalApi {
         let mut total = EvalSummary::default();
         let mut overview = Vec::with_capacity(worksets.len());
         for workset in worksets {
-            let coordinates = read_coordinates(&connection, workset.id, None)?;
+            let coordinates = read_coordinates(&connection, workset.id, None, None)?;
             let summary = summarize(&coordinates, now)?;
             add_summary(&mut total, &summary);
             let task_count = u64::try_from(
@@ -257,7 +257,7 @@ impl EvalApi {
             return Ok(None);
         };
         let now = now_ms()?;
-        let coordinates = read_coordinates(&connection, workset.id, None)?;
+        let coordinates = read_coordinates(&connection, workset.id, None, None)?;
         let summary = summarize(&coordinates, now)?;
         let task_count = coordinates
             .iter()
@@ -321,7 +321,7 @@ impl EvalApi {
             return Ok(None);
         };
         let now = now_ms()?;
-        let mut coordinates = read_coordinates(&connection, workset.id, Some(task.id))?;
+        let mut coordinates = read_coordinates(&connection, workset.id, Some(task.id), None)?;
         let mut treatments = Vec::<TreatmentDetail>::new();
         for coordinate in coordinates.drain(..) {
             let treatment = parse_treatment(&coordinate.treatment);
@@ -399,7 +399,7 @@ impl EvalApi {
         let Some(task) = find_task(&connection, workset.id, workset_digest, task_id)? else {
             return Ok(None);
         };
-        let coordinates = read_coordinates(&connection, workset.id, Some(task.id))?
+        let coordinates = read_coordinates(&connection, workset.id, Some(task.id), None)?
             .into_iter()
             .filter(|coordinate| {
                 coordinate.state == "terminal" && result_path(coordinate).is_some()
@@ -429,14 +429,18 @@ impl EvalApi {
 
     pub(crate) fn case(&self, id: &str) -> Result<Option<CaseEvidence>, String> {
         let connection = self.connection()?;
-        for workset in read_worksets(&connection)? {
-            for coordinate in read_coordinates(&connection, workset.id, None)? {
-                if case_id(&workset.digest, coordinate.id) == id {
-                    return self.evidence_for(&coordinate);
-                }
-            }
-        }
-        Ok(None)
+        let Some((workset_digest, coordinate_id)) = parse_case_id(id) else {
+            return Ok(None);
+        };
+        let Some(workset) = find_workset(&connection, workset_digest)? else {
+            return Ok(None);
+        };
+        let coordinate = read_coordinates(&connection, workset.id, None, Some(coordinate_id))?
+            .into_iter()
+            .next();
+        coordinate
+            .as_ref()
+            .map_or(Ok(None), |coordinate| self.evidence_for(coordinate))
     }
 
     fn connection(&self) -> Result<Connection, String> {
@@ -577,6 +581,7 @@ fn read_coordinates(
     connection: &Connection,
     workset_id: i64,
     task_id: Option<i64>,
+    coordinate_id: Option<i64>,
 ) -> Result<Vec<CoordinateRow>, String> {
     let mut statement = connection
         .prepare(
@@ -584,11 +589,12 @@ fn read_coordinates(
                     c.lease_expires_at_ms, c.result_path, t.name, t.digest \
              FROM coordinates c JOIN tasks t ON t.id = c.task_id \
              WHERE c.workset_id = ?1 AND (?2 IS NULL OR c.task_id = ?2) \
+                   AND (?3 IS NULL OR c.id = ?3) \
              ORDER BY t.name, c.family_key, c.repetition",
         )
         .map_err(|error| error.to_string())?;
     let mut coordinates = statement
-        .query_map((workset_id, task_id), |row| {
+        .query_map((workset_id, task_id, coordinate_id), |row| {
             Ok(CoordinateRow {
                 id: row.get(0)?,
                 family_key: row.get(1)?,
@@ -615,11 +621,12 @@ fn read_coordinates(
             "SELECT e.coordinate_id, e.state, e.started_at_ms, e.finished_at_ms, e.result_path \
              FROM executions e JOIN coordinates c ON c.id = e.coordinate_id \
              WHERE c.workset_id = ?1 AND (?2 IS NULL OR c.task_id = ?2) \
+                   AND (?3 IS NULL OR c.id = ?3) \
              ORDER BY e.coordinate_id, e.generation",
         )
         .map_err(|error| error.to_string())?;
     let rows = attempts
-        .query_map((workset_id, task_id), |row| {
+        .query_map((workset_id, task_id, coordinate_id), |row| {
             Ok((
                 row.get::<_, i64>(0)?,
                 ExecutionRow {
@@ -922,7 +929,15 @@ fn short_name(name: &str) -> &str {
 }
 
 fn case_id(workset_digest: &str, coordinate_id: i64) -> String {
-    public_id(&[workset_digest, &coordinate_id.to_string()])
+    format!("{workset_digest}:{coordinate_id}")
+}
+
+fn parse_case_id(id: &str) -> Option<(&str, i64)> {
+    let (workset_digest, coordinate_id) = id.rsplit_once(':')?;
+    if workset_digest.is_empty() {
+        return None;
+    }
+    Some((workset_digest, coordinate_id.parse().ok()?))
 }
 
 fn public_id(parts: &[&str]) -> String {

--- a/crates/experimental/nanocodex-eval/src/coordinator.rs
+++ b/crates/experimental/nanocodex-eval/src/coordinator.rs
@@ -1092,10 +1092,8 @@ allow_internet = false
             fs::write(&evidence, format!("{{\"worker\":\"{name}\"}}\n")).unwrap();
             fs::write(
                 output.join("events.jsonl"),
-                format!(
-                    "{{\"type\":\"attempt_started\",\"payload\":{{\"prompt\":\"do it\"}},\"attempt\":{{\"task_name\":\"one\"}}}}\n\
-                     {{\"type\":\"completed\",\"payload\":{{\"task_name\":\"one\",\"status\":\"passed\",\"outcome\":\"passed\",\"environment\":\"micro_vm\",\"agent\":{{\"model\":\"sol\",\"effort\":\"high\",\"tool_calls\":1,\"usage\":{{\"total_tokens\":10}}}},\"verifier\":{{\"exit_code\":0,\"rewards\":{{\"reward\":1}}}}}}}}\n"
-                ),
+                "{\"type\":\"attempt_started\",\"payload\":{\"prompt\":\"do it\"},\"attempt\":{\"task_name\":\"one\"}}\n\
+                 {\"type\":\"completed\",\"payload\":{\"task_name\":\"one\",\"status\":\"passed\",\"outcome\":\"passed\",\"environment\":\"micro_vm\",\"agent\":{\"model\":\"sol\",\"effort\":\"high\",\"tool_calls\":1,\"usage\":{\"total_tokens\":10}},\"verifier\":{\"exit_code\":0,\"rewards\":{\"reward\":1}}}}\n",
             )
             .unwrap();
             fs::write(

--- a/crates/experimental/nanocodex-eval/src/coordinator.rs
+++ b/crates/experimental/nanocodex-eval/src/coordinator.rs
@@ -12,7 +12,7 @@ use std::{
 use axum::{
     Json, Router,
     body::Body,
-    extract::{ConnectInfo, Path as AxumPath, State},
+    extract::{ConnectInfo, Path as AxumPath, Query, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{get, post, put},
@@ -26,7 +26,7 @@ use uuid::Uuid;
 
 use crate::{
     CoordinateClaim, Evaluation, EvaluationClaim, EvaluationSelector, EvaluationTreatment,
-    PreparationClaim,
+    PreparationClaim, api::EvalApi,
 };
 
 const MAX_COMPRESSED_ARTIFACT_BYTES: u64 = 512 * 1024 * 1024;
@@ -121,6 +121,7 @@ pub enum CoordinatorError {
 #[derive(Clone)]
 struct CoordinatorState {
     evaluation: Evaluation,
+    eval_api: EvalApi,
     lease_duration: Duration,
     active: Arc<Mutex<HashMap<String, ActiveClaim>>>,
 }
@@ -185,6 +186,12 @@ struct ErrorBody<'a> {
     error: &'a str,
 }
 
+#[derive(Deserialize)]
+struct EvalOutcomesQuery {
+    cursor: Option<usize>,
+    limit: Option<usize>,
+}
+
 struct ApiError {
     status: StatusCode,
     message: String,
@@ -208,9 +215,11 @@ impl CoordinatorServer {
         lease_duration: Duration,
         worker_timeout: Duration,
     ) -> Self {
+        let eval_api = EvalApi::new(evaluation.state_directory());
         Self {
             state: CoordinatorState {
                 evaluation,
+                eval_api,
                 lease_duration,
                 active: Arc::new(Mutex::new(HashMap::new())),
             },
@@ -229,6 +238,17 @@ impl CoordinatorServer {
         let reaper = spawn_reaper(self.state.active.clone(), self.worker_timeout);
         let app = Router::new()
             .route("/v1/status", get(status))
+            .route("/v1/evals", get(eval_overview))
+            .route("/v1/evals/worksets/{digest}", get(eval_workset))
+            .route(
+                "/v1/evals/worksets/{digest}/tasks/{task_id}",
+                get(eval_task),
+            )
+            .route(
+                "/v1/evals/worksets/{digest}/tasks/{task_id}/outcomes",
+                get(eval_task_outcomes),
+            )
+            .route("/v1/evals/cases/{id}", get(eval_case))
             .route("/v1/claims", post(claim))
             .route("/v1/claims/{token}/heartbeat", post(heartbeat))
             .route("/v1/claims/{token}/artifacts", put(upload_artifacts))
@@ -435,6 +455,78 @@ async fn status(
     Ok(Json(
         serde_json::to_value(status).map_err(ApiError::internal)?,
     ))
+}
+
+async fn eval_overview(State(state): State<CoordinatorState>) -> Result<Response, ApiError> {
+    let api = state.eval_api;
+    let overview = tokio::task::spawn_blocking(move || api.overview())
+        .await
+        .map_err(ApiError::internal)?
+        .map_err(ApiError::internal)?;
+    Ok(Json(overview).into_response())
+}
+
+async fn eval_workset(
+    State(state): State<CoordinatorState>,
+    AxumPath(digest): AxumPath<String>,
+) -> Result<Response, ApiError> {
+    let api = state.eval_api;
+    let workset = tokio::task::spawn_blocking(move || api.workset(&digest))
+        .await
+        .map_err(ApiError::internal)?
+        .map_err(ApiError::internal)?;
+    workset
+        .map(|workset| Json(workset).into_response())
+        .ok_or_else(|| ApiError::not_found("evaluation workset was not found"))
+}
+
+async fn eval_task(
+    State(state): State<CoordinatorState>,
+    AxumPath((digest, task_id)): AxumPath<(String, String)>,
+) -> Result<Response, ApiError> {
+    let api = state.eval_api;
+    let task = tokio::task::spawn_blocking(move || api.task(&digest, &task_id))
+        .await
+        .map_err(ApiError::internal)?
+        .map_err(ApiError::internal)?;
+    task.map(|task| Json(task).into_response())
+        .ok_or_else(|| ApiError::not_found("evaluation task was not found"))
+}
+
+async fn eval_task_outcomes(
+    State(state): State<CoordinatorState>,
+    AxumPath((digest, task_id)): AxumPath<(String, String)>,
+    Query(query): Query<EvalOutcomesQuery>,
+) -> Result<Response, ApiError> {
+    let cursor = query.cursor.unwrap_or(0);
+    let limit = query.limit.unwrap_or(8);
+    if !(1..=32).contains(&limit) {
+        return Err(ApiError::bad_request(
+            "evaluation outcome page limit must be between 1 and 32",
+        ));
+    }
+    let api = state.eval_api;
+    let page =
+        tokio::task::spawn_blocking(move || api.task_outcomes(&digest, &task_id, cursor, limit))
+            .await
+            .map_err(ApiError::internal)?
+            .map_err(ApiError::internal)?;
+    page.map(|page| Json(page).into_response())
+        .ok_or_else(|| ApiError::not_found("evaluation task was not found"))
+}
+
+async fn eval_case(
+    State(state): State<CoordinatorState>,
+    AxumPath(id): AxumPath<String>,
+) -> Result<Response, ApiError> {
+    let api = state.eval_api;
+    let evidence = tokio::task::spawn_blocking(move || api.case(&id))
+        .await
+        .map_err(ApiError::internal)?
+        .map_err(ApiError::internal)?;
+    evidence
+        .map(|evidence| Json(evidence).into_response())
+        .ok_or_else(|| ApiError::not_found("evaluation case was not found"))
 }
 
 async fn claim(
@@ -1000,7 +1092,10 @@ allow_internet = false
             fs::write(&evidence, format!("{{\"worker\":\"{name}\"}}\n")).unwrap();
             fs::write(
                 output.join("events.jsonl"),
-                format!("{{\"worker\":\"{name}\"}}\n"),
+                format!(
+                    "{{\"type\":\"attempt_started\",\"payload\":{{\"prompt\":\"do it\"}},\"attempt\":{{\"task_name\":\"one\"}}}}\n\
+                     {{\"type\":\"completed\",\"payload\":{{\"task_name\":\"one\",\"status\":\"passed\",\"outcome\":\"passed\",\"environment\":\"micro_vm\",\"agent\":{{\"model\":\"sol\",\"effort\":\"high\",\"tool_calls\":1,\"usage\":{{\"total_tokens\":10}}}},\"verifier\":{{\"exit_code\":0,\"rewards\":{{\"reward\":1}}}}}}}}\n"
+                ),
             )
             .unwrap();
             fs::write(
@@ -1020,6 +1115,91 @@ allow_internet = false
         assert_eq!(status["coordinates"]["complete"], 2);
         assert_eq!(status["coordinates"]["pending"], 0);
         assert_eq!(status["families"][0]["assigned_host"], "worker-one");
+        let overview: serde_json::Value = decode(
+            client
+                .http
+                .get(client.endpoint("v1/evals").unwrap())
+                .send()
+                .await
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(overview["worksets"][0]["summary"]["completed"], 2);
+        assert_eq!(overview["worksets"][0]["taskCount"], 1);
+        let digest = overview["worksets"][0]["id"].as_str().unwrap();
+        let workset: serde_json::Value = decode(
+            client
+                .http
+                .get(
+                    client
+                        .endpoint(&format!("v1/evals/worksets/{digest}"))
+                        .unwrap(),
+                )
+                .send()
+                .await
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(workset["tasks"][0]["summary"]["completed"], 2);
+        let task_id = workset["tasks"][0]["id"].as_str().unwrap();
+        let task: serde_json::Value = decode(
+            client
+                .http
+                .get(
+                    client
+                        .endpoint(&format!("v1/evals/worksets/{digest}/tasks/{task_id}"))
+                        .unwrap(),
+                )
+                .send()
+                .await
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            task["task"]["treatments"][0]["cells"]
+                .as_array()
+                .unwrap()
+                .len(),
+            2
+        );
+        assert!(task["task"]["treatments"][0]["cells"][0]["status"].is_null());
+        let outcomes: serde_json::Value = decode(
+            client
+                .http
+                .get(
+                    client
+                        .endpoint(&format!(
+                            "v1/evals/worksets/{digest}/tasks/{task_id}/outcomes?limit=1"
+                        ))
+                        .unwrap(),
+                )
+                .send()
+                .await
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(outcomes["total"], 2);
+        assert_eq!(outcomes["outcomes"][0]["status"], "passed");
+        assert_eq!(outcomes["nextCursor"], 1);
+        let case = task["task"]["treatments"][0]["cells"][0]["detailId"]
+            .as_str()
+            .unwrap();
+        let detail: serde_json::Value = decode(
+            client
+                .http
+                .get(client.endpoint(&format!("v1/evals/cases/{case}")).unwrap())
+                .send()
+                .await
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(detail["status"], "passed");
+        assert_eq!(detail["prompt"], "do it");
         let artifacts = directory.path().join("state/artifacts");
         assert_eq!(count_named_files(&artifacts, "events.jsonl"), 2);
         assert_eq!(count_named_files(&artifacts, "trajectory.json"), 2);

--- a/crates/experimental/nanocodex-eval/src/coordinator.rs
+++ b/crates/experimental/nanocodex-eval/src/coordinator.rs
@@ -879,8 +879,10 @@ impl IntoResponse for ApiError {
 mod tests {
     use std::{fs, path::Path};
 
+    use nanocodex_oai_api::{Model, Thinking};
+
     use super::*;
-    use crate::{EvaluationSelector, coordinator::RemoteClaim};
+    use crate::{EvaluationSelector, EvaluationWork, Task, coordinator::RemoteClaim};
 
     fn write_task(root: &Path) {
         let task = root.join("one");
@@ -931,20 +933,15 @@ allow_internet = false
     ) {
         let directory = tempfile::tempdir().unwrap();
         write_task(directory.path());
-        let config = directory.path().join("nanocodex.toml");
-        fs::write(
-            &config,
-            r#"[profiles.release]
-tasks = ["one"]
-trials = 2
-model = ["sol"]
-thinking = ["high"]
-"#,
-        )
-        .unwrap();
         let state = directory.path().join("state");
-        Evaluation::add_profile(&config, Some("release"), &state, "release", false).unwrap();
-        let evaluation = Evaluation::open(&config, "release", state).unwrap();
+        let task = Task::load(directory.path().join("one")).unwrap();
+        let work = EvaluationWork::new("one", task)
+            .model(Model::Sol)
+            .thinking(Thinking::High)
+            .trials(2);
+        Evaluation::add(&state, "release", &[work], false).unwrap();
+        let missing_profile = directory.path().join("profile-is-not-required.toml");
+        let evaluation = Evaluation::open(missing_profile, "release", state).unwrap();
         let selection = EvaluationSelector::new("one");
         let listener = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
             .await

--- a/crates/experimental/nanocodex-eval/src/coordinator.rs
+++ b/crates/experimental/nanocodex-eval/src/coordinator.rs
@@ -976,15 +976,16 @@ mod tests {
     use super::*;
     use crate::{EvaluationSelector, EvaluationWork, Task, coordinator::RemoteClaim};
 
-    fn write_task(root: &Path) {
-        let task = root.join("one");
+    fn write_task(root: &Path, name: &str) {
+        let task = root.join(name);
         fs::create_dir_all(task.join("environment")).unwrap();
         fs::create_dir_all(task.join("tests")).unwrap();
         fs::write(
             task.join("task.toml"),
-            r#"schema_version = "1.1"
+            format!(
+                r#"schema_version = "1.1"
 [task]
-name = "one"
+name = "{name}"
 description = "test"
 [agent]
 timeout_sec = 1.0
@@ -998,6 +999,8 @@ storage_mb = 128
 gpus = 0
 allow_internet = false
 "#,
+                name = name
+            ),
         )
         .unwrap();
         fs::write(task.join("instruction.md"), "do it").unwrap();
@@ -1011,12 +1014,13 @@ allow_internet = false
         EvaluationSelector,
         JoinHandle<()>,
     ) {
-        fixture_with_policy(Duration::from_secs(30), Duration::from_secs(5)).await
+        fixture_with_policy(Duration::from_secs(30), Duration::from_secs(5), 2).await
     }
 
     async fn fixture_with_policy(
         lease_duration: Duration,
         worker_timeout: Duration,
+        trials: u16,
     ) -> (
         tempfile::TempDir,
         CoordinatorClient,
@@ -1024,13 +1028,13 @@ allow_internet = false
         JoinHandle<()>,
     ) {
         let directory = tempfile::tempdir().unwrap();
-        write_task(directory.path());
+        write_task(directory.path(), "one");
         let state = directory.path().join("state");
         let task = Task::load(directory.path().join("one")).unwrap();
         let work = EvaluationWork::new("one", task)
             .model(Model::Sol)
             .thinking(Thinking::High)
-            .trials(2);
+            .trials(trials);
         Evaluation::add(&state, "release", &[work], false).unwrap();
         let missing_profile = directory.path().join("profile-is-not-required.toml");
         let evaluation = Evaluation::open(missing_profile, "release", state).unwrap();
@@ -1047,6 +1051,92 @@ allow_internet = false
         });
         let client = CoordinatorClient::new(&format!("http://{address}")).unwrap();
         (directory, client, selection, server)
+    }
+
+    #[tokio::test]
+    async fn running_coordinator_reads_appends_and_new_generations_from_sqlite() {
+        let (directory, client, _selection, server) = fixture().await;
+        let state = directory.path().join("state");
+        write_task(directory.path(), "two");
+        let two = Task::load(directory.path().join("two")).unwrap();
+        Evaluation::add(
+            &state,
+            "release",
+            &[EvaluationWork::new("two", two)
+                .model(Model::Sol)
+                .thinking(Thinking::High)],
+            false,
+        )
+        .unwrap();
+
+        let appended = client.status().await.unwrap();
+        assert_eq!(appended["coordinates"]["pending"], 3);
+        assert_eq!(appended["families"].as_array().unwrap().len(), 2);
+        let two = EvaluationSelector::new("two");
+        let RemoteClaim::Prepare { lease, .. } = client.claim(&two).await.unwrap() else {
+            panic!("the running coordinator must claim newly appended work");
+        };
+        client.prepared(&lease).await.unwrap();
+        let RemoteClaim::Run { lease, .. } = client.claim(&two).await.unwrap() else {
+            panic!("the appended task must become runnable");
+        };
+        client.retry(&lease, "test cleanup").await.unwrap();
+
+        let previous_generation = appended["generation"].as_str().unwrap().to_owned();
+        let one = Task::load(directory.path().join("one")).unwrap();
+        Evaluation::add(
+            &state,
+            "release",
+            &[EvaluationWork::new("one", one)
+                .model(Model::Sol)
+                .thinking(Thinking::High)
+                .trials(3)],
+            true,
+        )
+        .unwrap();
+
+        let replaced = client.status().await.unwrap();
+        assert_ne!(replaced["generation"], previous_generation);
+        assert_eq!(replaced["coordinates"]["pending"], 3);
+        assert_eq!(replaced["families"].as_array().unwrap().len(), 1);
+        server.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn concurrent_workers_claim_every_repetition_exactly_once() {
+        const TRIALS: u16 = 32;
+        let (_directory, client, selection, server) =
+            fixture_with_policy(Duration::from_secs(30), Duration::from_secs(5), TRIALS).await;
+        let client = client.worker("saturated-host");
+        let RemoteClaim::Prepare { lease, .. } = client.claim(&selection).await.unwrap() else {
+            panic!("first claim should prepare the task");
+        };
+        client.prepared(&lease).await.unwrap();
+
+        let claims = futures_util::future::join_all((0..TRIALS).map(|_| {
+            let client = client.clone();
+            let selection = selection.clone();
+            async move { client.claim(&selection).await }
+        }))
+        .await;
+        let mut repetitions = Vec::with_capacity(usize::from(TRIALS));
+        let mut leases = Vec::with_capacity(usize::from(TRIALS));
+        for claim in claims {
+            let RemoteClaim::Run {
+                lease, repetition, ..
+            } = claim.unwrap()
+            else {
+                panic!("every available repetition should be claimed");
+            };
+            repetitions.push(repetition);
+            leases.push(lease);
+        }
+        repetitions.sort_unstable();
+        assert_eq!(repetitions, (1..=TRIALS).collect::<Vec<_>>());
+        for lease in leases {
+            client.retry(&lease, "test cleanup").await.unwrap();
+        }
+        server.abort();
     }
 
     #[tokio::test]
@@ -1246,7 +1336,7 @@ allow_internet = false
     #[tokio::test]
     async fn unreachable_worker_is_reclaimed_and_its_stale_token_is_fenced() {
         let (_directory, client, selection, server) =
-            fixture_with_policy(Duration::from_millis(80), Duration::from_millis(20)).await;
+            fixture_with_policy(Duration::from_millis(80), Duration::from_millis(20), 2).await;
         let RemoteClaim::Prepare {
             lease: preparation, ..
         } = client.claim(&selection).await.unwrap()

--- a/crates/experimental/nanocodex-eval/src/coordinator.rs
+++ b/crates/experimental/nanocodex-eval/src/coordinator.rs
@@ -24,7 +24,10 @@ use tokio::{io::AsyncWriteExt as _, net::TcpListener, sync::Mutex, task::JoinHan
 use tokio_util::io::{ReaderStream, SyncIoBridge};
 use uuid::Uuid;
 
-use crate::{CoordinateClaim, Evaluation, EvaluationClaim, EvaluationSelection, PreparationClaim};
+use crate::{
+    CoordinateClaim, Evaluation, EvaluationClaim, EvaluationSelector, EvaluationTreatment,
+    PreparationClaim,
+};
 
 const MAX_COMPRESSED_ARTIFACT_BYTES: u64 = 512 * 1024 * 1024;
 const MAX_EXTRACTED_ARTIFACT_BYTES: u64 = 2 * 1024 * 1024 * 1024;
@@ -52,13 +55,20 @@ pub struct CoordinatorClient {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RemoteClaim {
     /// This host must prepare the selected task first.
-    Prepare(RemoteLease),
+    Prepare {
+        /// Opaque lease capability required for all later mutations.
+        lease: RemoteLease,
+        /// Exact treatment resolved by the coordinator from SQLite.
+        treatment: EvaluationTreatment,
+    },
     /// Execute one coordinator-allocated repetition.
     Run {
         /// Opaque lease capability required for all later mutations.
         lease: RemoteLease,
         /// Internal fungible repetition selected by SQLite.
         repetition: u16,
+        /// Exact treatment resolved by the coordinator from SQLite.
+        treatment: EvaluationTreatment,
     },
     /// Matching work is temporarily unavailable.
     Busy {
@@ -103,6 +113,9 @@ pub enum CoordinatorError {
     /// Blocking archive construction or extraction failed.
     #[error("evaluation artifact archive task failed: {0}")]
     ArchiveTask(#[from] tokio::task::JoinError),
+    /// Coordinator returned an invalid retained treatment.
+    #[error("evaluation coordinator returned an invalid treatment: {0}")]
+    InvalidTreatment(String),
 }
 
 #[derive(Clone)]
@@ -124,17 +137,38 @@ enum HeldClaim {
 
 #[derive(Deserialize)]
 struct ClaimRequest {
-    profile_digest: String,
-    family_key: String,
+    task: String,
+    harness: Option<String>,
+    model: Option<String>,
+    thinking: Option<String>,
+    web_search: Option<bool>,
     worker: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct WireTreatment {
+    harness: String,
+    model: String,
+    thinking: String,
+    web_search: bool,
 }
 
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
 enum ClaimResponse {
-    Prepare { lease: String },
-    Run { lease: String, repetition: u16 },
-    Busy { reason: String, retry_after_ms: u64 },
+    Prepare {
+        lease: String,
+        treatment: WireTreatment,
+    },
+    Run {
+        lease: String,
+        repetition: u16,
+        treatment: WireTreatment,
+    },
+    Busy {
+        reason: String,
+        retry_after_ms: u64,
+    },
     Complete,
 }
 
@@ -258,17 +292,20 @@ impl CoordinatorClient {
         decode(response).await
     }
 
-    /// Claims preparation or one repetition for an exact local profile selection.
+    /// Claims preparation or one repetition matching ordinary task selectors.
     pub async fn claim(
         &self,
-        selection: &EvaluationSelection,
+        selector: &EvaluationSelector,
     ) -> Result<RemoteClaim, CoordinatorError> {
         let response: ClaimResponse = decode(
             self.http
                 .post(self.endpoint("v1/claims")?)
                 .json(&serde_json::json!({
-                    "profile_digest": selection.profile_digest(),
-                    "family_key": selection.family_key(),
+                    "task": selector.task(),
+                    "harness": selector.harness_name(),
+                    "model": selector.model_value().map(|model| model.as_str()),
+                    "thinking": selector.thinking_value().map(|thinking| thinking.as_str()),
+                    "web_search": selector.web_search_value(),
                     "worker": self.worker,
                 }))
                 .send()
@@ -276,10 +313,18 @@ impl CoordinatorClient {
         )
         .await?;
         Ok(match response {
-            ClaimResponse::Prepare { lease } => RemoteClaim::Prepare(RemoteLease { token: lease }),
-            ClaimResponse::Run { lease, repetition } => RemoteClaim::Run {
+            ClaimResponse::Prepare { lease, treatment } => RemoteClaim::Prepare {
+                lease: RemoteLease { token: lease },
+                treatment: treatment.try_into()?,
+            },
+            ClaimResponse::Run {
+                lease,
+                repetition,
+                treatment,
+            } => RemoteClaim::Run {
                 lease: RemoteLease { token: lease },
                 repetition,
+                treatment: treatment.try_into()?,
             },
             ClaimResponse::Busy {
                 reason,
@@ -401,24 +446,38 @@ async fn claim(
         .worker
         .filter(|worker| !worker.trim().is_empty())
         .unwrap_or_else(|| peer.ip().to_string());
+    let model = request
+        .model
+        .map(|model| model.parse().map_err(ApiError::bad_request))
+        .transpose()?;
+    let thinking = request
+        .thinking
+        .map(|thinking| thinking.parse().map_err(ApiError::bad_request))
+        .transpose()?;
+    let selector = EvaluationSelector::new(request.task)
+        .harness(request.harness)
+        .model(model)
+        .thinking(thinking)
+        .web_search(request.web_search);
     let claim = state
         .evaluation
-        .claim_family_for_host(
-            &request.profile_digest,
-            &request.family_key,
-            &host,
-            state.lease_duration,
-        )
+        .claim_for_host(&selector, &host, state.lease_duration)
         .map_err(ApiError::bad_gateway)?;
     let response = match claim {
         EvaluationClaim::Prepare(claim) => {
+            let treatment = claim.treatment().into();
             let lease = insert_claim(&state, HeldClaim::Preparation(claim)).await;
-            ClaimResponse::Prepare { lease }
+            ClaimResponse::Prepare { lease, treatment }
         }
         EvaluationClaim::Run(claim) => {
             let repetition = claim.repetition();
+            let treatment = claim.treatment().into();
             let lease = insert_claim(&state, HeldClaim::Coordinate(claim)).await;
-            ClaimResponse::Run { lease, repetition }
+            ClaimResponse::Run {
+                lease,
+                repetition,
+                treatment,
+            }
         }
         EvaluationClaim::Busy(busy) => ClaimResponse::Busy {
             reason: busy.reason.to_owned(),
@@ -775,6 +834,38 @@ impl ApiError {
     }
 }
 
+impl From<&EvaluationTreatment> for WireTreatment {
+    fn from(treatment: &EvaluationTreatment) -> Self {
+        Self {
+            harness: treatment.harness.clone(),
+            model: treatment.model.as_str().to_owned(),
+            thinking: treatment.thinking.as_str().to_owned(),
+            web_search: treatment.web_search,
+        }
+    }
+}
+
+impl TryFrom<WireTreatment> for EvaluationTreatment {
+    type Error = CoordinatorError;
+
+    fn try_from(treatment: WireTreatment) -> Result<Self, Self::Error> {
+        let model = treatment
+            .model
+            .parse()
+            .map_err(|error| CoordinatorError::InvalidTreatment(format!("model: {error}")))?;
+        let thinking = treatment
+            .thinking
+            .parse()
+            .map_err(|error| CoordinatorError::InvalidTreatment(format!("thinking: {error}")))?;
+        Ok(Self {
+            harness: treatment.harness,
+            model,
+            thinking,
+            web_search: treatment.web_search,
+        })
+    }
+}
+
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         let body = Json(ErrorBody {
@@ -823,7 +914,7 @@ allow_internet = false
     async fn fixture() -> (
         tempfile::TempDir,
         CoordinatorClient,
-        EvaluationSelection,
+        EvaluationSelector,
         JoinHandle<()>,
     ) {
         fixture_with_policy(Duration::from_secs(30), Duration::from_secs(5)).await
@@ -835,7 +926,7 @@ allow_internet = false
     ) -> (
         tempfile::TempDir,
         CoordinatorClient,
-        EvaluationSelection,
+        EvaluationSelector,
         JoinHandle<()>,
     ) {
         let directory = tempfile::tempdir().unwrap();
@@ -851,11 +942,10 @@ thinking = ["high"]
 "#,
         )
         .unwrap();
-        let evaluation =
-            Evaluation::open(&config, Some("release"), directory.path().join("state")).unwrap();
-        let selection =
-            EvaluationSelection::load(&config, Some("release"), &EvaluationSelector::new("one"))
-                .unwrap();
+        let state = directory.path().join("state");
+        Evaluation::add_profile(&config, Some("release"), &state, "release", false).unwrap();
+        let evaluation = Evaluation::open(&config, "release", state).unwrap();
+        let selection = EvaluationSelector::new("one");
         let listener = TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
             .await
             .unwrap();
@@ -874,7 +964,10 @@ thinking = ["high"]
     async fn workers_prepare_claim_upload_and_converge_through_the_coordinator() {
         let (directory, client, selection, server) = fixture().await;
         let client = client.worker("worker-one");
-        let RemoteClaim::Prepare(preparation) = client.claim(&selection).await.unwrap() else {
+        let RemoteClaim::Prepare {
+            lease: preparation, ..
+        } = client.claim(&selection).await.unwrap()
+        else {
             panic!("first worker should prepare");
         };
         client.heartbeat(&preparation).await.unwrap();
@@ -884,6 +977,7 @@ thinking = ["high"]
         let RemoteClaim::Run {
             lease: first_lease,
             repetition: first_repetition,
+            ..
         } = first.unwrap()
         else {
             panic!("first worker should run");
@@ -891,6 +985,7 @@ thinking = ["high"]
         let RemoteClaim::Run {
             lease: second_lease,
             repetition: second_repetition,
+            ..
         } = second.unwrap()
         else {
             panic!("second worker should run");
@@ -977,7 +1072,10 @@ thinking = ["high"]
     async fn unreachable_worker_is_reclaimed_and_its_stale_token_is_fenced() {
         let (_directory, client, selection, server) =
             fixture_with_policy(Duration::from_millis(80), Duration::from_millis(20)).await;
-        let RemoteClaim::Prepare(preparation) = client.claim(&selection).await.unwrap() else {
+        let RemoteClaim::Prepare {
+            lease: preparation, ..
+        } = client.claim(&selection).await.unwrap()
+        else {
             panic!("first worker should prepare");
         };
         client.prepared(&preparation).await.unwrap();
@@ -985,6 +1083,7 @@ thinking = ["high"]
         let RemoteClaim::Run {
             lease: stale,
             repetition,
+            ..
         } = client.claim(&selection).await.unwrap()
         else {
             panic!("first worker should run");
@@ -994,6 +1093,7 @@ thinking = ["high"]
         let RemoteClaim::Run {
             lease: replacement,
             repetition: replacement_repetition,
+            ..
         } = client.claim(&selection).await.unwrap()
         else {
             panic!("expired work should be reclaimed");

--- a/crates/experimental/nanocodex-eval/src/coordinator.rs
+++ b/crates/experimental/nanocodex-eval/src/coordinator.rs
@@ -674,10 +674,31 @@ fn spawn_reaper(
         ticker.tick().await;
         loop {
             ticker.tick().await;
-            active
-                .lock()
-                .await
-                .retain(|_, claim| claim.last_seen.elapsed() <= worker_timeout);
+            let expired = {
+                let mut active = active.lock().await;
+                let tokens = active
+                    .iter()
+                    .filter(|(_, claim)| claim.last_seen.elapsed() > worker_timeout)
+                    .map(|(token, _)| token.clone())
+                    .collect::<Vec<_>>();
+                tokens
+                    .into_iter()
+                    .filter_map(|token| active.remove(&token))
+                    .collect::<Vec<_>>()
+            };
+            for expired in expired {
+                let result = match expired.claim {
+                    HeldClaim::Preparation(claim) => {
+                        claim.retry("coordinator worker heartbeat expired")
+                    }
+                    HeldClaim::Coordinate(claim) => {
+                        claim.retry("coordinator worker heartbeat expired")
+                    }
+                };
+                if let Err(error) = result {
+                    tracing::warn!(%error, "failed to release expired coordinator claim");
+                }
+            }
         }
     })
 }
@@ -1336,7 +1357,7 @@ allow_internet = false
     #[tokio::test]
     async fn unreachable_worker_is_reclaimed_and_its_stale_token_is_fenced() {
         let (_directory, client, selection, server) =
-            fixture_with_policy(Duration::from_millis(80), Duration::from_millis(20), 2).await;
+            fixture_with_policy(Duration::from_secs(30), Duration::from_millis(20), 2).await;
         let RemoteClaim::Prepare {
             lease: preparation, ..
         } = client.claim(&selection).await.unwrap()

--- a/crates/experimental/nanocodex-eval/src/coordinator.rs
+++ b/crates/experimental/nanocodex-eval/src/coordinator.rs
@@ -25,8 +25,8 @@ use tokio_util::io::{ReaderStream, SyncIoBridge};
 use uuid::Uuid;
 
 use crate::{
-    CoordinateClaim, Evaluation, EvaluationClaim, EvaluationSelector, EvaluationTreatment,
-    PreparationClaim, api::EvalApi,
+    CoordinateClaim, Evaluation, EvaluationClaim, EvaluationSelector, EvaluationStatus,
+    EvaluationTreatment, EvaluationWork, PreparationClaim, Task, api::EvalApi,
 };
 
 const MAX_COMPRESSED_ARTIFACT_BYTES: u64 = 512 * 1024 * 1024;
@@ -49,6 +49,37 @@ pub struct CoordinatorClient {
     base: Url,
     http: reqwest::Client,
     worker: Option<String>,
+}
+
+/// Work to append to the coordinator-owned SQLite evaluation.
+///
+/// Task paths are resolved on the coordinator host and must be absolute.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CoordinatorAddRequest {
+    /// Expected profile owned by the target coordinator.
+    pub profile: String,
+    /// Optional profile recipe resolved from the coordinator's configuration.
+    pub recipe: Option<String>,
+    /// Absolute task-package paths visible on the coordinator host.
+    #[serde(default)]
+    pub tasks: Vec<String>,
+    /// Harness matrix. An empty list selects built-in Nanocodex.
+    #[serde(default)]
+    pub harnesses: Vec<String>,
+    /// Model matrix. Values use ordinary Nanocodex model names.
+    #[serde(default)]
+    pub models: Vec<String>,
+    /// Reasoning-effort matrix.
+    #[serde(default)]
+    pub thinking: Vec<String>,
+    /// Desired repetitions for each concrete treatment.
+    pub trials: Option<u16>,
+    /// Whether model-facing web search is enabled.
+    #[serde(default)]
+    pub web_search: bool,
+    /// Whether to start a new generation instead of extending the latest one.
+    #[serde(default)]
+    pub new_generation: bool,
 }
 
 /// One action atomically allocated by the coordinator.
@@ -239,6 +270,7 @@ impl CoordinatorServer {
         let app = Router::new()
             .route("/v1/status", get(status))
             .route("/v1/evals", get(eval_overview))
+            .route("/v1/evals/work", post(add_work))
             .route("/v1/evals/worksets/{digest}", get(eval_workset))
             .route(
                 "/v1/evals/worksets/{digest}/tasks/{task_id}",
@@ -309,6 +341,20 @@ impl CoordinatorClient {
     /// Reads the coordinator's complete structured ledger snapshot.
     pub async fn status(&self) -> Result<serde_json::Value, CoordinatorError> {
         let response = self.http.get(self.endpoint("v1/status")?).send().await?;
+        decode(response).await
+    }
+
+    /// Appends work through the coordinator and returns the resulting status.
+    pub async fn add(
+        &self,
+        request: &CoordinatorAddRequest,
+    ) -> Result<serde_json::Value, CoordinatorError> {
+        let response = self
+            .http
+            .post(self.endpoint("v1/evals/work")?)
+            .json(request)
+            .send()
+            .await?;
         decode(response).await
     }
 
@@ -455,6 +501,130 @@ async fn status(
     Ok(Json(
         serde_json::to_value(status).map_err(ApiError::internal)?,
     ))
+}
+
+async fn add_work(
+    State(state): State<CoordinatorState>,
+    Json(request): Json<CoordinatorAddRequest>,
+) -> Result<Json<EvaluationStatus>, ApiError> {
+    let evaluation = state.evaluation;
+    let status = tokio::task::spawn_blocking(move || apply_add(&evaluation, request))
+        .await
+        .map_err(ApiError::internal)??;
+    Ok(Json(status))
+}
+
+fn apply_add(
+    evaluation: &Evaluation,
+    request: CoordinatorAddRequest,
+) -> Result<EvaluationStatus, ApiError> {
+    let CoordinatorAddRequest {
+        profile,
+        recipe,
+        tasks,
+        harnesses,
+        models,
+        thinking,
+        trials,
+        web_search,
+        new_generation,
+    } = request;
+    if profile != evaluation.name() {
+        return Err(ApiError::bad_request(format!(
+            "coordinator owns profile {:?}, not {:?}",
+            evaluation.name(),
+            profile
+        )));
+    }
+    if let Some(recipe) = recipe {
+        if !tasks.is_empty()
+            || !harnesses.is_empty()
+            || !models.is_empty()
+            || !thinking.is_empty()
+            || trials.is_some()
+            || web_search
+        {
+            return Err(ApiError::bad_request(
+                "recipe work cannot be combined with explicit work knobs",
+            ));
+        }
+        Evaluation::add_profile(
+            evaluation.config(),
+            Some(&recipe),
+            evaluation.state_directory(),
+            evaluation.name(),
+            new_generation,
+        )
+        .map_err(ApiError::ledger)?;
+        return evaluation.status().map_err(ApiError::ledger);
+    }
+    if tasks.is_empty() {
+        return Err(ApiError::bad_request(
+            "at least one task or recipe is required",
+        ));
+    }
+    let trials = trials.unwrap_or(1);
+    if trials == 0 {
+        return Err(ApiError::bad_request(
+            "evaluation treatments must request at least one trial",
+        ));
+    }
+    if harnesses.iter().any(|harness| harness.trim().is_empty()) {
+        return Err(ApiError::bad_request("harness names cannot be empty"));
+    }
+    let models = if models.is_empty() {
+        vec![nanocodex_oai_api::Model::default()]
+    } else {
+        models
+            .into_iter()
+            .map(|model| model.parse().map_err(ApiError::bad_request))
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    let thinking = if thinking.is_empty() {
+        vec![nanocodex_oai_api::Thinking::default()]
+    } else {
+        thinking
+            .into_iter()
+            .map(|thinking| thinking.parse().map_err(ApiError::bad_request))
+            .collect::<Result<Vec<_>, _>>()?
+    };
+    let mut work = Vec::new();
+    for selector in tasks {
+        let path = PathBuf::from(&selector);
+        if !path.is_absolute() {
+            return Err(ApiError::bad_request(format!(
+                "remote task paths must be absolute: {selector}"
+            )));
+        }
+        let task = Task::load(&path).map_err(ApiError::bad_request)?;
+        let selected_harnesses = harnesses
+            .iter()
+            .map(Some)
+            .chain(harnesses.is_empty().then_some(None));
+        for harness in selected_harnesses {
+            for model in &models {
+                for thinking in &thinking {
+                    let mut item = EvaluationWork::new(&selector, task.clone())
+                        .model(*model)
+                        .thinking(*thinking)
+                        .web_search(web_search)
+                        .trials(trials);
+                    if let Some(harness) = harness {
+                        item = item.harness(harness);
+                    }
+                    work.push(item);
+                }
+            }
+        }
+    }
+    Evaluation::add(
+        evaluation.state_directory(),
+        evaluation.name(),
+        &work,
+        new_generation,
+    )
+    .map_err(ApiError::ledger)?;
+    evaluation.status().map_err(ApiError::ledger)
 }
 
 async fn eval_overview(State(state): State<CoordinatorState>) -> Result<Response, ApiError> {
@@ -1120,6 +1290,131 @@ allow_internet = false
         assert_ne!(replaced["generation"], previous_generation);
         assert_eq!(replaced["coordinates"]["pending"], 3);
         assert_eq!(replaced["families"].as_array().unwrap().len(), 1);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn coordinator_add_route_appends_and_replaces_work_without_restart() {
+        let (directory, client, _selection, server) = fixture().await;
+        write_task(directory.path(), "two");
+        let two = directory.path().join("two");
+        let initial = client.status().await.unwrap();
+        let initial_generation = initial["generation"].as_str().unwrap().to_owned();
+
+        let appended = client
+            .add(&CoordinatorAddRequest {
+                profile: "release".to_owned(),
+                tasks: vec![two.to_string_lossy().into_owned()],
+                models: vec!["sol".to_owned()],
+                thinking: vec!["high".to_owned()],
+                trials: Some(3),
+                recipe: None,
+                harnesses: Vec::new(),
+                web_search: false,
+                new_generation: false,
+            })
+            .await
+            .unwrap();
+        assert_eq!(appended["generation"], initial_generation);
+        assert_eq!(appended["coordinates"]["pending"], 5);
+        assert_eq!(appended["families"].as_array().unwrap().len(), 2);
+
+        let selector = EvaluationSelector::new(two.to_string_lossy());
+        let RemoteClaim::Prepare { lease, .. } = client.claim(&selector).await.unwrap() else {
+            panic!("remotely appended work must be claimable immediately");
+        };
+        client.prepared(&lease).await.unwrap();
+        let RemoteClaim::Run { lease, .. } = client.claim(&selector).await.unwrap() else {
+            panic!("remotely appended work must become runnable");
+        };
+        client.retry(&lease, "test cleanup").await.unwrap();
+
+        let one = directory.path().join("one");
+        let replaced = client
+            .add(&CoordinatorAddRequest {
+                profile: "release".to_owned(),
+                tasks: vec![one.to_string_lossy().into_owned()],
+                models: vec!["sol".to_owned()],
+                thinking: vec!["high".to_owned()],
+                trials: Some(4),
+                new_generation: true,
+                recipe: None,
+                harnesses: Vec::new(),
+                web_search: false,
+            })
+            .await
+            .unwrap();
+        assert_ne!(replaced["generation"], initial_generation);
+        assert_eq!(replaced["coordinates"]["pending"], 4);
+        assert_eq!(replaced["families"].as_array().unwrap().len(), 1);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn coordinator_add_route_rejects_ambiguous_or_invalid_work() {
+        let (_directory, client, _selection, server) = fixture().await;
+        for request in [
+            CoordinatorAddRequest {
+                profile: "release".to_owned(),
+                tasks: vec!["relative/task".to_owned()],
+                recipe: None,
+                harnesses: Vec::new(),
+                models: Vec::new(),
+                thinking: Vec::new(),
+                trials: None,
+                web_search: false,
+                new_generation: false,
+            },
+            CoordinatorAddRequest {
+                profile: "release".to_owned(),
+                recipe: Some("release".to_owned()),
+                tasks: vec!["/srv/task".to_owned()],
+                harnesses: Vec::new(),
+                models: Vec::new(),
+                thinking: Vec::new(),
+                trials: None,
+                web_search: false,
+                new_generation: false,
+            },
+            CoordinatorAddRequest {
+                profile: "release".to_owned(),
+                tasks: vec!["/srv/task".to_owned()],
+                trials: Some(0),
+                recipe: None,
+                harnesses: Vec::new(),
+                models: Vec::new(),
+                thinking: Vec::new(),
+                web_search: false,
+                new_generation: false,
+            },
+        ] {
+            assert!(matches!(
+                client.add(&request).await,
+                Err(CoordinatorError::Rejected {
+                    status: StatusCode::BAD_REQUEST,
+                    ..
+                })
+            ));
+        }
+        assert!(matches!(
+            client
+                .add(&CoordinatorAddRequest {
+                    profile: "another-profile".to_owned(),
+                    recipe: None,
+                    tasks: vec!["/srv/task".to_owned()],
+                    harnesses: Vec::new(),
+                    models: Vec::new(),
+                    thinking: Vec::new(),
+                    trials: None,
+                    web_search: false,
+                    new_generation: false,
+                })
+                .await,
+            Err(CoordinatorError::Rejected {
+                status: StatusCode::BAD_REQUEST,
+                ..
+            })
+        ));
         server.abort();
     }
 

--- a/crates/experimental/nanocodex-eval/src/evaluation.rs
+++ b/crates/experimental/nanocodex-eval/src/evaluation.rs
@@ -14,7 +14,7 @@ use tokio::task::JoinHandle;
 
 use crate::{
     Task,
-    profile::{EvaluationManifest, ResolvedFamily, ResolvedHarness, ResolvedTask},
+    profile::{EvaluationManifest, ResolvedFamily, ResolvedHarness},
     workset::{
         BeginCoordinate, CoordinateLease, PreparationLease, Workset, WorksetBusy, WorksetError,
         WorksetFamily, WorksetTask,
@@ -27,10 +27,6 @@ const LEDGER_FILE: &str = "state.sqlite3";
 #[derive(Clone, Debug)]
 pub struct Evaluation {
     name: String,
-    generation: String,
-    tasks: Vec<ResolvedTask>,
-    families: Vec<ResolvedFamily>,
-    workset: Workset,
     state_directory: PathBuf,
     config: PathBuf,
 }
@@ -275,41 +271,9 @@ impl Evaluation {
         state_directory: impl Into<PathBuf>,
     ) -> Result<Self, EvaluationError> {
         let state_directory = state_directory.into();
-        let workset =
-            Workset::open(state_directory.join(LEDGER_FILE), workset_name).map_err(error)?;
-        let definition = workset.definition().map_err(error)?;
-        let mut tasks = Vec::with_capacity(definition.tasks.len());
-        for retained in definition.tasks {
-            let task = Task::load(&retained.root).map_err(error)?;
-            if task.name() != retained.name || task.package_digest() != retained.digest {
-                return Err(error(std::io::Error::other(format!(
-                    "retained task `{}` no longer matches SQLite content digest {}",
-                    retained.selector, retained.digest
-                ))));
-            }
-            tasks.push(ResolvedTask {
-                selector: retained.selector,
-                task,
-            });
-        }
-        let mut families = Vec::with_capacity(definition.families.len());
-        for retained in definition.families {
-            let family: ResolvedFamily =
-                serde_json::from_str(&retained.treatment).map_err(error)?;
-            if family.key != retained.key || family.task != retained.task_selector {
-                return Err(error(std::io::Error::other(format!(
-                    "invalid SQLite treatment for family `{}`",
-                    retained.key
-                ))));
-            }
-            families.push(family);
-        }
+        Workset::open(state_directory.join(LEDGER_FILE), workset_name).map_err(error)?;
         Ok(Self {
-            name: definition.name,
-            generation: definition.generation,
-            tasks,
-            families,
-            workset,
+            name: workset_name.to_owned(),
             state_directory,
             config: config.as_ref().to_path_buf(),
         })
@@ -327,26 +291,24 @@ impl Evaluation {
 
     /// Reads a structured snapshot from SQLite.
     pub fn status(&self) -> Result<EvaluationStatus, EvaluationError> {
-        let status = self.workset.status().map_err(error)?;
+        let status = self.workset()?.status().map_err(error)?;
         let families = status
             .families
             .into_iter()
             .map(|status| -> Result<_, EvaluationError> {
-                let family = self
-                    .families
-                    .iter()
-                    .find(|family| family.key == status.key)
-                    .ok_or_else(|| {
-                        error(std::io::Error::other(format!(
-                            "SQLite contains unknown workset family `{}`",
-                            status.key
-                        )))
-                    })?;
+                let family: ResolvedFamily =
+                    serde_json::from_str(&status.treatment).map_err(error)?;
+                if family.key != status.key || family.task != status.task {
+                    return Err(error(std::io::Error::other(format!(
+                        "invalid SQLite treatment for family `{}`",
+                        status.key
+                    ))));
+                }
                 Ok(EvaluationFamilyStatus {
                     id: status.key,
                     task: status.task,
                     assigned_host: status.assigned_host,
-                    treatment: family.into(),
+                    treatment: (&family).into(),
                     desired: status.desired,
                     pending: status.pending,
                     running: status.running,
@@ -380,8 +342,9 @@ impl Evaluation {
         selector: &EvaluationSelector,
         lease_duration: Duration,
     ) -> Result<EvaluationClaim, EvaluationError> {
-        let family = self.resolve_family(selector)?.clone();
-        self.claim_resolved(&family, "local", lease_duration, true)
+        let workset = self.workset()?;
+        let (task, family) = self.resolve_selection(&workset, selector)?;
+        self.claim_resolved(workset, task, family, "local", lease_duration, true)
     }
 
     /// Claims one family for the network host chosen by the coordinator.
@@ -391,22 +354,44 @@ impl Evaluation {
         host: &str,
         lease_duration: Duration,
     ) -> Result<EvaluationClaim, EvaluationError> {
-        let family = self.resolve_family(selector)?.clone();
-        self.claim_resolved(&family, host, lease_duration, false)
+        let workset = self.workset()?;
+        let (task, family) = self.resolve_selection(&workset, selector)?;
+        self.claim_resolved(workset, task, family, host, lease_duration, false)
     }
 
-    fn resolve_family(
+    fn resolve_selection(
         &self,
+        workset: &Workset,
         selector: &EvaluationSelector,
-    ) -> Result<&ResolvedFamily, EvaluationError> {
-        self.task(&selector.task)?;
+    ) -> Result<(Task, ResolvedFamily), EvaluationError> {
+        let Some((retained_task, retained_families)) =
+            workset.selected_definition(&selector.task).map_err(error)?
+        else {
+            return Err(error(std::io::Error::other(format!(
+                "task `{}` is not part of profile `{}`",
+                selector.task, self.name
+            ))));
+        };
+        let families = retained_families
+            .into_iter()
+            .map(|retained| {
+                let family: ResolvedFamily =
+                    serde_json::from_str(&retained.treatment).map_err(error)?;
+                if family.key != retained.key || family.task != retained.task_selector {
+                    return Err(error(std::io::Error::other(format!(
+                        "invalid SQLite treatment for family `{}`",
+                        retained.key
+                    ))));
+                }
+                Ok(family)
+            })
+            .collect::<Result<Vec<_>, EvaluationError>>()?;
         let harness = selector
             .harness
             .as_deref()
             .unwrap_or(crate::profile::BUILTIN_HARNESS);
-        let matching = self
-            .families
-            .iter()
+        let matching = families
+            .into_iter()
             .filter(|family| {
                 family.task == selector.task
                     && family.harness == harness
@@ -419,46 +404,54 @@ impl Evaluation {
                         .is_none_or(|web_search| family.web_search == web_search)
             })
             .collect::<Vec<_>>();
-        match matching.as_slice() {
-            [family] => Ok(family),
+        let family = match matching.as_slice() {
+            [family] => family.clone(),
             [] => Err(error(std::io::Error::other(format!(
                 "no treatment in profile `{}` matches task `{}` and the requested knobs",
                 self.name, selector.task
-            )))),
+            ))))?,
             _ => Err(error(std::io::Error::other(format!(
                 "task `{}` has multiple treatments in profile `{}`; select model and/or thinking",
                 selector.task, self.name
-            )))),
+            ))))?,
+        };
+        let task = Task::load(&retained_task.root).map_err(error)?;
+        if task.name() != retained_task.name || task.package_digest() != retained_task.digest {
+            return Err(error(std::io::Error::other(format!(
+                "retained task `{}` no longer matches SQLite content digest {}",
+                retained_task.selector, retained_task.digest
+            ))));
         }
+        Ok((task, family))
     }
 
     fn claim_resolved(
         &self,
-        family: &ResolvedFamily,
+        workset: Workset,
+        task: Task,
+        family: ResolvedFamily,
         host: &str,
         lease_duration: Duration,
         resolve_harness: bool,
     ) -> Result<EvaluationClaim, EvaluationError> {
-        let task = self.task(&family.task)?.task.clone();
         let harness = if resolve_harness {
             EvaluationManifest::load_harness(&self.config, &family.harness).map_err(error)?
         } else {
             None
         };
         let harnesses = harness.iter().cloned().collect::<Vec<_>>();
-        match self
-            .workset
+        match workset
             .begin_for_host(&family.key, host, lease_duration)
             .map_err(error)?
         {
             BeginCoordinate::Prepare(lease) => {
                 let heartbeat =
-                    preparation_heartbeat(self.workset.clone(), lease.clone(), lease_duration);
+                    preparation_heartbeat(workset.clone(), lease.clone(), lease_duration);
                 Ok(EvaluationClaim::Prepare(PreparationClaim {
-                    workset: self.workset.clone(),
+                    workset,
                     lease,
                     task,
-                    treatment: family.into(),
+                    treatment: (&family).into(),
                     harnesses,
                     heartbeat,
                 }))
@@ -466,18 +459,18 @@ impl Evaluation {
             BeginCoordinate::Execute(lease) => {
                 let output_directory = coordinate_output(
                     &self.state_directory,
-                    &self.generation,
+                    workset.generation(),
                     &family.key,
                     lease.repetition,
                     lease.generation,
                 );
                 let heartbeat =
-                    coordinate_heartbeat(self.workset.clone(), lease.clone(), lease_duration);
+                    coordinate_heartbeat(workset.clone(), lease.clone(), lease_duration);
                 Ok(EvaluationClaim::Run(CoordinateClaim {
-                    workset: self.workset.clone(),
+                    workset,
                     lease,
                     task,
-                    treatment: family.into(),
+                    treatment: (&family).into(),
                     harness,
                     harnesses,
                     output_directory,
@@ -489,16 +482,8 @@ impl Evaluation {
         }
     }
 
-    fn task(&self, selector: &str) -> Result<&ResolvedTask, EvaluationError> {
-        self.tasks
-            .iter()
-            .find(|task| task.selector == selector)
-            .ok_or_else(|| {
-                error(std::io::Error::other(format!(
-                    "task `{selector}` is not part of profile `{}`",
-                    self.name
-                )))
-            })
+    fn workset(&self) -> Result<Workset, EvaluationError> {
+        Workset::open(self.state_directory.join(LEDGER_FILE), &self.name).map_err(error)
     }
 }
 
@@ -847,14 +832,19 @@ mod tests {
     use super::*;
 
     fn write_task(root: &Path) {
-        let task = root.join("one");
+        write_named_task(root, "one");
+    }
+
+    fn write_named_task(root: &Path, name: &str) {
+        let task = root.join(name);
         fs::create_dir_all(task.join("environment")).unwrap();
         fs::create_dir_all(task.join("tests")).unwrap();
         fs::write(
             task.join("task.toml"),
-            r#"schema_version = "1.1"
+            format!(
+                r#"schema_version = "1.1"
 [task]
-name = "one"
+name = "{name}"
 description = "test"
 [agent]
 timeout_sec = 1.0
@@ -867,12 +857,59 @@ memory_mb = 128
 storage_mb = 128
 gpus = 0
 allow_internet = false
-"#,
+"#
+            ),
         )
         .unwrap();
         fs::write(task.join("instruction.md"), "do it").unwrap();
         fs::write(task.join("environment/Dockerfile"), "FROM scratch").unwrap();
         fs::write(task.join("tests/test.sh"), "#!/bin/sh\n").unwrap();
+    }
+
+    #[tokio::test]
+    async fn open_handle_reads_hot_appends_and_new_generations_from_sqlite() {
+        let directory = tempfile::tempdir().unwrap();
+        write_named_task(directory.path(), "one");
+        write_named_task(directory.path(), "two");
+        let state = directory.path().join("state");
+        let config = directory.path().join("nanocodex.toml");
+        let one = Task::load(directory.path().join("one")).unwrap();
+        let two = Task::load(directory.path().join("two")).unwrap();
+
+        Evaluation::add(
+            &state,
+            "release",
+            &[EvaluationWork::new("one", one.clone())],
+            false,
+        )
+        .unwrap();
+        let evaluation = Evaluation::open(&config, "release", &state).unwrap();
+        let first = evaluation.status().unwrap();
+        assert_eq!(first.coordinates.pending, 1);
+
+        Evaluation::add(&state, "release", &[EvaluationWork::new("two", two)], false).unwrap();
+        let extended = evaluation.status().unwrap();
+        assert_eq!(extended.coordinates.pending, 2);
+        assert_eq!(extended.families.len(), 2);
+        let EvaluationClaim::Prepare(preparation) = evaluation
+            .claim(&EvaluationSelector::new("two"), Duration::from_secs(30))
+            .unwrap()
+        else {
+            panic!("the already-open handle must claim newly appended work");
+        };
+        preparation.complete().unwrap();
+
+        Evaluation::add(
+            &state,
+            "release",
+            &[EvaluationWork::new("one", one).trials(3)],
+            true,
+        )
+        .unwrap();
+        let replaced = evaluation.status().unwrap();
+        assert_ne!(replaced.generation, first.generation);
+        assert_eq!(replaced.coordinates.pending, 3);
+        assert_eq!(replaced.families.len(), 1);
     }
 
     #[tokio::test]

--- a/crates/experimental/nanocodex-eval/src/evaluation.rs
+++ b/crates/experimental/nanocodex-eval/src/evaluation.rs
@@ -14,7 +14,7 @@ use tokio::task::JoinHandle;
 
 use crate::{
     Task,
-    profile::{EvaluationManifest, ResolvedFamily, ResolvedHarness, ResolvedProfile},
+    profile::{EvaluationManifest, ResolvedFamily, ResolvedHarness, ResolvedTask},
     workset::{
         BeginCoordinate, CoordinateLease, PreparationLease, Workset, WorksetBusy, WorksetError,
         WorksetFamily, WorksetTask,
@@ -26,13 +26,16 @@ const LEDGER_FILE: &str = "state.sqlite3";
 /// One named durable SQLite workset.
 #[derive(Clone, Debug)]
 pub struct Evaluation {
-    profile: ResolvedProfile,
+    name: String,
+    generation: String,
+    tasks: Vec<ResolvedTask>,
+    families: Vec<ResolvedFamily>,
     workset: Workset,
     state_directory: PathBuf,
     config: PathBuf,
 }
 
-/// Optional knobs selecting one exact family already present in a profile.
+/// Optional knobs selecting one exact family already present in a workset.
 #[derive(Clone, Debug)]
 pub struct EvaluationSelector {
     task: String,
@@ -78,7 +81,7 @@ pub struct PreparationClaim {
     heartbeat: JoinHandle<()>,
 }
 
-/// Leased ownership of one fungible profile trial.
+/// Leased ownership of one fungible workset trial.
 #[derive(Debug)]
 pub struct CoordinateClaim {
     workset: Workset,
@@ -96,9 +99,9 @@ pub struct CoordinateClaim {
 pub struct EvaluationTreatment {
     /// Built-in or configured harness used for this coordinate.
     pub harness: String,
-    /// Model fixed by the profile.
+    /// Model fixed by the workset.
     pub model: Model,
-    /// Reasoning effort fixed by the profile.
+    /// Reasoning effort fixed by the workset.
     #[serde(serialize_with = "crate::profile::serialize_one_thinking")]
     pub thinking: Thinking,
     /// Whether model-facing web search is enabled for this coordinate.
@@ -119,8 +122,8 @@ pub struct EvaluationBusy {
 pub struct EvaluationStatus {
     /// Selected profile name.
     pub profile: String,
-    /// Digest of the profile, tasks, harness, and treatments.
-    pub digest: String,
+    /// Stable identifier of the newest selected generation.
+    pub generation: String,
     /// Shared task-preparation counts.
     pub preparation: EvaluationCounts,
     /// Trial execution counts.
@@ -140,16 +143,16 @@ pub struct EvaluationCounts {
     pub complete: i64,
 }
 
-/// Durable status of one exact profile treatment.
+/// Durable status of one exact workset treatment.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct EvaluationFamilyStatus {
     /// Stable family identity.
     pub id: String,
-    /// Profile-visible task selector.
+    /// User-visible task selector.
     pub task: String,
     /// Host currently assigned to prepare and execute this task.
     pub assigned_host: Option<String>,
-    /// Semantic treatment fixed by the profile.
+    /// Semantic treatment fixed by the workset.
     pub treatment: EvaluationTreatment,
     /// Desired fungible trial count.
     pub desired: i64,
@@ -161,7 +164,7 @@ pub struct EvaluationFamilyStatus {
     pub complete: i64,
 }
 
-/// Profile resolution, selection, or durable-ledger failure.
+/// Profile expansion, workset selection, or durable-ledger failure.
 #[derive(Debug)]
 pub struct EvaluationError {
     source: Box<dyn Error + Send + Sync>,
@@ -169,10 +172,11 @@ pub struct EvaluationError {
 
 impl Evaluation {
     /// Appends concrete work to a named SQLite board, creating it when absent.
-    /// `new_generation` starts a fresh board under the same user-visible name.
+    /// By default this extends the latest generation. `new_generation` starts
+    /// a fresh generation under the same user-visible profile name.
     pub fn add(
         state_directory: impl Into<PathBuf>,
-        profile: &str,
+        workset_name: &str,
         work: &[EvaluationWork],
         new_generation: bool,
     ) -> Result<(), EvaluationError> {
@@ -183,11 +187,11 @@ impl Evaluation {
         }
         let path = state_directory.into().join(LEDGER_FILE);
         let workset = if new_generation {
-            Workset::create(&path, profile)
+            Workset::create(&path, workset_name)
         } else {
-            match Workset::open(&path, profile) {
+            match Workset::open(&path, workset_name) {
                 Ok(workset) => Ok(workset),
-                Err(WorksetError::UnknownWorkset(_)) => Workset::create(&path, profile),
+                Err(WorksetError::UnknownWorkset(_)) => Workset::create(&path, workset_name),
                 Err(error) => Err(error),
             }
         }
@@ -226,26 +230,29 @@ impl Evaluation {
         config: impl AsRef<Path>,
         recipe: Option<&str>,
         state_directory: impl Into<PathBuf>,
-        profile: &str,
+        workset_name: &str,
         new_generation: bool,
     ) -> Result<(), EvaluationError> {
         let recipe = EvaluationManifest::load_profile(config, recipe).map_err(error)?;
-        let work = recipe
-            .families
-            .iter()
-            .map(|family| {
-                Ok(EvaluationWork {
+        let mut work = Vec::with_capacity(recipe.families.len());
+        for task in &recipe.tasks {
+            for family in recipe
+                .families
+                .iter()
+                .filter(|family| family.task == task.selector)
+            {
+                work.push(EvaluationWork {
                     selector: family.task.clone(),
-                    task: recipe.task(&family.task).map_err(error)?.task.clone(),
+                    task: task.task.clone(),
                     harness: family.harness.clone(),
                     model: family.model,
                     thinking: family.thinking,
                     web_search: family.web_search,
                     trials: recipe.trials,
-                })
-            })
-            .collect::<Result<Vec<_>, EvaluationError>>()?;
-        Self::add(state_directory, profile, &work, new_generation)
+                });
+            }
+        }
+        Self::add(state_directory, workset_name, &work, new_generation)
     }
 
     /// Resolves one current runtime harness helper without consulting workset
@@ -264,25 +271,54 @@ impl Evaluation {
     /// SQLite.
     pub fn open(
         config: impl AsRef<Path>,
-        profile: &str,
+        workset_name: &str,
         state_directory: impl Into<PathBuf>,
     ) -> Result<Self, EvaluationError> {
         let state_directory = state_directory.into();
-        let workset = Workset::open(state_directory.join(LEDGER_FILE), profile).map_err(error)?;
-        let profile =
-            ResolvedProfile::from_workset(workset.definition().map_err(error)?).map_err(error)?;
+        let workset =
+            Workset::open(state_directory.join(LEDGER_FILE), workset_name).map_err(error)?;
+        let definition = workset.definition().map_err(error)?;
+        let mut tasks = Vec::with_capacity(definition.tasks.len());
+        for retained in definition.tasks {
+            let task = Task::load(&retained.root).map_err(error)?;
+            if task.name() != retained.name || task.package_digest() != retained.digest {
+                return Err(error(std::io::Error::other(format!(
+                    "retained task `{}` no longer matches SQLite content digest {}",
+                    retained.selector, retained.digest
+                ))));
+            }
+            tasks.push(ResolvedTask {
+                selector: retained.selector,
+                task,
+            });
+        }
+        let mut families = Vec::with_capacity(definition.families.len());
+        for retained in definition.families {
+            let family: ResolvedFamily =
+                serde_json::from_str(&retained.treatment).map_err(error)?;
+            if family.key != retained.key || family.task != retained.task_selector {
+                return Err(error(std::io::Error::other(format!(
+                    "invalid SQLite treatment for family `{}`",
+                    retained.key
+                ))));
+            }
+            families.push(family);
+        }
         Ok(Self {
-            profile,
+            name: definition.name,
+            generation: definition.generation,
+            tasks,
+            families,
             workset,
             state_directory,
             config: config.as_ref().to_path_buf(),
         })
     }
 
-    /// Selected profile name.
+    /// Selected workset name.
     #[must_use]
     pub fn name(&self) -> &str {
-        &self.profile.name
+        &self.name
     }
 
     /// Reads a structured snapshot from SQLite.
@@ -293,13 +329,12 @@ impl Evaluation {
             .into_iter()
             .map(|status| -> Result<_, EvaluationError> {
                 let family = self
-                    .profile
                     .families
                     .iter()
                     .find(|family| family.key == status.key)
                     .ok_or_else(|| {
                         error(std::io::Error::other(format!(
-                            "SQLite contains unknown profile family `{}`",
+                            "SQLite contains unknown workset family `{}`",
                             status.key
                         )))
                     })?;
@@ -316,8 +351,8 @@ impl Evaluation {
             })
             .collect::<Result<Vec<_>, _>>()?;
         Ok(EvaluationStatus {
-            profile: status.profile,
-            digest: status.digest,
+            profile: status.name,
+            generation: status.generation,
             preparation: EvaluationCounts {
                 pending: status.preparation.pending,
                 running: status.preparation.running,
@@ -360,15 +395,37 @@ impl Evaluation {
         &self,
         selector: &EvaluationSelector,
     ) -> Result<&ResolvedFamily, EvaluationError> {
-        self.profile
-            .family(
-                &selector.task,
-                selector.harness.as_deref(),
-                selector.model,
-                selector.thinking,
-                selector.web_search,
-            )
-            .map_err(error)
+        self.task(&selector.task)?;
+        let harness = selector
+            .harness
+            .as_deref()
+            .unwrap_or(crate::profile::BUILTIN_HARNESS);
+        let matching = self
+            .families
+            .iter()
+            .filter(|family| {
+                family.task == selector.task
+                    && family.harness == harness
+                    && selector.model.is_none_or(|model| family.model == model)
+                    && selector
+                        .thinking
+                        .is_none_or(|thinking| family.thinking == thinking)
+                    && selector
+                        .web_search
+                        .is_none_or(|web_search| family.web_search == web_search)
+            })
+            .collect::<Vec<_>>();
+        match matching.as_slice() {
+            [family] => Ok(family),
+            [] => Err(error(std::io::Error::other(format!(
+                "no treatment in profile `{}` matches task `{}` and the requested knobs",
+                self.name, selector.task
+            )))),
+            _ => Err(error(std::io::Error::other(format!(
+                "task `{}` has multiple treatments in profile `{}`; select model and/or thinking",
+                selector.task, self.name
+            )))),
+        }
     }
 
     fn claim_resolved(
@@ -378,7 +435,7 @@ impl Evaluation {
         lease_duration: Duration,
         resolve_harness: bool,
     ) -> Result<EvaluationClaim, EvaluationError> {
-        let task = self.profile.task(&family.task).map_err(error)?.task.clone();
+        let task = self.task(&family.task)?.task.clone();
         let harness = if resolve_harness {
             EvaluationManifest::load_harness(&self.config, &family.harness).map_err(error)?
         } else {
@@ -405,7 +462,7 @@ impl Evaluation {
             BeginCoordinate::Execute(lease) => {
                 let output_directory = coordinate_output(
                     &self.state_directory,
-                    &self.profile.digest,
+                    &self.generation,
                     &family.key,
                     lease.repetition,
                     lease.generation,
@@ -426,6 +483,18 @@ impl Evaluation {
             BeginCoordinate::Busy(busy) => Ok(EvaluationClaim::Busy(busy.into())),
             BeginCoordinate::Complete => Ok(EvaluationClaim::Complete),
         }
+    }
+
+    fn task(&self, selector: &str) -> Result<&ResolvedTask, EvaluationError> {
+        self.tasks
+            .iter()
+            .find(|task| task.selector == selector)
+            .ok_or_else(|| {
+                error(std::io::Error::other(format!(
+                    "task `{selector}` is not part of profile `{}`",
+                    self.name
+                )))
+            })
     }
 }
 
@@ -697,7 +766,7 @@ fn error(source: impl Error + Send + Sync + 'static) -> EvaluationError {
 
 fn coordinate_output(
     state_directory: &Path,
-    profile_digest: &str,
+    workset_generation: &str,
     family_key: &str,
     repetition: u16,
     generation: i64,
@@ -705,7 +774,7 @@ fn coordinate_output(
     let family_digest = hex::encode(Sha256::digest(family_key.as_bytes()));
     state_directory
         .join("artifacts")
-        .join(profile_digest)
+        .join(workset_generation)
         .join(family_digest)
         .join(format!("k-{repetition}"))
         .join(format!("attempt-{generation}"))

--- a/crates/experimental/nanocodex-eval/src/evaluation.rs
+++ b/crates/experimental/nanocodex-eval/src/evaluation.rs
@@ -1,4 +1,4 @@
-//! Profile-level durable execution API.
+//! SQLite-native durable evaluation API.
 
 use std::{
     error::Error,
@@ -15,17 +15,21 @@ use tokio::task::JoinHandle;
 use crate::{
     Task,
     profile::{EvaluationManifest, ResolvedFamily, ResolvedHarness, ResolvedProfile},
-    workset::{BeginCoordinate, CoordinateLease, PreparationLease, Workset, WorksetBusy},
+    workset::{
+        BeginCoordinate, CoordinateLease, PreparationLease, Workset, WorksetBusy, WorksetError,
+        WorksetFamily, WorksetTask,
+    },
 };
 
 const LEDGER_FILE: &str = "state.sqlite3";
 
-/// One initialized profile revision and its durable SQLite ledger.
+/// One named durable SQLite workset.
 #[derive(Clone, Debug)]
 pub struct Evaluation {
     profile: ResolvedProfile,
     workset: Workset,
     state_directory: PathBuf,
+    config: PathBuf,
 }
 
 /// Optional knobs selecting one exact family already present in a profile.
@@ -35,22 +39,22 @@ pub struct EvaluationSelector {
     harness: Option<String>,
     model: Option<Model>,
     thinking: Option<Thinking>,
+    web_search: Option<bool>,
 }
 
-/// One exact profile family resolved locally without opening a ledger.
+/// One concrete task treatment to append to a durable SQLite workset.
 #[derive(Clone, Debug)]
-pub struct EvaluationSelection {
-    profile: String,
-    profile_digest: String,
-    family_key: String,
+pub struct EvaluationWork {
+    selector: String,
     task: Task,
-    treatment: EvaluationTreatment,
+    harness: String,
+    model: Model,
+    thinking: Thinking,
     web_search: bool,
-    harness: Option<ResolvedHarness>,
-    harnesses: Vec<ResolvedHarness>,
+    trials: u16,
 }
 
-/// The next durable action for one profile family.
+/// The next durable action for one workset family.
 #[derive(Debug)]
 pub enum EvaluationClaim {
     /// Prepare immutable resources shared by every trial of this task.
@@ -69,6 +73,7 @@ pub struct PreparationClaim {
     workset: Workset,
     lease: PreparationLease,
     task: Task,
+    treatment: EvaluationTreatment,
     harnesses: Vec<ResolvedHarness>,
     heartbeat: JoinHandle<()>,
 }
@@ -80,14 +85,13 @@ pub struct CoordinateClaim {
     lease: CoordinateLease,
     task: Task,
     treatment: EvaluationTreatment,
-    web_search: bool,
     harness: Option<ResolvedHarness>,
     harnesses: Vec<ResolvedHarness>,
     output_directory: PathBuf,
     heartbeat: JoinHandle<()>,
 }
 
-/// Semantic knobs fixed by one profile family.
+/// Semantic knobs fixed by one SQLite family.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct EvaluationTreatment {
     /// Built-in or configured harness used for this coordinate.
@@ -97,6 +101,8 @@ pub struct EvaluationTreatment {
     /// Reasoning effort fixed by the profile.
     #[serde(serialize_with = "crate::profile::serialize_one_thinking")]
     pub thinking: Thinking,
+    /// Whether model-facing web search is enabled for this coordinate.
+    pub web_search: bool,
 }
 
 /// Temporary inability to claim the selected family.
@@ -108,7 +114,7 @@ pub struct EvaluationBusy {
     pub retry_after_ms: u64,
 }
 
-/// Complete durable status of one immutable profile revision.
+/// Complete durable status of one named workset generation.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct EvaluationStatus {
     /// Selected profile name.
@@ -162,20 +168,114 @@ pub struct EvaluationError {
 }
 
 impl Evaluation {
-    /// Resolves a profile, initializes its complete workset, and opens it.
+    /// Appends concrete work to a named SQLite board, creating it when absent.
+    /// `new_generation` starts a fresh board under the same user-visible name.
+    pub fn add(
+        state_directory: impl Into<PathBuf>,
+        profile: &str,
+        work: &[EvaluationWork],
+        new_generation: bool,
+    ) -> Result<(), EvaluationError> {
+        if work.is_empty() {
+            return Err(error(std::io::Error::other(
+                "at least one concrete evaluation treatment is required",
+            )));
+        }
+        let path = state_directory.into().join(LEDGER_FILE);
+        let workset = if new_generation {
+            Workset::create(&path, profile)
+        } else {
+            match Workset::open(&path, profile) {
+                Ok(workset) => Ok(workset),
+                Err(WorksetError::UnknownWorkset(_)) => Workset::create(&path, profile),
+                Err(error) => Err(error),
+            }
+        }
+        .map_err(error)?;
+        let mut tasks = std::collections::BTreeMap::new();
+        let mut families = Vec::with_capacity(work.len());
+        for item in work {
+            if item.trials == 0 {
+                return Err(error(std::io::Error::other(
+                    "evaluation treatments must request at least one trial",
+                )));
+            }
+            tasks
+                .entry(item.selector.clone())
+                .or_insert_with(|| WorksetTask {
+                    selector: item.selector.clone(),
+                    name: item.task.name().to_owned(),
+                    root: item.task.root().to_path_buf(),
+                    digest: item.task.package_digest().to_owned(),
+                });
+            let family = item.family();
+            families.push(WorksetFamily {
+                key: family.key.clone(),
+                task_selector: family.task.clone(),
+                treatment: family.treatment(),
+                trials: item.trials,
+            });
+        }
+        workset
+            .append(&tasks.into_values().collect::<Vec<_>>(), &families)
+            .map_err(error)
+    }
+
+    /// Expands one optional TOML profile recipe into a concrete SQLite board.
+    pub fn add_profile(
+        config: impl AsRef<Path>,
+        recipe: Option<&str>,
+        state_directory: impl Into<PathBuf>,
+        profile: &str,
+        new_generation: bool,
+    ) -> Result<(), EvaluationError> {
+        let recipe = EvaluationManifest::load_profile(config, recipe).map_err(error)?;
+        let work = recipe
+            .families
+            .iter()
+            .map(|family| {
+                Ok(EvaluationWork {
+                    selector: family.task.clone(),
+                    task: recipe.task(&family.task).map_err(error)?.task.clone(),
+                    harness: family.harness.clone(),
+                    model: family.model,
+                    thinking: family.thinking,
+                    web_search: family.web_search,
+                    trials: recipe.trials,
+                })
+            })
+            .collect::<Result<Vec<_>, EvaluationError>>()?;
+        Self::add(state_directory, profile, &work, new_generation)
+    }
+
+    /// Resolves one current runtime harness helper without consulting workset
+    /// definitions.
+    pub fn resolve_harness(
+        config: impl AsRef<Path>,
+        harness: &str,
+    ) -> Result<Option<ResolvedHarness>, EvaluationError> {
+        EvaluationManifest::load_harness(config, harness).map_err(error)
+    }
+
+    /// Opens the newest SQLite generation of a named workset.
+    ///
+    /// `config` is retained only to resolve a selected external harness when a
+    /// coordinate is claimed. Status and work definition come entirely from
+    /// SQLite.
     pub fn open(
         config: impl AsRef<Path>,
-        profile: Option<&str>,
+        profile: &str,
         state_directory: impl Into<PathBuf>,
     ) -> Result<Self, EvaluationError> {
-        let profile = EvaluationManifest::load_profile(config, profile).map_err(error)?;
         let state_directory = state_directory.into();
-        let workset = Workset::ensure(state_directory.join(LEDGER_FILE), &profile.workset_spec())
-            .map_err(error)?;
+        let workset = Workset::open(state_directory.join(LEDGER_FILE), profile).map_err(error)?;
+        let profile =
+            ResolvedProfile::from_workset(workset.definition().map_err(error)?).map_err(error)?;
         Ok(Self {
             profile,
             workset,
             state_directory,
+            config: config.as_ref().to_path_buf(),
         })
     }
 
@@ -183,12 +283,6 @@ impl Evaluation {
     #[must_use]
     pub fn name(&self) -> &str {
         &self.profile.name
-    }
-
-    /// Whether model-facing web search is enabled by the profile.
-    #[must_use]
-    pub const fn web_search(&self) -> bool {
-        self.profile.web_search
     }
 
     /// Reads a structured snapshot from SQLite.
@@ -238,7 +332,7 @@ impl Evaluation {
         })
     }
 
-    /// Claims the next action for one exact profile-owned family.
+    /// Claims the next action for one exact SQLite-owned family.
     ///
     /// Active claims renew their lease automatically until completed, retried,
     /// or dropped.
@@ -247,7 +341,8 @@ impl Evaluation {
         selector: &EvaluationSelector,
         lease_duration: Duration,
     ) -> Result<EvaluationClaim, EvaluationError> {
-        self.claim_for_host(selector, "local", lease_duration)
+        let family = self.resolve_family(selector)?.clone();
+        self.claim_resolved(&family, "local", lease_duration, true)
     }
 
     /// Claims one family for the network host chosen by the coordinator.
@@ -258,36 +353,7 @@ impl Evaluation {
         lease_duration: Duration,
     ) -> Result<EvaluationClaim, EvaluationError> {
         let family = self.resolve_family(selector)?.clone();
-        self.claim_resolved(&family, host, lease_duration)
-    }
-
-    /// Claims a locally resolved family after verifying its immutable profile digest.
-    pub(crate) fn claim_family_for_host(
-        &self,
-        profile_digest: &str,
-        family_key: &str,
-        host: &str,
-        lease_duration: Duration,
-    ) -> Result<EvaluationClaim, EvaluationError> {
-        if profile_digest != self.profile.digest {
-            return Err(error(std::io::Error::other(format!(
-                "coordinator profile digest is {}; worker requested {profile_digest}",
-                self.profile.digest
-            ))));
-        }
-        let family = self
-            .profile
-            .families
-            .iter()
-            .find(|family| family.key == family_key)
-            .ok_or_else(|| {
-                error(std::io::Error::other(format!(
-                    "family `{family_key}` is not part of profile `{}`",
-                    self.profile.name
-                )))
-            })?
-            .clone();
-        self.claim_resolved(&family, host, lease_duration)
+        self.claim_resolved(&family, host, lease_duration, false)
     }
 
     fn resolve_family(
@@ -300,6 +366,7 @@ impl Evaluation {
                 selector.harness.as_deref(),
                 selector.model,
                 selector.thinking,
+                selector.web_search,
             )
             .map_err(error)
     }
@@ -309,8 +376,15 @@ impl Evaluation {
         family: &ResolvedFamily,
         host: &str,
         lease_duration: Duration,
+        resolve_harness: bool,
     ) -> Result<EvaluationClaim, EvaluationError> {
         let task = self.profile.task(&family.task).map_err(error)?.task.clone();
+        let harness = if resolve_harness {
+            EvaluationManifest::load_harness(&self.config, &family.harness).map_err(error)?
+        } else {
+            None
+        };
+        let harnesses = harness.iter().cloned().collect::<Vec<_>>();
         match self
             .workset
             .begin_for_host(&family.key, host, lease_duration)
@@ -323,7 +397,8 @@ impl Evaluation {
                     workset: self.workset.clone(),
                     lease,
                     task,
-                    harnesses: self.profile.harnesses.values().cloned().collect(),
+                    treatment: family.into(),
+                    harnesses,
                     heartbeat,
                 }))
             }
@@ -342,9 +417,8 @@ impl Evaluation {
                     lease,
                     task,
                     treatment: family.into(),
-                    web_search: self.profile.web_search,
-                    harness: self.profile.harness(&family.harness).cloned(),
-                    harnesses: self.profile.harnesses.values().cloned().collect(),
+                    harness,
+                    harnesses,
                     output_directory,
                     heartbeat,
                 }))
@@ -355,89 +429,78 @@ impl Evaluation {
     }
 }
 
-impl EvaluationSelection {
-    /// Resolves one exact family from a local immutable profile without touching SQLite.
-    pub fn load(
-        config: impl AsRef<Path>,
-        profile: Option<&str>,
-        selector: &EvaluationSelector,
-    ) -> Result<Self, EvaluationError> {
-        let profile = EvaluationManifest::load_profile(config, profile).map_err(error)?;
-        let family = profile
-            .family(
-                &selector.task,
-                selector.harness.as_deref(),
-                selector.model,
-                selector.thinking,
-            )
-            .map_err(error)?
-            .clone();
-        let task = profile.task(&family.task).map_err(error)?.task.clone();
-        let harness = profile.harness(&family.harness).cloned();
-        let harnesses = profile.harnesses.values().cloned().collect();
-        Ok(Self {
-            profile: profile.name,
-            profile_digest: profile.digest,
-            family_key: family.key.clone(),
+impl EvaluationWork {
+    /// Creates one built-in Nanocodex treatment with default model policy.
+    #[must_use]
+    pub fn new(selector: impl Into<String>, task: Task) -> Self {
+        Self {
+            selector: selector.into(),
             task,
-            treatment: (&family).into(),
-            web_search: profile.web_search,
-            harness,
-            harnesses,
-        })
+            harness: crate::profile::BUILTIN_HARNESS.to_owned(),
+            model: Model::default(),
+            thinking: Thinking::default(),
+            web_search: false,
+            trials: 1,
+        }
     }
 
-    /// Selected profile name.
+    /// Selects the built-in or configured harness name stored in SQLite.
     #[must_use]
-    pub fn profile(&self) -> &str {
-        &self.profile
+    pub fn harness(mut self, harness: impl Into<String>) -> Self {
+        self.harness = harness.into();
+        self
     }
 
-    /// Stable digest of every resolved profile input.
+    /// Selects the model stored in SQLite.
     #[must_use]
-    pub fn profile_digest(&self) -> &str {
-        &self.profile_digest
+    pub const fn model(mut self, model: Model) -> Self {
+        self.model = model;
+        self
     }
 
-    /// Stable family key sent to the coordinator.
+    /// Selects the reasoning effort stored in SQLite.
     #[must_use]
-    pub fn family_key(&self) -> &str {
-        &self.family_key
+    pub const fn thinking(mut self, thinking: Thinking) -> Self {
+        self.thinking = thinking;
+        self
     }
 
-    /// Immutable task package executed by this worker.
+    /// Selects model-facing web-search policy stored in SQLite.
     #[must_use]
-    pub const fn task(&self) -> &Task {
-        &self.task
+    pub const fn web_search(mut self, web_search: bool) -> Self {
+        self.web_search = web_search;
+        self
     }
 
-    /// Exact semantic treatment fixed by the profile.
+    /// Selects the desired fungible repetition count stored in SQLite.
     #[must_use]
-    pub const fn treatment(&self) -> &EvaluationTreatment {
-        &self.treatment
+    pub const fn trials(mut self, trials: u16) -> Self {
+        self.trials = trials;
+        self
     }
 
-    /// Whether model-facing web search is enabled.
-    #[must_use]
-    pub const fn web_search(&self) -> bool {
-        self.web_search
-    }
-
-    /// Resolved configuration for the selected external harness.
-    #[must_use]
-    pub const fn harness(&self) -> Option<&ResolvedHarness> {
-        self.harness.as_ref()
-    }
-
-    /// External harnesses installed during this task's durable preparation.
-    #[must_use]
-    pub fn harnesses(&self) -> &[ResolvedHarness] {
-        &self.harnesses
+    fn family(&self) -> ResolvedFamily {
+        let key = format!(
+            "{}|{}|{}|{}{}",
+            self.selector,
+            self.harness,
+            self.model.as_str(),
+            self.thinking.as_str(),
+            if self.web_search { "|web-search" } else { "" },
+        );
+        ResolvedFamily {
+            key,
+            task: self.selector.clone(),
+            harness: self.harness.clone(),
+            model: self.model,
+            thinking: self.thinking,
+            web_search: self.web_search,
+        }
     }
 }
 
 impl EvaluationSelector {
-    /// Selects a task from the closed profile.
+    /// Selects a task already present in the workset.
     #[must_use]
     pub fn new(task: impl Into<String>) -> Self {
         Self {
@@ -445,6 +508,7 @@ impl EvaluationSelector {
             harness: None,
             model: None,
             thinking: None,
+            web_search: None,
         }
     }
 
@@ -455,18 +519,45 @@ impl EvaluationSelector {
         self
     }
 
-    /// Narrows the task to one profile-owned model treatment.
+    /// Narrows the task to one SQLite-owned model treatment.
     #[must_use]
     pub const fn model(mut self, model: Option<Model>) -> Self {
         self.model = model;
         self
     }
 
-    /// Narrows the task to one profile-owned reasoning treatment.
+    /// Narrows the task to one SQLite-owned reasoning treatment.
     #[must_use]
     pub const fn thinking(mut self, thinking: Option<Thinking>) -> Self {
         self.thinking = thinking;
         self
+    }
+
+    /// Narrows the task to one SQLite-owned web-search policy.
+    #[must_use]
+    pub const fn web_search(mut self, web_search: Option<bool>) -> Self {
+        self.web_search = web_search;
+        self
+    }
+
+    pub(crate) fn task(&self) -> &str {
+        &self.task
+    }
+
+    pub(crate) fn harness_name(&self) -> Option<&str> {
+        self.harness.as_deref()
+    }
+
+    pub(crate) const fn model_value(&self) -> Option<Model> {
+        self.model
+    }
+
+    pub(crate) const fn thinking_value(&self) -> Option<Thinking> {
+        self.thinking
+    }
+
+    pub(crate) const fn web_search_value(&self) -> Option<bool> {
+        self.web_search
     }
 }
 
@@ -475,6 +566,12 @@ impl PreparationClaim {
     #[must_use]
     pub const fn task(&self) -> &Task {
         &self.task
+    }
+
+    /// Semantic treatment whose resources are being prepared.
+    #[must_use]
+    pub const fn treatment(&self) -> &EvaluationTreatment {
+        &self.treatment
     }
 
     /// External harnesses installed into the immutable task image.
@@ -522,7 +619,7 @@ impl CoordinateClaim {
     /// Whether model-facing web search is enabled by the profile.
     #[must_use]
     pub const fn web_search(&self) -> bool {
-        self.web_search
+        self.treatment.web_search
     }
 
     /// Resolved configuration for the selected external harness.
@@ -566,6 +663,7 @@ impl From<&ResolvedFamily> for EvaluationTreatment {
             harness: family.harness.clone(),
             model: family.model,
             thinking: family.thinking,
+            web_search: family.web_search,
         }
     }
 }
@@ -720,7 +818,8 @@ thinking = ["high"]
         )
         .unwrap();
         let state = directory.path().join("state");
-        let evaluation = Evaluation::open(&config, Some("release"), &state).unwrap();
+        Evaluation::add_profile(&config, Some("release"), &state, "release", false).unwrap();
+        let evaluation = Evaluation::open(&config, "release", &state).unwrap();
         let selector = EvaluationSelector::new("one");
 
         let status = evaluation.status().unwrap();
@@ -769,12 +868,55 @@ trials = 1
 "#,
         )
         .unwrap();
-        let evaluation =
-            Evaluation::open(&config, Some("release"), directory.path().join("state")).unwrap();
+        let state = directory.path().join("state");
+        Evaluation::add_profile(&config, Some("release"), &state, "release", false).unwrap();
+        let evaluation = Evaluation::open(&config, "release", state).unwrap();
 
         let failure = evaluation
             .claim(&EvaluationSelector::new("outside"), Duration::from_secs(30))
             .unwrap_err();
         assert!(failure.to_string().contains("is not part of profile"));
+    }
+
+    #[test]
+    fn sqlite_board_survives_recipe_and_harness_config_removal() {
+        let directory = tempfile::tempdir().unwrap();
+        write_task(directory.path());
+        let config = directory.path().join("nanocodex.toml");
+        fs::write(
+            &config,
+            r#"[profiles.release]
+tasks = ["one"]
+trials = 3
+harness = ["codex"]
+model = ["sol"]
+thinking = ["high"]
+"#,
+        )
+        .unwrap();
+        let state = directory.path().join("state");
+
+        Evaluation::add_profile(&config, Some("release"), &state, "board", false).unwrap();
+        fs::remove_file(&config).unwrap();
+        let evaluation = Evaluation::open(&config, "board", &state).unwrap();
+        let status = evaluation.status().unwrap();
+
+        assert_eq!(status.coordinates.pending, 3);
+        assert_eq!(status.families[0].treatment.harness, "codex");
+        assert_eq!(
+            status.families[0].treatment.model,
+            "sol".parse::<Model>().unwrap()
+        );
+        let failure = evaluation
+            .claim(
+                &EvaluationSelector::new("one").harness(Some("codex")),
+                Duration::from_secs(30),
+            )
+            .unwrap_err();
+        assert!(
+            failure
+                .to_string()
+                .contains("failed to read evaluation manifest")
+        );
     }
 }

--- a/crates/experimental/nanocodex-eval/src/evaluation.rs
+++ b/crates/experimental/nanocodex-eval/src/evaluation.rs
@@ -289,6 +289,10 @@ impl Evaluation {
         &self.state_directory
     }
 
+    pub(crate) fn config(&self) -> &Path {
+        &self.config
+    }
+
     /// Reads a structured snapshot from SQLite.
     pub fn status(&self) -> Result<EvaluationStatus, EvaluationError> {
         let status = self.workset()?.status().map_err(error)?;

--- a/crates/experimental/nanocodex-eval/src/evaluation.rs
+++ b/crates/experimental/nanocodex-eval/src/evaluation.rs
@@ -321,6 +321,10 @@ impl Evaluation {
         &self.name
     }
 
+    pub(crate) fn state_directory(&self) -> &Path {
+        &self.state_directory
+    }
+
     /// Reads a structured snapshot from SQLite.
     pub fn status(&self) -> Result<EvaluationStatus, EvaluationError> {
         let status = self.workset.status().map_err(error)?;

--- a/crates/experimental/nanocodex-eval/src/lib.rs
+++ b/crates/experimental/nanocodex-eval/src/lib.rs
@@ -1,11 +1,11 @@
 //! Typed, VM-isolated evaluation for Nanocodex agents.
 //!
-//! This crate owns task loading, durable profile worksets, typed events and
-//! outcomes, and VM-isolated execution. Applications choose one exact profile
+//! This crate owns task loading, durable SQLite worksets, typed events and
+//! outcomes, and VM-isolated execution. Applications choose one exact workset
 //! coordinate family; SQLite allocates its internal repetition and fences the
 //! accepted completion.
 //!
-//! # Open a durable profile
+//! # Open a durable workset
 //!
 //! ```no_run
 //! use std::time::Duration;
@@ -14,7 +14,7 @@
 //! # async fn evaluate() -> Result<(), Box<dyn std::error::Error>> {
 //! let evaluation = Evaluation::open(
 //!     "nanocodex.toml",
-//!     Some("local-smoke"),
+//!     "local-smoke",
 //!     ".nanocodex/evals",
 //! )?;
 //! let selector = EvaluationSelector::new("tasks/write-greeting");
@@ -24,7 +24,7 @@
 //!         claim.complete()?;
 //!     }
 //!     EvaluationClaim::Run(claim) => {
-//!         // Execute exactly this profile treatment and retain its evidence.
+//!         // Execute exactly this SQLite treatment and retain its evidence.
 //!         let evidence = claim.output_directory().to_path_buf();
 //!         claim.complete(&evidence)?;
 //!     }
@@ -85,8 +85,8 @@ pub(crate) use atif::{
 pub(crate) use capture_proxy::{ResponsesCaptureProxy, ResponsesCaptureProxyConfig};
 pub use evaluation::{
     CoordinateClaim, Evaluation, EvaluationBusy, EvaluationClaim, EvaluationCounts,
-    EvaluationError, EvaluationFamilyStatus, EvaluationSelection, EvaluationSelector,
-    EvaluationStatus, EvaluationTreatment, PreparationClaim,
+    EvaluationError, EvaluationFamilyStatus, EvaluationSelector, EvaluationStatus,
+    EvaluationTreatment, EvaluationWork, PreparationClaim,
 };
 pub use evaluator::{EvalError, EvalRun, Evaluator, EvaluatorBuilder};
 pub use event::{

--- a/crates/experimental/nanocodex-eval/src/lib.rs
+++ b/crates/experimental/nanocodex-eval/src/lib.rs
@@ -47,6 +47,7 @@
     allow(dead_code, unused_imports)
 )]
 
+mod api;
 /// Agent Trajectory Interchange Format projection and wire types.
 pub mod atif;
 mod capture_proxy;

--- a/crates/experimental/nanocodex-eval/src/profile.rs
+++ b/crates/experimental/nanocodex-eval/src/profile.rs
@@ -11,7 +11,7 @@ use nanocodex_oai_api::{Model, Thinking};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
-use crate::{Task, TaskLoadError, workset::WorksetDefinition};
+use crate::{Task, TaskLoadError};
 
 pub(crate) const BUILTIN_HARNESS: &str = "nanocodex";
 
@@ -26,8 +26,8 @@ pub struct EvaluationManifest {
     profiles: BTreeMap<String, Profile>,
 }
 
-/// One pinned external evaluation harness.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+/// One configured external evaluation harness helper.
+#[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Harness {
     command: PathBuf,
@@ -56,7 +56,7 @@ pub struct Harness {
 }
 
 /// One convenience recipe expanded into SQLite by `eval add`.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Profile {
     #[serde(default)]
@@ -70,8 +70,7 @@ pub struct Profile {
     model: Vec<Model>,
     #[serde(
         default = "default_thinking",
-        deserialize_with = "deserialize_thinking",
-        serialize_with = "serialize_thinking"
+        deserialize_with = "deserialize_thinking"
     )]
     thinking: Vec<Thinking>,
     #[serde(default)]
@@ -81,10 +80,6 @@ pub struct Profile {
 /// Parsed profile recipe ready to materialize into SQLite.
 #[derive(Clone, Debug)]
 pub struct ResolvedProfile {
-    /// Selected profile name.
-    pub name: String,
-    /// Stable digest of the recipe and task inputs.
-    pub digest: String,
     /// Loaded immutable task packages.
     pub tasks: Vec<ResolvedTask>,
     /// Exact task/treatment families, excluding fungible repetitions.
@@ -102,7 +97,7 @@ pub struct ResolvedTask {
     pub task: Task,
 }
 
-/// One content-pinned external harness selected by a profile.
+/// One external harness helper resolved from the current runtime config.
 #[derive(Clone, Debug)]
 pub struct ResolvedHarness {
     /// Profile-visible harness name.
@@ -238,65 +233,6 @@ pub enum ProfileError {
         /// Filesystem failure.
         source: std::io::Error,
     },
-    /// Stable identity serialization failed.
-    #[error("failed to serialize resolved profile identity: {0}")]
-    Identity(#[from] serde_json::Error),
-    /// A retained task package no longer matches the content recorded in SQLite.
-    #[error("retained task `{selector}` no longer matches SQLite digest {digest}")]
-    TaskChanged {
-        /// SQLite task selector.
-        selector: String,
-        /// Content digest retained by SQLite.
-        digest: String,
-    },
-    /// A coordinate treatment retained in SQLite disagrees with its family row.
-    #[error("invalid SQLite treatment for family `{0}`")]
-    InvalidTreatment(String),
-}
-
-/// Closed-profile selector failure.
-#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
-pub enum ProfileSelectionError {
-    /// Requested task is outside the profile.
-    #[error("task `{selector}` is not part of profile `{profile}`")]
-    Task {
-        /// Selected profile.
-        profile: String,
-        /// Rejected selector.
-        selector: String,
-    },
-    /// No treatment matched explicit selectors.
-    #[error("no treatment in profile `{profile}` matches task `{task}` and the requested knobs")]
-    Treatment {
-        /// Selected profile.
-        profile: String,
-        /// Selected task.
-        task: String,
-    },
-    /// Omitted semantic knobs did not identify one family.
-    #[error(
-        "task `{task}` has multiple treatments in profile `{profile}`; select model and/or thinking"
-    )]
-    Ambiguous {
-        /// Selected profile.
-        profile: String,
-        /// Selected task.
-        task: String,
-    },
-}
-
-#[derive(Serialize)]
-struct ProfileIdentity<'a> {
-    schema: u32,
-    name: &'a str,
-    profile: &'a Profile,
-    tasks: Vec<TaskIdentity<'a>>,
-}
-
-#[derive(Serialize)]
-struct TaskIdentity<'a> {
-    selector: &'a str,
-    digest: &'a str,
 }
 
 impl EvaluationManifest {
@@ -382,109 +318,11 @@ impl EvaluationManifest {
             .expect("a canonical manifest path has a parent");
         let tasks = load_tasks(root, profile)?;
         let families = expand_families(profile, &tasks);
-        let identity = ProfileIdentity {
-            schema: 3,
-            name: &name,
-            profile,
-            tasks: tasks
-                .iter()
-                .map(|task| TaskIdentity {
-                    selector: &task.selector,
-                    digest: task.task.package_digest(),
-                })
-                .collect(),
-        };
-        let digest = hex::encode(Sha256::digest(serde_json::to_vec(&identity)?));
         Ok(ResolvedProfile {
-            name,
-            digest,
             tasks,
             families,
             trials: profile.trials,
         })
-    }
-}
-
-impl ResolvedProfile {
-    pub(crate) fn from_workset(definition: WorksetDefinition) -> Result<Self, ProfileError> {
-        let mut tasks = Vec::with_capacity(definition.tasks.len());
-        for retained in definition.tasks {
-            let task = Task::load(&retained.root)?;
-            if task.name() != retained.name || task.package_digest() != retained.digest {
-                return Err(ProfileError::TaskChanged {
-                    selector: retained.selector,
-                    digest: retained.digest,
-                });
-            }
-            tasks.push(ResolvedTask {
-                selector: retained.selector,
-                task,
-            });
-        }
-        let mut families = Vec::with_capacity(definition.families.len());
-        let mut trials = 0;
-        for retained in definition.families {
-            let family: ResolvedFamily = serde_json::from_str(&retained.treatment)?;
-            if family.key != retained.key || family.task != retained.task_selector {
-                return Err(ProfileError::InvalidTreatment(retained.key));
-            }
-            trials = trials.max(retained.trials);
-            families.push(family);
-        }
-        Ok(Self {
-            name: definition.profile,
-            digest: definition.digest,
-            tasks,
-            families,
-            trials,
-        })
-    }
-
-    /// Resolves one exact task selector without permitting ad-hoc expansion.
-    pub fn task(&self, selector: &str) -> Result<&ResolvedTask, ProfileSelectionError> {
-        self.tasks
-            .iter()
-            .find(|task| task.selector == selector)
-            .ok_or_else(|| ProfileSelectionError::Task {
-                profile: self.name.clone(),
-                selector: selector.to_owned(),
-            })
-    }
-
-    /// Resolves an exact task family. Omitted dimensions are accepted only
-    /// when the profile contains one unambiguous matching treatment.
-    pub fn family(
-        &self,
-        task: &str,
-        harness: Option<&str>,
-        model: Option<Model>,
-        thinking: Option<Thinking>,
-        web_search: Option<bool>,
-    ) -> Result<&ResolvedFamily, ProfileSelectionError> {
-        self.task(task)?;
-        let harness = harness.unwrap_or(BUILTIN_HARNESS);
-        let matching = self
-            .families
-            .iter()
-            .filter(|family| {
-                family.task == task
-                    && family.harness == harness
-                    && model.is_none_or(|model| family.model == model)
-                    && thinking.is_none_or(|thinking| family.thinking == thinking)
-                    && web_search.is_none_or(|web_search| family.web_search == web_search)
-            })
-            .collect::<Vec<_>>();
-        match matching.as_slice() {
-            [family] => Ok(family),
-            [] => Err(ProfileSelectionError::Treatment {
-                profile: self.name.clone(),
-                task: task.to_owned(),
-            }),
-            _ => Err(ProfileSelectionError::Ambiguous {
-                profile: self.name.clone(),
-                task: task.to_owned(),
-            }),
-        }
     }
 }
 
@@ -737,17 +575,6 @@ where
         .collect()
 }
 
-fn serialize_thinking<S>(values: &[Thinking], serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    values
-        .iter()
-        .map(|value| value.as_str())
-        .collect::<Vec<_>>()
-        .serialize(serializer)
-}
-
 pub(crate) fn serialize_one_thinking<S>(value: &Thinking, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
@@ -817,32 +644,9 @@ thinking = ["high"]
         .unwrap();
 
         let profile = EvaluationManifest::load_profile(&config, None).unwrap();
-        assert_eq!(profile.name, "release");
         assert_eq!(profile.families.len(), 1);
         assert_eq!(profile.trials, 3);
-        assert_eq!(profile.task("one").unwrap().task.name(), "one");
-    }
-
-    #[test]
-    fn task_selector_cannot_expand_the_profile() {
-        let directory = tempfile::tempdir().unwrap();
-        write_task(directory.path(), "included");
-        write_task(directory.path(), "outside");
-        let config = directory.path().join("nanocodex.toml");
-        fs::write(
-            &config,
-            r#"[profiles.release]
-tasks = ["included"]
-trials = 1
-"#,
-        )
-        .unwrap();
-        let profile = EvaluationManifest::load_profile(&config, Some("release")).unwrap();
-
-        assert!(matches!(
-            profile.task("outside"),
-            Err(ProfileSelectionError::Task { selector, .. }) if selector == "outside"
-        ));
+        assert_eq!(profile.tasks[0].task.name(), "one");
     }
 
     #[test]
@@ -867,19 +671,10 @@ harness = ["nanocodex", "codex"]
         )
         .unwrap();
 
-        let first = EvaluationManifest::load_profile(&config, Some("release")).unwrap();
-        assert_eq!(first.families.len(), 2);
-        assert_eq!(
-            first.family("one", None, None, None, None).unwrap().harness,
-            "nanocodex"
-        );
-        assert_eq!(
-            first
-                .family("one", Some("codex"), None, None, None)
-                .unwrap()
-                .harness,
-            "codex"
-        );
+        let profile = EvaluationManifest::load_profile(&config, Some("release")).unwrap();
+        assert_eq!(profile.families.len(), 2);
+        assert_eq!(profile.families[0].harness, "nanocodex");
+        assert_eq!(profile.families[1].harness, "codex");
         let first_helper = EvaluationManifest::load_harness(&config, "codex")
             .unwrap()
             .unwrap();
@@ -889,7 +684,7 @@ harness = ["nanocodex", "codex"]
             .unwrap()
             .unwrap();
 
-        assert_eq!(first.digest, second.digest);
+        assert_eq!(second.families, profile.families);
         assert_ne!(first_helper.version, second_helper.version);
     }
 
@@ -917,41 +712,15 @@ harness = ["nanocodex", "codex"]
             .unwrap();
         }
 
-        let first =
-            EvaluationManifest::load_profile(first.path().join("nanocodex.toml"), Some("release"))
-                .unwrap();
-        let second =
-            EvaluationManifest::load_profile(second.path().join("nanocodex.toml"), Some("release"))
-                .unwrap();
-
-        assert_eq!(first.digest, second.digest);
-    }
-
-    #[test]
-    fn profile_revision_is_independent_of_the_checkout_path() {
-        let first = tempfile::tempdir().unwrap();
-        let second = tempfile::tempdir().unwrap();
-        for directory in [&first, &second] {
-            write_task(directory.path(), "one");
-            fs::write(
-                directory.path().join("nanocodex.toml"),
-                r#"[profiles.release]
-tasks = ["one"]
-trials = 2
-model = ["sol"]
-thinking = ["high"]
-"#,
-            )
+        let first = EvaluationManifest::load_harness(first.path().join("nanocodex.toml"), "codex")
+            .unwrap()
             .unwrap();
-        }
-
-        let first =
-            EvaluationManifest::load_profile(first.path().join("nanocodex.toml"), Some("release"))
-                .unwrap();
         let second =
-            EvaluationManifest::load_profile(second.path().join("nanocodex.toml"), Some("release"))
+            EvaluationManifest::load_harness(second.path().join("nanocodex.toml"), "codex")
+                .unwrap()
                 .unwrap();
 
-        assert_eq!(first.digest, second.digest);
+        assert_eq!(first.version, "0.145.0");
+        assert_eq!(first.version, second.version);
     }
 }

--- a/crates/experimental/nanocodex-eval/src/profile.rs
+++ b/crates/experimental/nanocodex-eval/src/profile.rs
@@ -1,4 +1,4 @@
-//! Closed evaluation profiles over native Terminal-Bench task packages.
+//! Optional workset recipes and runtime harness helpers.
 
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -11,9 +11,9 @@ use nanocodex_oai_api::{Model, Thinking};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
-use crate::{Task, TaskLoadError, workset::WorksetSpec};
+use crate::{Task, TaskLoadError, workset::WorksetDefinition};
 
-const BUILTIN_HARNESS: &str = "nanocodex";
+pub(crate) const BUILTIN_HARNESS: &str = "nanocodex";
 
 /// Repository-level native evaluation configuration.
 #[derive(Clone, Debug, Deserialize)]
@@ -22,6 +22,7 @@ pub struct EvaluationManifest {
     default: Option<String>,
     #[serde(default)]
     harness: BTreeMap<String, Harness>,
+    #[serde(default)]
     profiles: BTreeMap<String, Profile>,
 }
 
@@ -54,7 +55,7 @@ pub struct Harness {
     api_upstream: Option<String>,
 }
 
-/// One closed desired bundle of native task coordinates.
+/// One convenience recipe expanded into SQLite by `eval add`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Profile {
@@ -77,23 +78,17 @@ pub struct Profile {
     web_search: bool,
 }
 
-/// Parsed and content-pinned profile revision.
+/// Parsed profile recipe ready to materialize into SQLite.
 #[derive(Clone, Debug)]
 pub struct ResolvedProfile {
     /// Selected profile name.
     pub name: String,
-    /// Stable digest of all resolved profile inputs.
+    /// Stable digest of the recipe and task inputs.
     pub digest: String,
-    /// Canonical source manifest path.
-    pub config_path: PathBuf,
     /// Loaded immutable task packages.
     pub tasks: Vec<ResolvedTask>,
     /// Exact task/treatment families, excluding fungible repetitions.
     pub families: Vec<ResolvedFamily>,
-    /// Pinned external harness commands selected by this revision.
-    pub harnesses: BTreeMap<String, ResolvedHarness>,
-    /// Whether model-facing web search is enabled.
-    pub web_search: bool,
     /// Number of desired repetitions for every family.
     pub trials: u16,
 }
@@ -133,7 +128,7 @@ pub struct ResolvedHarness {
 }
 
 /// One exact semantic treatment family.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ResolvedFamily {
     /// Stable identity excluding fungible repetition.
     pub key: String,
@@ -144,8 +139,14 @@ pub struct ResolvedFamily {
     /// Supported model selection.
     pub model: Model,
     /// Reasoning effort.
-    #[serde(serialize_with = "serialize_one_thinking")]
+    #[serde(
+        deserialize_with = "deserialize_one_thinking",
+        serialize_with = "serialize_one_thinking"
+    )]
     pub thinking: Thinking,
+    /// Whether model-facing web search is enabled for this treatment.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub web_search: bool,
 }
 
 /// Profile parsing or resolution failure.
@@ -207,14 +208,9 @@ pub enum ProfileError {
     /// A task package failed to load.
     #[error(transparent)]
     Task(#[from] TaskLoadError),
-    /// A profile selected an external harness without configuring it.
-    #[error("evaluation profile `{profile}` selects unknown harness `{harness}`")]
-    UnknownHarness {
-        /// Invalid profile.
-        profile: String,
-        /// Missing top-level harness configuration.
-        harness: String,
-    },
+    /// A selected external harness has no current runtime helper.
+    #[error("evaluation harness helper `{0}` is not configured")]
+    UnknownHarness(String),
     /// A semantic harness version was present but empty.
     #[error("evaluation harness `{0}` has an empty version")]
     EmptyHarnessVersion(String),
@@ -245,6 +241,17 @@ pub enum ProfileError {
     /// Stable identity serialization failed.
     #[error("failed to serialize resolved profile identity: {0}")]
     Identity(#[from] serde_json::Error),
+    /// A retained task package no longer matches the content recorded in SQLite.
+    #[error("retained task `{selector}` no longer matches SQLite digest {digest}")]
+    TaskChanged {
+        /// SQLite task selector.
+        selector: String,
+        /// Content digest retained by SQLite.
+        digest: String,
+    },
+    /// A coordinate treatment retained in SQLite disagrees with its family row.
+    #[error("invalid SQLite treatment for family `{0}`")]
+    InvalidTreatment(String),
 }
 
 /// Closed-profile selector failure.
@@ -284,7 +291,6 @@ struct ProfileIdentity<'a> {
     name: &'a str,
     profile: &'a Profile,
     tasks: Vec<TaskIdentity<'a>>,
-    harness_digests: &'a BTreeMap<String, String>,
 }
 
 #[derive(Serialize)]
@@ -294,7 +300,7 @@ struct TaskIdentity<'a> {
 }
 
 impl EvaluationManifest {
-    /// Loads a manifest and resolves one immutable profile revision.
+    /// Loads and expands one optional profile recipe.
     pub fn load_profile(
         path: impl AsRef<Path>,
         requested: Option<&str>,
@@ -318,6 +324,45 @@ impl EvaluationManifest {
         manifest.resolve(config_path, requested)
     }
 
+    /// Resolves one named external harness from the current helper config.
+    /// Built-in Nanocodex execution requires no helper entry.
+    pub fn load_harness(
+        path: impl AsRef<Path>,
+        name: &str,
+    ) -> Result<Option<ResolvedHarness>, ProfileError> {
+        if name == BUILTIN_HARNESS {
+            return Ok(None);
+        }
+        let requested_path = path.as_ref();
+        let text = fs::read_to_string(requested_path).map_err(|source| ProfileError::Read {
+            path: requested_path.to_path_buf(),
+            source,
+        })?;
+        let manifest: Self = toml::from_str(&text).map_err(|source| ProfileError::Parse {
+            path: requested_path.to_path_buf(),
+            source,
+        })?;
+        let config_path =
+            requested_path
+                .canonicalize()
+                .map_err(|source| ProfileError::ResolvePath {
+                    path: requested_path.to_path_buf(),
+                    source,
+                })?;
+        let harness = manifest
+            .harness
+            .get(name)
+            .ok_or_else(|| ProfileError::UnknownHarness(name.to_owned()))?;
+        resolve_harness(
+            config_path
+                .parent()
+                .expect("a canonical config path has a parent"),
+            name,
+            harness,
+        )
+        .map(Some)
+    }
+
     fn resolve(
         self,
         config_path: PathBuf,
@@ -336,67 +381,6 @@ impl EvaluationManifest {
             .parent()
             .expect("a canonical manifest path has a parent");
         let tasks = load_tasks(root, profile)?;
-        let mut harnesses = BTreeMap::new();
-        let mut harness_digests = BTreeMap::new();
-        for harness_name in &profile.harness {
-            if harness_name == BUILTIN_HARNESS {
-                continue;
-            }
-            let harness =
-                self.harness
-                    .get(harness_name)
-                    .ok_or_else(|| ProfileError::UnknownHarness {
-                        profile: name.clone(),
-                        harness: harness_name.clone(),
-                    })?;
-            if !Path::new(&harness.guest_command).is_absolute()
-                || harness.guest_command.chars().any(char::is_whitespace)
-                || !Path::new(&harness.guest_command)
-                    .components()
-                    .all(|component| {
-                        matches!(
-                            component,
-                            std::path::Component::RootDir | std::path::Component::Normal(_)
-                        )
-                    })
-            {
-                return Err(ProfileError::InvalidHarnessGuestCommand {
-                    harness: harness_name.clone(),
-                    path: harness.guest_command.clone(),
-                });
-            }
-            let command = resolve_path(root, &harness.command)?;
-            let command_identity = match harness.version.as_deref() {
-                Some(version) if version.trim().is_empty() => {
-                    return Err(ProfileError::EmptyHarnessVersion(harness_name.clone()));
-                }
-                Some(version) => format!("version:{version}"),
-                None => harness_digest(&command)?,
-            };
-            let digest = hex::encode(Sha256::digest(serde_json::to_vec(&(
-                harness,
-                &command_identity,
-            ))?));
-            harnesses.insert(
-                harness_name.clone(),
-                ResolvedHarness {
-                    name: harness_name.clone(),
-                    command,
-                    guest_command: harness.guest_command.clone(),
-                    arguments: harness.arguments.clone(),
-                    environment: harness.environment.clone(),
-                    home: harness.home.clone(),
-                    auth_file: harness.auth_file.clone(),
-                    api_key_environment: harness.api_key_environment.clone(),
-                    api_upstream: harness.api_upstream.clone(),
-                    version: harness
-                        .version
-                        .clone()
-                        .unwrap_or_else(|| command_identity.clone()),
-                },
-            );
-            harness_digests.insert(harness_name.clone(), digest);
-        }
         let families = expand_families(profile, &tasks);
         let identity = ProfileIdentity {
             schema: 3,
@@ -409,51 +393,51 @@ impl EvaluationManifest {
                     digest: task.task.package_digest(),
                 })
                 .collect(),
-            harness_digests: &harness_digests,
         };
         let digest = hex::encode(Sha256::digest(serde_json::to_vec(&identity)?));
         Ok(ResolvedProfile {
             name,
             digest,
-            config_path,
             tasks,
             families,
-            harnesses,
-            web_search: profile.web_search,
             trials: profile.trials,
         })
     }
 }
 
 impl ResolvedProfile {
-    /// Converts this immutable revision into the complete SQLite workset
-    /// definition before any execution begins.
-    pub fn workset_spec(&self) -> WorksetSpec {
-        WorksetSpec {
-            profile: self.name.clone(),
-            digest: self.digest.clone(),
-            config_path: self.config_path.clone(),
-            tasks: self
-                .tasks
-                .iter()
-                .map(|resolved| crate::workset::WorksetTask {
-                    selector: resolved.selector.clone(),
-                    name: resolved.task.name().to_owned(),
-                    root: resolved.task.root().to_path_buf(),
-                    digest: resolved.task.package_digest().to_owned(),
-                })
-                .collect(),
-            families: self
-                .families
-                .iter()
-                .map(|family| crate::workset::WorksetFamily {
-                    key: family.key.clone(),
-                    task_selector: family.task.clone(),
-                    treatment: family.treatment(),
-                    trials: self.trials,
-                })
-                .collect(),
+    pub(crate) fn from_workset(definition: WorksetDefinition) -> Result<Self, ProfileError> {
+        let mut tasks = Vec::with_capacity(definition.tasks.len());
+        for retained in definition.tasks {
+            let task = Task::load(&retained.root)?;
+            if task.name() != retained.name || task.package_digest() != retained.digest {
+                return Err(ProfileError::TaskChanged {
+                    selector: retained.selector,
+                    digest: retained.digest,
+                });
+            }
+            tasks.push(ResolvedTask {
+                selector: retained.selector,
+                task,
+            });
         }
+        let mut families = Vec::with_capacity(definition.families.len());
+        let mut trials = 0;
+        for retained in definition.families {
+            let family: ResolvedFamily = serde_json::from_str(&retained.treatment)?;
+            if family.key != retained.key || family.task != retained.task_selector {
+                return Err(ProfileError::InvalidTreatment(retained.key));
+            }
+            trials = trials.max(retained.trials);
+            families.push(family);
+        }
+        Ok(Self {
+            name: definition.profile,
+            digest: definition.digest,
+            tasks,
+            families,
+            trials,
+        })
     }
 
     /// Resolves one exact task selector without permitting ad-hoc expansion.
@@ -475,6 +459,7 @@ impl ResolvedProfile {
         harness: Option<&str>,
         model: Option<Model>,
         thinking: Option<Thinking>,
+        web_search: Option<bool>,
     ) -> Result<&ResolvedFamily, ProfileSelectionError> {
         self.task(task)?;
         let harness = harness.unwrap_or(BUILTIN_HARNESS);
@@ -486,6 +471,7 @@ impl ResolvedProfile {
                     && family.harness == harness
                     && model.is_none_or(|model| family.model == model)
                     && thinking.is_none_or(|thinking| family.thinking == thinking)
+                    && web_search.is_none_or(|web_search| family.web_search == web_search)
             })
             .collect::<Vec<_>>();
         match matching.as_slice() {
@@ -499,11 +485,6 @@ impl ResolvedProfile {
                 task: task.to_owned(),
             }),
         }
-    }
-
-    /// Returns the pinned command for an external harness.
-    pub fn harness(&self, harness: &str) -> Option<&ResolvedHarness> {
-        self.harnesses.get(harness)
     }
 }
 
@@ -616,11 +597,16 @@ fn expand_families(profile: &Profile, tasks: &[ResolvedTask]) -> Vec<ResolvedFam
             for model in &profile.model {
                 for thinking in &profile.thinking {
                     let key = format!(
-                        "{}|{}|{}|{}",
+                        "{}|{}|{}|{}{}",
                         task.selector,
                         harness,
                         model.as_str(),
                         thinking.as_str(),
+                        if profile.web_search {
+                            "|web-search"
+                        } else {
+                            ""
+                        },
                     );
                     families.push(ResolvedFamily {
                         key,
@@ -628,6 +614,7 @@ fn expand_families(profile: &Profile, tasks: &[ResolvedTask]) -> Vec<ResolvedFam
                         harness: harness.clone(),
                         model: *model,
                         thinking: *thinking,
+                        web_search: profile.web_search,
                     });
                 }
             }
@@ -670,6 +657,49 @@ fn harness_digest(path: &Path) -> Result<String, ProfileError> {
         digest.update(&buffer[..read]);
     }
     Ok(hex::encode(digest.finalize()))
+}
+
+fn resolve_harness(
+    root: &Path,
+    name: &str,
+    harness: &Harness,
+) -> Result<ResolvedHarness, ProfileError> {
+    if !Path::new(&harness.guest_command).is_absolute()
+        || harness.guest_command.chars().any(char::is_whitespace)
+        || !Path::new(&harness.guest_command)
+            .components()
+            .all(|component| {
+                matches!(
+                    component,
+                    std::path::Component::RootDir | std::path::Component::Normal(_)
+                )
+            })
+    {
+        return Err(ProfileError::InvalidHarnessGuestCommand {
+            harness: name.to_owned(),
+            path: harness.guest_command.clone(),
+        });
+    }
+    let command = resolve_path(root, &harness.command)?;
+    let command_identity = match harness.version.as_deref() {
+        Some(version) if version.trim().is_empty() => {
+            return Err(ProfileError::EmptyHarnessVersion(name.to_owned()));
+        }
+        Some(version) => format!("version:{version}"),
+        None => harness_digest(&command)?,
+    };
+    Ok(ResolvedHarness {
+        name: name.to_owned(),
+        command,
+        guest_command: harness.guest_command.clone(),
+        arguments: harness.arguments.clone(),
+        environment: harness.environment.clone(),
+        home: harness.home.clone(),
+        auth_file: harness.auth_file.clone(),
+        api_key_environment: harness.api_key_environment.clone(),
+        api_upstream: harness.api_upstream.clone(),
+        version: harness.version.clone().unwrap_or(command_identity),
+    })
 }
 
 fn default_models() -> Vec<Model> {
@@ -723,6 +753,15 @@ where
     S: serde::Serializer,
 {
     serializer.serialize_str(value.as_str())
+}
+
+fn deserialize_one_thinking<'de, D>(deserializer: D) -> Result<Thinking, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    String::deserialize(deserializer)?
+        .parse()
+        .map_err(serde::de::Error::custom)
 }
 
 #[cfg(test)]
@@ -780,7 +819,7 @@ thinking = ["high"]
         let profile = EvaluationManifest::load_profile(&config, None).unwrap();
         assert_eq!(profile.name, "release");
         assert_eq!(profile.families.len(), 1);
-        assert_eq!(profile.workset_spec().families[0].trials, 3);
+        assert_eq!(profile.trials, 3);
         assert_eq!(profile.task("one").unwrap().task.name(), "one");
     }
 
@@ -807,7 +846,7 @@ trials = 1
     }
 
     #[test]
-    fn external_harness_revision_pins_the_command_bytes() {
+    fn profile_recipe_retains_only_the_harness_name() {
         let directory = tempfile::tempdir().unwrap();
         write_task(directory.path(), "one");
         let codex = directory.path().join("codex");
@@ -831,20 +870,27 @@ harness = ["nanocodex", "codex"]
         let first = EvaluationManifest::load_profile(&config, Some("release")).unwrap();
         assert_eq!(first.families.len(), 2);
         assert_eq!(
-            first.family("one", None, None, None).unwrap().harness,
+            first.family("one", None, None, None, None).unwrap().harness,
             "nanocodex"
         );
         assert_eq!(
             first
-                .family("one", Some("codex"), None, None)
+                .family("one", Some("codex"), None, None, None)
                 .unwrap()
                 .harness,
             "codex"
         );
+        let first_helper = EvaluationManifest::load_harness(&config, "codex")
+            .unwrap()
+            .unwrap();
         fs::write(&codex, "second build").unwrap();
         let second = EvaluationManifest::load_profile(&config, Some("release")).unwrap();
+        let second_helper = EvaluationManifest::load_harness(&config, "codex")
+            .unwrap()
+            .unwrap();
 
-        assert_ne!(first.digest, second.digest);
+        assert_eq!(first.digest, second.digest);
+        assert_ne!(first_helper.version, second_helper.version);
     }
 
     #[test]

--- a/crates/experimental/nanocodex-eval/src/workset.rs
+++ b/crates/experimental/nanocodex-eval/src/workset.rs
@@ -46,17 +46,13 @@ pub struct WorksetFamily {
     pub trials: u16,
 }
 
-/// Complete work definition read back from SQLite.
+#[cfg(test)]
 #[derive(Clone, Debug)]
-pub struct WorksetDefinition {
-    /// User-visible name of the durable board.
-    pub name: String,
-    /// Stable identifier of this board generation.
-    pub generation: String,
-    /// Task packages retained by the board.
-    pub tasks: Vec<WorksetTask>,
-    /// Exact treatments and desired repetition counts retained by the board.
-    pub families: Vec<WorksetFamily>,
+struct WorksetDefinition {
+    name: String,
+    generation: String,
+    tasks: Vec<WorksetTask>,
+    families: Vec<WorksetFamily>,
 }
 
 /// Durable SQLite workset ledger.
@@ -261,8 +257,58 @@ impl Workset {
         Ok(())
     }
 
-    /// Reads the concrete task and coordinate definitions retained in SQLite.
-    pub fn definition(&self) -> Result<WorksetDefinition, WorksetError> {
+    pub(crate) fn generation(&self) -> &str {
+        &self.generation
+    }
+
+    pub(crate) fn selected_definition(
+        &self,
+        selector: &str,
+    ) -> Result<Option<(WorksetTask, Vec<WorksetFamily>)>, WorksetError> {
+        let connection = open_connection(&self.path)?;
+        let task = connection
+            .query_row(
+                "SELECT id, name, root, digest FROM tasks \
+                 WHERE workset_id = ?1 AND selector = ?2",
+                params![self.id, selector],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        WorksetTask {
+                            selector: selector.to_owned(),
+                            name: row.get(1)?,
+                            root: PathBuf::from(row.get::<_, String>(2)?),
+                            digest: row.get(3)?,
+                        },
+                    ))
+                },
+            )
+            .optional()?;
+        let Some((task_id, task)) = task else {
+            return Ok(None);
+        };
+        let mut statement = connection.prepare(
+            "SELECT family_key, treatment, COUNT(*) FROM coordinates \
+             WHERE workset_id = ?1 AND task_id = ?2 \
+             GROUP BY family_key, treatment ORDER BY family_key",
+        )?;
+        let families = statement
+            .query_map(params![self.id, task_id], |row| {
+                let trials: i64 = row.get(2)?;
+                Ok(WorksetFamily {
+                    key: row.get(0)?,
+                    task_selector: selector.to_owned(),
+                    treatment: row.get(1)?,
+                    trials: u16::try_from(trials)
+                        .map_err(|_| rusqlite::Error::IntegralValueOutOfRange(2, trials))?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Some((task, families)))
+    }
+
+    #[cfg(test)]
+    fn definition(&self) -> Result<WorksetDefinition, WorksetError> {
         let connection = open_connection(&self.path)?;
         let mut tasks = connection.prepare(
             "SELECT selector, name, root, digest FROM tasks \

--- a/crates/experimental/nanocodex-eval/src/workset.rs
+++ b/crates/experimental/nanocodex-eval/src/workset.rs
@@ -1,6 +1,6 @@
-//! Durable profile worksets without execution policy.
+//! Durable SQLite worksets without execution policy.
 //!
-//! A workset records the complete desired profile matrix, but never chooses a
+//! A workset records the complete desired coordinate matrix, but never chooses a
 //! task for its caller. Callers select an exact coordinate family and the
 //! ledger atomically allocates one fungible repetition within that family.
 
@@ -9,27 +9,12 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use rusqlite::{Connection, OptionalExtension as _, TransactionBehavior, params};
+use rusqlite::{Connection, OptionalExtension as _, Transaction, TransactionBehavior, params};
 use serde::Serialize;
 use uuid::Uuid;
 
-const SCHEMA_VERSION: u32 = 2;
+const SCHEMA_VERSION: u32 = 3;
 const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
-
-/// Complete immutable definition of one profile revision.
-#[derive(Clone, Debug)]
-pub struct WorksetSpec {
-    /// Human-readable profile name.
-    pub profile: String,
-    /// Digest of the resolved profile, task packages, and treatments.
-    pub digest: String,
-    /// Canonical source configuration path.
-    pub config_path: PathBuf,
-    /// Exact task packages included in this revision.
-    pub tasks: Vec<WorksetTask>,
-    /// Exact coordinate families included in this revision.
-    pub families: Vec<WorksetFamily>,
-}
 
 /// One task package included in a workset.
 #[derive(Clone, Debug)]
@@ -44,7 +29,7 @@ pub struct WorksetTask {
     pub digest: String,
 }
 
-/// One exact treatment with a profile-owned repetition count.
+/// One exact treatment with a ledger-owned repetition count.
 #[derive(Clone, Debug)]
 pub struct WorksetFamily {
     /// Stable identity of all semantic knobs except repetition.
@@ -57,7 +42,20 @@ pub struct WorksetFamily {
     pub trials: u16,
 }
 
-/// Durable SQLite profile ledger.
+/// Complete work definition read back from SQLite.
+#[derive(Clone, Debug)]
+pub struct WorksetDefinition {
+    /// User-visible name of the durable board.
+    pub profile: String,
+    /// Stable identifier of this board generation.
+    pub digest: String,
+    /// Task packages retained by the board.
+    pub tasks: Vec<WorksetTask>,
+    /// Exact treatments and desired repetition counts retained by the board.
+    pub families: Vec<WorksetFamily>,
+}
+
+/// Durable SQLite workset ledger.
 #[derive(Clone, Debug)]
 pub struct Workset {
     path: PathBuf,
@@ -87,7 +85,7 @@ pub struct PreparationLease {
     owner: String,
 }
 
-/// Fenced ownership of one internal profile repetition.
+/// Fenced ownership of one internal workset repetition.
 #[derive(Clone, Debug)]
 pub struct CoordinateLease {
     coordinate_id: i64,
@@ -107,7 +105,7 @@ pub struct WorksetBusy {
     pub retry_after_ms: u64,
 }
 
-/// Profile-level durable status.
+/// Workset-level durable status.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct WorksetStatus {
     /// Profile name.
@@ -174,10 +172,13 @@ pub enum WorksetError {
     /// SQLite operation failed.
     #[error(transparent)]
     Sqlite(#[from] rusqlite::Error),
-    /// The selected profile family is not part of the initialized workset.
-    #[error("coordinate family `{0}` is not part of this profile revision")]
+    /// No generation exists for the requested workset name.
+    #[error("evaluation workset `{0}` does not exist")]
+    UnknownWorkset(String),
+    /// The selected family is not part of the initialized workset.
+    #[error("coordinate family `{0}` is not part of this workset")]
     UnknownFamily(String),
-    /// A family references a task absent from the same profile revision.
+    /// A family references a task absent from the same workset.
     #[error("coordinate family `{family}` references unknown task `{task}`")]
     UnknownTask {
         /// Family containing the invalid reference.
@@ -185,8 +186,8 @@ pub enum WorksetError {
         /// Missing profile-visible task selector.
         task: String,
     },
-    /// An initialized profile revision disagrees with its immutable definition.
-    #[error("profile revision `{0}` conflicts with its initialized SQLite workset")]
+    /// Appended work disagrees with a definition already retained in SQLite.
+    #[error("workset `{0}` conflicts with its retained SQLite definition")]
     DefinitionConflict(String),
     /// A stale worker attempted to mutate work after losing its lease.
     #[error("stale {kind} lease was fenced before it could commit")]
@@ -200,87 +201,108 @@ pub enum WorksetError {
 }
 
 impl Workset {
-    /// Opens the SQLite file, initializes its schema, and idempotently
-    /// materializes every task and repetition in `spec`.
-    pub fn ensure(path: impl Into<PathBuf>, spec: &WorksetSpec) -> Result<Self, WorksetError> {
+    /// Opens the newest generation of a named durable workset.
+    pub fn open(path: impl Into<PathBuf>, profile: &str) -> Result<Self, WorksetError> {
         let path = path.into();
         let mut connection = open_connection(&path)?;
         initialize_schema(&mut connection)?;
-        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        transaction.execute(
-            "INSERT OR IGNORE INTO worksets(profile, digest, config_path, created_at_ms) \
-             VALUES (?1, ?2, ?3, ?4)",
-            params![
-                spec.profile,
-                spec.digest,
-                spec.config_path.to_string_lossy(),
-                now_ms()?
-            ],
-        )?;
-        let id: i64 = transaction.query_row(
-            "SELECT id FROM worksets WHERE profile = ?1 AND digest = ?2",
-            params![spec.profile, spec.digest],
-            |row| row.get(0),
-        )?;
-        for task in &spec.tasks {
-            transaction.execute(
-                "INSERT OR IGNORE INTO tasks( \
-                    workset_id, selector, name, root, digest, preparation_state, preparation_generation \
-                 ) VALUES (?1, ?2, ?3, ?4, ?5, 'pending', 0)",
-                params![
-                    id,
-                    task.selector,
-                    task.name,
-                    task.root.to_string_lossy(),
-                    task.digest
-                ],
-            )?;
-            let retained: Option<(String, String, String)> = transaction
-                .query_row(
-                    "SELECT name, root, digest FROM tasks WHERE workset_id = ?1 AND selector = ?2",
-                    params![id, task.selector],
-                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-                )
-                .optional()?;
-            if retained.as_ref()
-                != Some(&(
-                    task.name.clone(),
-                    task.root.to_string_lossy().into_owned(),
-                    task.digest.clone(),
-                ))
-            {
-                return Err(WorksetError::DefinitionConflict(spec.digest.clone()));
-            }
-        }
-        for family in &spec.families {
-            let task_id: Option<i64> = transaction
-                .query_row(
-                    "SELECT id FROM tasks WHERE workset_id = ?1 AND selector = ?2",
-                    params![id, family.task_selector],
-                    |row| row.get(0),
-                )
-                .optional()?;
-            let Some(task_id) = task_id else {
-                return Err(WorksetError::UnknownTask {
-                    family: family.key.clone(),
-                    task: family.task_selector.clone(),
-                });
-            };
-            for repetition in 1..=family.trials {
-                transaction.execute(
-                    "INSERT OR IGNORE INTO coordinates( \
-                        workset_id, task_id, family_key, treatment, repetition, state, generation \
-                     ) VALUES (?1, ?2, ?3, ?4, ?5, 'pending', 0)",
-                    params![id, task_id, family.key, family.treatment, repetition],
-                )?;
-            }
-        }
-        transaction.commit()?;
+        let retained: Option<(i64, String)> = connection
+            .query_row(
+                "SELECT id, digest FROM worksets WHERE profile = ?1 \
+                 ORDER BY created_at_ms DESC, id DESC LIMIT 1",
+                [profile],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+        let Some((id, digest)) = retained else {
+            return Err(WorksetError::UnknownWorkset(profile.to_owned()));
+        };
         Ok(Self {
             path,
             id,
-            profile: spec.profile.clone(),
-            digest: spec.digest.clone(),
+            profile: profile.to_owned(),
+            digest,
+        })
+    }
+
+    /// Creates a new empty generation of a named workset.
+    pub fn create(path: impl Into<PathBuf>, profile: &str) -> Result<Self, WorksetError> {
+        let path = path.into();
+        let mut connection = open_connection(&path)?;
+        initialize_schema(&mut connection)?;
+        let digest = Uuid::now_v7().simple().to_string();
+        connection.execute(
+            "INSERT INTO worksets(profile, digest, config_path, created_at_ms) \
+             VALUES (?1, ?2, '', ?3)",
+            params![profile, digest, now_ms()?],
+        )?;
+        Ok(Self {
+            path,
+            id: connection.last_insert_rowid(),
+            profile: profile.to_owned(),
+            digest,
+        })
+    }
+
+    /// Idempotently appends tasks, treatments, and any missing repetitions.
+    /// Existing accepted work is never rewritten or removed.
+    pub fn append(
+        &self,
+        tasks: &[WorksetTask],
+        families: &[WorksetFamily],
+    ) -> Result<(), WorksetError> {
+        let mut connection = open_connection(&self.path)?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        append_definition(&transaction, self.id, &self.digest, tasks, families)?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    /// Reads the concrete task and coordinate definitions retained in SQLite.
+    pub fn definition(&self) -> Result<WorksetDefinition, WorksetError> {
+        let connection = open_connection(&self.path)?;
+        let mut tasks = connection.prepare(
+            "SELECT selector, name, root, digest FROM tasks \
+             WHERE workset_id = ?1 ORDER BY selector",
+        )?;
+        let tasks = tasks
+            .query_map([self.id], |row| {
+                Ok(WorksetTask {
+                    selector: row.get(0)?,
+                    name: row.get(1)?,
+                    root: PathBuf::from(row.get::<_, String>(2)?),
+                    digest: row.get(3)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut families = connection.prepare(
+            "SELECT c.family_key, t.selector, c.treatment, COUNT(*) \
+             FROM coordinates c JOIN tasks t ON t.id = c.task_id \
+             WHERE c.workset_id = ?1 \
+             GROUP BY c.family_key, t.selector, c.treatment \
+             ORDER BY t.selector, c.family_key",
+        )?;
+        let families = families
+            .query_map([self.id], |row| {
+                let trials: i64 = row.get(3)?;
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?, trials))
+            })?
+            .map(|row| {
+                let (key, task_selector, treatment, trials) = row?;
+                Ok(WorksetFamily {
+                    key,
+                    task_selector,
+                    treatment,
+                    trials: u16::try_from(trials)
+                        .map_err(|_| WorksetError::OutOfRange("family trials"))?,
+                })
+            })
+            .collect::<Result<Vec<_>, WorksetError>>()?;
+        Ok(WorksetDefinition {
+            profile: self.profile.clone(),
+            digest: self.digest.clone(),
+            tasks,
+            families,
         })
     }
 
@@ -514,7 +536,7 @@ impl Workset {
         self.finish_coordinate(lease, "pending", None, Some(error))
     }
 
-    /// Reads a complete profile and family status snapshot.
+    /// Reads a complete workset and family status snapshot.
     pub fn status(&self) -> Result<WorksetStatus, WorksetError> {
         let connection = open_connection(&self.path)?;
         let now = now_ms()?;
@@ -631,6 +653,89 @@ impl Workset {
         transaction.commit()?;
         Ok(())
     }
+}
+
+fn append_definition(
+    transaction: &Transaction<'_>,
+    workset_id: i64,
+    workset_digest: &str,
+    tasks: &[WorksetTask],
+    families: &[WorksetFamily],
+) -> Result<(), WorksetError> {
+    for task in tasks {
+        transaction.execute(
+            "INSERT OR IGNORE INTO tasks( \
+                workset_id, selector, name, root, digest, preparation_state, preparation_generation \
+             ) VALUES (?1, ?2, ?3, ?4, ?5, 'pending', 0)",
+            params![
+                workset_id,
+                task.selector,
+                task.name,
+                task.root.to_string_lossy(),
+                task.digest
+            ],
+        )?;
+        let retained: Option<(String, String, String)> = transaction
+            .query_row(
+                "SELECT name, root, digest FROM tasks WHERE workset_id = ?1 AND selector = ?2",
+                params![workset_id, task.selector],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .optional()?;
+        if retained.as_ref()
+            != Some(&(
+                task.name.clone(),
+                task.root.to_string_lossy().into_owned(),
+                task.digest.clone(),
+            ))
+        {
+            return Err(WorksetError::DefinitionConflict(workset_digest.to_owned()));
+        }
+    }
+    for family in families {
+        let task_id: Option<i64> = transaction
+            .query_row(
+                "SELECT id FROM tasks WHERE workset_id = ?1 AND selector = ?2",
+                params![workset_id, family.task_selector],
+                |row| row.get(0),
+            )
+            .optional()?;
+        let Some(task_id) = task_id else {
+            return Err(WorksetError::UnknownTask {
+                family: family.key.clone(),
+                task: family.task_selector.clone(),
+            });
+        };
+        let retained: Option<(i64, String)> = transaction
+            .query_row(
+                "SELECT task_id, treatment FROM coordinates \
+                 WHERE workset_id = ?1 AND family_key = ?2 LIMIT 1",
+                params![workset_id, family.key],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?;
+        if retained
+            .as_ref()
+            .is_some_and(|retained| retained != &(task_id, family.treatment.clone()))
+        {
+            return Err(WorksetError::DefinitionConflict(workset_digest.to_owned()));
+        }
+        for repetition in 1..=family.trials {
+            transaction.execute(
+                "INSERT OR IGNORE INTO coordinates( \
+                    workset_id, task_id, family_key, treatment, repetition, state, generation \
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, 'pending', 0)",
+                params![
+                    workset_id,
+                    task_id,
+                    family.key,
+                    family.treatment,
+                    repetition
+                ],
+            )?;
+        }
+    }
+    Ok(())
 }
 
 fn open_connection(path: &Path) -> Result<Connection, WorksetError> {
@@ -771,29 +876,32 @@ const fn fenced(changed: usize, kind: &'static str) -> Result<(), WorksetError> 
 mod tests {
     use super::*;
 
-    fn spec(root: &Path, trials: u16) -> WorksetSpec {
-        WorksetSpec {
-            profile: "release".to_owned(),
-            digest: "profile-digest".to_owned(),
-            config_path: root.join("nanocodex.toml"),
-            tasks: vec![WorksetTask {
+    fn definition(root: &Path, trials: u16) -> (Vec<WorksetTask>, Vec<WorksetFamily>) {
+        (
+            vec![WorksetTask {
                 selector: "terminal/fix-git".to_owned(),
                 name: "fix-git".to_owned(),
                 root: root.join("fix-git"),
                 digest: "task-digest".to_owned(),
             }],
-            families: vec![WorksetFamily {
+            vec![WorksetFamily {
                 key: "terminal/fix-git|harness|high".to_owned(),
                 task_selector: "terminal/fix-git".to_owned(),
                 treatment: "codex high".to_owned(),
                 trials,
             }],
-        }
+        )
+    }
+
+    fn workset(directory: &Path, trials: u16) -> Workset {
+        let workset = Workset::create(directory.join("state.sqlite3"), "release").unwrap();
+        let (tasks, families) = definition(directory, trials);
+        workset.append(&tasks, &families).unwrap();
+        workset
     }
 
     fn prepared_workset(directory: &Path, trials: u16) -> Workset {
-        let workset =
-            Workset::ensure(directory.join("state.sqlite3"), &spec(directory, trials)).unwrap();
+        let workset = workset(directory, trials);
         let BeginCoordinate::Prepare(preparation) = workset
             .begin("terminal/fix-git|harness|high", Duration::from_secs(30))
             .unwrap()
@@ -805,18 +913,53 @@ mod tests {
     }
 
     #[test]
-    fn ensure_materializes_every_repetition_before_execution() {
+    fn append_materializes_every_repetition_before_execution() {
         let directory = tempfile::tempdir().unwrap();
-        let workset = Workset::ensure(
-            directory.path().join("state.sqlite3"),
-            &spec(directory.path(), 3),
-        )
-        .unwrap();
+        let workset = workset(directory.path(), 3);
         let status = workset.status().unwrap();
 
         assert_eq!(status.preparation.pending, 1);
         assert_eq!(status.coordinates.pending, 3);
         assert_eq!(status.families[0].desired, 3);
+    }
+
+    #[test]
+    fn named_workset_can_be_reopened_and_extended_without_a_manifest() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("state.sqlite3");
+        let workset = Workset::create(&path, "release").unwrap();
+        let (tasks, families) = definition(directory.path(), 2);
+        workset.append(&tasks, &families).unwrap();
+        let reopened = Workset::open(&path, "release").unwrap();
+        let retained = reopened.definition().unwrap();
+
+        assert_eq!(retained.profile, "release");
+        assert_eq!(retained.digest, workset.digest);
+        assert_eq!(retained.tasks.len(), 1);
+        assert_eq!(retained.families[0].trials, 2);
+
+        let (tasks, families) = definition(directory.path(), 5);
+        reopened.append(&tasks, &families).unwrap();
+        assert_eq!(reopened.status().unwrap().coordinates.pending, 5);
+        assert_eq!(reopened.definition().unwrap().families[0].trials, 5);
+    }
+
+    #[test]
+    fn new_generation_does_not_mutate_the_previous_board() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("state.sqlite3");
+        let first = Workset::create(&path, "release").unwrap();
+        let (tasks, families) = definition(directory.path(), 1);
+        first.append(&tasks, &families).unwrap();
+        let second = Workset::create(&path, "release").unwrap();
+
+        assert_ne!(first.digest, second.digest);
+        assert_eq!(
+            Workset::open(&path, "release").unwrap().digest,
+            second.digest
+        );
+        assert!(second.definition().unwrap().tasks.is_empty());
+        assert_eq!(first.definition().unwrap().tasks.len(), 1);
     }
 
     #[test]
@@ -851,11 +994,7 @@ mod tests {
     #[test]
     fn one_host_owns_task_preparation_and_every_coordinate() {
         let directory = tempfile::tempdir().unwrap();
-        let workset = Workset::ensure(
-            directory.path().join("state.sqlite3"),
-            &spec(directory.path(), 1),
-        )
-        .unwrap();
+        let workset = workset(directory.path(), 1);
         let BeginCoordinate::Prepare(preparation) = workset
             .begin_for_host(
                 "terminal/fix-git|harness|high",
@@ -901,11 +1040,7 @@ mod tests {
     #[test]
     fn expired_preparation_is_reported_pending_and_fenced_on_reclamation() {
         let directory = tempfile::tempdir().unwrap();
-        let workset = Workset::ensure(
-            directory.path().join("state.sqlite3"),
-            &spec(directory.path(), 1),
-        )
-        .unwrap();
+        let workset = workset(directory.path(), 1);
         let BeginCoordinate::Prepare(stale) = workset
             .begin("terminal/fix-git|harness|high", Duration::ZERO)
             .unwrap()
@@ -995,11 +1130,7 @@ mod tests {
     #[test]
     fn unknown_family_never_expands_the_closed_profile() {
         let directory = tempfile::tempdir().unwrap();
-        let workset = Workset::ensure(
-            directory.path().join("state.sqlite3"),
-            &spec(directory.path(), 1),
-        )
-        .unwrap();
+        let workset = workset(directory.path(), 1);
 
         assert!(matches!(
             workset.begin("not-in-profile", Duration::from_secs(30)),
@@ -1017,7 +1148,7 @@ mod tests {
         drop(connection);
 
         assert!(matches!(
-            Workset::ensure(&path, &spec(directory.path(), 1)),
+            Workset::open(&path, "release"),
             Err(WorksetError::DefinitionConflict(message)) if message.contains("schema 99")
         ));
         let connection = Connection::open(path).unwrap();
@@ -1061,7 +1192,9 @@ mod tests {
             .unwrap();
         drop(connection);
 
-        let workset = Workset::ensure(&path, &spec(directory.path(), 1)).unwrap();
+        let workset = Workset::create(&path, "release").unwrap();
+        let (tasks, families) = definition(directory.path(), 1);
+        workset.append(&tasks, &families).unwrap();
         let BeginCoordinate::Prepare(preparation) = workset
             .begin_for_host(
                 "terminal/fix-git|harness|high",

--- a/crates/experimental/nanocodex-eval/src/workset.rs
+++ b/crates/experimental/nanocodex-eval/src/workset.rs
@@ -13,13 +13,17 @@ use rusqlite::{Connection, OptionalExtension as _, Transaction, TransactionBehav
 use serde::Serialize;
 use uuid::Uuid;
 
-const SCHEMA_VERSION: u32 = 3;
+const SCHEMA_VERSION: u32 = 4;
 const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// One task package included in a workset.
+/// One host-local task reference included in a workset.
+///
+/// SQLite retains the selector, canonical root, task name, and content digest.
+/// The task package itself remains on the assigned host and is loaded from
+/// `root` before preparation or execution.
 #[derive(Clone, Debug)]
 pub struct WorksetTask {
-    /// Profile-visible task selector.
+    /// User-visible task selector.
     pub selector: String,
     /// Loaded task name.
     pub name: String,
@@ -46,9 +50,9 @@ pub struct WorksetFamily {
 #[derive(Clone, Debug)]
 pub struct WorksetDefinition {
     /// User-visible name of the durable board.
-    pub profile: String,
+    pub name: String,
     /// Stable identifier of this board generation.
-    pub digest: String,
+    pub generation: String,
     /// Task packages retained by the board.
     pub tasks: Vec<WorksetTask>,
     /// Exact treatments and desired repetition counts retained by the board.
@@ -60,8 +64,8 @@ pub struct WorksetDefinition {
 pub struct Workset {
     path: PathBuf,
     id: i64,
-    profile: String,
-    digest: String,
+    name: String,
+    generation: String,
 }
 
 /// Result of requesting one repetition from an exact coordinate family.
@@ -108,10 +112,10 @@ pub struct WorksetBusy {
 /// Workset-level durable status.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct WorksetStatus {
-    /// Profile name.
-    pub profile: String,
-    /// Immutable resolved-profile digest.
-    pub digest: String,
+    /// Workset name.
+    pub name: String,
+    /// Stable identifier of this workset generation.
+    pub generation: String,
     /// Task-preparation counts.
     pub preparation: StateCounts,
     /// Coordinate execution counts.
@@ -147,7 +151,7 @@ pub struct CoordinateCounts {
 pub struct FamilyStatus {
     /// Stable family identity.
     pub key: String,
-    /// Profile-visible task selector.
+    /// User-visible task selector.
     pub task: String,
     /// Network identity of the host that owns preparation and execution.
     pub assigned_host: Option<String>,
@@ -183,7 +187,7 @@ pub enum WorksetError {
     UnknownTask {
         /// Family containing the invalid reference.
         family: String,
-        /// Missing profile-visible task selector.
+        /// Missing user-visible task selector.
         task: String,
     },
     /// Appended work disagrees with a definition already retained in SQLite.
@@ -202,45 +206,44 @@ pub enum WorksetError {
 
 impl Workset {
     /// Opens the newest generation of a named durable workset.
-    pub fn open(path: impl Into<PathBuf>, profile: &str) -> Result<Self, WorksetError> {
+    pub fn open(path: impl Into<PathBuf>, name: &str) -> Result<Self, WorksetError> {
         let path = path.into();
         let mut connection = open_connection(&path)?;
         initialize_schema(&mut connection)?;
         let retained: Option<(i64, String)> = connection
             .query_row(
-                "SELECT id, digest FROM worksets WHERE profile = ?1 \
+                "SELECT id, generation FROM worksets WHERE name = ?1 \
                  ORDER BY created_at_ms DESC, id DESC LIMIT 1",
-                [profile],
+                [name],
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .optional()?;
-        let Some((id, digest)) = retained else {
-            return Err(WorksetError::UnknownWorkset(profile.to_owned()));
+        let Some((id, generation)) = retained else {
+            return Err(WorksetError::UnknownWorkset(name.to_owned()));
         };
         Ok(Self {
             path,
             id,
-            profile: profile.to_owned(),
-            digest,
+            name: name.to_owned(),
+            generation,
         })
     }
 
     /// Creates a new empty generation of a named workset.
-    pub fn create(path: impl Into<PathBuf>, profile: &str) -> Result<Self, WorksetError> {
+    pub fn create(path: impl Into<PathBuf>, name: &str) -> Result<Self, WorksetError> {
         let path = path.into();
         let mut connection = open_connection(&path)?;
         initialize_schema(&mut connection)?;
-        let digest = Uuid::now_v7().simple().to_string();
+        let generation = Uuid::now_v7().simple().to_string();
         connection.execute(
-            "INSERT INTO worksets(profile, digest, config_path, created_at_ms) \
-             VALUES (?1, ?2, '', ?3)",
-            params![profile, digest, now_ms()?],
+            "INSERT INTO worksets(name, generation, created_at_ms) VALUES (?1, ?2, ?3)",
+            params![name, generation, now_ms()?],
         )?;
         Ok(Self {
             path,
             id: connection.last_insert_rowid(),
-            profile: profile.to_owned(),
-            digest,
+            name: name.to_owned(),
+            generation,
         })
     }
 
@@ -253,7 +256,7 @@ impl Workset {
     ) -> Result<(), WorksetError> {
         let mut connection = open_connection(&self.path)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        append_definition(&transaction, self.id, &self.digest, tasks, families)?;
+        append_definition(&transaction, self.id, &self.generation, tasks, families)?;
         transaction.commit()?;
         Ok(())
     }
@@ -299,8 +302,8 @@ impl Workset {
             })
             .collect::<Result<Vec<_>, WorksetError>>()?;
         Ok(WorksetDefinition {
-            profile: self.profile.clone(),
-            digest: self.digest.clone(),
+            name: self.name.clone(),
+            generation: self.generation.clone(),
             tasks,
             families,
         })
@@ -584,8 +587,8 @@ impl Workset {
             })?
             .collect::<Result<Vec<_>, _>>()?;
         Ok(WorksetStatus {
-            profile: self.profile.clone(),
-            digest: self.digest.clone(),
+            name: self.name.clone(),
+            generation: self.generation.clone(),
             preparation,
             coordinates,
             families,
@@ -658,7 +661,7 @@ impl Workset {
 fn append_definition(
     transaction: &Transaction<'_>,
     workset_id: i64,
-    workset_digest: &str,
+    workset_generation: &str,
     tasks: &[WorksetTask],
     families: &[WorksetFamily],
 ) -> Result<(), WorksetError> {
@@ -689,7 +692,9 @@ fn append_definition(
                 task.digest.clone(),
             ))
         {
-            return Err(WorksetError::DefinitionConflict(workset_digest.to_owned()));
+            return Err(WorksetError::DefinitionConflict(
+                workset_generation.to_owned(),
+            ));
         }
     }
     for family in families {
@@ -718,7 +723,9 @@ fn append_definition(
             .as_ref()
             .is_some_and(|retained| retained != &(task_id, family.treatment.clone()))
         {
-            return Err(WorksetError::DefinitionConflict(workset_digest.to_owned()));
+            return Err(WorksetError::DefinitionConflict(
+                workset_generation.to_owned(),
+            ));
         }
         for repetition in 1..=family.trials {
             transaction.execute(
@@ -759,11 +766,10 @@ fn initialize_schema(connection: &mut Connection) -> Result<(), WorksetError> {
     connection.execute_batch(
         "CREATE TABLE IF NOT EXISTS worksets(
             id INTEGER PRIMARY KEY,
-            profile TEXT NOT NULL,
-            digest TEXT NOT NULL,
-            config_path TEXT NOT NULL,
+            name TEXT NOT NULL,
+            generation TEXT NOT NULL,
             created_at_ms INTEGER NOT NULL,
-            UNIQUE(profile, digest)
+            UNIQUE(name, generation)
          );
          CREATE TABLE IF NOT EXISTS tasks(
             id INTEGER PRIMARY KEY,
@@ -808,9 +814,18 @@ fn initialize_schema(connection: &mut Connection) -> Result<(), WorksetError> {
             UNIQUE(coordinate_id, generation)
          );",
     )?;
-    if version == 1 {
+    if version != 0 && version < SCHEMA_VERSION {
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        transaction.execute("ALTER TABLE tasks ADD COLUMN assigned_host TEXT", [])?;
+        if version == 1 {
+            transaction.execute("ALTER TABLE tasks ADD COLUMN assigned_host TEXT", [])?;
+        }
+        transaction.execute("ALTER TABLE worksets RENAME COLUMN profile TO name", [])?;
+        transaction.execute(
+            "ALTER TABLE worksets RENAME COLUMN digest TO generation",
+            [],
+        )?;
+        transaction.execute("ALTER TABLE worksets DROP COLUMN config_path", [])?;
+        transaction.execute("DROP TABLE IF EXISTS workset_seeds", [])?;
         transaction.pragma_update(None, "user_version", SCHEMA_VERSION)?;
         transaction.commit()?;
     } else {
@@ -933,8 +948,8 @@ mod tests {
         let reopened = Workset::open(&path, "release").unwrap();
         let retained = reopened.definition().unwrap();
 
-        assert_eq!(retained.profile, "release");
-        assert_eq!(retained.digest, workset.digest);
+        assert_eq!(retained.name, "release");
+        assert_eq!(retained.generation, workset.generation);
         assert_eq!(retained.tasks.len(), 1);
         assert_eq!(retained.families[0].trials, 2);
 
@@ -953,10 +968,10 @@ mod tests {
         first.append(&tasks, &families).unwrap();
         let second = Workset::create(&path, "release").unwrap();
 
-        assert_ne!(first.digest, second.digest);
+        assert_ne!(first.generation, second.generation);
         assert_eq!(
-            Workset::open(&path, "release").unwrap().digest,
-            second.digest
+            Workset::open(&path, "release").unwrap().generation,
+            second.generation
         );
         assert!(second.definition().unwrap().tasks.is_empty());
         assert_eq!(first.definition().unwrap().tasks.len(), 1);
@@ -1159,7 +1174,7 @@ mod tests {
     }
 
     #[test]
-    fn version_one_ledgers_gain_host_assignment_without_losing_work() {
+    fn legacy_ledgers_migrate_without_retaining_profile_columns_or_seed_tables() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("state.sqlite3");
         let connection = Connection::open(&path).unwrap();
@@ -1186,6 +1201,10 @@ mod tests {
                     preparation_expires_at_ms INTEGER,
                     preparation_error TEXT,
                     UNIQUE(workset_id, selector)
+                 );
+                 CREATE TABLE workset_seeds(
+                    workset_id INTEGER NOT NULL,
+                    config_path TEXT NOT NULL
                  );
                  PRAGMA user_version = 1;",
             )
@@ -1217,5 +1236,21 @@ mod tests {
             .pragma_query_value(None, "user_version", |row| row.get(0))
             .unwrap();
         assert_eq!(version, SCHEMA_VERSION);
+        let columns = connection
+            .prepare("PRAGMA table_info(worksets)")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(columns, ["id", "name", "generation", "created_at_ms"]);
+        let seeds: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'workset_seeds'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(seeds, 0);
     }
 }


### PR DESCRIPTION
## Summary

- make `~/.nanocodex/evals/state.sqlite3` the authority for named benchmark profiles
- add `nanocodex eval add PROFILE` for explicit matrices or optional TOML recipes
- reopen and extend the latest profile generation by default; use `--new` for a fresh generation
- retain only host-local task references in SQLite: selector, canonical root, task name, and content digest
- resolve external harness helpers from current TOML only when a selected job executes
- let remote workers claim with ordinary task selectors without the originating profile file
- preserve board-aware systemd supervision until every coordinate is terminal

## Command flow

```sh
nanocodex eval add terminal-bench --task tasks/example --harness nanocodex --harness codex --model luna --model sol --thinking low --thinking medium --thinking high --thinking xhigh --trials 5
nanocodex eval add terminal-bench --recipe terminal-bench-full
nanocodex eval status terminal-bench
nanocodex eval benchmark terminal-bench --systemd
nanocodex eval run terminal-bench --task tasks/example --harness codex --model luna --thinking high
```

A `[profiles.*]` entry is only an optional expansion recipe via `eval add PROFILE --recipe NAME`; it is not retained authority. `[harness.*]` entries remain runtime helper configuration. SQLite schema v4 replaces the legacy `profile`, `digest`, and `config_path` workset columns with `name` and `generation`, and removes the obsolete seed table.

## Validation

- 79 `nanocodex-eval` library tests
- 276 `nanocodex-bin` tests (2 ignored manual MCP tests)
- Clippy with warnings denied for both packages
- command smoke covering explicit add, TOML recipe expansion, latest-generation selection, `--new`, and the schema-v4 column shape