### PR TITLE
bench: isolate agent harness performance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@
 - Codex is evidence, not an API requirement. Copy relevant invariants and
   operational behavior while keeping Nanocodex's smaller public surface.
 - The reviewed upstream checkpoint is
-  `openai/codex@7ada37a15e1f6aa84f83b4b9410f9d29e66fefe4`. A parity review must
+  `openai/codex@50ea8fd411422b3f7bc906bcde6c1c4432019a2e`. A parity review must
   inspect every later commit, classify it as port/evaluate/defer/out-of-scope,
   and cite adopted behavior before advancing the checkpoint.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5236,6 +5236,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Justfile
+++ b/Justfile
@@ -179,6 +179,11 @@ bench-stream:
     cargo bench -p nanocodex-bin --bench tui_render -- tui_trace_render
     cargo bench -p nanocodex-bin --bench tui_render -- '^(tui_redraw_scope|tui_streaming_frame_budget)'
 
+# Measure the owned agent harness without provider, network, sandbox, or tool-process noise.
+bench-harness:
+    cargo bench -p nanocodex-agent --bench harness_performance -- \
+      --source-commit "$(git rev-parse HEAD)"
+
 # Rebuild every PR #50 hot-path estimate, then enforce the checked-in median
 # latency thresholds. TUI frame-count, changed-cell, and output-byte limits are
 # asserted inside the representative benchmark workloads themselves.

--- a/crates/nanocodex-agent/Cargo.toml
+++ b/crates/nanocodex-agent/Cargo.toml
@@ -45,12 +45,17 @@ criterion.workspace = true
 eyre.workspace = true
 futures-util.workspace = true
 reqwest.workspace = true
+sysinfo.workspace = true
 tempfile.workspace = true
 tokio-tungstenite.workspace = true
 tracing-subscriber.workspace = true
 
 [[bench]]
 name = "agent_lifecycle"
+harness = false
+
+[[bench]]
+name = "harness_performance"
 harness = false
 
 [lints]

