### PR TITLE
fix(cli): tolerate missing default browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Bug Fixes
+
+- [cli] Fall back to another installed Chromium-family browser when the default
+  Brave installation is absent, or omit browser tools when none is available,
+  while keeping explicit browser selection strict.
+
 ## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12
 
 ### Bug Fixes

--- a/bin/nanocodex/src/browser.rs
+++ b/bin/nanocodex/src/browser.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use clap::{Args, ValueEnum};
 use eyre::{Result, WrapErr, eyre};
 use nanocodex_browser::{
-    BraveSession, Browser, BrowserProfileKind, BrowserStorageState, BrowserTool,
+    BraveSession, BraveSessionError, Browser, BrowserProfileKind, BrowserStorageState, BrowserTool,
     FirefoxCookieSource, SafariCookieSource,
 };
 
@@ -40,14 +40,15 @@ enum CookieSource {
 pub(crate) struct BrowserArgs {
     /// Select the private browser exposed to Code Mode as `tools.browser`.
     ///
-    /// Brave is the default. Pass `chromium` to use private Chromium or `none`
-    /// to disable browser tools.
+    /// By default, Nanocodex prefers Brave, falls back to another installed
+    /// Chromium-family browser, and disables browser tools when none is
+    /// available. Pass `brave` to require the standard Brave installation,
+    /// `chromium` to skip Brave, or `none` to disable browser tools.
     #[arg(
         long,
         env = "NANOCODEX_BROWSER",
         value_enum,
         num_args = 0..=1,
-        default_value = "brave",
         default_missing_value = "brave",
         require_equals = true
     )]
