### PR TITLE
feat(eval): add GraphWalks adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "serde",
@@ -916,7 +917,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -933,7 +934,7 @@ dependencies = [
  "ark-serialize 0.3.0",
  "ark-std 0.3.0",
  "derivative",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "rustc_version 0.3.3",
@@ -953,7 +954,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "rustc_version 0.4.1",
@@ -974,7 +975,7 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "zeroize",
@@ -992,7 +993,7 @@ dependencies = [
  "ark-std 0.6.0",
  "digest 0.10.7",
  "educe",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "zeroize",
 ]
@@ -1043,7 +1044,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "quote",
  "syn 1.0.109",
@@ -1055,7 +1056,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1068,7 +1069,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1081,7 +1082,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1121,7 +1122,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.8",
 ]
 
 [[package]]
@@ -1134,7 +1135,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.8",
 ]
 
 [[package]]
@@ -1146,7 +1147,7 @@ dependencies = [
  "ark-serialize-derive 0.6.0",
  "ark-std 0.6.0",
  "digest 0.10.7",
- "num-bigint",
+ "num-bigint 0.4.8",
  "serde_with",
 ]
 
@@ -2174,6 +2175,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "const_format"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2661,7 +2682,7 @@ dependencies = [
  "asn1-rs 0.6.2",
  "displaydoc",
  "nom",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
 ]
@@ -2675,7 +2696,7 @@ dependencies = [
  "asn1-rs 0.7.2",
  "displaydoc",
  "nom",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
 ]
@@ -3629,6 +3650,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -5289,6 +5311,7 @@ dependencies = [
  "hex",
  "ignore",
  "nanocodex-eval",
+ "parquet",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -5672,7 +5695,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -5685,6 +5708,16 @@ name = "num-bigint"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -5747,7 +5780,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
 ]
@@ -6267,6 +6300,25 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "parquet"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7065842956a20c2a536924ce8e4d9955f7422451511b9eb7500d7bfe5077e59c"
+dependencies = [
+ "ahash",
+ "bytes",
+ "chrono",
+ "half",
+ "hashbrown 0.17.1",
+ "num-bigint 0.5.1",
+ "num-integer",
+ "num-traits",
+ "seq-macro",
+ "snap",
+ "twox-hash",
 ]
 
 [[package]]