--- a/crates/nanocodex-agent/benches/harness_performance.rs
+++ b/crates/nanocodex-agent/benches/harness_performance.rs
@@ -1,0 +1,817 @@
+//! Deterministic agent-harness benchmark with no provider, network, sandbox, or tool process.
+
+use std::{
+    collections::BTreeSet,
+    env, fs,
+    future::Future,
+    path::PathBuf,
+    pin::Pin,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+    task::{Context, Poll},
+    time::Instant,
+};
+
+use eyre::{Result, WrapErr, bail, eyre};
+use nanocodex_agent::{
+    AgentEvents, ExecutionEnvironment, Nanocodex, OpenAi, ResponseError, Thinking, Tools,
+    TurnResult,
+    events::{AgentEventKind, monotonic_now_ns},
+};
+use nanocodex_oai_api::{
+    ResponseEvent,
+    responses::{ContentItem, MessageRole, ResponseItem, Usage, WarmupResponse},
+    tower::{
+        GenerationOutput, ResponsePipelineStats, ResponsesAttempt, ResponsesAttemptKind,
+        ResponsesOutput, ResponsesServiceResponse,
+    },
+};
+use serde::{Deserialize, Serialize};
+use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, get_current_pid};
+use tower::Service;
+
+const PROMPT_CACHE_KEY: &str = "nanocodex-harness-performance-v1";
+
+#[derive(Clone)]
+struct ScriptedResponses {
+    service_id: u64,
+    state: Arc<HarnessState>,
+}
+
+#[derive(Default)]
+struct HarnessState {
+    next_service_id: AtomicU64,
+    next_response_id: AtomicU64,
+    attempts: Mutex<Vec<AttemptRecord>>,
+}
+
+#[derive(Clone, Serialize)]
+struct AttemptRecord {
+    service_id: u64,
+    kind: &'static str,
+    prompt_cache_key: String,
+    model_call_index: Option<u32>,
+    physical_attempt: u32,
+    full_replay: bool,
+    previous_response_id: bool,
+    input_items: usize,
+    input_bytes: usize,
+    input_fnv1a64: String,
+}
+
+impl HarnessState {
+    fn new_service(self: &Arc<Self>) -> ScriptedResponses {
+        ScriptedResponses {
+            service_id: self.next_service_id.fetch_add(1, Ordering::Relaxed) + 1,
+            state: Arc::clone(self),
+        }
+    }
+
+    fn response_id(&self) -> String {
+        let id = self.next_response_id.fetch_add(1, Ordering::Relaxed) + 1;
+        format!("resp_harness_{id}")
+    }
+
+    fn record(&self, record: AttemptRecord) {
+        self.attempts
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(record);
+    }
+
+    fn records(&self) -> Vec<AttemptRecord> {
+        self.attempts
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+}
+
+impl Service<ResponsesAttempt> for ScriptedResponses {
+    type Response = ResponsesServiceResponse;
+    type Error = ResponseError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _context: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: ResponsesAttempt) -> Self::Future {
+        let service_id = self.service_id;
+        let state = Arc::clone(&self.state);
+        Box::pin(async move {
+            let input = request.input_items().collect::<Vec<_>>();
+            let encoded = serde_json::to_vec(&input).map_err(ResponseError::service)?;
+            let input_bytes = encoded.len();
+            state.record(AttemptRecord {
+                service_id,
+                kind: attempt_kind(request.kind()),
+                prompt_cache_key: request.prompt_cache_key().to_owned(),
+                model_call_index: request.model_call_index(),
+                physical_attempt: request.attempt(),
+                full_replay: request.is_full_replay(),
+                previous_response_id: request.previous_response_id().is_some(),
+                input_items: input.len(),
+                input_bytes,
+                input_fnv1a64: fnv1a64(&encoded),
+            });
+
+            match request.kind() {
+                ResponsesAttemptKind::Warmup => Ok(ResponsesServiceResponse::new(
+                    ResponsesOutput::Warmup(WarmupResponse {
+                        id: state.response_id(),
+                        usage: None,
+                    }),
+                )),
+                ResponsesAttemptKind::Generation => {
+                    let started = Instant::now();
+                    tokio::task::yield_now().await;
+                    let first_output_ns = elapsed_ns(started);
+                    request
+                        .emit(ResponseEvent::OutputTextDelta("done".to_owned()))
+                        .await;
+                    let message = ResponseItem::message(
+                        MessageRole::Assistant,
+                        [ContentItem::output_text("done")],
+                    );
+                    request
+                        .emit(ResponseEvent::OutputItemDone(message.clone()))
+                        .await;
+                    let input_tokens = u64::try_from(input_bytes.div_ceil(4)).unwrap_or(u64::MAX);
+                    Ok(ResponsesServiceResponse::new(ResponsesOutput::Generation(
+                        GenerationOutput {
+                            id: state.response_id(),
+                            status: "completed".to_owned(),
+                            end_turn: Some(true),
+                            final_message: Some("done".to_owned()),
+                            output_items: vec![message],
+                            code_calls: Vec::new(),
+                            usage: Some(Usage {
+                                input_tokens,
+                                output_tokens: 1,
+                                total_tokens: input_tokens.saturating_add(1),
+                                ..Usage::default()
+                            }),
+                            time_to_first_event_ns: first_output_ns,
+                            time_to_first_output_ns: Some(first_output_ns),
+                            pipeline_stats: ResponsePipelineStats {
+                                event_count: 2,
+                                display_delta_count: 1,
+                                display_delta_bytes: 4,
+                                ..ResponsePipelineStats::default()
+                            },
+                        },
+                    )))
+                }
+                ResponsesAttemptKind::Compaction => Err(ResponseError::service(
+                    std::io::Error::other("the harness workload unexpectedly requested compaction"),
+                )),
+                _ => Err(ResponseError::service(std::io::Error::other(
+                    "the harness received an unknown Responses attempt kind",
+                ))),
+            }
+        })
+    }
+}
+
+fn attempt_kind(kind: ResponsesAttemptKind) -> &'static str {
+    match kind {
+        ResponsesAttemptKind::Warmup => "warmup",
+        ResponsesAttemptKind::Generation => "generation",
+        ResponsesAttemptKind::Compaction => "compaction",
+        _ => "unknown",
+    }
+}
+
+#[derive(Clone)]
+struct Args {
+    history_turns: usize,
+    prompt_bytes: usize,
+    prefix_bytes: usize,
+    retained_forks: usize,
+    cache_probe_forks: usize,
+    startup_samples: usize,
+    source_commit: String,
+    output: Option<PathBuf>,
+}
+
+impl Args {
+    fn parse() -> Result<Self> {
+        let mut args = Self {
+            history_turns: 32,
+            prompt_bytes: 4 * 1_024,
+            prefix_bytes: 32 * 1_024,
+            retained_forks: 128,
+            cache_probe_forks: 3,
+            startup_samples: 50,
+            source_commit: option_env!("NANOCODEX_SOURCE_COMMIT")
+                .unwrap_or("unknown")
+                .to_owned(),
+            output: None,
+        };
+        let mut values = env::args().skip(1);
+        while let Some(name) = values.next() {
+            if name == "--bench" {
+                continue;
+            }
+            let value = values
+                .next()
+                .ok_or_else(|| eyre!("missing value for {name}"))?;
+            match name.as_str() {
+                "--history-turns" => args.history_turns = parse_usize(&name, &value)?,
+                "--prompt-bytes" => args.prompt_bytes = parse_usize(&name, &value)?,
+                "--prefix-bytes" => args.prefix_bytes = parse_usize(&name, &value)?,
+                "--retained-forks" => args.retained_forks = parse_usize(&name, &value)?,
+                "--cache-probe-forks" => args.cache_probe_forks = parse_usize(&name, &value)?,
+                "--startup-samples" => args.startup_samples = parse_usize(&name, &value)?,
+                "--source-commit" => args.source_commit = value,
+                "--output" => args.output = Some(PathBuf::from(value)),
+                _ => bail!("unknown argument {name}"),
+            }
+        }
+        if args.history_turns < 4 {
+            bail!("--history-turns must be at least 4");
+        }
+        if args.prompt_bytes < 64 || args.prefix_bytes < 64 {
+            bail!("--prompt-bytes and --prefix-bytes must be at least 64");
+        }
+        if args.retained_forks == 0
+            || args.cache_probe_forks == 0
+            || args.cache_probe_forks > args.retained_forks
+            || args.startup_samples == 0
+        {
+            bail!(
+                "fork and startup sample counts must be non-zero, and cache probes cannot exceed retained forks"
+            );
+        }
+        Ok(args)
+    }
+}
+
+fn parse_usize(name: &str, value: &str) -> Result<usize> {
+    value
+        .parse()
+        .wrap_err_with(|| format!("{name} requires a positive integer"))
+}
+
+#[derive(Serialize)]
+struct BenchmarkReport {
+    schema_version: u32,
+    implementation: &'static str,
+    source_commit: String,
+    platform: Platform,
+    noise_boundary: NoiseBoundary,
+    configuration: Configuration,
+    startup: StartupReport,
+    ttft: TtftReport,
+    memory: MemoryReport,
+    fork: ForkReport,
+    prompt_cache: PromptCacheReport,
+}
+
+#[derive(Serialize)]
+struct Platform {
+    os: &'static str,
+    arch: &'static str,
+    tokio_worker_threads: usize,
+}
+
+#[derive(Serialize)]
+struct NoiseBoundary {
+    provider: &'static str,
+    network: &'static str,
+    sandbox: &'static str,
+    tools: &'static str,
+    model_output: &'static str,
+}
+
+#[derive(Serialize)]
+struct Configuration {
+    history_turns: usize,
+    prompt_bytes: usize,
+    prefix_bytes: usize,
+    retained_forks: usize,
+    cache_probe_forks: usize,
+    startup_samples: usize,
+}
+
+#[derive(Serialize)]
+struct StartupReport {
+    process_main_to_runtime_ready_ns: u64,
+    tokio_runtime_build_ns: u64,
+    fresh_agent_build_ns: Distribution,
+    build_start_to_prompt_accepted_ns: Distribution,
+    build_start_to_first_delta_ns: Distribution,
+}
+
+#[derive(Serialize)]
+struct TtftReport {
+    cold_submit_to_first_delta_ns: u64,
+    cold_accepted_to_first_delta_ns: u64,
+    warm_submit_to_first_delta_ns: Distribution,
+    warm_accepted_to_first_delta_ns: Distribution,
+    warm_event_delivery_ns: Distribution,
+    warm_submit_to_completion_ns: Distribution,
+}
+
+#[derive(Serialize)]
+struct MemoryReport {
+    unit: &'static str,
+    process_before_runtime: u64,
+    runtime_ready: u64,
+    root_agent_ready: u64,
+    after_history: u64,
+    with_retained_forks: u64,
+    retained_forks_delta: u64,
+    retained_forks_bytes_each: u64,
+}
+
+#[derive(Serialize)]
+struct ForkReport {
+    historical_turns: Vec<usize>,
+    retained_forks: usize,
+    construction_ns: Distribution,
+}
+
+#[derive(Serialize)]
+struct PromptCacheReport {
+    expected_key: &'static str,
+    observed_keys: Vec<String>,
+    stable_key: bool,
+    cache_probe_agents: usize,
+    warmup_lifecycle_count: usize,
+    warmup_sources: Vec<String>,
+    service_instances: usize,
+    service_warmup_attempts: usize,
+    service_warmups_avoided: usize,
+    service_warmup_avoidance_ratio: f64,
+    warmup_prefix_hashes: Vec<String>,
+    generation_requests: usize,
+    incremental_generation_requests: usize,
+    full_replay_generation_requests: usize,
+    incremental_generation_ratio: f64,
+    generation_input_items: usize,
+    generation_input_bytes: usize,
+    requests: Vec<AttemptRecord>,
+}
+
+#[derive(Serialize)]
+struct Distribution {
+    n: usize,
+    min: u64,
+    p50: u64,
+    p95: u64,
+    max: u64,
+    mean: u64,
+}
+
+impl Distribution {
+    fn new(samples: &[u64]) -> Self {
+        let mut ordered = samples.to_vec();
+        ordered.sort_unstable();
+        let total = ordered.iter().copied().fold(0_u128, |total, value| {
+            total.saturating_add(u128::from(value))
+        });
+        let mean = total
+            .checked_div(ordered.len() as u128)
+            .and_then(|value| u64::try_from(value).ok())
+            .unwrap_or(u64::MAX);
+        Self {
+            n: ordered.len(),
+            min: ordered[0],
+            p50: percentile(&ordered, 50),
+            p95: percentile(&ordered, 95),
+            max: ordered[ordered.len() - 1],
+            mean,
+        }
+    }
+}
+
+fn percentile(ordered: &[u64], percentile: usize) -> u64 {
+    let index = (ordered.len() - 1).saturating_mul(percentile).div_ceil(100);
+    ordered[index]
+}
+
+#[derive(Default)]
+struct TurnObservation {
+    accepted_ns: u64,
+    first_delta_emitted_ns: u64,
+    submit_to_first_delta_ns: u64,
+    accepted_to_first_delta_ns: u64,
+    event_delivery_ns: u64,
+    submit_to_completion_ns: u64,
+    warmup_key: Option<String>,
+    warmup_source: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct WarmupStartedPayload {
+    prompt_cache_key: String,
+}
+
+#[derive(Deserialize)]
+struct WarmupCompletedPayload {
+    source: String,
+}
+
+struct RssSampler {
+    system: System,
+    pid: sysinfo::Pid,
+}
+
+impl RssSampler {
+    fn new() -> Result<Self> {
+        Ok(Self {
+            system: System::new(),
+            pid: get_current_pid().map_err(|error| eyre!(error))?,
+        })
+    }
+
+    fn sample(&mut self) -> Result<u64> {
+        self.system.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[self.pid]),
+            true,
+            ProcessRefreshKind::nothing().with_memory(),
+        );
+        self.system
+            .process(self.pid)
+            .map(sysinfo::Process::memory)
+            .ok_or_else(|| eyre!("the benchmark process disappeared from the process table"))
+    }
+}
+
+fn main() -> Result<()> {
+    let entered = Instant::now();
+    let args = Args::parse()?;
+    let mut rss = RssSampler::new()?;
+    let process_before_runtime = rss.sample()?;
+    let runtime_started = Instant::now();
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .wrap_err("failed to build the benchmark Tokio runtime")?;
+    let tokio_runtime_build_ns = elapsed_ns(runtime_started);
+    let process_main_to_runtime_ready_ns = elapsed_ns(entered);
+    let runtime_ready = rss.sample()?;
+
+    let mut report = runtime.block_on(run_benchmark(&args, &mut rss))?;
+    report.startup.process_main_to_runtime_ready_ns = process_main_to_runtime_ready_ns;
+    report.startup.tokio_runtime_build_ns = tokio_runtime_build_ns;
+    report.memory.process_before_runtime = process_before_runtime;
+    report.memory.runtime_ready = runtime_ready;
+    let encoded = serde_json::to_string_pretty(&report)? + "\n";
+    if let Some(path) = &args.output {
+        fs::write(path, &encoded)
+            .wrap_err_with(|| format!("failed to write {}", path.display()))?;
+    }
+    print!("{encoded}");
+    Ok(())
+}
+
+async fn run_benchmark(args: &Args, rss: &mut RssSampler) -> Result<BenchmarkReport> {
+    let workspace = tempfile::tempdir().wrap_err("failed to create benchmark workspace")?;
+    let state = Arc::new(HarnessState::default());
+    let service_state = Arc::clone(&state);
+    let openai = OpenAi::builder("harness-only")
+        .service(move || service_state.new_service())
+        .build()?;
+    let tools = Tools::builder().without_defaults().build()?;
+    let instructions = sized_text("Deterministic harness prefix. ", args.prefix_bytes);
+    let environment = ExecutionEnvironment::new("2026-08-22", "Etc/UTC");
+    let root_builder = Nanocodex::builder(openai.clone())
+        .instructions(instructions.clone())
+        .thinking(Thinking::Low)
+        .workspace(workspace.path())
+        .execution_environment(environment.clone())
+        .prompt_cache_key(PROMPT_CACHE_KEY)
+        .shared_prompt_cache()
+        .tools(tools.clone());
+    let startup_builder = Nanocodex::builder(openai)
+        .instructions(instructions)
+        .thinking(Thinking::Low)
+        .workspace(workspace.path())
+        .execution_environment(environment)
+        .prompt_cache_key(PROMPT_CACHE_KEY)
+        .tools(tools);
+
+    let root_build_started = Instant::now();
+    let (root, mut root_events) = root_builder.build()?;
+    let _root_build_ns = elapsed_ns(root_build_started);
+    let root_agent_ready = rss.sample()?;
+
+    let mut checkpoints = Vec::with_capacity(args.history_turns);
+    let mut observations = Vec::with_capacity(args.history_turns);
+    for turn in 1..=args.history_turns {
+        let prompt = sized_text(&format!("Harness turn {turn:04}. "), args.prompt_bytes);
+        let (result, observation) = measured_turn(&root, &mut root_events, prompt).await?;
+        checkpoints.push(result);
+        observations.push(observation);
+    }
+    let after_history = rss.sample()?;
+
+    let historical_turns = historical_turns(args.history_turns);
+    let mut retained = Vec::with_capacity(args.retained_forks);
+    let mut fork_samples = Vec::with_capacity(args.retained_forks);
+    for sample in 0..args.retained_forks {
+        let turn = historical_turns[sample % historical_turns.len()];
+        let started = Instant::now();
+        let child = root.fork_from(&checkpoints[turn - 1]).await?;
+        fork_samples.push(elapsed_ns(started));
+        retained.push(child);
+    }
+    tokio::task::yield_now().await;
+    let with_retained_forks = rss.sample()?;
+    let retained_forks_delta = with_retained_forks.saturating_sub(after_history);
+
+    let mut cache_observations = Vec::with_capacity(args.cache_probe_forks + 1);
+    if let Some(first) = observations.first() {
+        cache_observations.push((first.warmup_key.clone(), first.warmup_source.clone()));
+    }
+    for (index, (child, events)) in retained.iter_mut().take(args.cache_probe_forks).enumerate() {
+        let prompt = sized_text(&format!("Fork cache probe {index:04}. "), args.prompt_bytes);
+        let (_, observation) = measured_turn(child, events, prompt).await?;
+        cache_observations.push((observation.warmup_key, observation.warmup_source));
+    }
+    let workload_attempts = state.records();
+
+    for (child, _) in &retained {
+        child.shutdown().await?;
+    }
+    drop(retained);
+    root.shutdown().await?;
+
+    let mut startup_build = Vec::with_capacity(args.startup_samples);
+    let mut startup_accept = Vec::with_capacity(args.startup_samples);
+    let mut startup_delta = Vec::with_capacity(args.startup_samples);
+    for sample in 0..args.startup_samples {
+        let build_started_ns = monotonic_now_ns();
+        let build_started = Instant::now();
+        let (agent, mut events) = startup_builder.clone().build()?;
+        startup_build.push(elapsed_ns(build_started));
+        let prompt = sized_text(
+            &format!("Fresh agent startup sample {sample:04}. "),
+            args.prompt_bytes,
+        );
+        let (_, observation) = measured_turn(&agent, &mut events, prompt).await?;
+        startup_accept.push(observation.accepted_ns.saturating_sub(build_started_ns));
+        startup_delta.push(
+            observation
+                .first_delta_emitted_ns
+                .saturating_sub(build_started_ns),
+        );
+        agent.shutdown().await?;
+    }
+
+    let cold = observations
+        .first()
+        .ok_or_else(|| eyre!("the benchmark produced no turn observations"))?;
+    let warm = observations
+        .get(1..)
+        .ok_or_else(|| eyre!("the benchmark produced no warm turn observations"))?;
+    let warm_submit = warm
+        .iter()
+        .map(|sample| sample.submit_to_first_delta_ns)
+        .collect::<Vec<_>>();
+    let warm_accepted = warm
+        .iter()
+        .map(|sample| sample.accepted_to_first_delta_ns)
+        .collect::<Vec<_>>();
+    let warm_delivery = warm
+        .iter()
+        .map(|sample| sample.event_delivery_ns)
+        .collect::<Vec<_>>();
+    let warm_completion = warm
+        .iter()
+        .map(|sample| sample.submit_to_completion_ns)
+        .collect::<Vec<_>>();
+    let prompt_cache = prompt_cache_report(&cache_observations, &workload_attempts);
+    if !prompt_cache.stable_key {
+        bail!("prompt-cache identity changed across root and fork requests");
+    }
+    if prompt_cache.service_warmup_attempts != 1
+        || prompt_cache.service_warmups_avoided != args.cache_probe_forks
+        || prompt_cache.service_instances != prompt_cache.cache_probe_agents
+    {
+        bail!(
+            "expected one service warmup, one avoided warmup per cache-probe fork, and one service per agent; got {}, {}, and {}",
+            prompt_cache.service_warmup_attempts,
+            prompt_cache.service_warmups_avoided,
+            prompt_cache.service_instances
+        );
+    }
+
+    Ok(BenchmarkReport {
+        schema_version: 1,
+        implementation: "nanocodex",
+        source_commit: args.source_commit.clone(),
+        platform: Platform {
+            os: env::consts::OS,
+            arch: env::consts::ARCH,
+            tokio_worker_threads: 1,
+        },
+        noise_boundary: NoiseBoundary {
+            provider: "in_process_scripted_tower_service",
+            network: "none",
+            sandbox: "none",
+            tools: "empty_registry",
+            model_output: "one_scheduled_yield_then_done",
+        },
+        configuration: Configuration {
+            history_turns: args.history_turns,
+            prompt_bytes: args.prompt_bytes,
+            prefix_bytes: args.prefix_bytes,
+            retained_forks: args.retained_forks,
+            cache_probe_forks: args.cache_probe_forks,
+            startup_samples: args.startup_samples,
+        },
+        startup: StartupReport {
+            process_main_to_runtime_ready_ns: 0,
+            tokio_runtime_build_ns: 0,
+            fresh_agent_build_ns: Distribution::new(&startup_build),
+            build_start_to_prompt_accepted_ns: Distribution::new(&startup_accept),
+            build_start_to_first_delta_ns: Distribution::new(&startup_delta),
+        },
+        ttft: TtftReport {
+            cold_submit_to_first_delta_ns: cold.submit_to_first_delta_ns,
+            cold_accepted_to_first_delta_ns: cold.accepted_to_first_delta_ns,
+            warm_submit_to_first_delta_ns: Distribution::new(&warm_submit),
+            warm_accepted_to_first_delta_ns: Distribution::new(&warm_accepted),
+            warm_event_delivery_ns: Distribution::new(&warm_delivery),
+            warm_submit_to_completion_ns: Distribution::new(&warm_completion),
+        },
+        memory: MemoryReport {
+            unit: "bytes_rss",
+            process_before_runtime: 0,
+            runtime_ready: 0,
+            root_agent_ready,
+            after_history,
+            with_retained_forks,
+            retained_forks_delta,
+            retained_forks_bytes_each: retained_forks_delta
+                / u64::try_from(args.retained_forks).unwrap_or(u64::MAX),
+        },
+        fork: ForkReport {
+            historical_turns,
+            retained_forks: args.retained_forks,
+            construction_ns: Distribution::new(&fork_samples),
+        },
+        prompt_cache,
+    })
+}
+
+async fn measured_turn(
+    agent: &Nanocodex,
+    events: &mut AgentEvents,
+    prompt: String,
+) -> Result<(TurnResult, TurnObservation)> {
+    let submitted_ns = monotonic_now_ns();
+    let turn = agent.prompt(prompt).await?;
+    let accepted_ns = monotonic_now_ns();
+    let mut observation = TurnObservation {
+        accepted_ns,
+        ..TurnObservation::default()
+    };
+    let mut completion_ns = None;
+    while let Some(timed) = events.recv_timed().await {
+        let received_ns = monotonic_now_ns();
+        match timed.event.kind {
+            AgentEventKind::ModelWarmupStarted => {
+                let payload: WarmupStartedPayload =
+                    serde_json::from_str(timed.event.payload.get())?;
+                observation.warmup_key = Some(payload.prompt_cache_key);
+            }
+            AgentEventKind::ModelWarmupCompleted => {
+                let payload: WarmupCompletedPayload =
+                    serde_json::from_str(timed.event.payload.get())?;
+                observation.warmup_source = Some(payload.source);
+            }
+            AgentEventKind::AssistantDelta if observation.first_delta_emitted_ns == 0 => {
+                observation.first_delta_emitted_ns = timed.timing.emitted_ns;
+                observation.submit_to_first_delta_ns =
+                    timed.timing.emitted_ns.saturating_sub(submitted_ns);
+                observation.accepted_to_first_delta_ns =
+                    timed.timing.emitted_ns.saturating_sub(accepted_ns);
+                observation.event_delivery_ns = received_ns.saturating_sub(timed.timing.emitted_ns);
+            }
+            AgentEventKind::RunCompleted | AgentEventKind::RunFailed => {
+                completion_ns = Some(timed.timing.emitted_ns);
+                break;
+            }
+            _ => {}
+        }
+    }
+    let result = turn.result().await?;
+    if result.final_message() != "done" {
+        bail!(
+            "scripted service returned an unexpected final message: {:?}",
+            result.final_message()
+        );
+    }
+    if observation.first_delta_emitted_ns == 0 {
+        bail!("turn completed without an assistant delta");
+    }
+    observation.submit_to_completion_ns = completion_ns
+        .ok_or_else(|| eyre!("turn completed without a terminal event"))?
+        .saturating_sub(submitted_ns);
+    Ok((result, observation))
+}
+
+fn prompt_cache_report(
+    observations: &[(Option<String>, Option<String>)],
+    attempts: &[AttemptRecord],
+) -> PromptCacheReport {
+    let observed_keys = attempts
+        .iter()
+        .map(|attempt| attempt.prompt_cache_key.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let warmup_lifecycle_count = observations.iter().filter(|(key, _)| key.is_some()).count();
+    let warmup_sources = observations
+        .iter()
+        .filter_map(|(_, source)| source.clone())
+        .collect();
+    let warmups = attempts
+        .iter()
+        .filter(|attempt| attempt.kind == "warmup")
+        .collect::<Vec<_>>();
+    let generations = attempts
+        .iter()
+        .filter(|attempt| attempt.kind == "generation")
+        .collect::<Vec<_>>();
+    let incremental_generation_requests = generations
+        .iter()
+        .filter(|attempt| attempt.previous_response_id && !attempt.full_replay)
+        .count();
+    let full_replay_generation_requests = generations
+        .iter()
+        .filter(|attempt| attempt.full_replay)
+        .count();
+    let cache_probe_agents = observations.len();
+    let service_instances = attempts
+        .iter()
+        .map(|attempt| attempt.service_id)
+        .collect::<BTreeSet<_>>()
+        .len();
+    let service_warmups_avoided = cache_probe_agents.saturating_sub(warmups.len());
+    let denominator = cache_probe_agents.max(1) as f64;
+    let generation_denominator = generations.len().max(1) as f64;
+    PromptCacheReport {
+        expected_key: PROMPT_CACHE_KEY,
+        stable_key: observed_keys.len() == 1 && observed_keys[0] == PROMPT_CACHE_KEY,
+        observed_keys,
+        cache_probe_agents,
+        warmup_lifecycle_count,
+        warmup_sources,
+        service_instances,
+        service_warmup_attempts: warmups.len(),
+        service_warmups_avoided,
+        service_warmup_avoidance_ratio: service_warmups_avoided as f64 / denominator,
+        warmup_prefix_hashes: warmups
+            .iter()
+            .map(|attempt| attempt.input_fnv1a64.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect(),
+        generation_requests: generations.len(),
+        incremental_generation_requests,
+        full_replay_generation_requests,
+        incremental_generation_ratio: incremental_generation_requests as f64
+            / generation_denominator,
+        generation_input_items: generations.iter().map(|attempt| attempt.input_items).sum(),
+        generation_input_bytes: generations.iter().map(|attempt| attempt.input_bytes).sum(),
+        requests: attempts.to_vec(),
+    }
+}
+
+fn historical_turns(turns: usize) -> Vec<usize> {
+    [turns / 4, turns / 2, turns]
+        .into_iter()
+        .map(|turn| turn.max(1))
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn sized_text(prefix: &str, bytes: usize) -> String {
+    let mut text = String::with_capacity(bytes);
+    text.push_str(prefix);
+    text.extend(std::iter::repeat_n('x', bytes.saturating_sub(text.len())));
+    text
+}
+
+fn elapsed_ns(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX)
+}
+
+fn fnv1a64(bytes: &[u8]) -> String {
+    let mut digest = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in bytes {
+        digest ^= u64::from(*byte);
+        digest = digest.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{digest:016x}")
+}

--- a/crates/nanocodex-agent/benches/harness_performance.rs
+++ b/crates/nanocodex-agent/benches/harness_performance.rs
@@ -176,7 +176,7 @@ impl Service<ResponsesAttempt> for ScriptedResponses {
     }
 }
 
-fn attempt_kind(kind: ResponsesAttemptKind) -> &'static str {
+const fn attempt_kind(kind: ResponsesAttemptKind) -> &'static str {
     match kind {
         ResponsesAttemptKind::Warmup => "warmup",
         ResponsesAttemptKind::Generation => "generation",

--- a/crates/nanocodex-oai-api/src/tower/attempt.rs
+++ b/crates/nanocodex-oai-api/src/tower/attempt.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use crate::{
-    AgentEventKind, EventError, EventSink, Model, ResponseEvent, ResponseItem, ResponsesTransport,
-    Thinking,
+    AgentEventKind, ContentItem, EventError, EventSink, MessagePhase, MessageRole, Model,
+    ResponseEvent, ResponseItem, ResponsesTransport, Thinking,
     responses::{RequestProfile, ResponseHistory, ResponsesInput, WarmupResponse},
     tower::transport_policy::SessionTransport,
 };
@@ -63,6 +63,26 @@ impl ResponsesObserver {
             drop(events.send(event).await);
         }
     }
+
+    fn projects_response_events(&self) -> bool {
+        self.response_events.is_none()
+    }
+}
+
+#[derive(Serialize)]
+struct ProjectedTextDelta<'a> {
+    model_call_index: u32,
+    text: &'a str,
+}
+
+#[derive(Serialize)]
+struct ProjectedAssistantMessage<'a> {
+    model_call_index: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    item_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    phase: Option<MessagePhase>,
+    text: String,
 }
 
 /// Shared atomic counters for one transport family.
