### PR TITLE
feat(eval): add ARC-AGI-3 public smoke adapter

### DIFF
--- a/crates/experimental/nanocodex-eval-adapters/assets/arc-agi-3/environment/Dockerfile
+++ b/crates/experimental/nanocodex-eval-adapters/assets/arc-agi-3/environment/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+
+COPY arc_agi_3.py /usr/local/bin/arc-agi-3
+COPY arc_case.json /opt/nanocodex/arc-agi-3/case.json
+RUN chmod 0755 /usr/local/bin/arc-agi-3
+
+WORKDIR /workspace

--- a/crates/experimental/nanocodex-eval-adapters/assets/arc-agi-3/environment/arc_agi_3.py
+++ b/crates/experimental/nanocodex-eval-adapters/assets/arc-agi-3/environment/arc_agi_3.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Scoped ARC-AGI-3 interaction client for one normalized eval task."""
+
+import http.cookiejar
+import json
+import math
+import os
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+CASE_PATH = Path("/opt/nanocodex/arc-agi-3/case.json")
+STATE_PATH = Path("/tmp/nanocodex-arc-agi-3-state.json")
+COOKIE_PATH = Path("/tmp/nanocodex-arc-agi-3-cookies.txt")
+
+
+class ArcError(RuntimeError):
+    pass
+
+
+class ArcSession:
+    def __init__(self):
+        self.case = json.loads(CASE_PATH.read_text())
+        self.cookies = http.cookiejar.MozillaCookieJar(str(COOKIE_PATH))
+        if COOKIE_PATH.exists():
+            self.cookies.load(ignore_discard=True, ignore_expires=True)
+        self.opener = urllib.request.build_opener(
+            urllib.request.HTTPCookieProcessor(self.cookies)
+        )
+
+    def observe(self):
+        state = self._load_state()
+        if state is None:
+            state = self._start()
+        print(self._render(state))
+
+    def act(self, argv):
+        state = self._load_state()
+        if state is None:
+            raise ArcError("run `arc-agi-3 observe` before taking an action")
+        if state["terminal"]:
+            print(self._render(state))
+            return
+        action, payload = self._parse_action(argv, state)
+        frame = self._validated_frame(self._request(
+            f"/api/cmd/{action}",
+            method="POST",
+            key=state["api_key"],
+            body={"game_id": self.case["game_id"], "guid": state["guid"], **payload},
+        ))
+        state["actions"] += 1
+        state["level_actions"] += 1
+        state["previous_action"] = action
+        state["guid"] = frame["guid"]
+        state["frame"] = frame
+        state["observations"] = [frame]
+        self._sync_level(state)
+        self._update_terminal(state)
+
+        if not state["terminal"] and frame["state"] in ("GAME_OVER", "NOT_PLAYED"):
+            frame = self._validated_frame(self._request(
+                "/api/cmd/RESET",
+                method="POST",
+                key=state["api_key"],
+                body={"game_id": self.case["game_id"], "guid": state["guid"]},
+            ))
+            state["actions"] += 1
+            state["level_actions"] += 1
+            state["forced_resets"] += 1
+            state["previous_action"] = "RESET"
+            state["guid"] = frame["guid"]
+            state["frame"] = frame
+            state["observations"].append(frame)
+            self._sync_level(state)
+
+        self._update_terminal(state)
+        self._save_state(state)
+        print(self._render(state))
+
+    def finish(self):
+        state = self._load_state()
+        if state is None:
+            raise ArcError("there is no ARC-AGI-3 session to finish")
+        if not state["terminal"]:
+            state["terminal"] = True
+            state["exit_reason"] = "AGENT_FINISHED"
+            self._save_state(state)
+        print(self._render(state))
+
+    def _start(self):
+        key = self._request("/api/games/anonkey")["api_key"]
+        games = self._request("/api/games", key=key)
+        metadata = next(
+            (game for game in games if game.get("game_id") == self.case["game_id"]),
+            None,
+        )
+        if metadata is None:
+            raise ArcError(f"official API does not offer {self.case['game_id']}")
+        if metadata.get("baseline_actions") != self.case["baseline_actions"]:
+            raise ArcError("official game baseline changed; run eval preparation again")
+        scorecard = self._request(
+            "/api/scorecard/open",
+            method="POST",
+            key=key,
+            body={"tags": ["nanocodex", "arc-agi-3", "adapter-smoke"]},
+        )
+        state = {
+            "schema_version": 1,
+            "api_key": key,
+            "card_id": scorecard["card_id"],
+            "guid": None,
+            "frame": None,
+            "observations": [],
+            "actions": 0,
+            "level_actions": 0,
+            "last_levels_completed": 0,
+            "level_just_advanced": False,
+            "forced_resets": 0,
+            "previous_action": None,
+            "terminal": False,
+            "exit_reason": None,
+        }
+        # Persist the close capability before starting the game so verifier
+        # cleanup can close a card even when RESET fails.
+        self._save_state(state)
+        frame = self._validated_frame(self._request(
+            "/api/cmd/RESET",
+            method="POST",
+            key=key,
+            body={"card_id": scorecard["card_id"], "game_id": self.case["game_id"]},
+        ))
+        state["guid"] = frame["guid"]
+        state["frame"] = frame
+        state["observations"] = [frame]
+        state["last_levels_completed"] = frame["levels_completed"]
+        self._update_terminal(state)
+        self._save_state(state)
+        return state
+
+    def _request(self, path, method="GET", key=None, body=None):
+        headers = {"Accept": "application/json"}
+        if key:
+            headers["X-API-Key"] = key
+        data = None
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+            data = json.dumps(body, separators=(",", ":")).encode()
+        request = urllib.request.Request(
+            self.case["api_base_url"] + path,
+            headers=headers,
+            data=data,
+            method=method,
+        )
+        last_error = None
+        attempts = 3 if method == "GET" else 1
+        for attempt in range(attempts):
+            try:
+                with self.opener.open(request, timeout=20) as response:
+                    document = json.load(response)
+                self.cookies.save(ignore_discard=True, ignore_expires=True)
+                os.chmod(COOKIE_PATH, 0o600)
+                return document
+            except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as error:
+                last_error = error
+                if attempt + 1 < attempts:
+                    time.sleep(0.5 * (2**attempt))
+        raise ArcError(f"official ARC API request failed for {path}: {last_error}")
+
+    def _parse_action(self, argv, state):
+        if not argv:
+            raise ArcError("missing action; use ACTION1 through ACTION7")
+        action = argv[0].upper()
+        available = {f"ACTION{value}" for value in state["frame"]["available_actions"]}
+        if state["actions"] > 0 and state["previous_action"] != "RESET":
+            available.add("RESET")
+        if action not in available:
+            raise ArcError(
+                f"{action} is unavailable; choose one of {', '.join(sorted(available))}"
+            )
+        if action == "ACTION6":
+            if len(argv) != 3:
+                raise ArcError("ACTION6 requires integer X and Y coordinates")
+            try:
+                x, y = int(argv[1]), int(argv[2])
+            except ValueError as error:
+                raise ArcError("ACTION6 coordinates must be integers") from error
+            if not 0 <= x <= 63 or not 0 <= y <= 63:
+                raise ArcError("ACTION6 coordinates must be between 0 and 63")
+            return action, {"x": x, "y": y}
+        if len(argv) != 1:
+            raise ArcError(f"{action} does not accept arguments")
+        return action, {}
+
+    def _sync_level(self, state):
+        completed = state["frame"]["levels_completed"]
+        if completed > state["last_levels_completed"]:
+            state["level_actions"] = 0
+            state["last_levels_completed"] = completed
+            state["level_just_advanced"] = True
+
+    def _update_terminal(self, state):
+        frame = state["frame"]
+        if frame["state"] == "WIN":
+            state["terminal"] = True
+            state["exit_reason"] = "GAME_WIN"
+            return
+        smoke_cap = self.case.get("smoke_action_cap")
+        if smoke_cap is not None and state["actions"] >= smoke_cap:
+            state["terminal"] = True
+            state["exit_reason"] = "SMOKE_ACTION_CAP"
+            return
+        level = frame["levels_completed"]
+        baselines = self.case["baseline_actions"]
+        if level < len(baselines):
+            budget = math.ceil(
+                baselines[level] * self.case["action_budget_multiplier"]
+            )
+            if state["level_actions"] >= budget:
+                state["terminal"] = True
+                state["exit_reason"] = "ACTION_BUDGET"
+                return
+        total_budget = sum(
+            math.ceil(value * self.case["action_budget_multiplier"])
+            for value in baselines
+        )
+        if state["actions"] >= total_budget:
+            state["terminal"] = True
+            state["exit_reason"] = "ACTION_BUDGET"
+
+    def _render(self, state):
+        if state["frame"] is None:
+            return "Status: SETUP_FAILED\nThe scorecard was opened but no initial frame was received."
+        observations = state.get("observations") or [state["frame"]]
+        rendered_observations = []
+        for observation_index, frame in enumerate(observations):
+            rendered_observations.append(
+                self._render_frame(
+                    frame,
+                    state["level_just_advanced"] and observation_index == len(observations) - 1,
+                    state,
+                )
+            )
+        state["level_just_advanced"] = False
+        status = "TERMINAL" if state["terminal"] else "ACTIVE"
+        rendered_observations.append(
+            f"Status: {status}\nActions recorded: {state['actions']}\n"
+            f"Exit reason: {state['exit_reason'] or 'NONE'}"
+        )
+        return "\n\n".join(rendered_observations)
+
+    def _render_frame(self, frame, new_level, state):
+        grids = self._interpolate(
+            frame["frame"], self.case["max_animation_frames"]
+        )
+        parts = [
+            f"State: {frame['state']}\nLevels completed: {frame['levels_completed']}"
+        ]
+        for index, grid in enumerate(grids):
+            lines = [f"Frame {index}:"]
+            if new_level and index == len(grids) - 1:
+                lines = ["New Level:", "", *lines]
+            lines.extend(f"  {row}" for row in grid)
+            parts.append("\n".join(lines))
+        actions = [f"ACTION{value}" for value in frame["available_actions"]]
+        if state["actions"] > 0 and state["previous_action"] != "RESET":
+            actions.insert(0, "RESET")
+        rendered = []
+        for action in actions:
+            if action == "ACTION6":
+                rendered.append("- ACTION6 x y  (where x and y are integers 0-63)")
+            else:
+                rendered.append(f"- {action}")
+        parts.append("Available actions:\n" + "\n".join(rendered))
+        return "\n\n".join(parts)
+
+    def _validated_frame(self, frame):
+        if not isinstance(frame, dict):
+            raise ArcError("official API returned a non-object frame")
+        required = {
+            "game_id", "frame", "state", "levels_completed", "win_levels",
+            "guid", "available_actions",
+        }
+        if not required.issubset(frame):
+            raise ArcError("official API returned an incomplete frame")
+        if frame["game_id"] != self.case["game_id"] or not isinstance(frame["guid"], str):
+            raise ArcError("official API returned a frame for the wrong game or session")
+        if frame["state"] not in {"NOT_PLAYED", "NOT_FINISHED", "WIN", "GAME_OVER"}:
+            raise ArcError(f"official API returned unknown state {frame['state']!r}")
+        if type(frame["levels_completed"]) is not int or type(frame["win_levels"]) is not int:
+            raise ArcError("official API returned invalid level counters")
+        actions = frame["available_actions"]
+        if not isinstance(actions, list) or any(type(value) is not int or not 1 <= value <= 7 for value in actions):
+            raise ArcError("official API returned invalid available actions")
+        if not isinstance(frame["frame"], list) or not frame["frame"]:
+            raise ArcError("official API returned no rendered frame")
+        for grid in frame["frame"]:
+            if not isinstance(grid, list) or any(not isinstance(row, list) for row in grid):
+                raise ArcError("official API returned an invalid rendered frame")
+        return frame
+
+    @staticmethod
+    def _interpolate(frames, target):
+        if len(frames) <= target:
+            return frames
+        if target == 1:
+            return [frames[-1]]
+        indexes = [round(index * (len(frames) - 1) / (target - 1)) for index in range(target)]
+        return [frames[index] for index in indexes]
+
+    @staticmethod
+    def _load_state():
+        if not STATE_PATH.exists():
+            return None
+        state = json.loads(STATE_PATH.read_text())
+        if state.get("schema_version") != 1:
+            raise ArcError("unsupported private session state")
+        return state
+
+    @staticmethod
+    def _save_state(state):
+        descriptor, name = tempfile.mkstemp(dir=STATE_PATH.parent, prefix=".arc-state-")
+        try:
+            with os.fdopen(descriptor, "w") as output:
+                json.dump(state, output, separators=(",", ":"))
+                output.flush()
+                os.fsync(output.fileno())
+            os.chmod(name, 0o600)
+            os.replace(name, STATE_PATH)
+        finally:
+            if os.path.exists(name):
+                os.unlink(name)
+
+
+def self_test():
+    session = object.__new__(ArcSession)
+    session.case = {
+        "api_base_url": "https://invalid.example",
+        "game_id": "ls20-test",
+        "max_animation_frames": 3,
+    }
+    state = {
+        "frame": {"available_actions": [1, 6]},
+        "actions": 0,
+        "previous_action": None,
+    }
+    assert session._parse_action(["ACTION1"], state) == ("ACTION1", {})
+    assert session._parse_action(["ACTION6", "2", "63"], state) == (
+        "ACTION6",
+        {"x": 2, "y": 63},
+    )
+    try:
+        session._parse_action(["ACTION6", "64", "0"], state)
+    except ArcError:
+        pass
+    else:
+        raise AssertionError("out-of-range coordinates were accepted")
+    assert session._interpolate([[0], [1], [2], [3], [4]], 3) == [[0], [2], [4]]
+
+    frame = {
+        "game_id": "ls20-test",
+        "frame": [[[0, 1], [1, 0]]],
+        "state": "NOT_FINISHED",
+        "levels_completed": 0,
+        "win_levels": 1,
+        "guid": "guid",
+        "available_actions": [1, 6],
+    }
+    assert session._validated_frame(frame) is frame
+    malformed = dict(frame, available_actions=[8])
+    try:
+        session._validated_frame(malformed)
+    except ArcError:
+        pass
+    else:
+        raise AssertionError("invalid action metadata was accepted")
+
+    class FailingOpener:
+        def __init__(self):
+            self.calls = 0
+
+        def open(self, request, timeout):
+            self.calls += 1
+            raise urllib.error.URLError("lost response")
+
+    session.opener = FailingOpener()
+    try:
+        session._request("/api/cmd/ACTION1", method="POST", body={})
+    except ArcError:
+        pass
+    else:
+        raise AssertionError("failed POST unexpectedly succeeded")
+    assert session.opener.calls == 1
+    print("ok")
+
+
+def main():
+    if len(sys.argv) == 2 and sys.argv[1] == "self-test":
+        self_test()
+        return
+    command = sys.argv[1] if len(sys.argv) > 1 else ""
+    session = ArcSession()
+    if command == "observe" and len(sys.argv) == 2:
+        session.observe()
+    elif command == "act":
+        session.act(sys.argv[2:])
+    elif command == "finish" and len(sys.argv) == 2:
+        session.finish()
+    else:
+        raise ArcError("usage: arc-agi-3 observe | act ACTION [X Y] | finish")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except ArcError as error:
+        print(f"ARC-AGI-3 error: {error}", file=sys.stderr)
+        raise SystemExit(2)

--- a/crates/experimental/nanocodex-eval-adapters/assets/arc-agi-3/verifier/grade.py
+++ b/crates/experimental/nanocodex-eval-adapters/assets/arc-agi-3/verifier/grade.py
@@ -1,0 +1,77 @@
+import http.cookiejar
+import json
+import os
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+STATE_PATH = Path("/tmp/nanocodex-arc-agi-3-state.json")
+COOKIE_PATH = Path("/tmp/nanocodex-arc-agi-3-cookies.txt")
+
+
+def close_scorecard(case, state):
+    cookies = http.cookiejar.MozillaCookieJar(str(COOKIE_PATH))
+    cookies.load(ignore_discard=True, ignore_expires=True)
+    opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cookies))
+    request = urllib.request.Request(
+        case["api_base_url"] + "/api/scorecard/close",
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "X-API-Key": state["api_key"],
+        },
+        data=json.dumps({"card_id": state["card_id"]}).encode(),
+        method="POST",
+    )
+    with opener.open(request, timeout=30) as response:
+        return json.load(response)
+
+
+def main():
+    logs = Path(os.environ.get("NANOCODEX_EVAL_VERIFIER_LOGS", "/logs/verifier"))
+    logs.mkdir(parents=True, exist_ok=True)
+    case = json.loads(Path("/tests/case.json").read_text())
+    evidence = {
+        "benchmark": "arc-agi-3",
+        "game_id": case["game_id"],
+        "benchmark_revision": case["benchmark_revision"],
+        "score_contract": case["score_contract"],
+        "smoke_action_cap": case["smoke_action_cap"],
+    }
+    protocol_complete = 0
+    environment_score = 0.0
+    failure = None
+    try:
+        state = json.loads(STATE_PATH.read_text())
+        evidence.update(
+            {
+                "actions_submitted": state["actions"],
+                "forced_resets": state["forced_resets"],
+                "exit_reason": state["exit_reason"] or "AGENT_STOPPED",
+            }
+        )
+        scorecard = close_scorecard(case, state)
+        environments = scorecard.get("environments", [])
+        if len(environments) != 1 or environments[0].get("id") != case["game_id"]:
+            raise ValueError("official scorecard does not contain exactly the selected game")
+        environment_score = float(environments[0]["score"])
+        protocol_complete = int(state["actions"] > 0)
+        evidence["scorecard"] = scorecard
+    except (OSError, KeyError, ValueError, json.JSONDecodeError, urllib.error.URLError) as error:
+        failure = error
+        evidence["error"] = str(error)
+    evidence["protocol_complete"] = protocol_complete
+    evidence["official_environment_score"] = environment_score
+    (logs / "arc-agi-3-scorecard.json").write_text(json.dumps(evidence, indent=2))
+    if failure is not None:
+        raise SystemExit(f"ARC-AGI-3 verifier infrastructure failure: {failure}")
+    (logs / "reward.json").write_text(
+        json.dumps({"protocol_complete": protocol_complete}) + "\n"
+    )
+    STATE_PATH.unlink(missing_ok=True)
+    COOKIE_PATH.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/experimental/nanocodex-eval-adapters/assets/arc-agi-3/verifier/test.sh
+++ b/crates/experimental/nanocodex-eval-adapters/assets/arc-agi-3/verifier/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+python3 /tests/grade.py

--- a/crates/experimental/nanocodex-eval-adapters/src/arc_agi_3.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/arc_agi_3.rs
@@ -1,0 +1,244 @@
+use std::{path::PathBuf, time::Duration};
+
+use nanocodex_eval::{
+    Resources, ScoringPolicy,
+    import::{
+        CasePlan, DatasetImporter, DatasetPlan, Environment, Harness, ImportError, SourceIdentity,
+    },
+};
+use serde::Serialize;
+
+use crate::{sha256_file, sha256_values};
+
+const LS20_BASELINE_ACTIONS: [u64; 7] = [22, 123, 73, 84, 96, 192, 186];
+const TN36_BASELINE_ACTIONS: [u64; 7] = [32, 72, 26, 40, 30, 55, 62];
+const SB26_BASELINE_ACTIONS: [u64; 8] = [18, 28, 18, 19, 31, 23, 58, 18];
+const SMOKE_GAMES: [ArcAgi3Smoke; 3] = [
+    ArcAgi3Smoke::new("ls20-9607627b", "LS20", "keyboard", &LS20_BASELINE_ACTIONS),
+    ArcAgi3Smoke::new("tn36-ef4dde99", "TN36", "click", &TN36_BASELINE_ACTIONS),
+    ArcAgi3Smoke::new(
+        "sb26-7fbdac44",
+        "SB26",
+        "keyboard_click",
+        &SB26_BASELINE_ACTIONS,
+    ),
+];
+const SMOKE_ACTION_CAP: u64 = 3;
+
+#[derive(Clone, Copy, Debug)]
+struct ArcAgi3Smoke {
+    game_id: &'static str,
+    title: &'static str,
+    controls: &'static str,
+    baseline_actions: &'static [u64],
+}
+
+impl ArcAgi3Smoke {
+    const fn new(
+        game_id: &'static str,
+        title: &'static str,
+        controls: &'static str,
+        baseline_actions: &'static [u64],
+    ) -> Self {
+        Self {
+            game_id,
+            title,
+            controls,
+            baseline_actions,
+        }
+    }
+}
+
+/// ARC Prize's public ARC-AGI-3 interactive environment contract.
+#[derive(Clone, Debug)]
+pub struct ArcAgi3 {
+    benchmarking: PathBuf,
+    toolkit: PathBuf,
+    revision: String,
+    environment: Environment,
+    harness: Harness,
+}
+
+impl ArcAgi3 {
+    /// Creates the public interactive smoke importer from pinned official checkouts.
+    #[must_use]
+    pub fn new(
+        benchmarking: impl Into<PathBuf>,
+        toolkit: impl Into<PathBuf>,
+        revision: impl Into<String>,
+        environment: Environment,
+        harness: Harness,
+    ) -> Self {
+        Self {
+            benchmarking: benchmarking.into(),
+            toolkit: toolkit.into(),
+            revision: revision.into(),
+            environment,
+            harness,
+        }
+    }
+
+    fn provenance_digest(&self) -> Result<String, ImportError> {
+        let files = [
+            self.benchmarking.join("benchmarking/agent.py"),
+            self.benchmarking.join("benchmarking/base.py"),
+            self.benchmarking.join("benchmarking/model_configs.yaml"),
+            self.toolkit.join("arc_agi/remote_wrapper.py"),
+            self.toolkit.join("arc_agi/scorecard.py"),
+        ];
+        let digests = files
+            .iter()
+            .map(|path| sha256_file(path))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(sha256_values(digests.iter().map(String::as_bytes)))
+    }
+}
+
+impl DatasetImporter for ArcAgi3 {
+    fn plan(&self) -> Result<DatasetPlan, ImportError> {
+        let source = SourceIdentity::new(
+            "arc-prize-arc-agi-3",
+            &self.revision,
+            self.provenance_digest()?,
+        )?;
+        let instructions = "You are playing a game. Your goal is to win. Include any context you want to carry forward in your reasoning, then execute exactly one available game action at a time with the arc-agi-3 command. The final action executed in each step is the action scored by the environment. This bounded shell-tool topology validates adapter plumbing only; it is not the official per-frame model-call harness.";
+        let mut plan = DatasetPlan::new("arc-agi-3-public-smoke", source)?;
+        for smoke in SMOKE_GAMES {
+            let case = ArcAgi3Case {
+                game_id: smoke.game_id,
+                title: smoke.title,
+                controls: smoke.controls,
+                baseline_actions: smoke.baseline_actions,
+                action_budget_multiplier: 5.0,
+                smoke_action_cap: SMOKE_ACTION_CAP,
+                max_animation_frames: 7,
+                api_base_url: "https://three.arcprize.org",
+                score_contract: "official ARC-AGI-3 environment scorecard (smoke evidence only)",
+                benchmark_revision: &self.revision,
+            };
+            let case_json = serde_json::to_vec_pretty(&case).map_err(|error| {
+                ImportError::Invalid(format!("failed to encode ARC-AGI-3 case: {error}"))
+            })?;
+            let prompt = format!(
+                "Play the public ARC-AGI-3 game {} ({}, {} controls) and maximize its official score. Start by running `arc-agi-3 observe`. Then use `arc-agi-3 act ACTION1` through `ACTION7`, or `arc-agi-3 act ACTION6 X Y` when coordinates are offered. Read every returned frame, continue until the tool reports TERMINAL, and do not inspect or modify the tool's private session files. This adapter-smoke task deliberately stops after {SMOKE_ACTION_CAP} submitted actions; it validates the interactive protocol and is not a headline ARC-AGI-3 score.",
+                smoke.game_id, smoke.title, smoke.controls
+            );
+            let task = CasePlan::hermetic(
+                smoke.game_id,
+                prompt,
+                self.environment.clone(),
+                self.harness.clone(),
+            )?
+            .instructions(instructions)
+            .benchmark_case_type(format!("interactive-public-smoke/{}", smoke.controls))
+            .resources(Resources {
+                cpus: 2,
+                memory_mb: 2_048,
+                storage_mb: 2_048,
+                gpus: 0,
+            })
+            .timeouts(Duration::from_secs(900), Duration::from_secs(120))
+            .scoring_policy(ScoringPolicy::AllRewardsPositive)
+            .allow_internet(true)
+            .environment_file("arc_case.json", case_json.clone(), 0o644)?
+            .harness_file("case.json", case_json, 0o600)?;
+            plan = plan.case(task);
+        }
+        Ok(plan)
+    }
+}
+
+#[derive(Serialize)]
+struct ArcAgi3Case<'a> {
+    game_id: &'a str,
+    title: &'a str,
+    controls: &'a str,
+    baseline_actions: &'a [u64],
+    action_budget_multiplier: f64,
+    smoke_action_cap: u64,
+    max_animation_frames: u64,
+    api_base_url: &'a str,
+    score_contract: &'a str,
+    benchmark_revision: &'a str,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path, process::Command};
+
+    use nanocodex_eval::{
+        NetworkPolicy,
+        import::{Environment, Harness, ImportStore},
+    };
+    use tempfile::tempdir;
+
+    use super::{ArcAgi3, SMOKE_ACTION_CAP, SMOKE_GAMES};
+
+    #[test]
+    fn imports_a_bounded_interactive_smoke_without_claiming_an_official_score() {
+        let source = tempdir().unwrap();
+        make_official_fixture(source.path());
+        let assets = Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/arc-agi-3");
+        let store = tempdir().unwrap();
+        let dataset = ImportStore::new(store.path())
+            .import(&ArcAgi3::new(
+                source.path().join("benchmarking"),
+                source.path().join("toolkit"),
+                "benchmark@abc+toolkit@def",
+                Environment::Dockerfile(assets.join("environment")),
+                Harness::directory(assets.join("verifier")).unwrap(),
+            ))
+            .unwrap();
+
+        assert_eq!(dataset.tasks().len(), SMOKE_GAMES.len());
+        for (task, smoke) in dataset.tasks().iter().zip(SMOKE_GAMES) {
+            assert_eq!(task.name(), smoke.game_id);
+            assert!(task.prompt().contains("not a headline ARC-AGI-3 score"));
+            assert!(task.prompt().contains(&SMOKE_ACTION_CAP.to_string()));
+            assert!(task.prompt().contains(smoke.controls));
+            assert_eq!(task.network(), NetworkPolicy::Public);
+            let case: serde_json::Value =
+                serde_json::from_slice(&fs::read(task.root().join("tests/case.json")).unwrap())
+                    .unwrap();
+            assert_eq!(case["game_id"], smoke.game_id);
+            assert_eq!(
+                case["baseline_actions"],
+                serde_json::json!(smoke.baseline_actions)
+            );
+            assert_eq!(case["controls"], smoke.controls);
+            assert_eq!(case["action_budget_multiplier"], 5.0);
+            assert_eq!(case["smoke_action_cap"], SMOKE_ACTION_CAP);
+        }
+    }
+
+    #[test]
+    fn task_owned_driver_self_test_covers_action_and_frame_validation() {
+        let script =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/arc-agi-3/environment/arc_agi_3.py");
+        let output = Command::new("python3")
+            .arg(script)
+            .arg("self-test")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(String::from_utf8(output.stdout).unwrap().trim(), "ok");
+    }
+
+    fn make_official_fixture(root: &Path) {
+        for path in [
+            "benchmarking/benchmarking/agent.py",
+            "benchmarking/benchmarking/base.py",
+            "benchmarking/benchmarking/model_configs.yaml",
+            "toolkit/arc_agi/remote_wrapper.py",
+            "toolkit/arc_agi/scorecard.py",
+        ] {
+            let path = root.join(path);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(path, "official fixture\n").unwrap();
+        }
+    }
+}

--- a/crates/experimental/nanocodex-eval-adapters/src/lib.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
+mod arc_agi_3;
 mod arena_hard;
 mod browsecomp;
 mod gdpval;
@@ -143,6 +144,11 @@ const INSTALLED_ADAPTERS: &[InstalledAdapter] = &[
         import: import_browsecomp,
         matches: exact_task,
     },
+    InstalledAdapter {
+        names: &["arc-agi-3-public-smoke"],
+        import: import_arc_agi_3,
+        matches: exact_task,
+    },
 ];
 
 const TERMINAL_BENCH_REVISION: &str = "5c8eadf1f393183288fa08b8f73ca9a469cc5e00";
@@ -202,6 +208,8 @@ const GPQA_DIAMOND_SHA256: &str =
     "41d1213cd7a4998605a26c2798500652572007161b3a92817ba46b35befcd305";
 const BROWSECOMP_REVISION: &str = "652c89d0ca9df547706735883097e9537d40dc47";
 const BROWSECOMP_SHA256: &str = "7b24471cd5b3eb2a46830a14802b5c029ea62f488ff75a0f88af7923d1454abf";
+const ARC_AGI_REVISION: &str = "f12822c4d550121c35a275008d964afbbed47d2f";
+const ARC_AGI_3_BENCHMARKING_REVISION: &str = "86d72170ce3155551712a9fafd290bab471d6eee";
 
 fn import_harbor(
     request: &BenchmarkRequest,
@@ -539,6 +547,33 @@ fn import_browsecomp(
         format!("openai/simple-evals@{BROWSECOMP_REVISION}"),
         nanocodex_eval::import::Environment::OciImage("python:3.12-slim".to_owned()),
         Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/browsecomp"),
+    ))?)
+}
+
+fn import_arc_agi_3(
+    _request: &BenchmarkRequest,
+    sources: &SourceStore,
+    store: &ImportStore,
+) -> Result<ImportedDataset, AdapterError> {
+    let benchmarking = sources.git_checkout(
+        "arc-agi-3-benchmarking",
+        "https://github.com/arcprize/arc-agi-3-benchmarking.git",
+        ARC_AGI_3_BENCHMARKING_REVISION,
+    )?;
+    let toolkit = sources.git_checkout(
+        "arc-agi",
+        "https://github.com/arcprize/arc-agi.git",
+        ARC_AGI_REVISION,
+    )?;
+    let assets = Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/arc-agi-3");
+    Ok(store.import(&arc_agi_3::ArcAgi3::new(
+        benchmarking,
+        toolkit,
+        format!(
+            "arcprize/arc-agi-3-benchmarking@{ARC_AGI_3_BENCHMARKING_REVISION}+arcprize/arc-agi@{ARC_AGI_REVISION}"
+        ),
+        nanocodex_eval::import::Environment::Dockerfile(assets.join("environment")),
+        nanocodex_eval::import::Harness::directory(assets.join("verifier"))?,
     ))?)
 }
 

--- a/nanocodex.toml
+++ b/nanocodex.toml
@@ -78,3 +78,13 @@ trials = 1
 model = ["sol"]
 thinking = ["high"]
 web_search = true
+
+[profiles.arc-agi-3-public-smoke]
+benchmarks = [
+  "arc-agi-3-public-smoke/ls20-9607627b",
+  "arc-agi-3-public-smoke/tn36-ef4dde99",
+  "arc-agi-3-public-smoke/sb26-7fbdac44",
+]
+trials = 1
+model = ["sol"]
+thinking = ["high"]


### PR DESCRIPTION
Adapter split from #72.

Adds pinned ARC-AGI-3 toolkit and benchmarking-agent provenance, task-owned action/frame validation, three public games covering keyboard/click/mixed controls, and official scorecard evidence with a three-action cap.

This is deliberately labeled adapter plumbing smoke, not an official-comparable ARC-AGI-3 score: the current topology does not perform a fresh model turn for every environment frame.

Validation:
- cargo fmt --all
- cargo test -p nanocodex-eval-adapters (25 passed, including driver self-test)
- cargo clippy -p nanocodex-eval-adapters --all-targets -- -D warnings

Stacked on #153.