### PR TITLE
feat(eval): add MRCR adapter

### DIFF
--- a/crates/experimental/nanocodex-eval-adapters/assets/mrcr/Dockerfile
+++ b/crates/experimental/nanocodex-eval-adapters/assets/mrcr/Dockerfile
@@ -1,0 +1,1 @@
+FROM python:3.12-slim

--- a/crates/experimental/nanocodex-eval-adapters/assets/mrcr/grade.py
+++ b/crates/experimental/nanocodex-eval-adapters/assets/mrcr/grade.py
@@ -1,0 +1,21 @@
+import difflib
+import json
+import os
+from pathlib import Path
+
+
+workspace = Path(os.environ["NANOCODEX_EVAL_WORKSPACE"])
+response = (workspace / "answer.txt").read_text()
+expected = json.loads(Path("/tests/expected.json").read_text())
+prefix = expected["prefix"]
+
+if not response.startswith(prefix):
+    similarity = 0.0
+else:
+    sampled = response.removeprefix(prefix)
+    answer = expected["answer"].removeprefix(prefix)
+    similarity = float(difflib.SequenceMatcher(None, sampled, answer).ratio())
+
+Path("/logs/verifier/reward.json").write_text(
+    json.dumps({"similarity": similarity}) + "\n"
+)

--- a/crates/experimental/nanocodex-eval-adapters/assets/mrcr/test.sh
+++ b/crates/experimental/nanocodex-eval-adapters/assets/mrcr/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+python3 /tests/grade.py

--- a/crates/experimental/nanocodex-eval-adapters/src/lib.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/lib.rs
@@ -371,7 +371,7 @@ fn import_graphwalks(
 }
 
 fn import_mrcr(
-    _request: &BenchmarkRequest,
+    request: &BenchmarkRequest,
     sources: &SourceStore,
     store: &ImportStore,
 ) -> Result<ImportedDataset, AdapterError> {
@@ -383,12 +383,16 @@ fn import_mrcr(
             sha256,
         )?;
     }
-    Ok(store.import(&mrcr::Mrcr::new(
+    let mut importer = mrcr::Mrcr::new(
         sources.root().join("mrcr"),
         format!("openai/mrcr@{MRCR_REVISION}"),
         nanocodex_eval::import::Environment::OciImage("python:3.12-slim".to_owned()),
         Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/mrcr"),
-    ))?)
+    );
+    if !request.all {
+        importer = importer.tasks(request.tasks.iter().cloned());
+    }
+    Ok(store.import(&importer)?)
 }
 
 impl AdapterCatalog {

--- a/crates/experimental/nanocodex-eval-adapters/src/lib.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/lib.rs
@@ -10,6 +10,7 @@ mod arena_hard;
 mod genebench_pro;
 mod graphwalks;
 mod harbor;
+mod mrcr;
 mod source;
 mod swe_atlas_qna;
 mod swe_bench;
@@ -113,6 +114,11 @@ const INSTALLED_ADAPTERS: &[InstalledAdapter] = &[
         import: import_graphwalks,
         matches: exact_task,
     },
+    InstalledAdapter {
+        names: &["mrcr-v2"],
+        import: import_mrcr,
+        matches: exact_task,
+    },
 ];
 
 const TERMINAL_BENCH_REVISION: &str = "5c8eadf1f393183288fa08b8f73ca9a469cc5e00";
@@ -133,6 +139,33 @@ const GRAPHWALKS_SHORT_SHA256: &str =
     "54036036c91d8e04bb2a5fcd9e36f8e2a852cacece5dfc2b1ee40e3a6182b516";
 const GRAPHWALKS_LONG_SHA256: &str =
     "537879431c72a42e3b500f80efc3047e7facb90390b6063d33679b4320985911";
