### PR TITLE
chore(release): prepare 0.5.1

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,9 +67,16 @@ jobs:
               --target ${{ matrix.target }}
       - name: Stage artifact
         shell: bash
+        env:
+          PR_NUMBER: ${{ inputs.pr }}
         run: |
           mkdir dist
-          cp "target/${{ matrix.target }}/nightly/nanocodex" "dist/${{ matrix.artifact }}"
+          if [[ -n "$PR_NUMBER" ]]; then
+            cp "target/${{ matrix.target }}/nightly/nanocodex" "dist/${{ matrix.artifact }}"
+          else
+            gzip -n -9 -c "target/${{ matrix.target }}/nightly/nanocodex" \
+              > "dist/${{ matrix.artifact }}.gz"
+          fi
       - name: Stage PR provenance and checksum
         if: github.event_name == 'workflow_dispatch' && inputs.pr != ''
         shell: bash
@@ -112,7 +119,7 @@ jobs:
         shell: bash
         run: |
           cd dist
-          sha256sum nanocodex-* > SHA256SUMS
+          sha256sum nanocodex-*.gz > SHA256SUMS
       - name: Publish immutable and rolling releases
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,8 @@ jobs:
         shell: bash
         run: |
           mkdir dist
-          cp "target/${{ matrix.target }}/release/nanocodex" "dist/${{ matrix.artifact }}"
+          gzip -n -9 -c "target/${{ matrix.target }}/release/nanocodex" \
+            > "dist/${{ matrix.artifact }}.gz"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.artifact }}
@@ -254,7 +255,7 @@ jobs:
         shell: bash
         run: |
           cd dist
