### PR TITLE
feat(browser): persist and select virtual passkeys

### DIFF
--- a/bin/nanocodex/src/browser.rs
+++ b/bin/nanocodex/src/browser.rs
@@ -131,9 +131,11 @@ impl BrowserArgs {
         else {
             return Ok(None);
         };
+        let virtual_authenticator = VirtualAuthenticator::platform_passkey()
+            .credential_store(default_virtual_credential_store()?);
         let mut builder = Browser::builder()
             .file_root(workspace)
-            .virtual_authenticator(VirtualAuthenticator::platform_passkey());
+            .virtual_authenticator(virtual_authenticator);
         if let Some(executable) = launch.executable {
             builder = builder.executable(executable);
         }
@@ -151,6 +153,21 @@ impl BrowserArgs {
             .wrap_err("failed to configure the browser tool")?;
         Ok(Some(ConfiguredBrowser { browser }))
     }
+}
+
+fn default_virtual_credential_store() -> Result<PathBuf> {
+    let root = if let Some(root) = std::env::var_os("NANOCODEX_DIR") {
+        PathBuf::from(root)
+    } else {
+        let home = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .ok_or_else(|| eyre!("HOME is not set; set NANOCODEX_DIR explicitly"))?;
+        PathBuf::from(home).join(".nanocodex")
+    };
+    if root.as_os_str().is_empty() {
+        return Err(eyre!("NANOCODEX_DIR cannot be empty"));
+    }
+    Ok(root.join("browser/passkeys.json"))
 }
 
 struct BrowserLaunch {

--- a/crates/experimental/nanocodex-browser/README.md
+++ b/crates/experimental/nanocodex-browser/README.md
@@ -153,8 +153,15 @@ installed Chrome, Chromium, or Edge when Brave is not installed. If none is
 available, the CLI starts without browser tools. It copies a standard desktop
 browser profile's complete cookie database by default. `all`
 auto-detects the source; `brave`, `chrome`, `chromium`, `edge`, `firefox`, and
-`safari` select it explicitly. Pass `none` to either option to disable that
-default:
+`safari` select it explicitly.
+
+The CLI's virtual platform authenticator persists testing passkeys across
+browser and Nanocodex restarts in `$NANOCODEX_DIR/browser/passkeys.json`, or
+`~/.nanocodex/browser/passkeys.json` by default. That owner-only file contains
+private keys. Library consumers opt into persistence explicitly with
+`VirtualAuthenticator::platform_passkey().credential_store(path)`.
+
+Pass `none` to either option to disable the browser or cookie-copy default:
 
 ```console
 nanocodex

--- a/crates/experimental/nanocodex-browser/README.md
+++ b/crates/experimental/nanocodex-browser/README.md
@@ -160,6 +160,11 @@ browser and Nanocodex restarts in `$NANOCODEX_DIR/browser/passkeys.json`, or
 `~/.nanocodex/browser/passkeys.json` by default. That owner-only file contains
 private keys. Library consumers opt into persistence explicitly with
 `VirtualAuthenticator::platform_passkey().credential_store(path)`.
+With persistence configured, the model-facing browser tool can call `passkeys`
+to inspect non-secret metadata, `passkey_use` to expose one saved credential,
+`passkey_new` to create against an empty authenticator, and `passkey_auto` to
+restore normal automatic credential selection. Selection never deletes the
+other credentials in the persisted store.
 
 Pass `none` to either option to disable the browser or cookie-copy default:
 

--- a/crates/experimental/nanocodex-browser/src/lib.rs
+++ b/crates/experimental/nanocodex-browser/src/lib.rs
@@ -1939,9 +1939,9 @@ pub enum BrowserGate {
 /// This is harness policy rather than a model-callable browser action. The
 /// driver installs it after the first navigation so `WebAuthn` requests never
 /// fall through to the host's passkey UI.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VirtualAuthenticator {
-    _private: (),
+    credential_store: Option<std::path::PathBuf>,
 }
 
 impl VirtualAuthenticator {
@@ -1949,7 +1949,24 @@ impl VirtualAuthenticator {
     /// registration and authentication.
     #[must_use]
     pub const fn platform_passkey() -> Self {
-        Self { _private: () }
+        Self {
+            credential_store: None,
+        }
+    }
+
+    /// Persists virtual passkeys at the supplied path and restores them in
+    /// later browser sessions.
+    ///
+    /// The file contains credential private keys. The file and a newly created
+    /// immediate parent directory are restricted to the current user on Unix.
+    #[must_use]
+    pub fn credential_store(mut self, path: impl Into<std::path::PathBuf>) -> Self {
+        self.credential_store = Some(path.into());
+        self
+    }
+
+    pub(crate) fn credential_store_path(&self) -> Option<&std::path::Path> {
+        self.credential_store.as_deref()
     }
 }
 
@@ -3239,10 +3256,7 @@ impl BrowserBuilder {
 
     /// Enables a harness-owned virtual authenticator for passkey flows.
     #[must_use]
-    pub const fn virtual_authenticator(
-        mut self,
-        virtual_authenticator: VirtualAuthenticator,
-    ) -> Self {
+    pub fn virtual_authenticator(mut self, virtual_authenticator: VirtualAuthenticator) -> Self {
         self.virtual_authenticator = Some(virtual_authenticator);
         self
     }
@@ -3374,6 +3388,16 @@ impl BrowserBuilder {
         if self.cdp_endpoint.is_some() && self.file_root.is_some() {
             return Err(BrowserBuildError::Configuration {
                 message: "`file_root` is not supported across a remote CDP boundary".to_owned(),
+            });
+        }
+        if self
+            .virtual_authenticator
+            .as_ref()
+            .and_then(VirtualAuthenticator::credential_store_path)
+            .is_some_and(|path| path.as_os_str().is_empty())
+        {
+            return Err(BrowserBuildError::Configuration {
+                message: "the virtual credential store path cannot be empty".to_owned(),
             });
         }
         if let Some(client) = &self.crux_client {

--- a/crates/experimental/nanocodex-browser/src/lib.rs
+++ b/crates/experimental/nanocodex-browser/src/lib.rs
@@ -189,6 +189,11 @@ Use `axe_audit` for the complete pinned axe-core engine, `pdf` for Chromium
 print output, `lighthouse_audit` for an exact explicitly configured Lighthouse
 CLI attached to this Chrome session, and `crux` for configured field data.
 Harness credentials and browser storage state never enter this action schema.
+When a virtual passkey store is configured, use `passkeys` to inspect its
+non-secret credential metadata. Before a WebAuthn ceremony, use `passkey_use`
+to expose one saved credential, `passkey_new` to expose an empty authenticator
+for registration, or `passkey_auto` to expose every saved credential and let
+the relying party choose. Persisted private keys never enter tool output.
 Use `matched_styles`, `force_pseudo_state`, and `event_listeners` for authored
 CSS and listener provenance. The debugger actions expose source-mapped
 breakpoints, exception policy, pause stacks/scopes, resume, and stepping;
@@ -701,6 +706,19 @@ pub enum BrowserAction {
     },
     /// Read downloads observed by the browser session.
     Downloads,
+    /// List persisted virtual passkeys and the current credential-selection mode.
+    Passkeys,
+    /// Expose only one persisted passkey to subsequent WebAuthn ceremonies.
+    PasskeyUse {
+        /// Base64-encoded credential identifier returned by `passkeys`.
+        credential_id: String,
+        /// Relying-party identifier returned by `passkeys`; required only when IDs are ambiguous.
+        relying_party_id: Option<String>,
+    },
+    /// Expose an empty virtual authenticator so the next ceremony can create a passkey.
+    PasskeyNew,
+    /// Expose every persisted passkey and let the relying party choose.
+    PasskeyAuto,
     /// Evaluate JavaScript in the active page.
     Evaluate {
         /// JavaScript expression to evaluate.
@@ -817,6 +835,10 @@ impl BrowserAction {
             Self::LighthouseAudit { .. } => BrowserActionName::LighthouseAudit,
             Self::Crux { .. } => BrowserActionName::Crux,
             Self::Downloads => BrowserActionName::Downloads,
+            Self::Passkeys => BrowserActionName::Passkeys,
+            Self::PasskeyUse { .. } => BrowserActionName::PasskeyUse,
+            Self::PasskeyNew => BrowserActionName::PasskeyNew,
+            Self::PasskeyAuto => BrowserActionName::PasskeyAuto,
             Self::Evaluate { .. } => BrowserActionName::Evaluate,
         }
     }
@@ -926,6 +948,10 @@ pub enum BrowserActionName {
     LighthouseAudit,
     Crux,
     Downloads,
+    Passkeys,
+    PasskeyUse,
+    PasskeyNew,
+    PasskeyAuto,
     Evaluate,
 }
 
@@ -1971,7 +1997,8 @@ impl VirtualAuthenticator {
 }
 
 /// Public, non-secret metadata for a credential in the virtual authenticator.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct VirtualCredential {
     /// Base64-encoded `WebAuthn` credential identifier.
     pub credential_id: String,
@@ -1987,6 +2014,22 @@ pub struct VirtualCredential {
     pub sign_count: i64,
 }
 
+/// Which persisted credentials are exposed to WebAuthn ceremonies.
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Eq, Serialize)]
+#[serde(tag = "mode", rename_all = "snake_case", deny_unknown_fields)]
+pub enum BrowserPasskeyMode {
+    /// Expose every saved credential and let the relying party choose.
+    #[default]
+    Auto,
+    /// Expose only the selected saved credential.
+    Use {
+        credential_id: String,
+        relying_party_id: Option<String>,
+    },
+    /// Expose no saved credentials so a relying party can register a new one.
+    New,
+}
+
 /// Typed result of one browser action.
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
 #[serde(tag = "result", rename_all = "snake_case", deny_unknown_fields)]
@@ -1998,6 +2041,14 @@ pub enum BrowserActionResult {
         executed: bool,
         /// Present for a real browser and absent for the recording backend.
         outcome: Option<Box<BrowserActionOutcome>>,
+    },
+    /// Non-secret persisted passkey metadata and active selection mode.
+    Passkeys {
+        sequence: u64,
+        executed: bool,
+        action: BrowserActionName,
+        mode: BrowserPasskeyMode,
+        credentials: Vec<VirtualCredential>,
     },
     /// Accessibility-tree text and its stable element references.
     Snapshot {
@@ -2309,6 +2360,7 @@ impl BrowserActionResult {
     const fn action_name(&self) -> BrowserActionName {
         match self {
             Self::Action { action, .. } => *action,
+            Self::Passkeys { action, .. } => *action,
             Self::Snapshot { .. } => BrowserActionName::Snapshot,
             Self::SnapshotFind { .. } => BrowserActionName::SnapshotFind,
             Self::DomSnapshot { .. } => BrowserActionName::DomSnapshot,
@@ -3049,6 +3101,40 @@ fn recording_result(
             sequence,
             executed,
             downloads: Vec::new(),
+        },
+        BrowserAction::Passkeys => BrowserActionResult::Passkeys {
+            sequence,
+            executed,
+            action: BrowserActionName::Passkeys,
+            mode: BrowserPasskeyMode::Auto,
+            credentials: Vec::new(),
+        },
+        BrowserAction::PasskeyUse {
+            credential_id,
+            relying_party_id,
+        } => BrowserActionResult::Passkeys {
+            sequence,
+            executed,
+            action: BrowserActionName::PasskeyUse,
+            mode: BrowserPasskeyMode::Use {
+                credential_id: credential_id.clone(),
+                relying_party_id: relying_party_id.clone(),
+            },
+            credentials: Vec::new(),
+        },
+        BrowserAction::PasskeyNew => BrowserActionResult::Passkeys {
+            sequence,
+            executed,
+            action: BrowserActionName::PasskeyNew,
+            mode: BrowserPasskeyMode::New,
+            credentials: Vec::new(),
+        },
+        BrowserAction::PasskeyAuto => BrowserActionResult::Passkeys {
+            sequence,
+            executed,
+            action: BrowserActionName::PasskeyAuto,
+            mode: BrowserPasskeyMode::Auto,
+            credentials: Vec::new(),
         },
         BrowserAction::Evaluate { .. } => BrowserActionResult::Evaluation {
             sequence,

--- a/crates/experimental/nanocodex-browser/src/native.rs
+++ b/crates/experimental/nanocodex-browser/src/native.rs
@@ -8,6 +8,7 @@ use std::{
 
 mod artifacts;
 mod audits;
+mod credential_store;
 mod devtools;
 mod har;
 mod interaction;
@@ -63,9 +64,9 @@ use chromiumoxide::{
             },
             target::{GetTargetsParams, SetAutoAttachParams, TargetId},
             web_authn::{
-                AddVirtualAuthenticatorParams, AuthenticatorId, AuthenticatorProtocol,
-                AuthenticatorTransport, EnableParams, GetCredentialsParams,
-                VirtualAuthenticatorOptions,
+                AddCredentialParams, AddVirtualAuthenticatorParams, AuthenticatorId,
+                AuthenticatorProtocol, AuthenticatorTransport, Credential, EnableParams,
+                GetCredentialsParams, RemoveCredentialParams, VirtualAuthenticatorOptions,
             },
         },
         js_protocol::runtime::{
@@ -100,6 +101,7 @@ use crate::{
     session::cookie_applies_to,
     trace_serialized,
 };
+use credential_store::VirtualCredentialStore;
 
 const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(25);
 const DEFAULT_NAVIGATION_TIMEOUT: Duration = Duration::from_secs(5);
@@ -180,6 +182,7 @@ struct Session {
     refs: HashMap<String, ElementTarget>,
     output_dir: PathBuf,
     virtual_authenticator: Option<VirtualAuthenticator>,
+    virtual_credential_store: Option<VirtualCredentialStore>,
     react_diagnostics_enabled: bool,
     authenticators: HashMap<String, InstalledAuthenticator>,
     allowed_origins: Vec<Url>,
@@ -676,7 +679,12 @@ impl Session {
         let cdp_endpoint = owner.cdp_endpoint.as_ref();
         let brave_session = owner.brave_session.as_ref();
         let launch_brave_executable = owner.launch_brave_executable;
-        let virtual_authenticator = owner.virtual_authenticator;
+        let virtual_authenticator = owner.virtual_authenticator.clone();
+        let virtual_credential_store = virtual_authenticator
+            .as_ref()
+            .and_then(VirtualAuthenticator::credential_store_path)
+            .map(|path| VirtualCredentialStore::load(path.to_path_buf()))
+            .transpose()?;
         let react_diagnostics = owner.react_diagnostics;
         let egress_policy = owner.egress_policy.clone();
         let file_root = owner.file_root.clone();
@@ -802,6 +810,7 @@ impl Session {
             refs: HashMap::new(),
             output_dir,
             virtual_authenticator,
+            virtual_credential_store,
             react_diagnostics_enabled: react_diagnostics.is_some(),
             authenticators: HashMap::new(),
             allowed_origins: brave_session
@@ -832,13 +841,16 @@ impl Session {
     }
 
     async fn close(mut self) -> Result<(), BrowserError> {
+        let credential_sync = self.synchronize_virtual_credentials().await;
         for task in &self.browser_tasks {
             task.abort();
         }
         for task in &self.page_tasks {
             task.abort();
         }
-        close_chromium(&mut self.browser, &self.handler).await
+        let close = close_chromium(&mut self.browser, &self.handler).await;
+        credential_sync?;
+        close
     }
 
     async fn refresh_remote_cookies(
@@ -1504,9 +1516,98 @@ impl Session {
             if self.authenticators.contains_key(&target_id) {
                 continue;
             }
-            let id = install_virtual_authenticator(&page).await?;
+            let credentials = self
+                .virtual_credential_store
+                .as_ref()
+                .map(|store| store.credentials().cloned().collect::<Vec<_>>())
+                .unwrap_or_default();
+            let id = install_virtual_authenticator(&page, &credentials).await?;
             self.authenticators
                 .insert(target_id, InstalledAuthenticator { page, id });
+        }
+        Ok(())
+    }
+
+    async fn synchronize_virtual_credentials(&mut self) -> Result<(), BrowserError> {
+        let Some(store) = self.virtual_credential_store.as_mut() else {
+            return Ok(());
+        };
+        if self.authenticators.is_empty() {
+            return Ok(());
+        }
+        let mut authenticators = self.authenticators.values().collect::<Vec<_>>();
+        authenticators.sort_unstable_by(|left, right| {
+            left.page
+                .target_id()
+                .as_ref()
+                .cmp(right.page.target_id().as_ref())
+        });
+        let mut snapshots = Vec::with_capacity(authenticators.len());
+        for authenticator in &authenticators {
+            snapshots.push(
+                authenticator
+                    .page
+                    .execute(GetCredentialsParams::new(authenticator.id.clone()))
+                    .await?
+                    .credentials
+                    .clone(),
+            );
+        }
+        store.reconcile(&snapshots)?;
+        let expected = store.snapshot();
+        for (authenticator, snapshot) in authenticators.into_iter().zip(snapshots) {
+            let current = snapshot
+                .into_iter()
+                .filter_map(|credential| {
+                    let relying_party = credential.rp_id.clone()?;
+                    let key = (
+                        relying_party,
+                        String::from(credential.credential_id.clone()),
+                    );
+                    Some((key, credential))
+                })
+                .collect::<BTreeMap<_, _>>();
+            for (key, credential) in &current {
+                if !expected.contains_key(key) {
+                    authenticator
+                        .page
+                        .execute(RemoveCredentialParams::new(
+                            authenticator.id.clone(),
+                            credential.credential_id.clone(),
+                        ))
+                        .await?;
+                }
+            }
+            for (key, credential) in &expected {
+                match current.get(key) {
+                    Some(current) if current == credential => {}
+                    Some(current) => {
+                        authenticator
+                            .page
+                            .execute(RemoveCredentialParams::new(
+                                authenticator.id.clone(),
+                                current.credential_id.clone(),
+                            ))
+                            .await?;
+                        authenticator
+                            .page
+                            .execute(AddCredentialParams::new(
+                                authenticator.id.clone(),
+                                credential.clone(),
+                            ))
+                            .await?;
+                    }
+                    None => {
+                        authenticator
+                            .page
+                            .execute(AddCredentialParams::new(
+                                authenticator.id.clone(),
+                                credential.clone(),
+                            ))
+                            .await?;
+                    }
+                }
+            }
         }
         Ok(())
     }
@@ -1698,7 +1799,10 @@ async fn close_chromium(
     wait
 }
 
-async fn install_virtual_authenticator(page: &Page) -> Result<AuthenticatorId, BrowserError> {
+async fn install_virtual_authenticator(
+    page: &Page,
+    credentials: &[Credential],
+) -> Result<AuthenticatorId, BrowserError> {
     page.execute(EnableParams::builder().enable_ui(false).build())
         .await?;
     let mut options = VirtualAuthenticatorOptions::new(
@@ -1712,6 +1816,13 @@ async fn install_virtual_authenticator(page: &Page) -> Result<AuthenticatorId, B
     let response = page
         .execute(AddVirtualAuthenticatorParams::new(options))
         .await?;
+    for credential in credentials {
+        page.execute(AddCredentialParams::new(
+            response.authenticator_id.clone(),
+            credential.clone(),
+        ))
+        .await?;
+    }
     Ok(response.authenticator_id.clone())
 }
 
@@ -2157,6 +2268,11 @@ impl NativeBrowser {
                 Ok::<_, BrowserError>(result)
             }
             .await;
+            let credential_sync = session.synchronize_virtual_credentials().await;
+            let execution = match (execution, credential_sync) {
+                (Ok(result), Ok(())) => Ok(result),
+                (Ok(_), Err(error)) | (Err(error), _) => Err(error),
+            };
             let duration = started.elapsed();
             let result = match execution {
                 Ok(result) => {
@@ -2367,6 +2483,7 @@ impl NativeBrowser {
             .as_mut()
             .ok_or(BrowserError::VirtualAuthenticatorNotReady)?;
         session.sync_virtual_authenticators().await?;
+        session.synchronize_virtual_credentials().await?;
         session.virtual_credentials().await
     }
 }
@@ -6254,6 +6371,8 @@ pub enum BrowserError {
     DialogNotPending,
     #[error("this browser was not configured with a virtual authenticator")]
     VirtualAuthenticatorNotConfigured,
+    #[error("virtual credential store {} is invalid: {message}", path.display())]
+    VirtualCredentialStore { path: PathBuf, message: String },
     #[error("this browser was not configured with an authenticated Brave session")]
     BraveSessionNotConfigured,
     #[error("the virtual authenticator is not ready; navigate to a page first")]

--- a/crates/experimental/nanocodex-browser/src/native.rs
+++ b/crates/experimental/nanocodex-browser/src/native.rs
@@ -186,6 +186,7 @@ struct Session {
     passkey_mode: BrowserPasskeyMode,
     react_diagnostics_enabled: bool,
     authenticators: HashMap<String, InstalledAuthenticator>,
+    closed_targets: HashSet<String>,
     allowed_origins: Vec<Url>,
     network_controls: network_control::NetworkControls,
     egress_targets: HashSet<String>,
@@ -815,6 +816,7 @@ impl Session {
             passkey_mode: BrowserPasskeyMode::Auto,
             react_diagnostics_enabled: react_diagnostics.is_some(),
             authenticators: HashMap::new(),
+            closed_targets: HashSet::new(),
             allowed_origins: brave_session
                 .map(|session| session.allowed_origins().to_vec())
                 .unwrap_or_default(),
@@ -1039,6 +1041,8 @@ impl Session {
                 .cloned()
         });
         page.close().await?;
+        self.authenticators.remove(tab_id);
+        self.closed_targets.insert(tab_id.to_owned());
         if let Some(Some(replacement)) = replacement {
             replacement.bring_to_front().await?;
             self.activate_page(replacement).await?;
@@ -1493,10 +1497,20 @@ impl Session {
             return Ok(());
         }
 
-        let mut pages = vec![self.page.clone()];
         let targets = self.browser.execute(GetTargetsParams::default()).await?;
+        let reported_targets = targets
+            .target_infos
+            .iter()
+            .map(|target| target.target_id.as_ref())
+            .collect::<HashSet<_>>();
+        self.closed_targets
+            .retain(|target_id| reported_targets.contains(target_id.as_str()));
+        let mut pages = Vec::new();
         for target in &targets.target_infos {
-            if target.r#type != "iframe" {
+            if !matches!(target.r#type.as_str(), "page" | "iframe") {
+                continue;
+            }
+            if self.closed_targets.contains(target.target_id.as_ref()) {
                 continue;
             }
             match self.browser.get_page(target.target_id.clone()).await {

--- a/crates/experimental/nanocodex-browser/src/native.rs
+++ b/crates/experimental/nanocodex-browser/src/native.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     io::{self, Write},
     path::{Path, PathBuf},
     sync::{Arc, Mutex as StdMutex},
@@ -93,10 +93,10 @@ use crate::{
     BrowserElementContext, BrowserElementReference, BrowserFrame, BrowserGate, BrowserHttpHeader,
     BrowserImageArtifact, BrowserNetworkBodyKind, BrowserNetworkCallFrame, BrowserNetworkContext,
     BrowserNetworkInitiator, BrowserNetworkRequest, BrowserNetworkTiming, BrowserOriginStorage,
-    BrowserPageError, BrowserPageState, BrowserPostActionSnapshot, BrowserReactEvent,
-    BrowserReactStatus, BrowserStorageState, BrowserTab, BrowserTarget, BrowserTargetIndex,
-    BrowserWebSocketDirection, BrowserWebSocketMessage, MAX_VIEWPORT_DIMENSION, ReactDiagnostics,
-    VirtualAuthenticator, VirtualCredential,
+    BrowserPageError, BrowserPageState, BrowserPasskeyMode, BrowserPostActionSnapshot,
+    BrowserReactEvent, BrowserReactStatus, BrowserStorageState, BrowserTab, BrowserTarget,
+    BrowserTargetIndex, BrowserWebSocketDirection, BrowserWebSocketMessage, MAX_VIEWPORT_DIMENSION,
+    ReactDiagnostics, VirtualAuthenticator, VirtualCredential,
     features::{BrowserColorScheme, BrowserContext, BrowserPermission, BrowserReducedMotion},
     session::cookie_applies_to,
     trace_serialized,
@@ -183,6 +183,7 @@ struct Session {
     output_dir: PathBuf,
     virtual_authenticator: Option<VirtualAuthenticator>,
     virtual_credential_store: Option<VirtualCredentialStore>,
+    passkey_mode: BrowserPasskeyMode,
     react_diagnostics_enabled: bool,
     authenticators: HashMap<String, InstalledAuthenticator>,
     allowed_origins: Vec<Url>,
@@ -811,6 +812,7 @@ impl Session {
             output_dir,
             virtual_authenticator,
             virtual_credential_store,
+            passkey_mode: BrowserPasskeyMode::Auto,
             react_diagnostics_enabled: react_diagnostics.is_some(),
             authenticators: HashMap::new(),
             allowed_origins: brave_session
@@ -1517,10 +1519,9 @@ impl Session {
                 continue;
             }
             let credentials = self
-                .virtual_credential_store
-                .as_ref()
-                .map(|store| store.credentials().cloned().collect::<Vec<_>>())
-                .unwrap_or_default();
+                .selected_virtual_credentials()
+                .into_values()
+                .collect::<Vec<_>>();
             let id = install_virtual_authenticator(&page, &credentials).await?;
             self.authenticators
                 .insert(target_id, InstalledAuthenticator { page, id });
@@ -1529,90 +1530,108 @@ impl Session {
     }
 
     async fn synchronize_virtual_credentials(&mut self) -> Result<(), BrowserError> {
-        let Some(store) = self.virtual_credential_store.as_mut() else {
+        if self.virtual_credential_store.is_none() {
             return Ok(());
-        };
+        }
         if self.authenticators.is_empty() {
             return Ok(());
         }
-        let mut authenticators = self.authenticators.values().collect::<Vec<_>>();
+        let presented = self
+            .selected_virtual_credentials()
+            .into_keys()
+            .collect::<BTreeSet<_>>();
+        let mut authenticators = self
+            .authenticators
+            .values()
+            .map(|authenticator| (authenticator.page.clone(), authenticator.id.clone()))
+            .collect::<Vec<_>>();
         authenticators.sort_unstable_by(|left, right| {
-            left.page
+            left.0
                 .target_id()
                 .as_ref()
-                .cmp(right.page.target_id().as_ref())
+                .cmp(right.0.target_id().as_ref())
         });
         let mut snapshots = Vec::with_capacity(authenticators.len());
-        for authenticator in &authenticators {
+        for (page, id) in &authenticators {
             snapshots.push(
-                authenticator
-                    .page
-                    .execute(GetCredentialsParams::new(authenticator.id.clone()))
+                page.execute(GetCredentialsParams::new(id.clone()))
                     .await?
                     .credentials
                     .clone(),
             );
         }
-        store.reconcile(&snapshots)?;
-        let expected = store.snapshot();
-        for (authenticator, snapshot) in authenticators.into_iter().zip(snapshots) {
-            let current = snapshot
-                .into_iter()
-                .filter_map(|credential| {
-                    let relying_party = credential.rp_id.clone()?;
-                    let key = (
-                        relying_party,
-                        String::from(credential.credential_id.clone()),
-                    );
-                    Some((key, credential))
-                })
-                .collect::<BTreeMap<_, _>>();
-            for (key, credential) in &current {
-                if !expected.contains_key(key) {
-                    authenticator
-                        .page
-                        .execute(RemoveCredentialParams::new(
-                            authenticator.id.clone(),
-                            credential.credential_id.clone(),
-                        ))
-                        .await?;
-                }
-            }
-            for (key, credential) in &expected {
-                match current.get(key) {
-                    Some(current) if current == credential => {}
-                    Some(current) => {
-                        authenticator
-                            .page
-                            .execute(RemoveCredentialParams::new(
-                                authenticator.id.clone(),
-                                current.credential_id.clone(),
-                            ))
-                            .await?;
-                        authenticator
-                            .page
-                            .execute(AddCredentialParams::new(
-                                authenticator.id.clone(),
-                                credential.clone(),
-                            ))
-                            .await?;
-                    }
-                    None => {
-                        authenticator
-                            .page
-                            .execute(AddCredentialParams::new(
-                                authenticator.id.clone(),
-                                credential.clone(),
-                            ))
-                            .await?;
-                    }
-                }
-            }
+        self.virtual_credential_store
+            .as_mut()
+            .ok_or(BrowserError::VirtualCredentialStoreNotConfigured)?
+            .reconcile(&snapshots, &presented)?;
+        let expected = self.selected_virtual_credentials();
+        synchronize_authenticator_snapshots(authenticators, snapshots, &expected).await
+    }
+
+    async fn apply_passkey_mode(&self) -> Result<(), BrowserError> {
+        let mut authenticators = self
+            .authenticators
+            .values()
+            .map(|authenticator| (authenticator.page.clone(), authenticator.id.clone()))
+            .collect::<Vec<_>>();
+        authenticators.sort_unstable_by(|left, right| {
+            left.0
+                .target_id()
+                .as_ref()
+                .cmp(right.0.target_id().as_ref())
+        });
+        let mut snapshots = Vec::with_capacity(authenticators.len());
+        for (page, id) in &authenticators {
+            snapshots.push(
+                page.execute(GetCredentialsParams::new(id.clone()))
+                    .await?
+                    .credentials
+                    .clone(),
+            );
         }
-        Ok(())
+        let expected = self.selected_virtual_credentials();
+        synchronize_authenticator_snapshots(authenticators, snapshots, &expected).await
+    }
+
+    fn selected_virtual_credentials(&self) -> BTreeMap<(String, String), Credential> {
+        let Some(store) = self.virtual_credential_store.as_ref() else {
+            return BTreeMap::new();
+        };
+        let mut credentials = store.snapshot();
+        match &self.passkey_mode {
+            BrowserPasskeyMode::Auto => {}
+            BrowserPasskeyMode::New => credentials.clear(),
+            BrowserPasskeyMode::Use {
+                credential_id,
+                relying_party_id,
+            } => credentials.retain(|(candidate_rp, candidate_id), _| {
+                candidate_id == credential_id
+                    && relying_party_id
+                        .as_ref()
+                        .is_none_or(|selected_rp| selected_rp == candidate_rp)
+            }),
+        }
+        credentials
+    }
+
+    fn persisted_virtual_credentials(&self) -> Result<Vec<VirtualCredential>, BrowserError> {
+        if self.virtual_authenticator.is_none() {
+            return Err(BrowserError::VirtualAuthenticatorNotConfigured);
+        }
+        let store = self
+            .virtual_credential_store
+            .as_ref()
+            .ok_or(BrowserError::VirtualCredentialStoreNotConfigured)?;
+        Ok(store
+            .credentials()
+            .map(virtual_credential_metadata)
+            .collect())
     }
 
     async fn virtual_credentials(&self) -> Result<Vec<VirtualCredential>, BrowserError> {
+        if self.virtual_credential_store.is_some() {
+            return self.persisted_virtual_credentials();
+        }
         if self.virtual_authenticator.is_none() {
             return Err(BrowserError::VirtualAuthenticatorNotConfigured);
         }
@@ -1625,22 +1644,118 @@ impl Session {
                 .page
                 .execute(GetCredentialsParams::new(authenticator.id.clone()))
                 .await?;
-            credentials.extend(
-                response
-                    .credentials
-                    .iter()
-                    .map(|credential| VirtualCredential {
-                        credential_id: String::from(credential.credential_id.clone()),
-                        relying_party_id: credential.rp_id.clone(),
-                        is_resident: credential.is_resident_credential,
-                        user_name: credential.user_name.clone(),
-                        user_display_name: credential.user_display_name.clone(),
-                        sign_count: credential.sign_count,
-                    }),
-            );
+            credentials.extend(response.credentials.iter().map(virtual_credential_metadata));
         }
         Ok(credentials)
     }
+
+    fn resolve_passkey_mode(
+        &self,
+        credential_id: String,
+        relying_party_id: Option<String>,
+    ) -> Result<BrowserPasskeyMode, BrowserError> {
+        let store = self
+            .virtual_credential_store
+            .as_ref()
+            .ok_or(BrowserError::VirtualCredentialStoreNotConfigured)?;
+        let mut matches = store.credentials().filter(|credential| {
+            String::from(credential.credential_id.clone()) == credential_id
+                && relying_party_id
+                    .as_ref()
+                    .is_none_or(|selected| credential.rp_id.as_ref() == Some(selected))
+        });
+        let selected = matches
+            .next()
+            .ok_or_else(|| BrowserError::UnknownVirtualCredential {
+                credential_id: credential_id.clone(),
+            })?;
+        if matches.next().is_some() {
+            return Err(BrowserError::AmbiguousVirtualCredential { credential_id });
+        }
+        Ok(BrowserPasskeyMode::Use {
+            credential_id,
+            relying_party_id: selected.rp_id.clone(),
+        })
+    }
+
+    fn passkeys_result(
+        &self,
+        sequence: u64,
+        action: BrowserActionName,
+    ) -> Result<BrowserActionResult, BrowserError> {
+        Ok(BrowserActionResult::Passkeys {
+            sequence,
+            executed: true,
+            action,
+            mode: self.passkey_mode.clone(),
+            credentials: self.persisted_virtual_credentials()?,
+        })
+    }
+}
+
+fn virtual_credential_metadata(credential: &Credential) -> VirtualCredential {
+    VirtualCredential {
+        credential_id: String::from(credential.credential_id.clone()),
+        relying_party_id: credential.rp_id.clone(),
+        is_resident: credential.is_resident_credential,
+        user_name: credential.user_name.clone(),
+        user_display_name: credential.user_display_name.clone(),
+        sign_count: credential.sign_count,
+    }
+}
+
+async fn synchronize_authenticator_snapshots(
+    authenticators: Vec<(Page, AuthenticatorId)>,
+    snapshots: Vec<Vec<Credential>>,
+    expected: &BTreeMap<(String, String), Credential>,
+) -> Result<(), BrowserError> {
+    for ((page, authenticator_id), snapshot) in authenticators.into_iter().zip(snapshots) {
+        let current = snapshot
+            .into_iter()
+            .filter_map(|credential| {
+                let relying_party = credential.rp_id.clone()?;
+                let key = (
+                    relying_party,
+                    String::from(credential.credential_id.clone()),
+                );
+                Some((key, credential))
+            })
+            .collect::<BTreeMap<_, _>>();
+        for (key, credential) in &current {
+            if !expected.contains_key(key) {
+                page.execute(RemoveCredentialParams::new(
+                    authenticator_id.clone(),
+                    credential.credential_id.clone(),
+                ))
+                .await?;
+            }
+        }
+        for (key, credential) in expected {
+            match current.get(key) {
+                Some(current) if current == credential => {}
+                Some(current) => {
+                    page.execute(RemoveCredentialParams::new(
+                        authenticator_id.clone(),
+                        current.credential_id.clone(),
+                    ))
+                    .await?;
+                    page.execute(AddCredentialParams::new(
+                        authenticator_id.clone(),
+                        credential.clone(),
+                    ))
+                    .await?;
+                }
+                None => {
+                    page.execute(AddCredentialParams::new(
+                        authenticator_id.clone(),
+                        credential.clone(),
+                    ))
+                    .await?;
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 fn validate_snapshot_wire(
@@ -2520,6 +2635,33 @@ async fn execute_action(
                 executed: true,
                 gate: classify_gate(&signals),
             })
+        }
+        BrowserAction::Passkeys => {
+            session.synchronize_virtual_credentials().await?;
+            session.passkeys_result(sequence, BrowserActionName::Passkeys)
+        }
+        BrowserAction::PasskeyUse {
+            credential_id,
+            relying_party_id,
+        } => {
+            session.synchronize_virtual_credentials().await?;
+            session.passkey_mode = session.resolve_passkey_mode(credential_id, relying_party_id)?;
+            session.apply_passkey_mode().await?;
+            session.passkeys_result(sequence, BrowserActionName::PasskeyUse)
+        }
+        BrowserAction::PasskeyNew => {
+            session.persisted_virtual_credentials()?;
+            session.synchronize_virtual_credentials().await?;
+            session.passkey_mode = BrowserPasskeyMode::New;
+            session.apply_passkey_mode().await?;
+            session.passkeys_result(sequence, BrowserActionName::PasskeyNew)
+        }
+        BrowserAction::PasskeyAuto => {
+            session.persisted_virtual_credentials()?;
+            session.synchronize_virtual_credentials().await?;
+            session.passkey_mode = BrowserPasskeyMode::Auto;
+            session.apply_passkey_mode().await?;
+            session.passkeys_result(sequence, BrowserActionName::PasskeyAuto)
         }
         BrowserAction::Snapshot {
             interactive,
@@ -6371,6 +6513,14 @@ pub enum BrowserError {
     DialogNotPending,
     #[error("this browser was not configured with a virtual authenticator")]
     VirtualAuthenticatorNotConfigured,
+    #[error("model-controlled passkeys require a configured virtual credential store")]
+    VirtualCredentialStoreNotConfigured,
+    #[error("virtual credential `{credential_id}` is not present in the persisted store")]
+    UnknownVirtualCredential { credential_id: String },
+    #[error(
+        "virtual credential `{credential_id}` exists for multiple relying parties; provide relying_party_id"
+    )]
+    AmbiguousVirtualCredential { credential_id: String },
     #[error("virtual credential store {} is invalid: {message}", path.display())]
     VirtualCredentialStore { path: PathBuf, message: String },
     #[error("this browser was not configured with an authenticated Brave session")]

--- a/crates/experimental/nanocodex-browser/src/native/credential_store.rs
+++ b/crates/experimental/nanocodex-browser/src/native/credential_store.rs
@@ -15,7 +15,7 @@ const STORE_VERSION: u32 = 1;
 const MAX_STORE_BYTES: u64 = 4 * 1024 * 1024;
 const MAX_CREDENTIALS: usize = 1_024;
 
-type CredentialKey = (String, String);
+pub(super) type CredentialKey = (String, String);
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
@@ -76,7 +76,11 @@ impl VirtualCredentialStore {
         self.credentials.values()
     }
 
-    pub(super) fn reconcile(&mut self, snapshots: &[Vec<Credential>]) -> Result<(), BrowserError> {
+    pub(super) fn reconcile(
+        &mut self,
+        snapshots: &[Vec<Credential>],
+        presented: &BTreeSet<CredentialKey>,
+    ) -> Result<(), BrowserError> {
         if snapshots.is_empty() {
             return Ok(());
         }
@@ -88,6 +92,7 @@ impl VirtualCredentialStore {
         let deleted = self
             .credentials
             .keys()
+            .filter(|key| presented.contains(*key))
             .filter(|key| {
                 snapshots
                     .iter()
@@ -220,13 +225,15 @@ fn store_error(path: &Path, message: impl Into<String>) -> BrowserError {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use chromiumoxide::{cdp::browser_protocol::web_authn::Credential, types::Binary};
 
     use super::VirtualCredentialStore;
 
-    fn credential(sign_count: i64) -> Credential {
+    fn credential_with_id(credential_id: &str, sign_count: i64) -> Credential {
         let mut credential = Credential::new(
-            Binary::from("credential-id".to_owned()),
+            Binary::from(credential_id.to_owned()),
             true,
             Binary::from("private-key".to_owned()),
             sign_count,
@@ -236,12 +243,22 @@ mod tests {
         credential
     }
 
+    fn credential(sign_count: i64) -> Credential {
+        credential_with_id("credential-id", sign_count)
+    }
+
+    fn presented() -> BTreeSet<(String, String)> {
+        BTreeSet::from([("wallet.example".to_owned(), "credential-id".to_owned())])
+    }
+
     #[test]
     fn credentials_round_trip_across_store_instances() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("browser/passkeys.json");
         let mut first = VirtualCredentialStore::load(path.clone()).unwrap();
-        first.reconcile(&[vec![credential(1)]]).unwrap();
+        first
+            .reconcile(&[vec![credential(1)]], &BTreeSet::new())
+            .unwrap();
 
         let second = VirtualCredentialStore::load(path).unwrap();
         assert_eq!(
@@ -255,9 +272,11 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("passkeys.json");
         let mut store = VirtualCredentialStore::load(path).unwrap();
-        store.reconcile(&[vec![credential(7)]]).unwrap();
         store
-            .reconcile(&[vec![credential(6)], vec![credential(8)]])
+            .reconcile(&[vec![credential(7)]], &BTreeSet::new())
+            .unwrap();
+        store
+            .reconcile(&[vec![credential(6)], vec![credential(8)]], &presented())
             .unwrap();
 
         assert_eq!(store.credentials().next().unwrap().sign_count, 8);
@@ -268,8 +287,12 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("passkeys.json");
         let mut store = VirtualCredentialStore::load(path.clone()).unwrap();
-        store.reconcile(&[vec![credential(1)]]).unwrap();
-        store.reconcile(&[Vec::new(), vec![credential(1)]]).unwrap();
+        store
+            .reconcile(&[vec![credential(1)]], &BTreeSet::new())
+            .unwrap();
+        store
+            .reconcile(&[Vec::new(), vec![credential(1)]], &presented())
+            .unwrap();
 
         assert!(
             VirtualCredentialStore::load(path)
@@ -277,6 +300,33 @@ mod tests {
                 .credentials()
                 .next()
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn credentials_hidden_by_selection_are_not_deleted() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("passkeys.json");
+        let selected = credential_with_id("selected", 1);
+        let hidden = credential_with_id("hidden", 2);
+        let mut store = VirtualCredentialStore::load(path.clone()).unwrap();
+        store
+            .reconcile(&[vec![selected.clone(), hidden.clone()]], &BTreeSet::new())
+            .unwrap();
+        store
+            .reconcile(
+                &[vec![selected.clone()]],
+                &BTreeSet::from([("wallet.example".to_owned(), "selected".to_owned())]),
+            )
+            .unwrap();
+
+        assert_eq!(
+            VirtualCredentialStore::load(path)
+                .unwrap()
+                .credentials()
+                .cloned()
+                .collect::<Vec<_>>(),
+            [hidden, selected]
         );
     }
 
@@ -288,7 +338,9 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("browser/passkeys.json");
         let mut store = VirtualCredentialStore::load(path.clone()).unwrap();
-        store.reconcile(&[vec![credential(1)]]).unwrap();
+        store
+            .reconcile(&[vec![credential(1)]], &BTreeSet::new())
+            .unwrap();
 
         assert_eq!(
             std::fs::metadata(path).unwrap().permissions().mode() & 0o777,

--- a/crates/experimental/nanocodex-browser/src/native/credential_store.rs
+++ b/crates/experimental/nanocodex-browser/src/native/credential_store.rs
@@ -1,0 +1,298 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
+
+use chromiumoxide::cdp::browser_protocol::web_authn::Credential;
+use serde::{Deserialize, Serialize};
+use tempfile::NamedTempFile;
+
+use super::BrowserError;
+
+const STORE_VERSION: u32 = 1;
+const MAX_STORE_BYTES: u64 = 4 * 1024 * 1024;
+const MAX_CREDENTIALS: usize = 1_024;
+
+type CredentialKey = (String, String);
+
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CredentialStoreFile {
+    version: u32,
+    credentials: Vec<Credential>,
+}
+
+pub(super) struct VirtualCredentialStore {
+    path: PathBuf,
+    credentials: BTreeMap<CredentialKey, Credential>,
+}
+
+impl VirtualCredentialStore {
+    pub(super) fn load(path: PathBuf) -> Result<Self, BrowserError> {
+        let metadata = match fs::symlink_metadata(&path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                return Ok(Self {
+                    path,
+                    credentials: BTreeMap::new(),
+                });
+            }
+            Err(error) => return Err(error.into()),
+        };
+        if metadata.file_type().is_symlink() {
+            return Err(store_error(&path, "must not be a symbolic link"));
+        }
+        if metadata.len() > MAX_STORE_BYTES {
+            return Err(store_error(
+                &path,
+                format!("file exceeds the {MAX_STORE_BYTES}-byte limit"),
+            ));
+        }
+        restrict_secret_permissions(&path)?;
+        let contents = fs::read(&path)?;
+        let stored: CredentialStoreFile = serde_json::from_slice(&contents)?;
+        if stored.version != STORE_VERSION {
+            return Err(store_error(
+                &path,
+                format!(
+                    "unsupported version {}; expected {STORE_VERSION}",
+                    stored.version
+                ),
+            ));
+        }
+        if stored.credentials.len() > MAX_CREDENTIALS {
+            return Err(store_error(
+                &path,
+                format!("contains more than {MAX_CREDENTIALS} credentials"),
+            ));
+        }
+        let credentials = credential_map(stored.credentials, &path)?;
+        Ok(Self { path, credentials })
+    }
+
+    pub(super) fn credentials(&self) -> impl Iterator<Item = &Credential> {
+        self.credentials.values()
+    }
+
+    pub(super) fn reconcile(&mut self, snapshots: &[Vec<Credential>]) -> Result<(), BrowserError> {
+        if snapshots.is_empty() {
+            return Ok(());
+        }
+        let snapshots = snapshots
+            .iter()
+            .cloned()
+            .map(|credentials| credential_map(credentials, &self.path))
+            .collect::<Result<Vec<_>, _>>()?;
+        let deleted = self
+            .credentials
+            .keys()
+            .filter(|key| {
+                snapshots
+                    .iter()
+                    .any(|snapshot| !snapshot.contains_key(*key))
+            })
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let mut next = self.credentials.clone();
+        next.retain(|key, _| !deleted.contains(key));
+        for snapshot in &snapshots {
+            for (key, credential) in snapshot {
+                if deleted.contains(key) {
+                    continue;
+                }
+                match next.get(key) {
+                    Some(current)
+                        if current.sign_count > credential.sign_count || current == credential => {}
+                    _ => {
+                        next.insert(key.clone(), credential.clone());
+                    }
+                }
+            }
+        }
+        if next.len() > MAX_CREDENTIALS {
+            return Err(store_error(
+                &self.path,
+                format!("would contain more than {MAX_CREDENTIALS} credentials"),
+            ));
+        }
+        if next != self.credentials {
+            self.persist(&next)?;
+            self.credentials = next;
+        }
+        Ok(())
+    }
+
+    pub(super) fn snapshot(&self) -> BTreeMap<(String, String), Credential> {
+        self.credentials.clone()
+    }
+
+    fn persist(
+        &self,
+        credentials: &BTreeMap<CredentialKey, Credential>,
+    ) -> Result<(), BrowserError> {
+        let contents = serde_json::to_vec_pretty(&CredentialStoreFile {
+            version: STORE_VERSION,
+            credentials: credentials.values().cloned().collect(),
+        })?;
+        if contents.len() as u64 > MAX_STORE_BYTES {
+            return Err(store_error(
+                &self.path,
+                format!("serialized file exceeds the {MAX_STORE_BYTES}-byte limit"),
+            ));
+        }
+        atomic_write_secret(&self.path, &contents)?;
+        Ok(())
+    }
+}
+
+fn credential_map(
+    credentials: Vec<Credential>,
+    path: &Path,
+) -> Result<BTreeMap<CredentialKey, Credential>, BrowserError> {
+    let mut mapped = BTreeMap::new();
+    for credential in credentials {
+        let relying_party = credential
+            .rp_id
+            .as_ref()
+            .filter(|relying_party| !relying_party.is_empty())
+            .ok_or_else(|| store_error(path, "credential is missing its relying-party ID"))?;
+        let credential_id = String::from(credential.credential_id.clone());
+        if credential_id.is_empty() {
+            return Err(store_error(path, "credential has an empty ID"));
+        }
+        let key = (relying_party.clone(), credential_id);
+        if mapped.insert(key, credential).is_some() {
+            return Err(store_error(path, "contains a duplicate credential"));
+        }
+    }
+    Ok(mapped)
+}
+
+fn atomic_write_secret(path: &Path, contents: &[u8]) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    #[cfg(unix)]
+    let parent_existed = parent.exists();
+    fs::create_dir_all(parent)?;
+    #[cfg(unix)]
+    if !parent_existed {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::set_permissions(parent, fs::Permissions::from_mode(0o700))?;
+    }
+    let mut temporary = NamedTempFile::new_in(parent)?;
+    temporary.write_all(contents)?;
+    temporary.as_file().sync_all()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        temporary
+            .as_file()
+            .set_permissions(fs::Permissions::from_mode(0o600))?;
+    }
+    temporary.persist(path).map_err(|error| error.error)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn restrict_secret_permissions(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(not(unix))]
+fn restrict_secret_permissions(_path: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+fn store_error(path: &Path, message: impl Into<String>) -> BrowserError {
+    BrowserError::VirtualCredentialStore {
+        path: path.to_path_buf(),
+        message: message.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chromiumoxide::{cdp::browser_protocol::web_authn::Credential, types::Binary};
+
+    use super::VirtualCredentialStore;
+
+    fn credential(sign_count: i64) -> Credential {
+        let mut credential = Credential::new(
+            Binary::from("credential-id".to_owned()),
+            true,
+            Binary::from("private-key".to_owned()),
+            sign_count,
+        );
+        credential.rp_id = Some("wallet.example".to_owned());
+        credential.user_name = Some("tester".to_owned());
+        credential
+    }
+
+    #[test]
+    fn credentials_round_trip_across_store_instances() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("browser/passkeys.json");
+        let mut first = VirtualCredentialStore::load(path.clone()).unwrap();
+        first.reconcile(&[vec![credential(1)]]).unwrap();
+
+        let second = VirtualCredentialStore::load(path).unwrap();
+        assert_eq!(
+            second.credentials().cloned().collect::<Vec<_>>(),
+            [credential(1)]
+        );
+    }
+
+    #[test]
+    fn the_highest_observed_signature_counter_wins() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("passkeys.json");
+        let mut store = VirtualCredentialStore::load(path).unwrap();
+        store.reconcile(&[vec![credential(7)]]).unwrap();
+        store
+            .reconcile(&[vec![credential(6)], vec![credential(8)]])
+            .unwrap();
+
+        assert_eq!(store.credentials().next().unwrap().sign_count, 8);
+    }
+
+    #[test]
+    fn deletion_from_one_synchronized_authenticator_removes_the_credential() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("passkeys.json");
+        let mut store = VirtualCredentialStore::load(path.clone()).unwrap();
+        store.reconcile(&[vec![credential(1)]]).unwrap();
+        store.reconcile(&[Vec::new(), vec![credential(1)]]).unwrap();
+
+        assert!(
+            VirtualCredentialStore::load(path)
+                .unwrap()
+                .credentials()
+                .next()
+                .is_none()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn persisted_credentials_are_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("browser/passkeys.json");
+        let mut store = VirtualCredentialStore::load(path.clone()).unwrap();
+        store.reconcile(&[vec![credential(1)]]).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+}

--- a/crates/experimental/nanocodex-browser/src/tests.rs
+++ b/crates/experimental/nanocodex-browser/src/tests.rs
@@ -278,6 +278,63 @@ async fn virtual_passkeys_persist_across_browser_sessions() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+#[ignore = "requires a local Chrome or Chromium installation"]
+async fn virtual_authenticator_is_reused_when_returning_to_a_tab() -> Result<()> {
+    let directory = tempfile::tempdir()?;
+    let credential_store = directory.path().join("browser/passkeys.json");
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let address = listener.local_addr()?;
+    let server = tokio::spawn(serve_passkey_fixture(listener));
+    let url = format!("http://localhost:{}/", address.port());
+    let browser = Browser::builder()
+        .virtual_authenticator(
+            VirtualAuthenticator::platform_passkey().credential_store(credential_store),
+        )
+        .build()?;
+
+    browser
+        .execute(BrowserAction::Open { url: url.clone() })
+        .await?;
+    let BrowserActionResult::Tabs { tabs, .. } = browser.execute(BrowserAction::ListTabs).await?
+    else {
+        return Err(eyre!("expected browser tabs"));
+    };
+    let original_tab = tabs
+        .into_iter()
+        .find(|tab| tab.active)
+        .ok_or_else(|| eyre!("missing active browser tab"))?
+        .tab_id;
+    browser
+        .execute(BrowserAction::NewTab { url: Some(url) })
+        .await?;
+    browser
+        .execute(BrowserAction::SelectTab {
+            tab_id: original_tab,
+        })
+        .await?;
+    browser.execute(BrowserAction::Passkeys).await?;
+    let BrowserActionResult::Tabs { tabs, .. } = browser.execute(BrowserAction::ListTabs).await?
+    else {
+        return Err(eyre!("expected browser tabs"));
+    };
+    let inactive_tab = tabs
+        .into_iter()
+        .find(|tab| !tab.active)
+        .ok_or_else(|| eyre!("missing inactive browser tab"))?
+        .tab_id;
+    browser
+        .execute(BrowserAction::CloseTab {
+            tab_id: inactive_tab,
+        })
+        .await?;
+    browser.execute(BrowserAction::Passkeys).await?;
+
+    browser.close().await?;
+    server.abort();
+    Ok(())
+}
+
 #[test]
 fn authentication_handoff_requires_an_authenticated_brave_session() -> Result<()> {
     let browser = Browser::new()?;

--- a/crates/experimental/nanocodex-browser/src/tests.rs
+++ b/crates/experimental/nanocodex-browser/src/tests.rs
@@ -18,10 +18,10 @@ use super::{
     BrowserCookie, BrowserCruxClient, BrowserCruxScope, BrowserDocumentReadyState,
     BrowserEgressPolicy, BrowserError, BrowserKeyModifier, BrowserLighthouseCategory,
     BrowserLighthouseFormFactor, BrowserLoadState, BrowserNetworkBodyKind, BrowserNetworkContext,
-    BrowserOriginStorage, BrowserPerformanceInsight, BrowserPostActionSnapshot, BrowserPseudoClass,
-    BrowserReactEventKind, BrowserReducedMotion, BrowserRouteHeader, BrowserRouteResponse,
-    BrowserStorageState, BrowserTarget, BrowserTool, BrowserViewport, BrowserWaitForSelectorState,
-    ReactDiagnostics, VirtualAuthenticator, browser_tool_builder,
+    BrowserOriginStorage, BrowserPasskeyMode, BrowserPerformanceInsight, BrowserPostActionSnapshot,
+    BrowserPseudoClass, BrowserReactEventKind, BrowserReducedMotion, BrowserRouteHeader,
+    BrowserRouteResponse, BrowserStorageState, BrowserTarget, BrowserTool, BrowserViewport,
+    BrowserWaitForSelectorState, ReactDiagnostics, VirtualAuthenticator, browser_tool_builder,
 };
 
 #[test]
@@ -206,6 +206,28 @@ async fn virtual_passkeys_persist_across_browser_sessions() -> Result<()> {
     let restored = second.virtual_credentials().await?;
     assert_eq!(restored.len(), 1);
     assert_eq!(restored[0].credential_id, credential_id);
+    let listed = second.execute(BrowserAction::Passkeys).await?;
+    assert!(matches!(
+        listed,
+        BrowserActionResult::Passkeys {
+            mode: BrowserPasskeyMode::Auto,
+            ref credentials,
+            ..
+        } if credentials.len() == 1 && credentials[0].credential_id == credential_id
+    ));
+    let selected = second
+        .execute(BrowserAction::PasskeyUse {
+            credential_id: credential_id.clone(),
+            relying_party_id: restored[0].relying_party_id.clone(),
+        })
+        .await?;
+    assert!(matches!(
+        selected,
+        BrowserActionResult::Passkeys {
+            mode: BrowserPasskeyMode::Use { ref credential_id, .. },
+            ..
+        } if credential_id == &registered[0].credential_id
+    ));
     second
         .execute(BrowserAction::Click {
             target: BrowserTarget::role("button").named("Authenticate passkey"),
@@ -233,6 +255,24 @@ async fn virtual_passkeys_persist_across_browser_sessions() -> Result<()> {
     assert_eq!(authenticated.len(), 1);
     assert_eq!(authenticated[0].credential_id, credential_id);
     assert!(authenticated[0].sign_count > registration_count);
+    let fresh = second.execute(BrowserAction::PasskeyNew).await?;
+    assert!(matches!(
+        fresh,
+        BrowserActionResult::Passkeys {
+            mode: BrowserPasskeyMode::New,
+            ref credentials,
+            ..
+        } if credentials.len() == 1 && credentials[0].credential_id == credential_id
+    ));
+    let automatic = second.execute(BrowserAction::PasskeyAuto).await?;
+    assert!(matches!(
+        automatic,
+        BrowserActionResult::Passkeys {
+            mode: BrowserPasskeyMode::Auto,
+            ref credentials,
+            ..
+        } if credentials.len() == 1 && credentials[0].credential_id == credential_id
+    ));
     second.close().await?;
     server.abort();
     Ok(())
@@ -350,6 +390,56 @@ text({ opened, snapshot, clicked, html, elementContext });
     Ok(())
 }
 
+#[test]
+fn recording_browser_exposes_model_controlled_passkey_modes() -> Result<()> {
+    let (_browser, recording) = BrowserTool::recording();
+
+    let listed = recording.record(BrowserAction::Passkeys)?;
+    let selected = recording.record(BrowserAction::PasskeyUse {
+        credential_id: "credential-id".to_owned(),
+        relying_party_id: Some("wallet.example".to_owned()),
+    })?;
+    let fresh = recording.record(BrowserAction::PasskeyNew)?;
+    let automatic = recording.record(BrowserAction::PasskeyAuto)?;
+
+    assert!(matches!(
+        listed,
+        BrowserActionResult::Passkeys {
+            action: BrowserActionName::Passkeys,
+            mode: BrowserPasskeyMode::Auto,
+            ..
+        }
+    ));
+    assert!(matches!(
+        selected,
+        BrowserActionResult::Passkeys {
+            action: BrowserActionName::PasskeyUse,
+            mode: BrowserPasskeyMode::Use {
+                credential_id,
+                relying_party_id: Some(relying_party_id),
+            },
+            ..
+        } if credential_id == "credential-id" && relying_party_id == "wallet.example"
+    ));
+    assert!(matches!(
+        fresh,
+        BrowserActionResult::Passkeys {
+            action: BrowserActionName::PasskeyNew,
+            mode: BrowserPasskeyMode::New,
+            ..
+        }
+    ));
+    assert!(matches!(
+        automatic,
+        BrowserActionResult::Passkeys {
+            action: BrowserActionName::PasskeyAuto,
+            mode: BrowserPasskeyMode::Auto,
+            ..
+        }
+    ));
+    Ok(())
+}
+
 #[tokio::test]
 async fn code_mode_description_exposes_browser_action_schema() -> Result<()> {
     let (browser, _recording) = BrowserTool::recording();
@@ -409,6 +499,10 @@ async fn code_mode_description_exposes_browser_action_schema() -> Result<()> {
     assert!(description.contains(r#"action: "axe_audit""#));
     assert!(description.contains(r#"action: "lighthouse_audit""#));
     assert!(description.contains(r#"action: "crux""#));
+    assert!(description.contains(r#"action: "passkeys""#));
+    assert!(description.contains(r#"action: "passkey_use""#));
+    assert!(description.contains(r#"action: "passkey_new""#));
+    assert!(description.contains(r#"action: "passkey_auto""#));
     assert!(description.contains(r#"action: "export_har""#));
     assert!(description.contains(r#"action: "list_frames""#));
     assert!(description.contains(r#"action: "list_tabs""#));

--- a/crates/experimental/nanocodex-browser/src/tests.rs
+++ b/crates/experimental/nanocodex-browser/src/tests.rs
@@ -149,6 +149,95 @@ async fn virtual_credentials_require_the_first_navigation() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+#[ignore = "requires a local Chrome or Chromium installation"]
+async fn virtual_passkeys_persist_across_browser_sessions() -> Result<()> {
+    let directory = tempfile::tempdir()?;
+    let credential_store = directory.path().join("browser/passkeys.json");
+    let listener = TcpListener::bind(("127.0.0.1", 0)).await?;
+    let address = listener.local_addr()?;
+    let server = tokio::spawn(serve_passkey_fixture(listener));
+    let url = format!("http://localhost:{}/", address.port());
+
+    let first = Browser::builder()
+        .virtual_authenticator(
+            VirtualAuthenticator::platform_passkey().credential_store(credential_store.clone()),
+        )
+        .build()?;
+    first
+        .execute(BrowserAction::Open { url: url.clone() })
+        .await?;
+    first
+        .execute(BrowserAction::Click {
+            target: BrowserTarget::role("button").named("Register passkey"),
+            options: None,
+        })
+        .await?;
+    let registration_wait = first
+        .execute(BrowserAction::WaitForText {
+            text: "registered".to_owned(),
+            target: Some(BrowserTarget::css("#status")),
+            hidden: false,
+        })
+        .await;
+    if let Err(error) = registration_wait {
+        let status = first
+            .execute(BrowserAction::Evaluate {
+                expression: "document.querySelector('#status').textContent".to_owned(),
+            })
+            .await?;
+        return Err(eyre!(
+            "passkey registration failed with {status:?}: {error}"
+        ));
+    }
+    let registered = first.virtual_credentials().await?;
+    assert_eq!(registered.len(), 1);
+    let credential_id = registered[0].credential_id.clone();
+    let registration_count = registered[0].sign_count;
+    first.close().await?;
+    assert!(credential_store.is_file());
+
+    let second = Browser::builder()
+        .virtual_authenticator(
+            VirtualAuthenticator::platform_passkey().credential_store(credential_store),
+        )
+        .build()?;
+    second.execute(BrowserAction::Open { url }).await?;
+    let restored = second.virtual_credentials().await?;
+    assert_eq!(restored.len(), 1);
+    assert_eq!(restored[0].credential_id, credential_id);
+    second
+        .execute(BrowserAction::Click {
+            target: BrowserTarget::role("button").named("Authenticate passkey"),
+            options: None,
+        })
+        .await?;
+    let authentication_wait = second
+        .execute(BrowserAction::WaitForText {
+            text: "authenticated".to_owned(),
+            target: Some(BrowserTarget::css("#status")),
+            hidden: false,
+        })
+        .await;
+    if let Err(error) = authentication_wait {
+        let status = second
+            .execute(BrowserAction::Evaluate {
+                expression: "document.querySelector('#status').textContent".to_owned(),
+            })
+            .await?;
+        return Err(eyre!(
+            "passkey authentication failed with {status:?}: {error}"
+        ));
+    }
+    let authenticated = second.virtual_credentials().await?;
+    assert_eq!(authenticated.len(), 1);
+    assert_eq!(authenticated[0].credential_id, credential_id);
+    assert!(authenticated[0].sign_count > registration_count);
+    second.close().await?;
+    server.abort();
+    Ok(())
+}
+
 #[test]
 fn authentication_handoff_requires_an_authenticated_brave_session() -> Result<()> {
     let browser = Browser::new()?;
@@ -2300,6 +2389,70 @@ async fn serve_action_fixture(listener: TcpListener) -> std::io::Result<()> {
         });
     }
 }
+
+async fn serve_passkey_fixture(listener: TcpListener) -> std::io::Result<()> {
+    loop {
+        let (mut stream, _) = listener.accept().await?;
+        tokio::spawn(async move {
+            let mut request = [0_u8; 4_096];
+            if stream.read(&mut request).await? == 0 {
+                return Ok(());
+            }
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{PASSKEY_FIXTURE_HTML}",
+                PASSKEY_FIXTURE_HTML.len()
+            );
+            stream.write_all(response.as_bytes()).await?;
+            stream.shutdown().await
+        });
+    }
+}
+
+const PASSKEY_FIXTURE_HTML: &str = r##"<!doctype html>
+<button id="register">Register passkey</button>
+<button id="authenticate">Authenticate passkey</button>
+<output id="status" role="status">idle</output>
+<script>
+const challenge = () => crypto.getRandomValues(new Uint8Array(32));
+const status = document.querySelector("#status");
+document.querySelector("#register").addEventListener("click", async () => {
+  try {
+    const credential = await navigator.credentials.create({ publicKey: {
+      challenge: challenge(),
+      rp: { id: location.hostname, name: "Nanocodex passkey fixture" },
+      user: {
+        id: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+        name: "tester@nanocodex.invalid",
+        displayName: "Nanocodex Tester"
+      },
+      pubKeyCredParams: [{ type: "public-key", alg: -7 }],
+      authenticatorSelection: {
+        authenticatorAttachment: "platform",
+        residentKey: "required",
+        userVerification: "required"
+      },
+      attestation: "none",
+      timeout: 5000
+    }});
+    status.textContent = credential ? "registered" : "registration failed";
+  } catch (error) {
+    status.textContent = `error:${error.name}:${error.message}`;
+  }
+});
+document.querySelector("#authenticate").addEventListener("click", async () => {
+  try {
+    const credential = await navigator.credentials.get({ publicKey: {
+      challenge: challenge(),
+      rpId: location.hostname,
+      userVerification: "required",
+      timeout: 5000
+    }});
+    status.textContent = credential ? "authenticated" : "authentication failed";
+  } catch (error) {
+    status.textContent = `error:${error.name}:${error.message}`;
+  }
+});
+</script>"##;
 
 const ACTION_FIXTURE_HTML: &str = r#"<!doctype html>
 <style>


### PR DESCRIPTION
## Summary

- persist complete CDP WebAuthn credentials across browser and Nanocodex sessions in an owner-only atomic store
- restore and synchronize credentials across browser targets, including assertion counters and explicit deletions
- expose model-callable `passkeys`, `passkey_use`, `passkey_new`, and `passkey_auto` actions while keeping private keys out of tool output
- preserve the complete credential vault while exposing only the model-selected subset to Chromium
- retain one virtual authenticator per live tab/iframe environment across tab switches and prune it only when Chrome closes that target
- make the CLI use `$NANOCODEX_DIR/browser/passkeys.json` or `~/.nanocodex/browser/passkeys.json` by default

## Validation

- `cargo test -p nanocodex-browser --lib`
- `cargo test -p nanocodex-browser virtual_ -- --ignored --nocapture --test-threads=1`
- `cargo clippy -p nanocodex-browser --all-targets -- -D warnings`
- `cargo clippy -p nanocodex-bin -- -D warnings`
- full `cargo run -p nanocodex-bin --bin nanocodex -- run ...` smoke through open, new tab, return to original tab, `passkeys`, close inactive tab, and `passkeys` again

The real-browser persistence test registers a resident platform passkey, closes Chromium, starts a fresh browser session from the persisted vault, lists and explicitly selects that credential through the browser action contract, authenticates with the same credential ID, verifies that the signature counter advances, switches to a clean authenticator for new registration, and restores automatic selection without losing the saved credential.

The tab-ownership regression test reproduces Chrome error `Chrome only supports one internal authenticator per environment` before the fix and proves returning to an existing tab and closing another tab both reuse/prune the correct authenticator afterward.