### PR TITLE
feat(cli): guide top-down subagent development

### DIFF
--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -421,14 +421,18 @@ const fn selected_subagent_tools(
 }
 
 const SUBAGENT_INSTRUCTIONS: &str = concat!(
-    "For larger tasks, delegate meaningful, separable work to subagents; handle trivial or tightly ",
-    "coupled work directly. Use code mode to build multi-agent pipelines: map independent subtasks ",
-    "across agents in parallel, await and reduce their results, then dispatch dependent stages. Do ",
-    "not repeat delegated work yourself; wait for delegated work to finish, then use its results for ",
-    "the next step. Double-check their results against the relevant evidence before relying on them. ",
-    "Use schemas that expose the fields downstream stages need, and use loops to iterate until the ",
-    "completion condition is met. Keep concurrent write scopes disjoint. You own final synthesis and ",
-    "verification."
+    "For larger tasks, remain the sole owner of production edits and the end-to-end vertical slice. ",
+    "Work top down from the consuming CLI, example, or observable contract through the affected ",
+    "public API and ownership boundaries, then events and OTEL, and only then internal implementation. ",
+    "Start bounded independent readers early for meaningful discovery, reuse, review, measurement, ",
+    "and validation work. Every reader task must explicitly prohibit production edits and further ",
+    "delegation. Continue non-conflicting primary work while readers run, and collect whichever result ",
+    "is ready when it informs the next decision or final verification instead of creating serial ",
+    "barriers. Do not repeat delegated work; reuse completed agents for later focused checks. Verify ",
+    "reader findings against the relevant evidence, and incorporate direction-changing feedback before ",
+    "dependent work. Do not create speculative tests. Once behavior and the public API stabilize, add ",
+    "only focused public-contract or demonstrated-regression tests. You own the diff, tests, synthesis, ",
+    "and final verification."
 );
 
 fn session_instructions(custom: Option<String>, subagents_enabled: bool) -> Option<String> {

--- a/docs/SUBAGENTS.md
+++ b/docs/SUBAGENTS.md
@@ -2,11 +2,12 @@
 
 Nanocodex’s native CLI ports the subagent runtime from
 [`clabby/tact@1d9ccaefd1d8613dab020812af04a91cd9b4c52c`](https://github.com/clabby/tact/tree/1d9ccaefd1d8613dab020812af04a91cd9b4c52c)
-under Apache-2.0. The runtime source, schemas, prompts, lifecycle, messaging,
-capacity policy, and focused tests are retained 1:1. The integration changes
-are limited to Nanocodex module paths, removal of Tact’s separate memory-tool
-coupling, CLI configuration, event draining, shutdown wiring, and explicit
-propagation of Nanocodex’s originating tool span into the child harness.
+under Apache-2.0. The runtime source, schemas, child prompts, lifecycle,
+messaging, capacity policy, and focused tests are retained 1:1. The integration
+changes are limited to Nanocodex module paths, removal of Tact’s separate
+memory-tool coupling, CLI configuration and root orchestration guidance, event
+draining, shutdown wiring, and explicit propagation of Nanocodex’s originating
+tool span into the child harness.
 
 Subagents are enabled by default for TUI and one-shot runs:
 
@@ -18,10 +19,25 @@ nanocodex run --max-subagents 32 "implement the change"
 Pass `--subagents false` or set `NANOCODEX_SUBAGENTS=false` to disable the
 general-purpose subagent tools for a session.
 
-When enabled, the root agent also receives Tact's fixed orchestration guidance:
-delegate only meaningful separable work, run independent children concurrently,
-use their typed outputs for dependent stages, avoid repeating delegated work,
-verify their findings, and keep concurrent write scopes disjoint.
+When enabled, the root agent also receives an advisory default development
+policy built on Tact's orchestration primitives. It remains the sole
+production-code writer and works top down from the consuming CLI, example, or
+observable behavior through the public API and ownership boundaries, then
+events and OTEL, and finally internal implementation. It starts bounded
+read-only scouts, reviewers, validators, and measurement agents early,
+continues non-conflicting work while they run, and consumes results at natural
+checkpoints instead of waiting at a barrier after every stage.
+
+Completed agents are reusable for later focused checks. The root owns every
+reader and explicitly prohibits production edits and further delegation in
+each task. It consumes direction-changing feedback before dependent work but
+does not stop unrelated work to wait for a review. The root also owns test
+creation: tests follow stable behavior and APIs and cover only public contracts
+or demonstrated regressions.
+
+This split is guidance, not a capability sandbox. Children retain the root's
+base tools and process authority, so each reader task must explicitly prohibit
+production edits and the root must inspect the final diff.
 
 `--max-subagents` bounds active child turns across the complete task tree. Idle
 reusable sessions consume no capacity. Lowering the limit does not cancel work;


### PR DESCRIPTION
## Summary

- keep the root agent as the sole production-code writer
- guide implementation top down from the consuming CLI or observable contract through API ownership, events/OTEL, and internals
- start bounded read-only readers early and consume their results at decision points instead of serial fan-in barriers
- defer tests until behavior and the public API stabilize, then keep them focused on public contracts or demonstrated regressions
- clarify that reader isolation is advisory and must be explicit in each delegated task

## Validation

- 
- 
- 
running 1 test
test config::tests::subagent_instructions_follow_the_enable_switch ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 326 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
- 
- 

## Workflow trial

This PR used the proposed one-writer/many-readers loop. Two read-only reviewers ran concurrently while the root edited and compiled. They identified the provenance wording, advisory isolation boundary, and serial/recursive orchestration problems incorporated here; neither reader touched the diff. The cold focused test compile took 2m36s, so overlapping reader work with validation materially reduced idle time. This is an initial workflow trial, not an eval result.