### PR TITLE
feat(auth): add Rust-owned ChatGPT subscriptions

### DIFF
--- a/crates/nanocodex-oai-api/Cargo.toml
+++ b/crates/nanocodex-oai-api/Cargo.toml
@@ -32,6 +32,7 @@ realtime = ["client", "dep:opusic-c", "dep:webrtc"]
 
 [dependencies]
 async-trait.workspace = true
+base64 = { workspace = true, optional = true }
 futures-util.workspace = true
 http.workspace = true
 serde.workspace = true
@@ -45,7 +46,6 @@ uuid.workspace = true
 web-time.workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-base64 = { workspace = true, optional = true }
 getrandom = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }

--- a/crates/nanocodex-oai-api/src/auth/mod.rs
+++ b/crates/nanocodex-oai-api/src/auth/mod.rs
@@ -7,12 +7,19 @@ use std::{
 
 #[cfg(not(target_family = "wasm"))]
 mod chatgpt;
+mod subscription;
 
 #[cfg(not(target_family = "wasm"))]
 #[cfg_attr(docsrs, doc(cfg(not(target_family = "wasm"))))]
 pub use chatgpt::{
     ChatGptAuthError, ChatGptAuthStatus, ChatGptLogin, chatgpt_access_token, chatgpt_auth_status,
     load_chatgpt_auth, logout_chatgpt, resolve_chatgpt_auth_status,
+};
+pub use subscription::{
+    ChatGptCredential, ChatGptCredentialSeed, ChatGptLoginStatus, ChatGptSubscription,
+    ChatGptSubscriptionError, ChatGptSubscriptionHost, SubscriptionCommit, SubscriptionFuture,
+    SubscriptionHostError, SubscriptionHttpRequest, SubscriptionHttpResponse,
+    SubscriptionStoreValue,
 };
 
 /// Authentication mode for the single `OpenAI` service family supported by Nanocodex.

--- a/crates/nanocodex-oai-api/src/auth/subscription.rs
+++ b/crates/nanocodex-oai-api/src/auth/subscription.rs
@@ -1,0 +1,1276 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex as SyncMutex},
+};
+
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use tokio::sync::Mutex;
+use web_time::{SystemTime, UNIX_EPOCH};
+
+use super::{
+    OpenAiAuth, OpenAiAuthError, OpenAiAuthFuture, OpenAiAuthMode, OpenAiAuthSnapshot,
+    OpenAiAuthSource,
+};
+
+const DEFAULT_ISSUER: &str = "https://auth.openai.com";
+const OAUTH_CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+const LOGIN_TTL_MILLIS: i64 = 15 * 60 * 1_000;
+const REFRESH_EARLY_MILLIS: i64 = 5 * 60 * 1_000;
+const MAX_RESPONSE_BYTES: usize = 16 * 1_024;
+
+#[cfg(not(target_family = "wasm"))]
+/// Boxed native future returned by a hosted ChatGPT subscription capability.
+pub type SubscriptionFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+#[cfg(target_family = "wasm")]
+/// Boxed browser future returned by a hosted ChatGPT subscription capability.
+pub type SubscriptionFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+
+/// Host failure while loading credentials or making an OAuth request.
+#[derive(Clone, Debug, thiserror::Error)]
+#[error("{detail}")]
+pub struct SubscriptionHostError {
+    detail: Arc<str>,
+}
+
+impl SubscriptionHostError {
+    /// Creates a host failure without retaining credential contents.
+    #[must_use]
+    pub fn new(detail: impl Into<Arc<str>>) -> Self {
+        Self {
+            detail: detail.into(),
+        }
+    }
+}
+
+/// One opaque subscription value loaded from host-owned durable storage.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SubscriptionStoreValue {
+    /// Monotonic storage revision used for compare-and-swap updates.
+    pub revision: u64,
+    /// Rust-owned serialized state. Hosts must treat this as secret.
+    pub payload: Option<String>,
+}
+
+/// Result of atomically replacing one subscription value.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SubscriptionCommit {
+    /// The value was stored at this new revision.
+    Committed(u64),
+    /// Another owner changed the value first.
+    Conflict(u64),
+}
+
+/// Bounded outbound request required by the Rust subscription state machine.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SubscriptionHttpRequest {
+    method: &'static str,
+    url: String,
+    content_type: &'static str,
+    body: String,
+    max_response_bytes: usize,
+}
+
+impl SubscriptionHttpRequest {
+    /// HTTP method selected by the state machine.
+    #[must_use]
+    pub const fn method(&self) -> &'static str {
+        self.method
+    }
+
+    /// Complete allowlisted OAuth endpoint.
+    #[must_use]
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Request content type.
+    #[must_use]
+    pub const fn content_type(&self) -> &'static str {
+        self.content_type
+    }
+
+    /// Encoded request body. Hosts must not log it.
+    #[must_use]
+    pub fn body(&self) -> &str {
+        &self.body
+    }
+
+    /// Maximum response bytes the host may return.
+    #[must_use]
+    pub const fn max_response_bytes(&self) -> usize {
+        self.max_response_bytes
+    }
+}
+
+/// Complete bounded response returned by a hosted HTTP capability.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SubscriptionHttpResponse {
+    /// HTTP response status.
+    pub status: u16,
+    /// Response body, bounded according to [`SubscriptionHttpRequest::max_response_bytes`].
+    pub body: String,
+}
+
+/// Minimal host capabilities needed by managed ChatGPT subscription authentication.
+///
+/// The host owns placement, encryption at rest, and outbound networking. Rust owns OAuth,
+/// device login, token decoding and rotation, account continuity, and unauthorized recovery.
+pub trait ChatGptSubscriptionHost: Send + Sync + 'static {
+    /// Loads one opaque state value. A missing value has revision zero.
+    fn load<'a>(
+        &'a self,
+        key: &'a str,
+    ) -> SubscriptionFuture<'a, Result<SubscriptionStoreValue, SubscriptionHostError>>;
+
+    /// Atomically replaces one opaque state value.
+    fn compare_and_swap<'a>(
+        &'a self,
+        key: &'a str,
+        expected_revision: u64,
+        payload: &'a str,
+    ) -> SubscriptionFuture<'a, Result<SubscriptionCommit, SubscriptionHostError>>;
+
+    /// Executes one bounded OAuth HTTP request.
+    fn request<'a>(
+        &'a self,
+        request: SubscriptionHttpRequest,
+    ) -> SubscriptionFuture<'a, Result<SubscriptionHttpResponse, SubscriptionHostError>>;
+}
+
+/// Initial credentials imported from a trusted host secret or Codex login.
+#[derive(Clone)]
+pub struct ChatGptCredentialSeed {
+    access_token: String,
+    refresh_token: String,
+    account_id: String,
+    fedramp: bool,
+}
+
+/// One immutable credential generation resolved by the Rust subscription manager.
+///
+/// Hosts receive this only to perform an authenticated outbound request. `Debug` redacts the
+/// bearer token.
+#[derive(Clone)]
+pub struct ChatGptCredential {
+    access_token: Arc<str>,
+    account_id: Arc<str>,
+    fedramp: bool,
+    revision: u64,
+}
+
+impl ChatGptCredential {
+    /// Bearer token for one outbound request. Do not retain or log it.
+    #[must_use]
+    pub fn access_token(&self) -> &str {
+        &self.access_token
+    }
+
+    /// Stable ChatGPT account routing identifier.
+    #[must_use]
+    pub fn account_id(&self) -> &str {
+        &self.account_id
+    }
+
+    /// Whether the request targets FedRAMP service boundaries.
+    #[must_use]
+    pub const fn is_fedramp(&self) -> bool {
+        self.fedramp
+    }
+
+    /// Credential generation used for unauthorized recovery.
+    #[must_use]
+    pub const fn revision(&self) -> u64 {
+        self.revision
+    }
+}
+
+impl std::fmt::Debug for ChatGptCredential {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ChatGptCredential")
+            .field("access_token", &"[redacted]")
+            .field("account_id", &self.account_id)
+            .field("fedramp", &self.fedramp)
+            .field("revision", &self.revision)
+            .finish()
+    }
+}
+
+impl ChatGptCredentialSeed {
+    /// Creates an importable credential. Values are validated when the subscription is opened.
+    #[must_use]
+    pub fn new(
+        access_token: impl Into<String>,
+        refresh_token: impl Into<String>,
+        account_id: impl Into<String>,
+        fedramp: bool,
+    ) -> Self {
+        Self {
+            access_token: access_token.into(),
+            refresh_token: refresh_token.into(),
+            account_id: account_id.into(),
+            fedramp,
+        }
+    }
+}
+
+impl std::fmt::Debug for ChatGptCredentialSeed {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ChatGptCredentialSeed")
+            .field("access_token", &"[redacted]")
+            .field("refresh_token", &"[redacted]")
+            .field("account_id", &self.account_id)
+            .field("fedramp", &self.fedramp)
+            .finish()
+    }
+}
+
+/// Public state of one hosted ChatGPT device login.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum ChatGptLoginStatus {
+    /// No credential or pending login exists.
+    SignedOut,
+    /// The device login expired before authorization completed.
+    Expired,
+    /// The caller should display the code and poll again after the suggested delay.
+    Pending {
+        /// Browser URL used to authorize the device.
+        #[serde(rename = "verificationUrl")]
+        verification_url: String,
+        /// Short code displayed to the user.
+        #[serde(rename = "userCode")]
+        user_code: String,
+        /// Absolute Unix time in milliseconds when this attempt expires.
+        #[serde(rename = "expiresAt")]
+        expires_at: i64,
+        /// Minimum delay before polling again.
+        #[serde(rename = "pollAfterMs")]
+        poll_after_ms: i64,
+    },
+    /// A refreshable credential is ready for an agent.
+    Authenticated {
+        /// Stable ChatGPT account ID.
+        #[serde(rename = "accountId")]
+        account_id: String,
+        /// Access-token expiry when the token contains one.
+        #[serde(rename = "expiresAt")]
+        expires_at: Option<i64>,
+    },
+}
+
+/// Managed subscription failure.
+#[derive(Clone, Debug, thiserror::Error)]
+pub enum ChatGptSubscriptionError {
+    /// Host storage or networking failed.
+    #[error("ChatGPT subscription host failed: {0}")]
+    Host(Arc<str>),
+    /// Stored state or an OAuth response violated the protocol.
+    #[error("invalid ChatGPT subscription state: {0}")]
+    Invalid(Arc<str>),
+    /// No authenticated credential is available.
+    #[error("ChatGPT subscription is not authenticated")]
+    NotAuthenticated,
+    /// A rotating refresh token can no longer be used.
+    #[error("ChatGPT login is required: {0}")]
+    LoginRequired(Arc<str>),
+    /// Concurrent updates did not converge within the bounded retry budget.
+    #[error("ChatGPT subscription state remained contended")]
+    Contended,
+}
+
+/// Cloneable Rust-owned ChatGPT device-login and credential lifecycle.
+#[derive(Clone)]
+pub struct ChatGptSubscription {
+    inner: Arc<SubscriptionInner>,
+}
+
+impl std::fmt::Debug for ChatGptSubscription {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ChatGptSubscription")
+            .field("key", &self.inner.key)
+            .field("issuer", &self.inner.issuer)
+            .finish_non_exhaustive()
+    }
+}
+
+struct SubscriptionInner {
+    host: Arc<dyn ChatGptSubscriptionHost>,
+    key: Arc<str>,
+    issuer: Arc<str>,
+    refresh: Mutex<()>,
+    known_authenticated: SyncMutex<bool>,
+}
+
+#[derive(Clone, Default, Deserialize, Serialize)]
+struct PersistedState {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    credential: Option<StoredCredential>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pending: Option<PendingLogin>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+struct StoredCredential {
+    access_token: String,
+    refresh_token: String,
+    account_id: String,
+    fedramp: bool,
+    generation: u64,
+    expires_at: Option<i64>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+struct PendingLogin {
+    device_auth_id: String,
+    user_code: String,
+    verification_url: String,
+    interval_ms: i64,
+    next_poll_at: i64,
+    expires_at: i64,
+}
+
+struct LoadedState {
+    revision: u64,
+    state: PersistedState,
+}
+
+#[derive(Deserialize)]
+struct DeviceCodeResponse {
+    device_auth_id: Option<String>,
+    user_code: Option<String>,
+    usercode: Option<String>,
+    interval: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct DeviceTokenResponse {
+    authorization_code: Option<String>,
+    code_verifier: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: Option<String>,
+    refresh_token: Option<String>,
+    id_token: Option<String>,
+}
+
+#[derive(Default, Deserialize)]
+struct IdClaims {
+    #[serde(rename = "https://api.openai.com/auth", default)]
+    auth: AuthClaims,
+}
+
+#[derive(Default, Deserialize)]
+struct AuthClaims {
+    #[serde(rename = "chatgpt_account_id", default)]
+    account_id: Option<String>,
+    #[serde(rename = "chatgpt_account_is_fedramp", default)]
+    fedramp: Option<bool>,
+}
+
+#[derive(Default, Deserialize)]
+struct ExpClaims {
+    #[serde(default)]
+    exp: Option<i64>,
+}
+
+impl ChatGptSubscription {
+    /// Opens one subscription over generic host persistence and HTTP capabilities.
+    ///
+    /// When storage is empty, `seed` is imported atomically. Existing durable state always wins.
+    pub async fn open(
+        host: impl ChatGptSubscriptionHost,
+        key: impl Into<Arc<str>>,
+        seed: Option<ChatGptCredentialSeed>,
+    ) -> Result<Self, ChatGptSubscriptionError> {
+        Self::open_with_issuer(host, key, seed, DEFAULT_ISSUER).await
+    }
+
+    #[doc(hidden)]
+    pub async fn open_with_issuer(
+        host: impl ChatGptSubscriptionHost,
+        key: impl Into<Arc<str>>,
+        seed: Option<ChatGptCredentialSeed>,
+        issuer: impl Into<Arc<str>>,
+    ) -> Result<Self, ChatGptSubscriptionError> {
+        let key = key.into();
+        if key.trim().is_empty() {
+            return Err(ChatGptSubscriptionError::Invalid(Arc::from(
+                "subscription key is empty",
+            )));
+        }
+        let issuer = issuer.into();
+        let issuer = Arc::<str>::from(issuer.trim().trim_end_matches('/'));
+        validate_issuer(&issuer)?;
+        let subscription = Self {
+            inner: Arc::new(SubscriptionInner {
+                host: Arc::new(host),
+                key,
+                issuer,
+                refresh: Mutex::new(()),
+                known_authenticated: SyncMutex::new(false),
+            }),
+        };
+        let loaded = subscription.load().await?;
+        if let Some(credential) = &loaded.state.credential {
+            validate_credential(credential)?;
+            subscription.set_known_authenticated(true);
+        } else if let Some(seed) = seed {
+            let credential = credential_from_seed(seed)?;
+            let state = PersistedState {
+                credential: Some(credential),
+                pending: None,
+            };
+            match subscription.commit(loaded.revision, &state).await? {
+                SubscriptionCommit::Committed(_) => subscription.set_known_authenticated(true),
+                SubscriptionCommit::Conflict(_) => {
+                    let current = subscription.load().await?;
+                    if current.state.credential.is_none() {
+                        return Err(ChatGptSubscriptionError::Contended);
+                    }
+                    subscription.set_known_authenticated(true);
+                }
+            }
+        }
+        Ok(subscription)
+    }
+
+    /// Returns managed authorization for an agent.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error while signed out or while a device login is pending.
+    pub async fn authorization(&self) -> Result<OpenAiAuth, ChatGptSubscriptionError> {
+        self.current_snapshot().await?;
+        Ok(OpenAiAuth::managed_chatgpt(Arc::new(
+            SubscriptionAuthSource {
+                subscription: self.clone(),
+            },
+        )))
+    }
+
+    /// Resolves one credential generation for a host-owned outbound request.
+    pub async fn credential(&self) -> Result<ChatGptCredential, ChatGptSubscriptionError> {
+        let snapshot = self.current_snapshot().await?;
+        Ok(ChatGptCredential {
+            access_token: Arc::from(snapshot.bearer()),
+            account_id: Arc::from(snapshot.account_id().unwrap_or_default()),
+            fedramp: snapshot.is_fedramp(),
+            revision: snapshot.revision(),
+        })
+    }
+
+    /// Refreshes the rejected generation and resolves the credential now current.
+    pub async fn recover(
+        &self,
+        rejected_revision: u64,
+    ) -> Result<ChatGptCredential, ChatGptSubscriptionError> {
+        self.refresh_if_current(rejected_revision).await?;
+        self.credential().await
+    }
+
+    /// Starts a new device login, replacing any prior credential or pending attempt.
+    pub async fn start_login(&self) -> Result<ChatGptLoginStatus, ChatGptSubscriptionError> {
+        let response = self
+            .request_json(
+                format!("{}/api/accounts/deviceauth/usercode", self.inner.issuer),
+                "application/json",
+                serde_json::json!({ "client_id": OAUTH_CLIENT_ID }).to_string(),
+            )
+            .await?;
+        ensure_success(&response, "login start")?;
+        let body: DeviceCodeResponse = decode_response(&response)?;
+        let device_auth_id = required(body.device_auth_id, "device authorization ID")?;
+        let user_code = required(body.user_code.or(body.usercode), "device user code")?;
+        let interval_ms = parse_interval(body.interval.as_ref()) * 1_000;
+        let now = unix_millis();
+        let pending = PendingLogin {
+            device_auth_id,
+            user_code,
+            verification_url: format!("{}/codex/device", self.inner.issuer),
+            interval_ms,
+            next_poll_at: now.saturating_add(interval_ms),
+            expires_at: now.saturating_add(LOGIN_TTL_MILLIS),
+        };
+        for _ in 0..4 {
+            let loaded = self.load().await?;
+            let state = PersistedState {
+                credential: None,
+                pending: Some(pending.clone()),
+            };
+            if matches!(
+                self.commit(loaded.revision, &state).await?,
+                SubscriptionCommit::Committed(_)
+            ) {
+                self.set_known_authenticated(false);
+                return Ok(pending_status(&pending, now));
+            }
+        }
+        Err(ChatGptSubscriptionError::Contended)
+    }
+
+    /// Polls a pending login when due and reports only non-secret state.
+    pub async fn status(&self) -> Result<ChatGptLoginStatus, ChatGptSubscriptionError> {
+        let loaded = self.load().await?;
+        if let Some(credential) = loaded.state.credential {
+            self.set_known_authenticated(true);
+            return Ok(authenticated_status(&credential));
+        }
+        self.set_known_authenticated(false);
+        let Some(mut pending) = loaded.state.pending else {
+            return Ok(ChatGptLoginStatus::SignedOut);
+        };
+        let now = unix_millis();
+        if pending.expires_at <= now {
+            let _ = self
+                .commit(loaded.revision, &PersistedState::default())
+                .await?;
+            return Ok(ChatGptLoginStatus::Expired);
+        }
+        if pending.next_poll_at > now {
+            return Ok(pending_status(&pending, now));
+        }
+
+        pending.next_poll_at = now.saturating_add(pending.interval_ms);
+        let claimed = PersistedState {
+            credential: None,
+            pending: Some(pending.clone()),
+        };
+        let claimed_revision = match self.commit(loaded.revision, &claimed).await? {
+            SubscriptionCommit::Committed(revision) => revision,
+            SubscriptionCommit::Conflict(_) => return self.status_without_poll().await,
+        };
+        let response = self
+            .request_json(
+                format!("{}/api/accounts/deviceauth/token", self.inner.issuer),
+                "application/json",
+                serde_json::json!({
+                    "device_auth_id": pending.device_auth_id,
+                    "user_code": pending.user_code,
+                })
+                .to_string(),
+            )
+            .await?;
+        if matches!(response.status, 403 | 404) {
+            return Ok(pending_status(&pending, now));
+        }
+        ensure_success(&response, "device authorization")?;
+        let body: DeviceTokenResponse = decode_response(&response)?;
+        let code = required(body.authorization_code, "authorization code")?;
+        let verifier = required(body.code_verifier, "PKCE verifier")?;
+        let credential = self.exchange_code(&code, &verifier).await?;
+        let authenticated = PersistedState {
+            credential: Some(credential.clone()),
+            pending: None,
+        };
+        match self.commit(claimed_revision, &authenticated).await? {
+            SubscriptionCommit::Committed(_) => {
+                self.set_known_authenticated(true);
+                Ok(authenticated_status(&credential))
+            }
+            SubscriptionCommit::Conflict(_) => self.status_without_poll().await,
+        }
+    }
+
+    /// Clears durable credentials and pending login state.
+    pub async fn logout(&self) -> Result<(), ChatGptSubscriptionError> {
+        for _ in 0..4 {
+            let loaded = self.load().await?;
+            if matches!(
+                self.commit(loaded.revision, &PersistedState::default())
+                    .await?,
+                SubscriptionCommit::Committed(_)
+            ) {
+                self.set_known_authenticated(false);
+                return Ok(());
+            }
+        }
+        Err(ChatGptSubscriptionError::Contended)
+    }
+
+    async fn status_without_poll(&self) -> Result<ChatGptLoginStatus, ChatGptSubscriptionError> {
+        let loaded = self.load().await?;
+        if let Some(credential) = loaded.state.credential {
+            self.set_known_authenticated(true);
+            return Ok(authenticated_status(&credential));
+        }
+        self.set_known_authenticated(false);
+        let Some(pending) = loaded.state.pending else {
+            return Ok(ChatGptLoginStatus::SignedOut);
+        };
+        let now = unix_millis();
+        Ok(if pending.expires_at <= now {
+            ChatGptLoginStatus::Expired
+        } else {
+            pending_status(&pending, now)
+        })
+    }
+
+    async fn exchange_code(
+        &self,
+        code: &str,
+        verifier: &str,
+    ) -> Result<StoredCredential, ChatGptSubscriptionError> {
+        let body = form(&[
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            (
+                "redirect_uri",
+                &format!("{}/deviceauth/callback", self.inner.issuer),
+            ),
+            ("client_id", OAUTH_CLIENT_ID),
+            ("code_verifier", verifier),
+        ]);
+        let response = self
+            .request_json(
+                format!("{}/oauth/token", self.inner.issuer),
+                "application/x-www-form-urlencoded",
+                body,
+            )
+            .await?;
+        ensure_success(&response, "token exchange")?;
+        credential_from_tokens(decode_response(&response)?, None, 0)
+    }
+
+    async fn current_snapshot(&self) -> Result<OpenAiAuthSnapshot, ChatGptSubscriptionError> {
+        let loaded = self.load().await?;
+        let credential = loaded
+            .state
+            .credential
+            .ok_or(ChatGptSubscriptionError::NotAuthenticated)?;
+        validate_credential(&credential)?;
+        if credential
+            .expires_at
+            .is_some_and(|expiry| expiry <= unix_millis().saturating_add(REFRESH_EARLY_MILLIS))
+        {
+            if let Err(error) = self.refresh_if_current(credential.generation).await {
+                tracing::warn!(error = %error, "proactive ChatGPT token refresh failed");
+            }
+            let refreshed = self
+                .load()
+                .await?
+                .state
+                .credential
+                .ok_or(ChatGptSubscriptionError::NotAuthenticated)?;
+            return Ok(snapshot(&refreshed));
+        }
+        Ok(snapshot(&credential))
+    }
+
+    async fn refresh_if_current(
+        &self,
+        rejected_generation: u64,
+    ) -> Result<(), ChatGptSubscriptionError> {
+        let _guard = self.inner.refresh.lock().await;
+        let loaded = self.load().await?;
+        let current = loaded
+            .state
+            .credential
+            .ok_or(ChatGptSubscriptionError::NotAuthenticated)?;
+        if current.generation != rejected_generation {
+            return Ok(());
+        }
+        if current.refresh_token.trim().is_empty() {
+            return Err(ChatGptSubscriptionError::LoginRequired(Arc::from(
+                "the stored credential has no refresh token",
+            )));
+        }
+        let response = self
+            .request_json(
+                format!("{}/oauth/token", self.inner.issuer),
+                "application/json",
+                serde_json::json!({
+                    "client_id": OAUTH_CLIENT_ID,
+                    "grant_type": "refresh_token",
+                    "refresh_token": current.refresh_token,
+                })
+                .to_string(),
+            )
+            .await?;
+        if !(200..300).contains(&response.status) {
+            let reloaded = self.load().await?;
+            if reloaded
+                .state
+                .credential
+                .as_ref()
+                .is_some_and(|credential| credential.generation != rejected_generation)
+            {
+                return Ok(());
+            }
+            let code = refresh_error_code(&response.body)
+                .unwrap_or_else(|| format!("token endpoint returned HTTP {}", response.status));
+            if response.status == 401
+                || matches!(
+                    code.as_str(),
+                    "refresh_token_expired" | "refresh_token_reused" | "refresh_token_invalidated"
+                )
+            {
+                return Err(ChatGptSubscriptionError::LoginRequired(Arc::from(code)));
+            }
+            return Err(ChatGptSubscriptionError::Host(Arc::from(code)));
+        }
+        let next = credential_from_tokens(
+            decode_response(&response)?,
+            Some(&current),
+            current.generation.wrapping_add(1),
+        )?;
+        if next.account_id != current.account_id {
+            return Err(ChatGptSubscriptionError::Invalid(Arc::from(
+                "the refreshed credential changed accounts",
+            )));
+        }
+        let state = PersistedState {
+            credential: Some(next),
+            pending: None,
+        };
+        match self.commit(loaded.revision, &state).await? {
+            SubscriptionCommit::Committed(_) => Ok(()),
+            SubscriptionCommit::Conflict(_) => {
+                let reloaded = self.load().await?;
+                if reloaded
+                    .state
+                    .credential
+                    .as_ref()
+                    .is_some_and(|credential| {
+                        credential.account_id == current.account_id
+                            && credential.generation != rejected_generation
+                    })
+                {
+                    Ok(())
+                } else {
+                    Err(ChatGptSubscriptionError::Contended)
+                }
+            }
+        }
+    }
+
+    async fn load(&self) -> Result<LoadedState, ChatGptSubscriptionError> {
+        let stored = self
+            .inner
+            .host
+            .load(&self.inner.key)
+            .await
+            .map_err(host_error)?;
+        let state = match stored.payload {
+            Some(payload) => serde_json::from_str(&payload).map_err(|error| {
+                ChatGptSubscriptionError::Invalid(Arc::from(format!(
+                    "host returned malformed state: {error}"
+                )))
+            })?,
+            None => PersistedState::default(),
+        };
+        Ok(LoadedState {
+            revision: stored.revision,
+            state,
+        })
+    }
+
+    async fn commit(
+        &self,
+        expected_revision: u64,
+        state: &PersistedState,
+    ) -> Result<SubscriptionCommit, ChatGptSubscriptionError> {
+        let payload = serde_json::to_string(state)
+            .map_err(|error| ChatGptSubscriptionError::Invalid(Arc::from(error.to_string())))?;
+        self.inner
+            .host
+            .compare_and_swap(&self.inner.key, expected_revision, &payload)
+            .await
+            .map_err(host_error)
+    }
+
+    async fn request_json(
+        &self,
+        url: String,
+        content_type: &'static str,
+        body: String,
+    ) -> Result<SubscriptionHttpResponse, ChatGptSubscriptionError> {
+        let request = SubscriptionHttpRequest {
+            method: "POST",
+            url,
+            content_type,
+            body,
+            max_response_bytes: MAX_RESPONSE_BYTES,
+        };
+        let response = self.inner.host.request(request).await.map_err(host_error)?;
+        if response.body.len() > MAX_RESPONSE_BYTES {
+            return Err(ChatGptSubscriptionError::Invalid(Arc::from(
+                "OAuth response exceeded 16384 bytes",
+            )));
+        }
+        Ok(response)
+    }
+
+    fn set_known_authenticated(&self, value: bool) {
+        if let Ok(mut authenticated) = self.inner.known_authenticated.lock() {
+            *authenticated = value;
+        }
+    }
+}
+
+struct SubscriptionAuthSource {
+    subscription: ChatGptSubscription,
+}
+
+impl OpenAiAuthSource for SubscriptionAuthSource {
+    fn validate(&self) -> Result<(), OpenAiAuthError> {
+        match self.subscription.inner.known_authenticated.lock() {
+            Ok(authenticated) if *authenticated => Ok(()),
+            Ok(_) => Err(OpenAiAuthError::LoginRequired(Arc::from(
+                "the hosted subscription is signed out",
+            ))),
+            Err(_) => Err(OpenAiAuthError::Unavailable(Arc::from(
+                "subscription state poisoned",
+            ))),
+        }
+    }
+
+    fn snapshot(&self) -> OpenAiAuthFuture<'_, Result<OpenAiAuthSnapshot, OpenAiAuthError>> {
+        Box::pin(async move {
+            self.subscription
+                .current_snapshot()
+                .await
+                .map_err(auth_error)
+        })
+    }
+
+    fn recover_unauthorized(
+        &self,
+        rejected: &OpenAiAuthSnapshot,
+    ) -> OpenAiAuthFuture<'_, Result<(), OpenAiAuthError>> {
+        let mode = rejected.mode();
+        let generation = rejected.revision();
+        Box::pin(async move {
+            if mode != OpenAiAuthMode::ChatGpt {
+                return Err(OpenAiAuthError::LoginRequired(Arc::from(
+                    "authorization mode changed",
+                )));
+            }
+            self.subscription
+                .refresh_if_current(generation)
+                .await
+                .map_err(auth_error)
+        })
+    }
+}
+
+fn credential_from_seed(
+    seed: ChatGptCredentialSeed,
+) -> Result<StoredCredential, ChatGptSubscriptionError> {
+    let credential = StoredCredential {
+        expires_at: jwt_expiration_millis(&seed.access_token),
+        access_token: seed.access_token,
+        refresh_token: seed.refresh_token,
+        account_id: seed.account_id,
+        fedramp: seed.fedramp,
+        generation: 0,
+    };
+    validate_credential(&credential)?;
+    Ok(credential)
+}
+
+fn credential_from_tokens(
+    tokens: TokenResponse,
+    previous: Option<&StoredCredential>,
+    generation: u64,
+) -> Result<StoredCredential, ChatGptSubscriptionError> {
+    let access_token = required(tokens.access_token, "access token")?;
+    let refresh_token = tokens
+        .refresh_token
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| previous.map(|credential| credential.refresh_token.clone()))
+        .unwrap_or_default();
+    let claims = tokens
+        .id_token
+        .as_deref()
+        .map(decode_jwt::<IdClaims>)
+        .transpose()?;
+    let account_id = claims
+        .as_ref()
+        .and_then(|claims| claims.auth.account_id.clone())
+        .or_else(|| previous.map(|credential| credential.account_id.clone()))
+        .ok_or_else(|| {
+            ChatGptSubscriptionError::Invalid(Arc::from(
+                "token response omitted the ChatGPT account ID",
+            ))
+        })?;
+    let fedramp = claims
+        .and_then(|claims| claims.auth.fedramp)
+        .or_else(|| previous.map(|credential| credential.fedramp))
+        .unwrap_or(false);
+    let credential = StoredCredential {
+        expires_at: jwt_expiration_millis(&access_token),
+        access_token,
+        refresh_token,
+        account_id,
+        fedramp,
+        generation,
+    };
+    validate_credential(&credential)?;
+    Ok(credential)
+}
+
+fn validate_credential(credential: &StoredCredential) -> Result<(), ChatGptSubscriptionError> {
+    if credential.access_token.trim().is_empty() || credential.account_id.trim().is_empty() {
+        return Err(ChatGptSubscriptionError::Invalid(Arc::from(
+            "required credential field is empty",
+        )));
+    }
+    Ok(())
+}
+
+fn snapshot(credential: &StoredCredential) -> OpenAiAuthSnapshot {
+    OpenAiAuthSnapshot::new(
+        OpenAiAuthMode::ChatGpt,
+        Arc::<str>::from(credential.access_token.as_str()),
+        Some(Arc::<str>::from(credential.account_id.as_str())),
+        credential.fedramp,
+        credential.generation,
+    )
+}
+
+fn pending_status(pending: &PendingLogin, now: i64) -> ChatGptLoginStatus {
+    ChatGptLoginStatus::Pending {
+        verification_url: pending.verification_url.clone(),
+        user_code: pending.user_code.clone(),
+        expires_at: pending.expires_at,
+        poll_after_ms: pending.next_poll_at.saturating_sub(now).max(250),
+    }
+}
+
+fn authenticated_status(credential: &StoredCredential) -> ChatGptLoginStatus {
+    ChatGptLoginStatus::Authenticated {
+        account_id: credential.account_id.clone(),
+        expires_at: credential.expires_at,
+    }
+}
+
+fn validate_issuer(issuer: &str) -> Result<(), ChatGptSubscriptionError> {
+    let issuer = issuer.trim().trim_end_matches('/');
+    if issuer == DEFAULT_ISSUER || issuer.starts_with("http://127.0.0.1:") {
+        Ok(())
+    } else {
+        Err(ChatGptSubscriptionError::Invalid(Arc::from(
+            "issuer must be auth.openai.com",
+        )))
+    }
+}
+
+fn ensure_success(
+    response: &SubscriptionHttpResponse,
+    operation: &str,
+) -> Result<(), ChatGptSubscriptionError> {
+    if (200..300).contains(&response.status) {
+        Ok(())
+    } else {
+        Err(ChatGptSubscriptionError::Host(Arc::from(format!(
+            "ChatGPT {operation} failed with HTTP {}",
+            response.status
+        ))))
+    }
+}
+
+fn decode_response<T: DeserializeOwned>(
+    response: &SubscriptionHttpResponse,
+) -> Result<T, ChatGptSubscriptionError> {
+    serde_json::from_str(&response.body).map_err(|error| {
+        ChatGptSubscriptionError::Invalid(Arc::from(format!(
+            "OAuth endpoint returned invalid JSON: {error}"
+        )))
+    })
+}
+
+fn decode_jwt<T: DeserializeOwned>(jwt: &str) -> Result<T, ChatGptSubscriptionError> {
+    let payload = jwt
+        .split('.')
+        .nth(1)
+        .filter(|payload| !payload.is_empty())
+        .ok_or_else(|| ChatGptSubscriptionError::Invalid(Arc::from("invalid JWT format")))?;
+    let decoded = URL_SAFE_NO_PAD.decode(payload).map_err(|error| {
+        ChatGptSubscriptionError::Invalid(Arc::from(format!("invalid JWT payload: {error}")))
+    })?;
+    serde_json::from_slice(&decoded).map_err(|error| {
+        ChatGptSubscriptionError::Invalid(Arc::from(format!("invalid JWT claims: {error}")))
+    })
+}
+
+fn jwt_expiration_millis(jwt: &str) -> Option<i64> {
+    decode_jwt::<ExpClaims>(jwt)
+        .ok()?
+        .exp
+        .and_then(|seconds| seconds.checked_mul(1_000))
+}
+
+fn parse_interval(value: Option<&serde_json::Value>) -> i64 {
+    let parsed = match value {
+        Some(serde_json::Value::Number(number)) => number.as_i64(),
+        Some(serde_json::Value::String(value)) => value.parse().ok(),
+        _ => None,
+    };
+    parsed.filter(|seconds| *seconds > 0).unwrap_or(5).min(30)
+}
+
+fn required(value: Option<String>, name: &str) -> Result<String, ChatGptSubscriptionError> {
+    value
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            ChatGptSubscriptionError::Invalid(Arc::from(format!(
+                "OAuth response omitted the {name}"
+            )))
+        })
+}
+
+fn refresh_error_code(body: &str) -> Option<String> {
+    let value = serde_json::from_str::<serde_json::Value>(body).ok()?;
+    match &value["error"] {
+        serde_json::Value::String(code) => Some(code.clone()),
+        serde_json::Value::Object(error) => error
+            .get("code")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_owned),
+        _ => None,
+    }
+}
+
+fn form(fields: &[(&str, &str)]) -> String {
+    fields
+        .iter()
+        .map(|(name, value)| format!("{}={}", form_component(name), form_component(value)))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+fn form_component(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(char::from(byte));
+            }
+            b' ' => encoded.push('+'),
+            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    encoded
+}
+
+fn unix_millis() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|duration| i64::try_from(duration.as_millis()).ok())
+        .unwrap_or(0)
+}
+
+fn host_error(error: SubscriptionHostError) -> ChatGptSubscriptionError {
+    ChatGptSubscriptionError::Host(error.detail)
+}
+
+fn auth_error(error: ChatGptSubscriptionError) -> OpenAiAuthError {
+    match error {
+        ChatGptSubscriptionError::NotAuthenticated => {
+            OpenAiAuthError::LoginRequired(Arc::from("the hosted subscription is signed out"))
+        }
+        ChatGptSubscriptionError::LoginRequired(detail) => OpenAiAuthError::LoginRequired(detail),
+        ChatGptSubscriptionError::Invalid(detail) => OpenAiAuthError::Refresh(detail),
+        ChatGptSubscriptionError::Host(detail) => OpenAiAuthError::Unavailable(detail),
+        ChatGptSubscriptionError::Contended => {
+            OpenAiAuthError::Unavailable(Arc::from("subscription state remained contended"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::VecDeque, sync::Mutex};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct MemoryHost {
+        stored: Mutex<SubscriptionStoreValue>,
+        responses: Mutex<VecDeque<SubscriptionHttpResponse>>,
+        requests: Mutex<Vec<SubscriptionHttpRequest>>,
+    }
+
+    impl MemoryHost {
+        fn with_responses(responses: impl IntoIterator<Item = SubscriptionHttpResponse>) -> Self {
+            Self {
+                responses: Mutex::new(responses.into_iter().collect()),
+                ..Self::default()
+            }
+        }
+    }
+
+    impl Default for SubscriptionStoreValue {
+        fn default() -> Self {
+            Self {
+                revision: 0,
+                payload: None,
+            }
+        }
+    }
+
+    impl ChatGptSubscriptionHost for Arc<MemoryHost> {
+        fn load<'a>(
+            &'a self,
+            _key: &'a str,
+        ) -> SubscriptionFuture<'a, Result<SubscriptionStoreValue, SubscriptionHostError>> {
+            Box::pin(async move { Ok(self.stored.lock().unwrap().clone()) })
+        }
+
+        fn compare_and_swap<'a>(
+            &'a self,
+            _key: &'a str,
+            expected_revision: u64,
+            payload: &'a str,
+        ) -> SubscriptionFuture<'a, Result<SubscriptionCommit, SubscriptionHostError>> {
+            Box::pin(async move {
+                let mut stored = self.stored.lock().unwrap();
+                if stored.revision != expected_revision {
+                    return Ok(SubscriptionCommit::Conflict(stored.revision));
+                }
+                stored.revision += 1;
+                stored.payload = Some(payload.to_owned());
+                Ok(SubscriptionCommit::Committed(stored.revision))
+            })
+        }
+
+        fn request<'a>(
+            &'a self,
+            request: SubscriptionHttpRequest,
+        ) -> SubscriptionFuture<'a, Result<SubscriptionHttpResponse, SubscriptionHostError>>
+        {
+            Box::pin(async move {
+                self.requests.lock().unwrap().push(request);
+                self.responses
+                    .lock()
+                    .unwrap()
+                    .pop_front()
+                    .ok_or_else(|| SubscriptionHostError::new("unexpected request"))
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn hosted_subscription_refreshes_in_rust_and_rotates_storage() {
+        let expired = jwt(1, None, None);
+        let fresh = jwt(unix_millis() / 1_000 + 3_600, Some("account-1"), Some(true));
+        let host = Arc::new(MemoryHost::with_responses([SubscriptionHttpResponse {
+            status: 200,
+            body: serde_json::json!({
+                "access_token": fresh,
+                "refresh_token": "refresh-2",
+                "id_token": jwt(0, Some("account-1"), Some(true)),
+            })
+            .to_string(),
+        }]));
+        let subscription = ChatGptSubscription::open(
+            Arc::clone(&host),
+            "account",
+            Some(ChatGptCredentialSeed::new(
+                expired,
+                "refresh-1",
+                "account-1",
+                false,
+            )),
+        )
+        .await
+        .unwrap();
+
+        let auth = subscription.authorization().await.unwrap();
+        let snapshot = auth.snapshot().await.unwrap();
+        assert_eq!(snapshot.account_id(), Some("account-1"));
+        assert!(snapshot.is_fedramp());
+        assert_eq!(snapshot.revision(), 1);
+        let requests = host.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].body().contains("refresh-1"));
+        assert!(!format!("{subscription:?}{auth:?}{snapshot:?}").contains("refresh-1"));
+    }
+
+    #[tokio::test]
+    async fn device_login_state_machine_is_host_agnostic() {
+        let host = Arc::new(MemoryHost::with_responses([
+            SubscriptionHttpResponse {
+                status: 200,
+                body: serde_json::json!({
+                    "device_auth_id": "device-1",
+                    "user_code": "ABCD-EFGH",
+                    "interval": 1,
+                })
+                .to_string(),
+            },
+            SubscriptionHttpResponse {
+                status: 200,
+                body: serde_json::json!({
+                    "authorization_code": "code-1",
+                    "code_verifier": "verifier-1",
+                })
+                .to_string(),
+            },
+            SubscriptionHttpResponse {
+                status: 200,
+                body: serde_json::json!({
+                    "access_token": jwt(unix_millis() / 1_000 + 3600, None, None),
+                    "refresh_token": "refresh-1",
+                    "id_token": jwt(0, Some("account-1"), Some(false)),
+                })
+                .to_string(),
+            },
+        ]));
+        let subscription = ChatGptSubscription::open(Arc::clone(&host), "account", None)
+            .await
+            .unwrap();
+
+        let pending = subscription.start_login().await.unwrap();
+        assert!(matches!(pending, ChatGptLoginStatus::Pending { .. }));
+        {
+            let mut stored = host.stored.lock().unwrap();
+            let mut state: PersistedState =
+                serde_json::from_str(stored.payload.as_deref().unwrap()).unwrap();
+            state.pending.as_mut().unwrap().next_poll_at = 0;
+            stored.payload = Some(serde_json::to_string(&state).unwrap());
+        }
+        let status = subscription.status().await.unwrap();
+        assert_eq!(
+            status,
+            ChatGptLoginStatus::Authenticated {
+                account_id: "account-1".to_owned(),
+                expires_at: jwt_expiration_millis(
+                    &subscription
+                        .load()
+                        .await
+                        .unwrap()
+                        .state
+                        .credential
+                        .unwrap()
+                        .access_token,
+                ),
+            }
+        );
+        assert!(subscription.authorization().await.is_ok());
+        assert_eq!(host.requests.lock().unwrap().len(), 3);
+    }
+
+    fn jwt(exp: i64, account_id: Option<&str>, fedramp: Option<bool>) -> String {
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"none"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(
+            serde_json::to_vec(&serde_json::json!({
+                "exp": exp,
+                "https://api.openai.com/auth": {
+                    "chatgpt_account_id": account_id,
+                    "chatgpt_account_is_fedramp": fedramp,
+                },
+            }))
+            .unwrap(),
+        );
+        format!("{header}.{payload}.")
+    }
+}

