### PR TITLE
feat(web): harden browser workspaces and Cloudflare Git

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,6 +308,141 @@ jobs:
       - name: Type-check and build the website
         working-directory: web
         run: npm test && npm run typecheck && npx --no-install vite build && npm run check:bundle
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: nanocodex-web-deployment
+          path: web/dist
+          include-hidden-files: true
+          retention-days: 1
+
+  production:
+    name: production website
+    if: github.repository == 'gakonst/nanocodex' && github.event_name == 'push' && github.ref == 'refs/heads/master' && vars.CLOUDFLARE_DEPLOY_ENABLED == 'true'
+    needs: [test, quality, vm-guest, policy, bindings, python, web, codeql]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    concurrency:
+      group: nanocodex-cloudflare
+      cancel-in-progress: false
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22.13.0
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: nanocodex-web-deployment
+          path: web/dist
+      - name: Install deployment tooling
+        run: npm ci --prefix web --ignore-scripts
+      - name: Select the current production revision
+        id: production
+        env:
+          TARGET_SHA: ${{ github.sha }}
+        run: |
+          current_sha="$(git ls-remote https://github.com/gakonst/nanocodex.git refs/heads/master | cut -f1)"
+          if [ "$current_sha" = "$TARGET_SHA" ]; then
+            echo "current=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "current=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping obsolete production revision $TARGET_SHA; master is $current_sha"
+          fi
+      - name: Deploy the attested Cloudflare Worker
+        if: steps.production.outputs.current == 'true'
+        working-directory: web
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          TARGET_SHA: ${{ github.sha }}
+        run: |
+          : "${CLOUDFLARE_ACCOUNT_ID:?configure the CLOUDFLARE_ACCOUNT_ID repository variable}"
+          : "${CLOUDFLARE_API_TOKEN:?configure the CLOUDFLARE_API_TOKEN repository secret}"
+          npx --no-install wrangler deploy \
+            --config dist/nanocodex/wrangler.json \
+            --strict \
+            --tag "$TARGET_SHA" \
+            --message "gakonst/nanocodex@$TARGET_SHA" \
+            --var "DEPLOYMENT_SHA:$TARGET_SHA"
+      - name: Verify the active Worker revision
+        if: steps.production.outputs.current == 'true'
+        env:
+          TARGET_SHA: ${{ github.sha }}
+        run: |
+          for attempt in $(seq 1 12); do
+            if body="$(curl -fsS "https://nanocodex.me-7fb.workers.dev/api/health?revision=$TARGET_SHA")" && \
+              DEPLOYMENT_HEALTH="$body" node -e '
+                const health = JSON.parse(process.env.DEPLOYMENT_HEALTH);
+                if (health.status !== "ok" || health.deployment_sha !== process.env.TARGET_SHA) process.exit(1);
+              '
+            then
+              exit 0
+            fi
+            if [ "$attempt" -lt 12 ]; then sleep 5; fi
+          done
+          echo "Cloudflare did not activate deployment $TARGET_SHA" >&2
+          exit 1
+      - name: Require master to remain on the deployed revision
+        if: steps.production.outputs.current == 'true'
+        env:
+          TARGET_SHA: ${{ github.sha }}
+        run: |
+          current_sha="$(git ls-remote https://github.com/gakonst/nanocodex.git refs/heads/master | cut -f1)"
+          test "$current_sha" = "$TARGET_SHA" || {
+            echo "Master advanced to $current_sha after deploying $TARGET_SHA; refusing to publish" >&2
+            exit 1
+          }
+      - name: Publish the matching repository generation
+        if: steps.production.outputs.current == 'true'
+        working-directory: web
+        env:
+          NANOCODEX_GIT_ORIGIN: https://nanocodex.me-7fb.workers.dev
+          NANOCODEX_GIT_TOKEN: ${{ secrets.NANOCODEX_GIT_TOKEN }}
+        run: npm run publish:repository
+      - name: Verify the repository snapshot and Git endpoint
+        if: steps.production.outputs.current == 'true'
+        env:
+          TARGET_SHA: ${{ github.sha }}
+        run: |
+          snapshot_ready=false
+          for attempt in $(seq 1 12); do
+            if curl -fsS \
+              "https://nanocodex.me-7fb.workers.dev/api/repository/snapshot?revision=$TARGET_SHA" \
+              -o "$RUNNER_TEMP/nanocodex-repository.json" && \
+              node -e '
+                const fs = require("node:fs");
+                const snapshot = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+                if (snapshot.repository?.head !== process.env.TARGET_SHA) process.exit(1);
+              ' "$RUNNER_TEMP/nanocodex-repository.json"
+            then
+              snapshot_ready=true
+              break
+            fi
+            if [ "$attempt" -lt 12 ]; then sleep 5; fi
+          done
+          test "$snapshot_ready" = true || {
+            echo "Repository snapshot did not advance to $TARGET_SHA" >&2
+            exit 1
+          }
+
+          for attempt in $(seq 1 12); do
+            if remote_shas="$(git ls-remote \
+              https://nanocodex.me-7fb.workers.dev/git \
+              HEAD refs/heads/master | awk '{print $1}' | sort -u)" && \
+              [ "$remote_shas" = "$TARGET_SHA" ]
+            then
+              exit 0
+            fi
+            if [ "$attempt" -lt 12 ]; then sleep 5; fi
+          done
+          echo "Git endpoint did not advance to $TARGET_SHA (observed: $remote_shas)" >&2
+          exit 1
 
   codeql:
     name: CodeQL actions
@@ -332,7 +467,7 @@ jobs:
   ci-success:
     name: ci success
     if: always()
-    needs: [test, quality, policy, bindings, python, web, codeql]
+    needs: [test, quality, vm-guest, policy, bindings, python, web, production, codeql]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -340,16 +475,20 @@ jobs:
         env:
           TEST: ${{ needs.test.result }}
           QUALITY: ${{ needs.quality.result }}
+          VM_GUEST: ${{ needs.vm-guest.result }}
           POLICY: ${{ needs.policy.result }}
           BINDINGS: ${{ needs.bindings.result }}
           PYTHON: ${{ needs.python.result }}
           WEB: ${{ needs.web.result }}
+          PRODUCTION: ${{ needs.production.result }}
           CODEQL: ${{ needs.codeql.result }}
         run: |
           test "$TEST" = success
           test "$QUALITY" = success
+          test "$VM_GUEST" = success
           test "$POLICY" = success
           test "$BINDINGS" = success
           test "$PYTHON" = success
           test "$WEB" = success
+          test "$PRODUCTION" = success || test "$PRODUCTION" = skipped
           test "$CODEQL" = success

--- a/.github/workflows/mirror-cloudflare-git.yml
+++ b/.github/workflows/mirror-cloudflare-git.yml
@@ -1,9 +1,12 @@
-name: Mirror Git to Cloudflare
+name: Publish Cloudflare Git
 
 on:
-  push:
-    branches: [master]
   workflow_dispatch:
+    inputs:
+      revision:
+        description: Deployed 40-character master commit SHA
+        required: true
+        type: string
 
 concurrency:
   group: nanocodex-cloudflare-git
@@ -14,7 +17,7 @@ permissions: {}
 jobs:
   publish:
     if: github.repository == 'gakonst/nanocodex'
-    name: publish repository generation
+    name: publish deployed repository generation
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -24,6 +27,13 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          ref: ${{ inputs.revision }}
+      - name: Require an exact master revision
+        env:
+          TARGET_SHA: ${{ inputs.revision }}
+        run: |
+          test "$(git rev-parse HEAD)" = "$TARGET_SHA"
+          test "$(git ls-remote https://github.com/gakonst/nanocodex.git refs/heads/master | cut -f1)" = "$TARGET_SHA"
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22.13.0
@@ -31,9 +41,25 @@ jobs:
           cache-dependency-path: web/package-lock.json
       - name: Install publisher dependency
         run: npm ci --prefix web --ignore-scripts
-      - name: Publish immutable repository generation
+      - name: Publish the attested repository generation
         working-directory: web
         env:
           NANOCODEX_GIT_ORIGIN: https://nanocodex.me-7fb.workers.dev
           NANOCODEX_GIT_TOKEN: ${{ secrets.NANOCODEX_GIT_TOKEN }}
         run: npm run publish:repository
+      - name: Verify the repository snapshot and Git endpoint
+        env:
+          TARGET_SHA: ${{ inputs.revision }}
+        run: |
+          curl -fsS \
+            "https://nanocodex.me-7fb.workers.dev/api/repository/snapshot?revision=$TARGET_SHA" \
+            -o "$RUNNER_TEMP/nanocodex-repository.json"
+          node -e '
+            const fs = require("node:fs");
+            const snapshot = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            if (snapshot.repository?.head !== process.env.TARGET_SHA) process.exit(1);
+          ' "$RUNNER_TEMP/nanocodex-repository.json"
+          remote_shas="$(git ls-remote \
+            https://nanocodex.me-7fb.workers.dev/git \
+            HEAD refs/heads/master | awk '{print $1}' | sort -u)"
+          test "$remote_shas" = "$TARGET_SHA"

--- a/crates/experimental/nanocodex-eval/src/workset.rs
+++ b/crates/experimental/nanocodex-eval/src/workset.rs
@@ -3,8 +3,9 @@
 //! Every desired task/treatment/repetition is one SQLite row. Coordinate state
 //! records scheduling and verifier outcome; an append-only attempt table keeps
 //! infrastructure failures and interruptions without consuming a coordinate.
