### PR TITLE
chore(release): prepare 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Prepare 0.5.0
 - [eval] Remove deprecated Python Harbor stack
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,54 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12
+
+### Bug Fixes
+
+- [update] Retry transient asset downloads
+- [tui] Handle terminal input as shell output
+- [events] Preserve structured results universally
+- [events] Retain structured nested tool results
+- [oai] Drop notifications orphaned by compaction
+- [eval] Keep neural waits within one tool call
+- [eval] Allow per-attempt evidence directories
+- [eval] Admit only missing neural workers
+- [eval] Disable browser in neural controller
+- [eval] Scope neural occupancy to its board
+
+### Features
+
+- [eval] Isolate workers in a systemd slice
+
+### Miscellaneous Tasks
+
+- [eval] Remove deprecated Python Harbor stack
+
+### Other
+
+- Merge pull request [#167](https://github.com/gakonst/nanocodex/issues/167) from clabby/cl/structured-events
+- :broom:
+- Merge pull request [#168](https://github.com/gakonst/nanocodex/issues/168) from clabby/cl/fix-orphaned-notifs
+- Merge pull request [#161](https://github.com/gakonst/nanocodex/issues/161) from gakonst/agent/simple-neural-eval-runtime
+- Merge pull request [#162](https://github.com/gakonst/nanocodex/issues/162) from gakonst/agent/remove-python-harbor
+
+### Refactor
+
+- [eval] Combine neural wait and observation
+- [eval] Own canonical task execution
+- [eval] Strip neural controller tools
+- [eval] Name workers as systemd instances
+- [eval] Replace compiled supervisor with neural control
+- [eval] Remove obsolete ledger migrations
+
 ## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11
 
 ### Bug Fixes
 
+- [http] Initialize rustls at client boundaries
+- [eval] Initialize rustls clients
+- [egress] Install rustls provider
+- [release] Normalize colored dependency trees
 - [ci] Stabilize process timing tests
 - [eval] Extract GPQA archive in process
 - [eval] Select the pinned Arena-Hard smoke case
@@ -227,6 +271,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- Exclude nanocodex-bin tests
+- [release] Refresh 0.4.0 changelogs
 - [release] Prepare 0.4.0
 - [eval] Update Harbor adapter lockfile
 - Update JavaScript package size budget
@@ -238,6 +284,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
+- Merge pull request [#160](https://github.com/gakonst/nanocodex/issues/160) from gakonst/release/v0.4.0
 - Merge pull request [#127](https://github.com/gakonst/nanocodex/issues/127) from gakonst/feat/simplify-workflow
 - Merge pull request [#157](https://github.com/gakonst/nanocodex/issues/157) from gakonst/feat/eval-adapter-external-v2
 - Merge pull request [#156](https://github.com/gakonst/nanocodex/issues/156) from gakonst/feat/eval-adapter-openai-evals-v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5123,7 +5123,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "nanocodex-agent",
  "nanocodex-oai-api",
@@ -5135,7 +5135,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-agent"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-bin"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "alloy-primitives",
  "arboard",
@@ -5223,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-browser"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -5256,7 +5256,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-egress"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-eval"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arcbox-ext4",
  "axum",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-eval-adapters"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64",
  "csv",
@@ -5337,7 +5337,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-examples"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "dotenvy",
  "eyre",
@@ -5360,7 +5360,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-exe-dev"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "axum",
  "chrono",
@@ -5380,7 +5380,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-oai-api"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -5412,7 +5412,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-observability"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-python"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "nanocodex",
  "pyo3",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-tools"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-tools-macros"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5484,7 +5484,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-vm"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arcbox-ext4",
  "async-trait",
@@ -5516,7 +5516,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-voice"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cpal",
  "futures-util",
@@ -5531,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-wasm"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "js-sys",
  "nanocodex",
@@ -5544,7 +5544,7 @@ dependencies = [
 
 [[package]]
 name = "nanousd"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "alloy-primitives",
  "reqwest",
@@ -5557,7 +5557,7 @@ dependencies = [
 
 [[package]]
 name = "nanousd-api"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "alloy",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ default-members = ["crates/nanocodex"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.97"
 authors = ["Nanocodex Contributors"]
@@ -71,19 +71,19 @@ jiff = { version = "0.2.35", default-features = false, features = ["std", "tz-sy
 jsonschema = { version = "0.48.5", default-features = false }
 krun = { package = "libkrun", version = "=2.0.0-dev", git = "https://github.com/containers/libkrun", rev = "df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0", features = ["blk", "net"] }
 mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "3e37469bb19434982b433ae44ea8c713f7ea923a", default-features = false }
-nanocodex = { version = "0.4.0", path = "crates/nanocodex" }
-nanocodex-agent = { version = "0.4.0", path = "crates/nanocodex-agent" }
-nanocodex-browser = { version = "0.4.0", path = "crates/experimental/nanocodex-browser" }
-nanocodex-egress = { version = "0.4.0", path = "crates/experimental/nanocodex-egress" }
-nanocodex-voice = { version = "0.4.0", path = "crates/experimental/nanocodex-voice" }
-nanocodex-eval = { version = "0.4.0", path = "crates/experimental/nanocodex-eval" }
-nanocodex-eval-adapters = { version = "0.4.0", path = "crates/experimental/nanocodex-eval-adapters" }
-nanocodex-vm = { version = "0.4.0", path = "crates/experimental/nanocodex-vm" }
-nanocodex-oai-api = { version = "0.4.0", path = "crates/nanocodex-oai-api" }
-nanocodex-observability = { version = "0.4.0", path = "crates/nanocodex-observability" }
-nanocodex-tools = { version = "0.4.0", path = "crates/nanocodex-tools" }
-nanocodex-tools-macros = { version = "0.4.0", path = "crates/nanocodex-tools/macros" }
-nanousd = { version = "0.4.0", path = "bin/nanousd" }
+nanocodex = { version = "0.5.0", path = "crates/nanocodex" }
+nanocodex-agent = { version = "0.5.0", path = "crates/nanocodex-agent" }
+nanocodex-browser = { version = "0.5.0", path = "crates/experimental/nanocodex-browser" }
+nanocodex-egress = { version = "0.5.0", path = "crates/experimental/nanocodex-egress" }
+nanocodex-voice = { version = "0.5.0", path = "crates/experimental/nanocodex-voice" }
+nanocodex-eval = { version = "0.5.0", path = "crates/experimental/nanocodex-eval" }
+nanocodex-eval-adapters = { version = "0.5.0", path = "crates/experimental/nanocodex-eval-adapters" }
+nanocodex-vm = { version = "0.5.0", path = "crates/experimental/nanocodex-vm" }
+nanocodex-oai-api = { version = "0.5.0", path = "crates/nanocodex-oai-api" }
+nanocodex-observability = { version = "0.5.0", path = "crates/nanocodex-observability" }
+nanocodex-tools = { version = "0.5.0", path = "crates/nanocodex-tools" }
+nanocodex-tools-macros = { version = "0.5.0", path = "crates/nanocodex-tools/macros" }
+nanousd = { version = "0.5.0", path = "bin/nanousd" }
 oci-client = { version = "0.17.0", git = "https://github.com/gakonst/rust-oci-client", rev = "17c22ce8842e9275ef6bc11fa4eb58101a4abd7f", default-features = false, features = ["rustls-tls-no-provider"] }
 rand = "0.9.2"
 reflink-copy = "0.1.30"

--- a/bin/nanocodex/src/update.rs
+++ b/bin/nanocodex/src/update.rs
@@ -7,7 +7,7 @@ use std::{
 
 use clap::{Args, ValueHint};
 use eyre::{Context, Result, bail, eyre};
-use reqwest::{Client, Url, header};
+use reqwest::{Client, StatusCode, Url, header};
 use semver::Version;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -25,6 +25,8 @@ const NIGHTLY_RELEASE_API: &str =
     "https://api.github.com/repos/gakonst/nanocodex/releases/tags/nightly";
 const TAGGED_RELEASE_API: &str = "https://api.github.com/repos/gakonst/nanocodex/releases/tags";
 const CHECKSUMS_ASSET: &str = "SHA256SUMS";
+const DOWNLOAD_ATTEMPTS: usize = 5;
+const DOWNLOAD_RETRY_DELAY: Duration = Duration::from_millis(250);
 
 #[derive(Debug, Args)]
 pub(crate) struct Update {
@@ -277,17 +279,45 @@ fn report_activation(previous: &str, selected: &str, downloaded: bool) {
 }
 
 async fn download(client: &Client, asset: &ReleaseAsset) -> Result<Vec<u8>> {
-    client
-        .get(asset.download_url()?)
-        .send()
-        .await
-        .wrap_err_with(|| format!("failed to download {}", asset.name))?
-        .error_for_status()
-        .wrap_err_with(|| format!("GitHub rejected the {} download", asset.name))?
-        .bytes()
-        .await
-        .wrap_err_with(|| format!("failed to read {}", asset.name))
-        .map(|bytes| bytes.to_vec())
+    let url = asset.download_url()?;
+    for attempt in 0..DOWNLOAD_ATTEMPTS {
+        let result: reqwest::Result<Vec<u8>> = async {
+            let response = client.get(url.clone()).send().await?.error_for_status()?;
+            Ok(response.bytes().await?.to_vec())
+        }
+        .await;
+
+        match result {
+            Ok(contents) => return Ok(contents),
+            Err(error) if attempt + 1 < DOWNLOAD_ATTEMPTS && retryable_download_error(&error) => {
+                tokio::time::sleep(DOWNLOAD_RETRY_DELAY.saturating_mul(1 << attempt)).await;
+            }
+            Err(error) => {
+                return Err(error).wrap_err_with(|| {
+                    format!(
+                        "failed to download {} after {} attempt{}",
+                        asset.name,
+                        attempt + 1,
+                        if attempt == 0 { "" } else { "s" }
+                    )
+                });
+            }
+        }
+    }
+
+    unreachable!("the download attempt loop always returns")
+}
+
+fn retryable_download_error(error: &reqwest::Error) -> bool {
+    error.status().is_none_or(retryable_download_status)
+}
+
+fn retryable_download_status(status: StatusCode) -> bool {
+    status.is_server_error()
+        || matches!(
+            status,
+            StatusCode::REQUEST_TIMEOUT | StatusCode::TOO_MANY_REQUESTS
+        )
 }
 
 fn parse_release_version(tag: &str) -> Result<Version> {
@@ -452,5 +482,13 @@ mod tests {
             asset.download_url().unwrap().as_str(),
             "https://github.com/gakonst/nanocodex/releases/download/nightly/SHA256SUMS?asset_id=496045871"
         );
+    }
+
+    #[test]
+    fn retries_only_transient_download_statuses() {
+        assert!(retryable_download_status(StatusCode::REQUEST_TIMEOUT));
+        assert!(retryable_download_status(StatusCode::TOO_MANY_REQUESTS));
+        assert!(retryable_download_status(StatusCode::SERVICE_UNAVAILABLE));
+        assert!(!retryable_download_status(StatusCode::NOT_FOUND));
     }
 }

--- a/crates/experimental/nanocodex-vm/Cargo.toml
+++ b/crates/experimental/nanocodex-vm/Cargo.toml
@@ -40,7 +40,7 @@ guest-runtime = ["dep:nix", "nanocodex-tools/workspace-runtime"]
 [dependencies]
 base64.workspace = true
 filetime.workspace = true
-nanocodex-tools = { path = "../../nanocodex-tools", version = "0.4.0", default-features = false }
+nanocodex-tools = { path = "../../nanocodex-tools", version = "0.5.0", default-features = false }
 nix = { workspace = true, optional = true, features = ["fs", "mount"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/nanocodex-agent/CHANGELOG.md
+++ b/crates/nanocodex-agent/CHANGELOG.md
@@ -5,10 +5,22 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12
+
+### Bug Fixes
+
+- [events] Preserve structured results universally
+- [events] Retain structured nested tool results
+
+### Other
+
+- Merge pull request [#167](https://github.com/gakonst/nanocodex/issues/167) from clabby/cl/structured-events
+
 ## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11
 
 ### Bug Fixes
 
+- [http] Initialize rustls at client boundaries
 - [eval] Preserve same-role benchmark messages
 - [ci] Preserve typed prompt consumer contracts
 - Close remaining Codex wire parity gaps
@@ -33,10 +45,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.4.0 changelogs
 - [release] Prepare 0.4.0
 
 ### Other
 
+- Merge pull request [#160](https://github.com/gakonst/nanocodex/issues/160) from gakonst/release/v0.4.0
 - Merge pull request [#142](https://github.com/gakonst/nanocodex/issues/142) from gakonst/feat/eval-adapter-foundation
 - Merge pull request [#124](https://github.com/gakonst/nanocodex/issues/124) from gakonst/fix/codex-parity-current
 - Merge pull request [#122](https://github.com/gakonst/nanocodex/issues/122) from Giulio2002/feat/resume-session-picker

--- a/crates/nanocodex-agent/CHANGELOG.md
+++ b/crates/nanocodex-agent/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [events] Preserve structured results universally
 - [events] Retain structured nested tool results
 
+### Miscellaneous Tasks
+
+- [release] Prepare 0.5.0
+
 ### Other
 
 - Merge pull request [#167](https://github.com/gakonst/nanocodex/issues/167) from clabby/cl/structured-events

--- a/crates/nanocodex-oai-api/CHANGELOG.md
+++ b/crates/nanocodex-oai-api/CHANGELOG.md
@@ -5,10 +5,26 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12
+
+### Bug Fixes
+
+- [tui] Handle terminal input as shell output
+- [events] Preserve structured results universally
+- [events] Retain structured nested tool results
+- [oai] Drop notifications orphaned by compaction
+
+### Other
+
+- Merge pull request [#167](https://github.com/gakonst/nanocodex/issues/167) from clabby/cl/structured-events
+- :broom:
+- Merge pull request [#168](https://github.com/gakonst/nanocodex/issues/168) from clabby/cl/fix-orphaned-notifs
+
 ## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11
 
 ### Bug Fixes
 
+- [http] Initialize rustls at client boundaries
 - [oai] Allow long silent response generations
 - [eval] Preserve same-role benchmark messages
 - [eval] Recover cleanly from worker infrastructure failures
@@ -35,10 +51,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.4.0 changelogs
 - [release] Prepare 0.4.0
 
 ### Other
 
+- Merge pull request [#160](https://github.com/gakonst/nanocodex/issues/160) from gakonst/release/v0.4.0
 - Merge pull request [#142](https://github.com/gakonst/nanocodex/issues/142) from gakonst/feat/eval-adapter-foundation
 - Merge pull request [#139](https://github.com/gakonst/nanocodex/issues/139) from gakonst/fix/websocket-403-fallback
 - Merge pull request [#124](https://github.com/gakonst/nanocodex/issues/124) from gakonst/fix/codex-parity-current

--- a/crates/nanocodex-oai-api/CHANGELOG.md
+++ b/crates/nanocodex-oai-api/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [events] Retain structured nested tool results
 - [oai] Drop notifications orphaned by compaction
 
+### Miscellaneous Tasks
+
+- [release] Prepare 0.5.0
+
 ### Other
 
 - Merge pull request [#167](https://github.com/gakonst/nanocodex/issues/167) from clabby/cl/structured-events

--- a/crates/nanocodex-observability/CHANGELOG.md
+++ b/crates/nanocodex-observability/CHANGELOG.md
@@ -18,10 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.4.0 changelogs
 - [release] Prepare 0.4.0
 
 ### Other
 
+- Merge pull request [#160](https://github.com/gakonst/nanocodex/issues/160) from gakonst/release/v0.4.0
 - Merge pull request [#86](https://github.com/gakonst/nanocodex/issues/86) from gakonst/fix/ring-only-rustls
 - Merge pull request [#80](https://github.com/gakonst/nanocodex/issues/80) from clabby/cl/luna
 

--- a/crates/nanocodex-observability/CHANGELOG.md
+++ b/crates/nanocodex-observability/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12
+
+### Miscellaneous Tasks
+
+- [release] Prepare 0.5.0
+
 ## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11
 
 ### Bug Fixes

--- a/crates/nanocodex-tools/CHANGELOG.md
+++ b/crates/nanocodex-tools/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [events] Preserve structured results universally
 - [events] Retain structured nested tool results
 
+### Miscellaneous Tasks
+
+- [release] Prepare 0.5.0
+
 ### Other
 
 - Merge pull request [#167](https://github.com/gakonst/nanocodex/issues/167) from clabby/cl/structured-events

--- a/crates/nanocodex-tools/CHANGELOG.md
+++ b/crates/nanocodex-tools/CHANGELOG.md
@@ -5,10 +5,24 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12
+
+### Bug Fixes
+
+- [tui] Handle terminal input as shell output
+- [events] Preserve structured results universally
+- [events] Retain structured nested tool results
+
+### Other
+
+- Merge pull request [#167](https://github.com/gakonst/nanocodex/issues/167) from clabby/cl/structured-events
+- :broom:
+
 ## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11
 
 ### Bug Fixes
 
+- [http] Initialize rustls at client boundaries
 - [browser] Keep deferred schema lookup private
 - [tools] Restore stock Codex code mode parity
 - Close remaining Codex wire parity gaps
@@ -30,10 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.4.0 changelogs
 - [release] Prepare 0.4.0
 
 ### Other
 
+- Merge pull request [#160](https://github.com/gakonst/nanocodex/issues/160) from gakonst/release/v0.4.0
 - Merge pull request [#124](https://github.com/gakonst/nanocodex/issues/124) from gakonst/fix/codex-parity-current
 - Merge pull request [#95](https://github.com/gakonst/nanocodex/issues/95) from gakonst/agent/pr61-code-mode
 - Merge pull request [#75](https://github.com/gakonst/nanocodex/issues/75) from gakonst/feat/wasm-host-transport

--- a/crates/nanocodex-tools/Cargo.toml
+++ b/crates/nanocodex-tools/Cargo.toml
@@ -46,7 +46,7 @@ native = [
 ]
 
 [dependencies]
-nanocodex-oai-api = { path = "../nanocodex-oai-api", version = "0.4.0", default-features = false }
+nanocodex-oai-api = { path = "../nanocodex-oai-api", version = "0.5.0", default-features = false }
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/nanocodex-tools/macros/CHANGELOG.md
+++ b/crates/nanocodex-tools/macros/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12
+
+### Miscellaneous Tasks
+
+- [release] Prepare 0.5.0
+
 ## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11
 
 ### Miscellaneous Tasks

--- a/crates/nanocodex-tools/macros/CHANGELOG.md
+++ b/crates/nanocodex-tools/macros/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.4.0 changelogs
 - [release] Prepare 0.4.0
+
+### Other
+
+- Merge pull request [#160](https://github.com/gakonst/nanocodex/issues/160) from gakonst/release/v0.4.0
 
 ## [0.3.0](https://github.com/gakonst/nanocodex/releases/tag/v0.3.0) - 2026-07-28
 

--- a/crates/nanocodex/CHANGELOG.md
+++ b/crates/nanocodex/CHANGELOG.md
@@ -22,10 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.4.0 changelogs
 - [release] Prepare 0.4.0
 
 ### Other
 
+- Merge pull request [#160](https://github.com/gakonst/nanocodex/issues/160) from gakonst/release/v0.4.0
 - Merge pull request [#119](https://github.com/gakonst/nanocodex/issues/119) from gakonst/feat/exe-dev-spike
 - Merge pull request [#121](https://github.com/gakonst/nanocodex/issues/121) from Slokh/kartik/upstream-contributions
 - Merge pull request [#95](https://github.com/gakonst/nanocodex/issues/95) from gakonst/agent/pr61-code-mode

--- a/crates/nanocodex/CHANGELOG.md
+++ b/crates/nanocodex/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12
+
+### Miscellaneous Tasks
+
+- [release] Prepare 0.5.0
+
 ## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11
 
 ### Bug Fixes

--- a/examples/browser-cdn/index.html
+++ b/examples/browser-cdn/index.html
@@ -20,7 +20,7 @@
     <output id="result">Ready.</output>
 
     <script type="module">
-      import { Agent } from "https://cdn.jsdelivr.net/npm/nanocodex@0.4.0/browser/index.mjs";
+      import { Agent } from "https://cdn.jsdelivr.net/npm/nanocodex@0.5.0/browser/index.mjs";
 
       const form = document.querySelector("#prompt-form");
       const prompt = document.querySelector("#prompt");

--- a/examples/cloudflare-workers/package-lock.json
+++ b/examples/cloudflare-workers/package-lock.json
@@ -25,7 +25,7 @@
     },
     "../../js/bindings": {
       "name": "nanocodex",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../js/bindings": {
       "name": "nanocodex",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"

--- a/examples/react-vite/package-lock.json
+++ b/examples/react-vite/package-lock.json
@@ -30,7 +30,7 @@
     },
     "../../js/bindings": {
       "name": "nanocodex",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"

--- a/examples/rivet-actors/package-lock.json
+++ b/examples/rivet-actors/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../../js/bindings": {
       "name": "nanocodex",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"

--- a/examples/vercel-workflows/package-lock.json
+++ b/examples/vercel-workflows/package-lock.json
@@ -32,7 +32,7 @@
     },
     "../../js/bindings": {
       "name": "nanocodex",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"

--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -286,7 +286,7 @@ manager or build step:
 
 ```html
 <script type="module">
-  import { Agent } from "https://cdn.jsdelivr.net/npm/nanocodex@0.4.0/browser/index.mjs";
+  import { Agent } from "https://cdn.jsdelivr.net/npm/nanocodex@0.5.0/browser/index.mjs";
   const agent = await Agent.create({ websocketUrl: "/api/responses" });
   const turn = agent.turn.prompt({ input: "Hello." });
   try {

--- a/js/bindings/package-lock.json
+++ b/js/bindings/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nanocodex",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nanocodex",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"

--- a/js/bindings/package.json
+++ b/js/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nanocodex",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Viem-style Node and browser bindings for the Nanocodex WASM agent",
   "type": "module",
   "sideEffects": false,

--- a/js/react/package-lock.json
+++ b/js/react/package-lock.json
@@ -16,13 +16,13 @@
         "node": ">=22.13.0"
       },
       "peerDependencies": {
-        "nanocodex": "^0.4.0",
+        "nanocodex": "^0.5.0",
         "react": ">=18"
       }
     },
     "../bindings": {
       "name": "nanocodex",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {

--- a/js/react/package.json
+++ b/js/react/package.json
@@ -28,7 +28,7 @@
     "test": "node --test test/*.test.mjs && npm run check:package && npm run check:pack"
   },
   "peerDependencies": {
-    "nanocodex": "^0.4.0",
+    "nanocodex": "^0.5.0",
     "react": ">=18"
   },
   "devDependencies": {

--- a/js/tui-react/package-lock.json
+++ b/js/tui-react/package-lock.json
@@ -47,7 +47,7 @@
         "node": ">=22.13.0"
       },
       "peerDependencies": {
-        "nanocodex": "^0.4.0",
+        "nanocodex": "^0.5.0",
         "react": ">=18"
       }
     },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -50,7 +50,7 @@
     },
     "../js/bindings": {
       "name": "nanocodex",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"
@@ -75,7 +75,7 @@
         "node": ">=22.13.0"
       },
       "peerDependencies": {
-        "nanocodex": "^0.4.0",
+        "nanocodex": "^0.5.0",
         "react": ">=18"
       }
     },


### PR DESCRIPTION
Prepare the v0.5.0 synchronized crate, npm, Python, binary, and harness release from current master.

- retry transient GitHub release asset download failures
- bump the workspace and internal dependency requirements to 0.5.0
- refresh JavaScript package/consumer versions and lockfiles
- regenerate root and per-crate changelogs
- use the required pre-1.0 minor bump for the new public structured-result fields

Validated with `cargo +1.97 semver-checks`, `just release-check 0.5.0`, and the complete `just check` gate on the equivalent release tree.