### PR TITLE
feat(eval): add OpenAI Evals adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5338,10 +5338,12 @@ dependencies = [
  "parquet",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "toml",
  "tracing",
  "zip",
 ]
@@ -8492,6 +8494,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serdect"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9940,6 +9955,12 @@ dependencies = [
  "crypto-common 0.1.7",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ self-replace = "1.5.0"
 semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = { version = "1.0.149", features = ["raw_value"] }
+serde_yaml_ng = "0.10.0"
 sha1 = "0.11.0"
 sha2 = { version = "0.11.0", default-features = false }
 shlex = "2.0.1"

--- a/bin/nanocodex/src/eval/profile.rs
+++ b/bin/nanocodex/src/eval/profile.rs
@@ -189,7 +189,9 @@ impl Add {
                     self.new,
                 )?;
             } else {
-                let tasks = AdapterCatalog::new(&state).resolve(&selectors).await?;
+                let tasks = AdapterCatalog::new(&state)
+                    .resolve(&self.config, &selectors)
+                    .await?;
                 Evaluation::add_profile_with_tasks(
                     &self.config,
                     Some(recipe),

--- a/crates/experimental/nanocodex-eval-adapters/Cargo.toml
+++ b/crates/experimental/nanocodex-eval-adapters/Cargo.toml
@@ -19,10 +19,12 @@ nanocodex-eval.workspace = true
 parquet.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_yaml_ng.workspace = true
 sha2.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt"] }
+toml.workspace = true
 tracing.workspace = true
 zip.workspace = true
 

--- a/crates/experimental/nanocodex-eval-adapters/assets/openai-evals/Dockerfile
+++ b/crates/experimental/nanocodex-eval-adapters/assets/openai-evals/Dockerfile
@@ -1,0 +1,1 @@
+FROM python:3.12-slim

--- a/crates/experimental/nanocodex-eval-adapters/assets/openai-evals/grade.py
+++ b/crates/experimental/nanocodex-eval-adapters/assets/openai-evals/grade.py
@@ -1,0 +1,22 @@
+import json
+import os
+from pathlib import Path
+
+workspace = Path(os.environ["NANOCODEX_EVAL_WORKSPACE"])
+answer = (workspace / "answer.txt").read_text()
+expected = json.loads(Path("/tests/expected.json").read_text())
+mode = Path("/tests/mode").read_text().strip()
+
+if not isinstance(expected, list):
+    expected = [expected]
+
+if mode == "match":
+    passed = any(answer.startswith(value) for value in expected)
+elif mode == "includes":
+    passed = any(value in answer for value in expected)
+elif mode == "includes_ignore_case":
+    passed = any(value.lower() in answer.lower() for value in expected)
+else:
+    raise RuntimeError(f"unknown OpenAI Evals mode: {mode}")
+
+Path("/logs/verifier/reward.txt").write_text("1\n" if passed else "0\n")

--- a/crates/experimental/nanocodex-eval-adapters/assets/openai-evals/test.sh
+++ b/crates/experimental/nanocodex-eval-adapters/assets/openai-evals/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+python3 /tests/grade.py

--- a/crates/experimental/nanocodex-eval-adapters/src/lib.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/lib.rs
@@ -17,6 +17,7 @@ mod graphwalks;
 mod harbor;
 mod healthbench_professional;
 mod mrcr;
+mod openai_evals;
 mod source;
 mod swe_atlas_qna;
 mod swe_bench;
@@ -33,6 +34,7 @@ use nanocodex_eval::{
     import::{ImportError, ImportStore, ImportedDataset},
 };
 use serde::Deserialize;
+use serde::de::DeserializeOwned;
 use sha2::{Digest as _, Sha256};
 use source::SourceStore;
 
@@ -72,6 +74,9 @@ pub enum AdapterError {
     /// A blocking adapter worker failed.
     #[error("evaluation adapter worker failed: {0}")]
     Worker(String),
+    /// Adapter configuration could not be read or decoded.
+    #[error("invalid adapter configuration: {0}")]
+    Configuration(String),
 }
 
 #[derive(Clone, Debug)]
@@ -83,76 +88,112 @@ pub(crate) struct BenchmarkRequest {
 
 #[derive(Clone, Copy)]
 struct InstalledAdapter {
+    kind: &'static str,
     names: &'static [&'static str],
-    import:
-        fn(&BenchmarkRequest, &SourceStore, &ImportStore) -> Result<ImportedDataset, AdapterError>,
+    import: fn(
+        &BenchmarkRequest,
+        &SourceStore,
+        &ImportStore,
+        Option<&AdapterConfiguration>,
+    ) -> Result<ImportedDataset, AdapterError>,
     matches: fn(&str, &str) -> bool,
+}
+
+#[derive(Clone, Debug)]
+struct AdapterConfiguration {
+    root: PathBuf,
+    value: toml::Value,
+}
+
+#[derive(Deserialize)]
+struct AdapterManifest {
+    #[serde(default)]
+    benchmark: BTreeMap<String, toml::Value>,
 }
 
 const INSTALLED_ADAPTERS: &[InstalledAdapter] = &[
     InstalledAdapter {
+        kind: "harbor",
         names: &["terminal-bench-2.1", "deep-swe-v1.1"],
         import: import_harbor,
         matches: matches_harbor_task,
     },
     InstalledAdapter {
+        kind: "arena-hard",
         names: &["arena-hard-v2"],
         import: import_arena_hard,
         matches: exact_task,
     },
     InstalledAdapter {
+        kind: "swe-bench",
         names: &["swe-bench-verified-smoke"],
         import: import_swe_bench,
         matches: exact_task,
     },
     InstalledAdapter {
+        kind: "swe-atlas-qna",
         names: &["swe-atlas-qna"],
         import: import_swe_atlas,
         matches: matches_swe_atlas_task,
     },
     InstalledAdapter {
+        kind: "genebench-pro",
         names: &["genebench-pro-public"],
         import: import_genebench_pro,
         matches: exact_task,
     },
     InstalledAdapter {
+        kind: "graphwalks",
         names: &["graphwalks"],
         import: import_graphwalks,
         matches: exact_task,
     },
     InstalledAdapter {
+        kind: "mrcr",
         names: &["mrcr-v2"],
         import: import_mrcr,
         matches: exact_task,
     },
     InstalledAdapter {
+        kind: "healthbench-professional",
         names: &["healthbench-professional"],
         import: import_healthbench_professional,
         matches: exact_task,
     },
     InstalledAdapter {
+        kind: "gdpval",
         names: &["gdpval"],
         import: import_gdpval,
         matches: exact_task,
     },
     InstalledAdapter {
+        kind: "gpqa-diamond",
         names: &["gpqa-diamond"],
         import: import_gpqa_diamond,
         matches: exact_task,
     },
     InstalledAdapter {
+        kind: "browsecomp",
         names: &["browsecomp"],
         import: import_browsecomp,
         matches: exact_task,
     },
     InstalledAdapter {
+        kind: "arc-agi-3",
         names: &["arc-agi-3-public-smoke"],
         import: import_arc_agi_3,
         matches: exact_task,
     },
     InstalledAdapter {
+        kind: "agents-last-exam",
         names: &["agents-last-exam"],
         import: import_agents_last_exam,
+        matches: exact_task,
+    },
+    InstalledAdapter {
+        kind: "openai-evals",
+        names: &[],
+        import: import_openai_evals,
         matches: exact_task,
     },
 ];
@@ -224,6 +265,7 @@ fn import_harbor(
     request: &BenchmarkRequest,
     sources: &SourceStore,
     store: &ImportStore,
+    _configuration: Option<&AdapterConfiguration>,
 ) -> Result<ImportedDataset, AdapterError> {
     let (root, revision) = match request.name.as_str() {
         "terminal-bench-2.1" => (
@@ -265,6 +307,7 @@ fn import_arena_hard(
     request: &BenchmarkRequest,
     sources: &SourceStore,
     store: &ImportStore,
+    _configuration: Option<&AdapterConfiguration>,
 ) -> Result<ImportedDataset, AdapterError> {
     let source = sources.git_checkout(
         "arena-hard-auto",
@@ -287,6 +330,7 @@ fn import_swe_bench(
     request: &BenchmarkRequest,
     sources: &SourceStore,
     store: &ImportStore,
+    _configuration: Option<&AdapterConfiguration>,
 ) -> Result<ImportedDataset, AdapterError> {
     let response = sources.download(
         "swe-bench/swe-bench-verified-smoke.response.json",
@@ -325,6 +369,7 @@ fn import_swe_atlas(
     _request: &BenchmarkRequest,
     sources: &SourceStore,
     store: &ImportStore,
+    _configuration: Option<&AdapterConfiguration>,
 ) -> Result<ImportedDataset, AdapterError> {
     let root = sources.git_checkout(
         "swe-atlas",
@@ -348,6 +393,7 @@ fn import_genebench_pro(
     _request: &BenchmarkRequest,
     sources: &SourceStore,
     store: &ImportStore,
+    _configuration: Option<&AdapterConfiguration>,
 ) -> Result<ImportedDataset, AdapterError> {
     let package_name = "genebench-pro-public-package";
     let manifest_relative = format!("{package_name}/manifest.json");
@@ -402,6 +448,7 @@ fn import_graphwalks(
     _request: &BenchmarkRequest,
     sources: &SourceStore,
     store: &ImportStore,
+    _configuration: Option<&AdapterConfiguration>,
 ) -> Result<ImportedDataset, AdapterError> {
     let base =
         format!("https://huggingface.co/datasets/openai/graphwalks/resolve/{GRAPHWALKS_REVISION}");
@@ -427,6 +474,7 @@ fn import_mrcr(
     request: &BenchmarkRequest,
     sources: &SourceStore,
     store: &ImportStore,
+    _configuration: Option<&AdapterConfiguration>,
 ) -> Result<ImportedDataset, AdapterError> {
     let base = format!("https://huggingface.co/datasets/openai/mrcr/resolve/{MRCR_REVISION}");
     for (relative, sha256) in MRCR_FILES {
@@ -452,6 +500,7 @@ fn import_healthbench_professional(
     _request: &BenchmarkRequest,
     sources: &SourceStore,
     store: &ImportStore,
+    _configuration: Option<&AdapterConfiguration>,
 ) -> Result<ImportedDataset, AdapterError> {
     let dataset = sources.download(
         "healthbench-professional/healthbench_professional_eval.jsonl",
@@ -474,6 +523,7 @@ fn import_gdpval(
     request: &BenchmarkRequest,
     sources: &SourceStore,
     store: &ImportStore,
+    _configuration: Option<&AdapterConfiguration>,
 ) -> Result<ImportedDataset, AdapterError> {
     let checkout = sources.git_checkout_with_materialized_lfs(
         "gdpval",
@@ -518,6 +568,7 @@ fn import_gpqa_diamond(
     _request: &BenchmarkRequest,
     sources: &SourceStore,
     store: &ImportStore,
+    _configuration: Option<&AdapterConfiguration>,
 ) -> Result<ImportedDataset, AdapterError> {
     let checkout = sources.git_checkout(
         "gpqa",
@@ -545,6 +596,7 @@ fn import_browsecomp(
     _request: &BenchmarkRequest,
     sources: &SourceStore,
     store: &ImportStore,
+    _configuration: Option<&AdapterConfiguration>,
 ) -> Result<ImportedDataset, AdapterError> {
     let dataset = sources.download(
         "browsecomp/browse_comp_test_set.csv",
@@ -563,6 +615,7 @@ fn import_arc_agi_3(
     _request: &BenchmarkRequest,
     sources: &SourceStore,
     store: &ImportStore,
+    _configuration: Option<&AdapterConfiguration>,
 ) -> Result<ImportedDataset, AdapterError> {
     let benchmarking = sources.git_checkout(
         "arc-agi-3-benchmarking",
@@ -590,6 +643,7 @@ fn import_agents_last_exam(
     _request: &BenchmarkRequest,
     sources: &SourceStore,
     store: &ImportStore,
+    _configuration: Option<&AdapterConfiguration>,
 ) -> Result<ImportedDataset, AdapterError> {
     let source = sources.git_checkout(
         "agents-last-exam",
@@ -615,6 +669,80 @@ fn import_agents_last_exam(
     ))?)
 }
 
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct OpenAiEvalsConfiguration {
+    adapter: String,
+    registry: PathBuf,
+    eval: String,
+    revision: String,
+    #[serde(default = "default_python_image")]
+    image: String,
+}
+
+fn import_openai_evals(
+    request: &BenchmarkRequest,
+    _sources: &SourceStore,
+    store: &ImportStore,
+    configuration: Option<&AdapterConfiguration>,
+) -> Result<ImportedDataset, AdapterError> {
+    let configuration =
+        configured::<OpenAiEvalsConfiguration>(&request.name, "openai-evals", configuration)?;
+    if configuration.recipe.adapter != "openai-evals" {
+        return Err(AdapterError::Configuration(format!(
+            "benchmark {:?} selected adapter {:?}, expected openai-evals",
+            request.name, configuration.recipe.adapter
+        )));
+    }
+    let assets = Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/openai-evals");
+    Ok(store.import(&openai_evals::OpenAiEvals::new(
+        &request.name,
+        resolve_config_path(&configuration.root, &configuration.recipe.registry),
+        assets,
+        configuration.recipe.eval,
+        configuration.recipe.revision,
+        nanocodex_eval::import::Environment::OciImage(configuration.recipe.image),
+    ))?)
+}
+
+struct Configured<T> {
+    root: PathBuf,
+    recipe: T,
+}
+
+fn configured<T: DeserializeOwned>(
+    benchmark: &str,
+    expected_adapter: &str,
+    configuration: Option<&AdapterConfiguration>,
+) -> Result<Configured<T>, AdapterError> {
+    let configuration = configuration.ok_or_else(|| {
+        AdapterError::Configuration(format!(
+            "benchmark {benchmark:?} requires [{expected_adapter}] configuration"
+        ))
+    })?;
+    let recipe = configuration
+        .value
+        .clone()
+        .try_into::<T>()
+        .map_err(|error| AdapterError::Configuration(error.to_string()))?;
+    Ok(Configured {
+        root: configuration.root.clone(),
+        recipe,
+    })
+}
+
+fn resolve_config_path(root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    }
+}
+
+fn default_python_image() -> String {
+    "python:3.12-slim".to_owned()
+}
+
 impl AdapterCatalog {
     /// Uses `imports/` and `sources/` below one durable evaluator state root.
     #[must_use]
@@ -627,17 +755,34 @@ impl AdapterCatalog {
     }
 
     /// Acquires, imports, and selects every configured benchmark task.
-    pub async fn resolve(&self, selectors: &[String]) -> Result<Vec<ResolvedTask>, AdapterError> {
+    pub async fn resolve(
+        &self,
+        config: impl AsRef<Path>,
+        selectors: &[String],
+    ) -> Result<Vec<ResolvedTask>, AdapterError> {
+        let config = config.as_ref();
+        let text = fs::read_to_string(config).map_err(|error| {
+            AdapterError::Configuration(format!("failed to read {}: {error}", config.display()))
+        })?;
+        let manifest: AdapterManifest = toml::from_str(&text).map_err(|error| {
+            AdapterError::Configuration(format!("failed to parse {}: {error}", config.display()))
+        })?;
+        let config = config.canonicalize().map_err(|error| {
+            AdapterError::Configuration(format!("failed to resolve {}: {error}", config.display()))
+        })?;
+        let root = config
+            .parent()
+            .ok_or_else(|| AdapterError::Configuration("config has no parent".to_owned()))?;
         let requests = parse_requests(selectors)?;
         let mut jobs = tokio::task::JoinSet::new();
         for request in requests.into_values() {
-            let adapter = installed_adapter(&request.name)?;
+            let (adapter, configuration) = installed_adapter(&request.name, &manifest, root)?;
             let imports = self.imports.clone();
             let sources = self.sources.clone();
             jobs.spawn_blocking(move || {
                 let store = ImportStore::new(imports);
                 let sources = SourceStore::new(sources);
-                let dataset = (adapter.import)(&request, &sources, &store)?;
+                let dataset = (adapter.import)(&request, &sources, &store, configuration.as_ref())?;
                 select_tasks(&request, &dataset, adapter.matches)
             });
         }
@@ -650,12 +795,40 @@ impl AdapterCatalog {
     }
 }
 
-fn installed_adapter(name: &str) -> Result<InstalledAdapter, AdapterError> {
-    INSTALLED_ADAPTERS
+fn installed_adapter(
+    name: &str,
+    manifest: &AdapterManifest,
+    root: &Path,
+) -> Result<(InstalledAdapter, Option<AdapterConfiguration>), AdapterError> {
+    if let Some(adapter) = INSTALLED_ADAPTERS
         .iter()
         .copied()
         .find(|adapter| adapter.names.contains(&name))
-        .ok_or_else(|| AdapterError::UnknownBenchmark(name.to_owned()))
+    {
+        return Ok((adapter, None));
+    }
+    let value = manifest
+        .benchmark
+        .get(name)
+        .ok_or_else(|| AdapterError::UnknownBenchmark(name.to_owned()))?;
+    let kind = value
+        .get("adapter")
+        .and_then(toml::Value::as_str)
+        .ok_or_else(|| {
+            AdapterError::Configuration(format!("benchmark {name:?} must declare a string adapter"))
+        })?;
+    let adapter = INSTALLED_ADAPTERS
+        .iter()
+        .copied()
+        .find(|adapter| adapter.kind == kind)
+        .ok_or_else(|| AdapterError::UnknownBenchmark(format!("{name} (adapter {kind})")))?;
+    Ok((
+        adapter,
+        Some(AdapterConfiguration {
+            root: root.to_path_buf(),
+            value: value.clone(),
+        }),
+    ))
 }
 
 fn parse_requests(

--- a/crates/experimental/nanocodex-eval-adapters/src/openai_evals.rs
+++ b/crates/experimental/nanocodex-eval-adapters/src/openai_evals.rs
@@ -1,0 +1,343 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde::Deserialize;
+use serde_yaml_ng::{Mapping, Value};
+
+use nanocodex_eval::{
+    TaskOutput,
+    import::{
+        CasePlan, DatasetImporter, DatasetPlan, Environment, Harness, ImportError, SourceIdentity,
+    },
+};
+
+use crate::{read_json_lines, safe_case_id, sha256_file, sha256_values};
+
+const MATCH_CLASS: &str = "evals.elsuite.basic.match:Match";
+const INCLUDES_CLASS: &str = "evals.elsuite.basic.includes:Includes";
+const HARNESS_FILES: &[&str] = &["Dockerfile", "test.sh", "grade.py"];
+
+/// Importer for the declarative `Match` and `Includes` families in OpenAI
+/// Evals. Custom Python eval classes must use [`crate::ExternalHarness`], which
+/// preserves their official implementation instead of guessing semantics.
+#[derive(Clone, Debug)]
+pub struct OpenAiEvals {
+    name: Box<str>,
+    registry: PathBuf,
+    harness: PathBuf,
+    eval: Box<str>,
+    revision: Box<str>,
+    environment: Environment,
+}
+
+impl OpenAiEvals {
+    /// Creates an importer for one registry eval ID.
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        registry: impl Into<PathBuf>,
+        harness: impl Into<PathBuf>,
+        eval: impl Into<String>,
+        revision: impl Into<String>,
+        environment: Environment,
+    ) -> Self {
+        Self {
+            name: name.into().into_boxed_str(),
+            registry: registry.into(),
+            harness: harness.into(),
+            eval: eval.into().into_boxed_str(),
+            revision: revision.into().into_boxed_str(),
+            environment,
+        }
+    }
+}
+
+impl DatasetImporter for OpenAiEvals {
+    fn plan(&self) -> Result<DatasetPlan, ImportError> {
+        validate_harness(&self.harness)?;
+        let definition = find_definition(&self.registry, &self.eval)?;
+        let class = string_field(&definition.value, "class")?;
+        let args = mapping_field(&definition.value, "args")?;
+        if args.contains_key(Value::String("num_few_shot".to_owned())) {
+            return Err(ImportError::Invalid(
+                "OpenAI Evals few-shot prompt rewriting requires the official external harness"
+                    .to_owned(),
+            ));
+        }
+        let samples = string_from_mapping(args, "samples_jsonl")?;
+        let sample_path = self.registry.join("data").join(samples);
+        let mode = match class.as_str() {
+            MATCH_CLASS => "match",
+            INCLUDES_CLASS => {
+                if bool_from_mapping(args, "ignore_case")?.unwrap_or(false) {
+                    "includes_ignore_case"
+                } else {
+                    "includes"
+                }
+            }
+            _ => {
+                return Err(ImportError::Invalid(format!(
+                    "OpenAI Evals class {class:?} owns executable semantics; import it through an external harness"
+                )));
+            }
+        };
+        let rows = read_json_lines::<EvalSample>(&sample_path)?;
+        let mut source_inputs = vec![
+            self.eval.to_string(),
+            sha256_file(&definition.path)?,
+            sha256_file(&sample_path)?,
+        ];
+        for relative in HARNESS_FILES {
+            source_inputs.push(sha256_file(&self.harness.join(relative))?);
+        }
+        let source_digest = sha256_values(source_inputs.iter().map(String::as_bytes));
+        let source = SourceIdentity::new("openai-evals", self.revision.as_ref(), source_digest)?;
+        let harness = Harness::directory(&self.harness)?;
+        let mut plan = DatasetPlan::new(self.name.as_ref(), source)?;
+        for (index, sample) in rows.into_iter().enumerate() {
+            let prompt = sample.prompt()?;
+            let expected = sample.ideal_strings()?;
+            let expected = serde_json::to_vec(&expected).map_err(|source| ImportError::Json {
+                path: sample_path.clone(),
+                source,
+            })?;
+            let id = format!("{}-{index:06}", safe_case_id(&self.eval));
+            plan = plan.case({
+                let mut case =
+                    CasePlan::hermetic(id, prompt.user, self.environment.clone(), harness.clone())?;
+                if let Some(instructions) = prompt.instructions {
+                    case = case.instructions(instructions);
+                }
+                case.output(TaskOutput::FinalMessage)
+                    .harness_file("expected.json", expected, 0o600)?
+                    .harness_file("mode", mode.as_bytes().to_vec(), 0o600)?
+            });
+        }
+        Ok(plan)
+    }
+}
+
+fn validate_harness(harness: &std::path::Path) -> Result<(), ImportError> {
+    for relative in HARNESS_FILES {
+        let path = harness.join(relative);
+        if !path.is_file() {
+            return Err(ImportError::Invalid(format!(
+                "OpenAI Evals harness is missing {}",
+                path.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+struct EvalDefinition {
+    path: PathBuf,
+    value: Mapping,
+}
+
+fn find_definition(registry: &Path, eval: &str) -> Result<EvalDefinition, ImportError> {
+    let root = registry.join("evals");
+    for entry in fs::read_dir(&root).map_err(|source| ImportError::Io {
+        path: root.clone(),
+        source,
+    })? {
+        let entry = entry.map_err(|source| ImportError::Io {
+            path: root.clone(),
+            source,
+        })?;
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("yaml") {
+            continue;
+        }
+        let text = fs::read_to_string(&path).map_err(|source| ImportError::Io {
+            path: path.clone(),
+            source,
+        })?;
+        let document: Mapping = serde_yaml_ng::from_str(&text).map_err(|source| {
+            ImportError::Invalid(format!("failed to decode {}: {source}", path.display()))
+        })?;
+        if let Some(Value::Mapping(value)) = document.get(Value::String(eval.to_owned())) {
+            return Ok(EvalDefinition {
+                path,
+                value: value.clone(),
+            });
+        }
+    }
+    Err(ImportError::Invalid(format!(
+        "OpenAI Evals registry does not define {eval:?}"
+    )))
+}
+
+fn string_field(mapping: &Mapping, name: &str) -> Result<String, ImportError> {
+    string_from_mapping(mapping, name)
+}
+
+fn mapping_field<'a>(mapping: &'a Mapping, name: &str) -> Result<&'a Mapping, ImportError> {
+    mapping
+        .get(Value::String(name.to_owned()))
+        .and_then(Value::as_mapping)
+        .ok_or_else(|| ImportError::Invalid(format!("OpenAI Evals field {name:?} must be a map")))
+}
+
+fn string_from_mapping(mapping: &Mapping, name: &str) -> Result<String, ImportError> {
+    mapping
+        .get(Value::String(name.to_owned()))
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| {
+            ImportError::Invalid(format!("OpenAI Evals field {name:?} must be a string"))
+        })
+}
+
+fn bool_from_mapping(mapping: &Mapping, name: &str) -> Result<Option<bool>, ImportError> {
+    match mapping.get(Value::String(name.to_owned())) {
+        None => Ok(None),
+        Some(value) => value.as_bool().map(Some).ok_or_else(|| {
+            ImportError::Invalid(format!("OpenAI Evals field {name:?} must be a boolean"))
+        }),
+    }
+}
+
+#[derive(Deserialize)]
+struct EvalSample {
+    input: serde_json::Value,
+    ideal: serde_json::Value,
+}
+
+impl EvalSample {
+    fn prompt(&self) -> Result<EvalPrompt, ImportError> {
+        if let Some(prompt) = self.input.as_str() {
+            return Ok(EvalPrompt {
+                instructions: None,
+                user: prompt.to_owned(),
+            });
+        }
+        let messages = self.input.as_array().ok_or_else(|| {
+            ImportError::Invalid(
+                "OpenAI Evals input must be text or one system message followed by one user message"
+                    .to_owned(),
+            )
+        })?;
+        if messages.is_empty() || messages.len() > 2 {
+            return Err(ImportError::Invalid(
+                "OpenAI Evals conversations beyond one system and one user message require an official external harness"
+                    .to_owned(),
+            ));
+        }
+        let user = messages
+            .last()
+            .and_then(serde_json::Value::as_object)
+            .ok_or_else(|| {
+                ImportError::Invalid("OpenAI Evals chat input must contain objects".to_owned())
+            })?;
+        if user.get("role").and_then(serde_json::Value::as_str) != Some("user") {
+            return Err(ImportError::Invalid(
+                "OpenAI Evals final message must be user".to_owned(),
+            ));
+        }
+        let user = user
+            .get("content")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned)
+            .ok_or_else(|| ImportError::Invalid("chat content must be text".to_owned()))?;
+        let instructions = if messages.len() == 2 {
+            let system = messages[0].as_object().ok_or_else(|| {
+                ImportError::Invalid("OpenAI Evals chat input must contain objects".to_owned())
+            })?;
+            if system.get("role").and_then(serde_json::Value::as_str) != Some("system") {
+                return Err(ImportError::Invalid(
+                    "OpenAI Evals first message must be system when two messages are present"
+                        .to_owned(),
+                ));
+            }
+            Some(
+                system
+                    .get("content")
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| ImportError::Invalid("chat content must be text".to_owned()))?
+                    .to_owned(),
+            )
+        } else {
+            None
+        };
+        Ok(EvalPrompt { instructions, user })
+    }
+
+    fn ideal_strings(&self) -> Result<Vec<String>, ImportError> {
+        if let Some(ideal) = self.ideal.as_str() {
+            return Ok(vec![ideal.to_owned()]);
+        }
+        self.ideal
+            .as_array()
+            .filter(|values| values.iter().all(serde_json::Value::is_string))
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(serde_json::Value::as_str)
+                    .map(str::to_owned)
+                    .collect()
+            })
+            .ok_or_else(|| {
+                ImportError::Invalid("OpenAI Evals ideal must be text or text array".to_owned())
+            })
+    }
+}
+
+struct EvalPrompt {
+    instructions: Option<String>,
+    user: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use nanocodex_eval::import::ImportStore;
+
+    use super::*;
+
+    #[test]
+    fn imports_match_without_reimplementing_custom_classes() {
+        let root = tempfile::tempdir().unwrap();
+        fs::create_dir_all(root.path().join("evals")).unwrap();
+        fs::create_dir_all(root.path().join("data/demo")).unwrap();
+        fs::write(
+            root.path().join("evals/demo.yaml"),
+            r#"demo.match-v1:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: demo/samples.jsonl
+"#,
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("data/demo/samples.jsonl"),
+            "{\"input\":[{\"role\":\"user\",\"content\":\"2 + 2?\"}],\"ideal\":[\"4\",\"four\"]}\n",
+        )
+        .unwrap();
+        let store = tempfile::tempdir().unwrap();
+        let harness = Path::new(env!("CARGO_MANIFEST_DIR")).join("assets/openai-evals");
+
+        let imported = ImportStore::new(store.path())
+            .import(&OpenAiEvals::new(
+                "openai-demo",
+                root.path(),
+                harness,
+                "demo.match-v1",
+                "openai-evals@fixture",
+                Environment::OciImage("python:3.12-slim".to_owned()),
+            ))
+            .unwrap();
+
+        assert_eq!(imported.tasks()[0].prompt(), "2 + 2?");
+        assert_eq!(imported.tasks()[0].output(), TaskOutput::FinalMessage);
+        assert!(
+            imported.tasks()[0]
+                .root()
+                .join("tests/expected.json")
+                .is_file()
+        );
+    }
+}

--- a/crates/experimental/nanocodex-eval/src/profile.rs
+++ b/crates/experimental/nanocodex-eval/src/profile.rs
@@ -22,6 +22,8 @@ pub struct EvaluationManifest {
     default: Option<String>,
     #[serde(default)]
     harness: BTreeMap<String, Harness>,
+    #[serde(default, rename = "benchmark")]
+    _benchmarks: BTreeMap<String, toml::Value>,
     profiles: BTreeMap<String, Profile>,
 }
 

--- a/evals/adapter-smoke/openai-evals/registry/data/demo/samples.jsonl
+++ b/evals/adapter-smoke/openai-evals/registry/data/demo/samples.jsonl
@@ -1,0 +1,1 @@
+{"input":[{"role":"user","content":"Return exactly: adapter-ok"}],"ideal":["adapter-ok"]}

--- a/evals/adapter-smoke/openai-evals/registry/evals/demo.yaml
+++ b/evals/adapter-smoke/openai-evals/registry/evals/demo.yaml
@@ -1,0 +1,4 @@
+demo.match-v1:
+  class: evals.elsuite.basic.match:Match
+  args:
+    samples_jsonl: demo/samples.jsonl

--- a/nanocodex.toml
+++ b/nanocodex.toml
@@ -1,5 +1,11 @@
 default = "local-smoke"
 
+[benchmark.openai-evals-smoke]
+adapter = "openai-evals"
+registry = "evals/adapter-smoke/openai-evals/registry"
+eval = "demo.match-v1"
+revision = "nanocodex/openai-evals-smoke@1"
+
 [profiles.local-smoke]
 tasks = ["tasks/write-greeting"]
 trials = 2
@@ -96,6 +102,12 @@ benchmarks = [
   "agents-last-exam/financial_stmt_reconstruction_aapl_fy2024",
   "agents-last-exam/atwood_2022_measles_vaccine_reproduction",
 ]
+trials = 1
+model = ["sol"]
+thinking = ["high"]
+
+[profiles.openai-evals-smoke]
+benchmarks = ["openai-evals-smoke/demo.match-v1-000000"]
 trials = 1
 model = ["sol"]
 thinking = ["high"]


### PR DESCRIPTION
## Summary

- import declarative OpenAI Evals Match and Includes registry definitions into native typed tasks
- configure caller-owned registries through benchmark recipes in nanocodex.toml
- reject few-shot rewriting and executable custom Python classes instead of approximating their semantics
- include a deterministic local registry fixture for adapter-contract smoke validation

## Stack

Depends on #155. The stack is rooted at the current master through #142.

## Validation

- cargo test -p nanocodex-eval-adapters -p nanocodex-eval --lib (27 adapter tests, 96 eval tests)
- cargo clippy -p nanocodex-eval -p nanocodex-eval-adapters -p nanocodex-bin --all-targets -- -D warnings

The fixture validates adapter wiring and Match grading; it is not presented as an OpenAI benchmark score.