### PR TITLE
fix: repair latest master CI and nightly publication

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -94,9 +94,7 @@ jobs:
           retention-days: ${{ inputs.pr && 7 || 1 }}
 
   build-vm-guest:
-    if: >-
-      github.repository == 'gakonst/nanocodex' &&
-      (github.event_name != 'workflow_dispatch' || inputs.pr == '')
+    if: github.repository == 'gakonst/nanocodex'
     name: build x86_64 Linux VM guest
     runs-on: ubuntu-22.04
     timeout-minutes: 45
@@ -105,7 +103,7 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ inputs.pr && format('refs/pull/{0}/head', inputs.pr) || github.sha }}
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9
         with:
@@ -141,7 +139,7 @@ jobs:
           name: nanocodex-vm-guest-x86_64-unknown-linux-musl
           path: dist/*
           if-no-files-found: error
-          retention-days: 1
+          retention-days: ${{ inputs.pr && 7 || 1 }}
 
   publish:
     if: >-

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -187,6 +187,20 @@ jobs:
           fi
           gh release upload "$immutable_tag" dist/* --repo "$GITHUB_REPOSITORY" --clobber
 
+          # SHA256SUMS is the commit marker for clients that still read rolling assets.
+          rolling_exists=false
+          if gh release view nightly --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            rolling_exists=true
+            checksum_asset_id=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/nightly" \
+              --jq '[.assets[] | select(.name == "SHA256SUMS") | .id][0] // empty')
+            if [ -n "$checksum_asset_id" ]; then
+              gh api --method DELETE \
+                "repos/${GITHUB_REPOSITORY}/releases/assets/${checksum_asset_id}"
+            fi
+            gh release upload nightly dist/nanocodex-* \
+              --repo "$GITHUB_REPOSITORY" --clobber
+          fi
+
           if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/nightly" >/dev/null 2>&1; then
             gh api --method PATCH "repos/${GITHUB_REPOSITORY}/git/refs/tags/nightly" \
               -f sha="$GITHUB_SHA" -F force=true >/dev/null
@@ -195,7 +209,7 @@ jobs:
               -f ref='refs/tags/nightly' -f sha="$GITHUB_SHA" >/dev/null
           fi
 
-          if gh release view nightly --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+          if [ "$rolling_exists" = true ]; then
             gh release edit nightly --repo "$GITHUB_REPOSITORY" \
               --target "$GITHUB_SHA" --title "Nanocodex Nightly" \
               --notes-file "$notes_file" --prerelease
@@ -203,5 +217,8 @@ jobs:
             gh release create nightly --repo "$GITHUB_REPOSITORY" \
               --target "$GITHUB_SHA" --title "Nanocodex Nightly" \
               --notes-file "$notes_file" --prerelease
+            gh release upload nightly dist/nanocodex-* \
+              --repo "$GITHUB_REPOSITORY" --clobber
           fi
-          gh release upload nightly dist/* --repo "$GITHUB_REPOSITORY" --clobber
+          gh release upload nightly dist/SHA256SUMS \
+            --repo "$GITHUB_REPOSITORY" --clobber

--- a/bin/nanocodex/src/eval/benchmark.rs
+++ b/bin/nanocodex/src/eval/benchmark.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 
 use clap::Args;
 use eyre::{Result, WrapErr as _};
-use nanocodex_eval::{Evaluation, EvaluationStatus, coordinator::CoordinatorClient};
+use nanocodex_eval::{
+    Evaluation, EvaluationStatus, coordinator::CoordinatorClient, validate_prepared_eval_host,
+};
 use serde::Deserialize;
 
 use super::{profile::default_state_dir, systemd};
@@ -99,6 +101,7 @@ impl Benchmark {
         if initial.is_complete() {
             return Ok(());
         }
+        validate_prepared_eval_host().wrap_err("evaluation host preflight failed")?;
         agent.restrict_to_host_control(CONTROLLER_INSTRUCTIONS);
         let workflow = if headless {
             let _observability = observability.install(false, agent.cwd())?;

--- a/bin/nanocodex/src/update.rs
+++ b/bin/nanocodex/src/update.rs
@@ -123,18 +123,11 @@ impl Update {
             .wrap_err("failed to create the update client")?;
         let release_description = self.release_description();
         let release_api = release_api(self.nightly, self.version.as_ref());
-        let release = client
-            .get(release_api.as_ref())
-            .header(header::ACCEPT, "application/vnd.github+json")
-            .header("X-GitHub-Api-Version", "2022-11-28")
-            .send()
-            .await
-            .wrap_err_with(|| format!("failed to query the {release_description}"))?
-            .error_for_status()
-            .wrap_err_with(|| format!("GitHub did not return the {release_description}"))?
-            .json::<Release>()
-            .await
-            .wrap_err("GitHub returned invalid release metadata")?;
+        let mut release =
+            fetch_release(&client, release_api.as_ref(), &release_description).await?;
+        if self.nightly {
+            release = fetch_immutable_nightly(&client, &release).await?;
+        }
 
         let latest = if self.nightly {
             None
@@ -195,6 +188,29 @@ impl Update {
             Cow::Borrowed("latest stable Nanocodex release")
         }
     }
+}
+
+async fn fetch_release(client: &Client, url: &str, description: &str) -> Result<Release> {
+    client
+        .get(url)
+        .header(header::ACCEPT, "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .send()
+        .await
+        .wrap_err_with(|| format!("failed to query the {description}"))?
+        .error_for_status()
+        .wrap_err_with(|| format!("GitHub did not return the {description}"))?
+        .json::<Release>()
+        .await
+        .wrap_err_with(|| format!("GitHub returned invalid {description} metadata"))
+}
+
+async fn fetch_immutable_nightly(client: &Client, pointer: &Release) -> Result<Release> {
+    let tag = immutable_nightly_tag(pointer)?;
+    let url = format!("{TAGGED_RELEASE_API}/{tag}");
+    let release = fetch_release(client, &url, &format!("immutable {tag} release")).await?;
+    validate_immutable_nightly(&release, &tag)?;
+    Ok(release)
 }
 
 fn release_api(nightly: bool, version: Option<&Version>) -> Cow<'static, str> {
@@ -353,10 +369,7 @@ fn nightly_key(release: &Release) -> Result<String> {
 }
 
 fn nightly_key_for(release: &Release, os: &str, arch: &str) -> Result<String> {
-    let sha = &release.target_commitish;
-    if sha.len() != 40 || !sha.bytes().all(|byte| byte.is_ascii_hexdigit()) {
-        bail!("nightly release target {sha:?} is not an exact Git commit");
-    }
+    let sha = exact_release_commit(release)?;
     let binary = find_asset(release, release_asset_name_for(os, arch)?)?;
     let mut key = format!("nightly-{}-{}", sha.to_ascii_lowercase(), binary.id);
     if let Some(guest_asset_name) = vm_guest_asset_name_for(os, arch) {
@@ -364,6 +377,47 @@ fn nightly_key_for(release: &Release, os: &str, arch: &str) -> Result<String> {
         key.push_str(&format!("-{}", guest.id));
     }
     Ok(key)
+}
+
+fn immutable_nightly_tag(pointer: &Release) -> Result<String> {
+    if pointer.tag_name != "nightly" {
+        bail!(
+            "GitHub returned release {} for the nightly release pointer",
+            pointer.tag_name
+        );
+    }
+    Ok(format!(
+        "nightly-{}",
+        exact_release_commit(pointer)?.to_ascii_lowercase()
+    ))
+}
+
+fn validate_immutable_nightly(release: &Release, expected_tag: &str) -> Result<()> {
+    if release.tag_name != expected_tag {
+        bail!(
+            "GitHub returned release {} for immutable nightly {expected_tag}",
+            release.tag_name
+        );
+    }
+    let expected_sha = expected_tag
+        .strip_prefix("nightly-")
+        .ok_or_else(|| eyre!("invalid immutable nightly tag {expected_tag:?}"))?;
+    let actual_sha = exact_release_commit(release)?;
+    if !actual_sha.eq_ignore_ascii_case(expected_sha) {
+        bail!("immutable nightly {expected_tag} targets {actual_sha}, expected {expected_sha}");
+    }
+    Ok(())
+}
+
+fn exact_release_commit(release: &Release) -> Result<&str> {
+    let sha = release.target_commitish.as_str();
+    if sha.len() != 40 || !sha.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        bail!(
+            "release {} target {sha:?} is not an exact Git commit",
+            release.tag_name
+        );
+    }
+    Ok(sha)
 }
 
 fn find_asset<'a>(release: &'a Release, name: &str) -> Result<&'a ReleaseAsset> {
@@ -544,7 +598,7 @@ mod tests {
     #[test]
     fn nightly_versions_are_bound_to_the_commit_and_both_assets() {
         let release = Release {
-            tag_name: "nightly".to_owned(),
+            tag_name: "nightly-0123456789abcdef0123456789abcdef01234567".to_owned(),
             target_commitish: "0123456789abcdef0123456789abcdef01234567".to_owned(),
             assets: vec![
                 ReleaseAsset {
@@ -569,5 +623,53 @@ mod tests {
             Some(VM_GUEST_ASSET)
         );
         assert_eq!(vm_guest_asset_name_for("macos", "aarch64"), None);
+    }
+
+    #[test]
+    fn resolves_and_validates_the_immutable_nightly_release() {
+        let pointer = Release {
+            tag_name: "nightly".to_owned(),
+            target_commitish: "ABCDEF0123456789ABCDEF0123456789ABCDEF01".to_owned(),
+            assets: Vec::new(),
+        };
+        let tag = immutable_nightly_tag(&pointer).unwrap();
+        assert_eq!(tag, "nightly-abcdef0123456789abcdef0123456789abcdef01");
+
+        let release = Release {
+            tag_name: tag.clone(),
+            target_commitish: "abcdef0123456789abcdef0123456789abcdef01".to_owned(),
+            assets: Vec::new(),
+        };
+        validate_immutable_nightly(&release, &tag).unwrap();
+    }
+
+    #[test]
+    fn rejects_misdirected_nightly_release_metadata() {
+        let branch_target = Release {
+            tag_name: "nightly".to_owned(),
+            target_commitish: "master".to_owned(),
+            assets: Vec::new(),
+        };
+        assert!(immutable_nightly_tag(&branch_target).is_err());
+
+        let wrong_pointer = Release {
+            tag_name: "nightly-other".to_owned(),
+            target_commitish: "0123456789abcdef0123456789abcdef01234567".to_owned(),
+            assets: Vec::new(),
+        };
+        assert!(immutable_nightly_tag(&wrong_pointer).is_err());
+
+        let wrong_target = Release {
+            tag_name: "nightly-0123456789abcdef0123456789abcdef01234567".to_owned(),
+            target_commitish: "fedcba9876543210fedcba9876543210fedcba98".to_owned(),
+            assets: Vec::new(),
+        };
+        assert!(
+            validate_immutable_nightly(
+                &wrong_target,
+                "nightly-0123456789abcdef0123456789abcdef01234567"
+            )
+            .is_err()
+        );
     }
 }

--- a/crates/experimental/nanocodex-eval/src/lib.rs
+++ b/crates/experimental/nanocodex-eval/src/lib.rs
@@ -102,7 +102,7 @@ pub use event::{
     all(target_os = "linux", not(target_env = "musl")),
     all(target_os = "macos", target_arch = "aarch64")
 ))]
-pub use execution::CanonicalTaskRunner;
+pub use execution::{CanonicalTaskRunner, validate_prepared_eval_host};
 pub use execution::{ClaimedEvaluationTask, EvaluationExecution, EvaluationExecutionError};
 pub(crate) use harness_exec::{
     HarnessCommandOutput, HarnessCommandRunner, HarnessCommandRunnerError, HarnessCommandStatus,

--- a/crates/experimental/nanocodex-eval/src/vm.rs
+++ b/crates/experimental/nanocodex-eval/src/vm.rs
@@ -1625,7 +1625,7 @@ pub(crate) struct VmAttempt {
 }
 
 impl VmAttempt {
-    pub(crate) fn take_capture_listener(&mut self) -> Option<TcpListener> {
+    pub(crate) const fn take_capture_listener(&mut self) -> Option<TcpListener> {
         self.capture_listener.take()
     }
 
@@ -1989,7 +1989,7 @@ fn spawn_capture_only_attempt_network(
 }
 
 #[cfg(target_os = "macos")]
-fn spawn_capture_only_attempt_network(
+const fn spawn_capture_only_attempt_network(
     _gvproxy: Option<&Path>,
     _vmm: &Path,
     _port: u16,

--- a/web/scripts/publish-repository.mjs
+++ b/web/scripts/publish-repository.mjs
@@ -24,10 +24,6 @@ const repositoryPath = resolve(
 );
 const uploadConcurrency = 12;
 
-if (resolve(process.argv[1] ?? "") === scriptPath) {
-  await main();
-}
-
 async function main() {
   const origin = requiredEnvironment("NANOCODEX_GIT_ORIGIN").replace(/\/$/, "");
   const token = requiredEnvironment("NANOCODEX_GIT_TOKEN");
@@ -595,4 +591,8 @@ function requiredEnvironment(name) {
   const value = process.env[name]?.trim();
   if (!value) throw new Error(`${name} is required`);
   return value;
+}
+
+if (resolve(process.argv[1] ?? "") === scriptPath) {
+  await main();
 }

--- a/web/scripts/publish-repository.test.mjs
+++ b/web/scripts/publish-repository.test.mjs
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { execFile } from "node:child_process";
+import { once } from "node:events";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
 
 import {
   buildGitArtifacts,
@@ -13,6 +16,73 @@ import {
 } from "./publish-repository.mjs";
 
 const execFileAsync = promisify(execFile);
+const publisherPath = fileURLToPath(new URL("./publish-repository.mjs", import.meta.url));
+
+test("the publisher CLI initializes its module before building a generation", async () => {
+  const directory = await mkdtemp(resolve(tmpdir(), "nanocodex-publisher-cli-test-"));
+  const repository = resolve(directory, "repo");
+  const requests = [];
+  const server = createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    const body = Buffer.concat(chunks).toString("utf8");
+    requests.push({
+      authorization: request.headers.authorization,
+      body,
+      method: request.method,
+      url: request.url,
+    });
+    if (request.method === "GET" && request.url === "/api/git/state") {
+      response.writeHead(404).end();
+      return;
+    }
+    if (request.method === "PUT" && request.url?.startsWith("/api/git/objects/")) {
+      response.writeHead(201).end();
+      return;
+    }
+    if (request.method === "PUT" && request.url === "/api/git/publish") {
+      response.writeHead(200).end();
+      return;
+    }
+    response.writeHead(404).end();
+  });
+  try {
+    await git(["init", "-q", "-b", "main", repository], directory);
+    await git(["config", "user.name", "Nanocodex Test"], repository);
+    await git(["config", "user.email", "test@nanocodex.invalid"], repository);
+    await writeFile(resolve(repository, "README.md"), "# publisher fixture\n");
+    await git(["add", "README.md"], repository);
+    await git(["commit", "-qm", "initial fixture"], repository);
+    const head = await git(["rev-parse", "HEAD"], repository);
+
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    const { stdout } = await execFileAsync(process.execPath, [publisherPath], {
+      env: {
+        ...process.env,
+        NANOCODEX_GIT_ORIGIN: `http://127.0.0.1:${address.port}`,
+        NANOCODEX_GIT_TOKEN: "publisher-test-token",
+        NANOCODEX_REPO: repository,
+      },
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+    });
+
+    assert.match(stdout, new RegExp(`Published gakonst/nanocodex ${head.slice(0, 7)}`));
+    assert.ok(requests.length > 3);
+    assert.ok(requests.every(({ authorization }) => authorization === "Bearer publisher-test-token"));
+    const publicationRequest = requests.find(({ url }) => url === "/api/git/publish");
+    assert.ok(publicationRequest);
+    const publication = JSON.parse(publicationRequest.body);
+    assert.equal(publication.expectedHead, null);
+    assert.equal(publication.publication.head, head);
+  } finally {
+    if (server.listening) await new Promise((resolveClose) => server.close(resolveClose));
+    await rm(directory, { recursive: true, force: true });
+  }
+});
 
 test("repository publication uploads only content absent from the prior inventory", () => {
   assert.deepEqual(

--- a/web/src/agent.worker.ts
+++ b/web/src/agent.worker.ts
@@ -8,7 +8,6 @@ import { createBrowserTools } from "./browserTools";
 import type { WebTuiCommand } from "./nanocodex";
 import { createPaymentSessionOwner } from "./paymentSessionOwner";
 import { MPP_RESPONSES_WEBSOCKET_URL } from "./tempo-constants";
-import { createWorkerManagedWebSocket } from "./workerManagedWebSocket";
 
 type IncomingMessage = WebTuiCommand | { type: "warmup" };
 type PaymentSession = Awaited<ReturnType<(typeof import("./tempo"))["createTempoMppSession"]>>;
@@ -51,20 +50,12 @@ async function createAgent(
   tools: AgentControllerTools,
 ) {
   await paymentSessions.clear();
-  const { execTool, workspace } = await (await import("./browserShell"))
+  const { execTool, instructions, workspace } = await (await import("./browserShell"))
     .prepareBrowserShell(start.threadId!, self.location.origin);
   const common = {
     filesystem: workspace,
     filesystemTools: false,
-    instructions: `You are working in a persistent browser filesystem rooted at /workspace.
-Use exec_command for bash commands such as ls, cat, find, grep, and git. The shell is implemented
-in-browser, so it has no host process or PTY. The repository's only publish branch is nanocodex;
-publish with git add, git commit -m "...", and git push origin nanocodex. Use the standard Rust
-apply_patch tool for focused edits. Custom React interfaces live in
-/workspace/.nanocodex/artifacts and are displayed by the web app from that same filesystem. To
-publish one, write a JavaScript source file that defines function App({ sendPrompt }); React and
-the html tagged template helper are already in scope. Then run
-artifact publish <source.js> --id <lowercase-id> --title "<title>". Re-run it after edits.`,
+    instructions,
     tools: {
       exec_command: execTool,
       ...createBrowserTools({
@@ -110,7 +101,9 @@ artifact publish <source.js> --id <lowercase-id> --title "<title>". Re-run it af
     );
   }
   const createWebSocket = (endpoint: string, sessionId: string) =>
-    createWorkerManagedWebSocket(endpoint, sessionId);
+    import("./workerManagedWebSocket").then(({ createWorkerManagedWebSocket }) =>
+      createWorkerManagedWebSocket(endpoint, sessionId)
+    );
   if (start.transport === "chatgpt") {
     return {
       agent: await Agent.create({

--- a/web/src/browserShell.ts
+++ b/web/src/browserShell.ts
@@ -27,6 +27,15 @@ const utf8 = new TextEncoder();
 const utf8Decoder = new TextDecoder();
 const MAX_OUTPUT_BYTES = 4 * 1024 * 1024;
 const MAX_EXECUTION_MS = 30_000;
+const AGENT_INSTRUCTIONS = `You are working in a persistent browser filesystem rooted at /workspace.
+Use exec_command for bash commands such as ls, cat, find, grep, and git. The shell is implemented
+in-browser, so it has no host process or PTY. The repository's only publish branch is nanocodex;
+publish with git add, git commit -m "...", and git push origin nanocodex. Use the standard Rust
+apply_patch tool for focused edits. Custom React interfaces live in
+/workspace/.nanocodex/artifacts and are displayed by the web app from that same filesystem. To
+publish one, write a JavaScript source file that defines function App({ sendPrompt }); React and
+the html tagged template helper are already in scope. Then run
+artifact publish <source.js> --id <lowercase-id> --title "<title>". Re-run it after edits.`;
 
 type ExecCommandInput = {
   cmd?: unknown;
@@ -66,6 +75,7 @@ export async function prepareBrowserShell(threadId: string, origin: string) {
     },
   });
   return {
+    instructions: AGENT_INSTRUCTIONS,
     workspace: notifyingWorkspace,
     execTool: {
       description: "Run a bash command in the browser thread workspace.",

--- a/web/worker/gitRoutes.test.ts
+++ b/web/worker/gitRoutes.test.ts
@@ -86,6 +86,19 @@ test("Git protocol requests accept the gzip encoding used by clone clients", asy
   assert.deepEqual(decoded, expected);
 });
 
+test("public Git requests are bounded after decompression", async () => {
+  const request = new Request("https://nanocodex.example/git/git-upload-pack", {
+    method: "POST",
+    headers: { "content-encoding": "gzip" },
+    body: gzipSync(new Uint8Array([1, 2, 3, 4, 5])),
+  });
+
+  const result = await readGitProtocolRequest(request, 4);
+  assert.ok(result instanceof Response);
+  assert.equal(result.status, 413);
+  assert.equal(await result.text(), "Git request is too large\n");
+});
+
 test("repository reads hit edge cache before the publication Durable Object", async () => {
   const cache = new Map<string, Response>();
   const originalCaches = globalThis.caches;

--- a/web/worker/gitRoutes.ts
+++ b/web/worker/gitRoutes.ts
@@ -243,16 +243,42 @@ export async function handleGitRequest(
   return undefined;
 }
 
-export async function readGitProtocolRequest(request: Request): Promise<Uint8Array | Response> {
+export async function readGitProtocolRequest(
+  request: Request,
+  maxBytes = 4 * 1024 * 1024,
+): Promise<Uint8Array | Response> {
   const encoding = request.headers.get("content-encoding")?.trim().toLowerCase();
   if (encoding && encoding !== "identity" && encoding !== "gzip") {
     return new Response("unsupported upload-pack content encoding\n", { status: 415 });
   }
   if (request.body == null) return new Uint8Array();
-  const body = encoding === "gzip"
+  const stream = encoding === "gzip"
     ? request.body.pipeThrough(new DecompressionStream("gzip"))
     : request.body;
-  return new Uint8Array(await new Response(body).arrayBuffer());
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const next = await reader.read();
+      if (next.done) break;
+      totalBytes += next.value.byteLength;
+      if (totalBytes > maxBytes) {
+        await reader.cancel("Git request is too large");
+        return new Response("Git request is too large\n", { status: 413 });
+      }
+      chunks.push(next.value);
+    }
+  } catch {
+    return new Response("Git request body could not be decoded\n", { status: 400 });
+  }
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
 }
 
 function gitUploadResponse(body: BodyInit): Response {


### PR DESCRIPTION
## Summary
- execute eval-host preflight before benchmark worker admission and resolve warnings-denied cross-platform lints
- initialize the repository publisher before CLI execution, preserve the Agent Worker bundle budget through real lazy loading, and bound public Git bodies after decompression
- resolve nightly downloads through immutable per-commit releases and publish the rolling checksum only after binaries and metadata agree

## Root causes
- the merged capture-only slice defined but never integrated the host preflight
- the repository publisher entered a module temporal dead zone on real packed repositories
- eager browser-shell and WebSocket support exceeded the existing worker budget
- public gzip Git bodies were unbounded after decompression
- the mutable nightly release could transiently pair a new commit with a self-consistent old artifact set

## Verification
- focused warnings-denied Clippy for nanocodex-eval and nanocodex-bin
- cargo fmt --all -- --check
- exact web CI sequence: tests, typecheck, production build, and bundle gate
- publisher CLI E2E and full current-repository artifact build
- focused updater/store tests and cargo check
- actionlint, typos, and git diff --check

No thresholds were raised and no workflow failure was bypassed.