### PR TITLE
feat(eval): add Harbor benchmark adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5287,6 +5287,7 @@ name = "nanocodex-eval-adapters"
 version = "0.3.0"
 dependencies = [
  "hex",
+ "ignore",
  "nanocodex-eval",
  "sha2 0.11.0",
  "tempfile",

--- a/crates/experimental/nanocodex-eval-adapters/Cargo.toml
+++ b/crates/experimental/nanocodex-eval-adapters/Cargo.toml
@@ -12,6 +12,7 @@ description = "Third-party benchmark adapters for nanocodex-eval"
 
 [dependencies]
 hex.workspace = true
+ignore.workspace = true
 nanocodex-eval.workspace = true
 sha2.workspace = true
 tempfile.workspace = true

--- a/crates/experimental/nanocodex-eval-adapters/src/harbor.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/harbor.rs
@@ -1,0 +1,111 @@
+use std::path::{Path, PathBuf};
+
+use nanocodex_eval::{
+    Task,
+    import::{CasePlan, DatasetImporter, DatasetPlan, ImportError, SourceIdentity},
+};
+
+use crate::{safe_case_id, sha256_values};
+
+/// Lossless importer for Harbor task packages, including Terminal-Bench,
+/// Frontier-Bench, and StableBench datasets.
+#[derive(Clone, Debug)]
+pub struct HarborDataset {
+    name: Box<str>,
+    root: PathBuf,
+    revision: Box<str>,
+}
+
+impl HarborDataset {
+    /// Creates an importer for one Harbor task or suite directory.
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        root: impl Into<PathBuf>,
+        revision: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into().into_boxed_str(),
+            root: root.into(),
+            revision: revision.into().into_boxed_str(),
+        }
+    }
+}
+
+impl DatasetImporter for HarborDataset {
+    fn plan(&self) -> Result<DatasetPlan, ImportError> {
+        let roots = discover_tasks(&self.root)?;
+        if roots.is_empty() {
+            return Err(ImportError::Invalid(format!(
+                "no Harbor task.toml files found under {}",
+                self.root.display()
+            )));
+        }
+        let mut loaded = Vec::with_capacity(roots.len());
+        for root in roots {
+            let task = Task::load(&root)?;
+            let id = safe_case_id(task.name());
+            loaded.push((id, root, task.package_digest().to_owned()));
+        }
+        let source_digest = sha256_values(
+            loaded
+                .iter()
+                .flat_map(|(id, _, digest)| [id.as_bytes(), digest.as_bytes()]),
+        );
+        let source = SourceIdentity::new("harbor", self.revision.as_ref(), source_digest)?;
+        let mut plan = DatasetPlan::new(self.name.as_ref(), source)?;
+        for (id, root, _) in loaded {
+            plan = plan.case(CasePlan::existing(id, root)?);
+        }
+        Ok(plan)
+    }
+}
+
+fn discover_tasks(root: &Path) -> Result<Vec<PathBuf>, ImportError> {
+    if root.join("task.toml").is_file() {
+        return Ok(vec![root.to_path_buf()]);
+    }
+    let mut tasks = Vec::new();
+    for entry in ignore::WalkBuilder::new(root)
+        .hidden(false)
+        .git_ignore(true)
+        .git_exclude(true)
+        .parents(true)
+        .follow_links(false)
+        .filter_entry(|entry| entry.file_name() != ".git")
+        .build()
+    {
+        let entry = entry.map_err(|error| {
+            ImportError::Invalid(format!("failed to walk {}: {error}", root.display()))
+        })?;
+        if entry.file_type().is_some_and(|kind| kind.is_file())
+            && entry.file_name() == "task.toml"
+            && let Some(parent) = entry.path().parent()
+        {
+            tasks.push(parent.to_path_buf());
+        }
+    }
+    tasks.sort();
+    tasks.dedup();
+    Ok(tasks)
+}
+
+#[cfg(test)]
+mod tests {
+    use nanocodex_eval::import::ImportStore;
+
+    use super::*;
+
+    #[test]
+    fn imports_an_existing_task_package_without_rewriting_it() {
+        let task = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../tasks/write-greeting");
+        let store = tempfile::tempdir().unwrap();
+
+        let imported = ImportStore::new(store.path())
+            .import(&HarborDataset::new("fixture", task, "fixture@1"))
+            .unwrap();
+
+        assert_eq!(imported.tasks().len(), 1);
+        assert_eq!(imported.tasks()[0].name(), "nanoeval/write-greeting");
+    }
+}