-          sha256sum nanocodex-* > SHA256SUMS
+          sha256sum nanocodex-*.gz > SHA256SUMS
       - name: Upload binary assets to draft release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,27 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.5.1](https://github.com/gakonst/nanocodex/releases/tag/v0.5.1) - 2026-08-14
 
 ### Bug Fixes
 
-- [cli] Fall back to another installed Chromium-family browser when the default
-  Brave installation is absent, or omit browser tools when none is available,
-  while keeping explicit browser selection strict.
+- [update] Download release assets through API
+- [mcp] Harden OAuth token refresh
+- [tui] Preserve colors under NO_COLOR
+- [cli] Tolerate missing default browser
+
+### Documentation
+
+- [eval] Define canonical host workflow
+
+### Other
+
+- Merge pull request [#138](https://github.com/gakonst/nanocodex/issues/138) from Giulio2002/fix/browser-missing-brave
+- Merge pull request [#163](https://github.com/gakonst/nanocodex/issues/163) from gakonst/agent/document-dev-georgios-workflow
+
+### Performance
+
+- [distribution] Ship gzip-compressed binaries
 
 ## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12
 
@@ -34,11 +48,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.5.0 changelogs
 - [release] Prepare 0.5.0
 - [eval] Remove deprecated Python Harbor stack
 
 ### Other
 
+- Merge pull request [#169](https://github.com/gakonst/nanocodex/issues/169) from gakonst/release/0.5.0
 - Merge pull request [#167](https://github.com/gakonst/nanocodex/issues/167) from clabby/cl/structured-events
 - :broom:
 - Merge pull request [#168](https://github.com/gakonst/nanocodex/issues/168) from clabby/cl/fix-orphaned-notifs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [eval] Define canonical host workflow
 
+### Miscellaneous Tasks
+
+- [release] Prepare 0.5.1
+
 ### Other
 
 - Merge pull request [#138](https://github.com/gakonst/nanocodex/issues/138) from Giulio2002/fix/browser-missing-brave

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [eval] Define canonical host workflow
 
+### Features
+
+- [update] Show download progress
+
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.5.1 changelogs
 - [release] Prepare 0.5.1
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "nanocodex-agent",
  "nanocodex-oai-api",
@@ -5141,7 +5141,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-agent"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5169,7 +5169,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-bin"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "alloy-primitives",
  "arboard",
@@ -5182,6 +5182,7 @@ dependencies = [
  "crossterm",
  "dotenvy",
  "eyre",
+ "flate2",
  "fs2",
  "futures-util",
  "hex",
@@ -5229,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-browser"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5262,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-egress"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -5284,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-eval"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arcbox-ext4",
  "axum",
@@ -5321,7 +5322,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-eval-adapters"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64 0.22.1",
  "csv",
@@ -5343,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-examples"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "dotenvy",
  "eyre",
@@ -5366,7 +5367,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-exe-dev"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "axum",
  "chrono",
@@ -5386,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-oai-api"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5418,7 +5419,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-observability"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5436,7 +5437,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-python"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "nanocodex",
  "pyo3",
@@ -5447,7 +5448,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-tools"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5480,7 +5481,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-tools-macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -5490,7 +5491,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-vm"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "arcbox-ext4",
  "async-trait",
@@ -5522,7 +5523,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-voice"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "cpal",
  "futures-util",
@@ -5537,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "nanocodex-wasm"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "js-sys",
  "nanocodex",
@@ -5550,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "nanousd"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "alloy-primitives",
  "reqwest",
@@ -5563,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "nanousd-api"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "alloy",
  "alloy-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2147,6 +2147,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width 0.2.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3048,6 +3060,12 @@ checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enum-ordinalize"
@@ -4233,6 +4251,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width 0.2.0",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5188,6 +5219,7 @@ dependencies = [
  "hex",
  "ignore",
  "image",
+ "indicatif",
  "jsonschema",
  "mpp",
  "nanocodex",
@@ -9875,6 +9907,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ http-body-util = "0.1.3"
 hmac = "0.13.0"
 hudsucker = { version = "0.25.0", git = "https://github.com/gakonst/hudsucker", rev = "9a13609adc4b37b3e7fba28a320546bf672f0f4d", default-features = false, features = ["rcgen-ca", "ring", "rustls-client"] }
 ignore = "0.4.31"
+indicatif = "0.18"
 jiff = { version = "0.2.35", default-features = false, features = ["std", "tz-system", "tzdb-zoneinfo"] }
 jsonschema = { version = "0.48.5", default-features = false }
 krun = { package = "libkrun", version = "=2.0.0-dev", git = "https://github.com/containers/libkrun", rev = "df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0", features = ["blk", "net"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ default-members = ["crates/nanocodex"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 rust-version = "1.97"
 authors = ["Nanocodex Contributors"]
@@ -71,19 +71,19 @@ jiff = { version = "0.2.35", default-features = false, features = ["std", "tz-sy
 jsonschema = { version = "0.48.5", default-features = false }
 krun = { package = "libkrun", version = "=2.0.0-dev", git = "https://github.com/containers/libkrun", rev = "df85b8b75f55e8ef1b06b5bc18f08dc6d7b5aeb0", features = ["blk", "net"] }
 mpp = { version = "=0.11.0", git = "https://github.com/tempoxyz/mpp-rs", rev = "3e37469bb19434982b433ae44ea8c713f7ea923a", default-features = false }
-nanocodex = { version = "0.5.0", path = "crates/nanocodex" }
-nanocodex-agent = { version = "0.5.0", path = "crates/nanocodex-agent" }
-nanocodex-browser = { version = "0.5.0", path = "crates/experimental/nanocodex-browser" }
-nanocodex-egress = { version = "0.5.0", path = "crates/experimental/nanocodex-egress" }
-nanocodex-voice = { version = "0.5.0", path = "crates/experimental/nanocodex-voice" }
-nanocodex-eval = { version = "0.5.0", path = "crates/experimental/nanocodex-eval" }
-nanocodex-eval-adapters = { version = "0.5.0", path = "crates/experimental/nanocodex-eval-adapters" }
-nanocodex-vm = { version = "0.5.0", path = "crates/experimental/nanocodex-vm" }
-nanocodex-oai-api = { version = "0.5.0", path = "crates/nanocodex-oai-api" }
-nanocodex-observability = { version = "0.5.0", path = "crates/nanocodex-observability" }
-nanocodex-tools = { version = "0.5.0", path = "crates/nanocodex-tools" }
-nanocodex-tools-macros = { version = "0.5.0", path = "crates/nanocodex-tools/macros" }
-nanousd = { version = "0.5.0", path = "bin/nanousd" }
+nanocodex = { version = "0.5.1", path = "crates/nanocodex" }
+nanocodex-agent = { version = "0.5.1", path = "crates/nanocodex-agent" }
+nanocodex-browser = { version = "0.5.1", path = "crates/experimental/nanocodex-browser" }
+nanocodex-egress = { version = "0.5.1", path = "crates/experimental/nanocodex-egress" }
+nanocodex-voice = { version = "0.5.1", path = "crates/experimental/nanocodex-voice" }
+nanocodex-eval = { version = "0.5.1", path = "crates/experimental/nanocodex-eval" }
+nanocodex-eval-adapters = { version = "0.5.1", path = "crates/experimental/nanocodex-eval-adapters" }
+nanocodex-vm = { version = "0.5.1", path = "crates/experimental/nanocodex-vm" }
+nanocodex-oai-api = { version = "0.5.1", path = "crates/nanocodex-oai-api" }
+nanocodex-observability = { version = "0.5.1", path = "crates/nanocodex-observability" }
+nanocodex-tools = { version = "0.5.1", path = "crates/nanocodex-tools" }
+nanocodex-tools-macros = { version = "0.5.1", path = "crates/nanocodex-tools/macros" }
+nanousd = { version = "0.5.1", path = "bin/nanousd" }
 oci-client = { version = "0.17.0", git = "https://github.com/gakonst/rust-oci-client", rev = "17c22ce8842e9275ef6bc11fa4eb58101a4abd7f", default-features = false, features = ["rustls-tls-no-provider"] }
 rand = "0.9.2"
 reflink-copy = "0.1.30"

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -38,6 +38,7 @@ crossterm.workspace = true
 dotenvy.workspace = true
 eyre.workspace = true
 fs2.workspace = true
+flate2.workspace = true
 futures-util.workspace = true
 hex.workspace = true
 image.workspace = true

--- a/bin/nanocodex/Cargo.toml
+++ b/bin/nanocodex/Cargo.toml
@@ -42,6 +42,7 @@ flate2.workspace = true
 futures-util.workspace = true
 hex.workspace = true
 image.workspace = true
+indicatif.workspace = true
 jsonschema.workspace = true
 nanocodex.workspace = true
 nanocodex-browser.workspace = true

--- a/bin/nanocodex/src/update.rs
+++ b/bin/nanocodex/src/update.rs
@@ -9,6 +9,8 @@ use std::{
 use clap::{Args, ValueHint};
 use eyre::{Context, Result, bail, eyre};
 use flate2::read::GzDecoder;
+use futures_util::StreamExt;
+use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::{Client, StatusCode, Url, header};
 use semver::Version;
 use serde::Deserialize;
@@ -162,9 +164,9 @@ impl Update {
         let asset_name = release_asset_name()?;
         let binary = find_asset(&release, &asset_name)?;
         let checksums = find_asset(&release, CHECKSUMS_ASSET)?;
-        let checksum_manifest = download(&client, checksums).await?;
+        let checksum_manifest = download(&client, checksums, false).await?;
         let expected = checksum_for(&checksum_manifest, &asset_name)?;
-        let archive = download(&client, binary).await?;
+        let archive = download(&client, binary, true).await?;
         let actual = hex::encode(Sha256::digest(&archive));
         if actual != expected {
             bail!("checksum mismatch for {asset_name}: expected {expected}, downloaded {actual}");
@@ -278,24 +280,20 @@ fn report_activation(previous: &str, selected: &str, downloaded: bool) {
     }
 }
 
-async fn download(client: &Client, asset: &ReleaseAsset) -> Result<Vec<u8>> {
+async fn download(client: &Client, asset: &ReleaseAsset, show_progress: bool) -> Result<Vec<u8>> {
     let url = asset.download_url()?;
+    if show_progress {
+        eprintln!("downloading {}...", asset.name);
+    }
     for attempt in 0..DOWNLOAD_ATTEMPTS {
-        let result: reqwest::Result<Vec<u8>> = async {
-            let response = client
-                .get(url.clone())
-                .header(header::ACCEPT, "application/octet-stream")
-                .header("X-GitHub-Api-Version", "2022-11-28")
-                .send()
-                .await?
-                .error_for_status()?;
-            Ok(response.bytes().await?.to_vec())
-        }
-        .await;
+        let result = download_once(client, url.clone(), show_progress).await;
 
         match result {
             Ok(contents) => return Ok(contents),
             Err(error) if attempt + 1 < DOWNLOAD_ATTEMPTS && retryable_download_error(&error) => {
+                if show_progress {
+                    eprintln!("download interrupted; retrying...");
+                }
                 tokio::time::sleep(DOWNLOAD_RETRY_DELAY.saturating_mul(1 << attempt)).await;
             }
             Err(error) => {
@@ -312,6 +310,61 @@ async fn download(client: &Client, asset: &ReleaseAsset) -> Result<Vec<u8>> {
     }
 
     unreachable!("the download attempt loop always returns")
+}
+
+async fn download_once(client: &Client, url: Url, show_progress: bool) -> reqwest::Result<Vec<u8>> {
+    let response = client
+        .get(url)
+        .header(header::ACCEPT, "application/octet-stream")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .send()
+        .await?
+        .error_for_status()?;
+    if !show_progress {
+        return Ok(response.bytes().await?.to_vec());
+    }
+
+    let progress = download_progress(response.content_length());
+    let mut contents = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        match chunk {
+            Ok(chunk) => {
+                progress.inc(chunk.len() as u64);
+                contents.extend_from_slice(&chunk);
+            }
+            Err(error) => {
+                progress.finish_and_clear();
+                return Err(error);
+            }
+        }
+    }
+    progress.finish_and_clear();
+    Ok(contents)
+}
+
+fn download_progress(total_size: Option<u64>) -> ProgressBar {
+    match total_size {
+        Some(size) => {
+            let progress = ProgressBar::new(size);
+            progress.set_style(
+                ProgressStyle::default_bar()
+                    .template("{spinner:.green} [{bar:40.cyan/blue}] {bytes}/{total_bytes} ({eta})")
+                    .expect("the download progress template is valid")
+                    .progress_chars("#>-"),
+            );
+            progress
+        }
+        None => {
+            let progress = ProgressBar::new_spinner();
+            progress.set_style(
+                ProgressStyle::default_spinner()
+                    .template("{spinner:.green} {bytes} downloaded")
+                    .expect("the download progress template is valid"),
+            );
+            progress
+        }
+    }
 }
 
 fn retryable_download_error(error: &reqwest::Error) -> bool {

--- a/bin/nanocodex/src/update.rs
+++ b/bin/nanocodex/src/update.rs
@@ -1,12 +1,14 @@
 use std::{
     borrow::Cow,
     fs,
+    io::Read,
     path::{Path, PathBuf},
     time::Duration,
 };
 
 use clap::{Args, ValueHint};
 use eyre::{Context, Result, bail, eyre};
+use flate2::read::GzDecoder;
 use reqwest::{Client, StatusCode, Url, header};
 use semver::Version;
 use serde::Deserialize;
@@ -27,6 +29,7 @@ const TAGGED_RELEASE_API: &str = "https://api.github.com/repos/gakonst/nanocodex
 const CHECKSUMS_ASSET: &str = "SHA256SUMS";
 const DOWNLOAD_ATTEMPTS: usize = 5;
 const DOWNLOAD_RETRY_DELAY: Duration = Duration::from_millis(250);
+const MAX_BINARY_BYTES: u64 = 256 * 1024 * 1024;
 
 #[derive(Debug, Args)]
 pub(crate) struct Update {
@@ -157,15 +160,16 @@ impl Update {
         }
 
         let asset_name = release_asset_name()?;
-        let binary = find_asset(&release, asset_name)?;
+        let binary = find_asset(&release, &asset_name)?;
         let checksums = find_asset(&release, CHECKSUMS_ASSET)?;
         let checksum_manifest = download(&client, checksums).await?;
-        let expected = checksum_for(&checksum_manifest, asset_name)?;
-        let contents = download(&client, binary).await?;
-        let actual = hex::encode(Sha256::digest(&contents));
+        let expected = checksum_for(&checksum_manifest, &asset_name)?;
+        let archive = download(&client, binary).await?;
+        let actual = hex::encode(Sha256::digest(&archive));
         if actual != expected {
             bail!("checksum mismatch for {asset_name}: expected {expected}, downloaded {actual}");
         }
+        let contents = decompress_release_asset(&archive, &asset_name)?;
 
         store.install(&key, &contents)?;
         store.activate(&key)?;
@@ -236,7 +240,7 @@ fn install_local_binary(path: &Path, store: &VersionStore, previous: &str) -> Re
 }
 
 async fn install_pr_binary(number: u64, store: &VersionStore, previous: &str) -> Result<()> {
-    let asset_name = release_asset_name()?;
+    let asset_name = binary_asset_name()?;
     let artifact = pr::download(number, asset_name).await?;
     let key = format!("pr-{number}-{}", artifact.head_sha);
     store.install(&key, &artifact.contents)?;
@@ -361,11 +365,15 @@ fn checksum_for(manifest: &[u8], asset_name: &str) -> Result<String> {
     bail!("SHA256SUMS does not contain {asset_name}")
 }
 
-fn release_asset_name() -> Result<&'static str> {
-    release_asset_name_for(std::env::consts::OS, std::env::consts::ARCH)
+fn release_asset_name() -> Result<String> {
+    Ok(format!("{}.gz", binary_asset_name()?))
 }
 
-fn release_asset_name_for(os: &str, arch: &str) -> Result<&'static str> {
+fn binary_asset_name() -> Result<&'static str> {
+    binary_asset_name_for(std::env::consts::OS, std::env::consts::ARCH)
+}
+
+fn binary_asset_name_for(os: &str, arch: &str) -> Result<&'static str> {
     match (os, arch) {
         ("linux", "x86_64") => Ok("nanocodex-x86_64-unknown-linux-gnu"),
         ("macos", "aarch64") => Ok("nanocodex-aarch64-apple-darwin"),
@@ -373,10 +381,24 @@ fn release_asset_name_for(os: &str, arch: &str) -> Result<&'static str> {
     }
 }
 
+fn decompress_release_asset(archive: &[u8], asset_name: &str) -> Result<Vec<u8>> {
+    let mut contents = Vec::new();
+    GzDecoder::new(archive)
+        .take(MAX_BINARY_BYTES + 1)
+        .read_to_end(&mut contents)
+        .wrap_err_with(|| format!("failed to decompress {asset_name}"))?;
+    if contents.len() as u64 > MAX_BINARY_BYTES {
+        bail!("decompressed {asset_name} exceeds the 256 MiB limit");
+    }
+    Ok(contents)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use clap::{Parser, Subcommand};
+    use flate2::{Compression, write::GzEncoder};
+    use std::io::Write;
 
     #[derive(Parser)]
     struct TestCli {
@@ -415,16 +437,16 @@ mod tests {
     #[test]
     fn publishes_only_linux_x86_64_and_apple_silicon_assets() {
         assert_eq!(
-            release_asset_name_for("linux", "x86_64").unwrap(),
+            binary_asset_name_for("linux", "x86_64").unwrap(),
             "nanocodex-x86_64-unknown-linux-gnu"
         );
         assert_eq!(
-            release_asset_name_for("macos", "aarch64").unwrap(),
+            binary_asset_name_for("macos", "aarch64").unwrap(),
             "nanocodex-aarch64-apple-darwin"
         );
-        assert!(release_asset_name_for("linux", "aarch64").is_err());
-        assert!(release_asset_name_for("macos", "x86_64").is_err());
-        assert!(release_asset_name_for("windows", "x86_64").is_err());
+        assert!(binary_asset_name_for("linux", "aarch64").is_err());
+        assert!(binary_asset_name_for("macos", "x86_64").is_err());
+        assert!(binary_asset_name_for("windows", "x86_64").is_err());
     }
 
     #[test]
@@ -468,6 +490,19 @@ mod tests {
     fn rejects_missing_and_malformed_checksums() {
         assert!(checksum_for(b"abcd  nanocodex-test\n", "nanocodex-test").is_err());
         assert!(checksum_for(b"", "nanocodex-test").is_err());
+    }
+
+    #[test]
+    fn decompresses_release_assets() {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
+        encoder.write_all(b"nanocodex binary").unwrap();
+        let archive = encoder.finish().unwrap();
+
+        assert_eq!(
+            decompress_release_asset(&archive, "nanocodex-test.gz").unwrap(),
+            b"nanocodex binary"
+        );
+        assert!(decompress_release_asset(b"not gzip", "nanocodex-test.gz").is_err());
     }
 
     #[test]

--- a/bin/nanocodex/src/update.rs
+++ b/bin/nanocodex/src/update.rs
@@ -73,18 +73,14 @@ struct Release {
 
 #[derive(Debug, Deserialize)]
 struct ReleaseAsset {
-    id: u64,
     name: String,
-    browser_download_url: String,
+    url: String,
 }
 
 impl ReleaseAsset {
     fn download_url(&self) -> Result<Url> {
-        let mut url = Url::parse(&self.browser_download_url)
-            .wrap_err_with(|| format!("GitHub returned an invalid URL for {}", self.name))?;
-        url.query_pairs_mut()
-            .append_pair("asset_id", &self.id.to_string());
-        Ok(url)
+        Url::parse(&self.url)
+            .wrap_err_with(|| format!("GitHub returned an invalid API URL for {}", self.name))
     }
 }
 
@@ -282,7 +278,13 @@ async fn download(client: &Client, asset: &ReleaseAsset) -> Result<Vec<u8>> {
     let url = asset.download_url()?;
     for attempt in 0..DOWNLOAD_ATTEMPTS {
         let result: reqwest::Result<Vec<u8>> = async {
-            let response = client.get(url.clone()).send().await?.error_for_status()?;
+            let response = client
+                .get(url.clone())
+                .header(header::ACCEPT, "application/octet-stream")
+                .header("X-GitHub-Api-Version", "2022-11-28")
+                .send()
+                .await?
+                .error_for_status()?;
             Ok(response.bytes().await?.to_vec())
         }
         .await;
@@ -469,18 +471,16 @@ mod tests {
     }
 
     #[test]
-    fn cache_busts_mutable_release_assets_with_their_identity() {
+    fn uses_the_immutable_release_asset_api_url() {
         let asset = ReleaseAsset {
-            id: 496_045_871,
             name: CHECKSUMS_ASSET.to_owned(),
-            browser_download_url:
-                "https://github.com/gakonst/nanocodex/releases/download/nightly/SHA256SUMS"
-                    .to_owned(),
+            url: "https://api.github.com/repos/gakonst/nanocodex/releases/assets/496045871"
+                .to_owned(),
         };
 
         assert_eq!(
             asset.download_url().unwrap().as_str(),
-            "https://github.com/gakonst/nanocodex/releases/download/nightly/SHA256SUMS?asset_id=496045871"
+            "https://api.github.com/repos/gakonst/nanocodex/releases/assets/496045871"
         );
     }
 

--- a/crates/experimental/nanocodex-vm/Cargo.toml
+++ b/crates/experimental/nanocodex-vm/Cargo.toml
@@ -40,7 +40,7 @@ guest-runtime = ["dep:nix", "nanocodex-tools/workspace-runtime"]
 [dependencies]
 base64.workspace = true
 filetime.workspace = true
-nanocodex-tools = { path = "../../nanocodex-tools", version = "0.5.0", default-features = false }
+nanocodex-tools = { path = "../../nanocodex-tools", version = "0.5.1", default-features = false }
 nix = { workspace = true, optional = true, features = ["fs", "mount"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/nanocodex-agent/CHANGELOG.md
+++ b/crates/nanocodex-agent/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1](https://github.com/gakonst/nanocodex/releases/tag/v0.5.1) - 2026-08-14
+
+### Miscellaneous Tasks
+
+- [release] Prepare 0.5.1
+
 ## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12
 
 ### Bug Fixes

--- a/crates/nanocodex-agent/CHANGELOG.md
+++ b/crates/nanocodex-agent/CHANGELOG.md
@@ -14,10 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.5.0 changelogs
 - [release] Prepare 0.5.0
 
 ### Other
 
+- Merge pull request [#169](https://github.com/gakonst/nanocodex/issues/169) from gakonst/release/0.5.0
 - Merge pull request [#167](https://github.com/gakonst/nanocodex/issues/167) from clabby/cl/structured-events
 
 ## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11

--- a/crates/nanocodex-agent/CHANGELOG.md
+++ b/crates/nanocodex-agent/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.5.1 changelogs
 - [release] Prepare 0.5.1
 
 ## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12

--- a/crates/nanocodex-oai-api/CHANGELOG.md
+++ b/crates/nanocodex-oai-api/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1](https://github.com/gakonst/nanocodex/releases/tag/v0.5.1) - 2026-08-14
+
+### Miscellaneous Tasks
+
+- [release] Prepare 0.5.1
+
 ## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12
 
 ### Bug Fixes

--- a/crates/nanocodex-oai-api/CHANGELOG.md
+++ b/crates/nanocodex-oai-api/CHANGELOG.md
@@ -16,10 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.5.0 changelogs
 - [release] Prepare 0.5.0
 
 ### Other
 
+- Merge pull request [#169](https://github.com/gakonst/nanocodex/issues/169) from gakonst/release/0.5.0
 - Merge pull request [#167](https://github.com/gakonst/nanocodex/issues/167) from clabby/cl/structured-events
 - :broom:
 - Merge pull request [#168](https://github.com/gakonst/nanocodex/issues/168) from clabby/cl/fix-orphaned-notifs

--- a/crates/nanocodex-oai-api/CHANGELOG.md
+++ b/crates/nanocodex-oai-api/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.5.1 changelogs
 - [release] Prepare 0.5.1
 
 ## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12

--- a/crates/nanocodex-observability/CHANGELOG.md
+++ b/crates/nanocodex-observability/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1](https://github.com/gakonst/nanocodex/releases/tag/v0.5.1) - 2026-08-14
+
+### Miscellaneous Tasks
+
+- [release] Prepare 0.5.1
+
 ## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12
 
 ### Miscellaneous Tasks

--- a/crates/nanocodex-observability/CHANGELOG.md
+++ b/crates/nanocodex-observability/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.5.0 changelogs
 - [release] Prepare 0.5.0
+
+### Other
+
+- Merge pull request [#169](https://github.com/gakonst/nanocodex/issues/169) from gakonst/release/0.5.0
 
 ## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11
 

--- a/crates/nanocodex-observability/CHANGELOG.md
+++ b/crates/nanocodex-observability/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.5.1 changelogs
 - [release] Prepare 0.5.1
 
 ## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12

--- a/crates/nanocodex-tools/CHANGELOG.md
+++ b/crates/nanocodex-tools/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1](https://github.com/gakonst/nanocodex/releases/tag/v0.5.1) - 2026-08-14
+
+### Bug Fixes
+
+- [mcp] Harden OAuth token refresh
+
 ## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12
 
 ### Bug Fixes
@@ -15,10 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.5.0 changelogs
 - [release] Prepare 0.5.0
 
 ### Other
 
+- Merge pull request [#169](https://github.com/gakonst/nanocodex/issues/169) from gakonst/release/0.5.0
 - Merge pull request [#167](https://github.com/gakonst/nanocodex/issues/167) from clabby/cl/structured-events
 - :broom:
 

--- a/crates/nanocodex-tools/CHANGELOG.md
+++ b/crates/nanocodex-tools/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.5.1 changelogs
 - [release] Prepare 0.5.1
 
 ## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12

--- a/crates/nanocodex-tools/CHANGELOG.md
+++ b/crates/nanocodex-tools/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [mcp] Harden OAuth token refresh
 
+### Miscellaneous Tasks
+
+- [release] Prepare 0.5.1
+
 ## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12
 
 ### Bug Fixes

--- a/crates/nanocodex-tools/Cargo.toml
+++ b/crates/nanocodex-tools/Cargo.toml
@@ -46,7 +46,7 @@ native = [
 ]
 
 [dependencies]
-nanocodex-oai-api = { path = "../nanocodex-oai-api", version = "0.5.0", default-features = false }
+nanocodex-oai-api = { path = "../nanocodex-oai-api", version = "0.5.1", default-features = false }
 serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true

--- a/crates/nanocodex-tools/macros/CHANGELOG.md
+++ b/crates/nanocodex-tools/macros/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1](https://github.com/gakonst/nanocodex/releases/tag/v0.5.1) - 2026-08-14
+
+### Miscellaneous Tasks
+
+- [release] Prepare 0.5.1
+
 ## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12
 
 ### Miscellaneous Tasks

--- a/crates/nanocodex-tools/macros/CHANGELOG.md
+++ b/crates/nanocodex-tools/macros/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.5.0 changelogs
 - [release] Prepare 0.5.0
+
+### Other
+
+- Merge pull request [#169](https://github.com/gakonst/nanocodex/issues/169) from gakonst/release/0.5.0
 
 ## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11
 

--- a/crates/nanocodex-tools/macros/CHANGELOG.md
+++ b/crates/nanocodex-tools/macros/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.5.1 changelogs
 - [release] Prepare 0.5.1
 
 ## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12

--- a/crates/nanocodex/CHANGELOG.md
+++ b/crates/nanocodex/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Nanocodex are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1](https://github.com/gakonst/nanocodex/releases/tag/v0.5.1) - 2026-08-14
+
+### Miscellaneous Tasks
+
+- [release] Prepare 0.5.1
+
 ## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12
 
 ### Miscellaneous Tasks

--- a/crates/nanocodex/CHANGELOG.md
+++ b/crates/nanocodex/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.5.0 changelogs
 - [release] Prepare 0.5.0
+
+### Other
+
+- Merge pull request [#169](https://github.com/gakonst/nanocodex/issues/169) from gakonst/release/0.5.0
 
 ## [0.4.0](https://github.com/gakonst/nanocodex/releases/tag/v0.4.0) - 2026-08-11
 

--- a/crates/nanocodex/CHANGELOG.md
+++ b/crates/nanocodex/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- [release] Refresh 0.5.1 changelogs
 - [release] Prepare 0.5.1
 
 ## [0.5.0](https://github.com/gakonst/nanocodex/releases/tag/v0.5.0) - 2026-08-12

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -8,8 +8,9 @@ Foundry's label-grouped, contributor-attributed GitHub release notes.
 
 The `Nightly Release` workflow runs daily and may also be dispatched manually.
 Each successful run publishes an immutable `nightly-<full SHA>` prerelease and
-refreshes the rolling `nightly` prerelease with the same binaries and
-`SHA256SUMS`. The rolling tag is what `nanocodex update --nightly` follows.
+refreshes the rolling `nightly` prerelease with the same gzip-compressed
+binaries and `SHA256SUMS`. The rolling tag is what
+`nanocodex update --nightly` follows.
 
 ## JavaScript package previews
 
@@ -117,7 +118,7 @@ The tag starts the release workflow. It:
 5. publishes the six crates to crates.io in dependency order;
 6. builds, tests, and publishes the Node/browser WASM package to npm with
    provenance;
-7. attaches the binaries and `SHA256SUMS` to the draft.
+7. attaches the gzip-compressed binaries and `SHA256SUMS` to the draft.
 
 Open the draft at <https://github.com/gakonst/nanocodex/releases>, inspect the
 notes, verify `SHA256SUMS`, and smoke-test a downloaded platform binary. Then

--- a/examples/browser-cdn/index.html
+++ b/examples/browser-cdn/index.html
@@ -20,7 +20,7 @@
     <output id="result">Ready.</output>
 
     <script type="module">
-      import { Agent } from "https://cdn.jsdelivr.net/npm/nanocodex@0.5.0/browser/index.mjs";
+      import { Agent } from "https://cdn.jsdelivr.net/npm/nanocodex@0.5.1/browser/index.mjs";
 
       const form = document.querySelector("#prompt-form");
       const prompt = document.querySelector("#prompt");

--- a/examples/cloudflare-workers/package-lock.json
+++ b/examples/cloudflare-workers/package-lock.json
@@ -25,7 +25,7 @@
     },
     "../../js/bindings": {
       "name": "nanocodex",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"

--- a/examples/node/package-lock.json
+++ b/examples/node/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../js/bindings": {
       "name": "nanocodex",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"

--- a/examples/react-vite/package-lock.json
+++ b/examples/react-vite/package-lock.json
@@ -30,7 +30,7 @@
     },
     "../../js/bindings": {
       "name": "nanocodex",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"

--- a/examples/rivet-actors/package-lock.json
+++ b/examples/rivet-actors/package-lock.json
@@ -27,7 +27,7 @@
     },
     "../../js/bindings": {
       "name": "nanocodex",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"

--- a/examples/vercel-workflows/package-lock.json
+++ b/examples/vercel-workflows/package-lock.json
@@ -32,7 +32,7 @@
     },
     "../../js/bindings": {
       "name": "nanocodex",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"

--- a/install
+++ b/install
@@ -26,7 +26,8 @@ case "$(uname -m)" in
     ;;
 esac
 
-asset="nanocodex-${architecture}-${platform}"
+binary="nanocodex-${architecture}-${platform}"
+asset="$binary.gz"
 temporary_dir="$(mktemp -d 2>/dev/null)" || {
   echo "nanocodex: failed to create a temporary directory" >&2
   exit 1
@@ -55,25 +56,39 @@ if [[ -z "$expected" ]]; then
   exit 1
 fi
 
-if command -v sha256sum >/dev/null 2>&1; then
-  actual="$(sha256sum "$temporary_dir/$asset" | awk '{ print $1 }')"
-elif command -v shasum >/dev/null 2>&1; then
-  actual="$(shasum -a 256 "$temporary_dir/$asset" | awk '{ print $1 }')"
-else
+if ! command -v gzip >/dev/null 2>&1; then
+  echo "nanocodex: gzip is required to unpack the download" >&2
+  exit 1
+fi
+if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
   echo "nanocodex: sha256sum or shasum is required to verify the download" >&2
   exit 1
 fi
 
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{ print $1 }'
+  else
+    shasum -a 256 "$1" | awk '{ print $1 }'
+  fi
+}
+
+actual="$(sha256_file "$temporary_dir/$asset")"
 if [[ "$actual" != "$expected" ]]; then
   echo "nanocodex: checksum mismatch for $asset" >&2
   exit 1
 fi
+if ! gzip -dc "$temporary_dir/$asset" > "$temporary_dir/$binary"; then
+  echo "nanocodex: failed to unpack $asset" >&2
+  exit 1
+fi
+binary_checksum="$(sha256_file "$temporary_dir/$binary")"
 
 version_dir="$versions_dir/$version"
 mkdir -p "$bin_dir" "$version_dir" "$updater_dir"
-install -m 755 "$temporary_dir/$asset" "$version_dir/nanocodex"
-printf '%s\n' "$actual" > "$version_dir/nanocodex.sha256"
-install -m 755 "$temporary_dir/$asset" "$updater_dir/nanocodex"
+install -m 755 "$temporary_dir/$binary" "$version_dir/nanocodex"
+printf '%s\n' "$binary_checksum" > "$version_dir/nanocodex.sha256"
+install -m 755 "$temporary_dir/$binary" "$updater_dir/nanocodex"
 
 ln -sfn "versions/$version" "$install_root/current"
 

--- a/install
+++ b/install
@@ -47,7 +47,8 @@ if [[ -z "$release_tag" || -z "$version" || "$version" == "$release_tag" ]]; the
   exit 1
 fi
 release_url="https://github.com/$repository/releases/download/$release_tag"
-curl --fail --silent --show-error --location "$release_url/$asset" --output "$temporary_dir/$asset"
+echo "Downloading $asset..."
+curl --fail --show-error --location --progress-bar "$release_url/$asset" --output "$temporary_dir/$asset"
 curl --fail --silent --show-error --location "$release_url/SHA256SUMS" --output "$temporary_dir/SHA256SUMS"
 
 expected="$(awk -v asset="$asset" '$2 == asset || $2 == "*" asset { print $1; exit }' "$temporary_dir/SHA256SUMS")"

--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -286,7 +286,7 @@ manager or build step:
 
 ```html
 <script type="module">
-  import { Agent } from "https://cdn.jsdelivr.net/npm/nanocodex@0.5.0/browser/index.mjs";
+  import { Agent } from "https://cdn.jsdelivr.net/npm/nanocodex@0.5.1/browser/index.mjs";
   const agent = await Agent.create({ websocketUrl: "/api/responses" });
   const turn = agent.turn.prompt({ input: "Hello." });
   try {

--- a/js/bindings/package-lock.json
+++ b/js/bindings/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nanocodex",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nanocodex",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"

--- a/js/bindings/package.json
+++ b/js/bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nanocodex",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Viem-style Node and browser bindings for the Nanocodex WASM agent",
   "type": "module",
   "sideEffects": false,

--- a/js/react/package-lock.json
+++ b/js/react/package-lock.json
@@ -16,13 +16,13 @@
         "node": ">=22.13.0"
       },
       "peerDependencies": {
-        "nanocodex": "^0.5.0",
+        "nanocodex": "^0.5.1",
         "react": ">=18"
       }
     },
     "../bindings": {
       "name": "nanocodex",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {

--- a/js/react/package.json
+++ b/js/react/package.json
@@ -28,7 +28,7 @@
     "test": "node --test test/*.test.mjs && npm run check:package && npm run check:pack"
   },
   "peerDependencies": {
-    "nanocodex": "^0.5.0",
+    "nanocodex": "^0.5.1",
     "react": ">=18"
   },
   "devDependencies": {

--- a/js/tui-react/package-lock.json
+++ b/js/tui-react/package-lock.json
@@ -47,7 +47,7 @@
         "node": ">=22.13.0"
       },
       "peerDependencies": {
-        "nanocodex": "^0.5.0",
+        "nanocodex": "^0.5.1",
         "react": ">=18"
       }
     },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -50,7 +50,7 @@
     },
     "../js/bindings": {
       "name": "nanocodex",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "ws": "^8.18.3"
@@ -75,7 +75,7 @@
         "node": ">=22.13.0"
       },
       "peerDependencies": {
-        "nanocodex": "^0.5.0",
+        "nanocodex": "^0.5.1",
         "react": ">=18"
       }
     },


### PR DESCRIPTION
## Summary

- download GitHub release assets through the reliable asset API
- distribute gzip-compressed native binaries only
- show Foundry-style progress for bootstrap installs and self-updates
- prepare the workspace, npm package, and changelogs for 0.5.1

## Validation

- `cargo +1.97.0 semver-checks`
- `RUSTUP_TOOLCHAIN=1.97.0 just release-check 0.5.1`
- `RUSTUP_TOOLCHAIN=1.97.0 just check`
- gzip round-trip comparison of the native binary