### PR TITLE
fix(events): preserve structured results universally

### DIFF
--- a/bin/nanocodex/src/tui/app.rs
+++ b/bin/nanocodex/src/tui/app.rs
@@ -570,11 +570,15 @@ impl Conversation {
             return self.on_cell_transport_result(&cell_id, &payload, status);
         }
         let pending_code_exec = self.pending_code_execs.contains_key(&payload.call_id);
+        let shell_tool = matches!(
+            payload.tool.as_deref(),
+            Some("exec_command" | "write_stdin")
+        );
         let shell_result = payload
             .structured_result
             .as_ref()
             .or(payload.result.as_ref());
-        if payload.tool.as_deref() == Some("exec_command")
+        if shell_tool
             && status == ToolStatus::Completed
             && let Some(session_id) = shell_result.and_then(result_session_id)
         {
@@ -606,7 +610,7 @@ impl Conversation {
         if self.pending_code_execs.remove(&payload.call_id).is_some() {
             return false;
         }
-        let result = if payload.tool.as_deref() == Some("exec_command") {
+        let result = if shell_tool {
             shell_result
         } else {
             payload.result.as_ref()
@@ -3216,7 +3220,7 @@ fn running_cell_id(result: &Value) -> Option<String> {
 }
 
 fn summarize_tool_result(tool: Option<&str>, result: &Value, status: ToolStatus) -> String {
-    if tool == Some("exec_command") {
+    if matches!(tool, Some("exec_command" | "write_stdin")) {
         let decoded = result
             .as_str()
             .and_then(|value| serde_json::from_str::<Value>(value).ok())

--- a/bin/nanocodex/src/tui/app.rs
+++ b/bin/nanocodex/src/tui/app.rs
@@ -570,9 +570,10 @@ impl Conversation {
             return self.on_cell_transport_result(&cell_id, &payload, status);
         }
         let pending_code_exec = self.pending_code_execs.contains_key(&payload.call_id);
+        let shell_result = payload.code_mode_value.as_ref().or(payload.result.as_ref());
         if payload.tool.as_deref() == Some("exec_command")
             && status == ToolStatus::Completed
-            && let Some(session_id) = payload.result.as_ref().and_then(result_session_id)
+            && let Some(session_id) = shell_result.and_then(result_session_id)
         {
             self.running_shell_sessions.insert(
                 session_id,
@@ -602,10 +603,12 @@ impl Conversation {
         if self.pending_code_execs.remove(&payload.call_id).is_some() {
             return false;
         }
-        let result = payload
-            .result
-            .as_ref()
-            .map(|result| summarize_tool_result(payload.tool.as_deref(), result, status));
+        let result = if payload.tool.as_deref() == Some("exec_command") {
+            shell_result
+        } else {
+            payload.result.as_ref()
+        }
+        .map(|result| summarize_tool_result(payload.tool.as_deref(), result, status));
         self.note_tail_will_change();
         let _ = if payload.started_after_ns.is_some() {
             self.transcript.set_tool_result_timing(
@@ -649,20 +652,13 @@ impl Conversation {
             return false;
         };
         continued.add_duration(payload.duration_ns);
-        if status == ToolStatus::Completed
-            && payload
-                .result
-                .as_ref()
-                .and_then(result_session_id)
-                .is_some()
-        {
+        let result = payload.code_mode_value.as_ref().or(payload.result.as_ref());
+        if status == ToolStatus::Completed && result.and_then(result_session_id).is_some() {
             self.running_shell_sessions.insert(session_id, continued);
             return false;
         }
-        let result = payload
-            .result
-            .as_ref()
-            .map(|result| summarize_tool_result(Some("exec_command"), result, status));
+        let result =
+            result.map(|result| summarize_tool_result(Some("exec_command"), result, status));
         self.finish_continued_tool(&continued, status, result)
     }
 
@@ -2896,6 +2892,8 @@ struct ToolResultPayload {
     started_after_ns: Option<u64>,
     #[serde(default)]
     result: Option<Value>,
+    #[serde(default)]
+    code_mode_value: Option<Value>,
 }
 
 struct ContinuedTool {
@@ -4621,7 +4619,8 @@ mod tests {
                 "tool": "exec_command",
                 "status": "completed",
                 "duration_ns": 10_000_000,
-                "result": "{\"session_id\":7,\"output\":\"\"}"
+                "result": "Wall time: 10.0000 seconds\nProcess running with session ID 7\nOutput:\n",
+                "code_mode_value": {"session_id": 7, "output": ""}
             }),
         ));
         app.main.on_agent_event(&event(
@@ -4639,7 +4638,8 @@ mod tests {
                 "tool": "write_stdin",
                 "status": "completed",
                 "duration_ns": 5_000_000,
-                "result": "{\"session_id\":7,\"output\":\"\"}"
+                "result": "Wall time: 5.0000 seconds\nProcess running with session ID 7\nOutput:\n",
+                "code_mode_value": {"session_id": 7, "output": ""}
             }),
         ));
         app.main.on_agent_event(&event(
@@ -4657,7 +4657,8 @@ mod tests {
                 "tool": "write_stdin",
                 "status": "completed",
                 "duration_ns": 1_000_000,
-                "result": "{\"exit_code\":130,\"output\":\"\"}"
+                "result": "Wall time: 1.0000 seconds\nProcess exited with code 130\nOutput:\n",
+                "code_mode_value": {"exit_code": 130, "output": ""}
             }),
         ));
         app.main.on_agent_event(&event(

--- a/bin/nanocodex/src/tui/app.rs
+++ b/bin/nanocodex/src/tui/app.rs
@@ -574,13 +574,9 @@ impl Conversation {
             payload.tool.as_deref(),
             Some("exec_command" | "write_stdin")
         );
-        let shell_result = payload
-            .structured_result
-            .as_ref()
-            .or(payload.result.as_ref());
         if shell_tool
             && status == ToolStatus::Completed
-            && let Some(session_id) = shell_result.and_then(result_session_id)
+            && let Some(session_id) = result_session_id(&payload.structured_result)
         {
             self.running_shell_sessions.insert(
                 session_id,
@@ -611,7 +607,7 @@ impl Conversation {
             return false;
         }
         let result = if shell_tool {
-            shell_result
+            Some(&payload.structured_result)
         } else {
             payload.result.as_ref()
         }
@@ -659,16 +655,17 @@ impl Conversation {
             return false;
         };
         continued.add_duration(payload.duration_ns);
-        let result = payload
-            .structured_result
-            .as_ref()
-            .or(payload.result.as_ref());
-        if status == ToolStatus::Completed && result.and_then(result_session_id).is_some() {
+        if status == ToolStatus::Completed
+            && result_session_id(&payload.structured_result).is_some()
+        {
             self.running_shell_sessions.insert(session_id, continued);
             return false;
         }
-        let result =
-            result.map(|result| summarize_tool_result(Some("exec_command"), result, status));
+        let result = Some(summarize_tool_result(
+            Some("exec_command"),
+            &payload.structured_result,
+            status,
+        ));
         self.finish_continued_tool(&continued, status, result)
     }
 
@@ -2902,8 +2899,7 @@ struct ToolResultPayload {
     started_after_ns: Option<u64>,
     #[serde(default)]
     result: Option<Value>,
-    #[serde(default)]
-    structured_result: Option<Value>,
+    structured_result: Value,
 }
 
 struct ContinuedTool {

--- a/bin/nanocodex/src/tui/app.rs
+++ b/bin/nanocodex/src/tui/app.rs
@@ -570,7 +570,10 @@ impl Conversation {
             return self.on_cell_transport_result(&cell_id, &payload, status);
         }
         let pending_code_exec = self.pending_code_execs.contains_key(&payload.call_id);
-        let shell_result = payload.code_mode_value.as_ref().or(payload.result.as_ref());
+        let shell_result = payload
+            .structured_result
+            .as_ref()
+            .or(payload.result.as_ref());
         if payload.tool.as_deref() == Some("exec_command")
             && status == ToolStatus::Completed
             && let Some(session_id) = shell_result.and_then(result_session_id)
@@ -652,7 +655,10 @@ impl Conversation {
             return false;
         };
         continued.add_duration(payload.duration_ns);
-        let result = payload.code_mode_value.as_ref().or(payload.result.as_ref());
+        let result = payload
+            .structured_result
+            .as_ref()
+            .or(payload.result.as_ref());
         if status == ToolStatus::Completed && result.and_then(result_session_id).is_some() {
             self.running_shell_sessions.insert(session_id, continued);
             return false;
@@ -2893,7 +2899,7 @@ struct ToolResultPayload {
     #[serde(default)]
     result: Option<Value>,
     #[serde(default)]
-    code_mode_value: Option<Value>,
+    structured_result: Option<Value>,
 }
 
 struct ContinuedTool {
@@ -4620,7 +4626,7 @@ mod tests {
                 "status": "completed",
                 "duration_ns": 10_000_000,
                 "result": "Wall time: 10.0000 seconds\nProcess running with session ID 7\nOutput:\n",
-                "code_mode_value": {"session_id": 7, "output": ""}
+                "structured_result": {"session_id": 7, "output": ""}
             }),
         ));
         app.main.on_agent_event(&event(
@@ -4639,7 +4645,7 @@ mod tests {
                 "status": "completed",
                 "duration_ns": 5_000_000,
                 "result": "Wall time: 5.0000 seconds\nProcess running with session ID 7\nOutput:\n",
-                "code_mode_value": {"session_id": 7, "output": ""}
+                "structured_result": {"session_id": 7, "output": ""}
             }),
         ));
         app.main.on_agent_event(&event(
@@ -4658,7 +4664,7 @@ mod tests {
                 "status": "completed",
                 "duration_ns": 1_000_000,
                 "result": "Wall time: 1.0000 seconds\nProcess exited with code 130\nOutput:\n",
-                "code_mode_value": {"exit_code": 130, "output": ""}
+                "structured_result": {"exit_code": 130, "output": ""}
             }),
         ));
         app.main.on_agent_event(&event(

--- a/crates/experimental/nanocodex-browser/src/lib.rs
+++ b/crates/experimental/nanocodex-browser/src/lib.rs
@@ -3782,7 +3782,7 @@ impl Tool for BrowserTool {
         } else {
             let mut code_mode_result = result.clone();
             code_mode_result.attach_model_images(&model_images);
-            let code_mode_value = match serde_json::to_value(code_mode_result) {
+            let structured_result = match serde_json::to_value(code_mode_result) {
                 Ok(value) => value,
                 Err(error) => {
                     return Ok(ToolOutput::error(format!(
@@ -3799,7 +3799,7 @@ impl Tool for BrowserTool {
                 }
             };
             content.insert(0, ToolOutputContent::InputText { text: encoded });
-            Ok(ToolOutput::content(content).with_code_mode_value(code_mode_value))
+            Ok(ToolOutput::content(content).with_structured_result(structured_result))
         }
     }
 }

--- a/crates/experimental/nanocodex-vm/README.md
+++ b/crates/experimental/nanocodex-vm/README.md
@@ -298,7 +298,7 @@ bounded writer channel. `duration_ns` covers the complete RPC.
 
 ```json
 {"kind":"tool","payload":{"id":1,"tool":"exec_command","input":{"function":{"arguments":{"cmd":"pwd"}}},"context":{"model":"gpt-5.6","session_id":"session-1","call_id":"call-1","output_token_budget":10000}}}
-{"kind":"tool","payload":{"id":1,"execution":{"output":"/app\n","success":true,"code_mode_value":null,"metadata":null,"process_trace":{"exit_code":0,"session_id":null,"original_token_count":null,"output_bytes":5,"wall_time_seconds":0.01}},"error":null}}
+{"kind":"tool","payload":{"id":1,"execution":{"output":"/app\n","success":true,"structured_result":null,"metadata":null,"process_trace":{"exit_code":0,"session_id":null,"original_token_count":null,"output_bytes":5,"wall_time_seconds":0.01}},"error":null}}
 ```
 
 The normal adapter sends `exec_command`, `write_stdin`, `apply_patch`, or
@@ -313,7 +313,7 @@ Function `arguments` remain opaque JSON. `context` contains `model`,
 `session_id`, `call_id`, and `output_token_budget`; conversation history is
 not copied into the guest context. `execution.output` is either a string or
 the canonical ordered multimodal array of `input_text`, `input_image`, and
-`input_audio` objects. `code_mode_value` and `metadata` are opaque JSON or
+`input_audio` objects. `structured_result` and `metadata` are opaque JSON or
 `null`. `process_trace` is `null` or contains `exit_code`, `session_id`,
 `original_token_count`, `output_bytes`, and `wall_time_seconds`.
 

--- a/crates/experimental/nanocodex-vm/src/tools/protocol.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/protocol.rs
@@ -344,7 +344,7 @@ mod tests {
         ));
         assert_eq!(
             serde_json::to_string(&response).unwrap(),
-            r#"{"kind":"tool","payload":{"id":1,"execution":{"output":"/app\n","success":true,"code_mode_value":null,"metadata":null,"process_trace":{"exit_code":0,"session_id":null,"original_token_count":null,"output_bytes":5,"wall_time_seconds":0.01}},"error":null}}"#
+            r#"{"kind":"tool","payload":{"id":1,"execution":{"output":"/app\n","success":true,"structured_result":null,"metadata":null,"process_trace":{"exit_code":0,"session_id":null,"original_token_count":null,"output_bytes":5,"wall_time_seconds":0.01}},"error":null}}"#
         );
     }
 

--- a/crates/experimental/nanocodex-vm/src/tools/session.rs
+++ b/crates/experimental/nanocodex-vm/src/tools/session.rs
@@ -2011,7 +2011,7 @@ mod tracing_tests {
     #[test]
     fn vm_rpc_is_timed_parented_and_records_admission_wait() {
         let _test_guard = TRACE_TEST_LOCK.lock().unwrap();
-        let response = r#"{"kind":"tool","payload":{"id":0,"execution":{"output":"ok","success":true,"code_mode_value":null,"metadata":null,"process_trace":null},"error":null}}"#;
+        let response = r#"{"kind":"tool","payload":{"id":0,"execution":{"output":"ok","success":true,"structured_result":null,"metadata":null,"process_trace":null},"error":null}}"#;
         let script = format!("IFS= read -r request\nprintf '%s\\n' '{response}'");
         let mut command = tokio::process::Command::new("/bin/sh");
         command.arg("-c").arg(script);

--- a/crates/nanocodex-agent/src/model/run/tool_calls.rs
+++ b/crates/nanocodex-agent/src/model/run/tool_calls.rs
@@ -78,6 +78,7 @@ impl CodeModeObserver for NestedToolEventObserver<'_> {
                         duration_ns: call.duration_ns,
                         started_after_ns: Some(call.started_after_ns),
                         result: &call.output,
+                        code_mode_value: Some(&call.code_mode_value),
                         metadata: call.metadata.as_deref(),
                     },
                 )
@@ -369,6 +370,7 @@ where
                 duration_ns: completed.duration_ns,
                 started_after_ns: None,
                 result: &completed.output,
+                code_mode_value: None,
                 metadata: completed.metadata.as_deref(),
             },
         )?;

--- a/crates/nanocodex-agent/src/model/run/tool_calls.rs
+++ b/crates/nanocodex-agent/src/model/run/tool_calls.rs
@@ -25,6 +25,7 @@ pub(super) struct CompletedToolCall {
     pub(super) duration_ns: u64,
     pub(super) work_duration_ns: u64,
     pub(super) output: ToolOutputBody,
+    pub(super) structured_result: Value,
     pub(super) metadata: Option<Box<RawValue>>,
     pub(super) response_items: Vec<ResponseItem>,
 }
@@ -78,7 +79,7 @@ impl CodeModeObserver for NestedToolEventObserver<'_> {
                         duration_ns: call.duration_ns,
                         started_after_ns: Some(call.started_after_ns),
                         result: &call.output,
-                        code_mode_value: Some(&call.code_mode_value),
+                        structured_result: &call.structured_result,
                         metadata: call.metadata.as_deref(),
                     },
                 )
@@ -370,7 +371,7 @@ where
                 duration_ns: completed.duration_ns,
                 started_after_ns: None,
                 result: &completed.output,
-                code_mode_value: None,
+                structured_result: &completed.structured_result,
                 metadata: completed.metadata.as_deref(),
             },
         )?;
@@ -384,6 +385,7 @@ where
         let message = panic_payload(payload);
         record_span_content(&active.span, "tool.panic", &message);
         let output = ToolOutputBody::Text("aborted".to_owned());
+        let structured_result = output.structured_result();
         let duration_ns = elapsed_ns(active.started_at);
         record_tool_span_terminal(&active.span, "failed", "ERROR", duration_ns, &output);
         let response_item = match active.kind {
@@ -398,6 +400,7 @@ where
             duration_ns,
             work_duration_ns: Self::completed_tool_work_duration(active),
             output,
+            structured_result,
             metadata: None,
             response_items: vec![response_item],
         }
@@ -420,6 +423,7 @@ where
         let qualified_name = qualified_tool_name(&call);
         if let Some(message) = unsupported_tool_message(tools, &call) {
             let output = ToolOutputBody::Text(message);
+            let structured_result = output.structured_result();
             record_tool_span_terminal(tool_span, "failed", "ERROR", 0, &output);
             let response_item = match call.kind {
                 CodeCallKind::Custom => custom_tool_output(call.call_id.clone(), output.clone()),
@@ -435,6 +439,7 @@ where
                 duration_ns: 0,
                 work_duration_ns: 0,
                 output,
+                structured_result,
                 metadata: None,
                 response_items: vec![response_item],
             });
@@ -477,6 +482,7 @@ where
                     unreachable!("tool search is not an ordinary direct tool")
                 }
             };
+            let structured_result = execution.structured_result();
             prepare_output_images(&mut execution.output).await;
             if let Some(content) = serialize_trace_content(&execution.output) {
                 record_span_content(tool_span, "tool.output", &content);
@@ -503,6 +509,7 @@ where
                     }
                 }],
                 output: execution.output,
+                structured_result,
                 metadata: execution.metadata,
             });
         }
