### PR TITLE
fix: remove stale CI work and SQLite lock churn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,6 @@ jobs:
           cache-dependency-path: |
             js/bindings/package-lock.json
             js/artifacts/package-lock.json
-            js/artifacts-react/package-lock.json
             js/react/package-lock.json
             js/tui/package-lock.json
             js/tui-react/package-lock.json
@@ -173,7 +172,6 @@ jobs:
           npm ci --prefix js/bindings
           npm ci --prefix js/artifacts
           npm run build --prefix js/artifacts
-          npm ci --prefix js/artifacts-react
           npm ci --prefix js/react
           npm ci --prefix js/tui
           npm run build --prefix js/tui
@@ -194,7 +192,6 @@ jobs:
           npm run test:typecheck --prefix js/bindings
           npm run check:package --prefix js/bindings
           npm test --prefix js/artifacts
-          npm test --prefix js/artifacts-react
           npm test --prefix js/react
           npm test --prefix js/tui
           npm test --prefix js/tui-react
@@ -291,7 +288,6 @@ jobs:
           cache-dependency-path: |
             js/react/package-lock.json
             js/artifacts/package-lock.json
-            js/artifacts-react/package-lock.json
             js/tui/package-lock.json
             js/tui-react/package-lock.json
             web/package-lock.json
@@ -304,8 +300,6 @@ jobs:
           npm ci --prefix js/react
           npm ci --prefix js/artifacts
           npm run build --prefix js/artifacts
-          npm ci --prefix js/artifacts-react
-          npm run build --prefix js/artifacts-react
           npm ci --prefix js/tui
           npm run build --prefix js/tui
           npm ci --prefix js/tui-react

--- a/crates/experimental/nanocodex-eval/src/workset.rs
+++ b/crates/experimental/nanocodex-eval/src/workset.rs
@@ -1137,7 +1137,6 @@ fn open_connection(path: &Path) -> Result<Connection, WorksetError> {
     }
     let connection = Connection::open(path)?;
     connection.busy_timeout(BUSY_TIMEOUT)?;
-    connection.pragma_update(None, "journal_mode", "WAL")?;
     connection.pragma_update(None, "foreign_keys", "ON")?;
     Ok(connection)
 }
@@ -1148,6 +1147,9 @@ fn initialize_schema(connection: &mut Connection) -> Result<(), WorksetError> {
         return Err(WorksetError::DefinitionConflict(format!(
             "schema {version}; expected {SCHEMA_VERSION}"
         )));
+    }
+    if version == 0 {
+        connection.pragma_update(None, "journal_mode", "WAL")?;
     }
     create_schema(connection)?;
     if version == 0 {


### PR DESCRIPTION
## Summary
- remove CI cache/install/test/build steps for the nonexistent `js/artifacts-react` package
- set persistent SQLite WAL mode only when initializing a new eval ledger instead of on every concurrent connection
- preserve per-connection busy timeout and foreign-key enforcement

## Root causes
- every JS CI job stopped at `npm ci --prefix js/artifacts-react`, so downstream binding tests never ran
- 64 claimers concurrently executing `PRAGMA journal_mode=WAL` contended before their short claim transactions and produced `SQLITE_BUSY`

## Verification
- `cargo fmt --all -- --check`
- focused 64-claimer test passed five consecutive runs