### PR TITLE
fix(oai): recover forbidden WebSocket handshakes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Bug Fixes
+
+- [oai] Retry transient HTTP 403 WebSocket upgrades before falling back to
+  HTTPS, and retain gateway diagnostics when the rejection body is empty.
+
 ### Features
 
 - [cli] Enable private Brave and complete desktop-profile cookie import by

--- a/crates/nanocodex-oai-api/src/transport/error.rs
+++ b/crates/nanocodex-oai-api/src/transport/error.rs
@@ -171,6 +171,9 @@ impl ResponsesError {
                 ..
             } => ("handshake_transport", None),
             Self::HandshakeTimeout { .. } => ("handshake_timeout", None),
+            // ChatGPT's edge can transiently reject an otherwise valid upgrade. Treating the
+            // rejection as bounded recovery also unlocks the standard HTTPS fallback.
+            Self::HandshakeRejected { status: 403, .. } => ("handshake_forbidden", None),
             Self::HandshakeRejected {
                 status,
                 retry_after,
@@ -303,6 +306,21 @@ mod tests {
             .expect("HTTP 429 handshake rejection must remain retryable");
         assert_eq!(advice.class, "handshake_rate_limit");
         assert_eq!(advice.server_delay, Some(delay));
+    }
+
+    #[test]
+    fn forbidden_handshake_rejection_is_retryable() {
+        let error = ResponsesError::HandshakeRejected {
+            status: 403,
+            body: "empty response body".to_owned(),
+            retry_after: None,
+        };
+
+        let advice = error
+            .retry_advice()
+            .expect("HTTP 403 handshake rejection must allow bounded recovery");
+        assert_eq!(advice.class, "handshake_forbidden");
+        assert_eq!(advice.server_delay, None);
     }
 
     #[test]

--- a/crates/nanocodex-oai-api/src/transport/socket.rs
+++ b/crates/nanocodex-oai-api/src/transport/socket.rs
@@ -347,14 +347,40 @@ fn map_handshake_error(error: WebSocketError) -> ResponsesError {
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.parse::<f64>().ok())
         .and_then(|seconds| Duration::try_from_secs_f64(seconds).ok());
-    let body = response.body().as_deref().map_or_else(
-        || "empty response body".to_owned(),
-        |body| String::from_utf8_lossy(body).into_owned(),
-    );
+    let body = handshake_rejection_detail(response.body().as_deref(), response.headers());
     ResponsesError::HandshakeRejected {
         status,
         body,
         retry_after,
+    }
+}
+
+fn handshake_rejection_detail(
+    body: Option<&[u8]>,
+    headers: &tokio_tungstenite::tungstenite::http::HeaderMap,
+) -> String {
+    let body = body.map_or_else(String::new, |body| {
+        String::from_utf8_lossy(body).into_owned()
+    });
+    if !body.trim().is_empty() {
+        return body;
+    }
+
+    let request_id = header_string(headers, "x-request-id")
+        .or_else(|| header_string(headers, "x-oai-request-id"));
+    let diagnostics = [
+        header_string(headers, "cf-ray").map(|value| format!("cf-ray={value}")),
+        request_id.map(|value| format!("request-id={value}")),
+        header_string(headers, "x-openai-authorization-error")
+            .map(|value| format!("authorization-error={value}")),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>();
+    if diagnostics.is_empty() {
+        "empty response body".to_owned()
+    } else {
+        format!("empty response body ({})", diagnostics.join(", "))
     }
 }
 
@@ -412,7 +438,10 @@ mod tests {
         tungstenite::{Message, handshake::server::Request},
     };
 
-    use super::{ResponsesSocket, SOCKET_MESSAGE_CAPACITY, parse_raw_json, turn_state_from_event};
+    use super::{
+        ResponsesSocket, SOCKET_MESSAGE_CAPACITY, handshake_rejection_detail, parse_raw_json,
+        turn_state_from_event,
+    };
 
     #[test]
     fn only_decodes_turn_state_metadata_events() {
@@ -429,6 +458,20 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn empty_handshake_rejection_retains_gateway_diagnostics() -> Result<()> {
+        let mut headers = tokio_tungstenite::tungstenite::http::HeaderMap::new();
+        headers.insert("cf-ray", "ray-test".parse()?);
+        headers.insert("x-oai-request-id", "req-test".parse()?);
+        headers.insert("x-openai-authorization-error", "edge-policy".parse()?);
+
+        assert_eq!(
+            handshake_rejection_detail(Some(b""), &headers),
+            "empty response body (cf-ray=ray-test, request-id=req-test, authorization-error=edge-policy)"
+        );
+        Ok(())
     }
 
     #[tokio::test]

--- a/crates/nanocodex-oai-api/tests/it/fallback.rs
+++ b/crates/nanocodex-oai-api/tests/it/fallback.rs
@@ -238,6 +238,80 @@ async fn upgrade_required_falls_back_without_another_websocket_attempt() -> Resu
     Ok(())
 }
 
+#[tokio::test]
+async fn forbidden_websocket_handshake_retries_then_falls_back_to_https() -> Result<()> {
+    let websocket_listener = TcpListener::bind("127.0.0.1:0").await?;
+    let websocket_url = format!("ws://{}", websocket_listener.local_addr()?);
+    let http_listener = TcpListener::bind("127.0.0.1:0").await?;
+    let api_base_url = format!("http://{}", http_listener.local_addr()?);
+
+    let websocket_server = tokio::spawn(async move {
+        for attempt in 1..=2 {
+            let (stream, _) = websocket_listener.accept().await?;
+            let cf_ray = format!("ray-{attempt}").parse()?;
+            let rejected =
+                accept_hdr_async(stream, move |_request: &Request, response: Response| {
+                    let mut response = response.map(|()| Some(String::new()));
+                    *response.status_mut() = StatusCode::FORBIDDEN;
+                    response.headers_mut().insert("cf-ray", cf_ray);
+                    Err(response)
+                })
+                .await;
+            assert!(rejected.is_err());
+        }
+        assert!(
+            timeout(
+                std::time::Duration::from_millis(250),
+                websocket_listener.accept()
+            )
+            .await
+            .is_err(),
+            "HTTP 403 recovery exceeded the configured WebSocket attempt budget"
+        );
+        Result::<()>::Ok(())
+    });
+    let http_server = tokio::spawn(async move {
+        let request = read_http_json(&http_listener).await?;
+        assert!(request.body.get("previous_response_id").is_none());
+        assert!(
+            request
+                .body
+                .to_string()
+                .contains("recover forbidden upgrade")
+        );
+        send_http_events(
+            request.stream,
+            None,
+            [completed_response("resp-forbidden", "recovered")],
+        )
+        .await
+    });
+
+    let openai = OpenAi::builder("test-key")
+        .websocket_url(websocket_url)
+        .api_base_url(api_base_url)
+        .max_attempts(NonZeroU32::new(2).unwrap())
+        .build()?;
+    let mut session = openai
+        .instructions("Recover transient WebSocket upgrade failures.")
+        .build()?;
+    assert_eq!(
+        session
+            .turn()
+            .create("recover forbidden upgrade")
+            .await?
+            .output_text(),
+        "recovered"
+    );
+    timeout(std::time::Duration::from_secs(5), websocket_server)
+        .await
+        .map_err(|_| eyre!("mock 403 WebSocket server did not finish"))???;
+    timeout(std::time::Duration::from_secs(5), http_server)
+        .await
+        .map_err(|_| eyre!("mock 403 fallback HTTP server did not finish"))???;
+    Ok(())
+}
+
 async fn next_ws_json<S>(socket: &mut WebSocketStream<S>) -> Result<Value>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,


### PR DESCRIPTION
## Summary

- classify HTTP 403 WebSocket upgrade rejections as bounded transport recovery so the existing retry budget and session-scoped HTTPS fallback can recover the turn
- retain `cf-ray`, OpenAI request ID, and authorization-error headers when a native handshake rejection has an empty body
- cover the complete two-attempt WebSocket exhaustion to authoritative HTTPS replay path with a deterministic integration test

## Context

A valid ChatGPT subscription session intermittently received an empty HTTP 403 during the Responses WebSocket upgrade. Fresh probes with the same credential, endpoint, and Nanocodex headers subsequently returned HTTP 101, but Nanocodex treated 403 as terminal. Each new prompt therefore opened another socket and surfaced the same hard failure instead of using the SDK-owned recovery and fallback path.

The upgrade happens before a model request is sent, so bounded handshake replay is side-effect free. If the rejection persists, the existing fallback switches the session to HTTPS and replays authoritative client-owned history.

## Validation

- `cargo test --locked --package nanocodex-oai-api`
- `cargo clippy --locked --package nanocodex-oai-api --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo check --locked --package nanocodex-examples --bins`
- `./scripts/check-crate-boundaries.sh`
