### PR TITLE
feat(eval): add SWE-bench adapter

### DIFF
--- a/crates/experimental/nanocodex-eval-adapters/assets/swe-bench/grade.py
+++ b/crates/experimental/nanocodex-eval-adapters/assets/swe-bench/grade.py
@@ -1,0 +1,56 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+def run(command, *, check=True):
+    return subprocess.run(
+        command,
+        cwd=workspace,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+
+workspace = Path(os.environ["NANOCODEX_EVAL_WORKSPACE"])
+logs = Path(os.environ.get("NANOCODEX_EVAL_VERIFIER_LOGS", "/logs/verifier"))
+logs.mkdir(parents=True, exist_ok=True)
+case = json.loads(Path("/tests/instance.json").read_text())
+
+# Preserve the candidate delta, install the benchmark's hidden test patch on a
+# clean base, and then restore the candidate delta exactly as the official
+# SWE-bench evaluation order requires.
+run(["git", "add", "-N", "."], check=False)
+candidate_patch = run(["git", "diff", "--binary", case["base_commit"]]).stdout
+(logs / "candidate.patch").write_text(candidate_patch)
+run(["git", "reset", "--hard", case["base_commit"]])
+run(["git", "clean", "-fd"])
+(logs / "test.patch").write_text(case["test_patch"])
+run(["git", "apply", str(logs / "test.patch")])
+if candidate_patch:
+    run(["git", "apply", str(logs / "candidate.patch")])
+
+fail_to_pass = json.loads(case["FAIL_TO_PASS"])
+pass_to_pass = json.loads(case["PASS_TO_PASS"])
+tests = fail_to_pass + pass_to_pass
+result = run(["python", "-m", "pytest", "-rA", *tests], check=False)
+(logs / "test-output.txt").write_text(result.stdout)
+reward = 1.0 if result.returncode == 0 else 0.0
+(logs / "swe-bench.json").write_text(
+    json.dumps(
+        {
+            "instance_id": case["instance_id"],
+            "base_commit": case["base_commit"],
+            "version": case["version"],
+            "fail_to_pass": fail_to_pass,
+            "pass_to_pass": pass_to_pass,
+            "exit_code": result.returncode,
+            "resolved": bool(reward),
+        },
+        indent=2,
+    )
+)
+(logs / "reward.txt").write_text(f"{reward}\n")

--- a/crates/experimental/nanocodex-eval-adapters/assets/swe-bench/test.sh
+++ b/crates/experimental/nanocodex-eval-adapters/assets/swe-bench/test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ -f /opt/miniconda3/etc/profile.d/conda.sh ]]; then
+  source /opt/miniconda3/etc/profile.d/conda.sh
+  conda activate testbed
+elif [[ -f /root/miniconda3/etc/profile.d/conda.sh ]]; then
+  source /root/miniconda3/etc/profile.d/conda.sh
+  conda activate testbed
+fi
+
+python /tests/grade.py

--- a/crates/experimental/nanocodex-eval-adapters/src/lib.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/lib.rs
@@ -9,6 +9,7 @@
 mod arena_hard;
 mod harbor;
 mod source;
+mod swe_bench;
 
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -89,11 +90,18 @@ const INSTALLED_ADAPTERS: &[InstalledAdapter] = &[
         import: import_arena_hard,
         matches: exact_task,
     },
+    InstalledAdapter {
+        names: &["swe-bench-verified-smoke"],
+        import: import_swe_bench,
+        matches: exact_task,
+    },
 ];
 
 const TERMINAL_BENCH_REVISION: &str = "5c8eadf1f393183288fa08b8f73ca9a469cc5e00";
 const DEEP_SWE_REVISION: &str = "e016041a6ccf8da29906afc9a3f5a8df940a1f78";
 const ARENA_HARD_REVISION: &str = "196f6b826783b3da7310e361a805fa36f0be83f3";
+const SWE_VERIFIED_ROW_RESPONSE_SHA256: &str =
+    "7c62220a467830a3a330dda51211ab4c1ba099124dffc8371fbec057933c47b8";
 
 fn import_harbor(
     request: &BenchmarkRequest,
@@ -155,6 +163,44 @@ fn import_arena_hard(
         nanocodex_eval::import::Harness::directory(assets)?,
     )
     .baseline_answers(source.join("data/arena-hard-v2.0/model_answer/o3-mini-2025-01-31.jsonl"));
+    Ok(store.import(&importer)?)
+}
+
+fn import_swe_bench(
+    request: &BenchmarkRequest,
+    sources: &SourceStore,
+    store: &ImportStore,
+) -> Result<ImportedDataset, AdapterError> {
+    let response = sources.download(
+        "swe-bench/swe-bench-verified-smoke.response.json",
+        "https://datasets-server.huggingface.co/rows?dataset=princeton-nlp/SWE-bench_Verified&config=default&split=test&offset=0&length=1",
+        SWE_VERIFIED_ROW_RESPONSE_SHA256,
+    )?;
+    let document: serde_json::Value =
+        serde_json::from_slice(&fs::read(&response).map_err(|error| {
+            AdapterError::Source(format!("failed to read {}: {error}", response.display()))
+        })?)
+        .map_err(|error| AdapterError::Source(error.to_string()))?;
+    let row = document
+        .get("rows")
+        .and_then(serde_json::Value::as_array)
+        .and_then(|rows| rows.first())
+        .and_then(|entry| entry.get("row"))
+        .ok_or_else(|| AdapterError::Source("SWE-bench response has no first row".to_owned()))?;
+    let mut bytes =
+        serde_json::to_vec(row).map_err(|error| AdapterError::Source(error.to_string()))?;
+    bytes.push(b'\n');
+    let instances = sources.write_verified("swe-bench/swe-bench-verified-smoke.jsonl", &bytes)?;
+    let harness = nanocodex_eval::import::Harness::directory(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/swe-bench"),
+    )?;
+    let importer = swe_bench::SweBench::new(
+        &request.name,
+        instances,
+        "princeton-nlp/SWE-bench_Verified@c104f840cc67f8b6eec6f759ebc8b2693d585d4a",
+        "swebench",
+        harness,
+    );
     Ok(store.import(&importer)?)
 }
 