--- a/crates/nanocodex-oai-api/src/auth/subscription.rs
+++ b/crates/nanocodex-oai-api/src/auth/subscription.rs
@@ -45,7 +45,7 @@ impl SubscriptionHostError {
 }
 
 /// One opaque subscription value loaded from host-owned durable storage.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct SubscriptionStoreValue {
     /// Monotonic storage revision used for compare-and-swap updates.
     pub revision: u64,
@@ -1104,15 +1104,6 @@ mod tests {
             Self {
                 responses: Mutex::new(responses.into_iter().collect()),
                 ..Self::default()
-            }
-        }
-    }
-
-    impl Default for SubscriptionStoreValue {
-        fn default() -> Self {
-            Self {
-                revision: 0,
-                payload: None,
             }
         }
     }

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -187,6 +187,7 @@ capability-gated relay on such a host:
 
 ```sh
 NANOCODEX_EGRESS_PORT=8791 \
+NANOCODEX_EGRESS_CAPABILITY="$(openssl rand -base64 32 | tr '+/' '-_' | tr -d '=')" \
   npm run relay:subscription --prefix examples/cloudflare-workers
 ```
 
@@ -196,7 +197,9 @@ For a disposable personal demo, a Cloudflare Quick Tunnel can expose the local
 port; use a stable relay under your control for anything long-lived. The relay
 still requires the Worker's bearer credential in addition to the unguessable
 path, never reads `auth.json`, bounds queued data, and forwards only the