@@ -533,9 +540,10 @@ where
             tool_span.record("status", status(execution.success));
             tool_span.record("otel.status_code", otel_status(execution.success));
             tool_span.record("duration_ns", duration_ns);
+            let structured_result = execution.structured_result();
             let tools = if execution.success {
-                match execution.code_mode_value() {
-                    Value::Array(tools) => tools,
+                match &structured_result {
+                    Value::Array(tools) => tools.clone(),
                     _ => Vec::new(),
                 }
             } else {
@@ -549,6 +557,7 @@ where
                 work_duration_ns: 0,
                 response_items: vec![tool_search_output(call.call_id, tools)],
                 output: execution.output,
+                structured_result,
                 metadata: execution.metadata,
             });
         }
@@ -576,6 +585,7 @@ where
         if let Some(error) = update_error {
             return Err(error);
         }
+        let structured_result = execution.output.structured_result();
         prepare_output_images(&mut execution.output).await;
         if let Some(content) = serialize_trace_content(&execution.output) {
             record_span_content(tool_span, "tool.output", &content);
@@ -609,6 +619,7 @@ where
             duration_ns,
             work_duration_ns: 0,
             output: execution.output,
+            structured_result,
             metadata: None,
             response_items: outputs,
         })

--- a/crates/nanocodex-agent/src/model/run/turn.rs
+++ b/crates/nanocodex-agent/src/model/run/turn.rs
@@ -543,6 +543,7 @@ where
             } else {
                 format!("aborted by user after {:.1}s", elapsed_seconds.max(0.1))
             });