+const MRCR_REVISION: &str = "f4c69fae7cf81f7ca26b9fee34b392a50f6b8a1d";
+const MRCR_FILES: [(&str, &str); 6] = [
+    (
+        "2needle/2needle_0.parquet",
+        "1c297b254bf64a31856b74918cd7db889a214503e0b67daa834e84f20df6aa93",
+    ),
+    (
+        "2needle/2needle_1.parquet",
+        "a5a1dc9ccc945623253d04d33c03d89aee2d676c88955ce368da2ab16a0ce94d",
+    ),
+    (
+        "4needle/4needle_0.parquet",
+        "4d4fa3d11ce064749de3cd039eef1a621e30a81c2c9b3e64f1df37f8afeaf312",
+    ),
+    (
+        "4needle/4needle_1.parquet",
+        "8dfdb94a208cf3eee73c4e7ac6ee8a5ccb7236c6934c13c6c5f67c0a9928cdf3",
+    ),
+    (
+        "8needle/8needle_0.parquet",
+        "65df601a2e0ae4a3cfb56920a6ef99f26c0de37c6b1018695e8aed684e6a94c1",
+    ),
+    (
+        "8needle/8needle_1.parquet",
+        "c80b19573bff1d38e1c157d6a0bdf9cfd1a8ab6372296174c9a7015e164189e3",
+    ),
+];
 
 fn import_harbor(
     request: &BenchmarkRequest,
@@ -334,6 +367,27 @@ fn import_graphwalks(
         format!("openai/graphwalks@{GRAPHWALKS_REVISION}"),
         nanocodex_eval::import::Environment::OciImage("python:3.12-slim".to_owned()),
         Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/graphwalks"),
+    ))?)
+}
+
+fn import_mrcr(
+    _request: &BenchmarkRequest,
+    sources: &SourceStore,
+    store: &ImportStore,
+) -> Result<ImportedDataset, AdapterError> {
+    let base = format!("https://huggingface.co/datasets/openai/mrcr/resolve/{MRCR_REVISION}");
+    for (relative, sha256) in MRCR_FILES {
+        sources.download(
+            &format!("mrcr/{relative}"),
+            &format!("{base}/{relative}"),
+            sha256,
+        )?;
+    }
+    Ok(store.import(&mrcr::Mrcr::new(
+        sources.root().join("mrcr"),
+        format!("openai/mrcr@{MRCR_REVISION}"),
+        nanocodex_eval::import::Environment::OciImage("python:3.12-slim".to_owned()),
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/mrcr"),
     ))?)
 }
 

