### PR TITLE
fix(eval): preserve capture-only external harness networking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3072,6 +3072,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "env_filter"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3967,7 +3987,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -3985,7 +4005,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4626,7 +4646,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
- "lru 0.12.5",
+ "lru 0.18.2",
  "nix 0.30.1",
  "rand 0.9.5",
  "virtio-bindings",
@@ -4748,6 +4768,17 @@ dependencies = [
  "kvm-bindings",
  "libc",
  "vmm-sys-util 0.15.0",
+]
+
+[[package]]
+name = "landlock"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cca98e95f35b29d469dade6724c6f96cec9236640f745a0e99b0334ec320ab1"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5505,11 +5536,15 @@ dependencies = [
  "futures-util",
  "hex",
  "ignore",
+ "landlock",
  "libkrun",
  "nanocodex-tools",
  "nix 0.31.3",
  "oci-client",
  "reflink-copy",
+ "rtnetlink",
+ "rustix 1.1.4",
+ "seccompiler",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -5622,6 +5657,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b897d7bd4f0af82e68d40d0344cf37e97f9c97ddf74a098de3e4da05e96ca395"
+dependencies = [
+ "paste",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93af8261786086024cd5e96e0a991dd65ced07bbf7c233a487bbc96b971d5539"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "libc",
+ "log",
+ "tokio",
 ]
 
 [[package]]
@@ -7816,6 +7900,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rtnetlink"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc19f84f710fa2f337617f9bc0400260a94224bde7bae28fd8879f3771ca5784"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-proto",
+ "netlink-sys",
+ "nix 0.30.1",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "rtp"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8188,6 +8290,15 @@ dependencies = [
  "serdect",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "seccompiler"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ axum = { version = "0.8.9", default-features = false, features = ["form", "http1
 bm25 = { version = "2.3.2", default-features = false }
 chrono = { version = "0.4.43", default-features = false, features = ["clock", "std", "wasmbind"] }
 chromiumoxide = "0.9.1"
+landlock = "0.4.4"
 clap = { version = "4.5.54", features = ["derive", "env"] }
 cpal = "0.16.0"
 crossterm = { version = "0.28.1", features = ["bracketed-paste", "event-stream"] }
@@ -110,9 +111,12 @@ ratatui = { version = "0.29.0", features = ["unstable-rendered-line-info"] }
 ratatex = "0.1.0"
 reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls-no-provider"] }
 reqwest-middleware = "0.5.2"
+rtnetlink = "0.21.0"
+rustix = { version = "1.1.4", features = ["thread"] }
 rustls = { version = "0.23.42", default-features = false, features = ["ring"] }
 regex = "1"
 rusqlite = { version = "0.38", features = ["bundled"] }
+seccompiler = "0.5.0"
 rquickjs = "0.12.1"
 rmcp = { version = "=3.0.0", default-features = false, features = ["auth", "client", "reqwest-tls-no-provider", "transport-async-rw", "transport-streamable-http-client-reqwest"] }
 oauth2 = { version = "5.0", default-features = false }
@@ -250,5 +254,6 @@ inherits = "profiling"
 inherits = "release"
 codegen-units = 1
 lto = "fat"
-opt-level = "s"
-strip = "debuginfo"
+opt-level = "z"
+panic = "abort"
+strip = "symbols"

--- a/crates/experimental/nanocodex-eval/src/execution.rs
+++ b/crates/experimental/nanocodex-eval/src/execution.rs
@@ -33,7 +33,7 @@ use crate::{
     all(target_os = "macos", target_arch = "aarch64")
 ))]
 use crate::{
-    harness::{Harness, HarnessAuth},
+    harness::{CAPTURE_ONLY_GUEST_RUNTIME, Harness, HarnessAuth},
     judge::JudgeRuntime,
     vm::{CachePolicy, VmBackend, VmResources},
 };
@@ -127,6 +127,7 @@ struct EvaluatorRunner {
 ))]
 struct PreparedVmHost {
     vmm: PathBuf,
+    runtime: PathBuf,
     runtime_image: PathBuf,
     cache: PathBuf,
 }