--- a/crates/experimental/nanocodex-eval-adapters/src/swe_bench.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/swe_bench.rs
@@ -1,0 +1,139 @@
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use nanocodex_eval::import::{
+    CasePlan, DatasetImporter, DatasetPlan, Environment, Harness, ImportError, SourceIdentity,
+};
+
+use crate::{read_json_lines, safe_case_id, sha256_file, sha256_values};
+
+/// SWE-bench instance importer using official prebuilt instance images and a
+/// caller-packaged official evaluation harness.
+#[derive(Clone, Debug)]
+pub struct SweBench {
+    name: Box<str>,
+    instances: PathBuf,
+    revision: Box<str>,
+    namespace: Box<str>,
+    architecture: Box<str>,
+    image_tag: Box<str>,
+    harness: Harness,
+}
+
+impl SweBench {
+    /// Creates an importer for SWE-bench dataset JSONL.
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        instances_jsonl: impl Into<PathBuf>,
+        revision: impl Into<String>,
+        namespace: impl Into<String>,
+        harness: Harness,
+    ) -> Self {
+        Self {
+            name: name.into().into_boxed_str(),
+            instances: instances_jsonl.into(),
+            revision: revision.into().into_boxed_str(),
+            namespace: namespace.into().into_boxed_str(),
+            architecture: "x86_64".into(),
+            image_tag: "latest".into(),
+            harness,
+        }
+    }
+}
+
+impl DatasetImporter for SweBench {
+    fn plan(&self) -> Result<DatasetPlan, ImportError> {
+        let instances = read_json_lines::<SweInstance>(&self.instances)?;
+        let source_digest = sha256_values([
+            sha256_file(&self.instances)?,
+            self.namespace.to_string(),
+            self.architecture.to_string(),
+            self.image_tag.to_string(),
+        ]);
+        let source = SourceIdentity::new("swe-bench", self.revision.as_ref(), source_digest)?;
+        let mut plan = DatasetPlan::new(self.name.as_ref(), source)?;
+        for instance in instances {
+            let encoded = instance.instance_id.to_lowercase().replace("__", "_1776_");
+            let image = format!(
+                "{}/sweb.eval.{}.{}:{}",
+                self.namespace, self.architecture, encoded, self.image_tag
+            );
+            let metadata = serde_json::to_vec(&instance).map_err(|source| ImportError::Json {
+                path: self.instances.clone(),
+                source,
+            })?;
+            plan = plan.case(
+                CasePlan::hermetic(
+                    safe_case_id(&instance.instance_id),
+                    instance.problem_statement.clone(),
+                    Environment::OciImage(image),
+                    self.harness.clone(),
+                )?
+                .harness_file("instance.json", metadata, 0o600)?,
+            );
+        }
+        Ok(plan)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, serde::Serialize)]
+struct SweInstance {
+    instance_id: String,
+    problem_statement: String,
+    repo: String,
+    base_commit: String,
+    version: String,
+    patch: String,
+    test_patch: String,
+    #[serde(default)]
+    hints_text: String,
+    #[serde(default, rename = "FAIL_TO_PASS")]
+    fail_to_pass: serde_json::Value,
+    #[serde(default, rename = "PASS_TO_PASS")]
+    pass_to_pass: serde_json::Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use nanocodex_eval::import::ImportStore;
+
+    use super::*;
+
+    #[test]
+    fn preserves_official_instance_metadata_and_image_identity() {
+        let source = tempfile::tempdir().unwrap();
+        let instances = source.path().join("instances.jsonl");
+        fs::write(
+            &instances,
+            r#"{"instance_id":"org__repo-1","problem_statement":"Fix it.","repo":"org/repo","base_commit":"abc","version":"1","patch":"","test_patch":"","FAIL_TO_PASS":"[]","PASS_TO_PASS":"[]"}
+"#,
+        )
+        .unwrap();
+        let harness =
+            Harness::directory(Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/swe-bench"))
+                .unwrap();
+        let store = tempfile::tempdir().unwrap();
+
+        let imported = ImportStore::new(store.path())
+            .import(&SweBench::new(
+                "swe-bench",
+                instances,
+                "fixture@1",
+                "swebench",
+                harness,
+            ))
+            .unwrap();
+
+        assert_eq!(imported.tasks()[0].name(), "org__repo-1");
+        assert!(
+            imported.tasks()[0]
+                .root()
+                .join("tests/instance.json")
+                .is_file()
+        );
+    }
+}

--- a/nanocodex.toml
+++ b/nanocodex.toml
@@ -23,3 +23,9 @@ benchmarks = ["arena-hard-v2/2edbb5f36f5b42be"]
 trials = 1
 model = ["sol"]
 thinking = ["high"]
+
+[profiles.swe-bench-smoke]
+benchmarks = ["swe-bench-verified-smoke/astropy__astropy-12907"]
+trials = 1
+model = ["sol"]
+thinking = ["high"]


### PR DESCRIPTION
Adapter split from #72.

Adds one pinned SWE-bench Verified smoke source, official instance-image mapping, immutable instance metadata, and verifier-owned hidden-test application. Includes an exact astropy smoke profile.

Validation:
- cargo fmt --all
- cargo test -p nanocodex-eval-adapters (6 passed)
- cargo clippy -p nanocodex-eval-adapters --all-targets -- -D warnings

Stacked on #144.