### PR TITLE
feat(eval): add GeneBench Pro adapter

### DIFF
--- a/crates/experimental/nanocodex-eval-adapters/assets/genebench-pro/environment/Dockerfile
+++ b/crates/experimental/nanocodex-eval-adapters/assets/genebench-pro/environment/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim-bookworm
+
+RUN python -m pip install --no-cache-dir \
+    numpy==2.3.2 \
+    pandas==2.3.1 \
+    scipy==1.16.1 \
+    scikit-learn==1.7.1 \
+    statsmodels==0.14.5
+
+WORKDIR /workspace
+COPY data_files/ /workspace/data_files/

--- a/crates/experimental/nanocodex-eval-adapters/assets/genebench-pro/verifier/Dockerfile
+++ b/crates/experimental/nanocodex-eval-adapters/assets/genebench-pro/verifier/Dockerfile
@@ -1,0 +1,1 @@
+FROM python:3.12-slim-bookworm

--- a/crates/experimental/nanocodex-eval-adapters/assets/genebench-pro/verifier/grade.py
+++ b/crates/experimental/nanocodex-eval-adapters/assets/genebench-pro/verifier/grade.py
@@ -1,0 +1,32 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+workspace = Path(os.environ["NANOCODEX_EVAL_WORKSPACE"])
+logs = Path(os.environ["NANOCODEX_EVAL_VERIFIER_LOGS"])
+completed = subprocess.run(
+    [
+        sys.executable,
+        "/tests/reference_grader.py",
+        "/tests/eval_config.json",
+        str(workspace / "answer.txt"),
+    ],
+    check=False,
+    capture_output=True,
+    text=True,
+)
+(logs / "official-grader.stdout.json").write_text(completed.stdout)
+(logs / "official-grader.stderr.txt").write_text(completed.stderr)
+
+passed = False
+if completed.returncode == 0:
+    try:
+        result = json.loads(completed.stdout)
+        passed = result.get("passed") is True
+    except (json.JSONDecodeError, AttributeError):
+        pass
+
+(logs / "reward.json").write_text(json.dumps({"reward": 1.0 if passed else 0.0}) + "\n")

--- a/crates/experimental/nanocodex-eval-adapters/assets/genebench-pro/verifier/test.sh
+++ b/crates/experimental/nanocodex-eval-adapters/assets/genebench-pro/verifier/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+python3 /tests/grade.py