@@ -310,6 +330,12 @@ impl ResponsesAttempt {
         self.call_index
     }
 
+    /// Returns the stable prompt-cache identity carried by this attempt.
+    #[must_use]
+    pub fn prompt_cache_key(&self) -> &str {
+        self.profile.prompt_cache_key()
+    }
+
     /// Returns the reasoning effort fixed for this replayable attempt.
     #[must_use]
     pub const fn thinking(&self) -> Thinking {
@@ -346,6 +372,53 @@ impl ResponsesAttempt {
     /// that only returns a completed aggregate may omit it; the managed
     /// response stream synthesizes its terminal completion event.
     pub async fn emit(&self, event: ResponseEvent) {
+        if self.observer.projects_response_events() {
+            match &event {
+                ResponseEvent::OutputTextDelta(text) => {
+                    drop(self.observer.emit(
+                        AgentEventKind::AssistantDelta,
+                        ProjectedTextDelta {
+                            model_call_index: self.call_index.unwrap_or_default(),
+                            text,
+                        },
+                    ));
+                }
+                ResponseEvent::ReasoningSummaryDelta { delta, .. } => {
+                    drop(self.observer.emit(
+                        AgentEventKind::ReasoningSummaryDelta,
+                        ProjectedTextDelta {
+                            model_call_index: self.call_index.unwrap_or_default(),
+                            text: delta,
+                        },
+                    ));
+                }
+                ResponseEvent::OutputItemDone(ResponseItem::Message {
+                    id,
+                    role: MessageRole::Assistant,
+                    content,
+                    phase,
+                    ..
+                }) => {
+                    let text = content
+                        .iter()
+                        .filter_map(|item| match item {
+                            ContentItem::OutputText { text, .. } => Some(text.as_ref()),
+                            _ => None,
+                        })
+                        .collect();
+                    drop(self.observer.emit(
+                        AgentEventKind::AssistantMessage,
+                        ProjectedAssistantMessage {
+                            model_call_index: self.call_index.unwrap_or_default(),
+                            item_id: id.as_deref(),
+                            phase: *phase,
+                            text,
+                        },
+                    ));
+                }
+                _ => {}
+            }
+        }
         self.observer.emit_response(event).await;
     }
 
@@ -623,11 +696,60 @@ impl ResponsesAttemptFactory {
 mod tests {
     use super::{ResponseHistory, ResponsesAttemptFactory, TransportStats};
     use crate::{
-        ContentItem, EventSink, MessageRole, Model, ResponseItem, ResponsesTransport, Thinking,
-        responses::RequestProfile,
+        AgentEventData, AgentEventKind, AssistantEvent, ContentItem, EventSink, MessageRole, Model,
+        ResponseEvent, ResponseItem, ResponsesTransport, Thinking, responses::RequestProfile,
     };
     use serde_json::json;
     use std::sync::Arc;
+
+    #[tokio::test]
+    async fn caller_service_delta_reaches_the_agent_event_stream() {
+        let (events, mut receiver) = EventSink::channel("attempt-test".to_owned());
+        let factory = ResponsesAttemptFactory::new(
+            RequestProfile::new("attempt-test", "attempt-test", Arc::from([])),
+            events,
+            Arc::new(TransportStats::default()),
+        );
+        let attempt = factory.generation(
+            7,
+            ResponseHistory::default(),
+            ResponseHistory::default(),
+            0,
+            None,
+            Model::Sol,
+            Thinking::Medium,
+            false,
+        );
+
+        attempt
+            .emit(ResponseEvent::OutputTextDelta("delta".to_owned()))
+            .await;
+
+        let event = receiver.recv().await.unwrap();
+        assert_eq!(event.kind, AgentEventKind::AssistantDelta);
+        let AgentEventData::Assistant(AssistantEvent::Delta(delta)) = event.data().unwrap() else {
+            panic!("expected an assistant delta");
+        };
+        assert_eq!(delta.model_call_index, 7);
+        assert_eq!(delta.text, "delta");
+        assert_eq!(delta.item_id, None);
+        assert_eq!(delta.phase, None);
+
+        attempt
+            .emit(ResponseEvent::OutputItemDone(ResponseItem::message(
+                MessageRole::Assistant,
+                [ContentItem::output_text("complete")],
+            )))
+            .await;
+        let event = receiver.recv().await.unwrap();
+        assert_eq!(event.kind, AgentEventKind::AssistantMessage);
+        let AgentEventData::Assistant(AssistantEvent::Message(message)) = event.data().unwrap()
+        else {
+            panic!("expected an assistant message");
+        };
+        assert_eq!(message.model_call_index, 7);
+        assert_eq!(message.text, "complete");
+    }
 
     #[test]
     fn retry_preserves_the_attempts_turn_policy() {
@@ -651,6 +773,7 @@ mod tests {
         assert_eq!(attempt.model(), Model::Luna);
         assert_eq!(attempt.thinking(), Thinking::High);
         assert!(attempt.fast_mode());
+        assert_eq!(attempt.prompt_cache_key(), "attempt-test");
         assert!(attempt.prepare_retry());
         assert_eq!(attempt.model(), Model::Luna);
         assert_eq!(attempt.thinking(), Thinking::High);

--- a/crates/nanocodex-oai-api/src/tower/attempt.rs
+++ b/crates/nanocodex-oai-api/src/tower/attempt.rs
@@ -64,7 +64,7 @@ impl ResponsesObserver {
         }
     }
 
-    fn projects_response_events(&self) -> bool {
+    const fn projects_response_events(&self) -> bool {
         self.response_events.is_none()
     }
 }

--- a/docs/CODEX_PARITY.md
+++ b/docs/CODEX_PARITY.md
@@ -1,21 +1,23 @@
 # Codex parity ledger
 
-This ledger records the review of all 555 commits in the exclusive local
+This ledger records the review of all 1,357 commits in the exclusive local
 checkout range
 
 ```text
 openai/codex@35eaf3ffb0bf2001486c68c47a3d946b34d16634
-    ..openai/codex@7ada37a15e1f6aa84f83b4b9410f9d29e66fefe4
+    ..openai/codex@50ea8fd411422b3f7bc906bcde6c1c4432019a2e
 ```
 
 The review used the clean local Codex checkout at the range head. The command
-`git rev-list --count <range>` returns `555`. The first 37 commits remain
+`git rev-list --count <range>` returns `1,357`. The first 37 commits remain
 expanded below; the following 279 are classified individually in
 [`codex-parity/8431dc59-3418498f.md`](codex-parity/8431dc59-3418498f.md), and
-the final seven are classified in
+the following seven are classified in
 [`codex-parity/3418498f-be2e4afc.md`](codex-parity/3418498f-be2e4afc.md). The
-latest 232 are classified in
-[`codex-parity/be2e4afc-7ada37a1.md`](codex-parity/be2e4afc-7ada37a1.md).
+next 232 are classified in
+[`codex-parity/be2e4afc-7ada37a1.md`](codex-parity/be2e4afc-7ada37a1.md), and
+the latest 802 are classified in
+[`codex-parity/7ada37a1-50ea8fd4.md`](codex-parity/7ada37a1-50ea8fd4.md).
 
 The classifications mean:
 
@@ -34,11 +36,11 @@ claims.
 
 | Classification | Count |
 | --- | ---: |
-| `port` | 53 |
-| `evaluate` | 44 |
-| `defer` | 10 |
-| `out-of-scope` | 448 |
-| Total | 555 |
+| `port` | 59 |
+| `evaluate` | 152 |
+| `defer` | 30 |
+| `out-of-scope` | 1,116 |
+| Total | 1,357 |
 
 ## First range: `35eaf3ff..8431dc59`
 

--- a/docs/HARNESS_PERFORMANCE.md
+++ b/docs/HARNESS_PERFORMANCE.md
@@ -1,0 +1,120 @@
+# Agent harness performance
+
+`harness_performance` measures the part of latency and memory that Nanocodex
+owns: runtime construction, agent startup, prompt admission, typed event
+delivery, retained history, historical forks, and prompt-cache-preserving
+request construction. It deliberately removes provider, network, sandbox, VM,
+and tool-process variance.
+
+This is the baseline beneath host adapters. A Cloudflare Worker, Vercel
+Workflow, native CLI, or VM-backed consumer may add its own cold-start and
+binding cost, but it should not redefine these SDK metrics or force a provider
+abstraction into the library.
+
+## Workload and boundary
+
+The default release-profile workload runs in one process on one Tokio worker:
+
+- one in-process scripted Tower service with a single scheduled yield before
+  the first `AssistantDelta`;
+- no socket, DNS, provider, sandbox, VM, or tool subprocess;
+- an empty tool registry, a 32-KiB stable prefix, 32 sequential 4-KiB prompts,
+  and historical checkpoints at turns 8, 16, and 32;
+- 128 retained historical forks, three cache-probe forks, and 50 fresh-agent
+  startup samples; and
+- typed JSON output containing distributions and every audited request shape.
+
+Compilation is outside the timed process. RSS is process resident memory from
+the host, so comparisons require the same OS, architecture, allocator, build
+profile, and workload.
+
+## Metrics
+
+| Metric | Starts | Ends | What it isolates |
+| --- | --- | --- | --- |
+| Runtime startup | process `main` / runtime build | Tokio runtime ready | executable and async-runtime startup |
+| Agent build | immediately before `Nanocodex::builder(...).build()` | driver handle and event stream returned | owned driver/channel/session construction |
+| Build-to-first-delta | fresh agent build start | typed `AssistantDelta` received | fresh agent plus prompt admission and event path |
+| Warm TTFT | `prompt()` submission | typed `AssistantDelta` received | reused-driver scheduling and event delivery |
+| Event delivery | service emits the delta | benchmark receives it | channel/event-envelope overhead |
+| Fork construction | before `fork_from(checkpoint)` | fork handle and stream returned | checkpoint/history sharing plus child-driver construction |
+| Retained-fork memory | RSS after history | RSS with all forks retained | amortized resident footprint of live forks |
+| Cache eligibility | every scripted request | audited request ledger | stable key/prefix, warmup reuse, incremental chaining, and request bytes |
+
+TTFT here is not model TTFT: the scripted service has no inference. It is the
+minimum client-side tax that live provider TTFT sits on top of.
+
+## Run it
+
+```sh
+just bench-harness
+```
+
+To retain the report explicitly:
+
+```sh
+cargo bench -p nanocodex-agent --bench harness_performance -- \
+  --source-commit "$(git rev-parse HEAD)" \
+  --output /tmp/nanocodex-harness-performance.json
+```
+
+The benchmark also accepts `--history-turns`, `--prompt-bytes`,
+`--prefix-bytes`, `--retained-forks`, `--cache-probe-forks`, and
+`--startup-samples`. Keep the default workload for comparisons; change one
+dimension at a time for diagnosis.
+
+The process exits unsuccessfully if the cache key changes, a fork unexpectedly
+warms a replacement service, or a generation stops using the expected
+incremental request path.
+
+## Reference baseline
+
+Seven consecutive post-build process launches on 2026-08-22 used
+macOS/aarch64 and source
+`0a37b9314b07c26a8713d4155836df3c1f907b9e`. The release binary and filesystem
+page cache were warm. Each row summarizes the seven per-run p50 values; these
+numbers are a reference shape, not a cross-host regression threshold:
+
+| Measurement | Median run p50 | Observed run-p50 range |
+| --- | ---: | ---: |
+| Process `main` to runtime ready | 132 µs | 127-156 µs |
+| Tokio runtime build | 52 µs | 51-57 µs |
+| Fresh agent build | 18.6 µs | 18.1-69.4 µs |
+| Fresh build-to-first-delta | 264 µs | 261-784 µs |
+| Warm submit-to-first-delta | 72.0 µs | 69.9-153.8 µs |
+| Delta emission-to-receipt | 6.7 µs | 6.5-6.8 µs |
+| Historical fork construction | 207 µs | 199-553 µs |
+| Retained RSS per fork | 85.2 KiB | 84.1-87.8 KiB |
+| 128-fork retained RSS delta | 10.66 MiB | 10.52-10.97 MiB |
+
+Every run observed one stable prompt-cache key, one shared warmup across four
+service instances, three avoided fork warmups, 35/35 incremental generation
+requests, and no full-history generation replay. The 32-turn history plus 128
+retained forks ended at a median 22.23 MiB process RSS.
+
+The startup clock begins inside process `main`; executable loading before
+`main` is a host/package measurement. Warm page-cache results should not be
+presented as cold package launch time. At this scale, scheduler placement still
+moves agent-build and fork distributions even without provider noise. Compare
+repeated idle-host runs and inspect p50, p95, and maxima rather than treating
+one sample as a product claim.
+
+## Prompt-cache interpretation
+
+The deterministic harness proves cache eligibility, not provider cache hits.
+It verifies the stable cache key and byte-stable prefix, records request hashes
+and sizes, checks response-ID chaining, and detects redundant warmups. It does
+not fabricate `cached_tokens` or a cache-hit percentage because only the
+provider can report those.
+
+Use the live [`RESPONSE_TRANSPORT_BENCH.md`](RESPONSE_TRANSPORT_BENCH.md) suite
+for cached-input tokens, network TTFT, WebSocket/HTTPS setup, and server-side
+checkpoint behavior. Keep the two result sets separate:
+
+1. this harness attributes SDK startup, scheduling, memory, and fork costs;
+2. a host-adapter benchmark adds Worker/Workflow/WASM/native startup and memory;
+3. a live provider benchmark adds network, queueing, inference, and actual
+   prompt-cache usage.
+
+That layering makes regressions actionable and avoids solving provider or
+sandbox variance with adapters in the core agent contract.

--- a/docs/HARNESS_PERFORMANCE.md
+++ b/docs/HARNESS_PERFORMANCE.md
@@ -71,26 +71,26 @@ incremental request path.
 
 Seven consecutive post-build process launches on 2026-08-22 used
 macOS/aarch64 and source
-`0a37b9314b07c26a8713d4155836df3c1f907b9e`. The release binary and filesystem
+`094476b4dbb8c36f903688586e6f1f8b182af2db`. The release binary and filesystem
 page cache were warm. Each row summarizes the seven per-run p50 values; these
 numbers are a reference shape, not a cross-host regression threshold:
 
 | Measurement | Median run p50 | Observed run-p50 range |
 | --- | ---: | ---: |
-| Process `main` to runtime ready | 132 µs | 127-156 µs |
-| Tokio runtime build | 52 µs | 51-57 µs |
-| Fresh agent build | 18.6 µs | 18.1-69.4 µs |
-| Fresh build-to-first-delta | 264 µs | 261-784 µs |
-| Warm submit-to-first-delta | 72.0 µs | 69.9-153.8 µs |
-| Delta emission-to-receipt | 6.7 µs | 6.5-6.8 µs |
-| Historical fork construction | 207 µs | 199-553 µs |
-| Retained RSS per fork | 85.2 KiB | 84.1-87.8 KiB |
-| 128-fork retained RSS delta | 10.66 MiB | 10.52-10.97 MiB |
+| Process `main` to runtime ready | 132 µs | 126-148 µs |
+| Tokio runtime build | 59 µs | 53-66 µs |
+| Fresh agent build | 18.0 µs | 17.7-18.9 µs |
+| Fresh build-to-first-delta | 275 µs | 269-276 µs |
+| Warm submit-to-first-delta | 73.6 µs | 67.3-77.4 µs |
+| Delta emission-to-receipt | 6.6 µs | 6.5-6.8 µs |
+| Historical fork construction | 211 µs | 209-213 µs |
+| Retained RSS per fork | 85.9 KiB | 85.0-86.5 KiB |
+| 128-fork retained RSS delta | 10.73 MiB | 10.63-10.81 MiB |
 
 Every run observed one stable prompt-cache key, one shared warmup across four
 service instances, three avoided fork warmups, 35/35 incremental generation
 requests, and no full-history generation replay. The 32-turn history plus 128
-retained forks ended at a median 22.23 MiB process RSS.
+retained forks ended at a median 22.25 MiB process RSS.
 
 The startup clock begins inside process `main`; executable loading before
 `main` is a host/package measurement. Warm page-cache results should not be

--- a/docs/codex-parity/7ada37a1-50ea8fd4.md
+++ b/docs/codex-parity/7ada37a1-50ea8fd4.md
@@ -1,0 +1,913 @@
+# Codex parity review: `7ada37a1..50ea8fd4`
+
+This appendix classifies every commit in the exclusive local-checkout range
+
+```text
+openai/codex@7ada37a15e1f6aa84f83b4b9410f9d29e66fefe4
+    ..openai/codex@50ea8fd411422b3f7bc906bcde6c1c4432019a2e
+```
+
+`git rev-list --count 7ada37a15e..50ea8fd411` returns `802`. The ordered
+list below is mechanically comparable with
+`git log --reverse --format=%h 7ada37a15e..50ea8fd411`.
+
+The audit inspected the subject and changed paths of all 802 commits, then
+inspected commit messages and diffs for changes touching the Responses client,
+conversation/history state, tool runtime, MCP, process cleanup, telemetry,
+WebSocket transport, Code Mode, and comparable TUI performance paths. A row is
+not a parity claim unless it is classified `port` and tied to concrete
+Nanocodex evidence below.
+
+The decision codes reuse the main ledger where noted:
+
+- `P36` — function and custom definitions preserve eager wire shapes while
+  supporting deferred loading, including custom namespace members.
+- `P39` — the model-visible `tool_search` source advertisement is bounded and
+  reserved without truncating UTF-8 or admitting namespace children.
+- `P41` — immutable instructions and model-visible tool definitions live in one
+  `Arc`-shared, byte-stable request prefix across prompts and forks.
+- `P42` — every scheduled Responses retry emits ordered typed and tracing
+  telemetry with attempt, failure, delay, replay, and connection metadata, and
+  contributes to aggregate retry counters and backoff duration.
+- `P43` — Responses Lite requests keep `parallel_tool_calls: false`; the owned
+  scheduler still accepts multiple calls and overlaps only explicitly safe
+  siblings.
+- `P44` — cancelling a turn terminates that turn's Code Mode cells and nested
+  tool processes while preserving reusable state owned by earlier turns.
+- `E16` — relevant runtime, transport, history, MCP, TUI, cleanup, security, or
+  performance behavior needs a focused Nanocodex regression, profile, or
+  consumer before adoption.
+- `D4` — the standalone gRPC/WebSocket Code Mode host and its remote recovery
+  protocol are intentionally deferred. Nanocodex retains its embedded QuickJS
+  host and caller-owned tool boundary.
+- `O16` — the inspected change is app-server, persisted-thread migration,
+  Guardian/approval, skills/plugin, alternate provider, generic environment or
+  remote-executor, browser/computer-use, build/release, test-only, or an
+  implementation pipeline with no remaining Nanocodex invariant.
+
+## Ordered classifications
+
+```text
+90314a9207 out-of-scope O16
+1e59dc5bda out-of-scope O16
+3ca9f375aa out-of-scope O16
+2b1357c27c out-of-scope O16
+d1fb77d692 out-of-scope O16
+1a7519fa07 out-of-scope O16
+ceaa818898 out-of-scope O16
+989a0b053e out-of-scope O16
+8bfa49e350 out-of-scope O16
+3b8d22ec2c out-of-scope O16
+dbcd837c20 out-of-scope O16
+449f099f1c out-of-scope O16
+b87981a510 out-of-scope O16
+9952933c1d evaluate E16
+4bd5b9fd09 evaluate E16
+92689b6b7b out-of-scope O16
+17801b4206 out-of-scope O16
+40d226e398 out-of-scope O16
+e9a692d53b out-of-scope O16
+78f00743f9 out-of-scope O16
+720c9d68e1 out-of-scope O16
+c607da9f37 evaluate E16
+1b90b1d16b out-of-scope O16
+1a5e152189 out-of-scope O16
+e1f39b5f5b out-of-scope O16
+b9ba969f39 out-of-scope O16
+bf05737da4 out-of-scope O16
+411f3f0680 out-of-scope O16
+1d952f027e out-of-scope O16
+eeae88d8a6 out-of-scope O16
+bae8d8f5b6 out-of-scope O16
+11e390bb10 out-of-scope O16
+44cb66e4ed out-of-scope O16
+e87e2b495b out-of-scope O16
+431c78eb9c port P36
+5d89ab65dc out-of-scope O16
+1e489adad0 evaluate E16
+f21dc46388 evaluate E16
+56b82e676c out-of-scope O16
+30d99232f4 out-of-scope O16
+1fe6be9719 out-of-scope O16
+bac3ef1d8e out-of-scope O16
+ed2f985a26 out-of-scope O16
+3171166881 evaluate E16
+757c151a0e out-of-scope O16
+fcc4ca552f evaluate E16
+f2d825533c evaluate E16
+5c44f11064 evaluate E16
+952e87d3f2 evaluate E16
+c4f42d161a out-of-scope O16
+2707dfc219 evaluate E16
+9d00bb01c0 evaluate E16
+778b869829 out-of-scope O16
+4cb8676d3a out-of-scope O16
+2994f545a7 out-of-scope O16
+fa5d5ae047 evaluate E16
+72d937ed4d out-of-scope O16
+2b915a2eed out-of-scope O16
+f5345f1ee8 out-of-scope O16
+a1890b6998 out-of-scope O16
+b6c3b51533 out-of-scope O16
+0c07c7ee47 out-of-scope O16
+b6cddbf6d5 out-of-scope O16
+c38a60ded2 out-of-scope O16
+bd36d69aae out-of-scope O16
+ad6e48ddd3 out-of-scope O16
+15ea598c6e out-of-scope O16
+e244a9d94e evaluate E16
+f380b48733 out-of-scope O16
+e3465b48ad out-of-scope O16
+6bb6e9045f out-of-scope O16
+a3ebd19fa4 out-of-scope O16
+928bda82cf out-of-scope O16
+98da2c4499 port P39
+92b83e226d out-of-scope O16
+f141dc77f0 out-of-scope O16
+aac9f84247 out-of-scope O16
+547080e4d6 out-of-scope O16
+70b4653232 out-of-scope O16
+bc8b25ea02 out-of-scope O16
+0a0ebb8535 evaluate E16
+1ae82ce6a5 out-of-scope O16
+7a0e974e08 out-of-scope O16
+74b8f8db93 evaluate E16
+82b17bc724 out-of-scope O16
+a17da5e6e4 evaluate E16
+1151b23f01 evaluate E16
+bfb6a6ea22 out-of-scope O16
+e1831db7c3 evaluate E16
+57f42a8113 evaluate E16
+303a292581 evaluate E16
+7257826ab2 out-of-scope O16
+b3ffe3d001 evaluate E16
+842547640e out-of-scope O16
+d9eac10406 out-of-scope O16
+f8ac8fa6c6 out-of-scope O16
+29dce2db43 out-of-scope O16
+bcea6447ee out-of-scope O16
+a9da0bdbac out-of-scope O16
+4ffeddcbcc evaluate E16
+270d93268c out-of-scope O16
+69b6152c17 evaluate E16
+4bb7ee3472 out-of-scope O16
+912524d6fe out-of-scope O16
+9457f8f734 out-of-scope O16
+d0c8f422ea evaluate E16
+9afb96faff out-of-scope O16
+b94343ab9f out-of-scope O16
+4d7e3e90d9 evaluate E16
+2801d12661 out-of-scope O16
+5bdc889708 out-of-scope O16
+81b9bc2109 out-of-scope O16
+9daa491f7c evaluate E16
+80858a8cce out-of-scope O16
+6622546169 out-of-scope O16
+1efd8fcb26 out-of-scope O16
+0bdce9f424 out-of-scope O16
+4ee41929ea out-of-scope O16
+c87a218bd3 out-of-scope O16
+957f8eedee out-of-scope O16
+95c7265e84 out-of-scope O16
+85e0661c3b evaluate E16
+51e36d2ec2 out-of-scope O16
+a7dcd20d38 out-of-scope O16
+a4b129eb3e out-of-scope O16
+e75a1888d7 out-of-scope O16
+e58d9ef447 out-of-scope O16
+964a227d8c evaluate E16
+a9d59d8b8e out-of-scope O16
+c5d9431971 out-of-scope O16
+33e365b19e out-of-scope O16
+3b366654f1 out-of-scope O16
+b3278e96cb out-of-scope O16
+5729546839 out-of-scope O16
+248d8c0e22 evaluate E16
+204389afcc out-of-scope O16
+92fb33b758 out-of-scope O16
+511262b984 out-of-scope O16
+509565820f port P44
+5a0d0929e2 evaluate E16
+27e4a05cd3 out-of-scope O16
+ce22ea9712 out-of-scope O16
+ba94150c2a out-of-scope O16
+2b1811e562 out-of-scope O16
+41014b11bd out-of-scope O16
+62b7386b07 out-of-scope O16
+6db53df37f evaluate E16
+8e4b10446e out-of-scope O16
+beac16cccd out-of-scope O16
+abc5d0b552 defer D4
+45f8cafa4e out-of-scope O16
+4ca25a2c4e out-of-scope O16
+8073dbb20b defer D4
+208f05b233 out-of-scope O16
+c2bcb9a26b out-of-scope O16
+e734a1a5c1 out-of-scope O16
+2e3a1702c2 out-of-scope O16
+dd916428cd out-of-scope O16
+f65ea998c7 out-of-scope O16
+61a3dd4387 defer D4
+6f647caa9b out-of-scope O16
+3aae5d885b out-of-scope O16
+c4513cb982 out-of-scope O16
+936f5eb3ee out-of-scope O16
+dd43a9967f out-of-scope O16
+266c6920d9 out-of-scope O16
+420accf199 out-of-scope O16
+a875dd6b22 out-of-scope O16
+94937de51b out-of-scope O16
+646f7c0a91 out-of-scope O16
+a16863f870 out-of-scope O16
+50ef7395fa out-of-scope O16
+c0ad3ab014 defer D4
+f344a80a3b out-of-scope O16
+21aa552e87 evaluate E16
+c9c6c0daa9 evaluate E16
+89a335ed50 out-of-scope O16
+8cabf5a6cf out-of-scope O16
+c8e6e8555c out-of-scope O16
+beeba1d2fc port P41
+09f47c8785 out-of-scope O16
+34ecac1f2b out-of-scope O16
+1c042dd4d8 out-of-scope O16
+d109393270 evaluate E16
+bfb7790eb3 out-of-scope O16
+680934adc4 out-of-scope O16
+3b67b03a3f out-of-scope O16
+3c60d4da64 out-of-scope O16
+8b1b065719 evaluate E16
+92cbfb4d24 out-of-scope O16
+4996cf05af out-of-scope O16
+97729885d4 out-of-scope O16
+78d3665d15 out-of-scope O16
+d06dc73290 out-of-scope O16
+afcc95b431 evaluate E16
+ee7815dad2 out-of-scope O16
+4b0e2a0bff out-of-scope O16
+dd22460869 out-of-scope O16
+a1c88e865d evaluate E16
+63002bdb26 out-of-scope O16
+46f5d6eba9 out-of-scope O16
+a603d7ca5c out-of-scope O16
+a9dee37f9c out-of-scope O16
+9558d830f6 out-of-scope O16
+cc2f262033 out-of-scope O16
+9742cc8ed5 out-of-scope O16
+7f928f6ddc out-of-scope O16
+7a18a5c528 evaluate E16
+9e301c8c9a out-of-scope O16
+92912d6d84 out-of-scope O16
+1549756b78 out-of-scope O16
+ab3b4d26d4 out-of-scope O16
+260261ed8f evaluate E16
+9be95745fb defer D4
+070a26a1f0 out-of-scope O16
+f8821d85eb defer D4
+722784e936 out-of-scope O16
+2cc9dbb984 out-of-scope O16
+41ece455b7 evaluate E16
+0ca439900e evaluate E16
+7d486ffa94 out-of-scope O16
+3d4d253f8f out-of-scope O16
+279b93242c out-of-scope O16
+4c5fc230a9 out-of-scope O16
+edcec13372 evaluate E16
+1dac3d9ca0 out-of-scope O16
+8f4a2c99dd out-of-scope O16
+4496ba3fd5 out-of-scope O16
+ed390a5dc4 out-of-scope O16
+e20616d265 evaluate E16
+dad1db87bb out-of-scope O16
+b2543af02b evaluate E16
+1e557a554e defer D4
+34db7e5563 out-of-scope O16
+be751dd1df out-of-scope O16
+99915080b6 evaluate E16
+f2a6f2585c out-of-scope O16
+d6ca19d99b out-of-scope O16
+eea28321ad out-of-scope O16
+965b9f263a out-of-scope O16
+6dc3ac8721 out-of-scope O16
+b28aa476f4 out-of-scope O16
+285abc0368 out-of-scope O16
+44d992c14e out-of-scope O16
+3a6f747d77 out-of-scope O16
+46c3268542 out-of-scope O16
+853d98b6b0 out-of-scope O16
+104e25ac5a out-of-scope O16
+c8f673fddc out-of-scope O16
+b43de77679 out-of-scope O16
+ba2fb48319 defer D4
+a817d9424d out-of-scope O16
+33aaf91366 out-of-scope O16
+f317dc8a17 out-of-scope O16
+7c47952f7c out-of-scope O16
+67afc79674 out-of-scope O16
+d7f4324492 out-of-scope O16
+52d9218424 evaluate E16
+f4936d7aba out-of-scope O16
+85f331772f defer D4
+4c89139da9 out-of-scope O16
+da2803c73c out-of-scope O16
+ca4d532b2a out-of-scope O16
+c909d1bc04 out-of-scope O16
+eb9dceba1a evaluate E16
+2230d64464 out-of-scope O16
+4ef836f883 out-of-scope O16
+3fe19fcd81 out-of-scope O16
+69ae78291d out-of-scope O16
+16fbfe5574 out-of-scope O16
+8270a7c74d out-of-scope O16
+0e82c62a44 out-of-scope O16
+93beee910d out-of-scope O16
+c4b287cf57 out-of-scope O16
+e1b7b1acb3 out-of-scope O16
+96c8be200c out-of-scope O16
+eb752e43d9 out-of-scope O16
+9dd22890f5 out-of-scope O16
+3d7f9b4637 out-of-scope O16
+95aada11c4 out-of-scope O16
+91d6f48992 evaluate E16
+7093e8c480 evaluate E16
+1ad4397821 evaluate E16
+9df9ff6ad9 out-of-scope O16
+1f4ea79853 out-of-scope O16
+dc8562d672 out-of-scope O16
+d6eefb26a6 out-of-scope O16
+74004b5397 out-of-scope O16
+3d7bb2dd2e evaluate E16
+0e0ef5d818 evaluate E16
+8d4d57387a out-of-scope O16
+379cb68444 out-of-scope O16
+8bb8d60234 evaluate E16
+9ca0337dbf out-of-scope O16
+6e7daed1e9 out-of-scope O16
+020f6c963e out-of-scope O16
+bde723ae7d defer D4
+18dcc7646f out-of-scope O16
+130c7c93a9 out-of-scope O16
+631bbb33cc out-of-scope O16
+5664a5c07c out-of-scope O16
+842fae26c9 out-of-scope O16
+361fe2d202 out-of-scope O16
+4b07886d59 out-of-scope O16
+cbb7e82a8b out-of-scope O16
+96e8afbfb8 out-of-scope O16
+c38d59fca0 out-of-scope O16
+27a98dde4d out-of-scope O16
+f1a1fce26a out-of-scope O16
+1e71e35df6 out-of-scope O16
+9579479d28 out-of-scope O16
+e766f75989 out-of-scope O16
+5104cb649e defer D4
+8d637ae398 out-of-scope O16
+b1373b74a2 out-of-scope O16
+357696c5e7 out-of-scope O16
+363427b5e3 evaluate E16
+902bd9e06b out-of-scope O16
+e0de12a126 defer D4
+fe614a6304 out-of-scope O16
+c30a3e49c9 out-of-scope O16
+80ceab7aaa evaluate E16
+4ca1af77a5 out-of-scope O16
+9ed0047a61 out-of-scope O16
+72fa74fbc9 out-of-scope O16
+a7b8c074b5 out-of-scope O16
+a7e9fb5480 out-of-scope O16
+d09cf7e5f4 out-of-scope O16
+6fc6b9d6d2 out-of-scope O16
+911012490c out-of-scope O16
+5e32f728f1 out-of-scope O16
+683716cee9 out-of-scope O16
+ef596c68ca out-of-scope O16
+779e9114ae out-of-scope O16
+053dda6b89 out-of-scope O16
+2bd8727a0c evaluate E16
+6851fae57c out-of-scope O16
+a70211249a out-of-scope O16
+66919805ea out-of-scope O16
+d167a3604c out-of-scope O16
+42bb50d502 out-of-scope O16
+73862481e5 out-of-scope O16
+2aba3219e6 out-of-scope O16
+4f7032173e out-of-scope O16
+f8a3db0b99 out-of-scope O16
+9946da9af1 out-of-scope O16
+588e18aae5 out-of-scope O16
+781445f7c6 out-of-scope O16
+990218bbbd out-of-scope O16
+5ed321ce00 out-of-scope O16
+507ef0b371 out-of-scope O16
+f898ebcafd out-of-scope O16
+93327c852a out-of-scope O16
+b87327f4e5 evaluate E16
+1992f8c018 out-of-scope O16
+4343b2bdc4 out-of-scope O16
+53eaa297e5 out-of-scope O16
+3ba52d6075 out-of-scope O16
+bff03ecce5 evaluate E16
+6344a655a5 out-of-scope O16
+ca83f7908c out-of-scope O16
+1da59ad257 out-of-scope O16
+5cc65ecb98 out-of-scope O16
+813dc5f08d out-of-scope O16
+1b4ea8b3be port P42
+4d9f3021c8 out-of-scope O16
+9341b38310 out-of-scope O16
+18bbb585e7 out-of-scope O16
+535795f7d1 out-of-scope O16
+c6dee5f49f out-of-scope O16
+3711943d11 out-of-scope O16
+d5e256ceb2 out-of-scope O16
+5c6f498b0e out-of-scope O16
+5620bab61c out-of-scope O16
+9d012ca4f5 out-of-scope O16
+cbe85e117b out-of-scope O16
+4e5a08feb6 out-of-scope O16
+45c9c74e29 evaluate E16
+636e505c5c out-of-scope O16
+86b1123ff6 port P43
+fdbab67c66 out-of-scope O16
+4eff3b788b out-of-scope O16
+8630bb3cae out-of-scope O16
+a44f266a4a out-of-scope O16
+db5b4a4cfb out-of-scope O16
+486df09a00 out-of-scope O16
+3134ab6572 out-of-scope O16
+08c48e3700 out-of-scope O16
+aa905bb962 out-of-scope O16
+d40dfcc3c7 out-of-scope O16
+1c4f42863c out-of-scope O16
+42d842a91a out-of-scope O16
+2a452d7dc1 out-of-scope O16
+7c194ff24b out-of-scope O16
+5bc8da6d78 out-of-scope O16
+23094236ac out-of-scope O16
+742edd6c16 out-of-scope O16
+3360f4a909 out-of-scope O16
+da898490fc evaluate E16
+588ee89324 out-of-scope O16
+1bb6384c19 out-of-scope O16
+3b3a91ccf0 out-of-scope O16
+a3cb1c14fb defer D4
+c0d59bf614 out-of-scope O16
+fb5aa093e0 out-of-scope O16
+f535950eaa out-of-scope O16
+0fce933290 defer D4
+fa595fbab8 out-of-scope O16
+086396f7f6 out-of-scope O16
+14a6813fa8 out-of-scope O16
+395723b238 out-of-scope O16
+478215c5c1 defer D4
+42b5f05cef evaluate E16
+1426592fcc out-of-scope O16
+d8d7ca73f8 out-of-scope O16
+baab1705c6 out-of-scope O16
+6595071e65 defer D4
+6bed213411 evaluate E16
+ccee70f813 out-of-scope O16
+7e65e4f330 out-of-scope O16
+58d2daba45 out-of-scope O16
+a0bed4be21 out-of-scope O16
+6d97d4c102 out-of-scope O16
+efa97f9bc6 out-of-scope O16
+fe556c4b6c defer D4
+cce33123a1 out-of-scope O16
+b8aa9e9a01 out-of-scope O16
+aa1b81e46f out-of-scope O16
+ff6e7c77a3 defer D4
+c530bcd4cd out-of-scope O16
+5186e2ccc3 evaluate E16
+848cbad7f4 out-of-scope O16
+274727d37f out-of-scope O16
+a186f5484d out-of-scope O16
+15fde8c1f2 out-of-scope O16
+1873e947f8 out-of-scope O16
+233739e76a out-of-scope O16
+22bf16a37e out-of-scope O16
+4e9a1a9073 out-of-scope O16
+eb147c0db3 out-of-scope O16
+2ca575026c out-of-scope O16
+4861236f06 out-of-scope O16
+53f3fa7496 out-of-scope O16
+e5470f1bce out-of-scope O16
+3685a61dad out-of-scope O16
+85fc4def35 out-of-scope O16
+3c7ae4a812 out-of-scope O16
+a7edf37cb4 out-of-scope O16
+12933b6955 out-of-scope O16
+c4941302c7 out-of-scope O16
+00f6a8a60e evaluate E16
+a95a6fe333 out-of-scope O16
+6efcdad4c3 out-of-scope O16
+899d1715c8 out-of-scope O16
+b3cc217378 defer D4
+5ba12929f8 out-of-scope O16
+fcdae21073 out-of-scope O16
+1ba9ce8910 evaluate E16
+49db349ffd evaluate E16
+c7a95f84b3 out-of-scope O16
+73abda8bfe out-of-scope O16
+9bfaf7a076 out-of-scope O16
+9ded177ce7 out-of-scope O16
+375996d3f5 out-of-scope O16
+ed32158e90 out-of-scope O16
+f85e81d30b out-of-scope O16
+6c108912ee out-of-scope O16
+2bc43d516e out-of-scope O16
+cd8dc1e9b6 evaluate E16
+772e88c8ae out-of-scope O16
+c8ddb210d2 out-of-scope O16
+935b1c4e3d out-of-scope O16
+1f41cc5d92 evaluate E16
+3b4569a920 out-of-scope O16
+89e297729e out-of-scope O16
+e38290846c out-of-scope O16
+c6058ccaa9 out-of-scope O16
+632e35ce8d out-of-scope O16
+53aa7bb1aa out-of-scope O16
+37cf6c84c0 out-of-scope O16
+8bf50439f2 out-of-scope O16
+ea10ae7d0f out-of-scope O16
+3666a46ea3 out-of-scope O16
+4885eb6c52 out-of-scope O16
+8e89e98cf6 out-of-scope O16
+02e9bfaac7 out-of-scope O16
+04caa22c82 out-of-scope O16
+def7ed5572 out-of-scope O16
+21cfd369ef out-of-scope O16
+32a383c0ba out-of-scope O16
+02360b48d1 evaluate E16
+09bc28f348 out-of-scope O16
+0841d9bba5 out-of-scope O16
+f0904922f6 evaluate E16
+c6ba7b7f8e out-of-scope O16
+171ae66d74 out-of-scope O16
+10fbb61838 out-of-scope O16
+8892aa8fa0 out-of-scope O16
+dc473903ab out-of-scope O16
+a8525b139c out-of-scope O16
+eeb82a156d out-of-scope O16
+71e5e1ec50 out-of-scope O16
+1d928cad2f out-of-scope O16
+9dd3d6a13e out-of-scope O16
+d0fd4e830a out-of-scope O16
+0f21cb3413 out-of-scope O16
+06418909a0 out-of-scope O16
+ff770113ca evaluate E16
+0c901fd141 out-of-scope O16
+1a8bac9405 out-of-scope O16
+d7d526b81d evaluate E16
+fe5889928c out-of-scope O16
+4a7b51c560 out-of-scope O16
+afb1b3c984 out-of-scope O16
+796325f1e5 evaluate E16
+14973840e0 out-of-scope O16
+80e925c28b out-of-scope O16
+386a7b629c evaluate E16
+b6e153c985 evaluate E16
+1aa3a68e7b out-of-scope O16
+d327527a3d evaluate E16
+51a9edc083 out-of-scope O16
+d24507a59b out-of-scope O16
+682f57254f out-of-scope O16
+45cf6cbc19 out-of-scope O16
+d65d315939 out-of-scope O16
+37efa18be2 evaluate E16
+e92627bf7e out-of-scope O16
+911335eed3 out-of-scope O16
+8ef139667f out-of-scope O16
+9c099e94a2 evaluate E16
+34e4823a1d out-of-scope O16
+a4f37a5b7f out-of-scope O16
+2013e04354 out-of-scope O16
+fc6268ad38 out-of-scope O16
+0c14c73471 out-of-scope O16
+31f23b6022 out-of-scope O16
+83d015375e out-of-scope O16
+4617d4d21d out-of-scope O16
+fd34ad7297 out-of-scope O16
+050aa077b5 evaluate E16
+7500ab4c8d evaluate E16
+2eee483e49 evaluate E16
+632420e67a out-of-scope O16
+319b2f72b1 out-of-scope O16
+13dfaab446 out-of-scope O16
+fd5018e044 out-of-scope O16
+ca08a58ab4 out-of-scope O16
+ede5247893 out-of-scope O16
+f97e775693 out-of-scope O16
+5ee6baee2f out-of-scope O16
+9a254ba1fa out-of-scope O16
+f47f77ada6 out-of-scope O16
+de7bbb0481 out-of-scope O16
+230791fd1f out-of-scope O16
+bc7a487039 out-of-scope O16
+6f95f19103 out-of-scope O16
+539a09cb28 out-of-scope O16
+3d47dc40be evaluate E16
+f6ba9110fa out-of-scope O16
+f5e9d66851 out-of-scope O16
+4216123b3d out-of-scope O16
+e2eea07140 out-of-scope O16
+0acf302db5 out-of-scope O16
+63b268c81b out-of-scope O16
+711a5f8b3a out-of-scope O16
+880f1135ea out-of-scope O16
+a397079287 evaluate E16
+b5ea64a203 out-of-scope O16
+a04940cb12 out-of-scope O16
+bb701f1e8c out-of-scope O16
+e13c1d569d out-of-scope O16
+76ceaddb29 out-of-scope O16
+2a30972fcb out-of-scope O16
+e7e13c68e2 out-of-scope O16
+9b9b614b02 out-of-scope O16
+3df5087f75 out-of-scope O16
+a998c7a1ce out-of-scope O16
+e683c3118b out-of-scope O16
+19d185fec8 out-of-scope O16
+a1dc95d5af out-of-scope O16
+8193c56a59 out-of-scope O16
+77e6889601 out-of-scope O16
+fa9a05f2d2 out-of-scope O16
+ecb8013dfa evaluate E16
+3006151ad4 evaluate E16
+785ecd7452 out-of-scope O16
+726ec7ecbf out-of-scope O16
+846a16852f out-of-scope O16
+d68b85a097 out-of-scope O16
+4a3e829c56 out-of-scope O16
+f950a1ba0b out-of-scope O16
+22b860e80b out-of-scope O16
+884a193b78 out-of-scope O16
+392328ed5d out-of-scope O16
+88c39c4578 out-of-scope O16
+681c82f497 out-of-scope O16
+2fe4e06cc2 out-of-scope O16
+ba37d0c45b out-of-scope O16
+e7f9fa9cd9 out-of-scope O16
+997a80020f out-of-scope O16
+ccf4191582 out-of-scope O16
+633bd4abf7 out-of-scope O16
+17de14558b out-of-scope O16
+701db965e5 out-of-scope O16
+87070a7792 out-of-scope O16
+45528c5132 out-of-scope O16
+1a6e07a4fe out-of-scope O16
+fe50b61689 out-of-scope O16
+b473c4e6ab out-of-scope O16
+e51a91b2f4 out-of-scope O16
+6ec012668b out-of-scope O16
+c97bd2dcb5 out-of-scope O16
+280d56b1d8 out-of-scope O16
+7d9990fa30 out-of-scope O16
+fb356f3d2c out-of-scope O16
+4d8c664a49 out-of-scope O16
+8ae72a9314 out-of-scope O16
+657bd889ae out-of-scope O16
+71dbf72b05 out-of-scope O16
+f1087ff151 out-of-scope O16
+b537d5a097 out-of-scope O16
+67ed4e717a out-of-scope O16
+d35e5495f9 out-of-scope O16
+fde2156057 out-of-scope O16
+8843960ba0 out-of-scope O16
+14a8ac89af out-of-scope O16
+956f590ad5 out-of-scope O16
+6cc2ba8a95 out-of-scope O16
+3929c99a97 out-of-scope O16
+f5a3dc5540 out-of-scope O16
+e741cd9ace out-of-scope O16
+d1d51f6315 out-of-scope O16
+fcdf2b5014 evaluate E16
+94a831d9dd out-of-scope O16
+af70018080 out-of-scope O16
+83915c7ca1 out-of-scope O16
+36268f177f out-of-scope O16
+b0cdcce616 out-of-scope O16
+eb5a25aaa2 out-of-scope O16
+6972c57c78 out-of-scope O16
+992f5c681f out-of-scope O16
+db675cc005 evaluate E16
+18937b2265 evaluate E16
+ffad922340 out-of-scope O16
+1b450c7912 out-of-scope O16
+3b45c29062 out-of-scope O16
+8e2265196e out-of-scope O16
+6141747444 out-of-scope O16
+3bebaea8f2 out-of-scope O16
+4b450d2f1b out-of-scope O16
+e7c0e8eb9f out-of-scope O16
+493e0efb7b out-of-scope O16
+1bfabb21fe evaluate E16
+8f4a48a6ad out-of-scope O16
+d75c85f651 out-of-scope O16
+f6950546e5 out-of-scope O16
+198f42067a out-of-scope O16
+8e7f646974 out-of-scope O16
+3434c2545b out-of-scope O16
+430bc36fb2 out-of-scope O16
+6869d17cc2 out-of-scope O16
+186b449bc2 out-of-scope O16
+5c305eb50b out-of-scope O16
+c19482a768 out-of-scope O16
+929e2b9c1d evaluate E16
+530c1aed58 out-of-scope O16
+250b5ea2bf evaluate E16
+bc3545b805 out-of-scope O16
+4bb7804a23 out-of-scope O16
+da6e68951b out-of-scope O16
+f1e06b3865 out-of-scope O16
+52e387daca out-of-scope O16
+e396ef3fc1 out-of-scope O16
+9ca99b5171 out-of-scope O16
+942af8447b out-of-scope O16
+910ecccf30 out-of-scope O16
+7ea7b29369 out-of-scope O16
+7edd0a4c9d out-of-scope O16
+fdc23b93b8 evaluate E16
+d944ce83a2 out-of-scope O16
+663da53823 evaluate E16
+af0e82c562 out-of-scope O16
+8aaf839774 out-of-scope O16
+ab82cddd04 out-of-scope O16
+7ece061767 out-of-scope O16
+1802a65571 out-of-scope O16
+4a432d180d out-of-scope O16
+5e3a6fe4ee out-of-scope O16
+4e1a772a7d out-of-scope O16
+e3e5ad2847 out-of-scope O16
+631d5a8b02 out-of-scope O16
+240bbfc14a evaluate E16
+97c82c0900 out-of-scope O16
+fec2dccfcf out-of-scope O16
+2584e88cad out-of-scope O16
+312b62ac95 evaluate E16
+478dbe9df0 out-of-scope O16
+f277e313f1 out-of-scope O16
+585b97d394 out-of-scope O16
+37a9da9901 out-of-scope O16
+02de49f718 out-of-scope O16
+3675fe014b out-of-scope O16
+59f7da58d6 out-of-scope O16
+4a942885c8 evaluate E16
+2c74b56fcd out-of-scope O16
+6d020311f0 out-of-scope O16
+1674b0a130 out-of-scope O16
+9894a14c81 out-of-scope O16
+9bf673718a evaluate E16
+bf2aee99c5 out-of-scope O16
+8c828b18d6 out-of-scope O16
+88da5520d4 out-of-scope O16
+4f38432d87 out-of-scope O16
+c3db180493 out-of-scope O16
+2e1f18e0db out-of-scope O16
+a26d50852a out-of-scope O16
+85a1b0e33d out-of-scope O16
+ce950dcf26 out-of-scope O16
+d0cc662b8c out-of-scope O16
+8a40095ea3 evaluate E16
+097825f75a out-of-scope O16
+39073ca3a7 out-of-scope O16
+5bcd7b0fbc out-of-scope O16
+bce5f2fcfc evaluate E16
+5cada24434 out-of-scope O16
+5663754f62 out-of-scope O16
+854cbb2fd4 out-of-scope O16
+763787d061 evaluate E16
+90c67e6f33 out-of-scope O16
+0cc80b8db5 out-of-scope O16
+9e680a52e7 out-of-scope O16
+43526b8561 out-of-scope O16
+aead844f64 out-of-scope O16
+010738a25c out-of-scope O16
+bfb8986f7f out-of-scope O16
+d9fd91edab out-of-scope O16
+cc801d7048 out-of-scope O16
+a3bce23f3b evaluate E16
+53cec04646 out-of-scope O16
+f3cd299428 out-of-scope O16
+2790c13899 out-of-scope O16
+3cde5d4ccd out-of-scope O16
+21facf2273 out-of-scope O16
+969efa5470 out-of-scope O16
+67b2c8c6fb out-of-scope O16
+54201093d4 out-of-scope O16
+f20b63e85c out-of-scope O16
+daa48072f4 out-of-scope O16
+d8ec270183 out-of-scope O16
+bd19459358 out-of-scope O16
+27c05a52e0 evaluate E16
+2151d3a5b7 out-of-scope O16
+9ab176f488 evaluate E16
+44e95c857f out-of-scope O16
+2aaefa32b0 out-of-scope O16
+536f86e5cc out-of-scope O16
+ff0e95007c out-of-scope O16
+93c54bca38 out-of-scope O16
+9c3da20b3f out-of-scope O16
+7f9832d0d0 evaluate E16
+748d8ac834 evaluate E16
+275ef855fa defer D4
+00a7b888b2 out-of-scope O16
+054588acfe out-of-scope O16
+d446960657 out-of-scope O16
+3882ced09c out-of-scope O16
+4e6ef3b418 out-of-scope O16
+8ce27647fb out-of-scope O16
+e482cc66ae out-of-scope O16
+3432d3f2c9 out-of-scope O16
+16e2722c50 out-of-scope O16
+41ab01a2ea out-of-scope O16
+d12a7f3fd8 out-of-scope O16
+696b4502df out-of-scope O16
+8edb95f274 out-of-scope O16
+f580dd886f out-of-scope O16
+c517cc6d84 out-of-scope O16
+51ebf5b184 out-of-scope O16
+f6519a355a evaluate E16
+45a3edc02a out-of-scope O16
+79b7606803 out-of-scope O16
+56012fafb8 out-of-scope O16
+950dd184a1 out-of-scope O16
+df6a54ee85 out-of-scope O16
+9cdc66904f out-of-scope O16
+0f1a30b5c2 out-of-scope O16
+ad9e8097fd out-of-scope O16
+dbe9dac1ae out-of-scope O16
+51d8d12236 out-of-scope O16
+e77c2a90af out-of-scope O16
+8b61c50ebe out-of-scope O16
+8b5beea5c0 out-of-scope O16
+ab8768306f out-of-scope O16
+9949c9eafa out-of-scope O16
+e6a3877e95 out-of-scope O16
+be6ebb1f6d evaluate E16
+95118dff65 out-of-scope O16
+677cfee000 out-of-scope O16
+6143217c67 out-of-scope O16
+9445ef227e out-of-scope O16
+50ea8fd411 out-of-scope O16
+```
+
+## Port evidence
+
+- `P36`: `custom_tools_opt_into_deferred_loading_and_namespace_membership`
+  covers deferred custom-tool indexing, loading, and executable routing while
+  preserving eager custom definitions.
+- `P39`: namespace wire tests reject nested namespace and `tool_search`
+  children, while `search_definition_bounds_aggregate_source_descriptions`
+  preserves complete UTF-8 source names within Nanocodex's deliberate 4-KiB
+  advertisement budget.
+- `P41`: `RequestProfile` owns its immutable prefix as
+  `Arc<[ResponseItem]>`; checkpoints call `shared_prefix`. The deterministic
+  `harness_performance` benchmark audits a stable cache key, byte-stable
+  request hashes, incremental follow-ons, and retained-fork memory without a
+  provider or sandbox.
+- `P42`: `ResponsesRetryPolicy` emits `ModelAttemptRetrying` before delay with
+  typed attempt/failure/delay/replay/connection fields, records the same
+  structural trace event, and updates `TransportStatsDelta`. Mock transport
+  tests observe the ordered retry event and terminal aggregate counters.
+- `P43`: request serialization and mock-server tests assert
+  `parallel_tool_calls: false`;
+  `parallel_results_emit_on_completion_but_enter_history_in_provider_order`
+  and `unsafe_tool_calls_exclude_parallel_safe_siblings` cover client-side
+  concurrency and deterministic history.
+- `P44`: `ToolRuntimeControl::cancel_turn` concurrently terminates Code Mode
+  cells and shell sessions for the current turn.
+  `cancellation_terminates_yielded_code_cells`,
+  `cancelling_a_turn_preserves_prior_turn_shell_sessions`, and busy-JavaScript
+  cancellation regressions cover cleanup and reusable-state ownership.
+
+## Notable evaluations
+
+- Codex's unbounded connection recovery (`5a0d0929e2`, later made
+  configurable by `da898490fc`) is not imported into Nanocodex's single
+  bounded retry owner.
+- The macOS process-group fallback and Windows job-object MCP cleanup
+  (`f2d825533c`, `9daa491f7c`) remain evaluations: Nanocodex owns process-group
+  cleanup and descendant regressions, but does not prove those exact platform
+  fallbacks.
+- Pending/cached MCP startup reuse, HTTP catalog caching, and stable binding
+  allocation (`952e87d3f`, `0ca439900e`, `45c9c74e29`) need an identity and
+  allocation profile before being called ports.
+- Client-authored developer-message envelopes and retention across compaction
+  (`99915080b6`, `0e0ef5d818`, `bff03ecce5`) do not map directly onto
+  Nanocodex's canonical developer-context ownership and remain unclaimed.
+- Codex raises its aggregate MCP source advertisement to 512 KiB in
+  `fcc4ca552f`; Nanocodex deliberately retains the measured 4-KiB bounded
+  advertisement until a consumer demonstrates that a larger model-visible
+  prefix is worth its cache and memory cost.
+
+## Classification totals
+
+| Classification | Count |
+| --- | ---: |
+| `port` | 6 |
+| `evaluate` | 108 |
+| `defer` | 20 |
+| `out-of-scope` | 668 |
+| Total | 802 |
+


### PR DESCRIPTION
## Summary

- add a deterministic in-process agent harness for runtime startup, agent construction, client-side TTFT, typed event delivery, historical fork construction, retained RSS, and prompt-cache eligibility
- project caller-supplied Tower service deltas into the public agent event stream and cover that path with a focused regression test
- document the layered harness, host-adapter, and live-provider performance boundaries
- advance the reviewed Codex checkpoint to `50ea8fd4` with an exact 802-commit classification ledger

## Reference shape

Seven macOS/aarch64 release runs on the rebased branch measured:

- process `main` to runtime-ready p50: 132 us
- fresh agent build p50: 18.0 us
- fresh build-to-first-delta p50: 275 us
- warm submit-to-first-delta p50: 73.6 us
- event delivery p50: 6.6 us
- historical fork construction p50: 211 us
- retained RSS per fork: 85.9 KiB

All runs preserved one stable cache key, avoided 3 of 4 service warmups, and used the incremental path for 35 of 35 generation requests. This proves provider-cache eligibility, not provider cache hits. These are native in-process numbers; JS/WASM and provider boundaries remain separate measurements.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p nanocodex-agent --bench harness_performance -- -D warnings`
- `cargo clippy -p nanocodex-oai-api --lib -- -D warnings`
- `cargo test -p nanocodex-oai-api caller_service_delta_reaches_the_agent_event_stream --lib`
- `./scripts/check-crate-boundaries.sh`
- `just bench-harness`
- exact 802-SHA Codex parity ledger comparison
