### PR TITLE
fix(release): install matching static VM guest with nightlies

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -93,12 +93,62 @@ jobs:
           if-no-files-found: error
           retention-days: ${{ inputs.pr && 7 || 1 }}
 
+  build-vm-guest:
+    if: >-
+      github.repository == 'gakonst/nanocodex' &&
+      (github.event_name != 'workflow_dispatch' || inputs.pr == '')
+    name: build x86_64 Linux VM guest
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
+        with:
+          toolchain: stable
+          targets: x86_64-unknown-linux-musl
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          cache-on-failure: true
+      - run: sudo apt-get update && sudo apt-get install --yes musl-tools
+      - name: Build nightly VM guest
+        shell: bash
+        run: >-
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
+          cargo build --locked --profile nightly --package nanocodex-vm
+          --bin nanocodex-vm-guest --no-default-features
+          --features guest-runtime --target x86_64-unknown-linux-musl
+      - name: Verify VM guest is static
+        shell: bash
+        run: |
+          guest=target/x86_64-unknown-linux-musl/nightly/nanocodex-vm-guest
+          if LC_ALL=C readelf -lW "$guest" | grep -q '[[:space:]]INTERP[[:space:]]'; then
+            echo "VM guest has a dynamic program interpreter" >&2
+            exit 1
+          fi
+      - name: Stage artifact
+        shell: bash
+        run: |
+          mkdir dist
+          cp target/x86_64-unknown-linux-musl/nightly/nanocodex-vm-guest \
+            dist/nanocodex-vm-guest-x86_64-unknown-linux-musl
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: nanocodex-vm-guest-x86_64-unknown-linux-musl
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 1
+
   publish:
     if: >-
       github.repository == 'gakonst/nanocodex' &&
       (github.event_name != 'workflow_dispatch' || inputs.pr == '')
     name: publish immutable and rolling nightlies
-    needs: build
+    needs: [build, build-vm-guest]
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     permissions:
@@ -151,6 +201,7 @@ jobs:
               --notes-file "$notes_file" --prerelease
           else
             gh release create nightly --repo "$GITHUB_REPOSITORY" \