--- a/crates/experimental/nanocodex-eval-adapters/src/genebench_pro.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/genebench_pro.rs
@@ -1,0 +1,322 @@
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Component, Path, PathBuf},
+    time::Duration,
+};
+
+use nanocodex_eval::{
+    Resources, TaskOutput,
+    import::{
+        CasePlan, DatasetImporter, DatasetPlan, Environment, Harness, ImportError, SourceIdentity,
+    },
+};
+use serde::Deserialize;
+use sha2::{Digest as _, Sha256};
+
+use crate::sha256_values;
+
+/// OpenAI's public GeneBench-Pro case-study package.
+#[derive(Clone, Debug)]
+pub struct GeneBenchPro {
+    package: PathBuf,
+    revision: String,
+    environment: Environment,
+    harness: Harness,
+}
+
+impl GeneBenchPro {
+    /// Creates an importer for one pinned public package checkout.
+    #[must_use]
+    pub fn new(
+        package: impl Into<PathBuf>,
+        revision: impl Into<String>,
+        environment: Environment,
+        harness: Harness,
+    ) -> Self {
+        Self {
+            package: package.into(),
+            revision: revision.into(),
+            environment,
+            harness,
+        }
+    }
+}
+
+impl DatasetImporter for GeneBenchPro {
+    fn plan(&self) -> Result<DatasetPlan, ImportError> {
+        let package = canonical_directory(&self.package)?;
+        let manifest_path = package.join("manifest.json");
+        let manifest_bytes = read_file(&manifest_path)?;
+        let manifest: PackageManifest = decode_json(&manifest_path, &manifest_bytes)?;
+        if manifest.problem_count != manifest.problems.len() {
+            return Err(ImportError::Invalid(format!(
+                "GeneBench-Pro manifest declares {} problems but contains {}",
+                manifest.problem_count,
+                manifest.problems.len()
+            )));
+        }
+        let grader_path = package.join("reference_grader.py");
+        let grader = read_file(&grader_path)?;
+        let mut source_values = vec![manifest_bytes, grader.clone()];
+        let mut cases = Vec::with_capacity(manifest.problems.len());
+        for problem in manifest.problems {
+            let config_path = resolve_package_file(&package, Path::new(&problem.eval_config))?;
+            let config_bytes =
+                read_verified_file(&config_path, problem.file(&problem.eval_config)?)?;
+            let config: EvalConfig = decode_json(&config_path, &config_bytes)?;
+            if config.id != problem.eval_id {
+                return Err(ImportError::Invalid(format!(
+                    "GeneBench-Pro problem {:?} contains eval config {:?}",
+                    problem.eval_id, config.id
+                )));
+            }
+            let problem_root = config_path.parent().ok_or_else(|| {
+                ImportError::Invalid(format!(
+                    "{} has no problem directory",
+                    config_path.display()
+                ))
+            })?;
+            let mut planned = CasePlan::hermetic(
+                &problem.eval_id,
+                config.task,
+                self.environment.clone(),
+                self.harness.clone(),
+            )?
+            .output(TaskOutput::FinalMessage)
+            .resources(Resources {
+                cpus: 4,
+                memory_mb: 8_192,
+                storage_mb: 12_288,
+                gpus: 0,
+            })
+            .timeouts(Duration::from_secs(1_800), Duration::from_secs(300))
+            // Guest CLI harnesses own their model transport inside the VM.
+            // This public case-study package publishes its answers and is not
+            // a hidden-answer leaderboard, so its operational recipe permits
+            // the network device required by those harnesses.
+            .allow_internet(true)
+            .harness_file("eval_config.json", config_bytes.clone(), 0o600)?
+            .harness_file("reference_grader.py", grader.clone(), 0o700)?;
+            source_values.push(config_bytes);
+            for relative in config.data_files {
+                validate_relative(&relative, "GeneBench-Pro data file")?;
+                let package_relative = problem_root
+                    .strip_prefix(&package)
+                    .map_err(|error| ImportError::Invalid(error.to_string()))?
+                    .join(&relative);
+                let package_path = resolve_package_file(&package, &package_relative)?;
+                let manifest_path = package_relative.to_string_lossy().replace('\\', "/");
+                let bytes = read_verified_file(&package_path, problem.file(&manifest_path)?)?;
+                planned = planned.environment_file(&relative, bytes.clone(), 0o644)?;
+                source_values.push(bytes);
+            }
+            cases.push(planned);
+        }
+        let source = SourceIdentity::new(
+            "openai-genebench-pro-public-package",
+            &self.revision,
+            sha256_values(source_values),
+        )?;
+        let mut plan = DatasetPlan::new("genebench-pro-public", source)?;
+        for case in cases {
+            plan = plan.case(case);
+        }
+        Ok(plan)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PackageManifest {
+    pub(crate) problem_count: usize,
+    pub(crate) problems: Vec<PackageProblem>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PackageProblem {
+    pub(crate) eval_id: String,
+    pub(crate) eval_config: String,
+    files: Vec<PackageFile>,
+}
+
+impl PackageProblem {
+    fn file(&self, path: &str) -> Result<&PackageFile, ImportError> {
+        self.files
+            .iter()
+            .find(|file| file.path == path)
+            .ok_or_else(|| {
+                ImportError::Invalid(format!(
+                    "GeneBench-Pro manifest problem {:?} omits {path:?}",
+                    self.eval_id
+                ))
+            })
+    }
+
+    pub(crate) fn execution_files(&self) -> impl Iterator<Item = &PackageFile> {
+        self.files
+            .iter()
+            .filter(|file| !file.path.ends_with("report_public.pdf"))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct PackageFile {
+    pub(crate) path: String,
+    pub(crate) bytes: u64,
+    pub(crate) sha256: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct EvalConfig {
+    id: String,
+    task: String,
+    data_files: Vec<PathBuf>,
+    #[serde(flatten)]
+    _grader_contract: BTreeMap<String, serde_json::Value>,
+}
+
+pub(crate) fn decode_manifest(path: &Path, bytes: &[u8]) -> Result<PackageManifest, String> {
+    serde_json::from_slice(bytes)
+        .map_err(|error| format!("failed to decode {}: {error}", path.display()))
+}
+
+fn decode_json<T: for<'de> Deserialize<'de>>(path: &Path, bytes: &[u8]) -> Result<T, ImportError> {
+    serde_json::from_slice(bytes).map_err(|source| {
+        ImportError::Invalid(format!("failed to decode {}: {source}", path.display()))
+    })
+}
+
+fn canonical_directory(path: &Path) -> Result<PathBuf, ImportError> {
+    let canonical = fs::canonicalize(path).map_err(|source| ImportError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if !canonical.is_dir() {
+        return Err(ImportError::Invalid(format!(
+            "GeneBench-Pro package is not a directory: {}",
+            canonical.display()
+        )));
+    }
+    Ok(canonical)
+}
+
+fn resolve_package_file(package: &Path, relative: &Path) -> Result<PathBuf, ImportError> {
+    validate_relative(relative, "GeneBench-Pro package file")?;
+    let path = package.join(relative);
+    let canonical = fs::canonicalize(&path).map_err(|source| ImportError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    if !canonical.starts_with(package) || !canonical.is_file() {
+        return Err(ImportError::Invalid(format!(
+            "GeneBench-Pro package file escapes its package: {}",
+            relative.display()
+        )));
+    }
+    Ok(canonical)
+}
+
+fn validate_relative(path: &Path, label: &str) -> Result<(), ImportError> {
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(ImportError::Invalid(format!(
+            "{label} is not a safe relative path: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn read_verified_file(path: &Path, expected: &PackageFile) -> Result<Vec<u8>, ImportError> {
+    let bytes = read_file(path)?;
+    let actual_len = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+    let digest = hex::encode(Sha256::digest(&bytes));
+    if actual_len != expected.bytes || digest != expected.sha256 {
+        return Err(ImportError::Invalid(format!(
+            "GeneBench-Pro package file does not match manifest: {}",
+            path.display()
+        )));
+    }
+    Ok(bytes)
+}
+
+fn read_file(path: &Path) -> Result<Vec<u8>, ImportError> {
+    fs::read(path).map_err(|source| ImportError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use nanocodex_eval::{NetworkPolicy, import::ImportStore};
+
+    use super::*;
+
+    #[test]
+    fn exposes_only_declared_data_to_the_candidate() {
+        let package = tempfile::tempdir().unwrap();
+        let problem = package.path().join("problems/case-1");
+        fs::create_dir_all(problem.join("data_files")).unwrap();
+        let config = br#"{
+  "id": "case-1",
+  "task": "Analyze the supplied data and return JSON.",
+  "data_files": ["data_files/input.tsv.gz"],
+  "ground_truth": {"value": 2},
+  "grader": {"type": "numeric_tolerance", "config": {"key": "value"}}
+}"#;
+        let data = b"compressed-fixture";
+        let grader = b"# official grader\n";
+        fs::write(problem.join("eval_config.json"), config).unwrap();
+        fs::write(problem.join("data_files/input.tsv.gz"), data).unwrap();
+        fs::write(package.path().join("reference_grader.py"), grader).unwrap();
+        let descriptor = |path: &str, bytes: &[u8]| {
+            serde_json::json!({
+                "path": path,
+                "bytes": bytes.len(),
+                "sha256": hex::encode(Sha256::digest(bytes)),
+            })
+        };
+        fs::write(
+            package.path().join("manifest.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "problem_count": 1,
+                "problems": [{
+                    "eval_id": "case-1",
+                    "eval_config": "problems/case-1/eval_config.json",
+                    "files": [
+                        descriptor("problems/case-1/eval_config.json", config),
+                        descriptor("problems/case-1/data_files/input.tsv.gz", data),
+                    ],
+                }],
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let assets = Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/genebench-pro");
+        let store = tempfile::tempdir().unwrap();
+
+        let imported = ImportStore::new(store.path())
+            .import(&GeneBenchPro::new(
+                package.path(),
+                "openai/genebench@fixture",
+                Environment::Dockerfile(assets.join("environment")),
+                Harness::directory(assets.join("verifier")).unwrap(),
+            ))
+            .unwrap();
+        let task = &imported.tasks()[0];
+
+        assert_eq!(task.output(), TaskOutput::FinalMessage);
+        assert_eq!(task.network(), NetworkPolicy::Public);
+        assert_eq!(
+            fs::read(task.root().join("environment/data_files/input.tsv.gz")).unwrap(),
+            data
+        );
+        assert!(task.root().join("tests/eval_config.json").is_file());
+        assert!(!task.root().join("environment/eval_config.json").exists());
+    }
+}

--- a/crates/experimental/nanocodex-eval-adapters/src/lib.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/lib.rs
@@ -7,6 +7,7 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
 mod arena_hard;
+mod genebench_pro;
 mod harbor;
 mod source;
 mod swe_atlas_qna;
@@ -101,6 +102,11 @@ const INSTALLED_ADAPTERS: &[InstalledAdapter] = &[
         import: import_swe_atlas,
         matches: matches_swe_atlas_task,
     },
+    InstalledAdapter {
+        names: &["genebench-pro-public"],
+        import: import_genebench_pro,
+        matches: exact_task,
+    },
 ];
 
 const TERMINAL_BENCH_REVISION: &str = "5c8eadf1f393183288fa08b8f73ca9a469cc5e00";
@@ -109,6 +115,13 @@ const ARENA_HARD_REVISION: &str = "196f6b826783b3da7310e361a805fa36f0be83f3";
 const SWE_VERIFIED_ROW_RESPONSE_SHA256: &str =
     "7c62220a467830a3a330dda51211ab4c1ba099124dffc8371fbec057933c47b8";
 const SWE_ATLAS_REVISION: &str = "6de82c3603fb9e254170b440d7560441eb257176";
+const GENEBENCH_PRO_REVISION: &str = "eb75a3c0996b3cedcc9af685bad02fd166848fa2";
+const GENEBENCH_PRO_MANIFEST_SHA256: &str =
+    "0e80d5dca9ac5211fb9dfa5c0ea8d26e9d557e2039c8f20b0f5a328ea3cd6c58";
+const GENEBENCH_PRO_GRADER_SHA256: &str =
+    "81a50853d1348237300ce90a7b48a9230b4edb5d1af30207c37f17f0de8bbb28";
+const GENEBENCH_PRO_BASE: &str =
+    "https://huggingface.co/datasets/openai/genebench-pro-public-package/resolve";
 
 fn import_harbor(
     request: &BenchmarkRequest,
@@ -232,6 +245,60 @@ fn matches_swe_atlas_task(selected: &str, normalized: &str) -> bool {
         || normalized
             .strip_prefix("scale-ai-")
             .is_some_and(|task| task == selected)
+}
+
+fn import_genebench_pro(
+    _request: &BenchmarkRequest,
+    sources: &SourceStore,
+    store: &ImportStore,
+) -> Result<ImportedDataset, AdapterError> {
+    let package_name = "genebench-pro-public-package";
+    let manifest_relative = format!("{package_name}/manifest.json");
+    let manifest = sources.download(
+        &manifest_relative,
+        &format!("{GENEBENCH_PRO_BASE}/{GENEBENCH_PRO_REVISION}/manifest.json"),
+        GENEBENCH_PRO_MANIFEST_SHA256,
+    )?;
+    sources.download(
+        &format!("{package_name}/reference_grader.py"),
+        &format!("{GENEBENCH_PRO_BASE}/{GENEBENCH_PRO_REVISION}/reference_grader.py"),
+        GENEBENCH_PRO_GRADER_SHA256,
+    )?;
+    let bytes = fs::read(&manifest).map_err(|error| {
+        AdapterError::Source(format!("failed to read {}: {error}", manifest.display()))
+    })?;
+    let package_manifest =
+        genebench_pro::decode_manifest(&manifest, &bytes).map_err(AdapterError::Source)?;
+    for problem in package_manifest.problems {
+        for file in problem.execution_files() {
+            let relative = Path::new(&file.path);
+            if relative.is_absolute()
+                || relative
+                    .components()
+                    .any(|component| !matches!(component, std::path::Component::Normal(_)))
+            {
+                return Err(AdapterError::Source(format!(
+                    "GeneBench-Pro manifest contains unsafe path {:?}",
+                    file.path
+                )));
+            }
+            sources.download(
+                &format!("{package_name}/{}", file.path),
+                &format!(
+                    "{GENEBENCH_PRO_BASE}/{GENEBENCH_PRO_REVISION}/{}",
+                    file.path
+                ),
+                &file.sha256,
+            )?;
+        }
+    }
+    let assets = Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/genebench-pro");
+    Ok(store.import(&genebench_pro::GeneBenchPro::new(
+        sources.root().join(package_name),
+        format!("openai/genebench-pro-public-package@{GENEBENCH_PRO_REVISION}"),
+        nanocodex_eval::import::Environment::Dockerfile(assets.join("environment")),
+        nanocodex_eval::import::Harness::directory(assets.join("verifier"))?,
+    ))?)
 }
 
 impl AdapterCatalog {

--- a/nanocodex.toml
+++ b/nanocodex.toml
@@ -35,3 +35,9 @@ benchmarks = ["swe-atlas-qna/task-6905333b74f22949d97ba9c2"]
 trials = 1
 model = ["sol"]
 thinking = ["high"]
+
+[profiles.genebench-pro-smoke]
+benchmarks = ["genebench-pro-public/multiparent_qtl_hmm_lmm"]
+trials = 1
+model = ["sol"]
+thinking = ["high"]


### PR DESCRIPTION
Adapter split from #72.

Adds the pinned public GeneBench Pro package manifest, official reference grader, scientific candidate image, and strict candidate/verifier file separation. The smoke profile selects the retained multiparent QTL case.

Validation:
- cargo fmt --all
- cargo test -p nanocodex-eval-adapters (8 passed)
- cargo clippy -p nanocodex-eval-adapters --all-targets -- -D warnings

Stacked on #146.