### PR TITLE
feat(js): add browser dataset tools

### DIFF
--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -103,6 +103,7 @@ and Rust/WASM extensions in the same array:
 ```js
 import { Agent, Subagents, Transport } from "nanocodex/browser";
 import {
+  dataset,
   imageGeneration,
   updatePlan,
   web,
@@ -115,6 +116,7 @@ const agent = await Agent.create({
   }),
   tools: [
     web(),
+    dataset(),
     imageGeneration({
       recentImages: (sessionId, count) => images.get(sessionId).slice(-count),
       rememberImage: (sessionId, imageUrl) => images.get(sessionId).push(imageUrl),
@@ -133,6 +135,38 @@ arguments before dispatch. In a browser, they default to the same-origin
 only a bounded JSON endpoint, credentials, authorization, and persistence.
 `web(...)` posts `{ commands, session_id }`; `imageGeneration(...)` posts
 `{ images, prompt }`. Pass `url` when the host route lives elsewhere.
+
+`dataset()` runs entirely in the caller and inspects public HTTPS Parquet,
+uncompressed JSONL, and Hugging Face datasets. It opens a session-scoped handle,
+returns schema metadata, and supports bounded projection and filtering queries.
+Parquet uses HTTP range reads and predicate pushdown where possible; JSONL scans
+the response stream incrementally. The implementation, Parquet reader, and
+non-Snappy codecs load only after the model first calls the tool. Direct URLs
+must allow browser CORS, and Parquet servers must support byte ranges.
+Consumers that only need this capability can import `dataset` from the smaller
+`nanocodex/tools/dataset` leaf entry.
+
+```js
+const datasets = dataset();
+const opened = await datasets.handler({
+  operation: "open",
+  source: {
+    kind: "huggingface",
+    dataset: "openai/gsm8k",
+    config: "main",
+    split: "train",
+  },
+}, { sessionId: "thread-1" });
+
+await datasets.handler({
+  operation: "query",
+  dataset_id: opened.datasetId,
+  columns: ["question", "answer"],
+  filters: [{ column: "question", op: "contains", value: "how many" }],
+  limit: 5,
+}, { sessionId: "thread-1" });
+```
+
 This same adapter works inside a Cloudflare Worker or Durable Object:
 
 ```js

--- a/js/bindings/package-lock.json
+++ b/js/bindings/package-lock.json
@@ -15,6 +15,8 @@
         "@modelcontextprotocol/sdk": "1.30.0",
         "buffer": "6.0.3",
         "diff": "^9.0.0",
+        "hyparquet": "1.28.2",
+        "hyparquet-compressors": "1.1.1",
         "isomorphic-git": "^1.41.5",
         "just-bash": "^3.4.0",
         "minisearch": "7.2.0",
@@ -24,6 +26,7 @@
       },
       "devDependencies": {
         "@jitl/quickjs-wasmfile-release-asyncify": "0.32.0",
+        "hyparquet-writer": "0.16.6",
         "pkg-pr-new": "0.0.79",
         "quickjs-emscripten-core": "0.32.0",
         "typescript": "5.9.3"
@@ -1265,6 +1268,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fzstd": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
+      "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==",
+      "license": "MIT"
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -1400,6 +1409,45 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/hyparquet": {
+      "version": "1.28.2",
+      "resolved": "https://registry.npmjs.org/hyparquet/-/hyparquet-1.28.2.tgz",
+      "integrity": "sha512-+24r0j3oA8dzFYQlPfSeua5JacoPmJPSqbyEGbhleuahOJ2cablgXTk862Pq8sMjkw7/uPucLgPpIOJzWxR8Jg==",
+      "license": "MIT"
+    },
+    "node_modules/hyparquet-compressors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hyparquet-compressors/-/hyparquet-compressors-1.1.1.tgz",
+      "integrity": "sha512-yx7aA3Rhj0YycbdV71+XznQSLAefa4cT0urpgNXy4aM6eSeCknaVDNne8y45Uz74Fb15yyXUzOStlceOJBan7A==",
+      "license": "MIT",
+      "dependencies": {
+        "fzstd": "0.1.1",
+        "hysnappy": "1.0.0"
+      }
+    },
+    "node_modules/hyparquet-writer": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/hyparquet-writer/-/hyparquet-writer-0.16.6.tgz",
+      "integrity": "sha512-KK3FhIf/yPhDi63rAEV6Di9tLZXDGYqXcOMVS2Ssm5zerEkrfc71REfGCFcEKtiiATGzd9kq5uWcy8JeCapQVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hyparquet": "1.28.1"
+      }
+    },
+    "node_modules/hyparquet-writer/node_modules/hyparquet": {
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/hyparquet/-/hyparquet-1.28.1.tgz",
+      "integrity": "sha512-04PlyhYZpNDVaOjJNX4SP00beWf9Y9vXEOEQXSMFqVQNzxGxTmsJOQgBjar8VzLpT6E2kxNiWKL539e1dHcOVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hysnappy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hysnappy/-/hysnappy-1.0.0.tgz",
+      "integrity": "sha512-MNrC4NfwDGPb889O6gIfEtbvEZCSWUsSEhsz4Oq2FRcpGtXHfeVz3KciSPp5Pnnz1NjFMgDQNfxdJozymJEDDA==",
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.7.3",

--- a/js/bindings/package.json
+++ b/js/bindings/package.json
@@ -43,6 +43,10 @@
       "types": "./tools/index.d.mts",
       "import": "./tools/index.mjs"
     },
+    "./tools/dataset": {
+      "types": "./tools/dataset.d.mts",
+      "import": "./tools/dataset.mjs"
+    },
     "./tools/browser": {
       "types": "./tools/browser/index.d.mts",
       "import": "./tools/browser/index.mjs"
@@ -85,6 +89,7 @@
     "prepack": "npm run check:package",
     "test": "node --test test/*.test.mjs && npm run test:performance && npm run test:typecheck && npm run check:package",
     "test:performance": "node --test test/performance.bench.mjs",
+    "bench:dataset": "node scripts/dataset.bench.mjs",
     "test:typecheck": "tsc -p test/tsconfig.json"
   },
   "dependencies": {
@@ -94,6 +99,8 @@
     "@modelcontextprotocol/sdk": "1.30.0",
     "buffer": "6.0.3",
     "diff": "^9.0.0",
+    "hyparquet": "1.28.2",
+    "hyparquet-compressors": "1.1.1",
     "isomorphic-git": "^1.41.5",
     "just-bash": "^3.4.0",
     "minisearch": "7.2.0",
@@ -103,6 +110,7 @@
   },
   "devDependencies": {
     "@jitl/quickjs-wasmfile-release-asyncify": "0.32.0",
+    "hyparquet-writer": "0.16.6",
     "pkg-pr-new": "0.0.79",
     "quickjs-emscripten-core": "0.32.0",
     "typescript": "5.9.3"

--- a/js/bindings/runtime/code-runtime.mjs
+++ b/js/bindings/runtime/code-runtime.mjs
@@ -231,10 +231,12 @@ export function createCodeRuntime(toolConfiguration = {}, extras = {}) {
     toolDefinitions: () => JSON.stringify(currentDefinitions()),
     releaseSession(sessionId) {
       stores.delete(sessionId);
+      for (const tool of configuredTools) tool.releaseSession?.(sessionId);
     },
     reset() {
       for (const execution of activeExecutions) execution.controller.abort();
       stores.clear();
+      for (const tool of configuredTools) tool.dispose?.();
     },
   });
 }