@@ -77,7 +78,7 @@ pub(crate) struct BrowserArgs {
 impl Default for BrowserArgs {
     fn default() -> Self {
         Self {
-            browser: Some(BrowserKind::Brave),
+            browser: None,
             cookies: Some(CookieSourceKind::All),
             browser_executable: None,
         }
@@ -97,7 +98,7 @@ impl BrowserArgs {
 
     #[cfg(test)]
     pub(crate) const fn is_enabled(&self) -> bool {
-        !matches!(self.browser, None | Some(BrowserKind::None))
+        !matches!(self.browser, Some(BrowserKind::None))
     }
 
     #[cfg(test)]
@@ -111,10 +112,7 @@ impl BrowserArgs {
     }
 
     pub(crate) fn configure(&self, workspace: &Path) -> Result<Option<ConfiguredBrowser>> {
-        let Some(kind) = self.browser else {
-            return Ok(None);
-        };
-        if kind == BrowserKind::None {
+        if self.browser == Some(BrowserKind::None) {
             if self.cookies.is_some_and(|source| {
                 !matches!(source, CookieSourceKind::All | CookieSourceKind::None)
             }) {
@@ -125,30 +123,23 @@ impl BrowserArgs {
             }
             return Ok(None);
         }
+        let Some(launch) = resolve_browser_launch(
+            self.browser,
+            self.browser_executable.as_deref(),
+            BraveSession::standard_for,
+        )?
+        else {
+            return Ok(None);
+        };
         let mut builder = Browser::builder().file_root(workspace);
-        match kind {
-            BrowserKind::Chromium => {
-                if let Some(executable) = &self.browser_executable {
-                    builder = builder.executable(executable);
-                }
-            }
-            BrowserKind::Brave => {
-                if self.browser_executable.is_some() {
-                    return Err(eyre!(
-                        "--browser-executable cannot be combined with --browser=brave"
-                    ));
-                }
-                let brave = BraveSession::standard()
-                    .wrap_err("failed to locate the standard Brave profile")?;
-                builder = builder.executable(brave.executable().to_path_buf());
-            }
-            BrowserKind::None => unreachable!("disabled browsers return before configuration"),
+        if let Some(executable) = launch.executable {
+            builder = builder.executable(executable);
         }
         if let Some(source) = self
             .cookies
             .filter(|source| *source != CookieSourceKind::None)
         {
-            builder = match cookie_source(source, kind)? {
+            builder = match cookie_source(source, launch.kind)? {
                 CookieSource::Chromium(source) => builder.cookie_source(source.copy_all_cookies()),
                 CookieSource::State(state) => builder.storage_state(state),
             };
@@ -157,6 +148,66 @@ impl BrowserArgs {
             .build()
             .wrap_err("failed to configure the browser tool")?;
         Ok(Some(ConfiguredBrowser { browser }))
+    }
+}
+
+struct BrowserLaunch {
+    kind: BrowserKind,
+    executable: Option<PathBuf>,
+}
+
+fn resolve_browser_launch(
+    requested: Option<BrowserKind>,
+    explicit_executable: Option<&Path>,
+    mut standard_profile: impl FnMut(BrowserProfileKind) -> Result<BraveSession, BraveSessionError>,
+) -> Result<Option<BrowserLaunch>> {
+    if requested == Some(BrowserKind::None) {
+        unreachable!("disabled browsers return before launch resolution");
+    }
+    if requested == Some(BrowserKind::Brave) && explicit_executable.is_some() {
+        return Err(eyre!(
+            "--browser-executable cannot be combined with --browser=brave"
+        ));
+    }
+    if let Some(executable) = explicit_executable {
+        return Ok(Some(BrowserLaunch {
+            kind: BrowserKind::Chromium,
+            executable: Some(executable.to_path_buf()),
+        }));
+    }
+    match requested {
+        None => Ok([
+            BrowserProfileKind::Brave,
+            BrowserProfileKind::Chrome,
+            BrowserProfileKind::Chromium,
+            BrowserProfileKind::Edge,
+        ]
+        .into_iter()
+        .find_map(|profile| {
+            standard_profile(profile).ok().map(|session| BrowserLaunch {
+                kind: if profile == BrowserProfileKind::Brave {
+                    BrowserKind::Brave
+                } else {
+                    BrowserKind::Chromium
+                },
+                executable: Some(session.executable().to_path_buf()),
+            })
+        })),
+        Some(BrowserKind::Chromium) => Ok(Some(BrowserLaunch {
+            kind: BrowserKind::Chromium,
+            executable: None,
+        })),
+        Some(BrowserKind::Brave) => {
+            let brave = standard_profile(BrowserProfileKind::Brave)
+                .wrap_err("failed to locate the standard Brave profile")?;
+            Ok(Some(BrowserLaunch {
+                kind: BrowserKind::Brave,
+                executable: Some(brave.executable().to_path_buf()),
+            }))
+        }
+        Some(BrowserKind::None) => {
+            unreachable!("disabled browsers return before launch resolution")
+        }
     }
 }
 
@@ -239,10 +290,76 @@ impl ConfiguredBrowser {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use nanocodex::Tools;
+    use nanocodex_browser::{BraveSession, BraveSessionError, BrowserProfileKind};
     use nanocodex_tools::runtime::ToolRuntime;
 
-    use super::BrowserArgs;
+    use super::{BrowserArgs, BrowserKind, resolve_browser_launch};
+
+    #[test]
+    fn automatic_browser_falls_back_when_brave_is_not_installed() {
+        let launch = resolve_browser_launch(None, None, |profile| {
+            if profile == BrowserProfileKind::Chrome {
+                return Ok(BraveSession::new("/installed/chrome", "/chrome/profile"));
+            }
+            Err(BraveSessionError::StandardInstallationUnavailable {
+                browser: profile.name(),
+            })
+        })
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(launch.kind, BrowserKind::Chromium);
+        assert_eq!(
+            launch.executable.as_deref(),
+            Some(Path::new("/installed/chrome"))
+        );
+    }
+
+    #[test]
+    fn automatic_browser_is_disabled_when_none_is_installed() {
+        let launch = resolve_browser_launch(None, None, |profile| {
+            Err(BraveSessionError::StandardInstallationUnavailable {
+                browser: profile.name(),
+            })
+        })
+        .unwrap();
+
+        assert!(launch.is_none());
+    }
+
+    #[test]
+    fn automatic_browser_prefers_an_installed_brave() {
+        let launch = resolve_browser_launch(None, None, |_| {
+            Ok(BraveSession::new("/installed/brave", "/brave/profile"))
+        })
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(launch.kind, BrowserKind::Brave);
+        assert_eq!(
+            launch.executable.as_deref(),
+            Some(Path::new("/installed/brave"))
+        );
+    }
+
+    #[test]
+    fn explicit_brave_still_requires_the_standard_installation() {
+        let error = resolve_browser_launch(Some(BrowserKind::Brave), None, |_| {
+            Err(BraveSessionError::ExecutableUnavailable {
+                path: "/missing/brave".into(),
+            })
+        })
+        .err()
+        .unwrap();
+
+        assert_eq!(
+            error.to_string(),
+            "failed to locate the standard Brave profile"
+        );
+    }
 
     #[tokio::test]
     async fn configured_browser_adds_no_model_facing_schema() {

--- a/bin/nanocodex/src/main.rs
+++ b/bin/nanocodex/src/main.rs
@@ -320,11 +320,10 @@ mod tests {
     }
 
     #[test]
-    fn brave_browser_tool_and_all_cookies_are_enabled_by_default() {
+    fn browser_and_cookie_selection_are_enabled_by_default() {
         let tui = Cli::try_parse_from(["nanocodex"]).unwrap();
         assert!(tui.agent.browser_enabled());
         assert!(tui.agent.copies_all_browser_cookies());
-        assert!(tui.agent.uses_brave_browser());
 
         let tui = Cli::try_parse_from(["nanocodex", "--browser"]).unwrap();
         assert!(tui.agent.browser_enabled());

--- a/crates/experimental/nanocodex-browser/README.md
+++ b/crates/experimental/nanocodex-browser/README.md
@@ -142,8 +142,10 @@ browser.close().await?;
 - Harness-owned cookies/storage, virtual passkeys, allowlisted source-browser handoff,
   upload roots, browser egress policy, remote CDP, and libkrun VM composition.
 
-The Nanocodex CLI exposes a private Brave session and copies a standard desktop
-browser profile's complete cookie database into it by default. `all`
+The Nanocodex CLI prefers a private Brave session and falls back to an
+installed Chrome, Chromium, or Edge when Brave is not installed. If none is
+available, the CLI starts without browser tools. It copies a standard desktop
+browser profile's complete cookie database by default. `all`
 auto-detects the source; `brave`, `chrome`, `chromium`, `edge`, `firefox`, and
 `safari` select it explicitly. Pass `none` to either option to disable that
 default:


### PR DESCRIPTION
## Summary

Make the CLI's default browser configuration capability-aware instead of requiring Brave to be installed at its standard path.

With this change, an unconfigured Nanocodex session prefers Brave, then tries Chrome, Chromium, and Edge. If no supported Chromium-family browser is available, Nanocodex starts normally without registering the browser provider. Explicit browser selections remain strict.

## Why this is needed

Launching Nanocodex with its default options currently fails before the TUI can start on a machine without Brave:

```text
Error: failed to locate the standard Brave profile

Caused by:
    source browser executable does not exist at /Applications/Brave Browser.app/Contents/MacOS/Brave Browser

Location:
    bin/nanocodex/src/browser.rs:136:22
```

now it does not do it
