### PR TITLE
perf(js): prewarm browser WASM once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,6 @@ jobs:
           cache-dependency-path: |
             js/bindings/package-lock.json
             js/artifacts/package-lock.json
-            js/artifacts-react/package-lock.json
             js/react/package-lock.json
             js/tui/package-lock.json
             js/tui-react/package-lock.json
@@ -173,7 +172,6 @@ jobs:
           npm ci --prefix js/bindings
           npm ci --prefix js/artifacts
           npm run build --prefix js/artifacts
-          npm ci --prefix js/artifacts-react
           npm ci --prefix js/react
           npm ci --prefix js/tui
           npm run build --prefix js/tui
@@ -194,7 +192,6 @@ jobs:
           npm run test:typecheck --prefix js/bindings
           npm run check:package --prefix js/bindings
           npm test --prefix js/artifacts
-          npm test --prefix js/artifacts-react
           npm test --prefix js/react
           npm test --prefix js/tui
           npm test --prefix js/tui-react
@@ -291,7 +288,6 @@ jobs:
           cache-dependency-path: |
             js/react/package-lock.json
             js/artifacts/package-lock.json
-            js/artifacts-react/package-lock.json
             js/tui/package-lock.json
             js/tui-react/package-lock.json
             web/package-lock.json
@@ -304,8 +300,6 @@ jobs:
           npm ci --prefix js/react
           npm ci --prefix js/artifacts
           npm run build --prefix js/artifacts
-          npm ci --prefix js/artifacts-react
-          npm run build --prefix js/artifacts-react
           npm ci --prefix js/tui
           npm run build --prefix js/tui
           npm ci --prefix js/tui-react

--- a/js/bindings/browser/Agent.d.mts
+++ b/js/bindings/browser/Agent.d.mts
@@ -17,6 +17,9 @@ type ToolExposureOptions =
   | { mcp?: false | undefined; toolMode?: "code" | "direct" | undefined }
   | { mcp: McpServers; toolMode?: "code" | undefined };
 