@@ -243,7 +245,12 @@ function addTool(name, tool, collection) {
   if (!tool || typeof tool.handler !== "function") {
     throw new TypeError(`tool ${name} requires a handler function`);
   }
-  const configured = Object.freeze({ handler: tool.handler, name });
+  const configured = Object.freeze({
+    dispose: typeof tool.dispose === "function" ? tool.dispose : undefined,
+    handler: tool.handler,
+    name,
+    releaseSession: typeof tool.releaseSession === "function" ? tool.releaseSession : undefined,
+  });
   collection.configuredTools.push(configured);
   collection.toolByName.set(name, configured);
   collection.definitions.push(deepFreeze({

--- a/js/bindings/scripts/check-package.mjs
+++ b/js/bindings/scripts/check-package.mjs
@@ -34,6 +34,11 @@ const requiredFiles = [
   "runtime/workspace.d.mts",
   "tools/index.mjs",
   "tools/index.d.mts",
+  "tools/dataset.mjs",
+  "tools/dataset.d.mts",
+  "tools/datasetContract.mjs",
+  "tools/datasetEngine.mjs",
+  "tools/namedTool.mjs",
   "tools/standardDescriptions.mjs",
   "tools/browser/index.mjs",
   "tools/browser/index.d.mts",
@@ -66,6 +71,7 @@ export async function checkPackage(packageRoot = root) {
   assert.equal(packageJson.exports?.["./node/workspace"]?.import, "./node/workspace.mjs");
   assert.equal(packageJson.exports?.["./worker"]?.import, "./worker/index.mjs");
   assert.equal(packageJson.exports?.["./tools"]?.import, "./tools/index.mjs");
+  assert.equal(packageJson.exports?.["./tools/dataset"]?.import, "./tools/dataset.mjs");
   assert.equal(packageJson.exports?.["./tools/browser"]?.import, "./tools/browser/index.mjs");
   assert.equal(packageJson.exports?.["./tools/vite"]?.import, "./tools/vite.mjs");
   assert.equal(packageJson.exports?.["./wasm"]?.import, "./pkg-web/nanocodex_bg.wasm");

--- a/js/bindings/scripts/dataset.bench.mjs
+++ b/js/bindings/scripts/dataset.bench.mjs
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { performance } from "node:perf_hooks";
+import { parquetWriteBuffer } from "hyparquet-writer";
+import { createDatasetTool } from "../tools/datasetEngine.mjs";
+const ROWS = 1e5;
+const PARQUET_URL = "https://bench.example/train.parquet";
+const JSONL_URL = "https://bench.example/train.jsonl";
+const context = { sessionId: "dataset-benchmark" };
+const ids = Array.from({ length: ROWS }, (_, index) => index);
+const languages = ids.map((index) => ["rust", "python", "typescript", "go"][index % 4]);
+const scores = ids.map((index) => index % 1e3);
+const texts = ids.map((index) => `training example ${index} ${languages[index]}`);
+const parquet = new Uint8Array(parquetWriteBuffer({
+  columnData: [
+    { name: "id", data: ids, type: "INT32", columnIndex: true },
+    { name: "language", data: languages, type: "STRING", columnIndex: true },
+    { name: "score", data: scores, type: "INT32", columnIndex: true },
+    { name: "text", data: texts, type: "STRING" }
+  ],
+  codec: "SNAPPY",
+  pageSize: 64 * 1024,
+  rowGroupSize: [1e3, 25e3]
+}));
+const encoder = new TextEncoder();
+const jsonl = encoder.encode(`${ids.map((id) => JSON.stringify({
+  id,
+  language: languages[id],
+  score: scores[id],
+  text: texts[id]
+})).join("\n")}
+`);
+const remote = benchmarkFetch(/* @__PURE__ */ new Map([
+  [PARQUET_URL, parquet],
+  [JSONL_URL, jsonl]
+]));
+const tool = createDatasetTool({ fetch: remote.fetch, randomId: sequentialIds() });
+const parquetOpen = await timed(() => tool.handler({
+  operation: "open",
+  source: { kind: "url", url: PARQUET_URL }
+}, context));
+const parquetOpened = parquetOpen.value;
+const parquetId = parquetOpened.datasetId;
+assert.equal(parquetOpened.format, "parquet");
+assert.equal(parquetOpened.rowCount, ROWS);
+const parquetOpenIo = remote.take();
+const parquetQuery = {
+  operation: "query",
+  dataset_id: parquetId,
+  columns: ["id", "text"],
+  filters: [
+    { column: "language", op: "eq", value: "rust" },
+    { column: "score", op: "gte", value: 900 }
+  ],
+  offset: 500,
+  limit: 100
+};
+const parquetCold = await timed(() => tool.handler(parquetQuery, context));
+const parquetColdResult = parquetCold.value;
+const parquetColdIo = remote.take();
+const parquetWarm = await timed(() => tool.handler(parquetQuery, context));
+const parquetWarmResult = parquetWarm.value;
+const parquetWarmIo = remote.take();
+assertQueryPair(parquetColdResult, parquetWarmResult, expectedRows());
+assert.ok(parquetColdIo.rangeRequests > 0);
+assert.ok(parquetColdIo.rangeBytes > 0);
+assertZeroNetwork(parquetWarmIo);
+const jsonlOpen = await timed(() => tool.handler({
+  operation: "open",
+  source: { kind: "url", url: JSONL_URL }
+}, context));
+const jsonlOpened = jsonlOpen.value;
+const jsonlId = jsonlOpened.datasetId;
+assert.equal(jsonlOpened.format, "jsonl");
+assert.equal(jsonlOpened.rowCount, null);
+const jsonlOpenIo = remote.take();
+const jsonlQuery = {
+  ...parquetQuery,
+  dataset_id: jsonlId
+};
+const jsonlCold = await timed(() => tool.handler(jsonlQuery, context));
+const jsonlColdResult = jsonlCold.value;
+const jsonlColdIo = remote.take();
+const jsonlRepeated = await timed(() => tool.handler(jsonlQuery, context));
+const jsonlRepeatedResult = jsonlRepeated.value;
+const jsonlRepeatedIo = remote.take();
+assertQueryPair(jsonlColdResult, jsonlRepeatedResult, expectedRows());
+assert.equal(jsonlColdResult.rowsScanned, 23997);
+assert.ok(jsonlColdIo.streamRequests > 0);
+assert.ok(jsonlColdIo.streamBytesPulled > 0);
+assertZeroNetwork(jsonlRepeatedIo);
+console.log(JSON.stringify({
+  corpus: {
+    rows: ROWS,
+    parquet: { codec: "SNAPPY", bytes: parquet.byteLength },
+    jsonl: { bytes: jsonl.byteLength }
+  },
+  parquet: {
+    open: openMeasurement(parquetOpen, parquetOpenIo),
+    coldQuery: queryMeasurement(parquetCold, parquetColdIo),
+    exactRepeat: queryMeasurement(parquetWarm, parquetWarmIo),
+    speedupX: speedup(parquetCold.milliseconds, parquetWarm.milliseconds)
+  },
+  jsonl: {
+    open: openMeasurement(jsonlOpen, jsonlOpenIo),
+    coldQuery: queryMeasurement(jsonlCold, jsonlColdIo),
+    exactRepeat: queryMeasurement(jsonlRepeated, jsonlRepeatedIo),
+    speedupX: speedup(jsonlCold.milliseconds, jsonlRepeated.milliseconds)
+  }
+}, null, 2));
+function expectedRows() {
+  return ids.filter((id) => languages[id] === "rust" && scores[id] >= 900).slice(500, 600).map((id) => ({ id, text: texts[id] }));
+}
+function assertQueryPair(cold, repeated, expected) {
+  assert.deepEqual(cold.rows, expected);
+  assert.deepEqual(repeated.rows, expected);
+  assert.equal(cold.returnedRows, expected.length);
+  assert.equal(repeated.returnedRows, expected.length);
+  assert.equal(cold.complete, false);
+  assert.equal(repeated.complete, false);
+  assert.equal(cold.truncatedReason, "limit");
+  assert.equal(repeated.truncatedReason, "limit");
+  assert.equal(cold.cacheHit, false);
+  assert.equal(repeated.cacheHit, true);
+  assert.ok(cold.bytesRead > 0);
+  assert.equal(repeated.bytesRead, 0);
+  assert.equal(repeated.rowsScanned, cold.rowsScanned);
+}
+function assertZeroNetwork(io) {
+  assert.deepEqual(io, emptyIo());
+}
+function openMeasurement(measurement, io) {
+  return { latencyMs: rounded(measurement.milliseconds), network: io };
+}
+function queryMeasurement(measurement, io) {
+  const value = measurement.value;
+  return {
+    latencyMs: rounded(measurement.milliseconds),
+    returnedRows: value.returnedRows,
+    rowsScanned: value.rowsScanned,
+    toolBytesRead: value.bytesRead,
+    cacheHit: value.cacheHit,
+    network: io
+  };
+}
+function speedup(coldMilliseconds, repeatedMilliseconds) {
+  return rounded(coldMilliseconds / repeatedMilliseconds);
+}
+async function timed(run) {
+  const started = performance.now();
+  const value = await run();
+  return { milliseconds: performance.now() - started, value };
+}
+function benchmarkFetch(objects) {
+  let io = emptyIo();
+  const fetch = async (input, init) => {
+    const data = objects.get(String(input));
+    if (!data) return new Response("not found", { status: 404 });
+    io.requests++;
+    if ((init?.method ?? "GET") === "HEAD") {
+      io.headRequests++;
+      return new Response(null, {
+        status: 200,
+        headers: { "content-length": String(data.byteLength) }
+      });
+    }
+    const range = new Headers(init?.headers).get("range");
+    if (range) {
+      const match = range.match(/^bytes=(\d+)-(\d+)$/);
+      if (!match) return new Response("bad range", { status: 416 });
+      const start = Number(match[1]);
+      const end = Number(match[2]);
+      const body = data.slice(start, end + 1);
+      io.rangeRequests++;
+      io.rangeBytes += body.byteLength;
+      return new Response(body, {
+        status: 206,
+        headers: {
+          "content-length": String(body.byteLength),
+          "content-range": `bytes ${start}-${end}/${data.byteLength}`
+        }
+      });
+    }
+    io.streamRequests++;
+    return new Response(chunked(data, 64 * 1024, (length) => io.streamBytesPulled += length), {
+      status: 200,
+      headers: { "content-length": String(data.byteLength) }
+    });
+  };
+  return {
+    fetch,
+    take() {
+      const snapshot = io;
+      io = emptyIo();
+      return snapshot;
+    }
+  };
+}
+function emptyIo() {
+  return {
+    requests: 0,
+    headRequests: 0,
+    rangeRequests: 0,
+    streamRequests: 0,
+    rangeBytes: 0,
+    streamBytesPulled: 0
+  };
+}
+function chunked(bytes, size, onChunk) {
+  let offset = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (offset >= bytes.byteLength) {
+        controller.close();
+        return;
+      }
+      const end = Math.min(offset + size, bytes.byteLength);
+      const chunk = bytes.slice(offset, end);
+      onChunk(chunk.byteLength);
+      controller.enqueue(chunk);
+      offset = end;
+    }
+  });
+}
+function sequentialIds() {
+  let id = 0;
+  return () => `dataset-${++id}`;
+}
+function rounded(value) {
+  return Math.round(value * 100) / 100;
+}

--- a/js/bindings/test/dataset.performance.test.mjs
+++ b/js/bindings/test/dataset.performance.test.mjs
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parquetWriteBuffer } from "hyparquet-writer";
+import { createDatasetTool } from "../tools/datasetEngine.mjs";
+const PARQUET_URL = "https://performance.example/records.parquet";
+const JSONL_URL = "https://performance.example/records.jsonl";
+const parquetBytes = new Uint8Array(parquetWriteBuffer({
+  columnData: [
+    { name: "id", data: [1, 2, 3, 4], type: "INT32" },
+    { name: "label", data: ["one", "two", "three", "four"], type: "STRING" }
+  ],
+  codec: "SNAPPY",
+  rowGroupSize: 2
+}));
+const jsonlBytes = new TextEncoder().encode([
+  { id: 1, label: "one" },
+  { id: 2, label: "two" },
+  { id: 3, label: "three" },
+  { id: 4, label: "four" }
+].map(JSON.stringify).join("\n") + "\n");
+test("an identical Parquet query is served from the result cache without fetching", async () => {
+  const remote = objectFetch(/* @__PURE__ */ new Map([[PARQUET_URL, parquetBytes]]));
+  const tool = createDatasetTool({ fetch: remote.fetch, randomId: () => "parquet-cache" });
+  const context = { sessionId: "parquet-cache-session" };
+  const opened = await tool.handler({
+    operation: "open",
+    source: { kind: "url", url: PARQUET_URL }
+  }, context);
+  const query = {
+    operation: "query",
+    dataset_id: opened.datasetId,
+    columns: ["id", "label"],
+    filters: [{ column: "id", op: "gte", value: 2 }],
+    limit: 2
+  };
+  const cold = await tool.handler(query, context);
+  const fetchesAfterColdQuery = remote.calls.length;
+  const warm = await tool.handler(query, context);
+  assert.equal(cold.cacheHit, false);
+  assert.equal(warm.cacheHit, true);
+  assert.equal(warm.bytesRead, 0);
+  assert.deepEqual(warm.rows, cold.rows);
+  assert.equal(remote.calls.length, fetchesAfterColdQuery);
+});
+test("an identical JSONL query is served from the result cache without fetching", async () => {
+  const remote = objectFetch(/* @__PURE__ */ new Map([[JSONL_URL, jsonlBytes]]));
+  const tool = createDatasetTool({ fetch: remote.fetch, randomId: () => "jsonl-cache" });
+  const context = { sessionId: "jsonl-cache-session" };
+  const opened = await tool.handler({
+    operation: "open",
+    source: { kind: "url", url: JSONL_URL }
+  }, context);
+  const query = {
+    operation: "query",
+    dataset_id: opened.datasetId,
+    columns: ["label"],
+    filters: [{ column: "id", op: "gte", value: 2 }],
+    limit: 2
+  };
+  const cold = await tool.handler(query, context);
+  const fetchesAfterColdQuery = remote.calls.length;
+  const warm = await tool.handler(query, context);
+  assert.equal(cold.cacheHit, false);
+  assert.equal(warm.cacheHit, true);
+  assert.equal(warm.bytesRead, 0);
+  assert.deepEqual(warm.rows, cold.rows);
+  assert.equal(remote.calls.length, fetchesAfterColdQuery);
+});
+test("Snappy Parquet uses hyparquet's built-in decoder without loading compressors", async () => {
+  const remote = objectFetch(/* @__PURE__ */ new Map([[PARQUET_URL, parquetBytes]]));
+  let compressorLoads = 0;
+  const tool = createDatasetTool({
+    fetch: remote.fetch,
+    randomId: () => "snappy",
+    loadCompressors: async () => {
+      compressorLoads++;
+      throw new Error("hyparquet-compressors must not load for Snappy");
+    }
+  });
+  const context = { sessionId: "snappy-session" };
+  const opened = await tool.handler({
+    operation: "open",
+    source: { kind: "url", url: PARQUET_URL }
+  }, context);
+  const queried = await tool.handler({
+    operation: "query",
+    dataset_id: opened.datasetId,
+    columns: ["label"],
+    limit: 4
+  }, context);
+  assert.deepEqual(queried.rows, [
+    { label: "one" },
+    { label: "two" },
+    { label: "three" },
+    { label: "four" }
+  ]);
+  assert.equal(compressorLoads, 0);
+});
+test("caller cancellation reaches an in-flight dataset fetch", async () => {
+  const controller = new AbortController();
+  let receivedSignal;
+  let signalReceived;
+  const started = new Promise((resolve) => signalReceived = resolve);
+  const fetch = async (_input, init) => {
+    receivedSignal = init?.signal ?? void 0;
+    assert.ok(receivedSignal);
+    signalReceived();
+    return await new Promise((_resolve, reject) => {
+      const rejectAborted = () => reject(receivedSignal.reason);
+      if (receivedSignal.aborted) rejectAborted();
+      else receivedSignal.addEventListener("abort", rejectAborted, { once: true });
+    });
+  };
+  const tool = createDatasetTool({ fetch, randomId: () => "cancelled" });
+  const pending = tool.handler({
+    operation: "open",
+    source: { kind: "url", url: JSONL_URL }
+  }, { sessionId: "cancellation-session", signal: controller.signal });
+  await started;
+  controller.abort();
+  await assert.rejects(pending, (error) => error?.name === "AbortError");
+  assert.equal(receivedSignal?.aborted, true);
+});
+test("opening JSONL performs one GET and no HEAD request", async () => {
+  const remote = objectFetch(/* @__PURE__ */ new Map([[JSONL_URL, jsonlBytes]]));
+  const tool = createDatasetTool({ fetch: remote.fetch, randomId: () => "jsonl-open" });
+  await tool.handler({
+    operation: "open",
+    source: { kind: "url", url: JSONL_URL }
+  }, { sessionId: "jsonl-open-session" });
+  assert.deepEqual(remote.calls, [{ method: "GET", url: JSONL_URL }]);
+});
+test("Parquet range responses cannot buffer past the requested length", async () => {
+  const fetch = async (_input, init) => {
+    if (init?.method === "HEAD") {
+      return new Response(null, {
+        status: 200,
+        headers: { "content-length": String(parquetBytes.byteLength) }
+      });
+    }
+    const range = new Headers(init?.headers).get("range");
+    const match = range.match(/^bytes=(\d+)-(\d+)$/);
+    const start = Number(match[1]);
+    const end = Number(match[2]);
+    const expected = end - start + 1;
+    return new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(expected + 1));
+        controller.close();
+      }
+    }), {
+      status: 206,
+      headers: { "content-range": `bytes ${start}-${end}/${parquetBytes.byteLength}` }
+    });
+  };
+  const tool = createDatasetTool({ fetch, randomId: () => "oversized-range" });
+  await assert.rejects(tool.handler({
+    operation: "open",
+    source: { kind: "url", url: PARQUET_URL }
+  }, { sessionId: "oversized-range-session" }), /exceeds expected/);
+});
+function objectFetch(objects) {
+  const calls = [];
+  const fetch = async (input, init) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+    calls.push({ method, url });
+    const bytes = objects.get(url);
+    if (!bytes) return new Response("not found", { status: 404 });
+    if (method === "HEAD") {
+      return new Response(null, {
+        status: 200,
+        headers: { "content-length": String(bytes.byteLength) }
+      });
+    }
+    const range = new Headers(init?.headers).get("range");
+    if (range) {
+      const match = range.match(/^bytes=(\d+)-(\d+)$/);
+      if (!match) return new Response("bad range", { status: 416 });
+      const start = Number(match[1]);
+      const end = Number(match[2]);
+      const body = bytes.slice(start, end + 1);
+      return new Response(body, {
+        status: 206,
+        headers: {
+          "content-length": String(body.byteLength),
+          "content-range": `bytes ${start}-${end}/${bytes.byteLength}`
+        }
+      });
+    }
+    return new Response(bytes, {
+      status: 200,
+      headers: { "content-length": String(bytes.byteLength) }
+    });
+  };
+  return { calls, fetch };
+}

