### PR TITLE
feat(eval): add Agents Last Exam adapter

### DIFF
--- a/crates/experimental/nanocodex-eval-adapters/assets/agents-last-exam/Dockerfile
+++ b/crates/experimental/nanocodex-eval-adapters/assets/agents-last-exam/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.12-slim
+
+RUN pip install --no-cache-dir numpy==2.2.6
+
+WORKDIR /tests

--- a/crates/experimental/nanocodex-eval-adapters/assets/agents-last-exam/grade.py
+++ b/crates/experimental/nanocodex-eval-adapters/assets/agents-last-exam/grade.py
@@ -1,0 +1,18 @@
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+
+spec = importlib.util.spec_from_file_location("ale_score_outputs", "/tests/score_outputs.py")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+workspace = Path(os.environ["NANOCODEX_EVAL_WORKSPACE"])
+report = module.score(workspace / "base/output", Path("/tests/reference"))
+score = float(report.get("score", 0.0))
+
+logs = Path("/logs/verifier")
+logs.mkdir(parents=True, exist_ok=True)
+(logs / "ale-score.json").write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+(logs / "reward.json").write_text(json.dumps({"ale_score": score}) + "\n")

--- a/crates/experimental/nanocodex-eval-adapters/assets/agents-last-exam/test.sh
+++ b/crates/experimental/nanocodex-eval-adapters/assets/agents-last-exam/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+python3 /tests/grade.py

