### PR TITLE
feat(auth): support persistent ChatGPT access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ nanocodex auth login # once; shares ~/.codex/auth.json with Codex
 cargo run -p nanocodex-examples --bin voice
 ```
 
+For non-interactive Business or Enterprise hosts, set
+`CODEX_ACCESS_TOKEN=at-...`; it takes precedence over the default stored
+credential and does not require browser login or OAuth refresh.
+
 The lower adapter leaves device and media ownership outside Nanocodex. It reads
 24 kHz mono PCM16 little-endian audio from stdin, writes the same format to
 stdout, and keeps transcripts and agent events on stderr:

--- a/bin/nanocodex/src/auth.rs
+++ b/bin/nanocodex/src/auth.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, process::Command};
 
 use clap::{Args, Subcommand};
 use eyre::{Result, WrapErr};
-use nanocodex::oai::auth::{ChatGptLogin, chatgpt_auth_status, logout_chatgpt};
+use nanocodex::oai::auth::{ChatGptLogin, logout_chatgpt, resolve_chatgpt_auth_status};
 
 use crate::config::default_auth_file;
 
@@ -33,7 +33,7 @@ impl Auth {
     pub(crate) async fn run(self) -> Result<()> {
         match self.command {
             AuthCommand::Login(args) => login(args.path()?).await,
-            AuthCommand::Status(args) => status(&args.path()?),
+            AuthCommand::Status(args) => status(&args.path()?).await,
             AuthCommand::Logout(args) => logout(&args.path()?),
         }
     }
@@ -70,8 +70,9 @@ async fn login(auth_file: PathBuf) -> Result<()> {
     Ok(())
 }
 
-fn status(auth_file: &PathBuf) -> Result<()> {
-    let account = chatgpt_auth_status(auth_file)
+async fn status(auth_file: &PathBuf) -> Result<()> {
+    let account = resolve_chatgpt_auth_status(auth_file)
+        .await
         .wrap_err_with(|| format!("could not load {}", auth_file.display()))?;
     println!("Logged in with ChatGPT");
     if let Some(email) = account.email {

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -59,6 +59,14 @@ pub(crate) struct AuthArgs {
     /// Explicitly use `ChatGPT` authorization from this credential file.
     #[arg(long, env = "NANOCODEX_AUTH_FILE")]
     auth_file: Option<PathBuf>,
+
+    /// Use a persistent `ChatGPT` Business or Enterprise access token.
+    #[arg(
+        long,
+        env = "CODEX_ACCESS_TOKEN",
+        value_parser = NonEmptyStringValueParser::new()
+    )]
+    access_token: Option<String>,
 }
 
 /// Model-facing flags shared by normal agents and evaluator agents.
@@ -78,6 +86,7 @@ pub(crate) struct ModelArgs {
 #[derive(Clone)]
 pub(crate) enum SharedAuth {
     ApiKey(Arc<str>),
+    AccessToken(Arc<str>),
     AuthFile(PathBuf),
 }
 
@@ -456,7 +465,12 @@ fn session_instructions(custom: Option<String>, subagents_enabled: bool) -> Opti
 
 impl AuthArgs {
     fn resolve(self) -> Result<SharedAuth> {
-        select_shared_auth(self.api_key, self.auth_file, environment_api_key()?)
+        select_shared_auth(
+            self.api_key,
+            self.auth_file,
+            self.access_token,
+            environment_api_key()?,
+        )
     }
 }
 
@@ -489,6 +503,10 @@ impl SharedAuth {
     fn nanocodex(&self) -> Result<OpenAiAuth> {
         match self {
             Self::ApiKey(api_key) => Ok(OpenAiAuth::api_key(Arc::clone(api_key))),
+            Self::AccessToken(access_token) => {
+                nanocodex::oai::auth::chatgpt_access_token(Arc::clone(access_token))
+                    .map_err(Into::into)
+            }
             Self::AuthFile(path) => load_subscription_auth(path),
         }
     }
@@ -566,11 +584,13 @@ fn selected_api_base_url(generic: Option<String>, tempo: Option<&str>) -> Option
 fn select_auth(
     explicit_api_key: Option<String>,
     auth_file: Option<PathBuf>,
+    access_token: Option<String>,
     environment_api_key: Option<String>,
 ) -> Result<OpenAiAuth> {
     select_shared_auth_with_default(
         explicit_api_key,
         auth_file,
+        access_token,
         environment_api_key,
         default_auth_file,
     )
@@ -581,6 +601,7 @@ fn select_auth(
 fn select_auth_with_default<F>(
     explicit_api_key: Option<String>,
     auth_file: Option<PathBuf>,
+    access_token: Option<String>,
     environment_api_key: Option<String>,
     resolve_default_auth_file: F,
 ) -> Result<OpenAiAuth>
@@ -590,6 +611,7 @@ where
     select_shared_auth_with_default(
         explicit_api_key,
         auth_file,
+        access_token,
         environment_api_key,
         resolve_default_auth_file,
     )
@@ -599,11 +621,13 @@ where
 fn select_shared_auth(
     explicit_api_key: Option<String>,
     auth_file: Option<PathBuf>,
+    access_token: Option<String>,
     environment_api_key: Option<String>,
 ) -> Result<SharedAuth> {
     select_shared_auth_with_default(
         explicit_api_key,
         auth_file,
+        access_token,
         environment_api_key,
         default_auth_file,
     )
@@ -612,6 +636,7 @@ fn select_shared_auth(
 fn select_shared_auth_with_default<F>(
     explicit_api_key: Option<String>,
     auth_file: Option<PathBuf>,
+    access_token: Option<String>,
     environment_api_key: Option<String>,
     resolve_default_auth_file: F,
 ) -> Result<SharedAuth>
@@ -623,6 +648,11 @@ where
     }
     if let Some(auth_file) = auth_file {
         return Ok(SharedAuth::AuthFile(auth_file));
+    }
+    if let Some(access_token) = access_token {
+        return Ok(SharedAuth::AccessToken(
+            access_token.trim().to_owned().into(),
+        ));
     }
     let auth_file = resolve_default_auth_file()?;
     if auth_file
@@ -884,6 +914,7 @@ mod tests {
         let auth = select_auth(
             Some("explicit-key".into()),
             Some(auth_file()),
+            Some("at-access-token".into()),
             Some("environment-key".into()),
         )
         .unwrap();
@@ -896,10 +927,11 @@ mod tests {
         let auth_file = auth_file();
         write_chatgpt_auth(&auth_file);
 
-        let auth = select_auth_with_default(None, None, Some("environment-key".into()), || {
-            Ok(auth_file.clone())
-        })
-        .unwrap();
+        let auth =
+            select_auth_with_default(None, None, None, Some("environment-key".into()), || {
+                Ok(auth_file.clone())
+            })
+            .unwrap();
 
         assert_eq!(auth.mode(), OpenAiAuthMode::ChatGpt);
         std::fs::remove_file(auth_file).unwrap();
@@ -909,8 +941,10 @@ mod tests {
     fn environment_key_is_used_when_the_default_auth_file_is_missing() {
         let auth_file = auth_file();
         let auth =
-            select_auth_with_default(None, None, Some("environment-key".into()), || Ok(auth_file))
-                .unwrap();
+            select_auth_with_default(None, None, None, Some("environment-key".into()), || {
+                Ok(auth_file)
+            })
+            .unwrap();
 
         assert_eq!(auth.mode(), OpenAiAuthMode::ApiKey);
     }
@@ -920,10 +954,11 @@ mod tests {
         let auth_file = auth_file();
         std::fs::write(&auth_file, b"{}").unwrap();
 
-        let error = select_auth_with_default(None, None, Some("environment-key".into()), || {
-            Ok(auth_file.clone())
-        })
-        .unwrap_err();
+        let error =
+            select_auth_with_default(None, None, None, Some("environment-key".into()), || {
+                Ok(auth_file.clone())
+            })
+            .unwrap_err();
 
         assert!(error.to_string().contains("no ChatGPT tokens"));
         std::fs::remove_file(auth_file).unwrap();
@@ -937,11 +972,30 @@ mod tests {
         let error = select_auth(
             None,
             Some(auth_file.clone()),
+            None,
             Some("environment-key".into()),
         )
         .unwrap_err();
 
         assert!(error.to_string().contains("no ChatGPT tokens"));
+        std::fs::remove_file(auth_file).unwrap();
+    }
+
+    #[test]
+    fn access_token_precedes_the_default_auth_file_and_environment_api_key() {
+        let auth_file = auth_file();
+        write_chatgpt_auth(&auth_file);
+
+        let auth = select_auth_with_default(
+            None,
+            None,
+            Some("at-persistent".into()),
+            Some("environment-key".into()),
+            || Ok(auth_file.clone()),
+        )
+        .unwrap();
+
+        assert_eq!(auth.mode(), OpenAiAuthMode::ChatGpt);
         std::fs::remove_file(auth_file).unwrap();
     }
 }

--- a/bin/nanocodex/src/eval/profile.rs
+++ b/bin/nanocodex/src/eval/profile.rs
@@ -556,6 +556,7 @@ fn canonical_runner(
         agent.shared_builder(treatment.model, treatment.thinking, treatment.web_search)?;
     let auth = match auth {
         SharedAuth::ApiKey(api_key) => HarnessAuth::api_key(api_key),
+        SharedAuth::AccessToken(access_token) => HarnessAuth::access_token(access_token),
         SharedAuth::AuthFile(path) => HarnessAuth::auth_file(path),
     };
     Ok(CanonicalTaskRunner::new(nanocodex, auth))

--- a/crates/experimental/nanocodex-eval/src/harness.rs
+++ b/crates/experimental/nanocodex-eval/src/harness.rs
@@ -70,6 +70,7 @@ pub struct HarnessAuth {
 #[derive(Clone)]
 enum HarnessAuthKind {
     ApiKey(Arc<str>),
+    AccessToken(Arc<str>),
     AuthFile(PathBuf),
 }
 
@@ -88,6 +89,14 @@ impl HarnessAuth {
     pub fn api_key(api_key: impl Into<Arc<str>>) -> Self {
         Self {
             kind: HarnessAuthKind::ApiKey(api_key.into()),
+        }
+    }
+
+    /// Uses a persistent ChatGPT access token in the harness guest.
+    #[must_use]
+    pub fn access_token(access_token: impl Into<Arc<str>>) -> Self {
+        Self {
+            kind: HarnessAuthKind::AccessToken(access_token.into()),
         }
     }
 

--- a/crates/experimental/nanocodex-eval/src/harness/sandbox.rs
+++ b/crates/experimental/nanocodex-eval/src/harness/sandbox.rs
@@ -64,6 +64,7 @@ impl HarnessVmResources {
 
 pub(super) enum GuestAuth {
     ApiKey(Arc<str>),
+    AccessToken(Arc<str>),
     AuthFile(Vec<u8>),
 }
 
@@ -108,6 +109,7 @@ impl VmHarnessRunner {
         fs::create_dir_all(&artifact_directory)?;
         let auth = match auth.kind {
             HarnessAuthKind::ApiKey(api_key) => GuestAuth::ApiKey(api_key),
+            HarnessAuthKind::AccessToken(access_token) => GuestAuth::AccessToken(access_token),
             HarnessAuthKind::AuthFile(path) => {
                 let contents = fs::read(&path)?;
                 GuestAuth::AuthFile(contents)
@@ -136,10 +138,18 @@ impl VmHarnessRunner {
         let auth_file = match auth {
             GuestAuth::ApiKey(api_key) => {
                 command_environment.insert(guest.api_key_environment.clone(), api_key.to_string());
+                command_environment.remove("CODEX_ACCESS_TOKEN");
+                None
+            }
+            GuestAuth::AccessToken(access_token) => {
+                command_environment.remove(&guest.api_key_environment);
+                command_environment
+                    .insert("CODEX_ACCESS_TOKEN".to_owned(), access_token.to_string());
                 None
             }
             GuestAuth::AuthFile(contents) => {
                 command_environment.remove(&guest.api_key_environment);
+                command_environment.remove("CODEX_ACCESS_TOKEN");
                 Some(contents)
             }
         };

--- a/crates/nanocodex-oai-api/README.md
+++ b/crates/nanocodex-oai-api/README.md
@@ -102,12 +102,29 @@ println!("{}", completed.output_text());
 
 Keep the credential file outside source control and reuse the same path on
 later runs. It uses Codex's `auth.json` format, so Codex and multiple Nanocodex
-processes can safely share the same path. [`auth::load_chatgpt_auth`] adopts a
-same-account rotation from disk before refreshing, refreshes expiring
-credentials, and recovers an unauthorized request once with the refreshed
-authorization.
-[`auth::chatgpt_auth_status`] inspects the selected account without exposing
-tokens, and [`auth::logout_chatgpt`] removes the stored credentials.
+processes can safely share the same path. The loader accepts both Codex OAuth
+sessions and its `personal_access_token` format. OAuth sessions adopt a
+same-account rotation from disk before refreshing; persistent Business and
+Enterprise access tokens resolve their account metadata once and never enter
+the OAuth refresh path.
+
+Applications that receive a persistent `at-...` token directly can skip the
+credential file:
+
+```rust,no_run
+use nanocodex_oai_api::{OpenAi, auth::chatgpt_access_token};
+
+# fn run() -> Result<(), Box<dyn std::error::Error>> {
+let auth = chatgpt_access_token(std::env::var("CODEX_ACCESS_TOKEN")?)?;
+let openai = OpenAi::new(auth)?;
+# let _ = openai;
+# Ok(())
+# }
+```
+
+[`auth::resolve_chatgpt_auth_status`] inspects either stored credential type
+without exposing tokens, and [`auth::logout_chatgpt`] removes the stored
+credentials.
 
 A [`Response`] is also a typed stream. It retains the completed aggregate
 after the stream reaches [`ResponseEvent::Completed`]:

--- a/crates/nanocodex-oai-api/src/auth/chatgpt.rs
+++ b/crates/nanocodex-oai-api/src/auth/chatgpt.rs
@@ -24,6 +24,10 @@ use tokio::{
 use url::Url;
 
 const AUTH_ISSUER: &str = "https://auth.openai.com";
+const AUTH_API_BASE_URL: &str = "https://auth.openai.com/api/accounts";
+const AUTH_API_BASE_URL_ENV: &str = "CODEX_AUTHAPI_BASE_URL";
+const PERSONAL_ACCESS_TOKEN_PREFIX: &str = "at-";
+const WHOAMI_PATH: &str = "/v1/user-auth-credential/whoami";
 const OAUTH_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 const OAUTH_SCOPE: &str =
     "openid profile email offline_access api.connectors.read api.connectors.invoke";
@@ -84,6 +88,9 @@ pub enum ChatGptAuthError {
     /// Authorization-code or refresh-token exchange failed.
     #[error("ChatGPT token exchange failed: {0}")]
     TokenExchange(String),
+    /// Persistent access-token metadata could not be resolved.
+    #[error("ChatGPT access-token metadata request failed: {0}")]
+    AccessTokenMetadata(String),
 }
 
 /// An in-progress authorization-code login using PKCE and a loopback callback.
@@ -247,18 +254,22 @@ impl OAuthCallback {
     }
 }
 
-/// Loads a persisted `ChatGPT` OAuth session as shared authorization for an agent family.
+/// Loads a persisted `ChatGPT` credential as shared authorization for an agent family.
 ///
 /// The file uses Codex's `auth.json` format and can be shared with Codex and other Nanocodex
-/// processes. Before refreshing, each authorization handle reloads a same-account credential
-/// written by another process. Refreshes within one handle are serialized, and successful writes
-/// preserve unknown fields while atomically replacing the file with owner-only permissions.
+/// processes. OAuth handles reload same-account rotations before refreshing, serialize refreshes,
+/// and atomically preserve unknown fields. Persistent access tokens resolve account metadata once
+/// and never enter the OAuth refresh path.
 ///
 /// # Errors
 ///
 /// Returns an error when the credential file cannot be read or is invalid.
 pub fn load_chatgpt_auth(auth_file: impl Into<PathBuf>) -> Result<OpenAiAuth, ChatGptAuthError> {
     let auth_file = auth_file.into();
+    let document = read_document(&auth_file)?;
+    if let Some(access_token) = personal_access_token_from_document(&document, &auth_file)? {
+        return chatgpt_access_token(access_token);
+    }
     let (credentials, auth_record) = read_stored_auth(&auth_file)?;
     credentials.validate(&auth_file)?;
     let manager = ManagedChatGptAuth {
@@ -276,7 +287,52 @@ pub fn load_chatgpt_auth(auth_file: impl Into<PathBuf>) -> Result<OpenAiAuth, Ch
     Ok(OpenAiAuth::managed_chatgpt(Arc::new(manager)))
 }
 
-/// Inspect a stored `ChatGPT` authorization without exposing its tokens.
+/// Creates `ChatGPT` authorization from a persistent Business or Enterprise access token.
+///
+/// The token must use Codex's `at-` prefix. Account routing metadata is resolved lazily from the
+/// ChatGPT authorization service on the first request and reused for the lifetime of the handle.
+/// Persistent access tokens do not participate in OAuth refresh.
+///
+/// # Errors
+///
+/// Returns an error when the token is empty, has the wrong credential type, or the authorization
+/// client cannot be constructed.
+pub fn chatgpt_access_token(
+    access_token: impl Into<Arc<str>>,
+) -> Result<OpenAiAuth, ChatGptAuthError> {
+    personal_access_token_auth(access_token.into(), &auth_api_base_url())
+}
+
+/// Resolves non-secret account information for any supported Codex `auth.json` credential.
+///
+/// Unlike [`chatgpt_auth_status`], this async variant also supports persistent access tokens,
+/// whose account metadata must be fetched from the authorization service.
+///
+/// # Errors
+///
+/// Returns an error when the credential file cannot be read, is invalid, or its access-token
+/// metadata cannot be resolved.
+pub async fn resolve_chatgpt_auth_status(
+    auth_file: impl AsRef<Path>,
+) -> Result<ChatGptAuthStatus, ChatGptAuthError> {
+    let auth_file = auth_file.as_ref();
+    let document = read_document(auth_file)?;
+    if let Some(access_token) = personal_access_token_from_document(&document, auth_file)? {
+        return hydrate_personal_access_token(
+            &auth_client()?,
+            &whoami_endpoint(&auth_api_base_url()),
+            &access_token,
+        )
+        .await;
+    }
+    let credentials = StoredCredentials::from_document(&document, auth_file)?;
+    credentials.validate(auth_file)?;
+    Ok(credentials.status())
+}
+
+/// Inspect a stored `ChatGPT` OAuth authorization without exposing its tokens.
+///
+/// Use [`resolve_chatgpt_auth_status`] when the file may contain a persistent access token.
 ///
 /// # Errors
 ///
@@ -414,6 +470,8 @@ struct CodexAuthDocument {
     tokens: Option<CodexTokenData>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     last_refresh: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    personal_access_token: Option<String>,
     #[serde(flatten)]
     extra: BTreeMap<String, serde_json::Value>,
 }
@@ -447,6 +505,175 @@ struct ManagedState {
 struct AuthScopedRefreshFailure {
     auth_record: CodexAuthDocument,
     detail: Arc<str>,
+}
+
+#[derive(Deserialize)]
+struct PersonalAccessTokenMetadata {
+    #[serde(default)]
+    email: Option<String>,
+    #[serde(rename = "chatgpt_user_id")]
+    _chatgpt_user_id: String,
+    chatgpt_account_id: String,
+    chatgpt_plan_type: String,
+    chatgpt_account_is_fedramp: bool,
+}
+
+struct PersonalAccessTokenAuth {
+    access_token: Arc<str>,
+    client: reqwest::Client,
+    whoami_endpoint: Arc<str>,
+    status: tokio::sync::OnceCell<ChatGptAuthStatus>,
+}
+
+impl PersonalAccessTokenAuth {
+    async fn status(&self) -> Result<&ChatGptAuthStatus, OpenAiAuthError> {
+        self.status
+            .get_or_try_init(|| async {
+                hydrate_personal_access_token(
+                    &self.client,
+                    &self.whoami_endpoint,
+                    &self.access_token,
+                )
+                .await
+                .map_err(|error| OpenAiAuthError::Unavailable(Arc::from(error.to_string())))
+            })
+            .await
+    }
+}
+
+impl OpenAiAuthSource for PersonalAccessTokenAuth {
+    fn validate(&self) -> Result<(), OpenAiAuthError> {
+        validate_personal_access_token(&self.access_token)
+            .map_err(|error| OpenAiAuthError::Unavailable(Arc::from(error.to_string())))
+    }
+
+    fn snapshot(&self) -> OpenAiAuthFuture<'_, Result<OpenAiAuthSnapshot, OpenAiAuthError>> {
+        Box::pin(async move {
+            let status = self.status().await?;
+            Ok(OpenAiAuthSnapshot::new(
+                OpenAiAuthMode::ChatGpt,
+                Arc::clone(&self.access_token),
+                Some(Arc::<str>::from(status.account_id.as_str())),
+                status.fedramp,
+                0,
+            ))
+        })
+    }
+
+    fn recover_unauthorized(
+        &self,
+        _rejected: &OpenAiAuthSnapshot,
+    ) -> OpenAiAuthFuture<'_, Result<(), OpenAiAuthError>> {
+        Box::pin(async {
+            Err(OpenAiAuthError::LoginRequired(Arc::from(
+                "persistent access token was rejected and cannot be refreshed",
+            )))
+        })
+    }
+}
+
+fn personal_access_token_auth(
+    access_token: Arc<str>,
+    auth_api_base_url: &str,
+) -> Result<OpenAiAuth, ChatGptAuthError> {
+    validate_personal_access_token(&access_token)?;
+    let source = PersonalAccessTokenAuth {
+        access_token,
+        client: auth_client()?,
+        whoami_endpoint: Arc::from(whoami_endpoint(auth_api_base_url)),
+        status: tokio::sync::OnceCell::new(),
+    };
+    Ok(OpenAiAuth::managed_chatgpt(Arc::new(source)))
+}
+
+fn validate_personal_access_token(access_token: &str) -> Result<(), ChatGptAuthError> {
+    if access_token.trim().is_empty() {
+        return Err(ChatGptAuthError::InvalidToken(
+            "persistent access token is empty".into(),
+        ));
+    }
+    if !access_token.starts_with(PERSONAL_ACCESS_TOKEN_PREFIX) {
+        return Err(ChatGptAuthError::InvalidToken(
+            "persistent access token must start with `at-`".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn personal_access_token_from_document(
+    document: &CodexAuthDocument,
+    path: &Path,
+) -> Result<Option<Arc<str>>, ChatGptAuthError> {
+    let selected = match document.auth_mode.as_deref() {
+        Some("personalAccessToken") => true,
+        Some(_) => false,
+        None => document.personal_access_token.is_some(),
+    };
+    if !selected {
+        return Ok(None);
+    }
+    let access_token = document.personal_access_token.as_deref().ok_or_else(|| {
+        ChatGptAuthError::InvalidStore {
+            path: path.to_path_buf(),
+            detail: "Codex auth.json has no personal access token".into(),
+        }
+    })?;
+    validate_personal_access_token(access_token).map_err(|error| {
+        ChatGptAuthError::InvalidStore {
+            path: path.to_path_buf(),
+            detail: error.to_string(),
+        }
+    })?;
+    Ok(Some(Arc::from(access_token)))
+}
+
+async fn hydrate_personal_access_token(
+    client: &reqwest::Client,
+    endpoint: &str,
+    access_token: &str,
+) -> Result<ChatGptAuthStatus, ChatGptAuthError> {
+    let response = client
+        .get(endpoint)
+        .bearer_auth(access_token)
+        .send()
+        .await
+        .map_err(|error| ChatGptAuthError::AccessTokenMetadata(error.to_string()))?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(ChatGptAuthError::AccessTokenMetadata(format!(
+            "authorization service returned HTTP {status}"
+        )));
+    }
+    let metadata = response
+        .json::<PersonalAccessTokenMetadata>()
+        .await
+        .map_err(|error| ChatGptAuthError::AccessTokenMetadata(error.to_string()))?;
+    if metadata.chatgpt_account_id.trim().is_empty() {
+        return Err(ChatGptAuthError::AccessTokenMetadata(
+            "authorization service returned an empty ChatGPT account ID".into(),
+        ));
+    }
+    Ok(ChatGptAuthStatus {
+        account_id: metadata.chatgpt_account_id,
+        email: metadata.email,
+        plan: Some(metadata.chatgpt_plan_type),
+        fedramp: metadata.chatgpt_account_is_fedramp,
+    })
+}
+
+fn whoami_endpoint(auth_api_base_url: &str) -> String {
+    format!(
+        "{}{WHOAMI_PATH}",
+        auth_api_base_url.trim().trim_end_matches('/')
+    )
+}
+
+fn auth_api_base_url() -> String {
+    std::env::var(AUTH_API_BASE_URL_ENV)
+        .ok()
+        .map(|value| value.trim().trim_end_matches('/').to_owned())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| AUTH_API_BASE_URL.to_owned())
 }
 
 impl ManagedChatGptAuth {

--- a/crates/nanocodex-oai-api/src/auth/chatgpt/tests.rs
+++ b/crates/nanocodex-oai-api/src/auth/chatgpt/tests.rs
@@ -4,10 +4,10 @@ use std::sync::{
 };
 
 use super::{
-    ManagedChatGptAuth, ManagedState, StoredCredentials, authorize_url, jwt_expiration, read_store,
-    refresh_error_code, rfc3339_utc, unix_now, write_store,
+    ManagedChatGptAuth, ManagedState, StoredCredentials, authorize_url, jwt_expiration,
+    personal_access_token_auth, read_store, refresh_error_code, rfc3339_utc, unix_now, write_store,
 };
-use crate::auth::{OpenAiAuth, OpenAiAuthError};
+use crate::auth::{OpenAiAuth, OpenAiAuthError, OpenAiAuthMode};
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -105,7 +105,7 @@ async fn read_http_request(stream: &mut tokio::net::TcpStream) -> String {
                     .map(str::trim)
                     .and_then(|length| length.parse::<usize>().ok())
             })
-            .unwrap();
+            .unwrap_or(0);
         if request.len() >= headers_end + content_length {
             return String::from_utf8(request).unwrap();
         }
@@ -214,6 +214,59 @@ fn authorization_url_contains_the_pkce_and_offline_access_contract() {
     assert_eq!(query.get("code_challenge").unwrap(), "challenge-value");
     assert_eq!(query.get("state").unwrap(), "state-value");
     assert!(query.get("scope").unwrap().contains("offline_access"));
+}
+
+#[test]
+fn loads_codex_personal_access_token_auth_files_without_oauth_tokens() {
+    let auth_file = temp_auth_file();
+    std::fs::write(&auth_file, br#"{"personal_access_token":"at-file-token"}"#).unwrap();
+
+    let auth = super::load_chatgpt_auth(&auth_file).unwrap();
+
+    assert_eq!(auth.mode(), OpenAiAuthMode::ChatGpt);
+    std::fs::remove_file(auth_file).unwrap();
+}
+
+#[tokio::test]
+async fn persistent_access_token_hydrates_account_metadata_once_and_never_refreshes() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+    let requests = Arc::new(AtomicUsize::new(0));
+    let server_requests = Arc::clone(&requests);
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        server_requests.fetch_add(1, Ordering::AcqRel);
+        let request = read_http_request(&mut stream).await;
+        assert!(request.starts_with("GET /v1/user-auth-credential/whoami HTTP/1.1"));
+        assert!(request.contains("authorization: Bearer at-persistent-token\r\n"));
+        reply_json(
+            &mut stream,
+            "200 OK",
+            &serde_json::json!({
+                "email": "business@example.com",
+                "chatgpt_user_id": "user-1",
+                "chatgpt_account_id": "account-business",
+                "chatgpt_plan_type": "business",
+                "chatgpt_account_is_fedramp": true
+            }),
+        )
+        .await;
+    });
+    let auth = personal_access_token_auth(Arc::from("at-persistent-token"), &base_url).unwrap();
+
+    let first = auth.snapshot().await.unwrap();
+    let second = auth.snapshot().await.unwrap();
+
+    assert_eq!(first.bearer(), "at-persistent-token");
+    assert_eq!(first.account_id(), Some("account-business"));
+    assert!(first.is_fedramp());
+    assert_eq!(second.account_id(), first.account_id());
+    assert!(matches!(
+        auth.recover_unauthorized(&first).await,
+        Err(OpenAiAuthError::LoginRequired(_))
+    ));
+    server.await.unwrap();
+    assert_eq!(requests.load(Ordering::Acquire), 1);
 }
 
 #[tokio::test]

--- a/crates/nanocodex-oai-api/src/auth/mod.rs
+++ b/crates/nanocodex-oai-api/src/auth/mod.rs
@@ -11,8 +11,8 @@ mod chatgpt;
 #[cfg(not(target_family = "wasm"))]
 #[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
 pub use chatgpt::{
-    ChatGptAuthError, ChatGptAuthStatus, ChatGptLogin, chatgpt_auth_status, load_chatgpt_auth,
-    logout_chatgpt,
+    ChatGptAuthError, ChatGptAuthStatus, ChatGptLogin, chatgpt_access_token, chatgpt_auth_status,
+    load_chatgpt_auth, logout_chatgpt, resolve_chatgpt_auth_status,
 };
 
 /// Authentication mode for the single `OpenAI` service family supported by Nanocodex.

--- a/examples/README.md
+++ b/examples/README.md
@@ -65,7 +65,8 @@ adapters over the same typed Realtime events and retained agent lifecycle.
 Both use the shared Codex/ChatGPT subscription credentials at
 `$CODEX_HOME/auth.json` or `~/.codex/auth.json`; `NANOCODEX_AUTH_FILE` overrides
 that path. Run `nanocodex auth login` once if the shared credential does not
-exist.
+exist. Business and Enterprise hosts can instead set a persistent
+`CODEX_ACCESS_TOKEN=at-...` without a browser login.
 
 The other command-line examples use `OPENAI_API_KEY` by default. The browser
 example instead asks the

--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -1,9 +1,14 @@
 use std::path::PathBuf;
 
 use eyre::{Result, eyre};
-use nanocodex::oai::auth::{OpenAiAuth, load_chatgpt_auth};
+use nanocodex::oai::auth::{OpenAiAuth, chatgpt_access_token, load_chatgpt_auth};
 
 pub(crate) fn load_codex_auth() -> Result<OpenAiAuth> {
+    if let Ok(access_token) = std::env::var("CODEX_ACCESS_TOKEN")
+        && !access_token.trim().is_empty()
+    {
+        return chatgpt_access_token(access_token.trim().to_owned()).map_err(Into::into);
+    }
     let auth_file = default_auth_file()?;
     load_chatgpt_auth(&auth_file).map_err(|error| {
         eyre!(


### PR DESCRIPTION
## Summary

- accept Codex `auth.json` files containing `personal_access_token` and expose a library constructor for direct `at-...` credentials
- resolve ChatGPT account routing and FedRAMP metadata once through the Codex `whoami` endpoint, then reuse it without entering OAuth refresh
- support `CODEX_ACCESS_TOKEN` / `--access-token` across the CLI, eval harness guests, and native examples
- make auth status work for both stored OAuth sessions and persistent access tokens

Agent Identity JWTs remain a separate signed-assertion lifecycle; non-`at-` values are rejected instead of being sent incorrectly as bearer tokens.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p nanocodex-oai-api auth::chatgpt::tests --lib`
- `cargo check -p nanocodex-bin --bin nanocodex`
- `cargo check -p nanocodex-examples --bin voice --bin realtime-pipe`
- `cargo clippy -p nanocodex-oai-api --lib -- -D warnings`
- `cargo clippy -p nanocodex-bin --bin nanocodex -- -D warnings`

Fixes #165
