### PR TITLE
fix(ci): install local bindings dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,6 +286,7 @@ jobs:
           node-version: 22.13.0
           cache: npm
           cache-dependency-path: |
+            js/bindings/package-lock.json
             js/react/package-lock.json
             js/artifacts/package-lock.json
             js/tui/package-lock.json
@@ -297,6 +298,7 @@ jobs:
           path: js/bindings/pkg-web
       - name: Build local website packages
         run: |
+          npm ci --prefix js/bindings
           npm ci --prefix js/react
           npm ci --prefix js/artifacts
           npm run build --prefix js/artifacts


### PR DESCRIPTION
The merged web-tools extraction moved browser runtime imports into the local nanocodex package. The website job installs that package through a file link, so Node resolves imports from js/bindings and requires its dependency tree there. Install and cache the bindings dependencies before running the website tests.\n\nVerified the three clean-worktree failures directly: browserShell, opfsGit, and threadGit (23/23 passing).