--- a/crates/experimental/nanocodex-eval-adapters/src/agents_last_exam.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/agents_last_exam.rs
@@ -1,0 +1,341 @@
+use std::{
+    fs,
+    os::unix::fs::PermissionsExt as _,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use nanocodex_eval::{
+    Resources, ScoringPolicy,
+    import::{
+        CasePlan, DatasetImporter, DatasetPlan, Environment, Harness, ImportError, SourceIdentity,
+    },
+};
+use serde::Deserialize;
+
+use crate::{sha256_file, sha256_values};
+
+const TASKS: [AleTask; 4] = [
+    AleTask::new("computing_math/branch_bound_atsp", "branch_bound_atsp"),
+    AleTask::new(
+        "business_finance/basel_operational_risk_bia_cn",
+        "basel_operational_risk_bia_cn",
+    ),
+    AleTask::new(
+        "business_finance/financial_stmt_reconstruction_aapl_fy2024",
+        "financial_stmt_reconstruction_aapl_fy2024",
+    ),
+    AleTask::new(
+        "social_sciences/atwood_2022_measles_vaccine_reproduction",
+        "atwood_2022_measles_vaccine_reproduction",
+    ),
+];
+
+#[derive(Clone, Copy, Debug)]
+struct AleTask {
+    source_id: &'static str,
+    case_id: &'static str,
+}
+
+impl AleTask {
+    const fn new(source_id: &'static str, case_id: &'static str) -> Self {
+        Self { source_id, case_id }
+    }
+}
+
+/// Berkeley RDI's public Agents' Last Exam CLI-compatible Linux task package.
+#[derive(Clone, Debug)]
+pub struct AgentsLastExam {
+    source: PathBuf,
+    task_data: PathBuf,
+    revision: String,
+    environment: Environment,
+    harness: Harness,
+}
+
+impl AgentsLastExam {
+    /// Creates an importer from a pinned ALE checkout and its separately staged
+    /// gated task-data archive.
+    #[must_use]
+    pub fn new(
+        source: impl Into<PathBuf>,
+        task_data: impl Into<PathBuf>,
+        revision: impl Into<String>,
+        environment: Environment,
+        harness: Harness,
+    ) -> Self {
+        Self {
+            source: source.into(),
+            task_data: task_data.into(),
+            revision: revision.into(),
+            environment,
+            harness,
+        }
+    }
+}
+
+impl DatasetImporter for AgentsLastExam {
+    fn plan(&self) -> Result<DatasetPlan, ImportError> {
+        let source = canonical_directory(&self.source, "ALE source checkout")?;
+        let mut source_digests = Vec::new();
+        let mut cases = Vec::with_capacity(TASKS.len());
+        for recipe in TASKS {
+            let task_root = source.join("tasks").join(recipe.source_id);
+            let task_card_path = task_root.join("task_card.json");
+            let task_card_bytes = read_file(&task_card_path)?;
+            let task_card: TaskCard =
+                serde_json::from_slice(&task_card_bytes).map_err(|error| {
+                    ImportError::Invalid(format!(
+                        "failed to decode {}: {error}",
+                        task_card_path.display()
+                    ))
+                })?;
+            if task_card.task_id != recipe.source_id {
+                return Err(ImportError::Invalid(format!(
+                    "ALE task card has taskId {:?}, expected {:?}",
+                    task_card.task_id, recipe.source_id
+                )));
+            }
+            let timeout = task_card.vm.timeout_seconds()?;
+            let scorer = task_root.join("scripts/score_outputs.py");
+            let data_root = canonical_directory(
+                &self.task_data.join(recipe.source_id).join("base"),
+                "ALE selected task data",
+            )?;
+
+            source_digests.push(sha256_values([&task_card_bytes]));
+            source_digests.push(sha256_file(&scorer)?);
+            let mut task = CasePlan::hermetic(
+                recipe.case_id,
+                task_card.task_prompt,
+                self.environment.clone(),
+                self.harness.clone(),
+            )?
+            .benchmark_case_type("ale-cli-linux")
+            .resources(Resources {
+                cpus: 4,
+                memory_mb: 15_360,
+                storage_mb: 204_800,
+                gpus: 0,
+            })
+            .timeouts(Duration::from_secs(timeout), Duration::from_secs(900))
+            .scoring_policy(ScoringPolicy::AllRewardsOne)
+            // ALE's published agent configurations explicitly permit internet
+            // access; task-level prompts remain authoritative about prohibited
+            // external solvers or replacement inputs.
+            .allow_internet(true)
+            .harness_file_from("score_outputs.py", &scorer, file_mode(&scorer)?)?;
+
+            for relative in ["input", "software"] {
+                let root = data_root.join(relative);
+                for file in regular_files(&root)? {
+                    let nested = file.strip_prefix(&data_root).map_err(|error| {
+                        ImportError::Invalid(format!("failed to relativize ALE task data: {error}"))
+                    })?;
+                    source_digests.push(sha256_file(&file)?);
+                    task = task.environment_file_from(
+                        Path::new("base").join(nested),
+                        &file,
+                        file_mode(&file)?,
+                    )?;
+                }
+            }
+            let references = data_root.join("reference");
+            for file in regular_files(&references)? {
+                let nested = file.strip_prefix(&references).map_err(|error| {
+                    ImportError::Invalid(format!(
+                        "failed to relativize ALE reference data: {error}"
+                    ))
+                })?;
+                source_digests.push(sha256_file(&file)?);
+                task = task.harness_file_from(
+                    Path::new("reference").join(nested),
+                    &file,
+                    file_mode(&file)?,
+                )?;
+            }
+            cases.push(task);
+        }
+
+        let source = SourceIdentity::new(
+            "agents-last-exam",
+            &self.revision,
+            sha256_values(source_digests.iter().map(String::as_bytes)),
+        )?;
+        let mut plan = DatasetPlan::new("agents-last-exam", source)?;
+        for case in cases {
+            plan = plan.case(case);
+        }
+        Ok(plan)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TaskCard {
+    task_id: String,
+    task_prompt: String,
+    vm: TaskVm,
+}
+
+#[derive(Debug, Deserialize)]
+struct TaskVm {
+    timeout: Option<u64>,
+    timeout_s: Option<u64>,
+}
+
+impl TaskVm {
+    fn timeout_seconds(&self) -> Result<u64, ImportError> {
+        self.timeout
+            .or(self.timeout_s)
+            .filter(|value| *value > 0)
+            .ok_or_else(|| {
+                ImportError::Invalid("ALE task card is missing a positive VM timeout".to_owned())
+            })
+    }
+}
+
+fn canonical_directory(path: &Path, label: &str) -> Result<PathBuf, ImportError> {
+    let canonical = fs::canonicalize(path).map_err(|source| ImportError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if !canonical.is_dir() {
+        return Err(ImportError::Invalid(format!(
+            "{label} is not a directory: {}",
+            canonical.display()
+        )));
+    }
+    Ok(canonical)
+}
+
+fn regular_files(root: &Path) -> Result<Vec<PathBuf>, ImportError> {
+    let root = canonical_directory(root, "ALE task-data component")?;
+    let mut files = ignore::WalkBuilder::new(&root)
+        .hidden(false)
+        .ignore(false)
+        .git_ignore(false)
+        .git_exclude(false)
+        .parents(false)
+        .follow_links(false)
+        .build()
+        .filter_map(|entry| match entry {
+            Ok(entry) if entry.path() == root => None,
+            Ok(entry) if entry.file_type().is_some_and(|kind| kind.is_file()) => {
+                Some(Ok(entry.into_path()))
+            }
+            Ok(entry) if entry.file_type().is_some_and(|kind| kind.is_dir()) => None,
+            Ok(entry) => Some(Err(ImportError::Invalid(format!(
+                "unsupported ALE task-data entry: {}",
+                entry.path().display()
+            )))),
+            Err(error) => Some(Err(ImportError::Invalid(format!(
+                "failed to walk ALE task data: {error}"
+            )))),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    files.sort_unstable();
+    Ok(files)
+}
+
+fn read_file(path: &Path) -> Result<Vec<u8>, ImportError> {
+    fs::read(path).map_err(|source| ImportError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn file_mode(path: &Path) -> Result<u32, ImportError> {
+    let mode = fs::metadata(path)
+        .map_err(|source| ImportError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?
+        .permissions()
+        .mode();
+    Ok(mode & 0o777)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use nanocodex_eval::{
+        NetworkPolicy, ScoringPolicy,
+        import::{Environment, Harness, ImportStore},
+    };
+    use tempfile::tempdir;
+
+    use super::AgentsLastExam;
+
+    #[test]
+    fn imports_cli_task_without_exposing_hidden_reference() {
+        let fixture = tempdir().unwrap();
+        make_fixture(fixture.path());
+        let assets = Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/agents-last-exam");
+        let store = tempdir().unwrap();
+        let dataset = ImportStore::new(store.path())
+            .import(&AgentsLastExam::new(
+                fixture.path().join("source"),
+                fixture.path().join("task-data"),
+                "rdi-berkeley/agents-last-exam@abc+data@def",
+                Environment::OciImage("ale.example/image@sha256:abc".to_owned()),
+                Harness::directory(assets).unwrap(),
+            ))
+            .unwrap();
+
+        assert_eq!(dataset.tasks().len(), 4);
+        for task in dataset.tasks() {
+            assert_eq!(task.network(), NetworkPolicy::Public);
+            assert_eq!(
+                task.verifier().scoring_policy(),
+                ScoringPolicy::AllRewardsOne
+            );
+            assert!(
+                task.root()
+                    .join("environment/base/input/input.txt")
+                    .is_file()
+            );
+            assert!(
+                task.root()
+                    .join("environment/base/software/python")
+                    .is_file()
+            );
+            assert!(
+                !task
+                    .root()
+                    .join("environment/base/reference/gold.json")
+                    .exists()
+            );
+            assert!(task.root().join("tests/reference/gold.json").is_file());
+            assert!(task.root().join("tests/score_outputs.py").is_file());
+        }
+    }
+
+    fn make_fixture(root: &Path) {
+        for recipe in super::TASKS {
+            let task = root.join("source/tasks").join(recipe.source_id);
+            fs::create_dir_all(task.join("scripts")).unwrap();
+            fs::write(
+                task.join("task_card.json"),
+                format!(
+                    "{{\"taskId\":{task_id:?},\"taskPrompt\":\"Solve it.\",\"vm\":{{\"timeout\":7200}}}}",
+                    task_id = recipe.source_id
+                ),
+            )
+            .unwrap();
+            fs::write(
+                task.join("scripts/score_outputs.py"),
+                "def score(output, reference):\n    return {'score': 1.0}\n",
+            )
+            .unwrap();
+            let data = root.join("task-data").join(recipe.source_id).join("base");
+            fs::create_dir_all(data.join("input")).unwrap();
+            fs::create_dir_all(data.join("software")).unwrap();
+            fs::create_dir_all(data.join("reference")).unwrap();
+            fs::write(data.join("input/input.txt"), "input").unwrap();
+            fs::write(data.join("software/python"), "#!/bin/sh\n").unwrap();
+            fs::write(data.join("reference/gold.json"), "{}\n").unwrap();
+        }
+    }
+}

--- a/crates/experimental/nanocodex-eval-adapters/src/lib.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
+mod agents_last_exam;
 mod arc_agi_3;
 mod arena_hard;
 mod browsecomp;
@@ -149,6 +150,11 @@ const INSTALLED_ADAPTERS: &[InstalledAdapter] = &[
         import: import_arc_agi_3,
         matches: exact_task,
     },
+    InstalledAdapter {
+        names: &["agents-last-exam"],
+        import: import_agents_last_exam,
+        matches: exact_task,
+    },
 ];
 
 const TERMINAL_BENCH_REVISION: &str = "5c8eadf1f393183288fa08b8f73ca9a469cc5e00";
@@ -210,6 +216,9 @@ const BROWSECOMP_REVISION: &str = "652c89d0ca9df547706735883097e9537d40dc47";
 const BROWSECOMP_SHA256: &str = "7b24471cd5b3eb2a46830a14802b5c029ea62f488ff75a0f88af7923d1454abf";
 const ARC_AGI_REVISION: &str = "f12822c4d550121c35a275008d964afbbed47d2f";
 const ARC_AGI_3_BENCHMARKING_REVISION: &str = "86d72170ce3155551712a9fafd290bab471d6eee";
+const AGENTS_LAST_EXAM_REVISION: &str = "1e615e456de7cef57706680613cb80ee13c7fc76";
+const AGENTS_LAST_EXAM_DATA_REVISION: &str = "5ae9b719a901c14a9ccec7b3bd156d663e3eedcb";
+const AGENTS_LAST_EXAM_IMAGE: &str = "agentslastexam/ale-ubuntu22-docker@sha256:78ec11afeb0008ed8bc2b59cf9c90c05e63d1ac66b9d3e7cb0fada10695fca6f";
 
 fn import_harbor(
     request: &BenchmarkRequest,
@@ -574,6 +583,35 @@ fn import_arc_agi_3(
         ),
         nanocodex_eval::import::Environment::Dockerfile(assets.join("environment")),
         nanocodex_eval::import::Harness::directory(assets.join("verifier"))?,
+    ))?)
+}
+
+fn import_agents_last_exam(
+    _request: &BenchmarkRequest,
+    sources: &SourceStore,
+    store: &ImportStore,
+) -> Result<ImportedDataset, AdapterError> {
+    let source = sources.git_checkout(
+        "agents-last-exam",
+        "https://github.com/rdi-berkeley/agents-last-exam.git",
+        AGENTS_LAST_EXAM_REVISION,
+    )?;
+    let task_data = sources.prepare_huggingface_archive(
+        "agents-last-exam/agents-last-exam-data-archive",
+        "ale-tasks-data.tar.gz",
+        AGENTS_LAST_EXAM_DATA_REVISION,
+        "agents-last-exam-task-data",
+    )?;
+    Ok(store.import(&agents_last_exam::AgentsLastExam::new(
+        source,
+        task_data,
+        format!(
+            "rdi-berkeley/agents-last-exam@{AGENTS_LAST_EXAM_REVISION}+agents-last-exam-data-archive@{AGENTS_LAST_EXAM_DATA_REVISION}"
+        ),
+        nanocodex_eval::import::Environment::OciImage(AGENTS_LAST_EXAM_IMAGE.to_owned()),
+        nanocodex_eval::import::Harness::directory(
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/agents-last-exam"),
+        )?,
     ))?)
 }
 

--- a/crates/experimental/nanocodex-eval-adapters/src/source.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/source.rs
@@ -321,6 +321,68 @@ impl SourceStore {
         }
         self.write_verified(relative, &bytes)
     }
+
+    pub(crate) fn prepare_huggingface_archive(
+        &self,
+        repository: &str,
+        filename: &str,
+        revision: &str,
+        destination_relative: &str,
+    ) -> Result<PathBuf, SourceError> {
+        let destination = self.root.join(destination_relative);
+        let marker = destination.join(".nanocodex-source-revision");
+        if destination.is_dir()
+            && fs::read_to_string(&marker).is_ok_and(|value| value.trim() == revision)
+        {
+            return Ok(destination);
+        }
+        if destination.exists() {
+            return Err(SourceError::Stale(format!(
+                "{} does not carry expected revision {revision}",
+                destination.display()
+            )));
+        }
+        let download = self.root.join(format!("{destination_relative}-archive"));
+        fs::create_dir_all(&download).map_err(|source| io_error(&download, source))?;
+        let executable = if Command::new("hf")
+            .arg("--help")
+            .output()
+            .is_ok_and(|output| output.status.success())
+        {
+            "hf"
+        } else if Command::new("huggingface-cli")
+            .arg("--help")
+            .output()
+            .is_ok_and(|output| output.status.success())
+        {
+            "huggingface-cli"
+        } else {
+            return Err(SourceError::Command(format!(
+                "preparing {repository} requires the authenticated Hugging Face CLI"
+            )));
+        };
+        command_status(
+            Command::new(executable)
+                .arg("download")
+                .arg(repository)
+                .arg(filename)
+                .args(["--repo-type", "dataset", "--revision", revision])
+                .arg("--local-dir")
+                .arg(&download),
+        )?;
+        fs::create_dir_all(&destination).map_err(|source| io_error(&destination, source))?;
+        let archive = download.join(filename);
+        command_status(
+            Command::new("tar")
+                .args(["-xzf"])
+                .arg(&archive)
+                .arg("--directory")
+                .arg(&destination),
+        )?;
+        fs::write(&marker, format!("{revision}\n")).map_err(|source| io_error(&marker, source))?;
+        fs::remove_file(&archive).map_err(|source| io_error(&archive, source))?;
+        Ok(destination)
+    }
 }
 
 #[allow(dead_code)]

--- a/nanocodex.toml
+++ b/nanocodex.toml
@@ -88,3 +88,14 @@ benchmarks = [
 trials = 1
 model = ["sol"]
 thinking = ["high"]
+
+[profiles.agents-last-exam-smoke]
+benchmarks = [
+  "agents-last-exam/branch_bound_atsp",
+  "agents-last-exam/basel_operational_risk_bia_cn",
+  "agents-last-exam/financial_stmt_reconstruction_aapl_fy2024",
+  "agents-last-exam/atwood_2022_measles_vaccine_reproduction",
+]
+trials = 1
+model = ["sol"]
+thinking = ["high"]


### PR DESCRIPTION
Adapter split from #72.

Adds Berkeley RDI Agents Last Exam at pinned framework/data revisions and image digest. The adapter stages the four official CLI-compatible smoke tasks, keeps references and official scorers verifier-only, and supports authenticated one-time Hugging Face archive preparation.

Validation:
- cargo fmt --all
- cargo test -p nanocodex-eval-adapters (26 passed)
- cargo clippy -p nanocodex-eval-adapters --all-targets -- -D warnings

Live execution remains gated on approved task-data access; dev-georgios retained data will be used where valid.

Stacked on #154.