-              --title "Nanocodex Nightly" --notes-file "$notes_file" --prerelease
+              --target "$GITHUB_SHA" --title "Nanocodex Nightly" \
+              --notes-file "$notes_file" --prerelease
           fi
           gh release upload nightly dist/* --repo "$GITHUB_REPOSITORY" --clobber

--- a/bin/nanocodex/src/update.rs
+++ b/bin/nanocodex/src/update.rs
@@ -25,6 +25,7 @@ const NIGHTLY_RELEASE_API: &str =
     "https://api.github.com/repos/gakonst/nanocodex/releases/tags/nightly";
 const TAGGED_RELEASE_API: &str = "https://api.github.com/repos/gakonst/nanocodex/releases/tags";
 const CHECKSUMS_ASSET: &str = "SHA256SUMS";
+const VM_GUEST_ASSET: &str = "nanocodex-vm-guest-x86_64-unknown-linux-musl";
 const DOWNLOAD_ATTEMPTS: usize = 5;
 const DOWNLOAD_RETRY_DELAY: Duration = Duration::from_millis(250);
 
@@ -68,6 +69,7 @@ pub(crate) struct Update {
 #[derive(Debug, Deserialize)]
 struct Release {
     tag_name: String,
+    target_commitish: String,
     assets: Vec<ReleaseAsset>,
 }
 
@@ -150,7 +152,7 @@ impl Update {
 
         let key = latest
             .as_ref()
-            .map_or_else(|| "nightly".to_owned(), ToString::to_string);
+            .map_or_else(|| nightly_key(&release), |version| Ok(version.to_string()))?;
         if !self.nightly && !self.force && store.is_cached(&key)? {
             store.activate(&key)?;
             if let Some(latest) = &latest {
@@ -164,16 +166,20 @@ impl Update {
         let binary = find_asset(&release, asset_name)?;
         let checksums = find_asset(&release, CHECKSUMS_ASSET)?;
         let checksum_manifest = download(&client, checksums).await?;
-        let expected = checksum_for(&checksum_manifest, asset_name)?;
-        let contents = download(&client, binary).await?;
-        let actual = hex::encode(Sha256::digest(&contents));
-        if actual != expected {
-            bail!("checksum mismatch for {asset_name}: expected {expected}, downloaded {actual}");
+        let contents = download_verified(&client, binary, &checksum_manifest).await?;
+        if self.nightly
+            && let Some(guest_asset_name) = vm_guest_asset_name()
+        {
+            let guest = find_asset(&release, guest_asset_name)?;
+            let guest_contents = download_verified(&client, guest, &checksum_manifest).await?;
+            store.install_with_vm_guest(&key, &contents, &guest_contents)?;
+        } else {
+            store.install(&key, &contents)?;
         }
-
-        store.install(&key, &contents)?;
         store.activate(&key)?;
-        if let Some(latest) = &latest {
+        if self.nightly {
+            store.promote_manager(&key)?;
+        } else if let Some(latest) = &latest {
             maybe_promote_manager(&store, &key, latest, &manager_version)?;
         }
         report_activation(&previous, &key, true);
@@ -308,6 +314,23 @@ async fn download(client: &Client, asset: &ReleaseAsset) -> Result<Vec<u8>> {
     unreachable!("the download attempt loop always returns")
 }
 
+async fn download_verified(
+    client: &Client,
+    asset: &ReleaseAsset,
+    checksum_manifest: &[u8],
+) -> Result<Vec<u8>> {
+    let expected = checksum_for(checksum_manifest, &asset.name)?;
+    let contents = download(client, asset).await?;
+    let actual = hex::encode(Sha256::digest(&contents));
+    if actual != expected {
+        bail!(
+            "checksum mismatch for {}: expected {expected}, downloaded {actual}",
+            asset.name
+        );
+    }
+    Ok(contents)
+}
+
 fn retryable_download_error(error: &reqwest::Error) -> bool {
     error.status().is_none_or(retryable_download_status)
 }
@@ -323,6 +346,24 @@ fn retryable_download_status(status: StatusCode) -> bool {
 fn parse_release_version(tag: &str) -> Result<Version> {
     Version::parse(tag.strip_prefix('v').unwrap_or(tag))
         .wrap_err_with(|| format!("release tag {tag:?} is not a semantic version"))
+}
+
+fn nightly_key(release: &Release) -> Result<String> {
+    nightly_key_for(release, std::env::consts::OS, std::env::consts::ARCH)
+}
+
+fn nightly_key_for(release: &Release, os: &str, arch: &str) -> Result<String> {
+    let sha = &release.target_commitish;
+    if sha.len() != 40 || !sha.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        bail!("nightly release target {sha:?} is not an exact Git commit");
+    }
+    let binary = find_asset(release, release_asset_name_for(os, arch)?)?;
+    let mut key = format!("nightly-{}-{}", sha.to_ascii_lowercase(), binary.id);
+    if let Some(guest_asset_name) = vm_guest_asset_name_for(os, arch) {
+        let guest = find_asset(release, guest_asset_name)?;
+        key.push_str(&format!("-{}", guest.id));
+    }
+    Ok(key)
 }
 
 fn find_asset<'a>(release: &'a Release, name: &str) -> Result<&'a ReleaseAsset> {
@@ -361,6 +402,14 @@ fn checksum_for(manifest: &[u8], asset_name: &str) -> Result<String> {
 
 fn release_asset_name() -> Result<&'static str> {
     release_asset_name_for(std::env::consts::OS, std::env::consts::ARCH)
+}
+
+fn vm_guest_asset_name() -> Option<&'static str> {
+    vm_guest_asset_name_for(std::env::consts::OS, std::env::consts::ARCH)
+}
+
+fn vm_guest_asset_name_for(os: &str, arch: &str) -> Option<&'static str> {
+    matches!((os, arch), ("linux", "x86_64")).then_some(VM_GUEST_ASSET)
 }
 
 fn release_asset_name_for(os: &str, arch: &str) -> Result<&'static str> {
@@ -490,5 +539,35 @@ mod tests {
         assert!(retryable_download_status(StatusCode::TOO_MANY_REQUESTS));
         assert!(retryable_download_status(StatusCode::SERVICE_UNAVAILABLE));
         assert!(!retryable_download_status(StatusCode::NOT_FOUND));
+    }
+
+    #[test]
+    fn nightly_versions_are_bound_to_the_commit_and_both_assets() {
+        let release = Release {
+            tag_name: "nightly".to_owned(),
+            target_commitish: "0123456789abcdef0123456789abcdef01234567".to_owned(),
+            assets: vec![
+                ReleaseAsset {
+                    id: 11,
+                    name: "nanocodex-x86_64-unknown-linux-gnu".to_owned(),
+                    browser_download_url: "https://example.invalid/nanocodex".to_owned(),
+                },
+                ReleaseAsset {
+                    id: 12,
+                    name: VM_GUEST_ASSET.to_owned(),
+                    browser_download_url: "https://example.invalid/nanocodex-vm-guest".to_owned(),
+                },
+            ],
+        };
+
+        assert_eq!(
+            nightly_key_for(&release, "linux", "x86_64").unwrap(),
+            "nightly-0123456789abcdef0123456789abcdef01234567-11-12"
+        );
+        assert_eq!(
+            vm_guest_asset_name_for("linux", "x86_64"),
+            Some(VM_GUEST_ASSET)
+        );
+        assert_eq!(vm_guest_asset_name_for("macos", "aarch64"), None);
     }
 }

--- a/bin/nanocodex/src/update/store.rs
+++ b/bin/nanocodex/src/update/store.rs
@@ -9,6 +9,8 @@ use sha2::{Digest, Sha256};
 use tempfile::NamedTempFile;
 
 const CHECKSUM_FILE: &str = "nanocodex.sha256";
+const VM_GUEST_BINARY_NAME: &str = "nanocodex-vm-guest";
+const VM_GUEST_CHECKSUM_FILE: &str = "nanocodex-vm-guest.sha256";
 
 #[cfg(windows)]
 const BINARY_NAME: &str = "nanocodex.exe";
@@ -77,20 +79,7 @@ impl VersionStore {
 
     pub(super) fn is_cached(&self, key: &str) -> Result<bool> {
         validate_key(key)?;
-        let binary = self.binary_path(key);
-        let checksum_path = self.checksum_path(key);
-        if !binary.is_file() || !checksum_path.is_file() {
-            return Ok(false);
-        }
-        let expected = fs::read_to_string(&checksum_path)
-            .wrap_err_with(|| format!("failed to read {}", checksum_path.display()))?;
-        let expected = expected.trim();
-        if expected.len() != 64 || !expected.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-            return Ok(false);
-        }
-        let contents = fs::read(&binary)
-            .wrap_err_with(|| format!("failed to read cached {}", binary.display()))?;
-        Ok(hex::encode(Sha256::digest(contents)) == expected.to_ascii_lowercase())
+        file_matches_checksum(&self.binary_path(key), &self.checksum_path(key))
     }
 
     pub(super) fn install(&self, key: &str, contents: &[u8]) -> Result<()> {
@@ -105,6 +94,57 @@ impl VersionStore {
             format!("{checksum}\n").as_bytes(),
             false,
         )
+    }
+
+    pub(super) fn install_with_vm_guest(
+        &self,
+        key: &str,
+        binary: &[u8],
+        vm_guest: &[u8],
+    ) -> Result<()> {
+        validate_key(key)?;
+        fs::create_dir_all(self.versions_dir())
+            .wrap_err("failed to create the Nanocodex version store")?;
+        if self.is_cached_with_vm_guest(key)? {
+            return Ok(());
+        }
+
+        let directory = self.version_dir(key);
+        if directory.exists() {
+            bail!(
+                "cannot coherently replace incomplete Nanocodex version {}; remove {} and retry",
+                key,
+                directory.display()
+            );
+        }
+
+        let staging = tempfile::Builder::new()
+            .prefix(".install-")
+            .tempdir_in(self.versions_dir())
+            .wrap_err("failed to stage the Nanocodex version")?;
+        atomic_write(&staging.path().join(BINARY_NAME), binary, true)?;
+        atomic_write(
+            &staging.path().join(CHECKSUM_FILE),
+            format!("{}\n", hex::encode(Sha256::digest(binary))).as_bytes(),
+            false,
+        )?;
+        atomic_write(&staging.path().join(VM_GUEST_BINARY_NAME), vm_guest, true)?;
+        atomic_write(
+            &staging.path().join(VM_GUEST_CHECKSUM_FILE),
+            format!("{}\n", hex::encode(Sha256::digest(vm_guest))).as_bytes(),
+            false,
+        )?;
+        fs::rename(staging.path(), &directory)
+            .wrap_err_with(|| format!("failed to install {}", directory.display()))?;
+        Ok(())
+    }
+
+    fn is_cached_with_vm_guest(&self, key: &str) -> Result<bool> {
+        Ok(self.is_cached(key)?
+            && file_matches_checksum(
+                &self.version_dir(key).join(VM_GUEST_BINARY_NAME),
+                &self.version_dir(key).join(VM_GUEST_CHECKSUM_FILE),
+            )?)
     }
 
     pub(super) fn activate(&self, key: &str) -> Result<()> {
@@ -261,6 +301,21 @@ fn validate_key(key: &str) -> Result<()> {
     Ok(())
 }
 
+fn file_matches_checksum(path: &Path, checksum_path: &Path) -> Result<bool> {
+    if !path.is_file() || !checksum_path.is_file() {
+        return Ok(false);
+    }
+    let expected = fs::read_to_string(checksum_path)
+        .wrap_err_with(|| format!("failed to read {}", checksum_path.display()))?;
+    let expected = expected.trim();
+    if expected.len() != 64 || !expected.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Ok(false);
+    }
+    let contents =
+        fs::read(path).wrap_err_with(|| format!("failed to read cached {}", path.display()))?;
+    Ok(hex::encode(Sha256::digest(contents)) == expected.to_ascii_lowercase())
+}
+
 fn atomic_write(path: &Path, contents: &[u8], executable: bool) -> Result<()> {
     let parent = path
         .parent()
@@ -333,5 +388,31 @@ mod tests {
 
         assert!(!store.is_cached("0.2.0").unwrap());
         assert!(store.activate("0.2.0").is_err());
+    }
+
+    #[test]
+    fn installs_cli_and_vm_guest_as_one_activatable_directory() {
+        let directory = tempfile::tempdir().unwrap();
+        let store = VersionStore::at(directory.path());
+
+        store
+            .install_with_vm_guest("nightly-build", b"cli", b"guest")
+            .unwrap();
+        store.activate("nightly-build").unwrap();
+
+        assert!(store.is_cached_with_vm_guest("nightly-build").unwrap());
+        assert_eq!(
+            fs::read(directory.path().join("current/nanocodex-vm-guest")).unwrap(),
+            b"guest"
+        );
+
+        fs::write(
+            store
+                .version_dir("nightly-build")
+                .join(VM_GUEST_BINARY_NAME),
+            b"corrupted",
+        )
+        .unwrap();
+        assert!(!store.is_cached_with_vm_guest("nightly-build").unwrap());
     }
 }


### PR DESCRIPTION
## Summary

- publish the static-musl `nanocodex-vm-guest` alongside x86_64 Linux nightly host binaries
- bind nightly store entries to the exact commit and both GitHub asset IDs so host and guest cannot mix across rolling releases
- checksum and atomically install the host/guest pair as one activatable directory
- reject dynamically linked guest artifacts in CI before publishing

## Why

`nanocodex update --nightly` previously installed only the host executable. A separately present GNU dynamically linked guest passed architecture validation but failed as `ENOENT` inside the minimal VM because its ELF interpreter was absent. The rolling `nightly` store key could also expose files from different releases.

## Validation

- `rustfmt --edition 2024 --check bin/nanocodex/src/update.rs bin/nanocodex/src/update/store.rs`
- `actionlint .github/workflows/nightly.yml`
- `git show --check HEAD`
- live eval recovery used a correctly built static-musl guest and verified Codex + Nanocodex GPQA attempts end to end