+            let structured_result = output.structured_result();
             self.finish_active_tool_progress(&call.progress);
             self.finish_cancelled_tool_work(&call);
             record_tool_span_terminal(&call.span, "cancelled", "ERROR", duration_ns, &output);
@@ -555,7 +556,7 @@ where
                     duration_ns,
                     started_after_ns: None,
                     result: &output,
-                    code_mode_value: None,
+                    structured_result: &structured_result,
                     metadata: None,
                 },
             )?;

--- a/crates/nanocodex-agent/src/model/run/turn.rs
+++ b/crates/nanocodex-agent/src/model/run/turn.rs
@@ -555,6 +555,7 @@ where
                     duration_ns,
                     started_after_ns: None,
                     result: &output,
+                    code_mode_value: None,
                     metadata: None,
                 },
             )?;

--- a/crates/nanocodex-agent/src/model/telemetry.rs
+++ b/crates/nanocodex-agent/src/model/telemetry.rs
@@ -4,7 +4,7 @@ use nanocodex_oai_api::{
     __private::ModelConfig, Thinking, responses::Usage, transport::TransportStatsDelta,
 };
 use serde::Serialize;
-use serde_json::value::RawValue;
+use serde_json::{Value, value::RawValue};
 use web_time::Instant;
 
 use crate::usage::TurnUsage;
@@ -121,6 +121,8 @@ pub(super) struct ToolResultEvent<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) started_after_ns: Option<u64>,
     pub(super) result: &'a ToolOutputBody,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) code_mode_value: Option<&'a Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) metadata: Option<&'a RawValue>,
 }

--- a/crates/nanocodex-agent/src/model/telemetry.rs
+++ b/crates/nanocodex-agent/src/model/telemetry.rs
@@ -121,8 +121,7 @@ pub(super) struct ToolResultEvent<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) started_after_ns: Option<u64>,
     pub(super) result: &'a ToolOutputBody,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) code_mode_value: Option<&'a Value>,
+    pub(super) structured_result: &'a Value,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) metadata: Option<&'a RawValue>,
 }

--- a/crates/nanocodex-agent/tests/it/model/tools/mod.rs
+++ b/crates/nanocodex-agent/tests/it/model/tools/mod.rs
@@ -621,7 +621,23 @@ async fn connection_local_response_code_mode_round_trip() -> Result<()> {
         .await
         .map_err(|_| eyre!("mock Responses server did not finish"))???;
     assert!(output.contains("\"tool\":\"exec\""));
-    assert!(output.contains("\"tool\":\"exec_command\""));
+    let shell_result = output
+        .lines()
+        .map(serde_json::from_str::<Value>)
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .find(|event| event["type"] == "tool.result" && event["payload"]["tool"] == "exec_command")
+        .ok_or_else(|| eyre!("nested shell result event was not emitted"))?;
+    assert!(
+        shell_result["payload"]["result"]
+            .as_str()
+            .is_some_and(|result| result.contains("Process exited with code 0"))
+    );
+    assert_eq!(shell_result["payload"]["code_mode_value"]["exit_code"], 0);
+    assert_eq!(
+        shell_result["payload"]["code_mode_value"]["output"],
+        "hello"
+    );
     std::fs::remove_dir_all(workspace)?;
     Ok(())
 }