--- a/crates/experimental/nanocodex-eval-adapters/src/mrcr.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/mrcr.rs
@@ -1,0 +1,379 @@
+use std::{fs::File, path::PathBuf, time::Duration};
+
+use nanocodex_eval::{
+    PromptMessage, Resources, ScoringPolicy, TaskOutput,
+    import::{
+        CasePlan, DatasetImporter, DatasetPlan, Environment, Harness, ImportError, SourceIdentity,
+    },
+};
+use parquet::{
+    file::reader::{FileReader as _, SerializedFileReader},
+    record::{Row, RowAccessor as _},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{sha256_file, sha256_values};
+
+const FILES: [(&str, &str); 6] = [
+    ("2needle-0", "2needle/2needle_0.parquet"),
+    ("2needle-1", "2needle/2needle_1.parquet"),
+    ("4needle-0", "4needle/4needle_0.parquet"),
+    ("4needle-1", "4needle/4needle_1.parquet"),
+    ("8needle-0", "8needle/8needle_0.parquet"),
+    ("8needle-1", "8needle/8needle_1.parquet"),
+];
+const HARNESS_FILES: [&str; 3] = ["Dockerfile", "test.sh", "grade.py"];
+
+/// OpenAI's public multi-round co-reference resolution dataset and grader.
+#[derive(Clone, Debug)]
+pub struct Mrcr {
+    source: PathBuf,
+    revision: String,
+    environment: Environment,
+    harness: PathBuf,
+}
+
+impl Mrcr {
+    /// Creates an importer for one pinned public MRCR snapshot.
+    #[must_use]
+    pub fn new(
+        source: impl Into<PathBuf>,
+        revision: impl Into<String>,
+        environment: Environment,
+        harness: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            source: source.into(),
+            revision: revision.into(),
+            environment,
+            harness: harness.into(),
+        }
+    }
+}
+
+impl DatasetImporter for Mrcr {
+    fn plan(&self) -> Result<DatasetPlan, ImportError> {
+        let mut source_values = Vec::with_capacity(FILES.len() + HARNESS_FILES.len());
+        for relative in HARNESS_FILES {
+            source_values.push(sha256_file(&self.harness.join(relative))?);
+        }
+        let harness = Harness::directory(&self.harness)?;
+        let mut cases = Vec::with_capacity(2_400);
+        for (partition, relative) in FILES {
+            let path = self.source.join(relative);
+            source_values.push(sha256_file(&path)?);
+            let file = File::open(&path).map_err(|source| ImportError::Io {
+                path: path.clone(),
+                source,
+            })?;
+            let reader = SerializedFileReader::new(file).map_err(|error| {
+                ImportError::Invalid(format!("failed to open {}: {error}", path.display()))
+            })?;
+            let rows = reader.get_row_iter(None).map_err(|error| {
+                ImportError::Invalid(format!("failed to read {}: {error}", path.display()))
+            })?;
+            for (index, row) in rows.enumerate() {
+                let row = row.map_err(|error| {
+                    ImportError::Invalid(format!(
+                        "failed to decode {} row {}: {error}",
+                        path.display(),
+                        index + 1
+                    ))
+                })?;
+                let case = MrcrCase::from_row(&path, index, &row)?;
+                let expected =
+                    serde_json::to_vec(&case.expected).map_err(|source| ImportError::Json {
+                        path: path.clone(),
+                        source,
+                    })?;
+                cases.push(
+                    CasePlan::hermetic(
+                        format!("{partition}-{index:06}"),
+                        case.instruction,
+                        self.environment.clone(),
+                        harness.clone(),
+                    )?
+                    .transcript(case.transcript)
+                    .benchmark_prompt_chars(case.expected.n_chars)
+                    .benchmark_case_type(format!("{}-needle", case.expected.n_needles))
+                    .output(TaskOutput::FinalMessage)
+                    .resources(Resources {
+                        cpus: 2,
+                        memory_mb: 4_096,
+                        storage_mb: 4_096,
+                        gpus: 0,
+                    })
+                    .timeouts(Duration::from_secs(1_800), Duration::from_secs(60))
+                    .scoring_policy(ScoringPolicy::AllRewardsOne)
+                    .harness_file("expected.json", expected, 0o600)?,
+                );
+            }
+        }
+        let source = SourceIdentity::new(
+            "openai-mrcr",
+            &self.revision,
+            sha256_values(source_values.iter().map(String::as_bytes)),
+        )?;
+        let mut plan = DatasetPlan::new("mrcr-v2", source)?;
+        for case in cases {
+            plan = plan.case(case);
+        }
+        Ok(plan)
+    }
+}
+
+#[derive(Debug)]
+struct MrcrCase {
+    transcript: Vec<PromptMessage>,
+    instruction: String,
+    expected: MrcrExpected,
+}
+
+#[derive(Debug, Serialize)]
+struct MrcrExpected {
+    answer: String,
+    prefix: String,
+    n_needles: u64,
+    desired_message_index: u64,
+    total_messages: u64,
+    n_chars: u64,
+    date_added: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawMessage {
+    role: RawRole,
+    content: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum RawRole {
+    User,
+    Assistant,
+}
+
+impl MrcrCase {
+    fn from_row(path: &std::path::Path, index: usize, row: &Row) -> Result<Self, ImportError> {
+        let text = |name: &str| -> Result<String, ImportError> {
+            let field = field(path, index, row, name)?;
+            row.get_string(field).cloned().map_err(|error| {
+                ImportError::Invalid(format!(
+                    "{} row {} {name} is not text: {error}",
+                    path.display(),
+                    index + 1
+                ))
+            })
+        };
+        let integer = |name: &str| -> Result<i64, ImportError> {
+            let field = field(path, index, row, name)?;
+            row.get_long(field).map_err(|error| {
+                ImportError::Invalid(format!(
+                    "{} row {} {name} is not an integer: {error}",
+                    path.display(),
+                    index + 1
+                ))
+            })
+        };
+        let prompt = text("prompt")?;
+        let mut messages = serde_json::from_str::<Vec<RawMessage>>(&prompt).map_err(|source| {
+            ImportError::Invalid(format!(
+                "failed to decode {} row {} prompt messages: {source}",
+                path.display(),
+                index + 1
+            ))
+        })?;
+        let final_message = messages.pop().ok_or_else(|| {
+            ImportError::Invalid(format!(
+                "{} row {} has an empty MRCR transcript",
+                path.display(),
+                index + 1
+            ))
+        })?;
+        if !matches!(final_message.role, RawRole::User) || final_message.content.trim().is_empty() {
+            return Err(ImportError::Invalid(format!(
+                "{} row {} must end in a non-empty user instruction",
+                path.display(),
+                index + 1
+            )));
+        }
+        let total_messages =
+            positive_u64(path, index, "total_messages", integer("total_messages")?)?;
+        if usize::try_from(total_messages).ok() != Some(messages.len() + 1) {
+            return Err(ImportError::Invalid(format!(
+                "{} row {} declares {total_messages} messages but contains {}",
+                path.display(),
+                index + 1,
+                messages.len() + 1
+            )));
+        }
+        let transcript = messages
+            .into_iter()
+            .map(|message| match message.role {
+                RawRole::User => PromptMessage::user(message.content),
+                RawRole::Assistant => PromptMessage::assistant(message.content),
+            })
+            .collect::<Vec<_>>();
+        let n_needles = positive_u64(path, index, "n_needles", integer("n_needles")?)?;
+        if !matches!(n_needles, 2 | 4 | 8) {
+            return Err(ImportError::Invalid(format!(
+                "{} row {} declares unsupported n_needles {n_needles}",
+                path.display(),
+                index + 1
+            )));
+        }
+        let prefix = text("random_string_to_prepend")?;
+        if prefix.chars().count() != 10 || !prefix.bytes().all(|byte| byte.is_ascii_alphanumeric())
+        {
+            return Err(ImportError::Invalid(format!(
+                "{} row {} has an invalid ten-character alphanumeric answer prefix",
+                path.display(),
+                index + 1
+            )));
+        }
+        let answer = text("answer")?;
+        if !answer.starts_with(&prefix) {
+            return Err(ImportError::Invalid(format!(
+                "{} row {} answer does not begin with its required prefix",
+                path.display(),
+                index + 1
+            )));
+        }
+        Ok(Self {
+            transcript,
+            instruction: final_message.content,
+            expected: MrcrExpected {
+                answer,
+                prefix,
+                n_needles,
+                desired_message_index: positive_u64(
+                    path,
+                    index,
+                    "desired_msg_index",
+                    integer("desired_msg_index")?,
+                )?,
+                total_messages,
+                n_chars: positive_u64(path, index, "n_chars", integer("n_chars")?)?,
+                date_added: text("date_added")?,
+            },
+        })
+    }
+}
+
+fn field(
+    path: &std::path::Path,
+    index: usize,
+    row: &Row,
+    name: &str,
+) -> Result<usize, ImportError> {
+    row.get_column_iter()
+        .position(|(candidate, _)| candidate == name)
+        .ok_or_else(|| {
+            ImportError::Invalid(format!(
+                "{} row {} has no {name:?} column",
+                path.display(),
+                index + 1
+            ))
+        })
+}
+
+fn positive_u64(
+    path: &std::path::Path,
+    index: usize,
+    name: &str,
+    value: i64,
+) -> Result<u64, ImportError> {
+    u64::try_from(value)
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or_else(|| {
+            ImportError::Invalid(format!(
+                "{} row {} declares invalid {name} {value}",
+                path.display(),
+                index + 1
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use nanocodex_eval::PromptMessageRole;
+    use parquet::record::{Field, Row};
+
+    use super::MrcrCase;
+
+    #[test]
+    fn preserves_alternating_messages_and_official_dimensions() {
+        let prompt = serde_json::json!([
+            {"role": "user", "content": "write a poem"},
+            {"role": "assistant", "content": "first poem"},
+            {"role": "user", "content": "write a poem"},
+            {"role": "assistant", "content": "second poem"},
+            {"role": "user", "content": "Prepend abc1234567 to the second poem."}
+        ])
+        .to_string();
+        let row = Row::new(vec![
+            ("prompt".to_owned(), Field::Str(prompt)),
+            (
+                "answer".to_owned(),
+                Field::Str("abc1234567second poem".to_owned()),
+            ),
+            (
+                "random_string_to_prepend".to_owned(),
+                Field::Str("abc1234567".to_owned()),
+            ),
+            ("n_needles".to_owned(), Field::Long(2)),
+            ("desired_msg_index".to_owned(), Field::Long(3)),
+            ("total_messages".to_owned(), Field::Long(5)),
+            ("n_chars".to_owned(), Field::Long(1234)),
+            ("date_added".to_owned(), Field::Str("2025-12-04".to_owned())),
+        ]);
+
+        let case = MrcrCase::from_row(std::path::Path::new("fixture.parquet"), 0, &row).unwrap();
+
+        assert_eq!(case.transcript.len(), 4);
+        assert_eq!(case.transcript[0].role(), PromptMessageRole::User);
+        assert_eq!(case.transcript[1].role(), PromptMessageRole::Assistant);
+        assert_eq!(case.instruction, "Prepend abc1234567 to the second poem.");
+        assert_eq!(case.expected.n_needles, 2);
+        assert_eq!(case.expected.n_chars, 1234);
+        assert_eq!(case.expected.total_messages, 5);
+    }
+
+    #[test]
+    fn rejects_a_declared_message_count_that_changes_benchmark_shape() {
+        let row = Row::new(vec![
+            (
+                "prompt".to_owned(),
+                Field::Str(
+                    serde_json::json!([
+                        {"role": "user", "content": "question"},
+                        {"role": "assistant", "content": "answer"},
+                        {"role": "user", "content": "repeat it"}
+                    ])
+                    .to_string(),
+                ),
+            ),
+            ("answer".to_owned(), Field::Str("prefixanswer".to_owned())),
+            (
+                "random_string_to_prepend".to_owned(),
+                Field::Str("prefix".to_owned()),
+            ),
+            ("n_needles".to_owned(), Field::Long(2)),
+            ("desired_msg_index".to_owned(), Field::Long(1)),
+            ("total_messages".to_owned(), Field::Long(4)),
+            ("n_chars".to_owned(), Field::Long(100)),
+            ("date_added".to_owned(), Field::Str("2025-12-04".to_owned())),
+        ]);
+
+        let error =
+            MrcrCase::from_row(std::path::Path::new("fixture.parquet"), 0, &row).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("declares 4 messages but contains 3")
+        );
+    }
+}

--- a/crates/experimental/nanocodex-eval-adapters/src/mrcr.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/mrcr.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, path::PathBuf, time::Duration};
+use std::{collections::BTreeSet, fs::File, path::PathBuf, time::Duration};
 
 use nanocodex_eval::{
     PromptMessage, Resources, ScoringPolicy, TaskOutput,
@@ -31,6 +31,7 @@ pub struct Mrcr {
     revision: String,
     environment: Environment,
     harness: PathBuf,
+    tasks: Option<BTreeSet<String>>,
 }
 
 impl Mrcr {
@@ -47,7 +48,26 @@ impl Mrcr {
             revision: revision.into(),
             environment,
             harness: harness.into(),
+            tasks: None,
         }
+    }
+
+    /// Restricts normalization to the requested stable task IDs.
+    #[must_use]
+    pub fn tasks(mut self, task_ids: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.tasks = Some(task_ids.into_iter().map(Into::into).collect());
+        self
+    }
+
+    fn includes_partition(&self, partition: &str) -> bool {
+        self.tasks.as_ref().is_none_or(|tasks| {
+            let prefix = format!("{partition}-");
+            tasks.iter().any(|task| task.starts_with(&prefix))
+        })
+    }
+
+    fn includes_case(&self, id: &str) -> bool {
+        self.tasks.as_ref().is_none_or(|tasks| tasks.contains(id))
     }
 }
 
@@ -58,10 +78,13 @@ impl DatasetImporter for Mrcr {
             source_values.push(sha256_file(&self.harness.join(relative))?);
         }
         let harness = Harness::directory(&self.harness)?;
-        let mut cases = Vec::with_capacity(2_400);
+        let mut cases = Vec::with_capacity(self.tasks.as_ref().map_or(2_400, BTreeSet::len));
         for (partition, relative) in FILES {
             let path = self.source.join(relative);
             source_values.push(sha256_file(&path)?);
+            if !self.includes_partition(partition) {
+                continue;
+            }
             let file = File::open(&path).map_err(|source| ImportError::Io {
                 path: path.clone(),
                 source,
@@ -73,6 +96,10 @@ impl DatasetImporter for Mrcr {
                 ImportError::Invalid(format!("failed to read {}: {error}", path.display()))
             })?;
             for (index, row) in rows.enumerate() {
+                let id = format!("{partition}-{index:06}");
+                if !self.includes_case(&id) {
+                    continue;
+                }
                 let row = row.map_err(|error| {
                     ImportError::Invalid(format!(
                         "failed to decode {} row {}: {error}",
@@ -88,7 +115,7 @@ impl DatasetImporter for Mrcr {
                     })?;
                 cases.push(
                     CasePlan::hermetic(
-                        format!("{partition}-{index:06}"),
+                        id,
                         case.instruction,
                         self.environment.clone(),
                         harness.clone(),
@@ -298,10 +325,26 @@ fn positive_u64(
 
 #[cfg(test)]
 mod tests {
-    use nanocodex_eval::PromptMessageRole;
+    use nanocodex_eval::{PromptMessageRole, import::Environment};
     use parquet::record::{Field, Row};
 
-    use super::MrcrCase;
+    use super::{Mrcr, MrcrCase};
+
+    #[test]
+    fn task_selection_skips_unrequested_partitions_and_rows() {
+        let importer = Mrcr::new(
+            "source",
+            "revision",
+            Environment::OciImage("python:3.12-slim".to_owned()),
+            "harness",
+        )
+        .tasks(["8needle-0-000000"]);
+
+        assert!(!importer.includes_partition("2needle-0"));
+        assert!(importer.includes_partition("8needle-0"));
+        assert!(importer.includes_case("8needle-0-000000"));
+        assert!(!importer.includes_case("8needle-0-000001"));
+    }
 
     #[test]
     fn preserves_alternating_messages_and_official_dimensions() {

--- a/crates/experimental/nanocodex-eval/src/lib.rs
+++ b/crates/experimental/nanocodex-eval/src/lib.rs
@@ -99,6 +99,7 @@ pub(crate) use harness_exec::{
     HarnessCommandOutput, HarnessCommandRunner, HarnessCommandRunnerError, HarnessCommandStatus,
     HarnessExec, HarnessExecError,
 };
+pub use nanocodex_oai_api::{PromptMessage, PromptMessageRole};
 pub use profile::{ResolvedHarness, ResolvedTask};
 pub use result::{
     AgentMetadata, AgentResult, AgentStatus, BillingCompleteness, CleanupDiagnostic, CleanupPhase,

--- a/nanocodex.toml
+++ b/nanocodex.toml
@@ -47,3 +47,9 @@ benchmarks = ["graphwalks/128k-and-shorter-000749"]
 trials = 1
 model = ["sol"]
 thinking = ["high"]
+
+[profiles.mrcr-smoke]
+benchmarks = ["mrcr-v2/8needle-0-000000"]
+trials = 1
+model = ["sol"]
+thinking = ["high"]


### PR DESCRIPTION
Adapter split from #72.

Adds all six pinned MRCR v2 Parquet partitions, preserves the alternating typed transcript, and retains the published prefix plus SequenceMatcher similarity grader. Raw similarity is evidence; generic pass classification remains exact-one. Includes the retained 8-needle smoke case.

Validation:
- cargo fmt --all
- cargo test -p nanocodex-eval-adapters (10 passed)
- cargo clippy -p nanocodex-eval -p nanocodex-eval-adapters --all-targets -- -D warnings

Stacked on #148.