### PR TITLE
fix(browser): enable virtual passkeys by default

### DIFF
--- a/bin/nanocodex/src/browser.rs
+++ b/bin/nanocodex/src/browser.rs
@@ -4,7 +4,7 @@ use clap::{Args, ValueEnum};
 use eyre::{Result, WrapErr, eyre};
 use nanocodex_browser::{
     BraveSession, BraveSessionError, Browser, BrowserProfileKind, BrowserStorageState, BrowserTool,
-    FirefoxCookieSource, SafariCookieSource,
+    FirefoxCookieSource, SafariCookieSource, VirtualAuthenticator,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -131,7 +131,9 @@ impl BrowserArgs {
         else {
             return Ok(None);
         };
-        let mut builder = Browser::builder().file_root(workspace);
+        let mut builder = Browser::builder()
+            .file_root(workspace)
+            .virtual_authenticator(VirtualAuthenticator::platform_passkey());
         if let Some(executable) = launch.executable {
             builder = builder.executable(executable);
         }

--- a/crates/experimental/nanocodex-browser/README.md
+++ b/crates/experimental/nanocodex-browser/README.md
@@ -39,6 +39,12 @@ out of the model-facing tool prefix. A runnable version lives at
 `examples/browser_agent.rs`. Callers that deliberately want the eager schema
 can register the same value with `.tool(browser)`.
 
+`BrowserTool::new()`, `BrowserTool::with_executable(...)`, and the Nanocodex CLI
+install an isolated virtual platform authenticator by default, so passkey
+registration and sign-in work unattended inside the private browser session.
+Low-level `Browser::builder()` consumers retain explicit control through
+`.virtual_authenticator(...)`.
+
 For isolation, one non-cloneable VM owner keeps the disposable browser alive
 and gives the agent a tool handle:
 

--- a/crates/experimental/nanocodex-browser/src/lib.rs
+++ b/crates/experimental/nanocodex-browser/src/lib.rs
@@ -3687,6 +3687,10 @@ pub struct BrowserTool {
     backend: BrowserBackend,
 }
 
+fn browser_tool_builder() -> BrowserBuilder {
+    Browser::builder().virtual_authenticator(VirtualAuthenticator::platform_passkey())
+}
+
 impl BrowserTool {
     /// Creates an isolated in-process headless Chromium session.
     ///
@@ -3699,7 +3703,7 @@ impl BrowserTool {
     /// created. A missing Chrome or Chromium installation is reported by the
     /// first tool call.
     pub fn new() -> Result<Self, BrowserBuildError> {
-        Ok(Self::from_browser(Browser::new()?))
+        Ok(Self::from_browser(browser_tool_builder().build()?))
     }
 
     /// Creates a managed browser tool using an explicit Chromium executable.
@@ -3711,7 +3715,9 @@ impl BrowserTool {
     pub fn with_executable(
         executable: impl Into<std::path::PathBuf>,
     ) -> Result<Self, BrowserBuildError> {
-        Ok(Self::from_browser(Browser::with_executable(executable)?))
+        Ok(Self::from_browser(
+            browser_tool_builder().executable(executable).build()?,
+        ))
     }
 
     /// Wraps an existing browser handle as a Nanocodex tool.

--- a/crates/experimental/nanocodex-browser/src/tests.rs
+++ b/crates/experimental/nanocodex-browser/src/tests.rs
@@ -21,8 +21,16 @@ use super::{
     BrowserOriginStorage, BrowserPerformanceInsight, BrowserPostActionSnapshot, BrowserPseudoClass,
     BrowserReactEventKind, BrowserReducedMotion, BrowserRouteHeader, BrowserRouteResponse,
     BrowserStorageState, BrowserTarget, BrowserTool, BrowserViewport, BrowserWaitForSelectorState,
-    ReactDiagnostics, VirtualAuthenticator,
+    ReactDiagnostics, VirtualAuthenticator, browser_tool_builder,
 };
+
+#[test]
+fn browser_tool_enables_virtual_platform_passkeys() {
+    assert_eq!(
+        browser_tool_builder().virtual_authenticator,
+        Some(VirtualAuthenticator::platform_passkey())
+    );
+}
 
 #[test]
 fn remote_browser_accepts_cookie_only_brave_sessions() -> Result<()> {


### PR DESCRIPTION
## Summary
- install a virtual platform authenticator for `BrowserTool::new()` and `BrowserTool::with_executable()`
- enable the same unattended passkey behavior in the Nanocodex CLI browser configuration
- keep low-level `Browser::builder()` passkey policy explicit and document the boundary

## Verification
- `cargo test -p nanocodex-browser browser_tool_enables_virtual_platform_passkeys`
- `cargo check -p nanocodex-bin --bin nanocodex`
- `cargo clippy -p nanocodex-browser --lib -- -D warnings`
- `cargo clippy -p nanocodex-bin --bin nanocodex -- -D warnings`