@@ -415,10 +416,24 @@ impl PreparedVmHost {
         );
         Ok(Self {
             vmm,
+            runtime,
             runtime_image: runtime_disk.path().to_path_buf(),
             cache,
         })
     }
+}
+
+/// Validates and prepares the complete VM-backed evaluation host installation.
+///
+/// Controllers call this before admitting workers so a missing, malformed, or
+/// incompatible guest runtime fails at the process boundary instead of being
+/// rediscovered independently by every claimed task.
+#[cfg(any(
+    all(target_os = "linux", not(target_env = "musl")),
+    all(target_os = "macos", target_arch = "aarch64")
+))]
+pub fn validate_prepared_eval_host() -> Result<(), EvaluationExecutionError> {
+    PreparedVmHost::open().map(drop)
 }
 
 #[cfg(any(
@@ -434,7 +449,11 @@ async fn prepare_resources(
         .task(task.clone())
         .cache_directory(&host.cache)
         .cache_policy(CachePolicy::Reuse)
-        .image_preparation_concurrency(1);
+        .image_preparation_concurrency(1)
+        .require_gvproxy(!harnesses.is_empty());
+    if !harnesses.is_empty() {
+        builder = builder.guest_executable(&host.runtime, CAPTURE_ONLY_GUEST_RUNTIME);
+    }
     for harness in harnesses {
         builder = builder.guest_executable(&harness.command, &harness.guest_command);
     }

--- a/crates/experimental/nanocodex-eval/src/harness.rs
+++ b/crates/experimental/nanocodex-eval/src/harness.rs
@@ -49,6 +49,7 @@ const DEFAULT_HARNESS_HOME: &str = "/run/nanocodex-harness-home";
 const DEFAULT_HARNESS_AUTH_FILE: &str = "/run/nanocodex-harness-home/auth.json";
 const DEFAULT_HARNESS_API_KEY_ENVIRONMENT: &str = "OPENAI_API_KEY";
 const HARNESS_OUTPUT_BYTES: usize = 8 * 1024 * 1024;
+pub(crate) const CAPTURE_ONLY_GUEST_RUNTIME: &str = "/usr/local/bin/nanocodex-vm-capture";
 #[cfg(target_arch = "aarch64")]
 const VM_GUEST_TARGET: &str = "aarch64-unknown-linux-musl";
 #[cfg(target_arch = "x86_64")]

--- a/crates/experimental/nanocodex-eval/src/harness/sandbox.rs
+++ b/crates/experimental/nanocodex-eval/src/harness/sandbox.rs
@@ -18,6 +18,7 @@ pub(super) async fn prepare_harness_vm_resources(
             VmBackend::builder()
                 .retain_passed_rootfs(false)
                 .retain_failed_rootfs(false)
+                .force_agent_network(true)
                 .web_search(web_search)
                 .verifier_environment(verifier_environment.clone()),
             task,
@@ -37,13 +38,14 @@ impl HarnessVmResources {
 
     pub(super) fn harness_attempt(
         &self,
-        runtime: VmAttempt,
+        mut runtime: VmAttempt,
         attempt: EvalAttempt<'_>,
         command: HarnessExec,
         guest_command: String,
         auth: HarnessAuth,
         guest: HarnessGuestConfig,
     ) -> InternalResult<AttemptAgent, VmAttemptError> {
+        let capture_listener = runtime.take_capture_listener();
         let session = runtime.session_handle()?;
         let runner = VmHarnessRunner::new(
             session,
@@ -52,6 +54,7 @@ impl HarnessVmResources {
             guest_command,
             auth,
             guest,
+            capture_listener,
         )?;
         let api_base_url = runner.api_base_url().to_owned();
         let runner = Arc::new(runner);
@@ -79,6 +82,7 @@ pub(super) struct VmHarnessRunner {
     capture_upstream: String,
     capture_listener: Mutex<Option<TcpListener>>,
     capture_base_url: String,
+    capture_only_port: Option<u16>,
     api_exchanges: PathBuf,
 }
 
@@ -90,6 +94,7 @@ impl VmHarnessRunner {
         guest_command: String,
         auth: HarnessAuth,
         guest: HarnessGuestConfig,
+        capture_listener: Option<TcpListener>,
     ) -> InternalResult<Self, VmAttemptError> {
         if !Path::new(&guest.home).is_absolute() || !Path::new(&guest.auth_file).is_absolute() {
             return Err(io::Error::new(
@@ -115,9 +120,22 @@ impl VmHarnessRunner {
                 GuestAuth::AuthFile(contents)
             }
         };
-        let capture_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))?;
+        let capture_listener = match capture_listener {
+            Some(listener) => listener,
+            None if attempt.task().network() == crate::NetworkPolicy::Public => {
+                TcpListener::bind((Ipv4Addr::LOCALHOST, 0))?
+            }
+            None => {
+                return Err(io::Error::other(
+                    "capture-only harness VM did not reserve its capture listener",
+                )
+                .into());
+            }
+        };
         let capture_port = capture_listener.local_addr()?.port();
         let capture_base_url = capture_proxy_vm_base_url(capture_port);
+        let capture_only_port =
+            (attempt.task().network() == crate::NetworkPolicy::Disabled).then_some(capture_port);
         let mut command_environment = environment.guest_environment(attempt.task());
         command_environment.extend(guest.environment.into_iter().map(|(key, value)| {
             let value = value
@@ -167,6 +185,7 @@ impl VmHarnessRunner {
             capture_upstream,
             capture_listener: Mutex::new(Some(capture_listener)),
             capture_base_url,
+            capture_only_port,
             api_exchanges: artifact_directory.join(HARNESS_API_EXCHANGES_FILENAME),
         })
     }
@@ -258,11 +277,18 @@ impl HarnessCommandRunner for VmHarnessRunner {
     > {
         Box::pin(async move {
             let capture_proxy = self.start_capture_proxy().await?;
-            let mut command = VmCommand::new(&self.guest_command)
-                .current_directory(&self.workspace)
-                .environment(self.environment.clone())
-                .timeout(timeout)
-                .max_output_bytes(HARNESS_OUTPUT_BYTES);
+            let mut command = if let Some(port) = self.capture_only_port {
+                VmCommand::new(CAPTURE_ONLY_GUEST_RUNTIME)
+                    .arg("--capture-only")
+                    .arg(port.to_string())
+                    .arg(&self.guest_command)
+            } else {
+                VmCommand::new(&self.guest_command)
+            }
+            .current_directory(&self.workspace)
+            .environment(self.environment.clone())
+            .timeout(timeout)
+            .max_output_bytes(HARNESS_OUTPUT_BYTES);
             for argument in arguments {
                 command = command.arg(argument);
             }

--- a/crates/experimental/nanocodex-eval/src/vm.rs
+++ b/crates/experimental/nanocodex-eval/src/vm.rs
@@ -14,6 +14,7 @@ use std::{
     future::Future,
     io,
     io::{Read as _, Write as _},
+    net::{Ipv4Addr, TcpListener},
     num::ParseFloatError,
     os::unix::fs::PermissionsExt as _,
     path::{Component, Path, PathBuf},
@@ -205,6 +206,7 @@ pub struct VmResourcesBuilder {
     image_network_retries: usize,
     image_preparation_concurrency: usize,
     gvproxy: Option<PathBuf>,
+    require_gvproxy: bool,
     guest_executables: Vec<VmGuestExecutable>,
 }
 
@@ -247,6 +249,7 @@ impl VmResources {
             image_network_retries: DEFAULT_IMAGE_NETWORK_RETRIES,
             image_preparation_concurrency: DEFAULT_IMAGE_PREPARATION_CONCURRENCY,
             gvproxy: None,
+            require_gvproxy: false,
             guest_executables: Vec::new(),
         }
     }
@@ -448,6 +451,16 @@ impl VmResourcesBuilder {
         self
     }
 
+    /// Prepares gvproxy even when the benchmark itself declares no public network.
+    ///
+    /// External harnesses need this evaluator-owned path to their host capture
+    /// proxy. Whether an attempt actually attaches to it remains backend policy.
+    #[must_use]
+    pub const fn require_gvproxy(mut self, required: bool) -> Self {
+        self.require_gvproxy = required;
+        self
+    }
+
     /// Installs one host executable into every immutable prepared task image.
     #[must_use]
     pub fn guest_executable(
@@ -528,10 +541,11 @@ impl VmResourcesBuilder {
             .iter()
             .map(|task| (task.root().to_path_buf(), Arc::new(AsyncOnceCell::new())))
             .collect();
-        let public_network = self.tasks.iter().any(|task| {
-            task.network() == NetworkPolicy::Public
-                || task.verifier().network() == NetworkPolicy::Public
-        });
+        let public_network = self.require_gvproxy
+            || self.tasks.iter().any(|task| {
+                task.network() == NetworkPolicy::Public
+                    || task.verifier().network() == NetworkPolicy::Public
+            });
         let gvproxy = if public_network {
             match self.gvproxy {
                 Some(path) if path.is_file() => Some(path),
@@ -1258,6 +1272,7 @@ pub struct VmBackend {
     web_search: bool,
     shared_directories: Arc<[SharedDirectory]>,
     verifier_environment: Arc<BTreeMap<String, String>>,
+    force_agent_network: bool,
 }
 
 /// Deliberate policy for a [`VmBackend`].
@@ -1267,6 +1282,7 @@ pub struct VmBackendBuilder {
     web_search: bool,
     shared_directories: Vec<SharedDirectory>,
     verifier_environment: BTreeMap<String, String>,
+    force_agent_network: bool,
 }
 
 impl Default for VmBackendBuilder {
@@ -1277,6 +1293,7 @@ impl Default for VmBackendBuilder {
             web_search: false,
             shared_directories: Vec::new(),
             verifier_environment: BTreeMap::new(),
+            force_agent_network: false,
         }
     }
 }
@@ -1330,6 +1347,7 @@ impl VmBackend {
                 web_search: self.web_search,
                 shared_directories: &self.shared_directories,
                 verifier_environment: &self.verifier_environment,
+                force_agent_network: self.force_agent_network,
             },
             attempt,
         )
@@ -1381,6 +1399,17 @@ impl VmBackendBuilder {
         self
     }
 
+    /// Attaches the agent VM to the prepared network independently of the task's
+    /// public-network policy.
+    ///
+    /// External harnesses use this only for their evaluator-owned capture proxy;
+    /// the verifier continues to follow the benchmark's declared policy.
+    #[must_use]
+    pub const fn force_agent_network(mut self, enabled: bool) -> Self {
+        self.force_agent_network = enabled;
+        self
+    }
+
     /// Builds a cloneable backend handle.
     #[must_use]
     pub fn build(self) -> VmBackend {
@@ -1391,6 +1420,7 @@ impl VmBackendBuilder {
             web_search: self.web_search,
             shared_directories: self.shared_directories.into(),
             verifier_environment: Arc::new(self.verifier_environment),
+            force_agent_network: self.force_agent_network,
         }
     }
 }
@@ -1468,6 +1498,7 @@ struct VmAttemptHost<'a> {
     web_search: bool,
     shared_directories: &'a [SharedDirectory],
     verifier_environment: &'a Arc<BTreeMap<String, String>>,
+    force_agent_network: bool,
 }
 
 struct AttemptGvproxy {
@@ -1478,6 +1509,18 @@ struct AttemptGvproxy {
 impl AttemptGvproxy {
     fn spawn(binary: &Path, log: &Path) -> Result<Self, VmAttemptError> {
         Self::spawn_with(binary, log, GvproxyProcess::spawn)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn spawn_capture_only(
+        binary: &Path,
+        wrapper: &Path,
+        port: u16,
+        log: &Path,
+    ) -> Result<Self, VmAttemptError> {
+        Self::spawn_with(binary, log, |binary, state_directory, log| {
+            GvproxyProcess::spawn_capture_only(binary, state_directory, log, wrapper, port)
+        })
     }
 
     fn spawn_with(
@@ -1532,6 +1575,10 @@ pub enum VmAttemptError {
     #[error("the task requires public networking but gvproxy was not prepared")]
     NetworkBackendNotPrepared,
 
+    /// Capture-only external harness networking requires Linux Landlock.
+    #[error("capture-only external harness networking is only supported on Linux hosts")]
+    CaptureOnlyNetworkUnsupported,
+
     /// Materializing the task root would overwrite attempt-owned data.
     #[error("rootfs entry collides with attempt data: {0}")]
     Collision(PathBuf),
@@ -1574,9 +1621,14 @@ pub(crate) struct VmAttempt {
     tools: Tools,
     timezone: String,
     verifier: VmVerifier,
+    capture_listener: Option<TcpListener>,
 }
 
 impl VmAttempt {
+    pub(crate) fn take_capture_listener(&mut self) -> Option<TcpListener> {
+        self.capture_listener.take()
+    }
+
     /// Returns a cheap handle for guest commands used by a custom attempt driver.
     ///
     /// # Errors
@@ -1816,11 +1868,26 @@ fn vm_attempt_inner(
     if let Some(disk) = root.writable_disk() {
         setup_guard.track_root_disk(disk.to_path_buf());
     }
-    let network = spawn_attempt_network(
-        attempt.task().network(),
-        host.gvproxy,
-        &attempt.directory().join("vm").join("gvproxy.log"),
-    )?;
+    let agent_network = if host.force_agent_network {
+        NetworkPolicy::Public
+    } else {
+        attempt.task().network()
+    };
+    let capture_listener = (host.force_agent_network
+        && attempt.task().network() == NetworkPolicy::Disabled)
+        .then(|| TcpListener::bind((Ipv4Addr::LOCALHOST, 0)))
+        .transpose()?;
+    let network_log = attempt.directory().join("vm").join("gvproxy.log");
+    let network = if let Some(listener) = &capture_listener {
+        spawn_capture_only_attempt_network(
+            host.gvproxy,
+            host.vmm,
+            listener.local_addr()?.port(),
+            &network_log,
+        )?
+    } else {
+        spawn_attempt_network(agent_network, host.gvproxy, &network_log)?
+    };
     let launch = VmLaunch {
         root,
         workspace: environment.workspace.clone(),
@@ -1905,7 +1972,30 @@ fn vm_attempt_inner(
         tools,
         timezone: environment.timezone.clone(),
         verifier,
+        capture_listener,
     })
+}
+
+#[cfg(target_os = "linux")]
+fn spawn_capture_only_attempt_network(
+    gvproxy: Option<&Path>,
+    vmm: &Path,
+    port: u16,
+    log: &Path,
+) -> Result<Option<AttemptGvproxy>, VmAttemptError> {
+    let binary = gvproxy.ok_or(VmAttemptError::NetworkBackendNotPrepared)?;
+    let wrapper = vmm.with_file_name("nanocodex-vm-guest");
+    AttemptGvproxy::spawn_capture_only(binary, &wrapper, port, log).map(Some)
+}
+
+#[cfg(target_os = "macos")]
+fn spawn_capture_only_attempt_network(
+    _gvproxy: Option<&Path>,
+    _vmm: &Path,
+    _port: u16,
+    _log: &Path,
+) -> Result<Option<AttemptGvproxy>, VmAttemptError> {
+    Err(VmAttemptError::CaptureOnlyNetworkUnsupported)
 }
 
 impl VmAttemptSetupGuard {

--- a/crates/experimental/nanocodex-vm/Cargo.toml
+++ b/crates/experimental/nanocodex-vm/Cargo.toml
@@ -35,13 +35,26 @@ host = [
     "dep:zstd",
     "nanocodex-tools/native",
 ]
-guest-runtime = ["dep:nix", "nanocodex-tools/workspace-runtime"]
+guest-runtime = [
+    "dep:futures-util",
+    "dep:landlock",
+    "dep:nix",
+    "dep:rtnetlink",
+    "dep:rustix",
+    "dep:seccompiler",
+    "nanocodex-tools/workspace-runtime",
+]
 
 [dependencies]
 base64.workspace = true
 filetime.workspace = true
+futures-util = { workspace = true, optional = true }
+landlock = { workspace = true, optional = true }
 nanocodex-tools = { path = "../../nanocodex-tools", version = "0.5.0", default-features = false }
 nix = { workspace = true, optional = true, features = ["fs", "mount"] }
+rtnetlink = { workspace = true, optional = true }
+rustix = { workspace = true, optional = true }
+seccompiler = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
@@ -52,7 +65,6 @@ arcbox-ext4 = { workspace = true, optional = true }
 async-trait = { workspace = true, optional = true }
 flate2 = { workspace = true, optional = true }
 fs2 = { workspace = true, optional = true }
-futures-util = { workspace = true, optional = true }
 hex = { workspace = true, optional = true }
 ignore = { workspace = true, optional = true }
 krun = { workspace = true, optional = true }

--- a/crates/experimental/nanocodex-vm/src/bin/nanocodex-vm-guest.rs
+++ b/crates/experimental/nanocodex-vm/src/bin/nanocodex-vm-guest.rs
@@ -1,11 +1,54 @@
 #[cfg(target_os = "linux")]
-use std::{ffi::OsStr, io, path::PathBuf};
+use std::{
+    collections::BTreeMap,
+    ffi::{OsStr, OsString},
+    io,
+    net::{Ipv4Addr, Ipv6Addr},
+    os::unix::process::CommandExt as _,
+    path::PathBuf,
+    process::Command,
+};
+
+#[cfg(target_os = "linux")]
+use futures_util::TryStreamExt as _;
+#[cfg(target_os = "linux")]
+use landlock::{
+    AccessNet, CompatLevel, Compatible, NetPort, Ruleset, RulesetAttr, RulesetCreatedAttr,
+    RulesetStatus,
+};
+#[cfg(target_os = "linux")]
+use nix::libc;
+#[cfg(target_os = "linux")]
+use rtnetlink::{Handle, RouteMessageBuilder, new_connection, packet_route::route::RouteMessage};
+#[cfg(target_os = "linux")]
+use rustix::thread::{
+    CapabilitySet, capabilities, remove_capability_from_bounding_set, set_capabilities,
+};
+#[cfg(target_os = "linux")]
+use seccompiler::{
+    BpfProgram, SeccompAction, SeccompCmpArgLen, SeccompCmpOp, SeccompCondition, SeccompFilter,
+    SeccompRule, TargetArch, apply_filter,
+};
 
 #[cfg(target_os = "linux")]
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut arguments = std::env::args_os().skip(1);
     let first = arguments.next();
+    if first.as_deref() == Some(OsStr::new("--host-capture-only")) {
+        let port = capture_port(&mut arguments, "--host-capture-only")?;
+        let program = arguments
+            .next()
+            .ok_or_else(|| invalid_input("--host-capture-only requires a program"))?;
+        return run_host_capture_only(port, program, arguments.collect());
+    }
+    if first.as_deref() == Some(OsStr::new("--capture-only")) {
+        let port = capture_port(&mut arguments, "--capture-only")?;
+        let program = arguments
+            .next()
+            .ok_or_else(|| invalid_input("--capture-only requires a program"))?;
+        return run_capture_only(port, program, arguments.collect()).await;
+    }
     if first.as_deref() == Some(OsStr::new("--overlay-root")) {
         let workspace = arguments.next().ok_or_else(|| {
             io::Error::new(
@@ -41,6 +84,172 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     nanocodex_vm::tools::serve_guest(workspace)
         .await
         .map_err(Into::into)
+}
+
+#[cfg(target_os = "linux")]
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+#[cfg(target_os = "linux")]
+fn capture_port(
+    arguments: &mut impl Iterator<Item = OsString>,
+    mode: &str,
+) -> Result<u16, io::Error> {
+    arguments
+        .next()
+        .ok_or_else(|| invalid_input(format!("{mode} requires a TCP port")))?
+        .to_string_lossy()
+        .parse::<u16>()
+        .map_err(|error| invalid_input(format!("invalid capture TCP port: {error}")))
+}
+
+#[cfg(target_os = "linux")]
+async fn run_capture_only(
+    _port: u16,
+    program: OsString,
+    arguments: Vec<OsString>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    remove_default_routes().await?;
+    drop_network_capabilities()?;
+    restrict_socket_families()?;
+    Err(Command::new(program).args(arguments).exec().into())
+}
+
+#[cfg(target_os = "linux")]
+fn drop_network_capabilities() -> Result<(), Box<dyn std::error::Error>> {
+    let network = CapabilitySet::NET_ADMIN | CapabilitySet::NET_RAW;
+    for capability in [CapabilitySet::NET_ADMIN, CapabilitySet::NET_RAW] {
+        remove_capability_from_bounding_set(capability)?;
+    }
+    let mut sets = capabilities(None)?;
+    sets.effective.remove(network);
+    sets.permitted.remove(network);
+    sets.inheritable.remove(network);
+    set_capabilities(None, sets)?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn run_host_capture_only(
+    port: u16,
+    program: OsString,
+    arguments: Vec<OsString>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    restrict_tcp_to_port(port)?;
+    restrict_socket_families()?;
+    Err(Command::new(program).args(arguments).exec().into())
+}
+
+#[cfg(target_os = "linux")]
+async fn remove_default_routes() -> Result<(), Box<dyn std::error::Error>> {
+    let (connection, handle, _) = new_connection()?;
+    let connection = tokio::spawn(connection);
+    delete_default_routes(&handle, RouteMessageBuilder::<Ipv4Addr>::new().build()).await?;
+    delete_default_routes(&handle, RouteMessageBuilder::<Ipv6Addr>::new().build()).await?;
+    connection.abort();
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+async fn delete_default_routes(
+    handle: &Handle,
+    request: RouteMessage,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut routes = handle.route().get(request).execute();
+    let mut defaults = Vec::new();
+    while let Some(route) = routes.try_next().await? {
+        if route.header.destination_prefix_length == 0 {
+            defaults.push(route);
+        }
+    }
+    drop(routes);
+    for route in defaults {
+        handle.route().del(route).execute().await?;
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn restrict_tcp_to_port(port: u16) -> Result<(), Box<dyn std::error::Error>> {
+    let status = Ruleset::default()
+        .set_compatibility(CompatLevel::HardRequirement)
+        .handle_access(AccessNet::ConnectTcp)?
+        .handle_access(AccessNet::BindTcp)?
+        .create()?
+        .add_rule(NetPort::new(port, AccessNet::ConnectTcp))?
+        .restrict_self()?;
+    if status.ruleset != RulesetStatus::FullyEnforced {
+        return Err(io::Error::other(format!(
+            "capture-only Landlock rules were not fully enforced: {status:?}"
+        ))
+        .into());
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn restrict_socket_families() -> Result<(), Box<dyn std::error::Error>> {
+    let deny_non_inet_or_unix = SeccompRule::new(vec![
+        SeccompCondition::new(
+            0,
+            SeccompCmpArgLen::Dword,
+            SeccompCmpOp::Ne,
+            libc::AF_INET as u64,
+        )?,
+        SeccompCondition::new(
+            0,
+            SeccompCmpArgLen::Dword,
+            SeccompCmpOp::Ne,
+            libc::AF_UNIX as u64,
+        )?,
+    ])?;
+    let mut deny_non_stream = vec![SeccompCondition::new(
+        0,
+        SeccompCmpArgLen::Dword,
+        SeccompCmpOp::Eq,
+        libc::AF_INET as u64,
+    )?];
+    for allowed_type in [
+        libc::SOCK_STREAM,
+        libc::SOCK_STREAM | libc::SOCK_CLOEXEC,
+        libc::SOCK_STREAM | libc::SOCK_NONBLOCK,
+        libc::SOCK_STREAM | libc::SOCK_CLOEXEC | libc::SOCK_NONBLOCK,
+    ] {
+        deny_non_stream.push(SeccompCondition::new(
+            1,
+            SeccompCmpArgLen::Dword,
+            SeccompCmpOp::Ne,
+            allowed_type as u64,
+        )?);
+    }
+    let deny_non_unix_socketpair = SeccompRule::new(vec![SeccompCondition::new(
+        0,
+        SeccompCmpArgLen::Dword,
+        SeccompCmpOp::Ne,
+        libc::AF_UNIX as u64,
+    )?])?;
+    let mut rules = BTreeMap::new();
+    rules.insert(
+        libc::SYS_socket,
+        vec![deny_non_inet_or_unix, SeccompRule::new(deny_non_stream)?],
+    );
+    rules.insert(libc::SYS_socketpair, vec![deny_non_unix_socketpair]);
+    let filter = SeccompFilter::new(
+        rules,
+        SeccompAction::Allow,
+        SeccompAction::Errno(libc::EPERM as u32),
+        if cfg!(target_arch = "x86_64") {
+            TargetArch::x86_64
+        } else if cfg!(target_arch = "aarch64") {
+            TargetArch::aarch64
+        } else {
+            return Err(io::Error::other("unsupported capture-only architecture").into());
+        },
+    )?;
+    let program: BpfProgram = filter.try_into()?;
+    apply_filter(&program)?;
+    Ok(())
 }
 
 #[cfg(not(target_os = "linux"))]

--- a/crates/experimental/nanocodex-vm/src/gvproxy.rs
+++ b/crates/experimental/nanocodex-vm/src/gvproxy.rs
@@ -99,7 +99,32 @@ impl Gvproxy {
     /// gvproxy cannot start, or its network and services sockets do not become
     /// ready before the startup deadline.
     pub fn spawn(binary: &Path, state_directory: &Path, log: &Path) -> Result<Self, GvproxyError> {
-        Self::spawn_with_process_group(binary, state_directory, log, ProcessGroup::Inherited)
+        Self::spawn_with_process_group(binary, state_directory, log, ProcessGroup::Inherited, None)
+    }
+
+    /// Starts gvproxy with host TCP connections restricted to one capture port.
+    ///
+    /// The wrapper must apply the restriction to itself and then replace itself
+    /// with gvproxy. This keeps the network policy out of post-fork callbacks.
+    ///
+    /// # Errors
+    ///
+    /// Returns the errors documented by [`Self::spawn`].
+    #[cfg(target_os = "linux")]
+    pub fn spawn_capture_only(
+        binary: &Path,
+        state_directory: &Path,
+        log: &Path,
+        wrapper: &Path,
+        port: u16,
+    ) -> Result<Self, GvproxyError> {
+        Self::spawn_with_process_group(
+            binary,
+            state_directory,
+            log,
+            ProcessGroup::Inherited,
+            Some((wrapper, port)),
+        )
     }
 
     /// Starts gvproxy in a new process group and waits for its sockets.
@@ -116,7 +141,7 @@ impl Gvproxy {
         state_directory: &Path,
         log: &Path,
     ) -> Result<Self, GvproxyError> {
-        Self::spawn_with_process_group(binary, state_directory, log, ProcessGroup::Isolated)
+        Self::spawn_with_process_group(binary, state_directory, log, ProcessGroup::Isolated, None)
     }
 
     fn spawn_with_process_group(
@@ -124,6 +149,7 @@ impl Gvproxy {
         state_directory: &Path,
         log: &Path,
         process_group: ProcessGroup,
+        capture_only: Option<(&Path, u16)>,
     ) -> Result<Self, GvproxyError> {
         fs::create_dir_all(state_directory)?;
         if let Some(parent) = log.parent() {
@@ -136,7 +162,16 @@ impl Gvproxy {
 
         let log_path = log.to_path_buf();
         let log = fs::File::create(log)?;
-        let mut command = std::process::Command::new(binary);
+        let mut command = if let Some((wrapper, port)) = capture_only {
+            let mut command = std::process::Command::new(wrapper);
+            command
+                .arg("--host-capture-only")
+                .arg(port.to_string())
+                .arg(binary);
+            command
+        } else {
+            std::process::Command::new(binary)
+        };
         command
             .arg("--listen-vfkit")
             .arg(format!("unixgram:{}", network_socket.display()))


### PR DESCRIPTION
## Summary

- route external harness traffic through the evaluator-owned capture proxy even when benchmark public networking is disabled
- reserve the one allowed host capture port and install a guest wrapper into prepared harness images
- remove guest default routes, drop network capabilities, and restrict socket families/host TCP access with Landlock + seccomp
- continue applying the benchmark network policy independently to the verifier

## Why

GPQA declares no public network, but Codex must reach the evaluator capture proxy for cloud configuration and Responses traffic. Clean `master` did not attach the harness VM to that private path, so Codex failed before its first captured request. The known-good deployment had this slice only as dirty source.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- built the host binary and static-musl guest on `dev-georgios`
- Codex-only GPQA gate passed end to end in 6.0s
- live full GPQA workset has sustained Codex and Nanocodex completions with zero infrastructure failures after deployment
