### PR TITLE
fix(js): bind browser dataset fetch

### DIFF
--- a/js/bindings/test/dataset.test.mjs
+++ b/js/bindings/test/dataset.test.mjs
@@ -15,6 +15,25 @@ test("the public dataset factory advertises the lazy dataset capability", () => 
   );
 });
 
+test("the default dataset fetch keeps the browser global receiver", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = function () {
+    if (this !== globalThis) throw new TypeError("Illegal invocation");
+    return Promise.resolve(new Response('{"id":1}\n', { status: 200 }));
+  };
+  try {
+    const tool = createDatasetTool({ randomId: () => "browser-fetch" });
+    const opened = await tool.handler({
+      operation: "open",
+      source: { kind: "url", url: "https://data.example/browser.jsonl" },
+    }, context);
+    assert.equal(opened.datasetId, "browser-fetch");
+    assert.deepEqual(opened.previewRows, [{ id: 1 }]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("the public dataset factory releases session handles and rejects work after disposal", async () => {
   const url = "https://data.example/release.jsonl";
   const tool = dataset({

--- a/js/bindings/tools/datasetEngine.mjs
+++ b/js/bindings/tools/datasetEngine.mjs
@@ -23,7 +23,10 @@ const QUERY_CACHE_BYTES = 2 * 1024 * 1024;
 const MAX_CACHED_QUERIES = 16;
 const MAX_BLOOM_FILTER_GROUPS = 8;
 function createDatasetTool(options = {}) {
-  const fetchImpl = options.fetch ?? globalThis.fetch;
+  const providedFetch = options.fetch;
+  const fetchImpl = providedFetch === undefined
+    ? globalThis.fetch.bind(globalThis)
+    : (input, init) => providedFetch(input, init);
   const randomId = options.randomId ?? (() => crypto.randomUUID());
   const loadParquet = options.loadParquet ?? (() => import("hyparquet"));
   const loadCompressors = options.loadCompressors ?? (() => import("hyparquet-compressors"));


### PR DESCRIPTION
Fix the deployed browser dataset tool failing with `TypeError: Illegal invocation`.

The dataset engine stored native `fetch` as an object method, so browser workers invoked it with the wrong receiver. Bind the default fetch to `globalThis` and wrap injected fetch implementations.

Verification:
- focused dataset tests
- web TypeScript check
- production Vite build and bundle budgets
- live `stanfordnlp/imdb` open/query/close smoke