--- a/js/bindings/test/dataset.test.mjs
+++ b/js/bindings/test/dataset.test.mjs
@@ -1,0 +1,348 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parquetWriteBuffer } from "hyparquet-writer";
+import { dataset } from "../tools/index.mjs";
+import { createDatasetTool } from "../tools/datasetEngine.mjs";
+const context = { sessionId: "session-a" };
+test("the public dataset factory advertises the lazy dataset capability", () => {
+  const tool = dataset();
+  assert.equal(tool.name, "dataset");
+  assert.ok(Object.isFrozen(tool));
+  assert.match(tool.description, /Parquet, uncompressed JSONL, or Hugging Face/);
+  assert.deepEqual(
+    tool.parameters.properties.operation.enum,
+    ["open", "query", "close"]
+  );
+});
+
+test("the public dataset factory releases session handles and rejects work after disposal", async () => {
+  const url = "https://data.example/release.jsonl";
+  const tool = dataset({
+    fetch: objectFetch(new Map([[url, new TextEncoder().encode('{"id":1}\n')]])),
+  });
+  const opened = await tool.handler({
+    operation: "open",
+    source: { kind: "url", url, format: "jsonl" },
+  }, context);
+  tool.releaseSession(context.sessionId);
+  await assert.rejects(
+    tool.handler({ operation: "query", dataset_id: opened.datasetId }, context),
+    /unavailable in this agent session/,
+  );
+  tool.dispose();
+  assert.throws(
+    () => tool.handler({ operation: "close", dataset_id: opened.datasetId }, context),
+    /disposed/,
+  );
+});
+test("Parquet datasets expose metadata and bounded projected queries", async () => {
+  const parquet = parquetWriteBuffer({
+    columnData: [
+      { name: "name", data: ["Ada", "Grace", "Linus", "Margaret"], type: "STRING" },
+      { name: "score", data: [10, 20, 30, 40], type: "INT32" },
+      { name: "bio", data: ["math", "compiler pioneer", "kernel", "compiler lead"], type: "STRING" }
+    ],
+    rowGroupSize: 2
+  });
+  const fetch = objectFetch(/* @__PURE__ */ new Map([
+    ["https://data.example/people.parquet", new Uint8Array(parquet)]
+  ]));
+  const tool = createDatasetTool({ fetch, randomId: () => "dataset-1" });
+  const opened = await tool.handler({
+    operation: "open",
+    source: { kind: "url", url: "https://data.example/people.parquet" }
+  }, context);
+  assert.equal(opened.datasetId, "dataset-1");
+  assert.equal(opened.format, "parquet");
+  assert.equal(opened.rowCount, 4);
+  assert.deepEqual(opened.schema.map((column) => column.name), ["name", "score", "bio"]);
+  const filtered = await tool.handler({
+    operation: "query",
+    dataset_id: opened.datasetId,
+    columns: ["name", "score"],
+    filters: [{ column: "score", op: "gte", value: 20 }],
+    limit: 2
+  }, context);
+  assert.deepEqual(filtered.rows, [
+    { name: "Grace", score: 20 },
+    { name: "Linus", score: 30 }
+  ]);
+  assert.equal(filtered.complete, false);
+  assert.equal(filtered.truncatedReason, "limit");
+  assert.ok(filtered.bytesRead > 0);
+  const searched = await tool.handler({
+    operation: "query",
+    dataset_id: opened.datasetId,
+    columns: ["name"],
+    filters: [{ column: "bio", op: "contains", value: "compiler" }],
+    limit: 10
+  }, context);
+  assert.deepEqual(searched.rows, [{ name: "Grace" }, { name: "Margaret" }]);
+  assert.equal(searched.complete, true);
+});
+test("JSONL datasets stream, filter, project, and report partial scans", async () => {
+  const records = [
+    { language: "rust", text: "ownership and borrowing", score: 5 },
+    { language: "python", text: "dataframes", score: 2 },
+    { language: "rust", text: "async runtimes", score: 8 },
+    { language: "rust", text: "unsafe internals", score: 9 }
+  ];
+  const bytes = new TextEncoder().encode(`${records.map(JSON.stringify).join("\n")}
+`);
+  const fetch = objectFetch(/* @__PURE__ */ new Map([["https://data.example/train.jsonl", bytes]]), 37);
+  const tool = createDatasetTool({ fetch, randomId: () => "jsonl-1" });
+  const opened = await tool.handler({
+    operation: "open",
+    source: { kind: "url", url: "https://data.example/train.jsonl" }
+  }, context);
+  assert.deepEqual(opened.schema.map((column) => column.name), ["language", "text", "score"]);
+  assert.deepEqual(opened.previewRows.slice(0, 2), records.slice(0, 2));
+  const queried = await tool.handler({
+    operation: "query",
+    dataset_id: opened.datasetId,
+    columns: ["text", "score"],
+    filters: [
+      { column: "language", op: "eq", value: "rust" },
+      { column: "score", op: "gte", value: 8 }
+    ],
+    offset: 1,
+    limit: 1
+  }, context);
+  assert.deepEqual(queried.rows, [{ text: "unsafe internals", score: 9 }]);
+  assert.equal(queried.rowsScanned, 4);
+  assert.equal(queried.complete, false);
+  assert.equal(queried.truncatedReason, "limit");
+  const longRows = Array.from({ length: 30 }, (_, index) => ({
+    index,
+    text: "x".repeat(90)
+  }));
+  const longBytes = new TextEncoder().encode(`${longRows.map(JSON.stringify).join("\n")}
+`);
+  const boundedTool = createDatasetTool({
+    fetch: objectFetch(/* @__PURE__ */ new Map([["https://data.example/long.jsonl", longBytes]])),
+    randomId: () => "jsonl-bounded"
+  });
+  const bounded = await boundedTool.handler({
+    operation: "open",
+    source: { kind: "url", url: "https://data.example/long.jsonl" }
+  }, context);
+  const partial = await boundedTool.handler({
+    operation: "query",
+    dataset_id: bounded.datasetId,
+    limit: 100,
+    max_bytes: 1024
+  }, context);
+  assert.ok(partial.rows.length > 0);
+  assert.equal(partial.complete, false);
+  assert.equal(partial.truncatedReason, "byte_limit");
+  assert.equal(partial.bytesRead, 1024);
+  const sparseRows = Array.from(
+    { length: 40 },
+    (_, index) => index === 35 ? { index, late: "discovered during query" } : { index }
+  );
+  const sparseBytes = new TextEncoder().encode(`${sparseRows.map(JSON.stringify).join("\n")}
+`);
+  const sparseTool = createDatasetTool({
+    fetch: objectFetch(/* @__PURE__ */ new Map([["https://data.example/sparse.jsonl", sparseBytes]]), 64),
+    randomId: () => "jsonl-sparse"
+  });
+  const sparse = await sparseTool.handler({
+    operation: "open",
+    source: { kind: "url", url: "https://data.example/sparse.jsonl" }
+  }, context);
+  assert.equal(sparse.schema.some((column) => column.name === "late"), false);
+  const late = await sparseTool.handler({
+    operation: "query",
+    dataset_id: sparse.datasetId,
+    columns: ["late"],
+    offset: 35,
+    limit: 1
+  }, context);
+  assert.deepEqual(late.rows, [{ late: "discovered during query" }]);
+});
+test("Hugging Face sources resolve the default training split to Parquet shards", async () => {
+  const parquet = new Uint8Array(parquetWriteBuffer({
+    columnData: [
+      { name: "text", data: ["one", "two"], type: "STRING" },
+      { name: "label", data: [0, 1], type: "INT32" }
+    ]
+  }));
+  const shardUrl = "https://huggingface.co/datasets/acme/demo/resolve/main/train.parquet";
+  const objects = /* @__PURE__ */ new Map([[shardUrl, parquet]]);
+  const baseFetch = objectFetch(objects);
+  let followedHuggingFaceRedirect = false;
+  const fetch = async (input, init) => {
+    const url = String(input);
+    if (url.startsWith("https://datasets-server.huggingface.co/parquet?")) {
+      return Response.json({
+        parquet_files: [
+          { config: "default", split: "test", url: shardUrl, filename: "test.parquet", size: parquet.byteLength },
+          { config: "default", split: "train", url: shardUrl, filename: "train.parquet", size: parquet.byteLength }
+        ],
+        pending: [],
+        failed: [],
+        partial: true
+      });
+    }
+    if (url.startsWith("https://datasets-server.huggingface.co/size?")) {
+      return Response.json({
+        size: {
+          splits: [{
+            config: "default",
+            split: "train",
+            num_rows: 2,
+            num_bytes_parquet_files: parquet.byteLength
+          }]
+        }
+      });
+    }
+    if (url === shardUrl) {
+      assert.equal(init?.redirect, "follow");
+      followedHuggingFaceRedirect = true;
+    }
+    return baseFetch(input, init);
+  };
+  const tool = createDatasetTool({ fetch, randomId: () => "hf-1" });
+  const opened = await tool.handler({
+    operation: "open",
+    source: { kind: "huggingface", dataset: "acme/demo" }
+  }, context);
+  assert.deepEqual(opened.source, {
+    kind: "huggingface",
+    dataset: "acme/demo",
+    config: "default",
+    split: "train",
+    partial: true
+  });
+  assert.equal(opened.rowCount, 2);
+  assert.equal(opened.shardCount, 1);
+  assert.equal(followedHuggingFaceRedirect, true);
+  const queried = await tool.handler({
+    operation: "query",
+    dataset_id: opened.datasetId,
+    limit: 10
+  }, context);
+  assert.equal(queried.complete, false);
+  assert.equal(queried.truncatedReason, "source_partial");
+});
+test("Parquet filters coerce JSON-safe INT64 values without losing precision", async () => {
+  const parquet = new Uint8Array(parquetWriteBuffer({
+    columnData: [{
+      name: "value",
+      data: [1n, 2n, 9007199254740993n],
+      type: "INT64"
+    }]
+  }));
+  const tool = createDatasetTool({
+    fetch: objectFetch(/* @__PURE__ */ new Map([["https://data.example/int64.parquet", parquet]])),
+    randomId: () => "int64"
+  });
+  const opened = await tool.handler({
+    operation: "open",
+    source: { kind: "url", url: "https://data.example/int64.parquet" }
+  }, context);
+  const safe = await tool.handler({
+    operation: "query",
+    dataset_id: opened.datasetId,
+    filters: [{ column: "value", op: "eq", value: 2 }],
+    limit: 10
+  }, context);
+  assert.deepEqual(safe.rows, [{ value: 2 }]);
+  const precise = await tool.handler({
+    operation: "query",
+    dataset_id: opened.datasetId,
+    filters: [{ column: "value", op: "eq", value: "9007199254740993" }],
+    limit: 10
+  }, context);
+  assert.deepEqual(precise.rows, [{ value: "9007199254740993" }]);
+  await assert.rejects(
+    tool.handler({ operation: "query", dataset_id: opened.datasetId, offset: 10001 }, context),
+    /between 0 and 10000/
+  );
+});
+test("dataset handles are session-scoped and arbitrary URLs reject local targets", async () => {
+  const bytes = new TextEncoder().encode('{"value":1}\n');
+  const baseFetch = objectFetch(/* @__PURE__ */ new Map([["https://data.example/one.jsonl", bytes]]));
+  const redirectModes = [];
+  const tool = createDatasetTool({
+    fetch: async (input, init) => {
+      redirectModes.push(init?.redirect);
+      return baseFetch(input, init);
+    },
+    randomId: () => "private-1"
+  });
+  const opened = await tool.handler({
+    operation: "open",
+    source: { kind: "url", url: "https://data.example/one.jsonl" }
+  }, context);
+  assert.deepEqual(redirectModes, ["error"]);
+  await assert.rejects(
+    tool.handler({ operation: "query", dataset_id: opened.datasetId }, { sessionId: "session-b" }),
+    /unavailable in this agent session/
+  );
+  await assert.rejects(
+    tool.handler({
+      operation: "open",
+      source: { kind: "url", url: "https://127.0.0.1/private.jsonl" }
+    }, context),
+    /public hostname/
+  );
+  await assert.rejects(
+    tool.handler({
+      operation: "open",
+      source: { kind: "url", url: "https://localhost./private.jsonl" }
+    }, context),
+    /public hostname/
+  );
+  assert.deepEqual(
+    await tool.handler({ operation: "close", dataset_id: opened.datasetId }, context),
+    { datasetId: opened.datasetId, closed: true }
+  );
+});
+function objectFetch(objects, chunkSize) {
+  return async (input, init) => {
+    const url = String(input);
+    const bytes = objects.get(url);
+    if (!bytes) return new Response("not found", { status: 404 });
+    const method = init?.method ?? "GET";
+    if (method === "HEAD") {
+      return new Response(null, {
+        status: 200,
+        headers: { "content-length": String(bytes.byteLength) }
+      });
+    }
+    const range = new Headers(init?.headers).get("range");
+    if (range) {
+      const match = range.match(/^bytes=(\d+)-(\d+)$/);
+      if (!match) return new Response("bad range", { status: 416 });
+      const start = Number(match[1]);
+      const end = Number(match[2]);
+      const body = bytes.slice(start, end + 1);
+      return new Response(body, {
+        status: 206,
+        headers: {
+          "content-length": String(body.byteLength),
+          "content-range": `bytes ${start}-${end}/${bytes.byteLength}`
+        }
+      });
+    }
+    return new Response(chunkSize ? chunked(bytes, chunkSize) : bytes, {
+      status: 200,
+      headers: { "content-length": String(bytes.byteLength) }
+    });
+  };
+}
+function chunked(bytes, size) {
+  let offset = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (offset >= bytes.byteLength) {
+        controller.close();
+        return;
+      }
+      const end = Math.min(offset + size, bytes.byteLength);
+      controller.enqueue(bytes.slice(offset, end));
+      offset = end;
+    }
+  });
+}