--- a/crates/nanocodex-agent/tests/it/model/tools/mod.rs
+++ b/crates/nanocodex-agent/tests/it/model/tools/mod.rs
@@ -218,7 +218,32 @@ async fn normal_code_mode_executes_direct_function_and_custom_tools() -> Result<
     assert!(output.contains(r#""tool":"update_plan""#));
     assert!(output.contains(r#""tool":"apply_patch""#));
     assert!(output.contains(r#""tool":"test_namespace__echo""#));
-    assert!(output.contains(r#""tool":"exec_command""#));
+    let events = output
+        .lines()
+        .map(serde_json::from_str::<Value>)
+        .collect::<Result<Vec<_>, _>>()?;
+    let direct_results = events
+        .iter()
+        .filter(|event| event["type"] == "tool.result")
+        .collect::<Vec<_>>();
+    assert_eq!(direct_results.len(), 4);
+    assert!(
+        direct_results
+            .iter()
+            .all(|event| event["payload"].get("structured_result").is_some())
+    );
+    let direct_shell_result = direct_results
+        .into_iter()
+        .find(|event| event["payload"]["tool"] == "exec_command")
+        .ok_or_else(|| eyre!("direct shell result event was not emitted"))?;
+    assert_eq!(
+        direct_shell_result["payload"]["structured_result"]["exit_code"],
+        0
+    );
+    assert_eq!(
+        direct_shell_result["payload"]["structured_result"]["output"],
+        "direct-shell-dispatch-worked"
+    );
     std::fs::remove_dir_all(workspace)?;
     Ok(())
 }
@@ -633,9 +658,9 @@ async fn connection_local_response_code_mode_round_trip() -> Result<()> {
             .as_str()
             .is_some_and(|result| result.contains("Process exited with code 0"))
     );
-    assert_eq!(shell_result["payload"]["code_mode_value"]["exit_code"], 0);
+    assert_eq!(shell_result["payload"]["structured_result"]["exit_code"], 0);
     assert_eq!(
-        shell_result["payload"]["code_mode_value"]["output"],
+        shell_result["payload"]["structured_result"]["output"],
         "hello"
     );
     std::fs::remove_dir_all(workspace)?;

--- a/crates/nanocodex-oai-api/src/events/data.rs
+++ b/crates/nanocodex-oai-api/src/events/data.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use serde::Deserialize;
-use serde_json::value::RawValue;
+use serde_json::{Value, value::RawValue};
 
 use crate::CostStatus;
 use crate::{AgentEventKind, EstimatedUsdCost, MessagePhase, ToolOutputBody, Usage};
@@ -326,6 +326,9 @@ pub struct ToolResultEvent {
     pub started_after_ns: Option<u64>,
     /// Complete model-visible output.
     pub result: ToolOutputBody,
+    /// Structured value returned to a containing Code Mode program.
+    #[serde(default)]
+    pub code_mode_value: Option<Value>,
     /// Optional application or remote-tool metadata.
     pub metadata: Option<Box<RawValue>>,
 }

--- a/crates/nanocodex-oai-api/src/events/data.rs
+++ b/crates/nanocodex-oai-api/src/events/data.rs
@@ -327,7 +327,6 @@ pub struct ToolResultEvent {
     /// Complete model-visible output.
     pub result: ToolOutputBody,
     /// Exact machine-readable tool result.
-    #[serde(default)]
     pub structured_result: Value,
     /// Optional application or remote-tool metadata.
     pub metadata: Option<Box<RawValue>>,

--- a/crates/nanocodex-oai-api/src/events/data.rs
+++ b/crates/nanocodex-oai-api/src/events/data.rs
@@ -326,9 +326,9 @@ pub struct ToolResultEvent {
     pub started_after_ns: Option<u64>,
     /// Complete model-visible output.
     pub result: ToolOutputBody,
-    /// Structured value returned to a containing Code Mode program.
+    /// Exact machine-readable tool result.
     #[serde(default)]
-    pub code_mode_value: Option<Value>,
+    pub structured_result: Value,
     /// Optional application or remote-tool metadata.
     pub metadata: Option<Box<RawValue>>,
 }

--- a/crates/nanocodex-oai-api/src/tools/mod.rs
+++ b/crates/nanocodex-oai-api/src/tools/mod.rs
@@ -29,9 +29,7 @@ impl ToolOutputBody {
     #[must_use]
     pub fn structured_result(&self) -> Value {
         match self {
-            Self::Text(text) => {
-                serde_json::from_str(text).unwrap_or_else(|_| Value::String(text.clone()))
-            }
+            Self::Text(text) => Value::String(text.clone()),
             Self::Content(content) => serde_json::to_value(content).unwrap_or(Value::Null),
         }
     }
@@ -150,8 +148,8 @@ impl ToolOutput {
     /// Serializes one successful function result as JSON text.
     #[must_use]
     pub fn json(output: &impl Serialize) -> Self {
-        match serde_json::to_string(output) {
-            Ok(output) => Self::text(output),
+        match serde_json::to_value(output) {
+            Ok(output) => Self::from_json(output, true),
             Err(error) => Self::error(format!("failed to encode tool result: {error}")),
         }
     }
@@ -204,9 +202,8 @@ impl ToolOutput {
 
     /// Returns the exact machine-readable tool result.
     ///
-    /// An explicit structured result takes precedence. Otherwise JSON text is
-    /// decoded, plain text remains a string, and multimodal content becomes an
-    /// array.
+    /// An explicit structured result takes precedence. Otherwise plain text
+    /// remains a string and multimodal content becomes an array.
     #[must_use]
     pub fn structured_result(&self) -> Value {
         if let Some(value) = &self.structured_result {
@@ -483,4 +480,17 @@ pub trait Tool: Send + Sync + 'static {
 
     /// Executes one invocation.
     async fn execute(&self, input: ToolInput, context: ToolContext<'_>) -> ToolResult;
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::ToolOutput;
+
+    #[test]
+    fn structured_result_preserves_text_and_json_types() {
+        assert_eq!(ToolOutput::text("42").structured_result(), json!("42"));
+        assert_eq!(ToolOutput::json(&42).structured_result(), json!(42));
+    }
 }

--- a/crates/nanocodex-oai-api/src/tools/mod.rs
+++ b/crates/nanocodex-oai-api/src/tools/mod.rs
@@ -24,6 +24,19 @@ pub enum ToolOutputBody {
     Content(Vec<ToolOutputContent>),
 }
 
+impl ToolOutputBody {
+    /// Returns the machine-readable value represented by this output.
+    #[must_use]
+    pub fn structured_result(&self) -> Value {
+        match self {
+            Self::Text(text) => {
+                serde_json::from_str(text).unwrap_or_else(|_| Value::String(text.clone()))
+            }
+            Self::Content(content) => serde_json::to_value(content).unwrap_or(Value::Null),
+        }
+    }
+}
+
 /// One model-visible item in a multimodal tool output.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -59,7 +72,7 @@ pub struct ToolOutput {
     pub success: bool,
     /// Optional validated opaque metadata for events and adapters.
     pub metadata: Option<Box<RawValue>>,
-    code_mode_value: Option<Value>,
+    structured_result: Option<Value>,
     process_trace: Option<ToolProcessTrace>,
 }
 
@@ -70,7 +83,7 @@ pub struct ToolOutput {
 pub struct ToolOutputWire {
     pub output: ToolOutputBody,
     pub success: bool,
-    pub code_mode_value: Option<Box<RawValue>>,
+    pub structured_result: Option<Box<RawValue>>,
     pub metadata: Option<Box<RawValue>>,
     pub process_trace: Option<ToolProcessTraceWire>,
 }
@@ -117,7 +130,7 @@ impl ToolOutput {
             output: ToolOutputBody::Text(output.into()),
             success: true,
             metadata: None,
-            code_mode_value: None,
+            structured_result: None,
             process_trace: None,
         }
     }
@@ -129,7 +142,7 @@ impl ToolOutput {
             output: ToolOutputBody::Text(error.into()),
             success: false,
             metadata: None,
-            code_mode_value: None,
+            structured_result: None,
             process_trace: None,
         }
     }
@@ -145,8 +158,8 @@ impl ToolOutput {
 
     /// Creates a JSON result with an explicit success state.
     ///
-    /// Code Mode receives the typed JSON value while the Responses API
-    /// receives its serialized text representation.
+    /// Structured consumers receive the typed JSON value while the Responses
+    /// API receives its serialized text representation.
     #[must_use]
     pub fn from_json(output: Value, success: bool) -> Self {
         match serde_json::to_string(&output) {
@@ -154,7 +167,7 @@ impl ToolOutput {
                 output: ToolOutputBody::Text(encoded),
                 success,
                 metadata: None,
-                code_mode_value: Some(output),
+                structured_result: Some(output),
                 process_trace: None,
             },
             Err(error) => Self::error(format!("failed to encode tool result: {error}")),
@@ -168,7 +181,7 @@ impl ToolOutput {
             output: ToolOutputBody::Content(output),
             success: true,
             metadata: None,
-            code_mode_value: None,
+            structured_result: None,
             process_trace: None,
         }
     }
@@ -189,28 +202,23 @@ impl ToolOutput {
         self
     }
 
-    /// Returns the value exposed to Code Mode.
-    #[doc(hidden)]
+    /// Returns the exact machine-readable tool result.
+    ///
+    /// An explicit structured result takes precedence. Otherwise JSON text is
+    /// decoded, plain text remains a string, and multimodal content becomes an
+    /// array.
     #[must_use]
-    pub fn code_mode_value(&self) -> Value {
-        if let Some(value) = &self.code_mode_value {
+    pub fn structured_result(&self) -> Value {
+        if let Some(value) = &self.structured_result {
             return value.clone();
         }
-        match &self.output {
-            ToolOutputBody::Text(text) => {
-                serde_json::from_str(text).unwrap_or_else(|_| Value::String(text.clone()))
-            }
-            ToolOutputBody::Content(content) => {
-                serde_json::to_value(content).unwrap_or(Value::Null)
-            }
-        }
+        self.output.structured_result()
     }
 
-    /// Replaces the value exposed to Code Mode.
-    #[doc(hidden)]
+    /// Sets the exact machine-readable result independently of model-visible output.
     #[must_use]
-    pub fn with_code_mode_value(mut self, value: Value) -> Self {
-        self.code_mode_value = Some(value);
+    pub fn with_structured_result(mut self, value: Value) -> Self {
+        self.structured_result = Some(value);
         self
     }
 
@@ -246,14 +254,14 @@ impl ToolOutput {
     ///
     /// # Errors
     ///
-    /// Returns an error if the internal Code Mode JSON cannot be encoded.
+    /// Returns an error if the internal structured result cannot be encoded.
     #[doc(hidden)]
     pub fn into_wire(self) -> Result<ToolOutputWire, serde_json::Error> {
         Ok(ToolOutputWire {
             output: self.output,
             success: self.success,
-            code_mode_value: self
-                .code_mode_value
+            structured_result: self
+                .structured_result
                 .map(|value| to_raw_value(&value))
                 .transpose()?,
             metadata: self.metadata,
@@ -265,15 +273,15 @@ impl ToolOutput {
     ///
     /// # Errors
     ///
-    /// Returns an error if an opaque Code Mode value cannot be decoded.
+    /// Returns an error if an opaque structured result cannot be decoded.
     #[doc(hidden)]
     pub fn from_wire(wire: ToolOutputWire) -> Result<Self, serde_json::Error> {
         Ok(Self {
             output: wire.output,
             success: wire.success,
             metadata: wire.metadata,
-            code_mode_value: wire
-                .code_mode_value
+            structured_result: wire
+                .structured_result
                 .map(|value| serde_json::from_str(value.get()))
                 .transpose()?,
             process_trace: wire.process_trace.map(Into::into),

--- a/crates/nanocodex-tools/src/apply_patch/mod.rs
+++ b/crates/nanocodex-tools/src/apply_patch/mod.rs
@@ -35,7 +35,7 @@ impl Tool for ApplyPatchHandler {
         let workspace = self.workspace.clone();
         Ok(
             match tokio::task::spawn_blocking(move || apply(&input, &workspace)).await {
-                Ok(Ok(output)) => ToolOutput::text(output).with_code_mode_value(json!({})),
+                Ok(Ok(output)) => ToolOutput::text(output).with_structured_result(json!({})),
                 Ok(Err(error)) => {
                     ToolOutput::error(format!("apply_patch verification failed: {error}"))
                 }

--- a/crates/nanocodex-tools/src/code_mode/mod.rs
+++ b/crates/nanocodex-tools/src/code_mode/mod.rs
@@ -1330,7 +1330,7 @@ async fn execute_nested_call(
     );
     let execution = tools.execute_nested(&name, input.clone(), context).await;
     let duration_ns = u64::try_from(started_at.elapsed().as_nanos()).unwrap_or(u64::MAX);
-    let value = execution.code_mode_value();
+    let value = execution.structured_result();
     let shell_session_id = execution
         .process_trace()
         .and_then(|process| process.session_id)
@@ -1344,7 +1344,7 @@ async fn execute_nested_call(
             name,
             input,
             output: execution.output,
-            code_mode_value: value,
+            structured_result: value,
             success: execution.success,
             started_after_ns,
             duration_ns,

--- a/crates/nanocodex-tools/src/code_mode/mod.rs
+++ b/crates/nanocodex-tools/src/code_mode/mod.rs
@@ -1337,13 +1337,14 @@ async fn execute_nested_call(
         .or_else(|| value.get("session_id").and_then(Value::as_i64));
     CompletedNestedCall {
         id,
-        value,
+        value: value.clone(),
         shell_session_id,
         call: NestedToolCall {
             call_id,
             name,
             input,
             output: execution.output,
+            code_mode_value: value,
             success: execution.success,
             started_after_ns,
             duration_ns,

--- a/crates/nanocodex-tools/src/code_mode/tests.rs
+++ b/crates/nanocodex-tools/src/code_mode/tests.rs
@@ -661,8 +661,11 @@ text({ closed, exit_code: interrupted.exit_code });
         serde_json::from_str::<Value>(emitted_text(&execution)?)?,
         serde_json::json!({ "closed": true, "exit_code": 130 })
     );
-    assert_eq!(execution.nested_calls[0].code_mode_value["session_id"], 1);
-    assert_eq!(execution.nested_calls[2].code_mode_value["exit_code"], 130);
+    assert_eq!(execution.nested_calls[0].structured_result["session_id"], 1);
+    assert_eq!(
+        execution.nested_calls[2].structured_result["exit_code"],
+        130
+    );
     std::fs::remove_dir_all(workspace)?;
     Ok(())
 }
@@ -691,7 +694,7 @@ text({
     assert_eq!(result["present"], true);
     assert_eq!(result["count"], 1);
     assert_eq!(
-        execution.nested_calls[0].code_mode_value["original_token_count"],
+        execution.nested_calls[0].structured_result["original_token_count"],
         1
     );
     std::fs::remove_dir_all(workspace)?;

--- a/crates/nanocodex-tools/src/code_mode/tests.rs
+++ b/crates/nanocodex-tools/src/code_mode/tests.rs
@@ -661,6 +661,8 @@ text({ closed, exit_code: interrupted.exit_code });
         serde_json::from_str::<Value>(emitted_text(&execution)?)?,
         serde_json::json!({ "closed": true, "exit_code": 130 })
     );
+    assert_eq!(execution.nested_calls[0].code_mode_value["session_id"], 1);
+    assert_eq!(execution.nested_calls[2].code_mode_value["exit_code"], 130);
     std::fs::remove_dir_all(workspace)?;
     Ok(())
 }
@@ -688,6 +690,10 @@ text({
     let result = serde_json::from_str::<Value>(emitted_text(&execution)?)?;
     assert_eq!(result["present"], true);
     assert_eq!(result["count"], 1);
+    assert_eq!(
+        execution.nested_calls[0].code_mode_value["original_token_count"],
+        1
+    );
     std::fs::remove_dir_all(workspace)?;
     Ok(())
 }

--- a/crates/nanocodex-tools/src/hosted/runtime.rs
+++ b/crates/nanocodex-tools/src/hosted/runtime.rs
@@ -426,31 +426,6 @@ mod tests {
         assert!(description.find("tools.alpha").unwrap() < description.find("tools.zeta").unwrap());
     }
 
-    #[test]
-    fn nested_calls_require_the_structured_result() {
-        let mut execution = json!({
-            "output": "done",
-            "success": true,
-            "nested_calls": [{
-                "call_id": "call-1/code-0",
-                "name": "example",
-                "input": {},
-                "output": "visible",
-                "success": true,
-                "started_after_ns": 1,
-                "duration_ns": 2
-            }]
-        });
-        assert!(serde_json::from_value::<CodeModeExecution>(execution.clone()).is_err());
-
-        execution["nested_calls"][0]["structured_result"] = json!({"answer": 42});
-        let execution = serde_json::from_value::<CodeModeExecution>(execution).unwrap();
-        assert_eq!(
-            execution.nested_calls[0].structured_result,
-            json!({"answer": 42})
-        );
-    }
-
     #[tokio::test]
     async fn execution_receives_the_standard_tool_context() {
         let tools = HostedTools::new(EchoHost);

--- a/crates/nanocodex-tools/src/hosted/runtime.rs
+++ b/crates/nanocodex-tools/src/hosted/runtime.rs
@@ -426,6 +426,31 @@ mod tests {
         assert!(description.find("tools.alpha").unwrap() < description.find("tools.zeta").unwrap());
     }
 
+    #[test]
+    fn nested_calls_require_the_code_mode_value() {
+        let mut execution = json!({
+            "output": "done",
+            "success": true,
+            "nested_calls": [{
+                "call_id": "call-1/code-0",
+                "name": "example",
+                "input": {},
+                "output": "visible",
+                "success": true,
+                "started_after_ns": 1,
+                "duration_ns": 2
+            }]
+        });
+        assert!(serde_json::from_value::<CodeModeExecution>(execution.clone()).is_err());
+
+        execution["nested_calls"][0]["code_mode_value"] = json!({"answer": 42});
+        let execution = serde_json::from_value::<CodeModeExecution>(execution).unwrap();
+        assert_eq!(
+            execution.nested_calls[0].code_mode_value,
+            json!({"answer": 42})
+        );
+    }
+
     #[tokio::test]
     async fn execution_receives_the_standard_tool_context() {
         let tools = HostedTools::new(EchoHost);

--- a/crates/nanocodex-tools/src/hosted/runtime.rs
+++ b/crates/nanocodex-tools/src/hosted/runtime.rs
@@ -427,7 +427,7 @@ mod tests {
     }
 
     #[test]
-    fn nested_calls_require_the_code_mode_value() {
+    fn nested_calls_require_the_structured_result() {
         let mut execution = json!({
             "output": "done",
             "success": true,
@@ -443,10 +443,10 @@ mod tests {
         });
         assert!(serde_json::from_value::<CodeModeExecution>(execution.clone()).is_err());
 
-        execution["nested_calls"][0]["code_mode_value"] = json!({"answer": 42});
+        execution["nested_calls"][0]["structured_result"] = json!({"answer": 42});
         let execution = serde_json::from_value::<CodeModeExecution>(execution).unwrap();
         assert_eq!(
-            execution.nested_calls[0].code_mode_value,
+            execution.nested_calls[0].structured_result,
             json!({"answer": 42})
         );
     }

--- a/crates/nanocodex-tools/src/hosted/types.rs
+++ b/crates/nanocodex-tools/src/hosted/types.rs
@@ -142,6 +142,8 @@ pub struct NestedToolCall {
     pub input: Value,
     /// Complete model-visible output.
     pub output: ToolOutputBody,
+    /// Structured value returned to the Code Mode program.
+    pub code_mode_value: Value,
     /// Whether the nested operation succeeded.
     pub success: bool,
     /// Nanoseconds from cell start until this call started.

--- a/crates/nanocodex-tools/src/hosted/types.rs
+++ b/crates/nanocodex-tools/src/hosted/types.rs
@@ -142,8 +142,8 @@ pub struct NestedToolCall {
     pub input: Value,
     /// Complete model-visible output.
     pub output: ToolOutputBody,
-    /// Structured value returned to the Code Mode program.
-    pub code_mode_value: Value,
+    /// Exact machine-readable tool result.
+    pub structured_result: Value,
     /// Whether the nested operation succeeded.
     pub success: bool,
     /// Nanoseconds from cell start until this call started.

--- a/crates/nanocodex-tools/src/image_generation/mod.rs
+++ b/crates/nanocodex-tools/src/image_generation/mod.rs
@@ -102,14 +102,14 @@ impl ImageGenerationHandler {
             image_url: image_url.clone(),
             detail: ImageDetail::High,
         }];
-        let mut code_mode_value = json!({ "image_url": image_url });
+        let mut structured_result = json!({ "image_url": image_url });
         if let Some(output_hint) = output_hint {
             output_items.push(ToolOutputContent::InputText {
                 text: output_hint.clone(),
             });
-            code_mode_value["output_hint"] = Value::String(output_hint);
+            structured_result["output_hint"] = Value::String(output_hint);
         }
-        ToolOutput::content(output_items).with_code_mode_value(code_mode_value)
+        ToolOutput::content(output_items).with_structured_result(structured_result)
     }
 
     async fn post_image_request<R: Serialize + ?Sized>(

--- a/crates/nanocodex-tools/src/image_generation/tests.rs
+++ b/crates/nanocodex-tools/src/image_generation/tests.rs
@@ -63,7 +63,7 @@ async fn generation_uses_codex_images_request_and_persists_result() -> Result<()
                 && text.contains("already displayed to the user")
     ));
     assert_eq!(
-        execution.code_mode_value()["image_url"],
+        execution.structured_result()["image_url"],
         format!("data:image/png;base64,{encoded}")
     );
     let saved_path = workspace

--- a/crates/nanocodex-tools/src/mcp/mod.rs
+++ b/crates/nanocodex-tools/src/mcp/mod.rs
@@ -709,7 +709,7 @@ impl Tool for McpSearch {
         }
         Ok(match result {
             Ok(result) => match result.loadable_tools() {
-                Ok(tools) => ToolOutput::json(&result).with_code_mode_value(tools),
+                Ok(tools) => ToolOutput::json(&result).with_structured_result(tools),
                 Err(error) => {
                     ToolOutput::error(format!("failed to encode MCP tool definitions: {error}"))
                 }
@@ -960,7 +960,7 @@ mod tests {
             .await;
         assert!(resources.success);
         assert_eq!(
-            resources.code_mode_value()["resources"],
+            resources.structured_result()["resources"],
             json!([
                 {
                     "server": "fixture",
@@ -987,7 +987,7 @@ mod tests {
             .await;
         assert!(templates.success);
         assert_eq!(
-            templates.code_mode_value()["resourceTemplates"][0],
+            templates.structured_result()["resourceTemplates"][0],
             json!({
                 "server": "fixture",
                 "uriTemplate": "fixture://item/{id}",
@@ -1010,10 +1010,10 @@ mod tests {
             )
             .await;
         assert!(read.success);
-        assert_eq!(read.code_mode_value()["server"], "fixture");
-        assert_eq!(read.code_mode_value()["uri"], "fixture://first");
+        assert_eq!(read.structured_result()["server"], "fixture");
+        assert_eq!(read.structured_result()["uri"], "fixture://first");
         assert_eq!(
-            read.code_mode_value()["contents"][0]["text"],
+            read.structured_result()["contents"][0]["text"],
             "fixture resource body"
         );
     }
@@ -1041,7 +1041,7 @@ mod tests {
             .unwrap();
         assert!(search.success);
         assert_eq!(
-            search.code_mode_value(),
+            search.structured_result(),
             json!([
                 {
                     "type": "namespace",

--- a/crates/nanocodex-tools/src/plan.rs
+++ b/crates/nanocodex-tools/src/plan.rs
@@ -48,7 +48,7 @@ impl Tool for UpdatePlanTool {
             );
         }
         *self.current.lock().await = Some(plan);
-        Ok(ToolOutput::text("Plan updated").with_code_mode_value(json!({})))
+        Ok(ToolOutput::text("Plan updated").with_structured_result(json!({})))
     }
 }
 

--- a/crates/nanocodex-tools/src/runtime/tests.rs
+++ b/crates/nanocodex-tools/src/runtime/tests.rs
@@ -82,7 +82,7 @@ impl Tool for Double {
 
     async fn execute(&self, input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
         let input = input.decode_json::<DoubleInput>()?;
-        Ok(ToolOutput::text((input.value * 2).to_string()))
+        Ok(ToolOutput::json(&(input.value * 2)))
     }
 }
 

--- a/crates/nanocodex-tools/src/runtime/tests.rs
+++ b/crates/nanocodex-tools/src/runtime/tests.rs
@@ -443,7 +443,7 @@ async fn parallel_safety_follows_direct_then_provider_dispatch_precedence() {
             context,
         )
         .await;
-    assert_eq!(direct.code_mode_value(), json!("direct"));
+    assert_eq!(direct.structured_result(), json!("direct"));
 
     let provider_collision = Tools::builder()
         .without_defaults()
@@ -469,7 +469,7 @@ async fn parallel_safety_follows_direct_then_provider_dispatch_precedence() {
             context,
         )
         .await;
-    assert_eq!(provider.code_mode_value(), json!("first"));
+    assert_eq!(provider.structured_result(), json!("first"));
 }
 
 #[test]
@@ -715,7 +715,7 @@ async fn extending_a_runtime_keeps_the_first_exact_tool_registration() {
         )
         .await;
 
-    assert_eq!(output.code_mode_value(), json!("first"));
+    assert_eq!(output.structured_result(), json!("first"));
 }
 
 #[test]
@@ -819,7 +819,7 @@ text(result);
     assert_eq!(execution.nested_calls.len(), 1);
     assert_eq!(execution.nested_calls[0].name, "double");
     assert_eq!(execution.nested_calls[0].input, json!({ "value": 21 }));
-    assert_eq!(execution.nested_calls[0].code_mode_value, json!(42));
+    assert_eq!(execution.nested_calls[0].structured_result, json!(42));
     let ToolOutputBody::Content(content) = execution.output else {
         panic!("expected content output");
     };
@@ -941,7 +941,7 @@ async fn direct_model_calls_reach_activated_dynamic_tools() {
         )
         .await;
     assert!(execution.success);
-    assert_eq!(execution.code_mode_value(), json!({ "value": 21 }));
+    assert_eq!(execution.structured_result(), json!({ "value": 21 }));
 }
 
 #[tokio::test]

--- a/crates/nanocodex-tools/src/runtime/tests.rs
+++ b/crates/nanocodex-tools/src/runtime/tests.rs
@@ -819,6 +819,7 @@ text(result);
     assert_eq!(execution.nested_calls.len(), 1);
     assert_eq!(execution.nested_calls[0].name, "double");
     assert_eq!(execution.nested_calls[0].input, json!({ "value": 21 }));
+    assert_eq!(execution.nested_calls[0].code_mode_value, json!(42));
     let ToolOutputBody::Content(content) = execution.output else {
         panic!("expected content output");
     };

--- a/crates/nanocodex-tools/src/shell/tool.rs
+++ b/crates/nanocodex-tools/src/shell/tool.rs
@@ -84,14 +84,14 @@ fn shell_execution(result: &super::ExecCommandResult) -> ToolOutput {
     if let Some(error) = &result.error {
         return ToolOutput::error(error);
     }
-    let code_mode_value = match serde_json::to_value(result) {
+    let structured_result = match serde_json::to_value(result) {
         Ok(value) => value,
         Err(error) => {
             return ToolOutput::error(format!("failed to encode tool result: {error}"));
         }
     };
     ToolOutput::text(shell_response_text(result))
-        .with_code_mode_value(code_mode_value)
+        .with_structured_result(structured_result)
         .with_process_trace(
             result.exit_code,
             result.session_id,
@@ -222,7 +222,7 @@ mod tests {
              hello\n"
         );
         assert_eq!(
-            output.code_mode_value(),
+            output.structured_result(),
             serde_json::json!({
                 "chunk_id": "a1b2c3",
                 "wall_time_seconds": 0.68754,

--- a/crates/nanocodex-tools/src/view_image.rs
+++ b/crates/nanocodex-tools/src/view_image.rs
@@ -109,7 +109,7 @@ impl Tool for ViewImageHandler {
             image_url: image_url.clone(),
             detail,
         }])
-        .with_code_mode_value(json!({
+        .with_structured_result(json!({
             "image_url": image_url,
             "detail": detail,
         })))

--- a/crates/nanocodex-tools/src/web_search/mod.rs
+++ b/crates/nanocodex-tools/src/web_search/mod.rs
@@ -9,7 +9,7 @@ use nanocodex_oai_api::{
     tools::ToolDefinition,
 };
 use reqwest::header::{AUTHORIZATION, USER_AGENT};
-use serde_json::{Value, json};
+use serde_json::json;
 use tokio::time::{sleep, timeout};
 
 use self::{
@@ -136,7 +136,7 @@ impl WebSearchHandler {
 
         let output = outputs.join("\n");
         let mut execution = if failures.is_empty() {
-            ToolOutput::text(output.clone()).with_structured_result(Value::String(output))
+            ToolOutput::text(output)
         } else {
             let mut error = failures.join("\n");
             if !output.is_empty() {

--- a/crates/nanocodex-tools/src/web_search/mod.rs
+++ b/crates/nanocodex-tools/src/web_search/mod.rs
@@ -136,7 +136,7 @@ impl WebSearchHandler {
 
         let output = outputs.join("\n");
         let mut execution = if failures.is_empty() {
-            ToolOutput::text(output.clone()).with_code_mode_value(Value::String(output))
+            ToolOutput::text(output.clone()).with_structured_result(Value::String(output))
         } else {
             let mut error = failures.join("\n");
             if !output.is_empty() {

--- a/crates/nanocodex-tools/src/workspace_runtime.rs
+++ b/crates/nanocodex-tools/src/workspace_runtime.rs
@@ -220,6 +220,6 @@ mod tests {
             .await;
 
         assert!(output.success);
-        assert_eq!(output.code_mode_value()["output"], "from-image");
+        assert_eq!(output.structured_result()["output"], "from-image");
     }
 }

--- a/js/bindings/runtime/code-runtime.mjs
+++ b/js/bindings/runtime/code-runtime.mjs
@@ -65,17 +65,20 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
             name,
             input: recordedInput,
             output: outputBody(result),
+            structured_result: clone(result) ?? null,
             success: true,
             started_after_ns: startedAfterNs,
             duration_ns: elapsedNs(toolStartedAt),
           });
           return result;
         } catch (error) {
+          const message = errorMessage(error);
           nestedCalls.push({
             call_id: callId,
             name,
             input: recordedInput,
-            output: errorMessage(error),
+            output: message,
+            structured_result: message,
             success: false,
             started_after_ns: startedAfterNs,
             duration_ns: elapsedNs(toolStartedAt),
@@ -177,11 +180,11 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
   });
 }
 
-function encodeToolOutput(output, success, codeModeValue) {
+function encodeToolOutput(output, success, structuredResult) {
   return JSON.stringify({
     output,
     success,
-    code_mode_value: codeModeValue,
+    structured_result: structuredResult,
     metadata: null,
     process_trace: null,
   });

--- a/js/bindings/runtime/code-runtime.mjs
+++ b/js/bindings/runtime/code-runtime.mjs
@@ -36,7 +36,7 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
     }
     try {
       const result = await tool.handler(input, { sessionId, parentCallId: "", callId });
-      return encodeToolOutput(outputBody(result), true, clone(result) ?? null);
+      return encodeToolOutput(outputBody(result), true, structuredResult(result, `tool ${name} result`));
     } catch (error) {
       return encodeToolOutput(errorMessage(error), false, null);
     }
@@ -65,7 +65,7 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
             name,
             input: recordedInput,
             output: outputBody(result),
-            structured_result: clone(result) ?? null,
+            structured_result: structuredResult(result, `tool ${name} result`),
             success: true,
             started_after_ns: startedAfterNs,
             duration_ns: elapsedNs(toolStartedAt),
@@ -218,6 +218,10 @@ function jsonSnapshot(value, label) {
   } catch (error) {
     throw new TypeError(`${label} must be JSON-serializable`, { cause: error });
   }
+}
+
+function structuredResult(value, label) {
+  return value === undefined ? null : jsonSnapshot(value, label);
 }
 
 function deepFreeze(value) {

--- a/js/bindings/test/browser-host.test.mjs
+++ b/js/bindings/test/browser-host.test.mjs
@@ -14,6 +14,10 @@ test("browser host carries ordered frames and application tools", async () => {
         parameters: { type: "object" },
         handler: ({ value }) => value * 2,
       },
+      numericText: {
+        parameters: { type: "object" },
+        handler: () => "42",
+      },
     },
   });
   const connecting = host.connect("ws://example.test", "not-forwarded", "session");
@@ -26,7 +30,7 @@ test("browser host carries ordered frames and application tools", async () => {
   assert.equal(JSON.parse(await host.next(1, 10)).text, '{"type":"two"}');
 
   const execution = JSON.parse(await host.executeCode(
-    "text(await tools.double({ value: 21 }));",
+    "text(await tools.double({ value: 21 })); text(await tools.numericText({}));",
     "session",
     "call-exec",
   ));
@@ -34,6 +38,8 @@ test("browser host carries ordered frames and application tools", async () => {
   assert.match(JSON.stringify(execution.output), /42/);
   assert.equal(execution.nested_calls[0].name, "double");
   assert.equal(execution.nested_calls[0].call_id, "call-exec/code-1");
+  assert.equal(execution.nested_calls[0].structured_result, 42);
+  assert.equal(execution.nested_calls[1].structured_result, "42");
   assert.equal(Number.isSafeInteger(execution.nested_calls[0].started_after_ns), true);
   assert.ok(execution.nested_calls[0].started_after_ns >= 0);
   assert.equal(JSON.parse(host.toolDefinitions())[0].name, "double");
@@ -60,6 +66,7 @@ test("browser host directly dispatches tools without dynamic code evaluation", a
   ));
   assert.equal(result.success, true);
   assert.deepEqual(JSON.parse(result.output), { runtime: "worker", call_id: "call-1" });
+  assert.deepEqual(result.structured_result, { runtime: "worker", call_id: "call-1" });
 });
 
 test("browser host opens application sockets through MPP", async () => {

--- a/js/bindings/test/browser-host.test.mjs
+++ b/js/bindings/test/browser-host.test.mjs
@@ -69,7 +69,7 @@ test("browser host directly dispatches tools without dynamic code evaluation", a
   assert.deepEqual(result.structured_result, { runtime: "worker", call_id: "call-1" });
 });
 
-test("browser host reports non-JSON nested results as tool failures", async () => {
+test("browser host reports non-JSON tool results as failures", async () => {
   const host = createBrowserHost({
     tools: {
       bigint: {

--- a/js/bindings/test/browser-host.test.mjs
+++ b/js/bindings/test/browser-host.test.mjs
@@ -69,6 +69,30 @@ test("browser host directly dispatches tools without dynamic code evaluation", a
   assert.deepEqual(result.structured_result, { runtime: "worker", call_id: "call-1" });
 });
 
+test("browser host reports non-JSON nested results as tool failures", async () => {
+  const host = createBrowserHost({
+    tools: {
+      bigint: {
+        parameters: { type: "object" },
+        handler: () => 1n,
+      },
+    },
+  });
+  const execution = JSON.parse(await host.executeCode(
+    "try { await tools.bigint({}); } catch (error) { text(error.message); }",
+    "session",
+    "call-exec",
+  ));
+
+  assert.equal(execution.success, true);
+  assert.equal(execution.nested_calls[0].success, false);
+  assert.match(execution.nested_calls[0].structured_result, /JSON-serializable/);
+
+  const direct = JSON.parse(await host.executeTool("bigint", "{}"));
+  assert.equal(direct.success, false);
+  assert.match(direct.output, /JSON-serializable/);
+});
+
 test("browser host opens application sockets through MPP", async () => {
   const socket = new FakeWebSocket("wss://paid.test");
   socket.readyState = FakeWebSocket.OPEN;


### PR DESCRIPTION
## Summary

- Keep the model-visible `result` separate from the exact machine-readable `structured_result`, emitted universally across direct, nested, native, hosted, and JS/WASM paths.
- Make the Nanocodex and Tact TUIs consume `structured_result`.
- Apply this as a hard rename with no `code_mode_value` aliases.

## Validation

- Rust tests, Clippy, and rustfmt.
- Full JavaScript/WASM bindings test suite.

Closes #166