### PR TITLE
feat(js): add physical dataset cursors

### DIFF
--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -138,10 +138,13 @@ only a bounded JSON endpoint, credentials, authorization, and persistence.
 
 `dataset()` runs entirely in the caller and inspects public HTTPS Parquet,
 uncompressed JSONL, and Hugging Face datasets. It opens a session-scoped handle,
-returns schema metadata, and supports bounded projection and filtering queries.
-Parquet uses HTTP range reads and predicate pushdown where possible; JSONL scans
-the response stream incrementally. The implementation, Parquet reader, and
-non-Snappy codecs load only after the model first calls the tool. Direct URLs
+returns schema metadata, and supports projection and filtering queries without
+hard row or offset ceilings. Input and output bytes remain bounded; partial
+results return an opaque `nextCursor` that retains the query and resumes from a
+physical Parquet row batch or JSONL byte position. Parquet uses HTTP range reads
+and predicate pushdown where possible; JSONL scans incrementally and requires
+byte-range support for cursor continuation. The implementation, Parquet reader,
+and non-Snappy codecs load only after the model first calls the tool. Direct URLs
 must allow browser CORS, and Parquet servers must support byte ranges.
 Consumers that only need this capability can import `dataset` from the smaller
 `nanocodex/tools/dataset` leaf entry.
@@ -158,13 +161,22 @@ const opened = await datasets.handler({
   },
 }, { sessionId: "thread-1" });
 
