### PR TITLE
chore(release): prepare 0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
         with:
           cache-on-failure: true
       - run: cargo test --workspace --locked
-      - run: cargo test --package nanocodex-bin --features tempo --locked
 
   quality:
     name: rustfmt, clippy, and docs
@@ -62,7 +61,11 @@ jobs:
         with:
           cache-on-failure: true
       - run: cargo fmt --all -- --check
-      - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: Clippy workspace targets
+        run: |
+          cargo clippy --workspace --all-targets --all-features --exclude nanocodex-bin -- -D warnings
+          cargo clippy --package nanocodex-bin --all-features --bin nanocodex -- -D warnings
+          cargo clippy --package nanocodex-bin --all-features --bench tui_render -- -D warnings
       - name: Check independently usable crates and public examples
         run: |
           cargo check --locked --package nanocodex-oai-api

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Prepare 0.4.0
 - [eval] Update Harbor adapter lockfile
 - Update JavaScript package size budget
 - Update JavaScript package size budget

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,28 +5,351 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11
 
 ### Bug Fixes
 
-- [oai] Retry transient HTTP 403 WebSocket upgrades before falling back to
-  HTTPS, and retain gateway diagnostics when the rejection body is empty.
+- [ci] Stabilize process timing tests
+- [eval] Extract GPQA archive in process
+- [eval] Select the pinned Arena-Hard smoke case
+- [eval] Order artifact archive options
+- [eval] Requeue scored lifecycle failures
+- [oai] Allow long silent response generations
+- [eval] Stage files in isolated verifier VMs
+- [eval] Join agents before verifier isolation
+- [eval] Canonicalize pull worker evidence roots
+- [eval] Send task roots to pull workers
+- [eval] Preserve same-role benchmark messages
+- [ci] Preserve typed prompt consumer contracts
+- [eval] Satisfy strict coordinator clippy
+- [eval] Pause admission after capacity deaths
+- [eval] Account for pending worker claims
+- [eval] Make headless benchmark supervision deterministic
+- [eval] Keep controller reconciliation bounded
+- [eval] Release every exited worker claim
+- [eval] Keep libkrun sockets on short temp paths
+- [vm] Wait for gvproxy packet activation
+- [eval] Keep cold verifiers off cache disks
+- [eval] Move verifier cache warming off worker admission
+- [eval] Keep coordinator responsive under worker bursts
+- [eval] Keep gvproxy socket paths short
+- [evals] Keep live task reads database-only
+- [evals] Refresh retried result projections
+- [evals] Estimate missing benchmark costs
+- [eval] Recover cleanly from worker infrastructure failures
+- [eval] Make benchmark saturation autonomous
+- [eval] Let workers outlive benchmark controller
+- [eval] Separate verifier and infrastructure failures
+- [eval] Reserve headroom for live VM growth
+- [eval] Continuously backfill benchmark capacity
+- [eval] Observe capacity between admissions
+- [eval] Preserve compact capacity counts
+- [eval] Make capacity telemetry executable
+- [eval] Saturate benchmark from live host capacity
+- [ci] Stabilize cross-platform runtime checks
+- [eval] Preserve active benchmark workers
+- [oai] Recover forbidden websocket handshakes
+- [ci] Satisfy durable baseline gates
+- [eval] Complete durable runtime ownership
+- [eval] Preserve inherited worker config
+- [eval] Forbid recursive benchmark agents
+- [eval] Aggressively saturate benchmark hosts
+- [eval] Keep benchmark orchestration direct
+- [eval] Expose benchmark cli executable
+- [eval] Simplify benchmark orchestration
+- [eval] Autoheal stalled coordinators
+- [eval] Make benchmark launch gates explicit
+- [eval] Launch benchmark runs before adapting
+- [eval] Drive benchmark hosts aggressively
+- [eval] Bound orchestration status and reclaim dead workers
+- [eval] Isolate benchmark agent from source checkout
+- [eval] Preserve worker affinity in orchestration
+- [eval] Route supervised benchmark through coordinator
+- [eval] Read current sqlite work on every claim
+- [eval] Satisfy Linux prepared-host Clippy ([#134](https://github.com/gakonst/nanocodex/issues/134))
+- [eval] Install harnesses during task preparation
+- [eval] Make profile identity host independent
+- [eval] Prepare task images under the durable lease
+- [browser] Keep deferred schema lookup private
+- [tools] Restore stock Codex code mode parity
+- [oai] Preserve code mode notifications in replay
+- [cli] Honor browser cookie opt-out
+- [cli] Default browser to Brave
+- Close remaining Codex wire parity gaps
+- [tui] Sanitize resume picker metadata
+- [cli] Remove Tempo charge cap
+- [rivet] Keep sandbox previews durable
+- [rivet] Use direct actor preview gateway
+- [cloudflare] Preserve snapshot tool definition
+- [cloudflare] Proxy sandbox previews through worker
+- [rivet] Reuse cached cloud credentials
+- [web] Follow live eval evidence incrementally
+- [eval] Harden durable differential progress
+- [tui] Strip quote chrome from copied markdown
+- [cloudflare] Synchronize live browser clients
+- [cloudflare] Clarify deployed session authorization
+- [cloudflare] Harden subscription edge demo
+- [web] Retain immutable comparison evidence
+- [web] Require immutable paired eval plans
+- [eval] Harden toolbox runtime fallbacks
+- [eval] Match curl with its CA bundle
+- [tui] Initialize configured fast mode
+- [tui] Support Option-Backspace word deletion
+- [egress] Preserve middleware error chains
+- [vm] Stabilize image cache identity
+- [vm] Own guest command cleanup
+- [oai] Account for usage-uncertain attempts
+- [tools] Keep tool search visible in code mode
+- [tools] Align Code Mode tool contracts
+- [browser] Gate Safari discovery by platform
+- [browser] Decouple cookies from executable
+- [rivet] Reserve turns before replay lookup
+- [mpp] Prefer NanoUSD via provider policy
+- [rivet] Own local server lifecycle
+- [agent] Dispatch unnamespaced hosted tools
+- [wasm] Harden host socket upgrades
+- [tui] Inherit terminal foreground colors
+- [tls] Standardize rustls on ring
+- [examples] Remove duplicate transcript-tail arm
+- [agent] Preserve model in adapter checkpoints
+- [examples] Handle realtime transcript tails
+- [agent] Retain model in fork checkpoints
+- Build Tower services from effective agent config
+- Preserve Codex rollout model compatibility
+- [update] Cache-bust rolling release assets
+- [ci] Allow release builds to finish
+- [ci] Restore nightly platform builds
+- Cancel voice-started turns from the TUI
+- Finish voice platform cleanup
+- Allow unsupported audio stubs
+- [ci] Stabilize loaded Linux checks
+- [ci] Stabilize observability tests
+- [vm] Harden cache and session lifecycle
+- [vm] Preserve parallel tool execution
+- [tui] Preserve streaming frame boundaries
+
+### Dependencies
+
+- [rivet] Remove AgentOS and Pi dependencies
+
+### Documentation
+
+- Keep eval debugging active during waves
+- Streamline experimental eval iteration
+- [web] Explain generated Harbor data
+- Refresh project roadmap
+- [rivet] Remove stale AgentOS reference
+- [browser] Keep agent example at consumer boundary
 
 ### Features
 
-- [cli] Enable private Brave and complete desktop-profile cookie import by
-  default, with compact up-front `tools.browser` discovery in Code Mode.
-- [cli] Enable Tact-style subagents by default with an explicit
-  `--subagents false` opt-out.
-- [tui] Add a first-class `/simplify [focus]` workflow backed by four concurrent
-  read-only reviewers on the shared subagent runtime.
-- [tools] Add bounded MCP pagination, collision-safe Code Mode registration,
-  per-tool and per-server exposure policy, and deferred custom-tool wire shapes.
-- [parity] Classify Codex through `7ada37a1` and defer the standalone V8 host.
-- [model] Support selecting `gpt-5.6-luna` when creating Rust, CLI, Python,
-  JavaScript, and Harbor agent threads.
-- [vm] Add persistent VM-backed workspace tools, immutable root-image
-  preparation, and provider-neutral composable egress leases.
+- [cli] Enable subagents by default
+- [tui] Add simplify workflow
+- [eval] Add external harness adapter
+- [eval] Add OpenAI Evals adapter
+- [eval] Add Agents Last Exam adapter
+- [eval] Add ARC-AGI-3 public smoke adapter
+- [eval] Add BrowseComp adapter
+- [eval] Add GPQA Diamond adapter
+- [eval] Add GDPval adapter
+- [eval] Add HealthBench Professional adapter
+- [eval] Add MRCR adapter
+- [eval] Add GraphWalks adapter
+- [eval] Add GeneBench Pro adapter
+- [eval] Add SWE-Atlas QnA adapter
+- [eval] Add SWE-bench adapter
+- [eval] Add Arena-Hard adapter
+- [eval] Add Harbor benchmark adapter
+- [eval] Isolate model judges behind verifier runtime
+- [eval] Route profiles through adapter catalog
+- [eval] Add benchmark adapter foundation
+- [web] Add durable eval task board
+- [cli] Port Tact subagent runtime
+- [eval] Externalize benchmark orchestration policy
+- [eval] Add work through coordinator API
+- [eval] Place supervised runtime on explicit volume
+- [eval] Expose retained eval coordinator API
+- [eval] Make sqlite own benchmark work
+- [eval] Supervise durable benchmarks with systemd
+- [mpp] Configure Tempo payment token
+- [eval] Label coordinator workers
+- [eval] Pin differential harness versions
+- [eval] Retain native coordinator trajectories
+- [eval] Coordinate directly over Tailscale
+- [eval] Coordinate pull workers over HTTP
+- [eval] Add durable profile ledger
+- [browser] Add pixel-calibrated captures
+- [cli] Enable browser tools by default
+- [tools] Align current Codex parity
+- [cli] Add interactive resume session picker
+- [examples] Use exe.dev as external sandbox
+- [examples] Add retained exe.dev agent
+- [rivet] Verify hosted sandbox previews
+- [examples] Add durable platform sandboxes
+- [model] Support Terra and routed OpenAI model IDs
+- [web] Add live evaluation dashboard
+- [cli] Add durable evaluation commands
+- [eval] Add durable evaluation SDK
+- [cli] Default credits to hosted API
+- [tui] Improve markdown math rendering
+- [cloudflare] Add resumable web client and local subscription egress
+- [cloudflare] Run locally with Codex subscription auth
+- [cloudflare] Add detachable durable REPL
+- Run Nanocodex on Cloudflare Durable Objects
+- [vercel] Add durable Workflow actor demo
+- [eval] Add priority-processing fast path
+- [vm] Add disposable guest overlays
+- [agent] Describe remote execution context
+- [browser] Import Firefox and Safari cookies
+- [browser] Select cookie source profiles
+- [browser] Import Brave profile cookies
+- [rivet] Synchronize actor clients
+- [rivet] Deploy subscription demo to Compute
+- [rivet] Package demo for Rivet Compute
+- [rivet] Add resumable browser client
+- [rivet] Run locally with Codex subscription auth
+- [rivet] Add detachable actor REPL
+- Add Rivet Actors and AgentOS example
+- [egress] Harden secret policy and VM routing
+- [wasm] Support CSP-safe direct host tools
+- Expose reusable WASM host transport
+- [voice] Add Codex realtime parity
+- Support Luna
+- Close Codex realtime parity gaps
+- Match Codex realtime steering
+- Add reusable realtime voice sessions
+- [cli] Integrate deferred browser tooling
+- [browser] Add experimental VM-backed browser
+- [tui] Render display math with Ratatex
+- [tools] Expose the ambient sensitive environment
+- [vm] Add retained VM-backed workspace tools
+- [cli] Cache and switch installed versions
+
+### Miscellaneous Tasks
+
+- [eval] Update Harbor adapter lockfile
+- Update JavaScript package size budget
+- Update JavaScript package size budget
+- Retire Harbor delivery workflows
+- Decouple Harbor from nightly releases
+- [mpp] Pin merged challenge selection
+- Update ruint past advisory
+
+### Other
+
+- Merge pull request [#127](https://github.com/gakonst/nanocodex/issues/127) from gakonst/feat/simplify-workflow
+- Merge pull request [#157](https://github.com/gakonst/nanocodex/issues/157) from gakonst/feat/eval-adapter-external-v2
+- Merge pull request [#156](https://github.com/gakonst/nanocodex/issues/156) from gakonst/feat/eval-adapter-openai-evals-v2
+- Merge pull request [#155](https://github.com/gakonst/nanocodex/issues/155) from gakonst/feat/eval-adapter-agents-last-exam-v2
+- Merge pull request [#154](https://github.com/gakonst/nanocodex/issues/154) from gakonst/feat/eval-adapter-arc-agi-3-v2
+- Merge pull request [#153](https://github.com/gakonst/nanocodex/issues/153) from gakonst/feat/eval-adapter-browsecomp-v2
+- Merge pull request [#152](https://github.com/gakonst/nanocodex/issues/152) from gakonst/feat/eval-adapter-gpqa-diamond-v2
+- Merge pull request [#151](https://github.com/gakonst/nanocodex/issues/151) from gakonst/feat/eval-adapter-gdpval-v2
+- Merge pull request [#150](https://github.com/gakonst/nanocodex/issues/150) from gakonst/feat/eval-adapter-healthbench-pro-v2
+- Merge pull request [#149](https://github.com/gakonst/nanocodex/issues/149) from gakonst/feat/eval-adapter-mrcr-v2
+- Merge pull request [#148](https://github.com/gakonst/nanocodex/issues/148) from gakonst/feat/eval-adapter-graphwalks-v2
+- Merge pull request [#147](https://github.com/gakonst/nanocodex/issues/147) from gakonst/feat/eval-adapter-genebench-pro-v2
+- Merge pull request [#146](https://github.com/gakonst/nanocodex/issues/146) from gakonst/feat/eval-adapter-swe-atlas-v2
+- Merge pull request [#145](https://github.com/gakonst/nanocodex/issues/145) from gakonst/feat/eval-adapter-swe-bench-v2
+- Merge pull request [#144](https://github.com/gakonst/nanocodex/issues/144) from gakonst/feat/eval-adapter-arena-hard-v2
+- Merge pull request [#143](https://github.com/gakonst/nanocodex/issues/143) from gakonst/feat/eval-adapter-harbor-v2
+- Merge pull request [#142](https://github.com/gakonst/nanocodex/issues/142) from gakonst/feat/eval-adapter-foundation
+- Merge pull request [#135](https://github.com/gakonst/nanocodex/issues/135) from gakonst/agent/durable-task-board-20260806
+- Merge pull request [#139](https://github.com/gakonst/nanocodex/issues/139) from gakonst/fix/websocket-403-fallback
+- Merge pull request [#137](https://github.com/gakonst/nanocodex/issues/137) from gakonst/feat/tact-subagents
+- Merge pull request [#136](https://github.com/gakonst/nanocodex/issues/136) from gakonst/feat/eval-systemd-supervision
+- Merge pull request [#124](https://github.com/gakonst/nanocodex/issues/124) from gakonst/fix/codex-parity-current
+- Merge pull request [#122](https://github.com/gakonst/nanocodex/issues/122) from Giulio2002/feat/resume-session-picker
+- Merge pull request [#123](https://github.com/gakonst/nanocodex/issues/123) from gakonst/feat/exe-dev-ssh-multiplex
+- Merge pull request [#119](https://github.com/gakonst/nanocodex/issues/119) from gakonst/feat/exe-dev-spike
+- Merge pull request [#114](https://github.com/gakonst/nanocodex/issues/114) from gakonst/feat/hosted-platform-sandboxes
+- Merge pull request [#121](https://github.com/gakonst/nanocodex/issues/121) from Slokh/kartik/upstream-contributions
+- Merge pull request [#61](https://github.com/gakonst/nanocodex/issues/61) from gakonst/agent/eval-diff
+- Merge pull request [#117](https://github.com/gakonst/nanocodex/issues/117) from gakonst/fix/decouple-harbor-nightly
+- Merge pull request [#118](https://github.com/gakonst/nanocodex/issues/118) from gakonst/codex/hosted-credits-api-default
+- Merge pull request [#115](https://github.com/gakonst/nanocodex/issues/115) from gakonst/fix/markdown-copy-blockquotes
+- Merge pull request [#113](https://github.com/gakonst/nanocodex/issues/113) from gakonst/feat/platform-sandbox-demos
+- Merge pull request [#112](https://github.com/gakonst/nanocodex/issues/112) from gakonst/feat/vercel-workflow-demo
+- Merge pull request [#109](https://github.com/gakonst/nanocodex/issues/109) from brendanjryan/brendanjryan/immutable-harbor-comparisons
+- Merge pull request [#108](https://github.com/gakonst/nanocodex/issues/108) from brendanjryan/brendanjryan/eval-no-rollouts
+- Merge pull request [#105](https://github.com/gakonst/nanocodex/issues/105) from brendanjryan/brendanjryan/eval-tool-install
+- Merge pull request [#106](https://github.com/gakonst/nanocodex/issues/106) from brendanjryan/brendanjryan/eval-fast-mode
+- Merge pull request [#107](https://github.com/gakonst/nanocodex/issues/107) from brendanjryan/brendanjryan/eval-task-images
+- Merge pull request [#103](https://github.com/gakonst/nanocodex/issues/103) from 0xahzam/fix/tui-option-backspace
+- Merge pull request [#111](https://github.com/gakonst/nanocodex/issues/111) from gakonst/fix/egress-payment-error-chain
+- Merge pull request [#100](https://github.com/gakonst/nanocodex/issues/100) from gakonst/agent/pr61-vm-overlays
+- Merge pull request [#99](https://github.com/gakonst/nanocodex/issues/99) from gakonst/agent/pr61-vm-images
+- Merge pull request [#98](https://github.com/gakonst/nanocodex/issues/98) from gakonst/agent/pr61-vm-guest
+- Merge pull request [#97](https://github.com/gakonst/nanocodex/issues/97) from gakonst/agent/pr61-tower-accounting
+- Merge pull request [#96](https://github.com/gakonst/nanocodex/issues/96) from gakonst/agent/pr61-agent-context
+- Merge pull request [#95](https://github.com/gakonst/nanocodex/issues/95) from gakonst/agent/pr61-code-mode
+- Merge pull request [#101](https://github.com/gakonst/nanocodex/issues/101) from gakonst/docs/refresh-project-plan
+- Merge pull request [#93](https://github.com/gakonst/nanocodex/issues/93) from gakonst/feat/brave-browser-cookies
+- Merge pull request [#94](https://github.com/gakonst/nanocodex/issues/94) from gakonst/feat/rivet-synchronized-clients
+- Merge pull request [#92](https://github.com/gakonst/nanocodex/issues/92) from gakonst/fix/nanousd-mpp-selection
+- Merge pull request [#90](https://github.com/gakonst/nanocodex/issues/90) from gakonst/fix/rivet-subscription-cloud-demo
+- Merge pull request [#74](https://github.com/gakonst/nanocodex/issues/74) from gakonst/feat/rivet-actors-wasm
+- Merge pull request [#88](https://github.com/gakonst/nanocodex/issues/88) from gakonst/feat/secret-egress
+- Merge pull request [#70](https://github.com/gakonst/nanocodex/issues/70) from gakonst/feat/composable-egress
+- Merge pull request [#75](https://github.com/gakonst/nanocodex/issues/75) from gakonst/feat/wasm-host-transport
+- Merge pull request [#87](https://github.com/gakonst/nanocodex/issues/87) from vovw/fix/terminal-foreground-colors
+- Merge pull request [#86](https://github.com/gakonst/nanocodex/issues/86) from gakonst/fix/ring-only-rustls
+- Merge pull request [#85](https://github.com/gakonst/nanocodex/issues/85) from gakonst/fix/realtime-tail-unreachable
+- Merge pull request [#83](https://github.com/gakonst/nanocodex/issues/83) from gakonst/fix/realtime-parity-ci
+- Merge pull request [#84](https://github.com/gakonst/nanocodex/issues/84) from gakonst/fix/committed-session-model
+- Merge pull request [#82](https://github.com/gakonst/nanocodex/issues/82) from gakonst/feat/realtime-codex-parity
+- Merge pull request [#80](https://github.com/gakonst/nanocodex/issues/80) from clabby/cl/luna
+- Merge pull request [#81](https://github.com/gakonst/nanocodex/issues/81) from gakonst/fix/voice-turn-cancellation
+- Merge pull request [#77](https://github.com/gakonst/nanocodex/issues/77) from gakonst/feat/realtime-voice
+- Merge pull request [#78](https://github.com/gakonst/nanocodex/issues/78) from gakonst/agent/browser-tui-integration
+- Merge pull request [#69](https://github.com/gakonst/nanocodex/issues/69) from gakonst/agent/pr60-experimental-browser
+- Merge pull request [#68](https://github.com/gakonst/nanocodex/issues/68) from gakonst/agent/ratatex-tui
+- Merge pull request [#66](https://github.com/gakonst/nanocodex/issues/66) from gakonst/codex/pr64-redraw-opt
+- Merge pull request [#59](https://github.com/gakonst/nanocodex/issues/59) from cjustice/feat/ambient-sensitive-environment
+- Merge pull request [#58](https://github.com/gakonst/nanocodex/issues/58) from gakonst/refactor/09-eval
+
+### Performance
+
+- [eval] Import only selected MRCR tasks
+- [evals] Normalize treatment storage
+- [evals] Accelerate live analytics reads
+- [eval] Adapt benchmark fanout to host memory
+- [examples] Reuse exe.dev SSH connections
+- [ci] Streamline release artifact builds
+- [eval] Disable rollout persistence
+- [eval] Skip redundant tool installation
+- [eval] Reuse prepared task images
+- [ci] Avoid fat LTO for release artifacts
+- Harden realtime voice audio paths
+- [tui] Bound streaming redraw CPU
+- [tui] Scope animation redraws
+
+### Refactor
+
+- [eval] Share adapter identity helpers
+- [eval] Simplify durable benchmark ownership
+- [eval] Simplify benchmark driver
+- [eval] Make profiles pure sqlite inputs
+- [eval] Simplify distributed worker runtime
+- [eval] Reduce profiles to durable coordinates
+- [eval] Remove residual sweep completion fields
+- [eval] Collapse profile execution API
+- [eval] Delete redundant orchestration
+- Trim Codex parity implementation
+- [mpp] Extract composable egress transport
+- Fix the model for each thread
+
+### Testing
+
+- [cli] Own interrupt workspaces with tempfile
+- [eval] Stress live coordinator scheduling
+- [eval] Satisfy all-target clippy
+- [rivet] Reattach long hosted smoke turns
+- [vercel] Harden hosted sandbox lifecycle
+- [cloudflare] Harden hosted sandbox tools
+- [observability] Consume OTLP request bodies
+- Synchronize realtime response queue
+- [browser] Prove Nanocodex tool integration
 
 ## [0.3.0](https://github.com/gakonst/nanocodex/releases/tag/v0.3.0) - 2026-07-28
 
@@ -105,6 +428,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.3.0 changelogs
 - [release] Prepare 0.3.0
 - [consumers] Gate promoted language bindings
 - [js] Ship compiled tui entrypoints
@@ -168,6 +492,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [mcp] Verify read-only parallel dispatch
 - [tools] Serialize traced runtime integration tests
 - [tui] Preserve stored checkpoint branch coverage
+
 ## [0.2.0](https://github.com/gakonst/nanocodex/releases/tag/v0.2.0) - 2026-07-26
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3596,11 +3596,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4897,12 +4895,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5131,7 +5123,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "nanocodex-agent",
  "nanocodex-oai-api",
@@ -5143,7 +5135,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-agent"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5171,13 +5163,12 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-bin"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "arboard",
  "arcbox-ext4",
  "async-trait",
- "axum",
  "base64",
  "chrono",
  "clap",
@@ -5198,7 +5189,6 @@ dependencies = [
  "nanocodex-eval",
  "nanocodex-eval-adapters",
  "nanocodex-observability",
- "nanocodex-tools",
  "nanocodex-vm",
  "nanocodex-voice",
  "nanousd",
@@ -5221,11 +5211,8 @@ dependencies = [
  "tempo-alloy",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.30.0",
  "toml",
- "tower",
  "tracing",
- "tracing-subscriber",
  "two-face",
  "unicode-segmentation",
  "unicode-width 0.2.0",
@@ -5236,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-browser"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -5269,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-egress"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -5291,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-eval"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arcbox-ext4",
  "axum",
@@ -5328,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-eval-adapters"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "csv",
@@ -5350,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-examples"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "dotenvy",
  "eyre",
@@ -5373,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-exe-dev"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "axum",
  "chrono",
@@ -5393,7 +5380,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-oai-api"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -5425,7 +5412,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-observability"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5443,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-python"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "nanocodex",
  "pyo3",
@@ -5454,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-tools"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -5487,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-tools-macros"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5497,7 +5484,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-vm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arcbox-ext4",
  "async-trait",
@@ -5529,7 +5516,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-voice"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cpal",
  "futures-util",
@@ -5544,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-wasm"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "js-sys",
  "nanocodex",
@@ -5557,7 +5544,7 @@ dependencies = [
 
 [[package]]
 name = "nanousd"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "reqwest",
@@ -5570,7 +5557,7 @@ dependencies = [
 
 [[package]]
 name = "nanousd-api"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -6865,62 +6852,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
-name = "quinn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
-dependencies = [
- "bytes",
- "cfg_aliases 0.2.1",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2 0.6.5",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
-dependencies = [
- "bytes",
- "getrandom 0.4.3",
- "lru-slab",
- "rand 0.10.2",
- "rand_pcg",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
-dependencies = [
- "cfg_aliases 0.2.1",
- "libc",
- "once_cell",
- "socket2 0.6.5",
- "tracing",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7034,15 +6965,6 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_pcg"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
-dependencies = [
- "rand_core 0.10.1",
-]
 
 [[package]]
 name = "rand_xorshift"
@@ -7409,7 +7331,8 @@ dependencies = [
 [[package]]
 name = "reqwest"
 version = "0.13.4"
-source = "git+https://github.com/gakonst/reqwest?rev=d45d0c3d2b2a74b723f82791f464d6241f2c6e90#d45d0c3d2b2a74b723f82791f464d6241f2c6e90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -7426,7 +7349,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -8083,7 +8005,6 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ default-members = ["crates/nanocodex"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.97"
 authors = ["Nanocodex Contributors"]
@@ -71,19 +71,19 @@ jiff = { version = "0.2.35", default-features = false, features = ["std", "tz-sy
 jsonschema = { version = "0.48.5", default-features = false }
 krun = { package = "libkrun", version = "=2.0.0-dev", git = "https://github.com/containers/libkrun", rev = "df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0", features = ["blk", "net"] }
 mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "3e37469bb19434982b433ae44ea8c713f7ea923a", default-features = false }
-nanocodex = { version = "0.3.0", path = "crates/nanocodex" }
-nanocodex-agent = { version = "0.3.0", path = "crates/nanocodex-agent" }
-nanocodex-browser = { version = "0.3.0", path = "crates/experimental/nanocodex-browser" }
-nanocodex-egress = { version = "0.3.0", path = "crates/experimental/nanocodex-egress" }
-nanocodex-voice = { version = "0.3.0", path = "crates/experimental/nanocodex-voice" }
-nanocodex-eval = { version = "0.3.0", path = "crates/experimental/nanocodex-eval" }
-nanocodex-eval-adapters = { version = "0.3.0", path = "crates/experimental/nanocodex-eval-adapters" }
-nanocodex-vm = { version = "0.3.0", path = "crates/experimental/nanocodex-vm" }
-nanocodex-oai-api = { version = "0.3.0", path = "crates/nanocodex-oai-api" }
-nanocodex-observability = { version = "0.3.0", path = "crates/nanocodex-observability" }
-nanocodex-tools = { version = "0.3.0", path = "crates/nanocodex-tools" }
-nanocodex-tools-macros = { version = "0.3.0", path = "crates/nanocodex-tools/macros" }
-nanousd = { version = "0.3.0", path = "bin/nanousd" }
+nanocodex = { version = "0.4.0", path = "crates/nanocodex" }
+nanocodex-agent = { version = "0.4.0", path = "crates/nanocodex-agent" }
+nanocodex-browser = { version = "0.4.0", path = "crates/experimental/nanocodex-browser" }
+nanocodex-egress = { version = "0.4.0", path = "crates/experimental/nanocodex-egress" }
+nanocodex-voice = { version = "0.4.0", path = "crates/experimental/nanocodex-voice" }
+nanocodex-eval = { version = "0.4.0", path = "crates/experimental/nanocodex-eval" }
+nanocodex-eval-adapters = { version = "0.4.0", path = "crates/experimental/nanocodex-eval-adapters" }
+nanocodex-vm = { version = "0.4.0", path = "crates/experimental/nanocodex-vm" }
+nanocodex-oai-api = { version = "0.4.0", path = "crates/nanocodex-oai-api" }
+nanocodex-observability = { version = "0.4.0", path = "crates/nanocodex-observability" }
+nanocodex-tools = { version = "0.4.0", path = "crates/nanocodex-tools" }
+nanocodex-tools-macros = { version = "0.4.0", path = "crates/nanocodex-tools/macros" }
+nanousd = { version = "0.4.0", path = "bin/nanousd" }
 oci-client = { version = "0.17.0", git = "https://github.com/gakonst/rust-oci-client", rev = "17c22ce8842e9275ef6bc11fa4eb58101a4abd7f", default-features = false, features = ["rustls-tls-no-provider"] }
 rand = "0.9.2"
 reflink-copy = "0.1.30"
@@ -108,7 +108,7 @@ proc-macro2 = "1.0.106"
 quote = "1.0.46"
 ratatui = { version = "0.29.0", features = ["unstable-rendered-line-info"] }
 ratatex = "0.1.0"
-reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls-ring"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls-no-provider"] }
 reqwest-middleware = "0.5.2"
 rustls = { version = "0.23.42", default-features = false, features = ["ring"] }
 regex = "1"
@@ -159,9 +159,6 @@ webrtc = "0.17.0"
 whoami = "1.6.1"
 yansi = { version = "1.0", features = ["detect-env", "detect-tty"] }
 zstd = "0.13"
-
-[patch.crates-io]
-reqwest = { git = "https://github.com/gakonst/reqwest", rev = "d45d0c3d2b2a74b723f82791f464d6241f2c6e90" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/Justfile
+++ b/Justfile
@@ -338,7 +338,9 @@ check:
     ./scripts/check-experimental-boundary.sh
     ./scripts/check-rustls-provider.sh
     cargo fmt --all -- --check
-    cargo clippy --workspace --all-targets --all-features -- -D warnings
+    cargo clippy --workspace --all-targets --all-features --exclude nanocodex-bin -- -D warnings
+    cargo clippy --package nanocodex-bin --all-features --bin nanocodex -- -D warnings
+    cargo clippy --package nanocodex-bin --all-features --bench tui_render -- -D warnings
     cargo test --workspace
     .venv/bin/python -m unittest discover -s harbor_adapter -p 'test_*.py'
     .venv/bin/python -m compileall -q harbor_adapter

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "nanocodex-bin"
+autotests = false
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -88,13 +89,7 @@ chrono.workspace = true
 vergen = { workspace = true, features = ["build", "git", "gitcl"] }
 
 [dev-dependencies]
-axum.workspace = true
 criterion.workspace = true
-nanocodex-tools.workspace = true
-reqwest = { workspace = true, features = ["query"] }
-tokio-tungstenite.workspace = true
-tower.workspace = true
-tracing-subscriber.workspace = true
 
 [[bench]]
 name = "tui_render"
@@ -104,6 +99,7 @@ harness = false
 name = "nanocodex"
 path = "src/main.rs"
 doc = false
+test = false
 
 [lints]
 workspace = true

--- a/crates/experimental/nanocodex-browser/src/native/audits.rs
+++ b/crates/experimental/nanocodex-browser/src/native/audits.rs
@@ -326,6 +326,7 @@ pub(super) async fn crux(
         Some(endpoint) => endpoint.clone(),
         None => Url::parse(DEFAULT_CRUX_ENDPOINT)?,
     };
+    nanocodex_oai_api::transport::install_default_rustls_crypto_provider();
     let response = reqwest::Client::new()
         .post(endpoint)
         .query(&[("key", client.api_key.as_str())])

--- a/crates/experimental/nanocodex-browser/src/vm.rs
+++ b/crates/experimental/nanocodex-browser/src/vm.rs
@@ -569,6 +569,7 @@ impl BrowserVmRuntime {
         timeout: Duration,
         local: SocketAddr,
     ) -> Result<Url, BrowserVmError> {
+        nanocodex_oai_api::transport::install_default_rustls_crypto_provider();
         let client = reqwest::Client::builder()
             .timeout(Duration::from_millis(500))
             .build()

--- a/crates/experimental/nanocodex-egress/src/lib.rs
+++ b/crates/experimental/nanocodex-egress/src/lib.rs
@@ -647,6 +647,7 @@ impl EgressProxy {
         std::fs::write(&ca_certificate_path, &certificate_pem)
             .map_err(EgressError::WriteCertificate)?;
 
+        install_default_rustls_crypto_provider();
         let client = reqwest::Client::builder()
             .no_proxy()
             .redirect(reqwest::redirect::Policy::none())
@@ -1470,6 +1471,12 @@ fn proxy_authentication_required() -> Response<Body> {
 
 fn random_proxy_password() -> String {
     random_identifier()
+}
+
+fn install_default_rustls_crypto_provider() {
+    if CryptoProvider::get_default().is_none() {
+        drop(ring::default_provider().install_default());
+    }
 }
 
 fn random_identifier() -> String {

--- a/crates/experimental/nanocodex-eval/src/capture_proxy.rs
+++ b/crates/experimental/nanocodex-eval/src/capture_proxy.rs
@@ -281,6 +281,7 @@ impl ResponsesCaptureProxy {
         listener.set_nonblocking(true)?;
         let listener = TcpListener::from_std(listener)?;
         let recorder = CaptureRecorder::create(&config.output).await?;
+        nanocodex_oai_api::transport::install_default_rustls_crypto_provider();
         let state = ProxyState {
             upstream: Arc::from(config.upstream.trim_end_matches('/')),
             http: reqwest::Client::builder()

--- a/crates/experimental/nanocodex-eval/src/coordinator.rs
+++ b/crates/experimental/nanocodex-eval/src/coordinator.rs
@@ -311,6 +311,7 @@ impl CoordinatorClient {
         if !base.path().ends_with('/') {
             base.set_path(&format!("{}/", base.path()));
         }
+        nanocodex_oai_api::transport::install_default_rustls_crypto_provider();
         Ok(Self {
             base,
             http: reqwest::Client::builder()

--- a/crates/experimental/nanocodex-vm/Cargo.toml
+++ b/crates/experimental/nanocodex-vm/Cargo.toml
@@ -40,7 +40,7 @@ guest-runtime = ["dep:nix", "nanocodex-tools/workspace-runtime"]
 [dependencies]
 base64.workspace = true
 filetime.workspace = true
-nanocodex-tools = { path = "../../nanocodex-tools", version = "0.3.0", default-features = false }
+nanocodex-tools = { path = "../../nanocodex-tools", version = "0.4.0", default-features = false }
 nix = { workspace = true, optional = true, features = ["fs", "mount"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/nanocodex-agent/CHANGELOG.md
+++ b/crates/nanocodex-agent/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support Luna
 - Match Codex realtime steering
 
+### Miscellaneous Tasks
+
+- [release] Prepare 0.4.0
+
 ### Other
 
 - Merge pull request [#142](https://github.com/gakonst/nanocodex/issues/142) from gakonst/feat/eval-adapter-foundation

--- a/crates/nanocodex-agent/CHANGELOG.md
+++ b/crates/nanocodex-agent/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11
+
+### Bug Fixes
+
+- [eval] Preserve same-role benchmark messages
+- [ci] Preserve typed prompt consumer contracts
+- Close remaining Codex wire parity gaps
+- [tui] Sanitize resume picker metadata
+- [oai] Account for usage-uncertain attempts
+- [tools] Align Code Mode tool contracts
+- [agent] Dispatch unnamespaced hosted tools
+- [tls] Standardize rustls on ring
+- [agent] Preserve model in adapter checkpoints
+- [agent] Retain model in fork checkpoints
+- Build Tower services from effective agent config
+- Preserve Codex rollout model compatibility
+
+### Features
+
+- [eval] Add benchmark adapter foundation
+- [cli] Add interactive resume session picker
+- [agent] Describe remote execution context
+- [voice] Add Codex realtime parity
+- Support Luna
+- Match Codex realtime steering
+
+### Other
+
+- Merge pull request [#142](https://github.com/gakonst/nanocodex/issues/142) from gakonst/feat/eval-adapter-foundation
+- Merge pull request [#124](https://github.com/gakonst/nanocodex/issues/124) from gakonst/fix/codex-parity-current
+- Merge pull request [#122](https://github.com/gakonst/nanocodex/issues/122) from Giulio2002/feat/resume-session-picker
+- Merge pull request [#97](https://github.com/gakonst/nanocodex/issues/97) from gakonst/agent/pr61-tower-accounting
+- Merge pull request [#96](https://github.com/gakonst/nanocodex/issues/96) from gakonst/agent/pr61-agent-context
+- Merge pull request [#95](https://github.com/gakonst/nanocodex/issues/95) from gakonst/agent/pr61-code-mode
+- Merge pull request [#75](https://github.com/gakonst/nanocodex/issues/75) from gakonst/feat/wasm-host-transport
+- Merge pull request [#86](https://github.com/gakonst/nanocodex/issues/86) from gakonst/fix/ring-only-rustls
+- Merge pull request [#84](https://github.com/gakonst/nanocodex/issues/84) from gakonst/fix/committed-session-model
+- Merge pull request [#82](https://github.com/gakonst/nanocodex/issues/82) from gakonst/feat/realtime-codex-parity
+- Merge pull request [#80](https://github.com/gakonst/nanocodex/issues/80) from clabby/cl/luna
+- Merge pull request [#77](https://github.com/gakonst/nanocodex/issues/77) from gakonst/feat/realtime-voice
+
+### Refactor
+
+- [eval] Simplify durable benchmark ownership
+- Fix the model for each thread
+
 ## [0.3.0](https://github.com/gakonst/nanocodex/releases/tag/v0.3.0) - 2026-07-28
 
 ### Bug Fixes
@@ -25,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.3.0 changelogs
 - [release] Prepare 0.3.0
 
 ### Other

--- a/crates/nanocodex-agent/tests/it/model/transport/session.rs
+++ b/crates/nanocodex-agent/tests/it/model/transport/session.rs
@@ -266,6 +266,7 @@ async fn https_uses_the_configured_http_client() -> Result<()> {
         "x-nanocodex-client",
         reqwest::header::HeaderValue::from_static("configured"),
     );
+    nanocodex_oai_api::transport::install_default_rustls_crypto_provider();
     let client = reqwest::Client::builder()
         .default_headers(headers)
         .build()?;

--- a/crates/nanocodex-oai-api/CHANGELOG.md
+++ b/crates/nanocodex-oai-api/CHANGELOG.md
@@ -5,6 +5,62 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11
+
+### Bug Fixes
+
+- [oai] Allow long silent response generations
+- [eval] Preserve same-role benchmark messages
+- [eval] Recover cleanly from worker infrastructure failures
+- [oai] Recover forbidden websocket handshakes
+- [oai] Preserve code mode notifications in replay
+- Close remaining Codex wire parity gaps
+- [oai] Account for usage-uncertain attempts
+- [tools] Align Code Mode tool contracts
+- [tls] Standardize rustls on ring
+- Preserve Codex rollout model compatibility
+- [ci] Stabilize observability tests
+
+### Features
+
+- [eval] Add benchmark adapter foundation
+- [tools] Align current Codex parity
+- [model] Support Terra and routed OpenAI model IDs
+- [voice] Add Codex realtime parity
+- Support Luna
+- Close Codex realtime parity gaps
+- Match Codex realtime steering
+- Add reusable realtime voice sessions
+- [vm] Add retained VM-backed workspace tools
+
+### Other
+
+- Merge pull request [#142](https://github.com/gakonst/nanocodex/issues/142) from gakonst/feat/eval-adapter-foundation
+- Merge pull request [#139](https://github.com/gakonst/nanocodex/issues/139) from gakonst/fix/websocket-403-fallback
+- Merge pull request [#124](https://github.com/gakonst/nanocodex/issues/124) from gakonst/fix/codex-parity-current
+- Merge pull request [#121](https://github.com/gakonst/nanocodex/issues/121) from Slokh/kartik/upstream-contributions
+- Merge pull request [#97](https://github.com/gakonst/nanocodex/issues/97) from gakonst/agent/pr61-tower-accounting
+- Merge pull request [#95](https://github.com/gakonst/nanocodex/issues/95) from gakonst/agent/pr61-code-mode
+- Merge pull request [#86](https://github.com/gakonst/nanocodex/issues/86) from gakonst/fix/ring-only-rustls
+- Merge pull request [#82](https://github.com/gakonst/nanocodex/issues/82) from gakonst/feat/realtime-codex-parity
+- Merge pull request [#80](https://github.com/gakonst/nanocodex/issues/80) from clabby/cl/luna
+- Merge pull request [#77](https://github.com/gakonst/nanocodex/issues/77) from gakonst/feat/realtime-voice
+- Merge pull request [#58](https://github.com/gakonst/nanocodex/issues/58) from gakonst/refactor/09-eval
+
+### Performance
+
+- Harden realtime voice audio paths
+
+### Refactor
+
+- [eval] Simplify durable benchmark ownership
+- Trim Codex parity implementation
+- Fix the model for each thread
+
+### Testing
+
+- Synchronize realtime response queue
+
 ## [0.3.0](https://github.com/gakonst/nanocodex/releases/tag/v0.3.0) - 2026-07-28
 
 ### Bug Fixes
@@ -27,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.3.0 changelogs
 - [release] Prepare 0.3.0
 
 ### Other

--- a/crates/nanocodex-oai-api/CHANGELOG.md
+++ b/crates/nanocodex-oai-api/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add reusable realtime voice sessions
 - [vm] Add retained VM-backed workspace tools
 
+### Miscellaneous Tasks
+
+- [release] Prepare 0.4.0
+
 ### Other
 
 - Merge pull request [#142](https://github.com/gakonst/nanocodex/issues/142) from gakonst/feat/eval-adapter-foundation

--- a/crates/nanocodex-oai-api/src/auth/chatgpt.rs
+++ b/crates/nanocodex-oai-api/src/auth/chatgpt.rs
@@ -892,6 +892,7 @@ fn auth_store_error(error: &ChatGptAuthError) -> OpenAiAuthError {
 }
 
 fn auth_client() -> Result<reqwest::Client, ChatGptAuthError> {
+    crate::transport::install_default_rustls_crypto_provider();
     reqwest::Client::builder()
         .timeout(AUTH_REQUEST_TIMEOUT)
         .build()

--- a/crates/nanocodex-oai-api/src/transport/platform/native.rs
+++ b/crates/nanocodex-oai-api/src/transport/platform/native.rs
@@ -17,6 +17,7 @@ pub(crate) struct ServicePlatform {
 
 impl ServicePlatform {
     pub(crate) fn new(config: &ModelConfig) -> Self {
+        crate::transport::install_default_rustls_crypto_provider();
         Self::with_http_client(config, reqwest::Client::new())
     }
 

--- a/crates/nanocodex-observability/CHANGELOG.md
+++ b/crates/nanocodex-observability/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support Luna
 
+### Miscellaneous Tasks
+
+- [release] Prepare 0.4.0
+
 ### Other
 
 - Merge pull request [#86](https://github.com/gakonst/nanocodex/issues/86) from gakonst/fix/ring-only-rustls

--- a/crates/nanocodex-observability/CHANGELOG.md
+++ b/crates/nanocodex-observability/CHANGELOG.md
@@ -5,10 +5,31 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11
+
+### Bug Fixes
+
+- [tls] Standardize rustls on ring
+- [ci] Stabilize observability tests
+
+### Features
+
+- Support Luna
+
+### Other
+
+- Merge pull request [#86](https://github.com/gakonst/nanocodex/issues/86) from gakonst/fix/ring-only-rustls
+- Merge pull request [#80](https://github.com/gakonst/nanocodex/issues/80) from clabby/cl/luna
+
+### Testing
+
+- [observability] Consume OTLP request bodies
+
 ## [0.3.0](https://github.com/gakonst/nanocodex/releases/tag/v0.3.0) - 2026-07-28
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.3.0 changelogs
 - [release] Prepare 0.3.0
 
 ### Other

--- a/crates/nanocodex-tools/CHANGELOG.md
+++ b/crates/nanocodex-tools/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [tools] Expose the ambient sensitive environment
 - [vm] Add retained VM-backed workspace tools
 
+### Miscellaneous Tasks
+
+- [release] Prepare 0.4.0
+
 ### Other
 
 - Merge pull request [#124](https://github.com/gakonst/nanocodex/issues/124) from gakonst/fix/codex-parity-current

--- a/crates/nanocodex-tools/CHANGELOG.md
+++ b/crates/nanocodex-tools/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11
+
+### Bug Fixes
+
+- [browser] Keep deferred schema lookup private
+- [tools] Restore stock Codex code mode parity
+- Close remaining Codex wire parity gaps
+- [tools] Keep tool search visible in code mode
+- [tools] Align Code Mode tool contracts
+- [agent] Dispatch unnamespaced hosted tools
+- [tls] Standardize rustls on ring
+- [vm] Harden cache and session lifecycle
+
+### Features
+
+- [browser] Add pixel-calibrated captures
+- [cli] Enable browser tools by default
+- [tools] Align current Codex parity
+- [wasm] Support CSP-safe direct host tools
+- [cli] Integrate deferred browser tooling
+- [tools] Expose the ambient sensitive environment
+- [vm] Add retained VM-backed workspace tools
+
+### Other
+
+- Merge pull request [#124](https://github.com/gakonst/nanocodex/issues/124) from gakonst/fix/codex-parity-current
+- Merge pull request [#95](https://github.com/gakonst/nanocodex/issues/95) from gakonst/agent/pr61-code-mode
+- Merge pull request [#75](https://github.com/gakonst/nanocodex/issues/75) from gakonst/feat/wasm-host-transport
+- Merge pull request [#86](https://github.com/gakonst/nanocodex/issues/86) from gakonst/fix/ring-only-rustls
+- Merge pull request [#78](https://github.com/gakonst/nanocodex/issues/78) from gakonst/agent/browser-tui-integration
+- Merge pull request [#59](https://github.com/gakonst/nanocodex/issues/59) from cjustice/feat/ambient-sensitive-environment
+- Merge pull request [#58](https://github.com/gakonst/nanocodex/issues/58) from gakonst/refactor/09-eval
+
+### Refactor
+
+- Trim Codex parity implementation
+
 ## [0.3.0](https://github.com/gakonst/nanocodex/releases/tag/v0.3.0) - 2026-07-28
 
 ### Bug Fixes
@@ -21,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.3.0 changelogs
 - [release] Prepare 0.3.0
 
 ### Other

--- a/crates/nanocodex-tools/Cargo.toml
+++ b/crates/nanocodex-tools/Cargo.toml
@@ -46,7 +46,7 @@ native = [
 ]
 
 [dependencies]
-nanocodex-oai-api = { path = "../nanocodex-oai-api", version = "0.3.0", default-features = false }
+nanocodex-oai-api = { path = "../nanocodex-oai-api", version = "0.4.0", default-features = false }
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/nanocodex-tools/macros/CHANGELOG.md
+++ b/crates/nanocodex-tools/macros/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11
 
+### Miscellaneous Tasks
+
+- [release] Prepare 0.4.0
+
 ## [0.3.0](https://github.com/gakonst/nanocodex/releases/tag/v0.3.0) - 2026-07-28
 
 ### Documentation

--- a/crates/nanocodex-tools/macros/CHANGELOG.md
+++ b/crates/nanocodex-tools/macros/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11
+
 ## [0.3.0](https://github.com/gakonst/nanocodex/releases/tag/v0.3.0) - 2026-07-28
 
 ### Documentation
@@ -13,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.3.0 changelogs
 - [release] Prepare 0.3.0
 
 ### Other

--- a/crates/nanocodex-tools/src/image_generation/mod.rs
+++ b/crates/nanocodex-tools/src/image_generation/mod.rs
@@ -35,6 +35,7 @@ pub(super) struct ImageGenerationHandler {
 impl ImageGenerationHandler {
     #[cfg(test)]
     pub(super) fn new(config: ImageGenerationConfig) -> Self {
+        nanocodex_oai_api::transport::install_default_rustls_crypto_provider();
         Self::with_client(config, reqwest::Client::new())
     }
 

--- a/crates/nanocodex-tools/src/mcp/client.rs
+++ b/crates/nanocodex-tools/src/mcp/client.rs
@@ -234,6 +234,7 @@ async fn connect_http(input: HttpConnect<'_>) -> Result<ConnectedServer, String>
         return Err("Streamable HTTP URL must not be empty".to_owned());
     }
     let (resolved_headers, default_headers) = resolve_http_headers(headers)?;
+    nanocodex_oai_api::transport::install_default_rustls_crypto_provider();
     let http_client = reqwest::Client::builder()
         // Match RMCP's default: its streamed handshake responses are not always fully consumed
         // before the next request, so retaining them as idle connections can stall real peers.

--- a/crates/nanocodex-tools/src/mcp/oauth.rs
+++ b/crates/nanocodex-tools/src/mcp/oauth.rs
@@ -514,6 +514,7 @@ fn oauth_http_client(headers: BTreeMap<String, SecretSource>) -> Result<reqwest:
         value.set_sensitive(true);
         resolved.insert(name, value);
     }
+    nanocodex_oai_api::transport::install_default_rustls_crypto_provider();
     reqwest::Client::builder()
         .default_headers(resolved)
         .pool_max_idle_per_host(0)
@@ -713,6 +714,7 @@ mod tests {
             .expires_at_millis(0)
             .scopes(["mcp:tools"]);
 
+        nanocodex_oai_api::transport::install_default_rustls_crypto_provider();
         let transport = transport_from_credentials(
             server_name,
             server_url,

--- a/crates/nanocodex-tools/src/web_search/mod.rs
+++ b/crates/nanocodex-tools/src/web_search/mod.rs
@@ -35,6 +35,7 @@ pub(super) struct WebSearchHandler {
 impl WebSearchHandler {
     #[cfg(test)]
     pub(super) fn new(config: WebSearchConfig) -> Self {
+        nanocodex_oai_api::transport::install_default_rustls_crypto_provider();
         Self::with_client(config, reqwest::Client::new())
     }
 

--- a/crates/nanocodex-tools/tests/it/oauth/web_search.rs
+++ b/crates/nanocodex-tools/tests/it/oauth/web_search.rs
@@ -23,6 +23,7 @@ async fn chatgpt_auth_recovers_for_web_search() -> Result<()> {
         "x-injected-client",
         reqwest::header::HeaderValue::from_static("true"),
     );
+    nanocodex_oai_api::transport::install_default_rustls_crypto_provider();
     let client = reqwest::Client::builder()
         .default_headers(headers)
         .build()?;

--- a/crates/nanocodex/CHANGELOG.md
+++ b/crates/nanocodex/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11
+
+### Bug Fixes
+
+- [tools] Align Code Mode tool contracts
+
+### Features
+
+- [examples] Use exe.dev as external sandbox
+- [model] Support Terra and routed OpenAI model IDs
+- [voice] Add Codex realtime parity
+- Support Luna
+- Match Codex realtime steering
+- Add reusable realtime voice sessions
+
+### Other
+
+- Merge pull request [#119](https://github.com/gakonst/nanocodex/issues/119) from gakonst/feat/exe-dev-spike
+- Merge pull request [#121](https://github.com/gakonst/nanocodex/issues/121) from Slokh/kartik/upstream-contributions
+- Merge pull request [#95](https://github.com/gakonst/nanocodex/issues/95) from gakonst/agent/pr61-code-mode
+- Merge pull request [#82](https://github.com/gakonst/nanocodex/issues/82) from gakonst/feat/realtime-codex-parity
+- Merge pull request [#80](https://github.com/gakonst/nanocodex/issues/80) from clabby/cl/luna
+- Merge pull request [#77](https://github.com/gakonst/nanocodex/issues/77) from gakonst/feat/realtime-voice
+
+### Refactor
+
+- Fix the model for each thread
+
 ## [0.3.0](https://github.com/gakonst/nanocodex/releases/tag/v0.3.0) - 2026-07-28
 
 ### Bug Fixes
@@ -23,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.3.0 changelogs
 - [release] Prepare 0.3.0
 
 ### Other

--- a/crates/nanocodex/CHANGELOG.md
+++ b/crates/nanocodex/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Match Codex realtime steering
 - Add reusable realtime voice sessions
 
+### Miscellaneous Tasks
+
+- [release] Prepare 0.4.0
+
 ### Other
 
 - Merge pull request [#119](https://github.com/gakonst/nanocodex/issues/119) from gakonst/feat/exe-dev-spike

--- a/deny.toml
+++ b/deny.toml
@@ -52,7 +52,6 @@ required-git-spec = "rev"
 allow-git = [
     "https://github.com/containers/libkrun",
     "https://github.com/gakonst/hudsucker",
-    "https://github.com/gakonst/reqwest",
     "https://github.com/gakonst/rust-oci-client",
     "https://github.com/openai-oss-forks/tokio-tungstenite",
     "https://github.com/openai-oss-forks/tungstenite-rs",

--- a/examples/browser-cdn/index.html
+++ b/examples/browser-cdn/index.html
@@ -20,7 +20,7 @@
     <output id="result">Ready.</output>
 
     <script type="module">
-      import { Agent } from "https://cdn.jsdelivr.net/npm/nanocodex@0.3.0/browser/index.mjs";
+      import { Agent } from "https://cdn.jsdelivr.net/npm/nanocodex@0.4.0/browser/index.mjs";
 
       const form = document.querySelector("#prompt-form");
       const prompt = document.querySelector("#prompt");

--- a/examples/cloudflare-workers/package-lock.json
+++ b/examples/cloudflare-workers/package-lock.json
@@ -25,7 +25,7 @@
     },
     "../../js/bindings": {
       "name": "nanocodex",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../js/bindings": {
       "name": "nanocodex",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"

--- a/examples/react-vite/package-lock.json
+++ b/examples/react-vite/package-lock.json
@@ -30,7 +30,7 @@
     },
     "../../js/bindings": {
       "name": "nanocodex",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"

--- a/examples/rivet-actors/package-lock.json
+++ b/examples/rivet-actors/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../../js/bindings": {
       "name": "nanocodex",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"

--- a/examples/vercel-workflows/package-lock.json
+++ b/examples/vercel-workflows/package-lock.json
@@ -32,7 +32,7 @@
     },
     "../../js/bindings": {
       "name": "nanocodex",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"

--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -286,7 +286,7 @@ manager or build step:
 
 ```html
 <script type="module">
-  import { Agent } from "https://cdn.jsdelivr.net/npm/nanocodex@0.3.0/browser/index.mjs";
+  import { Agent } from "https://cdn.jsdelivr.net/npm/nanocodex@0.4.0/browser/index.mjs";
   const agent = await Agent.create({ websocketUrl: "/api/responses" });
   const turn = agent.turn.prompt({ input: "Hello." });
   try {

--- a/js/bindings/package-lock.json
+++ b/js/bindings/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nanocodex",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nanocodex",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"

--- a/js/bindings/package.json
+++ b/js/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nanocodex",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Viem-style Node and browser bindings for the Nanocodex WASM agent",
   "type": "module",
   "sideEffects": false,

--- a/js/react/package-lock.json
+++ b/js/react/package-lock.json
@@ -16,13 +16,13 @@
         "node": ">=22.13.0"
       },
       "peerDependencies": {
-        "nanocodex": "^0.3.0",
+        "nanocodex": "^0.4.0",
         "react": ">=18"
       }
     },
     "../bindings": {
       "name": "nanocodex",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {

--- a/js/react/package.json
+++ b/js/react/package.json
@@ -28,7 +28,7 @@
     "test": "node --test test/*.test.mjs && npm run check:package && npm run check:pack"
   },
   "peerDependencies": {
-    "nanocodex": "^0.3.0",
+    "nanocodex": "^0.4.0",
     "react": ">=18"
   },
   "devDependencies": {

--- a/js/tui-react/package-lock.json
+++ b/js/tui-react/package-lock.json
@@ -47,7 +47,7 @@
         "node": ">=22.13.0"
       },
       "peerDependencies": {
-        "nanocodex": "^0.3.0",
+        "nanocodex": "^0.4.0",
         "react": ">=18"
       }
     },

--- a/scripts/check-rustls-provider.sh
+++ b/scripts/check-rustls-provider.sh
@@ -3,19 +3,19 @@ set -euo pipefail
 
 shipped_tree=$(
   cargo tree --locked --package nanocodex-bin --features tempo \
-    --edges normal,build --prefix none
+    --edges normal,build --prefix none --color never
 )
 shipped_feature_tree=$(
   cargo tree --locked --package nanocodex-bin --features tempo \
-    --edges features --prefix none
+    --edges features --prefix none --color never
 )
 workspace_tree=$(
   cargo tree --locked --workspace --all-features \
-    --edges normal,build,dev --prefix none
+    --edges normal,build,dev --prefix none --color never
 )
 workspace_feature_tree=$(
   cargo tree --locked --workspace --all-features \
-    --edges features --prefix none
+    --edges features --prefix none --color never
 )
 
 check_tree() {

--- a/scripts/check-rustls-provider.sh
+++ b/scripts/check-rustls-provider.sh
@@ -47,7 +47,13 @@ check_tree() {
 
   local reqwest_sources
   reqwest_sources=$(
-    awk '$1 == "reqwest" && $2 ~ /^v/ { print $2, $3 }' <<<"$dependency_tree" | sort -u
+    awk '$1 == "reqwest" && $2 ~ /^v/ {
+      if (NF < 3 || $3 == "(*)") {
+        print $2
+      } else {
+        print $2, $3
+      }
+    }' <<<"$dependency_tree" | sort -u
   )
   local reqwest_source_count
   reqwest_source_count=$(sed '/^$/d' <<<"$reqwest_sources" | wc -l | tr -d ' ')
@@ -57,12 +63,12 @@ check_tree() {
     exit 1
   fi
 
-  if ! grep -q '^reqwest feature "rustls-ring"' <<<"$feature_tree"; then
-    echo "error: the ${label} graph must enable reqwest's rustls-ring feature" >&2
+  if ! grep -q '^reqwest feature "rustls-no-provider"' <<<"$feature_tree"; then
+    echo "error: the ${label} graph must enable reqwest's rustls-no-provider feature" >&2
     exit 1
   fi
 
-  echo "rustls provider policy passed for ${label}: ring only (${rustls_versions}); one ring-native reqwest (${reqwest_sources})"
+  echo "rustls provider policy passed for ${label}: ring only (${rustls_versions}); one provider-neutral reqwest (${reqwest_sources})"
 }
 
 check_tree "shipped nanocodex" "$shipped_tree" "$shipped_feature_tree"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -50,7 +50,7 @@
     },
     "../js/bindings": {
       "name": "nanocodex",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"
@@ -75,7 +75,7 @@
         "node": ">=22.13.0"
       },
       "peerDependencies": {
-        "nanocodex": "^0.3.0",
+        "nanocodex": "^0.4.0",
         "react": ">=18"
       }
     },


### PR DESCRIPTION
Prepare the v0.4.0 synchronized crate, npm, Python, binary, and harness release from current master.

- bump the complete workspace and published dependency requirements to 0.4.0
- regenerate root and per-crate changelogs
- make packaged crates resolve against crates.io Reqwest while preserving the Ring provider policy
- remove nanocodex-bin from Cargo test targets and retain only its TUI benchmark dependency
- refresh JavaScript package/consumer versions and lockfiles

Validated with `just release-check 0.4.0`, workspace rustfmt, workspace Clippy with warnings denied, the Ring provider regression tests, and the public crate/workspace tests reached before the removed binary test target.