-allowlisted handshake headers. Rotate the route by restarting it.
+allowlisted handshake headers. Set `NANOCODEX_EGRESS_CAPABILITY` from a
+protected service environment file to keep the route stable across supervised
+restarts; omit it to generate a new route.
 
 The real edge validation for this example used only the current subscription
 access token and account ID—no API key and no refresh token—and completed three

--- a/examples/cloudflare-workers/scripts/subscription-egress-proxy.mjs
+++ b/examples/cloudflare-workers/scripts/subscription-egress-proxy.mjs
@@ -21,7 +21,10 @@ const FORWARDED_HEADERS = [
 
 export async function startSubscriptionEgressProxy(options = {}) {
   const upstreamUrl = options.upstreamUrl ?? DEFAULT_UPSTREAM;
-  const capability = randomBytes(32).toString("base64url");
+  const capability = options.capability ?? randomBytes(32).toString("base64url");
+  if (!/^[A-Za-z0-9_-]{43,}$/.test(capability)) {
+    throw new Error("subscription proxy capability must be at least 32 random bytes encoded as base64url");
+  }
   const path = `/v1/${capability}`;
   const sockets = new Set();
   const server = createServer((_request, response) => {

--- a/examples/cloudflare-workers/scripts/subscription-egress-relay.mjs
+++ b/examples/cloudflare-workers/scripts/subscription-egress-relay.mjs
@@ -6,6 +6,7 @@ if (!Number.isInteger(port) || port < 1 || port > 65_535) {
 }
 
 const proxy = await startSubscriptionEgressProxy({
+  capability: process.env.NANOCODEX_EGRESS_CAPABILITY,
   port,
   upstreamUrl: process.env.OPENAI_WEBSOCKET_URL,
   onEvent: ({ type, status, code }) => {

--- a/examples/cloudflare-workers/src/index.ts
+++ b/examples/cloudflare-workers/src/index.ts
@@ -61,7 +61,7 @@ export interface Env {
   CHATGPT_ACCOUNT_ID?: string;
   CHATGPT_FEDRAMP?: string;
   CHATGPT_REFRESH_TOKEN?: string;
-  CHATGPT_TOKEN_ENDPOINT?: string;
+  CHATGPT_ISSUER?: string;
 }
 
 type SessionRow = {
@@ -717,7 +717,7 @@ async function openSubscriptionWebSocket(
 async function subscriptionSnapshot(
   auth: DurableObjectStub<NanocodexSubscriptionAuth>,
   path: "/snapshot" | "/recover",
-  revision?: number,
+  revision?: string,
 ): Promise<SubscriptionSnapshot> {
   const response = await auth.fetch(`https://auth.internal${path}`, {
     method: "POST",

--- a/examples/cloudflare-workers/src/subscription-auth.ts
+++ b/examples/cloudflare-workers/src/subscription-auth.ts
@@ -1,305 +1,145 @@
 import { DurableObject } from "cloudflare:workers";
+import {
+  ChatGptSubscription,
+  subscriptionRevision,
+  type ChatGptCredential,
+  type ChatGptCredentialSeed,
+  type ChatGptSubscriptionHandle,
+  type ChatGptSubscriptionStore,
+  type SubscriptionCommitRequest,
+  type SubscriptionStoredValue,
+} from "nanocodex/browser";
 
-const OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
-const DEFAULT_TOKEN_ENDPOINT = "https://auth.openai.com/oauth/token";
-const REFRESH_EARLY_MS = 5 * 60_000;
-const MAX_TOKEN_RESPONSE_BYTES = 16 * 1024;
+import nanocodexWasm from "./nanocodex.wasm";
 
 export interface SubscriptionAuthEnv {
   CHATGPT_ACCESS_TOKEN?: string;
   CHATGPT_ACCOUNT_ID?: string;
   CHATGPT_FEDRAMP?: string;
   CHATGPT_REFRESH_TOKEN?: string;
-  CHATGPT_TOKEN_ENDPOINT?: string;
+  CHATGPT_ISSUER?: string;
 }
 
 export type SubscriptionSnapshot = {
   bearerToken: string;
   accountId: string;
   fedramp: boolean;
-  revision: number;
+  revision: string;
 };
 
-type CredentialRow = {
-  access_token: string;
-  refresh_token: string;
-  account_id: string;
-  fedramp: number;
-  revision: number;
-  expires_at: number | null;
-  refreshed_at: number;
-};
-
-type RefreshResponse = {
-  access_token?: unknown;
-  refresh_token?: unknown;
-  id_token?: unknown;
+type StoredValue = {
+  revision: string;
+  payload: string;
 };
 
 export class NanocodexSubscriptionAuth extends DurableObject<SubscriptionAuthEnv> {
-  #refreshing?: { revision: number; promise: Promise<CredentialRow> };
+  readonly #store: DurableObjectSubscriptionStore;
+  #subscription?: Promise<ChatGptSubscriptionHandle>;
 
   constructor(ctx: DurableObjectState, env: SubscriptionAuthEnv) {
     super(ctx, env);
-    this.ctx.storage.sql.exec(`
-      CREATE TABLE IF NOT EXISTS credentials (
-        singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
-        access_token TEXT NOT NULL,
-        refresh_token TEXT NOT NULL,
-        account_id TEXT NOT NULL,
-        fedramp INTEGER NOT NULL,
-        revision INTEGER NOT NULL,
-        expires_at INTEGER,
-        refreshed_at INTEGER NOT NULL
-      );
-    `);
+    this.#store = new DurableObjectSubscriptionStore(ctx.storage);
   }
 
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
     try {
+      if (request.method === "POST" && url.pathname === "/start") {
+        return Response.json(await (await this.#manager()).startLogin(), { headers: noStore() });
+      }
       if (request.method === "POST" && url.pathname === "/snapshot") {
-        let current = this.#credential();
-        if (!current) current = this.#seed();
-        if (current.expires_at !== null && current.expires_at <= Date.now() + REFRESH_EARLY_MS) {
-          current = await this.#refresh(current.revision);
-        }
-        return Response.json(toSnapshot(current), { headers: { "cache-control": "no-store" } });
+        return Response.json(toSnapshot(await (await this.#manager()).credential()), {
+          headers: noStore(),
+        });
       }
       if (request.method === "POST" && url.pathname === "/recover") {
         const body = await request.json<{ revision?: unknown }>();
-        if (!Number.isSafeInteger(body.revision) || Number(body.revision) < 0) {
-          return Response.json({ error: "invalid revision" }, { status: 400 });
+        if (typeof body.revision !== "string" || !/^(0|[1-9][0-9]*)$/.test(body.revision)) {
+          return Response.json({ error: "invalid revision" }, { status: 400, headers: noStore() });
         }
-        let current = this.#credential();
-        if (!current) current = this.#seed();
-        current = await this.#refresh(Number(body.revision));
-        return Response.json(toSnapshot(current), { headers: { "cache-control": "no-store" } });
+        const credential = await (await this.#manager()).recover(subscriptionRevision(body.revision));
+        return Response.json(toSnapshot(credential), { headers: noStore() });
       }
       if (request.method === "GET" && url.pathname === "/status") {
-        const current = this.#credential();
-        return Response.json({
-          configured: current !== undefined,
-          account_id: current?.account_id,
-          revision: current?.revision,
-          expires_at: current?.expires_at,
-          refreshed_at: current?.refreshed_at,
-        }, { headers: { "cache-control": "no-store" } });
+        return Response.json(await (await this.#manager()).status(), { headers: noStore() });
       }
       if (request.method === "DELETE" && url.pathname === "/credentials") {
-        if (this.#refreshing) {
-          try { await this.#refreshing.promise; } catch { /* Reset still wins after a failed refresh. */ }
-        }
-        this.ctx.storage.sql.exec("DELETE FROM credentials");
-        return new Response(null, { status: 204 });
+        await (await this.#manager()).logout();
+        return new Response(null, { status: 204, headers: noStore() });
       }
-      return Response.json({ error: "not_found" }, { status: 404 });
+      return Response.json({ error: "not_found" }, { status: 404, headers: noStore() });
     } catch (error) {
-      return Response.json({ error: safeError(error) }, {
-        status: 503,
-        headers: { "cache-control": "no-store" },
-      });
+      return Response.json({ error: safeError(error) }, { status: 503, headers: noStore() });
     }
   }
 
-  #seed(): CredentialRow {
-    const accessToken = requiredSecret(this.env.CHATGPT_ACCESS_TOKEN, "CHATGPT_ACCESS_TOKEN");
-    const refreshToken = optionalString(this.env.CHATGPT_REFRESH_TOKEN) ?? "";
-    const accountId = requiredSecret(this.env.CHATGPT_ACCOUNT_ID, "CHATGPT_ACCOUNT_ID");
-    const now = Date.now();
-    const expiresAt = jwtExpiration(accessToken);
-    const fedramp = this.env.CHATGPT_FEDRAMP === "true";
-    this.ctx.storage.sql.exec(
-      `INSERT INTO credentials
-       (singleton, access_token, refresh_token, account_id, fedramp, revision, expires_at, refreshed_at)
-       VALUES (1, ?, ?, ?, ?, 0, ?, ?)`,
-      accessToken,
-      refreshToken,
-      accountId,
-      fedramp ? 1 : 0,
-      expiresAt,
-      now,
-    );
-    return {
-      access_token: accessToken,
-      refresh_token: refreshToken,
-      account_id: accountId,
-      fedramp: fedramp ? 1 : 0,
-      revision: 0,
-      expires_at: expiresAt,
-      refreshed_at: now,
-    };
-  }
-
-  async #refresh(rejectedRevision: number): Promise<CredentialRow> {
-    const current = this.#credential();
-    if (!current) throw new Error("ChatGPT credentials are not initialized");
-    if (current.revision !== rejectedRevision) return current;
-
-    if (this.#refreshing?.revision === rejectedRevision) return this.#refreshing.promise;
-    const promise = this.#performRefresh(current);
-    this.#refreshing = { revision: rejectedRevision, promise };
-    try {
-      return await promise;
-    } finally {
-      if (this.#refreshing?.promise === promise) this.#refreshing = undefined;
-    }
-  }
-
-  async #performRefresh(current: CredentialRow): Promise<CredentialRow> {
-    if (!current.refresh_token) {
-      throw new Error(
-        "ChatGPT access token needs rotation; run `codex login` and restart the local subscription demo",
-      );
-    }
-    const response = await fetch(this.env.CHATGPT_TOKEN_ENDPOINT ?? DEFAULT_TOKEN_ENDPOINT, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        client_id: OAUTH_CLIENT_ID,
-        grant_type: "refresh_token",
-        refresh_token: current.refresh_token,
-      }),
+  #manager(): Promise<ChatGptSubscriptionHandle> {
+    if (this.#subscription) return this.#subscription;
+    const seed = credentialSeed(this.env);
+    this.#subscription = ChatGptSubscription.open({
+      id: "cloudflare:subscription",
+      store: this.#store,
+      module: nanocodexWasm,
+      ...(seed === undefined ? {} : { seed }),
+      ...(this.env.CHATGPT_ISSUER?.trim() ? { issuer: this.env.CHATGPT_ISSUER.trim() } : {}),
     });
-    const encoded = await readBoundedText(response, MAX_TOKEN_RESPONSE_BYTES);
-    if (!response.ok) {
-      const code = parseRefreshErrorCode(encoded);
-      throw new Error(code
-        ? `ChatGPT token refresh was rejected: ${code}`
-        : `ChatGPT token refresh failed with HTTP ${response.status}`);
-    }
-    let refreshed: RefreshResponse;
-    try {
-      refreshed = JSON.parse(encoded) as RefreshResponse;
-    } catch {
-      throw new Error("ChatGPT token refresh returned invalid JSON");
-    }
-    const accessToken = optionalString(refreshed.access_token);
-    if (accessToken === undefined) throw new Error("ChatGPT token refresh omitted access_token");
-    const refreshToken = optionalString(refreshed.refresh_token) ?? current.refresh_token;
-    const idToken = optionalString(refreshed.id_token);
-    const claims = idToken === undefined ? undefined : jwtPayload(idToken);
-    const claimedAccount = nestedString(claims, "https://api.openai.com/auth", "chatgpt_account_id");
-    if (claimedAccount !== undefined && claimedAccount !== current.account_id) {
-      throw new Error("the refreshed ChatGPT credential changed accounts");
-    }
-    const claimedFedramp = nestedBoolean(
-      claims,
-      "https://api.openai.com/auth",
-      "chatgpt_account_is_fedramp",
-    );
-    const next: CredentialRow = {
-      access_token: accessToken,
-      refresh_token: refreshToken,
-      account_id: current.account_id,
-      fedramp: claimedFedramp === undefined ? current.fedramp : (claimedFedramp ? 1 : 0),
-      revision: current.revision + 1,
-      expires_at: jwtExpiration(accessToken),
-      refreshed_at: Date.now(),
-    };
-    this.ctx.storage.sql.exec(
-      `UPDATE credentials SET
-         access_token = ?, refresh_token = ?, fedramp = ?, revision = ?, expires_at = ?, refreshed_at = ?
-       WHERE singleton = 1 AND revision = ?`,
-      next.access_token,
-      next.refresh_token,
-      next.fedramp,
-      next.revision,
-      next.expires_at,
-      next.refreshed_at,
-      current.revision,
-    );
-    return next;
-  }
-
-  #credential(): CredentialRow | undefined {
-    return this.ctx.storage.sql.exec<CredentialRow>(
-      `SELECT access_token, refresh_token, account_id, fedramp, revision, expires_at, refreshed_at
-       FROM credentials WHERE singleton = 1`,
-    ).toArray()[0];
+    return this.#subscription;
   }
 }
 
-function toSnapshot(row: CredentialRow): SubscriptionSnapshot {
+class DurableObjectSubscriptionStore implements ChatGptSubscriptionStore {
+  readonly #storage: DurableObjectStorage;
+
+  constructor(storage: DurableObjectStorage) {
+    this.#storage = storage;
+  }
+
+  async load(_id: string): Promise<SubscriptionStoredValue> {
+    const stored = await this.#storage.get<StoredValue>("subscription");
+    return stored
+      ? { revision: subscriptionRevision(stored.revision), payload: stored.payload }
+      : { revision: subscriptionRevision(0n) };
+  }
+
+  compareAndSwap(_id: string, request: SubscriptionCommitRequest) {
+    return this.#storage.transaction(async (transaction) => {
+      const current = await transaction.get<StoredValue>("subscription");
+      const actualRevision = subscriptionRevision(current?.revision ?? "0");
+      if (actualRevision !== request.expectedRevision) {
+        return { status: "conflict" as const, actualRevision };
+      }
+      const revision = subscriptionRevision(BigInt(actualRevision) + 1n);
+      await transaction.put("subscription", { revision, payload: request.payload });
+      return { status: "committed" as const, revision };
+    });
+  }
+}
+
+function credentialSeed(env: SubscriptionAuthEnv): ChatGptCredentialSeed | undefined {
+  const accessToken = env.CHATGPT_ACCESS_TOKEN?.trim();
+  const accountId = env.CHATGPT_ACCOUNT_ID?.trim();
+  if (!accessToken && !accountId) return undefined;
+  if (!accessToken) throw new Error("CHATGPT_ACCESS_TOKEN is not configured");
+  if (!accountId) throw new Error("CHATGPT_ACCOUNT_ID is not configured");
   return {
-    bearerToken: row.access_token,
-    accountId: row.account_id,
-    fedramp: row.fedramp !== 0,
-    revision: row.revision,
+    accessToken,
+    accountId,
+    refreshToken: env.CHATGPT_REFRESH_TOKEN?.trim() || undefined,
+    fedramp: env.CHATGPT_FEDRAMP === "true",
   };
 }
 
-function requiredSecret(value: string | undefined, name: string): string {
-  if (!value?.trim()) throw new Error(`${name} is not configured`);
-  return value;
+function toSnapshot(credential: ChatGptCredential): SubscriptionSnapshot {
+  return {
+    bearerToken: credential.accessToken,
+    accountId: credential.accountId,
+    fedramp: credential.fedramp,
+    revision: credential.revision,
+  };
 }
 
-function optionalString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value : undefined;
-}
-
-function jwtExpiration(token: string): number | null {
-  const payload = jwtPayload(token);
-  return typeof payload?.exp === "number" && Number.isFinite(payload.exp)
-    ? payload.exp * 1000
-    : null;
-}
-
-function jwtPayload(token: string): Record<string, unknown> | undefined {
-  const encoded = token.split(".")[1];
-  if (!encoded) return undefined;
-  try {
-    const base64 = encoded.replaceAll("-", "+").replaceAll("_", "/").padEnd(
-      encoded.length + ((4 - encoded.length % 4) % 4),
-      "=",
-    );
-    return JSON.parse(atob(base64)) as Record<string, unknown>;
-  } catch {
-    return undefined;
-  }
-}
-
-function nestedString(value: Record<string, unknown> | undefined, objectKey: string, key: string) {
-  const nested = value?.[objectKey];
-  if (!nested || typeof nested !== "object" || Array.isArray(nested)) return undefined;
-  const found = (nested as Record<string, unknown>)[key];
-  return typeof found === "string" ? found : undefined;
-}
-
-function nestedBoolean(value: Record<string, unknown> | undefined, objectKey: string, key: string) {
-  const nested = value?.[objectKey];
-  if (!nested || typeof nested !== "object" || Array.isArray(nested)) return undefined;
-  const found = (nested as Record<string, unknown>)[key];
-  return typeof found === "boolean" ? found : undefined;
-}
-
-async function readBoundedText(response: Response, limit: number): Promise<string> {
-  if (!response.body) return "";
-  const reader = response.body.getReader();
-  const decoder = new TextDecoder();
-  let total = 0;
-  let body = "";
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) return body + decoder.decode();
-    total += value.byteLength;
-    if (total > limit) {
-      await reader.cancel();
-      throw new Error(`ChatGPT token response exceeded ${limit} bytes`);
-    }
-    body += decoder.decode(value, { stream: true });
-  }
-}
-
-function parseRefreshErrorCode(body: string): string | undefined {
-  try {
-    const parsed = JSON.parse(body) as { error?: unknown };
-    if (typeof parsed.error === "string") return parsed.error;
-    if (parsed.error && typeof parsed.error === "object" && !Array.isArray(parsed.error)) {
-      return optionalString((parsed.error as Record<string, unknown>).code);
-    }
-  } catch { /* The status remains sufficient when the body is not JSON. */ }
-  return undefined;
+function noStore() {
+  return { "cache-control": "no-store" };
 }
 
 function safeError(error: unknown): string {

--- a/examples/cloudflare-workers/test-node/subscription-egress-proxy.test.mjs
+++ b/examples/cloudflare-workers/test-node/subscription-egress-proxy.test.mjs
@@ -21,9 +21,11 @@ test("subscription egress proxy is capability-gated and relays headers and frame
   assert(address && typeof address !== "string");
 
   const proxy = await startSubscriptionEgressProxy({
+    capability: "test-capability-0000000000000000000000000000",
     upstreamUrl: `ws://127.0.0.1:${address.port}/responses`,
   });
   try {
+    assert.match(proxy.url, /\/v1\/test-capability-0000000000000000000000000000$/);
     const denied = await rejected(proxy.url.replace(/\/v1\/[^/]+$/, "/v1/wrong"));
     assert.equal(denied, 404);
 
@@ -45,6 +47,13 @@ test("subscription egress proxy is capability-gated and relays headers and frame
     upstreamSockets.clients.forEach((socket) => socket.terminate());
     await new Promise((resolve, reject) => upstreamServer.close((error) => error ? reject(error) : resolve()));
   }
+});
+
+test("subscription egress proxy rejects weak configured capabilities", async () => {
+  await assert.rejects(
+    startSubscriptionEgressProxy({ capability: "short" }),
+    /at least 32 random bytes/,
+  );
 });
 
 test("an upstream rejection settles once and leaves the proxy alive", async () => {

--- a/examples/cloudflare-workers/test/worker.test.ts
+++ b/examples/cloudflare-workers/test/worker.test.ts
@@ -138,21 +138,20 @@ describe("Nanocodex Durable Object Worker", () => {
     expect(await snapshots[0]!.json()).toMatchObject({
       accountId: "test-account-id",
       fedramp: false,
-      revision: 1,
+      revision: "1",
     });
-    expect(await snapshots[1]!.json()).toMatchObject({ revision: 1 });
+    expect(await snapshots[1]!.json()).toMatchObject({ revision: "1" });
 
     const staleRecovery = await auth.fetch("https://auth.internal/recover", {
       method: "POST",
-      body: JSON.stringify({ revision: 0 }),
+      body: JSON.stringify({ revision: "0" }),
     });
-    expect(await staleRecovery.json()).toMatchObject({ revision: 1 });
+    expect(await staleRecovery.json()).toMatchObject({ revision: "1" });
 
     const status = await SELF.fetch("https://example.test/auth/chatgpt", { headers: authorization });
     expect(await status.json()).toMatchObject({
-      configured: true,
-      account_id: "test-account-id",
-      revision: 1,
+      state: "authenticated",
+      accountId: "test-account-id",
     });
     const reset = await SELF.fetch("https://example.test/auth/chatgpt", {
       method: "DELETE",

--- a/examples/cloudflare-workers/vitest.config.ts
+++ b/examples/cloudflare-workers/vitest.config.ts
@@ -13,14 +13,14 @@ export default defineConfig({
           CHATGPT_ACCESS_TOKEN: "e30.eyJleHAiOjF9.test",
           CHATGPT_ACCOUNT_ID: "test-account-id",
           CHATGPT_REFRESH_TOKEN: "test-refresh-token",
-          CHATGPT_TOKEN_ENDPOINT: "https://auth.test/oauth/token",
+          CHATGPT_ISSUER: "http://127.0.0.1:8799",
           NANOCODEX_ADMIN_TOKEN: "test-admin-token",
           NANOCODEX_AUTH_MODE: "api_key",
           OPENAI_API_KEY: "test-openai-key",
         },
         outboundService: async (request) => {
           const url = new URL(request.url);
-          if (request.method !== "POST" || url.href !== "https://auth.test/oauth/token") {
+          if (request.method !== "POST" || url.href !== "http://127.0.0.1:8799/oauth/token") {
             return new Response("not found", { status: 404 });
           }
           const payload = await request.json<{ refresh_token?: unknown }>();

--- a/examples/rivet-actors/Dockerfile
+++ b/examples/rivet-actors/Dockerfile
@@ -10,22 +10,29 @@ RUN rustup target add wasm32-unknown-unknown \
     && wasm_bindgen_version="$(awk '/^name = "wasm-bindgen"$/ { getline; gsub(/"/, "", $3); print $3; exit }' Cargo.lock)" \
     && test -n "$wasm_bindgen_version" \
     && cargo install wasm-bindgen-cli --version "$wasm_bindgen_version" --locked
+COPY js/bindings/package.json js/bindings/package-lock.json ./js/bindings/
+RUN npm ci --prefix js/bindings
 COPY . .
 RUN ./scripts/build-js-package.sh
+RUN package="$(npm pack ./js/bindings --pack-destination /tmp --silent | tail -n 1)" \
+    && mv "/tmp/$package" /tmp/nanocodex.tgz
 
 FROM node:24-bookworm-slim AS app-builder
 WORKDIR /app
 COPY --from=wasm-builder /src/js/bindings ./js/bindings
+COPY --from=wasm-builder /tmp/nanocodex.tgz /tmp/nanocodex.tgz
 COPY examples/rivet-actors/package.json examples/rivet-actors/package-lock.json ./examples/rivet-actors/
-RUN npm ci --prefix examples/rivet-actors
+RUN npm ci --prefix examples/rivet-actors \
+    && test -L examples/rivet-actors/node_modules/nanocodex
 COPY examples/rivet-actors ./examples/rivet-actors
 RUN npm run build --prefix examples/rivet-actors \
-    && npm prune --prefix examples/rivet-actors --omit=dev
+    && npm prune --prefix examples/rivet-actors --omit=dev \
+    && npm install --prefix examples/rivet-actors --omit=dev --no-save --package-lock=false /tmp/nanocodex.tgz \
+    && test ! -L examples/rivet-actors/node_modules/nanocodex
 
 FROM node:24-bookworm-slim
 ENV NODE_ENV=production
 WORKDIR /app
-COPY --from=app-builder --chown=node:node /app/js/bindings ./js/bindings
 COPY --from=app-builder --chown=node:node /app/examples/rivet-actors/package.json ./examples/rivet-actors/package.json
 COPY --from=app-builder --chown=node:node /app/examples/rivet-actors/package-lock.json ./examples/rivet-actors/package-lock.json
 COPY --from=app-builder --chown=node:node /app/examples/rivet-actors/node_modules ./examples/rivet-actors/node_modules

--- a/examples/rivet-actors/README.md
+++ b/examples/rivet-actors/README.md
@@ -176,7 +176,11 @@ This is the same access-token-only policy as the Cloudflare demo. It keeps
 working until the current access token expires or ChatGPT rejects it; then run
 `codex login` and deploy again. Once the Rivet CLI has cached credentials,
 `RIVET_CLOUD_TOKEN` may be omitted. `NANOCODEX_CODEX_AUTH_FILE`, `CODEX_HOME`,
-and `RIVET_NAMESPACE` override the auth path and target namespace.
+and `RIVET_NAMESPACE` override the auth path and target namespace. The helper
+derives the disposable credential actor key from a one-way token fingerprint,
+so a newly authenticated deployment seeds fresh state instead of reopening an
+expired access-token-only actor. Set `RIVET_REUSE_IMAGE=1` to update only this
+deployment environment after the current source image has already been pushed.
 
 For a long-lived deployment, give the auth actor dedicated rotating
 subscription credentials instead. This still does not require

--- a/examples/rivet-actors/scripts/deploy-subscription.ts
+++ b/examples/rivet-actors/scripts/deploy-subscription.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -11,8 +11,15 @@ const codexHome = process.env.CODEX_HOME ?? join(homedir(), ".codex");
 const authFile = resolve(process.env.NANOCODEX_CODEX_AUTH_FILE ?? join(codexHome, "auth.json"));
 const auth = await createCodexAuthFileProvider(authFile).snapshot();
 const namespace = process.env.RIVET_NAMESPACE?.trim() || "production";
+const refreshToken = process.env.CHATGPT_REFRESH_TOKEN?.trim();
+const disposableCredentialId = createHash("sha256")
+  .update(auth.bearerToken)
+  .digest("hex")
+  .slice(0, 16);
 const actorKey = process.env.NANOCODEX_AUTH_ACTOR_KEY?.trim()
-  || `nanocodex-subscription-${namespace}`;
+  || (refreshToken
+    ? `nanocodex-subscription-${namespace}`
+    : `nanocodex-subscription-${namespace}-${disposableCredentialId}`);
 const capability = process.env.NANOCODEX_AUTH_CAPABILITY?.trim()
   || randomBytes(32).toString("base64url");
 const repository = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
@@ -27,7 +34,6 @@ const environment = [
 ];
 const publicUrl = process.env.NANOCODEX_PUBLIC_URL?.trim();
 if (publicUrl) environment.push(`NANOCODEX_PUBLIC_URL=${publicUrl}`);
-const refreshToken = process.env.CHATGPT_REFRESH_TOKEN?.trim();
 if (refreshToken) environment.push(`CHATGPT_REFRESH_TOKEN=${refreshToken}`);
 
 process.stderr.write(
@@ -44,6 +50,7 @@ const child = spawn("npx", [
   ".",
   "--namespace",
   namespace,
+  ...(process.env.RIVET_REUSE_IMAGE === "1" ? ["--reuse-image"] : []),
   ...environment.flatMap((value) => ["--env", value]),
 ], {
   cwd: repository,

--- a/js/bindings/browser/Agent.d.mts
+++ b/js/bindings/browser/Agent.d.mts
@@ -1,6 +1,7 @@
 import type {
   AgentOptions,
   CodeEvaluator,
+  ChatGptSubscriptionHandle,
   DefaultAgent,
   McpServers,
   MppSession,
@@ -24,9 +25,10 @@ export function prewarm(options?: { module?: unknown }): Promise<void>;
 export function create(options?: create.Options): Promise<create.ReturnType>;
 export declare namespace create {
   type Options = AgentOptions & (
-    | { apiKey?: string | undefined; hostAuth?: never; mpp?: never }
-    | { apiKey?: never; hostAuth?: true; mpp?: never }
-    | { apiKey?: never; hostAuth?: never; mpp: MppSession }
+    | { apiKey?: string | undefined; hostAuth?: never; mpp?: never; subscription?: never }
+    | { apiKey?: never; hostAuth?: true; mpp?: never; subscription?: never }
+    | { apiKey?: never; hostAuth?: never; mpp: MppSession; subscription?: never }
+    | { apiKey?: never; hostAuth?: never; mpp?: never; subscription: ChatGptSubscriptionHandle }
   ) & ToolExposureOptions & {
     WebSocketImpl?: typeof WebSocket | undefined;
     apiBaseUrl?: string | undefined;

--- a/js/bindings/browser/Agent.mjs
+++ b/js/bindings/browser/Agent.mjs
@@ -7,6 +7,7 @@ import {
   createAgentClient,
   createEventChannel,
   defineRuntime,
+  loadSubscriptionRuntime,
   releaseHostSession,
   toWasmConfig,
 } from "../internal.mjs";
@@ -27,6 +28,7 @@ export function create(options = {}) {
   const {
     apiKey,
     hostAuth,
+    subscription,
     mpp,
     websocketUrl,
     apiBaseUrl,
@@ -55,6 +57,9 @@ export function create(options = {}) {
   if (hostAuth && (apiKey !== undefined || mpp !== undefined)) {
     throw new TypeError("hostAuth is mutually exclusive with apiKey and mpp");
   }
+  if (subscription !== undefined && (hostAuth || apiKey !== undefined || mpp !== undefined)) {
+    throw new TypeError("subscription is mutually exclusive with hostAuth, apiKey, and mpp");
+  }
   if (filesystem && workspace !== undefined && workspace !== filesystem.root) {
     throw new TypeError("workspace must match filesystem.root when both are provided");
   }
@@ -63,7 +68,8 @@ export function create(options = {}) {
   const host = createBrowserHost({
     WebSocketImpl,
     createWebSocket,
-    hostAuth: hostAuth === true || (apiKey === undefined && mpp === undefined),
+    hostAuth: hostAuth === true
+      || (apiKey === undefined && mpp === undefined && subscription === undefined),
     mpp,
     onEvent: events.emit,
     filesystem,
@@ -86,15 +92,23 @@ export function create(options = {}) {
         await host.ready();
         await prewarm({ module });
         activateHost(host);
-        return new Nanocodex(JSON.stringify(toWasmConfig({
-          apiKey: apiKey ?? (mpp === undefined ? "host-managed" : "mpp-managed"),
+        const configJson = JSON.stringify(toWasmConfig({
+          apiKey: apiKey ?? (mpp === undefined
+            ? subscription === undefined ? "host-managed" : "subscription-managed"
+            : "mpp-managed"),
           websocketUrl: websocketUrl ?? (mpp === undefined
             ? undefined
             : "wss://openai.mpp.tempo.xyz/v1/responses"),
           apiBaseUrl,
           websocketWarmup,
           ...config,
-        })));
+        }));
+        return subscription === undefined
+          ? new Nanocodex(configJson)
+          : Nanocodex.createWithChatGpt(
+              configJson,
+              (await loadSubscriptionRuntime()).rawSubscription(subscription),
+            );
       } catch (error) {
         await host.dispose();
         throw error;

--- a/js/bindings/browser/ChatGptSubscription.d.mts
+++ b/js/bindings/browser/ChatGptSubscription.d.mts
@@ -1,0 +1,7 @@
+import type {
+  ChatGptSubscriptionHandle,
+  ChatGptSubscriptionOptions,
+} from "../types.mjs";
+
+/** Opens the Rust-owned ChatGPT device-login and credential lifecycle. */
+export function open(options: ChatGptSubscriptionOptions): Promise<ChatGptSubscriptionHandle>;

--- a/js/bindings/browser/ChatGptSubscription.mjs
+++ b/js/bindings/browser/ChatGptSubscription.mjs
@@ -1,0 +1,19 @@
+import init, { ChatGptSubscription as WasmChatGptSubscription } from "../pkg-web/nanocodex.js";
+
+import { installHostBridge } from "../internal.mjs";
+import { openSubscription } from "../runtime/chatgpt-subscription.mjs";
+
+let initialized;
+
+/** Opens a Rust-managed ChatGPT subscription over caller-owned storage and fetch. */
+export async function open(options) {
+  installHostBridge();
+  initialized ||= init(options?.module === undefined
+    ? undefined
+    : { module_or_path: options.module }).catch((error) => {
+      initialized = undefined;
+      throw error;
+    });
+  await initialized;
+  return openSubscription(options, (config) => WasmChatGptSubscription.open(config));
+}

--- a/js/bindings/browser/index.d.mts
+++ b/js/bindings/browser/index.d.mts
@@ -1,4 +1,8 @@
-export { Actions } from "../index.mjs";
+export {
+  Actions,
+  createMemoryChatGptSubscriptionStore,
+  subscriptionRevision,
+} from "../index.mjs";
 export { createQuickJsEvaluator } from "../runtime/quickjs-evaluator.mjs";
 export {
   createTempoProvider,
@@ -12,6 +16,12 @@ export type {
 } from "../runtime/tempo-provider.mjs";
 export type {
   AgentEvent,
+  ChatGptCredential,
+  ChatGptCredentialSeed,
+  ChatGptLoginStatus,
+  ChatGptSubscriptionHandle,
+  ChatGptSubscriptionOptions,
+  ChatGptSubscriptionStore,
   CostStatus,
   CodeEvaluator,
   CodeEvaluatorEnvironment,
@@ -30,7 +40,13 @@ export type {
   McpPayment,
   McpServer,
   McpServers,
+  MemoryChatGptSubscriptionStore,
   MppSession,
+  SubscriptionCommitRequest,
+  SubscriptionCommitResult,
+  SubscriptionRevision,
+  SubscriptionStoredValue,
 } from "../types.mjs";
 export * as Agent from "./Agent.mjs";
+export * as ChatGptSubscription from "./ChatGptSubscription.mjs";
 export * as Workspace from "./workspace.mjs";

--- a/js/bindings/browser/index.mjs
+++ b/js/bindings/browser/index.mjs
@@ -1,4 +1,8 @@
-export { Actions } from "../index.mjs";
+export {
+  Actions,
+  createMemoryChatGptSubscriptionStore,
+  subscriptionRevision,
+} from "../index.mjs";
 export { createQuickJsEvaluator } from "../runtime/quickjs-evaluator.mjs";
 export {
   createTempoProvider,
@@ -6,4 +10,5 @@ export {
   DEFAULT_MERCATOR_MCP_URL,
 } from "../runtime/tempo-provider.mjs";
 export * as Agent from "./Agent.mjs";
+export * as ChatGptSubscription from "./ChatGptSubscription.mjs";
 export * as Workspace from "./workspace.mjs";

--- a/js/bindings/index.d.mts
+++ b/js/bindings/index.d.mts
@@ -1,4 +1,11 @@
 export * as Actions from "./actions/index.mjs";
+export declare function subscriptionRevision(
+  value: string | bigint,
+): import("./types.mjs").SubscriptionRevision;
+export declare function createMemoryChatGptSubscriptionStore(
+  id: string,
+  initial?: import("./types.mjs").SubscriptionStoredValue,
+): import("./types.mjs").MemoryChatGptSubscriptionStore;
 export { createQuickJsEvaluator } from "./runtime/quickjs-evaluator.mjs";
 export type { AsyncQuickJsModule, QuickJsEvaluatorOptions } from "./runtime/quickjs-evaluator.mjs";
 export {
@@ -16,6 +23,12 @@ export type {
   AgentActions,
   AgentEvent,
   AgentOptions,
+  ChatGptCredential,
+  ChatGptCredentialSeed,
+  ChatGptLoginStatus,
+  ChatGptSubscriptionHandle,
+  ChatGptSubscriptionOptions,
+  ChatGptSubscriptionStore,
   CostStatus,
   CodeEvaluator,
   CodeEvaluatorEnvironment,
@@ -28,11 +41,16 @@ export type {
   McpServer,
   McpServers,
   McpTool,
+  MemoryChatGptSubscriptionStore,
   MppSession,
   PromptInput,
   PromptItem,
   ReasoningMode,
   SessionSnapshot,
+  SubscriptionCommitRequest,
+  SubscriptionCommitResult,
+  SubscriptionRevision,
+  SubscriptionStoredValue,
   Thinking,
   Tool,
   ToolContext,

--- a/js/bindings/index.mjs
+++ b/js/bindings/index.mjs
@@ -1,4 +1,45 @@
 export * as Actions from "./actions/index.mjs";
+
+export function subscriptionRevision(value) {
+  const revision = String(value);
+  if (!/^(0|[1-9][0-9]*)$/.test(revision)) {
+    throw new TypeError("subscription revision must be an unsigned decimal string");
+  }
+  return revision;
+}
+
+export function createMemoryChatGptSubscriptionStore(id, initial) {
+  if (typeof id !== "string" || !id.trim()) {
+    throw new TypeError("subscription ID must be a non-empty string");
+  }
+  let stored = Object.freeze({
+    revision: subscriptionRevision(initial?.revision ?? 0n),
+    ...(initial?.payload === undefined ? {} : { payload: initial.payload }),
+  });
+  const select = (selected) => {
+    if (selected !== id) throw new Error(`unknown ChatGPT subscription: ${selected}`);
+  };
+  return Object.freeze({
+    id,
+    load(selected) {
+      select(selected);
+      return stored;
+    },
+    compareAndSwap(selected, request) {
+      select(selected);
+      if (request.expectedRevision !== stored.revision) {
+        return { status: "conflict", actualRevision: stored.revision };
+      }
+      const revision = subscriptionRevision(BigInt(stored.revision) + 1n);
+      stored = Object.freeze({ revision, payload: request.payload });
+      return { status: "committed", revision };
+    },
+    snapshot() {
+      return stored;
+    },
+  });
+}
+
 export { createQuickJsEvaluator } from "./runtime/quickjs-evaluator.mjs";
 export {
   createTempoProvider,

--- a/js/bindings/internal.mjs
+++ b/js/bindings/internal.mjs
@@ -176,6 +176,10 @@ export function activateHost(host) {
     throw new TypeError("a Nanocodex host must define connect()");
   }
   activeHost = host;
+  installHostBridge();
+}
+
+export function installHostBridge() {
   globalThis.nanocodexHost = hostBridge;
 }
 
@@ -249,6 +253,19 @@ const hostBridge = Object.freeze({
   removeWorkspaceFile(path, sessionId) {
     return requiredSessionHost(sessionId).removeWorkspaceFile(path);
   },
+  async subscriptionLoad(subscriptionId) {
+    return (await loadSubscriptionRuntime()).load(subscriptionId);
+  },
+  async subscriptionCompareAndSwap(subscriptionId, expectedRevision, payload) {
+    return (await loadSubscriptionRuntime()).compareAndSwap(
+      subscriptionId,
+      expectedRevision,
+      payload,
+    );
+  },
+  async subscriptionRequest(subscriptionId, request) {
+    return (await loadSubscriptionRuntime()).request(subscriptionId, request);
+  },
   toolMode(sessionId) {
     // The WASM constructor asks before its session is adopted.
     return (hostSessions.get(sessionId) ?? requiredActiveHost()).toolMode();
@@ -264,6 +281,10 @@ const hostBridge = Object.freeze({
     requiredSessionHost(event.request_id).emitEvent(eventJson);
   },
 });
+
+export function loadSubscriptionRuntime() {
+  return import("./runtime/chatgpt-subscription.mjs");
+}
 
 function createAgent(raw, runtime) {
   if (!raw || typeof raw.prompt !== "function") {

--- a/js/bindings/node/Agent.d.mts
+++ b/js/bindings/node/Agent.d.mts
@@ -1,6 +1,7 @@
 import type {
   AgentOptions,
   CodeEvaluator,
+  ChatGptSubscriptionHandle,
   DefaultAgent,
   McpServers,
   MppSession,
@@ -16,7 +17,11 @@ type ToolExposureOptions =
 /** Creates a Node-hosted Rust/WASM Agent. */
 export function create(options: create.Options): Promise<create.ReturnType>;
 export declare namespace create {
-  type Options = AgentOptions & ({ apiKey: string; mpp?: never } | { apiKey?: never; mpp: MppSession }) & ToolExposureOptions & {
+  type Options = AgentOptions & (
+    | { apiKey: string; mpp?: never; subscription?: never }
+    | { apiKey?: never; mpp: MppSession; subscription?: never }
+    | { apiKey?: never; mpp?: never; subscription: ChatGptSubscriptionHandle }
+  ) & ToolExposureOptions & {
     apiBaseUrl?: string | undefined;
     codeEvaluator?: CodeEvaluator | undefined;
     /** Caller-owned rooted filesystem mounted through standard workspace tools. */

--- a/js/bindings/node/Agent.mjs
+++ b/js/bindings/node/Agent.mjs
@@ -8,6 +8,7 @@ import {
   createAgentClient,
   createEventChannel,
   defineRuntime,
+  loadSubscriptionRuntime,
   releaseHostSession,
   toWasmConfig,
 } from "../internal.mjs";
@@ -28,6 +29,7 @@ export function create(options = {}) {
     workspace,
     resume,
     apiKey,
+    subscription,
     mpp,
     websocketUrl,
     apiBaseUrl,
@@ -41,6 +43,9 @@ export function create(options = {}) {
   const events = createEventChannel();
   if (mpp !== undefined && apiKey !== undefined) {
     throw new TypeError("apiKey and mpp are mutually exclusive");
+  }
+  if (subscription !== undefined && (apiKey !== undefined || mpp !== undefined)) {
+    throw new TypeError("subscription is mutually exclusive with apiKey and mpp");
   }
   if (filesystem && workspace !== undefined && workspace !== filesystem.root) {
     throw new TypeError("workspace must match filesystem.root when both are provided");
@@ -71,15 +76,23 @@ export function create(options = {}) {
           ? loadNodeNanocodex()
           : await loadWebNanocodex(module);
         activateHost(host);
-        return new Nanocodex(JSON.stringify(toWasmConfig({
-          apiKey: apiKey ?? (mpp === undefined ? undefined : "mpp-managed"),
+        const configJson = JSON.stringify(toWasmConfig({
+          apiKey: apiKey ?? (subscription === undefined
+            ? mpp === undefined ? undefined : "mpp-managed"
+            : "subscription-managed"),
           websocketUrl: websocketUrl ?? (mpp === undefined
             ? undefined
             : "wss://openai.mpp.tempo.xyz/v1/responses"),
           apiBaseUrl,
           websocketWarmup,
           ...config,
-        })));
+        }));
+        return subscription === undefined
+          ? new Nanocodex(configJson)
+          : Nanocodex.createWithChatGpt(
+              configJson,
+              (await loadSubscriptionRuntime()).rawSubscription(subscription),
+            );
       } catch (error) {
         await host.dispose();
         throw error;

--- a/js/bindings/node/ChatGptSubscription.d.mts
+++ b/js/bindings/node/ChatGptSubscription.d.mts
@@ -1,0 +1,9 @@
+import type {
+  ChatGptSubscriptionHandle,
+  ChatGptSubscriptionOptions,
+} from "../types.mjs";
+
+/** Opens the Rust-owned ChatGPT device-login and credential lifecycle. */
+export function open(
+  options: Omit<ChatGptSubscriptionOptions, "module"> & { module?: never },
+): Promise<ChatGptSubscriptionHandle>;

--- a/js/bindings/node/ChatGptSubscription.mjs
+++ b/js/bindings/node/ChatGptSubscription.mjs
@@ -1,0 +1,17 @@
+import { createRequire } from "node:module";
+
+import { installHostBridge } from "../internal.mjs";
+import { openSubscription } from "../runtime/chatgpt-subscription.mjs";
+
+const require = createRequire(import.meta.url);
+let WasmChatGptSubscription;
+
+/** Opens a Rust-managed ChatGPT subscription over caller-owned storage and fetch. */
+export async function open(options) {
+  if (options?.module !== undefined) {
+    throw new TypeError("Node ChatGptSubscription does not accept a browser WASM module");
+  }
+  installHostBridge();
+  WasmChatGptSubscription ||= require("../pkg-node/nanocodex.js").ChatGptSubscription;
+  return openSubscription(options, (config) => WasmChatGptSubscription.open(config));
+}

--- a/js/bindings/node/index.d.mts
+++ b/js/bindings/node/index.d.mts
@@ -1,4 +1,8 @@
-export { Actions } from "../index.mjs";
+export {
+  Actions,
+  createMemoryChatGptSubscriptionStore,
+  subscriptionRevision,
+} from "../index.mjs";
 export { createQuickJsEvaluator } from "../runtime/quickjs-evaluator.mjs";
 export {
   createTempoProvider,
@@ -12,6 +16,12 @@ export type {
 } from "../runtime/tempo-provider.mjs";
 export type {
   AgentEvent,
+  ChatGptCredential,
+  ChatGptCredentialSeed,
+  ChatGptLoginStatus,
+  ChatGptSubscriptionHandle,
+  ChatGptSubscriptionOptions,
+  ChatGptSubscriptionStore,
   CostStatus,
   CodeEvaluator,
   CodeEvaluatorEnvironment,
@@ -30,7 +40,13 @@ export type {
   McpPayment,
   McpServer,
   McpServers,
+  MemoryChatGptSubscriptionStore,
   MppSession,
+  SubscriptionCommitRequest,
+  SubscriptionCommitResult,
+  SubscriptionRevision,
+  SubscriptionStoredValue,
 } from "../types.mjs";
 export * as Agent from "./Agent.mjs";
+export * as ChatGptSubscription from "./ChatGptSubscription.mjs";
 export * as Workspace from "./workspace.mjs";

--- a/js/bindings/node/index.mjs
+++ b/js/bindings/node/index.mjs
@@ -1,4 +1,8 @@
-export { Actions } from "../index.mjs";
+export {
+  Actions,
+  createMemoryChatGptSubscriptionStore,
+  subscriptionRevision,
+} from "../index.mjs";
 export { createQuickJsEvaluator } from "../runtime/quickjs-evaluator.mjs";
 export {
   createTempoProvider,
@@ -6,4 +10,5 @@ export {
   DEFAULT_MERCATOR_MCP_URL,
 } from "../runtime/tempo-provider.mjs";
 export * as Agent from "./Agent.mjs";
+export * as ChatGptSubscription from "./ChatGptSubscription.mjs";
 export * as Workspace from "./workspace.mjs";

--- a/js/bindings/package.json
+++ b/js/bindings/package.json
@@ -25,6 +25,10 @@
       "types": "./browser/workspace.d.mts",
       "import": "./browser/workspace.mjs"
     },
+    "./worker": {
+      "types": "./worker/index.d.mts",
+      "import": "./worker/index.mjs"
+    },
     "./wasm": {
       "types": "./wasm.d.mts",
       "import": "./pkg-web/nanocodex_bg.wasm"
@@ -34,6 +38,7 @@
     "actions",
     "browser",
     "node",
+    "worker",
     "pkg-node",
     "pkg-web",
     "runtime",

--- a/js/bindings/runtime/chatgpt-subscription.mjs
+++ b/js/bindings/runtime/chatgpt-subscription.mjs
@@ -1,0 +1,204 @@
+const hosts = new Map();
+const RAW_SUBSCRIPTION = Symbol.for("nanocodex.chatgpt.subscription");
+const DEFAULT_MAX_RESPONSE_BYTES = 16 * 1024;
+
+export async function openSubscription(options, openRaw) {
+  if (!options || typeof options !== "object") {
+    throw new TypeError("ChatGptSubscription.open requires options");
+  }
+  const id = requiredId(options.id);
+  const host = {
+    store: options.store,
+    fetch: options.fetch ?? globalThis.fetch,
+    references: 0,
+  };
+  validateHost(host);
+  bind(id, host);
+  try {
+    const raw = await openRaw(JSON.stringify({
+      id,
+      ...(options.issuer === undefined ? {} : { issuer: options.issuer }),
+      ...(options.seed === undefined ? {} : { seed: options.seed }),
+    }));
+    const view = Object.freeze({
+      id,
+      [RAW_SUBSCRIPTION]: raw,
+      async startLogin() {
+        return JSON.parse(await raw.startLogin());
+      },
+      async status() {
+        return JSON.parse(await raw.status());
+      },
+      async credential() {
+        return parseCredential(await raw.credential());
+      },
+      async recover(rejectedRevision) {
+        return parseCredential(await raw.recover(revision(
+          rejectedRevision,
+          "rejected credential revision",
+        )));
+      },
+      async logout() {
+        await raw.logout();
+      },
+      dispose() {
+        release(id, host);
+        raw.free();
+      },
+    });
+    host.references += 1;
+    return view;
+  } catch (error) {
+    release(id, host);
+    throw error;
+  }
+}
+
+export function rawSubscription(subscription) {
+  const raw = subscription?.[RAW_SUBSCRIPTION];
+  if (!raw || typeof raw.status !== "function") {
+    throw new TypeError("subscription must be an open ChatGptSubscription");
+  }
+  return raw;
+}
+
+export async function load(subscriptionId) {
+  const stored = await requiredHost(subscriptionId).store.load(subscriptionId);
+  if (!stored || typeof stored !== "object") {
+    throw new TypeError("subscription store load() must return { revision, payload? }");
+  }
+  return JSON.stringify({
+    revision: revision(stored.revision, "subscription load revision"),
+    ...(stored.payload === undefined || stored.payload === null
+      ? {}
+      : { payload: requiredString(stored.payload, "subscription payload") }),
+  });
+}
+
+export async function compareAndSwap(subscriptionId, expectedRevision, payload) {
+  const result = await requiredHost(subscriptionId).store.compareAndSwap(subscriptionId, {
+    expectedRevision,
+    payload,
+  });
+  if (result?.status === "committed") {
+    return JSON.stringify({
+      status: "committed",
+      revision: revision(result.revision, "subscription commit revision"),
+    });
+  }
+  if (result?.status === "conflict") {
+    return JSON.stringify({
+      status: "conflict",
+      actual_revision: revision(result.actualRevision, "subscription conflict revision"),
+    });
+  }
+  throw new TypeError("subscription compareAndSwap() must return committed or conflict");
+}
+
+export async function request(subscriptionId, encoded) {
+  const host = requiredHost(subscriptionId);
+  const request = JSON.parse(encoded);
+  if (request.method !== "POST") throw new TypeError("subscription HTTP method must be POST");
+  const url = new URL(request.url);
+  if (url.origin !== "https://auth.openai.com" && url.hostname !== "127.0.0.1") {
+    throw new TypeError("subscription HTTP is restricted to auth.openai.com");
+  }
+  const maxResponseBytes = positiveInteger(
+    request.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES,
+    "subscription response limit",
+  );
+  const response = await host.fetch(url, {
+    method: "POST",
+    headers: { "content-type": requiredString(request.contentType, "subscription content type") },
+    body: requiredString(request.body, "subscription request body"),
+    redirect: "manual",
+  });
+  if (!(response instanceof Response)) {
+    throw new TypeError("subscription fetch() must return a Response");
+  }
+  return JSON.stringify({
+    status: response.status,
+    body: await readBoundedText(response, maxResponseBytes),
+  });
+}
+
+function bind(id, host) {
+  if (hosts.has(id)) throw new Error(`ChatGPT subscription is already open: ${id}`);
+  hosts.set(id, host);
+}
+
+function release(id, host) {
+  if (hosts.get(id) !== host) return;
+  if (host.references > 0) host.references -= 1;
+  if (host.references === 0) hosts.delete(id);
+}
+
+function requiredHost(id) {
+  const host = hosts.get(id);
+  if (!host) throw new Error(`no host owns ChatGPT subscription: ${id}`);
+  return host;
+}
+
+function validateHost(host) {
+  if (!host.store || typeof host.store.load !== "function"
+      || typeof host.store.compareAndSwap !== "function") {
+    throw new TypeError("ChatGPT subscription requires load and compareAndSwap storage");
+  }
+  if (typeof host.fetch !== "function") {
+    throw new TypeError("ChatGPT subscription requires a fetch capability");
+  }
+}
+
+async function readBoundedText(response, limit) {
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let size = 0;
+  let body = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) return body + decoder.decode();
+    size += value.byteLength;
+    if (size > limit) {
+      await reader.cancel();
+      throw new Error(`subscription response exceeded ${limit} bytes`);
+    }
+    body += decoder.decode(value, { stream: true });
+  }
+}
+
+function revision(value, name) {
+  if (typeof value !== "string" || !/^(0|[1-9][0-9]*)$/.test(value)) {
+    throw new TypeError(`${name} must be an unsigned decimal string`);
+  }
+  return value;
+}
+
+function requiredId(value) {
+  if (typeof value !== "string" || !/^[A-Za-z0-9._:-]{1,200}$/.test(value)) {
+    throw new TypeError("subscription id must be a bounded stable identifier");
+  }
+  return value;
+}
+
+function requiredString(value, name) {
+  if (typeof value !== "string") throw new TypeError(`${name} must be a string`);
+  return value;
+}
+
+function positiveInteger(value, name) {
+  if (!Number.isSafeInteger(value) || value <= 0) throw new TypeError(`${name} must be positive`);
+  return value;
+}
+
+function parseCredential(encoded) {
+  const credential = JSON.parse(encoded);
+  if (credential?.kind !== "chatgpt" || typeof credential.accessToken !== "string"
+      || typeof credential.accountId !== "string" || typeof credential.fedramp !== "boolean") {
+    throw new TypeError("Rust returned an invalid ChatGPT credential");
+  }
+  return Object.freeze({
+    ...credential,
+    revision: revision(credential.revision, "credential revision"),
+  });
+}

--- a/js/bindings/scripts/check-package.mjs
+++ b/js/bindings/scripts/check-package.mjs
@@ -28,12 +28,16 @@ const requiredFiles = [
   "node/index.d.mts",
   "node/workspace.mjs",
   "node/workspace.d.mts",
+  "worker/index.mjs",
+  "worker/index.d.mts",
   "runtime/workspace.mjs",
   "runtime/workspace.d.mts",
   "wasm.d.mts",
   "pkg-web/nanocodex.js",
   "pkg-web/nanocodex.d.ts",
+  "pkg-web/nanocodex_bg.js",
   "pkg-web/nanocodex_bg.wasm",
+  "pkg-web/nanocodex_worker.js",
   "pkg-node/nanocodex.js",
   "pkg-node/nanocodex.d.ts",
   "pkg-node/nanocodex_bg.wasm",
@@ -53,6 +57,7 @@ export async function checkPackage(packageRoot = root) {
   assert.equal(packageJson.exports?.["./browser/workspace"]?.import, "./browser/workspace.mjs");
   assert.equal(packageJson.exports?.["./node"]?.import, "./node/index.mjs");
   assert.equal(packageJson.exports?.["./node/workspace"]?.import, "./node/workspace.mjs");
+  assert.equal(packageJson.exports?.["./worker"]?.import, "./worker/index.mjs");
   assert.equal(packageJson.exports?.["./wasm"]?.import, "./pkg-web/nanocodex_bg.wasm");
   checkDocumentedBrowserVersion(readme, packageJson.version);
 

--- a/js/bindings/src/wasm.rs
+++ b/js/bindings/src/wasm.rs
@@ -8,6 +8,11 @@ use nanocodex::{
         input::{Prompt, UserInput},
         session::{SessionId, SessionSnapshot},
     },
+    oai::auth::{
+        ChatGptCredentialSeed, ChatGptLoginStatus, ChatGptSubscription, ChatGptSubscriptionHost,
+        SubscriptionCommit, SubscriptionFuture, SubscriptionHostError, SubscriptionHttpRequest,
+        SubscriptionHttpResponse, SubscriptionStoreValue,
+    },
     tools::{
         ToolContext, ToolDefinition, ToolInput, ToolOutput,
         contract::ToolOutputWire,
@@ -62,6 +67,131 @@ extern "C" {
 
     #[wasm_bindgen(catch, js_namespace = ["globalThis", "nanocodexHost"], js_name = removeWorkspaceFile)]
     fn host_remove_workspace_file(path: &str, session_id: &str) -> Result<Promise, JsValue>;
+
+    #[wasm_bindgen(catch, js_namespace = ["globalThis", "nanocodexHost"], js_name = subscriptionLoad)]
+    fn host_subscription_load(subscription_id: &str) -> Result<Promise, JsValue>;
+
+    #[wasm_bindgen(catch, js_namespace = ["globalThis", "nanocodexHost"], js_name = subscriptionCompareAndSwap)]
+    fn host_subscription_compare_and_swap(
+        subscription_id: &str,
+        expected_revision: &str,
+        payload: &str,
+    ) -> Result<Promise, JsValue>;
+
+    #[wasm_bindgen(catch, js_namespace = ["globalThis", "nanocodexHost"], js_name = subscriptionRequest)]
+    fn host_subscription_request(subscription_id: &str, request: &str) -> Result<Promise, JsValue>;
+}
+
+struct JavaScriptSubscriptionHost {
+    subscription_id: String,
+}
+
+#[derive(Deserialize)]
+struct JavaScriptSubscriptionValue {
+    revision: String,
+    #[serde(default)]
+    payload: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum JavaScriptSubscriptionCommit {
+    Committed { revision: String },
+    Conflict { actual_revision: String },
+}
+
+#[derive(Deserialize)]
+struct JavaScriptSubscriptionResponse {
+    status: u16,
+    body: String,
+}
+
+impl ChatGptSubscriptionHost for JavaScriptSubscriptionHost {
+    fn load<'a>(
+        &'a self,
+        _key: &'a str,
+    ) -> SubscriptionFuture<'a, Result<SubscriptionStoreValue, SubscriptionHostError>> {
+        Box::pin(async move {
+            let promise =
+                host_subscription_load(&self.subscription_id).map_err(subscription_host_error)?;
+            let stored: JavaScriptSubscriptionValue = await_subscription_json(promise).await?;
+            Ok(SubscriptionStoreValue {
+                revision: parse_subscription_revision(&stored.revision)?,
+                payload: stored.payload,
+            })
+        })
+    }
+
+    fn compare_and_swap<'a>(
+        &'a self,
+        _key: &'a str,
+        expected_revision: u64,
+        payload: &'a str,
+    ) -> SubscriptionFuture<'a, Result<SubscriptionCommit, SubscriptionHostError>> {
+        Box::pin(async move {
+            let expected = expected_revision.to_string();
+            let promise =
+                host_subscription_compare_and_swap(&self.subscription_id, &expected, payload)
+                    .map_err(subscription_host_error)?;
+            match await_subscription_json::<JavaScriptSubscriptionCommit>(promise).await? {
+                JavaScriptSubscriptionCommit::Committed { revision } => Ok(
+                    SubscriptionCommit::Committed(parse_subscription_revision(&revision)?),
+                ),
+                JavaScriptSubscriptionCommit::Conflict { actual_revision } => Ok(
+                    SubscriptionCommit::Conflict(parse_subscription_revision(&actual_revision)?),
+                ),
+            }
+        })
+    }
+
+    fn request<'a>(
+        &'a self,
+        request: SubscriptionHttpRequest,
+    ) -> SubscriptionFuture<'a, Result<SubscriptionHttpResponse, SubscriptionHostError>> {
+        Box::pin(async move {
+            let encoded = serde_json::json!({
+                "method": request.method(),
+                "url": request.url(),
+                "contentType": request.content_type(),
+                "body": request.body(),
+                "maxResponseBytes": request.max_response_bytes(),
+            })
+            .to_string();
+            let promise = host_subscription_request(&self.subscription_id, &encoded)
+                .map_err(subscription_host_error)?;
+            let response: JavaScriptSubscriptionResponse = await_subscription_json(promise).await?;
+            Ok(SubscriptionHttpResponse {
+                status: response.status,
+                body: response.body,
+            })
+        })
+    }
+}
+
+async fn await_subscription_json<T: for<'de> Deserialize<'de>>(
+    promise: Promise,
+) -> Result<T, SubscriptionHostError> {
+    let value = JsFuture::from(promise)
+        .await
+        .map_err(subscription_host_error)?;
+    let encoded = value.as_string().ok_or_else(|| {
+        SubscriptionHostError::new("JavaScript subscription host returned a non-string")
+    })?;
+    serde_json::from_str(&encoded).map_err(|error| {
+        SubscriptionHostError::new(format!(
+            "JavaScript subscription host returned invalid JSON: {error}"
+        ))
+    })
+}
+
+fn parse_subscription_revision(revision: &str) -> Result<u64, SubscriptionHostError> {
+    revision.parse().map_err(|error| {
+        SubscriptionHostError::new(format!("invalid subscription revision: {error}"))
+    })
+}
+
+fn subscription_host_error(error: JsValue) -> SubscriptionHostError {
+    SubscriptionHostError::new(host_error_message(&error))
 }
 
 struct JavaScriptCodeModeHost {
@@ -238,6 +368,110 @@ struct WasmConfig {
     resume: Option<SessionSnapshot>,
 }
 
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct WasmSubscriptionConfig {
+    id: String,
+    #[serde(default)]
+    issuer: Option<String>,
+    #[serde(default)]
+    seed: Option<WasmSubscriptionSeed>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct WasmSubscriptionSeed {
+    access_token: String,
+    #[serde(default)]
+    refresh_token: String,
+    account_id: String,
+    #[serde(default)]
+    fedramp: bool,
+}
+
+/// JavaScript binding over the Rust-owned hosted ChatGPT credential lifecycle.
+#[wasm_bindgen(js_name = ChatGptSubscription)]
+pub struct WasmChatGptSubscription {
+    inner: ChatGptSubscription,
+}
+
+#[wasm_bindgen(js_class = ChatGptSubscription)]
+impl WasmChatGptSubscription {
+    /// Opens a subscription over the currently registered generic host capabilities.
+    #[wasm_bindgen(js_name = open)]
+    pub async fn open(config_json: &str) -> Result<Self, JsValue> {
+        let config = serde_json::from_str::<WasmSubscriptionConfig>(config_json)
+            .map_err(|error| js_error(format!("invalid ChatGPT subscription config: {error}")))?;
+        let seed = config.seed.map(|seed| {
+            ChatGptCredentialSeed::new(
+                seed.access_token,
+                seed.refresh_token,
+                seed.account_id,
+                seed.fedramp,
+            )
+        });
+        let host = JavaScriptSubscriptionHost {
+            subscription_id: config.id.clone(),
+        };
+        let inner = if let Some(issuer) = config.issuer {
+            ChatGptSubscription::open_with_issuer(host, config.id, seed, issuer).await
+        } else {
+            ChatGptSubscription::open(host, config.id, seed).await
+        }
+        .map_err(js_error)?;
+        Ok(Self { inner })
+    }
+
+    /// Starts a ChatGPT device login and returns public pending state as JSON.
+    #[wasm_bindgen(js_name = startLogin)]
+    pub async fn start_login(&self) -> Result<String, JsValue> {
+        encode_login_status(self.inner.start_login().await)
+    }
+
+    /// Polls device login and returns public state as JSON.
+    pub async fn status(&self) -> Result<String, JsValue> {
+        encode_login_status(self.inner.status().await)
+    }
+
+    /// Resolves one credential generation for a host-owned outbound request.
+    pub async fn credential(&self) -> Result<String, JsValue> {
+        encode_subscription_credential(self.inner.credential().await)
+    }
+
+    /// Refreshes a rejected generation and returns the credential now current.
+    pub async fn recover(&self, rejected_revision: &str) -> Result<String, JsValue> {
+        let revision = rejected_revision
+            .parse::<u64>()
+            .map_err(|error| js_error(format!("invalid credential revision: {error}")))?;
+        encode_subscription_credential(self.inner.recover(revision).await)
+    }
+
+    /// Clears the persisted credential and pending login.
+    pub async fn logout(&self) -> Result<(), JsValue> {
+        self.inner.logout().await.map_err(js_error)
+    }
+}
+
+fn encode_login_status<E: ToString>(
+    status: Result<ChatGptLoginStatus, E>,
+) -> Result<String, JsValue> {
+    serde_json::to_string(&status.map_err(js_error)?).map_err(js_error)
+}
+
+fn encode_subscription_credential(
+    credential: Result<nanocodex::oai::auth::ChatGptCredential, impl ToString>,
+) -> Result<String, JsValue> {
+    let credential = credential.map_err(js_error)?;
+    Ok(serde_json::json!({
+        "kind": "chatgpt",
+        "accessToken": credential.access_token(),
+        "accountId": credential.account_id(),
+        "fedramp": credential.is_fedramp(),
+        "revision": credential.revision().to_string(),
+    })
+    .to_string())
+}
+
 /// JavaScript binding over the shared Rust agent lifecycle.
 #[wasm_bindgen(js_name = Nanocodex)]
 pub struct WasmNanocodex {
@@ -255,6 +489,26 @@ impl WasmNanocodex {
     pub fn new(config_json: &str) -> Result<Self, JsValue> {
         let config = serde_json::from_str::<WasmConfig>(config_json)
             .map_err(|error| js_error(format!("invalid Nanocodex configuration: {error}")))?;
+        let auth = nanocodex::oai::auth::OpenAiAuth::api_key(config.api_key.clone());
+        Self::create_with_auth(config, auth)
+    }
+
+    /// Builds an agent whose ChatGPT credential lifecycle is owned by Rust.
+    #[wasm_bindgen(js_name = createWithChatGpt)]
+    pub async fn create_with_chat_gpt(
+        config_json: &str,
+        subscription: &WasmChatGptSubscription,
+    ) -> Result<Self, JsValue> {
+        let config = serde_json::from_str::<WasmConfig>(config_json)
+            .map_err(|error| js_error(format!("invalid Nanocodex configuration: {error}")))?;
+        let auth = subscription.inner.authorization().await.map_err(js_error)?;
+        Self::create_with_auth(config, auth)
+    }
+
+    fn create_with_auth(
+        config: WasmConfig,
+        auth: nanocodex::oai::auth::OpenAiAuth,
+    ) -> Result<Self, JsValue> {
         validate(&config)?;
 
         let model = config.model.parse::<Model>().map_err(js_error)?;
@@ -263,7 +517,7 @@ impl WasmNanocodex {
             .reasoning_mode
             .parse::<ReasoningMode>()
             .map_err(js_error)?;
-        let openai = OpenAi::builder(config.api_key)
+        let openai = OpenAi::builder(auth)
             .model(model)
             .thinking(thinking)
             .reasoning_mode(reasoning_mode)

--- a/js/bindings/test/subscription.test.mjs
+++ b/js/bindings/test/subscription.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createMemoryChatGptSubscriptionStore,
+  subscriptionRevision,
+} from "../index.mjs";
+import { ChatGptSubscription } from "../node/index.mjs";
+
+test("Rust owns hosted ChatGPT credential state over a generic store", async () => {
+  const id = "subscription-1";
+  const store = createMemoryChatGptSubscriptionStore(id);
+  const expiresAt = (Math.floor(Date.now() / 1_000) + 3_600) * 1_000;
+  const subscription = await ChatGptSubscription.open({
+    id,
+    store,
+    seed: {
+      accessToken: jwt(expiresAt / 1_000),
+      refreshToken: "refresh-secret",
+      accountId: "account-1",
+      fedramp: true,
+    },
+  });
+
+  assert.deepEqual(await subscription.status(), {
+    state: "authenticated",
+    accountId: "account-1",
+    expiresAt,
+  });
+  const persisted = store.snapshot();
+  assert.equal(persisted.revision, subscriptionRevision(1n));
+  assert.match(persisted.payload, /refresh-secret/);
+
+  await subscription.logout();
+  assert.deepEqual(await subscription.status(), { state: "signed_out" });
+  subscription.dispose();
+});
+
+test("memory subscription store rejects stale compare-and-swap writes", () => {
+  const store = createMemoryChatGptSubscriptionStore("subscription-2");
+  assert.deepEqual(store.compareAndSwap("subscription-2", {
+    expectedRevision: subscriptionRevision(0n),
+    payload: "first",
+  }), { status: "committed", revision: subscriptionRevision(1n) });
+  assert.deepEqual(store.compareAndSwap("subscription-2", {
+    expectedRevision: subscriptionRevision(0n),
+    payload: "stale",
+  }), { status: "conflict", actualRevision: subscriptionRevision(1n) });
+  assert.equal(store.snapshot().payload, "first");
+});
+
+function jwt(exp) {
+  const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "none" })}.${encode({ exp })}.`;
+}

--- a/js/bindings/test/types.test-d.mts
+++ b/js/bindings/test/types.test-d.mts
@@ -1,9 +1,11 @@
 import {
   Actions,
   Agent,
+  ChatGptSubscription,
   type AccountsWallet,
   type CostStatus,
   createTempoProviderFromAccounts,
+  createMemoryChatGptSubscriptionStore,
   type SessionSnapshot,
   type Turn,
   type TurnResult,
@@ -65,6 +67,14 @@ async function check() {
     session: { bootstrap: true },
   });
   await Agent.create({ mpp: tempoProvider, mcp: false });
+  const subscription = await ChatGptSubscription.open({
+    id: "account-1",
+    store: createMemoryChatGptSubscriptionStore("account-1"),
+  });
+  await subscription.status();
+  await Agent.create({ subscription });
+  // @ts-expect-error API-key and managed subscription authentication are mutually exclusive.
+  await Agent.create({ apiKey, subscription });
 
   const fork = await Actions.session.fork(agent, { at: completed });
   fork.turn.prompt({ input: [{ type: "text", text: "continue" }] });
@@ -89,6 +99,7 @@ async function check() {
   await BrowserAgent.create({ hostAuth: true, websocketUrl: "wss://example.com" });
   await BrowserAgent.create({ apiKey, filesystem: browserWorkspace });
   await BrowserAgent.create({ mpp: { async ws() { return {} as WebSocket; } } });
+  await BrowserAgent.create({ subscription });
   // @ts-expect-error API-key and MPP authentication are mutually exclusive.
   await BrowserAgent.create({ apiKey, mpp: { async ws() { return {} as WebSocket; } } });
   // @ts-expect-error API-key and host-managed authentication are mutually exclusive.

--- a/js/bindings/types.d.mts
+++ b/js/bindings/types.d.mts
@@ -28,6 +28,95 @@ export type AgentOptions = {
   resume?: SessionSnapshot | undefined;
 };
 
+/** Unsigned decimal revision for opaque ChatGPT subscription state. */
+declare const subscriptionRevisionBrand: unique symbol;
+export type SubscriptionRevision = string & {
+  readonly [subscriptionRevisionBrand]: "NanocodexSubscriptionRevision";
+};
+
+export type SubscriptionStoredValue = Readonly<{
+  revision: SubscriptionRevision;
+  payload?: string | undefined;
+}>;
+
+export type SubscriptionCommitRequest = Readonly<{
+  expectedRevision: SubscriptionRevision;
+  /** Opaque Rust-owned credential state. Hosts must store it as a secret. */
+  payload: string;
+}>;
+
+export type SubscriptionCommitResult =
+  | Readonly<{ status: "committed"; revision: SubscriptionRevision }>
+  | Readonly<{ status: "conflict"; actualRevision: SubscriptionRevision }>;
+
+/** Generic secret persistence consumed by the Rust ChatGPT lifecycle. */
+export type ChatGptSubscriptionStore = Readonly<{
+  load(id: string): SubscriptionStoredValue | Promise<SubscriptionStoredValue>;
+  compareAndSwap(
+    id: string,
+    request: SubscriptionCommitRequest,
+  ): SubscriptionCommitResult | Promise<SubscriptionCommitResult>;
+}>;
+
+export type MemoryChatGptSubscriptionStore = ChatGptSubscriptionStore & Readonly<{
+  id: string;
+  snapshot(): SubscriptionStoredValue;
+}>;
+
+export type ChatGptCredentialSeed = Readonly<{
+  accessToken: string;
+  refreshToken?: string | undefined;
+  accountId: string;
+  fedramp?: boolean | undefined;
+}>;
+
+export type ChatGptLoginStatus =
+  | Readonly<{ state: "signed_out" | "expired" }>
+  | Readonly<{
+      state: "pending";
+      verificationUrl: string;
+      userCode: string;
+      expiresAt: number;
+      pollAfterMs: number;
+    }>
+  | Readonly<{
+      state: "authenticated";
+      accountId: string;
+      expiresAt: number | null;
+    }>;
+
+export type ChatGptCredential = Readonly<{
+  kind: "chatgpt";
+  /** Resolved bearer credential. Do not retain or log it. */
+  accessToken: string;
+  accountId: string;
+  fedramp: boolean;
+  revision: SubscriptionRevision;
+}>;
+
+export type ChatGptSubscriptionHandle = Readonly<{
+  id: string;
+  startLogin(): Promise<ChatGptLoginStatus>;
+  status(): Promise<ChatGptLoginStatus>;
+  credential(): Promise<ChatGptCredential>;
+  recover(rejectedRevision: SubscriptionRevision): Promise<ChatGptCredential>;
+  logout(): Promise<void>;
+  dispose(): void;
+}>;
+
+export type ChatGptSubscriptionOptions = Readonly<{
+  id: string;
+  store: ChatGptSubscriptionStore;
+  /** Generic bounded HTTP capability; defaults to global fetch. */
+  fetch?: typeof globalThis.fetch | undefined;
+  /** Trusted initial credentials, typically imported from Codex auth.json. */
+  seed?: ChatGptCredentialSeed | undefined;
+  /** Test-only local issuer override. */
+  issuer?: string | undefined;
+  /** Browser WASM module compiled from the same nanocodex package. */
+  module?: unknown;
+}>;
+
 export type EstimatedUsdCost = Readonly<{
   usd: string;
   input_usd: string;

--- a/js/bindings/worker/ChatGptSubscription.d.mts
+++ b/js/bindings/worker/ChatGptSubscription.d.mts
@@ -1,0 +1,7 @@
+import type {
+  ChatGptSubscriptionHandle,
+  ChatGptSubscriptionOptions,
+} from "../types.mjs";
+
+/** Opens the Rust-owned ChatGPT lifecycle in a module Worker. */
+export function open(options: ChatGptSubscriptionOptions): Promise<ChatGptSubscriptionHandle>;

--- a/js/bindings/worker/ChatGptSubscription.mjs
+++ b/js/bindings/worker/ChatGptSubscription.mjs
@@ -1,0 +1,10 @@
+import { ChatGptSubscription as WasmChatGptSubscription } from "../pkg-web/nanocodex_worker.js";
+
+import { installHostBridge } from "../internal.mjs";
+import { openSubscription } from "../runtime/chatgpt-subscription.mjs";
+
+/** Opens the Rust-owned ChatGPT lifecycle in a module Worker. */
+export function open(options) {
+  installHostBridge();
+  return openSubscription(options, (config) => WasmChatGptSubscription.open(config));
+}

--- a/js/bindings/worker/index.d.mts
+++ b/js/bindings/worker/index.d.mts
@@ -1,0 +1,18 @@
+export {
+  createMemoryChatGptSubscriptionStore,
+  subscriptionRevision,
+} from "../index.mjs";
+export type {
+  ChatGptCredential,
+  ChatGptCredentialSeed,
+  ChatGptLoginStatus,
+  ChatGptSubscriptionHandle,
+  ChatGptSubscriptionOptions,
+  ChatGptSubscriptionStore,
+  MemoryChatGptSubscriptionStore,
+  SubscriptionCommitRequest,
+  SubscriptionCommitResult,
+  SubscriptionRevision,
+  SubscriptionStoredValue,
+} from "../types.mjs";
+export * as ChatGptSubscription from "./ChatGptSubscription.mjs";

--- a/js/bindings/worker/index.mjs
+++ b/js/bindings/worker/index.mjs
@@ -1,0 +1,5 @@
+export {
+  createMemoryChatGptSubscriptionStore,
+  subscriptionRevision,
+} from "../index.mjs";
+export * as ChatGptSubscription from "./ChatGptSubscription.mjs";

--- a/scripts/build-js-package.sh
+++ b/scripts/build-js-package.sh
@@ -13,9 +13,11 @@ fi
 cargo build --locked -p nanocodex-wasm --target "$wasm_target" --profile wasm
 wasm_artifact="$target_dir/$wasm_target/wasm/nanocodex_wasm.wasm"
 stamp_path="js/bindings/pkg-web/.nanocodex-bindgen-stamp"
-fingerprint="$(wasm-bindgen --version; cksum < "$wasm_artifact")"
+fingerprint="$(wasm-bindgen --version; printf 'worker-bundler-v1\n'; cksum < "$wasm_artifact")"
 if [[ -f "$stamp_path" ]] \
   && [[ -f js/bindings/pkg-web/nanocodex_bg.wasm ]] \
+  && [[ -f js/bindings/pkg-web/nanocodex_bg.js ]] \
+  && [[ -f js/bindings/pkg-web/nanocodex_worker.js ]] \
   && [[ -f js/bindings/pkg-node/nanocodex_bg.wasm ]] \
   && [[ "$(<"$stamp_path")" == "$fingerprint" ]]; then
   echo "wasm-bindgen outputs are current"
@@ -30,5 +32,14 @@ wasm-bindgen "$wasm_artifact" \
   --target web \
   --out-dir js/bindings/pkg-web \
   --out-name nanocodex
+worker_bindings="$(mktemp -d)"
+trap 'rm -rf "$worker_bindings"' EXIT
+wasm-bindgen "$wasm_artifact" \
+  --target bundler \
+  --out-dir "$worker_bindings" \
+  --out-name nanocodex
+cmp "$worker_bindings/nanocodex_bg.wasm" js/bindings/pkg-web/nanocodex_bg.wasm
+cp "$worker_bindings/nanocodex_bg.js" js/bindings/pkg-web/nanocodex_bg.js
+cp "$worker_bindings/nanocodex.js" js/bindings/pkg-web/nanocodex_worker.js
 node js/bindings/scripts/write-package-types.mjs
 printf '%s\n' "$fingerprint" > "$stamp_path"

--- a/web/scripts/check-bundle.mjs
+++ b/web/scripts/check-bundle.mjs
@@ -12,9 +12,9 @@ const budgets = Object.freeze({
   initialCss: 60_000,
   initialCssGzip: 12_000,
   agentJavaScript: 830_000,
-  // OPFS, artifacts, voice routing, and the paid MCP seam add lazy Worker edges.
-  agentWorker: 51_000,
-  agentWorkerGzip: 16_500,
+  // OPFS, artifacts, voice routing, subscription auth, and paid MCP stay in the Worker.
+  agentWorker: 55_000,
+  agentWorkerGzip: 17_500,
   // just-bash and its built-in Unix command set stay behind Agent startup.
   browserShellJavaScript: 1_600_000,
   browserShellJavaScriptGzip: 450_000,

--- a/web/scripts/publish-repository.mjs
+++ b/web/scripts/publish-repository.mjs
@@ -107,7 +107,7 @@ async function main() {
       mapConcurrent(commitPageNames, uploadConcurrency, (name) => uploadFile(
           origin,
           token,
-          `${generationPrefix}/commits/${name}`,
+          `${generationPrefix}/commits/${name}.json`,
           resolve(dataDirectory, "commit-pages", `${name}.json`),
         )),
     ]);

--- a/web/scripts/publish-repository.test.mjs
+++ b/web/scripts/publish-repository.test.mjs
@@ -78,6 +78,12 @@ test("the publisher CLI initializes its module before building a generation", as
     const publication = JSON.parse(publicationRequest.body);
     assert.equal(publication.expectedHead, null);
     assert.equal(publication.publication.head, head);
+    assert.ok(requests.some(({ url }) =>
+      url === `/api/git/objects/generations/${head}/commits/0000.json`
+    ));
+    assert.equal(requests.some(({ url }) =>
+      url === `/api/git/objects/generations/${head}/commits/0000`
+    ), false);
   } finally {
     if (server.listening) await new Promise((resolveClose) => server.close(resolveClose));
     await rm(directory, { recursive: true, force: true });

--- a/web/worker/index.test.ts
+++ b/web/worker/index.test.ts
@@ -65,7 +65,7 @@ function createChatGptSessions() {
               accessToken: "subscription-secret",
               accountId: "account-1",
               fedramp: false,
-              revision: 0,
+              revision: "0",
             });
           }
           return Response.json({ error: "not_found" }, { status: 404 });

--- a/web/worker/index.ts
+++ b/web/worker/index.ts
@@ -1003,8 +1003,8 @@ function isChatGptCredential(value: unknown): value is ChatGptCredential {
     && typeof credential.accountId === "string"
     && credential.accountId.length > 0
     && typeof credential.fedramp === "boolean"
-    && Number.isSafeInteger(credential.revision)
-    && Number(credential.revision) >= 0;
+    && typeof credential.revision === "string"
+    && /^(0|[1-9][0-9]*)$/.test(credential.revision);
 }
 
 async function deleteSession(request: Request, env: WorkerEnv): Promise<void> {

--- a/web/worker/subscriptionAuth.test.ts
+++ b/web/worker/subscriptionAuth.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import { test } from "node:test";
 
 import {
@@ -31,6 +32,10 @@ class MemoryStorage {
 
   async setAlarm(timestamp: number): Promise<void> {
     this.alarm = timestamp;
+  }
+
+  async transaction<T>(callback: (transaction: MemoryStorage) => T | Promise<T>): Promise<T> {
+    return callback(this);
   }
 }
 
@@ -86,16 +91,20 @@ test("device login stores and rotates ChatGPT tokens without exposing them in pu
       id: { toString: () => "session-id" },
       storage,
     } as unknown as DurableObjectState;
+    const module = await WebAssembly.compile(await readFile(new URL(
+      "../../js/bindings/pkg-web/nanocodex_bg.wasm",
+      import.meta.url,
+    )));
     const session = new ChatGptSession(state, {
-      CHATGPT_ISSUER: "https://auth.openai.test/",
+      CHATGPT_ISSUER: "http://127.0.0.1:8799/",
       ENVIRONMENT: "test",
       SESSION_CREDENTIAL_KEY: TEST_KEY,
-    });
+    }, module);
 
     const started = await session.fetch(new Request("https://session.test/start", { method: "POST" }));
     assert.deepEqual(await started.json(), {
       state: "pending",
-      verificationUrl: "https://auth.openai.test/codex/device",
+      verificationUrl: "http://127.0.0.1:8799/codex/device",
       userCode: "ABCD-EFGH",
       expiresAt: now + 900_000,
       pollAfterMs: 1_000,
@@ -126,7 +135,7 @@ test("device login stores and rotates ChatGPT tokens without exposing them in pu
     assert.equal(credential.kind, "chatgpt");
     assert.equal(credential.accountId, "account-1");
     assert.equal(credential.fedramp, true);
-    assert.equal(credential.revision, 0);
+    assert.equal(credential.revision, "0");
     assert.equal("refreshToken" in credential, false);
 
     for (let requestIndex = 0; requestIndex < 4; requestIndex += 1) {
@@ -174,12 +183,12 @@ test("device login stores and rotates ChatGPT tokens without exposing them in pu
     const recovered = await session.fetch(new Request("https://session.test/recover", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ revision: 0 }),
+      body: JSON.stringify({ revision: "0" }),
     }));
     const rotated = await recovered.json() as Record<string, unknown>;
-    assert.equal(rotated.revision, 1);
+    assert.equal(rotated.revision, "1");
     assert.equal(rotated.accountId, "account-1");
-    const stored = JSON.stringify(storage.values.get("credential"));
+    const stored = JSON.stringify(storage.values.get("subscription"));
     assert.doesNotMatch(stored, /refresh-2|refresh-1|account-1/);
   } finally {
     globalThis.fetch = originalFetch;

--- a/web/worker/subscriptionAuth.test.ts
+++ b/web/worker/subscriptionAuth.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { test } from "node:test";
+import { ChatGptSubscription } from "nanocodex/browser";
 
 import {
   CHATGPT_LOGIN_TTL_MS,
@@ -99,7 +100,9 @@ test("device login stores and rotates ChatGPT tokens without exposing them in pu
       CHATGPT_ISSUER: "http://127.0.0.1:8799/",
       ENVIRONMENT: "test",
       SESSION_CREDENTIAL_KEY: TEST_KEY,
-    }, module);
+    }, {
+      open: (options) => ChatGptSubscription.open({ ...options, module }),
+    });
 
     const started = await session.fetch(new Request("https://session.test/start", { method: "POST" }));
     assert.deepEqual(await started.json(), {

--- a/web/worker/subscriptionAuth.ts
+++ b/web/worker/subscriptionAuth.ts
@@ -1,11 +1,18 @@
+import {
+  ChatGptSubscription,
+  subscriptionRevision,
+  type ChatGptCredential,
+  type ChatGptLoginStatus,
+  type ChatGptSubscriptionHandle,
+  type ChatGptSubscriptionStore,
+  type SubscriptionCommitRequest,
+  type SubscriptionStoredValue,
+} from "nanocodex/browser";
+
 import { CredentialVault, type CredentialVaultEnv, type EncryptedEnvelope } from "./credentialVault.ts";
 
-const OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann";
-const DEFAULT_ISSUER = "https://auth.openai.com";
-const REFRESH_EARLY_MS = 5 * 60_000;
 export const CHATGPT_LOGIN_TTL_MS = 15 * 60_000;
 export const CHATGPT_SESSION_TTL_MS = 7 * 24 * 60 * 60_000;
-const MAX_RESPONSE_BYTES = 16 * 1024;
 const USAGE_WINDOW_MS = 60_000;
 const SOCKET_LEASE_MS = 2 * 60 * 60_000;
 const MAX_ACTIVE_SOCKETS = 3;
@@ -16,76 +23,51 @@ const OPERATION_LIMITS = {
 } as const;
 
 export type ChatGptOperation = "health" | keyof typeof OPERATION_LIMITS;
-
-export type ChatGptCredential = {
-  kind: "chatgpt";
-  accessToken: string;
-  accountId: string;
-  fedramp: boolean;
-  revision: number;
-};
-
-type StoredCredential = ChatGptCredential & {
-  refreshToken: string;
-  expiresAt: number | null;
-};
+export type { ChatGptCredential };
 
 type StoredUsage = {
   windows: Partial<Record<keyof typeof OPERATION_LIMITS, { startedAt: number; count: number }>>;
   socketLeases: Record<string, number>;
 };
 
-type PendingLogin = {
-  deviceAuthId: string;
-  userCode: string;
-  verificationUrl: string;
-  intervalMs: number;
-  nextPollAt: number;
-  expiresAt: number;
-};
-
-type DeviceCodeResponse = {
-  device_auth_id?: unknown;
-  user_code?: unknown;
-  usercode?: unknown;
-  interval?: unknown;
-};
-
-type DeviceTokenResponse = {
-  authorization_code?: unknown;
-  code_verifier?: unknown;
-};
-
-type TokenResponse = {
-  access_token?: unknown;
-  refresh_token?: unknown;
-  id_token?: unknown;
+type StoredSubscriptionRow = {
+  revision: string;
+  envelope: EncryptedEnvelope;
 };
 
 export class ChatGptSession {
   readonly #state: DurableObjectState;
-  readonly #issuer: string;
-  readonly #vault: CredentialVault;
-  #refreshing?: { revision: number; promise: Promise<StoredCredential> };
+  readonly #store: DurableSubscriptionStore;
+  readonly #issuer?: string;
+  readonly #module?: unknown;
+  #subscription?: Promise<ChatGptSubscriptionHandle>;
 
   constructor(
     state: DurableObjectState,
     env: CredentialVaultEnv & { CHATGPT_ISSUER?: string },
+    module?: unknown,
   ) {
     this.#state = state;
-    this.#issuer = (env.CHATGPT_ISSUER?.trim() || DEFAULT_ISSUER).replace(/\/$/, "");
-    this.#vault = new CredentialVault(env, `chatgpt/${state.id?.toString() ?? "test"}`);
+    const scope = `chatgpt/${state.id?.toString() ?? "test"}`;
+    this.#store = new DurableSubscriptionStore(state.storage, new CredentialVault(env, scope));
+    this.#issuer = env.CHATGPT_ISSUER?.trim() || undefined;
+    this.#module = module;
   }
 
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
     try {
       if (request.method === "POST" && url.pathname === "/start") {
-        const pending = await this.#start();
-        return Response.json(publicPending(pending), { headers: noStoreHeaders() });
+        const status = await (await this.#manager()).startLogin();
+        await this.#state.storage.setAlarm(Date.now() + CHATGPT_LOGIN_TTL_MS);
+        return Response.json(status, { headers: noStoreHeaders() });
       }
       if (request.method === "GET" && url.pathname === "/status") {
-        return Response.json(await this.#status(), { headers: noStoreHeaders() });
+        const status = await (await this.#manager()).status();
+        if (status.state === "authenticated") {
+          await this.#state.storage.setAlarm(Date.now() + CHATGPT_SESSION_TTL_MS);
+        }
+        return Response.json(status, { headers: noStoreHeaders() });
       }
       if (request.method === "POST" && url.pathname === "/credential") {
         const body = await request.json<{ operation?: unknown; leaseId?: unknown }>();
@@ -93,17 +75,14 @@ export class ChatGptSession {
         if (!operation) {
           return Response.json({ error: "invalid operation" }, { status: 400, headers: noStoreHeaders() });
         }
-        const credential = await this.#currentCredential();
-        if (!credential) {
-          return Response.json({ error: "not_authenticated" }, { status: 404, headers: noStoreHeaders() });
-        }
+        const credential = await (await this.#manager()).credential();
         if (!await this.#consume(operation, body.leaseId)) {
           return Response.json(
             { error: "session_rate_limit_exceeded" },
             { status: 429, headers: { ...noStoreHeaders(), "retry-after": "60" } },
           );
         }
-        return Response.json(publicCredential(credential), { headers: noStoreHeaders() });
+        return Response.json(credential, { headers: noStoreHeaders() });
       }
       if (request.method === "DELETE" && url.pathname === "/lease") {
         const body = await request.json<{ leaseId?: unknown }>();
@@ -112,19 +91,23 @@ export class ChatGptSession {
       }
       if (request.method === "POST" && url.pathname === "/recover") {
         const body = await request.json<{ revision?: unknown }>();
-        if (!Number.isSafeInteger(body.revision) || Number(body.revision) < 0) {
+        const revision = parseRevision(body.revision);
+        if (!revision) {
           return Response.json({ error: "invalid revision" }, { status: 400, headers: noStoreHeaders() });
         }
-        const credential = await this.#refresh(Number(body.revision));
-        return Response.json(publicCredential(credential), { headers: noStoreHeaders() });
+        const credential = await (await this.#manager()).recover(revision);
+        return Response.json(credential, { headers: noStoreHeaders() });
       }
       if (request.method === "DELETE") {
-        await this.#state.storage.deleteAll();
+        await (await this.#manager()).logout();
+        await this.#state.storage.delete("usage");
         return new Response(null, { status: 204, headers: noStoreHeaders() });
       }
       return Response.json({ error: "not_found" }, { status: 404, headers: noStoreHeaders() });
     } catch (error) {
-      return Response.json({ error: safeError(error) }, { status: 503, headers: noStoreHeaders() });
+      const message = safeError(error);
+      const status = message.includes("not authenticated") ? 404 : 503;
+      return Response.json({ error: message }, { status, headers: noStoreHeaders() });
     }
   }
 
@@ -132,152 +115,18 @@ export class ChatGptSession {
     await this.#state.storage.deleteAll();
   }
 
-  async #start(): Promise<PendingLogin> {
-    const response = await fetch(`${this.#issuer}/api/accounts/deviceauth/usercode`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ client_id: OAUTH_CLIENT_ID }),
+  #manager(): Promise<ChatGptSubscriptionHandle> {
+    return this.#subscription ??= this.#openManager();
+  }
+
+  async #openManager(): Promise<ChatGptSubscriptionHandle> {
+    const module = this.#module ?? (await import("nanocodex/wasm")).default;
+    return ChatGptSubscription.open({
+      id: `chatgpt:${this.#state.id?.toString() ?? "test"}`,
+      store: this.#store,
+      module,
+      ...(this.#issuer === undefined ? {} : { issuer: this.#issuer }),
     });
-    const body = await readJson<DeviceCodeResponse>(response);
-    if (!response.ok) throw new Error(`ChatGPT login start failed with HTTP ${response.status}`);
-    const deviceAuthId = requiredString(body.device_auth_id, "device authorization ID");
-    const userCode = requiredString(body.user_code ?? body.usercode, "device user code");
-    const intervalSeconds = parseInterval(body.interval);
-    const now = Date.now();
-    const pending: PendingLogin = {
-      deviceAuthId,
-      userCode,
-      verificationUrl: `${this.#issuer}/codex/device`,
-      intervalMs: intervalSeconds * 1_000,
-      nextPollAt: now + intervalSeconds * 1_000,
-      expiresAt: now + CHATGPT_LOGIN_TTL_MS,
-    };
-    await this.#state.storage.delete("credential");
-    await this.#state.storage.delete("usage");
-    await this.#state.storage.put("pending", pending);
-    await this.#state.storage.setAlarm(pending.expiresAt);
-    return pending;
-  }
-
-  async #status(): Promise<Record<string, unknown>> {
-    const credential = await this.#currentCredential();
-    if (credential) {
-      return {
-        state: "authenticated",
-        accountId: credential.accountId,
-        expiresAt: credential.expiresAt,
-      };
-    }
-    const pending = await this.#state.storage.get<PendingLogin>("pending");
-    if (!pending) return { state: "signed_out" };
-    const now = Date.now();
-    if (pending.expiresAt <= now) {
-      await this.#state.storage.delete("pending");
-      return { state: "expired" };
-    }
-    if (pending.nextPollAt > now) return publicPending(pending);
-    const result = await this.#poll(pending);
-    if (!result) return publicPending(pending);
-    await this.#putCredential(result);
-    await this.#state.storage.delete("pending");
-    await this.#state.storage.setAlarm(now + CHATGPT_SESSION_TTL_MS);
-    return {
-      state: "authenticated",
-      accountId: result.accountId,
-      expiresAt: result.expiresAt,
-    };
-  }
-
-  async #poll(pending: PendingLogin): Promise<StoredCredential | undefined> {
-    pending.nextPollAt = Date.now() + pending.intervalMs;
-    await this.#state.storage.put("pending", pending);
-    const response = await fetch(`${this.#issuer}/api/accounts/deviceauth/token`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        device_auth_id: pending.deviceAuthId,
-        user_code: pending.userCode,
-      }),
-    });
-    if (response.status === 403 || response.status === 404) {
-      await response.body?.cancel();
-      return undefined;
-    }
-    const body = await readJson<DeviceTokenResponse>(response);
-    if (!response.ok) throw new Error(`ChatGPT device authorization failed with HTTP ${response.status}`);
-    const authorizationCode = requiredString(body.authorization_code, "authorization code");
-    const codeVerifier = requiredString(body.code_verifier, "PKCE verifier");
-    return this.#exchange(authorizationCode, codeVerifier);
-  }
-
-  async #exchange(authorizationCode: string, codeVerifier: string): Promise<StoredCredential> {
-    const form = new URLSearchParams({
-      grant_type: "authorization_code",
-      code: authorizationCode,
-      redirect_uri: `${this.#issuer}/deviceauth/callback`,
-      client_id: OAUTH_CLIENT_ID,
-      code_verifier: codeVerifier,
-    });
-    const response = await fetch(`${this.#issuer}/oauth/token`, {
-      method: "POST",
-      headers: { "content-type": "application/x-www-form-urlencoded" },
-      body: form.toString(),
-    });
-    const tokens = await readJson<TokenResponse>(response);
-    if (!response.ok) throw new Error(`ChatGPT token exchange failed with HTTP ${response.status}`);
-    return credentialFromTokens(tokens, undefined, 0);
-  }
-
-  async #currentCredential(): Promise<StoredCredential | undefined> {
-    const envelope = await this.#state.storage.get<EncryptedEnvelope>("credential");
-    if (!envelope) return undefined;
-    const opened = await this.#vault.open<StoredCredential>(envelope);
-    let credential = opened.value;
-    if (opened.reseal) await this.#putCredential(credential);
-    if (credential.expiresAt !== null && credential.expiresAt <= Date.now() + REFRESH_EARLY_MS) {
-      credential = await this.#refresh(credential.revision);
-    }
-    return credential;
-  }
-
-  async #refresh(rejectedRevision: number): Promise<StoredCredential> {
-    const envelope = await this.#state.storage.get<EncryptedEnvelope>("credential");
-    const current = envelope ? (await this.#vault.open<StoredCredential>(envelope)).value : undefined;
-    if (!current) throw new Error("ChatGPT credentials are not initialized");
-    if (current.revision !== rejectedRevision) return current;
-    if (this.#refreshing?.revision === rejectedRevision) return this.#refreshing.promise;
-    const promise = this.#performRefresh(current);
-    this.#refreshing = { revision: rejectedRevision, promise };
-    try {
-      return await promise;
-    } finally {
-      if (this.#refreshing?.promise === promise) this.#refreshing = undefined;
-    }
-  }
-
-  async #performRefresh(current: StoredCredential): Promise<StoredCredential> {
-    if (!current.refreshToken) throw new Error("ChatGPT login expired; sign in again");
-    const response = await fetch(`${this.#issuer}/oauth/token`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        client_id: OAUTH_CLIENT_ID,
-        grant_type: "refresh_token",
-        refresh_token: current.refreshToken,
-      }),
-    });
-    const tokens = await readJson<TokenResponse>(response);
-    if (!response.ok) throw new Error(`ChatGPT token refresh failed with HTTP ${response.status}`);
-    const next = credentialFromTokens(tokens, current, current.revision + 1);
-    if (next.accountId !== current.accountId) {
-      throw new Error("the refreshed ChatGPT credential changed accounts");
-    }
-    await this.#putCredential(next);
-    return next;
-  }
-
-  async #putCredential(credential: StoredCredential): Promise<void> {
-    await this.#state.storage.put("credential", await this.#vault.seal(credential));
   }
 
   async #consume(operation: ChatGptOperation, leaseId: unknown): Promise<boolean> {
@@ -316,50 +165,50 @@ export class ChatGptSession {
   }
 }
 
-function credentialFromTokens(
-  tokens: TokenResponse,
-  previous: StoredCredential | undefined,
-  revision: number,
-): StoredCredential {
-  const accessToken = requiredString(tokens.access_token, "access token");
-  const refreshToken = optionalString(tokens.refresh_token) ?? previous?.refreshToken ?? "";
-  const idToken = optionalString(tokens.id_token);
-  const claims = idToken ? jwtPayload(idToken) : undefined;
-  const authClaims = asObject(claims?.["https://api.openai.com/auth"]);
-  const accountId = optionalString(authClaims?.chatgpt_account_id) ?? previous?.accountId;
-  if (!accountId) throw new Error("ChatGPT token response omitted the account ID");
-  const fedramp = typeof authClaims?.chatgpt_account_is_fedramp === "boolean"
-    ? authClaims.chatgpt_account_is_fedramp
-    : previous?.fedramp ?? false;
-  return {
-    kind: "chatgpt",
-    accessToken,
-    refreshToken,
-    accountId,
-    fedramp,
-    revision,
-    expiresAt: jwtExpiration(accessToken),
-  };
-}
+class DurableSubscriptionStore implements ChatGptSubscriptionStore {
+  readonly #storage: DurableObjectStorage;
+  readonly #vault: CredentialVault;
 
-function publicCredential(credential: StoredCredential): ChatGptCredential {
-  return {
-    kind: "chatgpt",
-    accessToken: credential.accessToken,
-    accountId: credential.accountId,
-    fedramp: credential.fedramp,
-    revision: credential.revision,
-  };
-}
+  constructor(storage: DurableObjectStorage, vault: CredentialVault) {
+    this.#storage = storage;
+    this.#vault = vault;
+  }
 
-function publicPending(pending: PendingLogin) {
-  return {
-    state: "pending",
-    verificationUrl: pending.verificationUrl,
-    userCode: pending.userCode,
-    expiresAt: pending.expiresAt,
-    pollAfterMs: Math.max(250, pending.nextPollAt - Date.now()),
-  };
+  async load(_id: string): Promise<SubscriptionStoredValue> {
+    const row = await this.#storage.get<StoredSubscriptionRow>("subscription");
+    if (!row) return { revision: subscriptionRevision(0n) };
+    const opened = await this.#vault.open<{ payload: string }>(row.envelope);
+    if (opened.reseal) {
+      await this.#storage.put("subscription", {
+        revision: row.revision,
+        envelope: await this.#vault.seal(opened.value),
+      } satisfies StoredSubscriptionRow);
+    }
+    return {
+      revision: subscriptionRevision(row.revision),
+      payload: opened.value.payload,
+    };
+  }
+
+  async compareAndSwap(
+    _id: string,
+    request: SubscriptionCommitRequest,
+  ) {
+    const envelope: EncryptedEnvelope = await this.#vault.seal({ payload: request.payload });
+    return this.#storage.transaction(async (transaction) => {
+      const current = await transaction.get<StoredSubscriptionRow>("subscription");
+      const actualRevision = subscriptionRevision(current?.revision ?? "0");
+      if (actualRevision !== request.expectedRevision) {
+        return { status: "conflict" as const, actualRevision };
+      }
+      const revision = subscriptionRevision(BigInt(actualRevision) + 1n);
+      await transaction.put("subscription", {
+        revision,
+        envelope,
+      } satisfies StoredSubscriptionRow);
+      return { status: "committed" as const, revision };
+    });
+  }
 }
 
 function parseOperation(value: unknown): ChatGptOperation | undefined {
@@ -368,81 +217,17 @@ function parseOperation(value: unknown): ChatGptOperation | undefined {
     : undefined;
 }
 
+function parseRevision(value: unknown) {
+  if (typeof value !== "string" || !/^(0|[1-9][0-9]*)$/.test(value)) return undefined;
+  return subscriptionRevision(value);
+}
+
 function isLeaseId(value: unknown): value is string {
   return typeof value === "string" && /^[A-Za-z0-9_-]{43}$/.test(value);
 }
 
 function noStoreHeaders() {
   return { "cache-control": "no-store" };
-}
-
-function parseInterval(value: unknown): number {
-  const parsed = typeof value === "number" ? value : Number.parseInt(String(value), 10);
-  return Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, 30) : 5;
-}
-
-function requiredString(value: unknown, name: string): string {
-  const found = optionalString(value);
-  if (!found) throw new Error(`ChatGPT response omitted the ${name}`);
-  return found;
-}
-
-function optionalString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value : undefined;
-}
-
-function asObject(value: unknown): Record<string, unknown> | undefined {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-    ? value as Record<string, unknown>
-    : undefined;
-}
-
-function jwtExpiration(token: string): number | null {
-  const payload = jwtPayload(token);
-  return typeof payload?.exp === "number" && Number.isFinite(payload.exp)
-    ? payload.exp * 1_000
-    : null;
-}
-
-function jwtPayload(token: string): Record<string, unknown> | undefined {
-  const encoded = token.split(".")[1];
-  if (!encoded) return undefined;
-  try {
-    const base64 = encoded.replaceAll("-", "+").replaceAll("_", "/").padEnd(
-      encoded.length + ((4 - encoded.length % 4) % 4),
-      "=",
-    );
-    return asObject(JSON.parse(atob(base64)));
-  } catch {
-    return undefined;
-  }
-}
-
-async function readJson<T>(response: Response): Promise<T> {
-  const text = await readBoundedText(response, MAX_RESPONSE_BYTES);
-  try {
-    return JSON.parse(text) as T;
-  } catch {
-    throw new Error(`ChatGPT returned invalid JSON with HTTP ${response.status}`);
-  }
-}
-
-async function readBoundedText(response: Response, limit: number): Promise<string> {
-  if (!response.body) return "";
-  const reader = response.body.getReader();
-  const decoder = new TextDecoder();
-  let total = 0;
-  let body = "";
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) return body + decoder.decode();
-    total += value.byteLength;
-    if (total > limit) {
-      await reader.cancel();
-      throw new Error(`ChatGPT response exceeded ${limit} bytes`);
-    }
-    body += decoder.decode(value, { stream: true });
-  }
 }
 
 function safeError(error: unknown): string {

--- a/web/worker/subscriptionAuth.ts
+++ b/web/worker/subscriptionAuth.ts
@@ -1,5 +1,4 @@
 import {
-  ChatGptSubscription,
   subscriptionRevision,
   type ChatGptCredential,
   type ChatGptLoginStatus,
@@ -7,7 +6,7 @@ import {
   type ChatGptSubscriptionStore,
   type SubscriptionCommitRequest,
   type SubscriptionStoredValue,
-} from "nanocodex/browser";
+} from "nanocodex";
 
 import { CredentialVault, type CredentialVaultEnv, type EncryptedEnvelope } from "./credentialVault.ts";
 
@@ -35,23 +34,31 @@ type StoredSubscriptionRow = {
   envelope: EncryptedEnvelope;
 };
 
+type SubscriptionRuntime = {
+  open(options: {
+    id: string;
+    store: ChatGptSubscriptionStore;
+    issuer?: string;
+  }): Promise<ChatGptSubscriptionHandle>;
+};
+
 export class ChatGptSession {
   readonly #state: DurableObjectState;
   readonly #store: DurableSubscriptionStore;
   readonly #issuer?: string;
-  readonly #module?: unknown;
+  readonly #runtime?: SubscriptionRuntime;
   #subscription?: Promise<ChatGptSubscriptionHandle>;
 
   constructor(
     state: DurableObjectState,
     env: CredentialVaultEnv & { CHATGPT_ISSUER?: string },
-    module?: unknown,
+    runtime?: SubscriptionRuntime,
   ) {
     this.#state = state;
     const scope = `chatgpt/${state.id?.toString() ?? "test"}`;
     this.#store = new DurableSubscriptionStore(state.storage, new CredentialVault(env, scope));
     this.#issuer = env.CHATGPT_ISSUER?.trim() || undefined;
-    this.#module = module;
+    this.#runtime = runtime;
   }
 
   async fetch(request: Request): Promise<Response> {
@@ -120,11 +127,10 @@ export class ChatGptSession {
   }
 
   async #openManager(): Promise<ChatGptSubscriptionHandle> {
-    const module = this.#module ?? (await import("nanocodex/wasm")).default;
-    return ChatGptSubscription.open({
+    const runtime = this.#runtime ?? (await import("nanocodex/worker")).ChatGptSubscription;
+    return runtime.open({
       id: `chatgpt:${this.#state.id?.toString() ?? "test"}`,
       store: this.#store,
-      module,
       ...(this.#issuer === undefined ? {} : { issuer: this.#issuer }),
     });
   }


### PR DESCRIPTION
## Summary

- move ChatGPT subscription login, refresh, and credential ownership into the Rust OpenAI boundary
- expose the managed subscription lifecycle through the Node and browser bindings
- update Cloudflare and Rivet deployment adapters to use the Rust-owned flow
- fix repository publication to use the generation-pinned commit key accepted by the Worker

## Validation

- `cargo check -p nanocodex-oai-api --all-features`
- `cargo test -p nanocodex-oai-api auth::subscription`
- `cargo check -p nanocodex-wasm --target wasm32-unknown-unknown`
- `just build-wasm`
- `npm test --prefix js/bindings`
- `npm run typecheck --prefix web`
- `npm test --prefix web`
- Cloudflare example typecheck and Node/Worker tests