--- a/crates/experimental/nanocodex-eval-adapters/src/lib.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
+mod harbor;
 mod source;
 
 use std::{
@@ -73,7 +74,55 @@ struct InstalledAdapter {
     matches: fn(&str, &str) -> bool,
 }
 
-const INSTALLED_ADAPTERS: &[InstalledAdapter] = &[];
+const INSTALLED_ADAPTERS: &[InstalledAdapter] = &[InstalledAdapter {
+    names: &["terminal-bench-2.1", "deep-swe-v1.1"],
+    import: import_harbor,
+    matches: matches_harbor_task,
+}];
+
+const TERMINAL_BENCH_REVISION: &str = "5c8eadf1f393183288fa08b8f73ca9a469cc5e00";
+const DEEP_SWE_REVISION: &str = "e016041a6ccf8da29906afc9a3f5a8df940a1f78";
+
+fn import_harbor(
+    request: &BenchmarkRequest,
+    sources: &SourceStore,
+    store: &ImportStore,
+) -> Result<ImportedDataset, AdapterError> {
+    let (root, revision) = match request.name.as_str() {
+        "terminal-bench-2.1" => (
+            sources
+                .git_checkout(
+                    "terminal-bench-2-1",
+                    "https://github.com/harbor-framework/terminal-bench-2-1.git",
+                    TERMINAL_BENCH_REVISION,
+                )?
+                .join("tasks"),
+            format!("harbor-framework/terminal-bench-2-1@{TERMINAL_BENCH_REVISION}"),
+        ),
+        "deep-swe-v1.1" => (
+            sources
+                .git_checkout(
+                    "deep-swe",
+                    "https://github.com/datacurve-ai/deep-swe.git",
+                    DEEP_SWE_REVISION,
+                )?
+                .join("tasks"),
+            format!("datacurve-ai/deep-swe@{DEEP_SWE_REVISION}"),
+        ),
+        _ => return Err(AdapterError::UnknownBenchmark(request.name.clone())),
+    };
+    Ok(store.import(&harbor::HarborDataset::new(&request.name, root, revision))?)
+}
+
+fn matches_harbor_task(selected: &str, normalized: &str) -> bool {
+    selected == normalized
+        || normalized
+            .strip_prefix("terminal-bench/")
+            .is_some_and(|task| task == selected)
+        || normalized
+            .strip_prefix("datacurve/")
+            .is_some_and(|task| task == selected)
+}
 
 impl AdapterCatalog {
     /// Uses `imports/` and `sources/` below one durable evaluator state root.
@@ -253,5 +302,14 @@ mod tests {
         let error = parse_requests(&["one/*".to_owned(), "one/a".to_owned()]).unwrap_err();
 
         assert!(error.to_string().contains("mixes *"));
+    }
+
+    #[test]
+    fn harbor_selectors_hide_upstream_name_prefixes() {
+        assert!(matches_harbor_task("fix-git", "terminal-bench/fix-git"));
+        assert!(matches_harbor_task(
+            "aiomonitor-task-snapshots-diff",
+            "datacurve/aiomonitor-task-snapshots-diff"
+        ));
     }
 }

--- a/nanocodex.toml
+++ b/nanocodex.toml
@@ -5,3 +5,15 @@ tasks = ["tasks/write-greeting"]
 trials = 2
 model = ["sol", "luna"]
 thinking = ["low", "medium"]
+
+[profiles.terminal-bench-smoke]
+benchmarks = ["terminal-bench-2.1/fix-git"]
+trials = 1
+model = ["sol"]
+thinking = ["high"]
+
+[profiles.deep-swe-smoke]
+benchmarks = ["deep-swe-v1.1/aiomonitor-task-snapshots-diff"]
+trials = 1
+model = ["sol"]
+thinking = ["high"]


### PR DESCRIPTION
First adapter split from #72.

Adds one lossless Harbor task-package adapter with pinned recipes for:
- Terminal-Bench 2.1
- DeepSWE v1.1

Profiles can select an exact case or all cases through `benchmarks = ["terminal-bench-2.1/fix-git"]` / `benchmarks = ["terminal-bench-2.1/*"]`. The checked-in smoke profiles cover both routes.

Validation:
- cargo fmt --all
- cargo test -p nanocodex-eval-adapters (4 passed)
- cargo clippy -p nanocodex-eval-adapters --all-targets -- -D warnings

Stacked on #142; the stack is rooted at current master.