@@ -7832,7 +7884,7 @@ dependencies = [
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
- "num-bigint",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "parity-scale-codec",
@@ -8279,6 +8331,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8659,6 +8717,12 @@ checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "snap"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
 
 [[package]]
 name = "socket2"
@@ -9260,6 +9324,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tiny-skia"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9722,6 +9795,12 @@ dependencies = [
  "serde_derive",
  "syntect",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ opentelemetry-otlp = { version = "0.32", default-features = false, features = ["
 opentelemetry-semantic-conventions = "0.32"
 opentelemetry_sdk = { version = "0.32", default-features = false, features = ["experimental_trace_batch_span_processor_with_async_runtime", "rt-tokio", "trace"] }
 percent-encoding = "2.3.2"
+parquet = { version = "59.1.0", default-features = false, features = ["snap"] }
 opusic-c = "1.6.1"
 pyo3 = "0.29.0"
 proc-macro-crate = "3"

--- a/crates/experimental/nanocodex-eval-adapters/Cargo.toml
+++ b/crates/experimental/nanocodex-eval-adapters/Cargo.toml
@@ -14,6 +14,7 @@ description = "Third-party benchmark adapters for nanocodex-eval"
 hex.workspace = true
 ignore.workspace = true
 nanocodex-eval.workspace = true
+parquet.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/experimental/nanocodex-eval-adapters/assets/graphwalks/Dockerfile
+++ b/crates/experimental/nanocodex-eval-adapters/assets/graphwalks/Dockerfile
@@ -1,0 +1,1 @@
+FROM python:3.12-slim

--- a/crates/experimental/nanocodex-eval-adapters/assets/graphwalks/grade.py
+++ b/crates/experimental/nanocodex-eval-adapters/assets/graphwalks/grade.py
@@ -1,0 +1,34 @@
+import json
+import os
+import re
+from pathlib import Path
+
+
+def extract(response: str) -> tuple[list[str], bool]:
+    # This intentionally preserves the extractor published by OpenAI for the
+    # pinned public dataset, including its current prefix handling.
+    line = response.split("\n")[-1]
+    if "Final Answer:" not in line:
+        return [], True
+    list_part = re.search(r"Final Answer: ?\[.*\]", line)
+    if list_part:
+        result = list_part.group(0).strip("[]").split(",")
+        return [item.strip() for item in result if item.strip()], False
+    return [], True
+
+
+workspace = Path(os.environ["NANOCODEX_EVAL_WORKSPACE"])
+response = (workspace / "answer.txt").read_text()
+truth = set(json.loads(Path("/tests/expected.json").read_text()))
+sampled, extraction_error = extract(response)
+sampled = set(sampled)
+
+if extraction_error:
+    f1 = 0.0
+else:
+    overlap = len(sampled & truth)
+    recall = overlap / len(truth) if truth else 0.0
+    precision = overlap / len(sampled) if sampled else 0.0
+    f1 = 2 * recall * precision / (recall + precision) if recall + precision else 1.0
+
+Path("/logs/verifier/reward.json").write_text(json.dumps({"f1": f1}) + "\n")

--- a/crates/experimental/nanocodex-eval-adapters/assets/graphwalks/test.sh
+++ b/crates/experimental/nanocodex-eval-adapters/assets/graphwalks/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+python3 /tests/grade.py

--- a/crates/experimental/nanocodex-eval-adapters/src/graphwalks.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/graphwalks.rs
@@ -1,0 +1,210 @@
+use std::{fs::File, path::PathBuf, time::Duration};
+
+use nanocodex_eval::{
+    Resources, ScoringPolicy, TaskOutput,
+    import::{
+        CasePlan, DatasetImporter, DatasetPlan, Environment, Harness, ImportError, SourceIdentity,
+    },
+};
+use parquet::{
+    file::reader::{FileReader as _, SerializedFileReader},
+    record::{ListAccessor as _, Row, RowAccessor as _},
+};
+
+use crate::{sha256_file, sha256_values};
+
+const FILES: [(&str, &str); 2] = [
+    ("128k-and-shorter", "graphwalks_128k_and_shorter.parquet"),
+    ("256k-to-1mil", "graphwalks_256k_to_1mil.parquet"),
+];
+const HARNESS_FILES: [&str; 3] = ["Dockerfile", "test.sh", "grade.py"];
+
+/// OpenAI's public GraphWalks long-context dataset and published F1 grader.
+#[derive(Clone, Debug)]
+pub struct GraphWalks {
+    source: PathBuf,
+    revision: String,
+    environment: Environment,
+    harness: PathBuf,
+}
+
+impl GraphWalks {
+    /// Creates an importer for one pinned public dataset snapshot.
+    #[must_use]
+    pub fn new(
+        source: impl Into<PathBuf>,
+        revision: impl Into<String>,
+        environment: Environment,
+        harness: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            source: source.into(),
+            revision: revision.into(),
+            environment,
+            harness: harness.into(),
+        }
+    }
+}
+
+impl DatasetImporter for GraphWalks {
+    fn plan(&self) -> Result<DatasetPlan, ImportError> {
+        let mut source_values = Vec::with_capacity(FILES.len() + HARNESS_FILES.len());
+        for relative in HARNESS_FILES {
+            source_values.push(sha256_file(&self.harness.join(relative))?);
+        }
+        let harness = Harness::directory(&self.harness)?;
+        let mut cases = Vec::with_capacity(1_150);
+        for (partition, relative) in FILES {
+            let path = self.source.join(relative);
+            source_values.push(sha256_file(&path)?);
+            let file = File::open(&path).map_err(|source| ImportError::Io {
+                path: path.clone(),
+                source,
+            })?;
+            let reader = SerializedFileReader::new(file).map_err(|error| {
+                ImportError::Invalid(format!("failed to open {}: {error}", path.display()))
+            })?;
+            let rows = reader.get_row_iter(None).map_err(|error| {
+                ImportError::Invalid(format!("failed to read {}: {error}", path.display()))
+            })?;
+            for (index, row) in rows.enumerate() {
+                let row = row.map_err(|error| {
+                    ImportError::Invalid(format!(
+                        "failed to decode {} row {}: {error}",
+                        path.display(),
+                        index + 1
+                    ))
+                })?;
+                let case = GraphWalksCase::from_row(&path, index, &row)?;
+                let expected =
+                    serde_json::to_vec(&case.answer).map_err(|source| ImportError::Json {
+                        path: path.clone(),
+                        source,
+                    })?;
+                cases.push(
+                    CasePlan::hermetic(
+                        format!("{partition}-{index:06}"),
+                        case.prompt,
+                        self.environment.clone(),
+                        harness.clone(),
+                    )?
+                    .benchmark_prompt_chars(case.prompt_chars)
+                    .benchmark_case_type(case.problem_type)
+                    .output(TaskOutput::FinalMessage)
+                    .resources(Resources {
+                        cpus: 2,
+                        memory_mb: 4_096,
+                        storage_mb: 4_096,
+                        gpus: 0,
+                    })
+                    .timeouts(Duration::from_secs(1_800), Duration::from_secs(60))
+                    .scoring_policy(ScoringPolicy::AllRewardsOne)
+                    .harness_file("expected.json", expected, 0o600)?,
+                );
+            }
+        }
+        let source = SourceIdentity::new(
+            "openai-graphwalks",
+            &self.revision,
+            sha256_values(source_values.iter().map(String::as_bytes)),
+        )?;
+        let mut plan = DatasetPlan::new("graphwalks", source)?;
+        for case in cases {
+            plan = plan.case(case);
+        }
+        Ok(plan)
+    }
+}
+
+struct GraphWalksCase {
+    prompt: String,
+    prompt_chars: u64,
+    problem_type: String,
+    answer: Vec<String>,
+}
+
+impl GraphWalksCase {
+    fn from_row(path: &std::path::Path, index: usize, row: &Row) -> Result<Self, ImportError> {
+        let field = |name: &str| {
+            row.get_column_iter()
+                .position(|(candidate, _)| candidate == name)
+                .ok_or_else(|| {
+                    ImportError::Invalid(format!(
+                        "{} row {} has no {name:?} column",
+                        path.display(),
+                        index + 1
+                    ))
+                })
+        };
+        let prompt_index = field("prompt")?;
+        let answer_index = field("answer_nodes").or_else(|_| field("answer"))?;
+        let prompt_chars_index = field("prompt_chars")?;
+        let problem_type_index = field("problem_type")?;
+        let prompt = row.get_string(prompt_index).map_err(|error| {
+            ImportError::Invalid(format!(
+                "{} row {} prompt is not text: {error}",
+                path.display(),
+                index + 1
+            ))
+        })?;
+        let prompt_chars = row.get_long(prompt_chars_index).map_err(|error| {
+            ImportError::Invalid(format!(
+                "{} row {} prompt_chars is not an integer: {error}",
+                path.display(),
+                index + 1
+            ))
+        })?;
+        let prompt_chars = u64::try_from(prompt_chars).map_err(|_| {
+            ImportError::Invalid(format!(
+                "{} row {} declares invalid prompt_chars {prompt_chars}",
+                path.display(),
+                index + 1
+            ))
+        })?;
+        if prompt_chars == 0 {
+            return Err(ImportError::Invalid(format!(
+                "{} row {} declares zero prompt_chars",
+                path.display(),
+                index + 1
+            )));
+        }
+        let problem_type = row.get_string(problem_type_index).map_err(|error| {
+            ImportError::Invalid(format!(
+                "{} row {} problem_type is not text: {error}",
+                path.display(),
+                index + 1
+            ))
+        })?;
+        if problem_type.trim().is_empty() {
+            return Err(ImportError::Invalid(format!(
+                "{} row {} has an empty GraphWalks problem type",
+                path.display(),
+                index + 1
+            )));
+        }
+        let answers = row.get_list(answer_index).map_err(|error| {
+            ImportError::Invalid(format!(
+                "{} row {} answer is not a string list: {error}",
+                path.display(),
+                index + 1
+            ))
+        })?;
+        let answer = (0..answers.len())
+            .map(|answer| {
+                answers.get_string(answer).cloned().map_err(|error| {
+                    ImportError::Invalid(format!(
+                        "{} row {} answer contains non-text: {error}",
+                        path.display(),
+                        index + 1
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            prompt: prompt.clone(),
+            prompt_chars,
+            problem_type: problem_type.clone(),
+            answer,
+        })
+    }
+}

--- a/crates/experimental/nanocodex-eval-adapters/src/lib.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod arena_hard;
 mod genebench_pro;
+mod graphwalks;
 mod harbor;
 mod source;
 mod swe_atlas_qna;
@@ -107,6 +108,11 @@ const INSTALLED_ADAPTERS: &[InstalledAdapter] = &[
         import: import_genebench_pro,
         matches: exact_task,
     },
+    InstalledAdapter {
+        names: &["graphwalks"],
+        import: import_graphwalks,
+        matches: exact_task,
+    },
 ];
 
 const TERMINAL_BENCH_REVISION: &str = "5c8eadf1f393183288fa08b8f73ca9a469cc5e00";
@@ -122,6 +128,11 @@ const GENEBENCH_PRO_GRADER_SHA256: &str =
     "81a50853d1348237300ce90a7b48a9230b4edb5d1af30207c37f17f0de8bbb28";
 const GENEBENCH_PRO_BASE: &str =
     "https://huggingface.co/datasets/openai/genebench-pro-public-package/resolve";
+const GRAPHWALKS_REVISION: &str = "f338bb265735a56a79f4b0f5def722c9c3268ead";
+const GRAPHWALKS_SHORT_SHA256: &str =
+    "54036036c91d8e04bb2a5fcd9e36f8e2a852cacece5dfc2b1ee40e3a6182b516";
+const GRAPHWALKS_LONG_SHA256: &str =
+    "537879431c72a42e3b500f80efc3047e7facb90390b6063d33679b4320985911";
 
 fn import_harbor(
     request: &BenchmarkRequest,
@@ -298,6 +309,31 @@ fn import_genebench_pro(
         format!("openai/genebench-pro-public-package@{GENEBENCH_PRO_REVISION}"),
         nanocodex_eval::import::Environment::Dockerfile(assets.join("environment")),
         nanocodex_eval::import::Harness::directory(assets.join("verifier"))?,
+    ))?)
+}
+
+fn import_graphwalks(
+    _request: &BenchmarkRequest,
+    sources: &SourceStore,
+    store: &ImportStore,
+) -> Result<ImportedDataset, AdapterError> {
+    let base =
+        format!("https://huggingface.co/datasets/openai/graphwalks/resolve/{GRAPHWALKS_REVISION}");
+    sources.download(
+        "graphwalks/graphwalks_128k_and_shorter.parquet",
+        &format!("{base}/graphwalks_128k_and_shorter.parquet"),
+        GRAPHWALKS_SHORT_SHA256,
+    )?;
+    sources.download(
+        "graphwalks/graphwalks_256k_to_1mil.parquet",
+        &format!("{base}/graphwalks_256k_to_1mil.parquet"),
+        GRAPHWALKS_LONG_SHA256,
+    )?;
+    Ok(store.import(&graphwalks::GraphWalks::new(
+        sources.root().join("graphwalks"),
+        format!("openai/graphwalks@{GRAPHWALKS_REVISION}"),
+        nanocodex_eval::import::Environment::OciImage("python:3.12-slim".to_owned()),
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/graphwalks"),
     ))?)
 }
 

--- a/nanocodex.toml
+++ b/nanocodex.toml
@@ -41,3 +41,9 @@ benchmarks = ["genebench-pro-public/multiparent_qtl_hmm_lmm"]
 trials = 1
 model = ["sol"]
 thinking = ["high"]
+
+[profiles.graphwalks-smoke]
+benchmarks = ["graphwalks/128k-and-shorter-000749"]
+trials = 1
+model = ["sol"]
+thinking = ["high"]


### PR DESCRIPTION
Adapter split from #72.

Adds OpenAI GraphWalks at the pinned corrected dataset revision, parses both official Parquet partitions without flattening prompts, and retains the published set-F1 grader with exact-one pass classification. Includes the retained 128k smoke case.

Validation:
- cargo fmt --all
- cargo test -p nanocodex-eval-adapters (8 passed)
- cargo clippy -p nanocodex-eval-adapters --all-targets -- -D warnings

The pinned real-data import and VM trial are part of the dev-georgios validation pass.

Stacked on #147.