--- a/js/bindings/test/package.test.mjs
+++ b/js/bindings/test/package.test.mjs
@@ -65,7 +65,8 @@ test("the packed package installs and runs every public entry point", async () =
       import { dirname, resolve } from "node:path";
       import { fileURLToPath } from "node:url";
       import { Actions } from "nanocodex";
-      import { web } from "nanocodex/tools";
+      import { dataset as aggregateDataset, web } from "nanocodex/tools";
+      import { dataset } from "nanocodex/tools/dataset";
       import { nanocodexTools } from "nanocodex/tools/vite";
       import { Agent as NodeAgent, Subagents as NodeSubagents, Transport as NodeTransport, Workspace as NodeWorkspace } from "nanocodex/node";
       import { Agent as BrowserAgent, Subagents as BrowserSubagents, Transport as BrowserTransport, Workspace as BrowserWorkspace } from "nanocodex/browser";
@@ -74,6 +75,21 @@ test("the packed package installs and runs every public entry point", async () =
       assert.equal(typeof NodeWorkspace.open, "function");
       assert.equal(typeof BrowserWorkspace.open, "function");
       assert.equal(web({ url: "https://example.test/tools/web" }).name, "web__run");
+      assert.equal(aggregateDataset().name, "dataset");
+      const datasetTool = dataset({
+        fetch: async () => new Response('{"id":1}\\n'),
+      });
+      assert(Object.isFrozen(datasetTool));
+      const opened = await datasetTool.handler({
+        operation: "open",
+        source: { kind: "url", url: "https://example.test/data.jsonl", format: "jsonl" },
+      }, {
+        callId: "dataset-open",
+        parentCallId: "",
+        sessionId: "package-test",
+        signal: new AbortController().signal,
+      });
+      assert.deepEqual(opened.previewRows, [{ id: 1 }]);
       assert.match(nanocodexTools().resolveId("node-rsa"), /unsupportedNodeRsa\.mjs$/);
       const nodeAgent = await NodeAgent.create({
         transport: NodeTransport.openAi({ apiKey: "package-test" }),
@@ -101,6 +117,10 @@ test("the packed package installs and runs every public entry point", async () =
 
       await assert.rejects(
         import("nanocodex/internal.mjs"),
+        (error) => error.code === "ERR_PACKAGE_PATH_NOT_EXPORTED",
+      );
+      await assert.rejects(
+        import("nanocodex/tools/datasetEngine"),
         (error) => error.code === "ERR_PACKAGE_PATH_NOT_EXPORTED",
       );
     `);

--- a/js/bindings/test/tools.test.mjs
+++ b/js/bindings/test/tools.test.mjs
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { test } from "node:test";
+import { createCodeRuntime } from "../runtime/code-runtime.mjs";
 
 import {
+  dataset,
   imageGeneration,
   updatePlan,
   viewImage,
@@ -104,7 +106,25 @@ test("image generation resolves recent session images without owning conversatio
 
 test("each factory returns an immutable named tool for direct array composition", () => {
   assert(Object.isFrozen(updatePlan()));
+  assert.equal(dataset().name, "dataset");
   assert.equal(viewImage({ workspace: { readFile: async () => new Uint8Array() } }).name, "view_image");
+});
+
+test("the code runtime forwards session and host lifecycle to stateful tools", () => {
+  const released = [];
+  let disposals = 0;
+  const runtime = createCodeRuntime({
+    stateful: {
+      description: "stateful test tool",
+      handler: () => null,
+      releaseSession: (sessionId) => released.push(sessionId),
+      dispose: () => disposals++,
+    },
+  });
+  runtime.releaseSession("session-1");
+  runtime.reset();
+  assert.deepEqual(released, ["session-1"]);
+  assert.equal(disposals, 1);
 });
 
 test("image generation implements the canonical workspace-path edit mode", async () => {

--- a/js/bindings/test/types.test-d.mts
+++ b/js/bindings/test/types.test-d.mts
@@ -22,11 +22,16 @@ import {
 import type { WorkspaceEntry as BrowserWorkspaceEntry } from "../browser/workspace.mjs";
 import type { WorkspaceEntry as NodeWorkspaceEntry } from "../node/workspace.mjs";
 import {
+  dataset,
   imageGeneration,
   updatePlan,
   viewImage,
   web,
 } from "../tools/index.mjs";
+import {
+  dataset as leafDataset,
+  type DatasetOptions,
+} from "../tools/dataset.mjs";
 import { browser as browserTools } from "../tools/browser/index.mjs";
 import { nanocodexTools } from "../tools/vite.mjs";
 
@@ -34,6 +39,8 @@ declare const apiKey: string;
 declare const accountsWallet: AccountsWallet;
 
 async function check() {
+  const datasetOptions: DatasetOptions = { fetch: globalThis.fetch };
+  leafDataset(datasetOptions);
   const nodeWorkspace = await Workspace.open({ path: "/tmp/nanocodex" });
   await nodeWorkspace.writeFile("notes.txt", "hello");
   Workspace.tools(nodeWorkspace);
@@ -119,6 +126,7 @@ async function check() {
     filesystem: browserWorkspace,
     tools: [
       web({ url: "https://example.com/tools/web" }),
+      dataset(),
       imageGeneration({
         url: "https://example.com/tools/images",
         recentImages: () => [],
@@ -134,6 +142,7 @@ async function check() {
     origin: "https://example.com",
     web: { url: "https://example.com/tools/web" },
     images: { url: "https://example.com/tools/images" },
+    dataset: { fetch: globalThis.fetch },
     recentImages: () => [],
     rememberImage: () => {},
   });

--- a/js/bindings/tools/browser/index.d.mts
+++ b/js/bindings/tools/browser/index.d.mts
@@ -1,6 +1,6 @@
 import type { Workspace } from "../../runtime/workspace.mjs";
 import type { NamedTool } from "../../types.mjs";
-import type { JsonToolOptions } from "../index.mjs";
+import type { DatasetOptions, JsonToolOptions } from "../index.mjs";
 
 export type BrowserThread = Readonly<{
   id: string;
@@ -127,6 +127,7 @@ export type BrowserOptions = Readonly<{
   origin?: string | undefined;
   web?: JsonToolOptions | undefined;
   images?: JsonToolOptions | undefined;
+  dataset?: DatasetOptions | undefined;
   recentImages?(sessionId: string, count: number): string[];
   rememberImage?(sessionId: string, imageUrl: string): void;
 }>;

--- a/js/bindings/tools/browser/index.mjs
+++ b/js/bindings/tools/browser/index.mjs
@@ -34,9 +34,10 @@ export async function browser(options) {
   if (typeof origin !== "string" || !origin) {
     throw new TypeError("browser origin is required outside a browser location");
   }
-  const [shellModule, standard] = await Promise.all([
+  const [shellModule, standard, datasets] = await Promise.all([
     import("./browserShell.mjs"),
     import("../standard.mjs"),
+    import("../dataset.mjs"),
   ]);
   const shell = await shellModule.prepareBrowserShell(options.threadId, origin);
   return Object.freeze({
@@ -54,6 +55,7 @@ export async function browser(options) {
       }),
       standard.viewImage({ workspace: shell.workspace }),
       standard.updatePlan(),
+      datasets.dataset(options.dataset),
     ]),
   });
 }

--- a/js/bindings/tools/dataset.d.mts
+++ b/js/bindings/tools/dataset.d.mts
@@ -1,0 +1,9 @@
+import type { NamedTool } from "../types.mjs";
+
+export type DatasetOptions = Readonly<{
+  /** Fetch implementation used for dataset metadata, ranges, and streams. */
+  fetch?: typeof globalThis.fetch | undefined;
+}>;
+
+/** A lazy, session-scoped inspector for public Parquet, JSONL, and Hugging Face datasets. */
+export function dataset(options?: DatasetOptions): NamedTool;

--- a/js/bindings/tools/dataset.mjs
+++ b/js/bindings/tools/dataset.mjs
@@ -1,0 +1,46 @@
+import { namedTool } from "./namedTool.mjs";
+import { DATASET_DESCRIPTION, datasetParameters } from "./datasetContract.mjs";
+
+/** A session-scoped, lazy browser dataset inspector. */
+export function dataset(options = {}) {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    throw new TypeError("dataset tool options must be an object");
+  }
+  if (options.fetch !== undefined && typeof options.fetch !== "function") {
+    throw new TypeError("dataset tool fetch must be a function");
+  }
+  const engineOptions = Object.freeze({ fetch: options.fetch });
+  let loaded;
+  let resolved;
+  let disposed = false;
+  const releasedSessions = new Set();
+  const tool = namedTool("dataset", {
+    description: DATASET_DESCRIPTION,
+    parameters: datasetParameters,
+    handler(input, context) {
+      if (disposed) throw new Error("dataset tool is disposed");
+      loaded ??= import("./datasetEngine.mjs")
+        .then(({ createDatasetTool }) => {
+          resolved = createDatasetTool(engineOptions);
+          for (const sessionId of releasedSessions) resolved.releaseSession(sessionId);
+          releasedSessions.clear();
+          if (disposed) resolved.dispose();
+          return resolved;
+        });
+      return loaded.then((tool) => {
+        if (disposed) throw new Error("dataset tool is disposed");
+        return tool.handler(input, context);
+      });
+    },
+    releaseSession(sessionId) {
+      if (resolved) resolved.releaseSession(sessionId);
+      else if (loaded) releasedSessions.add(sessionId);
+    },
+    dispose() {
+      disposed = true;
+      releasedSessions.clear();
+      resolved?.dispose();
+    },
+  });
+  return tool;
+}

--- a/js/bindings/tools/datasetContract.mjs
+++ b/js/bindings/tools/datasetContract.mjs
@@ -1,0 +1,52 @@
+export const DATASET_DESCRIPTION = `Inspect public Parquet, uncompressed JSONL, or Hugging Face datasets in the
+browser. Open a URL source or {kind:"huggingface",dataset:"owner/name",config?,split?}; open returns
+schema and an immediate JSONL preview. Query its dataset_id with columns, filters, offset, and limit,
+then close it. Parquet uses HTTP ranges; JSONL scans sequentially. Never infer absence when complete
+is false. Handles assume immutable source URLs; close and reopen to refresh changed data.`;
+
+export const MAX_QUERY_LIMIT = 100;
+export const MAX_QUERY_BYTES = 128 * 1024 * 1024;
+export const MAX_QUERY_OFFSET = 10_000;
+
+const sourceSchema = {
+  type: "object",
+  properties: {
+    kind: { type: "string", enum: ["url", "huggingface"] },
+    url: { type: "string" },
+    format: { type: "string", enum: ["parquet", "jsonl"] },
+    dataset: { type: "string" },
+    config: { type: "string" },
+    split: { type: "string" },
+  },
+  required: ["kind"],
+  additionalProperties: false,
+};
+
+export const datasetParameters = {
+  type: "object",
+  properties: {
+    operation: { type: "string", enum: ["open", "query", "close"] },
+    source: sourceSchema,
+    dataset_id: { type: "string" },
+    columns: { type: "array", maxItems: 64, items: { type: "string" } },
+    filters: {
+      type: "array",
+      maxItems: 8,
+      items: {
+        type: "object",
+        properties: {
+          column: { type: "string" },
+          op: { type: "string", enum: ["eq", "ne", "gt", "gte", "lt", "lte", "in", "contains"] },
+          value: {},
+        },
+        required: ["column", "op", "value"],
+        additionalProperties: false,
+      },
+    },
+    offset: { type: "integer", minimum: 0, maximum: MAX_QUERY_OFFSET },
+    limit: { type: "integer", minimum: 1, maximum: MAX_QUERY_LIMIT },
+    max_bytes: { type: "integer", minimum: 1024, maximum: MAX_QUERY_BYTES },
+  },
+  required: ["operation"],
+  additionalProperties: false,
+};

--- a/js/bindings/tools/datasetEngine.mjs
+++ b/js/bindings/tools/datasetEngine.mjs
@@ -1,0 +1,1040 @@
+import {
+  DATASET_DESCRIPTION,
+  MAX_QUERY_BYTES,
+  MAX_QUERY_LIMIT,
+  MAX_QUERY_OFFSET,
+  datasetParameters
+} from "./datasetContract.mjs";
+const MAX_OPEN_DATASETS = 8;
+const MAX_TOTAL_OPEN_DATASETS = 16;
+const DEFAULT_QUERY_LIMIT = 20;
+const DEFAULT_QUERY_BYTES = 32 * 1024 * 1024;
+const OPEN_METADATA_BYTES = 8 * 1024 * 1024;
+const JSONL_SCHEMA_BYTES = 1024 * 1024;
+const JSONL_SCHEMA_ROWS = 32;
+const MAX_JSONL_LINE_BYTES = 2 * 1024 * 1024;
+const MAX_API_RESPONSE_BYTES = 4 * 1024 * 1024;
+const MAX_TOOL_OUTPUT_BYTES = 256 * 1024;
+const MAX_CELL_STRING_LENGTH = 16 * 1024;
+const FETCH_TIMEOUT_MS = 2e4;
+const RANGE_CACHE_BYTES = 32 * 1024 * 1024;
+const MAX_CACHED_RANGE_BYTES = 4 * 1024 * 1024;
+const QUERY_CACHE_BYTES = 2 * 1024 * 1024;
+const MAX_CACHED_QUERIES = 16;
+const MAX_BLOOM_FILTER_GROUPS = 8;
+function createDatasetTool(options = {}) {
+  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const randomId = options.randomId ?? (() => crypto.randomUUID());
+  const loadParquet = options.loadParquet ?? (() => import("hyparquet"));
+  const loadCompressors = options.loadCompressors ?? (() => import("hyparquet-compressors"));
+  const sessions = /* @__PURE__ */ new Map();
+  const rangeCache = new RangeCache(RANGE_CACHE_BYTES, MAX_CACHED_RANGE_BYTES);
+  const pendingOpens = /* @__PURE__ */ new Map();
+  return {
+    description: DATASET_DESCRIPTION,
+    parameters: datasetParameters,
+    async handler(input, context) {
+      context.signal?.throwIfAborted();
+      const args = requireObject(input, "dataset");
+      const operation = requireString(args.operation, "dataset.operation");
+      const runtime = { fetch: fetchImpl, rangeCache, signal: context.signal };
+      if (operation === "open") {
+        const sessionPending = pendingOpens.get(context.sessionId) ?? 0;
+        if ((sessions.get(context.sessionId)?.size ?? 0) + sessionPending >= MAX_OPEN_DATASETS) {
+          throw new Error(`dataset session already has ${MAX_OPEN_DATASETS} open datasets; close one first`);
+        }
+        if (openDatasetCount(sessions) + pendingOpenCount(pendingOpens) >= MAX_TOTAL_OPEN_DATASETS) {
+          throw new Error(`dataset tool already has ${MAX_TOTAL_OPEN_DATASETS} open datasets; close one first`);
+        }
+        pendingOpens.set(context.sessionId, sessionPending + 1);
+        let dataset;
+        try {
+          dataset = await openDataset({
+            args,
+            id: randomId(),
+            loadParquet,
+            runtime
+          });
+        } finally {
+          const remaining = (pendingOpens.get(context.sessionId) ?? 1) - 1;
+          if (remaining > 0) pendingOpens.set(context.sessionId, remaining);
+          else pendingOpens.delete(context.sessionId);
+        }
+        const datasets = sessionDatasets(sessions, context.sessionId);
+        if (datasets.size >= MAX_OPEN_DATASETS) {
+          throw new Error(`dataset session already has ${MAX_OPEN_DATASETS} open datasets; close one first`);
+        }
+        if (openDatasetCount(sessions) >= MAX_TOTAL_OPEN_DATASETS) {
+          throw new Error(`dataset tool already has ${MAX_TOTAL_OPEN_DATASETS} open datasets; close one first`);
+        }
+        datasets.set(dataset.id, dataset);
+        return publicDataset(dataset);
+      }
+      if (operation === "query") {
+        const dataset = requireDataset(sessions, context.sessionId, args.dataset_id);
+        const query = parseQuery(args, dataset);
+        const cacheKey = queryCacheKey(query);
+        const cached = dataset.queryCache.get(cacheKey);
+        if (cached) return { ...cached, bytesRead: 0, cacheHit: true };
+        const budget = new ByteBudget(query.maxBytes);
+        const progress = dataset.format === "parquet" ? await queryParquet(dataset, query, budget, runtime, loadParquet, loadCompressors) : await queryJsonl(dataset, query, budget, runtime);
+        const result = boundedQueryResult(dataset, query, budget, progress);
+        dataset.queryCache.set(cacheKey, result);
+        return { ...result, cacheHit: false };
+      }
+      if (operation === "close") {
+        const id = requireString(args.dataset_id, "dataset.dataset_id");
+        const removed = sessions.get(context.sessionId)?.delete(id) ?? false;
+        if (sessions.get(context.sessionId)?.size === 0) sessions.delete(context.sessionId);
+        if (removed) rangeCache.deleteDataset(id);
+        return { datasetId: id, closed: removed };
+      }
+      throw new Error("dataset.operation must be open, query, or close");
+    },
+    releaseSession(sessionId) {
+      for (const dataset of sessions.get(sessionId)?.values() ?? []) {
+        rangeCache.deleteDataset(dataset.id);
+      }
+      sessions.delete(sessionId);
+      pendingOpens.delete(sessionId);
+    },
+    dispose() {
+      sessions.clear();
+      pendingOpens.clear();
+      rangeCache.clear();
+    }
+  };
+}
+async function openDataset({
+  args,
+  id,
+  loadParquet,
+  runtime
+}) {
+  const source = requireObject(args.source, "dataset.source");
+  const kind = requireString(source.kind, "dataset.source.kind");
+  if (kind === "huggingface") {
+    return openHuggingFace(source, id, runtime, loadParquet);
+  }
+  if (kind !== "url") throw new Error("dataset.source.kind must be url or huggingface");
+  const url = publicHttpsUrl(requireString(source.url, "dataset.source.url"));
+  const format = parseFormat(source.format, url);
+  if (format === "parquet") {
+    const parquetPromise = loadParquet();
+    const byteLength = await remoteByteLength(url, runtime);
+    if (byteLength == null) {
+      throw new Error("Parquet URL must expose Content-Length or support a one-byte range request");
+    }
+    const shard = {
+      url: url.href,
+      byteLength,
+      cacheKey: id,
+      allowRedirects: false
+    };
+    const budget2 = new ByteBudget(OPEN_METADATA_BYTES);
+    const parquet = await parquetPromise;
+    shard.metadata = await parquet.parquetMetadataAsync(remoteBuffer(shard, budget2, runtime));
+    const schema = parquet.parquetSchema(shard.metadata);
+    return {
+      id,
+      format,
+      source: { kind: "url", url: url.href },
+      byteLength,
+      rowCount: safeCount(shard.metadata.num_rows),
+      schema: parquetColumns(schema),
+      queryCache: new QueryResultCache(QUERY_CACHE_BYTES, MAX_CACHED_QUERIES),
+      parquet: { shards: [shard], filterKinds: parquetFilterKinds(schema) }
+    };
+  }
+  const dataset = {
+    id,
+    format,
+    source: { kind: "url", url: url.href },
+    byteLength: null,
+    rowCount: null,
+    schema: [],
+    queryCache: new QueryResultCache(QUERY_CACHE_BYTES, MAX_CACHED_QUERIES),
+    jsonl: {
+      object: { url: url.href, byteLength: null, cacheKey: id, allowRedirects: false },
+      preview: []
+    }
+  };
+  const budget = new ByteBudget(JSONL_SCHEMA_BYTES);
+  const inferred = await scanJsonl(dataset, {
+    datasetId: id,
+    filters: [],
+    offset: 0,
+    limit: JSONL_SCHEMA_ROWS,
+    maxBytes: JSONL_SCHEMA_BYTES
+  }, budget, runtime);
+  dataset.schema = inferJsonlSchema(inferred.rows);
+  dataset.jsonl.preview = inferred.rows.slice(0, 10);
+  return dataset;
+}
+async function openHuggingFace(source, id, runtime, loadParquet) {
+  const datasetName = requireString(source.dataset, "dataset.source.dataset");
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(datasetName) || datasetName.length > 200) {
+    throw new Error("Hugging Face dataset must be owner/name");
+  }
+  const encoded = encodeURIComponent(datasetName);
+  const parquetPromise = loadParquet();
+  const [parquetResponse, sizeResponse] = await Promise.all([
+    fetchJson(
+      `https://datasets-server.huggingface.co/parquet?dataset=${encoded}`,
+      runtime
+    ),
+    fetchJson(
+      `https://datasets-server.huggingface.co/size?dataset=${encoded}`,
+      runtime
+    ).catch(() => ({}))
+  ]);
+  const allFiles = parquetResponse.parquet_files ?? [];
+  if (!allFiles.length) {
+    const pending = parquetResponse.pending?.length ?? 0;
+    const failed = parquetResponse.failed?.length ?? 0;
+    throw new Error(`Hugging Face has no Parquet shards for ${datasetName} (${pending} pending, ${failed} failed)`);
+  }
+  const requestedConfig = optionalString(source.config, "dataset.source.config");
+  const configs = unique(allFiles.map((file) => file.config));
+  const config = chooseDatasetPart(requestedConfig, configs, "default", "config");
+  const configFiles = allFiles.filter((file) => file.config === config);
+  const requestedSplit = optionalString(source.split, "dataset.source.split");
+  const splits = unique(configFiles.map((file) => file.split));
+  const split = chooseDatasetPart(requestedSplit, splits, "train", "split");
+  const selected = configFiles.filter((file) => file.split === split);
+  const shards = selected.map((file, index) => {
+    const url = publicHttpsUrl(file.url);
+    return {
+      url: url.href,
+      byteLength: boundedNonnegativeInteger(file.size, "Hugging Face shard size"),
+      cacheKey: `${id}:${index}`,
+      allowRedirects: huggingFaceRedirectUrl(url)
+    };
+  });
+  const budget = new ByteBudget(OPEN_METADATA_BYTES);
+  const parquet = await parquetPromise;
+  shards[0].metadata = await parquet.parquetMetadataAsync(remoteBuffer(shards[0], budget, runtime));
+  const schema = parquet.parquetSchema(shards[0].metadata);
+  const splitSize = sizeResponse.size?.splits?.find(
+    (entry) => entry.config === config && entry.split === split
+  );
+  const byteLength = shards.reduce((total, shard) => total + (shard.byteLength ?? 0), 0);
+  return {
+    id,
+    format: "parquet",
+    source: {
+      kind: "huggingface",
+      dataset: datasetName,
+      config,
+      split,
+      partial: parquetResponse.partial === true
+    },
+    byteLength: splitSize?.num_bytes_parquet_files ?? byteLength,
+    rowCount: splitSize?.num_rows ?? null,
+    schema: parquetColumns(schema),
+    queryCache: new QueryResultCache(QUERY_CACHE_BYTES, MAX_CACHED_QUERIES),
+    parquet: { shards, filterKinds: parquetFilterKinds(schema) }
+  };
+}
+async function queryParquet(dataset, query, budget, runtime, loadParquet, loadCompressors) {
+  const parquet = await loadParquet();
+  const shards = dataset.parquet?.shards;
+  if (!shards) throw new Error("Parquet dataset is unavailable");
+  const pushdownFilters = query.filters.filter((filter) => filter.op !== "contains");
+  const postFilters = query.filters.filter((filter) => filter.op === "contains");
+  const rows = [];
+  let skip = query.offset;
+  let complete = true;
+  let truncatedReason;
+  let compressors;
+  try {
+    for (const shard of shards) {
+      const metadata = await parquetMetadata(shard, budget, runtime, parquet);
+      const file = remoteBuffer(shard, budget, runtime);
+      if (!compressors && needsCustomCompressors(metadata, query)) {
+        compressors = (await loadCompressors()).compressors;
+      }
+      const useBloomFilters = pushdownFilters.length > 0 && metadata.row_groups.length <= MAX_BLOOM_FILTER_GROUPS;
+      if (!postFilters.length && !pushdownFilters.length) {
+        const shardRows = safeCount(metadata.num_rows);
+        if (skip >= shardRows) {
+          skip -= shardRows;
+          continue;
+        }
+        const rowStart = skip;
+        const rowEnd = Math.min(shardRows, rowStart + query.limit - rows.length);
+        rows.push(...await parquet.parquetQuery({
+          file,
+          metadata,
+          columns: query.columns,
+          rowStart,
+          rowEnd,
+          compressors,
+          useOffsetIndex: true
+        }));
+        skip = 0;
+      } else if (!postFilters.length) {
+        const requested = skip + (query.limit - rows.length);
+        const found = await parquet.parquetQuery({
+          file,
+          metadata,
+          columns: query.columns,
+          filter: parquetFilter(pushdownFilters),
+          rowStart: 0,
+          rowEnd: requested,
+          compressors,
+          useBloomFilters,
+          usePageIndex: pushdownFilters.length > 0,
+          useOffsetIndex: true
+        });
+        if (skip >= found.length) {
+          skip -= found.length;
+          continue;
+        }
+        rows.push(...found.slice(skip, skip + query.limit - rows.length));
+        skip = 0;
+      } else {
+        let groupStart = 0;
+        for (const group of metadata.row_groups) {
+          const groupEnd = groupStart + safeCount(group.num_rows);
+          const found = await parquet.parquetReadObjects({
+            file,
+            metadata,
+            columns: columnsForPostFilter(query.columns, postFilters),
+            filter: parquetFilter(pushdownFilters),
+            rowStart: groupStart,
+            rowEnd: groupEnd,
+            compressors,
+            useBloomFilters,
+            usePageIndex: pushdownFilters.length > 0,
+            useOffsetIndex: true
+          });
+          for (const candidate of found) {
+            if (!matchesFilters(candidate, postFilters)) continue;
+            if (skip > 0) {
+              skip--;
+              continue;
+            }
+            rows.push(projectRow(candidate, query.columns));
+            if (rows.length >= query.limit) break;
+          }
+          groupStart = groupEnd;
+          if (rows.length >= query.limit) break;
+        }
+      }
+      if (rows.length >= query.limit) {
+        complete = false;
+        truncatedReason = "limit";
+        break;
+      }
+    }
+  } catch (error) {
+    if (!(error instanceof ByteLimitError)) throw error;
+    complete = false;
+    truncatedReason = "byte_limit";
+  }
+  if (complete && dataset.source.kind === "huggingface" && dataset.source.partial) {
+    complete = false;
+    truncatedReason = "source_partial";
+  }
+  return { rows, rowsScanned: null, complete, truncatedReason };
+}
+async function queryJsonl(dataset, query, budget, runtime) {
+  return scanJsonl(dataset, query, budget, runtime);
+}
+function needsCustomCompressors(metadata, query) {
+  const selected = query.columns ? /* @__PURE__ */ new Set([...query.columns, ...query.filters.map((filter) => filter.path[0])]) : void 0;
+  return metadata.row_groups.some((group) => group.columns.some((column) => {
+    const meta = column.meta_data;
+    const name = meta?.path_in_schema[0];
+    return name && (!selected || selected.has(name)) && meta.codec !== "UNCOMPRESSED" && meta.codec !== "SNAPPY";
+  }));
+}
+async function scanJsonl(dataset, query, budget, runtime) {
+  const object = dataset.jsonl?.object;
+  if (!object) throw new Error("JSONL dataset is unavailable");
+  const response = await safeFetch(object.url, runtime, { method: "GET" }, object.allowRedirects);
+  if (!response.ok || !response.body) {
+    await response.body?.cancel().catch(() => void 0);
+    throw new Error(`JSONL fetch failed with HTTP ${response.status}`);
+  }
+  if (object.byteLength == null) {
+    object.byteLength = contentLength(response.headers.get("content-length"));
+    dataset.byteLength = object.byteLength;
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const rows = [];
+  let buffer = "";
+  let rowsScanned = 0;
+  let skip = query.offset;
+  let complete = true;
+  let truncatedReason;
+  const processLine = (line) => {
+    const trimmed = line.endsWith("\r") ? line.slice(0, -1) : line;
+    if (!trimmed) return false;
+    if (trimmed.length > MAX_JSONL_LINE_BYTES) {
+      throw new Error(`JSONL row exceeds ${MAX_JSONL_LINE_BYTES} characters`);
+    }
+    let value;
+    try {
+      value = JSON.parse(trimmed);
+    } catch (error) {
+      throw new Error(`JSONL row ${rowsScanned + 1} is invalid: ${errorMessage(error)}`);
+    }
+    rowsScanned++;
+    if (!isRecord(value) || !matchesFilters(value, query.filters)) return false;
+    if (skip > 0) {
+      skip--;
+      return false;
+    }
+    rows.push(projectRow(value, query.columns));
+    return rows.length >= query.limit;
+  };
+  try {
+    read: while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      const acceptedBytes = Math.min(chunk.value.byteLength, budget.remaining);
+      if (acceptedBytes > 0) {
+        budget.consume(acceptedBytes);
+        buffer += decoder.decode(chunk.value.subarray(0, acceptedBytes), { stream: true });
+      }
+      const hitByteLimit = acceptedBytes < chunk.value.byteLength || budget.remaining === 0 && (object.byteLength == null || budget.used < object.byteLength);
+      if (buffer.length > MAX_JSONL_LINE_BYTES && !buffer.includes("\n")) {
+        throw new Error(`JSONL row exceeds ${MAX_JSONL_LINE_BYTES} characters`);
+      }
+      let newline = buffer.indexOf("\n");
+      while (newline >= 0) {
+        const line = buffer.slice(0, newline);
+        buffer = buffer.slice(newline + 1);
+        if (processLine(line)) {
+          complete = false;
+          truncatedReason = "limit";
+          break read;
+        }
+        newline = buffer.indexOf("\n");
+      }
+      if (hitByteLimit) {
+        complete = false;
+        truncatedReason = "byte_limit";
+        break;
+      }
+    }
+    buffer += decoder.decode();
+    if (complete && buffer && processLine(buffer)) {
+      complete = false;
+      truncatedReason = "limit";
+    }
+  } catch (error) {
+    if (!(error instanceof ByteLimitError)) throw error;
+    complete = false;
+    truncatedReason = "byte_limit";
+  } finally {
+    await reader.cancel().catch(() => void 0);
+  }
+  return { rows, rowsScanned, complete, truncatedReason };
+}
+async function parquetMetadata(shard, budget, runtime, parquet) {
+  shard.metadata ??= await parquet.parquetMetadataAsync(remoteBuffer(shard, budget, runtime));
+  return shard.metadata;
+}
+function remoteBuffer(object, budget, runtime) {
+  if (object.byteLength == null) throw new Error("remote object size is unknown");
+  return {
+    byteLength: object.byteLength,
+    async slice(start, end = object.byteLength) {
+      const normalizedStart = Math.max(0, start);
+      const normalizedEnd = Math.min(object.byteLength, end);
+      if (!Number.isSafeInteger(normalizedStart) || !Number.isSafeInteger(normalizedEnd) || normalizedStart > normalizedEnd) {
+        throw new Error(`invalid dataset byte range ${start}-${end}`);
+      }
+      const length = normalizedEnd - normalizedStart;
+      budget.consume(length);
+      if (length === 0) return new ArrayBuffer(0);
+      const key = `${object.cacheKey}
+${normalizedStart}-${normalizedEnd}`;
+      return runtime.rangeCache.read(key, length, async () => {
+        const response = await safeFetch(object.url, runtime, {
+          method: "GET",
+          headers: { range: `bytes=${normalizedStart}-${normalizedEnd - 1}` }
+        }, object.allowRedirects);
+        if (response.status !== 206) {
+          await response.body?.cancel().catch(() => void 0);
+          throw new Error(`dataset server ignored byte range and returned HTTP ${response.status}`);
+        }
+        const contentRange = response.headers.get("content-range");
+        if (contentRange !== `bytes ${normalizedStart}-${normalizedEnd - 1}/${object.byteLength}`) {
+          await response.body?.cancel().catch(() => void 0);
+          throw new Error("dataset server returned an invalid Content-Range");
+        }
+        return readExactResponse(response, length);
+      });
+    }
+  };
+}
+async function remoteByteLength(url, runtime) {
+  const head = await safeFetch(url.href, runtime, { method: "HEAD" }).catch(() => void 0);
+  if (head?.ok) {
+    const length = contentLength(head.headers.get("content-length"));
+    if (length != null) return length;
+  }
+  const response = await safeFetch(url.href, runtime, {
+    method: "GET",
+    headers: { range: "bytes=0-0" }
+  });
+  const match = response.status === 206 ? response.headers.get("content-range")?.match(/^bytes 0-0\/(\d+)$/) : void 0;
+  await response.body?.cancel().catch(() => void 0);
+  return match ? contentLength(match[1]) : null;
+}
+async function fetchJson(url, runtime) {
+  const response = await safeFetch(url, runtime, { method: "GET" });
+  if (!response.ok) {
+    await response.body?.cancel().catch(() => void 0);
+    throw new Error(`dataset metadata request failed with HTTP ${response.status}`);
+  }
+  const declared = contentLength(response.headers.get("content-length"));
+  if (declared != null && declared > MAX_API_RESPONSE_BYTES) {
+    throw new Error("dataset metadata response is too large");
+  }
+  const body = await readBoundedText(response, MAX_API_RESPONSE_BYTES);
+  try {
+    return JSON.parse(body);
+  } catch (error) {
+    throw new Error(`dataset metadata response is invalid JSON: ${errorMessage(error)}`);
+  }
+}
+async function readExactResponse(response, expectedBytes) {
+  const declared = contentLength(response.headers.get("content-length"));
+  if (declared != null && declared !== expectedBytes) {
+    await response.body?.cancel().catch(() => void 0);
+    throw new Error(`dataset byte range declared ${declared} bytes; expected ${expectedBytes}`);
+  }
+  if (!response.body) throw new Error("dataset byte range has no response body");
+  const reader = response.body.getReader();
+  const output = new Uint8Array(expectedBytes);
+  let offset = 0;
+  let finished = false;
+  try {
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      if (offset + chunk.value.byteLength > expectedBytes) {
+        throw new Error(`dataset byte range exceeds expected ${expectedBytes} bytes`);
+      }
+      output.set(chunk.value, offset);
+      offset += chunk.value.byteLength;
+    }
+    finished = offset === expectedBytes;
+  } finally {
+    if (!finished) await reader.cancel().catch(() => void 0);
+  }
+  if (offset !== expectedBytes) {
+    throw new Error(`dataset byte range returned ${offset} bytes; expected ${expectedBytes}`);
+  }
+  return output.buffer;
+}
+async function readBoundedText(response, maxBytes) {
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = "";
+  try {
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      bytes += chunk.value.byteLength;
+      if (bytes > maxBytes) throw new Error("dataset metadata response is too large");
+      text += decoder.decode(chunk.value, { stream: true });
+    }
+    return text + decoder.decode();
+  } finally {
+    await reader.cancel().catch(() => void 0);
+  }
+}
+async function safeFetch(input, runtime, init, allowRedirects = false) {
+  publicHttpsUrl(input);
+  const timeout = AbortSignal.timeout(FETCH_TIMEOUT_MS);
+  const signal = runtime.signal ? AbortSignal.any([runtime.signal, timeout]) : timeout;
+  const response = await runtime.fetch(input, {
+    ...init,
+    credentials: "omit",
+    mode: "cors",
+    redirect: allowRedirects ? "follow" : "error",
+    referrerPolicy: "no-referrer",
+    signal
+  });
+  if (response.url) publicHttpsUrl(response.url);
+  return response;
+}
+function parseQuery(args, dataset) {
+  const datasetId = requireString(args.dataset_id, "dataset.dataset_id");
+  const columns = optionalStringArray(args.columns, "dataset.columns");
+  if (columns && dataset.format === "parquet") {
+    const known = new Set(dataset.schema.map((column) => column.name));
+    const unknown = columns.filter((column) => !known.has(column));
+    if (unknown.length) throw new Error(`dataset columns not found: ${unknown.join(", ")}`);
+  }
+  let filters = parseFilters(args.filters);
+  if (dataset.format === "parquet") {
+    const known = new Set(dataset.schema.map((column) => column.name));
+    const unknown = filters.map((filter) => filter.column.split(".")[0]).filter((column) => !known.has(column));
+    if (unknown.length) throw new Error(`dataset filter columns not found: ${unique(unknown).join(", ")}`);
+    filters = coerceParquetFilters(filters, dataset.parquet?.filterKinds ?? /* @__PURE__ */ new Map());
+  }
+  const offset = optionalBoundedInteger(args.offset, 0, MAX_QUERY_OFFSET, 0, "dataset.offset");
+  const limit = optionalBoundedInteger(args.limit, 1, MAX_QUERY_LIMIT, DEFAULT_QUERY_LIMIT, "dataset.limit");
+  const maxBytes = optionalBoundedInteger(
+    args.max_bytes,
+    1024,
+    MAX_QUERY_BYTES,
+    DEFAULT_QUERY_BYTES,
+    "dataset.max_bytes"
+  );
+  return { datasetId, columns, filters, offset, limit, maxBytes };
+}
+function coerceParquetFilters(filters, kinds) {
+  return filters.map((filter) => {
+    const kind = kinds.get(filter.column);
+    if (!kind) return filter;
+    if (filter.op === "contains") {
+      throw new Error(`dataset filter ${filter.column} does not support contains`);
+    }
+    const value = filter.op === "in" ? filter.value.map((entry) => coerceParquetFilterValue(entry, kind, filter.column)) : coerceParquetFilterValue(filter.value, kind, filter.column);
+    return { ...filter, value };
+  });
+}
+function coerceParquetFilterValue(value, kind, column) {
+  if (value === null) return null;
+  if (kind === "bigint") {
+    if (typeof value === "bigint") return value;
+    if (typeof value === "number" && Number.isSafeInteger(value)) return BigInt(value);
+    if (typeof value === "string" && /^-?\d+$/.test(value)) return BigInt(value);
+    throw new Error(`dataset filter ${column} requires a safe integer or integer string`);
+  }
+  if (value instanceof Date && Number.isFinite(value.getTime())) return value;
+  if (typeof value === "string" || typeof value === "number") {
+    const date = new Date(value);
+    if (Number.isFinite(date.getTime())) return date;
+  }
+  throw new Error(`dataset filter ${column} requires an ISO date or timestamp`);
+}
+function parseFilters(value) {
+  if (value === void 0) return [];
+  if (!Array.isArray(value)) throw new Error("dataset.filters must be an array");
+  if (value.length > 8) throw new Error("dataset.filters supports at most 8 filters");
+  return value.map((entry, index) => {
+    const filter = requireObject(entry, `dataset.filters[${index}]`);
+    const column = requireString(filter.column, `dataset.filters[${index}].column`);
+    const op = requireString(filter.op, `dataset.filters[${index}].op`);
+    if (!["eq", "ne", "gt", "gte", "lt", "lte", "in", "contains"].includes(op)) {
+      throw new Error(`dataset.filters[${index}].op is unsupported`);
+    }
+    if (op === "in" && (!Array.isArray(filter.value) || filter.value.length > 100)) {
+      throw new Error(`dataset.filters[${index}].value must be an array with at most 100 values`);
+    }
+    if (op === "contains" && typeof filter.value !== "string") {
+      throw new Error(`dataset.filters[${index}].value must be a string for contains`);
+    }
+    return { column, path: column.split("."), op, value: filter.value };
+  });
+}
+function parquetFilter(filters) {
+  if (!filters.length) return void 0;
+  const clauses = filters.map((filter) => ({
+    [filter.column]: { [`$${filter.op}`]: filter.value }
+  }));
+  return clauses.length === 1 ? clauses[0] : { $and: clauses };
+}
+function matchesFilters(row, filters) {
+  return filters.every((filter) => {
+    const actual = pathPartsValue(row, filter.path);
+    switch (filter.op) {
+      case "eq":
+        return actual === filter.value;
+      case "ne":
+        return actual !== filter.value;
+      case "gt":
+        return comparable(actual, filter.value) > 0;
+      case "gte":
+        return comparable(actual, filter.value) >= 0;
+      case "lt":
+        return comparable(actual, filter.value) < 0;
+      case "lte":
+        return comparable(actual, filter.value) <= 0;
+      case "in":
+        return filter.value.some((value) => value === actual);
+      case "contains":
+        return typeof actual === "string" && actual.includes(filter.value);
+    }
+  });
+}
+function comparable(left, right) {
+  if (typeof left === "number" && typeof right === "number") return left - right;
+  if (typeof left === "string" && typeof right === "string") return left.localeCompare(right);
+  return Number.NaN;
+}
+function pathValue(row, path) {
+  return pathPartsValue(row, path.split("."));
+}
+function pathPartsValue(row, path) {
+  let value = row;
+  for (const part of path) {
+    if (!isRecord(value)) return void 0;
+    value = value[part];
+  }
+  return value;
+}
+function projectRow(row, columns) {
+  if (!columns) return row;
+  return Object.fromEntries(columns.map((column) => [column, pathValue(row, column)]));
+}
+function columnsForPostFilter(columns, filters) {
+  if (!columns) return void 0;
+  return unique([...columns, ...filters.map((filter) => filter.column.split(".")[0])]);
+}
+function parquetColumns(schema) {
+  return schema.children.map((column) => ({
+    name: column.element.name,
+    type: column.element.logical_type?.type ?? column.element.converted_type ?? column.element.type ?? (column.children.length ? "STRUCT" : "UNKNOWN"),
+    nullable: column.element.repetition_type !== "REQUIRED"
+  }));
+}
+function parquetFilterKinds(schema) {
+  const kinds = /* @__PURE__ */ new Map();
+  const visit = (node, prefix) => {
+    for (const child of node.children) {
+      const path = [...prefix, child.element.name];
+      if (child.children.length) {
+        visit(child, path);
+        continue;
+      }
+      const element = child.element;
+      const logical = element.logical_type?.type;
+      const converted = element.converted_type;
+      if (logical === "DATE" || logical === "TIMESTAMP" || converted === "DATE" || converted === "TIMESTAMP_MILLIS" || converted === "TIMESTAMP_MICROS" || element.type === "INT96") {
+        kinds.set(path.join("."), "date");
+      } else if (element.type === "INT64" && logical !== "DECIMAL" && converted !== "DECIMAL") {
+        kinds.set(path.join("."), "bigint");
+      }
+    }
+  };
+  visit(schema, []);
+  return kinds;
+}
+function inferJsonlSchema(rows) {
+  const types = /* @__PURE__ */ new Map();
+  for (const row of rows) {
+    for (const [key, value] of Object.entries(row)) {
+      let seen = types.get(key);
+      if (!seen) {
+        seen = /* @__PURE__ */ new Set();
+        types.set(key, seen);
+      }
+      seen.add(valueType(value));
+    }
+  }
+  return [...types].map(([name, seen]) => ({ name, type: [...seen].sort().join(" | ") }));
+}
+function valueType(value) {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value === "object" ? "object" : typeof value;
+}
+function boundedQueryResult(dataset, query, budget, progress) {
+  const normalized = progress.rows.map((row) => normalizeValue(row));
+  const rows = [];
+  let outputBytes = 0;
+  const encoder = new TextEncoder();
+  for (const row of normalized) {
+    const bytes = encoder.encode(JSON.stringify(row)).byteLength;
+    if (outputBytes + bytes > MAX_TOOL_OUTPUT_BYTES) break;
+    rows.push(row);
+    outputBytes += bytes;
+  }
+  const outputTruncated = rows.length !== normalized.length;
+  return {
+    datasetId: dataset.id,
+    format: dataset.format,
+    rows,
+    returnedRows: rows.length,
+    rowsScanned: progress.rowsScanned,
+    bytesRead: budget.used,
+    complete: progress.complete && !outputTruncated,
+    truncatedReason: outputTruncated ? "output_limit" : progress.truncatedReason,
+    offset: query.offset,
+    limit: query.limit
+  };
+}
+function queryCacheKey(query) {
+  return JSON.stringify({
+    columns: query.columns,
+    filters: query.filters.map(({ column, op, value }) => ({ column, op, value })),
+    offset: query.offset,
+    limit: query.limit,
+    maxBytes: query.maxBytes
+  }, (_key, value) => typeof value === "bigint" ? { $bigint: value.toString() } : value);
+}
+function normalizeValue(value, seen = /* @__PURE__ */ new WeakSet()) {
+  if (value === void 0) return null;
+  if (typeof value === "bigint") {
+    const number = Number(value);
+    return Number.isSafeInteger(number) ? number : value.toString();
+  }
+  if (typeof value === "string") {
+    return value.length <= MAX_CELL_STRING_LENGTH ? value : `${value.slice(0, MAX_CELL_STRING_LENGTH)}\u2026[truncated ${value.length - MAX_CELL_STRING_LENGTH} chars]`;
+  }
+  if (value instanceof Date) return value.toISOString();
+  if (value instanceof Uint8Array) {
+    return { binaryBytes: value.byteLength, previewHex: hex(value.subarray(0, 32)) };
+  }
+  if (Array.isArray(value)) return value.map((entry) => normalizeValue(entry, seen));
+  if (isRecord(value)) {
+    if (seen.has(value)) return "[circular]";
+    seen.add(value);
+    return Object.fromEntries(Object.entries(value).map(([key, entry]) => [key, normalizeValue(entry, seen)]));
+  }
+  return value;
+}
+function publicDataset(dataset) {
+  return {
+    datasetId: dataset.id,
+    format: dataset.format,
+    source: dataset.source,
+    byteLength: dataset.byteLength,
+    rowCount: dataset.rowCount,
+    schema: dataset.schema,
+    shardCount: dataset.parquet?.shards.length ?? 1,
+    previewRows: dataset.jsonl?.preview.map((row) => normalizeValue(row))
+  };
+}
+function requireDataset(sessions, sessionId, value) {
+  const id = requireString(value, "dataset.dataset_id");
+  const dataset = sessions.get(sessionId)?.get(id);
+  if (!dataset) throw new Error("dataset handle is unavailable in this agent session");
+  return dataset;
+}
+function sessionDatasets(sessions, sessionId) {
+  let datasets = sessions.get(sessionId);
+  if (!datasets) {
+    datasets = /* @__PURE__ */ new Map();
+    sessions.set(sessionId, datasets);
+  }
+  return datasets;
+}
+function openDatasetCount(sessions) {
+  let count = 0;
+  for (const datasets of sessions.values()) count += datasets.size;
+  return count;
+}
+function pendingOpenCount(pending) {
+  let count = 0;
+  for (const value of pending.values()) count += value;
+  return count;
+}
+function parseFormat(value, url) {
+  if (value !== void 0) {
+    if (value === "parquet" || value === "jsonl") return value;
+    throw new Error("dataset.source.format must be parquet or jsonl");
+  }
+  const path = url.pathname.toLowerCase();
+  if (path.endsWith(".parquet")) return "parquet";
+  if (path.endsWith(".jsonl") || path.endsWith(".ndjson")) return "jsonl";
+  if (path.endsWith(".jsonl.gz") || path.endsWith(".ndjson.gz") || path.endsWith(".jsonl.zst")) {
+    throw new Error("compressed JSONL requires a converted Parquet source or an uncompressed streaming URL");
+  }
+  throw new Error("dataset.source.format is required when the URL extension is not .parquet, .jsonl, or .ndjson");
+}
+function publicHttpsUrl(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("dataset URL is invalid");
+  }
+  if (url.protocol !== "https:" || url.username || url.password) {
+    throw new Error("dataset URL must be credential-free HTTPS");
+  }
+  const hostname = url.hostname.toLowerCase().replace(/\.$/, "");
+  if (unsafeHostname(hostname)) throw new Error("dataset URL must use a public hostname");
+  return url;
+}
+function huggingFaceRedirectUrl(url) {
+  const hostname = url.hostname.toLowerCase().replace(/\.$/, "");
+  return hostname === "huggingface.co" || hostname.endsWith(".huggingface.co");
+}
+function unsafeHostname(hostname) {
+  if (hostname === "localhost" || hostname.endsWith(".localhost") || hostname.endsWith(".local") || hostname.endsWith(".internal") || hostname.includes(":")) return true;
+  const parts = hostname.split(".");
+  if (parts.length !== 4 || parts.some((part) => !/^\d+$/.test(part))) return false;
+  const octets = parts.map(Number);
+  if (octets.some((part) => part < 0 || part > 255)) return true;
+  const [a, b] = octets;
+  return a === 0 || a === 10 || a === 127 || a >= 224 || a === 100 && b >= 64 && b <= 127 || a === 169 && b === 254 || a === 172 && b >= 16 && b <= 31 || a === 192 && b === 168;
+}
+function chooseDatasetPart(requested, available, preferred, label) {
+  if (requested) {
+    if (!available.includes(requested)) {
+      throw new Error(`Hugging Face ${label} ${requested} was not found; available: ${available.join(", ")}`);
+    }
+    return requested;
+  }
+  if (available.includes(preferred)) return preferred;
+  if (available.length === 1) return available[0];
+  throw new Error(`Hugging Face ${label} is required; available: ${available.join(", ")}`);
+}
+function requireObject(value, name) {
+  if (!isRecord(value)) throw new Error(`${name} requires an object`);
+  return value;
+}
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function requireString(value, name) {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${name} must be a non-empty string`);
+  return value;
+}
+function optionalString(value, name) {
+  return value === void 0 ? void 0 : requireString(value, name);
+}
+function optionalStringArray(value, name) {
+  if (value === void 0) return void 0;
+  if (!Array.isArray(value) || value.length > 64 || value.some((entry) => typeof entry !== "string" || !entry)) {
+    throw new Error(`${name} must be an array of at most 64 non-empty strings`);
+  }
+  return unique(value);
+}
+function optionalBoundedInteger(value, minimum, maximum, fallback, name) {
+  if (value === void 0) return fallback;
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw new Error(`${name} must be an integer between ${minimum} and ${maximum}`);
+  }
+  return value;
+}
+function boundedNonnegativeInteger(value, name) {
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error(`${name} is invalid`);
+  return value;
+}
+function contentLength(value) {
+  if (value == null || !/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+function safeCount(value) {
+  const number = Number(value);
+  if (!Number.isSafeInteger(number) || number < 0) throw new Error("dataset row count exceeds JavaScript safe integers");
+  return number;
+}
+function unique(values) {
+  return [...new Set(values)];
+}
+function hex(bytes) {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+class ByteLimitError extends Error {
+}
+class ByteBudget {
+  used = 0;
+  limit;
+  constructor(limit) {
+    this.limit = limit;
+  }
+  get remaining() {
+    return this.limit - this.used;
+  }
+  consume(bytes) {
+    if (!Number.isSafeInteger(bytes) || bytes < 0) throw new Error("dataset byte count is invalid");
+    if (this.used + bytes > this.limit) throw new ByteLimitError("dataset byte limit reached");
+    this.used += bytes;
+  }
+}
+class RangeCache {
+  entries = /* @__PURE__ */ new Map();
+  maxBytes;
+  maxEntryBytes;
+  bytes = 0;
+  constructor(maxBytes, maxEntryBytes) {
+    this.maxBytes = maxBytes;
+    this.maxEntryBytes = maxEntryBytes;
+  }
+  async read(key, length, load) {
+    const cached = this.entries.get(key);
+    if (cached) {
+      this.entries.delete(key);
+      this.entries.set(key, cached);
+      return cached;
+    }
+    const buffer = await load();
+    if (length <= this.maxEntryBytes) this.insert(key, buffer);
+    return buffer;
+  }
+  insert(key, buffer) {
+    const existing = this.entries.get(key);
+    if (existing) {
+      this.entries.delete(key);
+      this.bytes -= existing.byteLength;
+    }
+    while (this.bytes + buffer.byteLength > this.maxBytes && this.entries.size) {
+      const oldest = this.entries.keys().next().value;
+      const removed = this.entries.get(oldest);
+      this.entries.delete(oldest);
+      this.bytes -= removed.byteLength;
+    }
+    if (buffer.byteLength > this.maxBytes) return;
+    this.entries.set(key, buffer);
+    this.bytes += buffer.byteLength;
+  }
+  deleteDataset(datasetId) {
+    for (const [key, buffer] of this.entries) {
+      if (!key.startsWith(`${datasetId}\n`) && !key.startsWith(`${datasetId}:`)) continue;
+      this.entries.delete(key);
+      this.bytes -= buffer.byteLength;
+    }
+  }
+  clear() {
+    this.entries.clear();
+    this.bytes = 0;
+  }
+}
+class QueryResultCache {
+  entries = /* @__PURE__ */ new Map();
+  maxBytes;
+  maxEntries;
+  bytes = 0;
+  constructor(maxBytes, maxEntries) {
+    this.maxBytes = maxBytes;
+    this.maxEntries = maxEntries;
+  }
+  get(key) {
+    const entry = this.entries.get(key);
+    if (!entry) return void 0;
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    return structuredClone(entry.result);
+  }
+  set(key, result) {
+    const copy = structuredClone(result);
+    const bytes = new TextEncoder().encode(JSON.stringify(copy)).byteLength;
+    if (bytes > this.maxBytes) return;
+    const existing = this.entries.get(key);
+    if (existing) {
+      this.entries.delete(key);
+      this.bytes -= existing.bytes;
+    }
+    while ((this.bytes + bytes > this.maxBytes || this.entries.size >= this.maxEntries) && this.entries.size) {
+      const oldest = this.entries.keys().next().value;
+      const removed = this.entries.get(oldest);
+      this.entries.delete(oldest);
+      this.bytes -= removed.bytes;
+    }
+    this.entries.set(key, { bytes, result: copy });
+    this.bytes += bytes;
+  }
+}
+export {
+  createDatasetTool
+};

--- a/js/bindings/tools/index.d.mts
+++ b/js/bindings/tools/index.d.mts
@@ -26,3 +26,6 @@ export function viewImage(options: {
 
 /** A session-scoped planning tool. */
 export function updatePlan(): NamedTool;
+
+export { dataset } from "./dataset.mjs";
+export type { DatasetOptions } from "./dataset.mjs";

--- a/js/bindings/tools/index.mjs
+++ b/js/bindings/tools/index.mjs
@@ -4,3 +4,4 @@ export {
   viewImage,
   web,
 } from "./standard.mjs";
+export { dataset } from "./dataset.mjs";

--- a/js/bindings/tools/namedTool.mjs
+++ b/js/bindings/tools/namedTool.mjs
@@ -1,0 +1,3 @@
+export function namedTool(name, tool) {
+  return Object.freeze({ name, ...tool });
+}

--- a/js/bindings/tools/standard.mjs
+++ b/js/bindings/tools/standard.mjs
@@ -1,4 +1,7 @@
 import { IMAGE_DESCRIPTION, WEB_DESCRIPTION } from "./standardDescriptions.mjs";
+import { namedTool } from "./namedTool.mjs";
+
+export { namedTool };
 
 const MAX_VIEW_IMAGE_BYTES = 10 * 1024 * 1024;
 const DEFAULT_WEB_URL = "/api/tools/web-search";
@@ -138,10 +141,6 @@ export function updatePlan() {
       return { updated: true };
     },
   });
-}
-
-export function namedTool(name, tool) {
-  return Object.freeze({ name, ...tool });
 }
 
 function jsonRequester(options, defaultUrl) {

--- a/js/bindings/types.d.mts
+++ b/js/bindings/types.d.mts
@@ -228,6 +228,10 @@ export type Tool = {
   /** Runtime JSON Schema for model-generated input. Defaults to an open object. */
   parameters?: Record<string, unknown> | undefined;
   handler(input: unknown, context: ToolContext): unknown | Promise<unknown>;
+  /** Releases state owned by one completed agent session. */
+  releaseSession?(sessionId: string): void;
+  /** Releases all retained tool state when the owning host shuts down. */
+  dispose?(): void;
 };
 
 export type ToolMap = Record<string, Tool>;

--- a/web/README.md
+++ b/web/README.md
@@ -164,6 +164,31 @@ A user key takes precedence over the optional deployment-owned
 `OPENAI_API_KEY`; forgetting or expiring it falls back to that deployment key
 when present.
 
+The reusable `browser(...)` tool bundle gives the browser agent a bounded
+`dataset` tool. It can inspect public
+Parquet URLs, Hugging Face dataset/config/split exports, and uncompressed JSONL
+URLs without downloading whole datasets into memory. Parquet reads use HTTP
+ranges and filter/projection pushdown where possible; JSONL reads incrementally
+scan the response stream. Dataset handles are scoped to an agent session, every
+query has row, input-byte, and output-byte limits, and partial results explicitly
+report `complete: false`. The implementation and Parquet codecs are lazy chunks,
+so ordinary agent sessions do not download them. Direct sources must permit
+browser CORS, and Parquet sources must honor byte-range requests.
+
+For example, ask the web agent to “inspect the `main` config’s `train` split of
+`openai/gsm8k`, show its schema, and find five examples containing arithmetic.”
+The resulting tool flow is equivalent to:
+
+```json
+{"operation":"open","source":{"kind":"huggingface","dataset":"openai/gsm8k","config":"main","split":"train"}}
+{"operation":"query","dataset_id":"<returned id>","columns":["question","answer"],"filters":[{"column":"question","op":"contains","value":"how many"}],"limit":5}
+{"operation":"close","dataset_id":"<returned id>"}
+```
+
+Run `npm run bench:dataset` in `js/bindings` for the deterministic 100,000-row
+Snappy Parquet/JSONL browser-path benchmark. It reports cold and repeated query
+latency, pulled bytes, range requests, scanned rows, and cache hits.
+
 OpenAI remains the default agent connection. A user can explicitly select
 Tempo MPP instead; only then does React lazy-load Wagmi and Tempo Accounts,
 open the standard embedded Tempo Wallet dialog for its account and passkey flow, and

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -78,6 +78,8 @@
         "@modelcontextprotocol/sdk": "1.30.0",
         "buffer": "6.0.3",
         "diff": "^9.0.0",
+        "hyparquet": "1.28.2",
+        "hyparquet-compressors": "1.1.1",
         "isomorphic-git": "^1.41.5",
         "just-bash": "^3.4.0",
         "minisearch": "7.2.0",
@@ -87,6 +89,7 @@
       },
       "devDependencies": {
         "@jitl/quickjs-wasmfile-release-asyncify": "0.32.0",
+        "hyparquet-writer": "0.16.6",
         "pkg-pr-new": "0.0.79",
         "quickjs-emscripten-core": "0.32.0",
         "typescript": "5.9.3"

--- a/web/scripts/check-bundle.mjs
+++ b/web/scripts/check-bundle.mjs
@@ -16,6 +16,16 @@ const budgets = Object.freeze({
   // OPFS, artifacts, voice routing, subscription auth, and paid MCP stay in the Worker.
   agentWorker: 55_000,
   agentWorkerGzip: 17_500,
+  datasetFacadeJavaScript: 1_500,
+  datasetFacadeJavaScriptGzip: 700,
+  datasetContractJavaScript: 1_500,
+  datasetContractJavaScriptGzip: 700,
+  datasetToolJavaScript: 21_000,
+  datasetToolJavaScriptGzip: 7_200,
+  parquetJavaScript: 60_000,
+  parquetJavaScriptGzip: 18_000,
+  parquetCompressorsJavaScript: 116_000,
+  parquetCompressorsJavaScriptGzip: 75_500,
   // just-bash and its built-in Unix command set stay behind Agent startup.
   browserShellJavaScript: 1_600_000,
   browserShellJavaScriptGzip: 450_000,
@@ -221,6 +231,100 @@ assert(
   "the compiler command must create its isolated Worker only on execution",
 );
 
+const datasetFacadeFile = await findLazyAsset(
+  workerSource,
+  (_file, source) => source.includes("dataset tool options must be an object"),
+);
+assert(datasetFacadeFile, "the package-owned browser tools must lazy-load the dataset facade");
+assert(!html.includes(datasetFacadeFile), "index.html must not preload the dataset facade");
+assert(
+  !browserShellFiles.has(datasetFacadeFile),
+  "the dataset facade must not enter the browser shell's static closure",
+);
+const datasetFacadeSource = await readFile(join(assetsDirectory, datasetFacadeFile), "utf8");
+const datasetFacade = byteStats(datasetFacadeSource);
+within("Dataset facade JavaScript", datasetFacade.bytes, budgets.datasetFacadeJavaScript);
+within(
+  "Dataset facade JavaScript gzip",
+  datasetFacade.gzipBytes,
+  budgets.datasetFacadeJavaScriptGzip,
+);
+const datasetImport = datasetFacadeSource.match(
+  /import\((?:`|'|")\.\/(datasetEngine-[^`'"]+\.js)(?:`|'|")\)/,
+);
+assert(datasetImport, "the dataset facade must retain an explicit lazy engine edge");
+const datasetFile = datasetImport[1];
+assert(assets.includes(datasetFile), `the lazy dataset tool ${datasetFile} is missing`);
+assert(!html.includes(datasetFile), "index.html must not preload the dataset tool");
+const datasetPath = join(assetsDirectory, datasetFile);
+const datasetSource = await readFile(datasetPath, "utf8");
+const dataset = byteStats(datasetSource);
+within("Dataset tool JavaScript", dataset.bytes, budgets.datasetToolJavaScript);
+within(
+  "Dataset tool JavaScript gzip",
+  dataset.gzipBytes,
+  budgets.datasetToolJavaScriptGzip,
+);
+const datasetContractFile = exactlyOne(
+  assets.filter((file) => /^datasetContract-.*\.js$/.test(file)),
+  "dataset tool contract",
+);
+assert(!html.includes(datasetContractFile), "index.html must not preload the dataset contract");
+const datasetFacadeFiles = await staticAssetClosure(datasetFacadeFile);
+assert(
+  datasetFacadeFiles.has(datasetContractFile),
+  "the dataset facade must statically own its model-visible contract",
+);
+const datasetContract = await fileStats([`assets/${datasetContractFile}`]);
+within(
+  "Dataset contract JavaScript",
+  datasetContract.bytes,
+  budgets.datasetContractJavaScript,
+);
+within(
+  "Dataset contract JavaScript gzip",
+  datasetContract.gzipBytes,
+  budgets.datasetContractJavaScriptGzip,
+);
+const datasetRuntimeImports = [...datasetSource.matchAll(
+  /import\((?:`|'|")\.\/(src-[^`'"]+\.js)(?:`|'|")\)/g,
+)].map((match) => match[1]);
+assert.equal(datasetRuntimeImports.length, 2, "the dataset tool must lazily load Parquet and its codecs");
+for (const file of datasetRuntimeImports) {
+  assert(assets.includes(file), `the lazy dataset runtime ${file} is missing`);
+  assert(!html.includes(file), `index.html must not preload the dataset runtime ${file}`);
+}
+const datasetRuntimeSources = await Promise.all(datasetRuntimeImports.map(async (file) => ({
+  file,
+  source: await readFile(join(assetsDirectory, file), "utf8"),
+})));
+const parquetFile = exactlyOne(
+  datasetRuntimeSources
+    .filter(({ source }) => source.includes("parquet expected AsyncBuffer"))
+    .map(({ file }) => file),
+  "Hyparquet runtime",
+);
+const parquetCompressorsFile = exactlyOne(
+  datasetRuntimeSources
+    .filter(({ source }) => source.includes("lz4 offset out of range"))
+    .map(({ file }) => file),
+  "Parquet compressor runtime",
+);
+const parquet = await fileStats([`assets/${parquetFile}`]);
+within("Hyparquet JavaScript", parquet.bytes, budgets.parquetJavaScript);
+within("Hyparquet JavaScript gzip", parquet.gzipBytes, budgets.parquetJavaScriptGzip);
+const parquetCompressors = await fileStats([`assets/${parquetCompressorsFile}`]);
+within(
+  "Parquet compressors JavaScript",
+  parquetCompressors.bytes,
+  budgets.parquetCompressorsJavaScript,
+);
+within(
+  "Parquet compressors JavaScript gzip",
+  parquetCompressors.gzipBytes,
+  budgets.parquetCompressorsJavaScriptGzip,
+);
+
 const tempoImport = workerSource.match(
   /import\((?:`|'|")\.\/(tempo-[^`'"]+\.js)(?:`|'|")\)/,
 );
@@ -315,6 +419,18 @@ console.log(JSON.stringify({
     pythonEntry: pythonFile,
     compilerEntry: compilerFile,
     sshEntry: sshFile,
+    dataset: {
+      facadeBytes: datasetFacade.bytes,
+      facadeGzipBytes: datasetFacade.gzipBytes,
+      contractBytes: datasetContract.bytes,
+      contractGzipBytes: datasetContract.gzipBytes,
+      toolBytes: dataset.bytes,
+      toolGzipBytes: dataset.gzipBytes,
+      parquetBytes: parquet.bytes,
+      parquetGzipBytes: parquet.gzipBytes,
+      compressorsBytes: parquetCompressors.bytes,
+      compressorsGzipBytes: parquetCompressors.gzipBytes,
+    },
   },
   artifacts: {
     coreJavaScriptBytes: artifactCoreJavaScript.bytes,


### PR DESCRIPTION
## Summary
- add a lazy, stateful dataset tool for Parquet, JSONL/NDJSON, and Hugging Face dataset exports
- compose dataset capability into browser tools while preserving direct leaf-package usage
- add bounded range/stream reads, caches, lifecycle cleanup, SSRF/CORS guards, and bundle budgets

## Verification
- `npm test` in `js/bindings`
- `npm test && npm run build` in `web`
- live Hugging Face GSM8K smoke and focused dataset benchmark completed before final replay