-//! Claiming is a short `BEGIN IMMEDIATE` compare-and-set transaction; execution
-//! never holds a SQLite transaction open.
+//! Ledger mutations are serialized by a process-safe writer lock. Claiming is a
+//! short `BEGIN IMMEDIATE` compare-and-set transaction; execution never holds a
+//! SQLite transaction open.
 
 use std::{
     fs::{self, File, OpenOptions},
@@ -240,6 +241,7 @@ impl Workset {
         let path = path.into();
         let claim_directory = claim_directory(&path);
         fs::create_dir_all(&claim_directory)?;
+        let _writer = lock_workset_writer(&claim_directory)?;
         let mut connection = open_connection(&path)?;
         initialize_schema(&mut connection)?;
         let retained: Option<(i64, String)> = connection
@@ -267,6 +269,7 @@ impl Workset {
         let path = path.into();
         let claim_directory = claim_directory(&path);
         fs::create_dir_all(&claim_directory)?;
+        let _writer = lock_workset_writer(&claim_directory)?;
         let mut connection = open_connection(&path)?;
         initialize_schema(&mut connection)?;
         let digest = Uuid::now_v7().simple().to_string();
@@ -289,6 +292,7 @@ impl Workset {
         tasks: &[WorksetTask],
         families: &[WorksetFamily],
     ) -> Result<(), WorksetError> {
+        let _writer = lock_workset_writer(&self.claim_directory)?;
         let mut connection = open_connection(&self.path)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         append_definition(&transaction, self.id, &self.digest, tasks, families)?;
@@ -403,8 +407,9 @@ impl Workset {
         family_key: &str,
         worker: &str,
     ) -> Result<BeginTask, WorksetError> {
-        self.reconcile_abandoned()?;
+        let _writer = lock_workset_writer(&self.claim_directory)?;
         let mut connection = open_connection(&self.path)?;
+        self.reconcile_abandoned_with_connection(&mut connection)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let row: Option<(i64, u16)> = transaction
             .query_row(
@@ -478,8 +483,9 @@ impl Workset {
 
     /// Atomically claims the next unclaimed row in the benchmark.
     pub fn begin_next_for_worker(&self, worker: &str) -> Result<BeginTask, WorksetError> {
-        self.reconcile_abandoned()?;
+        let _writer = lock_workset_writer(&self.claim_directory)?;
         let mut connection = open_connection(&self.path)?;
+        self.reconcile_abandoned_with_connection(&mut connection)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let row: Option<(i64, String, u16)> = transaction
             .query_row(
@@ -616,7 +622,15 @@ impl Workset {
 
     /// Releases every running row whose OS ownership lock is no longer held.
     pub fn reconcile_abandoned(&self) -> Result<usize, WorksetError> {
+        let _writer = lock_workset_writer(&self.claim_directory)?;
         let mut connection = open_connection(&self.path)?;
+        self.reconcile_abandoned_with_connection(&mut connection)
+    }
+
+    fn reconcile_abandoned_with_connection(
+        &self,
+        connection: &mut Connection,
+    ) -> Result<usize, WorksetError> {
         let mut statement = connection.prepare(
             "SELECT id, claim_id FROM eval_tasks \
              WHERE workset_id = ?1 AND state = 'running' ORDER BY id",
@@ -673,6 +687,7 @@ impl Workset {
         result_path: Option<&Path>,
         error: Option<&str>,
     ) -> Result<(), WorksetError> {
+        let _writer = lock_workset_writer(&self.claim_directory)?;
         let mut connection = open_connection(&self.path)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let finished_at_ms = now_ms()?;
@@ -714,6 +729,7 @@ impl Workset {
         result_path: Option<&Path>,
         error: Option<&str>,
     ) -> Result<(), WorksetError> {
+        let _writer = lock_workset_writer(&self.claim_directory)?;
         let mut connection = open_connection(&self.path)?;
         let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let finished_at_ms = now_ms()?;
@@ -1125,6 +1141,18 @@ fn open_claim_lock(directory: &Path, id: i64) -> Result<File, WorksetError> {
         .create(true)
         .truncate(false)
         .open(directory.join(format!("{id}.lock")))?)
+}
+
+fn lock_workset_writer(directory: &Path) -> Result<File, WorksetError> {
+    fs::create_dir_all(directory)?;
+    let lock = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(directory.join("writer.lock"))?;
+    lock.lock_exclusive()?;
+    Ok(lock)
 }
 
 fn sqlite_data_version(connection: &Connection) -> Result<i64, WorksetError> {

--- a/crates/nanocodex-tools/src/hosted/mod.rs
+++ b/crates/nanocodex-tools/src/hosted/mod.rs
@@ -152,4 +152,9 @@ pub trait CodeModeHost: Send + Sync + 'static {
             )))
         })
     }
+
+    /// Cancels host-owned Code Mode and nested-tool work for one agent session.
+    fn cancel<'a>(&'a self, _session_id: &'a str) -> HostFuture<'a, Result<(), CodeModeHostError>> {
+        Box::pin(async { Ok(()) })
+    }
 }

--- a/crates/nanocodex-tools/src/hosted/runtime.rs
+++ b/crates/nanocodex-tools/src/hosted/runtime.rs
@@ -28,6 +28,7 @@ const DEFERRED_TOOLS_DESCRIPTION: &str = r"Some deferred nested tools are omitte
 #[derive(Clone, Default)]
 pub struct HostedTools {
     host: Option<Arc<dyn CodeModeHost>>,
+    session_id: Option<Arc<str>>,
 }
 
 impl HostedTools {
@@ -36,6 +37,7 @@ impl HostedTools {
     pub fn new(host: impl CodeModeHost) -> Self {
         Self {
             host: Some(Arc::new(host)),
+            session_id: None,
         }
     }
 
@@ -56,7 +58,8 @@ impl HostedTools {
     /// Hosted tool discovery and execution receive the session ID directly, so
     /// there is no Rust-owned subprocess environment to update here.
     #[must_use]
-    pub const fn for_session(self, _session_id: &str) -> Self {
+    pub fn for_session(mut self, session_id: &str) -> Self {
+        self.session_id = Some(Arc::from(session_id));
         self
     }
 
@@ -71,16 +74,18 @@ impl HostedTools {
 pub struct HostedToolRuntime {
     working_directory: Arc<str>,
     host: Option<Arc<dyn CodeModeHost>>,
+    session_id: Option<Arc<str>>,
     callable_tool_names: RwLock<HashSet<String>>,
 }
 
 /// Cancellation handle for a hosted runtime.
 ///
-/// A host call is cancelled by dropping its future. This handle exists so the
-/// hosted runtime can satisfy the same lifecycle contract as the native
-/// runtime.
-#[derive(Clone, Copy)]
-pub struct HostedToolRuntimeControl;
+/// Cancellation handle for work owned by an embedding host.
+#[derive(Clone, Default)]
+pub struct HostedToolRuntimeControl {
+    host: Option<Arc<dyn CodeModeHost>>,
+    session_id: Option<Arc<str>>,
+}
 
 impl HostedToolRuntime {
     /// Creates a runtime without an application host.
@@ -97,6 +102,7 @@ impl HostedToolRuntime {
         Self {
             working_directory: Arc::from(workspace.to_string_lossy().into_owned()),
             host: None,
+            session_id: None,
             callable_tool_names: RwLock::new(HashSet::new()),
         }
     }
@@ -116,6 +122,7 @@ impl HostedToolRuntime {
     #[must_use]
     pub fn with_tools(mut self, tools: &HostedTools) -> Self {
         self.host.clone_from(&tools.host);
+        self.session_id.clone_from(&tools.session_id);
         self
     }
 
@@ -133,8 +140,11 @@ impl HostedToolRuntime {
 
     /// Returns a cancellation handle for the runtime.
     #[must_use]
-    pub const fn control(&self) -> HostedToolRuntimeControl {
-        HostedToolRuntimeControl
+    pub fn control(&self) -> HostedToolRuntimeControl {
+        HostedToolRuntimeControl {
+            host: self.host.clone(),
+            session_id: self.session_id.clone(),
+        }
     }
 
     /// Builds the `exec` definition from the host's current tool definitions.
@@ -368,21 +378,23 @@ impl HostedToolRuntimeControl {
     pub const fn begin_turn(&self) {}
 
     /// Cancels work owned by the current logical turn.
-    #[allow(
-        clippy::unused_async,
-        reason = "matches the native tool-runtime control contract"
-    )]
-    pub async fn cancel_turn(&self) {}
+    pub async fn cancel_turn(&self) {
+        self.cancel().await;
+    }
 
     /// Cancels active work.
     ///
-    /// Hosted calls are cancelled by dropping their futures, so no additional
-    /// control message is required.
-    #[allow(
-        clippy::unused_async,
-        reason = "matches the native tool-runtime control contract"
-    )]
-    pub async fn cancel(&self) {}
+    pub async fn cancel(&self) {
+        if let (Some(host), Some(session_id)) = (&self.host, &self.session_id)
+            && let Err(error) = host.cancel(session_id).await
+        {
+            tracing::warn!(
+                target: "nanocodex_tools",
+                %error,
+                "hosted Code Mode cancellation failed"
+            );
+        }
+    }
 }
 
 fn replay_nested_updates(execution: &CodeModeExecution, observer: &mut dyn CodeModeObserver) {

--- a/js/bindings/browser/Agent.d.mts
+++ b/js/bindings/browser/Agent.d.mts
@@ -3,6 +3,7 @@ import type {
   CodeEvaluator,
   ChatGptSubscriptionHandle,
   DefaultAgent,
+  ExecutionEnvironment,
   McpServers,
   MppSession,
   ToolMap,
@@ -42,6 +43,8 @@ export declare namespace create {
     /** Disable the legacy list/read/write workspace functions when a shell owns filesystem access. */
     filesystemTools?: boolean | undefined;
     module?: unknown;
+    /** Fixed browser workspace facts, including its AGENTS.md snapshot. */
+    executionEnvironment?: ExecutionEnvironment | undefined;
     /** Optional CSP-compatible Code Mode evaluator, such as createQuickJsEvaluator(). */
     codeEvaluator?: CodeEvaluator | undefined;
     tools?: ToolMap | undefined;

--- a/js/bindings/browser/Agent.mjs
+++ b/js/bindings/browser/Agent.mjs
@@ -49,6 +49,7 @@ export function create(options = {}) {
     tools,
     toolMode,
     mcp,
+    executionEnvironment,
     codeEvaluator,
   } = options;
   if (mpp !== undefined && apiKey !== undefined) {
@@ -138,6 +139,7 @@ export function create(options = {}) {
     instructions,
     sessionId,
     workspace: workspace ?? filesystem?.root,
+    executionEnvironment,
     resume,
   });
 }

--- a/js/bindings/browser/host.d.mts
+++ b/js/bindings/browser/host.d.mts
@@ -5,7 +5,7 @@ export type BrowserTool = {
   parameters: Record<string, unknown>;
   handler: (
     input: unknown,
-    context: { sessionId: string },
+    context: { sessionId: string; signal: AbortSignal },
   ) => unknown | Promise<unknown>;
 };
 

--- a/js/bindings/browser/host.mjs
+++ b/js/bindings/browser/host.mjs
@@ -278,6 +278,7 @@ export function createBrowserHost(options = {}) {
     sleep: (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
     executeCode: code.executeCode,
     executeTool: code.executeTool,
+    cancelCode: code.cancel,
     readWorkspaceFile: async (path) => {
       if (!options.filesystem) throw new Error("browser workspace is unavailable");
       return new TextDecoder("utf-8", { fatal: true })

--- a/js/bindings/browser/index.d.mts
+++ b/js/bindings/browser/index.d.mts
@@ -26,6 +26,7 @@ export type {
   CodeEvaluator,
   CodeEvaluatorEnvironment,
   EstimatedUsdCost,
+  ExecutionEnvironment,
   PromptInput,
   PromptItem,
   ReasoningMode,

--- a/js/bindings/index.d.mts
+++ b/js/bindings/index.d.mts
@@ -35,6 +35,7 @@ export type {
   DefaultAgent,
   EventWatcher,
   EstimatedUsdCost,
+  ExecutionEnvironment,
   ForkOptions,
   McpClient,
   McpPayment,

--- a/js/bindings/internal.mjs
+++ b/js/bindings/internal.mjs
@@ -151,6 +151,21 @@ export function toWasmConfig(options = {}) {
   copy(config, "instructions", options.instructions);
   copy(config, "session_id", options.sessionId);
   copy(config, "workspace", options.workspace);
+  if (options.executionEnvironment !== undefined) {
+    const environment = options.executionEnvironment;
+    if (!environment || typeof environment !== "object" || Array.isArray(environment)) {
+      throw new TypeError("executionEnvironment must be an object");
+    }
+    config.execution_environment = {
+      current_date: environment.currentDate,
+      timezone: environment.timezone,
+    };
+    copy(
+      config.execution_environment,
+      "project_instructions",
+      environment.projectInstructions,
+    );
+  }
   copy(config, "resume", options.resume);
   return config;
 }
@@ -243,6 +258,9 @@ const hostBridge = Object.freeze({
   },
   executeTool(name, input, sessionId, callId) {
     return requiredSessionHost(sessionId).executeTool(name, input, sessionId, callId);
+  },
+  cancelCode(sessionId) {
+    hostSessions.get(sessionId)?.cancelCode?.(sessionId);
   },
   readWorkspaceFile(path, sessionId) {
     return requiredSessionHost(sessionId).readWorkspaceFile(path);

--- a/js/bindings/node/host.mjs
+++ b/js/bindings/node/host.mjs
@@ -284,6 +284,7 @@ export function createNodeHost(options = {}) {
     sleep: (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)),
     executeCode: code.executeCode,
     executeTool: code.executeTool,
+    cancelCode: code.cancel,
     toolMode: () => toolMode,
     toolDefinitions: code.toolDefinitions,
     emitEvent: onEvent,

--- a/js/bindings/runtime/code-runtime.mjs
+++ b/js/bindings/runtime/code-runtime.mjs
@@ -1,4 +1,5 @@
 export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
+  const activeExecutions = new Set();
   const stores = new Map();
   const providers = [];
   let nextCallId = 1;
@@ -70,11 +71,21 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
     } catch (error) {
       return encodeToolOutput(`invalid tool input: ${errorMessage(error)}`, false, null);
     }
+    const controller = new AbortController();
+    const execution = { callId, controller, sessionId };
+    activeExecutions.add(execution);
     try {
-      const result = await tool.handler(input, { sessionId, parentCallId: "", callId });
+      const result = await tool.handler(input, {
+        sessionId,
+        parentCallId: "",
+        callId,
+        signal: controller.signal,
+      });
       return encodeToolOutput(outputBody(result), true, structuredResult(result, `tool ${name} result`));
     } catch (error) {
       return encodeToolOutput(errorMessage(error), false, null);
+    } finally {
+      activeExecutions.delete(execution);
     }
   }
 
@@ -84,6 +95,9 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
     const stored = stores.get(sessionId) || new Map();
     stores.set(sessionId, stored);
     const nestedCalls = [];
+    const controller = new AbortController();
+    const execution = { callId: parentCallId, controller, sessionId };
+    activeExecutions.add(execution);
     const tools = Object.create(null);
     const availableTools = currentTools();
     const availableDefinitions = currentCodeDefinitions();
@@ -97,7 +111,13 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
         );
         const recordedInput = clone(input) ?? null;
         try {
-          const result = await handler(input, { sessionId, parentCallId, callId });
+          if (controller.signal.aborted) throw new Error("Code Mode execution was cancelled");
+          const result = await handler(input, {
+            sessionId,
+            parentCallId,
+            callId,
+            signal: controller.signal,
+          });
           nestedCalls.push({
             call_id: callId,
             name,
@@ -191,6 +211,8 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
         success: false,
         nested_calls: nestedCalls,
       });
+    } finally {
+      activeExecutions.delete(execution);
     }
   }
 
@@ -204,8 +226,16 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
     },
     executeCode,
     executeTool,
+    cancel(sessionId) {
+      for (const execution of activeExecutions) {
+        if (sessionId === undefined || execution.sessionId === sessionId) {
+          execution.controller.abort();
+        }
+      }
+    },
     toolDefinitions: () => JSON.stringify(currentDefinitions()),
     reset() {
+      for (const execution of activeExecutions) execution.controller.abort();
       stores.clear();
     },
   });

--- a/js/bindings/runtime/mcp-runtime.mjs
+++ b/js/bindings/runtime/mcp-runtime.mjs
@@ -6,20 +6,27 @@ import { toolResult } from "./code-runtime.mjs";
 
 const DEFAULT_SEARCH_LIMIT = 8;
 const MAX_SEARCH_LIMIT = 32;
+const DEFAULT_STARTUP_TIMEOUT_MS = 30_000;
 const DEFAULT_TOOL_TIMEOUT_MS = 5 * 60_000;
 const SEARCH_DESCRIPTION_PREFIX = "# Tool discovery\n\nSearches over deferred tool metadata with BM25 and exposes matching tools for the next model call.";
+const RESOURCE_TOOL_NAMES = new Set([
+  "list_mcp_resources",
+  "list_mcp_resource_templates",
+  "read_mcp_resource",
+]);
 
 export async function createMcpRuntime(configuration, options = {}) {
   const servers = normalizeServers(configuration);
   const entries = [];
   const failures = Object.create(null);
   const ownedClients = [];
+  const connectedServers = [];
 
   await Promise.all(servers.map(async (server) => {
     try {
-      const connection = await connectServer(server, options);
+      const { connection, tools } = await initializeServer(server, options);
       if (connection.owned) ownedClients.push(connection.client);
-      const tools = await listAllTools(connection.client);
+      connectedServers.push({ client: connection.client, server });
       for (const tool of tools) {
         if (!includesTool(server, tool.name)) continue;
         entries.push(createEntry(server, connection.client, tool));
@@ -45,6 +52,7 @@ export async function createMcpRuntime(configuration, options = {}) {
     name: "tool_search",
     handler: ({ query, limit }) => searchTools(query, limit),
   };
+  const resourceTools = createResourceTools(connectedServers);
 
   function searchTools(query, limit = DEFAULT_SEARCH_LIMIT) {
     if (typeof query !== "string" || !query.trim()) {
@@ -74,10 +82,17 @@ export async function createMcpRuntime(configuration, options = {}) {
 
   return Object.freeze({
     definitions() {
-      return [toolSearchDefinition(servers), ...entries.map((entry) => entry.definition)];
+      return [
+        toolSearchDefinition(servers),
+        ...resourceTools.map((tool) => tool.definition),
+        ...entries.map((entry) => entry.definition),
+      ];
     },
     resolve(name) {
       if (name === "tool_search") return toolSearch;
+      if (RESOURCE_TOOL_NAMES.has(name)) {
+        return resourceTools.find((tool) => tool.name === name);
+      }
       const entry = byName.get(name);
       if (!entry) return undefined;
       return {
@@ -91,12 +106,52 @@ export async function createMcpRuntime(configuration, options = {}) {
   });
 }
 
-async function listAllTools(client) {
+async function initializeServer(server, options) {
+  const controller = new AbortController();
+  let timeout;
+  const deadline = new Promise((_resolve, reject) => {
+    timeout = setTimeout(() => {
+      controller.abort();
+      reject(new Error("MCP startup deadline exceeded"));
+    }, server.startupTimeoutMs);
+  });
+  let connection;
+  try {
+    return await Promise.race([
+      (async () => {
+        connection = await connectServer(server, options, controller.signal);
+        const tools = await listAllTools(
+          connection.client,
+          server.startupTimeoutMs,
+          controller.signal,
+        );
+        return { connection, tools };
+      })(),
+      deadline,
+    ]);
+  } catch (error) {
+    if (connection?.owned) await connection.client.close().catch(() => {});
+    if (controller.signal.aborted) {
+      throw new Error(
+        `MCP server ${server.name} startup exceeded ${server.startupTimeoutMs} milliseconds`,
+        { cause: error },
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function listAllTools(client, timeoutMs, signal) {
   const tools = [];
   const seen = new Set();
   let cursor;
   for (let page = 0; page < 100; page += 1) {
-    const listed = await client.listTools(cursor ? { cursor } : undefined);
+    const listed = await client.listTools(
+      cursor ? { cursor } : undefined,
+      { maxTotalTimeout: timeoutMs, signal, timeout: timeoutMs },
+    );
     tools.push(...listed.tools);
     if (!listed.nextCursor) return tools;
     if (seen.has(listed.nextCursor)) throw new Error("MCP tools/list returned a repeated cursor");
@@ -106,7 +161,7 @@ async function listAllTools(client) {
   throw new Error("MCP tools/list exceeded 100 pages");
 }
 
-async function connectServer(server, options) {
+async function connectServer(server, options, signal) {
   const client = server.client ?? new Client({
     name: options.clientName ?? "nanocodex-js",
     version: options.clientVersion ?? "0.0.0",
@@ -122,7 +177,11 @@ async function connectServer(server, options) {
     ...(server.headers ? { requestInit: { headers: server.headers } } : {}),
   });
   try {
-    await client.connect(transport);
+    await client.connect(transport, {
+      maxTotalTimeout: server.startupTimeoutMs,
+      signal,
+      timeout: server.startupTimeoutMs,
+    });
     return { client, owned: true };
   } catch (error) {
     await client.close().catch(() => {});
@@ -156,10 +215,15 @@ function normalizeServers(configuration) {
       && (!Number.isFinite(server.timeoutMs) || server.timeoutMs <= 0)) {
       throw new TypeError(`MCP server ${name} timeoutMs must be a positive number`);
     }
+    if (server.startupTimeoutMs !== undefined
+      && (!Number.isFinite(server.startupTimeoutMs) || server.startupTimeoutMs <= 0)) {
+      throw new TypeError(`MCP server ${name} startupTimeoutMs must be a positive number`);
+    }
     return {
       ...server,
       name,
       url: server.url?.toString(),
+      startupTimeoutMs: server.startupTimeoutMs ?? DEFAULT_STARTUP_TIMEOUT_MS,
       timeoutMs: server.timeoutMs ?? DEFAULT_TOOL_TIMEOUT_MS,
     };
   });
@@ -169,6 +233,172 @@ function normalizeServers(configuration) {
 
 function isStringArray(value) {
   return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function createResourceTools(connectedServers) {
+  const byServer = new Map(connectedServers.map((connection) => [
+    connection.server.name,
+    connection,
+  ]));
+  return [
+    {
+      name: "list_mcp_resources",
+      definition: listResourcesDefinition(
+        "list_mcp_resources",
+        "Lists resources provided by MCP servers. Resources allow servers to share data that provides context to language models, such as files, database schemas, or application-specific information. Prefer resources over web search when possible.",
+        "resources",
+      ),
+      handler: (input, context) => listMcpEntries(byServer, input, "resources", context?.signal),
+    },
+    {
+      name: "list_mcp_resource_templates",
+      definition: listResourcesDefinition(
+        "list_mcp_resource_templates",
+        "Lists resource templates provided by MCP servers. Parameterized resource templates allow servers to share data that takes parameters and provides context to language models, such as files, database schemas, or application-specific information. Prefer resource templates over web search when possible.",
+        "resource templates",
+      ),
+      handler: (input, context) =>
+        listMcpEntries(byServer, input, "resourceTemplates", context?.signal),
+    },
+    {
+      name: "read_mcp_resource",
+      definition: {
+        type: "function",
+        name: "read_mcp_resource",
+        description: "Read a specific resource from an MCP server given the server name and resource URI.",
+        strict: false,
+        parameters: {
+          type: "object",
+          properties: {
+            server: {
+              type: "string",
+              description: "MCP server name exactly as configured. Must match the 'server' field returned by list_mcp_resources.",
+            },
+            uri: {
+              type: "string",
+              description: "Resource URI to read. Must be one of the URIs returned by list_mcp_resources.",
+            },
+          },
+          required: ["server", "uri"],
+          additionalProperties: false,
+        },
+      },
+      handler: (input, context) => readMcpResource(byServer, input, context?.signal),
+    },
+  ];
+}
+
+function listResourcesDefinition(name, description, noun) {
+  return {
+    type: "function",
+    name,
+    description,
+    strict: false,
+    parameters: {
+      type: "object",
+      properties: {
+        cursor: {
+          type: "string",
+          description: `Opaque cursor from a previous ${name} call; omit for the first page.`,
+        },
+        server: {
+          type: "string",
+          description: `MCP server name. Omit to list ${noun} from every configured server.`,
+        },
+      },
+      additionalProperties: false,
+    },
+  };
+}
+
+async function listMcpEntries(byServer, input, kind, signal) {
+  const { cursor, server } = normalizeListInput(input);
+  if (server) {
+    const connection = requiredMcpConnection(byServer, server);
+    const result = await listMcpPage(connection, kind, cursor, signal);
+    return {
+      server,
+      [kind]: tagMcpEntries(result[kind], server),
+      ...(result.nextCursor ? { nextCursor: result.nextCursor } : {}),
+    };
+  }
+  if (cursor) throw new Error("cursor can only be used when a server is specified");
+  const pages = await Promise.allSettled([...byServer].map(async ([name, connection]) =>
+    tagMcpEntries(await listAllMcpEntries(connection, kind, signal), name)));
+  return {
+    [kind]: pages.flatMap((page) => page.status === "fulfilled" ? page.value : []),
+  };
+}
+
+function normalizeListInput(input) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("MCP resource listing requires an object");
+  }
+  const normalized = {};
+  for (const field of ["cursor", "server"]) {
+    const value = input[field];
+    if (value === undefined) continue;
+    if (typeof value !== "string") throw new TypeError(`${field} must be a string`);
+    if (value.trim()) normalized[field] = value.trim();
+  }
+  return normalized;
+}
+
+async function listAllMcpEntries(connection, kind, signal) {
+  const entries = [];
+  const seen = new Set();
+  let cursor;
+  for (let page = 0; page < 100; page += 1) {
+    const result = await listMcpPage(connection, kind, cursor, signal);
+    entries.push(...(result[kind] ?? []));
+    if (!result.nextCursor) return entries;
+    if (seen.has(result.nextCursor)) {
+      throw new Error(`MCP ${kind} returned a repeated cursor`);
+    }
+    seen.add(result.nextCursor);
+    cursor = result.nextCursor;
+  }
+  throw new Error(`MCP ${kind} exceeded 100 pages`);
+}
+
+function listMcpPage(connection, kind, cursor, signal) {
+  const params = cursor ? { cursor } : undefined;
+  return withMcpRequest(connection.server, signal, (options) =>
+    kind === "resources"
+      ? connection.client.listResources(params, options)
+      : connection.client.listResourceTemplates(params, options));
+}
+
+function tagMcpEntries(entries = [], server) {
+  return entries.map((entry) => ({ ...entry, server }));
+}
+
+async function readMcpResource(byServer, input, signal) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("read_mcp_resource requires an object");
+  }
+  const server = requiredString(input.server, "server");
+  const uri = requiredString(input.uri, "uri");
+  const connection = requiredMcpConnection(byServer, server);
+  const result = await withMcpRequest(connection.server, signal, (options) =>
+    connection.client.readResource({ uri }, options));
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    throw new Error("MCP resources/read returned a non-object result");
+  }
+  return { ...result, server, uri };
+}
+
+function requiredMcpConnection(byServer, server) {
+  const connection = byServer.get(server);
+  if (!connection) throw new Error(`unknown MCP server: ${server}`);
+  return connection;
+}
+
+function requiredString(value, name) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new TypeError(`${name} must not be empty`);
+  }
+  return value.trim();
 }
 
 function createEntry(server, client, tool) {
@@ -212,12 +442,10 @@ function createSearchIndex(entries) {
   return index;
 }
 
-async function callRemoteTool(entry, input) {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), entry.server.timeoutMs);
-  try {
+async function callRemoteTool(entry, input, context) {
+  return withMcpRequest(entry.server, context?.signal, async (requestOptions) => {
     const options = {
-      signal: controller.signal,
+      ...requestOptions,
       ...(entry.server.payment?.context !== undefined
         ? { context: entry.server.payment.context }
         : {}),
@@ -227,16 +455,26 @@ async function callRemoteTool(entry, input) {
       undefined,
       options,
     );
+  });
+}
+
+async function withMcpRequest(server, outerSignal, operation) {
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  if (outerSignal?.aborted) abort();
+  else outerSignal?.addEventListener("abort", abort, { once: true });
+  const timeout = setTimeout(abort, server.timeoutMs);
+  try {
+    return await operation({ signal: controller.signal, timeout: server.timeoutMs });
   } catch (error) {
     if (controller.signal.aborted) {
-      throw new Error(
-        `MCP tool ${entry.server.name}/${entry.remoteName} exceeded ${entry.server.timeoutMs} milliseconds`,
-        { cause: error },
-      );
+      const reason = outerSignal?.aborted ? "was cancelled" : `exceeded ${server.timeoutMs} milliseconds`;
+      throw new Error(`MCP request to ${server.name} ${reason}`, { cause: error });
     }
     throw error;
   } finally {
     clearTimeout(timeout);
+    outerSignal?.removeEventListener("abort", abort);
   }
 }
 

--- a/js/bindings/src/wasm.rs
+++ b/js/bindings/src/wasm.rs
@@ -5,6 +5,7 @@ use nanocodex::{
     AgentEvents, Model, Nanocodex as RustNanocodex, OpenAi, ReasoningMode, Thinking, TurnControl,
     TurnResult,
     agent::{
+        ExecutionEnvironment,
         input::{Prompt, UserInput},
         session::{SessionId, SessionSnapshot},
     },
@@ -48,6 +49,9 @@ extern "C" {
         session_id: &str,
         call_id: &str,
     ) -> Result<Promise, JsValue>;
+
+    #[wasm_bindgen(js_namespace = ["globalThis", "nanocodexHost"], js_name = cancelCode)]
+    fn host_cancel_code(session_id: &str);
 
     #[wasm_bindgen(js_namespace = ["globalThis", "nanocodexHost"], js_name = toolMode)]
     fn host_tool_mode(session_id: &str) -> String;
@@ -226,7 +230,6 @@ impl CodeModeHost for JavaScriptCodeModeHost {
             })?;
         for definition in &mut definitions {
             let standard = match definition.name() {
-                name if name == StandardTool::ExecCommand.name() => Some(StandardTool::ExecCommand),
                 name if name == StandardTool::WriteStdin.name() => Some(StandardTool::WriteStdin),
                 name if name == StandardTool::UpdatePlan.name() => Some(StandardTool::UpdatePlan),
                 name if name == StandardTool::ApplyPatch.name() => Some(StandardTool::ApplyPatch),
@@ -294,6 +297,13 @@ impl CodeModeHost for JavaScriptCodeModeHost {
             ToolOutput::from_wire(wire).map_err(|error| {
                 CodeModeHostError::new(format!("JavaScript tool result was invalid: {error}"))
             })
+        })
+    }
+
+    fn cancel<'a>(&'a self, session_id: &'a str) -> HostFuture<'a, Result<(), CodeModeHostError>> {
+        Box::pin(async move {
+            host_cancel_code(session_id);
+            Ok(())
         })
     }
 }
@@ -365,7 +375,18 @@ struct WasmConfig {
     #[serde(default)]
     workspace: Option<String>,
     #[serde(default)]
+    execution_environment: Option<WasmExecutionEnvironment>,
+    #[serde(default)]
     resume: Option<SessionSnapshot>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct WasmExecutionEnvironment {
+    current_date: String,
+    timezone: String,
+    #[serde(default)]
+    project_instructions: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -538,6 +559,14 @@ impl WasmNanocodex {
         }
         if let Some(workspace) = config.workspace {
             builder = builder.workspace(workspace);
+        }
+        if let Some(configured) = config.execution_environment {
+            let mut environment =
+                ExecutionEnvironment::new(configured.current_date, configured.timezone);
+            if let Some(project_instructions) = configured.project_instructions {
+                environment = environment.project_instructions(project_instructions);
+            }
+            builder = builder.execution_environment(environment);
         }
         if let Some(resume) = config.resume {
             builder = builder.resume(resume);

--- a/js/bindings/test/browser-host.test.mjs
+++ b/js/bindings/test/browser-host.test.mjs
@@ -100,6 +100,43 @@ test("browser host reports non-JSON tool results as failures", async () => {
   assert.match(direct.output, /JSON-serializable/);
 });
 
+test("browser host cancellation is scoped to one session", async () => {
+  const started = new Map();
+  const host = createBrowserHost({
+    tools: {
+      blocked: {
+        parameters: { type: "object" },
+        handler(_input, context) {
+          started.get(context.sessionId)?.();
+          return new Promise((_resolve, reject) => {
+            context.signal.addEventListener(
+              "abort",
+              () => reject(new Error(`${context.sessionId} cancelled`)),
+              { once: true },
+            );
+          });
+        },
+      },
+    },
+  });
+  const startA = new Promise((resolve) => started.set("session-a", resolve));
+  const startB = new Promise((resolve) => started.set("session-b", resolve));
+  const callA = host.executeTool("blocked", "{}", "session-a", "call-a");
+  const callB = host.executeTool("blocked", "{}", "session-b", "call-b");
+  await Promise.all([startA, startB]);
+  host.cancelCode("session-a");
+  const resultA = JSON.parse(await callA);
+  assert.equal(resultA.success, false);
+  assert.match(resultA.output, /session-a cancelled/);
+  const stillPending = await Promise.race([
+    callB.then(() => false),
+    new Promise((resolve) => setTimeout(() => resolve(true), 10)),
+  ]);
+  assert.equal(stillPending, true);
+  host.cancelCode("session-b");
+  assert.match(JSON.parse(await callB).output, /session-b cancelled/);
+});
+
 test("browser host opens application sockets through MPP", async () => {
   const socket = new FakeWebSocket("wss://paid.test");
   socket.readyState = FakeWebSocket.OPEN;

--- a/js/bindings/test/mcp-runtime.test.mjs
+++ b/js/bindings/test/mcp-runtime.test.mjs
@@ -123,7 +123,11 @@ test("remote MCP stays deferred behind tool_search and executes through Code Mod
   const definitions = JSON.parse(runtime.toolDefinitions());
   assert.equal(definitions[0].type, "tool_search");
   assert.deepEqual(
-    definitions.slice(1).map((definition) => [definition.name, definition.defer_loading]),
+    definitions.slice(1, 4).map((definition) => definition.name),
+    ["list_mcp_resources", "list_mcp_resource_templates", "read_mcp_resource"],
+  );
+  assert.deepEqual(
+    definitions.slice(4).map((definition) => [definition.name, definition.defer_loading]),
     [
       ["mcp__mercator__call", true],
       ["mcp__mercator__search_endpoints", true],
@@ -153,6 +157,58 @@ test("remote MCP stays deferred behind tool_search and executes through Code Mod
   assert.match(JSON.stringify(execution.output), /called call/);
 });
 
+test("browser MCP exposes native-compatible resource listing and reads", async () => {
+  const client = {
+    async listTools() {
+      return { tools: [] };
+    },
+    async listResources(params) {
+      return params?.cursor
+        ? { resources: [{ uri: "docs://two", name: "Two" }] }
+        : { resources: [{ uri: "docs://one", name: "One" }], nextCursor: "next" };
+    },
+    async listResourceTemplates() {
+      return { resourceTemplates: [{ uriTemplate: "docs://{slug}", name: "Docs" }] };
+    },
+    async readResource({ uri }) {
+      return { contents: [{ uri, text: "resource body" }] };
+    },
+  };
+  const mcp = await createMcpRuntime({ docs: { client } });
+  const runtime = createCodeRuntime();
+  runtime.addProvider(mcp);
+
+  const listed = JSON.parse(await runtime.executeTool(
+    "list_mcp_resources",
+    "{}",
+  ));
+  assert.deepEqual(JSON.parse(listed.output), {
+    resources: [
+      { server: "docs", uri: "docs://one", name: "One" },
+      { server: "docs", uri: "docs://two", name: "Two" },
+    ],
+  });
+
+  const templates = JSON.parse(await runtime.executeTool(
+    "list_mcp_resource_templates",
+    JSON.stringify({ server: "docs" }),
+  ));
+  assert.deepEqual(JSON.parse(templates.output), {
+    server: "docs",
+    resourceTemplates: [{ server: "docs", uriTemplate: "docs://{slug}", name: "Docs" }],
+  });
+
+  const read = JSON.parse(await runtime.executeTool(
+    "read_mcp_resource",
+    JSON.stringify({ server: "docs", uri: "docs://one" }),
+  ));
+  assert.deepEqual(JSON.parse(read.output), {
+    contents: [{ uri: "docs://one", text: "resource body" }],
+    server: "docs",
+    uri: "docs://one",
+  });
+});
+
 test("remote MCP failures are reported by tool_search without breaking agent creation", async () => {
   const mcp = await createMcpRuntime({
     unavailable: {
@@ -172,6 +228,39 @@ test("remote MCP failures are reported by tool_search without breaking agent cre
   assert.deepEqual(JSON.parse(result.output).failed_servers, {
     unavailable: "connection refused",
   });
+});
+
+test("MCP startup timeout bounds complete paginated discovery", async () => {
+  let pages = 0;
+  const mcp = await createMcpRuntime({
+    slow: {
+      startupTimeoutMs: 20,
+      client: {
+        async listTools(_params, options) {
+          pages += 1;
+          if (pages === 1) return { tools: [], nextCursor: "next" };
+          await new Promise((_resolve, reject) => {
+            options.signal.addEventListener(
+              "abort",
+              () => reject(new Error("aborted")),
+              { once: true },
+            );
+          });
+        },
+      },
+    },
+  });
+  const runtime = createCodeRuntime();
+  runtime.addProvider(mcp);
+  const result = JSON.parse(await runtime.executeTool(
+    "tool_search",
+    JSON.stringify({ query: "slow" }),
+  ));
+  assert.match(
+    JSON.parse(result.output).failed_servers.slow,
+    /startup exceeded 20 milliseconds/,
+  );
+  assert.equal(pages, 2);
 });
 
 test("remote MCP tools retry payment challenges through McpClient.wrap", async () => {

--- a/js/bindings/test/node.test.mjs
+++ b/js/bindings/test/node.test.mjs
@@ -85,9 +85,12 @@ test("Node host loads and calls deferred Mercator MCP tools", async () => {
     const definitions = JSON.parse(host.toolDefinitions());
     assert.deepEqual(definitions.map((definition) => definition.name ?? definition.type), [
       "tool_search",
+      "list_mcp_resources",
+      "list_mcp_resource_templates",
+      "read_mcp_resource",
       "mcp__mercator__search_services",
     ]);
-    assert.equal(definitions[1].defer_loading, true);
+    assert.equal(definitions[4].defer_loading, true);
     const execution = JSON.parse(await host.executeCode(
       "text(await tools.mcp__mercator__search_services({ query: 'weather' }));",
       "node-session",

--- a/js/bindings/test/quickjs-evaluator.test.mjs
+++ b/js/bindings/test/quickjs-evaluator.test.mjs
@@ -42,3 +42,26 @@ test("QuickJS evaluator reports guest failures as Code Mode failures", async () 
   assert.equal(result.success, false);
   assert.match(result.output, /guest exploded/);
 });
+
+test("Code Mode cancellation aborts active nested tools", async () => {
+  let started;
+  const toolStarted = new Promise((resolve) => { started = resolve; });
+  const runtime = createCodeRuntime({
+    blocked: {
+      async handler(_input, context) {
+        started();
+        await new Promise((resolve, reject) => {
+          context.signal.addEventListener("abort", () => reject(new Error("nested tool cancelled")), {
+            once: true,
+          });
+        });
+      },
+    },
+  }, { evaluate: createQuickJsEvaluator(quickJs) });
+  const execution = runtime.executeCode("await tools.blocked({});", "cancel", "exec-cancel");
+  await toolStarted;
+  runtime.cancel();
+  const result = JSON.parse(await execution);
+  assert.equal(result.success, false);
+  assert.match(result.output, /nested tool cancelled/);
+});

--- a/js/bindings/test/web-wasm.test.mjs
+++ b/js/bindings/test/web-wasm.test.mjs
@@ -27,6 +27,11 @@ test("web-target WASM runs the shared model loop through the browser host", asyn
     websocketUrl: endpoint,
     thinking: "low",
     sessionId: "018f1f9a-7b3c-7a07-8000-000000000007",
+    executionEnvironment: {
+      currentDate: "2026-08-18",
+      timezone: "America/Los_Angeles",
+      projectInstructions: "BROWSER_PROJECT_INSTRUCTIONS",
+    },
   });
   const watch = agent.events.watch({ includeAllSessions: true });
   watch.onEvent((event) => events.push(event));
@@ -37,6 +42,7 @@ test("web-target WASM runs the shared model loop through the browser host", asyn
     await reader.next();
     send(socket, { type: "response.completed", response: { id: "web-warmup", usage: null } });
     const generation = await reader.next();
+    assert.match(JSON.stringify(generation.input), /BROWSER_PROJECT_INSTRUCTIONS/);
     assert.equal(generation.previous_response_id, "web-warmup");
     send(socket, {
       type: "response.completed",
@@ -248,6 +254,10 @@ test("web-target WASM exposes browser bash and Rust apply_patch as standard tool
       "exec_command",
       "apply_patch",
     ]);
+    assert.equal(
+      toolPrefix.tools.find((tool) => tool.name === "exec_command").description,
+      "Run browser bash.",
+    );
     assert.equal(toolPrefix.tools.some((tool) => tool.name === "read_file"), false);
     send(socket, { type: "response.completed", response: { id: "workspace-warmup", usage: null } });
     await reader.next();

--- a/js/bindings/types.d.mts
+++ b/js/bindings/types.d.mts
@@ -28,6 +28,13 @@ export type AgentOptions = {
   resume?: SessionSnapshot | undefined;
 };
 
+/** Model-visible facts for tools executing outside the embedding process. */
+export type ExecutionEnvironment = Readonly<{
+  currentDate: string;
+  timezone: string;
+  projectInstructions?: string | undefined;
+}>;
+
 /** Unsigned decimal revision for opaque ChatGPT subscription state. */
 declare const subscriptionRevisionBrand: unique symbol;
 export type SubscriptionRevision = string & {
@@ -213,6 +220,7 @@ export type ToolContext = {
   callId: string;
   parentCallId: string;
   sessionId: string;
+  signal: AbortSignal;
 };
 
 export type Tool = {
@@ -253,7 +261,7 @@ export type McpPayment = {
 };
 
 export type McpClient = {
-  listTools(params?: { cursor?: string | undefined }): Promise<{
+  listTools(params?: { cursor?: string | undefined }, options?: Record<string, unknown>): Promise<{
     tools: readonly McpTool[];
     nextCursor?: string | undefined;
   }>;
@@ -262,6 +270,24 @@ export type McpClient = {
     resultSchema?: unknown,
     options?: Record<string, unknown>,
   ): Promise<unknown>;
+  listResources?(
+    params?: { cursor?: string | undefined },
+    options?: Record<string, unknown>,
+  ): Promise<{
+    resources: readonly Record<string, unknown>[];
+    nextCursor?: string | undefined;
+  }>;
+  listResourceTemplates?(
+    params?: { cursor?: string | undefined },
+    options?: Record<string, unknown>,
+  ): Promise<{
+    resourceTemplates: readonly Record<string, unknown>[];
+    nextCursor?: string | undefined;
+  }>;
+  readResource?(
+    params: { uri: string },
+    options?: Record<string, unknown>,
+  ): Promise<Record<string, unknown>>;
 };
 
 export type McpTool = {
@@ -282,6 +308,7 @@ export type McpServer = {
   payment?: McpPayment | undefined;
   enabledTools?: readonly string[] | undefined;
   disabledTools?: readonly string[] | undefined;
+  startupTimeoutMs?: number | undefined;
   timeoutMs?: number | undefined;
 };
 

--- a/js/tui-react/structure.css
+++ b/js/tui-react/structure.css
@@ -338,12 +338,33 @@
   content: "  │ ";
 }
 
-@media (max-width: 740px) {
+@media (max-width: 740px), (pointer: coarse) and (orientation: landscape) and (max-width: 950px) {
   .agent-tui {
-    height: var(--nc-mobile-height, min(680px, calc(100svh - 112px)));
-    min-height: var(--nc-mobile-min-height, 500px);
+    height: var(--nc-mobile-height, calc(100dvh - 50px - env(safe-area-inset-bottom)));
+    min-height: var(--nc-mobile-min-height, 0);
     font-size: var(--nc-mobile-font-size, 10px);
     line-height: 16px;
+  }
+
+  .tui-inline-edit textarea,
+  .agent-tui-composer textarea,
+  .agent-tui-editor textarea {
+    font-size: 16px;
+  }
+
+  .agent-tui-composer {
+    min-height: 52px !important;
+  }
+
+  .agent-tui-composer:has(.agent-tui-voice) textarea {
+    padding-right: 52px;
+  }
+
+  .agent-tui-voice {
+    right: 4px;
+    bottom: 4px;
+    min-width: 44px;
+    height: 44px;
   }
 
   .agent-tui-header,

--- a/web/README.md
+++ b/web/README.md
@@ -60,7 +60,9 @@ Object owns the current generation with compare-and-swap publication. D1 is
 deliberately absent: there is no repository registry, account model, search
 index, or relational query to justify it. Publishing requires the same
 `GIT_MIRROR_TOKEN` secret on the Worker and `NANOCODEX_GIT_TOKEN` in the
-publisher environment:
+publisher environment. The publisher also requires `/api/health` to attest the
+same complete Git SHA before it makes an authenticated request or uploads an
+object:
 
 ```bash
 NANOCODEX_GIT_ORIGIN=https://nanocodex.me-7fb.workers.dev \
@@ -71,8 +73,11 @@ npm run publish:repository
 Production serves the website indexes, immutable file and patch objects, and a
 read-only Git protocol-v2 endpoint from that publication. Clone the mirror with
 `git clone https://nanocodex.me-7fb.workers.dev/git`. GitHub remains the write
-remote; a workflow publishes each new `master` commit to Cloudflare after it is
-pushed.
+remote. After each current `master` commit passes CI, the website job deploys
+the exact tested Worker with that SHA, waits for `/api/health` to return it as
+`deployment_sha`, publishes the repository generation, and verifies both the
+snapshot and Git protocol advertise the same SHA. An obsolete queued CI run is
+not allowed to deploy or publish.
 
 Each browser thread owns an OPFS working tree and an `origin` Cloudflare Git
 remote on branch `nanocodex`. The Files and Commits surfaces read that thread's
@@ -191,11 +196,37 @@ scrolling are left to Pierre CodeView and the browser's native input behavior.
 
 ## Production
 
+`master` CI can own production deployment after the `CLOUDFLARE_API_TOKEN`
+repository secret, `CLOUDFLARE_ACCOUNT_ID` repository variable, and
+`CLOUDFLARE_DEPLOY_ENABLED=true` repository variable are configured. The
+existing `NANOCODEX_GIT_TOKEN` publishes the matching repository generation.
+Without that explicit enablement, CI still validates the complete production
+graph but does not mutate the hosted Worker. Local commands build and preview
+it:
+
 ```bash
 npm run build
 npm run preview
-npm run deploy:preview
-npm run deploy
+```
+
+For a break-glass production deployment, start from a clean commit and preserve
+the same attestation contract before running `publish:repository`:
+
+```bash
+revision=$(git rev-parse HEAD)
+npm run build
+npx wrangler deploy --strict \
+  --tag "$revision" \
+  --message "gakonst/nanocodex@$revision" \
+  --var "DEPLOYMENT_SHA:$revision"
+```
+
+Do not publish repository data until the hosted `/api/health` reports that
+exact `deployment_sha`. The publisher enforces this ordering independently. An
+authenticated operator can publish the already-deployed master revision with:
+
+```bash
+gh workflow run mirror-cloudflare-git.yml --ref master -f revision="$revision"
 ```
 
 The proposal endpoint is intentionally a testnet-preview `402` until a live MPP

--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,6 @@
     "build": "tsc --noEmit && vite build && npm run check:bundle",
     "check:bundle": "node scripts/check-bundle.mjs",
     "preview": "vite preview",
-    "deploy:preview": "npm run build && wrangler deploy --env preview",
     "deploy": "npm run build && wrangler deploy"
   },
   "dependencies": {

--- a/web/scripts/check-bundle.mjs
+++ b/web/scripts/check-bundle.mjs
@@ -9,7 +9,8 @@ const budgets = Object.freeze({
   initialJavaScript: 260_000,
   initialJavaScriptGzip: 83_000,
   initialCssFiles: 2,
-  initialCss: 60_000,
+  // Includes compact Code/Commits controls for portrait and phone landscape.
+  initialCss: 60_500,
   initialCssGzip: 12_000,
   agentJavaScript: 830_000,
   // OPFS, artifacts, voice routing, subscription auth, and paid MCP stay in the Worker.

--- a/web/scripts/publish-repository.mjs
+++ b/web/scripts/publish-repository.mjs
@@ -26,9 +26,10 @@ const uploadConcurrency = 12;
 
 async function main() {
   const origin = requiredEnvironment("NANOCODEX_GIT_ORIGIN").replace(/\/$/, "");
+  const head = await git(["rev-parse", "HEAD"]);
+  await requireDeploymentSha(origin, head);
   const token = requiredEnvironment("NANOCODEX_GIT_TOKEN");
   const previous = await readRemoteState(origin, token);
-  const head = await git(["rev-parse", "HEAD"]);
   if (previous?.publication?.head === head && process.env.NANOCODEX_FORCE_SYNC !== "1") {
     console.log(`Cloudflare repository is current (${head.slice(0, 7)})`);
     return;
@@ -140,6 +141,29 @@ async function main() {
     );
   } finally {
     await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+async function requireDeploymentSha(origin, expected) {
+  const response = await fetch(`${origin}/api/health`, {
+    headers: { accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(await responseError("read deployment health", response));
+  }
+  let health;
+  try {
+    health = await response.json();
+  } catch {
+    throw new Error("Cloudflare Worker health returned invalid JSON");
+  }
+  const observed = typeof health?.deployment_sha === "string"
+    ? health.deployment_sha
+    : "unattested";
+  if (observed !== expected) {
+    throw new Error(
+      `Cloudflare Worker revision ${observed} does not match repository ${expected}; deploy the Worker before publishing`,
+    );
   }
 }
 

--- a/web/scripts/publish-repository.test.mjs
+++ b/web/scripts/publish-repository.test.mjs
@@ -22,6 +22,7 @@ test("the publisher CLI initializes its module before building a generation", as
   const directory = await mkdtemp(resolve(tmpdir(), "nanocodex-publisher-cli-test-"));
   const repository = resolve(directory, "repo");
   const requests = [];
+  let deploymentSha;
   const server = createServer(async (request, response) => {
     const chunks = [];
     for await (const chunk of request) chunks.push(chunk);
@@ -32,6 +33,11 @@ test("the publisher CLI initializes its module before building a generation", as
       method: request.method,
       url: request.url,
     });
+    if (request.method === "GET" && request.url === "/api/health") {
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ deployment_sha: deploymentSha }));
+      return;
+    }
     if (request.method === "GET" && request.url === "/api/git/state") {
       response.writeHead(404).end();
       return;
@@ -54,6 +60,7 @@ test("the publisher CLI initializes its module before building a generation", as
     await git(["add", "README.md"], repository);
     await git(["commit", "-qm", "initial fixture"], repository);
     const head = await git(["rev-parse", "HEAD"], repository);
+    deploymentSha = head;
 
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
@@ -72,7 +79,11 @@ test("the publisher CLI initializes its module before building a generation", as
 
     assert.match(stdout, new RegExp(`Published gakonst/nanocodex ${head.slice(0, 7)}`));
     assert.ok(requests.length > 3);
-    assert.ok(requests.every(({ authorization }) => authorization === "Bearer publisher-test-token"));
+    assert.equal(requests[0]?.url, "/api/health");
+    assert.equal(requests[0]?.authorization, undefined);
+    assert.ok(requests.slice(1).every(
+      ({ authorization }) => authorization === "Bearer publisher-test-token"
+    ));
     const publicationRequest = requests.find(({ url }) => url === "/api/git/publish");
     assert.ok(publicationRequest);
     const publication = JSON.parse(publicationRequest.body);
@@ -84,6 +95,30 @@ test("the publisher CLI initializes its module before building a generation", as
     assert.equal(requests.some(({ url }) =>
       url === `/api/git/objects/generations/${head}/commits/0000`
     ), false);
+
+    deploymentSha = "0".repeat(40);
+    const mismatchRequestIndex = requests.length;
+    await assert.rejects(
+      execFileAsync(process.execPath, [publisherPath], {
+        env: {
+          ...process.env,
+          NANOCODEX_GIT_ORIGIN: `http://127.0.0.1:${address.port}`,
+          NANOCODEX_GIT_TOKEN: "publisher-test-token",
+          NANOCODEX_REPO: repository,
+        },
+        encoding: "utf8",
+        maxBuffer: 16 * 1024 * 1024,
+      }),
+      new RegExp(`Cloudflare Worker revision ${"0".repeat(40)} does not match repository ${head}`),
+    );
+    assert.deepEqual(
+      requests.slice(mismatchRequestIndex).map(({ authorization, method, url }) => ({
+        authorization,
+        method,
+        url,
+      })),
+      [{ authorization: undefined, method: "GET", url: "/api/health" }],
+    );
   } finally {
     if (server.listening) await new Promise((resolveClose) => server.close(resolveClose));
     await rm(directory, { recursive: true, force: true });

--- a/web/src/AgentTerminal.css
+++ b/web/src/AgentTerminal.css
@@ -51,12 +51,13 @@
 .workspace-git button:focus-visible { background: var(--surface-hover); }
 .workspace-git button svg { width: 13px; height: 13px; }
 
-@media (max-width: 740px) {
+@media (max-width: 740px), (pointer: coarse) and (orientation: landscape) and (max-width: 950px) {
   .nanocodex-demo { width: 100%; min-width: 0; }
   .agent-transport { display: grid; grid-template-columns: 1fr 1fr; width: 100%; margin-top: 20px; }
   .agent-transport button,
   .agent-byok button,
   .agent-byok input { min-height: 44px; }
+  .agent-byok input { font-size: 16px; }
   .agent-byok { padding: 10px; }
   .agent-byok-summary { align-items: flex-start; }
   .agent-byok-summary > div { flex-wrap: wrap; justify-content: flex-end; }
@@ -64,7 +65,7 @@
   .agent-mobile-nav {
     position: sticky;
     z-index: 30;
-    top: var(--mobile-header-height);
+    top: 0;
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     width: 100%;
@@ -78,7 +79,7 @@
   }
 
   .agent-mobile-nav button {
-    min-height: 38px;
+    min-height: 44px;
     padding: 0 10px;
     color: var(--text-muted);
     font: 600 11px "Paradigm SemiMono", monospace;
@@ -98,7 +99,7 @@
     display: grid;
     grid-template: minmax(0, 1fr) / minmax(0, 1fr);
     width: 100%;
-    height: max(480px, calc(100svh - var(--mobile-header-height) - 54px));
+    height: calc(100dvh - 50px - env(safe-area-inset-bottom));
     min-height: 0;
     margin: 0 0 max(24px, env(safe-area-inset-bottom));
     overflow: hidden;
@@ -132,17 +133,21 @@
   .agent-workspace-shell > .workspace-panel,
   .agent-workspace-shell > .workspace-panel.is-collapsed { display: flex; width: 100%; height: 100%; }
   .workspace-panel-header,
-  .workspace-git { min-height: 46px; }
+  .workspace-git { min-height: 50px; }
   .workspace-panel-toggle { display: none; }
   .workspace-panel-toggle,
   .workspace-panel-actions button,
   .workspace-git button,
-  .workspace-editor footer button { width: 40px; height: 40px; }
-  .workspace-git { grid-template-columns: minmax(0, 1fr) auto repeat(3, 40px); padding-block: 3px; }
-  .workspace-tree-item { min-height: 38px; height: auto; }
+  .workspace-editor footer button { width: 44px; height: 44px; }
+  .workspace-git { grid-template-columns: minmax(0, 1fr) auto repeat(3, 44px); padding-block: 3px; }
+  .workspace-create input,
+  .workspace-create button { min-height: 44px; }
+  .workspace-create input,
+  .workspace-editor textarea { font-size: 16px; }
+  .workspace-tree-item { min-height: 44px; height: auto; }
+  .workspace-selection button { min-height: 44px; }
   .workspace-tree { min-height: 120px; }
   .workspace-editor { min-height: 220px; }
-  .workspace-editor textarea { font-size: 13px; }
   .agent-workspace-shell > .agent-tui { height: 100%; min-height: 0; border: 0; }
 
   .agent-workspace-shell > .artifact-dock,
@@ -156,7 +161,9 @@
   }
 
   .artifact-dock-header { min-height: 46px; padding-left: 10px; }
-  .artifact-dock-header button { width: 40px; height: 40px; }
+  .artifact-dock-header button { width: 44px; height: 44px; }
+  .artifact-dock-header select { min-height: 44px; font-size: 16px; }
+  .artifact-preview-button { min-height: 44px; }
   .artifact-dock-header > div button:last-child,
   .artifact-dock-header > div button:nth-last-child(2) { display: none; }
   .live-react-artifact { min-height: 100%; }

--- a/web/src/ArtifactDock.tsx
+++ b/web/src/ArtifactDock.tsx
@@ -21,6 +21,12 @@ import {
   subscribeThreadWorkspaceChanges,
 } from "./workspace";
 
+export const COMPACT_WORKSPACE_MEDIA_QUERY = "(max-width: 740px), (pointer: coarse) and (orientation: landscape) and (max-width: 950px)";
+
+function compactWorkspace(): boolean {
+  return window.matchMedia(COMPACT_WORKSPACE_MEDIA_QUERY).matches;
+}
+
 export const ArtifactDock = memo(function ArtifactDock({
   agentReady,
   onPrompt,
@@ -32,7 +38,7 @@ export const ArtifactDock = memo(function ArtifactDock({
   const [store, setStore] = useState<ArtifactStore>();
   const [artifacts, setArtifacts] = useState<readonly ArtifactDocument[]>([initialArtifact]);
   const [selectedId, setSelectedId] = useState(initialArtifact.id);
-  const [fullscreen, setFullscreen] = useState(() => !window.matchMedia("(max-width: 740px)").matches);
+  const [fullscreen, setFullscreen] = useState(() => !compactWorkspace());
   const [message, setMessage] = useState("");
   const refreshEpoch = useRef(0);
   const selected = artifacts.find((artifact) => artifact.id === selectedId) ?? artifacts[0];
@@ -92,6 +98,16 @@ export const ArtifactDock = memo(function ArtifactDock({
     return () => document.removeEventListener("visibilitychange", onVisible);
   }, [refresh, store]);
 
+  useEffect(() => {
+    const compact = window.matchMedia(COMPACT_WORKSPACE_MEDIA_QUERY);
+    const exitFullscreen = () => {
+      if (compact.matches) setFullscreen(false);
+    };
+    exitFullscreen();
+    compact.addEventListener("change", exitFullscreen);
+    return () => compact.removeEventListener("change", exitFullscreen);
+  }, []);
+
   const remove = async () => {
     if (!store || !selected || !window.confirm(`Delete the artifact “${selected.title}”?`)) return;
     try {
@@ -130,7 +146,7 @@ export const ArtifactDock = memo(function ArtifactDock({
       refreshEpoch.current++;
       setArtifacts((current) => [artifact, ...current.filter(({ id }) => id !== artifact.id)]);
       setSelectedId(artifact.id);
-      setFullscreen(!window.matchMedia("(max-width: 740px)").matches);
+      setFullscreen(!compactWorkspace());
       setMessage("");
     } catch (error) {
       setMessage(errorMessage(error));

--- a/web/src/CodeBrowser.tsx
+++ b/web/src/CodeBrowser.tsx
@@ -21,19 +21,13 @@ import { fuzzyScore } from "./fuzzy";
 import { usePierreRenderer } from "./PierreWorkerProvider";
 import { CODE_VIEW_CUSTOM_CSS, CODE_VIEW_LAYOUT } from "./pierreCodeView";
 import { syntaxLanguageForFile } from "./syntax";
-
-export type RepositoryFile = {
-  path: string;
-  mode: string;
-  objectId: string;
-  size: number | null;
-  contentUrl: string | null;
-};
+import type { RepositoryFile } from "./threadRepositorySnapshot";
 
 type CodeBrowserProps = {
   files: RepositoryFile[];
   branch: string;
   head: string;
+  readFile(file: RepositoryFile): Promise<string>;
   theme: "light" | "dark";
 };
 
@@ -61,7 +55,7 @@ function countLines(contents: string | null): number | null {
 }
 
 function CodeBrowserComponent(
-  { files, branch, head, theme }: CodeBrowserProps,
+  { files, branch, head, readFile, theme }: CodeBrowserProps,
   ref: ForwardedRef<CodeBrowserHandle>,
 ) {
   const defaultPath = useMemo(
@@ -75,8 +69,12 @@ function CodeBrowserComponent(
   const [selectedPath, setSelectedPath] = useState(defaultPath);
   const selectedPathRef = useRef(selectedPath);
   selectedPathRef.current = selectedPath;
-  const [contents, setContents] = useState<string | null>(null);
-  const [loadedObjectId, setLoadedObjectId] = useState<string | null>(null);
+  const readFileRef = useRef(readFile);
+  readFileRef.current = readFile;
+  const [loaded, setLoaded] = useState<{
+    contents: string;
+    file: RepositoryFile;
+  } | null>(null);
   const [fileError, setFileError] = useState<string | null>(null);
   const [treeOpen, setTreeOpen] = useState(false);
   const [fileSearchOpen, setFileSearchOpen] = useState(false);
@@ -104,14 +102,10 @@ function CodeBrowserComponent(
     icons: { set: "standard", colored: false },
   });
   const selected = files.find((file) => file.path === selectedPath) ?? files[0];
-  const displayed = loadedObjectId == null
-    ? undefined
-    : files.find((file) => file.objectId === loadedObjectId);
+  const displayed = loaded?.file;
+  const contents = loaded?.contents ?? null;
   const viewFile = displayed ?? selected;
-  const codeReady =
-    displayed != null &&
-    contents !== null &&
-    renderer.ready;
+  const codeReady = loaded != null && renderer.ready;
   const fileSearchResults = useMemo(() => {
     const tokens = fileQuery.trim().split(/\s+/).filter(Boolean);
     const matches = files
@@ -230,47 +224,46 @@ function CodeBrowserComponent(
   }, [files, model]);
 
   useEffect(() => {
-    if (!selected?.contentUrl) {
-      setFileError(selected?.path ?? null);
+    if (!selected) {
+      setFileError(null);
       return;
     }
-    const controller = new AbortController();
+    let active = true;
     setFileError(null);
-    fetch(selected.contentUrl, { signal: controller.signal })
-      .then((response) => {
-        if (!response.ok) throw new Error(`File request failed: ${response.status}`);
-        return response.text();
-      })
+    readFileRef.current(selected)
       .then((nextContents) => {
-        setContents(nextContents);
-        setLoadedObjectId(selected.objectId);
+        if (!active) return;
+        setLoaded({ contents: nextContents, file: selected });
         setFileError(null);
       })
-      .catch((error) => {
-        if (error instanceof DOMException && error.name === "AbortError") return;
+      .catch(() => {
+        if (!active) return;
+        setLoaded(null);
         setFileError(selected.path);
       });
-    return () => controller.abort();
-  }, [selected?.contentUrl, selected?.objectId]);
+    return () => {
+      active = false;
+    };
+  }, [selected?.objectId, selected?.path]);
 
   const lineCount = useMemo(() => countLines(contents), [contents]);
   const codeItems = useMemo<CodeViewItem<undefined>[]>(
     () =>
-      codeReady
+      codeReady && loaded
         ? [
             {
-              id: `file:${displayed.objectId}`,
+              id: `file:${loaded.file.objectId}`,
               type: "file",
               file: {
-                name: displayed.path,
-                contents,
-                cacheKey: displayed.objectId,
-                lang: syntaxLanguageForFile(displayed.path, contents),
+                name: loaded.file.path,
+                contents: loaded.contents,
+                cacheKey: loaded.file.objectId,
+                lang: syntaxLanguageForFile(loaded.file.path, loaded.contents),
               },
             },
           ]
         : [],
-    [codeReady, contents, displayed],
+    [codeReady, loaded],
   );
   const codeViewOptions = useMemo<CodeViewOptions<undefined>>(
     () => ({

--- a/web/src/NanocodexApp.tsx
+++ b/web/src/NanocodexApp.tsx
@@ -73,9 +73,9 @@ const queryClient = new QueryClient({
   },
 });
 
-function loadRepositorySnapshot(): Promise<RepositorySnapshot> {
+function loadRepositorySnapshot(includeHistory: boolean): Promise<RepositorySnapshot> {
   return import("./threadRepositorySnapshot")
-    .then((module) => module.loadThreadRepositorySnapshot());
+    .then((module) => module.loadThreadRepositorySnapshot(includeHistory));
 }
 
 const scopes: Array<{ id: Scope; label: string }> = [
@@ -165,13 +165,22 @@ function NanocodexShell() {
   const [proposalTitle, setProposalTitle] = useState("");
   const [commitRailOpen, setCommitRailOpen] = useState(false);
   const [installCopied, setInstallCopied] = useState(false);
+  const needsRepository = surface === "code" || surface === "commits" || proposalOpen;
+  const needsRepositoryHistory = surface === "commits" || proposalOpen;
   const searchInputRef = useRef<HTMLInputElement>(null);
   const headerCenterRef = useRef<HTMLDivElement>(null);
   const codeBrowserRef = useRef<CodeBrowserHandle>(null);
   const commitStreamRef = useRef<CommitCodeStreamHandle>(null);
   const snapshotRef = useRef<RepositorySnapshot | undefined>(undefined);
   const repositoryRequestId = useRef(0);
+  const repositoryRefreshInFlight = useRef(false);
+  const repositoryRefreshTrailing = useRef(false);
+  const repositoryConsumerActiveRef = useRef(needsRepository);
+  const repositoryHistoryNeededRef = useRef(needsRepositoryHistory);
+  const refreshRepositoryRef = useRef<() => void>(() => undefined);
   snapshotRef.current = snapshot;
+  repositoryConsumerActiveRef.current = needsRepository;
+  repositoryHistoryNeededRef.current = needsRepositoryHistory;
 
   const commits = snapshot?.commits ?? emptyCommits;
   const selected = useMemo(
@@ -241,12 +250,22 @@ function NanocodexShell() {
     [commits, queryTokens, searchOpen],
   );
 
-  const refreshRepository = useCallback(() => {
+  refreshRepositoryRef.current = () => {
+    if (!repositoryConsumerActiveRef.current) return;
+    if (repositoryRefreshInFlight.current) {
+      repositoryRefreshTrailing.current = true;
+      return;
+    }
+    repositoryRefreshInFlight.current = true;
     const requestId = ++repositoryRequestId.current;
+    const includeHistory = repositoryHistoryNeededRef.current;
     setRepositoryLoadError(false);
-    void loadRepositorySnapshot().then(
+    void loadRepositorySnapshot(includeHistory).then(
       (loaded) => {
-        if (repositoryRequestId.current !== requestId) {
+        if (
+          repositoryRequestId.current !== requestId ||
+          !repositoryConsumerActiveRef.current
+        ) {
           loaded.release();
           return;
         }
@@ -259,16 +278,42 @@ function NanocodexShell() {
           : loaded.repository.head);
       },
       () => {
-        if (repositoryRequestId.current === requestId) setRepositoryLoadError(true);
+        if (
+          repositoryRequestId.current === requestId &&
+          repositoryConsumerActiveRef.current
+        ) {
+          setRepositoryLoadError(true);
+        }
       },
-    );
-  }, []);
+    ).finally(() => {
+      repositoryRefreshInFlight.current = false;
+      if (
+        repositoryRefreshTrailing.current &&
+        repositoryConsumerActiveRef.current
+      ) {
+        repositoryRefreshTrailing.current = false;
+        queueMicrotask(() => refreshRepositoryRef.current());
+      }
+    });
+  };
+  const refreshRepository = useCallback(() => refreshRepositoryRef.current(), []);
 
   useEffect(() => {
-    const needsRepository =
-      surface === "code" || surface === "commits" || proposalOpen;
-    if (needsRepository && !snapshot) refreshRepository();
-  }, [proposalOpen, refreshRepository, snapshot, surface]);
+    repositoryConsumerActiveRef.current = needsRepository;
+    repositoryHistoryNeededRef.current = needsRepositoryHistory;
+    if (!needsRepository) {
+      repositoryRequestId.current++;
+      repositoryRefreshTrailing.current = false;
+      snapshotRef.current?.release();
+      snapshotRef.current = undefined;
+      setSnapshot(undefined);
+      setRepositoryLoadError(false);
+      return;
+    }
+    if (!snapshot || (needsRepositoryHistory && !snapshot.historyLoaded)) {
+      refreshRepository();
+    }
+  }, [needsRepository, needsRepositoryHistory, refreshRepository, snapshot]);
 
   useEffect(() => {
     let unsubscribe: (() => void) | undefined;
@@ -276,7 +321,7 @@ function NanocodexShell() {
     void import("./threadGit").then(({ subscribeThreadGitChanges }) => {
       if (!active) return;
       unsubscribe = subscribeThreadGitChanges(thread, () => {
-        if (snapshotRef.current) refreshRepository();
+        if (repositoryConsumerActiveRef.current) refreshRepository();
       });
     });
     return () => {
@@ -287,6 +332,8 @@ function NanocodexShell() {
 
   useEffect(() => () => {
     repositoryRequestId.current++;
+    repositoryConsumerActiveRef.current = false;
+    repositoryRefreshTrailing.current = false;
     snapshotRef.current?.release();
   }, []);
 
@@ -686,14 +733,15 @@ function NanocodexShell() {
                     ref={codeBrowserRef}
                     files={snapshot.tree}
                     branch={snapshot.repository.branch}
-                  head={snapshot.repository.head}
-                  theme={theme}
-                />
+                    head={snapshot.repository.head}
+                    readFile={snapshot.readFile}
+                    theme={theme}
+                  />
               </PierreWorkerProvider>
             </Suspense>
           ) : (
             <RepositorySurfaceLoading failed={repositoryLoadError} />
-          ) : surface === "commits" ? snapshot ? (
+          ) : surface === "commits" ? snapshot?.historyLoaded && snapshot.commitPatchUrl ? (
             <Suspense fallback={null}>
               <PierreWorkerProvider>
                 <section

--- a/web/src/WorkspacePanel.tsx
+++ b/web/src/WorkspacePanel.tsx
@@ -35,6 +35,7 @@ import {
   relativeWorkspacePath,
   type WorkspaceTreeNode,
 } from "./workspaceTree";
+import { listVisibleWorkspaceEntries } from "./workspaceListing";
 
 const decoder = new TextDecoder("utf-8", { fatal: true });
 
@@ -55,6 +56,7 @@ export const WorkspacePanel = memo(function WorkspacePanel() {
   const [gitBusy, setGitBusy] = useState(false);
   const [message, setMessage] = useState("");
   const uploadRef = useRef<HTMLInputElement>(null);
+  const notificationSource = useRef(crypto.randomUUID()).current;
   const selected = entries.find((entry) => entry.path === selectedPath);
   const dirty = selected?.kind === "file"
     && selected.path === loadedFile?.path
@@ -63,10 +65,7 @@ export const WorkspacePanel = memo(function WorkspacePanel() {
   const refresh = useCallback(async (nextWorkspace: Workspace | undefined) => {
     if (!nextWorkspace) return;
     try {
-      const nextEntries = (await nextWorkspace.list(".", { recursive: true }))
-        .filter((entry) =>
-          !entry.path.startsWith(`${nextWorkspace.root}/.nanocodex`) &&
-          !entry.path.startsWith(`${nextWorkspace.root}/.git`));
+      const nextEntries = await listVisibleWorkspaceEntries(nextWorkspace);
       setEntries(nextEntries);
       setSelectedPath((current) => current && nextEntries.some(({ path }) => path === current)
         ? current
@@ -94,16 +93,36 @@ export const WorkspacePanel = memo(function WorkspacePanel() {
 
   useEffect(() => {
     if (!workspace) return;
-    const timer = window.setInterval(() => void refresh(workspace), 2_000);
+    let unsubscribe: (() => void) | undefined;
+    let active = true;
+    const refreshWorkspace = async () => {
+      try {
+        const { threadGitStatus } = await import("./threadGit");
+        const [nextGitStatus] = await Promise.all([
+          threadGitStatus(thread),
+          refresh(workspace),
+        ]);
+        if (active) setGitStatus(nextGitStatus);
+      } catch (error) {
+        if (active) setMessage(errorMessage(error));
+      }
+    };
+    void import("./threadGit").then(({ subscribeThreadGitChanges }) => {
+      if (!active) return;
+      unsubscribe = subscribeThreadGitChanges(thread, (source) => {
+        if (source !== notificationSource) void refreshWorkspace();
+      });
+    });
     const onVisible = () => {
-      if (document.visibilityState === "visible") void refresh(workspace);
+      if (document.visibilityState === "visible") void refreshWorkspace();
     };
     document.addEventListener("visibilitychange", onVisible);
     return () => {
-      window.clearInterval(timer);
+      active = false;
+      unsubscribe?.();
       document.removeEventListener("visibilitychange", onVisible);
     };
-  }, [refresh, workspace]);
+  }, [notificationSource, refresh, thread, workspace]);
 
   useEffect(() => {
     const mobile = window.matchMedia("(max-width: 740px)");
@@ -165,7 +184,8 @@ export const WorkspacePanel = memo(function WorkspacePanel() {
     try {
       await operation();
       await refresh(workspace);
-      const { threadGitStatus } = await import("./threadGit");
+      const { notifyThreadGitChanged, threadGitStatus } = await import("./threadGit");
+      notifyThreadGitChanged(thread, notificationSource);
       setGitStatus(await threadGitStatus(thread));
       setMessage(success);
       return true;
@@ -203,7 +223,11 @@ export const WorkspacePanel = memo(function WorkspacePanel() {
           setSavedContents(contents);
         }
         const { commitAndPushThread } = await import("./threadGit");
-        return commitAndPushThread(thread, "Update Nanocodex workspace");
+        return commitAndPushThread(
+          thread,
+          "Update Nanocodex workspace",
+          notificationSource,
+        );
       },
       "Committed and pushed origin nanocodex.",
     );
@@ -215,7 +239,7 @@ export const WorkspacePanel = memo(function WorkspacePanel() {
     )) return;
     await syncGit(async () => {
       const { pullThread } = await import("./threadGit");
-      return pullThread(thread);
+      return pullThread(thread, notificationSource);
     }, "Pulled origin nanocodex into OPFS.");
   };
 

--- a/web/src/agent.worker.ts
+++ b/web/src/agent.worker.ts
@@ -4,7 +4,6 @@ import {
   type AgentControllerStart,
   type AgentControllerTools,
 } from "./agentController";
-import { createBrowserTools } from "./browserTools";
 import type { WebTuiCommand } from "./nanocodex";
 import { createPaymentSessionOwner } from "./paymentSessionOwner";
 import { MPP_RESPONSES_WEBSOCKET_URL } from "./tempo-constants";
@@ -50,17 +49,25 @@ async function createAgent(
   tools: AgentControllerTools,
 ) {
   await paymentSessions.clear();
-  const { execTool, instructions, workspace } = await (await import("./browserShell"))
-    .prepareBrowserShell(start.threadId!, self.location.origin);
+  const [shellModule, mcpModule, toolModule] = await Promise.all([
+    import("./browserShell"),
+    import("./browserMcp"),
+    import("./browserTools"),
+  ]);
+  const { execTool, instructions, projectInstructions, workspace } =
+    await shellModule.prepareBrowserShell(start.threadId!, self.location.origin);
   const common = {
     filesystem: workspace,
     filesystemTools: false,
     instructions,
+    executionEnvironment: browserExecutionEnvironment(projectInstructions),
+    mcp: mcpModule.browserMcpConfiguration(self.location.origin),
     tools: {
       exec_command: execTool,
-      ...createBrowserTools({
+      ...toolModule.createBrowserTools({
         recentImages: tools.recentImages,
         rememberImage: tools.rememberImage,
+        workspace,
       }),
     },
     thinking: start.thinking,
@@ -122,6 +129,25 @@ async function createAgent(
       websocketUrl: workerEndpoint(),
       createWebSocket,
     }),
+  };
+}
+
+function browserExecutionEnvironment(projectInstructions?: string) {
+  const now = new Date();
+  const resolvedTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const timezone = resolvedTimezone || "Etc/UTC";
+  const year = resolvedTimezone ? now.getFullYear() : now.getUTCFullYear();
+  const month = resolvedTimezone ? now.getMonth() + 1 : now.getUTCMonth() + 1;
+  const day = resolvedTimezone ? now.getDate() : now.getUTCDate();
+  const currentDate = [
+    year.toString().padStart(4, "0"),
+    month.toString().padStart(2, "0"),
+    day.toString().padStart(2, "0"),
+  ].join("-");
+  return {
+    currentDate,
+    timezone,
+    ...(projectInstructions === undefined ? {} : { projectInstructions }),
   };
 }
 

--- a/web/src/browserMcp.ts
+++ b/web/src/browserMcp.ts
@@ -1,0 +1,43 @@
+export const DEFAULT_BROWSER_MCP_SERVERS = Object.freeze({
+  openaiDeveloperDocs: {
+    path: "/api/mcp/openai-developer-docs",
+    description: "Search OpenAI developer documentation.",
+    enabledTools: ["fetch_openai_doc", "search_openai_docs"],
+  },
+  tempo: {
+    path: "/api/mcp/tempo",
+    description: "Tempo network and protocol tools.",
+    enabledTools: ["code", "search"],
+  },
+  cloudflare: {
+    path: "/api/mcp/cloudflare",
+    description: "Search Cloudflare developer documentation.",
+    enabledTools: ["search_cloudflare_documentation"],
+  },
+  viem: {
+    path: "/api/mcp/viem",
+    description: "Search Viem developer documentation.",
+    enabledTools: ["list_pages", "read_page", "search_docs", "search_source"],
+  },
+  vocs: {
+    path: "/api/mcp/vocs",
+    description: "Search Vocs developer documentation.",
+    enabledTools: ["list_pages", "read_page", "search_docs", "search_source"],
+  },
+});
+
+export function browserMcpConfiguration(origin: string) {
+  return Object.fromEntries(
+    Object.entries(DEFAULT_BROWSER_MCP_SERVERS).map(([name, server]) => [
+      name,
+      {
+        description: server.description,
+        enabledTools: [...server.enabledTools],
+        headers: { "x-nanocodex-request": "1" },
+        startupTimeoutMs: 30_000,
+        timeoutMs: 300_000,
+        url: new URL(server.path, origin).href,
+      },
+    ]),
+  );
+}

--- a/web/src/browserShell.ts
+++ b/web/src/browserShell.ts
@@ -14,10 +14,6 @@ import {
 
 import { openOpfsGitFs, type OpfsGitFs } from "./opfsGit.ts";
 import {
-  MAX_COMMIT_HISTORY,
-  MAX_DIFF_FILE_BYTES,
-} from "./threadRepositorySnapshot.ts";
-import {
   browserThread,
   initializeThreadGit,
   notifyThreadGitChanged,
@@ -32,6 +28,8 @@ const utf8Decoder = new TextDecoder();
 const diffDecoder = new TextDecoder("utf-8", { fatal: true });
 const MAX_OUTPUT_BYTES = 4 * 1024 * 1024;
 const MAX_EXECUTION_MS = 30_000;
+const MAX_GIT_LOG_DEPTH = 200;
+const MAX_DIFF_FILE_BYTES = 1024 * 1024;
 const MAX_INDEXED_PATHS = 100_000;
 const DIFF_TRUNCATION_NOTICE = "\n[diff truncated by browser git]\n";
 const AGENT_INSTRUCTIONS = `You are working in a persistent browser filesystem rooted at /workspace.
@@ -455,8 +453,8 @@ async function gitPull(fs: OpfsGitFs, thread: BrowserThread, args: string[]): Pr
 async function gitLog(fs: OpfsGitFs, args: string[]): Promise<string> {
   const countArgument = args.find((arg) => /^-\d+$/.test(arg));
   const depth = countArgument ? Number(countArgument.slice(1)) : 20;
-  if (!Number.isSafeInteger(depth) || depth > MAX_COMMIT_HISTORY) {
-    throw new Error(`browser git log depth cannot exceed ${MAX_COMMIT_HISTORY}`);
+  if (!Number.isSafeInteger(depth) || depth > MAX_GIT_LOG_DEPTH) {
+    throw new Error(`browser git log depth cannot exceed ${MAX_GIT_LOG_DEPTH}`);
   }
   const commits = await git.log({ fs, dir: THREAD_GIT_DIRECTORY, depth }).catch(() => []);
   if (args.includes("--oneline")) {

--- a/web/src/browserShell.ts
+++ b/web/src/browserShell.ts
@@ -31,6 +31,8 @@ const MAX_EXECUTION_MS = 30_000;
 const MAX_GIT_LOG_DEPTH = 200;
 const MAX_DIFF_FILE_BYTES = 1024 * 1024;
 const MAX_INDEXED_PATHS = 100_000;
+const MAX_PROJECT_INSTRUCTIONS_BYTES = 32 * 1024;
+const PROJECT_INSTRUCTION_FILES = ["AGENTS.override.md", "AGENTS.md"] as const;
 const DIFF_TRUNCATION_NOTICE = "\n[diff truncated by browser git]\n";
 const AGENT_INSTRUCTIONS = `You are working in a persistent browser filesystem rooted at /workspace.
 Use exec_command for bash commands such as ls, cat, find, grep, and git. The shell is implemented
@@ -59,11 +61,16 @@ type BrowserBashOptions = {
   onChanged?: () => void;
 };
 
+type ExecCommandContext = {
+  signal?: AbortSignal;
+};
+
 export async function prepareBrowserShell(threadId: string, origin: string) {
   const thread = browserThread(threadId, origin);
   await initializeThreadGit(thread);
   const rawFs = await openOpfsGitFs(thread.workspaceName);
   const { exec, filesystem: shellFs } = await createBrowserBash(rawFs, thread);
+  const projectInstructions = await loadBrowserProjectInstructions(rawFs);
 
   const workspace = await openThreadWorkspace(threadId);
   const notifyingWorkspace = Object.freeze({
@@ -97,6 +104,7 @@ export async function prepareBrowserShell(threadId: string, origin: string) {
   });
   return {
     instructions: AGENT_INSTRUCTIONS,
+    projectInstructions,
     workspace: notifyingWorkspace,
     execTool: {
       description: "Run a bash command in the browser thread workspace.",
@@ -109,6 +117,41 @@ export async function prepareBrowserShell(threadId: string, origin: string) {
       handler: exec,
     },
   };
+}
+
+/** Captures the root project instructions using the native Nanocodex precedence and budget. */
+export async function loadBrowserProjectInstructions(
+  rawFs: OpfsGitFs,
+): Promise<string | undefined> {
+  for (const filename of PROJECT_INSTRUCTION_FILES) {
+    const path = `${THREAD_GIT_DIRECTORY}/${filename}`;
+    let stat: Awaited<ReturnType<OpfsGitFs["promises"]["stat"]>>;
+    try {
+      stat = await rawFs.promises.stat(path);
+    } catch (error) {
+      if ((error as { code?: unknown })?.code === "ENOENT") continue;
+      console.warn("failed to read project AGENTS.md instructions", { path, error });
+      return undefined;
+    }
+    if (!stat.isFile()) continue;
+    if (stat.size > MAX_PROJECT_INSTRUCTIONS_BYTES) {
+      console.warn("project doc exceeds remaining budget; truncating", {
+        path,
+        remainingBytes: MAX_PROJECT_INSTRUCTIONS_BYTES,
+      });
+    }
+    try {
+      const bytes = await rawFs.promises.readFile(path, {
+        maxBytes: MAX_PROJECT_INSTRUCTIONS_BYTES,
+      }) as Uint8Array;
+      const instructions = utf8Decoder.decode(bytes);
+      return instructions.trim() ? instructions : undefined;
+    } catch (error) {
+      console.warn("failed to read project AGENTS.md instructions", { path, error });
+      return undefined;
+    }
+  }
+  return undefined;
 }
 
 /** Builds the browser shell over an already-open OPFS Git adapter. */
@@ -152,12 +195,13 @@ export async function createBrowserBash(
   return {
     bash,
     filesystem,
-    exec: (input: ExecCommandInput) => execute(
+    exec: (input: ExecCommandInput, context?: ExecCommandContext) => execute(
       bash,
       filesystem,
       thread,
       input,
       options.onChanged ?? (() => notifyThreadGitChanged(thread)),
+      context?.signal,
     ),
   };
 }
@@ -168,6 +212,7 @@ async function execute(
   thread: BrowserThread,
   input: ExecCommandInput,
   onChanged: () => void,
+  signal?: AbortSignal,
 ) {
   if (typeof input?.cmd !== "string" || !input.cmd.trim()) {
     throw new TypeError("exec_command.cmd must be a non-empty string");
@@ -185,11 +230,11 @@ async function execute(
   const result = await withThreadGitLock(thread, async () => {
     const mutationVersion = shellFs.mutationVersion;
     try {
-      return await bash.exec(input.cmd as string, { cwd: workdir });
+      return await bash.exec(input.cmd as string, { cwd: workdir, signal });
     } finally {
       if (shellFs.mutationVersion !== mutationVersion) onChanged();
     }
-  });
+  }, signal);
   const combined = `${result.stdout}${result.stderr}`;
   const maxCharacters = maxTokens * 4;
   const truncated = combined.length > maxCharacters;

--- a/web/src/browserShell.ts
+++ b/web/src/browserShell.ts
@@ -14,6 +14,10 @@ import {
 
 import { openOpfsGitFs, type OpfsGitFs } from "./opfsGit.ts";
 import {
+  MAX_COMMIT_HISTORY,
+  MAX_DIFF_FILE_BYTES,
+} from "./threadRepositorySnapshot.ts";
+import {
   browserThread,
   initializeThreadGit,
   notifyThreadGitChanged,
@@ -25,8 +29,11 @@ import { openThreadWorkspace, type BrowserThread } from "./workspace.ts";
 
 const utf8 = new TextEncoder();
 const utf8Decoder = new TextDecoder();
+const diffDecoder = new TextDecoder("utf-8", { fatal: true });
 const MAX_OUTPUT_BYTES = 4 * 1024 * 1024;
 const MAX_EXECUTION_MS = 30_000;
+const MAX_INDEXED_PATHS = 100_000;
+const DIFF_TRUNCATION_NOTICE = "\n[diff truncated by browser git]\n";
 const AGENT_INSTRUCTIONS = `You are working in a persistent browser filesystem rooted at /workspace.
 Use exec_command for bash commands such as ls, cat, find, grep, and git. The shell is implemented
 in-browser, so it has no host process or PTY. The repository's only publish branch is nanocodex;
@@ -50,11 +57,15 @@ type ExecCommandInput = {
   prefix_rule?: unknown;
 };
 
+type BrowserBashOptions = {
+  onChanged?: () => void;
+};
+
 export async function prepareBrowserShell(threadId: string, origin: string) {
   const thread = browserThread(threadId, origin);
   await initializeThreadGit(thread);
   const rawFs = await openOpfsGitFs(thread.workspaceName);
-  const { bash, filesystem: shellFs } = await createBrowserBash(rawFs, thread);
+  const { exec, filesystem: shellFs } = await createBrowserBash(rawFs, thread);
 
   const workspace = await openThreadWorkspace(threadId);
   const notifyingWorkspace = Object.freeze({
@@ -63,15 +74,27 @@ export async function prepareBrowserShell(threadId: string, origin: string) {
     readFile: workspace.readFile,
     async writeFile(path: string, contents: string | ArrayBuffer | ArrayBufferView) {
       await workspace.writeFile(path, contents);
-      notifyThreadGitChanged(thread);
+      try {
+        shellFs.recordExternalWrite(path);
+      } finally {
+        notifyThreadGitChanged(thread);
+      }
     },
     async remove(path: string, options?: { recursive?: boolean }) {
       await workspace.remove(path, options);
-      notifyThreadGitChanged(thread);
+      try {
+        shellFs.recordExternalRemove(path);
+      } finally {
+        notifyThreadGitChanged(thread);
+      }
     },
     async mkdir(path: string) {
       await workspace.mkdir(path);
-      notifyThreadGitChanged(thread);
+      try {
+        shellFs.recordExternalWrite(path);
+      } finally {
+        notifyThreadGitChanged(thread);
+      }
     },
   });
   return {
@@ -85,13 +108,17 @@ export async function prepareBrowserShell(threadId: string, origin: string) {
         required: ["cmd"],
         additionalProperties: true,
       },
-      handler: (input: ExecCommandInput) => execute(bash, shellFs, thread, input),
+      handler: exec,
     },
   };
 }
 
 /** Builds the browser shell over an already-open OPFS Git adapter. */
-export async function createBrowserBash(rawFs: OpfsGitFs, thread: BrowserThread) {
+export async function createBrowserBash(
+  rawFs: OpfsGitFs,
+  thread: BrowserThread,
+  options: BrowserBashOptions = {},
+) {
   const filesystem = new OpfsShellFileSystem(rawFs);
   await filesystem.refreshPaths();
   const bash = new Bash({
@@ -105,7 +132,11 @@ export async function createBrowserBash(rawFs: OpfsGitFs, thread: BrowserThread)
       GIT_COMMITTER_EMAIL: THREAD_GIT_AUTHOR.email,
     },
     fs: filesystem,
-    customCommands: [gitCommand(rawFs, thread), ghCommand(rawFs, thread), artifactCommand()],
+    customCommands: [
+      gitCommand(rawFs, thread, filesystem),
+      ghCommand(rawFs, thread),
+      artifactCommand(),
+    ],
     executionLimitProfile: "hardened",
     executionLimits: {
       maxCommandCount: 10_000,
@@ -120,7 +151,17 @@ export async function createBrowserBash(rawFs: OpfsGitFs, thread: BrowserThread)
     },
   });
 
-  return { bash, filesystem };
+  return {
+    bash,
+    filesystem,
+    exec: (input: ExecCommandInput) => execute(
+      bash,
+      filesystem,
+      thread,
+      input,
+      options.onChanged ?? (() => notifyThreadGitChanged(thread)),
+    ),
+  };
 }
 
 async function execute(
@@ -128,6 +169,7 @@ async function execute(
   shellFs: OpfsShellFileSystem,
   thread: BrowserThread,
   input: ExecCommandInput,
+  onChanged: () => void,
 ) {
   if (typeof input?.cmd !== "string" || !input.cmd.trim()) {
     throw new TypeError("exec_command.cmd must be a non-empty string");
@@ -143,10 +185,12 @@ async function execute(
   const maxTokens = optionalPositiveInteger(input.max_output_tokens, 10_000);
   const startedAt = performance.now();
   const result = await withThreadGitLock(thread, async () => {
-    await shellFs.refreshPaths();
-    const next = await bash.exec(input.cmd as string, { cwd: workdir });
-    notifyThreadGitChanged(thread);
-    return next;
+    const mutationVersion = shellFs.mutationVersion;
+    try {
+      return await bash.exec(input.cmd as string, { cwd: workdir });
+    } finally {
+      if (shellFs.mutationVersion !== mutationVersion) onChanged();
+    }
   });
   const combined = `${result.stdout}${result.stderr}`;
   const maxCharacters = maxTokens * 4;
@@ -161,7 +205,11 @@ async function execute(
   };
 }
 
-function gitCommand(fs: OpfsGitFs, thread: BrowserThread) {
+function gitCommand(
+  fs: OpfsGitFs,
+  thread: BrowserThread,
+  shellFs: OpfsShellFileSystem,
+) {
   return defineCommand("git", async (args, context) => {
     try {
       const command = args[0];
@@ -172,14 +220,28 @@ function gitCommand(fs: OpfsGitFs, thread: BrowserThread) {
           return ok(gitHelp());
         case "status":
           return ok(await gitStatus(fs, thread, args.slice(1)));
-        case "add":
-          return ok(await gitAdd(fs, args.slice(1), context.cwd));
-        case "commit":
-          return ok(await gitCommit(fs, args.slice(1)));
+        case "add": {
+          const output = await gitAdd(
+            fs,
+            args.slice(1),
+            context.cwd,
+            () => shellFs.recordRepositoryMutation(),
+          );
+          return ok(output);
+        }
+        case "commit": {
+          const output = await gitCommit(fs, args.slice(1));
+          shellFs.recordRepositoryMutation();
+          return ok(output);
+        }
         case "push":
           return ok(await gitPush(fs, thread, args.slice(1)));
-        case "pull":
-          return ok(await gitPull(fs, thread, args.slice(1)));
+        case "pull": {
+          const output = await gitPull(fs, thread, args.slice(1));
+          await shellFs.refreshPaths();
+          shellFs.recordRepositoryMutation();
+          return ok(output);
+        }
         case "log":
           return ok(await gitLog(fs, args.slice(1)));
         case "diff":
@@ -319,7 +381,12 @@ async function gitStatus(fs: OpfsGitFs, thread: BrowserThread, args: string[]): 
   ].join("\n");
 }
 
-async function gitAdd(fs: OpfsGitFs, args: string[], cwd: string): Promise<string> {
+async function gitAdd(
+  fs: OpfsGitFs,
+  args: string[],
+  cwd: string,
+  onStaged: () => void,
+): Promise<string> {
   const requested = args.filter((arg) => !arg.startsWith("-"));
   if (!requested.length && !args.includes("-A") && !args.includes("--all")) {
     throw new Error("nothing specified, nothing added");
@@ -329,9 +396,15 @@ async function gitAdd(fs: OpfsGitFs, args: string[], cwd: string): Promise<strin
   const prefixes = requested.filter((path) => path !== ".").map((path) => repositoryPath(path, cwd));
   const selected = matrix.filter(([path]) => all || prefixes.some((prefix) => path === prefix || path.startsWith(`${prefix}/`)));
   if (!all && selected.length === 0) throw new Error(`pathspec '${requested.join(" ")}' did not match any files`);
-  for (const [filepath, , workdirStatus] of selected) {
-    if (workdirStatus === 0) await git.remove({ fs, dir: THREAD_GIT_DIRECTORY, filepath });
-    else await git.add({ fs, dir: THREAD_GIT_DIRECTORY, filepath });
+  let staged = false;
+  try {
+    for (const [filepath, , workdirStatus] of selected) {
+      if (workdirStatus === 0) await git.remove({ fs, dir: THREAD_GIT_DIRECTORY, filepath });
+      else await git.add({ fs, dir: THREAD_GIT_DIRECTORY, filepath });
+      staged = true;
+    }
+  } finally {
+    if (staged) onStaged();
   }
   return "";
 }
@@ -382,6 +455,9 @@ async function gitPull(fs: OpfsGitFs, thread: BrowserThread, args: string[]): Pr
 async function gitLog(fs: OpfsGitFs, args: string[]): Promise<string> {
   const countArgument = args.find((arg) => /^-\d+$/.test(arg));
   const depth = countArgument ? Number(countArgument.slice(1)) : 20;
+  if (!Number.isSafeInteger(depth) || depth > MAX_COMMIT_HISTORY) {
+    throw new Error(`browser git log depth cannot exceed ${MAX_COMMIT_HISTORY}`);
+  }
   const commits = await git.log({ fs, dir: THREAD_GIT_DIRECTORY, depth }).catch(() => []);
   if (args.includes("--oneline")) {
     return commits.map(({ oid, commit }) => `${oid.slice(0, 7)} ${firstLine(commit.message)}`).join("\n") + (commits.length ? "\n" : "");
@@ -406,16 +482,69 @@ async function gitDiff(fs: OpfsGitFs, args: string[]): Promise<string> {
   const files = matrix.filter(([path, headStatus, workdirStatus]) =>
     headStatus !== workdirStatus && (!requested.length || requested.includes(path)));
   const patches: string[] = [];
+  let outputLength = 0;
   for (const [filepath, headStatus, workdirStatus] of files) {
-    const before = head && headStatus !== 0
-      ? utf8Decoder.decode((await git.readBlob({ fs, dir: THREAD_GIT_DIRECTORY, oid: head, filepath })).blob)
-      : "";
-    const after = workdirStatus === 0
-      ? ""
-      : utf8Decoder.decode(await fs.promises.readFile(`${THREAD_GIT_DIRECTORY}/${filepath}`) as Uint8Array);
-    patches.push(createTwoFilesPatch(`a/${filepath}`, `b/${filepath}`, before, after, "HEAD", "worktree"));
+    const worktreePath = `${THREAD_GIT_DIRECTORY}/${filepath}`;
+    const worktreeTooLarge = workdirStatus !== 0 &&
+      (await fs.promises.stat(worktreePath)).size > MAX_DIFF_FILE_BYTES;
+    const beforeBytes = head && headStatus !== 0 && !worktreeTooLarge
+      ? (await git.readBlob({ fs, dir: THREAD_GIT_DIRECTORY, oid: head, filepath })).blob
+      : undefined;
+    const afterBytes = workdirStatus !== 0 && !worktreeTooLarge
+      ? await fs.promises.readFile(worktreePath) as Uint8Array
+      : undefined;
+    const patch = worktreeTooLarge ||
+        (beforeBytes?.byteLength ?? 0) > MAX_DIFF_FILE_BYTES ||
+        (afterBytes?.byteLength ?? 0) > MAX_DIFF_FILE_BYTES ||
+        beforeBytes?.includes(0) ||
+        afterBytes?.includes(0)
+      ? binaryFilePatch(filepath, headStatus, workdirStatus)
+      : textFilePatch(filepath, headStatus, workdirStatus, beforeBytes, afterBytes);
+    const separatorLength = patches.length ? 1 : 0;
+    const remaining = MAX_OUTPUT_BYTES - outputLength - separatorLength;
+    if (patch.length > remaining) {
+      if (remaining > DIFF_TRUNCATION_NOTICE.length) {
+        patches.push(`${patch.slice(0, remaining - DIFF_TRUNCATION_NOTICE.length)}${DIFF_TRUNCATION_NOTICE}`);
+      } else if (outputLength + DIFF_TRUNCATION_NOTICE.length <= MAX_OUTPUT_BYTES) {
+        patches.push(DIFF_TRUNCATION_NOTICE);
+      }
+      break;
+    }
+    patches.push(patch);
+    outputLength += separatorLength + patch.length;
   }
   return patches.join("\n");
+}
+
+function textFilePatch(
+  filepath: string,
+  headStatus: number,
+  workdirStatus: number,
+  beforeBytes: Uint8Array | undefined,
+  afterBytes: Uint8Array | undefined,
+): string {
+  let before: string;
+  let after: string;
+  try {
+    before = beforeBytes ? diffDecoder.decode(beforeBytes) : "";
+    after = afterBytes ? diffDecoder.decode(afterBytes) : "";
+  } catch {
+    return binaryFilePatch(filepath, headStatus, workdirStatus);
+  }
+  return createTwoFilesPatch(
+    headStatus === 0 ? "/dev/null" : `a/${filepath}`,
+    workdirStatus === 0 ? "/dev/null" : `b/${filepath}`,
+    before,
+    after,
+    "HEAD",
+    "worktree",
+  );
+}
+
+function binaryFilePatch(filepath: string, headStatus: number, workdirStatus: number): string {
+  const before = headStatus === 0 ? "/dev/null" : `a/${filepath}`;
+  const after = workdirStatus === 0 ? "/dev/null" : `b/${filepath}`;
+  return `diff --git a/${filepath} b/${filepath}\nBinary files ${before} and ${after} differ\n`;
 }
 
 function gitBranch(thread: BrowserThread, args: string[]): string {
@@ -504,16 +633,37 @@ function fail(stderr: string, exitCode: number) {
 
 class OpfsShellFileSystem implements IFileSystem {
   readonly #fs: OpfsGitFs;
-  readonly #paths = new Set<string>([THREAD_GIT_DIRECTORY]);
+  #paths = new Set<string>([THREAD_GIT_DIRECTORY]);
+  #sortedPaths: string[] | undefined;
+  #mutationVersion = 0;
 
   constructor(fs: OpfsGitFs) {
     this.#fs = fs;
   }
 
+  get mutationVersion(): number {
+    return this.#mutationVersion;
+  }
+
   async refreshPaths(): Promise<void> {
-    this.#paths.clear();
-    this.#paths.add(THREAD_GIT_DIRECTORY);
-    await this.#visit(THREAD_GIT_DIRECTORY);
+    const paths = new Set<string>([THREAD_GIT_DIRECTORY]);
+    await this.#visit(THREAD_GIT_DIRECTORY, paths);
+    this.#paths = paths;
+    this.#sortedPaths = undefined;
+  }
+
+  recordExternalWrite(path: string): void {
+    this.#recordMutation();
+    this.#addPath(resolveWorkspacePath(THREAD_GIT_DIRECTORY, path));
+  }
+
+  recordExternalRemove(path: string): void {
+    this.#recordMutation();
+    this.#removePath(resolveWorkspacePath(THREAD_GIT_DIRECTORY, path));
+  }
+
+  recordRepositoryMutation(): void {
+    this.#recordMutation();
   }
 
   async readFile(path: string, options?: { encoding?: BufferEncoding | null } | BufferEncoding): Promise<string> {
@@ -538,6 +688,7 @@ class OpfsShellFileSystem implements IFileSystem {
   ): Promise<void> {
     const absolute = resolveWorkspacePath(THREAD_GIT_DIRECTORY, path);
     await this.#fs.promises.writeFile(absolute, encode(content, options));
+    this.#recordMutation();
     this.#addPath(absolute);
   }
 
@@ -546,15 +697,10 @@ class OpfsShellFileSystem implements IFileSystem {
     content: FileContent,
     options?: { encoding?: BufferEncoding } | BufferEncoding,
   ): Promise<void> {
-    const previous = await this.readFileBuffer(path).catch((error) => {
-      if (isCode(error, "ENOENT")) return new Uint8Array();
-      throw error;
-    });
-    const addition = encode(content, options);
-    const combined = new Uint8Array(previous.length + addition.length);
-    combined.set(previous);
-    combined.set(addition, previous.length);
-    await this.writeFile(path, combined);
+    const absolute = resolveWorkspacePath(THREAD_GIT_DIRECTORY, path);
+    await this.#fs.promises.appendFile(absolute, encode(content, options));
+    this.#recordMutation();
+    this.#addPath(absolute);
   }
 
   async exists(path: string): Promise<boolean> {
@@ -583,6 +729,7 @@ class OpfsShellFileSystem implements IFileSystem {
   async mkdir(path: string): Promise<void> {
     const absolute = resolveWorkspacePath(THREAD_GIT_DIRECTORY, path);
     await this.#fs.promises.mkdir(absolute);
+    this.#recordMutation();
     this.#addPath(absolute);
   }
 
@@ -592,26 +739,21 @@ class OpfsShellFileSystem implements IFileSystem {
 
   async readdirWithFileTypes(path: string) {
     const absolute = resolveWorkspacePath(THREAD_GIT_DIRECTORY, path);
-    return Promise.all((await this.readdir(absolute)).map(async (name) => {
-      const entry = await this.stat(`${absolute}/${name}`);
-      return {
-        name,
-        isFile: entry.isFile,
-        isDirectory: entry.isDirectory,
-        isSymbolicLink: entry.isSymbolicLink,
-      };
-    }));
+    return this.#fs.promises.readdirWithFileTypes(absolute);
   }
 
   async rm(path: string, options?: RmOptions): Promise<void> {
     const absolute = resolveWorkspacePath(THREAD_GIT_DIRECTORY, path);
+    let removed = false;
     try {
       await this.#fs.promises.rm(absolute, { recursive: options?.recursive });
+      removed = true;
     } catch (error) {
       if (!options?.force || !isCode(error, "ENOENT")) throw error;
     }
-    for (const candidate of this.#paths) {
-      if (candidate === absolute || candidate.startsWith(`${absolute}/`)) this.#paths.delete(candidate);
+    if (removed) {
+      this.#recordMutation();
+      this.#removePath(absolute);
     }
   }
 
@@ -641,7 +783,8 @@ class OpfsShellFileSystem implements IFileSystem {
   }
 
   getAllPaths(): string[] {
-    return [...this.#paths].sort();
+    this.#sortedPaths ??= [...this.#paths].sort();
+    return this.#sortedPaths.slice();
   }
 
   async chmod(path: string): Promise<void> {
@@ -674,22 +817,51 @@ class OpfsShellFileSystem implements IFileSystem {
     await this.stat(path);
   }
 
-  async #visit(directory: string): Promise<void> {
-    for (const name of await this.readdir(directory)) {
-      const path = `${directory}/${name}`;
-      this.#paths.add(path);
-      if ((await this.stat(path)).isDirectory) await this.#visit(path);
+  async #visit(directory: string, paths: Set<string>): Promise<void> {
+    for (const entry of await this.readdirWithFileTypes(directory)) {
+      if (directory === THREAD_GIT_DIRECTORY && entry.name === ".git") continue;
+      const path = `${directory}/${entry.name}`;
+      this.#addIndexedPath(paths, path);
+      if (entry.isDirectory) await this.#visit(path, paths);
     }
   }
 
   #addPath(path: string): void {
+    const gitDirectory = `${THREAD_GIT_DIRECTORY}/.git`;
+    if (path === gitDirectory || path.startsWith(`${gitDirectory}/`)) return;
     const segments = path.slice(THREAD_GIT_DIRECTORY.length + 1).split("/");
     let current = THREAD_GIT_DIRECTORY;
+    let changed = false;
     for (const segment of segments) {
       if (!segment) continue;
       current += `/${segment}`;
-      this.#paths.add(current);
+      changed = this.#addIndexedPath(this.#paths, current) || changed;
     }
+    if (changed) this.#sortedPaths = undefined;
+  }
+
+  #addIndexedPath(paths: Set<string>, path: string): boolean {
+    if (paths.has(path)) return false;
+    if (paths.size >= MAX_INDEXED_PATHS) {
+      throw fsError("EFBIG", `browser shell path index exceeds ${MAX_INDEXED_PATHS} entries`);
+    }
+    paths.add(path);
+    return true;
+  }
+
+  #removePath(path: string): void {
+    let changed = false;
+    for (const candidate of this.#paths) {
+      if (candidate === path || candidate.startsWith(`${path}/`)) {
+        this.#paths.delete(candidate);
+        changed = true;
+      }
+    }
+    if (changed) this.#sortedPaths = undefined;
+  }
+
+  #recordMutation(): void {
+    this.#mutationVersion += 1;
   }
 }
 

--- a/web/src/browserTools.ts
+++ b/web/src/browserTools.ts
@@ -1,5 +1,6 @@
 type ToolContext = {
   sessionId: string;
+  signal?: AbortSignal;
 };
 
 type ToolDefinition = {
@@ -11,7 +12,12 @@ type ToolDefinition = {
 type BrowserToolOptions = {
   recentImages(sessionId: string, count: number): string[];
   rememberImage(sessionId: string, imageUrl: string): void;
+  workspace: {
+    readFile(path: string): Promise<Uint8Array>;
+  };
 };
+
+const MAX_VIEW_IMAGE_BYTES = 10 * 1024 * 1024;
 
 const WEB_DESCRIPTION = `Search and inspect the public internet. Use search_query for web
 search, image_query for image-source discovery, open/click/find for pages, and the specialized
@@ -33,7 +39,7 @@ export function createBrowserTools(options: BrowserToolOptions): Record<string, 
         const result = await postJson<{ output: string }>("/api/tools/web-search", {
           commands,
           session_id: context.sessionId,
-        });
+        }, context.signal);
         return result.output;
       },
     },
@@ -66,9 +72,39 @@ export function createBrowserTools(options: BrowserToolOptions): Record<string, 
         const result = await postJson<{ image_url: string }>("/api/tools/image-generation", {
           images,
           prompt,
-        });
+        }, context.signal);
         options.rememberImage(context.sessionId, result.image_url);
         return result;
+      },
+    },
+    view_image: {
+      description: "View an image file from the browser thread workspace.",
+      parameters: {
+        type: "object",
+        properties: {
+          path: { type: "string" },
+          detail: { type: "string", enum: ["high", "original"] },
+        },
+        required: ["path"],
+        additionalProperties: false,
+      },
+      async handler(input) {
+        const args = requireObject(input, "view_image");
+        const path = requireString(args.path, "view_image.path");
+        const detail = args.detail === undefined ? "high" : args.detail;
+        if (detail !== "high" && detail !== "original") {
+          throw new Error("view_image.detail must be high or original");
+        }
+        const bytes = await options.workspace.readFile(path);
+        if (bytes.byteLength > MAX_VIEW_IMAGE_BYTES) {
+          throw new Error("view_image input exceeds 10 MiB");
+        }
+        const mimeType = imageMimeType(bytes);
+        if (!mimeType) throw new Error("view_image supports PNG, JPEG, GIF, WebP, and SVG files");
+        return {
+          detail,
+          image_url: `data:${mimeType};base64,${base64(bytes)}`,
+        };
       },
     },
     update_plan: {
@@ -110,7 +146,7 @@ export function createBrowserTools(options: BrowserToolOptions): Record<string, 
   };
 }
 
-async function postJson<T>(path: string, body: unknown): Promise<T> {
+async function postJson<T>(path: string, body: unknown, signal?: AbortSignal): Promise<T> {
   const response = await fetch(path, {
     method: "POST",
     headers: {
@@ -118,6 +154,7 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
       "x-nanocodex-request": "1",
     },
     body: JSON.stringify(body),
+    signal,
   });
   const payload = await response.json().catch(() => undefined) as { error?: unknown } | undefined;
   if (!response.ok) {
@@ -143,6 +180,31 @@ function optionalInteger(value: unknown): number | undefined {
   if (value === undefined) return undefined;
   if (!Number.isInteger(value)) throw new Error("num_last_images_to_include must be an integer");
   return value as number;
+}
+
+function imageMimeType(bytes: Uint8Array): string | undefined {
+  if (startsWith(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) return "image/png";
+  if (startsWith(bytes, [0xff, 0xd8, 0xff])) return "image/jpeg";
+  if (startsWith(bytes, [0x47, 0x49, 0x46, 0x38])) return "image/gif";
+  if (startsWith(bytes, [0x52, 0x49, 0x46, 0x46])
+    && startsWith(bytes.subarray(8), [0x57, 0x45, 0x42, 0x50])) return "image/webp";
+  const prefix = new TextDecoder().decode(bytes.subarray(0, 1024)).trimStart();
+  if (prefix.startsWith("<svg") || (/^<\?xml\b/.test(prefix) && prefix.includes("<svg"))) {
+    return "image/svg+xml";
+  }
+  return undefined;
+}
+
+function startsWith(bytes: Uint8Array, signature: number[]): boolean {
+  return signature.every((value, index) => bytes[index] === value);
+}
+
+function base64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += 32_768) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 32_768));
+  }
+  return btoa(binary);
 }
 
 const query = {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -3601,7 +3601,7 @@ html[data-theme="dark"] .tui-syntax .shiki span {
   }
 }
 
-@media (max-width: 740px) {
+@media (max-width: 740px), (pointer: coarse) and (orientation: landscape) and (max-width: 950px) {
   .surface-code .header-actions,
   .surface-commits .header-actions {
     display: none;
@@ -3614,6 +3614,13 @@ html[data-theme="dark"] .tui-syntax .shiki span {
 
   .code-workspace {
     display: block;
+  }
+
+  .commits-workspace {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "header"
+      "viewer";
   }
 
   .commit-sidebar {
@@ -3676,8 +3683,8 @@ html[data-theme="dark"] .tui-syntax .shiki span {
 
   .pierre-tree-heading button {
     display: grid;
-    width: 36px;
-    height: 36px;
+    width: 44px;
+    height: 44px;
   }
 
   .pierre-tree-heading .tree-search-trigger {
@@ -3687,8 +3694,8 @@ html[data-theme="dark"] .tui-syntax .shiki span {
   .mobile-tree-toggle {
     display: grid;
     flex: 0 0 auto;
-    width: 36px;
-    height: 36px;
+    width: 44px;
+    height: 44px;
     padding: 0;
     background: var(--surface-subtle);
     border-radius: var(--radius-small);
@@ -3703,13 +3710,18 @@ html[data-theme="dark"] .tui-syntax .shiki span {
 
   .commit-sidebar-header .icon-button,
   .commit-scope-tabs button {
-    min-height: 36px;
+    min-height: 44px;
+  }
+
+  .commit-sidebar-header .icon-button {
+    width: 44px;
+    height: 44px;
   }
 
   .mobile-drawer-close {
     display: grid;
-    width: 36px;
-    height: 36px;
+    width: 44px;
+    height: 44px;
     padding: 0;
     background: var(--surface-raised);
     border-radius: var(--radius-small);
@@ -3740,9 +3752,31 @@ html[data-theme="dark"] .tui-syntax .shiki span {
 
   .code-file-search {
     justify-content: center;
-    width: 36px;
-    min-height: 36px;
+    width: 44px;
+    min-height: 44px;
     padding: 0;
+  }
+
+  .commit-view-button {
+    width: 44px;
+    height: 44px;
+    flex-basis: 44px;
+  }
+
+  .commit-query button {
+    width: 44px;
+    height: 44px;
+    padding: 0;
+  }
+
+  .commit-display-menu-item,
+  .commit-setting-row {
+    min-height: 44px;
+  }
+
+  .commit-indicator-options button {
+    min-width: 44px;
+    height: 44px;
   }
 
   .file-search-result {

--- a/web/src/opfsGit.ts
+++ b/web/src/opfsGit.ts
@@ -50,17 +50,48 @@ function createPromises(root: FileSystemDirectoryHandle) {
         throw translateError(error, "ENOENT", `cannot write ${relative}`);
       }
     },
+    async appendFile(path?: string, value?: unknown) {
+      const relative = normalize(path);
+      if (!relative) throw fsError("EISDIR", "cannot append to a directory");
+      try {
+        const { parent, name } = await parentHandle(root, relative, false);
+        const handle = await parent.getFileHandle(name, { create: true });
+        const size = (await handle.getFile()).size;
+        const writable = await handle.createWritable({ keepExistingData: true });
+        try {
+          await writable.seek(size);
+          await writable.write(asWriteValue(value));
+          await writable.close();
+        } catch (error) {
+          await writable.abort(error).catch(() => undefined);
+          throw error;
+        }
+      } catch (error) {
+        throw translateError(error, "ENOENT", `cannot append ${relative}`);
+      }
+    },
     async unlink(path?: string) {
       await remove(root, normalize(path), false);
     },
     async readdir(path?: string) {
       const directory = await directoryHandle(root, normalize(path), false);
       const names: string[] = [];
-      const entries = (directory as FileSystemDirectoryHandle & {
-        entries(): AsyncIterableIterator<[string, FileSystemHandle]>;
-      }).entries();
+      const entries = directoryEntries(directory);
       for await (const [name] of entries) names.push(name);
       return names;
+    },
+    async readdirWithFileTypes(path?: string) {
+      const directory = await directoryHandle(root, normalize(path), false);
+      const entries = [];
+      for await (const [name, handle] of directoryEntries(directory)) {
+        entries.push({
+          name,
+          isFile: handle.kind === "file",
+          isDirectory: handle.kind === "directory",
+          isSymbolicLink: false,
+        });
+      }
+      return entries;
     },
     async mkdir(path?: string) {
       await directoryHandle(root, normalize(path), true);
@@ -88,6 +119,12 @@ function createPromises(root: FileSystemDirectoryHandle) {
       throw fsError("ENOSYS", "OPFS does not support symbolic links");
     },
   };
+}
+
+function directoryEntries(directory: FileSystemDirectoryHandle) {
+  return (directory as FileSystemDirectoryHandle & {
+    entries(): AsyncIterableIterator<[string, FileSystemHandle]>;
+  }).entries();
 }
 
 async function stat(root: FileSystemDirectoryHandle, relative: string) {

--- a/web/src/opfsGit.ts
+++ b/web/src/opfsGit.ts
@@ -19,13 +19,21 @@ export function createOpfsGitFs(root: FileSystemDirectoryHandle): OpfsGitFs {
 
 function createPromises(root: FileSystemDirectoryHandle) {
   return {
-    async readFile(path?: string, options?: { encoding?: string } | string) {
+    async readFile(
+      path?: string,
+      options?: { encoding?: string; maxBytes?: number } | string,
+    ) {
       const relative = normalize(path);
       if (!relative) throw fsError("EISDIR", "cannot read a directory");
       try {
         const { parent, name } = await parentHandle(root, relative, false);
         const file = await (await parent.getFileHandle(name)).getFile();
-        const bytes = new Uint8Array(await file.arrayBuffer());
+        const maxBytes = typeof options === "object" ? options.maxBytes : undefined;
+        const source = maxBytes === undefined ? file : file.slice(0, maxBytes);
+        let bytes = new Uint8Array(await source.arrayBuffer());
+        if (maxBytes !== undefined && bytes.byteLength > maxBytes) {
+          bytes = bytes.subarray(0, maxBytes);
+        }
         const encoding = typeof options === "string" ? options : options?.encoding;
         return encoding ? new TextDecoder(encoding).decode(bytes) : bytes;
       } catch (error) {

--- a/web/src/threadGit.ts
+++ b/web/src/threadGit.ts
@@ -8,7 +8,6 @@ export const THREAD_GIT_DIRECTORY = "/workspace";
 export const THREAD_GIT_AUTHOR = { name: "Nanocodex", email: "agent@nanocodex.dev" };
 const directory = THREAD_GIT_DIRECTORY;
 const author = THREAD_GIT_AUTHOR;
-const localLocks = new Map<string, Promise<unknown>>();
 
 export type ThreadGitStatus = {
   branch: "nanocodex";
@@ -21,13 +20,16 @@ export function browserThread(threadId: string, origin: string): BrowserThread {
   if (!/^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/.test(threadId)) {
     throw new Error("invalid browser thread id");
   }
+  const baseUrl = new URL(origin);
+  const shareUrl = new URL("/", baseUrl);
+  shareUrl.searchParams.set("thread", threadId);
   return {
     id: threadId,
     workspaceName: `nanocodex-thread-${threadId}`,
     repositoryName: `thread-${threadId}`,
     branch: "nanocodex",
-    remoteUrl: `${origin}/git/thread-${threadId}`,
-    shareUrl: origin,
+    remoteUrl: `${baseUrl.origin}/git/thread-${threadId}`,
+    shareUrl: shareUrl.toString(),
   };
 }
 
@@ -62,6 +64,7 @@ export async function threadGitStatus(thread: BrowserThread): Promise<ThreadGitS
 export async function commitAndPushThread(
   thread: BrowserThread,
   message = "Update workspace",
+  notificationSource?: string,
 ): Promise<ThreadGitStatus> {
   return withThreadGitLock(thread, async () => {
     const fs = await openOpfsGitFs(thread.workspaceName);
@@ -87,12 +90,15 @@ export async function commitAndPushThread(
       remoteRef: thread.branch,
     });
     const next = await status(fs, thread);
-    notifyThreadGitChanged(thread);
+    notifyThreadGitChanged(thread, notificationSource);
     return next;
   });
 }
 
-export async function pullThread(thread: BrowserThread): Promise<ThreadGitStatus> {
+export async function pullThread(
+  thread: BrowserThread,
+  notificationSource?: string,
+): Promise<ThreadGitStatus> {
   return withThreadGitLock(thread, async () => {
     const fs = await openOpfsGitFs(thread.workspaceName);
     if (!(await exists(fs, `${directory}/.git/config`))) await initializeOrRestore(fs, thread);
@@ -107,25 +113,31 @@ export async function pullThread(thread: BrowserThread): Promise<ThreadGitStatus
       await restoreRemote(fs, thread);
     }
     const next = await status(fs, thread);
-    notifyThreadGitChanged(thread);
+    notifyThreadGitChanged(thread, notificationSource);
     return next;
   });
 }
 
 export function subscribeThreadGitChanges(
   thread: BrowserThread,
-  listener: () => void,
+  listener: (source?: string) => void,
 ): () => void {
   if (typeof BroadcastChannel === "undefined") return () => undefined;
   const channel = new BroadcastChannel(`nanocodex-git-${thread.id}`);
-  channel.addEventListener("message", listener);
+  channel.addEventListener("message", (event) => {
+    const source = event.data != null && typeof event.data === "object" &&
+        typeof (event.data as { source?: unknown }).source === "string"
+      ? (event.data as { source: string }).source
+      : undefined;
+    listener(source);
+  });
   return () => channel.close();
 }
 
-export function notifyThreadGitChanged(thread: BrowserThread): void {
+export function notifyThreadGitChanged(thread: BrowserThread, source?: string): void {
   if (typeof BroadcastChannel === "undefined") return;
   const channel = new BroadcastChannel(`nanocodex-git-${thread.id}`);
-  channel.postMessage({ type: "changed" });
+  channel.postMessage({ type: "changed", source });
   channel.close();
 }
 
@@ -198,15 +210,8 @@ export async function withThreadGitLock<T>(
   thread: BrowserThread,
   operation: () => Promise<T>,
 ): Promise<T> {
-  if (navigator.locks) {
-    return navigator.locks.request(`nanocodex-git-${thread.id}`, operation);
+  if (!navigator.locks) {
+    throw new Error("This browser must support Web Locks to safely share the OPFS Git repository");
   }
-  const previous = localLocks.get(thread.id) ?? Promise.resolve();
-  const current = previous.catch(() => undefined).then(operation);
-  localLocks.set(thread.id, current);
-  try {
-    return await current;
-  } finally {
-    if (localLocks.get(thread.id) === current) localLocks.delete(thread.id);
-  }
+  return navigator.locks.request(`nanocodex-git-${thread.id}`, operation);
 }

--- a/web/src/threadGit.ts
+++ b/web/src/threadGit.ts
@@ -209,9 +209,13 @@ async function exists(fs: Awaited<ReturnType<typeof openOpfsGitFs>>, path: strin
 export async function withThreadGitLock<T>(
   thread: BrowserThread,
   operation: () => Promise<T>,
+  signal?: AbortSignal,
 ): Promise<T> {
   if (!navigator.locks) {
     throw new Error("This browser must support Web Locks to safely share the OPFS Git repository");
   }
-  return navigator.locks.request(`nanocodex-git-${thread.id}`, operation);
+  const name = `nanocodex-git-${thread.id}`;
+  return signal
+    ? navigator.locks.request(name, { signal }, operation)
+    : navigator.locks.request(name, operation);
 }

--- a/web/src/threadRepositorySnapshot.ts
+++ b/web/src/threadRepositorySnapshot.ts
@@ -5,29 +5,24 @@ import type { OpfsGitFs } from "./opfsGit.ts";
 
 const directory = "/workspace";
 const textDecoder = new TextDecoder("utf-8", { fatal: true });
+export const MAX_COMMIT_HISTORY = 200;
+export const MAX_DIFF_FILE_BYTES = 1024 * 1024;
+export const MAX_COMMIT_PATCH_BYTES = 4 * 1024 * 1024;
+const MAX_CACHED_DIFF_BLOBS = 32;
+const PATCH_TRUNCATION_NOTICE = "# Patch output truncated at 4 MiB.\n";
 
 export type RepositoryFile = {
   path: string;
   mode: string;
   objectId: string;
   size: number | null;
-  contentUrl: string | null;
-};
-
-export type SerializedTreeInput = {
-  paths: string[];
-  preparedPaths: Array<{
-    basename: string;
-    isDirectory: boolean;
-    path: string;
-    segments: string[];
-  }>;
 };
 
 export type ChangedFile = {
   path: string;
   previousPath: string | null;
   status: string;
+  binary: boolean;
   additions: number | null;
   deletions: number | null;
 };
@@ -59,47 +54,70 @@ export type RepositorySnapshot = {
     dirtyCount: number;
   };
   generatedAt: string;
-  commitPatchUrl: string;
+  historyLoaded: boolean;
+  commitPatchUrl: string | null;
   tree: RepositoryFile[];
-  treeInput: SerializedTreeInput;
+  readFile(file: RepositoryFile): Promise<string>;
   commits: HarnessCommit[];
   release(): void;
 };
 
-export async function loadThreadRepositorySnapshot(): Promise<RepositorySnapshot> {
+export async function loadThreadRepositorySnapshot(
+  includeHistory = true,
+): Promise<RepositorySnapshot> {
   const [{ inspectThreadGit }, { getBrowserThread }] = await Promise.all([
     import("./threadGit.ts"),
     import("./workspace.ts"),
   ]);
   const thread = getBrowserThread();
-  return inspectThreadGit(thread, (fs) => buildThreadRepositorySnapshot(
+  const snapshot = await inspectThreadGit(thread, (fs) => buildThreadRepositorySnapshot(
     fs,
     thread.repositoryName,
     thread.branch,
+    { includeHistory },
   ));
+  const head = snapshot.repository.head === "unborn"
+    ? undefined
+    : snapshot.repository.head;
+  return {
+    ...snapshot,
+    readFile: (file) => inspectThreadGit(
+      thread,
+      (fs) => readRepositoryFile(fs, head, file),
+    ),
+  };
 }
 
 export async function buildThreadRepositorySnapshot(
   fs: OpfsGitFs,
   repositoryName: string,
   branch: "nanocodex",
+  { includeHistory = true }: { includeHistory?: boolean } = {},
 ): Promise<RepositorySnapshot> {
   const head = await git.resolveRef({ fs, dir: directory, ref: "HEAD" })
     .catch(() => undefined);
-  const blobCache = new Map<string, Uint8Array>();
   const resourceUrls: string[] = [];
   const tree = head
-    ? await readHeadFiles(fs, head, blobCache, resourceUrls)
-    : await readWorktreeFiles(fs, resourceUrls);
-  const log = head
-    ? await git.log({ fs, dir: directory, ref: head, includeChanges: true })
+    ? await readHeadFiles(fs, head)
+    : await readWorktreeFiles(fs);
+  const log = head && includeHistory
+    ? await git.log({
+        fs,
+        dir: directory,
+        ref: head,
+        depth: MAX_COMMIT_HISTORY,
+        includeChanges: true,
+      })
     : [];
-  const { commits, patch } = await readCommits(fs, log, head, blobCache);
-  const commitPatchUrl = resourceUrl(new Blob([patch], { type: "text/x-diff" }), resourceUrls);
+  const { commits, patch } = includeHistory
+    ? await readCommits(fs, log, head)
+    : { commits: [], patch: "" };
+  const commitPatchUrl = includeHistory
+    ? resourceUrl(new Blob([patch], { type: "text/x-diff" }), resourceUrls)
+    : null;
   const dirtyCount = (await git.statusMatrix({ fs, dir: directory }))
     .filter(([, headStatus, workdirStatus, stageStatus]) =>
       headStatus !== workdirStatus || headStatus !== stageStatus).length;
-  const paths = tree.map(({ path }) => path);
 
   return {
     repository: {
@@ -111,20 +129,10 @@ export async function buildThreadRepositorySnapshot(
       dirtyCount,
     },
     generatedAt: new Date().toISOString(),
+    historyLoaded: includeHistory,
     commitPatchUrl,
     tree,
-    treeInput: {
-      paths,
-      preparedPaths: paths.map((path) => {
-        const segments = path.split("/");
-        return {
-          basename: segments.at(-1) ?? path,
-          isDirectory: false,
-          path,
-          segments,
-        };
-      }),
-    },
+    readFile: (file) => readRepositoryFile(fs, head, file),
     commits,
     release() {
       for (const url of resourceUrls) URL.revokeObjectURL(url);
@@ -133,10 +141,7 @@ export async function buildThreadRepositorySnapshot(
   };
 }
 
-async function readWorktreeFiles(
-  fs: OpfsGitFs,
-  resourceUrls: string[],
-): Promise<RepositoryFile[]> {
+async function readWorktreeFiles(fs: OpfsGitFs): Promise<RepositoryFile[]> {
   const files: RepositoryFile[] = [];
   const visit = async (relativeDirectory: string): Promise<void> => {
     const absoluteDirectory = relativeDirectory
@@ -146,21 +151,16 @@ async function readWorktreeFiles(
     for (const name of names.sort()) {
       if (!relativeDirectory && name === ".git") continue;
       const path = relativeDirectory ? `${relativeDirectory}/${name}` : name;
-      const absolutePath = `${directory}/${path}`;
-      const stat = await fs.promises.stat(absolutePath);
+      const stat = await fs.promises.stat(`${directory}/${path}`);
       if (stat.isDirectory()) {
         await visit(path);
         continue;
       }
-      const contents = await fs.promises.readFile(absolutePath);
-      if (typeof contents === "string") throw new Error(`Unexpected text read for ${path}`);
-      const bytes = contents.slice();
       files.push({
         path,
         mode: "100644",
-        objectId: (await git.hashBlob({ object: bytes })).oid,
-        size: bytes.byteLength,
-        contentUrl: resourceUrl(new Blob([bytes.buffer]), resourceUrls),
+        objectId: `worktree:${path}:${stat.size}:${stat.mtimeMs}`,
+        size: stat.size,
       });
     }
   };
@@ -171,8 +171,6 @@ async function readWorktreeFiles(
 async function readHeadFiles(
   fs: OpfsGitFs,
   head: string,
-  blobCache: Map<string, Uint8Array>,
-  resourceUrls: string[],
 ): Promise<RepositoryFile[]> {
   const files = await git.walk({
     fs,
@@ -181,17 +179,11 @@ async function readHeadFiles(
     map: async (path: string, entries: Array<WalkerEntry | null>) => {
       const entry = entries[0];
       if (path === "." || !entry || await entry.type() !== "blob") return [];
-      const bytes = await entry.content();
-      if (!bytes) return [];
-      const oid = await entry.oid();
-      const contents = bytes.slice();
-      blobCache.set(oid, contents);
       return [{
         path,
         mode: (await entry.mode()).toString(8).padStart(6, "0"),
-        objectId: oid,
-        size: contents.byteLength,
-        contentUrl: resourceUrl(new Blob([contents.buffer]), resourceUrls),
+        objectId: await entry.oid(),
+        size: null,
       } satisfies RepositoryFile];
     },
     reduce: async (parent: RepositoryFile[], children: RepositoryFile[][]) => [
@@ -202,34 +194,85 @@ async function readHeadFiles(
   return files.sort((left, right) => left.path.localeCompare(right.path));
 }
 
+async function readRepositoryFile(
+  fs: OpfsGitFs,
+  head: string | undefined,
+  file: RepositoryFile,
+): Promise<string> {
+  const bytes = head
+    ? (await git.readBlob({ fs, dir: directory, oid: file.objectId })).blob
+    : await fs.promises.readFile(`${directory}/${file.path}`);
+  if (typeof bytes === "string") return bytes;
+  const text = decodeText(bytes);
+  if (text === undefined) throw new Error(`${file.path} is not a text file`);
+  return text;
+}
+
 async function readCommits(
   fs: OpfsGitFs,
   log: ReadCommitResult[],
   head: string | undefined,
-  blobCache: Map<string, Uint8Array>,
 ): Promise<{ commits: HarnessCommit[]; patch: string }> {
   const commits: HarnessCommit[] = [];
   const patches: string[] = [];
+  const blobCache = new Map<string, { binary: boolean; text: string }>();
+  let patchLength = 0;
+  let patchTruncated = false;
   for (const entry of log) {
     const files: ChangedFile[] = [];
     const filePatches: string[] = [];
+    const commitPatchPrefix = `From ${entry.oid} Mon Sep 17 00:00:00 2001\n`;
+    const commitSeparatorLength = patches.length ? 1 : 0;
+    const wasPatchOpen = !patchTruncated &&
+      patchLength + commitSeparatorLength + commitPatchPrefix.length <=
+        MAX_COMMIT_PATCH_BYTES;
+    if (!wasPatchOpen) patchTruncated = true;
+    let commitPatchLength = commitPatchPrefix.length;
     for (const change of entry.commit.changes ?? []) {
       const [newOid, oldOid, path] = change;
       if (typeof path !== "string") continue;
-      const oldBytes = typeof oldOid === "string" ? await readBlob(fs, oldOid, blobCache) : undefined;
-      const newBytes = typeof newOid === "string" ? await readBlob(fs, newOid, blobCache) : undefined;
-      const oldText = decodeText(oldBytes);
-      const newText = decodeText(newBytes);
-      const stats = oldText === undefined || newText === undefined
+      const oldBlob = await readTextBlob(fs, oldOid, blobCache);
+      const newBlob = await readTextBlob(fs, newOid, blobCache);
+      const binary = oldBlob.binary || newBlob.binary;
+      const stats = binary
         ? { additions: null, deletions: null }
-        : lineStats(oldText, newText);
+        : lineStats(oldBlob.text, newBlob.text);
       files.push({
         path,
         previousPath: null,
         status: oldOid == null ? "A" : newOid == null ? "D" : "M",
+        binary,
         ...stats,
       });
-      filePatches.push(filePatch(path, oldOid, newOid, oldText, newText));
+      if (!patchTruncated) {
+        const nextPatch = filePatch(
+          path,
+          oldOid,
+          newOid,
+          oldBlob.text,
+          newBlob.text,
+          binary,
+        );
+        const fileSeparatorLength = filePatches.length ? 1 : 0;
+        if (
+          patchLength + commitSeparatorLength + commitPatchLength +
+            fileSeparatorLength + nextPatch.length <= MAX_COMMIT_PATCH_BYTES
+        ) {
+          filePatches.push(nextPatch);
+          commitPatchLength += fileSeparatorLength + nextPatch.length;
+        } else {
+          const noticeSeparatorLength = filePatches.length ? 1 : 0;
+          if (
+            patchLength + commitSeparatorLength + commitPatchLength +
+              noticeSeparatorLength + PATCH_TRUNCATION_NOTICE.length <=
+                MAX_COMMIT_PATCH_BYTES
+          ) {
+            filePatches.push(PATCH_TRUNCATION_NOTICE);
+            commitPatchLength += noticeSeparatorLength + PATCH_TRUNCATION_NOTICE.length;
+          }
+          patchTruncated = true;
+        }
+      }
     }
     const [subject = "Untitled commit", ...bodyLines] = entry.commit.message.trimEnd().split("\n");
     const additions = files.reduce((sum, file) => sum + (file.additions ?? 0), 0);
@@ -246,25 +289,57 @@ async function readCommits(
       files,
       stats: { files: files.length, additions, deletions },
     });
-    patches.push(`From ${entry.oid} Mon Sep 17 00:00:00 2001\n${filePatches.join("\n")}`);
+    if (wasPatchOpen) {
+      const commitPatch = `${commitPatchPrefix}${filePatches.join("\n")}`;
+      patches.push(commitPatch);
+      patchLength += commitSeparatorLength + commitPatch.length;
+    }
   }
   return { commits, patch: patches.join("\n") };
 }
 
-async function readBlob(
+async function readTextBlob(
   fs: OpfsGitFs,
-  oid: string,
-  cache: Map<string, Uint8Array>,
-): Promise<Uint8Array> {
-  const retained = cache.get(oid);
-  if (retained) return retained;
-  const bytes = (await git.readBlob({ fs, dir: directory, oid })).blob.slice();
-  cache.set(oid, bytes);
-  return bytes;
+  oid: string | null,
+  cache: Map<string, { binary: boolean; text: string }>,
+): Promise<{ binary: boolean; text: string }> {
+  if (oid == null) return { binary: false, text: "" };
+  const cached = cache.get(oid);
+  if (cached) {
+    cache.delete(oid);
+    cache.set(oid, cached);
+    return cached;
+  }
+  const bytes = (await git.readBlob({ fs, dir: directory, oid })).blob;
+  if (bytes.byteLength > MAX_DIFF_FILE_BYTES || bytes.includes(0)) {
+    const blob = { binary: true, text: "" };
+    cacheDiffBlob(cache, oid, blob);
+    return blob;
+  }
+  try {
+    const blob = { binary: false, text: textDecoder.decode(bytes) };
+    cacheDiffBlob(cache, oid, blob);
+    return blob;
+  } catch {
+    const blob = { binary: true, text: "" };
+    cacheDiffBlob(cache, oid, blob);
+    return blob;
+  }
 }
 
-function decodeText(bytes: Uint8Array | undefined): string | undefined {
-  if (!bytes) return "";
+function cacheDiffBlob(
+  cache: Map<string, { binary: boolean; text: string }>,
+  oid: string,
+  blob: { binary: boolean; text: string },
+): void {
+  if (cache.size >= MAX_CACHED_DIFF_BLOBS) {
+    const oldest = cache.keys().next().value;
+    if (oldest) cache.delete(oldest);
+  }
+  cache.set(oid, blob);
+}
+
+function decodeText(bytes: Uint8Array): string | undefined {
   if (bytes.includes(0)) return undefined;
   try {
     return textDecoder.decode(bytes);
@@ -287,8 +362,9 @@ function filePatch(
   path: string,
   oldOid: string | null,
   newOid: string | null,
-  oldText: string | undefined,
-  newText: string | undefined,
+  oldText: string,
+  newText: string,
+  binary: boolean,
 ): string {
   const oldPath = oldOid == null ? "/dev/null" : `a/${path}`;
   const newPath = newOid == null ? "/dev/null" : `b/${path}`;
@@ -297,9 +373,7 @@ function filePatch(
     oldOid == null ? "new file mode 100644" : newOid == null ? "deleted file mode 100644" : "",
     oldOid && newOid ? `index ${oldOid.slice(0, 7)}..${newOid.slice(0, 7)} 100644` : "",
   ].filter(Boolean).join("\n");
-  if (oldText === undefined || newText === undefined) {
-    return `${header}\nBinary files ${oldPath} and ${newPath} differ\n`;
-  }
+  if (binary) return `${header}\nBinary files ${oldPath} and ${newPath} differ\n`;
   const unified = createTwoFilesPatch(oldPath, newPath, oldText, newText, "", "", { context: 3 });
   return `${header}\n${unified.replace(/^={3,}\n/, "")}`;
 }

--- a/web/src/workspaceListing.ts
+++ b/web/src/workspaceListing.ts
@@ -1,0 +1,30 @@
+import type { Workspace, WorkspaceEntry } from "nanocodex/browser/workspace";
+
+const MAX_VISIBLE_WORKSPACE_ENTRIES = 2_000;
+
+export async function listVisibleWorkspaceEntries(
+  workspace: Workspace,
+): Promise<readonly WorkspaceEntry[]> {
+  const hidden = new Set([
+    `${workspace.root}/.git`,
+    `${workspace.root}/.nanocodex`,
+  ]);
+  const rootEntries = (await workspace.list(".", {
+    maxEntries: MAX_VISIBLE_WORKSPACE_ENTRIES,
+  })).filter(({ path }) => !hidden.has(path));
+  const entries = [...rootEntries];
+  for (const entry of rootEntries) {
+    if (entry.kind !== "directory") continue;
+    const remaining = MAX_VISIBLE_WORKSPACE_ENTRIES - entries.length;
+    if (remaining <= 0) {
+      throw new RangeError(
+        `visible workspace listing exceeds ${MAX_VISIBLE_WORKSPACE_ENTRIES} entries`,
+      );
+    }
+    entries.push(...await workspace.list(entry.path, {
+      recursive: true,
+      maxEntries: remaining,
+    }));
+  }
+  return entries.sort((left, right) => left.path.localeCompare(right.path));
+}

--- a/web/test/browserMcp.test.ts
+++ b/web/test/browserMcp.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { browserMcpConfiguration } from "../src/browserMcp.ts";
+
+test("browser agents receive the CLI default MCP catalog through same-origin routes", () => {
+  const configuration = browserMcpConfiguration("https://demo.test/thread/1");
+  assert.deepEqual(Object.keys(configuration), [
+    "openaiDeveloperDocs",
+    "tempo",
+    "cloudflare",
+    "viem",
+    "vocs",
+  ]);
+  assert.equal(configuration.openaiDeveloperDocs.url, "https://demo.test/api/mcp/openai-developer-docs");
+  assert.deepEqual(configuration.openaiDeveloperDocs.headers, { "x-nanocodex-request": "1" });
+  assert.deepEqual(configuration.openaiDeveloperDocs.enabledTools, [
+    "fetch_openai_doc",
+    "search_openai_docs",
+  ]);
+  assert.equal(configuration.tempo.startupTimeoutMs, 30_000);
+  assert.equal(configuration.tempo.timeoutMs, 300_000);
+});

--- a/web/test/browserShell.test.ts
+++ b/web/test/browserShell.test.ts
@@ -2,13 +2,27 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import git from "isomorphic-git";
 
-import { createBrowserBash } from "../src/browserShell.ts";
+import { createBrowserBash, loadBrowserProjectInstructions } from "../src/browserShell.ts";
 import { createOpfsGitFs, type OpfsGitFs } from "../src/opfsGit.ts";
+
+const observedLockSignals: Array<AbortSignal | undefined> = [];
 
 Object.defineProperty(globalThis.navigator, "locks", {
   configurable: true,
   value: {
-    request: async <T>(_name: string, operation: () => Promise<T>) => operation(),
+    request: async <T>(
+      _name: string,
+      optionsOrOperation: LockOptions | (() => Promise<T>),
+      requestedOperation?: () => Promise<T>,
+    ) => {
+      const options = typeof optionsOrOperation === "function" ? undefined : optionsOrOperation;
+      const operation = typeof optionsOrOperation === "function"
+        ? optionsOrOperation
+        : requestedOperation!;
+      observedLockSignals.push(options?.signal);
+      if (options?.signal?.aborted) throw options.signal.reason;
+      return operation();
+    },
   },
 });
 
@@ -20,6 +34,74 @@ const thread = {
   remoteUrl: "https://example.test/git/thread-browser-shell-test",
   shareUrl: "https://example.test/?thread=browser-shell-test",
 };
+
+test("browser project instructions prefer override files and enforce the native byte budget", async () => {
+  const root = new MemoryDirectory();
+  const fs = createOpfsGitFs(root as unknown as FileSystemDirectoryHandle);
+  await fs.promises.mkdir("/workspace");
+  await fs.promises.writeFile("/workspace/AGENTS.md", "default\n");
+  const prefix = "override:";
+  const source = `${prefix}${"x".repeat(32 * 1024 - prefix.length - 1)}€ignored`;
+  await fs.promises.writeFile(
+    "/workspace/AGENTS.override.md",
+    source,
+  );
+
+  const warnings = await captureWarnings(() => loadBrowserProjectInstructions(fs));
+  const expected = new TextDecoder().decode(
+    new TextEncoder().encode(source).subarray(0, 32 * 1024),
+  );
+  assert.equal(warnings.value, expected);
+  assert.match(warnings.value, /^override:/);
+  assert.match(warnings.value, /�$/);
+  assert.equal(warnings.messages.length, 1);
+  assert.match(String(warnings.messages[0]?.[0]), /exceeds remaining budget/);
+
+  const override = root.entriesByName.get("AGENTS.override.md");
+  assert(override instanceof MemoryFile);
+  assert.deepEqual(override.sliceRequests, [[0, 32 * 1024]]);
+  assert.deepEqual(override.materializedByteLengths, [32 * 1024]);
+});
+
+test("browser project instruction selection matches native blank and non-file behavior", async () => {
+  const blankRoot = new MemoryDirectory();
+  const blankFs = createOpfsGitFs(blankRoot as unknown as FileSystemDirectoryHandle);
+  await blankFs.promises.writeFile("/workspace/AGENTS.md", " default with spaces \n");
+  await blankFs.promises.writeFile("/workspace/AGENTS.override.md", " \n\t");
+  assert.equal(await loadBrowserProjectInstructions(blankFs), undefined);
+
+  const directoryRoot = new MemoryDirectory();
+  const directoryFs = createOpfsGitFs(directoryRoot as unknown as FileSystemDirectoryHandle);
+  await directoryFs.promises.writeFile("/workspace/AGENTS.md", " default with spaces \n");
+  await directoryFs.promises.mkdir("/workspace/AGENTS.override.md");
+  assert.equal(
+    await loadBrowserProjectInstructions(directoryFs),
+    " default with spaces \n",
+  );
+});
+
+test("browser project instruction read failures warn without falling through or aborting", async () => {
+  const root = new MemoryDirectory();
+  const base = createOpfsGitFs(root as unknown as FileSystemDirectoryHandle);
+  await base.promises.writeFile("/workspace/AGENTS.md", "default\n");
+  await base.promises.writeFile("/workspace/AGENTS.override.md", "override\n");
+  const fs: OpfsGitFs = {
+    promises: {
+      ...base.promises,
+      async readFile(path, options) {
+        if (path === "/workspace/AGENTS.override.md") {
+          throw Object.assign(new Error("instruction disappeared"), { code: "ENOENT" });
+        }
+        return base.promises.readFile(path, options);
+      },
+    },
+  };
+
+  const warnings = await captureWarnings(() => loadBrowserProjectInstructions(fs));
+  assert.equal(warnings.value, undefined);
+  assert.equal(warnings.messages.length, 1);
+  assert.match(String(warnings.messages[0]?.[0]), /failed to read project AGENTS\.md/);
+});
 
 test("browser shell indexes the worktree once and notifies only for mutations", async () => {
   const root = new MemoryDirectory();
@@ -99,6 +181,34 @@ test("browser shell appends through OPFS and reports one mutation", async () => 
   assert(shell.filesystem.getAllPaths().includes("/workspace/output.log"));
 });
 
+test("browser exec forwards ToolContext cancellation through Web Locks and bash", async () => {
+  const root = new MemoryDirectory();
+  const fs = createOpfsGitFs(root as unknown as FileSystemDirectoryHandle);
+  await git.init({ fs, dir: "/workspace", defaultBranch: "nanocodex" });
+  const shell = await createBrowserBash(fs, thread);
+  const controller = new AbortController();
+  const originalExec = shell.bash.exec.bind(shell.bash);
+  let bashSignal: AbortSignal | undefined;
+  shell.bash.exec = (script, options) => {
+    bashSignal = options?.signal;
+    return originalExec(script, options);
+  };
+
+  const result = await shell.exec({ cmd: "true" }, { signal: controller.signal });
+  assert.equal(result.exit_code, 0);
+  assert.equal(observedLockSignals.at(-1), controller.signal);
+  assert.equal(bashSignal, controller.signal);
+
+  const cancelled = new AbortController();
+  cancelled.abort(new Error("cancelled before lock acquisition"));
+  await assert.rejects(
+    shell.exec({ cmd: "touch cancelled.txt" }, { signal: cancelled.signal }),
+    /cancelled before lock acquisition/,
+  );
+  assert.equal(observedLockSignals.at(-1), cancelled.signal);
+  await assert.rejects(fs.promises.stat("/workspace/cancelled.txt"), /cannot stat/);
+});
+
 test("browser git bounds log depth and avoids text diffs for oversized files", async () => {
   const root = new MemoryDirectory();
   const fs = createOpfsGitFs(root as unknown as FileSystemDirectoryHandle);
@@ -152,7 +262,10 @@ function instrument(base: OpfsGitFs) {
   const fs: OpfsGitFs = {
     promises: {
       ...base.promises,
-      async readFile(path?: string, options?: { encoding?: string } | string) {
+      async readFile(
+        path?: string,
+        options?: { encoding?: string; maxBytes?: number } | string,
+      ) {
         counters.readFile += 1;
         return base.promises.readFile(path, options);
       },
@@ -224,13 +337,26 @@ class MemoryFile {
   readonly kind = "file";
   bytes = new Uint8Array();
   modifiedAt = Date.now();
+  readonly sliceRequests: Array<[number, number | undefined]> = [];
+  readonly materializedByteLengths: number[] = [];
 
   async getFile() {
     const bytes = this.bytes.slice();
+    return this.fileView(bytes);
+  }
+
+  private fileView(bytes: Uint8Array) {
     return {
       size: bytes.byteLength,
       lastModified: this.modifiedAt,
-      arrayBuffer: async () => bytes.buffer,
+      arrayBuffer: async () => {
+        this.materializedByteLengths.push(bytes.byteLength);
+        return bytes.buffer;
+      },
+      slice: (start = 0, end?: number) => {
+        this.sliceRequests.push([start, end]);
+        return this.fileView(bytes.slice(start, end));
+      },
     };
   }
 
@@ -262,5 +388,16 @@ class MemoryFile {
       },
       abort: async () => undefined,
     };
+  }
+}
+
+async function captureWarnings<T>(operation: () => Promise<T>) {
+  const messages: unknown[][] = [];
+  const original = console.warn;
+  console.warn = (...args: unknown[]) => messages.push(args);
+  try {
+    return { messages, value: await operation() };
+  } finally {
+    console.warn = original;
   }
 }

--- a/web/test/browserShell.test.ts
+++ b/web/test/browserShell.test.ts
@@ -1,0 +1,266 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import git from "isomorphic-git";
+
+import { createBrowserBash } from "../src/browserShell.ts";
+import { createOpfsGitFs, type OpfsGitFs } from "../src/opfsGit.ts";
+
+Object.defineProperty(globalThis.navigator, "locks", {
+  configurable: true,
+  value: {
+    request: async <T>(_name: string, operation: () => Promise<T>) => operation(),
+  },
+});
+
+const thread = {
+  id: "12345678-1234-4123-8123-123456789abc",
+  workspaceName: "nanocodex-thread-browser-shell-test",
+  repositoryName: "thread-browser-shell-test",
+  branch: "nanocodex" as const,
+  remoteUrl: "https://example.test/git/thread-browser-shell-test",
+  shareUrl: "https://example.test/?thread=browser-shell-test",
+};
+
+test("browser shell indexes the worktree once and notifies only for mutations", async () => {
+  const root = new MemoryDirectory();
+  const baseFs = createOpfsGitFs(root as unknown as FileSystemDirectoryHandle);
+  await git.init({ fs: baseFs, dir: "/workspace", defaultBranch: "nanocodex" });
+  await baseFs.promises.mkdir("/workspace/.git/index-probe");
+  await baseFs.promises.writeFile("/workspace/.git/index-probe/object", "internal\n");
+  await baseFs.promises.mkdir("/workspace/src");
+  await baseFs.promises.writeFile("/workspace/src/index.ts", "export {};\n");
+  await baseFs.promises.writeFile("/workspace/README.md", "# workspace\n");
+
+  const { counters, fs } = instrument(baseFs);
+  let notifications = 0;
+  const shell = await createBrowserBash(fs, thread, {
+    onChanged: () => notifications += 1,
+  });
+  assert.equal(
+    shell.filesystem.getAllPaths().some((path) => path === "/workspace/.git" || path.startsWith("/workspace/.git/")),
+    false,
+  );
+  assert(shell.filesystem.getAllPaths().includes("/workspace/src/index.ts"));
+  assert.equal(counters.stat, 0);
+  assert.equal(counters.readdirWithFileTypes, 2);
+  const indexedReaddir = counters.readdir;
+
+  const read = await shell.exec({ cmd: "cat README.md" });
+  assert.equal(read.exit_code, 0);
+  assert.equal(read.output, "# workspace\n");
+  assert.equal(counters.readdir, indexedReaddir);
+  assert.equal(notifications, 0);
+
+  const write = await shell.exec({ cmd: "mkdir generated && printf 'hello\\n' > generated/result.txt" });
+  assert.equal(write.exit_code, 0);
+  assert.equal(notifications, 1);
+  assert.equal(counters.readdir, indexedReaddir);
+  assert(shell.filesystem.getAllPaths().includes("/workspace/generated/result.txt"));
+
+  const secondRead = await shell.exec({ cmd: "cat generated/result.txt" });
+  assert.equal(secondRead.output, "hello\n");
+  assert.equal(notifications, 1);
+  assert.equal(counters.readdir, indexedReaddir);
+
+  const remove = await shell.exec({ cmd: "rm -r generated" });
+  assert.equal(remove.exit_code, 0);
+  assert.equal(notifications, 2);
+  assert.equal(
+    shell.filesystem.getAllPaths().some((path) => path.startsWith("/workspace/generated")),
+    false,
+  );
+});
+
+test("browser shell appends through OPFS and reports one mutation", async () => {
+  const root = new MemoryDirectory();
+  const baseFs = createOpfsGitFs(root as unknown as FileSystemDirectoryHandle);
+  await git.init({ fs: baseFs, dir: "/workspace", defaultBranch: "nanocodex" });
+  await baseFs.promises.writeFile("/workspace/output.log", "existing\n");
+
+  const { counters, fs } = instrument(baseFs);
+  let notifications = 0;
+  const shell = await createBrowserBash(fs, thread, {
+    onChanged: () => notifications += 1,
+  });
+  counters.appended.length = 0;
+  counters.readFile = 0;
+  counters.writeFile = 0;
+
+  const append = await shell.exec({ cmd: "printf 'suffix\\n' >> output.log" });
+  assert.equal(append.exit_code, 0);
+  assert.equal(
+    new TextDecoder().decode(await baseFs.promises.readFile("/workspace/output.log") as Uint8Array),
+    "existing\nsuffix\n",
+  );
+  assert.equal(notifications, 1);
+  assert.equal(counters.readFile, 0);
+  assert.equal(counters.writeFile, 0);
+  assert.deepEqual(counters.appended.map((bytes) => new TextDecoder().decode(bytes)), ["", "suffix\n"]);
+  assert(shell.filesystem.getAllPaths().includes("/workspace/output.log"));
+});
+
+test("browser git bounds log depth and avoids text diffs for oversized files", async () => {
+  const root = new MemoryDirectory();
+  const fs = createOpfsGitFs(root as unknown as FileSystemDirectoryHandle);
+  await git.init({ fs, dir: "/workspace", defaultBranch: "nanocodex" });
+  await fs.promises.writeFile("/workspace/README.md", "before\n");
+  await git.add({ fs, dir: "/workspace", filepath: "README.md" });
+  await git.commit({
+    fs,
+    dir: "/workspace",
+    message: "Initial commit",
+    author: { name: "Nanocodex", email: "agent@nanocodex.dev" },
+  });
+  await fs.promises.writeFile("/workspace/README.md", "after\n");
+  await fs.promises.writeFile("/workspace/large.txt", new Uint8Array(1024 * 1024 + 1).fill(97));
+  await fs.promises.writeFile("/workspace/binary.dat", new Uint8Array([0, 1, 2, 3]));
+
+  let notifications = 0;
+  const shell = await createBrowserBash(fs, thread, {
+    onChanged: () => notifications += 1,
+  });
+  const diff = await shell.exec({ cmd: "git diff" });
+  assert.equal(diff.exit_code, 0);
+  assert.match(diff.output, /\+after/);
+  assert.match(diff.output, /Binary files \/dev\/null and b\/large\.txt differ/);
+  assert.match(diff.output, /Binary files \/dev\/null and b\/binary\.dat differ/);
+  assert(diff.output.length <= 4 * 1024 * 1024);
+  assert.equal(notifications, 0);
+
+  const add = await shell.exec({ cmd: "git add README.md" });
+  assert.equal(add.exit_code, 0);
+  assert.equal(notifications, 1);
+  const commit = await shell.exec({ cmd: "git commit -m 'Update readme'" });
+  assert.equal(commit.exit_code, 0);
+  assert.equal(notifications, 2);
+
+  const log = await shell.exec({ cmd: "git log -201" });
+  assert.equal(log.exit_code, 1);
+  assert.match(log.output, /log depth cannot exceed 200/);
+  assert.equal(notifications, 2);
+});
+
+function instrument(base: OpfsGitFs) {
+  const counters = {
+    readdir: 0,
+    readdirWithFileTypes: 0,
+    stat: 0,
+    readFile: 0,
+    writeFile: 0,
+    appended: [] as Uint8Array[],
+  };
+  const fs: OpfsGitFs = {
+    promises: {
+      ...base.promises,
+      async readFile(path?: string, options?: { encoding?: string } | string) {
+        counters.readFile += 1;
+        return base.promises.readFile(path, options);
+      },
+      async writeFile(path?: string, value?: unknown) {
+        counters.writeFile += 1;
+        return base.promises.writeFile(path, value);
+      },
+      async appendFile(path?: string, value?: unknown) {
+        const bytes = value instanceof Uint8Array ? value.slice() : new TextEncoder().encode(String(value ?? ""));
+        counters.appended.push(bytes);
+        return base.promises.appendFile(path, value);
+      },
+      async readdir(path?: string) {
+        counters.readdir += 1;
+        return base.promises.readdir(path);
+      },
+      async readdirWithFileTypes(path?: string) {
+        counters.readdirWithFileTypes += 1;
+        return base.promises.readdirWithFileTypes(path);
+      },
+      async stat(path?: string) {
+        counters.stat += 1;
+        return base.promises.stat(path);
+      },
+    },
+  };
+  return { counters, fs };
+}
+
+class MemoryDirectory {
+  readonly kind = "directory";
+  readonly entriesByName = new Map<string, MemoryDirectory | MemoryFile>();
+
+  async getDirectoryHandle(name: string, options?: { create?: boolean }) {
+    const current = this.entriesByName.get(name);
+    if (current instanceof MemoryDirectory) return current;
+    if (current) throw new DOMException("not a directory", "TypeMismatchError");
+    if (!options?.create) throw new DOMException("not found", "NotFoundError");
+    const directory = new MemoryDirectory();
+    this.entriesByName.set(name, directory);
+    return directory;
+  }
+
+  async getFileHandle(name: string, options?: { create?: boolean }) {
+    const current = this.entriesByName.get(name);
+    if (current instanceof MemoryFile) return current;
+    if (current) throw new DOMException("not a file", "TypeMismatchError");
+    if (!options?.create) throw new DOMException("not found", "NotFoundError");
+    const file = new MemoryFile();
+    this.entriesByName.set(name, file);
+    return file;
+  }
+
+  async removeEntry(name: string, options?: { recursive?: boolean }) {
+    const current = this.entriesByName.get(name);
+    if (!current) throw new DOMException("not found", "NotFoundError");
+    if (current instanceof MemoryDirectory && current.entriesByName.size && !options?.recursive) {
+      throw new DOMException("not empty", "InvalidModificationError");
+    }
+    this.entriesByName.delete(name);
+  }
+
+  async *entries(): AsyncIterableIterator<[string, MemoryDirectory | MemoryFile]> {
+    yield* this.entriesByName.entries();
+  }
+}
+
+class MemoryFile {
+  readonly kind = "file";
+  bytes = new Uint8Array();
+  modifiedAt = Date.now();
+
+  async getFile() {
+    const bytes = this.bytes.slice();
+    return {
+      size: bytes.byteLength,
+      lastModified: this.modifiedAt,
+      arrayBuffer: async () => bytes.buffer,
+    };
+  }
+
+  async createWritable(options?: FileSystemCreateWritableOptions) {
+    let bytes = options?.keepExistingData ? this.bytes.slice() : new Uint8Array();
+    let position = 0;
+    return {
+      write: async (value: FileSystemWriteChunkType) => {
+        const buffer = typeof value === "string"
+          ? new TextEncoder().encode(value)
+          : value instanceof Blob
+            ? new Uint8Array(await value.arrayBuffer())
+            : value instanceof ArrayBuffer
+              ? new Uint8Array(value)
+              : new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+        const length = Math.max(bytes.byteLength, position + buffer.byteLength);
+        const next = new Uint8Array(length);
+        next.set(bytes);
+        next.set(buffer, position);
+        bytes = next;
+        position += buffer.byteLength;
+      },
+      seek: async (nextPosition: number) => {
+        position = nextPosition;
+      },
+      close: async () => {
+        this.bytes = bytes;
+        this.modifiedAt = Date.now();
+      },
+      abort: async () => undefined,
+    };
+  }
+}

--- a/web/test/browserTools.test.ts
+++ b/web/test/browserTools.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { createBrowserTools } from "../src/browserTools.ts";
+
+test("view_image returns browser workspace images to Code Mode", async () => {
+  const tools = createBrowserTools({
+    recentImages: () => [],
+    rememberImage: () => undefined,
+    workspace: {
+      async readFile(path) {
+        assert.equal(path, "/workspace/pixel.png");
+        return new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      },
+    },
+  });
+  const result = await tools.view_image.handler(
+    { path: "/workspace/pixel.png", detail: "original" },
+    { sessionId: "session-1" },
+  ) as { detail: string; image_url: string };
+  assert.equal(result.detail, "original");
+  assert.equal(result.image_url, "data:image/png;base64,iVBORw0KGgo=");
+});

--- a/web/test/mobileLayout.test.ts
+++ b/web/test/mobileLayout.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const indexCss = source("../src/index.css");
+const terminalCss = source("../src/AgentTerminal.css");
+const artifactDock = source("../src/ArtifactDock.tsx");
+const tuiCss = source("../../js/tui-react/structure.css");
+const compactQuery = "(max-width: 740px), (pointer: coarse) and (orientation: landscape) and (max-width: 950px)";
+
+test("compact workspace policy includes portrait and coarse landscape phones", () => {
+  assert.ok(artifactDock.includes(`COMPACT_WORKSPACE_MEDIA_QUERY = ${JSON.stringify(compactQuery)}`));
+  assert.ok(indexCss.includes(`@media ${compactQuery} {`));
+  assert.ok(terminalCss.includes(`@media ${compactQuery} {`));
+  assert.ok(tuiCss.includes(`@media ${compactQuery} {`));
+  assert.match(artifactDock, /const \[fullscreen, setFullscreen\] = useState\(\(\) => !compactWorkspace\(\)\)/);
+  assert.match(artifactDock, /if \(compact\.matches\) setFullscreen\(false\)/);
+  assert.match(artifactDock, /setFullscreen\(!compactWorkspace\(\)\)/);
+});
+
+test("portrait commits collapse to an in-viewport viewer column", () => {
+  const mobile = lastRuleBlock(indexCss, ".commits-workspace {");
+  assert.match(mobile, /grid-template-columns:\s*minmax\(0,\s*1fr\)/);
+  assert.match(mobile, /grid-template-areas:\s*"header"\s*"viewer"/);
+});
+
+test("compact workspace removes the phantom header offset and fixed height floor", () => {
+  const nav = ruleBlock(terminalCss, ".agent-mobile-nav", terminalCss.indexOf(`@media ${compactQuery}`));
+  const shell = ruleBlock(terminalCss, ".agent-workspace-shell,", terminalCss.indexOf(`@media ${compactQuery}`));
+  assert.match(nav, /top:\s*0/);
+  assert.match(nav, /min-height:\s*44px/);
+  assert.match(shell, /height:\s*calc\(100dvh - 50px - env\(safe-area-inset-bottom\)\)/);
+  assert.doesNotMatch(shell, /max\(480px/);
+});
+
+test("phone text controls and prioritized touch targets meet mobile baselines", () => {
+  for (const declaration of [
+    ".workspace-editor textarea { font-size: 16px; }",
+    ".workspace-tree-item { min-height: 44px; height: auto; }",
+    ".artifact-dock-header button { width: 44px; height: 44px; }",
+    ".artifact-preview-button { min-height: 44px; }",
+  ]) assert.ok(terminalCss.includes(declaration), declaration);
+
+  for (const declaration of [
+    "min-width: 44px;\n    height: 44px;",
+    ".agent-tui-composer {\n    min-height: 52px !important;",
+    ".agent-tui-editor textarea {\n    font-size: 16px;",
+  ]) assert.ok(tuiCss.includes(declaration), declaration);
+
+  for (const selector of [
+    ".pierre-tree-heading button",
+    ".mobile-tree-toggle",
+    ".mobile-drawer-close",
+    ".code-file-search",
+    ".commit-view-button",
+    ".commit-query button",
+    ".commit-indicator-options button",
+  ]) {
+    const block = lastRuleBlock(indexCss, `${selector} {`);
+    assert.match(block, /(?:width|min-width|min-height|height):\s*44px/, selector);
+  }
+  assert.ok(indexCss.includes(".commit-display-menu-item,\n  .commit-setting-row {\n    min-height: 44px;"));
+});
+
+function source(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+function lastRuleBlock(css: string, selector: string): string {
+  const start = css.lastIndexOf(selector);
+  assert.notEqual(start, -1, `missing ${selector}`);
+  return ruleBlock(css, selector, start);
+}
+
+function ruleBlock(css: string, selector: string, from: number): string {
+  const start = css.indexOf(selector, from);
+  assert.notEqual(start, -1, `missing ${selector}`);
+  const open = css.indexOf("{", start);
+  const close = css.indexOf("}", open);
+  return css.slice(start, close + 1);
+}

--- a/web/test/opfsGit.test.ts
+++ b/web/test/opfsGit.test.ts
@@ -5,7 +5,11 @@ import git from "isomorphic-git";
 
 import { createBrowserBash } from "../src/browserShell.ts";
 import { createOpfsGitFs } from "../src/opfsGit.ts";
-import { buildThreadRepositorySnapshot } from "../src/threadRepositorySnapshot.ts";
+import {
+  MAX_COMMIT_HISTORY,
+  MAX_COMMIT_PATCH_BYTES,
+  buildThreadRepositorySnapshot,
+} from "../src/threadRepositorySnapshot.ts";
 
 test("an unborn thread exposes its OPFS working tree without inventing a commit", async () => {
   const root = new MemoryDirectory();
@@ -67,10 +71,8 @@ test("the OPFS adapter supports a real isomorphic-git repository", async () => {
     { path: "App.tsx", status: "A" },
     { path: "README.md", status: "M" },
   ]);
-  assert.equal(
-    await fetch(snapshot.tree[0]!.contentUrl!).then((response) => response.text()),
-    "export default function App() { return <main>Hello</main> }\n",
-  );
+  assert.equal(await snapshot.readFile(snapshot.tree[0]!),
+    "export default function App() { return <main>Hello</main> }\n");
   const patch = await fetch(snapshot.commitPatchUrl).then((response) => response.text());
   assert.match(patch, new RegExp(`^From ${head}`));
   assert.match(patch, /diff --git a\/App\.tsx b\/App\.tsx/);
@@ -78,6 +80,110 @@ test("the OPFS adapter supports a real isomorphic-git repository", async () => {
   const parsed = parsePatchFiles(patch, "thread-test");
   assert.equal(parsed.length, 2);
   assert.deepEqual(parsed[0]?.files.map(({ name }) => name), ["App.tsx", "README.md"]);
+  snapshot.release();
+});
+
+test("a lightweight repository snapshot defers HEAD blobs and commit history", async () => {
+  const root = new MemoryDirectory();
+  const fs = createOpfsGitFs(root as unknown as FileSystemDirectoryHandle);
+  await git.init({ fs, dir: "/workspace", defaultBranch: "nanocodex" });
+  await fs.promises.writeFile("/workspace/lazy.txt", "loaded on demand\n");
+  await git.add({ fs, dir: "/workspace", filepath: "lazy.txt" });
+  await git.commit({
+    fs,
+    dir: "/workspace",
+    message: "Create lazy file",
+    author: { name: "Nanocodex", email: "agent@nanocodex.dev" },
+  });
+
+  const snapshot = await buildThreadRepositorySnapshot(
+    fs,
+    "thread-test",
+    "nanocodex",
+    { includeHistory: false },
+  );
+  assert.equal(snapshot.historyLoaded, false);
+  assert.equal(snapshot.commitPatchUrl, null);
+  assert.deepEqual(snapshot.commits, []);
+  assert.equal(snapshot.tree[0]?.size, null);
+  assert.equal(await snapshot.readFile(snapshot.tree[0]!), "loaded on demand\n");
+  snapshot.release();
+});
+
+test("commit snapshots cap history and classify unsafe diff blobs as binary", async () => {
+  const root = new MemoryDirectory();
+  const fs = createOpfsGitFs(root as unknown as FileSystemDirectoryHandle);
+  await git.init({ fs, dir: "/workspace", defaultBranch: "nanocodex" });
+  await fs.promises.writeFile("/workspace/large.txt", new Uint8Array(1024 * 1024 + 1).fill(97));
+  await fs.promises.writeFile("/workspace/nul.txt", new Uint8Array([97, 0, 98]));
+  await fs.promises.writeFile("/workspace/invalid.txt", new Uint8Array([0xc3, 0x28]));
+  for (const path of ["large.txt", "nul.txt", "invalid.txt"]) {
+    await git.add({ fs, dir: "/workspace", filepath: path });
+  }
+  await git.commit({
+    fs,
+    dir: "/workspace",
+    message: "Add binary fixtures",
+    author: { name: "Nanocodex", email: "agent@nanocodex.dev" },
+  });
+  const binarySnapshot = await buildThreadRepositorySnapshot(fs, "thread-test", "nanocodex");
+  assert.deepEqual(
+    binarySnapshot.commits[0]?.files.map(({ binary, additions, deletions }) => ({
+      binary,
+      additions,
+      deletions,
+    })),
+    [
+      { binary: true, additions: null, deletions: null },
+      { binary: true, additions: null, deletions: null },
+      { binary: true, additions: null, deletions: null },
+    ],
+  );
+  const binaryPatch = await fetch(binarySnapshot.commitPatchUrl!)
+    .then((response) => response.text());
+  assert.equal(binaryPatch.match(/Binary files/g)?.length, 3);
+  assert.ok(binaryPatch.length < 2_000);
+  binarySnapshot.release();
+
+  for (let index = 1; index <= MAX_COMMIT_HISTORY; index += 1) {
+    await fs.promises.writeFile("/workspace/counter.txt", `${index}\n`);
+    await git.add({ fs, dir: "/workspace", filepath: "counter.txt" });
+    await git.commit({
+      fs,
+      dir: "/workspace",
+      message: `Update ${index}`,
+      author: { name: "Nanocodex", email: "agent@nanocodex.dev" },
+    });
+  }
+
+  const snapshot = await buildThreadRepositorySnapshot(fs, "thread-test", "nanocodex");
+  assert.equal(snapshot.commits.length, MAX_COMMIT_HISTORY);
+  assert.equal(snapshot.commits.at(-1)?.subject, "Update 1");
+  const patch = await fetch(snapshot.commitPatchUrl!).then((response) => response.text());
+  assert.ok(patch.length <= MAX_COMMIT_PATCH_BYTES);
+  snapshot.release();
+});
+
+test("commit patch memory is capped at four MiB", async () => {
+  const root = new MemoryDirectory();
+  const fs = createOpfsGitFs(root as unknown as FileSystemDirectoryHandle);
+  await git.init({ fs, dir: "/workspace", defaultBranch: "nanocodex" });
+  const contents = "a\n".repeat((1024 * 1024 - 2) / 2);
+  for (const path of ["one.txt", "two.txt", "three.txt", "four.txt"]) {
+    await fs.promises.writeFile(`/workspace/${path}`, contents);
+    await git.add({ fs, dir: "/workspace", filepath: path });
+  }
+  await git.commit({
+    fs,
+    dir: "/workspace",
+    message: "Add large text files",
+    author: { name: "Nanocodex", email: "agent@nanocodex.dev" },
+  });
+
+  const snapshot = await buildThreadRepositorySnapshot(fs, "thread-test", "nanocodex");
+  const patch = await fetch(snapshot.commitPatchUrl!).then((response) => response.text());
+  assert.ok(patch.length <= MAX_COMMIT_PATCH_BYTES);
+  assert.match(patch, /Patch output truncated at 4 MiB/);
   snapshot.release();
 });
 
@@ -117,6 +223,27 @@ test("just-bash and browser git share the same OPFS working tree", async () => {
   ));
   assert.equal(artifact.title, "Hello UI");
   assert.match(artifact.source, /function App/);
+});
+
+test("OPFS append preserves existing data and writes only the suffix at end", async () => {
+  const root = new MemoryDirectory();
+  const fs = createOpfsGitFs(root as unknown as FileSystemDirectoryHandle);
+  await fs.promises.writeFile("/workspace/output.log", "existing");
+  const file = root.entriesByName.get("output.log");
+  assert(file instanceof MemoryFile);
+  file.resetWriteInstrumentation();
+
+  await fs.promises.appendFile("/workspace/output.log", "-one");
+  await fs.promises.appendFile("/workspace/output.log", new TextEncoder().encode("-two"));
+
+  assert.deepEqual(file.writableOptions, [
+    { keepExistingData: true },
+    { keepExistingData: true },
+  ]);
+  assert.deepEqual(file.seekPositions, [8, 12]);
+  assert.deepEqual(file.writtenChunks.map((bytes) => new TextDecoder().decode(bytes)), ["-one", "-two"]);
+  assert.equal(file.arrayBufferReads, 0);
+  assert.equal(new TextDecoder().decode(file.bytes), "existing-one-two");
 });
 
 class MemoryDirectory {
@@ -161,17 +288,34 @@ class MemoryFile {
   readonly kind = "file";
   bytes = new Uint8Array();
   modifiedAt = Date.now();
+  writableOptions: FileSystemCreateWritableOptions[] = [];
+  seekPositions: number[] = [];
+  writtenChunks: Uint8Array[] = [];
+  arrayBufferReads = 0;
+
+  resetWriteInstrumentation() {
+    this.writableOptions = [];
+    this.seekPositions = [];
+    this.writtenChunks = [];
+    this.arrayBufferReads = 0;
+  }
 
   async getFile() {
     const bytes = this.bytes.slice();
     return {
       size: bytes.byteLength,
       lastModified: this.modifiedAt,
-      arrayBuffer: async () => bytes.buffer,
+      arrayBuffer: async () => {
+        this.arrayBufferReads += 1;
+        return bytes.buffer;
+      },
     };
   }
 
-  async createWritable() {
+  async createWritable(options: FileSystemCreateWritableOptions = {}) {
+    this.writableOptions.push({ ...options });
+    let bytes = options.keepExistingData ? this.bytes.slice() : new Uint8Array();
+    let position = 0;
     return {
       write: async (value: FileSystemWriteChunkType) => {
         const buffer = typeof value === "string"
@@ -181,10 +325,22 @@ class MemoryFile {
             : value instanceof ArrayBuffer
               ? new Uint8Array(value)
               : new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
-        this.bytes = buffer.slice();
+        this.writtenChunks.push(buffer.slice());
+        const length = Math.max(bytes.byteLength, position + buffer.byteLength);
+        const next = new Uint8Array(length);
+        next.set(bytes);
+        next.set(buffer, position);
+        bytes = next;
+        position += buffer.byteLength;
+      },
+      seek: async (nextPosition: number) => {
+        this.seekPositions.push(nextPosition);
+        position = nextPosition;
+      },
+      close: async () => {
+        this.bytes = bytes;
         this.modifiedAt = Date.now();
       },
-      close: async () => undefined,
       abort: async () => undefined,
     };
   }

--- a/web/test/threadGit.test.ts
+++ b/web/test/threadGit.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { browserThread } from "../src/threadGit.ts";
+
+test("worker-owned thread metadata keeps the shareable thread identity", () => {
+  const id = "12345678-1234-4123-8123-123456789abc";
+  const thread = browserThread(id, "https://nanocodex.example/app?ignored=true");
+
+  assert.equal(thread.remoteUrl, `https://nanocodex.example/git/thread-${id}`);
+  const share = new URL(thread.shareUrl);
+  assert.equal(share.origin, "https://nanocodex.example");
+  assert.equal(share.pathname, "/");
+  assert.equal(share.searchParams.get("thread"), id);
+  assert.equal(share.searchParams.get("ignored"), null);
+});
+
+test("worker-owned thread metadata rejects unscoped repository identities", () => {
+  assert.throws(
+    () => browserThread("../../other-thread", "https://nanocodex.example"),
+    /invalid browser thread id/,
+  );
+});

--- a/web/test/workspaceListing.test.ts
+++ b/web/test/workspaceListing.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { Workspace, WorkspaceEntry } from "nanocodex/browser/workspace";
+
+import { listVisibleWorkspaceEntries } from "../src/workspaceListing.ts";
+
+test("visible workspace listing prunes Git metadata before recursion", async () => {
+  const calls: Array<{ path: string; recursive: boolean }> = [];
+  const listings = new Map<string, readonly WorkspaceEntry[]>([
+    [".", [
+      { kind: "directory", path: "/workspace/.git" },
+      { kind: "directory", path: "/workspace/.nanocodex" },
+      { kind: "file", path: "/workspace/README.md", size: 12 },
+      { kind: "directory", path: "/workspace/src" },
+    ]],
+    ["/workspace/src", [
+      { kind: "file", path: "/workspace/src/main.tsx", size: 24 },
+    ]],
+  ]);
+  const workspace = {
+    root: "/workspace",
+    async list(path = ".", options: { recursive?: boolean } = {}) {
+      calls.push({ path, recursive: options.recursive === true });
+      const entries = listings.get(path);
+      if (!entries) throw new Error(`unexpected traversal of ${path}`);
+      return entries;
+    },
+  } as Workspace;
+
+  assert.deepEqual(await listVisibleWorkspaceEntries(workspace), [
+    { kind: "file", path: "/workspace/README.md", size: 12 },
+    { kind: "directory", path: "/workspace/src" },
+    { kind: "file", path: "/workspace/src/main.tsx", size: 24 },
+  ]);
+  assert.deepEqual(calls, [
+    { path: ".", recursive: false },
+    { path: "/workspace/src", recursive: true },
+  ]);
+});

--- a/web/worker/index.test.ts
+++ b/web/worker/index.test.ts
@@ -161,6 +161,25 @@ test("tool proxies reject cross-origin calls before using the credential", async
   assert.equal(response.status, 403);
 });
 
+test("same-origin Fetch Metadata admits MCP GET streams without a referrer", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response("event: message\ndata: {}\n\n", {
+    headers: { "content-type": "text/event-stream" },
+  })) as typeof fetch;
+  try {
+    const response = await worker.fetch(new Request("https://demo.test/api/mcp/tempo", {
+      headers: {
+        "sec-fetch-site": "same-origin",
+        "x-nanocodex-request": "1",
+      },
+    }), { ENVIRONMENT: "test" });
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("content-type"), "text/event-stream");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("BYOK sessions keep the key behind an opaque HttpOnly cookie and take precedence", async () => {
   const { credentials, namespace } = createByokSessions();
   const env = {

--- a/web/worker/index.test.ts
+++ b/web/worker/index.test.ts
@@ -193,6 +193,7 @@ test("BYOK sessions keep the key behind an opaque HttpOnly cookie and take prece
   assert.deepEqual(await health.json(), {
     agent_configured: true,
     credential_source: "user",
+    deployment_sha: null,
     service: "nanocodex",
     runtime: "cloudflare-workers",
     status: "ok",
@@ -271,10 +272,32 @@ test("production never exposes a configured deployment API key as a public proxy
   assert.deepEqual(await response.json(), {
     agent_configured: false,
     credential_source: null,
+    deployment_sha: null,
     service: "nanocodex",
     runtime: "cloudflare-workers",
     status: "ok",
   });
+});
+
+test("health attests only a complete deployment commit SHA", async () => {
+  const deploymentSha = "0123456789abcdef0123456789abcdef01234567";
+  const attested = await worker.fetch(
+    new Request("https://demo.test/api/health"),
+    { ENVIRONMENT: "production", DEPLOYMENT_SHA: deploymentSha },
+  );
+  assert.equal(
+    ((await attested.json()) as { deployment_sha: string | null }).deployment_sha,
+    deploymentSha,
+  );
+
+  const malformed = await worker.fetch(
+    new Request("https://demo.test/api/health"),
+    { ENVIRONMENT: "production", DEPLOYMENT_SHA: "master" },
+  );
+  assert.equal(
+    ((await malformed.json()) as { deployment_sha: string | null }).deployment_sha,
+    null,
+  );
 });
 
 test("custom headers never bypass the same-origin boundary", async () => {
@@ -316,6 +339,7 @@ test("ChatGPT login exposes only device state while subscription credentials sta
   assert.deepEqual(await health.json(), {
     agent_configured: true,
     credential_source: "subscription",
+    deployment_sha: null,
     service: "nanocodex",
     runtime: "cloudflare-workers",
     status: "ok",

--- a/web/worker/index.ts
+++ b/web/worker/index.ts
@@ -71,10 +71,12 @@ const BYOK_COOKIE = "nanocodex_byok_v2";
 const SECURE_BYOK_COOKIE = "__Secure-nanocodex_byok_v2";
 const CHATGPT_COOKIE = "nanocodex_chatgpt_v2";
 const SECURE_CHATGPT_COOKIE = "__Secure-nanocodex_chatgpt_v2";
+const GIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
 
 type WorkerEnv = GitStorageEnv & ThreadGitStorageEnv & EvalStorageEnv & ChatGptEgressEnv
   & PublicSecurityEnv & CredentialVaultEnv & {
   ENVIRONMENT: string;
+  DEPLOYMENT_SHA?: string;
   OPENAI_API_KEY?: string;
   CHATGPT_ISSUER?: string;
   BYOK_SESSIONS?: DurableObjectNamespace;
@@ -127,6 +129,9 @@ export default {
       return json({
         agent_configured: Boolean(credential),
         credential_source: credential?.source ?? null,
+        deployment_sha: GIT_SHA_PATTERN.test(env.DEPLOYMENT_SHA ?? "")
+          ? env.DEPLOYMENT_SHA
+          : null,
         service: "nanocodex",
         runtime: "cloudflare-workers",
         status: "ok",

--- a/web/worker/index.ts
+++ b/web/worker/index.ts
@@ -15,6 +15,7 @@ import { EvalCoordinator, routeEvalMutation, type EvalStorageEnv } from "./evalC
 import { routeEvalRead } from "./evalReadApi.ts";
 import { handleGitRequest, type GitStorageEnv } from "./gitRoutes.ts";
 import { GitRepository } from "./gitRepository.ts";
+import { proxyDefaultMcp } from "./mcpProxy.ts";
 import {
   handleThreadGitRequest,
   type ThreadGitStorageEnv,
@@ -119,6 +120,8 @@ export default {
     if (gitResponse != null) return gitResponse;
     const threadGitResponse = await handleThreadGitRequest(request, env, url, context);
     if (threadGitResponse != null) return threadGitResponse;
+    const mcpResponse = await proxyDefaultMcp(request, url, sameOrigin(request, url, env));
+    if (mcpResponse != null) return mcpResponse;
 
     if (url.pathname === "/api/health" && request.method === "GET") {
       const resolved = await resolveCredential(request, env, "health");
@@ -1082,6 +1085,10 @@ async function deleteChatGptSession(request: Request, env: WorkerEnv): Promise<v
 }
 
 function sameOrigin(request: Request, url: URL, env: WorkerEnv): boolean {
+  if (
+    request.headers.get("x-nanocodex-request") === "1" &&
+    request.headers.get("sec-fetch-site") === "same-origin"
+  ) return true;
   const origin = request.headers.get("Origin");
   if (origin) return matchesRequestOrigin(origin, url, env.ENVIRONMENT === "development");
   const referer = request.headers.get("Referer");

--- a/web/worker/mcpProxy.test.ts
+++ b/web/worker/mcpProxy.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { proxyDefaultMcp } from "./mcpProxy.ts";
+
+test("default MCP proxy is same-origin, allowlisted, and preserves protocol state", async () => {
+  const originalFetch = globalThis.fetch;
+  const seen: Array<{ request: Request; url: string }> = [];
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const request = new Request(input, init);
+    seen.push({ request, url: request.url });
+    return new Response("event: message\ndata: {}\n\n", {
+      headers: {
+        "content-type": "text/event-stream",
+        "mcp-session-id": "session-2",
+        "set-cookie": "must-not-leak=1",
+      },
+    });
+  }) as typeof fetch;
+  try {
+    const url = new URL("https://demo.test/api/mcp/tempo?cursor=next");
+    const response = await proxyDefaultMcp(new Request(url, {
+      method: "POST",
+      headers: {
+        authorization: "must-not-forward",
+        "content-type": "application/json",
+        "mcp-protocol-version": "2025-11-25",
+        "mcp-session-id": "session-1",
+      },
+      body: "{}",
+    }), url, true);
+
+    assert.equal(response?.status, 200);
+    assert.equal(response?.headers.get("content-type"), "text/event-stream");
+    assert.equal(response?.headers.get("mcp-session-id"), "session-2");
+    assert.equal(response?.headers.get("set-cookie"), null);
+    assert.equal(seen[0]?.url, "https://mcp.tempo.xyz/?cursor=next");
+    assert.equal(seen[0]?.request.headers.get("authorization"), null);
+    assert.equal(seen[0]?.request.headers.get("mcp-session-id"), "session-1");
+    assert.equal(await seen[0]?.request.text(), "{}");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("default MCP proxy rejects forged origins, unknown servers, and methods", async () => {
+  const url = new URL("https://demo.test/api/mcp/tempo");
+  assert.equal((await proxyDefaultMcp(new Request(url), url, false))?.status, 403);
+
+  const unknown = new URL("https://demo.test/api/mcp/arbitrary");
+  assert.equal((await proxyDefaultMcp(new Request(unknown), unknown, true))?.status, 404);
+
+  assert.equal((await proxyDefaultMcp(new Request(url, { method: "PUT" }), url, true))?.status, 405);
+  assert.equal(await proxyDefaultMcp(new Request("https://demo.test/api/other"), new URL("https://demo.test/api/other"), true), undefined);
+});
+
+test("default MCP proxy rejects declared oversized bodies before upstream fetch", async () => {
+  const originalFetch = globalThis.fetch;
+  let fetches = 0;
+  globalThis.fetch = (async () => {
+    fetches += 1;
+    return new Response();
+  }) as typeof fetch;
+  try {
+    const url = new URL("https://demo.test/api/mcp/tempo");
+    const response = await proxyDefaultMcp(new Request(url, {
+      method: "POST",
+      headers: { "content-length": String(16 * 1024 * 1024 + 1) },
+      body: "{}",
+    }), url, true);
+
+    assert.equal(response?.status, 413);
+    assert.equal(fetches, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("default MCP proxy cancels chunked bodies at the streaming cap without fetching upstream", async () => {
+  const originalFetch = globalThis.fetch;
+  let fetches = 0;
+  let cancelled = false;
+  globalThis.fetch = (async () => {
+    fetches += 1;
+    return new Response();
+  }) as typeof fetch;
+  try {
+    let chunk = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (chunk++ === 0) controller.enqueue(new Uint8Array(16 * 1024 * 1024));
+        else controller.enqueue(new Uint8Array(1));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const url = new URL("https://demo.test/api/mcp/tempo");
+    const response = await proxyDefaultMcp(new Request(url, {
+      method: "POST",
+      body,
+      duplex: "half",
+    } as RequestInit & { duplex: "half" }), url, true);
+
+    assert.equal(response?.status, 413);
+    assert.equal(cancelled, true);
+    assert.equal(fetches, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/web/worker/mcpProxy.ts
+++ b/web/worker/mcpProxy.ts
@@ -1,0 +1,134 @@
+const MCP_UPSTREAMS = Object.freeze({
+  "openai-developer-docs": "https://developers.openai.com/mcp",
+  tempo: "https://mcp.tempo.xyz",
+  cloudflare: "https://docs.mcp.cloudflare.com/mcp",
+  viem: "https://viem.sh/api/mcp",
+  vocs: "https://vocs.dev/api/mcp",
+});
+
+const REQUEST_HEADERS = [
+  "accept",
+  "content-type",
+  "last-event-id",
+  "mcp-protocol-version",
+  "mcp-session-id",
+];
+const RESPONSE_HEADERS = [
+  "cache-control",
+  "content-type",
+  "mcp-protocol-version",
+  "mcp-session-id",
+  "retry-after",
+  "www-authenticate",
+];
+const METHODS = new Set(["GET", "POST", "DELETE"]);
+const MAX_REQUEST_BYTES = 16 * 1024 * 1024;
+
+export async function proxyDefaultMcp(
+  request: Request,
+  url: URL,
+  authorized: boolean,
+): Promise<Response | undefined> {
+  const match = /^\/api\/mcp\/([a-z-]+)$/.exec(url.pathname);
+  if (!match) return undefined;
+  const upstreamBase = MCP_UPSTREAMS[match[1] as keyof typeof MCP_UPSTREAMS];
+  if (!upstreamBase) return error("unknown MCP server", 404);
+  if (!authorized) return error("forbidden", 403);
+  if (!METHODS.has(request.method)) {
+    return error("method not allowed", 405, { allow: "GET, POST, DELETE" });
+  }
+
+  const bodyResult = request.method === "GET"
+    ? { ok: true as const, body: undefined }
+    : await readBoundedBody(request);
+  if (!bodyResult.ok) return bodyResult.response;
+
+  const upstream = new URL(upstreamBase);
+  upstream.search = url.search;
+  const headers = new Headers();
+  for (const name of REQUEST_HEADERS) {
+    const value = request.headers.get(name);
+    if (value !== null) headers.set(name, value);
+  }
+  const response = await fetch(upstream, {
+    method: request.method,
+    headers,
+    body: bodyResult.body,
+    redirect: "follow",
+  });
+  const responseHeaders = new Headers({
+    "cache-control": "no-store",
+    "x-content-type-options": "nosniff",
+  });
+  for (const name of RESPONSE_HEADERS) {
+    const value = response.headers.get(name);
+    if (value !== null) responseHeaders.set(name, value);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: responseHeaders,
+  });
+}
+
+async function readBoundedBody(request: Request): Promise<
+  | { ok: true; body: ArrayBuffer | undefined }
+  | { ok: false; response: Response }
+> {
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength !== null) {
+    const normalized = declaredLength.trim();
+    if (!/^(0|[1-9][0-9]*)$/.test(normalized)) {
+      await cancelBody(request, "invalid Content-Length");
+      return { ok: false, response: error("invalid Content-Length", 400) };
+    }
+    const length = Number(normalized);
+    if (!Number.isSafeInteger(length) || length > MAX_REQUEST_BYTES) {
+      await cancelBody(request, "MCP request body is too large");
+      return { ok: false, response: error("MCP request body is too large", 413) };
+    }
+  }
+
+  if (request.body === null) return { ok: true, body: undefined };
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let bytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value.byteLength > MAX_REQUEST_BYTES - bytes) {
+        await reader.cancel("MCP request body is too large").catch(() => undefined);
+        return { ok: false, response: error("MCP request body is too large", 413) };
+      }
+      chunks.push(value);
+      bytes += value.byteLength;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const body = new ArrayBuffer(bytes);
+  const target = new Uint8Array(body);
+  let offset = 0;
+  for (const chunk of chunks) {
+    target.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return { ok: true, body };
+}
+
+async function cancelBody(request: Request, reason: string): Promise<void> {
+  await request.body?.cancel(reason).catch(() => undefined);
+}
+
+function error(message: string, status: number, headers?: HeadersInit): Response {
+  return Response.json({ error: message }, {
+    status,
+    headers: {
+      "cache-control": "no-store",
+      "x-content-type-options": "nosniff",
+      ...headers,
+    },
+  });
+}

--- a/web/worker/threadPack.test.ts
+++ b/web/worker/threadPack.test.ts
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { test } from "node:test";
+import { deflateSync } from "node:zlib";
+
+import { createThreadPackStream } from "./threadPack.ts";
+import type { ThreadPack } from "./threadRepository.ts";
+
+test("composes retained source packs into one strict Git pack", async () => {
+  const first = sourcePack("first blob\n");
+  const second = sourcePack("second blob\n");
+  const headA = gitBlobOid("first blob\n");
+  const headB = gitBlobOid("second blob\n");
+  const firstMetadata = metadata("first.pack", first, "0".repeat(40), headA);
+  const secondMetadata = metadata("second.pack", second, headA, headB);
+  const bucket = new MemoryBucket(new Map([
+    [firstMetadata.key, first],
+    [secondMetadata.key, second],
+  ]));
+  const stream = await createThreadPackStream(bucket as unknown as R2Bucket, [
+    firstMetadata,
+    secondMetadata,
+  ]);
+  const combined = await readStream(stream);
+
+  assert.equal(new TextDecoder().decode(combined.subarray(0, 4)), "PACK");
+  const view = new DataView(combined.buffer, combined.byteOffset, combined.byteLength);
+  assert.equal(view.getUint32(4), 2);
+  assert.equal(view.getUint32(8), 2);
+  assert.deepEqual(
+    combined.subarray(12, -20),
+    concatenate([first.subarray(12, -20), second.subarray(12, -20)]),
+  );
+  assert.deepEqual(
+    combined.subarray(-20),
+    sha1(combined.subarray(0, -20)),
+  );
+  await assertGitAccepts(combined);
+  const suffix = await readStream(await createThreadPackStream(
+    bucket as unknown as R2Bucket,
+    [secondMetadata],
+  ));
+  await assertGitAcceptsAfter(first, headA, suffix);
+  assert.ok(bucket.maxConcurrentHeads > 1);
+  assert.ok(bucket.maxConcurrentHeads <= 4);
+  assert.deepEqual(bucket.deleted, []);
+});
+
+test("rejects missing and corrupted retained packs", async () => {
+  const bytes = sourcePack("fixture\n");
+  const missing = new MemoryBucket(new Map());
+  await assert.rejects(
+    createThreadPackStream(missing as unknown as R2Bucket, [
+      metadata("missing.pack", bytes, "0".repeat(40), "a".repeat(40)),
+    ]),
+    /missing/,
+  );
+
+  const corrupted = bytes.slice();
+  corrupted[12] ^= 1;
+  const corruptedMetadata = metadata(
+    "corrupt.pack",
+    bytes,
+    "0".repeat(40),
+    "a".repeat(40),
+  );
+  const bucket = new MemoryBucket(new Map([[corruptedMetadata.key, corrupted]]));
+  const stream = await createThreadPackStream(bucket as unknown as R2Bucket, [
+    corruptedMetadata,
+  ]);
+  await assert.rejects(readStream(stream), /checksum/);
+});
+
+class MemoryBucket {
+  readonly deleted: string[] = [];
+  readonly objects: Map<string, Uint8Array>;
+  maxConcurrentHeads = 0;
+  #activeHeads = 0;
+
+  constructor(objects: Map<string, Uint8Array>) {
+    this.objects = objects;
+  }
+
+  async head(key: string) {
+    this.#activeHeads++;
+    this.maxConcurrentHeads = Math.max(this.maxConcurrentHeads, this.#activeHeads);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    try {
+      const bytes = this.objects.get(key);
+      return bytes ? { size: bytes.byteLength } : null;
+    } finally {
+      this.#activeHeads--;
+    }
+  }
+
+  async get(key: string) {
+    const bytes = this.objects.get(key);
+    return bytes
+      ? { arrayBuffer: async () => bytes.slice().buffer }
+      : null;
+  }
+
+  async delete(key: string) {
+    this.deleted.push(key);
+    this.objects.delete(key);
+  }
+}
+
+function sourcePack(contents: string): Uint8Array {
+  const object = new TextEncoder().encode(contents);
+  assert.ok(object.byteLength < 16);
+  const header = new Uint8Array(12);
+  header.set(new TextEncoder().encode("PACK"));
+  const view = new DataView(header.buffer);
+  view.setUint32(4, 2);
+  view.setUint32(8, 1);
+  const entry = concatenate([
+    Uint8Array.of((3 << 4) | object.byteLength),
+    deflateSync(object),
+  ]);
+  const body = concatenate([header, entry]);
+  return concatenate([body, sha1(body)]);
+}
+
+function metadata(
+  key: string,
+  bytes: Uint8Array,
+  oldOid: string,
+  newOid: string,
+): ThreadPack {
+  return {
+    key: `thread-repositories/thread-12345678-1234-4123-8123-123456789abc/${key}`,
+    hash: Buffer.from(bytes.subarray(-20)).toString("hex"),
+    size: bytes.byteLength,
+    objectCount: 1,
+    oldOid,
+    newOid,
+  };
+}
+
+async function readStream(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = [];
+  const reader = stream.getReader();
+  while (true) {
+    const result = await reader.read();
+    if (result.done) break;
+    chunks.push(result.value);
+  }
+  return concatenate(chunks);
+}
+
+async function assertGitAccepts(pack: Uint8Array): Promise<void> {
+  const directory = await mkdtemp(resolve(tmpdir(), "nanocodex-thread-pack-"));
+  try {
+    await run("git", ["init", "--bare", "-q"], directory);
+    await run("git", ["index-pack", "--stdin", "--strict"], directory, pack);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+async function assertGitAcceptsAfter(
+  firstPack: Uint8Array,
+  firstOid: string,
+  suffix: Uint8Array,
+): Promise<void> {
+  const directory = await mkdtemp(resolve(tmpdir(), "nanocodex-thread-suffix-"));
+  try {
+    await run("git", ["init", "--bare", "-q"], directory);
+    await run("git", ["index-pack", "--stdin", "--strict"], directory, firstPack);
+    await run("git", ["cat-file", "-e", firstOid], directory);
+    await run("git", ["index-pack", "--stdin", "--strict"], directory, suffix);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+function run(command: string, args: string[], cwd: string, input?: Uint8Array): Promise<void> {
+  return new Promise((resolveRun, reject) => {
+    const child = spawn(command, args, { cwd, stdio: ["pipe", "ignore", "pipe"] });
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.once("error", reject);
+    child.once("close", (code) => {
+      if (code === 0) resolveRun();
+      else reject(new Error(stderr.trim() || `${command} exited with ${code}`));
+    });
+    child.stdin.end(input);
+  });
+}
+
+function sha1(bytes: Uint8Array): Uint8Array {
+  return new Uint8Array(createHash("sha1").update(bytes).digest());
+}
+
+function gitBlobOid(contents: string): string {
+  const bytes = new TextEncoder().encode(contents);
+  return createHash("sha1")
+    .update(`blob ${bytes.byteLength}\0`)
+    .update(bytes)
+    .digest("hex");
+}
+
+function concatenate(chunks: readonly Uint8Array[]): Uint8Array {
+  const output = new Uint8Array(chunks.reduce((total, chunk) => total + chunk.byteLength, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return output;
+}

--- a/web/worker/threadPack.ts
+++ b/web/worker/threadPack.ts
@@ -1,0 +1,106 @@
+import { sha1 } from "@noble/hashes/legacy";
+
+import type { ThreadPack } from "./threadRepository.ts";
+
+const PACK_HEADER_BYTES = 12;
+const PACK_TRAILER_BYTES = 20;
+const PACK_HEAD_CONCURRENCY = 4;
+
+export async function createThreadPackStream(
+  bucket: R2Bucket,
+  packs: readonly ThreadPack[],
+): Promise<ReadableStream<Uint8Array>> {
+  const objectCount = packs.reduce((total, pack) => total + pack.objectCount, 0);
+  if (!Number.isSafeInteger(objectCount) || objectCount > 0xffff_ffff) {
+    throw new Error("thread repository pack object count exceeds version 2 limits");
+  }
+  for (let offset = 0; offset < packs.length; offset += PACK_HEAD_CONCURRENCY) {
+    const batch = packs.slice(offset, offset + PACK_HEAD_CONCURRENCY);
+    const objects = await Promise.all(batch.map((pack) => bucket.head(pack.key)));
+    for (let index = 0; index < batch.length; index++) {
+      const pack = batch[index]!;
+      const object = objects[index];
+      if (!object) throw new Error(`thread pack is missing: ${pack.key}`);
+      if (object.size !== pack.size) {
+        throw new Error(`thread pack has an invalid size: ${pack.key}`);
+      }
+    }
+  }
+
+  const header = packHeader(objectCount);
+  const hash = sha1.create();
+  let phase: "header" | "packs" | "trailer" | "done" = "header";
+  let packIndex = 0;
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        if (phase === "header") {
+          hash.update(header);
+          controller.enqueue(header);
+          phase = "packs";
+          return;
+        }
+        if (phase === "packs" && packIndex < packs.length) {
+          const pack = packs[packIndex++]!;
+          const object = await bucket.get(pack.key);
+          if (!object) throw new Error(`thread pack is missing: ${pack.key}`);
+          const bytes = new Uint8Array(await object.arrayBuffer());
+          validateSourcePack(bytes, pack);
+          const entries = bytes.subarray(PACK_HEADER_BYTES, bytes.byteLength - PACK_TRAILER_BYTES);
+          hash.update(entries);
+          controller.enqueue(entries);
+          return;
+        }
+        if (phase === "packs") phase = "trailer";
+        if (phase === "trailer") {
+          controller.enqueue(hash.digest());
+          phase = "done";
+          controller.close();
+        }
+      } catch (error) {
+        phase = "done";
+        controller.error(error);
+      }
+    },
+  });
+}
+
+function validateSourcePack(bytes: Uint8Array, pack: ThreadPack): void {
+  if (bytes.byteLength !== pack.size || bytes.byteLength < PACK_HEADER_BYTES + PACK_TRAILER_BYTES) {
+    throw new Error(`thread pack has an invalid size: ${pack.key}`);
+  }
+  if (new TextDecoder().decode(bytes.subarray(0, 4)) !== "PACK") {
+    throw new Error(`thread pack has an invalid header: ${pack.key}`);
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  if (view.getUint32(4) !== 2 || view.getUint32(8) !== pack.objectCount) {
+    throw new Error(`thread pack has invalid metadata: ${pack.key}`);
+  }
+  const trailer = bytes.subarray(bytes.byteLength - PACK_TRAILER_BYTES);
+  const actual = sha1(bytes.subarray(0, bytes.byteLength - PACK_TRAILER_BYTES));
+  if (!equalBytes(actual, trailer) || bytesToHex(trailer) !== pack.hash) {
+    throw new Error(`thread pack checksum is invalid: ${pack.key}`);
+  }
+}
+
+function packHeader(objectCount: number): Uint8Array {
+  const header = new Uint8Array(PACK_HEADER_BYTES);
+  header.set(new TextEncoder().encode("PACK"));
+  const view = new DataView(header.buffer);
+  view.setUint32(4, 2);
+  view.setUint32(8, objectCount);
+  return header;
+}
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.byteLength !== right.byteLength) return false;
+  let difference = 0;
+  for (let index = 0; index < left.byteLength; index++) {
+    difference |= left[index]! ^ right[index]!;
+  }
+  return difference === 0;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}

--- a/web/worker/threadProtocol.test.ts
+++ b/web/worker/threadProtocol.test.ts
@@ -31,10 +31,13 @@ test("upload-pack advertises protocol v2 and an empty repository has no refs", (
   assert.deepEqual(parsePacketLines(buildLsRefsResponse(undefined, [])), [{ kind: "flush" }]);
 });
 
-test("receive-pack advertises an empty capability repository on every push", () => {
+test("receive-pack advertises empty and persisted thread refs", () => {
   const lines = dataLines(receiveAdvertisement());
   assert.equal(lines[0], "# service=git-receive-pack\n");
   assert.match(lines[1]!, new RegExp(`^${zero} capabilities\\^\\{\\}\\0report-status`));
+  const persisted = dataLines(receiveAdvertisement(repository()));
+  assert.equal(persisted[0], "# service=git-receive-pack\n");
+  assert.match(persisted[1]!, new RegExp(`^${head} refs/heads/nanocodex\\0report-status`));
 });
 
 test("protocol v0 advertises the persisted branch for browser Git clients", () => {
@@ -77,9 +80,14 @@ function repository(): ThreadRepository {
     branch: "nanocodex",
     head,
     refs: [{ name: "refs/heads/nanocodex", oid: head }],
-    packKey: "thread-repositories/thread-123/pack.pack",
-    packHash: "b".repeat(40),
-    packSize: 123,
+    packs: [{
+      key: "thread-repositories/thread-123/pack.pack",
+      hash: "b".repeat(40),
+      size: 123,
+      objectCount: 3,
+      oldOid: "0".repeat(40),
+      newOid: head,
+    }],
     updatedAt: "2026-08-18T00:00:00.000Z",
   };
 }

--- a/web/worker/threadProtocol.ts
+++ b/web/worker/threadProtocol.ts
@@ -70,7 +70,7 @@ export function legacyRepositoryAdvertisement(repository: RepositoryView | undef
   ]);
 }
 
-export function receiveAdvertisement(): Uint8Array {
+export function receiveAdvertisement(repository?: RepositoryView): Uint8Array {
   const capabilities = [
     "report-status",
     "side-band-64k",
@@ -80,7 +80,9 @@ export function receiveAdvertisement(): Uint8Array {
   return concatenate([
     encodePacketLine("# service=git-receive-pack\n"),
     flushPacket,
-    encodePacketLine(`${zeroOid} capabilities^{}\0${capabilities}\n`),
+    encodePacketLine(repository
+      ? `${repository.head} refs/heads/${repository.branch}\0${capabilities}\n`
+      : `${zeroOid} capabilities^{}\0${capabilities}\n`),
     flushPacket,
   ]);
 }
@@ -167,10 +169,12 @@ export function buildLsRefsResponse(
   ]);
 }
 
-export function buildNegotiationResponse(): Uint8Array {
+export function buildNegotiationResponse(commonHaves: readonly string[] = []): Uint8Array {
   return concatenate([
     encodePacketLine("acknowledgments\n"),
-    encodePacketLine("NAK\n"),
+    ...(commonHaves.length === 0
+      ? [encodePacketLine("NAK\n")]
+      : commonHaves.map((oid) => encodePacketLine(`ACK ${oid}\n`))),
     flushPacket,
   ]);
 }
@@ -198,8 +202,9 @@ export function buildFullPackResponse(
 
 export function buildLegacyFullPackResponse(
   pack: ReadableStream<Uint8Array>,
+  acknowledgedHave?: string,
 ): ReadableStream<Uint8Array> {
-  return buildPackResponse(pack, "NAK\n");
+  return buildPackResponse(pack, acknowledgedHave ? `ACK ${acknowledgedHave}\n` : "NAK\n");
 }
 
 function buildPackResponse(

--- a/web/worker/threadRepository.test.ts
+++ b/web/worker/threadRepository.test.ts
@@ -4,53 +4,170 @@ import { test } from "node:test";
 import {
   ThreadGitRepository,
   isThreadRepository,
+  type ThreadPack,
+  type ThreadPackMetadata,
   type ThreadRepository,
 } from "./threadRepository.ts";
 
-const head = "a".repeat(40);
+const zero = "0".repeat(40);
+const headA = "a".repeat(40);
+const headB = "b".repeat(40);
+const headC = "c".repeat(40);
+const ref = "refs/heads/nanocodex";
 
-test("thread repository state accepts only the nanocodex branch and scoped pack keys", () => {
+test("thread repository state accepts only one nanocodex ref and a valid pack chain", () => {
   assert.equal(isThreadRepository(repository()), true);
   assert.equal(isThreadRepository({ ...repository(), branch: "main" }), false);
-  assert.equal(isThreadRepository({ ...repository(), packKey: "../escape.pack" }), false);
+  assert.equal(isThreadRepository({ ...repository(), refs: [{ name: ref, oid: headB }] }), false);
+  assert.equal(isThreadRepository({ ...repository(), packs: [] }), false);
+  assert.equal(isThreadRepository({
+    ...repository(),
+    packs: [{ ...pack("a", zero, headA), key: "../escape.pack" }],
+  }), false);
+  assert.equal(isThreadRepository({
+    ...repository(),
+    packs: [pack("a", zero, headA), pack("a", headA, headB)],
+  }), false);
+  assert.equal(isThreadRepository({
+    ...repository(),
+    head: headB,
+    refs: [{ name: ref, oid: headB }],
+    packs: [pack("a", zero, headA), pack("b", headC, headB)],
+  }), false);
 });
 
-test("receive leases serialize and atomically replace thread refs", async () => {
+test("receive leases CAS the old OID and append immutable packs", async () => {
+  const { durable } = memoryRepository();
+
+  const first = await begin(durable, zero, headA);
+  assert.equal(first.status, 200);
+  const busy = await begin(durable, zero, headA);
+  assert.equal(busy.status, 409);
+  assert.deepEqual(await busy.json(), { error: "receive_busy" });
+  const firstToken = await leaseToken(first);
+  assert.equal((await finalize(durable, firstToken, packMetadata("a"))).status, 200);
+
+  const firstState = await current(durable);
+  assert.equal(firstState.head, headA);
+  assert.deepEqual(firstState.refs, [{ name: ref, oid: headA }]);
+  assert.deepEqual(firstState.packs, [pack("a", zero, headA)]);
+
+  const second = await begin(durable, headA, headB);
+  const secondToken = await leaseToken(second);
+  assert.equal((await finalize(durable, secondToken, packMetadata("b"))).status, 200);
+  const secondState = await current(durable);
+  assert.equal(secondState.head, headB);
+  assert.deepEqual(secondState.packs, [
+    pack("a", zero, headA),
+    pack("b", headA, headB),
+  ]);
+
+  const stale = await begin(durable, headA, headC);
+  assert.equal(stale.status, 409);
+  assert.deepEqual(await stale.json(), { error: "stale_receive", currentHead: headB });
+  assert.deepEqual(await current(durable), secondState);
+});
+
+test("finalize rejects malformed metadata and abort is token scoped", async () => {
+  const { durable } = memoryRepository();
+  const started = await begin(durable, zero, headA);
+  const token = await leaseToken(started);
+
+  const malformed = await finalize(durable, token, { ...packMetadata("a"), objectCount: 0 });
+  assert.equal(malformed.status, 400);
+  const wrongAbort = await durable.fetch(new Request("https://repository.test/receive/abort", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ token: "wrong" }),
+  }));
+  assert.equal(wrongAbort.status, 200);
+  assert.equal((await begin(durable, zero, headB)).status, 409);
+
+  await durable.fetch(new Request("https://repository.test/receive/abort", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ token }),
+  }));
+  assert.equal((await begin(durable, zero, headB)).status, 200);
+});
+
+test("finalize owns transition metadata from the receive lease", async () => {
+  const { durable } = memoryRepository();
+  const token = await leaseToken(await begin(durable, zero, headA));
+  const callerPack = {
+    ...packMetadata("a"),
+    oldOid: headC,
+    newOid: headC,
+  };
+  const response = await finalize(durable, token, callerPack);
+  assert.equal(response.status, 200);
+  assert.deepEqual((await current(durable)).packs, [pack("a", zero, headA)]);
+});
+
+function memoryRepository(): { durable: ThreadGitRepository } {
   const values = new Map<string, unknown>();
   const state = {
     storage: {
-      get: async <T>(key: string) => values.get(key) as T | undefined,
-      put: async (key: string, value: unknown) => { values.set(key, value); },
+      get: async <T>(key: string) => structuredClone(values.get(key)) as T | undefined,
+      put: async (key: string, value: unknown) => { values.set(key, structuredClone(value)); },
       delete: async (key: string) => values.delete(key),
     },
     blockConcurrencyWhile: async <T>(callback: () => Promise<T>) => callback(),
   } as unknown as DurableObjectState;
-  const durable = new ThreadGitRepository(state);
+  return { durable: new ThreadGitRepository(state) };
+}
 
-  const first = await durable.fetch(new Request("https://repository.test/receive/begin", { method: "POST" }));
-  assert.equal(first.status, 200);
-  const busy = await durable.fetch(new Request("https://repository.test/receive/begin", { method: "POST" }));
-  assert.equal(busy.status, 409);
-  const token = ((await first.json()) as { lease: { token: string } }).lease.token;
-  const finalized = await durable.fetch(new Request("https://repository.test/receive/finalize", {
+function begin(durable: ThreadGitRepository, oldOid: string, newOid: string): Promise<Response> {
+  return durable.fetch(new Request("https://repository.test/receive/begin", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ oldOid, newOid, ref }),
+  }));
+}
+
+function finalize(
+  durable: ThreadGitRepository,
+  token: string,
+  nextPack: ThreadPackMetadata,
+): Promise<Response> {
+  return durable.fetch(new Request("https://repository.test/receive/finalize", {
     method: "PUT",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ token, repository: repository() }),
+    body: JSON.stringify({ token, pack: nextPack }),
   }));
-  assert.equal(finalized.status, 200);
-  const current = await durable.fetch(new Request("https://repository.test/thread"));
-  assert.deepEqual(await current.json(), repository());
-});
+}
+
+async function leaseToken(response: Response): Promise<string> {
+  assert.equal(response.status, 200);
+  return ((await response.json()) as { lease: { token: string } }).lease.token;
+}
+
+async function current(durable: ThreadGitRepository): Promise<ThreadRepository> {
+  const response = await durable.fetch(new Request("https://repository.test/thread"));
+  assert.equal(response.status, 200);
+  return response.json() as Promise<ThreadRepository>;
+}
+
+function packMetadata(name: string): ThreadPackMetadata {
+  return {
+    key: `thread-repositories/thread-12345678-1234-4123-8123-123456789abc/${name}.pack`,
+    hash: name.charCodeAt(0).toString(16).padStart(2, "0").repeat(20),
+    size: 123,
+    objectCount: 3,
+  };
+}
+
+function pack(name: string, oldOid: string, newOid: string): ThreadPack {
+  return { ...packMetadata(name), oldOid, newOid };
+}
 
 function repository(): ThreadRepository {
   return {
     version: 1,
     branch: "nanocodex",
-    head,
-    refs: [{ name: "refs/heads/nanocodex", oid: head }],
-    packKey: "thread-repositories/thread-12345678-1234-4123-8123-123456789abc/pack.pack",
-    packHash: "b".repeat(40),
-    packSize: 123,
+    head: headA,
+    refs: [{ name: ref, oid: headA }],
+    packs: [pack("a", zero, headA)],
     updatedAt: "2026-08-18T00:00:00.000Z",
   };
 }

--- a/web/worker/threadRepository.ts
+++ b/web/worker/threadRepository.ts
@@ -1,27 +1,48 @@
 const SHA1_PATTERN = /^[a-f0-9]{40}$/;
-const REF_PATTERN = /^refs\/(heads|tags)\/[A-Za-z0-9][A-Za-z0-9._\/-]*$/;
+const PACK_KEY_PATTERN = /^thread-repositories\/[A-Za-z0-9._-]+\/[A-Za-z0-9-]+\.pack$/;
+const THREAD_BRANCH = "nanocodex";
+const THREAD_REF = `refs/heads/${THREAD_BRANCH}` as const;
+const ZERO_OID = "0".repeat(40);
+const MAX_PACK_BYTES = 32 * 1024 * 1024;
+const MAX_PACK_OBJECTS = 0xffff_ffff;
 const receiveLeaseTtlMs = 2 * 60 * 1_000;
 
 export type RepositoryRef = {
-  name: string;
+  name: typeof THREAD_REF;
   oid: string;
+};
+
+export type ThreadPackMetadata = {
+  key: string;
+  hash: string;
+  size: number;
+  objectCount: number;
+};
+
+export type ThreadPack = ThreadPackMetadata & {
+  oldOid: string;
+  newOid: string;
 };
 
 export type RepositoryView = {
   head: string;
-  branch: string;
-  refs: RepositoryRef[];
-  packKey: string;
+  branch: typeof THREAD_BRANCH;
+  refs: [RepositoryRef];
+  packs: ThreadPack[];
 };
 
 export type ThreadRepository = RepositoryView & {
   version: 1;
-  packHash: string;
-  packSize: number;
   updatedAt: string;
 };
 
-type ReceiveLease = { token: string; expiresAt: number };
+type ReceiveLease = {
+  token: string;
+  oldOid: string;
+  newOid: string;
+  ref: typeof THREAD_REF;
+  expiresAt: number;
+};
 
 const threadStorageKey = "thread";
 const receiveLeaseStorageKey = "receive-lease";
@@ -42,7 +63,7 @@ export class ThreadGitRepository {
         : Response.json({ error: "not_found" }, { status: 404 });
     }
     if (url.pathname === "/receive/begin" && request.method === "POST") {
-      return this.#beginReceive();
+      return this.#beginReceive(request);
     }
     if (url.pathname === "/receive/finalize" && request.method === "PUT") {
       return this.#finalizeReceive(request);
@@ -53,15 +74,31 @@ export class ThreadGitRepository {
     return Response.json({ error: "not_found" }, { status: 404 });
   }
 
-  async #beginReceive(): Promise<Response> {
+  async #beginReceive(request: Request): Promise<Response> {
+    const command = await request.json().catch(() => undefined) as {
+      oldOid?: unknown;
+      newOid?: unknown;
+      ref?: unknown;
+    } | undefined;
+    if (!isReceiveCommand(command)) {
+      return Response.json({ error: "invalid_receive" }, { status: 400 });
+    }
     return this.#state.blockConcurrencyWhile(async () => {
       const now = Date.now();
-      const current = await this.#state.storage.get<ReceiveLease>(receiveLeaseStorageKey);
-      if (current && current.expiresAt > now) {
+      const active = await this.#state.storage.get<ReceiveLease>(receiveLeaseStorageKey);
+      if (active && active.expiresAt > now) {
         return Response.json({ error: "receive_busy" }, { status: 409 });
       }
-      const lease = {
+      const repository = await this.#state.storage.get<ThreadRepository>(threadStorageKey);
+      const currentHead = repository?.head ?? ZERO_OID;
+      if (command.oldOid !== currentHead) {
+        return Response.json({ error: "stale_receive", currentHead }, { status: 409 });
+      }
+      const lease: ReceiveLease = {
         token: crypto.randomUUID(),
+        oldOid: command.oldOid,
+        newOid: command.newOid,
+        ref: command.ref,
         expiresAt: now + receiveLeaseTtlMs,
       };
       await this.#state.storage.put(receiveLeaseStorageKey, lease);
@@ -72,9 +109,10 @@ export class ThreadGitRepository {
   async #finalizeReceive(request: Request): Promise<Response> {
     const body = await request.json().catch(() => undefined) as {
       token?: unknown;
-      repository?: unknown;
+      pack?: unknown;
     } | undefined;
-    if (typeof body?.token !== "string" || !isThreadRepository(body.repository)) {
+    const packMetadata = body?.pack;
+    if (typeof body?.token !== "string" || !isThreadPackMetadata(packMetadata)) {
       return Response.json({ error: "invalid_receive" }, { status: 400 });
     }
     return this.#state.blockConcurrencyWhile(async () => {
@@ -82,10 +120,31 @@ export class ThreadGitRepository {
       if (!lease || lease.token !== body.token || lease.expiresAt <= Date.now()) {
         return Response.json({ error: "receive_lease_expired" }, { status: 409 });
       }
-      const previous = await this.#state.storage.get<ThreadRepository>(threadStorageKey);
-      await this.#state.storage.put(threadStorageKey, body.repository);
+      const current = await this.#state.storage.get<ThreadRepository>(threadStorageKey);
+      const currentHead = current?.head ?? ZERO_OID;
+      if (currentHead !== lease.oldOid) {
+        await this.#state.storage.delete(receiveLeaseStorageKey);
+        return Response.json({ error: "stale_receive", currentHead }, { status: 409 });
+      }
+      const pack: ThreadPack = {
+        ...packMetadata,
+        oldOid: lease.oldOid,
+        newOid: lease.newOid,
+      };
+      const repository: ThreadRepository = {
+        version: 1,
+        head: lease.newOid,
+        branch: THREAD_BRANCH,
+        refs: [{ name: THREAD_REF, oid: lease.newOid }],
+        packs: [...(current?.packs ?? []), pack],
+        updatedAt: new Date().toISOString(),
+      };
+      if (!isThreadRepository(repository)) {
+        return Response.json({ error: "invalid_receive" }, { status: 400 });
+      }
+      await this.#state.storage.put(threadStorageKey, repository);
       await this.#state.storage.delete(receiveLeaseStorageKey);
-      return Response.json({ repository: body.repository, previousPackKey: previous?.packKey });
+      return Response.json({ repository });
     });
   }
 
@@ -105,27 +164,61 @@ export class ThreadGitRepository {
 }
 
 export function isThreadRepository(value: unknown): value is ThreadRepository {
-  if (!isRepositoryView(value)) return false;
+  if (value == null || typeof value !== "object") return false;
   const repository = value as Partial<ThreadRepository>;
-  return repository.version === 1 &&
-    repository.branch === "nanocodex" &&
-    typeof repository.packHash === "string" && SHA1_PATTERN.test(repository.packHash) &&
-    typeof repository.packSize === "number" && Number.isSafeInteger(repository.packSize) &&
-    repository.packSize > 0 &&
-    typeof repository.updatedAt === "string" && Number.isFinite(Date.parse(repository.updatedAt)) &&
-    typeof repository.packKey === "string" &&
-    /^thread-repositories\/[A-Za-z0-9._-]+\/[A-Za-z0-9-]+\.pack$/.test(repository.packKey);
+  if (
+    repository.version !== 1 ||
+    typeof repository.head !== "string" ||
+    !SHA1_PATTERN.test(repository.head) ||
+    repository.branch !== THREAD_BRANCH ||
+    !Array.isArray(repository.refs) ||
+    repository.refs.length !== 1 ||
+    repository.refs[0]?.name !== THREAD_REF ||
+    repository.refs[0].oid !== repository.head ||
+    !Array.isArray(repository.packs) ||
+    repository.packs.length === 0 ||
+    !repository.packs.every(isThreadPack) ||
+    typeof repository.updatedAt !== "string" ||
+    !Number.isFinite(Date.parse(repository.updatedAt))
+  ) {
+    return false;
+  }
+  const keys = new Set(repository.packs.map(({ key }) => key));
+  let previousOid = ZERO_OID;
+  let objectCount = 0;
+  for (const pack of repository.packs) {
+    if (pack.oldOid !== previousOid) return false;
+    previousOid = pack.newOid;
+    objectCount += pack.objectCount;
+  }
+  return keys.size === repository.packs.length &&
+    objectCount <= MAX_PACK_OBJECTS &&
+    previousOid === repository.head;
 }
 
-function isRepositoryView(value: unknown): value is RepositoryView {
+export function isThreadPack(value: unknown): value is ThreadPack {
+  if (!isThreadPackMetadata(value)) return false;
+  const pack = value as Partial<ThreadPack>;
+  return typeof pack.oldOid === "string" && SHA1_PATTERN.test(pack.oldOid) &&
+    typeof pack.newOid === "string" && SHA1_PATTERN.test(pack.newOid) &&
+    pack.newOid !== ZERO_OID;
+}
+
+export function isThreadPackMetadata(value: unknown): value is ThreadPackMetadata {
   if (value == null || typeof value !== "object") return false;
-  const repository = value as Partial<RepositoryView>;
-  return typeof repository.head === "string" && SHA1_PATTERN.test(repository.head) &&
-    typeof repository.branch === "string" && /^[A-Za-z0-9][A-Za-z0-9._\/-]*$/.test(repository.branch) &&
-    typeof repository.packKey === "string" && repository.packKey.length > 0 &&
-    Array.isArray(repository.refs) && repository.refs.every((ref) =>
-      ref != null && typeof ref === "object" &&
-      typeof ref.name === "string" && REF_PATTERN.test(ref.name) &&
-      typeof ref.oid === "string" && SHA1_PATTERN.test(ref.oid)
-    );
+  const pack = value as Partial<ThreadPackMetadata>;
+  return typeof pack.key === "string" && PACK_KEY_PATTERN.test(pack.key) &&
+    typeof pack.hash === "string" && SHA1_PATTERN.test(pack.hash) &&
+    typeof pack.size === "number" && Number.isSafeInteger(pack.size) &&
+    pack.size >= 32 && pack.size <= MAX_PACK_BYTES &&
+    typeof pack.objectCount === "number" && Number.isSafeInteger(pack.objectCount) &&
+    pack.objectCount > 0 && pack.objectCount <= MAX_PACK_OBJECTS;
+}
+
+function isReceiveCommand(value: unknown): value is Pick<ReceiveLease, "oldOid" | "newOid" | "ref"> {
+  if (value == null || typeof value !== "object") return false;
+  const command = value as { oldOid?: unknown; newOid?: unknown; ref?: unknown };
+  return typeof command.oldOid === "string" && SHA1_PATTERN.test(command.oldOid) &&
+    typeof command.newOid === "string" && SHA1_PATTERN.test(command.newOid) &&
+    command.newOid !== ZERO_OID && command.ref === THREAD_REF;
 }

--- a/web/worker/threadRoutes.test.ts
+++ b/web/worker/threadRoutes.test.ts
@@ -1,7 +1,20 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { test } from "node:test";
 
-import { readGitProtocolRequest } from "./threadRoutes.ts";
+import { encodePacketLine, parsePacketLines } from "./threadProtocol.ts";
+import { ThreadGitRepository, type ThreadRepository } from "./threadRepository.ts";
+import { handleThreadGitRequest, readGitProtocolRequest } from "./threadRoutes.ts";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const repositoryName = "thread-12345678-1234-4123-8123-123456789abc";
+const remote = `https://repository.test/git/${repositoryName}`;
+const ref = "refs/heads/nanocodex";
+const zero = "0".repeat(40);
+const headA = "a".repeat(40);
+const headB = "b".repeat(40);
+const headC = "c".repeat(40);
 
 test("Git request bodies are rejected while reading once they exceed the limit", async () => {
   const result = await readGitProtocolRequest(new Request("https://repository.test", {
@@ -11,3 +24,270 @@ test("Git request bodies are rejected while reading once they exceed the limit",
   assert.ok(result instanceof Response);
   assert.equal(result.status, 413);
 });
+
+test("thread routes persist refs, CAS updates, and retain every finalized pack", async () => {
+  const durable = memoryRepository();
+  const bucket = new MemoryBucket();
+  const env = {
+    GIT_OBJECTS: bucket as unknown as R2Bucket,
+    THREAD_GIT_REPOSITORY: namespace(durable) as unknown as DurableObjectNamespace,
+  };
+
+  const empty = await advertise(env);
+  assert.match((await responseLines(empty))[1]!, new RegExp(`^${zero} capabilities\\^\\{\\}`));
+
+  assert.equal((await push(env, zero, headA)).status, 200);
+  const firstAdvertisement = await advertise(env);
+  assert.match((await responseLines(firstAdvertisement))[1]!, new RegExp(`^${headA} ${ref}`));
+  assert.equal((await push(env, headA, headB)).status, 200);
+
+  const current = await durable.fetch(new Request("https://repository.internal/thread"));
+  const repository = await current.json() as ThreadRepository;
+  assert.equal(repository.head, headB);
+  assert.equal(repository.packs.length, 2);
+  assert.deepEqual(repository.packs.map(({ oldOid, newOid }) => ({ oldOid, newOid })), [
+    { oldOid: zero, newOid: headA },
+    { oldOid: headA, newOid: headB },
+  ]);
+  assert.equal(bucket.objects.size, 2);
+  assert.deepEqual(bucket.deleted, []);
+
+  const [packA, packB] = repository.packs.map(({ key }) => key);
+  bucket.resetReads();
+  const incremental = await fetchV2(env, headB, [headA]);
+  assert.equal(packObjectCount(await uploadPackBytes(incremental)), 1);
+  assert.deepEqual(bucket.headCalls, [packB]);
+  assert.deepEqual(bucket.getCalls, [packB]);
+
+  bucket.resetReads();
+  const legacyIncremental = await fetchLegacy(env, headB, [headA]);
+  assert.equal(packObjectCount(await uploadPackBytes(legacyIncremental)), 1);
+  assert.deepEqual(bucket.headCalls, [packB]);
+  assert.deepEqual(bucket.getCalls, [packB]);
+
+  bucket.resetReads();
+  const currentFetch = await fetchV2(env, headB, [headA, headB]);
+  assert.equal(packObjectCount(await uploadPackBytes(currentFetch)), 0);
+  assert.deepEqual(bucket.headCalls, []);
+  assert.deepEqual(bucket.getCalls, []);
+
+  bucket.resetReads();
+  const clone = await fetchV2(env, headB, []);
+  assert.equal(packObjectCount(await uploadPackBytes(clone)), 2);
+  assert.deepEqual(bucket.headCalls, [packA, packB]);
+  assert.deepEqual(bucket.getCalls, [packA, packB]);
+
+  const stale = await push(env, headA, headC);
+  assert.equal(stale.status, 200);
+  assert.deepEqual((await responseLines(stale)).slice(0, 2), [
+    "unpack error stale ref; pull and retry\n",
+    `ng ${ref} stale ref; pull and retry\n`,
+  ]);
+  assert.equal(bucket.objects.size, 2);
+  assert.deepEqual(bucket.deleted, []);
+  const unchanged = await durable.fetch(new Request("https://repository.internal/thread"));
+  assert.equal(((await unchanged.json()) as ThreadRepository).head, headB);
+});
+
+test("a lost finalize response cannot delete a pack that the DO committed", async () => {
+  const durable = memoryRepository();
+  const bucket = new MemoryBucket();
+  const env = {
+    GIT_OBJECTS: bucket as unknown as R2Bucket,
+    THREAD_GIT_REPOSITORY: namespace(durable, true) as unknown as DurableObjectNamespace,
+  };
+
+  const response = await push(env, zero, headA);
+  assert.equal(response.status, 200);
+  assert.match((await responseLines(response))[0]!, /^unpack error/);
+
+  const current = await durable.fetch(new Request("https://repository.internal/thread"));
+  const repository = await current.json() as ThreadRepository;
+  assert.equal(repository.head, headA);
+  assert.equal(repository.packs.length, 1);
+  assert.equal(bucket.objects.size, 1);
+  assert.deepEqual(bucket.deleted, []);
+});
+
+function memoryRepository(): ThreadGitRepository {
+  const values = new Map<string, unknown>();
+  const state = {
+    storage: {
+      get: async <T>(key: string) => structuredClone(values.get(key)) as T | undefined,
+      put: async (key: string, value: unknown) => { values.set(key, structuredClone(value)); },
+      delete: async (key: string) => values.delete(key),
+    },
+    blockConcurrencyWhile: async <T>(callback: () => Promise<T>) => callback(),
+  } as unknown as DurableObjectState;
+  return new ThreadGitRepository(state);
+}
+
+function namespace(durable: ThreadGitRepository, loseFinalizeResponse = false) {
+  return {
+    idFromName: () => ({}),
+    get: () => ({ fetch: async (request: Request | string, init?: RequestInit) => {
+      const internal = request instanceof Request ? request : new Request(request, init);
+      const response = await durable.fetch(internal);
+      if (loseFinalizeResponse && internal.url.endsWith("/receive/finalize") && response.ok) {
+        throw new Error("simulated lost finalize response");
+      }
+      return response;
+    } }),
+  };
+}
+
+async function advertise(env: {
+  GIT_OBJECTS: R2Bucket;
+  THREAD_GIT_REPOSITORY: DurableObjectNamespace;
+}): Promise<Response> {
+  const request = new Request(`${remote}/info/refs?service=git-receive-pack`);
+  const response = await handleThreadGitRequest(request, env, new URL(request.url));
+  assert.ok(response);
+  return response;
+}
+
+async function push(env: {
+  GIT_OBJECTS: R2Bucket;
+  THREAD_GIT_REPOSITORY: DurableObjectNamespace;
+}, oldOid: string, newOid: string): Promise<Response> {
+  const pack = sourcePack();
+  const body = concatenate([
+    encodePacketLine(`${oldOid} ${newOid} ${ref}\0 report-status\n`),
+    encoder.encode("0000"),
+    pack,
+  ]);
+  const request = new Request(`${remote}/git-receive-pack`, {
+    method: "POST",
+    body: body.slice().buffer,
+  });
+  const response = await handleThreadGitRequest(request, env, new URL(request.url));
+  assert.ok(response);
+  return response;
+}
+
+async function fetchV2(env: {
+  GIT_OBJECTS: R2Bucket;
+  THREAD_GIT_REPOSITORY: DurableObjectNamespace;
+}, want: string, haves: readonly string[]): Promise<Response> {
+  const body = concatenate([
+    encodePacketLine("command=fetch\n"),
+    encoder.encode("0001"),
+    encodePacketLine(`want ${want}\n`),
+    ...haves.map((oid) => encodePacketLine(`have ${oid}\n`)),
+    encodePacketLine("done\n"),
+    encoder.encode("0000"),
+  ]);
+  const request = new Request(`${remote}/git-upload-pack`, {
+    method: "POST",
+    headers: { "git-protocol": "version=2" },
+    body: body.slice().buffer,
+  });
+  const response = await handleThreadGitRequest(request, env, new URL(request.url));
+  assert.ok(response);
+  return response;
+}
+
+async function fetchLegacy(env: {
+  GIT_OBJECTS: R2Bucket;
+  THREAD_GIT_REPOSITORY: DurableObjectNamespace;
+}, want: string, haves: readonly string[]): Promise<Response> {
+  const body = concatenate([
+    encodePacketLine(`want ${want} side-band-64k ofs-delta\n`),
+    encoder.encode("0000"),
+    ...haves.map((oid) => encodePacketLine(`have ${oid}\n`)),
+    encodePacketLine("done\n"),
+  ]);
+  const request = new Request(`${remote}/git-upload-pack`, {
+    method: "POST",
+    body: body.slice().buffer,
+  });
+  const response = await handleThreadGitRequest(request, env, new URL(request.url));
+  assert.ok(response);
+  return response;
+}
+
+async function uploadPackBytes(response: Response): Promise<Uint8Array> {
+  assert.equal(response.status, 200);
+  const packets = parsePacketLines(new Uint8Array(await response.arrayBuffer()));
+  const chunks: Uint8Array[] = [];
+  for (const packet of packets) {
+    if (packet.kind !== "data") continue;
+    const line = decoder.decode(packet.data);
+    if (line === "packfile\n" || line === "NAK\n" || line.startsWith("ACK ")) continue;
+    assert.equal(packet.data[0], 1);
+    chunks.push(packet.data.subarray(1));
+  }
+  return concatenate(chunks);
+}
+
+function packObjectCount(pack: Uint8Array): number {
+  assert.equal(decoder.decode(pack.subarray(0, 4)), "PACK");
+  return new DataView(pack.buffer, pack.byteOffset, pack.byteLength).getUint32(8);
+}
+
+async function responseLines(response: Response): Promise<string[]> {
+  return packetLines(new Uint8Array(await response.arrayBuffer()));
+}
+
+function packetLines(bytes: Uint8Array): string[] {
+  return parsePacketLines(bytes)
+    .filter((packet) => packet.kind === "data")
+    .map((packet) => decoder.decode(packet.data));
+}
+
+class MemoryBucket {
+  readonly objects = new Map<string, Uint8Array>();
+  readonly deleted: string[] = [];
+  readonly headCalls: string[] = [];
+  readonly getCalls: string[] = [];
+
+  async put(key: string, value: unknown) {
+    const bytes = value instanceof Uint8Array
+      ? value
+      : new Uint8Array(await new Response(value as BodyInit).arrayBuffer());
+    this.objects.set(key, bytes.slice());
+    return {};
+  }
+
+  async delete(key: string) {
+    this.deleted.push(key);
+    this.objects.delete(key);
+  }
+
+  async head(key: string) {
+    this.headCalls.push(key);
+    const bytes = this.objects.get(key);
+    return bytes ? { size: bytes.byteLength } : null;
+  }
+
+  async get(key: string) {
+    this.getCalls.push(key);
+    const bytes = this.objects.get(key);
+    return bytes ? { arrayBuffer: async () => bytes.slice().buffer } : null;
+  }
+
+  resetReads() {
+    this.headCalls.length = 0;
+    this.getCalls.length = 0;
+  }
+}
+
+function sourcePack(): Uint8Array {
+  const header = new Uint8Array(12);
+  header.set(encoder.encode("PACK"));
+  const view = new DataView(header.buffer);
+  view.setUint32(4, 2);
+  view.setUint32(8, 1);
+  const body = concatenate([header, Uint8Array.of(0x31, 0x78, 0x9c, 0x03, 0x00, 0x00, 0x00, 0x00, 0x01)]);
+  return concatenate([body, new Uint8Array(createHash("sha1").update(body).digest())]);
+}
+
+function concatenate(chunks: readonly Uint8Array[]): Uint8Array {
+  const output = new Uint8Array(chunks.reduce((total, chunk) => total + chunk.byteLength, 0));
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return output;
+}

--- a/web/worker/threadRoutes.ts
+++ b/web/worker/threadRoutes.ts
@@ -13,7 +13,13 @@ import {
   repositoryAdvertisement,
   type ReceiveCommand,
 } from "./threadProtocol.ts";
-import { isThreadRepository, type RepositoryView, type ThreadRepository } from "./threadRepository.ts";
+import { createThreadPackStream } from "./threadPack.ts";
+import {
+  isThreadRepository,
+  type RepositoryView,
+  type ThreadPack,
+  type ThreadPackMetadata,
+} from "./threadRepository.ts";
 
 // Smart-HTTP/DO/R2 ownership follows the MIT-licensed Git-on-Cloudflare design.
 // Its account, admin, registry, and D1 product layers are intentionally absent;
@@ -58,7 +64,9 @@ export async function handleThreadGitRequest(
       });
     }
     if (service === "git-receive-pack") {
-      return new Response(byteBody(receiveAdvertisement()), {
+      const repository = await getThreadRepository(env, route.repository);
+      if (repository instanceof Response) return repository;
+      return new Response(byteBody(receiveAdvertisement(repository)), {
         headers: gitHeaders("application/x-git-receive-pack-advertisement"),
       });
     }
@@ -98,19 +106,27 @@ async function uploadPack(
   if (command.command !== "fetch") return gitError("unsupported Git protocol command", 400);
   if (!repository) return gitError("thread repository is empty", 404);
 
-  const wants = command.arguments
-    .filter((argument) => argument.startsWith("want "))
-    .map((argument) => argument.slice("want ".length));
+  let wants: string[];
+  let haves: string[];
+  try {
+    wants = parseFetchOids(command.arguments, "want");
+    haves = parseFetchOids(command.arguments, "have");
+  } catch (error) {
+    return gitError(errorMessage(error), 400);
+  }
   const advertisedOids = new Set([repository.head, ...repository.refs.map((ref) => ref.oid)]);
   if (wants.length === 0 || wants.some((oid) => !advertisedOids.has(oid))) {
     return gitError("invalid fetch wants", 400);
   }
+  const selection = selectPackSuffix(repository.packs, haves);
   if (!command.arguments.includes("done")) {
-    return uploadResponse(byteBody(buildNegotiationResponse()));
+    return uploadResponse(byteBody(buildNegotiationResponse(
+      selection.have ? [selection.have] : [],
+    )));
   }
-  const pack = await env.GIT_OBJECTS!.get(repository.packKey);
-  if (!pack) return gitError("thread pack is missing", 503);
-  return uploadResponse(buildFullPackResponse(pack.body));
+  const pack = await fetchPackStream(env.GIT_OBJECTS!, selection.packs);
+  if (pack instanceof Response) return pack;
+  return uploadResponse(buildFullPackResponse(pack));
 }
 
 async function legacyUploadPack(
@@ -120,22 +136,24 @@ async function legacyUploadPack(
 ): Promise<Response> {
   if (!repository) return gitError("thread repository is empty", 404);
   let wants: string[];
+  let haves: string[];
   try {
-    wants = parsePacketLines(body)
+    const lines = parsePacketLines(body)
       .filter((packet) => packet.kind === "data")
-      .map((packet) => new TextDecoder().decode(packet.data).replace(/\n$/, ""))
-      .filter((line) => line.startsWith("want "))
-      .map((line) => line.slice("want ".length).split(" ", 1)[0]!);
-  } catch {
-    return gitError("malformed git-upload-pack request", 400);
+      .map((packet) => new TextDecoder().decode(packet.data).replace(/\n$/, ""));
+    wants = parseFetchOids(lines, "want");
+    haves = parseFetchOids(lines, "have");
+  } catch (error) {
+    return gitError(errorMessage(error), 400);
   }
   const advertisedOids = new Set([repository.head, ...repository.refs.map((ref) => ref.oid)]);
   if (wants.length === 0 || wants.some((oid) => !advertisedOids.has(oid))) {
     return gitError("invalid fetch wants", 400);
   }
-  const pack = await env.GIT_OBJECTS!.get(repository.packKey);
-  if (!pack) return gitError("thread pack is missing", 503);
-  return uploadResponse(buildLegacyFullPackResponse(pack.body));
+  const selection = selectPackSuffix(repository.packs, haves);
+  const pack = await fetchPackStream(env.GIT_OBJECTS!, selection.packs);
+  if (pack instanceof Response) return pack;
+  return uploadResponse(buildLegacyFullPackResponse(pack, selection.have));
 }
 
 async function receivePack(
@@ -149,25 +167,45 @@ async function receivePack(
 
   let command: ReceiveCommand | undefined;
   let pack: Uint8Array | undefined;
+  let packMetadata: Awaited<ReturnType<typeof validatePack>> | undefined;
   let sideBand64k = false;
   try {
     const parsed = parseReceiveRequest(body);
     sideBand64k = parsed.sideBand64k;
     if (parsed.commands.length !== 1) throw new Error("only one branch may be pushed at a time");
     command = parsed.commands[0]!;
-    if (command.oldOid !== ZERO_OID || command.ref !== THREAD_REF || !SHA1_PATTERN.test(command.newOid)) {
-      throw new Error(`push refs/heads/${THREAD_BRANCH} from the advertised empty repository`);
+    if (
+      !SHA1_PATTERN.test(command.oldOid) ||
+      !SHA1_PATTERN.test(command.newOid) ||
+      command.newOid === ZERO_OID ||
+      command.ref !== THREAD_REF
+    ) {
+      throw new Error(`only updates to refs/heads/${THREAD_BRANCH} are supported`);
     }
     pack = parsed.pack;
-    await validatePack(pack);
+    packMetadata = await validatePack(pack);
   } catch (error) {
     const fallback = command ?? { oldOid: ZERO_OID, newOid: ZERO_OID, ref: THREAD_REF };
     return receiveResponse(buildReceiveReport(fallback, errorMessage(error)), sideBand64k);
   }
+  if (!command || !pack || !packMetadata) return gitError("invalid receive state", 500);
 
   const stub = repositoryStub(env, repositoryName);
-  const begin = await stub.fetch("https://repository.internal/receive/begin", { method: "POST" });
-  if (begin.status === 409) return gitError("repository is busy; retry the push", 503);
+  const begin = await stub.fetch("https://repository.internal/receive/begin", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(command),
+  });
+  if (begin.status === 409) {
+    const conflict = await begin.json().catch(() => undefined) as { error?: unknown } | undefined;
+    if (conflict?.error === "stale_receive") {
+      return receiveResponse(
+        buildReceiveReport(command, "stale ref; pull and retry"),
+        sideBand64k,
+      );
+    }
+    return gitError("repository is busy; retry the push", 503);
+  }
   if (!begin.ok) return gitError("could not reserve repository receive", 503);
   const beginBody = await begin.json() as { lease?: { token?: unknown } };
   const token = typeof beginBody.lease?.token === "string" ? beginBody.lease.token : "";
@@ -175,8 +213,8 @@ async function receivePack(
 
   const packKey = `thread-repositories/${repositoryName}/${crypto.randomUUID()}.pack`;
   let uploaded = false;
+  let finalizeAttempted = false;
   try {
-    const packHash = bytesToHex(pack.slice(-20));
     await env.GIT_OBJECTS!.put(packKey, pack, {
       httpMetadata: {
         contentType: "application/x-git-packed-objects",
@@ -185,32 +223,23 @@ async function receivePack(
       customMetadata: { repository: repositoryName, head: command.newOid },
     });
     uploaded = true;
-    const repository: ThreadRepository = {
-      version: 1,
-      head: command.newOid,
-      branch: THREAD_BRANCH,
-      refs: [{ name: THREAD_REF, oid: command.newOid }],
-      packKey,
-      packHash,
-      packSize: pack.byteLength,
-      updatedAt: new Date().toISOString(),
+    const storedPack: ThreadPackMetadata = {
+      key: packKey,
+      hash: packMetadata.hash,
+      size: packMetadata.size,
+      objectCount: packMetadata.objectCount,
     };
+    finalizeAttempted = true;
     const finalized = await stub.fetch("https://repository.internal/receive/finalize", {
       method: "PUT",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ token, repository }),
+      body: JSON.stringify({ token, pack: storedPack }),
     });
     if (!finalized.ok) throw new Error("receive lease expired before refs were committed");
-    const result = await finalized.json() as { previousPackKey?: unknown };
-    if (typeof result.previousPackKey === "string" && result.previousPackKey !== packKey) {
-      const cleanup = env.GIT_OBJECTS!.delete(result.previousPackKey);
-      if (context) context.waitUntil(cleanup);
-      else await cleanup;
-    }
     return receiveResponse(buildReceiveReport(command), sideBand64k);
   } catch (error) {
     const cleanup = Promise.all([
-      uploaded ? env.GIT_OBJECTS!.delete(packKey) : Promise.resolve(),
+      uploaded && !finalizeAttempted ? env.GIT_OBJECTS!.delete(packKey) : Promise.resolve(),
       stub.fetch("https://repository.internal/receive/abort", {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -223,7 +252,11 @@ async function receivePack(
   }
 }
 
-async function validatePack(pack: Uint8Array): Promise<void> {
+async function validatePack(pack: Uint8Array): Promise<{
+  hash: string;
+  size: number;
+  objectCount: number;
+}> {
   if (pack.byteLength > MAX_THREAD_PACK_BYTES) throw new Error("pack exceeds 32 MiB");
   if (pack.byteLength < 32) throw new Error("pack is truncated");
   if (new TextDecoder().decode(pack.subarray(0, 4)) !== "PACK") {
@@ -231,13 +264,50 @@ async function validatePack(pack: Uint8Array): Promise<void> {
   }
   const view = new DataView(pack.buffer, pack.byteOffset, pack.byteLength);
   if (view.getUint32(4) !== 2) throw new Error("only Git pack version 2 is supported");
-  if (view.getUint32(8) === 0) throw new Error("pack contains no objects");
+  const objectCount = view.getUint32(8);
+  if (objectCount === 0) throw new Error("pack contains no objects");
   const expected = pack.subarray(pack.byteLength - 20);
+  const digestBytes = arrayBufferView(pack, pack.byteLength - 20);
   const actual = new Uint8Array(await crypto.subtle.digest(
     "SHA-1",
-    byteBody(pack.subarray(0, pack.byteLength - 20)),
+    digestBytes,
   ));
   if (!constantTimeEqual(actual, expected)) throw new Error("pack checksum is invalid");
+  return { hash: bytesToHex(expected), size: pack.byteLength, objectCount };
+}
+
+async function fetchPackStream(
+  bucket: R2Bucket,
+  packs: readonly ThreadPack[],
+): Promise<ReadableStream<Uint8Array> | Response> {
+  try {
+    return await createThreadPackStream(bucket, packs);
+  } catch (error) {
+    return gitError(errorMessage(error), 503);
+  }
+}
+
+function parseFetchOids(lines: readonly string[], kind: "want" | "have"): string[] {
+  const prefix = `${kind} `;
+  return lines.filter((line) => line.startsWith(prefix)).map((line) => {
+    const oid = line.slice(prefix.length).split(" ", 1)[0]!;
+    if (!SHA1_PATTERN.test(oid)) throw new Error(`invalid fetch ${kind}`);
+    return oid;
+  });
+}
+
+function selectPackSuffix(
+  packs: readonly ThreadPack[],
+  haves: readonly string[],
+): { packs: readonly ThreadPack[]; have?: string } {
+  const clientOids = new Set(haves);
+  for (let index = packs.length - 1; index >= 0; index--) {
+    const newOid = packs[index]!.newOid;
+    if (clientOids.has(newOid)) {
+      return { packs: packs.slice(index + 1), have: newOid };
+    }
+  }
+  return { packs };
 }
 
 async function getThreadRepository(
@@ -335,6 +405,13 @@ function gitError(message: string, status: number): Response {
 
 function byteBody(bytes: Uint8Array): ArrayBuffer {
   return bytes.slice().buffer;
+}
+
+function arrayBufferView(bytes: Uint8Array, byteLength: number): Uint8Array<ArrayBuffer> {
+  if (bytes.buffer instanceof ArrayBuffer) {
+    return new Uint8Array(bytes.buffer, bytes.byteOffset, byteLength);
+  }
+  return bytes.subarray(0, byteLength).slice();
 }
 
 function bytesToHex(bytes: Uint8Array): string {

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -138,16 +138,46 @@
   "env": {
     "development": {
       "name": "nanocodex-development",
+      "durable_objects": {
+        "bindings": [
+          { "name": "BYOK_SESSIONS", "class_name": "ByokSession" },
+          { "name": "CHATGPT_SESSIONS", "class_name": "ChatGptSession" },
+          { "name": "GIT_REPOSITORY", "class_name": "GitRepository" },
+          { "name": "THREAD_GIT_REPOSITORY", "class_name": "ThreadGitRepository" },
+          { "name": "EVAL_COORDINATOR", "class_name": "EvalCoordinator" },
+          { "name": "CHATGPT_EGRESS", "class_name": "ChatGptEgress" }
+        ]
+      },
+      "containers": [
+        {
+          "class_name": "ChatGptEgress",
+          "image": "./container/Dockerfile",
+          "max_instances": 1000,
+          "instance_type": "lite"
+        }
+      ],
+      "ratelimits": [
+        { "name": "AUTH_START_LIMIT", "namespace_id": "987601", "simple": { "limit": 5, "period": 60 } },
+        { "name": "AUTH_GLOBAL_LIMIT", "namespace_id": "987602", "simple": { "limit": 100, "period": 60 } },
+        { "name": "SESSION_POLL_LIMIT", "namespace_id": "987603", "simple": { "limit": 120, "period": 60 } },
+        { "name": "AGENT_SOCKET_LIMIT", "namespace_id": "987604", "simple": { "limit": 12, "period": 60 } },
+        { "name": "AGENT_TOOL_LIMIT", "namespace_id": "987605", "simple": { "limit": 30, "period": 60 } },
+        { "name": "AGENT_IMAGE_LIMIT", "namespace_id": "987606", "simple": { "limit": 4, "period": 60 } }
+      ],
+      "r2_buckets": [
+        { "binding": "GIT_OBJECTS", "bucket_name": "nanocodex-git" },
+        { "binding": "EVALS_ARTIFACTS", "bucket_name": "nanocodex-evals" }
+      ],
+      "d1_databases": [
+        {
+          "binding": "EVALS_DB",
+          "database_name": "nanocodex-evals",
+          "database_id": "b5a4b6e9-8e9f-489a-b0af-b1813d97dcd5",
+          "migrations_dir": "migrations"
+        }
+      ],
       "vars": {
         "ENVIRONMENT": "development"
-      }
-    },
-    "preview": {
-      "name": "nanocodex-preview",
-      "workers_dev": true,
-      "routes": [],
-      "vars": {
-        "ENVIRONMENT": "preview"
       }
     }
   }


### PR DESCRIPTION
## Summary
- make browser workspaces mutation-driven and bounded across OPFS, just-bash, Files, Code, and Commits
- support repeated native Git pushes with CAS-backed immutable thread pack chains
- fix compact mobile layouts and touch targets
- attest exact Cloudflare deployment SHAs before publishing the Git mirror
- serialize eval workset mutations across processes

PR #190 is already merged. This deliberately excludes the durability work in #181, which remains open separately.

## Evidence
- stock Git: three sequential pushes, fresh clone, and fast-forward pull against the local Worker
- `npm test` (103 tests)
- focused browser shell/mobile/thread Git tests (13 tests)
- `npm run build` including TypeScript, Vite, WASM, and bundle budgets
- `cargo test -p nanocodex-eval workset::tests::` (12 tests)
- `cargo fmt --all -- --check`
- `actionlint`
- Wrangler production dry-run with all bindings
