### PR TITLE
feat(eval): add benchmark adapter foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5152,6 +5152,7 @@ dependencies = [
  "nanocodex-browser",
  "nanocodex-egress",
  "nanocodex-eval",
+ "nanocodex-eval-adapters",
  "nanocodex-observability",
  "nanocodex-tools",
  "nanocodex-vm",
@@ -5278,6 +5279,19 @@ dependencies = [
  "tracing",
  "uuid",
  "zstd",
+]
+
+[[package]]
+name = "nanocodex-eval-adapters"
+version = "0.3.0"
+dependencies = [
+ "hex",
+ "nanocodex-eval",
+ "sha2 0.11.0",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5254,6 +5254,7 @@ dependencies = [
  "base64",
  "chrono",
  "filetime",
+ "flate2",
  "fs2",
  "futures-util",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5256,6 +5256,7 @@ dependencies = [
  "fs2",
  "futures-util",
  "hex",
+ "ignore",
  "jiff",
  "nanocodex-agent",
  "nanocodex-oai-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/experimental/nanocodex-egress",
     "crates/experimental/nanocodex-voice",
     "crates/experimental/nanocodex-eval",
+    "crates/experimental/nanocodex-eval-adapters",
     "crates/experimental/nanocodex-vm",
     "crates/nanocodex-oai-api",
     "crates/nanocodex-observability",
@@ -75,6 +76,7 @@ nanocodex-browser = { version = "0.3.0", path = "crates/experimental/nanocodex-b
 nanocodex-egress = { version = "0.3.0", path = "crates/experimental/nanocodex-egress" }
 nanocodex-voice = { version = "0.3.0", path = "crates/experimental/nanocodex-voice" }
 nanocodex-eval = { version = "0.3.0", path = "crates/experimental/nanocodex-eval" }
+nanocodex-eval-adapters = { version = "0.3.0", path = "crates/experimental/nanocodex-eval-adapters" }
 nanocodex-vm = { version = "0.3.0", path = "crates/experimental/nanocodex-vm" }
 nanocodex-oai-api = { version = "0.3.0", path = "crates/nanocodex-oai-api" }
 nanocodex-observability = { version = "0.3.0", path = "crates/nanocodex-observability" }

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -77,6 +77,7 @@ arcbox-ext4.workspace = true
 chrono.workspace = true
 ignore.workspace = true
 nanocodex-eval.workspace = true
+nanocodex-eval-adapters.workspace = true
 nanocodex-vm.workspace = true
 regex.workspace = true
 sysinfo.workspace = true

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -431,16 +431,6 @@ impl AuthArgs {
     all(target_os = "macos", target_arch = "aarch64")
 ))]
 impl EvalAgentArgs {
-    pub(crate) fn builder(
-        self,
-        model: Model,
-        thinking: Thinking,
-        web_search: bool,
-    ) -> Result<NanocodexBuilder> {
-        let auth = self.auth.resolve()?;
-        eval_builder_with_auth(auth.nanocodex()?, model, thinking, web_search)
-    }
-
     pub(crate) fn shared_builder(
         self,
         model: Model,

--- a/bin/nanocodex/src/eval/profile.rs
+++ b/bin/nanocodex/src/eval/profile.rs
@@ -15,6 +15,7 @@ use nanocodex_eval::{
     atif::AtifBuilder,
     coordinator::{CoordinatorClient, RemoteClaim},
     harness::{Harness, HarnessAuth},
+    judge::JudgeRuntime,
     vm::{CachePolicy, VmBackend, VmResources},
 };
 use nanocodex_eval_adapters::AdapterCatalog;
@@ -710,16 +711,20 @@ async fn execute_coordinate(
     agent: EvalAgentArgs,
 ) -> Result<ExecutionResult> {
     std::fs::create_dir_all(&output)?;
+    let (nanocodex, auth) =
+        agent.shared_builder(treatment.model, treatment.thinking, web_search)?;
+    let judge = JudgeRuntime::start(nanocodex.clone().thinking(Thinking::Low)).await?;
+    let verifier_environment = judge.verifier_environment();
     match treatment.harness.as_str() {
         "nanocodex" => {
             let backend = resources
                 .backend_with(
                     VmBackend::builder()
                         .retain_passed_rootfs(false)
-                        .retain_failed_rootfs(false),
+                        .retain_failed_rootfs(false)
+                        .verifier_environment(verifier_environment),
                 )
                 .await?;
-            let nanocodex = agent.builder(treatment.model, treatment.thinking, web_search)?;
             let evaluator = Evaluator::builder(nanocodex, backend)
                 .output_directory(&output)
                 .build()?;
@@ -728,8 +733,6 @@ async fn execute_coordinate(
             Ok(classify_execution(&outcome, evidence))
         }
         _ => {
-            let (nanocodex, auth) =
-                agent.shared_builder(treatment.model, treatment.thinking, web_search)?;
             let harness_auth = match auth {
                 SharedAuth::ApiKey(api_key) => HarnessAuth::api_key(api_key),
                 SharedAuth::AuthFile(path) => HarnessAuth::auth_file(path),
@@ -751,6 +754,7 @@ async fn execute_coordinate(
             .guest_memory_mb(task.resources().memory_mb)
             .arguments(configured.arguments)
             .environment(configured.environment.into_iter().collect())
+            .verifier_environment(verifier_environment)
             .credentials(
                 configured.home,
                 configured.auth_file,

--- a/bin/nanocodex/src/eval/profile.rs
+++ b/bin/nanocodex/src/eval/profile.rs
@@ -10,8 +10,8 @@ use eyre::{Result, WrapErr as _, eyre};
 use fs2::FileExt as _;
 use nanocodex::{Model, Thinking};
 use nanocodex_eval::{
-    EvalAttemptOutcome, EvalEventKind, EvalEventStream, EvalStatus, Evaluation, EvaluationClaim,
-    EvaluationSelector, EvaluationWork, Evaluator, ResolvedHarness, Task,
+    EvalAttemptOutcome, EvalEventKind, EvalEventStream, EvalOutcome, EvalStatus, Evaluation,
+    EvaluationClaim, EvaluationSelector, EvaluationWork, Evaluator, ResolvedHarness, Task,
     atif::AtifBuilder,
     coordinator::{CoordinatorClient, RemoteClaim},
     harness::{Harness, HarnessAuth},
@@ -668,6 +668,12 @@ enum ExecutionResult {
     },
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ExecutionDisposition {
+    Completed(EvalStatus),
+    Retry,
+}
+
 const fn eval_status_name(status: EvalStatus) -> &'static str {
     match status {
         EvalStatus::Passed => "passed",
@@ -676,18 +682,25 @@ const fn eval_status_name(status: EvalStatus) -> &'static str {
 }
 
 fn classify_execution(outcome: &EvalAttemptOutcome, evidence: PathBuf) -> ExecutionResult {
-    match outcome.scored() {
-        Some(result) => ExecutionResult::Completed {
-            status: result.status,
-            evidence,
-        },
-        None => ExecutionResult::InfrastructureFailed {
-            error: outcome.unscored().map_or_else(
+    match execution_disposition(outcome.outcome()) {
+        ExecutionDisposition::Completed(status) => ExecutionResult::Completed { status, evidence },
+        ExecutionDisposition::Retry => ExecutionResult::InfrastructureFailed {
+            error: outcome.exception().map_or_else(
                 || "evaluation attempt was not scored".to_owned(),
-                |failure| failure.traceback().to_owned(),
+                |exception| exception.traceback.clone(),
             ),
             evidence,
         },
+    }
+}
+
+const fn execution_disposition(outcome: EvalOutcome) -> ExecutionDisposition {
+    match outcome {
+        EvalOutcome::Passed => ExecutionDisposition::Completed(EvalStatus::Passed),
+        EvalOutcome::VerifierFailed | EvalOutcome::SafetyRefusal => {
+            ExecutionDisposition::Completed(EvalStatus::Failed)
+        }
+        EvalOutcome::AgentTimeout | EvalOutcome::InfrastructureError => ExecutionDisposition::Retry,
     }
 }
 
@@ -914,7 +927,9 @@ mod tests {
 
     use clap::Parser as _;
 
-    use super::default_state_dir;
+    use nanocodex_eval::{EvalOutcome, EvalStatus};
+
+    use super::{ExecutionDisposition, default_state_dir, execution_disposition};
     use crate::{Cli, Command, eval::EvalCommand};
 
     #[test]
@@ -1017,6 +1032,30 @@ mod tests {
         assert_eq!(
             path.file_name().and_then(|name| name.to_str()),
             Some("evals")
+        );
+    }
+
+    #[test]
+    fn lifecycle_failures_cannot_become_scored_successes() {
+        assert_eq!(
+            execution_disposition(EvalOutcome::InfrastructureError),
+            ExecutionDisposition::Retry
+        );
+        assert_eq!(
+            execution_disposition(EvalOutcome::AgentTimeout),
+            ExecutionDisposition::Retry
+        );
+        assert_eq!(
+            execution_disposition(EvalOutcome::SafetyRefusal),
+            ExecutionDisposition::Completed(EvalStatus::Failed)
+        );
+        assert_eq!(
+            execution_disposition(EvalOutcome::Passed),
+            ExecutionDisposition::Completed(EvalStatus::Passed)
+        );
+        assert_eq!(
+            execution_disposition(EvalOutcome::VerifierFailed),
+            ExecutionDisposition::Completed(EvalStatus::Failed)
         );
     }
 }

--- a/bin/nanocodex/src/eval/profile.rs
+++ b/bin/nanocodex/src/eval/profile.rs
@@ -17,6 +17,7 @@ use nanocodex_eval::{
     harness::{Harness, HarnessAuth},
     vm::{CachePolicy, VmBackend, VmResources},
 };
+use nanocodex_eval_adapters::AdapterCatalog;
 use serde::Serialize;
 use tokio::io::AsyncWriteExt as _;
 
@@ -177,7 +178,26 @@ impl Add {
                     "--recipe is complete; use either --recipe or explicit work knobs"
                 ));
             }
-            Evaluation::add_profile(&self.config, Some(recipe), &state, &self.profile, self.new)?;
+            let selectors = Evaluation::profile_benchmarks(&self.config, Some(recipe))?;
+            if selectors.is_empty() {
+                Evaluation::add_profile(
+                    &self.config,
+                    Some(recipe),
+                    &state,
+                    &self.profile,
+                    self.new,
+                )?;
+            } else {
+                let tasks = AdapterCatalog::new(&state).resolve(&selectors).await?;
+                Evaluation::add_profile_with_tasks(
+                    &self.config,
+                    Some(recipe),
+                    tasks,
+                    &state,
+                    &self.profile,
+                    self.new,
+                )?;
+            }
         } else {
             if self.task.is_empty() {
                 return Err(eyre!("at least one --task or --recipe is required"));

--- a/bin/nanocodex/src/eval/profile.rs
+++ b/bin/nanocodex/src/eval/profile.rs
@@ -423,12 +423,13 @@ async fn run_remote(
             claim,
             repetition,
             task: task_selector,
+            task_root,
             treatment,
             ..
         } => {
             let setup = (|| {
                 validate_web_search(&agent, profile, treatment.web_search)?;
-                let task = Task::load(&task_selector)?;
+                let task = Task::load(&task_root)?;
                 let harness = Evaluation::resolve_harness(config, &treatment.harness)?;
                 let harnesses = harness.iter().cloned().collect::<Vec<_>>();
                 let host = run::PreparedVmHost::open()?;

--- a/bin/nanocodex/src/eval/profile.rs
+++ b/bin/nanocodex/src/eval/profile.rs
@@ -437,6 +437,7 @@ async fn run_remote(
                 let output = tempfile::Builder::new()
                     .prefix(WORKER_DIRECTORY_PREFIX)
                     .tempdir_in(host.cache())?;
+                let output_directory = fs::canonicalize(output.path())?;
                 let output_lease = OpenOptions::new()
                     .create(true)
                     .read(true)
@@ -444,17 +445,27 @@ async fn run_remote(
                     .truncate(false)
                     .open(output.path().join(".active.lock"))?;
                 output_lease.lock_exclusive()?;
-                Ok::<_, eyre::Report>((task, harness, harnesses, host, output, output_lease))
+                Ok::<_, eyre::Report>((
+                    task,
+                    harness,
+                    harnesses,
+                    host,
+                    output,
+                    output_directory,
+                    output_lease,
+                ))
             })();
-            let (task, harness, harnesses, host, output, _output_lease) = match setup {
-                Ok(setup) => setup,
-                Err(error) => {
-                    let detail = format!("{error:#}");
-                    let finish = coordinator.retry(&claim, &detail).await;
-                    finish?;
-                    return Err(error).wrap_err("remote task setup failed and row was requeued");
-                }
-            };
+            let (task, harness, harnesses, host, _output, output_directory, _output_lease) =
+                match setup {
+                    Ok(setup) => setup,
+                    Err(error) => {
+                        let detail = format!("{error:#}");
+                        let finish = coordinator.retry(&claim, &detail).await;
+                        finish?;
+                        return Err(error)
+                            .wrap_err("remote task setup failed and row was requeued");
+                    }
+                };
             let execution = async {
                 let resources = prepare_resources_from(&task, &harnesses, &host).await?;
                 execute_coordinate(
@@ -462,7 +473,7 @@ async fn run_remote(
                     treatment.clone(),
                     treatment.web_search,
                     harness,
-                    output.path().to_path_buf(),
+                    output_directory.clone(),
                     resources,
                     agent,
                 )
@@ -473,13 +484,15 @@ async fn run_remote(
                 Ok(ExecutionResult::Completed { status, evidence }) => {
                     let finish = match status {
                         EvalStatus::Passed => {
-                            coordinator.succeed(&claim, output.path(), &evidence).await
+                            coordinator
+                                .succeed(&claim, &output_directory, &evidence)
+                                .await
                         }
                         EvalStatus::Failed => {
                             coordinator
                                 .fail_with_evidence(
                                     &claim,
-                                    output.path(),
+                                    &output_directory,
                                     &evidence,
                                     "verifier returned a failing score",
                                 )
@@ -498,7 +511,7 @@ async fn run_remote(
                 }
                 Ok(ExecutionResult::InfrastructureFailed { error, evidence }) => {
                     let finish = coordinator
-                        .retry_with_evidence(&claim, output.path(), &evidence, &error)
+                        .retry_with_evidence(&claim, &output_directory, &evidence, &error)
                         .await;
                     finish?;
                     write_json(&RunOutput::InfrastructureFailed {
@@ -515,8 +528,8 @@ async fn run_remote(
                     let finish = coordinator
                         .retry_with_evidence(
                             &claim,
-                            output.path(),
-                            output.path(),
+                            &output_directory,
+                            &output_directory,
                             &format!("{error:#}"),
                         )
                         .await;

--- a/crates/experimental/nanocodex-eval-adapters/Cargo.toml
+++ b/crates/experimental/nanocodex-eval-adapters/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "nanocodex-eval-adapters"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Third-party benchmark adapters for nanocodex-eval"
+
+[dependencies]
+hex.workspace = true
+nanocodex-eval.workspace = true
+sha2.workspace = true
+tempfile.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["rt"] }
+tracing.workspace = true
+
+[lints]
+workspace = true

--- a/crates/experimental/nanocodex-eval-adapters/src/lib.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/lib.rs
@@ -17,6 +17,7 @@ use nanocodex_eval::{
     ResolvedTask,
     import::{ImportError, ImportStore, ImportedDataset},
 };
+use sha2::{Digest as _, Sha256};
 use source::SourceStore;
 
 /// Installed adapter catalog bound to one durable evaluator state directory.
@@ -197,6 +198,39 @@ pub(crate) fn exact_task(selected: &str, normalized: &str) -> bool {
 impl From<source::SourceError> for AdapterError {
     fn from(error: source::SourceError) -> Self {
         Self::Source(error.to_string())
+    }
+}
+
+#[allow(dead_code)]
+fn sha256_values(values: impl IntoIterator<Item = impl AsRef<[u8]>>) -> String {
+    let mut digest = Sha256::new();
+    for value in values {
+        digest.update(Sha256::digest(value));
+    }
+    hex::encode(digest.finalize())
+}
+
+#[allow(dead_code)]
+fn safe_case_id(value: &str) -> String {
+    let mut output = String::with_capacity(value.len());
+    let mut separator = false;
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-' | b'+') {
+            output.push(char::from(byte));
+            separator = false;
+        } else if !separator && !output.is_empty() {
+            output.push('-');
+            separator = true;
+        }
+    }
+    while output.ends_with('-') {
+        output.pop();
+    }
+    if output.is_empty() || output == "." || output == ".." {
+        let digest = Sha256::digest(value.as_bytes());
+        format!("case-{}", &hex::encode(digest)[..16])
+    } else {
+        output
     }
 }
 

--- a/crates/experimental/nanocodex-eval-adapters/src/lib.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/lib.rs
@@ -1,0 +1,223 @@
+//! Pinned third-party benchmark adapters for `nanocodex-eval`.
+//!
+//! Adapters acquire authoritative source material and normalize it into the
+//! evaluator's immutable task boundary. Scheduling and runtime policy remain
+//! owned by `nanocodex-eval`.
+
+#![deny(missing_docs, rustdoc::broken_intra_doc_links)]
+
+mod source;
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::{Path, PathBuf},
+};
+
+use nanocodex_eval::{
+    ResolvedTask,
+    import::{ImportError, ImportStore, ImportedDataset},
+};
+use source::SourceStore;
+
+/// Installed adapter catalog bound to one durable evaluator state directory.
+#[derive(Clone, Debug)]
+pub struct AdapterCatalog {
+    imports: PathBuf,
+    sources: PathBuf,
+}
+
+/// Adapter source acquisition, normalization, or task selection failed.
+#[derive(Debug, thiserror::Error)]
+pub enum AdapterError {
+    /// A selector did not use the stable `<benchmark>/<task>` shape.
+    #[error("invalid benchmark selector {0:?}; expected <benchmark>/<task> or <benchmark>/*")]
+    InvalidSelector(String),
+    /// A profile selected the same benchmark task more than once.
+    #[error("duplicate benchmark selector {0:?}")]
+    DuplicateSelector(String),
+    /// No installed adapter owns the benchmark name.
+    #[error("no installed evaluation adapter owns benchmark {0:?}")]
+    UnknownBenchmark(String),
+    /// An installed dataset did not contain requested normalized tasks.
+    #[error("benchmark {benchmark:?} has no normalized task(s): {tasks}")]
+    MissingTasks {
+        /// Selected benchmark.
+        benchmark: String,
+        /// Missing task names.
+        tasks: String,
+    },
+    /// Adapter source acquisition failed.
+    #[error("adapter source acquisition failed: {0}")]
+    Source(String),
+    /// Immutable dataset import failed.
+    #[error(transparent)]
+    Import(#[from] ImportError),
+    /// A blocking adapter worker failed.
+    #[error("evaluation adapter worker failed: {0}")]
+    Worker(String),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct BenchmarkRequest {
+    name: String,
+    all: bool,
+    tasks: BTreeSet<String>,
+}
+
+#[derive(Clone, Copy)]
+struct InstalledAdapter {
+    names: &'static [&'static str],
+    import:
+        fn(&BenchmarkRequest, &SourceStore, &ImportStore) -> Result<ImportedDataset, AdapterError>,
+    matches: fn(&str, &str) -> bool,
+}
+
+const INSTALLED_ADAPTERS: &[InstalledAdapter] = &[];
+
+impl AdapterCatalog {
+    /// Uses `imports/` and `sources/` below one durable evaluator state root.
+    #[must_use]
+    pub fn new(state_directory: impl AsRef<Path>) -> Self {
+        let root = state_directory.as_ref();
+        Self {
+            imports: root.join("imports"),
+            sources: root.join("sources"),
+        }
+    }
+
+    /// Acquires, imports, and selects every configured benchmark task.
+    pub async fn resolve(&self, selectors: &[String]) -> Result<Vec<ResolvedTask>, AdapterError> {
+        let requests = parse_requests(selectors)?;
+        let mut jobs = tokio::task::JoinSet::new();
+        for request in requests.into_values() {
+            let adapter = installed_adapter(&request.name)?;
+            let imports = self.imports.clone();
+            let sources = self.sources.clone();
+            jobs.spawn_blocking(move || {
+                let store = ImportStore::new(imports);
+                let sources = SourceStore::new(sources);
+                let dataset = (adapter.import)(&request, &sources, &store)?;
+                select_tasks(&request, &dataset, adapter.matches)
+            });
+        }
+        let mut selected = Vec::new();
+        while let Some(result) = jobs.join_next().await {
+            selected.extend(result.map_err(|error| AdapterError::Worker(error.to_string()))??);
+        }
+        selected.sort_by(|left, right| left.selector.cmp(&right.selector));
+        Ok(selected)
+    }
+}
+
+fn installed_adapter(name: &str) -> Result<InstalledAdapter, AdapterError> {
+    INSTALLED_ADAPTERS
+        .iter()
+        .copied()
+        .find(|adapter| adapter.names.contains(&name))
+        .ok_or_else(|| AdapterError::UnknownBenchmark(name.to_owned()))
+}
+
+fn parse_requests(
+    selectors: &[String],
+) -> Result<BTreeMap<String, BenchmarkRequest>, AdapterError> {
+    let mut unique = BTreeSet::new();
+    let mut requests = BTreeMap::<String, BenchmarkRequest>::new();
+    for selector in selectors {
+        if !unique.insert(selector) {
+            return Err(AdapterError::DuplicateSelector(selector.clone()));
+        }
+        let (benchmark, task) = selector
+            .split_once('/')
+            .filter(|(benchmark, task)| !benchmark.is_empty() && !task.is_empty())
+            .ok_or_else(|| AdapterError::InvalidSelector(selector.clone()))?;
+        let request = requests
+            .entry(benchmark.to_owned())
+            .or_insert_with(|| BenchmarkRequest {
+                name: benchmark.to_owned(),
+                all: false,
+                tasks: BTreeSet::new(),
+            });
+        if task == "*" {
+            request.all = true;
+        } else {
+            request.tasks.insert(task.to_owned());
+        }
+    }
+    for request in requests.values() {
+        if request.all && !request.tasks.is_empty() {
+            return Err(AdapterError::InvalidSelector(format!(
+                "{} mixes * with explicit tasks",
+                request.name
+            )));
+        }
+    }
+    Ok(requests)
+}
+
+fn select_tasks(
+    request: &BenchmarkRequest,
+    dataset: &ImportedDataset,
+    matches: fn(&str, &str) -> bool,
+) -> Result<Vec<ResolvedTask>, AdapterError> {
+    let mut missing = request.tasks.clone();
+    let mut selected = Vec::new();
+    for task in dataset.tasks() {
+        let selected_name = request
+            .tasks
+            .iter()
+            .find(|selected| matches(selected, task.name()));
+        if request.all || selected_name.is_some() {
+            if let Some(name) = selected_name {
+                missing.remove(name);
+            }
+            selected.push(ResolvedTask {
+                selector: format!(
+                    "{}/{}",
+                    request.name,
+                    selected_name.map_or_else(|| task.name(), String::as_str)
+                ),
+                task: task.clone(),
+            });
+        }
+    }
+    if !missing.is_empty() {
+        return Err(AdapterError::MissingTasks {
+            benchmark: request.name.clone(),
+            tasks: missing.into_iter().collect::<Vec<_>>().join(", "),
+        });
+    }
+    Ok(selected)
+}
+
+#[allow(dead_code)]
+pub(crate) fn exact_task(selected: &str, normalized: &str) -> bool {
+    selected == normalized
+}
+
+impl From<source::SourceError> for AdapterError {
+    fn from(error: source::SourceError) -> Self {
+        Self::Source(error.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn groups_exact_and_all_task_selections() {
+        let requests =
+            parse_requests(&["one/a".to_owned(), "one/b".to_owned(), "two/*".to_owned()]).unwrap();
+
+        assert_eq!(requests["one"].tasks.len(), 2);
+        assert!(!requests["one"].all);
+        assert!(requests["two"].all);
+    }
+
+    #[test]
+    fn rejects_ambiguous_all_selection() {
+        let error = parse_requests(&["one/*".to_owned(), "one/a".to_owned()]).unwrap_err();
+
+        assert!(error.to_string().contains("mixes *"));
+    }
+}

--- a/crates/experimental/nanocodex-eval-adapters/src/source.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/source.rs
@@ -1,0 +1,219 @@
+use std::{
+    fs,
+    io::Write as _,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+use sha2::{Digest as _, Sha256};
+
+#[derive(Clone, Debug)]
+pub(crate) struct SourceStore {
+    root: PathBuf,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SourceError {
+    #[error("benchmark source filesystem operation failed at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("benchmark source command failed: {0}")]
+    Command(String),
+    #[error("retained benchmark source is stale: {0}")]
+    Stale(String),
+}
+
+impl SourceStore {
+    pub(crate) fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn root(&self) -> &Path {
+        &self.root
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn git_checkout(
+        &self,
+        relative: &str,
+        url: &str,
+        revision: &str,
+    ) -> Result<PathBuf, SourceError> {
+        let destination = self.root.join(relative);
+        if destination.exists() {
+            let head = command_text(
+                Command::new("git")
+                    .arg("-C")
+                    .arg(&destination)
+                    .args(["rev-parse", "HEAD"]),
+            )?;
+            if head.trim() != revision {
+                return Err(SourceError::Stale(format!(
+                    "{} is at {}, expected {revision}",
+                    destination.display(),
+                    head.trim()
+                )));
+            }
+            let dirty = command_text(
+                Command::new("git")
+                    .arg("-C")
+                    .arg(&destination)
+                    .args(["status", "--porcelain=v1"]),
+            )?;
+            if !dirty.trim().is_empty() {
+                return Err(SourceError::Stale(format!(
+                    "{} has local changes",
+                    destination.display()
+                )));
+            }
+            return Ok(destination);
+        }
+        fs::create_dir_all(&self.root).map_err(|source| io_error(&self.root, source))?;
+        let temporary = tempfile::Builder::new()
+            .prefix(".source-")
+            .tempdir_in(&self.root)
+            .map_err(|source| io_error(&self.root, source))?;
+        command_status(Command::new("git").arg("init").arg(temporary.path()))?;
+        command_status(Command::new("git").arg("-C").arg(temporary.path()).args([
+            "fetch",
+            "--depth=1",
+            url,
+            revision,
+        ]))?;
+        command_status(
+            Command::new("git")
+                .arg("-C")
+                .arg(temporary.path())
+                .args(["checkout", "--detach", "FETCH_HEAD"])
+                .env("GIT_LFS_SKIP_SMUDGE", "1"),
+        )?;
+        fs::rename(temporary.keep(), &destination)
+            .map_err(|source| io_error(&destination, source))?;
+        Ok(destination)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn download(
+        &self,
+        relative: &str,
+        url: &str,
+        expected_sha256: &str,
+    ) -> Result<PathBuf, SourceError> {
+        let destination = self.root.join(relative);
+        if destination.is_file() {
+            validate_sha256(&destination, expected_sha256)?;
+            return Ok(destination);
+        }
+        let parent = destination.parent().unwrap_or(&self.root);
+        fs::create_dir_all(parent).map_err(|source| io_error(parent, source))?;
+        let temporary =
+            tempfile::NamedTempFile::new_in(parent).map_err(|source| io_error(parent, source))?;
+        command_status(
+            Command::new("curl")
+                .args([
+                    "--fail",
+                    "--location",
+                    "--silent",
+                    "--show-error",
+                    "--output",
+                ])
+                .arg(temporary.path())
+                .arg(url),
+        )?;
+        validate_sha256(temporary.path(), expected_sha256)?;
+        temporary
+            .persist(&destination)
+            .map_err(|error| io_error(&destination, error.error))?;
+        Ok(destination)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn write_verified(
+        &self,
+        relative: &str,
+        bytes: &[u8],
+    ) -> Result<PathBuf, SourceError> {
+        let destination = self.root.join(relative);
+        if destination.is_file() {
+            let retained =
+                fs::read(&destination).map_err(|source| io_error(&destination, source))?;
+            if retained != bytes {
+                return Err(SourceError::Stale(format!(
+                    "{} does not match the derived pinned content",
+                    destination.display()
+                )));
+            }
+            return Ok(destination);
+        }
+        let parent = destination.parent().unwrap_or(&self.root);
+        fs::create_dir_all(parent).map_err(|source| io_error(parent, source))?;
+        let mut temporary =
+            tempfile::NamedTempFile::new_in(parent).map_err(|source| io_error(parent, source))?;
+        temporary
+            .write_all(bytes)
+            .and_then(|()| temporary.as_file().sync_all())
+            .map_err(|source| io_error(temporary.path(), source))?;
+        temporary
+            .persist(&destination)
+            .map_err(|error| io_error(&destination, error.error))?;
+        Ok(destination)
+    }
+}
+
+#[allow(dead_code)]
+fn validate_sha256(path: &Path, expected: &str) -> Result<(), SourceError> {
+    let bytes = fs::read(path).map_err(|source| io_error(path, source))?;
+    let actual = hex::encode(Sha256::digest(bytes));
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(SourceError::Stale(format!(
+            "{} has digest {actual}, expected {expected}",
+            path.display()
+        )))
+    }
+}
+
+#[allow(dead_code)]
+fn command_status(command: &mut Command) -> Result<(), SourceError> {
+    let rendered = format!("{command:?}");
+    let output = command
+        .output()
+        .map_err(|error| SourceError::Command(format!("{rendered}: {error}")))?;
+    ensure_success(rendered, output).map(drop)
+}
+
+#[allow(dead_code)]
+fn command_text(command: &mut Command) -> Result<String, SourceError> {
+    let rendered = format!("{command:?}");
+    let output = command
+        .output()
+        .map_err(|error| SourceError::Command(format!("{rendered}: {error}")))?;
+    let output = ensure_success(rendered, output)?;
+    String::from_utf8(output.stdout).map_err(|error| SourceError::Command(error.to_string()))
+}
+
+#[allow(dead_code)]
+fn ensure_success(rendered: String, output: Output) -> Result<Output, SourceError> {
+    if output.status.success() {
+        Ok(output)
+    } else {
+        Err(SourceError::Command(format!(
+            "{rendered} exited {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        )))
+    }
+}
+
+#[allow(dead_code)]
+fn io_error(path: &Path, source: std::io::Error) -> SourceError {
+    SourceError::Io {
+        path: path.to_path_buf(),
+        source,
+    }
+}

--- a/crates/experimental/nanocodex-eval/Cargo.toml
+++ b/crates/experimental/nanocodex-eval/Cargo.toml
@@ -19,6 +19,7 @@ arcbox-ext4.workspace = true
 base64.workspace = true
 chrono.workspace = true
 filetime.workspace = true
+flate2.workspace = true
 futures-util.workspace = true
 fs2.workspace = true
 hex.workspace = true

--- a/crates/experimental/nanocodex-eval/Cargo.toml
+++ b/crates/experimental/nanocodex-eval/Cargo.toml
@@ -22,6 +22,7 @@ filetime.workspace = true
 futures-util.workspace = true
 fs2.workspace = true
 hex.workspace = true
+ignore.workspace = true
 jiff.workspace = true
 nanocodex-agent.workspace = true
 nanocodex-oai-api.workspace = true

--- a/crates/experimental/nanocodex-eval/src/coordinator.rs
+++ b/crates/experimental/nanocodex-eval/src/coordinator.rs
@@ -60,6 +60,8 @@ pub enum RemoteClaim {
         family_key: String,
         /// Task package selector retained in SQLite.
         task: String,
+        /// Canonical task package root retained by the coordinator host.
+        task_root: PathBuf,
         /// Exact treatment retained in SQLite.
         treatment: EvaluationTreatment,
     },
@@ -152,6 +154,7 @@ enum ClaimResponse {
         repetition: u16,
         family_key: String,
         task: String,
+        task_root: PathBuf,
         treatment: WireTreatment,
     },
     Busy {
@@ -358,12 +361,14 @@ impl CoordinatorClient {
                 repetition,
                 family_key,
                 task,
+                task_root,
                 treatment,
             } => RemoteClaim::Run {
                 claim: RemoteTaskClaim { token: claim },
                 repetition,
                 family_key,
                 task,
+                task_root,
                 treatment: treatment.try_into()?,
             },
             ClaimResponse::Busy {
@@ -395,12 +400,14 @@ impl CoordinatorClient {
                 repetition,
                 family_key,
                 task,
+                task_root,
                 treatment,
             } => RemoteClaim::Run {
                 claim: RemoteTaskClaim { token: claim },
                 repetition,
                 family_key,
                 task,
+                task_root,
                 treatment: treatment.try_into()?,
             },
             ClaimResponse::Busy {
@@ -724,6 +731,7 @@ async fn claim(
             let repetition = claim.repetition();
             let family_key = claim.family_key().to_owned();
             let task = claim.task_selector().to_owned();
+            let task_root = claim.task().root().to_path_buf();
             let treatment = WireTreatment::from(claim.treatment());
             let claim = insert_claim(&state, claim, host).await;
             ClaimResponse::Run {
@@ -731,6 +739,7 @@ async fn claim(
                 repetition,
                 family_key,
                 task,
+                task_root,
                 treatment,
             }
         }
@@ -1259,6 +1268,7 @@ thinking = ["high"]
             claim: first_claim,
             repetition: first_repetition,
             family_key: first_family_key,
+            task_root: first_task_root,
             ..
         } = first.unwrap()
         else {
@@ -1273,6 +1283,10 @@ thinking = ["high"]
             panic!("second worker should run");
         };
         assert_ne!(first_repetition, second_repetition);
+        assert_eq!(
+            first_task_root,
+            fs::canonicalize(directory.path().join("one")).unwrap()
+        );
 
         let status = client.status().await.unwrap();
         let profile_digest = status["digest"].as_str().unwrap();

--- a/crates/experimental/nanocodex-eval/src/digest.rs
+++ b/crates/experimental/nanocodex-eval/src/digest.rs
@@ -7,7 +7,13 @@ use std::{
 use filetime::FileTime;
 use sha2::{Digest, Sha256};
 
-const PACKAGE_FILES: [&str; 3] = ["task.toml", "instruction.md", "README.md"];
+const PACKAGE_FILES: [&str; 5] = [
+    "task.toml",
+    "instruction.md",
+    "transcript.json",
+    "README.md",
+    "pre_artifacts.sh",
+];
 const PACKAGE_DIRECTORIES: [&str; 4] = ["environment", "tests", "solution", "steps"];
 const PACKAGE_DIGEST_DOMAIN: &[u8] = b"nanocodex-task-package-v1\0";
 
@@ -160,6 +166,39 @@ impl TaskPackage {
                     package_directory.display()
                 ),
             ));
+        }
+        for (directory, mode) in directory_modes.into_iter().rev() {
+            set_mode(&directory, mode)?;
+            normalize_times(&directory)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn materialize(&self, destination: &Path) -> io::Result<()> {
+        fs::create_dir(destination)?;
+        let mut directory_modes = vec![(destination.to_path_buf(), 0o755)];
+        for entry in &self.entries {
+            let target = destination.join(&entry.relative);
+            match &entry.kind {
+                TaskPackageEntryKind::Directory => {
+                    fs::create_dir(&target)?;
+                    directory_modes.push((target, entry.mode));
+                }
+                TaskPackageEntryKind::File { bytes, digest } => {
+                    let mut file = OpenOptions::new()
+                        .write(true)
+                        .create_new(true)
+                        .open(&target)?;
+                    copy_file_verified(
+                        &self.root.join(&entry.relative),
+                        &mut file,
+                        *bytes,
+                        *digest,
+                    )?;
+                    set_mode(&target, entry.mode)?;
+                    normalize_times(&target)?;
+                }
+            }
         }
         for (directory, mode) in directory_modes.into_iter().rev() {
             set_mode(&directory, mode)?;

--- a/crates/experimental/nanocodex-eval/src/evaluation.rs
+++ b/crates/experimental/nanocodex-eval/src/evaluation.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::{
     Task,
-    profile::{EvaluationManifest, ResolvedFamily, ResolvedHarness},
+    profile::{EvaluationManifest, ResolvedFamily, ResolvedHarness, ResolvedProfile, ResolvedTask},
     workset::{
         BeginTask, TaskClaim, Workset, WorksetBusy, WorksetError, WorksetFamily, WorksetObserver,
         WorksetStatus, WorksetTask,
@@ -175,6 +175,14 @@ pub struct EvaluationError {
 }
 
 impl Evaluation {
+    /// Reads the adapter-owned benchmark selectors requested by a TOML profile.
+    pub fn profile_benchmarks(
+        config: impl AsRef<Path>,
+        recipe: Option<&str>,
+    ) -> Result<Vec<String>, EvaluationError> {
+        EvaluationManifest::load_benchmarks(config, recipe).map_err(error)
+    }
+
     /// Appends concrete work, creating the benchmark when it does not exist.
     pub fn add(
         state_directory: impl Into<PathBuf>,
@@ -239,6 +247,29 @@ impl Evaluation {
         new_generation: bool,
     ) -> Result<(), EvaluationError> {
         let recipe = EvaluationManifest::load_profile(config, recipe).map_err(error)?;
+        Self::add_resolved_profile(recipe, state_directory, name, new_generation)
+    }
+
+    /// Expands a TOML profile plus adapter-resolved tasks into durable rows.
+    pub fn add_profile_with_tasks(
+        config: impl AsRef<Path>,
+        recipe: Option<&str>,
+        benchmark_tasks: Vec<ResolvedTask>,
+        state_directory: impl Into<PathBuf>,
+        name: &str,
+        new_generation: bool,
+    ) -> Result<(), EvaluationError> {
+        let recipe = EvaluationManifest::load_profile_with_tasks(config, recipe, benchmark_tasks)
+            .map_err(error)?;
+        Self::add_resolved_profile(recipe, state_directory, name, new_generation)
+    }
+
+    fn add_resolved_profile(
+        recipe: ResolvedProfile,
+        state_directory: impl Into<PathBuf>,
+        name: &str,
+        new_generation: bool,
+    ) -> Result<(), EvaluationError> {
         let mut work = Vec::with_capacity(recipe.families.len());
         for task in &recipe.tasks {
             for family in recipe

--- a/crates/experimental/nanocodex-eval/src/evaluator.rs
+++ b/crates/experimental/nanocodex-eval/src/evaluator.rs
@@ -212,6 +212,7 @@ pub(crate) struct EvalAttempt<'a> {
     task: &'a Task,
     directory: &'a Path,
     workspace: &'a Path,
+    final_message: Option<&'a str>,
 }
 
 /// Failure to configure, execute, verify, or durably retain an attempt.
@@ -514,8 +515,12 @@ impl Evaluator {
             ));
         }
         emitter.emit(EvalEventKind::VerifierStarted);
+        let final_message = agent
+            .result
+            .as_ref()
+            .map(|result| result.final_message.as_str());
         let verifier = match self
-            .execute_verifier(&task, &attempt, agent.verifier.take())
+            .execute_verifier(&task, &attempt, final_message, agent.verifier.take())
             .await
         {
             Ok(verifier) => verifier,
@@ -554,7 +559,7 @@ impl Evaluator {
 
         agent.shutdown().await;
 
-        let status = verifier_status(&verifier.result);
+        let status = verifier_status(&task, &verifier.result);
         let score_outcome = match status {
             EvalStatus::Passed => EvalOutcome::Passed,
             EvalStatus::Failed => EvalOutcome::VerifierFailed,
@@ -604,6 +609,7 @@ impl Evaluator {
         &self,
         task: &Task,
         attempt: &NativeAttempt,
+        final_message: Option<&str>,
         verifier: Option<Box<dyn AttemptVerifier>>,
     ) -> Result<VerifierExecution, VerifierExecutionFailure> {
         let span = info_span!(
@@ -634,6 +640,7 @@ impl Evaluator {
                             task,
                             directory: &attempt.paths.root,
                             workspace: &attempt.paths.workspace,
+                            final_message,
                         },
                     )
                     .await
@@ -674,20 +681,22 @@ impl Evaluator {
                 })
             } else {
                 let started_at = Utc::now();
-                attempt
-                    .verify(task)
-                    .await
-                    .map_err(|error| VerifierExecutionFailure {
+                attempt.verify(task, final_message).await.map_err(|error| {
+                    VerifierExecutionFailure {
                         error: RecordedEvalError::now(error),
                         cleanup: CleanupPhase::not_required(),
                         timing: Some(PhaseTiming::finished(started_at)),
-                    })
+                    }
+                })
             }
         }
         .instrument(span.clone())
         .await;
         if let Ok(verifier) = &result {
-            let passed = verifier.result.rewards.values().all(|reward| *reward > 0.0);
+            let passed = task
+                .verifier()
+                .scoring_policy()
+                .passes(&verifier.result.rewards);
             span.record("process.exit.code", verifier.result.exit_code);
             span.record(
                 "verifier.reward.total",
@@ -770,7 +779,7 @@ impl Evaluator {
         );
         let trace_started = Instant::now();
         let result = async {
-            let turn = agent.prompt(task.prompt()).await?;
+            let turn = agent.prompt(task.agent_prompt()).await?;
             let mut observation = AgentObservation::default();
             let event_result = timeout(
                 task.agent_timeout(),
@@ -1027,6 +1036,7 @@ impl Evaluator {
                         task,
                         directory: &attempt.paths.root,
                         workspace: &attempt.paths.workspace,
+                        final_message: None,
                     },
                     builder,
                 ) {
@@ -1990,6 +2000,12 @@ impl EvalAttempt<'_> {
     pub(crate) const fn workspace(&self) -> &Path {
         self.workspace
     }
+
+    /// Returns the exact final assistant message produced by the candidate.
+    #[must_use]
+    pub(crate) const fn final_message(&self) -> Option<&str> {
+        self.final_message
+    }
 }
 
 #[derive(Clone)]
@@ -2595,8 +2611,8 @@ fn validate_attempt_environment(task: &Task, custom_backend: bool) -> Result<(),
     Ok(())
 }
 
-fn verifier_status(verifier: &crate::VerifierResult) -> EvalStatus {
-    if verifier.rewards.values().all(|reward| *reward > 0.0) {
+fn verifier_status(task: &Task, verifier: &crate::VerifierResult) -> EvalStatus {
+    if task.verifier().scoring_policy().passes(&verifier.rewards) {
         EvalStatus::Passed
     } else {
         EvalStatus::Failed

--- a/crates/experimental/nanocodex-eval/src/evaluator.rs
+++ b/crates/experimental/nanocodex-eval/src/evaluator.rs
@@ -514,18 +514,28 @@ impl Evaluator {
                 verifier_cleanup,
             ));
         }
-        emitter.emit(EvalEventKind::VerifierStarted);
         let final_message = agent
             .result
             .as_ref()
-            .map(|result| result.final_message.as_str());
+            .map(|result| result.final_message.clone());
+        // Joining the agent drops its caller-defined tools before a verifier
+        // may shut down the agent environment and launch an isolated verifier
+        // environment. The verifier retains the owning environment session;
+        // keeping the agent driver alive here would leave a sibling tool
+        // capability that correctly prevents graceful VM shutdown.
+        agent.shutdown().await;
+        emitter.emit(EvalEventKind::VerifierStarted);
         let verifier = match self
-            .execute_verifier(&task, &attempt, final_message, agent.verifier.take())
+            .execute_verifier(
+                &task,
+                &attempt,
+                final_message.as_deref(),
+                agent.verifier.take(),
+            )
             .await
         {
             Ok(verifier) => verifier,
             Err(failure) => {
-                agent.shutdown().await;
                 let primary = agent.error.take();
                 return Err(AttemptRunFailure::after_verifier_failure(
                     &attempt, &agent, primary, failure,
@@ -533,7 +543,6 @@ impl Evaluator {
             }
         };
         if let Err(error) = task.validate_package() {
-            agent.shutdown().await;
             return Err(AttemptRunFailure::after_verifier(
                 &attempt,
                 &agent,
@@ -548,7 +557,6 @@ impl Evaluator {
         emitter.emit(EvalEventKind::VerifierCompleted(verifier.result.clone()));
 
         if let Some(error) = verifier_bootstrap_error(&verifier) {
-            agent.shutdown().await;
             return Err(AttemptRunFailure::after_verifier(
                 &attempt,
                 &agent,
@@ -556,8 +564,6 @@ impl Evaluator {
                 RecordedEvalError::now(error),
             ));
         }
-
-        agent.shutdown().await;
 
         let status = verifier_status(&task, &verifier.result);
         let score_outcome = match status {

--- a/crates/experimental/nanocodex-eval/src/harness.rs
+++ b/crates/experimental/nanocodex-eval/src/harness.rs
@@ -5,6 +5,7 @@
 //! verifier lifecycle.
 
 use std::{
+    collections::BTreeMap,
     error::Error,
     fs,
     future::Future,
@@ -120,6 +121,7 @@ pub struct Harness {
     api_upstream: Option<String>,
     version: String,
     name: String,
+    verifier_environment: BTreeMap<String, String>,
 }
 
 impl Harness {
@@ -153,6 +155,7 @@ impl Harness {
             api_upstream: None,
             version: "configured".to_owned(),
             name: "harness".to_owned(),
+            verifier_environment: BTreeMap::new(),
         }
     }
 
@@ -202,6 +205,16 @@ impl Harness {
     #[must_use]
     pub fn environment(mut self, environment: Vec<(String, String)>) -> Self {
         self.environment = environment;
+        self
+    }
+
+    /// Adds run-scoped values visible only to verifier commands.
+    #[must_use]
+    pub fn verifier_environment(
+        mut self,
+        environment: impl IntoIterator<Item = (String, String)>,
+    ) -> Self {
+        self.verifier_environment.extend(environment);
         self
     }
 
@@ -262,6 +275,7 @@ impl Harness {
             &self.resources,
             self.guest_memory_mb,
             self.web_search,
+            &self.verifier_environment,
         )
         .await
         .map_err(HarnessError::from_box)?;

--- a/crates/experimental/nanocodex-eval/src/harness/sandbox.rs
+++ b/crates/experimental/nanocodex-eval/src/harness/sandbox.rs
@@ -10,6 +10,7 @@ pub(super) async fn prepare_harness_vm_resources(
     vm: &VmResources,
     guest_memory_mb: u64,
     web_search: bool,
+    verifier_environment: &BTreeMap<String, String>,
 ) -> InternalResult<HarnessVmResources> {
     let environment = vm.environment(task).await?;
     let backend = vm
@@ -17,7 +18,8 @@ pub(super) async fn prepare_harness_vm_resources(
             VmBackend::builder()
                 .retain_passed_rootfs(false)
                 .retain_failed_rootfs(false)
-                .web_search(web_search),
+                .web_search(web_search)
+                .verifier_environment(verifier_environment.clone()),
             task,
             guest_memory_mb,
         )

--- a/crates/experimental/nanocodex-eval/src/import/mod.rs
+++ b/crates/experimental/nanocodex-eval/src/import/mod.rs
@@ -1,0 +1,1788 @@
+//! Third-party dataset conversion into immutable evaluator tasks.
+//!
+//! Import is a build step. Format-specific readers produce a
+//! [`DatasetPlan`](crate::import::DatasetPlan), and
+//! [`ImportStore`](crate::import::ImportStore) snapshots every execution input
+//! into a content-addressed
+//! dataset. The normal evaluator then sees only [`Task`] values; VM image
+//! caching, writable overlays, scheduling, resume, and evidence retention do
+//! not branch on the upstream benchmark.
+
+use std::{
+    collections::BTreeSet,
+    fs::{self, OpenOptions},
+    io::{self, Read as _, Write as _},
+    os::unix::fs::PermissionsExt as _,
+    path::{Component, Path, PathBuf},
+    time::Duration,
+};
+
+use nanocodex_oai_api::PromptMessage;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{Resources, ScoringPolicy, Task, TaskLoadError, TaskOutput};
+
+const IMPORT_SCHEMA: &str = "nanocodex-import-v1";
+const PLAN_INDEX_SCHEMA: &str = "nanocodex-import-plan-index-v1";
+const MANIFEST_FILE: &str = "dataset.json";
+
+/// A format-specific reader that describes a deterministic dataset import.
+pub trait DatasetImporter {
+    /// Produces the complete import plan without running an agent or grader.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] when upstream metadata is malformed, missing,
+    /// or cannot be represented without changing benchmark semantics.
+    fn plan(&self) -> Result<DatasetPlan, ImportError>;
+}
+
+/// Durable content-addressed storage for normalized datasets.
+#[derive(Clone, Debug)]
+pub struct ImportStore {
+    root: PathBuf,
+}
+
+/// One immutable imported dataset and its evaluator-ready tasks.
+#[derive(Clone, Debug)]
+pub struct ImportedDataset {
+    root: PathBuf,
+    digest: Box<str>,
+    source: SourceIdentity,
+    tasks: Vec<Task>,
+}
+
+/// A complete, deterministic dataset conversion plan.
+#[derive(Debug)]
+pub struct DatasetPlan {
+    name: Box<str>,
+    source: SourceIdentity,
+    cases: Vec<CasePlan>,
+}
+
+/// Safe provenance retained for an imported upstream source.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct SourceIdentity {
+    kind: Box<str>,
+    revision: Box<str>,
+    digest: Box<str>,
+}
+
+/// One normalized case in a [`DatasetPlan`].
+#[derive(Debug)]
+pub struct CasePlan {
+    id: Box<str>,
+    package: CasePackage,
+}
+
+/// Builder for one generated hermetic evaluator case.
+#[derive(Debug)]
+pub struct HermeticCasePlan {
+    id: Box<str>,
+    case: HermeticCase,
+}
+
+#[derive(Debug)]
+enum CasePackage {
+    Existing(PathBuf),
+    Hermetic(HermeticCase),
+}
+
+#[derive(Debug)]
+struct HermeticCase {
+    prompt: String,
+    transcript: Vec<PromptMessage>,
+    benchmark_prompt_chars: Option<u64>,
+    benchmark_case_type: Option<String>,
+    environment: Environment,
+    environment_files: Vec<GeneratedFile>,
+    harness: Harness,
+    harness_files: Vec<GeneratedFile>,
+    output: TaskOutput,
+    resources: Resources,
+    agent_timeout: Duration,
+    agent_instructions: Option<String>,
+    verifier_timeout: Duration,
+    scoring_policy: ScoringPolicy,
+    artifacts: Vec<HermeticArtifact>,
+    allow_internet: bool,
+    verifier_allow_internet: bool,
+}
+
+#[derive(Debug)]
+struct HermeticArtifact {
+    source: PathBuf,
+    exclude: Vec<PathBuf>,
+}
+
+/// Agent environment used by a generated case.
+#[derive(Clone, Debug)]
+pub enum Environment {
+    /// Pull a pinned or otherwise caller-selected OCI image.
+    OciImage(String),
+    /// Build an image from this Dockerfile context.
+    Dockerfile(PathBuf),
+}
+
+/// Canonical verifier package used by a generated case.
+#[derive(Clone, Debug)]
+pub struct Harness {
+    directory: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+struct GeneratedFile {
+    path: PathBuf,
+    contents: GeneratedFileContents,
+    mode: u32,
+}
+
+#[derive(Clone, Debug)]
+enum GeneratedFileContents {
+    Inline(Vec<u8>),
+    Source(PathBuf),
+}
+
+/// Failure to inspect, normalize, store, or reload an imported dataset.
+#[derive(Debug, thiserror::Error)]
+pub enum ImportError {
+    /// A source or generated package could not be read or written.
+    #[error("dataset import I/O failed at {path}: {source}")]
+    Io {
+        /// Affected path.
+        path: PathBuf,
+        /// Filesystem failure.
+        #[source]
+        source: io::Error,
+    },
+
+    /// JSON or JSONL metadata was malformed.
+    #[error("failed to decode dataset JSON at {path}: {source}")]
+    Json {
+        /// Affected path.
+        path: PathBuf,
+        /// Decoder failure.
+        #[source]
+        source: serde_json::Error,
+    },
+
+    /// A normalized task package was invalid.
+    #[error("imported task package is invalid: {0}")]
+    Task(#[from] TaskLoadError),
+
+    /// Upstream metadata cannot be represented faithfully.
+    #[error("invalid dataset import: {0}")]
+    Invalid(String),
+
+    /// The content-addressed destination exists with different contents.
+    #[error("import destination collision at {0}")]
+    Collision(PathBuf),
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct DatasetManifest {
+    schema: Box<str>,
+    name: Box<str>,
+    source: SourceIdentity,
+    digest: Box<str>,
+    tasks: Vec<ManifestTask>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct ManifestTask {
+    id: Box<str>,
+    path: Box<str>,
+    digest: Box<str>,
+}
+
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct PlanIndex {
+    schema: Box<str>,
+    key: Box<str>,
+    dataset: Box<str>,
+}
+
+#[derive(Serialize)]
+struct DigestManifest<'a> {
+    schema: &'a str,
+    name: &'a str,
+    source: &'a SourceIdentity,
+    tasks: &'a [ManifestTask],
+}
+
+impl ImportStore {
+    /// Creates a store rooted at `directory`.
+    #[must_use]
+    pub fn new(directory: impl Into<PathBuf>) -> Self {
+        Self {
+            root: directory.into(),
+        }
+    }
+
+    /// Imports or reopens one content-identical dataset.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] when the importer rejects its source, a package
+    /// cannot be materialized, or retained content fails validation.
+    pub fn import(&self, importer: &impl DatasetImporter) -> Result<ImportedDataset, ImportError> {
+        let plan = importer.plan()?;
+        validate_component("dataset name", &plan.name)?;
+        if plan.cases.is_empty() {
+            return Err(ImportError::Invalid(
+                "an imported dataset must contain at least one case".to_owned(),
+            ));
+        }
+        create_dir_all(&self.root)?;
+        let plan_key = plan.fingerprint()?;
+        if let Some(dataset) = self.load_plan(&plan_key)? {
+            return Ok(dataset);
+        }
+        let temporary = tempfile::Builder::new()
+            .prefix(".import-")
+            .tempdir_in(&self.root)
+            .map_err(|source| io_error(&self.root, source))?;
+        let staged = temporary.path().join("dataset");
+        let tasks_root = staged.join("tasks");
+        create_dir_all(&tasks_root)?;
+
+        let mut ids = BTreeSet::new();
+        let mut tasks = Vec::with_capacity(plan.cases.len());
+        for case in plan.cases {
+            let CasePlan { id, package } = case;
+            validate_component("case id", &id)?;
+            if !ids.insert(id.clone()) {
+                return Err(ImportError::Invalid(format!("duplicate case id {:?}", id)));
+            }
+            let relative = PathBuf::from("tasks").join(id.as_ref());
+            let destination = staged.join(&relative);
+            match package {
+                CasePackage::Existing(root) => {
+                    let task = Task::load(root)?;
+                    task.materialize_package(&destination)?;
+                }
+                CasePackage::Hermetic(case) => {
+                    materialize_hermetic_case(&id, case, &destination)?;
+                }
+            }
+            let task = Task::load(&destination)?;
+            tasks.push(ManifestTask {
+                id,
+                path: normalized_relative(&relative)?.into_boxed_str(),
+                digest: task.content_digest().to_owned().into_boxed_str(),
+            });
+        }
+
+        let digest = digest_manifest(&plan.name, &plan.source, &tasks)?;
+        let manifest = DatasetManifest {
+            schema: IMPORT_SCHEMA.into(),
+            name: plan.name.clone(),
+            source: plan.source,
+            digest: digest.clone().into_boxed_str(),
+            tasks,
+        };
+        write_json(&staged.join(MANIFEST_FILE), &manifest)?;
+
+        let dataset_parent = self.root.join(plan.name.as_ref());
+        create_dir_all(&dataset_parent)?;
+        let destination = dataset_parent.join(&digest);
+        let imported = if destination.exists() {
+            load_matching_dataset(&destination, &manifest)?
+        } else if let Err(source) = fs::rename(&staged, &destination) {
+            // Another importer may have published the same digest after the
+            // existence check. Accept only an identical, fully valid result.
+            if destination.exists() {
+                load_matching_dataset(&destination, &manifest)?
+            } else {
+                return Err(io_error(&destination, source));
+            }
+        } else {
+            sync_directory(&dataset_parent)?;
+            ImportedDataset::load(destination)?
+        };
+        self.publish_plan(&plan_key, &imported)?;
+        Ok(imported)
+    }
+
+    /// Returns the root containing all imported datasets.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn load_plan(&self, key: &str) -> Result<Option<ImportedDataset>, ImportError> {
+        let path = self.root.join(".plans").join(format!("{key}.json"));
+        let bytes = match fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(source) => return Err(io_error(&path, source)),
+        };
+        let index: PlanIndex =
+            serde_json::from_slice(&bytes).map_err(|source| ImportError::Json { path, source })?;
+        if index.schema.as_ref() != PLAN_INDEX_SCHEMA || index.key.as_ref() != key {
+            return Err(ImportError::Invalid(format!(
+                "import plan index {key} has an incompatible identity"
+            )));
+        }
+        let relative = safe_manifest_path(&index.dataset)?;
+        Ok(Some(ImportedDataset::load(self.root.join(relative))?))
+    }
+
+    fn publish_plan(&self, key: &str, dataset: &ImportedDataset) -> Result<(), ImportError> {
+        let directory = self.root.join(".plans");
+        create_dir_all(&directory)?;
+        let relative = dataset
+            .root
+            .strip_prefix(
+                fs::canonicalize(&self.root).map_err(|source| io_error(&self.root, source))?,
+            )
+            .map_err(|error| ImportError::Invalid(error.to_string()))?;
+        let relative = normalized_relative(relative)?;
+        let index = PlanIndex {
+            schema: PLAN_INDEX_SCHEMA.into(),
+            key: key.into(),
+            dataset: relative.into_boxed_str(),
+        };
+        let path = directory.join(format!("{key}.json"));
+        if path.is_file() {
+            let bytes = fs::read(&path).map_err(|source| io_error(&path, source))?;
+            let retained: PlanIndex =
+                serde_json::from_slice(&bytes).map_err(|source| ImportError::Json {
+                    path: path.clone(),
+                    source,
+                })?;
+            if retained == index {
+                return Ok(());
+            }
+            return Err(ImportError::Collision(path));
+        }
+        let temporary = tempfile::NamedTempFile::new_in(&directory)
+            .map_err(|source| io_error(&directory, source))?;
+        serde_json::to_writer_pretty(temporary.as_file(), &index).map_err(|source| {
+            ImportError::Json {
+                path: path.clone(),
+                source,
+            }
+        })?;
+        temporary
+            .as_file()
+            .sync_all()
+            .map_err(|source| io_error(&path, source))?;
+        match temporary.persist_noclobber(&path) {
+            Ok(_) => sync_directory(&directory),
+            Err(error) if error.error.kind() == io::ErrorKind::AlreadyExists => {
+                self.publish_plan(key, dataset)
+            }
+            Err(error) => Err(io_error(&path, error.error)),
+        }
+    }
+}
+
+impl DatasetPlan {
+    fn fingerprint(&self) -> Result<String, ImportError> {
+        let mut digest = Sha256::new();
+        Self::update_digest(&mut digest, PLAN_INDEX_SCHEMA.as_bytes());
+        Self::update_digest(&mut digest, self.name.as_bytes());
+        Self::update_digest(&mut digest, self.source.kind.as_bytes());
+        Self::update_digest(&mut digest, self.source.revision.as_bytes());
+        Self::update_digest(&mut digest, self.source.digest.as_bytes());
+        for case in &self.cases {
+            Self::update_digest(&mut digest, case.id.as_bytes());
+            match &case.package {
+                CasePackage::Existing(root) => {
+                    Self::update_digest(&mut digest, b"existing");
+                    let task = Task::load(root)?;
+                    Self::update_digest(&mut digest, task.content_digest().as_bytes());
+                }
+                CasePackage::Hermetic(case) => {
+                    Self::update_digest(&mut digest, b"hermetic");
+                    Self::update_digest(&mut digest, case.prompt.as_bytes());
+                    Self::update_digest(
+                        &mut digest,
+                        &serde_json::to_vec(&case.transcript).map_err(|source| {
+                            ImportError::Json {
+                                path: PathBuf::from("<import-plan>"),
+                                source,
+                            }
+                        })?,
+                    );
+                    Self::update_digest(
+                        &mut digest,
+                        &case
+                            .benchmark_prompt_chars
+                            .unwrap_or_default()
+                            .to_le_bytes(),
+                    );
+                    Self::update_digest(
+                        &mut digest,
+                        case.benchmark_case_type.as_deref().unwrap_or("").as_bytes(),
+                    );
+                    match &case.environment {
+                        Environment::OciImage(image) => {
+                            Self::update_digest(&mut digest, b"oci");
+                            Self::update_digest(&mut digest, image.as_bytes());
+                        }
+                        Environment::Dockerfile(root) => {
+                            Self::update_digest(&mut digest, b"dockerfile");
+                            Self::update_directory(&mut digest, root)?;
+                        }
+                    }
+                    for file in &case.environment_files {
+                        Self::update_digest(
+                            &mut digest,
+                            normalized_relative(&file.path)?.as_bytes(),
+                        );
+                        Self::update_digest(&mut digest, &file.mode.to_le_bytes());
+                        Self::update_generated_file(&mut digest, file)?;
+                    }
+                    Self::update_directory(&mut digest, &case.harness.directory)?;
+                    for file in &case.harness_files {
+                        Self::update_digest(
+                            &mut digest,
+                            normalized_relative(&file.path)?.as_bytes(),
+                        );
+                        Self::update_digest(&mut digest, &file.mode.to_le_bytes());
+                        Self::update_generated_file(&mut digest, file)?;
+                    }
+                    Self::update_digest(
+                        &mut digest,
+                        serde_json::to_string(&case.output)
+                            .map_err(|source| ImportError::Json {
+                                path: PathBuf::from("<import-plan>"),
+                                source,
+                            })?
+                            .as_bytes(),
+                    );
+                    Self::update_digest(&mut digest, &case.resources.cpus.to_le_bytes());
+                    Self::update_digest(&mut digest, &case.resources.memory_mb.to_le_bytes());
+                    Self::update_digest(&mut digest, &case.resources.storage_mb.to_le_bytes());
+                    Self::update_digest(&mut digest, &case.resources.gpus.to_le_bytes());
+                    Self::update_digest(&mut digest, &case.agent_timeout.as_nanos().to_le_bytes());
+                    Self::update_digest(
+                        &mut digest,
+                        &case.verifier_timeout.as_nanos().to_le_bytes(),
+                    );
+                    Self::update_digest(&mut digest, case.scoring_policy.as_str().as_bytes());
+                    for artifact in &case.artifacts {
+                        Self::update_digest(
+                            &mut digest,
+                            artifact.source.to_string_lossy().as_bytes(),
+                        );
+                        for excluded in &artifact.exclude {
+                            Self::update_digest(
+                                &mut digest,
+                                normalized_relative(excluded)?.as_bytes(),
+                            );
+                        }
+                    }
+                    Self::update_digest(
+                        &mut digest,
+                        case.agent_instructions.as_deref().unwrap_or("").as_bytes(),
+                    );
+                    Self::update_digest(&mut digest, &[u8::from(case.allow_internet)]);
+                    Self::update_digest(&mut digest, &[u8::from(case.verifier_allow_internet)]);
+                }
+            }
+        }
+        Ok(hex::encode(digest.finalize()))
+    }
+
+    fn update_directory(digest: &mut Sha256, root: &Path) -> Result<(), ImportError> {
+        let root = fs::canonicalize(root).map_err(|source| io_error(root, source))?;
+        let mut entries = ignore::WalkBuilder::new(&root)
+            .hidden(false)
+            .ignore(false)
+            .git_ignore(false)
+            .git_exclude(false)
+            .parents(false)
+            .follow_links(false)
+            .build()
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| ImportError::Invalid(error.to_string()))?;
+        entries.sort_unstable_by(|left, right| left.path().cmp(right.path()));
+        for entry in entries {
+            if entry.path() == root {
+                continue;
+            }
+            let relative = entry
+                .path()
+                .strip_prefix(&root)
+                .map_err(|error| ImportError::Invalid(error.to_string()))?;
+            Self::update_digest(digest, normalized_relative(relative)?.as_bytes());
+            let metadata = fs::symlink_metadata(entry.path())
+                .map_err(|source| io_error(entry.path(), source))?;
+            Self::update_digest(digest, &metadata.permissions().mode().to_le_bytes());
+            if metadata.is_file() {
+                Self::update_digest(digest, b"file");
+                let bytes =
+                    fs::read(entry.path()).map_err(|source| io_error(entry.path(), source))?;
+                Self::update_digest(digest, &bytes);
+            } else if metadata.is_dir() {
+                Self::update_digest(digest, b"directory");
+            } else {
+                return Err(ImportError::Invalid(format!(
+                    "unsupported import-plan entry: {}",
+                    entry.path().display()
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn update_generated_file(digest: &mut Sha256, file: &GeneratedFile) -> Result<(), ImportError> {
+        match &file.contents {
+            GeneratedFileContents::Inline(bytes) => {
+                Self::update_digest(digest, bytes);
+                Ok(())
+            }
+            GeneratedFileContents::Source(path) => {
+                let mut source = fs::File::open(path).map_err(|error| io_error(path, error))?;
+                let length = source
+                    .metadata()
+                    .map_err(|error| io_error(path, error))?
+                    .len();
+                digest.update(length.to_le_bytes());
+                let mut buffer = [0_u8; 64 * 1024];
+                loop {
+                    let read = source
+                        .read(&mut buffer)
+                        .map_err(|error| io_error(path, error))?;
+                    if read == 0 {
+                        break;
+                    }
+                    digest.update(&buffer[..read]);
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn update_digest(digest: &mut Sha256, value: &[u8]) {
+        digest.update(u64::try_from(value.len()).unwrap_or(u64::MAX).to_le_bytes());
+        digest.update(value);
+    }
+}
+
+fn load_matching_dataset(
+    destination: &Path,
+    expected: &DatasetManifest,
+) -> Result<ImportedDataset, ImportError> {
+    let existing = ImportedDataset::load(destination)?;
+    if &existing.manifest()? != expected {
+        return Err(ImportError::Collision(destination.to_path_buf()));
+    }
+    Ok(existing)
+}
+
+impl ImportedDataset {
+    /// Loads and validates a previously imported dataset.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] when the manifest or any immutable task package
+    /// is missing, malformed, or content-inconsistent.
+    pub fn load(directory: impl AsRef<Path>) -> Result<Self, ImportError> {
+        let requested = directory.as_ref();
+        let root = fs::canonicalize(requested).map_err(|source| io_error(requested, source))?;
+        let manifest = read_manifest(&root)?;
+        if manifest.schema.as_ref() != IMPORT_SCHEMA {
+            return Err(ImportError::Invalid(format!(
+                "unsupported import schema {:?}",
+                manifest.schema
+            )));
+        }
+        let expected = digest_manifest(&manifest.name, &manifest.source, &manifest.tasks)?;
+        if manifest.digest.as_ref() != expected {
+            return Err(ImportError::Invalid(format!(
+                "dataset digest mismatch: manifest has {}, computed {expected}",
+                manifest.digest
+            )));
+        }
+        let mut tasks = Vec::with_capacity(manifest.tasks.len());
+        for entry in &manifest.tasks {
+            let relative = safe_manifest_path(&entry.path)?;
+            let task = Task::load(root.join(relative))?;
+            if task.content_digest() != entry.digest.as_ref() {
+                return Err(ImportError::Invalid(format!(
+                    "task {} digest mismatch",
+                    entry.id
+                )));
+            }
+            tasks.push(task.attach_dataset(&manifest.name, Some(manifest.source.revision())));
+        }
+        Ok(Self {
+            root,
+            digest: manifest.digest,
+            source: manifest.source,
+            tasks,
+        })
+    }
+
+    /// Returns the immutable dataset root.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Returns the content digest covering source identity and every task.
+    #[must_use]
+    pub fn digest(&self) -> &str {
+        &self.digest
+    }
+
+    /// Returns safe upstream provenance.
+    #[must_use]
+    pub const fn source(&self) -> &SourceIdentity {
+        &self.source
+    }
+
+    /// Returns evaluator-ready immutable tasks in source order.
+    #[must_use]
+    pub fn tasks(&self) -> &[Task] {
+        &self.tasks
+    }
+
+    fn manifest(&self) -> Result<DatasetManifest, ImportError> {
+        read_manifest(&self.root)
+    }
+}
+
+impl DatasetPlan {
+    /// Creates an empty plan with stable source provenance.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] when the dataset name is unsafe.
+    pub fn new(name: impl Into<String>, source: SourceIdentity) -> Result<Self, ImportError> {
+        let name = name.into();
+        validate_component("dataset name", &name)?;
+        Ok(Self {
+            name: name.into_boxed_str(),
+            source,
+            cases: Vec::new(),
+        })
+    }
+
+    /// Appends one case in stable source order.
+    #[must_use]
+    pub fn case(mut self, case: impl Into<CasePlan>) -> Self {
+        self.cases.push(case.into());
+        self
+    }
+}
+
+impl SourceIdentity {
+    /// Creates source provenance without retaining a local path or credential.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] for an empty kind/revision or a digest other
+    /// than lowercase SHA-256.
+    pub fn new(
+        kind: impl Into<String>,
+        revision: impl Into<String>,
+        digest: impl Into<String>,
+    ) -> Result<Self, ImportError> {
+        let kind = kind.into();
+        let revision = revision.into();
+        let digest = digest.into();
+        if kind.trim().is_empty() || revision.trim().is_empty() {
+            return Err(ImportError::Invalid(
+                "source kind and revision must not be empty".to_owned(),
+            ));
+        }
+        if !is_sha256(&digest) {
+            return Err(ImportError::Invalid(
+                "source digest must be a lowercase SHA-256 digest".to_owned(),
+            ));
+        }
+        Ok(Self {
+            kind: kind.into_boxed_str(),
+            revision: revision.into_boxed_str(),
+            digest: digest.into_boxed_str(),
+        })
+    }
+
+    /// Returns the stable importer/source kind.
+    #[must_use]
+    pub fn kind(&self) -> &str {
+        &self.kind
+    }
+
+    /// Returns the caller-pinned upstream revision.
+    #[must_use]
+    pub fn revision(&self) -> &str {
+        &self.revision
+    }
+
+    /// Returns the SHA-256 of consumed source metadata.
+    #[must_use]
+    pub fn digest(&self) -> &str {
+        &self.digest
+    }
+}
+
+impl CasePlan {
+    /// Snapshots an existing evaluator task package without semantic changes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] when `id` is unsafe.
+    pub fn existing(
+        id: impl Into<String>,
+        package: impl Into<PathBuf>,
+    ) -> Result<Self, ImportError> {
+        let id = id.into();
+        validate_component("case id", &id)?;
+        Ok(Self {
+            id: id.into_boxed_str(),
+            package: CasePackage::Existing(package.into()),
+        })
+    }
+
+    /// Creates a generated hermetic case.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] when `id` is unsafe.
+    pub fn hermetic(
+        id: impl Into<String>,
+        prompt: impl Into<String>,
+        environment: Environment,
+        harness: Harness,
+    ) -> Result<HermeticCasePlan, ImportError> {
+        let id = id.into();
+        validate_component("case id", &id)?;
+        let prompt = prompt.into();
+        if prompt.trim().is_empty() {
+            return Err(ImportError::Invalid(format!(
+                "case {id:?} has an empty prompt"
+            )));
+        }
+        Ok(HermeticCasePlan {
+            id: id.into_boxed_str(),
+            case: HermeticCase {
+                prompt,
+                transcript: Vec::new(),
+                benchmark_prompt_chars: None,
+                benchmark_case_type: None,
+                environment,
+                environment_files: Vec::new(),
+                harness,
+                harness_files: Vec::new(),
+                output: TaskOutput::Workspace,
+                resources: Resources {
+                    cpus: 2,
+                    memory_mb: 4096,
+                    storage_mb: 10_240,
+                    gpus: 0,
+                },
+                agent_timeout: Duration::from_secs(900),
+                agent_instructions: None,
+                verifier_timeout: Duration::from_secs(300),
+                scoring_policy: ScoringPolicy::AllRewardsPositive,
+                artifacts: Vec::new(),
+                allow_internet: true,
+                verifier_allow_internet: true,
+            },
+        })
+    }
+}
+
+impl HermeticCasePlan {
+    /// Prepends a synthetic text-only conversation to the final user prompt.
+    #[must_use]
+    pub fn transcript(mut self, messages: impl IntoIterator<Item = PromptMessage>) -> Self {
+        self.case.transcript = messages.into_iter().collect();
+        self
+    }
+
+    /// Retains the source benchmark's prompt-size dimension for official binning.
+    #[must_use]
+    pub const fn benchmark_prompt_chars(mut self, chars: u64) -> Self {
+        self.case.benchmark_prompt_chars = Some(chars);
+        self
+    }
+
+    /// Retains the source benchmark's case-type dimension for official grouping.
+    #[must_use]
+    pub fn benchmark_case_type(mut self, case_type: impl Into<String>) -> Self {
+        self.case.benchmark_case_type = Some(case_type.into());
+        self
+    }
+
+    /// Adds one case-specific file to the candidate environment.
+    ///
+    /// Native attempts copy this file into the disposable workspace. A
+    /// Dockerfile-backed VM environment may place it in the guest workspace
+    /// with an ordinary `COPY` instruction.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] when `path` is not a safe relative path.
+    pub fn environment_file(
+        mut self,
+        path: impl Into<PathBuf>,
+        bytes: impl Into<Vec<u8>>,
+        mode: u32,
+    ) -> Result<Self, ImportError> {
+        self.case.environment_files.push(GeneratedFile::inline(
+            path.into(),
+            bytes.into(),
+            mode,
+            "environment",
+        )?);
+        Ok(self)
+    }
+
+    /// Snapshots one existing file into the candidate environment without
+    /// buffering its contents in the import plan.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] when either path is unsafe or the source is not
+    /// an ordinary file.
+    pub fn environment_file_from(
+        mut self,
+        path: impl Into<PathBuf>,
+        source: impl Into<PathBuf>,
+        mode: u32,
+    ) -> Result<Self, ImportError> {
+        self.case.environment_files.push(GeneratedFile::source(
+            path.into(),
+            source.into(),
+            mode,
+            "environment",
+        )?);
+        Ok(self)
+    }
+
+    /// Applies benchmark-owned model instructions separately from the user prompt.
+    #[must_use]
+    pub fn instructions(mut self, instructions: impl Into<String>) -> Self {
+        self.case.agent_instructions = Some(instructions.into());
+        self
+    }
+
+    /// Selects which candidate value the verifier consumes.
+    #[must_use]
+    pub const fn output(mut self, output: TaskOutput) -> Self {
+        self.case.output = output;
+        self
+    }
+
+    /// Selects task resource admission and VM sizing.
+    #[must_use]
+    pub const fn resources(mut self, resources: Resources) -> Self {
+        self.case.resources = resources;
+        self
+    }
+
+    /// Selects agent and verifier deadlines.
+    #[must_use]
+    pub const fn timeouts(mut self, agent: Duration, verifier: Duration) -> Self {
+        self.case.agent_timeout = agent;
+        self.case.verifier_timeout = verifier;
+        self
+    }
+
+    /// Selects how numeric verifier rewards map to binary pass/fail status.
+    #[must_use]
+    pub const fn scoring_policy(mut self, policy: ScoringPolicy) -> Self {
+        self.case.scoring_policy = policy;
+        self
+    }
+
+    /// Captures one absolute guest path after agent execution for a separate verifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] when the source is not a safe absolute guest path.
+    pub fn artifact(mut self, source: impl Into<PathBuf>) -> Result<Self, ImportError> {
+        let source = source.into();
+        if source.to_str().is_none() || !safe_absolute_guest_path(&source) {
+            return Err(ImportError::Invalid(format!(
+                "unsafe generated artifact source: {}",
+                source.display()
+            )));
+        }
+        self.case.artifacts.push(HermeticArtifact {
+            source,
+            exclude: Vec::new(),
+        });
+        Ok(self)
+    }
+
+    /// Selects whether the agent environment has a network device.
+    #[must_use]
+    pub const fn allow_internet(mut self, allow: bool) -> Self {
+        self.case.allow_internet = allow;
+        self.case.verifier_allow_internet = allow;
+        self
+    }
+
+    /// Selects whether a separate verifier environment has a network device.
+    ///
+    /// This may differ from the agent policy only when the harness supplies a
+    /// separate verifier Dockerfile.
+    #[must_use]
+    pub const fn verifier_allow_internet(mut self, allow: bool) -> Self {
+        self.case.verifier_allow_internet = allow;
+        self
+    }
+
+    /// Adds one case-specific file to the canonical verifier package.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] when `path` is not a safe relative path.
+    pub fn harness_file(
+        mut self,
+        path: impl Into<PathBuf>,
+        bytes: impl Into<Vec<u8>>,
+        mode: u32,
+    ) -> Result<Self, ImportError> {
+        self.case.harness_files.push(GeneratedFile::inline(
+            path.into(),
+            bytes.into(),
+            mode,
+            "harness",
+        )?);
+        Ok(self)
+    }
+
+    /// Snapshots one existing file into the verifier package without
+    /// buffering its contents in the import plan.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] when either path is unsafe or the source is not
+    /// an ordinary file.
+    pub fn harness_file_from(
+        mut self,
+        path: impl Into<PathBuf>,
+        source: impl Into<PathBuf>,
+        mode: u32,
+    ) -> Result<Self, ImportError> {
+        self.case.harness_files.push(GeneratedFile::source(
+            path.into(),
+            source.into(),
+            mode,
+            "harness",
+        )?);
+        Ok(self)
+    }
+}
+
+impl GeneratedFile {
+    fn inline(path: PathBuf, bytes: Vec<u8>, mode: u32, kind: &str) -> Result<Self, ImportError> {
+        Self::new(path, GeneratedFileContents::Inline(bytes), mode, kind)
+    }
+
+    fn source(path: PathBuf, source: PathBuf, mode: u32, kind: &str) -> Result<Self, ImportError> {
+        if !source.is_file() {
+            return Err(ImportError::Invalid(format!(
+                "generated {kind} source is not a file: {}",
+                source.display()
+            )));
+        }
+        Self::new(path, GeneratedFileContents::Source(source), mode, kind)
+    }
+
+    fn new(
+        path: PathBuf,
+        contents: GeneratedFileContents,
+        mode: u32,
+        kind: &str,
+    ) -> Result<Self, ImportError> {
+        if path.as_os_str().is_empty()
+            || path.is_absolute()
+            || path
+                .components()
+                .any(|component| !matches!(component, Component::Normal(_)))
+        {
+            return Err(ImportError::Invalid(format!(
+                "unsafe generated {kind} path: {}",
+                path.display()
+            )));
+        }
+        Ok(Self {
+            path,
+            contents,
+            mode,
+        })
+    }
+}
+
+impl From<HermeticCasePlan> for CasePlan {
+    fn from(value: HermeticCasePlan) -> Self {
+        Self {
+            id: value.id,
+            package: CasePackage::Hermetic(value.case),
+        }
+    }
+}
+
+impl Harness {
+    /// Uses a directory containing canonical `test.sh` and optional
+    /// `Dockerfile` verifier inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImportError`] when the directory lacks `test.sh`.
+    pub fn directory(directory: impl Into<PathBuf>) -> Result<Self, ImportError> {
+        let directory = directory.into();
+        let script = directory.join("test.sh");
+        if !script.is_file() {
+            return Err(ImportError::Invalid(format!(
+                "harness is missing {}",
+                script.display()
+            )));
+        }
+        Ok(Self { directory })
+    }
+}
+
+fn materialize_hermetic_case(
+    id: &str,
+    case: HermeticCase,
+    destination: &Path,
+) -> Result<(), ImportError> {
+    create_dir_all(destination)?;
+    fs::write(destination.join("instruction.md"), case.prompt)
+        .map_err(|source| io_error(destination.join("instruction.md"), source))?;
+    if !case.transcript.is_empty() {
+        write_json(
+            &destination.join("transcript.json"),
+            &TaskTranscript {
+                messages: &case.transcript,
+            },
+        )?;
+    }
+    let environment = destination.join("environment");
+    let image = match &case.environment {
+        Environment::OciImage(image) => Some(image.clone()),
+        Environment::Dockerfile(_) => None,
+    };
+    match case.environment {
+        Environment::OciImage(_) => create_dir_all(&environment)?,
+        Environment::Dockerfile(source) => copy_tree(&source, &environment)?,
+    }
+    materialize_generated_files(case.environment_files, &environment)?;
+    materialize_harness(case.harness, &destination.join("tests"))?;
+    materialize_generated_files(case.harness_files, &destination.join("tests"))?;
+
+    let separate = destination.join("tests/Dockerfile").is_file();
+    let mut artifacts = case
+        .artifacts
+        .iter()
+        .map(|artifact| GeneratedTaskArtifact {
+            source: &artifact.source,
+            exclude: &artifact.exclude,
+        })
+        .collect::<Vec<_>>();
+    let workspace_excludes = [
+        PathBuf::from("Dockerfile"),
+        PathBuf::from("instruction.md"),
+        PathBuf::from("reference_files"),
+        PathBuf::from(".git"),
+        PathBuf::from(".nanocodex"),
+    ];
+    if separate && case.output == TaskOutput::Workspace {
+        artifacts.push(GeneratedTaskArtifact {
+            source: Path::new("/workspace"),
+            exclude: &workspace_excludes,
+        });
+    }
+    let raw = GeneratedTaskManifest {
+        schema_version: "1.3",
+        output: match case.output {
+            TaskOutput::Workspace => "workspace",
+            TaskOutput::FinalMessage => "final_message",
+        },
+        task: GeneratedTaskInfo {
+            name: id,
+            benchmark_prompt_chars: case.benchmark_prompt_chars,
+            benchmark_case_type: case.benchmark_case_type.as_deref(),
+        },
+        agent: GeneratedPhase {
+            timeout_sec: case.agent_timeout.as_secs_f64(),
+            instructions: case.agent_instructions.as_deref(),
+        },
+        verifier: GeneratedVerifier {
+            timeout_sec: case.verifier_timeout.as_secs_f64(),
+            environment_mode: if separate { "separate" } else { "same" },
+            scoring_policy: case.scoring_policy,
+            network_mode: (case.verifier_allow_internet != case.allow_internet).then_some(
+                if case.verifier_allow_internet {
+                    "public"
+                } else {
+                    "no-network"
+                },
+            ),
+        },
+        environment: GeneratedEnvironment {
+            docker_image: image.as_deref(),
+            cpus: case.resources.cpus,
+            memory_mb: case.resources.memory_mb,
+            storage_mb: case.resources.storage_mb,
+            gpus: case.resources.gpus,
+            allow_internet: case.allow_internet,
+        },
+        artifacts: (!artifacts.is_empty()).then_some(artifacts.as_slice()),
+    };
+    let manifest = toml::to_string(&raw).map_err(|source| {
+        ImportError::Invalid(format!("failed to encode generated task {id}: {source}"))
+    })?;
+    fs::write(destination.join("task.toml"), manifest)
+        .map_err(|source| io_error(destination.join("task.toml"), source))?;
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct TaskTranscript<'a> {
+    messages: &'a [PromptMessage],
+}
+
+fn materialize_harness(harness: Harness, destination: &Path) -> Result<(), ImportError> {
+    copy_tree(&harness.directory, destination)
+}
+
+fn materialize_generated_files(
+    files: Vec<GeneratedFile>,
+    destination: &Path,
+) -> Result<(), ImportError> {
+    for file in files {
+        let path = destination.join(file.path);
+        if let Some(parent) = path.parent() {
+            create_dir_all(parent)?;
+        }
+        match file.contents {
+            GeneratedFileContents::Inline(bytes) => {
+                fs::write(&path, bytes).map_err(|source| io_error(&path, source))?;
+            }
+            GeneratedFileContents::Source(source) => {
+                fs::copy(&source, &path).map_err(|error| io_error(&source, error))?;
+            }
+        }
+        fs::set_permissions(&path, fs::Permissions::from_mode(file.mode))
+            .map_err(|source| io_error(&path, source))?;
+    }
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct GeneratedTaskManifest<'a> {
+    schema_version: &'a str,
+    output: &'a str,
+    task: GeneratedTaskInfo<'a>,
+    agent: GeneratedPhase<'a>,
+    verifier: GeneratedVerifier<'a>,
+    environment: GeneratedEnvironment<'a>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    artifacts: Option<&'a [GeneratedTaskArtifact<'a>]>,
+}
+
+#[derive(Serialize)]
+struct GeneratedTaskArtifact<'a> {
+    source: &'a Path,
+    exclude: &'a [PathBuf],
+}
+
+#[derive(Serialize)]
+struct GeneratedTaskInfo<'a> {
+    name: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    benchmark_prompt_chars: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    benchmark_case_type: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct GeneratedPhase<'a> {
+    timeout_sec: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    instructions: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct GeneratedVerifier<'a> {
+    timeout_sec: f64,
+    environment_mode: &'a str,
+    scoring_policy: ScoringPolicy,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    network_mode: Option<&'a str>,
+}
+
+#[derive(Serialize)]
+struct GeneratedEnvironment<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    docker_image: Option<&'a str>,
+    cpus: u32,
+    memory_mb: u64,
+    storage_mb: u64,
+    gpus: u32,
+    allow_internet: bool,
+}
+
+fn copy_tree(source: &Path, destination: &Path) -> Result<(), ImportError> {
+    let source = fs::canonicalize(source).map_err(|error| io_error(source, error))?;
+    if !source.is_dir() {
+        return Err(ImportError::Invalid(format!(
+            "package root is not a directory: {}",
+            source.display()
+        )));
+    }
+    create_dir_all(destination)?;
+    let mut directories = Vec::new();
+    for entry in ignore::WalkBuilder::new(&source)
+        .hidden(false)
+        .ignore(false)
+        .git_ignore(false)
+        .git_exclude(false)
+        .parents(false)
+        .follow_links(false)
+        .build()
+    {
+        let entry = entry.map_err(|error| {
+            ImportError::Invalid(format!("failed to walk {}: {error}", source.display()))
+        })?;
+        if entry.path() == source {
+            continue;
+        }
+        let relative = entry
+            .path()
+            .strip_prefix(&source)
+            .map_err(|error| ImportError::Invalid(error.to_string()))?;
+        let target = destination.join(relative);
+        let metadata =
+            fs::symlink_metadata(entry.path()).map_err(|error| io_error(entry.path(), error))?;
+        if metadata.file_type().is_symlink() {
+            return Err(ImportError::Invalid(format!(
+                "package symlinks are unsupported: {}",
+                entry.path().display()
+            )));
+        }
+        if metadata.is_dir() {
+            create_dir_all(&target)?;
+            directories.push((target, metadata.permissions().mode()));
+        } else if metadata.is_file() {
+            fs::copy(entry.path(), &target).map_err(|error| io_error(&target, error))?;
+            fs::set_permissions(
+                &target,
+                fs::Permissions::from_mode(metadata.permissions().mode()),
+            )
+            .map_err(|error| io_error(&target, error))?;
+        } else {
+            return Err(ImportError::Invalid(format!(
+                "unsupported package entry: {}",
+                entry.path().display()
+            )));
+        }
+    }
+    for (directory, mode) in directories.into_iter().rev() {
+        fs::set_permissions(&directory, fs::Permissions::from_mode(mode))
+            .map_err(|error| io_error(&directory, error))?;
+    }
+    Ok(())
+}
+
+fn read_manifest(root: &Path) -> Result<DatasetManifest, ImportError> {
+    let path = root.join(MANIFEST_FILE);
+    let bytes = fs::read(&path).map_err(|source| io_error(&path, source))?;
+    serde_json::from_slice(&bytes).map_err(|source| ImportError::Json { path, source })
+}
+
+fn write_json(path: &Path, value: &impl Serialize) -> Result<(), ImportError> {
+    let bytes = serde_json::to_vec_pretty(value).map_err(|source| ImportError::Json {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|source| io_error(path, source))?;
+    file.write_all(&bytes)
+        .and_then(|()| file.write_all(b"\n"))
+        .and_then(|()| file.sync_all())
+        .map_err(|source| io_error(path, source))
+}
+
+fn digest_manifest(
+    name: &str,
+    source: &SourceIdentity,
+    tasks: &[ManifestTask],
+) -> Result<String, ImportError> {
+    let bytes = serde_json::to_vec(&DigestManifest {
+        schema: IMPORT_SCHEMA,
+        name,
+        source,
+        tasks,
+    })
+    .map_err(|source| ImportError::Json {
+        path: PathBuf::from("<import-digest>"),
+        source,
+    })?;
+    Ok(hex::encode(Sha256::digest(bytes)))
+}
+
+fn safe_manifest_path(path: &str) -> Result<PathBuf, ImportError> {
+    let path = PathBuf::from(path);
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(ImportError::Invalid(format!(
+            "unsafe task path in import manifest: {}",
+            path.display()
+        )));
+    }
+    Ok(path)
+}
+
+fn normalized_relative(path: &Path) -> Result<String, ImportError> {
+    safe_manifest_path(&path.to_string_lossy())?;
+    Ok(path
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => value.to_str(),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/"))
+}
+
+fn safe_absolute_guest_path(path: &Path) -> bool {
+    path.is_absolute()
+        && path.strip_prefix("/").is_ok_and(|relative| {
+            !relative.as_os_str().is_empty()
+                && relative
+                    .components()
+                    .all(|component| matches!(component, Component::Normal(_)))
+        })
+}
+
+fn validate_component(label: &str, value: &str) -> Result<(), ImportError> {
+    let valid = !value.is_empty()
+        && value != "."
+        && value != ".."
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-' | b'+'));
+    if valid {
+        Ok(())
+    } else {
+        Err(ImportError::Invalid(format!(
+            "{label} {value:?} is not a safe path component"
+        )))
+    }
+}
+
+fn is_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn create_dir_all(path: impl AsRef<Path>) -> Result<(), ImportError> {
+    let path = path.as_ref();
+    fs::create_dir_all(path).map_err(|source| io_error(path, source))
+}
+
+fn sync_directory(path: &Path) -> Result<(), ImportError> {
+    fs::File::open(path)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|source| io_error(path, source))
+}
+
+fn io_error(path: impl AsRef<Path>, source: io::Error) -> ImportError {
+    ImportError::Io {
+        path: path.as_ref().to_path_buf(),
+        source,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use tempfile::tempdir;
+
+    use crate::ScoringPolicy;
+
+    use super::{
+        CasePackage, CasePlan, DatasetImporter, DatasetPlan, Environment, Harness, ImportError,
+        ImportStore, SourceIdentity, materialize_hermetic_case,
+    };
+
+    struct FixtureImporter {
+        task: std::path::PathBuf,
+        revision: &'static str,
+    }
+
+    struct WorkspaceImporter<'a> {
+        environment: &'a Path,
+        harness: &'a Path,
+        contents: &'a [u8],
+        scoring_policy: ScoringPolicy,
+        benchmark_prompt_chars: u64,
+        benchmark_case_type: &'a str,
+    }
+
+    struct PathWorkspaceImporter<'a> {
+        environment: &'a Path,
+        harness: &'a Path,
+        candidate: &'a Path,
+        verifier: &'a Path,
+    }
+
+    impl DatasetImporter for FixtureImporter {
+        fn plan(&self) -> Result<DatasetPlan, ImportError> {
+            Ok(DatasetPlan::new(
+                "fixture",
+                SourceIdentity::new("fixture", self.revision, "a".repeat(64))?,
+            )?
+            .case(CasePlan::existing("case-1", &self.task)?))
+        }
+    }
+
+    impl DatasetImporter for WorkspaceImporter<'_> {
+        fn plan(&self) -> Result<DatasetPlan, ImportError> {
+            Ok(DatasetPlan::new(
+                "workspace-input",
+                SourceIdentity::new("fixture", "fixture@1", "b".repeat(64))?,
+            )?
+            .case(
+                CasePlan::hermetic(
+                    "case-1",
+                    "Inspect the supplied data.",
+                    Environment::Dockerfile(self.environment.to_path_buf()),
+                    Harness::directory(self.harness)?,
+                )?
+                .benchmark_prompt_chars(self.benchmark_prompt_chars)
+                .benchmark_case_type(self.benchmark_case_type)
+                .scoring_policy(self.scoring_policy)
+                .environment_file("data_files/input.csv", self.contents, 0o644)?,
+            ))
+        }
+    }
+
+    impl DatasetImporter for PathWorkspaceImporter<'_> {
+        fn plan(&self) -> Result<DatasetPlan, ImportError> {
+            Ok(DatasetPlan::new(
+                "path-workspace-input",
+                SourceIdentity::new("fixture", "fixture@1", "c".repeat(64))?,
+            )?
+            .case(
+                CasePlan::hermetic(
+                    "case-1",
+                    "Inspect the supplied data.",
+                    Environment::Dockerfile(self.environment.to_path_buf()),
+                    Harness::directory(self.harness)?,
+                )?
+                .environment_file_from("data_files/input.bin", self.candidate, 0o640)?
+                .harness_file_from("expected.bin", self.verifier, 0o600)?,
+            ))
+        }
+    }
+
+    #[test]
+    fn imports_content_addressed_tasks_and_reopens_identical_content() {
+        let source = tempdir().unwrap();
+        make_task(source.path(), "first");
+        let store = tempdir().unwrap();
+        let importer = FixtureImporter {
+            task: source.path().to_path_buf(),
+            revision: "upstream@1",
+        };
+
+        let first = ImportStore::new(store.path()).import(&importer).unwrap();
+        let second = ImportStore::new(store.path()).import(&importer).unwrap();
+
+        assert_eq!(first.root(), second.root());
+        assert_eq!(first.digest(), second.digest());
+        assert_eq!(first.tasks().len(), 1);
+        assert_eq!(first.tasks()[0].prompt(), "first");
+        assert_eq!(first.tasks()[0].dataset(), Some("fixture"));
+        assert_eq!(first.tasks()[0].dataset_revision(), Some("upstream@1"));
+        let manifest = fs::read_to_string(first.root().join("dataset.json")).unwrap();
+        assert!(!manifest.contains(&source.path().display().to_string()));
+
+        fs::write(source.path().join("instruction.md"), "changed").unwrap();
+        let changed = ImportStore::new(store.path()).import(&importer).unwrap();
+        assert_ne!(first.digest(), changed.digest());
+        assert_ne!(first.root(), changed.root());
+    }
+
+    #[test]
+    fn generated_environment_files_are_candidate_inputs_and_affect_identity() {
+        let source = tempdir().unwrap();
+        fs::write(
+            source.path().join("Dockerfile"),
+            "FROM debian:bookworm-slim\nCOPY data_files /workspace/data_files\n",
+        )
+        .unwrap();
+        let harness = tempdir().unwrap();
+        fs::write(
+            harness.path().join("test.sh"),
+            "#!/bin/sh\nprintf '1\\n' > \"$NANOCODEX_EVAL_VERIFIER_LOGS/reward.txt\"\n",
+        )
+        .unwrap();
+        let store = tempdir().unwrap();
+
+        let first = ImportStore::new(store.path())
+            .import(&WorkspaceImporter {
+                environment: source.path(),
+                harness: harness.path(),
+                contents: b"value\n1\n",
+                scoring_policy: ScoringPolicy::AllRewardsOne,
+                benchmark_prompt_chars: 21,
+                benchmark_case_type: "fixture",
+            })
+            .unwrap();
+        let changed = ImportStore::new(store.path())
+            .import(&WorkspaceImporter {
+                environment: source.path(),
+                harness: harness.path(),
+                contents: b"value\n2\n",
+                scoring_policy: ScoringPolicy::AllRewardsOne,
+                benchmark_prompt_chars: 21,
+                benchmark_case_type: "fixture",
+            })
+            .unwrap();
+
+        assert_eq!(
+            fs::read(
+                first.tasks()[0]
+                    .root()
+                    .join("environment/data_files/input.csv")
+            )
+            .unwrap(),
+            b"value\n1\n"
+        );
+        assert_eq!(
+            first.tasks()[0].verifier().scoring_policy(),
+            ScoringPolicy::AllRewardsOne
+        );
+        assert_eq!(first.tasks()[0].benchmark_prompt_chars(), Some(21));
+        assert_eq!(first.tasks()[0].benchmark_case_type(), Some("fixture"));
+        assert_ne!(first.digest(), changed.digest());
+
+        let changed_policy = ImportStore::new(store.path())
+            .import(&WorkspaceImporter {
+                environment: source.path(),
+                harness: harness.path(),
+                contents: b"value\n1\n",
+                scoring_policy: ScoringPolicy::AllRewardsPositive,
+                benchmark_prompt_chars: 21,
+                benchmark_case_type: "fixture",
+            })
+            .unwrap();
+        assert_ne!(first.digest(), changed_policy.digest());
+
+        let changed_dimensions = ImportStore::new(store.path())
+            .import(&WorkspaceImporter {
+                environment: source.path(),
+                harness: harness.path(),
+                contents: b"value\n1\n",
+                scoring_policy: ScoringPolicy::AllRewardsOne,
+                benchmark_prompt_chars: 22,
+                benchmark_case_type: "other",
+            })
+            .unwrap();
+        assert_ne!(first.digest(), changed_dimensions.digest());
+    }
+
+    #[test]
+    fn generated_workspace_output_is_transferred_to_a_separate_verifier() {
+        let environment = tempdir().unwrap();
+        fs::write(
+            environment.path().join("Dockerfile"),
+            "FROM debian:bookworm-slim\nWORKDIR /workspace\n",
+        )
+        .unwrap();
+        let harness = tempdir().unwrap();
+        fs::write(
+            harness.path().join("Dockerfile"),
+            "FROM debian:bookworm-slim\nWORKDIR /workspace\n",
+        )
+        .unwrap();
+        fs::write(
+            harness.path().join("test.sh"),
+            "#!/bin/sh\nprintf '1\\n' > \"$NANOCODEX_EVAL_VERIFIER_LOGS/reward.txt\"\n",
+        )
+        .unwrap();
+        let store = tempdir().unwrap();
+
+        let imported = ImportStore::new(store.path())
+            .import(&WorkspaceImporter {
+                environment: environment.path(),
+                harness: harness.path(),
+                contents: b"value\n1\n",
+                scoring_policy: ScoringPolicy::AllRewardsPositive,
+                benchmark_prompt_chars: 21,
+                benchmark_case_type: "fixture",
+            })
+            .unwrap();
+        let task = &imported.tasks()[0];
+
+        assert_eq!(task.artifacts().len(), 1);
+        assert_eq!(task.artifacts()[0].source(), Path::new("/workspace"));
+        assert_eq!(
+            task.artifacts()[0].exclude(),
+            &[
+                Path::new("Dockerfile").to_path_buf(),
+                Path::new("instruction.md").to_path_buf(),
+                Path::new("reference_files").to_path_buf(),
+                Path::new(".git").to_path_buf(),
+                Path::new(".nanocodex").to_path_buf(),
+            ]
+        );
+    }
+
+    #[test]
+    fn generated_case_can_capture_an_explicit_guest_artifact() {
+        let environment = tempdir().unwrap();
+        fs::write(
+            environment.path().join("Dockerfile"),
+            "FROM debian:bookworm-slim\nWORKDIR /workspace\n",
+        )
+        .unwrap();
+        let harness = tempdir().unwrap();
+        fs::write(
+            harness.path().join("Dockerfile"),
+            "FROM debian:bookworm-slim\n",
+        )
+        .unwrap();
+        fs::write(
+            harness.path().join("test.sh"),
+            "#!/bin/sh\nprintf '1\\n' > /logs/verifier/reward.txt\n",
+        )
+        .unwrap();
+        let plan = DatasetPlan::new(
+            "artifact-input",
+            SourceIdentity::new("fixture", "fixture@1", "d".repeat(64)).unwrap(),
+        )
+        .unwrap()
+        .case(
+            CasePlan::hermetic(
+                "case-1",
+                "Write the answer artifact.",
+                Environment::Dockerfile(environment.path().to_path_buf()),
+                Harness::directory(harness.path()).unwrap(),
+            )
+            .unwrap()
+            .output(crate::TaskOutput::FinalMessage)
+            .artifact("/logs/agent/answer.txt")
+            .unwrap(),
+        );
+        let destination = tempdir().unwrap();
+        let temporary = tempfile::Builder::new()
+            .prefix("artifact-case-")
+            .tempdir_in(destination.path())
+            .unwrap();
+        let CasePackage::Hermetic(case) = plan.cases.into_iter().next().unwrap().package else {
+            panic!("expected generated case");
+        };
+        materialize_hermetic_case("case-1", case, temporary.path()).unwrap();
+        let task = crate::Task::load(temporary.path()).unwrap();
+
+        assert_eq!(task.artifacts().len(), 1);
+        assert_eq!(
+            task.artifacts()[0].source(),
+            Path::new("/logs/agent/answer.txt")
+        );
+    }
+
+    #[test]
+    fn path_backed_generated_files_are_snapshotted_and_affect_identity() {
+        let source = tempdir().unwrap();
+        fs::write(
+            source.path().join("Dockerfile"),
+            "FROM debian:bookworm-slim\nCOPY data_files /workspace/data_files\n",
+        )
+        .unwrap();
+        let harness = tempdir().unwrap();
+        fs::write(
+            harness.path().join("test.sh"),
+            "#!/bin/sh\nprintf '1\\n' > \"$NANOCODEX_EVAL_VERIFIER_LOGS/reward.txt\"\n",
+        )
+        .unwrap();
+        let inputs = tempdir().unwrap();
+        let candidate = inputs.path().join("candidate.bin");
+        let verifier = inputs.path().join("verifier.bin");
+        fs::write(&candidate, b"candidate-v1").unwrap();
+        fs::write(&verifier, b"verifier-v1").unwrap();
+        let store = tempdir().unwrap();
+        let first = ImportStore::new(store.path())
+            .import(&PathWorkspaceImporter {
+                environment: source.path(),
+                harness: harness.path(),
+                candidate: &candidate,
+                verifier: &verifier,
+            })
+            .unwrap();
+
+        assert_eq!(
+            fs::read(
+                first.tasks()[0]
+                    .root()
+                    .join("environment/data_files/input.bin")
+            )
+            .unwrap(),
+            b"candidate-v1"
+        );
+        assert_eq!(
+            fs::read(first.tasks()[0].root().join("tests/expected.bin")).unwrap(),
+            b"verifier-v1"
+        );
+
+        fs::write(&candidate, b"candidate-v2").unwrap();
+        let changed = ImportStore::new(store.path())
+            .import(&PathWorkspaceImporter {
+                environment: source.path(),
+                harness: harness.path(),
+                candidate: &candidate,
+                verifier: &verifier,
+            })
+            .unwrap();
+        assert_ne!(first.digest(), changed.digest());
+    }
+
+    fn make_task(root: &Path, prompt: &str) {
+        fs::create_dir(root.join("environment")).unwrap();
+        fs::create_dir(root.join("tests")).unwrap();
+        fs::write(root.join("instruction.md"), prompt).unwrap();
+        fs::write(
+            root.join("task.toml"),
+            r#"schema_version = "1.3"
+
+[task]
+name = "case-1"
+
+[agent]
+timeout_sec = 30
+
+[verifier]
+timeout_sec = 30
+
+[environment]
+docker_image = "debian:bookworm-slim"
+cpus = 1
+memory_mb = 512
+storage_mb = 1024
+"#,
+        )
+        .unwrap();
+        fs::write(
+            root.join("tests/test.sh"),
+            "#!/bin/sh\nprintf '1\\n' > \"$NANOCODEX_EVAL_VERIFIER_LOGS/reward.txt\"\n",
+        )
+        .unwrap();
+    }
+}

--- a/crates/experimental/nanocodex-eval/src/judge.rs
+++ b/crates/experimental/nanocodex-eval/src/judge.rs
@@ -1,0 +1,609 @@
+//! Evaluator-owned OpenAI judge service for isolated benchmark verifiers.
+
+use std::{
+    collections::BTreeMap,
+    io::Read as _,
+    net::Ipv4Addr,
+    str::FromStr as _,
+    sync::{Arc, Mutex},
+};
+
+use axum::{
+    Json, Router,
+    body::Bytes,
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode, header::CONTENT_ENCODING},
+    response::{IntoResponse as _, Response},
+    routing::{get, post},
+};
+use flate2::read::GzDecoder;
+use nanocodex_agent::NanocodexBuilder;
+use nanocodex_oai_api::Model;
+use nanocodex_tools::Tools;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio::{
+    net::TcpListener,
+    sync::{Mutex as AsyncMutex, oneshot},
+    task::{AbortHandle, JoinHandle},
+};
+use uuid::Uuid;
+
+const GUEST_HOST: Ipv4Addr = Ipv4Addr::new(192, 168, 127, 254);
+const MAX_JUDGE_REQUEST_BYTES: usize = 2 * 1024 * 1024;
+
+/// A run-scoped judge endpoint backed by the evaluator's selected OpenAI auth.
+pub struct JudgeRuntime {
+    port: u16,
+    token: Arc<str>,
+    shutdown: Option<oneshot::Sender<()>>,
+    task: JoinHandle<()>,
+    workers: Arc<Mutex<Vec<AbortHandle>>>,
+}
+
+#[derive(Clone)]
+struct JudgeState {
+    builder: NanocodexBuilder,
+    token: Arc<str>,
+    jobs: Arc<AsyncMutex<BTreeMap<String, JudgeJob>>>,
+    workers: Arc<Mutex<Vec<AbortHandle>>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JudgeRequest {
+    model: String,
+    input: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionRequest {
+    model: String,
+    messages: Value,
+}
+
+#[derive(Clone)]
+struct JudgeAnswer {
+    model: Model,
+    message: String,
+}
+
+#[derive(Clone)]
+struct JudgeFailure {
+    status: StatusCode,
+    message: String,
+}
+
+enum JudgeJob {
+    Pending,
+    Complete(Result<JudgeAnswer, JudgeFailure>),
+}
+
+#[derive(Debug, Serialize)]
+struct JudgeError {
+    error: JudgeErrorBody,
+}
+
+#[derive(Debug, Serialize)]
+struct JudgeErrorBody {
+    message: String,
+}
+
+/// Judge service startup failed.
+#[derive(Debug, thiserror::Error)]
+pub enum JudgeRuntimeError {
+    /// The loopback listener could not be created or inspected.
+    #[error("judge runtime listener failed: {0}")]
+    Listener(#[from] std::io::Error),
+    /// The deliberately empty verifier tool registry could not be built.
+    #[error("judge runtime tool policy failed: {0}")]
+    Tools(#[from] nanocodex_tools::ToolsBuildError),
+}
+
+impl JudgeRuntime {
+    /// Starts a no-tools judge service on host loopback.
+    pub async fn start(builder: NanocodexBuilder) -> Result<Self, JudgeRuntimeError> {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await?;
+        let port = listener.local_addr()?.port();
+        let token: Arc<str> = Uuid::now_v7().simple().to_string().into();
+        let workers = Arc::new(Mutex::new(Vec::new()));
+        let state = JudgeState {
+            builder: builder.tools(Tools::builder().without_defaults().build()?),
+            token: Arc::clone(&token),
+            jobs: Arc::new(AsyncMutex::new(BTreeMap::new())),
+            workers: Arc::clone(&workers),
+        };
+        let application = Router::new()
+            .route("/v1/responses", post(Self::respond))
+            .route("/v1/responses/async", post(Self::submit))
+            .route("/v1/responses/async/{id}", get(Self::poll))
+            .route("/v1/chat/completions", post(Self::chat_completion))
+            .with_state(state);
+        let (shutdown, receiver) = oneshot::channel();
+        let task = tokio::spawn(async move {
+            let result = axum::serve(listener, application)
+                .with_graceful_shutdown(async move {
+                    let _ = receiver.await;
+                })
+                .await;
+            if let Err(error) = result {
+                tracing::error!(%error, "judge runtime stopped unexpectedly");
+            }
+        });
+        Ok(Self {
+            port,
+            token,
+            shutdown: Some(shutdown),
+            task,
+            workers,
+        })
+    }
+
+    /// Returns verifier-only values that route through the guest host gateway.
+    #[must_use]
+    pub fn verifier_environment(&self) -> BTreeMap<String, String> {
+        let base_url = format!("http://{GUEST_HOST}:{}/v1", self.port);
+        BTreeMap::from([
+            ("NANOCODEX_JUDGE_BASE_URL".to_owned(), base_url.clone()),
+            ("NANOCODEX_JUDGE_TOKEN".to_owned(), self.token.to_string()),
+            ("EVAL_BASE_URL".to_owned(), base_url.clone()),
+            ("EVAL_API_KEY".to_owned(), self.token.to_string()),
+            ("EVAL_MODEL".to_owned(), "gpt-5.6-sol".to_owned()),
+            ("OPENAI_BASE_URL".to_owned(), base_url.clone()),
+            ("OPENAI_API_BASE".to_owned(), base_url),
+            ("OPENAI_API_KEY".to_owned(), self.token.to_string()),
+        ])
+    }
+
+    async fn chat_completion(
+        State(state): State<JudgeState>,
+        headers: HeaderMap,
+        Json(request): Json<ChatCompletionRequest>,
+    ) -> Response {
+        if !state.authorized(&headers) {
+            return Self::error(StatusCode::UNAUTHORIZED, "invalid judge token");
+        }
+        let answer = match state.answer(request.model, request.messages).await {
+            Ok(answer) => answer,
+            Err(error) => return Self::error(error.status, error.message),
+        };
+        Self::chat_answer(format!("chatcmpl_{}", Uuid::now_v7().simple()), answer)
+    }
+
+    async fn respond(
+        State(state): State<JudgeState>,
+        headers: HeaderMap,
+        Json(request): Json<JudgeRequest>,
+    ) -> Response {
+        if !state.authorized(&headers) {
+            return Self::error(StatusCode::UNAUTHORIZED, "invalid judge token");
+        }
+        let answer = match state.answer(request.model, request.input).await {
+            Ok(answer) => answer,
+            Err(error) => return Self::error(error.status, error.message),
+        };
+        Self::answer(format!("judge_{}", Uuid::now_v7().simple()), answer)
+    }
+
+    async fn submit(State(state): State<JudgeState>, headers: HeaderMap, body: Bytes) -> Response {
+        if !state.authorized(&headers) {
+            return Self::error(StatusCode::UNAUTHORIZED, "invalid judge token");
+        }
+        let request = match Self::decode_request(&headers, &body) {
+            Ok(request) => request,
+            Err(error) => return error,
+        };
+        let id = format!("judge_{}", Uuid::now_v7().simple());
+        state
+            .jobs
+            .lock()
+            .await
+            .insert(id.clone(), JudgeJob::Pending);
+        let worker_state = state.clone();
+        let worker_id = id.clone();
+        let worker = tokio::spawn(async move {
+            let result = worker_state.answer(request.model, request.input).await;
+            if let Err(error) = &result {
+                tracing::warn!(
+                    judge_job = %worker_id,
+                    status = error.status.as_u16(),
+                    message = %error.message,
+                    "asynchronous judge job failed"
+                );
+            }
+            worker_state
+                .jobs
+                .lock()
+                .await
+                .insert(worker_id, JudgeJob::Complete(result));
+        });
+        let registered = if let Ok(mut workers) = state.workers.lock() {
+            workers.push(worker.abort_handle());
+            true
+        } else {
+            false
+        };
+        if !registered {
+            worker.abort();
+            state.jobs.lock().await.remove(&id);
+            return Self::error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "judge worker registry is unavailable",
+            );
+        }
+        (
+            StatusCode::ACCEPTED,
+            Json(json!({"id": id, "object": "response", "status": "in_progress"})),
+        )
+            .into_response()
+    }
+
+    async fn poll(
+        State(state): State<JudgeState>,
+        Path(id): Path<String>,
+        headers: HeaderMap,
+    ) -> Response {
+        if !state.authorized(&headers) {
+            return Self::error(StatusCode::UNAUTHORIZED, "invalid judge token");
+        }
+        let jobs = state.jobs.lock().await;
+        match jobs.get(&id) {
+            Some(JudgeJob::Pending) => Json(json!({
+                "id": id,
+                "object": "response",
+                "status": "in_progress"
+            }))
+            .into_response(),
+            Some(JudgeJob::Complete(Ok(answer))) => Self::answer(id, answer.clone()),
+            Some(JudgeJob::Complete(Err(error))) => {
+                Self::error(error.status, error.message.clone())
+            }
+            None => Self::error(StatusCode::NOT_FOUND, "unknown judge job"),
+        }
+    }
+
+    fn answer(id: String, answer: JudgeAnswer) -> Response {
+        Json(json!({
+            "id": id,
+            "object": "response",
+            "status": "completed",
+            "model": answer.model,
+            "output": [{
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": answer.message}]
+            }],
+            "usage": {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "total_tokens": 0
+            }
+        }))
+        .into_response()
+    }
+
+    fn chat_answer(id: String, answer: JudgeAnswer) -> Response {
+        Json(json!({
+            "id": id,
+            "object": "chat.completion",
+            "created": 0,
+            "model": answer.model,
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": answer.message},
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0
+            }
+        }))
+        .into_response()
+    }
+
+    fn prompt(input: Value) -> Result<(Option<String>, String), String> {
+        match input {
+            Value::String(prompt) if !prompt.trim().is_empty() => Ok((None, prompt)),
+            Value::Array(messages) => {
+                let mut instructions = Vec::new();
+                let mut prompt = Vec::new();
+                for message in messages {
+                    let role = message
+                        .get("role")
+                        .and_then(Value::as_str)
+                        .ok_or_else(|| "judge input message has no role".to_owned())?;
+                    let content = message
+                        .get("content")
+                        .ok_or_else(|| "judge input message has no content".to_owned())?;
+                    let content = Self::text_content(content)?;
+                    if role == "system" || role == "developer" {
+                        instructions.push(content);
+                    } else {
+                        prompt.push(format!("{role}:\n{content}"));
+                    }
+                }
+                if prompt.is_empty() {
+                    return Err("judge input contains no user prompt".to_owned());
+                }
+                Ok((
+                    (!instructions.is_empty()).then(|| instructions.join("\n\n")),
+                    prompt.join("\n\n"),
+                ))
+            }
+            _ => Err("judge input must be text or an array of text messages".to_owned()),
+        }
+    }
+
+    fn text_content(content: &Value) -> Result<String, String> {
+        if let Some(content) = content.as_str() {
+            return Ok(content.to_owned());
+        }
+        let parts = content
+            .as_array()
+            .ok_or_else(|| "judge input message content must be text".to_owned())?;
+        let text = parts
+            .iter()
+            .filter_map(|part| part.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join("\n");
+        if text.is_empty() {
+            return Err("judge input message contains no text".to_owned());
+        }
+        Ok(text)
+    }
+
+    fn error(status: StatusCode, message: impl Into<String>) -> Response {
+        (
+            status,
+            Json(JudgeError {
+                error: JudgeErrorBody {
+                    message: message.into(),
+                },
+            }),
+        )
+            .into_response()
+    }
+
+    fn decode_request(headers: &HeaderMap, body: &[u8]) -> Result<JudgeRequest, Response> {
+        if body.len() > MAX_JUDGE_REQUEST_BYTES {
+            return Err(Self::error(
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "judge request exceeds 2 MiB",
+            ));
+        }
+        let decoded = match headers
+            .get(CONTENT_ENCODING)
+            .and_then(|value| value.to_str().ok())
+        {
+            None => body.to_vec(),
+            Some("gzip") => {
+                let mut decoded = Vec::new();
+                let limit = u64::try_from(MAX_JUDGE_REQUEST_BYTES)
+                    .unwrap_or(u64::MAX)
+                    .saturating_add(1);
+                if let Err(error) = GzDecoder::new(body).take(limit).read_to_end(&mut decoded) {
+                    return Err(Self::error(
+                        StatusCode::BAD_REQUEST,
+                        format!("invalid gzip judge request: {error}"),
+                    ));
+                }
+                if decoded.len() > MAX_JUDGE_REQUEST_BYTES {
+                    return Err(Self::error(
+                        StatusCode::PAYLOAD_TOO_LARGE,
+                        "decompressed judge request exceeds 2 MiB",
+                    ));
+                }
+                decoded
+            }
+            Some(encoding) => {
+                return Err(Self::error(
+                    StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                    format!("unsupported judge content encoding {encoding:?}"),
+                ));
+            }
+        };
+        serde_json::from_slice(&decoded).map_err(|error| {
+            Self::error(
+                StatusCode::BAD_REQUEST,
+                format!("invalid judge request JSON: {error}"),
+            )
+        })
+    }
+}
+
+impl JudgeState {
+    async fn answer(
+        &self,
+        requested_model: String,
+        input: Value,
+    ) -> Result<JudgeAnswer, JudgeFailure> {
+        let model = Model::from_str(&requested_model).map_err(|message| JudgeFailure {
+            status: StatusCode::BAD_REQUEST,
+            message,
+        })?;
+        let (instructions, prompt) =
+            JudgeRuntime::prompt(input).map_err(|message| JudgeFailure {
+                status: StatusCode::BAD_REQUEST,
+                message,
+            })?;
+        let mut builder = self.builder.clone().model(model);
+        if let Some(instructions) = instructions {
+            builder = builder.instructions(instructions);
+        }
+        let (agent, events) = match builder.build() {
+            Ok(agent) => agent,
+            Err(error) => {
+                return Err(JudgeFailure {
+                    status: StatusCode::INTERNAL_SERVER_ERROR,
+                    message: format!("judge agent build failed: {error}"),
+                });
+            }
+        };
+        drop(events);
+        let result = match agent.prompt(prompt).await {
+            Ok(turn) => turn.result().await,
+            Err(error) => Err(error),
+        };
+        let _ = agent.shutdown().await;
+        let message = match result {
+            Ok(result) => result.into_final_message(),
+            Err(error) => {
+                return Err(JudgeFailure {
+                    status: StatusCode::BAD_GATEWAY,
+                    message: format!("OpenAI judge failed: {error}"),
+                });
+            }
+        };
+        Ok(JudgeAnswer { model, message })
+    }
+
+    fn authorized(&self, headers: &HeaderMap) -> bool {
+        headers
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.strip_prefix("Bearer "))
+            == Some(self.token.as_ref())
+    }
+}
+
+impl Drop for JudgeRuntime {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        if let Ok(workers) = self.workers.lock() {
+            for worker in workers.iter() {
+                worker.abort();
+            }
+        }
+        self.task.abort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::to_bytes,
+        http::{HeaderValue, header::AUTHORIZATION},
+    };
+    use flate2::{Compression, write::GzEncoder};
+    use nanocodex_agent::{Nanocodex, OpenAi};
+    use std::io::Write as _;
+
+    use super::*;
+
+    #[test]
+    fn prompt_accepts_responses_text_shapes() {
+        let (instructions, prompt) = JudgeRuntime::prompt(json!([
+            {"role": "system", "content": "Grade precisely."},
+            {
+                "role": "user",
+                "content": [{"type": "input_text", "text": "candidate answer"}]
+            }
+        ]))
+        .unwrap();
+
+        assert_eq!(instructions.as_deref(), Some("Grade precisely."));
+        assert_eq!(prompt, "user:\ncandidate answer");
+    }
+
+    #[tokio::test]
+    async fn verifier_environment_exposes_responses_and_openai_compatible_judges() {
+        let (shutdown, _receiver) = oneshot::channel();
+        let runtime = JudgeRuntime {
+            port: 43123,
+            token: Arc::from("judge-token"),
+            shutdown: Some(shutdown),
+            task: tokio::spawn(std::future::pending()),
+            workers: Arc::new(Mutex::new(Vec::new())),
+        };
+
+        let environment = runtime.verifier_environment();
+
+        assert_eq!(
+            environment
+                .get("NANOCODEX_JUDGE_BASE_URL")
+                .map(String::as_str),
+            Some("http://192.168.127.254:43123/v1")
+        );
+        assert_eq!(
+            environment["EVAL_BASE_URL"],
+            "http://192.168.127.254:43123/v1"
+        );
+        assert_eq!(environment["EVAL_API_KEY"], "judge-token");
+        assert_eq!(environment["EVAL_MODEL"], "gpt-5.6-sol");
+        assert_eq!(environment["OPENAI_API_KEY"], "judge-token");
+        assert_eq!(
+            environment["OPENAI_BASE_URL"],
+            "http://192.168.127.254:43123/v1"
+        );
+        assert_eq!(environment.len(), 8);
+    }
+
+    #[tokio::test]
+    async fn chat_completion_answer_uses_openai_compatible_shape() {
+        let response = JudgeRuntime::chat_answer(
+            "chatcmpl_test".to_owned(),
+            JudgeAnswer {
+                model: Model::from_str("gpt-5.6-sol").unwrap(),
+                message: "judge result".to_owned(),
+            },
+        );
+
+        let body = to_bytes(response.into_body(), 64 * 1024).await.unwrap();
+        let document: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(document["object"], "chat.completion");
+        assert_eq!(document["choices"][0]["message"]["content"], "judge result");
+    }
+
+    #[tokio::test]
+    async fn completed_async_answer_remains_available_after_transport_retries() {
+        let jobs = Arc::new(AsyncMutex::new(BTreeMap::from([(
+            "judge-test".to_owned(),
+            JudgeJob::Complete(Ok(JudgeAnswer {
+                model: Model::from_str("gpt-5.6-sol").unwrap(),
+                message: "stable answer".to_owned(),
+            })),
+        )])));
+        let state = JudgeState {
+            builder: Nanocodex::builder(OpenAi::new("test-key").unwrap()),
+            token: Arc::from("judge-token"),
+            jobs,
+            workers: Arc::new(Mutex::new(Vec::new())),
+        };
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static("Bearer judge-token"),
+        );
+
+        for _ in 0..2 {
+            let response = JudgeRuntime::poll(
+                State(state.clone()),
+                Path("judge-test".to_owned()),
+                headers.clone(),
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = to_bytes(response.into_body(), 64 * 1024).await.unwrap();
+            let document: Value = serde_json::from_slice(&body).unwrap();
+            assert_eq!(document["status"], "completed");
+            assert_eq!(document["output"][0]["content"][0]["text"], "stable answer");
+        }
+    }
+
+    #[test]
+    fn async_request_accepts_bounded_gzip_payloads() {
+        let body = br#"{"model":"gpt-5.6-sol","input":"grade this"}"#;
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+        encoder.write_all(body).unwrap();
+        let compressed = encoder.finish().unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_ENCODING, HeaderValue::from_static("gzip"));
+
+        let request = JudgeRuntime::decode_request(&headers, &compressed).unwrap();
+
+        assert_eq!(request.model, "gpt-5.6-sol");
+        assert_eq!(request.input, "grade this");
+    }
+}

--- a/crates/experimental/nanocodex-eval/src/lib.rs
+++ b/crates/experimental/nanocodex-eval/src/lib.rs
@@ -64,6 +64,8 @@ mod harness_exec;
 /// Content-addressed normalization of third-party datasets into native tasks.
 pub mod import;
 mod job;
+/// Evaluator-owned model judge endpoint for isolated verifier processes.
+pub mod judge;
 mod native;
 #[cfg(any(
     all(target_os = "linux", not(target_env = "musl")),

--- a/crates/experimental/nanocodex-eval/src/lib.rs
+++ b/crates/experimental/nanocodex-eval/src/lib.rs
@@ -61,6 +61,8 @@ mod event;
 /// Configured external harness execution inside evaluator-owned sandboxes.
 pub mod harness;
 mod harness_exec;
+/// Content-addressed normalization of third-party datasets into native tasks.
+pub mod import;
 mod job;
 mod native;
 #[cfg(any(
@@ -95,7 +97,7 @@ pub(crate) use harness_exec::{
     HarnessCommandOutput, HarnessCommandRunner, HarnessCommandRunnerError, HarnessCommandStatus,
     HarnessExec, HarnessExecError,
 };
-pub use profile::ResolvedHarness;
+pub use profile::{ResolvedHarness, ResolvedTask};
 pub use result::{
     AgentMetadata, AgentResult, AgentStatus, BillingCompleteness, CleanupDiagnostic, CleanupPhase,
     CleanupStatus, EvalArtifacts, EvalAttemptOutcome, EvalCleanup, EvalEnvironment, EvalException,
@@ -103,8 +105,8 @@ pub use result::{
     EvalTiming, MeasurementCompleteness, PhaseTiming, UsageTotals, VerifierResult,
 };
 pub use task::{
-    NetworkPolicy, OciImage, Resources, Task, TaskLoadError, Verifier, VerifierCollect,
-    VerifierEnvironmentMode,
+    NetworkPolicy, OciImage, Resources, ScoringPolicy, Task, TaskArtifact, TaskLoadError,
+    TaskOutput, Verifier, VerifierCollect, VerifierEnvironmentMode,
 };
 #[cfg(any(
     all(target_os = "linux", not(target_env = "musl")),

--- a/crates/experimental/nanocodex-eval/src/native.rs
+++ b/crates/experimental/nanocodex-eval/src/native.rs
@@ -8,7 +8,7 @@ use std::{
 use chrono::Utc;
 use tokio::{process::Command, time::timeout};
 
-use crate::{CleanupPhase, EvalError, PhaseTiming, Task, VerifierResult};
+use crate::{CleanupPhase, EvalError, PhaseTiming, Task, TaskOutput, VerifierResult};
 
 pub(crate) struct AttemptPaths {
     pub root: PathBuf,
@@ -61,8 +61,18 @@ impl NativeAttempt {
         })
     }
 
-    pub async fn verify(&self, task: &Task) -> Result<VerifierExecution, EvalError> {
+    pub async fn verify(
+        &self,
+        task: &Task,
+        final_message: Option<&str>,
+    ) -> Result<VerifierExecution, EvalError> {
         let started_at = Utc::now();
+        if task.output() == TaskOutput::FinalMessage {
+            fs::write(
+                self.paths.workspace.join("answer.txt"),
+                final_message.unwrap_or_default(),
+            )?;
+        }
         let mut command = Command::new("/bin/sh");
         command
             .arg(self.paths.tests.join("test.sh"))
@@ -95,10 +105,14 @@ impl NativeAttempt {
         };
         fs::write(&self.paths.verifier_output, combined)?;
 
-        let reward_text = fs::read_to_string(&self.paths.reward)?;
-        let reward = reward_text.trim().parse::<f64>()?;
-        let mut rewards = BTreeMap::new();
-        rewards.insert("reward".to_owned(), reward);
+        let reward_json = self.paths.verifier.join("reward.json");
+        let rewards = if reward_json.is_file() {
+            serde_json::from_slice::<BTreeMap<String, f64>>(&fs::read(reward_json)?)?
+        } else {
+            let reward_text = fs::read_to_string(&self.paths.reward)?;
+            let reward = reward_text.trim().parse::<f64>()?;
+            BTreeMap::from([("reward".to_owned(), reward)])
+        };
 
         Ok(VerifierExecution {
             result: VerifierResult {
@@ -143,7 +157,7 @@ mod tests {
             "hello from nanoeval\n",
         )
         .unwrap();
-        let execution = attempt.verify(&task).await.unwrap();
+        let execution = attempt.verify(&task, None).await.unwrap();
 
         assert!((execution.result.rewards["reward"] - 1.0).abs() < f64::EPSILON);
         assert_eq!(execution.result.exit_code, 0);

--- a/crates/experimental/nanocodex-eval/src/profile.rs
+++ b/crates/experimental/nanocodex-eval/src/profile.rs
@@ -58,6 +58,9 @@ pub struct Harness {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Profile {
+    /// Adapter-owned benchmark selectors resolved before durable work is added.
+    #[serde(default)]
+    benchmarks: Vec<String>,
     #[serde(default)]
     tasks: Vec<PathBuf>,
     #[serde(default)]
@@ -172,8 +175,16 @@ pub enum ProfileError {
     #[error("evaluation profile `{0}` does not exist")]
     UnknownProfile(String),
     /// Profile had no task inputs.
-    #[error("evaluation profile `{0}` contains no tasks or suites")]
+    #[error("evaluation profile `{0}` contains no benchmarks, tasks, or suites")]
     EmptyProfile(String),
+    /// Adapter-backed benchmark selectors were not resolved to immutable tasks.
+    #[error("evaluation profile `{profile}` requires adapter resolution for: {benchmarks}")]
+    UnresolvedBenchmarks {
+        /// Selected profile.
+        profile: String,
+        /// Adapter-owned selectors requiring resolution.
+        benchmarks: String,
+    },
     /// Profile requested no repetitions.
     #[error("evaluation profile `{0}` must request at least one trial")]
     ZeroTrials(String),
@@ -298,6 +309,15 @@ impl EvaluationManifest {
         path: impl AsRef<Path>,
         requested: Option<&str>,
     ) -> Result<ResolvedProfile, ProfileError> {
+        Self::load_profile_with_tasks(path, requested, Vec::new())
+    }
+
+    /// Loads a manifest after adapters resolved its benchmark selectors.
+    pub fn load_profile_with_tasks(
+        path: impl AsRef<Path>,
+        requested: Option<&str>,
+        benchmark_tasks: Vec<ResolvedTask>,
+    ) -> Result<ResolvedProfile, ProfileError> {
         let requested_path = path.as_ref();
         let text = fs::read_to_string(requested_path).map_err(|source| ProfileError::Read {
             path: requested_path.to_path_buf(),
@@ -314,7 +334,33 @@ impl EvaluationManifest {
                     path: requested_path.to_path_buf(),
                     source,
                 })?;
-        manifest.resolve(config_path, requested)
+        manifest.resolve(config_path, requested, benchmark_tasks)
+    }
+
+    /// Reads the adapter-owned benchmark selectors requested by one profile.
+    pub fn load_benchmarks(
+        path: impl AsRef<Path>,
+        requested: Option<&str>,
+    ) -> Result<Vec<String>, ProfileError> {
+        let requested_path = path.as_ref();
+        let text = fs::read_to_string(requested_path).map_err(|source| ProfileError::Read {
+            path: requested_path.to_path_buf(),
+            source,
+        })?;
+        let manifest: Self = toml::from_str(&text).map_err(|source| ProfileError::Parse {
+            path: requested_path.to_path_buf(),
+            source,
+        })?;
+        let name = requested
+            .map(ToOwned::to_owned)
+            .or_else(|| manifest.default.clone())
+            .ok_or(ProfileError::MissingProfile)?;
+        let profile = manifest
+            .profiles
+            .get(&name)
+            .ok_or_else(|| ProfileError::UnknownProfile(name.clone()))?;
+        validate_profile(&name, profile)?;
+        Ok(profile.benchmarks.clone())
     }
 
     /// Resolves one named runtime harness helper from current local config.
@@ -385,6 +431,7 @@ impl EvaluationManifest {
         self,
         config_path: PathBuf,
         requested: Option<&str>,
+        benchmark_tasks: Vec<ResolvedTask>,
     ) -> Result<ResolvedProfile, ProfileError> {
         let name = requested
             .map(ToOwned::to_owned)
@@ -395,10 +442,16 @@ impl EvaluationManifest {
             .get(&name)
             .ok_or_else(|| ProfileError::UnknownProfile(name.clone()))?;
         validate_profile(&name, profile)?;
+        if !profile.benchmarks.is_empty() && benchmark_tasks.is_empty() {
+            return Err(ProfileError::UnresolvedBenchmarks {
+                profile: name.clone(),
+                benchmarks: profile.benchmarks.join(", "),
+            });
+        }
         let root = config_path
             .parent()
             .expect("a canonical manifest path has a parent");
-        let tasks = load_tasks(root, profile)?;
+        let tasks = load_tasks(root, profile, benchmark_tasks)?;
         let mut harness_digests = BTreeMap::new();
         for harness_name in &profile.harness {
             if harness_name == BUILTIN_HARNESS {
@@ -525,7 +578,7 @@ fn validate_profile(name: &str, profile: &Profile) -> Result<(), ProfileError> {
     if profile.trials == 0 {
         return Err(ProfileError::ZeroTrials(name.to_owned()));
     }
-    if profile.tasks.is_empty() && profile.suites.is_empty() {
+    if profile.benchmarks.is_empty() && profile.tasks.is_empty() && profile.suites.is_empty() {
         return Err(ProfileError::EmptyProfile(name.to_owned()));
     }
     for (values, dimension) in [
@@ -552,7 +605,11 @@ fn validate_profile(name: &str, profile: &Profile) -> Result<(), ProfileError> {
     Ok(())
 }
 
-fn load_tasks(root: &Path, profile: &Profile) -> Result<Vec<ResolvedTask>, ProfileError> {
+fn load_tasks(
+    root: &Path,
+    profile: &Profile,
+    benchmark_tasks: Vec<ResolvedTask>,
+) -> Result<Vec<ResolvedTask>, ProfileError> {
     let mut inputs = profile
         .tasks
         .iter()
@@ -599,7 +656,7 @@ fn load_tasks(root: &Path, profile: &Profile) -> Result<Vec<ResolvedTask>, Profi
     }
     let mut selectors = BTreeSet::new();
     let mut roots = BTreeSet::new();
-    inputs
+    let mut tasks = inputs
         .into_iter()
         .map(|(selector, path)| {
             if !selectors.insert(selector.clone()) {
@@ -613,7 +670,18 @@ fn load_tasks(root: &Path, profile: &Profile) -> Result<Vec<ResolvedTask>, Profi
                 task: Task::load(path)?,
             })
         })
-        .collect()
+        .collect::<Result<Vec<_>, _>>()?;
+    for task in benchmark_tasks {
+        if !selectors.insert(task.selector.clone()) {
+            return Err(ProfileError::DuplicateTask(task.selector));
+        }
+        let root = task.task.root().to_path_buf();
+        if !roots.insert(root.clone()) {
+            return Err(ProfileError::DuplicateTaskRoot(root));
+        }
+        tasks.push(task);
+    }
+    Ok(tasks)
 }
 
 fn expand_families(profile: &Profile, tasks: &[ResolvedTask]) -> Vec<ResolvedFamily> {
@@ -789,6 +857,43 @@ thinking = ["high"]
         assert_eq!(profile.families.len(), 1);
         assert_eq!(profile.trials, 3);
         assert_eq!(profile.task("one").unwrap().task.name(), "one");
+    }
+
+    #[test]
+    fn adapter_tasks_resolve_declared_benchmark_selectors() {
+        let directory = tempfile::tempdir().unwrap();
+        write_task(directory.path(), "imported");
+        let config = directory.path().join("nanocodex.toml");
+        fs::write(
+            &config,
+            r#"default = "smoke"
+[profiles.smoke]
+benchmarks = ["terminal-bench-2.1/fix-git"]
+trials = 1
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            EvaluationManifest::load_benchmarks(&config, None).unwrap(),
+            ["terminal-bench-2.1/fix-git"]
+        );
+        assert!(matches!(
+            EvaluationManifest::load_profile(&config, None),
+            Err(ProfileError::UnresolvedBenchmarks { .. })
+        ));
+        let profile = EvaluationManifest::load_profile_with_tasks(
+            &config,
+            None,
+            vec![ResolvedTask {
+                selector: "terminal-bench-2.1/fix-git".to_owned(),
+                task: Task::load(directory.path().join("imported")).unwrap(),
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(profile.tasks.len(), 1);
+        assert_eq!(profile.tasks[0].selector, "terminal-bench-2.1/fix-git");
     }
 
     #[test]

--- a/crates/experimental/nanocodex-eval/src/task.rs
+++ b/crates/experimental/nanocodex-eval/src/task.rs
@@ -6,14 +6,17 @@ use std::{
     time::{Duration, Instant},
 };
 
+use nanocodex_oai_api::{Prompt, PromptMessage};
 use serde::{Deserialize, Serialize};
 
 use crate::digest::TaskPackage;
 
 const TASK_CONFIG: &str = "task.toml";
 const TASK_INSTRUCTION: &str = "instruction.md";
+const TASK_TRANSCRIPT: &str = "transcript.json";
 const TASK_ENVIRONMENT: &str = "environment";
 const VERIFIER_SCRIPT: &str = "tests/test.sh";
+const PRE_ARTIFACTS_SCRIPT: &str = "pre_artifacts.sh";
 
 /// One immutable benchmark task loaded from a Terminal-Bench task directory.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -21,13 +24,21 @@ pub struct Task {
     root: PathBuf,
     content_digest: Box<str>,
     package: Arc<TaskPackage>,
+    dataset: Option<Box<str>>,
+    dataset_revision: Option<Box<str>>,
     name: Box<str>,
     description: Box<str>,
     prompt: Box<str>,
+    transcript: Vec<PromptMessage>,
+    prompt_chars: u64,
+    benchmark_prompt_chars: Option<u64>,
+    benchmark_case_type: Option<Box<str>>,
+    agent_instructions: Option<Box<str>>,
     image: OciImage,
     agent_timeout: Duration,
     verifier: Verifier,
-    artifacts: Vec<PathBuf>,
+    artifacts: Vec<TaskArtifact>,
+    output: TaskOutput,
     resources: Resources,
     network: NetworkPolicy,
     environment: BTreeMap<String, String>,
@@ -48,6 +59,19 @@ pub struct Verifier {
     environment: BTreeMap<String, String>,
     environment_mode: VerifierEnvironmentMode,
     collect: Vec<VerifierCollect>,
+    scoring_policy: ScoringPolicy,
+    network: NetworkPolicy,
+}
+
+/// Binary classification applied to benchmark-owned numeric rewards.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ScoringPolicy {
+    /// Every named reward must be strictly positive.
+    #[default]
+    AllRewardsPositive,
+    /// Every named reward must be exactly one.
+    AllRewardsOne,
 }
 
 /// Whether verification reuses the agent environment or a separate image.
@@ -65,6 +89,26 @@ pub enum VerifierEnvironmentMode {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct VerifierCollect {
     command: Box<str>,
+}
+
+/// One guest artifact retained after agent execution.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct TaskArtifact {
+    source: PathBuf,
+    exclude: Vec<PathBuf>,
+    service: Option<Box<str>>,
+}
+
+/// Candidate value made available to the canonical verifier.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskOutput {
+    /// The verifier consumes mutations in the task workspace.
+    #[default]
+    Workspace,
+    /// The verifier consumes the final assistant message at `answer.txt` in
+    /// the task workspace.
+    FinalMessage,
 }
 
 /// Task-declared resource requirements used by admission and VM sizing.
@@ -122,8 +166,18 @@ pub enum TaskLoadError {
         source: toml::de::Error,
     },
 
+    /// `transcript.json` was not valid JSON.
+    #[error("failed to parse task transcript {path}: {source}")]
+    TranscriptParse {
+        /// Transcript path.
+        path: PathBuf,
+        /// JSON parser failure.
+        #[source]
+        source: serde_json::Error,
+    },
+
     /// The manifest declares an unsupported schema revision.
-    #[error("unsupported task schema version {found:?}; expected \"1.1\"")]
+    #[error("unsupported task schema version {found:?}; expected \"1.1\" or \"1.3\"")]
     UnsupportedSchema {
         /// Unsupported revision read from the manifest.
         found: String,
@@ -201,7 +255,7 @@ impl Task {
             path: config_path.clone(),
             source,
         })?;
-        if raw.schema_version != "1.1" {
+        if !matches!(raw.schema_version.as_str(), "1.1" | "1.3") {
             return Err(TaskLoadError::UnsupportedSchema {
                 found: raw.schema_version,
             });
@@ -215,6 +269,30 @@ impl Task {
                 message: "instruction is empty".to_owned(),
             });
         }
+        let transcript_path = root.join(TASK_TRANSCRIPT);
+        let transcript = package
+            .read_file(Path::new(TASK_TRANSCRIPT))
+            .map_err(|source| TaskLoadError::Read {
+                path: transcript_path.clone(),
+                source,
+            })?
+            .map(|bytes| {
+                serde_json::from_slice::<TaskTranscript>(&bytes).map_err(|source| {
+                    TaskLoadError::TranscriptParse {
+                        path: transcript_path.clone(),
+                        source,
+                    }
+                })
+            })
+            .transpose()?
+            .map_or_else(Vec::new, |transcript| transcript.messages);
+        Prompt::new(prompt.clone())
+            .with_transcript(transcript.clone())
+            .validate()
+            .map_err(|error| TaskLoadError::Invalid {
+                path: transcript_path,
+                message: error.to_string(),
+            })?;
 
         let verifier_script = root.join(VERIFIER_SCRIPT);
         require_file(&verifier_script)?;
@@ -225,19 +303,55 @@ impl Task {
             });
         }
 
+        let (network, verifier_network) = raw.network_policies(&config_path)?;
         let name = required_string(&config_path, "task.name", raw.task.name)?;
+        if raw.task.benchmark_prompt_chars == Some(0) {
+            return Err(TaskLoadError::Invalid {
+                path: config_path,
+                message: "task.benchmark_prompt_chars must be positive when present".to_owned(),
+            });
+        }
+        let benchmark_case_type = raw
+            .task
+            .benchmark_case_type
+            .map(|value| required_string(&config_path, "task.benchmark_case_type", value))
+            .transpose()?
+            .map(String::into_boxed_str);
         let image = raw
             .environment
             .docker_image
+            .map(|image| required_string(&config_path, "environment.docker_image", image))
+            .transpose()?
             .unwrap_or_else(|| "local-dockerfile".to_owned());
         let content_digest = package.digest().to_owned().into_boxed_str();
         let task = Self {
             root,
             content_digest,
             package: Arc::new(package),
+            dataset: None,
+            dataset_revision: None,
             name: name.into_boxed_str(),
             description: raw.task.description.into_boxed_str(),
+            prompt_chars: u64::try_from(
+                transcript
+                    .iter()
+                    .map(|message| message.content().chars().count())
+                    .sum::<usize>()
+                    .saturating_add(prompt.chars().count()),
+            )
+            .unwrap_or(u64::MAX),
+            benchmark_prompt_chars: raw.task.benchmark_prompt_chars,
+            benchmark_case_type,
             prompt: prompt.into_boxed_str(),
+            transcript,
+            agent_instructions: raw
+                .agent
+                .instructions
+                .map(|instructions| {
+                    required_string(&config_path, "agent.instructions", instructions)
+                        .map(String::into_boxed_str)
+                })
+                .transpose()?,
             image: OciImage {
                 reference: image.into_boxed_str(),
             },
@@ -252,8 +366,15 @@ impl Task {
                 environment: raw.verifier.env,
                 environment_mode: raw.verifier.environment_mode,
                 collect: raw.verifier.collect,
+                scoring_policy: raw.verifier.scoring_policy,
+                network: verifier_network,
             },
-            artifacts: raw.artifacts,
+            artifacts: raw
+                .artifacts
+                .into_iter()
+                .map(|artifact| artifact.validate(&config_path))
+                .collect::<Result<_, _>>()?,
+            output: raw.output,
             resources: Resources {
                 cpus: positive(&config_path, "environment.cpus", raw.environment.cpus)?,
                 memory_mb: positive(
@@ -268,11 +389,7 @@ impl Task {
                 )?,
                 gpus: raw.environment.gpus,
             },
-            network: if raw.environment.allow_internet {
-                NetworkPolicy::Public
-            } else {
-                NetworkPolicy::Disabled
-            },
+            network,
             environment: raw.environment.env,
             requires_compose: raw.environment.custom_docker_compose
                 || (raw.metadata.custom_docker_compose
@@ -342,7 +459,17 @@ impl Task {
     /// failed, or the package mutated during the copy.
     #[doc(hidden)]
     pub fn materialize_environment(&self, destination: &Path) -> Result<(), TaskLoadError> {
-        self.materialize_package_directory(Path::new(TASK_ENVIRONMENT), destination)
+        self.materialize_package_directory(Path::new(TASK_ENVIRONMENT), destination)?;
+        let dockerfile = destination.join("Dockerfile");
+        if !dockerfile.exists() && self.image.reference() != "local-dockerfile" {
+            fs::write(&dockerfile, format!("FROM {}\n", self.image.reference())).map_err(
+                |source| TaskLoadError::Fingerprint {
+                    path: dockerfile,
+                    source,
+                },
+            )?;
+        }
+        Ok(())
     }
 
     /// Materializes the verifier tree captured when this task was loaded.
@@ -358,6 +485,16 @@ impl Task {
     #[doc(hidden)]
     pub fn materialize_verifier_files(&self, destination: &Path) -> Result<(), TaskLoadError> {
         self.materialize_package_directory(Path::new("tests"), destination)
+    }
+
+    pub(crate) fn materialize_package(&self, destination: &Path) -> Result<(), TaskLoadError> {
+        self.package
+            .materialize(destination)
+            .map_err(|source| TaskLoadError::Fingerprint {
+                path: self.root.clone(),
+                source,
+            })?;
+        self.validate_package()
     }
 
     /// Reads the verifier script captured when this task was loaded.
@@ -388,6 +525,24 @@ impl Task {
         &self.name
     }
 
+    /// Returns the evaluator dataset identity attached by a prepared profile.
+    #[must_use]
+    pub fn dataset(&self) -> Option<&str> {
+        self.dataset.as_deref()
+    }
+
+    /// Returns the pinned upstream revision attached by an imported dataset.
+    #[must_use]
+    pub fn dataset_revision(&self) -> Option<&str> {
+        self.dataset_revision.as_deref()
+    }
+
+    pub(crate) fn attach_dataset(mut self, dataset: &str, revision: Option<&str>) -> Self {
+        self.dataset = Some(dataset.to_owned().into_boxed_str());
+        self.dataset_revision = revision.map(|revision| revision.to_owned().into_boxed_str());
+        self
+    }
+
     /// Returns the human-readable task description.
     #[must_use]
     pub fn description(&self) -> &str {
@@ -398,6 +553,43 @@ impl Task {
     #[must_use]
     pub fn prompt(&self) -> &str {
         &self.prompt
+    }
+
+    /// Returns the synthetic conversation preceding the final user prompt.
+    #[must_use]
+    pub fn transcript(&self) -> &[PromptMessage] {
+        &self.transcript
+    }
+
+    /// Builds the complete typed prompt accepted by the native agent.
+    #[must_use]
+    pub fn agent_prompt(&self) -> Prompt {
+        Prompt::new(self.prompt.to_string()).with_transcript(self.transcript.clone())
+    }
+
+    /// Returns the number of Unicode scalar values across the complete
+    /// transcript and final user prompt.
+    #[must_use]
+    pub const fn prompt_chars(&self) -> u64 {
+        self.prompt_chars
+    }
+
+    /// Returns the source benchmark's declared prompt-size dimension, when present.
+    #[must_use]
+    pub const fn benchmark_prompt_chars(&self) -> Option<u64> {
+        self.benchmark_prompt_chars
+    }
+
+    /// Returns the source benchmark's case-type dimension, when present.
+    #[must_use]
+    pub fn benchmark_case_type(&self) -> Option<&str> {
+        self.benchmark_case_type.as_deref()
+    }
+
+    /// Benchmark-owned model instructions applied independently of the user prompt.
+    #[must_use]
+    pub fn agent_instructions(&self) -> Option<&str> {
+        self.agent_instructions.as_deref()
     }
 
     /// Files copied into the disposable native workspace before an attempt.
@@ -426,8 +618,33 @@ impl Task {
 
     /// Returns task-relative artifact paths requested after verification.
     #[must_use]
-    pub fn artifacts(&self) -> &[PathBuf] {
+    pub fn artifacts(&self) -> &[TaskArtifact] {
         &self.artifacts
+    }
+
+    /// Reads the optional benchmark-owned artifact capture phase.
+    ///
+    /// The script runs in the candidate VM after agent tools have stopped and
+    /// before declared artifacts are copied into a separate verifier VM.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TaskLoadError`] when the captured script changed or became
+    /// unreadable after the task was loaded.
+    #[doc(hidden)]
+    pub fn pre_artifacts_script_bytes(&self) -> Result<Option<Vec<u8>>, TaskLoadError> {
+        self.package
+            .read_file(Path::new(PRE_ARTIFACTS_SCRIPT))
+            .map_err(|source| TaskLoadError::Read {
+                path: self.root.join(PRE_ARTIFACTS_SCRIPT),
+                source,
+            })
+    }
+
+    /// Returns the candidate value consumed by the verifier.
+    #[must_use]
+    pub const fn output(&self) -> TaskOutput {
+        self.output
     }
 
     /// Returns declared resource requirements.
@@ -485,6 +702,12 @@ impl Task {
     }
 }
 
+#[derive(Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct TaskTranscript {
+    messages: Vec<PromptMessage>,
+}
+
 impl OciImage {
     /// Returns the manifest's image reference.
     #[must_use]
@@ -534,6 +757,40 @@ impl Verifier {
     pub fn collect(&self) -> &[VerifierCollect] {
         &self.collect
     }
+
+    /// Returns the benchmark-owned binary classification policy.
+    #[must_use]
+    pub const fn scoring_policy(&self) -> ScoringPolicy {
+        self.scoring_policy
+    }
+
+    /// Returns the verifier VM's network policy.
+    #[must_use]
+    pub const fn network(&self) -> NetworkPolicy {
+        self.network
+    }
+}
+
+impl ScoringPolicy {
+    /// Classifies a non-empty set of finite verifier rewards.
+    #[must_use]
+    pub fn passes(self, rewards: &BTreeMap<String, f64>) -> bool {
+        match self {
+            Self::AllRewardsPositive => rewards.values().all(|reward| *reward > 0.0),
+            Self::AllRewardsOne => rewards
+                .values()
+                .all(|reward| reward.to_bits() == 1.0_f64.to_bits()),
+        }
+    }
+
+    /// Returns the stable retained-evidence spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::AllRewardsPositive => "all_rewards_positive-v1",
+            Self::AllRewardsOne => "all_rewards_one-v1",
+        }
+    }
 }
 
 impl VerifierCollect {
@@ -541,6 +798,26 @@ impl VerifierCollect {
     #[must_use]
     pub fn command(&self) -> &str {
         &self.command
+    }
+}
+
+impl TaskArtifact {
+    /// Returns the absolute source path inside the guest.
+    #[must_use]
+    pub fn source(&self) -> &Path {
+        &self.source
+    }
+
+    /// Returns source-relative paths omitted while archiving this artifact.
+    #[must_use]
+    pub fn exclude(&self) -> &[PathBuf] {
+        &self.exclude
+    }
+
+    /// Returns the Compose service that owns the artifact, when declared.
+    #[must_use]
+    pub fn service(&self) -> Option<&str> {
+        self.service.as_deref()
     }
 }
 
@@ -559,13 +836,105 @@ impl VerifierEnvironmentMode {
 struct RawTask {
     schema_version: String,
     #[serde(default)]
-    artifacts: Vec<PathBuf>,
+    artifacts: Vec<RawTaskArtifact>,
+    #[serde(default)]
+    output: TaskOutput,
     task: RawTaskInfo,
     #[serde(default)]
     metadata: RawMetadata,
     agent: RawPhase,
     verifier: RawVerifier,
     environment: RawEnvironment,
+}
+
+impl RawTask {
+    fn network_policies(
+        &self,
+        config: &Path,
+    ) -> Result<(NetworkPolicy, NetworkPolicy), TaskLoadError> {
+        let environment = self.environment.network_policy(config)?;
+        let agent = self.agent.network_mode.unwrap_or(environment);
+        let verifier = self.verifier.network_mode.unwrap_or(environment);
+        if agent != verifier && self.verifier.environment_mode != VerifierEnvironmentMode::Separate
+        {
+            return Err(TaskLoadError::Invalid {
+                path: config.to_path_buf(),
+                message: "distinct agent and verifier network modes require a separate verifier environment"
+                    .to_owned(),
+            });
+        }
+        Ok((agent.policy(config)?, verifier.policy(config)?))
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawTaskArtifact {
+    Path(PathBuf),
+    Detailed {
+        source: PathBuf,
+        #[serde(default)]
+        exclude: Vec<PathBuf>,
+        #[serde(default)]
+        service: Option<String>,
+    },
+}
+
+impl RawTaskArtifact {
+    fn validate(self, config: &Path) -> Result<TaskArtifact, TaskLoadError> {
+        let (source, exclude, service) = match self {
+            Self::Path(source) => (source, Vec::new(), None),
+            Self::Detailed {
+                source,
+                exclude,
+                service,
+            } => (source, exclude, service),
+        };
+        if !safe_absolute_guest_path(&source) {
+            return Err(TaskLoadError::Invalid {
+                path: config.to_path_buf(),
+                message: format!(
+                    "artifact source must be a safe absolute guest path: {}",
+                    source.display()
+                ),
+            });
+        }
+        for path in &exclude {
+            if path.as_os_str().is_empty()
+                || path.is_absolute()
+                || path
+                    .components()
+                    .any(|component| !matches!(component, std::path::Component::Normal(_)))
+            {
+                return Err(TaskLoadError::Invalid {
+                    path: config.to_path_buf(),
+                    message: format!(
+                        "artifact exclusion must be a safe source-relative path: {}",
+                        path.display()
+                    ),
+                });
+            }
+        }
+        let service = service
+            .map(|service| required_string(config, "artifacts.service", service))
+            .transpose()?
+            .map(String::into_boxed_str);
+        Ok(TaskArtifact {
+            source,
+            exclude,
+            service,
+        })
+    }
+}
+
+fn safe_absolute_guest_path(path: &Path) -> bool {
+    path.is_absolute()
+        && path.strip_prefix("/").is_ok_and(|relative| {
+            !relative.as_os_str().is_empty()
+                && relative
+                    .components()
+                    .all(|component| matches!(component, std::path::Component::Normal(_)))
+        })
 }
 
 #[derive(Default, Deserialize)]
@@ -581,11 +950,19 @@ struct RawTaskInfo {
     name: String,
     #[serde(default)]
     description: String,
+    #[serde(default)]
+    benchmark_prompt_chars: Option<u64>,
+    #[serde(default)]
+    benchmark_case_type: Option<String>,
 }
 
 #[derive(Deserialize)]
 struct RawPhase {
     timeout_sec: f64,
+    #[serde(default)]
+    instructions: Option<String>,
+    #[serde(default)]
+    network_mode: Option<RawNetworkMode>,
 }
 
 #[derive(Deserialize)]
@@ -597,6 +974,10 @@ struct RawVerifier {
     environment_mode: VerifierEnvironmentMode,
     #[serde(default)]
     collect: Vec<VerifierCollect>,
+    #[serde(default)]
+    network_mode: Option<RawNetworkMode>,
+    #[serde(default)]
+    scoring_policy: ScoringPolicy,
 }
 
 #[derive(Deserialize)]
@@ -611,9 +992,47 @@ struct RawEnvironment {
     #[serde(default = "enabled")]
     allow_internet: bool,
     #[serde(default)]
+    network_mode: Option<RawNetworkMode>,
+    #[serde(default)]
     custom_docker_compose: bool,
     #[serde(default)]
     env: BTreeMap<String, String>,
+}
+
+impl RawEnvironment {
+    fn network_policy(&self, config: &Path) -> Result<RawNetworkMode, TaskLoadError> {
+        let compatibility = if self.allow_internet {
+            RawNetworkMode::Public
+        } else {
+            RawNetworkMode::NoNetwork
+        };
+        let policy = self.network_mode.unwrap_or(compatibility);
+        policy.policy(config)?;
+        Ok(policy)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum RawNetworkMode {
+    Public,
+    NoNetwork,
+    Allowlist,
+}
+
+impl RawNetworkMode {
+    fn policy(self, config: &Path) -> Result<NetworkPolicy, TaskLoadError> {
+        match self {
+            Self::Public => Ok(NetworkPolicy::Public),
+            Self::NoNetwork => Ok(NetworkPolicy::Disabled),
+            Self::Allowlist => Err(TaskLoadError::Invalid {
+                path: config.to_path_buf(),
+                message:
+                    "allowlist network mode is not implemented; refusing to widen it to public"
+                        .to_owned(),
+            }),
+        }
+    }
 }
 
 impl<'de> Deserialize<'de> for VerifierEnvironmentMode {
@@ -748,7 +1167,7 @@ mod tests {
 
     use tempfile::tempdir;
 
-    use super::{NetworkPolicy, Task, VerifierEnvironmentMode};
+    use super::{NetworkPolicy, ScoringPolicy, Task, VerifierEnvironmentMode};
 
     #[test]
     fn loads_terminal_bench_2_1_task_directory() {
@@ -763,6 +1182,8 @@ schema_version = "1.1"
 [task]
 name = "terminal-bench/example"
 description = "Example task"
+benchmark_prompt_chars = 12
+benchmark_case_type = "fixture"
 
 [metadata]
 custom_docker_compose = true
@@ -800,12 +1221,87 @@ MODE = "test"
 
         assert_eq!(task.name(), "terminal-bench/example");
         assert_eq!(task.prompt(), "Fix the task.");
+        assert_eq!(task.prompt_chars(), 13);
+        assert_eq!(task.benchmark_prompt_chars(), Some(12));
+        assert_eq!(task.benchmark_case_type(), Some("fixture"));
         assert_eq!(task.image().reference(), "example/task:20251031");
         assert_eq!(task.resources().cpus, 2);
         assert_eq!(task.network(), NetworkPolicy::Disabled);
         assert_eq!(task.environment()["MODE"], "test");
         assert_eq!(task.verifier().environment()["ANSWER"], "42");
+        assert_eq!(
+            task.verifier().scoring_policy(),
+            ScoringPolicy::AllRewardsPositive
+        );
         assert!(task.requires_compose());
+        let materialized = tempdir().unwrap();
+        task.materialize_environment(materialized.path()).unwrap();
+        assert_eq!(
+            fs::read_to_string(materialized.path().join("Dockerfile")).unwrap(),
+            "FROM example/task:20251031\n"
+        );
+    }
+
+    #[test]
+    fn loads_and_fingerprints_a_synthetic_transcript() {
+        let directory = tempdir().unwrap();
+        fs::create_dir(directory.path().join("tests")).unwrap();
+        fs::create_dir(directory.path().join("environment")).unwrap();
+        fs::write(
+            directory.path().join("task.toml"),
+            r#"schema_version = "1.3"
+[task]
+name = "mrcr/example"
+[agent]
+timeout_sec = 10.0
+[verifier]
+timeout_sec = 10.0
+[environment]
+docker_image = "debian:bookworm-slim"
+cpus = 1
+memory_mb = 1024
+storage_mb = 1024
+"#,
+        )
+        .unwrap();
+        fs::write(
+            directory.path().join("instruction.md"),
+            "Return the second answer.",
+        )
+        .unwrap();
+        fs::write(
+            directory.path().join("transcript.json"),
+            r#"{"messages":[{"role":"user","content":"first"},{"role":"assistant","content":"one"},{"role":"user","content":"second"},{"role":"assistant","content":"two"}]}"#,
+        )
+        .unwrap();
+        fs::write(directory.path().join("tests/test.sh"), "#!/bin/sh\n").unwrap();
+
+        let task = Task::load(directory.path()).unwrap();
+
+        assert_eq!(task.transcript().len(), 4);
+        assert_eq!(task.agent_prompt().transcript(), task.transcript());
+        assert_eq!(task.prompt_chars(), 42);
+        let digest = task.content_digest().to_owned();
+        fs::write(
+            directory.path().join("transcript.json"),
+            r#"{"messages":[{"role":"user","content":"first"},{"role":"assistant","content":"changed"}]}"#,
+        )
+        .unwrap();
+        assert_ne!(
+            Task::load(directory.path()).unwrap().content_digest(),
+            digest
+        );
+    }
+
+    #[test]
+    fn scoring_policies_distinguish_partial_from_exact_continuous_rewards() {
+        let partial = std::collections::BTreeMap::from([("f1".to_owned(), 2.0 / 3.0)]);
+        let exact = std::collections::BTreeMap::from([("f1".to_owned(), 1.0)]);
+
+        assert!(ScoringPolicy::AllRewardsPositive.passes(&partial));
+        assert!(!ScoringPolicy::AllRewardsOne.passes(&partial));
+        assert!(ScoringPolicy::AllRewardsOne.passes(&exact));
+        assert_eq!(ScoringPolicy::AllRewardsOne.as_str(), "all_rewards_one-v1");
     }
 
     #[test]
@@ -927,10 +1423,12 @@ name = "terminal-bench/frontier-example"
 
 [agent]
 timeout_sec = 900.0
+network_mode = "no-network"
 
 [verifier]
 timeout_sec = 600.0
 environment_mode = "separate"
+network_mode = "public"
 
 [[verifier.collect]]
 command = "cp /app/output.txt /tmp/output.txt"
@@ -950,18 +1448,32 @@ storage_mb = 10240
         .unwrap();
         fs::write(directory.path().join("tests/Dockerfile"), "FROM scratch\n").unwrap();
         fs::write(directory.path().join("tests/test.sh"), "#!/bin/sh\n").unwrap();
+        fs::write(
+            directory.path().join("pre_artifacts.sh"),
+            "#!/bin/sh\ncp /app/output.txt /tmp/output.txt\n",
+        )
+        .unwrap();
 
         let task = Task::load(directory.path()).unwrap();
 
         assert_eq!(task.image().reference(), "local-dockerfile");
+        assert_eq!(task.network(), NetworkPolicy::Disabled);
+        assert_eq!(task.verifier().network(), NetworkPolicy::Public);
         assert_eq!(
             task.verifier().environment_mode(),
             VerifierEnvironmentMode::Separate
         );
-        assert_eq!(task.artifacts(), [PathBuf::from("/app/output.txt")]);
+        assert_eq!(
+            task.artifacts()[0].source(),
+            PathBuf::from("/app/output.txt")
+        );
         assert_eq!(
             task.verifier().collect()[0].command(),
             "cp /app/output.txt /tmp/output.txt"
+        );
+        assert_eq!(
+            task.pre_artifacts_script_bytes().unwrap().unwrap(),
+            b"#!/bin/sh\ncp /app/output.txt /tmp/output.txt\n"
         );
     }
 

--- a/crates/experimental/nanocodex-eval/src/vm.rs
+++ b/crates/experimental/nanocodex-eval/src/vm.rs
@@ -1257,6 +1257,7 @@ pub struct VmBackend {
     retain_failed_rootfs: bool,
     web_search: bool,
     shared_directories: Arc<[SharedDirectory]>,
+    verifier_environment: Arc<BTreeMap<String, String>>,
 }
 
 /// Deliberate policy for a [`VmBackend`].
@@ -1265,6 +1266,7 @@ pub struct VmBackendBuilder {
     retain_failed_rootfs: bool,
     web_search: bool,
     shared_directories: Vec<SharedDirectory>,
+    verifier_environment: BTreeMap<String, String>,
 }
 
 impl Default for VmBackendBuilder {
@@ -1274,6 +1276,7 @@ impl Default for VmBackendBuilder {
             retain_failed_rootfs: true,
             web_search: false,
             shared_directories: Vec::new(),
+            verifier_environment: BTreeMap::new(),
         }
     }
 }
@@ -1326,6 +1329,7 @@ impl VmBackend {
                 retain_failed_rootfs: self.retain_failed_rootfs,
                 web_search: self.web_search,
                 shared_directories: &self.shared_directories,
+                verifier_environment: &self.verifier_environment,
             },
             attempt,
         )
@@ -1367,6 +1371,16 @@ impl VmBackendBuilder {
         self
     }
 
+    /// Adds run-scoped values visible only to verifier commands.
+    #[must_use]
+    pub fn verifier_environment(
+        mut self,
+        environment: impl IntoIterator<Item = (String, String)>,
+    ) -> Self {
+        self.verifier_environment.extend(environment);
+        self
+    }
+
     /// Builds a cloneable backend handle.
     #[must_use]
     pub fn build(self) -> VmBackend {
@@ -1376,6 +1390,7 @@ impl VmBackendBuilder {
             retain_failed_rootfs: self.retain_failed_rootfs,
             web_search: self.web_search,
             shared_directories: self.shared_directories.into(),
+            verifier_environment: Arc::new(self.verifier_environment),
         }
     }
 }
@@ -1452,6 +1467,7 @@ struct VmAttemptHost<'a> {
     retain_failed_rootfs: bool,
     web_search: bool,
     shared_directories: &'a [SharedDirectory],
+    verifier_environment: &'a Arc<BTreeMap<String, String>>,
 }
 
 struct AttemptGvproxy {
@@ -1687,6 +1703,7 @@ struct VmVerifier {
     retain_failed_rootfs: bool,
     root_disks_finalized: bool,
     artifact_directory: PathBuf,
+    verifier_environment: Arc<BTreeMap<String, String>>,
     _network: Option<AttemptGvproxy>,
     _verifier_network: Option<AttemptGvproxy>,
 }
@@ -1879,6 +1896,7 @@ fn vm_attempt_inner(
         retain_failed_rootfs: host.retain_failed_rootfs,
         root_disks_finalized: false,
         artifact_directory: attempt.directory().to_path_buf(),
+        verifier_environment: Arc::clone(host.verifier_environment),
         _network: network,
         _verifier_network: verifier_network,
     };
@@ -3184,7 +3202,11 @@ impl VmVerifier {
         };
         command = command
             .current_directory(&launch.workspace)
-            .environment(base_guest_environment(task, &launch.workspace))
+            .environment(verifier_guest_environment(
+                task,
+                &launch.workspace,
+                &self.verifier_environment,
+            ))
             .timeout(task.verifier().timeout());
         Ok(command)
     }
@@ -3357,6 +3379,18 @@ fn base_guest_environment(task: &Task, workspace: &str) -> Vec<(String, String)>
     ]);
     environment.extend(task.environment().clone());
     environment.extend(task.verifier().environment().clone());
+    environment.into_iter().collect()
+}
+
+fn verifier_guest_environment(
+    task: &Task,
+    workspace: &str,
+    runtime: &BTreeMap<String, String>,
+) -> Vec<(String, String)> {
+    let mut environment = base_guest_environment(task, workspace)
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+    environment.extend(runtime.clone());
     environment.into_iter().collect()
 }
 

--- a/crates/experimental/nanocodex-eval/src/vm.rs
+++ b/crates/experimental/nanocodex-eval/src/vm.rs
@@ -2915,30 +2915,15 @@ impl VmVerifier {
             }
             session
         } else {
-            let setup = async {
-                let tests = tempfile::tempdir()?;
-                task.materialize_verifier_files(tests.path())?;
-                Self::copy_directory(
-                    &agent_session,
-                    tests.path(),
-                    tests.path(),
-                    Path::new("/tests"),
-                )
-                .await
-            }
-            .await;
-            if let Err(primary) = setup {
-                let occurred_at = Utc::now();
-                let cleanup = self.cleanup_session(Some(&agent_session)).await;
-                return Err(AttemptVerificationFailure::observed_at(
-                    primary,
-                    occurred_at,
-                    cleanup,
-                ));
-            }
             agent_session
         };
         let setup = async {
+            // Verifier files are execution inputs, not image contents. Stage
+            // them for both retained agent environments and freshly launched
+            // isolated verifier environments.
+            let tests = tempfile::tempdir()?;
+            task.materialize_verifier_files(tests.path())?;
+            Self::copy_directory(&session, tests.path(), tests.path(), Path::new("/tests")).await?;
             session
                 .write_file("/logs/verifier/.nanoeval", Vec::new(), 0o600)
                 .await?;

--- a/crates/experimental/nanocodex-eval/src/vm.rs
+++ b/crates/experimental/nanocodex-eval/src/vm.rs
@@ -2596,55 +2596,9 @@ impl VmVerifier {
             return Ok(None);
         }
 
-        let mut command = VmCommand::new("/bin/tar")
-            .arg("-C")
-            .arg("/")
-            .arg("-cf")
-            .arg("/tmp/nanoeval-artifacts.tar")
-            .arg("--");
-        for artifact in task.artifacts() {
-            if let Some(service) = artifact.service() {
-                return Err(io::Error::other(format!(
-                    "artifact {} belongs to unsupported service {service:?}",
-                    artifact.source().display()
-                ))
-                .into());
-            }
-            let relative = artifact.source().strip_prefix("/").map_err(|_| {
-                io::Error::other(format!(
-                    "artifact path must be absolute: {}",
-                    artifact.source().display()
-                ))
-            })?;
-            if relative.as_os_str().is_empty()
-                || relative
-                    .components()
-                    .any(|component| !matches!(component, std::path::Component::Normal(_)))
-            {
-                return Err(io::Error::other(format!(
-                    "artifact path is not a safe guest path: {}",
-                    artifact.source().display()
-                ))
-                .into());
-            }
-            for excluded in artifact.exclude() {
-                command = command.arg(format!(
-                    "--exclude={}/{}",
-                    relative.to_string_lossy(),
-                    excluded.to_string_lossy()
-                ));
-            }
-            command = command.arg(
-                relative
-                    .to_str()
-                    .ok_or_else(|| {
-                        io::Error::other(format!(
-                            "artifact path is not UTF-8: {}",
-                            artifact.source().display()
-                        ))
-                    })?
-                    .to_owned(),
-            );
+        let mut command = VmCommand::new("/bin/tar");
+        for argument in artifact_archive_arguments(task)? {
+            command = command.arg(argument);
         }
         let output = session
             .command(command.timeout(task.verifier().timeout()))
@@ -3236,6 +3190,63 @@ impl VmVerifier {
             Ok(())
         })
     }
+}
+
+fn artifact_archive_arguments(task: &Task) -> Result<Vec<String>, VmAttemptError> {
+    let mut arguments = vec![
+        "-C".to_owned(),
+        "/".to_owned(),
+        "-cf".to_owned(),
+        "/tmp/nanoeval-artifacts.tar".to_owned(),
+    ];
+    let mut sources = Vec::with_capacity(task.artifacts().len());
+    for artifact in task.artifacts() {
+        if let Some(service) = artifact.service() {
+            return Err(io::Error::other(format!(
+                "artifact {} belongs to unsupported service {service:?}",
+                artifact.source().display()
+            ))
+            .into());
+        }
+        let relative = artifact.source().strip_prefix("/").map_err(|_| {
+            io::Error::other(format!(
+                "artifact path must be absolute: {}",
+                artifact.source().display()
+            ))
+        })?;
+        if relative.as_os_str().is_empty()
+            || relative
+                .components()
+                .any(|component| !matches!(component, std::path::Component::Normal(_)))
+        {
+            return Err(io::Error::other(format!(
+                "artifact path is not a safe guest path: {}",
+                artifact.source().display()
+            ))
+            .into());
+        }
+        for excluded in artifact.exclude() {
+            arguments.push(format!(
+                "--exclude={}/{}",
+                relative.to_string_lossy(),
+                excluded.to_string_lossy()
+            ));
+        }
+        sources.push(
+            relative
+                .to_str()
+                .ok_or_else(|| {
+                    io::Error::other(format!(
+                        "artifact path is not UTF-8: {}",
+                        artifact.source().display()
+                    ))
+                })?
+                .to_owned(),
+        );
+    }
+    arguments.push("--".to_owned());
+    arguments.extend(sources);
+    Ok(arguments)
 }
 
 impl Drop for VmVerifier {

--- a/crates/experimental/nanocodex-eval/src/vm.rs
+++ b/crates/experimental/nanocodex-eval/src/vm.rs
@@ -59,7 +59,7 @@ pub use nanocodex_vm::{
 
 use crate::{
     CleanupPhase, EvalEnvironment, Evaluator, EvaluatorBuilder, HarnessExec, NetworkPolicy, Task,
-    TaskLoadError, VerifierEnvironmentMode, VerifierResult,
+    TaskLoadError, TaskOutput, VerifierEnvironmentMode, VerifierResult,
     evaluator::{
         AttemptAgent, AttemptVerification, AttemptVerificationFailure, AttemptVerifier, EvalAttempt,
     },
@@ -95,6 +95,7 @@ const VERIFIER_CACHE_BLOCK_DEVICE: &str = "/dev/vdc";
 const OVERLAY_VERIFIER_CACHE_BLOCK_DEVICE: &str = "/dev/vdd";
 const VERIFIER_CACHE_MOUNT: &str = "/run/nanoeval-verifier-cache";
 const CACHED_VERIFIER_SCRIPT: &str = "/tmp/nanoeval-verifier.sh";
+const PRE_ARTIFACTS_GUEST_SCRIPT: &str = "/tmp/nanocodex-pre-artifacts.sh";
 const GUEST_PUBLIC_RESOLV_CONF: &str =
     "nameserver 192.168.127.1\\nnameserver 1.1.1.1\\noptions timeout:2 attempts:5\\n";
 const DEFAULT_IMAGE_NETWORK_RETRIES: usize = 2;
@@ -527,10 +528,10 @@ impl VmResourcesBuilder {
             .iter()
             .map(|task| (task.root().to_path_buf(), Arc::new(AsyncOnceCell::new())))
             .collect();
-        let public_network = self
-            .tasks
-            .iter()
-            .any(|task| task.network() == NetworkPolicy::Public);
+        let public_network = self.tasks.iter().any(|task| {
+            task.network() == NetworkPolicy::Public
+                || task.verifier().network() == NetworkPolicy::Public
+        });
         let gvproxy = if public_network {
             match self.gvproxy {
                 Some(path) if path.is_file() => Some(path),
@@ -1685,7 +1686,9 @@ struct VmVerifier {
     retain_passed_rootfs: bool,
     retain_failed_rootfs: bool,
     root_disks_finalized: bool,
+    artifact_directory: PathBuf,
     _network: Option<AttemptGvproxy>,
+    _verifier_network: Option<AttemptGvproxy>,
 }
 
 struct VmAttemptSetupGuard {
@@ -1821,8 +1824,22 @@ fn vm_attempt_inner(
             .map(|network| network.socket().to_path_buf()),
         shared_directories: host.shared_directories.to_vec(),
     };
-    let separate_launch =
-        prepare_separate_verifier_launch(environment, &launch, host, attempt, root_policy)?;
+    let verifier_network = if environment.verifier.is_some() {
+        spawn_attempt_network(
+            attempt.task().verifier().network(),
+            host.gvproxy,
+            &attempt.directory().join("verifier-vm").join("gvproxy.log"),
+        )?
+    } else {
+        None
+    };
+    let separate_launch = prepare_separate_verifier_launch(
+        environment,
+        host,
+        attempt,
+        root_policy,
+        verifier_network.as_ref(),
+    )?;
     if let Some(separate) = &separate_launch
         && let Some(disk) = separate.root.writable_disk()
     {
@@ -1861,7 +1878,9 @@ fn vm_attempt_inner(
         retain_passed_rootfs: host.retain_passed_rootfs,
         retain_failed_rootfs: host.retain_failed_rootfs,
         root_disks_finalized: false,
+        artifact_directory: attempt.directory().to_path_buf(),
         _network: network,
+        _verifier_network: verifier_network,
     };
     setup_guard.disarm();
     Ok(VmAttempt {
@@ -1983,10 +2002,10 @@ fn materialize_attempt_root(
 
 fn prepare_separate_verifier_launch(
     environment: &VmEnvironment,
-    agent: &VmLaunch,
     host: VmAttemptHost<'_>,
     attempt: EvalAttempt<'_>,
     root_policy: AttemptRootPolicy,
+    network: Option<&AttemptGvproxy>,
 ) -> Result<Option<VmLaunch>, VmAttemptError> {
     environment
         .verifier
@@ -2010,9 +2029,10 @@ fn prepare_separate_verifier_launch(
                     attempt.task().resources().memory_mb,
                     host.max_guest_memory_mb,
                 ),
-                resolver_configuration: agent.resolver_configuration.clone(),
+                resolver_configuration: network
+                    .map_or_else(String::new, |_| GUEST_PUBLIC_RESOLV_CONF.to_owned()),
                 environment: verifier.environment.clone(),
-                network_socket: agent.network_socket.clone(),
+                network_socket: network.map(|network| network.socket().to_path_buf()),
                 shared_directories: Vec::new(),
             })
         })
@@ -2379,6 +2399,41 @@ fn verifier_bootstrap_network_failed(output: &VmCommandOutput) -> bool {
     apt_bootstrap_failed || dependency_runner_missing && network_failed
 }
 
+async fn read_verifier_rewards(
+    session: &VmToolSession,
+) -> Result<(&'static str, Vec<u8>, BTreeMap<String, f64>), VmAttemptError> {
+    if let Ok(bytes) = session.read_file("/logs/verifier/reward.json").await {
+        let rewards = serde_json::from_slice::<BTreeMap<String, f64>>(&bytes).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("invalid verifier reward.json: {error}"),
+            )
+        })?;
+        validate_verifier_rewards(&rewards)?;
+        return Ok(("reward.json", bytes, rewards));
+    }
+    let bytes = session.read_file("/logs/verifier/reward.txt").await?;
+    let reward = String::from_utf8_lossy(&bytes).trim().parse::<f64>()?;
+    let rewards = BTreeMap::from([("reward".to_owned(), reward)]);
+    validate_verifier_rewards(&rewards)?;
+    Ok(("reward.txt", bytes, rewards))
+}
+
+fn validate_verifier_rewards(rewards: &BTreeMap<String, f64>) -> Result<(), VmAttemptError> {
+    if rewards.is_empty()
+        || rewards
+            .iter()
+            .any(|(name, reward)| name.trim().is_empty() || !reward.is_finite())
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "verifier rewards must contain non-empty names and finite numeric values",
+        )
+        .into());
+    }
+    Ok(())
+}
+
 impl AttemptVerifier for VmVerifier {
     fn verify<'a>(
         &'a mut self,
@@ -2400,11 +2455,105 @@ impl AttemptVerifier for VmVerifier {
 }
 
 impl VmVerifier {
+    async fn stage_verifier_logs(
+        session: &VmToolSession,
+        destination: &Path,
+    ) -> Result<(), VmAttemptError> {
+        let listed = session
+            .command(
+                VmCommand::new("/bin/sh")
+                    .arg("-c")
+                    .arg("find /logs/verifier -type f -printf '%P\\0'")
+                    .max_output_bytes(1024 * 1024)
+                    .timeout(Duration::from_secs(30)),
+            )
+            .await?;
+        if listed.exit_code != 0 {
+            return Err(io::Error::other(format!(
+                "listing verifier evidence exited {}: {}",
+                listed.exit_code,
+                String::from_utf8_lossy(&listed.stderr)
+            ))
+            .into());
+        }
+        for encoded in listed
+            .stdout
+            .split(|byte| *byte == 0)
+            .filter(|path| !path.is_empty())
+        {
+            let relative = std::str::from_utf8(encoded)
+                .map_err(|_| io::Error::other("verifier evidence path is not UTF-8"))?;
+            let relative = Path::new(relative);
+            if relative.is_absolute()
+                || relative
+                    .components()
+                    .any(|component| !matches!(component, std::path::Component::Normal(_)))
+            {
+                return Err(io::Error::other(format!(
+                    "verifier evidence path is unsafe: {}",
+                    relative.display()
+                ))
+                .into());
+            }
+            let target = destination.join(relative);
+            if let Some(parent) = target.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            let guest = Path::new("/logs/verifier")
+                .join(relative)
+                .to_string_lossy()
+                .into_owned();
+            fs::write(target, session.read_file(guest).await?)?;
+        }
+        Ok(())
+    }
+
+    async fn run_pre_artifacts(
+        &self,
+        session: &VmToolSession,
+        task: &Task,
+        launch: &VmLaunch,
+    ) -> Result<(), VmAttemptError> {
+        let Some(script) = task.pre_artifacts_script_bytes()? else {
+            return Ok(());
+        };
+        session
+            .write_file(PRE_ARTIFACTS_GUEST_SCRIPT, script, 0o700)
+            .await?;
+        let output = session
+            .command(
+                VmCommand::new(PRE_ARTIFACTS_GUEST_SCRIPT)
+                    .current_directory(&launch.workspace)
+                    .environment(base_guest_environment(task, &launch.workspace))
+                    .timeout(task.verifier().timeout()),
+            )
+            .await?;
+        fs::write(
+            self.artifact_directory.join("pre-artifacts-stdout.log"),
+            &output.stdout,
+        )?;
+        fs::write(
+            self.artifact_directory.join("pre-artifacts-stderr.log"),
+            &output.stderr,
+        )?;
+        if output.exit_code != 0 {
+            return Err(io::Error::other(format!(
+                "pre-artifact capture exited {}: {}",
+                output.exit_code,
+                String::from_utf8_lossy(&output.stderr)
+            ))
+            .into());
+        }
+        Ok(())
+    }
+
     async fn collect_artifacts(
+        &self,
         session: &VmToolSession,
         task: &Task,
         launch: &VmLaunch,
     ) -> Result<Option<Vec<u8>>, VmAttemptError> {
+        self.run_pre_artifacts(session, task, launch).await?;
         for collect in task.verifier().collect() {
             let output = session
                 .command(
@@ -2436,10 +2585,17 @@ impl VmVerifier {
             .arg("/tmp/nanoeval-artifacts.tar")
             .arg("--");
         for artifact in task.artifacts() {
-            let relative = artifact.strip_prefix("/").map_err(|_| {
+            if let Some(service) = artifact.service() {
+                return Err(io::Error::other(format!(
+                    "artifact {} belongs to unsupported service {service:?}",
+                    artifact.source().display()
+                ))
+                .into());
+            }
+            let relative = artifact.source().strip_prefix("/").map_err(|_| {
                 io::Error::other(format!(
                     "artifact path must be absolute: {}",
-                    artifact.display()
+                    artifact.source().display()
                 ))
             })?;
             if relative.as_os_str().is_empty()
@@ -2449,9 +2605,16 @@ impl VmVerifier {
             {
                 return Err(io::Error::other(format!(
                     "artifact path is not a safe guest path: {}",
-                    artifact.display()
+                    artifact.source().display()
                 ))
                 .into());
+            }
+            for excluded in artifact.exclude() {
+                command = command.arg(format!(
+                    "--exclude={}/{}",
+                    relative.to_string_lossy(),
+                    excluded.to_string_lossy()
+                ));
             }
             command = command.arg(
                 relative
@@ -2459,7 +2622,7 @@ impl VmVerifier {
                     .ok_or_else(|| {
                         io::Error::other(format!(
                             "artifact path is not UTF-8: {}",
-                            artifact.display()
+                            artifact.source().display()
                         ))
                     })?
                     .to_owned(),
@@ -2540,6 +2703,19 @@ impl VmVerifier {
         }
         let (verifier_launch, verifier_session) = self.start_verifier_session(task).await?;
         let verification = async {
+            if task.output() == TaskOutput::FinalMessage {
+                verifier_session
+                    .write_file(
+                        format!("{}/answer.txt", verifier_launch.workspace),
+                        attempt
+                            .final_message()
+                            .unwrap_or_default()
+                            .as_bytes()
+                            .to_vec(),
+                        0o600,
+                    )
+                    .await?;
+            }
             let command =
                 self.verifier_command(task, &verifier_launch, self.attempt_cache.as_ref())?;
             let (output, verifier_timed_out) = self
@@ -2553,14 +2729,17 @@ impl VmVerifier {
                 (false, false) => format!("{stdout}\n{stderr}"),
             };
             fs::write(verifier_directory.join("test-stdout.txt"), combined)?;
-            let reward_bytes = if verifier_timed_out {
-                b"0\n".to_vec()
+            let (reward_name, reward_bytes, rewards) = if verifier_timed_out {
+                (
+                    "reward.txt",
+                    b"0\n".to_vec(),
+                    BTreeMap::from([("reward".to_owned(), 0.0)]),
+                )
             } else {
-                verifier_session
-                    .read_file("/logs/verifier/reward.txt")
-                    .await?
+                read_verifier_rewards(&verifier_session).await?
             };
-            fs::write(verifier_directory.join("reward.txt"), &reward_bytes)?;
+            Self::stage_verifier_logs(&verifier_session, &verifier_directory).await?;
+            fs::write(verifier_directory.join(reward_name), &reward_bytes)?;
             if let Ok(ctrf) = verifier_session.read_file("/logs/verifier/ctrf.json").await {
                 fs::write(verifier_directory.join("ctrf.json"), ctrf)?;
             }
@@ -2568,17 +2747,14 @@ impl VmVerifier {
             if let Ok(answer) = verifier_session.read_file(answer_path).await {
                 fs::write(attempt.workspace().join("answer.txt"), answer)?;
             }
-            let reward = String::from_utf8_lossy(&reward_bytes)
-                .trim()
-                .parse::<f64>()?;
             task.validate_package()?;
-            Ok::<_, VmAttemptError>((output, stdout, stderr, reward))
+            Ok::<_, VmAttemptError>((output, stdout, stderr, rewards))
         }
         .await;
         let verification_error_at = verification.as_ref().err().map(|_| Utc::now());
         let cleanup_started = Utc::now();
         let shutdown = verifier_session.shutdown().await;
-        let (output, stdout, stderr, reward) = match verification {
+        let (output, stdout, stderr, rewards) = match verification {
             Ok(verification) => verification,
             Err(primary) => {
                 let cleanup = self.cleanup_after_shutdown(cleanup_started, shutdown, false);
@@ -2592,7 +2768,9 @@ impl VmVerifier {
         let cleanup = match shutdown {
             Ok(()) => {
                 let cache_cleanup = self.finish_verifier_cache();
-                let disk_cleanup = self.remove_disposable_root_disks(reward > 0.0);
+                let disk_cleanup = self.remove_disposable_root_disks(
+                    task.verifier().scoring_policy().passes(&rewards),
+                );
                 match cache_cleanup.and(disk_cleanup) {
                     Ok(()) => CleanupPhase::completed(cleanup_started),
                     Err(error) => CleanupPhase::failed(cleanup_started, &error),
@@ -2607,7 +2785,9 @@ impl VmVerifier {
                         "verifier cache cleanup also failed after VM shutdown failure"
                     );
                 }
-                if let Err(disk_error) = self.remove_disposable_root_disks(reward > 0.0) {
+                if let Err(disk_error) = self
+                    .remove_disposable_root_disks(task.verifier().scoring_policy().passes(&rewards))
+                {
                     warn!(
                         target: "nanocodex_eval",
                         error = %disk_error,
@@ -2621,7 +2801,7 @@ impl VmVerifier {
         Ok(AttemptVerification {
             result: VerifierResult {
                 exit_code: output.exit_code,
-                rewards: BTreeMap::from([("reward".to_owned(), reward)]),
+                rewards,
             },
             stdout,
             stderr,
@@ -2653,7 +2833,9 @@ impl VmVerifier {
             .clone()
             .unwrap_or_else(|| self.launch.clone());
         let session = if self.separate_launch.is_some() {
-            let artifacts = match Self::collect_artifacts(&agent_session, task, &self.launch).await
+            let artifacts = match self
+                .collect_artifacts(&agent_session, task, &self.launch)
+                .await
             {
                 Ok(artifacts) => artifacts,
                 Err(primary) => {

--- a/crates/experimental/nanocodex-eval/src/vm/tests.rs
+++ b/crates/experimental/nanocodex-eval/src/vm/tests.rs
@@ -494,7 +494,9 @@ fn verifier_with_launch_root(root: VmLaunchRoot, retain_failed_rootfs: bool) -> 
         retain_passed_rootfs: false,
         retain_failed_rootfs,
         root_disks_finalized: false,
+        artifact_directory: directory,
         _network: None,
+        _verifier_network: None,
     }
 }
 
@@ -804,7 +806,9 @@ done
         retain_passed_rootfs: false,
         retain_failed_rootfs: true,
         root_disks_finalized: false,
+        artifact_directory: control.path().to_path_buf(),
         _network: None,
+        _verifier_network: None,
     };
 
     let (_, session) = verifier.start_verifier_session(&task).await.unwrap();

--- a/crates/experimental/nanocodex-eval/src/vm/tests.rs
+++ b/crates/experimental/nanocodex-eval/src/vm/tests.rs
@@ -25,6 +25,24 @@ fn evaluator_vm_builder_records_the_backend_environment() {
 }
 
 #[test]
+fn run_scoped_judge_credentials_are_verifier_only() {
+    let task =
+        Task::load(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../tasks/write-greeting"))
+            .unwrap();
+    let runtime = BTreeMap::from([("NANOCODEX_JUDGE_TOKEN".to_owned(), "run-secret".to_owned())]);
+
+    let candidate = base_guest_environment(&task, "/workspace")
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+    let verifier = verifier_guest_environment(&task, "/workspace", &runtime)
+        .into_iter()
+        .collect::<BTreeMap<_, _>>();
+
+    assert!(!candidate.contains_key("NANOCODEX_JUDGE_TOKEN"));
+    assert_eq!(verifier["NANOCODEX_JUDGE_TOKEN"], "run-secret");
+}
+
+#[test]
 fn eval_guest_memory_cap_only_reduces_large_task_allocations() {
     assert_eq!(effective_guest_memory_mb(8_192, None), 8_192);
     assert_eq!(effective_guest_memory_mb(8_192, Some(1_024)), 1_024);
@@ -495,6 +513,7 @@ fn verifier_with_launch_root(root: VmLaunchRoot, retain_failed_rootfs: bool) -> 
         retain_failed_rootfs,
         root_disks_finalized: false,
         artifact_directory: directory,
+        verifier_environment: Arc::new(BTreeMap::new()),
         _network: None,
         _verifier_network: None,
     }
@@ -807,6 +826,7 @@ done
         retain_failed_rootfs: true,
         root_disks_finalized: false,
         artifact_directory: control.path().to_path_buf(),
+        verifier_environment: Arc::new(BTreeMap::new()),
         _network: None,
         _verifier_network: None,
     };

--- a/crates/experimental/nanocodex-eval/src/vm/tests.rs
+++ b/crates/experimental/nanocodex-eval/src/vm/tests.rs
@@ -79,6 +79,64 @@ fn guest_executables_are_installed_by_the_task_image_recipe() {
     assert_eq!(fs::read(staged).unwrap(), b"codex-binary");
 }
 
+#[test]
+fn artifact_archive_options_precede_the_path_terminator() {
+    let directory = tempfile::tempdir().unwrap();
+    fs::create_dir(directory.path().join("tests")).unwrap();
+    fs::create_dir(directory.path().join("environment")).unwrap();
+    fs::write(
+        directory.path().join("task.toml"),
+        r#"
+schema_version = "1.1"
+artifacts = [
+  { source = "/workspace", exclude = ["Dockerfile", "instruction.md"] },
+  "/--option-shaped-output",
+]
+
+[task]
+name = "adapter/artifact-order"
+
+[agent]
+timeout_sec = 1.0
+
+[verifier]
+timeout_sec = 1.0
+
+[environment]
+docker_image = "example/task:latest"
+cpus = 1
+memory_mb = 1
+storage_mb = 1
+"#,
+    )
+    .unwrap();
+    fs::write(directory.path().join("instruction.md"), "Create output.").unwrap();
+    fs::write(directory.path().join("tests/test.sh"), "exit 0\n").unwrap();
+    fs::write(
+        directory.path().join("environment/Dockerfile"),
+        "FROM scratch\n",
+    )
+    .unwrap();
+    let task = Task::load(directory.path()).unwrap();
+
+    let arguments = artifact_archive_arguments(&task).unwrap();
+
+    assert_eq!(
+        arguments,
+        [
+            "-C",
+            "/",
+            "-cf",
+            "/tmp/nanoeval-artifacts.tar",
+            "--exclude=workspace/Dockerfile",
+            "--exclude=workspace/instruction.md",
+            "--",
+            "workspace",
+            "--option-shaped-output",
+        ]
+    );
+}
+
 #[tokio::test]
 async fn vm_resources_leave_task_environments_lazy_and_single_flight() {
     let task =

--- a/crates/nanocodex-agent/src/agent/driver/mod.rs
+++ b/crates/nanocodex-agent/src/agent/driver/mod.rs
@@ -136,7 +136,7 @@ where
                                     effort: thinking,
                                 },
                                 turn_index,
-                                prompt.instruction.text_bytes(),
+                                prompt.text_bytes(),
                             );
                             drop(parent);
                             turn_span.record("status", "cancelled");
@@ -514,7 +514,7 @@ where
                     effort: thinking,
                 },
                 turn_index,
-                prompt.instruction.text_bytes(),
+                prompt.text_bytes(),
             );
             drop(parent);
             if let Some(prompt_content) = &prompt_content {

--- a/crates/nanocodex-agent/src/agent/handle.rs
+++ b/crates/nanocodex-agent/src/agent/handle.rs
@@ -158,11 +158,9 @@ impl Nanocodex {
     /// Returns an error for an empty prompt or if the driver stopped.
     pub async fn prompt(&self, prompt: impl Into<Prompt>) -> Result<Turn> {
         let prompt = prompt.into();
-        if prompt.instruction.is_empty() {
-            return Err(NanocodexError::InvalidRequest(
-                "prompt instruction must not be empty".to_owned(),
-            ));
-        }
+        prompt
+            .validate()
+            .map_err(|error| NanocodexError::InvalidRequest(error.to_string()))?;
         let key = TurnKey(self.next_turn.fetch_add(1, Ordering::Relaxed));
         let parent = tracing::Span::current();
         let parent = (!parent.is_disabled()).then_some(parent);
@@ -210,11 +208,9 @@ impl Nanocodex {
     /// agent driver stopped.
     pub async fn route_prompt(&self, prompt: impl Into<Prompt>) -> Result<PromptRoute> {
         let prompt = prompt.into();
-        if prompt.instruction.is_empty() {
-            return Err(NanocodexError::InvalidRequest(
-                "prompt instruction must not be empty".to_owned(),
-            ));
-        }
+        prompt
+            .validate()
+            .map_err(|error| NanocodexError::InvalidRequest(error.to_string()))?;
         let key = TurnKey(self.next_turn.fetch_add(1, Ordering::Relaxed));
         let parent = tracing::Span::current();
         let parent = (!parent.is_disabled()).then_some(parent);

--- a/crates/nanocodex-agent/src/agent/turn.rs
+++ b/crates/nanocodex-agent/src/agent/turn.rs
@@ -109,11 +109,9 @@ impl TurnControl {
     /// its steering queue is full, or if the driver stops.
     pub async fn steer(&self, prompt: impl Into<Prompt>) -> Result<()> {
         let prompt = prompt.into();
-        if prompt.instruction.is_empty() {
-            return Err(NanocodexError::InvalidRequest(
-                "steer instruction must not be empty".to_owned(),
-            ));
-        }
+        prompt
+            .validate()
+            .map_err(|error| NanocodexError::InvalidRequest(error.to_string()))?;
         request_command(&self.commands, |result| Command::Steer {
             key: self.key,
             prompt,

--- a/crates/nanocodex-agent/src/agent/turn.rs
+++ b/crates/nanocodex-agent/src/agent/turn.rs
@@ -1,4 +1,5 @@
 use super::*;
+use nanocodex_oai_api::PromptValidationError;
 
 /// Completion handle for an accepted turn.
 ///
@@ -109,9 +110,7 @@ impl TurnControl {
     /// its steering queue is full, or if the driver stops.
     pub async fn steer(&self, prompt: impl Into<Prompt>) -> Result<()> {
         let prompt = prompt.into();
-        prompt
-            .validate()
-            .map_err(|error| NanocodexError::InvalidRequest(error.to_string()))?;
+        prompt.validate().map_err(steer_validation_error)?;
         request_command(&self.commands, |result| Command::Steer {
             key: self.key,
             prompt,
@@ -133,6 +132,14 @@ impl TurnControl {
         })
         .await
     }
+}
+
+fn steer_validation_error(error: PromptValidationError) -> NanocodexError {
+    let message = match error {
+        PromptValidationError::EmptyInstruction => "steer instruction must not be empty".to_owned(),
+        error => error.to_string(),
+    };
+    NanocodexError::InvalidRequest(message)
 }
 
 #[derive(Clone, Copy, Eq, PartialEq)]

--- a/crates/nanocodex-agent/src/lib.rs
+++ b/crates/nanocodex-agent/src/lib.rs
@@ -54,7 +54,7 @@ pub mod events {
 /// Prompts and multimodal user input accepted by the agent.
 pub mod input {
     pub use nanocodex_oai_api::{
-        ImageDetail, Prompt, PromptInput, UserInput,
+        ImageDetail, Prompt, PromptInput, PromptMessage, PromptMessageRole, UserInput,
         responses::{AgentMessageContent, ContentItem},
     };
 }

--- a/crates/nanocodex-agent/src/model/input.rs
+++ b/crates/nanocodex-agent/src/model/input.rs
@@ -1,5 +1,8 @@
-use nanocodex_oai_api::responses::{
-    ContentItem, FunctionOutputBody, FunctionOutputContent, MessageRole, ResponseItem,
+use nanocodex_oai_api::{
+    Prompt, PromptMessageRole,
+    responses::{
+        ContentItem, FunctionOutputBody, FunctionOutputContent, MessageRole, ResponseItem,
+    },
 };
 use nanocodex_tools::contract::{ToolOutputBody, ToolOutputContent};
 use serde_json::Value;
@@ -17,14 +20,33 @@ const PERMISSIONS_INSTRUCTIONS: &str = concat!(
 );
 
 pub(in crate::model) fn task_input(
+    prompt: &Prompt,
     user_content: Vec<ContentItem>,
     context: &ContextSnapshot,
 ) -> Vec<ResponseItem> {
-    vec![
-        developer_context(),
-        context.full_item(),
-        ResponseItem::message(MessageRole::User, user_content),
-    ]
+    let mut input = vec![developer_context(), context.full_item()];
+    input.extend(prompt_messages(prompt, user_content));
+    input
+}
+
+pub(in crate::model) fn prompt_messages(
+    prompt: &Prompt,
+    user_content: Vec<ContentItem>,
+) -> Vec<ResponseItem> {
+    let mut input = Vec::with_capacity(prompt.transcript().len() + 1);
+    input.extend(prompt.transcript().iter().map(|message| {
+        let role = match message.role() {
+            PromptMessageRole::User => MessageRole::User,
+            PromptMessageRole::Assistant => MessageRole::Assistant,
+        };
+        let content = match message.role() {
+            PromptMessageRole::User => ContentItem::input_text(message.content()),
+            PromptMessageRole::Assistant => ContentItem::output_text(message.content()),
+        };
+        ResponseItem::message(role, [content])
+    }));
+    input.push(ResponseItem::message(MessageRole::User, user_content));
+    input
 }
 
 pub(in crate::model) fn turn_aborted() -> ResponseItem {
@@ -116,7 +138,7 @@ fn function_output(output: ToolOutputBody) -> FunctionOutputBody {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nanocodex_oai_api::ImageDetail;
+    use nanocodex_oai_api::{ImageDetail, PromptMessage};
     use nanocodex_tools::contract::ToolOutputContent;
     use serde_json::json;
 
@@ -129,7 +151,9 @@ mod tests {
             "2026-07-17",
             "America/Los_Angeles",
         );
+        let prompt = Prompt::new("fix the bug");
         let input = task_input(
+            &prompt,
             vec![ContentItem::InputText {
                 text: "fix the bug".into(),
             }],
@@ -171,6 +195,39 @@ mod tests {
                     }],
                 }),
             ]),
+        );
+    }
+
+    #[test]
+    fn task_input_preserves_synthetic_message_roles() {
+        let context =
+            ContextSnapshot::capture_at("/workspace", "bash", None, "2026-08-05", "Etc/UTC");
+        let prompt = Prompt::new("return the second answer").with_transcript([
+            PromptMessage::user("question one"),
+            PromptMessage::assistant("answer one"),
+            PromptMessage::user("question two"),
+            PromptMessage::assistant("answer two"),
+        ]);
+        let input = task_input(
+            &prompt,
+            vec![ContentItem::input_text("return the second answer")],
+            &context,
+        );
+
+        let roles = input
+            .iter()
+            .skip(2)
+            .map(|item| serde_json::to_value(item).unwrap()["role"].clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            roles,
+            vec![
+                json!("user"),
+                json!("assistant"),
+                json!("user"),
+                json!("assistant"),
+                json!("user")
+            ]
         );
     }
 

--- a/crates/nanocodex-agent/src/model/input.rs
+++ b/crates/nanocodex-agent/src/model/input.rs
@@ -232,6 +232,31 @@ mod tests {
     }
 
     #[test]
+    fn task_input_preserves_consecutive_synthetic_user_messages() {
+        let prompt = Prompt::new("continue").with_transcript([
+            PromptMessage::user("benchmark preamble"),
+            PromptMessage::user("question"),
+            PromptMessage::assistant("answer"),
+        ]);
+
+        let input = prompt_messages(&prompt, vec![ContentItem::input_text("continue")]);
+        let roles = input
+            .iter()
+            .map(|item| serde_json::to_value(item).unwrap()["role"].clone())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            roles,
+            vec![
+                json!("user"),
+                json!("user"),
+                json!("assistant"),
+                json!("user")
+            ]
+        );
+    }
+
+    #[test]
     fn turn_aborted_matches_codex_context_shape() {
         assert_eq!(
             serde_json::to_value(turn_aborted()).unwrap(),

--- a/crates/nanocodex-agent/src/model/run/mod.rs
+++ b/crates/nanocodex-agent/src/model/run/mod.rs
@@ -48,7 +48,7 @@ use super::{
     display_endpoint, elapsed_ns,
     input::{
         custom_tool_notification, custom_tool_output, developer_context, function_tool_output,
-        task_input, tool_search_output, turn_aborted,
+        prompt_messages, task_input, tool_search_output, turn_aborted,
     },
     terminal_payload,
 };

--- a/crates/nanocodex-agent/src/model/run/turn.rs
+++ b/crates/nanocodex-agent/src/model/run/turn.rs
@@ -115,7 +115,7 @@ where
                 orchestration: ModelConfig::orchestration(),
                 websocket_url: display_endpoint(self.responses_endpoint()),
                 workspace,
-                instruction_bytes: task.instruction.text_bytes(),
+                instruction_bytes: task.text_bytes(),
             },
         )?;
         let error = NanocodexError::TurnCancelled;
@@ -170,7 +170,7 @@ where
                 orchestration: ModelConfig::orchestration(),
                 websocket_url: display_endpoint(self.responses_endpoint()),
                 workspace: workspace.as_deref(),
-                instruction_bytes: task.instruction.text_bytes(),
+                instruction_bytes: task.text_bytes(),
             },
         )?;
 
@@ -329,7 +329,7 @@ where
             let user_content = prepare_user_input(&task.instruction).await;
             session
                 .conversation
-                .append([ResponseItem::message(MessageRole::User, user_content)]);
+                .append(prompt_messages(task, user_content));
             return Ok(false);
         };
         if compacted || session.preserve_inherited_delta {
@@ -365,7 +365,7 @@ where
         let user_content = prepare_user_input(&task.instruction).await;
         session
             .conversation
-            .append([ResponseItem::message(MessageRole::User, user_content)]);
+            .append(prompt_messages(task, user_content));
         Ok(true)
     }
 
@@ -426,13 +426,9 @@ where
                 tools.default_shell_name(),
                 self.context_source.execution_environment(),
             );
-            let mut history = task_input(user_content, &context_snapshot);
+            let mut history = task_input(&task, user_content, &context_snapshot);
             if !self.pending_developer_messages.is_empty() {
-                let user = history
-                    .pop()
-                    .expect("task input always ends with user input");
-                history.append(&mut self.pending_developer_messages);
-                history.push(user);
+                history.splice(2..2, self.pending_developer_messages.drain(..));
             }
             context.establish(context_snapshot);
             let conversation = ConversationState::new(history)?;
@@ -747,9 +743,9 @@ where
                     "turn content"
                 );
             }
-            let instruction_bytes = steer.instruction.text_bytes();
+            let instruction_bytes = steer.text_bytes();
             let user_content = prepare_user_input(&steer.instruction).await;
-            conversation.append([ResponseItem::message(MessageRole::User, user_content)]);
+            conversation.append(prompt_messages(&steer, user_content));
             self.stats.steers += 1;
             self.events.emit(
                 AgentEventKind::RunSteered,

--- a/crates/nanocodex-oai-api/src/lib.rs
+++ b/crates/nanocodex-oai-api/src/lib.rs
@@ -222,6 +222,9 @@ pub const CONTEXT_WINDOW_TOKENS: u64 = 272_000;
 pub struct Prompt {
     /// Ordered text and multimodal content for this turn.
     pub instruction: PromptInput,
+    /// Synthetic text-only conversation supplied before this turn.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    transcript: Vec<PromptMessage>,
 }
 
 impl Prompt {
@@ -230,6 +233,7 @@ impl Prompt {
     pub fn new(instruction: impl Into<String>) -> Self {
         Self {
             instruction: PromptInput::Text(instruction.into()),
+            transcript: Vec::new(),
         }
     }
 
@@ -238,8 +242,145 @@ impl Prompt {
     pub fn content(input: impl IntoIterator<Item = UserInput>) -> Self {
         Self {
             instruction: PromptInput::Content(input.into_iter().collect()),
+            transcript: Vec::new(),
         }
     }
+
+    /// Prepends an explicit text-only conversation to this turn.
+    ///
+    /// This is intended for synthetic conversation benchmarks. Normal
+    /// follow-on turns should continue to rely on the agent's retained
+    /// session history.
+    #[must_use]
+    pub fn with_transcript(mut self, messages: impl IntoIterator<Item = PromptMessage>) -> Self {
+        self.transcript = messages.into_iter().collect();
+        self
+    }
+
+    /// Returns the synthetic conversation preceding this turn.
+    #[must_use]
+    pub fn transcript(&self) -> &[PromptMessage] {
+        &self.transcript
+    }
+
+    /// Returns the total UTF-8 byte length of model-visible text.
+    #[must_use]
+    pub fn text_bytes(&self) -> usize {
+        self.transcript
+            .iter()
+            .map(PromptMessage::text_bytes)
+            .sum::<usize>()
+            .saturating_add(self.instruction.text_bytes())
+    }
+
+    /// Returns whether the turn instruction contains no usable content.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.instruction.is_empty()
+    }
+
+    /// Validates the instruction and synthetic transcript invariants.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed failure for empty text or a transcript that does not
+    /// alternate from user to assistant before the final user instruction.
+    pub fn validate(&self) -> Result<(), PromptValidationError> {
+        if self.instruction.is_empty() {
+            return Err(PromptValidationError::EmptyInstruction);
+        }
+        if self.transcript.iter().any(PromptMessage::is_empty) {
+            return Err(PromptValidationError::EmptyTranscriptMessage);
+        }
+        if self
+            .transcript
+            .first()
+            .is_some_and(|message| message.role() != PromptMessageRole::User)
+            || self
+                .transcript
+                .last()
+                .is_some_and(|message| message.role() != PromptMessageRole::Assistant)
+            || !self
+                .transcript
+                .windows(2)
+                .all(|pair| pair[0].role() != pair[1].role())
+        {
+            return Err(PromptValidationError::InvalidTranscriptOrdering);
+        }
+        Ok(())
+    }
+}
+
+/// Invalid model-visible prompt content.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum PromptValidationError {
+    /// The final user instruction has no usable content.
+    #[error("prompt instruction must not be empty")]
+    EmptyInstruction,
+    /// One synthetic message has no usable content.
+    #[error("prompt transcript messages must not be empty")]
+    EmptyTranscriptMessage,
+    /// Synthetic messages do not form complete user/assistant pairs.
+    #[error("prompt transcript must alternate user and assistant messages in complete pairs")]
+    InvalidTranscriptOrdering,
+}
+
+/// One text-only message in a synthetic prompt transcript.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PromptMessage {
+    role: PromptMessageRole,
+    content: String,
+}
+
+impl PromptMessage {
+    /// Creates a synthetic user message.
+    #[must_use]
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            role: PromptMessageRole::User,
+            content: content.into(),
+        }
+    }
+
+    /// Creates a synthetic assistant message.
+    #[must_use]
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            role: PromptMessageRole::Assistant,
+            content: content.into(),
+        }
+    }
+
+    /// Returns the message role.
+    #[must_use]
+    pub const fn role(&self) -> PromptMessageRole {
+        self.role
+    }
+
+    /// Returns the complete message text.
+    #[must_use]
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+
+    const fn text_bytes(&self) -> usize {
+        self.content.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.content.trim().is_empty()
+    }
+}
+
+/// Role of one message in a synthetic prompt transcript.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PromptMessageRole {
+    /// User-supplied text.
+    User,
+    /// Assistant text supplied by the benchmark.
+    Assistant,
 }
 
 impl From<String> for Prompt {
@@ -508,7 +649,7 @@ impl FromStr for Thinking {
 mod tests {
     use serde_json::json;
 
-    use super::{Model, Prompt, ReasoningMode, Thinking};
+    use super::{Model, Prompt, PromptMessage, PromptValidationError, ReasoningMode, Thinking};
 
     #[test]
     fn model_parses_short_and_api_names() {
@@ -544,6 +685,42 @@ mod tests {
         assert_eq!(
             serde_json::to_value(prompt).unwrap(),
             json!({ "instruction": "inspect the repository" })
+        );
+    }
+
+    #[test]
+    fn synthetic_transcript_is_typed_serialized_and_counted() {
+        let prompt = Prompt::new("repeat the second answer").with_transcript([
+            PromptMessage::user("first request"),
+            PromptMessage::assistant("first answer"),
+            PromptMessage::user("second request"),
+            PromptMessage::assistant("second answer"),
+        ]);
+
+        assert_eq!(prompt.validate(), Ok(()));
+        assert_eq!(prompt.text_bytes(), 76);
+        assert_eq!(
+            serde_json::to_value(prompt).unwrap(),
+            json!({
+                "instruction": "repeat the second answer",
+                "transcript": [
+                    {"role": "user", "content": "first request"},
+                    {"role": "assistant", "content": "first answer"},
+                    {"role": "user", "content": "second request"},
+                    {"role": "assistant", "content": "second answer"},
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn synthetic_transcript_requires_complete_pairs() {
+        let prompt =
+            Prompt::new("continue").with_transcript([PromptMessage::user("unanswered request")]);
+
+        assert_eq!(
+            prompt.validate(),
+            Err(PromptValidationError::InvalidTranscriptOrdering)
         );
     }
 

--- a/crates/nanocodex-oai-api/src/lib.rs
+++ b/crates/nanocodex-oai-api/src/lib.rs
@@ -284,7 +284,9 @@ impl Prompt {
     /// # Errors
     ///
     /// Returns a typed failure for empty text or a transcript that does not
-    /// alternate from user to assistant before the final user instruction.
+    /// start with user input and end with assistant output before the final
+    /// user instruction. Consecutive messages with the same role are retained
+    /// because benchmark transcripts may contain them intentionally.
     pub fn validate(&self) -> Result<(), PromptValidationError> {
         if self.instruction.is_empty() {
             return Err(PromptValidationError::EmptyInstruction);
@@ -300,12 +302,8 @@ impl Prompt {
                 .transcript
                 .last()
                 .is_some_and(|message| message.role() != PromptMessageRole::Assistant)
-            || !self
-                .transcript
-                .windows(2)
-                .all(|pair| pair[0].role() != pair[1].role())
         {
-            return Err(PromptValidationError::InvalidTranscriptOrdering);
+            return Err(PromptValidationError::InvalidTranscriptEndpoints);
         }
         Ok(())
     }
@@ -320,9 +318,9 @@ pub enum PromptValidationError {
     /// One synthetic message has no usable content.
     #[error("prompt transcript messages must not be empty")]
     EmptyTranscriptMessage,
-    /// Synthetic messages do not form complete user/assistant pairs.
-    #[error("prompt transcript must alternate user and assistant messages in complete pairs")]
-    InvalidTranscriptOrdering,
+    /// Synthetic messages do not begin with user input and end with assistant output.
+    #[error("prompt transcript must start with a user message and end with an assistant message")]
+    InvalidTranscriptEndpoints,
 }
 
 /// One text-only message in a synthetic prompt transcript.
@@ -714,14 +712,26 @@ mod tests {
     }
 
     #[test]
-    fn synthetic_transcript_requires_complete_pairs() {
+    fn synthetic_transcript_requires_user_and_assistant_endpoints() {
         let prompt =
             Prompt::new("continue").with_transcript([PromptMessage::user("unanswered request")]);
 
         assert_eq!(
             prompt.validate(),
-            Err(PromptValidationError::InvalidTranscriptOrdering)
+            Err(PromptValidationError::InvalidTranscriptEndpoints)
         );
+    }
+
+    #[test]
+    fn synthetic_transcript_preserves_consecutive_same_role_messages() {
+        let prompt = Prompt::new("continue").with_transcript([
+            PromptMessage::user("benchmark preamble"),
+            PromptMessage::user("first request"),
+            PromptMessage::assistant("first answer"),
+        ]);
+
+        assert_eq!(prompt.validate(), Ok(()));
+        assert_eq!(prompt.transcript().len(), 3);
     }
 
     #[test]

--- a/crates/nanocodex-oai-api/src/transport/http.rs
+++ b/crates/nanocodex-oai-api/src/transport/http.rs
@@ -10,7 +10,7 @@ use crate::{EncodedRequest, ResponsesError, socket::ReceivedText};
 const EVENT_IDLE_TIMEOUT: Duration = if cfg!(test) {
     Duration::from_millis(100)
 } else {
-    Duration::from_secs(60)
+    Duration::from_mins(5)
 };
 const RESPONSES_LITE_HEADER: &str = "x-openai-internal-codex-responses-lite";
 const TURN_STATE_HEADER: &str = "x-codex-turn-state";

--- a/crates/nanocodex-oai-api/src/transport/socket.rs
+++ b/crates/nanocodex-oai-api/src/transport/socket.rs
@@ -24,7 +24,7 @@ const SEND_TIMEOUT: Duration = Duration::from_secs(30);
 const EVENT_IDLE_TIMEOUT: Duration = if cfg!(test) {
     Duration::from_millis(100)
 } else {
-    Duration::from_secs(60)
+    Duration::from_mins(5)
 };
 const SOCKET_MESSAGE_CAPACITY: usize = 32;
 const RESPONSES_WEBSOCKETS_BETA: &str = "responses_websockets=2026-02-06";

--- a/js/bindings/test/package.test.mjs
+++ b/js/bindings/test/package.test.mjs
@@ -36,7 +36,7 @@ test("the packed package installs and runs every public entry point", async () =
     assert.equal(packed.version, packageJson.version);
     assert.ok(packed.size <= 1_100_000, `compressed package grew to ${packed.size} bytes`);
     assert.ok(
-      packed.unpackedSize <= 4_920_000,
+      packed.unpackedSize <= 4_940_000,
       `unpacked package grew to ${packed.unpackedSize} bytes`,
     );
     assert.equal(


### PR DESCRIPTION
Rebuilds the shared benchmark-import boundary from #72 on current master.

This PR intentionally contains no benchmark-specific acquisition recipe. It adds the immutable imported-task representation, transcript and verifier contracts required by the adapters, and lets profiles name adapter-owned benchmark selectors before durable SQLite rows are created.

Live dev-host validation also hardened two shared boundaries:
- lifecycle failures such as agent timeout and infrastructure error are retained and requeued even if a verifier emits a positive floor reward
- tar archive options for excluded candidate artifacts are emitted before the path terminator, preserving safe option-shaped paths and allowing GDPval evidence staging

Validation at the final stacked tip:
- cargo fmt --all -- --check
- cargo test -p nanocodex-eval-adapters -p nanocodex-eval --lib (103 eval tests, 31 adapter tests)
- cargo test -p nanocodex-bin lifecycle_failures_cannot_become_scored_successes
- cargo clippy -p nanocodex-eval -p nanocodex-eval-adapters -p nanocodex-bin --all-targets -- -D warnings
- cargo check --locked -p nanocodex-examples --bins
- scripts/check-crate-boundaries.sh