-await datasets.handler({
+const page = await datasets.handler({
   operation: "query",
   dataset_id: opened.datasetId,
   columns: ["question", "answer"],
   filters: [{ column: "question", op: "contains", value: "how many" }],
   limit: 5,
 }, { sessionId: "thread-1" });
+
+if (page.nextCursor) {
+  await datasets.handler({
+    operation: "query",
+    dataset_id: opened.datasetId,
+    cursor: page.nextCursor,
+    limit: 5,
+  }, { sessionId: "thread-1" });
+}
 ```
 
 This same adapter works inside a Cloudflare Worker or Durable Object:

--- a/js/bindings/scripts/dataset.bench.mjs
+++ b/js/bindings/scripts/dataset.bench.mjs
@@ -57,10 +57,18 @@ const parquetQuery = {
 const parquetCold = await timed(() => tool.handler(parquetQuery, context));
 const parquetColdResult = parquetCold.value;
 const parquetColdIo = remote.take();
+const parquetNext = await timed(() => tool.handler({
+  operation: "query",
+  dataset_id: parquetId,
+  cursor: parquetColdResult.nextCursor,
+  limit: 100
+}, context));
+const parquetNextIo = remote.take();
 const parquetWarm = await timed(() => tool.handler(parquetQuery, context));
 const parquetWarmResult = parquetWarm.value;
 const parquetWarmIo = remote.take();
-assertQueryPair(parquetColdResult, parquetWarmResult, expectedRows());
+assertQueryPair(parquetColdResult, parquetWarmResult, expectedRows(500, 600));
+assertQueryPage(parquetNext.value, expectedRows(600, 700), 600);
 assert.ok(parquetColdIo.rangeRequests > 0);
 assert.ok(parquetColdIo.rangeBytes > 0);
 assertZeroNetwork(parquetWarmIo);
@@ -80,13 +88,24 @@ const jsonlQuery = {
 const jsonlCold = await timed(() => tool.handler(jsonlQuery, context));
 const jsonlColdResult = jsonlCold.value;
 const jsonlColdIo = remote.take();
+const jsonlNext = await timed(() => tool.handler({
+  operation: "query",
+  dataset_id: jsonlId,
+  cursor: jsonlColdResult.nextCursor,
+  limit: 100
+}, context));
+const jsonlNextIo = remote.take();
 const jsonlRepeated = await timed(() => tool.handler(jsonlQuery, context));
 const jsonlRepeatedResult = jsonlRepeated.value;
 const jsonlRepeatedIo = remote.take();
-assertQueryPair(jsonlColdResult, jsonlRepeatedResult, expectedRows());
+assertQueryPair(jsonlColdResult, jsonlRepeatedResult, expectedRows(500, 600));
+assertQueryPage(jsonlNext.value, expectedRows(600, 700), 600);
 assert.equal(jsonlColdResult.rowsScanned, 23997);
 assert.ok(jsonlColdIo.streamRequests > 0);
 assert.ok(jsonlColdIo.streamBytesPulled > 0);
+assert.equal(jsonlNextIo.streamRequests, 0);
+assert.equal(jsonlNextIo.rangeRequests, 1);
+assert.ok(jsonlNextIo.rangeBytes < jsonlColdIo.streamBytesPulled);
 assertZeroNetwork(jsonlRepeatedIo);
 console.log(JSON.stringify({
   corpus: {
@@ -97,18 +116,20 @@ console.log(JSON.stringify({
   parquet: {
     open: openMeasurement(parquetOpen, parquetOpenIo),
     coldQuery: queryMeasurement(parquetCold, parquetColdIo),
+    cursorContinuation: queryMeasurement(parquetNext, parquetNextIo),
     exactRepeat: queryMeasurement(parquetWarm, parquetWarmIo),
     speedupX: speedup(parquetCold.milliseconds, parquetWarm.milliseconds)
   },
   jsonl: {
     open: openMeasurement(jsonlOpen, jsonlOpenIo),
     coldQuery: queryMeasurement(jsonlCold, jsonlColdIo),
+    cursorContinuation: queryMeasurement(jsonlNext, jsonlNextIo),
     exactRepeat: queryMeasurement(jsonlRepeated, jsonlRepeatedIo),
     speedupX: speedup(jsonlCold.milliseconds, jsonlRepeated.milliseconds)
   }
 }, null, 2));
-function expectedRows() {
-  return ids.filter((id) => languages[id] === "rust" && scores[id] >= 900).slice(500, 600).map((id) => ({ id, text: texts[id] }));
+function expectedRows(start, end) {
+  return ids.filter((id) => languages[id] === "rust" && scores[id] >= 900).slice(start, end).map((id) => ({ id, text: texts[id] }));
 }
 function assertQueryPair(cold, repeated, expected) {
   assert.deepEqual(cold.rows, expected);
@@ -124,6 +145,14 @@ function assertQueryPair(cold, repeated, expected) {
   assert.ok(cold.bytesRead > 0);
   assert.equal(repeated.bytesRead, 0);
   assert.equal(repeated.rowsScanned, cold.rowsScanned);
+}
+function assertQueryPage(page, expected, offset) {
+  assert.deepEqual(page.rows, expected);
+  assert.equal(page.returnedRows, expected.length);
+  assert.equal(page.offset, offset);
+  assert.equal(page.complete, false);
+  assert.equal(page.truncatedReason, "limit");
+  assert.ok(page.nextCursor);
 }
 function assertZeroNetwork(io) {
   assert.deepEqual(io, emptyIo());
@@ -171,8 +200,7 @@ function benchmarkFetch(objects) {
       const end = Number(match[2]);
       const body = data.slice(start, end + 1);
       io.rangeRequests++;
-      io.rangeBytes += body.byteLength;
-      return new Response(body, {
+      return new Response(chunked(body, 64 * 1024, (length) => io.rangeBytes += length), {
         status: 206,
         headers: {
           "content-length": String(body.byteLength),

--- a/js/bindings/test/dataset.test.mjs
+++ b/js/bindings/test/dataset.test.mjs
@@ -13,6 +13,9 @@ test("the public dataset factory advertises the lazy dataset capability", () => 
     tool.parameters.properties.operation.enum,
     ["open", "query", "close"]
   );
+  assert.equal(tool.parameters.properties.limit.maximum, undefined);
+  assert.equal(tool.parameters.properties.offset.maximum, undefined);
+  assert.equal(tool.parameters.properties.cursor.type, "string");
 });
 
 test("the default dataset fetch keeps the browser global receiver", async () => {
@@ -155,6 +158,24 @@ test("JSONL datasets stream, filter, project, and report partial scans", async (
   assert.equal(partial.complete, false);
   assert.equal(partial.truncatedReason, "byte_limit");
   assert.equal(partial.bytesRead, 1024);
+  let deepPage = await boundedTool.handler({
+    operation: "query",
+    dataset_id: bounded.datasetId,
+    columns: ["index"],
+    offset: 20,
+    limit: 1,
+    max_bytes: 1024
+  }, context);
+  for (let page = 0; deepPage.rows.length === 0 && page < 10; page++) {
+    deepPage = await boundedTool.handler({
+      operation: "query",
+      dataset_id: bounded.datasetId,
+      cursor: deepPage.nextCursor,
+      limit: 1,
+      max_bytes: 1024
+    }, context);
+  }
+  assert.deepEqual(deepPage.rows, [{ index: 20 }]);
   const sparseRows = Array.from(
     { length: 40 },
     (_, index) => index === 35 ? { index, late: "discovered during query" } : { index }
@@ -178,6 +199,89 @@ test("JSONL datasets stream, filter, project, and report partial scans", async (
     limit: 1
   }, context);
   assert.deepEqual(late.rows, [{ late: "discovered during query" }]);
+});
+test("queries allow deep offsets and continue JSONL scans from byte cursors", async () => {
+  const records = Array.from({ length: 12_050 }, (_, id) => ({ id, tag: id % 2 ? "é" : "雪" }));
+  const url = "https://data.example/deep.jsonl";
+  const bytes = new TextEncoder().encode(`${records.map(JSON.stringify).join("\n")}\n`);
+  const baseFetch = objectFetch(new Map([[url, bytes]]), 4096);
+  const ranges = [];
+  const tool = createDatasetTool({
+    fetch: (input, init) => {
+      ranges.push(new Headers(init?.headers).get("range"));
+      return baseFetch(input, init);
+    },
+    randomId: () => "deep-jsonl"
+  });
+  const opened = await tool.handler({
+    operation: "open",
+    source: { kind: "url", url }
+  }, context);
+  const first = await tool.handler({
+    operation: "query",
+    dataset_id: opened.datasetId,
+    columns: ["id"],
+    filters: [{ column: "tag", op: "eq", value: "雪" }],
+    offset: 5_500,
+    limit: 2
+  }, context);
+  assert.deepEqual(first.rows, [{ id: 11_000 }, { id: 11_002 }]);
+  assert.ok(first.nextCursor);
+  const second = await tool.handler({
+    operation: "query",
+    dataset_id: opened.datasetId,
+    cursor: first.nextCursor,
+    limit: 2
+  }, context);
+  assert.deepEqual(second.rows, [{ id: 11_004 }, { id: 11_006 }]);
+  assert.equal(second.offset, 5_502);
+  assert.equal(second.rowsScanned, 4);
+  assert.match(ranges.at(-1), /^bytes=\d+-\d+$/);
+  await assert.rejects(
+    tool.handler({
+      operation: "query",
+      dataset_id: opened.datasetId,
+      cursor: first.nextCursor,
+      offset: 0
+    }, context),
+    /do not combine them with cursor/
+  );
+});
+test("Parquet queries accept limits above 100 and continue from physical cursors", async () => {
+  const ids = Array.from({ length: 12_500 }, (_, id) => id);
+  const parquet = new Uint8Array(parquetWriteBuffer({
+    columnData: [{ name: "id", data: ids, type: "INT32" }],
+    rowGroupSize: 1000
+  }));
+  const url = "https://data.example/deep.parquet";
+  const tool = createDatasetTool({
+    fetch: objectFetch(new Map([[url, parquet]])),
+    randomId: () => "deep-parquet"
+  });
+  const opened = await tool.handler({
+    operation: "open",
+    source: { kind: "url", url }
+  }, context);
+  const first = await tool.handler({
+    operation: "query",
+    dataset_id: opened.datasetId,
+    columns: ["id"],
+    offset: 11_000,
+    limit: 150
+  }, context);
+  assert.equal(first.returnedRows, 150);
+  assert.equal(first.rows[0].id, 11_000);
+  assert.equal(first.rows.at(-1).id, 11_149);
+  assert.ok(first.nextCursor);
+  const second = await tool.handler({
+    operation: "query",
+    dataset_id: opened.datasetId,
+    cursor: first.nextCursor,
+    limit: 150
+  }, context);
+  assert.equal(second.rows[0].id, 11_150);
+  assert.equal(second.rows.at(-1).id, 11_299);
+  assert.equal(second.offset, 11_150);
 });
 test("Hugging Face sources resolve the default training split to Parquet shards", async () => {
   const parquet = new Uint8Array(parquetWriteBuffer({
@@ -274,10 +378,13 @@ test("Parquet filters coerce JSON-safe INT64 values without losing precision", a
     limit: 10
   }, context);
   assert.deepEqual(precise.rows, [{ value: "9007199254740993" }]);
-  await assert.rejects(
-    tool.handler({ operation: "query", dataset_id: opened.datasetId, offset: 10001 }, context),
-    /between 0 and 10000/
-  );
+  const beyondDataset = await tool.handler({
+    operation: "query",
+    dataset_id: opened.datasetId,
+    offset: 10001
+  }, context);
+  assert.deepEqual(beyondDataset.rows, []);
+  assert.equal(beyondDataset.complete, true);
 });
 test("dataset handles are session-scoped and arbitrary URLs reject local targets", async () => {
   const bytes = new TextEncoder().encode('{"value":1}\n');

--- a/js/bindings/tools/datasetContract.mjs
+++ b/js/bindings/tools/datasetContract.mjs
@@ -1,12 +1,11 @@
 export const DATASET_DESCRIPTION = `Inspect public Parquet, uncompressed JSONL, or Hugging Face datasets in the
 browser. Open a URL source or {kind:"huggingface",dataset:"owner/name",config?,split?}; open returns
-schema and an immediate JSONL preview. Query its dataset_id with columns, filters, offset, and limit,
-then close it. Parquet uses HTTP ranges; JSONL scans sequentially. Never infer absence when complete
-is false. Handles assume immutable source URLs; close and reopen to refresh changed data.`;
+schema and a JSONL preview. Query dataset_id with columns, filters, offset, and limit. Continue a
+partial result by passing nextCursor as cursor; it retains projection and filters and resumes physical
+Parquet or JSONL scans. Never infer absence
+when complete is false. Handles assume immutable source URLs; close and reopen to refresh changed data.`;
 
-export const MAX_QUERY_LIMIT = 100;
 export const MAX_QUERY_BYTES = 128 * 1024 * 1024;
-export const MAX_QUERY_OFFSET = 10_000;
 
 const sourceSchema = {
   type: "object",
@@ -28,6 +27,7 @@ export const datasetParameters = {
     operation: { type: "string", enum: ["open", "query", "close"] },
     source: sourceSchema,
     dataset_id: { type: "string" },
+    cursor: { type: "string" },
     columns: { type: "array", maxItems: 64, items: { type: "string" } },
     filters: {
       type: "array",
@@ -43,8 +43,8 @@ export const datasetParameters = {
         additionalProperties: false,
       },
     },
-    offset: { type: "integer", minimum: 0, maximum: MAX_QUERY_OFFSET },
-    limit: { type: "integer", minimum: 1, maximum: MAX_QUERY_LIMIT },
+    offset: { type: "integer", minimum: 0 },
+    limit: { type: "integer", minimum: 1 },
     max_bytes: { type: "integer", minimum: 1024, maximum: MAX_QUERY_BYTES },
   },
   required: ["operation"],

--- a/js/bindings/tools/datasetEngine.mjs
+++ b/js/bindings/tools/datasetEngine.mjs
@@ -1,8 +1,6 @@
 import {
   DATASET_DESCRIPTION,
   MAX_QUERY_BYTES,
-  MAX_QUERY_LIMIT,
-  MAX_QUERY_OFFSET,
   datasetParameters
 } from "./datasetContract.mjs";
 const MAX_OPEN_DATASETS = 8;
@@ -22,6 +20,8 @@ const MAX_CACHED_RANGE_BYTES = 4 * 1024 * 1024;
 const QUERY_CACHE_BYTES = 2 * 1024 * 1024;
 const MAX_CACHED_QUERIES = 16;
 const MAX_BLOOM_FILTER_GROUPS = 8;
+const PARQUET_SCAN_ROWS = 2048;
+const CURSOR_VERSION = 1;
 function createDatasetTool(options = {}) {
   const providedFetch = options.fetch;
   const fetchImpl = providedFetch === undefined
@@ -81,7 +81,7 @@ function createDatasetTool(options = {}) {
         if (cached) return { ...cached, bytesRead: 0, cacheHit: true };
         const budget = new ByteBudget(query.maxBytes);
         const progress = dataset.format === "parquet" ? await queryParquet(dataset, query, budget, runtime, loadParquet, loadCompressors) : await queryJsonl(dataset, query, budget, runtime);
-        const result = boundedQueryResult(dataset, query, budget, progress);
+        const result = queryResult(dataset, query, budget, progress);
         dataset.queryCache.set(cacheKey, result);
         return { ...result, cacheHit: false };
       }
@@ -245,102 +245,85 @@ async function queryParquet(dataset, query, budget, runtime, loadParquet, loadCo
   if (!shards) throw new Error("Parquet dataset is unavailable");
   const pushdownFilters = query.filters.filter((filter) => filter.op !== "contains");
   const postFilters = query.filters.filter((filter) => filter.op === "contains");
-  const rows = [];
-  let skip = query.offset;
-  let complete = true;
-  let truncatedReason;
+  const filtered = pushdownFilters.length > 0 || postFilters.length > 0;
+  const rows = new QueryRows(query.limit);
+  let position = query.position ?? { format: "parquet", shard: 0, row: 0, match: 0 };
+  let skip = query.skip;
+  let rowsScanned = 0;
   let compressors;
   try {
-    for (const shard of shards) {
+    for (let shardIndex = position.shard; shardIndex < shards.length; shardIndex++) {
+      const shard = shards[shardIndex];
       const metadata = await parquetMetadata(shard, budget, runtime, parquet);
       const file = remoteBuffer(shard, budget, runtime);
       if (!compressors && needsCustomCompressors(metadata, query)) {
         compressors = (await loadCompressors()).compressors;
       }
       const useBloomFilters = pushdownFilters.length > 0 && metadata.row_groups.length <= MAX_BLOOM_FILTER_GROUPS;
-      if (!postFilters.length && !pushdownFilters.length) {
-        const shardRows = safeCount(metadata.num_rows);
-        if (skip >= shardRows) {
-          skip -= shardRows;
+      const shardRows = safeCount(metadata.num_rows);
+      let rowStart = shardIndex === position.shard ? position.row : 0;
+      let matchStart = shardIndex === position.shard ? position.match : 0;
+      if (!filtered && skip > 0) {
+        const available = shardRows - rowStart;
+        if (skip >= available) {
+          skip -= available;
+          position = { format: "parquet", shard: shardIndex + 1, row: 0, match: 0 };
           continue;
         }
-        const rowStart = skip;
-        const rowEnd = Math.min(shardRows, rowStart + query.limit - rows.length);
-        rows.push(...await parquet.parquetQuery({
+        rowStart += skip;
+        skip = 0;
+      }
+      while (rowStart < shardRows) {
+        const rowEnd = Math.min(shardRows, rowStart + PARQUET_SCAN_ROWS);
+        position = { format: "parquet", shard: shardIndex, row: rowStart, match: matchStart };
+        const found = await parquet.parquetReadObjects({
           file,
           metadata,
-          columns: query.columns,
+          columns: postFilters.length ? columnsForPostFilter(query.columns, postFilters) : query.columns,
+          filter: pushdownFilters.length ? parquetFilter(pushdownFilters) : void 0,
           rowStart,
           rowEnd,
-          compressors,
-          useOffsetIndex: true
-        }));
-        skip = 0;
-      } else if (!postFilters.length) {
-        const requested = skip + (query.limit - rows.length);
-        const found = await parquet.parquetQuery({
-          file,
-          metadata,
-          columns: query.columns,
-          filter: parquetFilter(pushdownFilters),
-          rowStart: 0,
-          rowEnd: requested,
           compressors,
           useBloomFilters,
           usePageIndex: pushdownFilters.length > 0,
           useOffsetIndex: true
         });
-        if (skip >= found.length) {
-          skip -= found.length;
-          continue;
-        }
-        rows.push(...found.slice(skip, skip + query.limit - rows.length));
-        skip = 0;
-      } else {
-        let groupStart = 0;
-        for (const group of metadata.row_groups) {
-          const groupEnd = groupStart + safeCount(group.num_rows);
-          const found = await parquet.parquetReadObjects({
-            file,
-            metadata,
-            columns: columnsForPostFilter(query.columns, postFilters),
-            filter: parquetFilter(pushdownFilters),
-            rowStart: groupStart,
-            rowEnd: groupEnd,
-            compressors,
-            useBloomFilters,
-            usePageIndex: pushdownFilters.length > 0,
-            useOffsetIndex: true
-          });
-          for (const candidate of found) {
-            if (!matchesFilters(candidate, postFilters)) continue;
-            if (skip > 0) {
-              skip--;
-              continue;
-            }
-            rows.push(projectRow(candidate, query.columns));
-            if (rows.length >= query.limit) break;
+        rowsScanned += rowEnd - rowStart;
+        const candidates = postFilters.length
+          ? found.filter((candidate) => matchesFilters(candidate, postFilters)).map((candidate) => projectRow(candidate, query.columns))
+          : found;
+        for (let match = matchStart; match < candidates.length; match++) {
+          const nextPosition = match + 1 < candidates.length
+            ? { format: "parquet", shard: shardIndex, row: rowStart, match: match + 1 }
+            : { format: "parquet", shard: shardIndex, row: rowEnd, match: 0 };
+          if (skip > 0) {
+            skip--;
+            position = nextPosition;
+            continue;
           }
-          groupStart = groupEnd;
-          if (rows.length >= query.limit) break;
+          const status = rows.add(candidates[match]);
+          if (status === "output_limit") {
+            return partialQuery(rows, rowsScanned, "output_limit", position, skip);
+          }
+          position = nextPosition;
+          if (status === "limit") {
+            return partialQuery(rows, rowsScanned, "limit", position, skip);
+          }
         }
+        rowStart = rowEnd;
+        matchStart = 0;
+        position = { format: "parquet", shard: shardIndex, row: rowStart, match: 0 };
       }
-      if (rows.length >= query.limit) {
-        complete = false;
-        truncatedReason = "limit";
-        break;
-      }
+      position = { format: "parquet", shard: shardIndex + 1, row: 0, match: 0 };
     }
   } catch (error) {
     if (!(error instanceof ByteLimitError)) throw error;
-    complete = false;
-    truncatedReason = "byte_limit";
+    return partialQuery(rows, rowsScanned, "byte_limit", position, skip);
   }
-  if (complete && dataset.source.kind === "huggingface" && dataset.source.partial) {
-    complete = false;
-    truncatedReason = "source_partial";
+  if (dataset.source.kind === "huggingface" && dataset.source.partial) {
+    return { rows: rows.rows, rowsScanned, complete: false, truncatedReason: "source_partial" };
   }
-  return { rows, rowsScanned: null, complete, truncatedReason };
+  return { rows: rows.rows, rowsScanned, complete: true };
 }
 async function queryJsonl(dataset, query, budget, runtime) {
   return scanJsonl(dataset, query, budget, runtime);
@@ -356,26 +339,51 @@ function needsCustomCompressors(metadata, query) {
 async function scanJsonl(dataset, query, budget, runtime) {
   const object = dataset.jsonl?.object;
   if (!object) throw new Error("JSONL dataset is unavailable");
-  const response = await safeFetch(object.url, runtime, { method: "GET" }, object.allowRedirects);
+  const rows = new QueryRows(query.limit);
+  const startByte = query.position?.byte ?? 0;
+  if (object.byteLength != null && startByte >= object.byteLength) {
+    return { rows: rows.rows, rowsScanned: 0, complete: true };
+  }
+  const headers = startByte > 0
+    ? { range: `bytes=${startByte}-${object.byteLength == null ? "" : object.byteLength - 1}` }
+    : void 0;
+  const response = await safeFetch(object.url, runtime, { method: "GET", headers }, object.allowRedirects);
   if (!response.ok || !response.body) {
     await response.body?.cancel().catch(() => void 0);
     throw new Error(`JSONL fetch failed with HTTP ${response.status}`);
   }
-  if (object.byteLength == null) {
+  if (startByte > 0 && response.status !== 206) {
+    await response.body.cancel().catch(() => void 0);
+    throw new Error("JSONL server does not support byte-range continuation");
+  }
+  if (response.status === 206) {
+    const range = parseContentRange(response.headers.get("content-range"));
+    if (!range || range.start !== startByte) {
+      await response.body.cancel().catch(() => void 0);
+      throw new Error("JSONL server returned an invalid Content-Range");
+    }
+    if (range.total != null) {
+      object.byteLength = range.total;
+      dataset.byteLength = range.total;
+    }
+  } else if (object.byteLength == null) {
     object.byteLength = contentLength(response.headers.get("content-length"));
     dataset.byteLength = object.byteLength;
   }
   const reader = response.body.getReader();
-  const decoder = new TextDecoder();
-  const rows = [];
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  const encoder = new TextEncoder();
   let buffer = "";
+  let networkOffset = startByte;
+  let position = { format: "jsonl", byte: startByte };
   let rowsScanned = 0;
-  let skip = query.offset;
-  let complete = true;
-  let truncatedReason;
-  const processLine = (line) => {
+  let skip = query.skip;
+  const processLine = (line, newlineBytes) => {
+    const lineStart = position.byte;
+    const lineEnd = lineStart + encoder.encode(line).byteLength + newlineBytes;
+    position = { format: "jsonl", byte: lineEnd };
     const trimmed = line.endsWith("\r") ? line.slice(0, -1) : line;
-    if (!trimmed) return false;
+    if (!trimmed) return "accepted";
     if (trimmed.length > MAX_JSONL_LINE_BYTES) {
       throw new Error(`JSONL row exceeds ${MAX_JSONL_LINE_BYTES} characters`);
     }
@@ -386,57 +394,54 @@ async function scanJsonl(dataset, query, budget, runtime) {
       throw new Error(`JSONL row ${rowsScanned + 1} is invalid: ${errorMessage(error)}`);
     }
     rowsScanned++;
-    if (!isRecord(value) || !matchesFilters(value, query.filters)) return false;
+    if (!isRecord(value) || !matchesFilters(value, query.filters)) return "accepted";
     if (skip > 0) {
       skip--;
-      return false;
+      return "accepted";
     }
-    rows.push(projectRow(value, query.columns));
-    return rows.length >= query.limit;
+    const status = rows.add(projectRow(value, query.columns));
+    if (status === "output_limit") {
+      position = { format: "jsonl", byte: lineStart };
+    }
+    return status;
   };
   try {
-    read: while (true) {
+    while (true) {
       const chunk = await reader.read();
       if (chunk.done) break;
       const acceptedBytes = Math.min(chunk.value.byteLength, budget.remaining);
-      if (acceptedBytes > 0) {
-        budget.consume(acceptedBytes);
-        buffer += decoder.decode(chunk.value.subarray(0, acceptedBytes), { stream: true });
-      }
-      const hitByteLimit = acceptedBytes < chunk.value.byteLength || budget.remaining === 0 && (object.byteLength == null || budget.used < object.byteLength);
+      if (acceptedBytes === 0) throw new ByteLimitError("dataset byte limit reached");
+      budget.consume(acceptedBytes);
+      buffer += decoder.decode(chunk.value.subarray(0, acceptedBytes), { stream: true });
+      networkOffset += acceptedBytes;
       if (buffer.length > MAX_JSONL_LINE_BYTES && !buffer.includes("\n")) {
         throw new Error(`JSONL row exceeds ${MAX_JSONL_LINE_BYTES} characters`);
       }
-      let newline = buffer.indexOf("\n");
-      while (newline >= 0) {
-        const line = buffer.slice(0, newline);
+      for (let newline = buffer.indexOf("\n"); newline >= 0; newline = buffer.indexOf("\n")) {
+        const status = processLine(buffer.slice(0, newline), 1);
         buffer = buffer.slice(newline + 1);
-        if (processLine(line)) {
-          complete = false;
-          truncatedReason = "limit";
-          break read;
+        if (status === "limit" || status === "output_limit") {
+          return partialQuery(rows, rowsScanned, status, position, skip);
         }
-        newline = buffer.indexOf("\n");
       }
-      if (hitByteLimit) {
-        complete = false;
-        truncatedReason = "byte_limit";
-        break;
+      if (acceptedBytes < chunk.value.byteLength || budget.remaining === 0 && (object.byteLength == null || networkOffset < object.byteLength)) {
+        return partialQuery(rows, rowsScanned, "byte_limit", position, skip);
       }
     }
     buffer += decoder.decode();
-    if (complete && buffer && processLine(buffer)) {
-      complete = false;
-      truncatedReason = "limit";
+    if (buffer) {
+      const status = processLine(buffer, 0);
+      if (status === "limit" || status === "output_limit") {
+        return partialQuery(rows, rowsScanned, status, position, skip);
+      }
     }
   } catch (error) {
     if (!(error instanceof ByteLimitError)) throw error;
-    complete = false;
-    truncatedReason = "byte_limit";
+    return partialQuery(rows, rowsScanned, "byte_limit", position, skip);
   } finally {
     await reader.cancel().catch(() => void 0);
   }
-  return { rows, rowsScanned, complete, truncatedReason };
+  return { rows: rows.rows, rowsScanned, complete: true };
 }
 async function parquetMetadata(shard, budget, runtime, parquet) {
   shard.metadata ??= await parquet.parquetMetadataAsync(remoteBuffer(shard, budget, runtime));
@@ -573,21 +578,41 @@ async function safeFetch(input, runtime, init, allowRedirects = false) {
 }
 function parseQuery(args, dataset) {
   const datasetId = requireString(args.dataset_id, "dataset.dataset_id");
-  const columns = optionalStringArray(args.columns, "dataset.columns");
+  const cursor = args.cursor === void 0 ? void 0 : requireString(args.cursor, "dataset.cursor");
+  let source = args;
+  let position;
+  let offset;
+  let skip;
+  if (cursor !== void 0) {
+    if (args.columns !== void 0 || args.filters !== void 0 || args.offset !== void 0) {
+      throw new Error("dataset.cursor retains columns, filters, and position; do not combine them with cursor");
+    }
+    const state = decodeQueryCursor(cursor);
+    if (state.v !== CURSOR_VERSION || state.d !== dataset.id || !isRecord(state.q)) {
+      throw new Error("dataset.cursor is unavailable for this dataset handle");
+    }
+    source = state.q;
+    position = parseCursorPosition(state.p, dataset.format);
+    offset = nonnegativeSafeInteger(state.o, "dataset.cursor offset");
+    skip = nonnegativeSafeInteger(state.s, "dataset.cursor remaining offset");
+  } else {
+    offset = optionalIntegerAtLeast(args.offset, 0, 0, "dataset.offset");
+    skip = offset;
+  }
+  const columns = optionalStringArray(source.columns, "dataset.columns");
   if (columns && dataset.format === "parquet") {
     const known = new Set(dataset.schema.map((column) => column.name));
     const unknown = columns.filter((column) => !known.has(column));
     if (unknown.length) throw new Error(`dataset columns not found: ${unknown.join(", ")}`);
   }
-  let filters = parseFilters(args.filters);
+  let filters = parseFilters(source.filters);
   if (dataset.format === "parquet") {
     const known = new Set(dataset.schema.map((column) => column.name));
     const unknown = filters.map((filter) => filter.column.split(".")[0]).filter((column) => !known.has(column));
     if (unknown.length) throw new Error(`dataset filter columns not found: ${unique(unknown).join(", ")}`);
     filters = coerceParquetFilters(filters, dataset.parquet?.filterKinds ?? /* @__PURE__ */ new Map());
   }
-  const offset = optionalBoundedInteger(args.offset, 0, MAX_QUERY_OFFSET, 0, "dataset.offset");
-  const limit = optionalBoundedInteger(args.limit, 1, MAX_QUERY_LIMIT, DEFAULT_QUERY_LIMIT, "dataset.limit");
+  const limit = optionalIntegerAtLeast(args.limit, 1, DEFAULT_QUERY_LIMIT, "dataset.limit");
   const maxBytes = optionalBoundedInteger(
     args.max_bytes,
     1024,
@@ -595,7 +620,20 @@ function parseQuery(args, dataset) {
     DEFAULT_QUERY_BYTES,
     "dataset.max_bytes"
   );
-  return { datasetId, columns, filters, offset, limit, maxBytes };
+  return {
+    datasetId,
+    columns,
+    filters,
+    offset,
+    limit,
+    maxBytes,
+    position,
+    skip,
+    cursorQuery: {
+      ...(columns === void 0 ? {} : { columns }),
+      ...(source.filters === void 0 ? {} : { filters: source.filters })
+    }
+  };
 }
 function coerceParquetFilters(filters, kinds) {
   return filters.map((filter) => {
@@ -745,39 +783,86 @@ function valueType(value) {
   if (Array.isArray(value)) return "array";
   return typeof value === "object" ? "object" : typeof value;
 }
-function boundedQueryResult(dataset, query, budget, progress) {
-  const normalized = progress.rows.map((row) => normalizeValue(row));
-  const rows = [];
-  let outputBytes = 0;
-  const encoder = new TextEncoder();
-  for (const row of normalized) {
-    const bytes = encoder.encode(JSON.stringify(row)).byteLength;
-    if (outputBytes + bytes > MAX_TOOL_OUTPUT_BYTES) break;
-    rows.push(row);
-    outputBytes += bytes;
-  }
-  const outputTruncated = rows.length !== normalized.length;
+function queryResult(dataset, query, budget, progress) {
+  const nextCursor = progress.nextPosition === void 0 ? void 0 : encodeQueryCursor({
+    v: CURSOR_VERSION,
+    d: dataset.id,
+    q: query.cursorQuery,
+    p: progress.nextPosition,
+    o: safeIntegerSum(query.offset, progress.rows.length, "dataset cursor offset"),
+    s: progress.nextSkip
+  });
   return {
     datasetId: dataset.id,
     format: dataset.format,
-    rows,
-    returnedRows: rows.length,
+    rows: progress.rows,
+    returnedRows: progress.rows.length,
     rowsScanned: progress.rowsScanned,
     bytesRead: budget.used,
-    complete: progress.complete && !outputTruncated,
-    truncatedReason: outputTruncated ? "output_limit" : progress.truncatedReason,
+    complete: progress.complete,
+    truncatedReason: progress.truncatedReason,
     offset: query.offset,
-    limit: query.limit
+    limit: query.limit,
+    ...(nextCursor === void 0 ? {} : { nextCursor })
   };
 }
 function queryCacheKey(query) {
   return JSON.stringify({
-    columns: query.columns,
-    filters: query.filters.map(({ column, op, value }) => ({ column, op, value })),
+    cursorQuery: query.cursorQuery,
+    position: query.position,
     offset: query.offset,
+    skip: query.skip,
     limit: query.limit,
     maxBytes: query.maxBytes
   }, (_key, value) => typeof value === "bigint" ? { $bigint: value.toString() } : value);
+}
+function partialQuery(rows, rowsScanned, truncatedReason, nextPosition, nextSkip) {
+  return {
+    rows: rows.rows,
+    rowsScanned,
+    complete: false,
+    truncatedReason,
+    nextPosition,
+    nextSkip
+  };
+}
+function encodeQueryCursor(state) {
+  return encodeURIComponent(JSON.stringify(state));
+}
+function decodeQueryCursor(cursor) {
+  try {
+    const state = JSON.parse(decodeURIComponent(cursor));
+    if (!isRecord(state)) throw new Error("cursor state must be an object");
+    return state;
+  } catch {
+    throw new Error("dataset.cursor is invalid");
+  }
+}
+function parseCursorPosition(value, format) {
+  if (!isRecord(value) || value.format !== format) {
+    throw new Error("dataset.cursor is unavailable for this dataset format");
+  }
+  if (format === "parquet") {
+    return {
+      format,
+      shard: nonnegativeSafeInteger(value.shard, "dataset.cursor shard"),
+      row: nonnegativeSafeInteger(value.row, "dataset.cursor row"),
+      match: nonnegativeSafeInteger(value.match, "dataset.cursor match")
+    };
+  }
+  return {
+    format,
+    byte: nonnegativeSafeInteger(value.byte, "dataset.cursor byte")
+  };
+}
+function parseContentRange(value) {
+  const match = value?.match(/^bytes (\d+)-(\d+)\/(\d+|\*)$/);
+  if (!match) return null;
+  const start = contentLength(match[1]);
+  const end = contentLength(match[2]);
+  const total = match[3] === "*" ? null : contentLength(match[3]);
+  if (start == null || end == null || end < start || total != null && end >= total) return null;
+  return { start, end, total };
 }
 function normalizeValue(value, seen = /* @__PURE__ */ new WeakSet()) {
   if (value === void 0) return null;
@@ -915,6 +1000,24 @@ function optionalBoundedInteger(value, minimum, maximum, fallback, name) {
   }
   return value;
 }
+function optionalIntegerAtLeast(value, minimum, fallback, name) {
+  if (value === void 0) return fallback;
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw new Error(`${name} must be a safe integer greater than or equal to ${minimum}`);
+  }
+  return value;
+}
+function nonnegativeSafeInteger(value, name) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${name} must be a nonnegative safe integer`);
+  }
+  return value;
+}
+function safeIntegerSum(left, right, name) {
+  const sum = left + right;
+  if (!Number.isSafeInteger(sum)) throw new Error(`${name} exceeds JavaScript safe integers`);
+  return sum;
+}
 function boundedNonnegativeInteger(value, name) {
   if (!Number.isSafeInteger(value) || value < 0) throw new Error(`${name} is invalid`);
   return value;
@@ -953,6 +1056,27 @@ class ByteBudget {
     if (!Number.isSafeInteger(bytes) || bytes < 0) throw new Error("dataset byte count is invalid");
     if (this.used + bytes > this.limit) throw new ByteLimitError("dataset byte limit reached");
     this.used += bytes;
+  }
+}
+class QueryRows {
+  rows = [];
+  bytes = 0;
+  limit;
+  encoder = new TextEncoder();
+  constructor(limit) {
+    this.limit = limit;
+  }
+  add(value) {
+    if (this.rows.length >= this.limit) return "limit";
+    const normalized = normalizeValue(value);
+    const bytes = this.encoder.encode(JSON.stringify(normalized)).byteLength;
+    if (bytes > MAX_TOOL_OUTPUT_BYTES && this.rows.length === 0) {
+      throw new Error("dataset row exceeds the tool output budget; select fewer columns");
+    }
+    if (this.bytes + bytes > MAX_TOOL_OUTPUT_BYTES) return "output_limit";
+    this.rows.push(normalized);
+    this.bytes += bytes;
+    return this.rows.length >= this.limit ? "limit" : "accepted";
   }
 }
 class RangeCache {

--- a/web/README.md
+++ b/web/README.md
@@ -169,11 +169,14 @@ The reusable `browser(...)` tool bundle gives the browser agent a bounded
 Parquet URLs, Hugging Face dataset/config/split exports, and uncompressed JSONL
 URLs without downloading whole datasets into memory. Parquet reads use HTTP
 ranges and filter/projection pushdown where possible; JSONL reads incrementally
-scan the response stream. Dataset handles are scoped to an agent session, every
-query has row, input-byte, and output-byte limits, and partial results explicitly
-report `complete: false`. The implementation and Parquet codecs are lazy chunks,
-so ordinary agent sessions do not download them. Direct sources must permit
-browser CORS, and Parquet sources must honor byte-range requests.
+scan the response stream. Dataset handles are scoped to an agent session. Query
+limits and offsets accept any nonnegative safe range; input-byte and output-byte
+budgets remain bounded. Partial results report `complete: false` and an opaque
+`nextCursor` that retains projection and filters while resuming at the physical
+Parquet row batch or JSONL byte position. The implementation and Parquet codecs
+are lazy chunks, so ordinary agent sessions do not download them. Direct sources
+must permit browser CORS. Parquet sources must honor byte-range requests; JSONL
+sources must honor them when continuing from a cursor.
 
 For example, ask the web agent to “inspect the `main` config’s `train` split of
 `openai/gsm8k`, show its schema, and find five examples containing arithmetic.”
@@ -182,6 +185,7 @@ The resulting tool flow is equivalent to:
 ```json
 {"operation":"open","source":{"kind":"huggingface","dataset":"openai/gsm8k","config":"main","split":"train"}}
 {"operation":"query","dataset_id":"<returned id>","columns":["question","answer"],"filters":[{"column":"question","op":"contains","value":"how many"}],"limit":5}
+{"operation":"query","dataset_id":"<returned id>","cursor":"<returned nextCursor>","limit":5}
 {"operation":"close","dataset_id":"<returned id>"}
 ```
 

--- a/web/scripts/check-bundle.mjs
+++ b/web/scripts/check-bundle.mjs
@@ -20,8 +20,9 @@ const budgets = Object.freeze({
   datasetFacadeJavaScriptGzip: 700,
   datasetContractJavaScript: 1_500,
   datasetContractJavaScriptGzip: 700,
-  datasetToolJavaScript: 21_000,
-  datasetToolJavaScriptGzip: 7_200,
+  // Includes stateless physical cursors for bounded Parquet and JSONL continuation.
+  datasetToolJavaScript: 24_500,
+  datasetToolJavaScriptGzip: 8_300,
   parquetJavaScript: 60_000,
   parquetJavaScriptGzip: 18_000,
   parquetCompressorsJavaScript: 116_000,


### PR DESCRIPTION
Removes the artificial dataset query ceilings on `limit` and `offset`.

Adds stateless continuation cursors that resume Parquet at bounded physical row batches and JSONL at byte ranges, while retaining byte/output safety budgets. Includes deep-offset regressions and continuation benchmarks.

Validation:
- `npm test` in `js/bindings` (93 tests)
- dataset continuation benchmark
- web typecheck, production build, and bundle gate