### PR TITLE
feat(eval): add BrowseComp adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5330,6 +5330,7 @@ dependencies = [
 name = "nanocodex-eval-adapters"
 version = "0.3.0"
 dependencies = [
+ "base64",
  "csv",
  "hex",
  "ignore",

--- a/crates/experimental/nanocodex-eval-adapters/Cargo.toml
+++ b/crates/experimental/nanocodex-eval-adapters/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 description = "Third-party benchmark adapters for nanocodex-eval"
 
 [dependencies]
+base64.workspace = true
 csv.workspace = true
 hex.workspace = true
 ignore.workspace = true

--- a/crates/experimental/nanocodex-eval-adapters/assets/browsecomp/Dockerfile
+++ b/crates/experimental/nanocodex-eval-adapters/assets/browsecomp/Dockerfile
@@ -1,0 +1,1 @@
+FROM python:3.12-slim

--- a/crates/experimental/nanocodex-eval-adapters/assets/browsecomp/grade.py
+++ b/crates/experimental/nanocodex-eval-adapters/assets/browsecomp/grade.py
@@ -1,0 +1,100 @@
+import json
+import os
+import re
+import urllib.request
+from pathlib import Path
+
+
+GRADER_TEMPLATE = r"""Judge whether the following [response] to [question] is correct or not based on the precise and unambiguous [correct_answer] below.
+
+[question]: {question}
+
+[response]: {response}
+
+Your judgement must be in the format and criteria specified below:
+
+extracted_final_answer: The final exact answer extracted from the [response]. Put the extracted answer as 'None' if there is no exact, final answer to extract from the response.
+
+[correct_answer]: {correct_answer}
+
+reasoning: Explain why the extracted_final_answer is correct or incorrect based on [correct_answer], focusing only on if there are meaningful differences between [correct_answer] and the extracted_final_answer. Do not comment on any background to the problem, do not attempt to solve the problem, do not argue for any answer different than [correct_answer], focus only on whether the answers match.
+
+correct: Answer 'yes' if extracted_final_answer matches the [correct_answer] given above, or is within a small margin of error for numerical problems. Answer 'no' otherwise, i.e. if there if there is any inconsistency, ambiguity, non-equivalency, or if the extracted answer is incorrect.
+
+
+confidence: The extracted confidence score between 0|\%| and 100|\%| from [response]. Put 100 if there is no confidence score available."""
+
+
+def parse_decision(text):
+    match = re.search(r"correct: (yes|no)", text)
+    return match.group(1) if match else "no"
+
+
+def judge(question, correct_answer, candidate, scoring):
+    prompt = GRADER_TEMPLATE.format(
+        question=question,
+        correct_answer=correct_answer,
+        response=candidate,
+    )
+    body = json.dumps(
+        {
+            "model": scoring["grader_model"],
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": prompt},
+            ],
+            "temperature": scoring["reference_temperature"],
+            "max_tokens": scoring["reference_max_output_tokens"],
+        }
+    ).encode()
+    request = urllib.request.Request(
+        f"{os.environ['NANOCODEX_JUDGE_BASE_URL']}/chat/completions",
+        data=body,
+        headers={
+            "Authorization": f"Bearer {os.environ['NANOCODEX_JUDGE_TOKEN']}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=300) as response:
+        document = json.load(response)
+    text = document["choices"][0]["message"]["content"]
+    return {
+        "response_id": document.get("id"),
+        "effective_model": document.get("model"),
+        "text": text,
+        "decision": parse_decision(text),
+    }
+
+
+def main():
+    workspace = Path(os.environ["NANOCODEX_EVAL_WORKSPACE"])
+    logs = Path(os.environ.get("NANOCODEX_EVAL_VERIFIER_LOGS", "/logs/verifier"))
+    logs.mkdir(parents=True, exist_ok=True)
+    case = json.loads(
+        Path(os.environ.get("NANOCODEX_EVAL_CASE", "/tests/case.json")).read_text()
+    )
+    candidate = (workspace / "answer.txt").read_text()
+    judgment = judge(
+        case["question"], case["correct_answer"], candidate, case["scoring"]
+    )
+    accuracy = 1 if judgment["decision"] == "yes" else 0
+    evidence = {
+        "benchmark": "browsecomp",
+        "case_id": case["id"],
+        "topic": case["topic"],
+        "grader_contract": case["scoring"]["grader_contract"],
+        "requested_model": case["scoring"]["grader_model"],
+        "reference_model": case["scoring"]["reference_model"],
+        "reference_temperature": case["scoring"]["reference_temperature"],
+        "reference_max_output_tokens": case["scoring"]["reference_max_output_tokens"],
+        "candidate_chars": len(candidate),
+        "judgment": judgment,
+        "accuracy": accuracy,
+    }
+    (logs / "judgment.json").write_text(json.dumps(evidence, indent=2))
+    (logs / "reward.json").write_text(json.dumps({"accuracy": accuracy}) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/experimental/nanocodex-eval-adapters/assets/browsecomp/test.sh
+++ b/crates/experimental/nanocodex-eval-adapters/assets/browsecomp/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+python3 /tests/grade.py

--- a/crates/experimental/nanocodex-eval-adapters/src/browsecomp.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/browsecomp.rs
@@ -1,0 +1,353 @@
+use std::{collections::HashSet, path::PathBuf, time::Duration};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use nanocodex_eval::{
+    Resources, ScoringPolicy, TaskOutput,
+    import::{
+        CasePlan, DatasetImporter, DatasetPlan, Environment, Harness, ImportError, SourceIdentity,
+    },
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+use crate::{sha256_file, sha256_values};
+
+const EXPECTED_CASES: usize = 1_266;
+const HARNESS_FILES: [&str; 3] = ["Dockerfile", "test.sh", "grade.py"];
+const QUERY_SUFFIX: &str = "Your response should be in the following format:\nExplanation: {your explanation for your final answer}\nExact Answer: {your succinct, final answer}\nConfidence: {your confidence score between 0% and 100% for your answer}";
+
+/// OpenAI's encrypted BrowseComp release and subscription-judge reproduction.
+#[derive(Clone, Debug)]
+pub struct BrowseComp {
+    source: PathBuf,
+    revision: String,
+    environment: Environment,
+    harness: PathBuf,
+}
+
+impl BrowseComp {
+    /// Creates an importer for the exact official encrypted CSV snapshot.
+    #[must_use]
+    pub fn new(
+        source: impl Into<PathBuf>,
+        revision: impl Into<String>,
+        environment: Environment,
+        harness: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            source: source.into(),
+            revision: revision.into(),
+            environment,
+            harness: harness.into(),
+        }
+    }
+
+    fn cases(&self) -> Result<Vec<BrowseCompCase>, ImportError> {
+        let mut reader = csv::Reader::from_path(&self.source).map_err(|error| {
+            ImportError::Invalid(format!("failed to read {}: {error}", self.source.display()))
+        })?;
+        let headers = reader.headers().map_err(|error| {
+            ImportError::Invalid(format!(
+                "failed to read {} headers: {error}",
+                self.source.display()
+            ))
+        })?;
+        if headers.iter().collect::<Vec<_>>() != ["problem", "answer", "problem_topic", "canary"] {
+            return Err(ImportError::Invalid(format!(
+                "{} does not have the exact BrowseComp columns",
+                self.source.display()
+            )));
+        }
+        let mut cases = Vec::new();
+        let mut encrypted_problems = HashSet::new();
+        for (index, row) in reader.deserialize::<BrowseCompRow>().enumerate() {
+            let row = row.map_err(|error| {
+                ImportError::Invalid(format!(
+                    "{} row {} is not a BrowseComp record: {error}",
+                    self.source.display(),
+                    index + 2
+                ))
+            })?;
+            if !encrypted_problems.insert(row.problem.clone()) {
+                return Err(ImportError::Invalid(format!(
+                    "{} contains a duplicate encrypted problem at row {}",
+                    self.source.display(),
+                    index + 2
+                )));
+            }
+            cases.push(BrowseCompCase::new(index, row)?);
+        }
+        if cases.len() != EXPECTED_CASES {
+            return Err(ImportError::Invalid(format!(
+                "{} contains {} BrowseComp rows, expected {EXPECTED_CASES}",
+                self.source.display(),
+                cases.len()
+            )));
+        }
+        Ok(cases)
+    }
+}
+
+impl DatasetImporter for BrowseComp {
+    fn plan(&self) -> Result<DatasetPlan, ImportError> {
+        let source_values = std::iter::once(sha256_file(&self.source)?)
+            .chain(
+                HARNESS_FILES
+                    .into_iter()
+                    .map(|file| sha256_file(&self.harness.join(file)))
+                    .collect::<Result<Vec<_>, _>>()?,
+            )
+            .collect::<Vec<_>>();
+        let source = SourceIdentity::new(
+            "openai-browsecomp",
+            &self.revision,
+            sha256_values(source_values.iter().map(String::as_bytes)),
+        )?;
+        let harness = Harness::directory(&self.harness)?;
+        let mut plan = DatasetPlan::new("browsecomp", source)?;
+        for case in self.cases()? {
+            let prompt_chars = u64::try_from(case.prompt.chars().count()).map_err(|_| {
+                ImportError::Invalid(format!("BrowseComp prompt {:?} is too large", case.id))
+            })?;
+            let verifier = serde_json::to_vec(&BrowseCompVerifierCase {
+                id: &case.id,
+                question: &case.question,
+                correct_answer: &case.correct_answer,
+                topic: &case.topic,
+                scoring: BrowseCompScoring {
+                    grader_model: "gpt-5.6-sol",
+                    grader_contract: "openai-subscription-judge-reproduction",
+                    reference_model: "gpt-4.1-2025-04-14",
+                    reference_temperature: 0.5,
+                    reference_max_output_tokens: 2_048,
+                },
+            })
+            .map_err(|error| {
+                ImportError::Invalid(format!("failed to encode BrowseComp case: {error}"))
+            })?;
+            let task = CasePlan::hermetic(
+                &case.id,
+                case.prompt,
+                self.environment.clone(),
+                harness.clone(),
+            )?
+            .benchmark_prompt_chars(prompt_chars)
+            .benchmark_case_type(case.topic)
+            .output(TaskOutput::FinalMessage)
+            .scoring_policy(ScoringPolicy::AllRewardsOne)
+            .resources(Resources {
+                cpus: 1,
+                memory_mb: 1_024,
+                storage_mb: 1_024,
+                gpus: 0,
+            })
+            .timeouts(Duration::from_secs(3_600), Duration::from_secs(900))
+            .allow_internet(true)
+            .verifier_allow_internet(true)
+            .harness_file("case.json", verifier, 0o600)?;
+            plan = plan.case(task);
+        }
+        Ok(plan)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BrowseCompRow {
+    problem: String,
+    answer: String,
+    problem_topic: String,
+    canary: String,
+}
+
+struct BrowseCompCase {
+    id: String,
+    prompt: String,
+    question: String,
+    correct_answer: String,
+    topic: String,
+}
+
+impl BrowseCompCase {
+    fn new(index: usize, row: BrowseCompRow) -> Result<Self, ImportError> {
+        if row.problem.is_empty()
+            || row.answer.is_empty()
+            || row.problem_topic.trim().is_empty()
+            || row.canary.is_empty()
+        {
+            return Err(ImportError::Invalid(format!(
+                "BrowseComp row {} has an empty field",
+                index + 2
+            )));
+        }
+        let question = BrowseCompCiphertext::new(&row.problem, &row.canary).decrypt(index)?;
+        let correct_answer = BrowseCompCiphertext::new(&row.answer, &row.canary).decrypt(index)?;
+        if question.trim().is_empty() || correct_answer.trim().is_empty() {
+            return Err(ImportError::Invalid(format!(
+                "BrowseComp row {} decrypts to an empty field",
+                index + 2
+            )));
+        }
+        let digest = hex::encode(Sha256::digest(row.problem.as_bytes()));
+        let id = format!("{index:06}-{}", &digest[..16]);
+        let prompt = format!("{question}\n\n{QUERY_SUFFIX}");
+        Ok(Self {
+            id,
+            prompt,
+            question,
+            correct_answer,
+            topic: row.problem_topic,
+        })
+    }
+}
+
+struct BrowseCompCiphertext<'a> {
+    ciphertext: &'a str,
+    password: &'a str,
+}
+
+impl<'a> BrowseCompCiphertext<'a> {
+    const fn new(ciphertext: &'a str, password: &'a str) -> Self {
+        Self {
+            ciphertext,
+            password,
+        }
+    }
+
+    fn decrypt(&self, index: usize) -> Result<String, ImportError> {
+        let encrypted = STANDARD.decode(self.ciphertext).map_err(|error| {
+            ImportError::Invalid(format!(
+                "BrowseComp row {} has invalid base64 ciphertext: {error}",
+                index + 2
+            ))
+        })?;
+        let key = Sha256::digest(self.password.as_bytes());
+        let decrypted = encrypted
+            .iter()
+            .enumerate()
+            .map(|(offset, byte)| byte ^ key[offset % key.len()])
+            .collect::<Vec<_>>();
+        String::from_utf8(decrypted).map_err(|error| {
+            ImportError::Invalid(format!(
+                "BrowseComp row {} ciphertext is not valid UTF-8: {error}",
+                index + 2
+            ))
+        })
+    }
+}
+
+#[derive(Serialize)]
+struct BrowseCompVerifierCase<'a> {
+    id: &'a str,
+    question: &'a str,
+    correct_answer: &'a str,
+    topic: &'a str,
+    scoring: BrowseCompScoring,
+}
+
+#[derive(Serialize)]
+struct BrowseCompScoring {
+    grader_model: &'static str,
+    grader_contract: &'static str,
+    reference_model: &'static str,
+    reference_temperature: f64,
+    reference_max_output_tokens: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+    use nanocodex_eval::import::Environment;
+    use sha2::{Digest as _, Sha256};
+    use tempfile::tempdir;
+
+    use super::{BrowseComp, BrowseCompCase, BrowseCompRow, EXPECTED_CASES};
+
+    fn encrypt(value: &str, password: &str) -> String {
+        let key = Sha256::digest(password.as_bytes());
+        let encrypted = value
+            .as_bytes()
+            .iter()
+            .enumerate()
+            .map(|(offset, byte)| byte ^ key[offset % key.len()])
+            .collect::<Vec<_>>();
+        STANDARD.encode(encrypted)
+    }
+
+    #[test]
+    fn case_decrypts_the_official_xor_shape_without_leaking_the_answer() {
+        let password = "private canary";
+        let case = BrowseCompCase::new(
+            788,
+            BrowseCompRow {
+                problem: encrypt("Which record is correct?", password),
+                answer: encrypt("The hidden answer", password),
+                problem_topic: "Records".to_owned(),
+                canary: password.to_owned(),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(case.question, "Which record is correct?");
+        assert_eq!(case.correct_answer, "The hidden answer");
+        assert_eq!(case.topic, "Records");
+        assert_eq!(
+            case.prompt,
+            "Which record is correct?\n\nYour response should be in the following format:\nExplanation: {your explanation for your final answer}\nExact Answer: {your succinct, final answer}\nConfidence: {your confidence score between 0% and 100% for your answer}"
+        );
+        assert!(!case.prompt.contains("The hidden answer"));
+        assert!(!case.prompt.contains(password));
+        assert!(case.id.starts_with("000788-"));
+    }
+
+    #[test]
+    fn malformed_ciphertext_fails_closed() {
+        let error = BrowseCompCase::new(
+            0,
+            BrowseCompRow {
+                problem: "%%%".to_owned(),
+                answer: "%%%".to_owned(),
+                problem_topic: "Records".to_owned(),
+                canary: "canary".to_owned(),
+            },
+        )
+        .err()
+        .unwrap();
+
+        assert!(error.to_string().contains("invalid base64 ciphertext"));
+    }
+
+    #[test]
+    fn complete_release_shape_requires_unique_ordered_records() {
+        let directory = tempdir().unwrap();
+        let source = directory.path().join("browsecomp.csv");
+        let mut writer = csv::Writer::from_path(&source).unwrap();
+        writer
+            .write_record(["problem", "answer", "problem_topic", "canary"])
+            .unwrap();
+        for index in 0..EXPECTED_CASES {
+            let password = format!("canary-{index}");
+            writer
+                .write_record([
+                    encrypt(&format!("Question {index}?"), &password),
+                    encrypt(&format!("Answer {index}"), &password),
+                    "Synthetic".to_owned(),
+                    password,
+                ])
+                .unwrap();
+        }
+        writer.flush().unwrap();
+        let importer = BrowseComp::new(
+            &source,
+            "browsecomp@test",
+            Environment::OciImage("python:3.12-slim".to_owned()),
+            directory.path().join("harness"),
+        );
+
+        let cases = importer.cases().unwrap();
+
+        assert_eq!(cases.len(), EXPECTED_CASES);
+        assert!(cases[788].id.starts_with("000788-"));
+        assert_eq!(cases[788].question, "Question 788?");
+    }
+}

--- a/crates/experimental/nanocodex-eval-adapters/src/lib.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/lib.rs
@@ -7,6 +7,7 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
 mod arena_hard;
+mod browsecomp;
 mod gdpval;
 mod genebench_pro;
 mod gpqa_diamond;
@@ -137,6 +138,11 @@ const INSTALLED_ADAPTERS: &[InstalledAdapter] = &[
         import: import_gpqa_diamond,
         matches: exact_task,
     },
+    InstalledAdapter {
+        names: &["browsecomp"],
+        import: import_browsecomp,
+        matches: exact_task,
+    },
 ];
 
 const TERMINAL_BENCH_REVISION: &str = "5c8eadf1f393183288fa08b8f73ca9a469cc5e00";
@@ -194,6 +200,8 @@ const GPQA_REVISION: &str = "56686c06f5e19865c153de0fdb11be3890014df7";
 const GPQA_ZIP_SHA256: &str = "461ae7329f15a3e35f8184d2dac24b990f34fdf12f366ca4062d8e6638cd08dc";
 const GPQA_DIAMOND_SHA256: &str =
     "41d1213cd7a4998605a26c2798500652572007161b3a92817ba46b35befcd305";
+const BROWSECOMP_REVISION: &str = "652c89d0ca9df547706735883097e9537d40dc47";
+const BROWSECOMP_SHA256: &str = "7b24471cd5b3eb2a46830a14802b5c029ea62f488ff75a0f88af7923d1454abf";
 
 fn import_harbor(
     request: &BenchmarkRequest,
@@ -513,6 +521,24 @@ fn import_gpqa_diamond(
         format!("idavidrein/gpqa@{GPQA_REVISION}"),
         nanocodex_eval::import::Environment::OciImage("python:3.12-slim".to_owned()),
         Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/gpqa-diamond"),
+    ))?)
+}
+
+fn import_browsecomp(
+    _request: &BenchmarkRequest,
+    sources: &SourceStore,
+    store: &ImportStore,
+) -> Result<ImportedDataset, AdapterError> {
+    let dataset = sources.download(
+        "browsecomp/browse_comp_test_set.csv",
+        "https://openaipublic.blob.core.windows.net/simple-evals/browse_comp_test_set.csv",
+        BROWSECOMP_SHA256,
+    )?;
+    Ok(store.import(&browsecomp::BrowseComp::new(
+        dataset,
+        format!("openai/simple-evals@{BROWSECOMP_REVISION}"),
+        nanocodex_eval::import::Environment::OciImage("python:3.12-slim".to_owned()),
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/browsecomp"),
     ))?)
 }
 

--- a/nanocodex.toml
+++ b/nanocodex.toml
@@ -71,3 +71,10 @@ benchmarks = ["gpqa-diamond/rec06pnAkLOr2t2mp"]
 trials = 1
 model = ["sol"]
 thinking = ["high"]
+
+[profiles.browsecomp-smoke]
+benchmarks = ["browsecomp/000788-b1fa2bf2323cd70e"]
+trials = 1
+model = ["sol"]
+thinking = ["high"]
+web_search = true


### PR DESCRIPTION
Adapter split from #72.

Adds OpenAI BrowseComp at the pinned encrypted 1,266-row release, reproduces its XOR decryption and answer format without exposing references to the candidate, enables browsing for the smoke treatment, and packages the subscription-judge reproduction in a separate verifier VM.

Validation:
- cargo fmt --all
- cargo test -p nanocodex-eval-adapters (23 passed)
- cargo clippy -p nanocodex-eval-adapters --all-targets -- -D warnings

Stacked on #152.