### PR TITLE
feat(eval): add GDPval adapter

### DIFF
--- a/crates/experimental/nanocodex-eval-adapters/assets/gdpval/environment/Dockerfile
+++ b/crates/experimental/nanocodex-eval-adapters/assets/gdpval/environment/Dockerfile
@@ -1,0 +1,21 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+        ca-certificates \
+        curl \
+        ffmpeg \
+        file \
+        fonts-dejavu-core \
+        jq \
+        libreoffice-calc \
+        libreoffice-draw \
+        libreoffice-impress \
+        libreoffice-writer \
+        poppler-utils \
+        python3 \
+        python3-pip \
+        unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace

--- a/crates/experimental/nanocodex-eval-adapters/assets/gdpval/verifier/Dockerfile
+++ b/crates/experimental/nanocodex-eval-adapters/assets/gdpval/verifier/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends \
+        file \
+        libreoffice-calc \
+        libreoffice-draw \
+        libreoffice-impress \
+        libreoffice-writer \
+        poppler-utils \
+    && rm -rf /var/lib/apt/lists/*

--- a/crates/experimental/nanocodex-eval-adapters/assets/gdpval/verifier/grade.py
+++ b/crates/experimental/nanocodex-eval-adapters/assets/gdpval/verifier/grade.py
@@ -1,0 +1,410 @@
+import json
+import gzip
+import os
+import re
+import subprocess
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+PAIRWISE_PROMPT = """You are evaluating two anonymous professional work submissions against the original task and its human-authored rubric.
+
+Return one JSON object with exactly these fields:
+- "winner": one of "A", "B", or "tie".
+- "explanation": a concise evidence-based comparison.
+- "rubric_decisions": an array containing exactly one object for every rubric item, in the supplied order. Each object must have exactly "rubric_item_id", "a_score", "b_score", and "explanation". Scores must be numbers between 0 and 1.
+
+Judge only the supplied artifacts. Missing, malformed, or unusable deliverables count against that submission. Negative-point rubric items describe undesirable behavior; a higher per-item score means the submission better avoids that behavior.
+
+# Original task
+<<TASK>>
+
+# Rubric
+<<RUBRIC>>
+
+# Submission A
+<<A>>
+
+# Submission B
+<<B>>
+"""
+
+RUBRIC_PROMPT = """You are evaluating one professional work submission against the original task and its human-authored rubric. No expert submission is available.
+
+Return one JSON object with exactly these fields:
+- "explanation": a concise evidence-based evaluation.
+- "rubric_decisions": an array containing exactly one object for every rubric item, in the supplied order. Each object must have exactly "rubric_item_id", "criteria_met", and "explanation". "criteria_met" must be boolean. For a negative-point item, true means the undesirable behavior is present.
+
+Judge only the supplied artifacts. Missing, malformed, or unusable deliverables count against the submission.
+
+# Original task
+<<TASK>>
+
+# Rubric
+<<RUBRIC>>
+
+# Submission
+<<SUBMISSION>>
+"""
+
+TEXT_EXTENSIONS = {
+    ".csv",
+    ".html",
+    ".ipynb",
+    ".json",
+    ".md",
+    ".overpassql",
+    ".py",
+    ".sql",
+    ".txt",
+    ".xml",
+    ".yaml",
+    ".yml",
+}
+OFFICE_EXTENSIONS = {
+    ".doc",
+    ".docx",
+    ".odp",
+    ".ods",
+    ".odt",
+    ".ppt",
+    ".pptx",
+    ".xls",
+    ".xlsx",
+}
+MAX_ARTIFACT_CHARS = 120_000
+MAX_SUBMISSION_CHARS = 240_000
+
+
+def response_text(response):
+    return "".join(
+        part.get("text", "")
+        for item in response.get("output", [])
+        for part in item.get("content", [])
+        if part.get("type") == "output_text"
+    )
+
+
+def parse_document(text):
+    cleaned = re.sub(r"^```(?:json)?\s*|\s*```$", "", text.strip(), flags=re.IGNORECASE)
+    document = json.loads(cleaned)
+    if not isinstance(document, dict):
+        raise ValueError("judge response is not an object")
+    return document
+
+
+def call_judge(prompt, model, validator, rubric_ids):
+    attempts = []
+    last_error = None
+    for attempt in range(1, 4):
+        response_document = {}
+        text = ""
+        poll_errors = []
+        uncompressed = json.dumps(
+            {
+                "model": model,
+                "input": [{"role": "user", "content": prompt}],
+            }
+        ).encode()
+        body = gzip.compress(uncompressed, compresslevel=1)
+        print(
+            json.dumps(
+                {
+                    "judge_request": {
+                        "attempt": attempt,
+                        "uncompressed_bytes": len(uncompressed),
+                        "compressed_bytes": len(body),
+                    }
+                }
+            ),
+            flush=True,
+        )
+        request = urllib.request.Request(
+            f"{os.environ['NANOCODEX_JUDGE_BASE_URL']}/responses/async",
+            data=body,
+            headers={
+                "Authorization": f"Bearer {os.environ['NANOCODEX_JUDGE_TOKEN']}",
+                "Content-Type": "application/json",
+                "Content-Encoding": "gzip",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                submitted = json.load(response)
+            response_id = submitted["id"]
+            response_document = submitted
+            deadline = time.monotonic() + 600
+            while True:
+                poll = urllib.request.Request(
+                    f"{os.environ['NANOCODEX_JUDGE_BASE_URL']}/responses/async/{response_id}",
+                    headers={
+                        "Authorization": f"Bearer {os.environ['NANOCODEX_JUDGE_TOKEN']}"
+                    },
+                )
+                try:
+                    with urllib.request.urlopen(poll, timeout=30) as response:
+                        response_document = json.load(response)
+                except urllib.error.HTTPError:
+                    raise
+                except OSError as error:
+                    poll_errors.append(f"{type(error).__name__}: {error}")
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError(
+                            f"judge polling did not recover: {poll_errors[-1]}"
+                        ) from error
+                    time.sleep(2)
+                    continue
+                if response_document.get("status") == "completed":
+                    break
+                if response_document.get("status") != "in_progress":
+                    raise ValueError("judge job returned an unexpected status")
+                if time.monotonic() >= deadline:
+                    raise TimeoutError("judge job did not complete within 600 seconds")
+                time.sleep(2)
+            text = response_text(response_document)
+            document = parse_document(text)
+            validator(document, rubric_ids)
+            attempts.append(
+                {
+                    "attempt": attempt,
+                    "response_id": response_document.get("id"),
+                    "text": text,
+                    "poll_errors": poll_errors,
+                    "error": None,
+                }
+            )
+            return document, attempts
+        except (OSError, ValueError) as error:
+            last_error = error
+            attempts.append(
+                {
+                    "attempt": attempt,
+                    "response_id": response_document.get("id"),
+                    "text": text,
+                    "poll_errors": poll_errors,
+                    "error": f"{type(error).__name__}: {error}",
+                }
+            )
+            print(json.dumps({"judge_attempt_failed": attempts[-1]}), flush=True)
+    raise RuntimeError(f"GDPval judge failed after 3 attempts: {last_error}")
+
+
+def truncate(value):
+    if len(value) <= MAX_ARTIFACT_CHARS:
+        return value
+    return value[:MAX_ARTIFACT_CHARS] + "\n[artifact text truncated by public reproduction grader]"
+
+
+def command_text(command):
+    result = subprocess.run(command, check=True, capture_output=True, text=True, timeout=120)
+    return result.stdout
+
+
+def artifact_text(path):
+    suffix = path.suffix.lower()
+    try:
+        if suffix in TEXT_EXTENSIONS:
+            return truncate(path.read_text(errors="replace"))
+        if suffix == ".pdf":
+            return truncate(command_text(["pdftotext", str(path), "-"]))
+        if suffix in OFFICE_EXTENSIONS:
+            with tempfile.TemporaryDirectory() as temporary:
+                subprocess.run(
+                    [
+                        "libreoffice",
+                        "--headless",
+                        "--convert-to",
+                        "pdf",
+                        "--outdir",
+                        temporary,
+                        str(path),
+                    ],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=180,
+                )
+                converted = list(Path(temporary).glob("*.pdf"))
+                if len(converted) != 1:
+                    raise RuntimeError("LibreOffice did not produce one PDF")
+                return truncate(command_text(["pdftotext", str(converted[0]), "-"]))
+        kind = command_text(["file", "--brief", str(path)]).strip()
+        return f"[binary artifact: {kind}; {path.stat().st_size} bytes]"
+    except (OSError, subprocess.SubprocessError, RuntimeError) as error:
+        return f"[artifact extraction failed: {type(error).__name__}: {error}]"
+
+
+def render_submission(root, deliverables):
+    rendered = []
+    missing = []
+    remaining = MAX_SUBMISSION_CHARS
+    for deliverable in deliverables:
+        name = Path(deliverable["path"]).name
+        path = root / name
+        if not path.is_file():
+            missing.append(name)
+            content = "[MISSING]"
+        else:
+            content = artifact_text(path)
+        retained = content[:remaining]
+        rendered.append(f"## {name}\n{retained}")
+        remaining -= len(retained)
+        if len(retained) != len(content):
+            rendered.append("[submission text truncated by public reproduction grader]")
+        if remaining == 0:
+            break
+    return "\n\n".join(rendered), missing
+
+
+def render_workspace(root):
+    rendered = []
+    files = []
+    remaining = MAX_SUBMISSION_CHARS
+    truncated = False
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(root)
+        if (
+            relative in {Path("Dockerfile"), Path("instruction.md")}
+            or relative.parts[:1] in {("reference_files",), (".git",), (".nanocodex",)}
+        ):
+            continue
+        files.append(str(relative))
+        if remaining == 0:
+            truncated = True
+            continue
+        content = artifact_text(path)
+        retained = content[:remaining]
+        rendered.append(f"## {relative}\n{retained}")
+        remaining -= len(retained)
+        truncated = truncated or len(retained) != len(content)
+    if truncated:
+        rendered.append("[submission text truncated by public reproduction grader]")
+    return "\n\n".join(rendered), files
+
+
+def validate_pairwise(document, rubric_ids):
+    if set(document) != {"winner", "explanation", "rubric_decisions"}:
+        raise ValueError("pairwise judge response has unexpected fields")
+    if document["winner"] not in {"A", "B", "tie"} or not isinstance(
+        document["explanation"], str
+    ):
+        raise ValueError("pairwise judge response has invalid verdict")
+    decisions = document["rubric_decisions"]
+    if not isinstance(decisions, list) or len(decisions) != len(rubric_ids):
+        raise ValueError("pairwise judge response has wrong rubric count")
+    for decision, rubric_id in zip(decisions, rubric_ids):
+        if set(decision) != {"rubric_item_id", "a_score", "b_score", "explanation"}:
+            raise ValueError("pairwise rubric decision has unexpected fields")
+        if decision["rubric_item_id"] != rubric_id:
+            raise ValueError("pairwise rubric decisions are out of order")
+        if not all(
+            isinstance(decision[key], (int, float)) and 0 <= decision[key] <= 1
+            for key in ("a_score", "b_score")
+        ) or not isinstance(decision["explanation"], str):
+            raise ValueError("pairwise rubric decision has invalid values")
+
+
+def validate_rubric(document, rubric_ids):
+    if set(document) != {"explanation", "rubric_decisions"}:
+        raise ValueError("rubric judge response has unexpected fields")
+    if not isinstance(document["explanation"], str):
+        raise ValueError("rubric judge explanation is not text")
+    decisions = document["rubric_decisions"]
+    if not isinstance(decisions, list) or len(decisions) != len(rubric_ids):
+        raise ValueError("rubric judge response has wrong rubric count")
+    for decision, rubric_id in zip(decisions, rubric_ids):
+        if set(decision) != {"rubric_item_id", "criteria_met", "explanation"}:
+            raise ValueError("rubric decision has unexpected fields")
+        if (
+            decision["rubric_item_id"] != rubric_id
+            or not isinstance(decision["criteria_met"], bool)
+            or not isinstance(decision["explanation"], str)
+        ):
+            raise ValueError("rubric decision has invalid values")
+
+
+def pairwise_score(winner, candidate_label):
+    if winner == "tie":
+        return 0.5
+    return 1.0 if winner == candidate_label else 0.0
+
+
+# Generated workspace-output tasks stage the candidate tree at this canonical
+# path even when the isolated verifier image has a different working directory.
+workspace = Path("/workspace")
+logs = Path(os.environ.get("NANOCODEX_EVAL_VERIFIER_LOGS", "/logs/verifier"))
+logs.mkdir(parents=True, exist_ok=True)
+case = json.loads(Path(os.environ.get("NANOCODEX_EVAL_CASE", "/tests/case.json")).read_text())
+model = os.environ.get("GDPVAL_JUDGE", case["scoring"]["grader_model"])
+rubric_json = json.dumps(case["rubric_items"], indent=2)
+rubric_ids = [item["rubric_item_id"] for item in case["rubric_items"]]
+candidate, candidate_files = render_workspace(workspace)
+expert_root = Path(os.environ.get("NANOCODEX_EVAL_EXPERT", "/tests/expert"))
+
+evidence = {
+    "benchmark": "gdpval-public-reproduction",
+    "case_id": case["task_id"],
+    "judge_model": model,
+    "judge_reasoning_effort": case["scoring"]["grader_reasoning_effort"],
+    "candidate_deliverables": candidate_files,
+    "method": None,
+    "judgments": [],
+}
+
+if not candidate_files:
+    score = 0.0
+    evidence["method"] = "deterministic-no-deliverables"
+elif case["deliverables"]:
+    expert, missing_expert = render_submission(expert_root, case["deliverables"])
+    if missing_expert:
+        raise RuntimeError(f"GDPval verifier package is missing expert deliverables: {missing_expert}")
+    score = 0.0
+    for candidate_label, submission_a, submission_b in (
+        ("B", expert, candidate),
+        ("A", candidate, expert),
+    ):
+        prompt = (
+            PAIRWISE_PROMPT.replace("<<TASK>>", case["prompt"])
+            .replace("<<RUBRIC>>", rubric_json)
+            .replace("<<A>>", submission_a)
+            .replace("<<B>>", submission_b)
+        )
+        judgment, attempts = call_judge(prompt, model, validate_pairwise, rubric_ids)
+        order_score = pairwise_score(judgment["winner"], candidate_label)
+        evidence["judgments"].append(
+            {
+                "candidate_label": candidate_label,
+                "score": order_score,
+                "judgment": judgment,
+                "attempts": attempts,
+            }
+        )
+        score += order_score / 2.0
+    evidence["method"] = "order-swapped-pairwise"
+else:
+    prompt = (
+        RUBRIC_PROMPT.replace("<<TASK>>", case["prompt"])
+        .replace("<<RUBRIC>>", rubric_json)
+        .replace("<<SUBMISSION>>", candidate)
+    )
+    judgment, attempts = call_judge(prompt, model, validate_rubric, rubric_ids)
+    achieved = 0
+    positive = sum(item["score"] for item in case["rubric_items"] if item["score"] > 0)
+    for rubric, decision in zip(case["rubric_items"], judgment["rubric_decisions"]):
+        if decision["criteria_met"]:
+            achieved += rubric["score"]
+    score = achieved / positive
+    evidence["method"] = "rubric-only-no-expert"
+    evidence["achieved_points"] = achieved
+    evidence["positive_points"] = positive
+    evidence["judgments"].append({"judgment": judgment, "attempts": attempts})
+
+evidence["public_score"] = score
+(logs / "judgments.json").write_text(json.dumps(evidence, indent=2))
+(logs / "reward.json").write_text(json.dumps({"public_score": score}) + "\n")

--- a/crates/experimental/nanocodex-eval-adapters/assets/gdpval/verifier/test.sh
+++ b/crates/experimental/nanocodex-eval-adapters/assets/gdpval/verifier/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -eu
+python3 /tests/grade.py

--- a/crates/experimental/nanocodex-eval-adapters/src/gdpval.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/gdpval.rs
@@ -1,0 +1,649 @@
+use std::{
+    collections::{BTreeSet, HashSet},
+    fs::File,
+    path::{Component, Path, PathBuf},
+    time::Duration,
+};
+
+use nanocodex_eval::{
+    Resources, TaskOutput,
+    import::{
+        CasePlan, DatasetImporter, DatasetPlan, Environment, Harness, ImportError, SourceIdentity,
+    },
+};
+use parquet::{
+    file::reader::{FileReader as _, SerializedFileReader},
+    record::{ListAccessor as _, Row, RowAccessor as _},
+};
+use serde::{Deserialize, Serialize};
+
+use crate::{sha256_file, sha256_values};
+
+pub(crate) const PARQUET_PATH: &str = "data/train-00000-of-00001.parquet";
+const HARNESS_FILES: [&str; 3] = ["Dockerfile", "test.sh", "grade.py"];
+const EXPECTED_CASES: usize = 220;
+const EXPECTED_SECTORS: usize = 9;
+const EXPECTED_OCCUPATIONS: usize = 44;
+const EXPECTED_RUBRICS: usize = 10_453;
+const EXPECTED_REFERENCE_FILES: usize = 261;
+const EXPECTED_DELIVERABLE_FILES: usize = 248;
+const COLUMNS: [&str; 12] = [
+    "task_id",
+    "sector",
+    "occupation",
+    "prompt",
+    "reference_files",
+    "reference_file_urls",
+    "reference_file_hf_uris",
+    "deliverable_files",
+    "deliverable_file_urls",
+    "deliverable_file_hf_uris",
+    "rubric_pretty",
+    "rubric_json",
+];
+const AGENT_INSTRUCTIONS: &str = "Complete the professional task in the writable workspace. Create every requested final deliverable as a file in the workspace; the evaluator scores those files, not a response that only describes their contents. Use clear descriptive filenames and do not write outputs inside reference_files.";
+
+/// OpenAI's public GDPval task, workspace-artifact, and rubric release.
+#[derive(Clone, Debug)]
+pub struct Gdpval {
+    source: PathBuf,
+    revision: String,
+    environment: Environment,
+    harness: PathBuf,
+    task_ids: Option<BTreeSet<String>>,
+}
+
+impl Gdpval {
+    /// Creates an importer for one pinned public GDPval repository snapshot.
+    #[must_use]
+    pub fn new(
+        source: impl Into<PathBuf>,
+        revision: impl Into<String>,
+        environment: Environment,
+        harness: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            source: source.into(),
+            revision: revision.into(),
+            environment,
+            harness: harness.into(),
+            task_ids: None,
+        }
+    }
+
+    /// Restricts normalization to task IDs selected by the resolved profile.
+    #[must_use]
+    pub fn tasks(mut self, task_ids: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        self.task_ids = Some(task_ids.into_iter().map(Into::into).collect());
+        self
+    }
+}
+
+impl DatasetImporter for Gdpval {
+    fn plan(&self) -> Result<DatasetPlan, ImportError> {
+        let parquet = self.source.join(PARQUET_PATH);
+        let cases = read_cases(&parquet)?;
+        validate_release(&parquet, &cases)?;
+        let cases = cases
+            .into_iter()
+            .filter(|case| {
+                self.task_ids
+                    .as_ref()
+                    .is_none_or(|task_ids| task_ids.contains(&case.task_id))
+            })
+            .collect::<Vec<_>>();
+        if cases.is_empty() {
+            return Err(ImportError::Invalid(
+                "GDPval profile selection contains no task from the pinned release".to_owned(),
+            ));
+        }
+
+        let mut source_values = Vec::with_capacity(
+            1 + HARNESS_FILES.len() + EXPECTED_REFERENCE_FILES + EXPECTED_DELIVERABLE_FILES,
+        );
+        source_values.push(sha256_file(&parquet)?);
+        for relative in HARNESS_FILES {
+            source_values.push(sha256_file(&self.harness.join(relative))?);
+        }
+        let harness = Harness::directory(&self.harness)?;
+        let mut planned = Vec::with_capacity(cases.len());
+        for case in cases {
+            let metadata = case.verifier_metadata();
+            let metadata = serde_json::to_vec(&metadata).map_err(|source| ImportError::Json {
+                path: parquet.clone(),
+                source,
+            })?;
+            let mut task = CasePlan::hermetic(
+                &case.task_id,
+                &case.prompt,
+                self.environment.clone(),
+                harness.clone(),
+            )?
+            .benchmark_prompt_chars(character_count(&case.prompt, &case.task_id)?)
+            .benchmark_case_type(format!("{}/{}", case.sector, case.occupation))
+            .instructions(AGENT_INSTRUCTIONS)
+            .output(TaskOutput::Workspace)
+            .resources(Resources {
+                cpus: 4,
+                memory_mb: 8_192,
+                storage_mb: 16_384,
+                gpus: 0,
+            })
+            .timeouts(Duration::from_secs(7_200), Duration::from_secs(1_800))
+            .allow_internet(true)
+            .verifier_allow_internet(true)
+            .harness_file("case.json", metadata, 0o600)?;
+
+            for asset in &case.reference_files {
+                let source = self.source.join(&asset.path);
+                source_values.push(sha256_file(&source)?);
+                task = task.environment_file_from(
+                    Path::new("reference_files").join(asset.basename()?),
+                    source,
+                    0o644,
+                )?;
+            }
+            for asset in &case.deliverable_files {
+                let source = self.source.join(&asset.path);
+                source_values.push(sha256_file(&source)?);
+                task = task.harness_file_from(
+                    Path::new("expert").join(asset.basename()?),
+                    source,
+                    0o600,
+                )?;
+            }
+            planned.push(task);
+        }
+
+        let source = SourceIdentity::new(
+            "openai-gdpval-public",
+            &self.revision,
+            sha256_values(source_values.iter().map(String::as_bytes)),
+        )?;
+        let mut plan = DatasetPlan::new("gdpval", source)?;
+        for case in planned {
+            plan = plan.case(case);
+        }
+        Ok(plan)
+    }
+}
+
+#[derive(Clone)]
+struct GdpvalCase {
+    task_id: String,
+    sector: String,
+    occupation: String,
+    prompt: String,
+    reference_files: Vec<Asset>,
+    deliverable_files: Vec<Asset>,
+    rubric_pretty: String,
+    rubric_items: Vec<RubricItem>,
+}
+
+#[derive(Clone, Serialize)]
+struct Asset {
+    path: PathBuf,
+    url: String,
+    hf_uri: String,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct RubricItem {
+    score: i64,
+    criterion: String,
+    required: Option<()>,
+    rubric_item_id: String,
+    author_type: AuthorType,
+    tags: Vec<String>,
+    read_only: Option<()>,
+    #[serde(default)]
+    form_content: Option<()>,
+}
+
+#[derive(Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum AuthorType {
+    Human,
+}
+
+#[derive(Serialize)]
+struct VerifierCase<'a> {
+    task_id: &'a str,
+    sector: &'a str,
+    occupation: &'a str,
+    prompt: &'a str,
+    deliverables: &'a [Asset],
+    rubric_pretty: &'a str,
+    rubric_items: &'a [RubricItem],
+    scoring: ScoringContract,
+}
+
+#[derive(Serialize)]
+struct ScoringContract {
+    reproduction: &'static str,
+    grader_model: &'static str,
+    grader_reasoning_effort: &'static str,
+    presentation_orders: u8,
+}
+
+impl GdpvalCase {
+    fn from_row(path: &Path, index: usize, row: &Row) -> Result<Self, ImportError> {
+        let columns = row
+            .get_column_iter()
+            .map(|(name, _)| name.as_str())
+            .collect::<BTreeSet<_>>();
+        let expected = COLUMNS.into_iter().collect::<BTreeSet<_>>();
+        if columns != expected {
+            return Err(ImportError::Invalid(format!(
+                "{} row {} has GDPval columns {columns:?}, expected {expected:?}",
+                path.display(),
+                index + 1
+            )));
+        }
+        let task_id = text(path, index, row, "task_id")?;
+        let sector = text(path, index, row, "sector")?;
+        let occupation = text(path, index, row, "occupation")?;
+        let prompt = text(path, index, row, "prompt")?;
+        let reference_files = assets(path, index, row, "reference")?;
+        let deliverable_files = assets(path, index, row, "deliverable")?;
+        let rubric_pretty = text(path, index, row, "rubric_pretty")?;
+        let rubric_json = text(path, index, row, "rubric_json")?;
+        let rubric_items =
+            serde_json::from_str::<Vec<RubricItem>>(&rubric_json).map_err(|error| {
+                ImportError::Invalid(format!(
+                    "{} row {} has invalid rubric_json: {error}",
+                    path.display(),
+                    index + 1
+                ))
+            })?;
+        let case = Self {
+            task_id,
+            sector,
+            occupation,
+            prompt,
+            reference_files,
+            deliverable_files,
+            rubric_pretty,
+            rubric_items,
+        };
+        case.validate(path, index)?;
+        Ok(case)
+    }
+
+    fn validate(&self, path: &Path, index: usize) -> Result<(), ImportError> {
+        if !is_uuid(&self.task_id) {
+            return invalid_case(path, index, &self.task_id, "invalid task UUID");
+        }
+        if self.sector.trim().is_empty()
+            || self.occupation.trim().is_empty()
+            || self.prompt.trim().is_empty()
+            || self.rubric_pretty.trim().is_empty()
+        {
+            return invalid_case(path, index, &self.task_id, "empty task metadata");
+        }
+        let mut basenames = HashSet::new();
+        for asset in &self.reference_files {
+            validate_asset(asset, "reference_files", &self.task_id)?;
+            if !basenames.insert(asset.basename()?.to_owned()) {
+                return invalid_case(path, index, &self.task_id, "duplicate reference basename");
+            }
+        }
+        basenames.clear();
+        for asset in &self.deliverable_files {
+            validate_asset(asset, "deliverable_files", &self.task_id)?;
+            if !basenames.insert(asset.basename()?.to_owned()) {
+                return invalid_case(path, index, &self.task_id, "duplicate deliverable basename");
+            }
+        }
+        if self.rubric_items.is_empty()
+            || !self.rubric_items.iter().any(|item| item.score > 0)
+            || self.rubric_items.iter().any(|item| {
+                item.score == 0
+                    || item.criterion.trim().is_empty()
+                    || !is_uuid(&item.rubric_item_id)
+            })
+        {
+            return invalid_case(path, index, &self.task_id, "invalid rubric");
+        }
+        Ok(())
+    }
+
+    fn verifier_metadata(&self) -> VerifierCase<'_> {
+        VerifierCase {
+            task_id: &self.task_id,
+            sector: &self.sector,
+            occupation: &self.occupation,
+            prompt: &self.prompt,
+            deliverables: &self.deliverable_files,
+            rubric_pretty: &self.rubric_pretty,
+            rubric_items: &self.rubric_items,
+            scoring: ScoringContract {
+                reproduction: "nanocodex-public-gdpval-pairwise-v1",
+                grader_model: "gpt-5.6-sol",
+                grader_reasoning_effort: "low",
+                presentation_orders: 2,
+            },
+        }
+    }
+}
+
+impl Asset {
+    fn basename(&self) -> Result<&std::ffi::OsStr, ImportError> {
+        self.path.file_name().ok_or_else(|| {
+            ImportError::Invalid(format!(
+                "GDPval asset has no basename: {}",
+                self.path.display()
+            ))
+        })
+    }
+}
+
+fn read_cases(path: &Path) -> Result<Vec<GdpvalCase>, ImportError> {
+    let file = File::open(path).map_err(|source| ImportError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let reader = SerializedFileReader::new(file).map_err(|error| {
+        ImportError::Invalid(format!("failed to open {}: {error}", path.display()))
+    })?;
+    reader
+        .get_row_iter(None)
+        .map_err(|error| {
+            ImportError::Invalid(format!("failed to read {}: {error}", path.display()))
+        })?
+        .enumerate()
+        .map(|(index, row)| {
+            let row = row.map_err(|error| {
+                ImportError::Invalid(format!(
+                    "failed to decode {} row {}: {error}",
+                    path.display(),
+                    index + 1
+                ))
+            })?;
+            GdpvalCase::from_row(path, index, &row)
+        })
+        .collect()
+}
+
+pub(crate) fn asset_paths(
+    path: &Path,
+    task_ids: Option<&BTreeSet<String>>,
+) -> Result<Vec<PathBuf>, ImportError> {
+    let cases = read_cases(path)?;
+    validate_release(path, &cases)?;
+    Ok(cases
+        .into_iter()
+        .filter(|case| task_ids.is_none_or(|task_ids| task_ids.contains(&case.task_id)))
+        .flat_map(|case| {
+            case.reference_files
+                .into_iter()
+                .chain(case.deliverable_files)
+                .map(|asset| asset.path)
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect())
+}
+
+fn validate_release(path: &Path, cases: &[GdpvalCase]) -> Result<(), ImportError> {
+    let ids = cases
+        .iter()
+        .map(|case| case.task_id.as_str())
+        .collect::<HashSet<_>>();
+    let sectors = cases
+        .iter()
+        .map(|case| case.sector.as_str())
+        .collect::<HashSet<_>>();
+    let occupations = cases
+        .iter()
+        .map(|case| case.occupation.as_str())
+        .collect::<HashSet<_>>();
+    let rubrics = cases
+        .iter()
+        .flat_map(|case| &case.rubric_items)
+        .collect::<Vec<_>>();
+    let rubric_ids = rubrics
+        .iter()
+        .map(|rubric| rubric.rubric_item_id.as_str())
+        .collect::<HashSet<_>>();
+    let references = cases
+        .iter()
+        .flat_map(|case| case.reference_files.iter().map(|asset| &asset.path))
+        .collect::<HashSet<_>>();
+    let deliverables = cases
+        .iter()
+        .flat_map(|case| case.deliverable_files.iter().map(|asset| &asset.path))
+        .collect::<HashSet<_>>();
+    if cases.len() != EXPECTED_CASES
+        || ids.len() != EXPECTED_CASES
+        || sectors.len() != EXPECTED_SECTORS
+        || occupations.len() != EXPECTED_OCCUPATIONS
+        || rubrics.len() != EXPECTED_RUBRICS
+        || rubric_ids.len() != EXPECTED_RUBRICS
+        || references.len() != EXPECTED_REFERENCE_FILES
+        || deliverables.len() != EXPECTED_DELIVERABLE_FILES
+    {
+        return Err(ImportError::Invalid(format!(
+            "{} is not the pinned GDPval release: cases={}/{EXPECTED_CASES}, unique_ids={}, sectors={}/{EXPECTED_SECTORS}, occupations={}/{EXPECTED_OCCUPATIONS}, rubrics={}/{EXPECTED_RUBRICS}, unique_rubrics={}, references={}/{EXPECTED_REFERENCE_FILES}, deliverables={}/{EXPECTED_DELIVERABLE_FILES}",
+            path.display(),
+            cases.len(),
+            ids.len(),
+            sectors.len(),
+            occupations.len(),
+            rubrics.len(),
+            rubric_ids.len(),
+            references.len(),
+            deliverables.len(),
+        )));
+    }
+    Ok(())
+}
+
+fn text(path: &Path, row_number: usize, row: &Row, name: &str) -> Result<String, ImportError> {
+    let index = field(path, row_number, row, name)?;
+    row.get_string(index).cloned().map_err(|error| {
+        ImportError::Invalid(format!(
+            "{} row {} {name} is not text: {error}",
+            path.display(),
+            row_number + 1
+        ))
+    })
+}
+
+fn strings(
+    path: &Path,
+    row_number: usize,
+    row: &Row,
+    name: &str,
+) -> Result<Vec<String>, ImportError> {
+    let index = field(path, row_number, row, name)?;
+    let values = row.get_list(index).map_err(|error| {
+        ImportError::Invalid(format!(
+            "{} row {} {name} is not a list: {error}",
+            path.display(),
+            row_number + 1
+        ))
+    })?;
+    (0..values.len())
+        .map(|item| {
+            values.get_string(item).cloned().map_err(|error| {
+                ImportError::Invalid(format!(
+                    "{} row {} {name} contains non-text: {error}",
+                    path.display(),
+                    row_number + 1
+                ))
+            })
+        })
+        .collect()
+}
+
+fn assets(
+    path: &Path,
+    row_number: usize,
+    row: &Row,
+    kind: &str,
+) -> Result<Vec<Asset>, ImportError> {
+    let paths = strings(path, row_number, row, &format!("{kind}_files"))?;
+    let urls = strings(path, row_number, row, &format!("{kind}_file_urls"))?;
+    let uris = strings(path, row_number, row, &format!("{kind}_file_hf_uris"))?;
+    if paths.len() != urls.len() || paths.len() != uris.len() {
+        return Err(ImportError::Invalid(format!(
+            "{} row {} {kind} asset arrays have different lengths",
+            path.display(),
+            row_number + 1
+        )));
+    }
+    Ok(paths
+        .into_iter()
+        .zip(urls)
+        .zip(uris)
+        .map(|((path, url), hf_uri)| Asset {
+            path: PathBuf::from(path),
+            url,
+            hf_uri,
+        })
+        .collect())
+}
+
+fn field(path: &Path, row_number: usize, row: &Row, name: &str) -> Result<usize, ImportError> {
+    row.get_column_iter()
+        .position(|(candidate, _)| candidate == name)
+        .ok_or_else(|| {
+            ImportError::Invalid(format!(
+                "{} row {} has no {name:?} column",
+                path.display(),
+                row_number + 1
+            ))
+        })
+}
+
+fn validate_asset(asset: &Asset, prefix: &str, task_id: &str) -> Result<(), ImportError> {
+    let components = asset.path.components().collect::<Vec<_>>();
+    let valid = matches!(components.as_slice(), [Component::Normal(root), Component::Normal(hash), Component::Normal(name)]
+        if *root == std::ffi::OsStr::new(prefix)
+            && hash.to_str().is_some_and(is_hex_id)
+            && !name.is_empty());
+    if !valid
+        || asset.url.trim().is_empty()
+        || asset.hf_uri.trim().is_empty()
+        || !asset.url.contains("huggingface.co/datasets/openai/gdpval/")
+        || !asset
+            .hf_uri
+            .starts_with("hf://datasets/openai/gdpval@main/")
+    {
+        return Err(ImportError::Invalid(format!(
+            "GDPval task {task_id} has invalid {prefix} asset {}",
+            asset.path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn is_hex_id(value: &str) -> bool {
+    value.len() == 32
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+fn is_uuid(value: &str) -> bool {
+    value.len() == 36
+        && value.bytes().enumerate().all(|(index, byte)| {
+            if matches!(index, 8 | 13 | 18 | 23) {
+                byte == b'-'
+            } else {
+                byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')
+            }
+        })
+}
+
+fn character_count(value: &str, task_id: &str) -> Result<u64, ImportError> {
+    u64::try_from(value.chars().count())
+        .map_err(|_| ImportError::Invalid(format!("GDPval task {task_id} prompt length overflows")))
+}
+
+fn invalid_case<T>(
+    path: &Path,
+    index: usize,
+    task_id: &str,
+    message: &str,
+) -> Result<T, ImportError> {
+    Err(ImportError::Invalid(format!(
+        "{} row {} GDPval task {task_id:?} has {message}",
+        path.display(),
+        index + 1
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn asset(prefix: &str, name: &str) -> Asset {
+        Asset {
+            path: PathBuf::from(format!("{prefix}/0123456789abcdef0123456789abcdef/{name}")),
+            url: format!(
+                "https://huggingface.co/datasets/openai/gdpval/resolve/main/{prefix}/{name}"
+            ),
+            hf_uri: format!("hf://datasets/openai/gdpval@main/{prefix}/{name}"),
+        }
+    }
+
+    fn case() -> GdpvalCase {
+        GdpvalCase {
+            task_id: "854f3814-681c-4950-91ac-55b0db0e3781".to_owned(),
+            sector: "Professional Services".to_owned(),
+            occupation: "Software Developers".to_owned(),
+            prompt: "Produce both requested files.".to_owned(),
+            reference_files: Vec::new(),
+            deliverable_files: vec![asset("deliverable_files", "answer.md")],
+            rubric_pretty: "Complete and correct.".to_owned(),
+            rubric_items: vec![RubricItem {
+                score: 5,
+                criterion: "The answer is complete.".to_owned(),
+                required: None,
+                rubric_item_id: "01234567-89ab-cdef-0123-456789abcdef".to_owned(),
+                author_type: AuthorType::Human,
+                tags: Vec::new(),
+                read_only: None,
+                form_content: None,
+            }],
+        }
+    }
+
+    #[test]
+    fn keeps_expert_and_rubrics_in_verifier_metadata() {
+        let case = case();
+        case.validate(Path::new("fixture.parquet"), 0).unwrap();
+        let metadata = serde_json::to_string(&case.verifier_metadata()).unwrap();
+
+        assert!(metadata.contains("deliverable_files"));
+        assert!(metadata.contains("Complete and correct"));
+        assert!(!case.prompt.contains("Complete and correct"));
+    }
+
+    #[test]
+    fn rejects_asset_traversal() {
+        let mut case = case();
+        case.deliverable_files[0].path = PathBuf::from("deliverable_files/../answer.md");
+
+        let error = case.validate(Path::new("fixture.parquet"), 0).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("invalid deliverable_files asset")
+        );
+    }
+
+    #[test]
+    fn rejects_rubric_without_positive_points() {
+        let mut case = case();
+        case.rubric_items[0].score = -5;
+
+        let error = case.validate(Path::new("fixture.parquet"), 0).unwrap_err();
+
+        assert!(error.to_string().contains("invalid rubric"));
+    }
+}

--- a/crates/experimental/nanocodex-eval-adapters/src/lib.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/lib.rs
@@ -7,6 +7,7 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
 mod arena_hard;
+mod gdpval;
 mod genebench_pro;
 mod graphwalks;
 mod harbor;
@@ -125,6 +126,11 @@ const INSTALLED_ADAPTERS: &[InstalledAdapter] = &[
         import: import_healthbench_professional,
         matches: exact_task,
     },
+    InstalledAdapter {
+        names: &["gdpval"],
+        import: import_gdpval,
+        matches: exact_task,
+    },
 ];
 
 const TERMINAL_BENCH_REVISION: &str = "5c8eadf1f393183288fa08b8f73ca9a469cc5e00";
@@ -175,6 +181,9 @@ const MRCR_FILES: [(&str, &str); 6] = [
 const HEALTHBENCH_PROFESSIONAL_REVISION: &str = "349962fd46dd02343a0d8a606491baf59154ea1a";
 const HEALTHBENCH_PROFESSIONAL_SHA256: &str =
     "d44b08e6e952e04c945e2c406f02533d9e7a989a84e35820ee7efdff20c9e4e2";
+const GDPVAL_REVISION: &str = "11e7900cdcac61bc4daf59e65feb238acda98fbf";
+const GDPVAL_PARQUET_SHA256: &str =
+    "f8422fab9b21d90c0ee5f0659842ab666d418cb8940842918f9f4b0df7ae0202";
 
 fn import_harbor(
     request: &BenchmarkRequest,
@@ -424,6 +433,50 @@ fn import_healthbench_professional(
             Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/healthbench-professional"),
         ))?,
     )
+}
+
+fn import_gdpval(
+    request: &BenchmarkRequest,
+    sources: &SourceStore,
+    store: &ImportStore,
+) -> Result<ImportedDataset, AdapterError> {
+    let checkout = sources.git_checkout_with_materialized_lfs(
+        "gdpval",
+        "https://huggingface.co/datasets/openai/gdpval.git",
+        GDPVAL_REVISION,
+    )?;
+    let parquet = Path::new(gdpval::PARQUET_PATH);
+    let parquet_digest = sources.materialize_checkout_lfs_file(
+        "gdpval",
+        parquet,
+        GDPVAL_REVISION,
+        "openai/gdpval",
+    )?;
+    if parquet_digest != GDPVAL_PARQUET_SHA256 {
+        return Err(AdapterError::Source(format!(
+            "GDPval Parquet has pinned digest {parquet_digest}, expected {GDPVAL_PARQUET_SHA256}"
+        )));
+    }
+    let selected = (!request.all).then_some(&request.tasks);
+    for asset in gdpval::asset_paths(&checkout.join(parquet), selected)? {
+        sources.materialize_checkout_lfs_file(
+            "gdpval",
+            &asset,
+            GDPVAL_REVISION,
+            "openai/gdpval",
+        )?;
+    }
+    let assets = Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/gdpval");
+    let mut importer = gdpval::Gdpval::new(
+        checkout,
+        format!("openai/gdpval@{GDPVAL_REVISION}"),
+        nanocodex_eval::import::Environment::Dockerfile(assets.join("environment")),
+        assets.join("verifier"),
+    );
+    if !request.all {
+        importer = importer.tasks(request.tasks.iter().cloned());
+    }
+    Ok(store.import(&importer)?)
 }
 
 impl AdapterCatalog {

--- a/crates/experimental/nanocodex-eval-adapters/src/source.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/source.rs
@@ -43,6 +43,25 @@ impl SourceStore {
         url: &str,
         revision: &str,
     ) -> Result<PathBuf, SourceError> {
+        self.git_checkout_with_policy(relative, url, revision, false)
+    }
+
+    pub(crate) fn git_checkout_with_materialized_lfs(
+        &self,
+        relative: &str,
+        url: &str,
+        revision: &str,
+    ) -> Result<PathBuf, SourceError> {
+        self.git_checkout_with_policy(relative, url, revision, true)
+    }
+
+    fn git_checkout_with_policy(
+        &self,
+        relative: &str,
+        url: &str,
+        revision: &str,
+        allow_materialized_lfs: bool,
+    ) -> Result<PathBuf, SourceError> {
         let destination = self.root.join(relative);
         if destination.exists() {
             let head = command_text(
@@ -58,13 +77,14 @@ impl SourceStore {
                     head.trim()
                 )));
             }
-            let dirty = command_text(
-                Command::new("git")
-                    .arg("-C")
-                    .arg(&destination)
-                    .args(["status", "--porcelain=v1"]),
-            )?;
-            if !dirty.trim().is_empty() {
+            let dirty = command_text(Command::new("git").arg("-C").arg(&destination).args([
+                "status",
+                "--porcelain=v1",
+                "-z",
+            ]))?;
+            if !dirty.trim().is_empty()
+                && !(allow_materialized_lfs && self.allowed_materialized_lfs(relative, &dirty)?)
+            {
                 return Err(SourceError::Stale(format!(
                     "{} has local changes",
                     destination.display()
@@ -94,6 +114,94 @@ impl SourceStore {
         fs::rename(temporary.keep(), &destination)
             .map_err(|source| io_error(&destination, source))?;
         Ok(destination)
+    }
+
+    pub(crate) fn materialize_checkout_lfs_file(
+        &self,
+        checkout: &str,
+        relative: &Path,
+        revision: &str,
+        dataset: &str,
+    ) -> Result<String, SourceError> {
+        let relative_text = relative.to_str().ok_or_else(|| {
+            SourceError::Stale(format!("non-UTF-8 LFS path: {}", relative.display()))
+        })?;
+        let object = self.checkout_object(checkout, relative_text)?;
+        let expected = object.sha256;
+        let destination = self.root.join(checkout).join(relative);
+        if destination.is_file() && validate_sha256(&destination, &expected).is_ok() {
+            return Ok(expected);
+        }
+        if let Some(bytes) = object.git_bytes {
+            fs::write(&destination, bytes).map_err(|source| io_error(&destination, source))?;
+            validate_sha256(&destination, &expected)?;
+            return Ok(expected);
+        }
+        if destination.exists() {
+            let pointer = fs::read_to_string(&destination)
+                .map_err(|source| io_error(&destination, source))?;
+            if parse_lfs_sha256(&pointer).as_deref() != Some(expected.as_str()) {
+                return Err(SourceError::Stale(format!(
+                    "{} is neither the pinned LFS pointer nor its object",
+                    destination.display()
+                )));
+            }
+            fs::remove_file(&destination).map_err(|source| io_error(&destination, source))?;
+        }
+        let url = format!(
+            "https://huggingface.co/datasets/{dataset}/resolve/{revision}/{}",
+            encode_url_path(relative_text)
+        );
+        self.download(&format!("{checkout}/{relative_text}"), &url, &expected)?;
+        Ok(expected)
+    }
+
+    fn allowed_materialized_lfs(&self, checkout: &str, status: &str) -> Result<bool, SourceError> {
+        let records = status
+            .split('\0')
+            .filter(|record| !record.is_empty())
+            .collect::<Vec<_>>();
+        if records.is_empty() {
+            return Ok(false);
+        }
+        for record in records {
+            let (state, relative) = record.split_at(3.min(record.len()));
+            if state != " M " {
+                return Ok(false);
+            }
+            let expected = self.checkout_object(checkout, relative)?.sha256;
+            if validate_sha256(&self.root.join(checkout).join(relative), &expected).is_err() {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    fn checkout_object(
+        &self,
+        checkout: &str,
+        relative: &str,
+    ) -> Result<CheckoutObject, SourceError> {
+        let bytes = command_bytes(
+            Command::new("git")
+                .arg("-C")
+                .arg(self.root.join(checkout))
+                .arg("show")
+                .arg(format!("HEAD:{relative}")),
+        )?;
+        if let Ok(pointer) = std::str::from_utf8(&bytes)
+            && let Some(sha256) = parse_lfs_sha256(pointer)
+        {
+            Ok(CheckoutObject {
+                sha256,
+                git_bytes: None,
+            })
+        } else {
+            Ok(CheckoutObject {
+                sha256: hex::encode(Sha256::digest(&bytes)),
+                git_bytes: Some(bytes),
+            })
+        }
     }
 
     #[allow(dead_code)]
@@ -197,6 +305,14 @@ fn command_text(command: &mut Command) -> Result<String, SourceError> {
     String::from_utf8(output.stdout).map_err(|error| SourceError::Command(error.to_string()))
 }
 
+fn command_bytes(command: &mut Command) -> Result<Vec<u8>, SourceError> {
+    let rendered = format!("{command:?}");
+    let output = command
+        .output()
+        .map_err(|error| SourceError::Command(format!("{rendered}: {error}")))?;
+    Ok(ensure_success(rendered, output)?.stdout)
+}
+
 #[allow(dead_code)]
 fn ensure_success(rendered: String, output: Output) -> Result<Output, SourceError> {
     if output.status.success() {
@@ -215,5 +331,58 @@ fn io_error(path: &Path, source: std::io::Error) -> SourceError {
     SourceError::Io {
         path: path.to_path_buf(),
         source,
+    }
+}
+
+struct CheckoutObject {
+    sha256: String,
+    git_bytes: Option<Vec<u8>>,
+}
+
+fn parse_lfs_sha256(pointer: &str) -> Option<String> {
+    if !pointer.starts_with("version https://git-lfs.github.com/spec/v1\n") {
+        return None;
+    }
+    pointer.lines().find_map(|line| {
+        let digest = line.strip_prefix("oid sha256:")?;
+        (digest.len() == 64
+            && digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')))
+        .then(|| digest.to_owned())
+    })
+}
+
+fn encode_url_path(path: &str) -> String {
+    let mut encoded = String::with_capacity(path.len());
+    for byte in path.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~' | b'/') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push('%');
+            encoded.push(char::from(b"0123456789ABCDEF"[usize::from(byte >> 4)]));
+            encoded.push(char::from(b"0123456789ABCDEF"[usize::from(byte & 0x0f)]));
+        }
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{encode_url_path, parse_lfs_sha256};
+
+    #[test]
+    fn parses_only_canonical_git_lfs_pointers() {
+        let digest = "a".repeat(64);
+        let pointer =
+            format!("version https://git-lfs.github.com/spec/v1\noid sha256:{digest}\nsize 12\n");
+
+        assert_eq!(parse_lfs_sha256(&pointer), Some(digest));
+        assert_eq!(parse_lfs_sha256("ordinary file"), None);
+    }
+
+    #[test]
+    fn encodes_asset_paths_without_hiding_directory_boundaries() {
+        assert_eq!(encode_url_path("files/a b#.pdf"), "files/a%20b%23.pdf");
     }
 }

--- a/nanocodex.toml
+++ b/nanocodex.toml
@@ -59,3 +59,9 @@ benchmarks = ["healthbench-professional/e339f34a3a35f3f067422b5768287f7c"]
 trials = 1
 model = ["sol"]
 thinking = ["high"]
+
+[profiles.gdpval-smoke]
+benchmarks = ["gdpval/854f3814-681c-4950-91ac-55b0db0e3781"]
+trials = 1
+model = ["sol"]
+thinking = ["high"]


### PR DESCRIPTION
Adapter split from #72.

Adds OpenAI GDPval at its pinned 220-task release with selective Git-LFS materialization, candidate-only reference files, verifier-only expert deliverables/rubrics, and the order-swapped public pairwise judge reproduction. The smoke profile downloads only one task and its assets.

Validation:
- cargo fmt --all
- cargo test -p nanocodex-eval-adapters (18 passed)
- cargo clippy -p nanocodex-eval-adapters --all-targets -- -D warnings

This is explicitly the public reproduction, not GDPval-AA v2.

Stacked on #150.