+/** Downloads and compiles the browser runtime without opening an agent session. */
+export function prewarm(options?: { module?: unknown }): Promise<void>;
+
 /** Creates a browser- or Worker-hosted Rust/WASM Agent. */
 export function create(options?: create.Options): Promise<create.ReturnType>;
 export declare namespace create {
@@ -38,6 +41,8 @@ export declare namespace create {
     /** Optional CSP-compatible Code Mode evaluator, such as createQuickJsEvaluator(). */
     codeEvaluator?: CodeEvaluator | undefined;
     tools?: ToolMap | undefined;
+    /** Sends an optional non-generating request before the first turn. */
+    websocketWarmup?: boolean | undefined;
     websocketUrl?: string | undefined;
   };
   type ReturnType = Agent;

--- a/js/bindings/browser/Agent.mjs
+++ b/js/bindings/browser/Agent.mjs
@@ -14,6 +14,15 @@ import { createBrowserHost } from "./host.mjs";
 
 let initialized;
 
+export function prewarm(options = {}) {
+  return initialized ||= (options.module === undefined
+    ? init()
+    : init({ module_or_path: options.module })).catch((error) => {
+      initialized = undefined;
+      throw error;
+    });
+}
+
 export function create(options = {}) {
   const {
     apiKey,
@@ -26,6 +35,7 @@ export function create(options = {}) {
     thinking,
     reasoningMode,
     fastMode,
+    websocketWarmup,
     instructions,
     sessionId,
     workspace,
@@ -72,8 +82,7 @@ export function create(options = {}) {
       try {
         activateHost(host);
         await host.ready();
-        initialized ||= module === undefined ? init() : init({ module_or_path: module });
-        await initialized;
+        await prewarm({ module });
         activateHost(host);
         return new Nanocodex(JSON.stringify(toWasmConfig({
           apiKey: apiKey ?? (mpp === undefined ? "host-managed" : "mpp-managed"),
@@ -81,6 +90,7 @@ export function create(options = {}) {
             ? undefined
             : "wss://openai.mpp.tempo.xyz/v1/responses"),
           apiBaseUrl,
+          websocketWarmup,
           ...config,
         })));
       } catch (error) {

--- a/js/bindings/internal.mjs
+++ b/js/bindings/internal.mjs
@@ -145,6 +145,7 @@ export function toWasmConfig(options = {}) {
   copy(config, "thinking", options.thinking);
   copy(config, "reasoning_mode", options.reasoningMode);
   copy(config, "fast_mode", options.fastMode);
+  copy(config, "websocket_warmup", options.websocketWarmup);
   copy(config, "websocket_url", options.websocketUrl);
   copy(config, "api_base_url", options.apiBaseUrl);
   copy(config, "instructions", options.instructions);

--- a/js/bindings/node/Agent.d.mts
+++ b/js/bindings/node/Agent.d.mts
@@ -23,6 +23,8 @@ export declare namespace create {
     filesystem?: Workspace | undefined;
     module?: unknown;
     tools?: ToolMap | undefined;
+    /** Sends an optional non-generating request before the first turn. */
+    websocketWarmup?: boolean | undefined;
     websocketUrl?: string | undefined;
   };
   type ReturnType = Agent;

--- a/js/bindings/node/Agent.mjs
+++ b/js/bindings/node/Agent.mjs
@@ -22,6 +22,7 @@ export function create(options = {}) {
     thinking,
     reasoningMode,
     fastMode,
+    websocketWarmup,
     instructions,
     sessionId,
     workspace,
@@ -76,6 +77,7 @@ export function create(options = {}) {
             ? undefined
             : "wss://openai.mpp.tempo.xyz/v1/responses"),
           apiBaseUrl,
+          websocketWarmup,
           ...config,
         })));
       } catch (error) {

--- a/js/bindings/src/wasm.rs
+++ b/js/bindings/src/wasm.rs
@@ -148,6 +148,8 @@ struct WasmConfig {
     reasoning_mode: String,
     #[serde(default)]
     fast_mode: bool,
+    #[serde(default)]
+    websocket_warmup: bool,
     #[serde(default = "default_websocket_url")]
     websocket_url: String,
     #[serde(default = "default_api_base_url")]
@@ -192,6 +194,7 @@ impl WasmNanocodex {
             .thinking(thinking)
             .reasoning_mode(reasoning_mode)
             .fast_mode(config.fast_mode)
+            .websocket_warmup(config.websocket_warmup)
             .websocket_url(config.websocket_url)
             .api_base_url(config.api_base_url)
             .host_transport(JavaScriptResponsesHost)

--- a/js/bindings/test/lifecycle.test.mjs
+++ b/js/bindings/test/lifecycle.test.mjs
@@ -24,13 +24,18 @@ const SESSION_IDS = Object.freeze({
   shutdown: "018f1f9a-7b3c-7a17-8000-000000000017",
 });
 
+const createWarmAgent = (options) => Agent.create({
+  ...options,
+  websocketWarmup: true,
+});
+
 test("prompt acceptance is separate from results and healthy follow-ons reuse one socket", async () => {
   const server = await startResponsesServer();
   const firstSeen = deferred();
   const releaseFirst = deferred();
   const events = [];
   let socketClosed;
-  const agent = await Agent.create({
+  const agent = await createWarmAgent({
     apiKey: "test-key",
     websocketUrl: server.url,
     thinking: "none",
@@ -97,7 +102,7 @@ test("steering joins the active turn at the next model boundary", async () => {
   const server = await startResponsesServer();
   const initialSeen = deferred();
   const releaseInitial = deferred();
-  const agent = await Agent.create({
+  const agent = await createWarmAgent({
     apiKey: "test-key",
     websocketUrl: server.url,
     thinking: "none",
@@ -135,7 +140,7 @@ test("steering joins the active turn at the next model boundary", async () => {
 test("cancellation stops the active socket and replays only committed and aborted input", async () => {
   const server = await startResponsesServer();
   const activeSeen = deferred();
-  const agent = await Agent.create({
+  const agent = await createWarmAgent({
     apiKey: "test-key",
     websocketUrl: server.url,
     thinking: "none",
@@ -184,7 +189,7 @@ test("graceful shutdown cancels active work and joins transport cleanup exactly 
   const server = await startResponsesServer();
   const activeSeen = deferred();
   const socketClosed = deferred();
-  const agent = await Agent.create({
+  const agent = await createWarmAgent({
     apiKey: "test-key",
     websocketUrl: server.url,
     thinking: "none",
@@ -218,7 +223,7 @@ test("graceful shutdown cancels active work and joins transport cleanup exactly 
   await agent.session.shutdown();
   turn.dispose();
 
-  const replacement = await Agent.create({
+  const replacement = await createWarmAgent({
     apiKey: "test-key",
     websocketUrl: server.url,
     thinking: "none",
@@ -231,7 +236,7 @@ test("graceful shutdown cancels active work and joins transport cleanup exactly 
 test("a replacement socket drops the remote response ID and replays committed history", async () => {
   const server = await startResponsesServer();
   const firstClosed = deferred();
-  const agent = await Agent.create({
+  const agent = await createWarmAgent({
     apiKey: "test-key",
     websocketUrl: server.url,
     thinking: "none",
@@ -276,7 +281,7 @@ test("a replacement socket drops the remote response ID and replays committed hi
 
 test("manual compaction and historical forks preserve exact committed boundaries", async () => {
   const server = await startResponsesServer();
-  const agent = await Agent.create({
+  const agent = await createWarmAgent({
     apiKey: "test-key",
     websocketUrl: server.url,
     thinking: "none",

--- a/js/bindings/test/node.test.mjs
+++ b/js/bindings/test/node.test.mjs
@@ -15,6 +15,11 @@ const SESSION_IDS = Object.freeze({
   left: "018f1f9a-7b3c-7a05-8000-000000000005",
   right: "018f1f9a-7b3c-7a06-8000-000000000006",
 });
+
+const createWarmAgent = (options) => Agent.create({
+  ...options,
+  websocketWarmup: true,
+});
 const PACKAGE_VERSION = JSON.parse(
   await readFile(new URL("../package.json", import.meta.url), "utf8"),
 ).version;
@@ -133,7 +138,7 @@ test("Node host preserves structured WebSocket handshake rejection detail", asyn
 test("Node-hosted WASM preserves follow-ons, cache identity, events, and custom tools", async () => {
   const server = await startServer();
   const events = [];
-  const agent = await Agent.create({
+  const agent = await createWarmAgent({
     apiKey: "test-key",
     websocketUrl: server.url,
     thinking: "none",
@@ -242,7 +247,7 @@ test("Node-hosted WASM preserves follow-ons, cache identity, events, and custom 
 
 test("WASM snapshots resume authoritative history in a fresh agent", async () => {
   const originalServer = await startServer();
-  const original = await Agent.create({
+  const original = await createWarmAgent({
     apiKey: "test-key",
     websocketUrl: originalServer.url,
     thinking: "none",
@@ -269,7 +274,7 @@ test("WASM snapshots resume authoritative history in a fresh agent", async () =>
   await originalServer.close();
 
   const resumedServer = await startServer();
-  const resumed = await Agent.create({
+  const resumed = await createWarmAgent({
     apiKey: "test-key",
     websocketUrl: resumedServer.url,
     thinking: "none",
@@ -344,7 +349,7 @@ test("Node can load an application-owned web module and resume Codex rollout his
       },
     ],
   };
-  const agent = await Agent.create({
+  const agent = await createWarmAgent({
     apiKey: "test-key",
     module: wasm,
     websocketUrl: server.url,
@@ -375,7 +380,7 @@ test("Node can load an application-owned web module and resume Codex rollout his
 test("independent agents keep their host connections isolated", async () => {
   const leftServer = await startServer();
   const rightServer = await startServer();
-  const left = await Agent.create({
+  const left = await createWarmAgent({
     apiKey: "left-key",
     websocketUrl: leftServer.url,
     thinking: "none",
@@ -388,7 +393,7 @@ test("independent agents keep their host connections isolated", async () => {
       },
     },
   });
-  const right = await Agent.create({
+  const right = await createWarmAgent({
     apiKey: "right-key",
     websocketUrl: rightServer.url,
     thinking: "none",

--- a/js/bindings/test/web-wasm.test.mjs
+++ b/js/bindings/test/web-wasm.test.mjs
@@ -5,6 +5,11 @@ import WebSocket, { WebSocketServer } from "ws";
 
 import { Agent } from "../browser/index.mjs";
 
+const createWarmAgent = (options) => Agent.create({
+  ...options,
+  websocketWarmup: true,
+});
+
 test("web-target WASM runs the shared model loop through the browser host", async () => {
   const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
   await new Promise((resolve, reject) => {
@@ -15,7 +20,7 @@ test("web-target WASM runs the shared model loop through the browser host", asyn
   const events = [];
   const wasm = await readFile(new URL("../pkg-web/nanocodex_bg.wasm", import.meta.url));
   const endpoint = `ws://127.0.0.1:${server.address().port}`;
-  const agent = await Agent.create({
+  const agent = await createWarmAgent({
     apiKey: "test-key",
     WebSocketImpl: WebSocket,
     module: wasm,
@@ -115,7 +120,7 @@ test("web-target WASM directly dispatches a CSP-safe application tool", async ()
   const connection = new Promise((resolve) => server.once("connection", resolve));
   const events = [];
   const wasm = await readFile(new URL("../pkg-web/nanocodex_bg.wasm", import.meta.url));
-  const agent = await Agent.create({
+  const agent = await createWarmAgent({
     apiKey: "test-key",
     WebSocketImpl: WebSocket,
     module: wasm,
@@ -220,7 +225,7 @@ test("web-target WASM keeps remote MCP deferred behind tool_search and Code Mode
       };
     },
   };
-  const agent = await Agent.create({
+  const agent = await createWarmAgent({
     apiKey: "test-key",
     WebSocketImpl: WebSocket,
     module: wasm,

--- a/js/tui-react/src/NanocodexTui.tsx
+++ b/js/tui-react/src/NanocodexTui.tsx
@@ -1151,7 +1151,7 @@ const Footer = memo(function Footer({ tui, conversation, mode, workerStatus, wor
     : workerStatus === "error"
       ? workerError ?? "Agent worker failed"
       : workerStatus === "starting"
-        ? "Loading Rust/WASM..."
+        ? conversation.status
         : workerStatus === "idle" || !enabled
           ? unavailableMessage
           : conversation.status;

--- a/scripts/build-js-package.sh
+++ b/scripts/build-js-package.sh
@@ -11,12 +11,24 @@ if [[ "$target_dir" != /* ]]; then
 fi
 
 cargo build --locked -p nanocodex-wasm --target "$wasm_target" --profile wasm
-wasm-bindgen "$target_dir/$wasm_target/wasm/nanocodex_wasm.wasm" \
+wasm_artifact="$target_dir/$wasm_target/wasm/nanocodex_wasm.wasm"
+stamp_path="js/bindings/pkg-web/.nanocodex-bindgen-stamp"
+fingerprint="$(wasm-bindgen --version; cksum < "$wasm_artifact")"
+if [[ -f "$stamp_path" ]] \
+  && [[ -f js/bindings/pkg-web/nanocodex_bg.wasm ]] \
+  && [[ -f js/bindings/pkg-node/nanocodex_bg.wasm ]] \
+  && [[ "$(<"$stamp_path")" == "$fingerprint" ]]; then
+  echo "wasm-bindgen outputs are current"
+  exit 0
+fi
+
+wasm-bindgen "$wasm_artifact" \
   --target nodejs \
   --out-dir js/bindings/pkg-node \
   --out-name nanocodex
-wasm-bindgen "$target_dir/$wasm_target/wasm/nanocodex_wasm.wasm" \
+wasm-bindgen "$wasm_artifact" \
   --target web \
   --out-dir js/bindings/pkg-web \
   --out-name nanocodex
 node js/bindings/scripts/write-package-types.mjs
+printf '%s\n' "$fingerprint" > "$stamp_path"


### PR DESCRIPTION
## Summary
- expose a browser WASM prewarm API and reuse the initialized module
- plumb opt-in Responses WebSocket warmup through browser and Node bindings
- skip redundant wasm-bindgen generation when the artifact and tool version are unchanged
- remove the visible Rust/WASM startup label from the React TUI

## Verification
- `just build-wasm`
- `npm ci --prefix js/bindings`
- `npm --prefix js/bindings test` (54 tests + 3 performance gates)