### PR TITLE
bench: make model latency the performance score

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5490,6 +5490,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanocodex-model-latency-bench"
+version = "0.5.0"
+dependencies = [
+ "eyre",
+ "nanocodex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "nanocodex-oai-api"
 version = "0.5.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/nanocodex-tools/macros",
     "examples",
     "examples/exe-dev",
+    "examples/model-latency-bench",
     "js/bindings",
     "py/bindings",
 ]

--- a/Justfile
+++ b/Justfile
@@ -184,6 +184,56 @@ bench-harness:
     cargo bench -p nanocodex-agent --bench harness_performance -- \
       --source-commit "$(git rev-parse HEAD)"
 
+# Validate the paid paired runner without credentials or provider requests.
+test-model-latency-runner:
+    cargo check -p nanocodex-model-latency-bench --bin model-latency-bench
+    python3 -m unittest -v benchmarks.test_paired_fx_model_latency
+    python3 -m py_compile \
+      benchmarks/paired_fx_model_latency.py \
+      benchmarks/test_paired_fx_model_latency.py
+
+# Run the reviewed immutable fx and Nanocodex artifacts through the six-request
+# provider-free loopback preflight. This is intentionally separate from the
+# portable unit suite because the pinned fx checkout is operator-supplied.
+test-model-latency-actual-binaries fx_source_root fx_bin: test-model-latency-runner
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cargo build --locked --release -p nanocodex-model-latency-bench --bin model-latency-bench
+    env \
+      NANOCODEX_PAIRED_FX_SOURCE_ROOT="{{fx_source_root}}" \
+      NANOCODEX_PAIRED_FX_BIN="{{fx_bin}}" \
+      NANOCODEX_PAIRED_NANOCODEX_BIN="{{justfile_directory()}}/target/release/model-latency-bench" \
+      NANOCODEX_PAIRED_NANOCODEX_COMMIT="$(git rev-parse HEAD)" \
+      PYTHONDONTWRITEBYTECODE=1 \
+      python3 -m unittest -v \
+        benchmarks.test_paired_fx_model_latency.ActualBinaryPreflightIntegrationTests.actual_binary_preflight
+
+# Measure native and Chromium prompt-to-typed-model-output tax without provider calls.
+bench-model-latency-local: bench-harness test-model-latency-runner build-wasm
+    npm run bench:browser:model --prefix examples/react-vite
+
+# Run the paid controlled fx comparison with an explicit confirmation literal.
+bench-model-latency-live fx_source_root fx_bin auth_file confirm trials="20" warmup_pairs="2": test-model-latency-runner
+    #!/usr/bin/env bash
+    set -euo pipefail
+    test "{{confirm}}" = "I_ACCEPT_PAID_MODEL_CALLS" || {
+      echo "pass I_ACCEPT_PAID_MODEL_CALLS as the confirm argument" >&2
+      exit 2
+    }
+    mkdir -p "{{justfile_directory()}}/.nanocodex/benchmarks"
+    cargo build --release -p nanocodex-model-latency-bench --bin model-latency-bench
+    python3 benchmarks/paired_fx_model_latency.py \
+      --fx-source-root "{{fx_source_root}}" \
+      --fx-bin "{{fx_bin}}" \
+      --nanocodex-source-root "{{justfile_directory()}}" \
+      --nanocodex-bin "{{justfile_directory()}}/target/release/model-latency-bench" \
+      --nanocodex-commit "$(git rev-parse HEAD)" \
+      --auth-file "{{auth_file}}" \
+      --warmup-pairs "{{warmup_pairs}}" \
+      --trials "{{trials}}" \
+      --output "{{justfile_directory()}}/.nanocodex/benchmarks/paired-fx-model-latency.json" \
+      --confirm-paid-live-run
+
 # Rebuild every PR #50 hot-path estimate, then enforce the checked-in median
 # latency thresholds. TUI frame-count, changed-cell, and output-byte limits are
 # asserted inside the representative benchmark workloads themselves.

--- a/README.md
+++ b/README.md
@@ -669,6 +669,7 @@ Further reading:
 - [Examples and runnable commands](examples/README.md)
 - [Migration guide](docs/MIGRATING.md)
 - [Responses + Tower design](docs/RESPONSES_TOWER.md)
+- [Model-latency scorecard and controlled fx protocol](docs/MODEL_LATENCY.md)
 - [Observability contract](docs/OBSERVABILITY.md)
 - [Subagent design](docs/SUBAGENTS.md)
 - [VM operations](docs/VM.md)

--- a/benchmarks/paired_fx_model_latency.py
+++ b/benchmarks/paired_fx_model_latency.py
@@ -1,0 +1,4736 @@
+#!/usr/bin/env python3
+"""Paid, explicitly opted-in fx/Nanocodex product-latency comparison.
+
+The loopback observer validates each product's controlled, product-as-shipped
+request before forwarding it to the one official upstream. Credentials and raw
+headers are deliberately absent from every serializable result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import contextlib
+import dataclasses
+import datetime as dt
+import hashlib
+import http.client
+import http.server
+import ipaddress
+import json
+import math
+import os
+import platform
+import pwd
+import re
+import selectors
+import shutil
+import signal
+import socket
+import ssl
+import stat
+import subprocess
+import socketserver
+import sys
+import tempfile
+import threading
+import time
+import unicodedata
+import urllib.parse
+import uuid
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+
+MODEL = "gpt-5.6-sol"
+EFFORT = "low"
+ACK_TOKEN = "ACK_NANOCODEX_FX_MODEL_LATENCY_V1"
+NANOCODEX_PROMPT_CACHE_KEY = "nanocodex-paired-fx-model-latency-v1"
+SYSTEM_INSTRUCTIONS = (
+    "This is an explicit paid model-latency benchmark. Return exactly the "
+    "user-provided ACK token and nothing else. Do not call any tool."
+)
+NANOCODEX_PERMISSIONS_INSTRUCTIONS = (
+    "<permissions instructions>\n"
+    "Filesystem sandboxing defines which files can be read or written. `sandbox_mode` is "
+    "`danger-full-access`: No filesystem sandboxing - all commands are permitted. Network "
+    "access is enabled.\n"
+    "Approval policy is currently never. Do not provide the `sandbox_permissions` for any "
+    "reason, commands will be rejected.\n"
+    "</permissions instructions>"
+)
+DEFAULT_UPSTREAM_URL = "https://chatgpt.com/backend-api/codex/responses"
+FX_COMMIT = "4a8f765c94f4e205ecae293d6d5c98ec9aef2200"
+FX_USER_AGENT = "fx/0.0.5"
+NANOCODEX_USER_AGENT = "nanocodex/0.5.0"
+FX_MODELS_CLIENT_VERSION = "0.148.0"
+FX_TOOL_NAMES = (
+    "read_file",
+    "glob_files",
+    "grep_files",
+    "list_files",
+    "file_info",
+    "semantic_search",
+    "edit_file",
+    "write_file",
+    "delete_file",
+    "rename_file",
+    "copy_file",
+    "create_folder",
+    "terminal",
+    "skill",
+    "install_skill",
+    "mcp_search_tools",
+    "mcp_select_tool",
+    "mcp_features",
+    "memory",
+    "ask_user_question",
+    "open_file",
+    "web_fetch",
+    "read_tool_result",
+)
+NANOCODEX_CODE_MODE_TOOL_NAMES = (
+    "apply_patch",
+    "exec_command",
+    "image_gen__imagegen",
+    "update_plan",
+    "view_image",
+    "web__run",
+    "write_stdin",
+)
+# Independently captured from the complete recursively serialized declarations
+# emitted by pinned fx ReleaseSafe and the reviewed Nanocodex reference binary.
+# Arrays retain order; object keys are sorted before hashing.
+FX_TOOL_DECLARATIONS_SHA256 = (
+    "db7668aa7bca40ca33a29f20a84862451981c6cbce8e63e184ced3e839ef838e"
+)
+NANOCODEX_TOOL_DECLARATIONS_SHA256 = (
+    "6bd9e3fa5ff2c7133df9896655a39dd5996aa5d1095f51e813e4cb9aceef213e"
+)
+FX_INSTRUCTIONS_TEMPLATE_SHA256 = (
+    "b7b8d2cfd6e009aa15fe38c5aa04f347467f0b6f60790081a5530d5db5bdc5b4"
+)
+NANOCODEX_ENVIRONMENT_TEMPLATE_SHA256 = (
+    "39fbdebee16a345383192ec568c8769e20b6f9d71695f6c169ffde166bc3b263"
+)
+NANOCODEX_TURN_METADATA_SHA256 = (
+    "5c9c0f1c728d07f8b0aa8f3ac48677cd7603c1ab6296161298519b0c909849a1"
+)
+# Filled only from independently reviewed reference requests. Candidate
+# preflight fingerprints remain a second live shape-switching guard.
+REFERENCE_BODY_FINGERPRINTS: dict[str, str] = {
+    "fx": "1b03392fc1a91cc8351fe24f5af0fb9fa49c627f229f302a4ecfb1f0d0239366",
+    "nanocodex": "ffc48fa031415e2dcd56e464cc60246fad491545e9fd61399468fa90cd3551a9",
+}
+AUTH_MINIMUM_LIFETIME_SECONDS = 10 * 60
+MAX_AUTH_BYTES = 1024 * 1024
+MAX_REQUEST_BYTES = 512 * 1024
+MAX_CLIENT_OUTPUT_BYTES = 1024 * 1024
+MAX_CLIENT_STDERR_BYTES = 1024 * 1024
+MAX_SSE_LINE_BYTES = 1024 * 1024
+MAX_SSE_FRAME_BYTES = 1024 * 1024
+CLIENT_TIMEOUT_SECONDS = 5 * 60
+UPSTREAM_CONNECT_TIMEOUT_SECONDS = 4
+UPSTREAM_RESOLVE_TIMEOUT_SECONDS = 4
+OBSERVER_RESULT_TIMEOUT_SECONDS = CLIENT_TIMEOUT_SECONDS + 30
+OBSERVER_SHUTDOWN_TIMEOUT_SECONDS = 5
+PROCESS_SHUTDOWN_TIMEOUT_SECONDS = 5
+MIN_TRIALS = 20
+MIN_PRIMARY_ELIGIBLE_PAIRS = 20
+MAX_TRIALS = 100
+MAX_WARMUP_PAIRS = 10
+MAX_PROVIDER_REQUESTS = 2 * (MAX_TRIALS + MAX_WARMUP_PAIRS)
+TIE_THRESHOLD_NS = 1_000_000
+XML_METACHAR_PREFLIGHT_DIRECTORY = "xml-path-&<>\"'"
+COMMIT_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+CLIENT_MESSAGE_ID_RE = re.compile(
+    r"^msg_[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+MODELS_DOCUMENT = {
+    "models": [
+        {
+            "slug": MODEL,
+            "visibility": "list",
+            "supported_in_api": True,
+            "supported_reasoning_levels": [{"effort": EFFORT}],
+            "additional_speed_tiers": [],
+            "input_modalities": ["text"],
+            "context_window": 272000,
+        },
+        {
+            "slug": "gpt-5.4-mini",
+            "visibility": "list",
+            "supported_in_api": True,
+            "supported_reasoning_levels": [{"effort": EFFORT}],
+            "additional_speed_tiers": [],
+            "input_modalities": ["text"],
+            "context_window": 128000,
+        },
+    ]
+}
+MODELS_BYTES = json.dumps(MODELS_DOCUMENT, separators=(",", ":")).encode("utf-8")
+
+RESPONSE_HEADER_NAMES = {
+    "content-type",
+    "cache-control",
+    "retry-after",
+    "x-request-id",
+    "x-reasoning-included",
+    "x-codex-turn-state",
+}
+PRODUCT_METADATA_HEADERS = {
+    "user-agent",
+    "originator",
+    "openai-beta",
+    "session-id",
+    "thread-id",
+    "x-client-request-id",
+    "x-openai-internal-codex-responses-lite",
+    "x-openai-fedramp",
+    "x-codex-turn-state",
+}
+TRANSPORT_REQUEST_HEADERS = {"host"}
+COMMON_GENERATION_REQUEST_HEADERS = {
+    "authorization",
+    "chatgpt-account-id",
+    "content-type",
+    "accept",
+    "content-length",
+}
+FX_GENERATION_REQUEST_HEADERS = TRANSPORT_REQUEST_HEADERS | (
+    COMMON_GENERATION_REQUEST_HEADERS
+    | {"user-agent", "originator", "openai-beta", "connection"}
+)
+NANOCODEX_GENERATION_REQUEST_HEADERS = TRANSPORT_REQUEST_HEADERS | (
+    COMMON_GENERATION_REQUEST_HEADERS
+    | {
+        "user-agent",
+        "session-id",
+        "thread-id",
+        "x-client-request-id",
+        "x-openai-internal-codex-responses-lite",
+    }
+)
+FX_MODELS_REQUEST_HEADERS = TRANSPORT_REQUEST_HEADERS | {
+    "authorization",
+    "chatgpt-account-id",
+    "user-agent",
+    "originator",
+    "accept",
+    "connection",
+}
+
+
+class BenchmarkError(RuntimeError):
+    """A safe-to-display benchmark configuration or integrity failure."""
+
+
+class RequestValidationError(BenchmarkError):
+    """A request failed its product-specific controlled-workload contract."""
+
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+@dataclasses.dataclass(frozen=True, repr=False)
+class AuthMaterial:
+    raw_codex_auth: bytes = dataclasses.field(repr=False)
+    access_token: str = dataclasses.field(repr=False)
+    refresh_token: str = dataclasses.field(repr=False)
+    account_id: str = dataclasses.field(repr=False)
+    expires_at_ms: int
+    secret_values: tuple[str, ...] = dataclasses.field(repr=False)
+    fedramp: bool = False
+
+    def __repr__(self) -> str:
+        return f"AuthMaterial(expires_at_ms={self.expires_at_ms}, credentials=<redacted>)"
+
+    def assert_live_window(self, now_seconds: float | None = None) -> None:
+        now = time.time() if now_seconds is None else now_seconds
+        if self.expires_at_ms / 1000 <= now + AUTH_MINIMUM_LIFETIME_SECONDS:
+            raise BenchmarkError(
+                "access JWT expires within the required 10-minute safety window"
+            )
+
+    def fx_document(self) -> dict[str, Any]:
+        return {
+            "version": 1,
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+            "expires_at_ms": self.expires_at_ms,
+            "account_id": self.account_id,
+        }
+
+    def safe_metadata(self) -> dict[str, Any]:
+        return {
+            "mode": "shared_codex_chatgpt_snapshot",
+            "minimum_remaining_lifetime_seconds": AUTH_MINIMUM_LIFETIME_SECONDS,
+            "fedramp": self.fedramp,
+        }
+
+
+@dataclasses.dataclass(frozen=True, repr=False)
+class _FakeAuthMaterial(AuthMaterial):
+    """Unmistakably fake credentials accepted only by the private test seam."""
+
+
+def _fake_auth_material(*, fedramp: bool = False) -> _FakeAuthMaterial:
+    def encoded(value: Mapping[str, Any]) -> str:
+        return base64.urlsafe_b64encode(
+            json.dumps(value, separators=(",", ":")).encode("utf-8")
+        ).decode("ascii").rstrip("=")
+
+    account_id = "00000000-0000-4000-8000-000000000001"
+    expires_at = 4_102_444_800  # 2100-01-01T00:00:00Z; unmistakably offline-only.
+    auth_claims = {
+        "chatgpt_account_id": account_id,
+        "chatgpt_account_is_fedramp": fedramp,
+    }
+
+    def token(claims: Mapping[str, Any], kind: str) -> str:
+        return ".".join(
+            (
+                encoded({"alg": "none", "typ": "JWT"}),
+                encoded(
+                    {
+                        "exp": expires_at,
+                        "https://api.openai.com/auth": claims,
+                    }
+                ),
+                f"offline-{kind}-signature",
+            )
+        )
+
+    # Deliberately contradictory claims prove that the product follows only
+    # the ID token for FedRAMP policy instead of accidentally consulting the
+    # bearer access token.
+    access_claims = {
+        "chatgpt_account_id": account_id,
+        "chatgpt_account_is_fedramp": not fedramp,
+    }
+    access_token = token(access_claims, "access")
+    id_token = token(auth_claims, "id")
+    refresh_token = "fake-benchmark-refresh-token"
+    raw_codex_auth = json.dumps(
+        {
+            "auth_mode": "chatgpt",
+            "tokens": {
+                "id_token": id_token,
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "account_id": account_id,
+            },
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+    derived_fedramp = _jwt_fedramp(_decode_jwt_payload(id_token))
+    return _FakeAuthMaterial(
+        raw_codex_auth=raw_codex_auth,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        account_id=account_id,
+        expires_at_ms=expires_at * 1_000,
+        secret_values=(
+            access_token,
+            id_token,
+            refresh_token,
+            account_id,
+        ),
+        fedramp=derived_fedramp,
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class ValidatedRequest:
+    model: str
+    reasoning_effort: str
+    service_tier: str
+    tool_count: int
+    tool_names_sha256: str
+    fingerprint_sha256: str
+    session_id: str | None
+    fresh_identifiers: tuple[str, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class ExpectedRequest:
+    implementation: str
+    pair: int
+    phase: str
+    instructions: str = SYSTEM_INSTRUCTIONS
+    prompt: str = ACK_TOKEN
+    home: str | None = None
+    workspace: str | None = None
+
+
+@dataclasses.dataclass
+class ProcessCapture:
+    returncode: int | None
+    stdout: bytes
+    stderr_bytes: int
+    timed_out: bool
+    stdout_truncated: bool = False
+    stderr_truncated: bool = False
+    output_limit_exceeded: bool = False
+
+
+@dataclasses.dataclass(frozen=True, repr=False)
+class CanonicalRequestHeaders:
+    authorization: str = dataclasses.field(repr=False)
+    account_id: str = dataclasses.field(repr=False)
+    content_length: int
+    session_id: str | None
+    metadata: tuple[tuple[str, str], ...]
+
+
+def _combined_request_fingerprint(
+    validated: ValidatedRequest, headers: CanonicalRequestHeaders
+) -> str:
+    normalized_metadata = [
+        [
+            name.lower(),
+            "<fresh-session>"
+            if name.lower()
+            in {"session-id", "thread-id", "x-client-request-id"}
+            else value,
+        ]
+        for name, value in headers.metadata
+        if name.lower() != "x-openai-fedramp"
+    ]
+    document = {
+        "body_sha256": validated.fingerprint_sha256,
+        "metadata_headers": normalized_metadata,
+    }
+    encoded = json.dumps(
+        document, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _required_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise BenchmarkError(f"auth snapshot is missing {label}")
+    return value
+
+
+def _decode_jwt_payload(token: str) -> Mapping[str, Any]:
+    parts = token.split(".")
+    if len(parts) != 3 or not parts[1]:
+        raise BenchmarkError("access token is not a three-part JWT")
+    payload = parts[1]
+    payload += "=" * (-len(payload) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(payload.encode("ascii"))
+        value = json.loads(decoded)
+    except (ValueError, UnicodeError, json.JSONDecodeError) as error:
+        raise BenchmarkError("access JWT payload is malformed") from error
+    if not isinstance(value, dict):
+        raise BenchmarkError("access JWT payload is not an object")
+    return value
+
+
+def _jwt_account_id(payload: Mapping[str, Any]) -> str | None:
+    claim = payload.get("https://api.openai.com/auth")
+    if isinstance(claim, dict):
+        account = claim.get("chatgpt_account_id")
+        if isinstance(account, str) and account:
+            return account
+    account = payload.get("chatgpt_account_id")
+    if isinstance(account, str) and account:
+        return account
+    return None
+
+
+def _jwt_fedramp(payload: Mapping[str, Any]) -> bool:
+    claim = payload.get("https://api.openai.com/auth")
+    if not isinstance(claim, dict):
+        return False
+    value = claim.get("chatgpt_account_is_fedramp")
+    return value is True
+
+
+def _collect_auth_secrets(document: Mapping[str, Any]) -> tuple[str, ...]:
+    found: list[str] = []
+
+    def visit(value: Any, key: str = "") -> None:
+        if isinstance(value, dict):
+            for child_key, child_value in value.items():
+                visit(child_value, str(child_key).lower())
+        elif isinstance(value, list):
+            for child in value:
+                visit(child, key)
+        elif isinstance(value, str) and value and (
+            "token" in key or "api_key" in key or key.endswith("key")
+        ):
+            found.append(value)
+
+    visit(document)
+    return tuple(dict.fromkeys(found))
+
+
+def load_auth_snapshot(
+    path: Path, *, now_seconds: float | None = None
+) -> AuthMaterial:
+    try:
+        info = path.stat()
+    except OSError as error:
+        raise BenchmarkError("Codex auth snapshot is not readable") from error
+    if not stat.S_ISREG(info.st_mode):
+        raise BenchmarkError("Codex auth snapshot is not a regular file")
+    if stat.S_IMODE(info.st_mode) & 0o077:
+        raise BenchmarkError("Codex auth snapshot must not be group/world accessible")
+    if info.st_size <= 0 or info.st_size > MAX_AUTH_BYTES:
+        raise BenchmarkError("Codex auth snapshot has an invalid size")
+    try:
+        raw = path.read_bytes()
+        document = json.loads(raw)
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise BenchmarkError("Codex auth snapshot is malformed") from error
+    if not isinstance(document, dict) or not isinstance(document.get("tokens"), dict):
+        raise BenchmarkError("Codex auth snapshot does not contain ChatGPT tokens")
+    tokens = document["tokens"]
+    access_token = _required_string(tokens.get("access_token"), "tokens.access_token")
+    refresh_token = _required_string(tokens.get("refresh_token"), "tokens.refresh_token")
+    payload = _decode_jwt_payload(access_token)
+    id_token = _required_string(tokens.get("id_token"), "tokens.id_token")
+    id_payload = _decode_jwt_payload(id_token)
+    expiry = payload.get("exp")
+    if isinstance(expiry, bool) or not isinstance(expiry, int) or expiry <= 0:
+        raise BenchmarkError("access JWT has no valid exp claim")
+    token_account = _jwt_account_id(payload)
+    stored_account = tokens.get("account_id")
+    if stored_account is not None and (
+        not isinstance(stored_account, str) or not stored_account
+    ):
+        raise BenchmarkError("Codex auth snapshot has an invalid account_id")
+    account_id = stored_account or token_account
+    if not account_id:
+        raise BenchmarkError("Codex auth snapshot has no ChatGPT account identity")
+    if token_account is not None and token_account != account_id:
+        raise BenchmarkError("Codex auth snapshot account identity disagrees with its JWT")
+    id_account = _jwt_account_id(id_payload)
+    if id_account is not None and id_account != account_id:
+        raise BenchmarkError("Codex auth snapshot account identity disagrees with its ID token")
+    secret_values = tuple(
+        dict.fromkeys((*_collect_auth_secrets(document), account_id))
+    )
+    material = AuthMaterial(
+        raw_codex_auth=raw,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        account_id=account_id,
+        expires_at_ms=expiry * 1000,
+        secret_values=secret_values,
+        fedramp=_jwt_fedramp(id_payload),
+    )
+    material.assert_live_window(now_seconds)
+    return material
+
+
+def _mkdir_private(path: Path) -> None:
+    path.mkdir(mode=0o700, parents=True, exist_ok=False)
+    os.chmod(path, 0o700)
+
+
+def _write_private(path: Path, contents: bytes) -> None:
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb", closefd=True) as handle:
+            handle.write(contents)
+            handle.flush()
+        os.chmod(path, 0o600)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.close(descriptor)
+        raise
+
+
+def prepare_fx_home(home: Path, auth: AuthMaterial) -> Path:
+    _mkdir_private(home)
+    fx_dir = home / ".fx"
+    _mkdir_private(fx_dir)
+    auth_bytes = (
+        json.dumps(auth.fx_document(), separators=(",", ":")) + "\n"
+    ).encode("utf-8")
+    settings = {
+        "provider": "codex",
+        "codex_model": MODEL,
+        "effort": EFFORT,
+        "fast_mode": False,
+    }
+    _write_private(fx_dir / "chatgpt-auth.json", auth_bytes)
+    _write_private(
+        fx_dir / "settings.json",
+        (json.dumps(settings, separators=(",", ":")) + "\n").encode("utf-8"),
+    )
+    return fx_dir
+
+
+def prepare_nanocodex_home(home: Path, auth: AuthMaterial) -> Path:
+    _mkdir_private(home)
+    codex_dir = home / ".codex"
+    _mkdir_private(codex_dir)
+    auth_path = codex_dir / "auth.json"
+    _write_private(auth_path, auth.raw_codex_auth)
+    return auth_path
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def fnv1a64(text: str) -> str:
+    value = 0xCBF29CE484222325
+    for byte in text.encode("utf-8"):
+        value ^= byte
+        value = (value * 0x100000001B3) & 0xFFFFFFFFFFFFFFFF
+    return f"{value:016x}"
+
+
+def _canonical_json_sha256(value: Any) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("ascii")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _host_shell_name() -> str:
+    configured = os.environ.get("SHELL")
+    if not configured:
+        configured = pwd.getpwuid(os.getuid()).pw_shell
+    name = Path(configured).name
+    if re.fullmatch(r"[A-Za-z0-9._+-]{1,128}", name) is None:
+        raise BenchmarkError("host login shell cannot be represented safely")
+    return name
+
+
+def _host_timezone_name() -> str:
+    zoneinfo_marker = "/zoneinfo/"
+    resolved = os.path.realpath("/etc/localtime")
+    if zoneinfo_marker in resolved:
+        name = resolved.split(zoneinfo_marker, 1)[1]
+    else:
+        local = time.localtime()
+        index = 1 if local.tm_isdst > 0 and len(time.tzname) > 1 else 0
+        name = time.tzname[index]
+    if (
+        not name
+        or len(name.encode("utf-8")) > 256
+        or any(ord(character) < 0x20 or ord(character) > 0x7E for character in name)
+    ):
+        raise BenchmarkError("host timezone cannot be represented safely")
+    return name
+
+
+def _nanocodex_environment_text(
+    workspace: str, *, shell: str, current_date: str, timezone: str
+) -> str:
+    workspace = _xml_escape_text(workspace)
+    shell = _xml_escape_text(shell)
+    current_date = _xml_escape_text(current_date)
+    timezone = _xml_escape_text(timezone)
+    return (
+        "<environment_context>\n"
+        f"  <cwd>{workspace}</cwd>\n"
+        f"  <shell>{shell}</shell>\n"
+        f"  <current_date>{current_date}</current_date>\n"
+        f"  <timezone>{timezone}</timezone>\n"
+        "  <filesystem><workspace_roots><root>"
+        f"{workspace}"
+        "</root></workspace_roots><permission_profile type=\"disabled\">"
+        "<file_system type=\"unrestricted\" /></permission_profile></filesystem>\n"
+        "</environment_context>"
+    )
+
+
+def _xml_escape_text(value: str) -> str:
+    return "".join(
+        {
+            "&": "&amp;",
+            "<": "&lt;",
+            ">": "&gt;",
+            '"': "&quot;",
+            "'": "&apos;",
+        }.get(character, character)
+        for character in value
+    )
+
+
+def _expected_nanocodex_environment_text(workspace: str) -> str:
+    return _nanocodex_environment_text(
+        workspace,
+        shell=_host_shell_name(),
+        current_date=dt.datetime.now().astimezone().date().isoformat(),
+        timezone=_host_timezone_name(),
+    )
+
+
+def _canonical_nanocodex_environment_text() -> str:
+    return _nanocodex_environment_text(
+        "<private-workspace>",
+        shell="<host-shell>",
+        current_date="<current-local-date>",
+        timezone="<host-timezone>",
+    )
+
+
+def _normalized_fx_instructions(
+    value: Any,
+    *,
+    instructions: str,
+    home: str | None,
+    workspace: str | None,
+) -> str:
+    if not isinstance(value, str):
+        raise RequestValidationError("fx_runtime_context_invalid")
+    start = "<fx-turn-context>\n"
+    end = "\n</fx-turn-context>"
+    if value.count(start) != 1 or value.count(end) != 1:
+        raise RequestValidationError("fx_runtime_context_invalid")
+    prefix, remainder = value.split(start, 1)
+    context, suffix = remainder.split(end, 1)
+    if not prefix.startswith(instructions + "\n\n"):
+        raise RequestValidationError("benchmark_instructions_mismatch")
+    lines = context.splitlines()
+    if len(lines) != 7 or any(": " not in line for line in lines):
+        raise RequestValidationError("fx_runtime_context_invalid")
+    fields = dict(line.split(": ", 1) for line in lines)
+    expected_keys = (
+        "workspace_root",
+        "current_directory",
+        "operating_system",
+        "shell_path",
+        "date_utc",
+        "home_directory",
+        "git_worktree",
+    )
+    if tuple(fields) != expected_keys:
+        raise RequestValidationError("fx_runtime_context_invalid")
+    expected_workspace = workspace or fields["workspace_root"]
+    expected_home = home or fields["home_directory"]
+    expected_values = {
+        "workspace_root": expected_workspace,
+        "current_directory": expected_workspace,
+        "operating_system": f"{platform.system()} {platform.release()}",
+        "shell_path": "(unknown)",
+        "date_utc": dt.datetime.now(dt.timezone.utc).date().isoformat(),
+        "home_directory": expected_home,
+        "git_worktree": "unknown",
+    }
+    if fields != expected_values:
+        raise RequestValidationError("fx_runtime_context_invalid")
+    normalized_context = "\n".join(
+        (
+            "workspace_root: <private-workspace>",
+            "current_directory: <private-workspace>",
+            "operating_system: <host-operating-system>",
+            "shell_path: (unknown)",
+            "date_utc: <current-utc-date>",
+            "home_directory: <private-home>",
+            "git_worktree: unknown",
+        )
+    )
+    normalized = prefix + start + normalized_context + end + suffix
+    if hashlib.sha256(normalized.encode("utf-8")).hexdigest() != (
+        FX_INSTRUCTIONS_TEMPLATE_SHA256
+    ):
+        raise RequestValidationError("fx_instructions_contract_mismatch")
+    return normalized
+
+
+def _tool_declaration_name(tool: Any) -> str:
+    if not isinstance(tool, dict):
+        raise RequestValidationError("tool_declaration_not_object")
+    kind = tool.get("type")
+    if not isinstance(kind, str) or not kind:
+        raise RequestValidationError("tool_declaration_missing_type")
+    if kind == "function":
+        name = tool.get("name")
+        if not isinstance(name, str) or not name or not isinstance(tool.get("parameters"), dict):
+            raise RequestValidationError("invalid_function_tool_declaration")
+        return name
+    if kind == "custom":
+        name = tool.get("name")
+        if not isinstance(name, str) or not name or not isinstance(tool.get("format"), dict):
+            raise RequestValidationError("invalid_custom_tool_declaration")
+        return name
+    if kind == "namespace":
+        name = tool.get("name")
+        children = tool.get("tools")
+        if not isinstance(name, str) or not name or not isinstance(children, list) or not children:
+            raise RequestValidationError("invalid_namespace_tool_declaration")
+        for child in children:
+            _tool_declaration_name(child)
+        return name
+    if kind == "tool_search":
+        if not isinstance(tool.get("execution"), str) or not tool["execution"]:
+            raise RequestValidationError("invalid_tool_search_declaration")
+        if not isinstance(tool.get("parameters"), dict):
+            raise RequestValidationError("invalid_tool_search_declaration")
+        return "tool_search"
+    raise RequestValidationError("unsupported_tool_declaration_type")
+
+
+def _extract_tools(body: Mapping[str, Any], implementation: str) -> list[Any]:
+    if implementation == "fx":
+        tools = body.get("tools")
+        if not isinstance(tools, list) or not tools:
+            raise RequestValidationError("fx_top_level_tools_missing")
+        return tools
+    if implementation != "nanocodex":
+        raise RequestValidationError("unknown_implementation")
+    request_input = body.get("input")
+    if not isinstance(request_input, list) or len(request_input) != 5:
+        raise RequestValidationError("nanocodex_input_missing")
+    additional = request_input[0]
+    if (
+        not isinstance(additional, dict)
+        or set(additional) != {"type", "role", "tools"}
+        or additional.get("type") != "additional_tools"
+        or additional.get("role") != "developer"
+        or not isinstance(additional.get("tools"), list)
+    ):
+        raise RequestValidationError("nanocodex_additional_tools_missing")
+    tools = additional["tools"]
+    if not tools:
+        raise RequestValidationError("nanocodex_additional_tools_empty")
+    return tools
+
+
+def _reject_duplicate_json_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, child in pairs:
+        if key in value:
+            raise RequestValidationError("duplicate_json_object_key")
+        value[key] = child
+    return value
+
+
+def _exact_text_message(
+    item: Any,
+    *,
+    role: str,
+    text: str,
+    typed: bool,
+    client_id: bool = False,
+) -> bool:
+    expected_keys = {"role", "content"} | ({"type"} if typed else set())
+    if client_id:
+        expected_keys.add("id")
+    if not isinstance(item, dict) or set(item) != expected_keys:
+        return False
+    if item.get("role") != role or (typed and item.get("type") != "message"):
+        return False
+    if client_id and not _valid_client_message_id(item.get("id")):
+        return False
+    return item.get("content") == [{"type": "input_text", "text": text}]
+
+
+def _valid_client_message_id(value: Any) -> bool:
+    return _client_message_uuid(value) is not None
+
+
+def _client_message_uuid(value: Any) -> str | None:
+    if not isinstance(value, str) or CLIENT_MESSAGE_ID_RE.fullmatch(value) is None:
+        return None
+    candidate = value.removeprefix("msg_")
+    return candidate if _valid_uuid7(candidate) else None
+
+
+def _valid_uuid7(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    try:
+        parsed = uuid.UUID(value)
+    except (ValueError, AttributeError):
+        return False
+    return parsed.version == 7 and str(parsed) == value
+
+
+def _validate_nanocodex_environment_item(item: Any, workspace: str | None) -> str:
+    if (
+        not isinstance(item, dict)
+        or set(item) != {"type", "id", "role", "content"}
+        or item.get("type") != "message"
+        or item.get("role") != "user"
+        or not _valid_client_message_id(item.get("id"))
+    ):
+        raise RequestValidationError("nanocodex_environment_context_invalid")
+    content = item.get("content")
+    if (
+        not isinstance(content, list)
+        or len(content) != 1
+        or not isinstance(content[0], dict)
+        or set(content[0]) != {"type", "text"}
+        or content[0].get("type") != "input_text"
+        or not isinstance(content[0].get("text"), str)
+    ):
+        raise RequestValidationError("nanocodex_environment_context_invalid")
+    raw_text = content[0]["text"]
+    try:
+        root = ET.fromstring(raw_text)
+    except ET.ParseError as error:
+        raise RequestValidationError("nanocodex_environment_context_invalid") from error
+    if root.tag != "environment_context" or root.attrib:
+        raise RequestValidationError("nanocodex_environment_context_invalid")
+    children = list(root)
+    if [child.tag for child in children] != [
+        "cwd",
+        "shell",
+        "current_date",
+        "timezone",
+        "filesystem",
+    ]:
+        raise RequestValidationError("nanocodex_environment_context_invalid")
+    cwd, shell, current_date, timezone, filesystem = children
+    for child in (cwd, shell, current_date, timezone):
+        if child.attrib or list(child) or not isinstance(child.text, str) or not child.text:
+            raise RequestValidationError("nanocodex_environment_context_invalid")
+    if workspace is not None and cwd.text != workspace:
+        raise RequestValidationError("nanocodex_workspace_context_mismatch")
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", current_date.text or "") is None:
+        raise RequestValidationError("nanocodex_environment_context_invalid")
+    if filesystem.attrib or (filesystem.text or "").strip() or len(filesystem) != 2:
+        raise RequestValidationError("nanocodex_environment_context_invalid")
+    workspace_roots = filesystem[0]
+    if workspace_roots.tag != "workspace_roots" or workspace_roots.attrib or len(workspace_roots) != 1:
+        raise RequestValidationError("nanocodex_environment_context_invalid")
+    workspace_root = workspace_roots[0]
+    if (
+        workspace_root.tag != "root"
+        or workspace_root.attrib
+        or list(workspace_root)
+        or workspace_root.text != cwd.text
+        or len(filesystem) != 2
+    ):
+        raise RequestValidationError("nanocodex_environment_context_invalid")
+    permission_profile = filesystem[1]
+    if (
+        permission_profile.tag != "permission_profile"
+        or permission_profile.attrib != {"type": "disabled"}
+        or (permission_profile.text or "").strip()
+        or len(permission_profile) != 1
+    ):
+        raise RequestValidationError("nanocodex_environment_context_invalid")
+    file_system = permission_profile[0]
+    if (
+        file_system.tag != "file_system"
+        or file_system.attrib != {"type": "unrestricted"}
+        or list(file_system)
+        or (file_system.text or "").strip()
+    ):
+        raise RequestValidationError("nanocodex_environment_context_invalid")
+    if workspace is not None:
+        if (
+            shell.text != _host_shell_name()
+            or current_date.text
+            != dt.datetime.now().astimezone().date().isoformat()
+            or timezone.text != _host_timezone_name()
+            or raw_text != _expected_nanocodex_environment_text(workspace)
+        ):
+            raise RequestValidationError("nanocodex_environment_context_invalid")
+    canonical = _canonical_nanocodex_environment_text()
+    if hashlib.sha256(canonical.encode("utf-8")).hexdigest() != (
+        NANOCODEX_ENVIRONMENT_TEMPLATE_SHA256
+    ):
+        raise RequestValidationError("nanocodex_environment_contract_mismatch")
+    return canonical
+
+
+def _validated_nanocodex_metadata(body: Mapping[str, Any]) -> dict[str, Any]:
+    cache_key = body.get("prompt_cache_key")
+    if cache_key != NANOCODEX_PROMPT_CACHE_KEY:
+        raise RequestValidationError("nanocodex_prompt_cache_key_mismatch")
+    metadata = body.get("client_metadata")
+    if not isinstance(metadata, dict):
+        raise RequestValidationError("nanocodex_client_metadata_invalid")
+    if set(metadata) != {"session_id", "thread_id", "x-codex-turn-metadata"}:
+        raise RequestValidationError("nanocodex_client_metadata_invalid")
+    session_id = metadata.get("session_id")
+    if (
+        not _valid_uuid7(session_id)
+        or metadata.get("thread_id") != session_id
+    ):
+        raise RequestValidationError("nanocodex_session_identity_invalid")
+    normalized: dict[str, Any] = {
+        "session_id": "<fresh-session>",
+        "thread_id": "<fresh-session>",
+    }
+    turn_metadata = metadata["x-codex-turn-metadata"]
+    if not isinstance(turn_metadata, str) or not turn_metadata:
+        raise RequestValidationError("nanocodex_turn_metadata_invalid")
+    try:
+        decoded = json.loads(
+            turn_metadata, object_pairs_hook=_reject_duplicate_json_pairs
+        )
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise RequestValidationError("nanocodex_turn_metadata_invalid") from error
+    expected_names = {
+        name: {"name": name, "namespace": None}
+        for name in NANOCODEX_CODE_MODE_TOOL_NAMES
+    }
+    if decoded != {"code_mode_tool_names": expected_names}:
+        raise RequestValidationError("nanocodex_turn_metadata_invalid")
+    if _canonical_json_sha256(decoded) != NANOCODEX_TURN_METADATA_SHA256:
+        raise RequestValidationError("nanocodex_turn_metadata_contract_mismatch")
+    normalized["x-codex-turn-metadata"] = decoded
+    return normalized
+
+
+def _stable_request_fingerprint(
+    body: Mapping[str, Any],
+    implementation: str,
+    *,
+    instructions: str = SYSTEM_INSTRUCTIONS,
+    home: str | None,
+    workspace: str | None,
+) -> str:
+    normalized = json.loads(json.dumps(body, separators=(",", ":")))
+    if implementation == "nanocodex":
+        normalized["client_metadata"] = _validated_nanocodex_metadata(body)
+        for item in normalized["input"][2:]:
+            item["id"] = "<fresh-client-item>"
+        normalized["input"][3]["content"][0]["text"] = (
+            _validate_nanocodex_environment_item(body["input"][3], workspace)
+        )
+    elif implementation == "fx":
+        normalized["instructions"] = _normalized_fx_instructions(
+            body.get("instructions"),
+            instructions=instructions,
+            home=home,
+            workspace=workspace,
+        )
+    else:
+        raise RequestValidationError("unknown_implementation")
+    return _canonical_json_sha256(normalized)
+
+
+def validate_request_body(
+    raw_body: bytes,
+    implementation: str,
+    *,
+    instructions: str = SYSTEM_INSTRUCTIONS,
+    prompt: str = ACK_TOKEN,
+    home: str | None = None,
+    workspace: str | None = None,
+) -> ValidatedRequest:
+    if not raw_body or len(raw_body) > MAX_REQUEST_BYTES:
+        raise RequestValidationError("invalid_request_size")
+    try:
+        body = json.loads(raw_body, object_pairs_hook=_reject_duplicate_json_pairs)
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise RequestValidationError("request_body_not_json") from error
+    if not isinstance(body, dict):
+        raise RequestValidationError("request_body_not_object")
+    if implementation not in {"fx", "nanocodex"}:
+        raise RequestValidationError("unknown_implementation")
+    if "previous_response_id" in body:
+        raise RequestValidationError("unexpected_previous_response_id")
+    if "service_tier" in body:
+        raise RequestValidationError("service_tier_must_be_standard_omission")
+    if "type" in body:
+        raise RequestValidationError("https_request_type_must_be_absent")
+    if body.get("store") is not False:
+        raise RequestValidationError("store_must_be_false")
+    if "background" in body:
+        raise RequestValidationError("background_must_be_absent")
+    if body.get("model") != MODEL:
+        raise RequestValidationError("model_mismatch")
+    if body.get("stream") is not True:
+        raise RequestValidationError("stream_must_be_true")
+    request_input = body.get("input")
+    if not isinstance(request_input, list):
+        raise RequestValidationError("request_input_missing")
+    session_id: str | None = None
+    fresh_identifiers: tuple[str, ...] = ()
+
+    if implementation == "fx":
+        required = {
+            "model",
+            "store",
+            "stream",
+            "instructions",
+            "input",
+            "tools",
+            "tool_choice",
+            "parallel_tool_calls",
+            "include",
+            "text",
+            "reasoning",
+        }
+        if set(body) != required:
+            raise RequestValidationError("fx_top_level_shape_invalid")
+        _normalized_fx_instructions(
+            body.get("instructions"),
+            instructions=instructions,
+            home=home,
+            workspace=workspace,
+        )
+        if len(request_input) != 1 or not _exact_text_message(
+            request_input[0], role="user", text=prompt, typed=False
+        ):
+            raise RequestValidationError("fresh_user_input_mismatch")
+        if body.get("reasoning") != {"effort": EFFORT, "summary": "auto"}:
+            raise RequestValidationError("reasoning_controls_mismatch")
+        expected_parallel = True
+        reasoning_effort = EFFORT
+    else:
+        required = {
+            "model",
+            "store",
+            "stream",
+            "input",
+            "tool_choice",
+            "parallel_tool_calls",
+            "include",
+            "prompt_cache_key",
+            "text",
+            "reasoning",
+            "client_metadata",
+        }
+        if set(body) != required:
+            raise RequestValidationError("nanocodex_top_level_shape_invalid")
+        _extract_tools(body, implementation)
+        if len(request_input) != 5:
+            raise RequestValidationError("nanocodex_input_missing")
+        if not _exact_text_message(
+            request_input[1], role="developer", text=instructions, typed=True
+        ):
+            raise RequestValidationError("benchmark_instructions_mismatch")
+        if not _exact_text_message(
+            request_input[2],
+            role="developer",
+            text=NANOCODEX_PERMISSIONS_INSTRUCTIONS,
+            typed=True,
+            client_id=True,
+        ):
+            raise RequestValidationError("nanocodex_permissions_context_mismatch")
+        _validate_nanocodex_environment_item(request_input[3], workspace)
+        if not _exact_text_message(
+            request_input[4],
+            role="user",
+            text=prompt,
+            typed=True,
+            client_id=True,
+        ):
+            raise RequestValidationError("fresh_user_input_mismatch")
+        item_ids = tuple(request_input[index]["id"] for index in range(2, 5))
+        item_uuids = tuple(_client_message_uuid(value) for value in item_ids)
+        if any(value is None for value in item_uuids):
+            raise RequestValidationError("nanocodex_client_item_id_invalid")
+        if body.get("reasoning") != {
+            "effort": EFFORT,
+            "summary": "auto",
+            "context": "all_turns",
+        }:
+            raise RequestValidationError("reasoning_controls_mismatch")
+        _validated_nanocodex_metadata(body)
+        session_id = body["client_metadata"]["session_id"]
+        fresh_identifiers = (session_id, *(value for value in item_uuids if value))
+        if len(set(fresh_identifiers)) != len(fresh_identifiers):
+            raise RequestValidationError("nanocodex_request_identifiers_reused")
+        expected_parallel = False
+        reasoning_effort = EFFORT
+
+    if body.get("tool_choice") != "auto":
+        raise RequestValidationError("tool_choice_mismatch")
+    if body.get("parallel_tool_calls") is not expected_parallel:
+        raise RequestValidationError("parallel_tool_calls_mismatch")
+    if body.get("include") != ["reasoning.encrypted_content"]:
+        raise RequestValidationError("include_mismatch")
+    if body.get("text") != {"verbosity": "low"}:
+        raise RequestValidationError("text_controls_mismatch")
+
+    tools = _extract_tools(body, implementation)
+    names = [_tool_declaration_name(tool) for tool in tools]
+    if len(set(names)) != len(names):
+        raise RequestValidationError("duplicate_tool_declaration_name")
+    tool_contract_hash = _canonical_json_sha256(tools)
+    if implementation == "nanocodex":
+        if names != ["exec", "wait"]:
+            raise RequestValidationError("nanocodex_default_tool_surface_mismatch")
+        if tool_contract_hash != NANOCODEX_TOOL_DECLARATIONS_SHA256:
+            raise RequestValidationError("nanocodex_tool_contract_mismatch")
+    else:
+        if names != list(FX_TOOL_NAMES):
+            raise RequestValidationError("fx_default_tool_surface_mismatch")
+        if tool_contract_hash != FX_TOOL_DECLARATIONS_SHA256:
+            raise RequestValidationError("fx_tool_contract_mismatch")
+    names_bytes = json.dumps(sorted(names), separators=(",", ":")).encode("utf-8")
+    fingerprint = _stable_request_fingerprint(
+        body,
+        implementation,
+        instructions=instructions,
+        home=home,
+        workspace=workspace,
+    )
+    reference = REFERENCE_BODY_FINGERPRINTS[implementation]
+    if reference and fingerprint != reference:
+        raise RequestValidationError(f"{implementation}_request_contract_mismatch")
+    return ValidatedRequest(
+        model=MODEL,
+        reasoning_effort=reasoning_effort,
+        service_tier="standard",
+        tool_count=len(tools),
+        tool_names_sha256=hashlib.sha256(names_bytes).hexdigest(),
+        fingerprint_sha256=fingerprint,
+        session_id=session_id,
+        fresh_identifiers=fresh_identifiers,
+    )
+
+
+def _nonempty_delta(event: Mapping[str, Any]) -> str | None:
+    value = event.get("delta")
+    if isinstance(value, str) and value:
+        return value
+    if isinstance(value, dict):
+        for key in ("text", "content", "refusal"):
+            child = value.get(key)
+            if isinstance(child, str) and child:
+                return child
+    return None
+
+
+def _cached_input_tokens(event: Mapping[str, Any]) -> int | None:
+    response = event.get("response")
+    if not isinstance(response, dict):
+        return None
+    usage = response.get("usage")
+    if not isinstance(usage, dict):
+        return None
+    candidates: list[Any] = [usage.get("cached_input_tokens")]
+    for key in ("input_tokens_details", "input_token_details"):
+        details = usage.get(key)
+        if isinstance(details, dict):
+            candidates.append(details.get("cached_tokens"))
+    observed: list[int] = []
+    for value in candidates:
+        if value is None:
+            continue
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError("invalid cached token count")
+        observed.append(value)
+    if len(set(observed)) > 1:
+        raise ValueError("conflicting cached token counts")
+    return observed[0] if observed else None
+
+
+TOOL_OUTPUT_TYPES = {
+    "function_call",
+    "custom_tool_call",
+    "computer_call",
+    "mcp_call",
+    "shell_call",
+    "local_shell_call",
+    "web_search_call",
+    "code_interpreter_call",
+    "image_generation_call",
+    "tool_search_call",
+}
+BENIGN_OUTPUT_ITEM_TYPES = {"message", "reasoning"}
+
+
+def _event_indicates_tool_call(event_type: str, item_kind: Any) -> bool:
+    if isinstance(item_kind, str):
+        if item_kind in TOOL_OUTPUT_TYPES or item_kind.endswith("_call"):
+            return True
+        if event_type in {
+            "response.output_item.added",
+            "response.output_item.done",
+        } and item_kind not in BENIGN_OUTPUT_ITEM_TYPES:
+            return True
+    return any(kind in event_type for kind in TOOL_OUTPUT_TYPES) or (
+        "function_call_arguments" in event_type
+        or "tool_call" in event_type
+        or re.search(r"(?:^|\.)[^.]*_call(?:\.|$)", event_type) is not None
+    )
+
+
+class SSEObservation:
+    """Incrementally extracts provider timestamps without retaining event data."""
+
+    def __init__(self, t0_ns: int):
+        self.t0_ns = t0_ns
+        self.first_model_output_ns: int | None = None
+        self.first_answer_text_ns: int | None = None
+        self.terminal_ns: int | None = None
+        self.terminal_type: str | None = None
+        self.status = "streaming"
+        self.cached_input_tokens: int | None = None
+        self.tool_call_ids: set[str] = set()
+        self.tool_call_without_id = False
+        self.error: str | None = None
+        self._data_lines: list[str] = []
+        self._event_latest_ns: int | None = None
+
+    def feed_line(self, raw_line: bytes, received_ns: int) -> None:
+        try:
+            line = raw_line.decode("utf-8").rstrip("\r\n")
+        except UnicodeError:
+            self.error = self.error or "malformed_sse_utf8"
+            return
+        if not line:
+            self._dispatch()
+            return
+        if line.startswith(":"):
+            return
+        if line.startswith("data:"):
+            value = line[5:]
+            if value.startswith(" "):
+                value = value[1:]
+            self._event_latest_ns = received_ns
+            self._data_lines.append(value)
+
+    def finish(self) -> None:
+        self._dispatch()
+        if self.terminal_ns is None and self.error is None:
+            self.error = "missing_terminal_event"
+            self.status = "incomplete"
+
+    def _dispatch(self) -> None:
+        if not self._data_lines:
+            self._event_latest_ns = None
+            return
+        data = "\n".join(self._data_lines)
+        event_ns = (
+            self._event_latest_ns
+            if self._event_latest_ns is not None
+            else self.t0_ns
+        )
+        self._data_lines.clear()
+        self._event_latest_ns = None
+        if data == "[DONE]":
+            return
+        try:
+            event = json.loads(data)
+        except json.JSONDecodeError:
+            self.error = self.error or "malformed_sse_json"
+            return
+        if not isinstance(event, dict):
+            self.error = self.error or "malformed_sse_event"
+            return
+        self._observe_event(event, event_ns)
+
+    def _observe_event(self, event: Mapping[str, Any], event_ns: int) -> None:
+        event_type = event.get("type")
+        if not isinstance(event_type, str):
+            return
+        delta = _nonempty_delta(event)
+        if delta is not None and event_type in {
+            "response.output_text.delta",
+            "response.refusal.delta",
+            "response.reasoning_summary_text.delta",
+            "response.reasoning_summary.delta",
+            "response.reasoning_text.delta",
+        }:
+            if self.first_model_output_ns is None:
+                self.first_model_output_ns = event_ns
+            if event_type == "response.output_text.delta" and self.first_answer_text_ns is None:
+                self.first_answer_text_ns = event_ns
+
+        item = event.get("item")
+        item_kind = item.get("type") if isinstance(item, dict) else None
+        tool_event = _event_indicates_tool_call(event_type, item_kind)
+        if tool_event:
+            identity: Any = event.get("call_id")
+            if identity is None and isinstance(item, dict):
+                identity = item.get("call_id") or item.get("id")
+            if isinstance(identity, str) and identity:
+                self.tool_call_ids.add(identity)
+            else:
+                self.tool_call_without_id = True
+
+        if event_type in {
+            "response.completed",
+            "response.failed",
+            "response.incomplete",
+            "response.cancelled",
+        }:
+            if self.terminal_ns is not None:
+                self.error = "duplicate_terminal_event"
+                self.status = "failed"
+                return
+            self.terminal_ns = event_ns
+            self.terminal_type = event_type
+            response = event.get("response")
+            response_status = response.get("status") if isinstance(response, dict) else None
+            if isinstance(response_status, str) and response_status:
+                self.status = response_status
+            else:
+                self.status = event_type.removeprefix("response.")
+            try:
+                self.cached_input_tokens = _cached_input_tokens(event)
+            except ValueError:
+                self.error = self.error or "invalid_cached_input_tokens"
+            if isinstance(response, dict) and isinstance(response.get("output"), list):
+                for output_item in response["output"]:
+                    if isinstance(output_item, dict) and _event_indicates_tool_call(
+                        "response.output_item.done", output_item.get("type")
+                    ):
+                        identity = output_item.get("call_id") or output_item.get("id")
+                        if isinstance(identity, str) and identity:
+                            self.tool_call_ids.add(identity)
+                        else:
+                            self.tool_call_without_id = True
+            if event_type != "response.completed":
+                self.error = self.error or "provider_terminal_failure"
+
+    @staticmethod
+    def _elapsed(timestamp: int | None, origin: int) -> int | None:
+        return None if timestamp is None else max(0, timestamp - origin)
+
+    def has_tool_call(self) -> bool:
+        return bool(self.tool_call_ids) or self.tool_call_without_id
+
+    def record(self) -> dict[str, Any]:
+        tool_count = len(self.tool_call_ids) + int(self.tool_call_without_id)
+        return {
+            "t0_monotonic_ns": self.t0_ns,
+            "first_model_output_monotonic_ns": self.first_model_output_ns,
+            "first_answer_text_monotonic_ns": self.first_answer_text_ns,
+            "terminal_monotonic_ns": self.terminal_ns,
+            "timing_ns": {
+                "time_to_first_model_output": self._elapsed(
+                    self.first_model_output_ns, self.t0_ns
+                ),
+                "time_to_first_answer_text": self._elapsed(
+                    self.first_answer_text_ns, self.t0_ns
+                ),
+                "time_to_terminal": self._elapsed(self.terminal_ns, self.t0_ns),
+            },
+            "terminal_event": self.terminal_type,
+            "cached_input_tokens": self.cached_input_tokens,
+            "tool_call_detected": tool_count > 0,
+            "tool_call_count": tool_count,
+            "status": self.status,
+            "error": self.error,
+        }
+
+
+def observe_sse_lines(
+    lines: Iterable[tuple[bytes, int]], *, t0_ns: int
+) -> dict[str, Any]:
+    observation = SSEObservation(t0_ns)
+    for line, received_ns in lines:
+        observation.feed_line(line, received_ns)
+    observation.finish()
+    return observation.record()
+
+
+class AuthIdentityMatcher:
+    """Retains only expected credential fingerprints in process memory."""
+
+    def __init__(self, auth: AuthMaterial):
+        self._bearer = hashlib.sha256(auth.access_token.encode("utf-8")).digest()
+        self._account = hashlib.sha256(auth.account_id.encode("utf-8")).digest()
+        self.fedramp = auth.fedramp
+        self._seen: set[str] = set()
+        self._mismatch = False
+        self._lock = threading.Lock()
+
+    def observe(self, implementation: str, authorization: str | None, account: str | None) -> None:
+        if not isinstance(authorization, str) or not authorization.startswith("Bearer "):
+            self._reject()
+        token = authorization[7:] if authorization is not None else ""
+        if (
+            not token
+            or token != token.strip()
+            or not isinstance(account, str)
+            or not account
+            or account != account.strip()
+        ):
+            self._reject()
+        bearer = hashlib.sha256(token.encode("utf-8")).digest()
+        account_fingerprint = hashlib.sha256(account.encode("utf-8")).digest()
+        with self._lock:
+            if bearer != self._bearer or account_fingerprint != self._account:
+                self._mismatch = True
+                raise RequestValidationError("shared_auth_identity_mismatch")
+            self._seen.add(implementation)
+
+    def _reject(self) -> None:
+        with self._lock:
+            self._mismatch = True
+        raise RequestValidationError("shared_auth_identity_missing")
+
+    def verified(self) -> bool:
+        return self.verified_for({"fx", "nanocodex"})
+
+    def verified_for(self, implementations: set[str]) -> bool:
+        with self._lock:
+            return not self._mismatch and self._seen == implementations
+
+
+@dataclasses.dataclass
+class _Armed:
+    expected: ExpectedRequest
+    claimed: bool = False
+    models_requests: int = 0
+    result: dict[str, Any] | None = None
+
+
+class FreshUuid7Ledger:
+    """Run-scoped evidence that canonical UUIDv7 identities are used once."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._identities: set[str] = set()
+        self._accepted_identity_uses = 0
+        self._reuse_detected = False
+        self._noncanonical_identity_detected = False
+
+    def observe(self, identifiers: Sequence[str]) -> None:
+        values = tuple(identifiers)
+        if not values:
+            return
+        with self._lock:
+            if not all(_valid_uuid7(value) for value in values):
+                self._noncanonical_identity_detected = True
+                raise RequestValidationError("fresh_request_identifier_invalid")
+            if len(set(values)) != len(values) or any(
+                value in self._identities for value in values
+            ):
+                self._reuse_detected = True
+                raise RequestValidationError("fresh_request_identifier_reused")
+            self._identities.update(values)
+            self._accepted_identity_uses += len(values)
+
+    def evidence(self) -> dict[str, int | bool]:
+        with self._lock:
+            distinct_identities = len(self._identities)
+            verified = (
+                distinct_identities > 0
+                and self._accepted_identity_uses == distinct_identities
+                and not self._reuse_detected
+                and not self._noncanonical_identity_detected
+            )
+            return {
+                "accepted_identity_uses": self._accepted_identity_uses,
+                "distinct_canonical_uuid7_identities": distinct_identities,
+                "reuse_detected": self._reuse_detected,
+                "noncanonical_identity_detected": self._noncanonical_identity_detected,
+                "distinct_and_one_use_verified": verified,
+            }
+
+    def distinct_and_one_use_verified(self) -> bool:
+        return bool(self.evidence()["distinct_and_one_use_verified"])
+
+
+class ObserverState:
+    def __init__(
+        self,
+        auth_matcher: AuthIdentityMatcher,
+        provider_request_budget: int,
+        expected_fingerprints: Mapping[str, str] | None = None,
+        *,
+        fresh_identifier_ledger: FreshUuid7Ledger | None = None,
+        require_fx_models_discovery: bool = False,
+    ):
+        if provider_request_budget <= 0 or provider_request_budget > MAX_PROVIDER_REQUESTS:
+            raise BenchmarkError("provider request budget is outside the bounded range")
+        self.auth_matcher = auth_matcher
+        self.provider_request_budget = provider_request_budget
+        self.require_fx_models_discovery = require_fx_models_discovery
+        self._condition = threading.Condition()
+        self._next_ticket = 1
+        self._armed: dict[int, _Armed] = {}
+        self._request_fingerprints: dict[str, str] = {}
+        self._expected_fingerprints = dict(expected_fingerprints or {})
+        if self._expected_fingerprints and set(self._expected_fingerprints) != {
+            "fx",
+            "nanocodex",
+        }:
+            raise BenchmarkError("offline request templates must cover both implementations")
+        if any(
+            re.fullmatch(r"[0-9a-f]{64}", fingerprint) is None
+            for fingerprint in self._expected_fingerprints.values()
+        ):
+            raise BenchmarkError("offline request template fingerprint is invalid")
+        self._fingerprint_mismatch = False
+        self.fresh_identifier_ledger = (
+            fresh_identifier_ledger
+            if fresh_identifier_ledger is not None
+            else FreshUuid7Ledger()
+        )
+        self.unexpected_requests = 0
+        self.models_requests = 0
+        self.refresh_attempts_blocked = 0
+        self.provider_requests_forwarded = 0
+
+    def arm(self, expected: ExpectedRequest) -> int:
+        with self._condition:
+            if any(entry.result is None for entry in self._armed.values()):
+                raise BenchmarkError("observer already has an armed request")
+            ticket = self._next_ticket
+            self._next_ticket += 1
+            self._armed[ticket] = _Armed(expected=expected)
+            return ticket
+
+    def claim(self) -> tuple[int, ExpectedRequest] | None:
+        with self._condition:
+            for ticket, armed in self._armed.items():
+                if armed.result is None and not armed.claimed:
+                    armed.claimed = True
+                    return ticket, armed.expected
+            self.unexpected_requests += 1
+            return None
+
+    def accept_fx_models_discovery(self) -> bool:
+        with self._condition:
+            for armed in self._armed.values():
+                if (
+                    armed.result is None
+                    and not armed.claimed
+                    and armed.expected.implementation == "fx"
+                ):
+                    if armed.models_requests != 0:
+                        return False
+                    armed.models_requests = 1
+                    self.models_requests += 1
+                    return True
+            return False
+
+    def fx_models_discovery_complete(self, ticket: int) -> bool:
+        if not self.require_fx_models_discovery:
+            return True
+        with self._condition:
+            armed = self._armed.get(ticket)
+            return armed is not None and armed.models_requests == 1
+
+    def complete(self, ticket: int, result: dict[str, Any]) -> None:
+        with self._condition:
+            armed = self._armed.get(ticket)
+            if armed is not None and armed.result is None:
+                armed.result = result
+            self._condition.notify_all()
+
+    def wait(self, ticket: int, timeout_seconds: float) -> dict[str, Any] | None:
+        deadline = time.monotonic() + timeout_seconds
+        with self._condition:
+            while True:
+                armed = self._armed.get(ticket)
+                if armed is None:
+                    return None
+                if armed.result is not None:
+                    result = armed.result
+                    del self._armed[ticket]
+                    return result
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    del self._armed[ticket]
+                    return None
+                self._condition.wait(remaining)
+
+    def cancel_unclaimed(self, ticket: int) -> bool:
+        with self._condition:
+            armed = self._armed.get(ticket)
+            if armed is not None and not armed.claimed:
+                del self._armed[ticket]
+                self._condition.notify_all()
+                return True
+            return False
+
+    def count_refresh_block(self) -> None:
+        with self._condition:
+            self.refresh_attempts_blocked += 1
+
+    def count_unexpected_request(self) -> None:
+        with self._condition:
+            self.unexpected_requests += 1
+
+    def observe_request_fingerprint(
+        self, implementation: str, fingerprint: str
+    ) -> None:
+        with self._condition:
+            expected = self._expected_fingerprints.get(implementation)
+            if expected is not None and fingerprint != expected:
+                self._fingerprint_mismatch = True
+                raise RequestValidationError("request_fingerprint_preflight_mismatch")
+            previous = self._request_fingerprints.get(implementation)
+            if previous is None:
+                self._request_fingerprints[implementation] = fingerprint
+            elif previous != fingerprint:
+                self._fingerprint_mismatch = True
+                raise RequestValidationError("unstable_request_fingerprint")
+
+    def observe_fresh_identifiers(self, identifiers: Sequence[str]) -> None:
+        self.fresh_identifier_ledger.observe(identifiers)
+
+    def reserve_provider_request(self) -> None:
+        with self._condition:
+            if self.provider_requests_forwarded >= self.provider_request_budget:
+                raise RequestValidationError("provider_request_budget_exhausted")
+            self.provider_requests_forwarded += 1
+
+    def request_fingerprints(self) -> dict[str, str]:
+        with self._condition:
+            return dict(sorted(self._request_fingerprints.items()))
+
+    def fingerprints_stable(self) -> bool:
+        with self._condition:
+            fingerprints_stable = (
+                not self._fingerprint_mismatch
+                and set(self._request_fingerprints) == {"fx", "nanocodex"}
+            )
+        return (
+            fingerprints_stable
+            and self.fresh_identifier_ledger.distinct_and_one_use_verified()
+        )
+
+    def stats(self) -> dict[str, int]:
+        with self._condition:
+            return {
+                "unexpected_requests": self.unexpected_requests,
+                "models_requests": self.models_requests,
+                "refresh_attempts_blocked": self.refresh_attempts_blocked,
+                "provider_request_budget": self.provider_request_budget,
+                "provider_requests_forwarded": self.provider_requests_forwarded,
+            }
+
+
+class _ResolvedSocketMixin:
+    sock: socket.socket | None
+
+    def _initialize_resolved_socket(
+        self,
+        endpoints: tuple[tuple[int, tuple[Any, ...]], ...],
+        timeout: float,
+    ) -> None:
+        self._resolved_endpoints = endpoints
+        self._connect_timeout = timeout
+        self._connect_cancelled = threading.Event()
+
+    def _connect_deadline(self) -> float:
+        return time.monotonic() + self._connect_timeout
+
+    def _remaining_connect_timeout(self, deadline: float) -> float:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("upstream connection deadline expired")
+        return remaining
+
+    def _raise_if_connect_cancelled(self) -> None:
+        if self._connect_cancelled.is_set():
+            raise OSError("upstream connection was cancelled")
+
+    @staticmethod
+    def _shutdown_and_close_sockets(*resources: socket.socket | None) -> None:
+        seen: set[int] = set()
+        for resource in resources:
+            if resource is None or id(resource) in seen:
+                continue
+            seen.add(id(resource))
+            with contextlib.suppress(OSError):
+                resource.shutdown(socket.SHUT_RDWR)
+            with contextlib.suppress(OSError):
+                resource.close()
+
+    def _connect_resolved_tcp(self, deadline: float) -> socket.socket:
+        last_error: OSError | None = None
+        for family, address in self._resolved_endpoints:
+            self._raise_if_connect_cancelled()
+            self._remaining_connect_timeout(deadline)
+            candidate = socket.socket(family, socket.SOCK_STREAM, socket.IPPROTO_TCP)
+            self.sock = candidate
+            try:
+                self._raise_if_connect_cancelled()
+                candidate.settimeout(self._remaining_connect_timeout(deadline))
+                candidate.connect(address)
+                self._raise_if_connect_cancelled()
+                return candidate
+            except OSError as error:
+                last_error = error
+                self._shutdown_and_close_sockets(candidate)
+                if self.sock is candidate:
+                    self.sock = None
+                if self._connect_cancelled.is_set():
+                    raise OSError("upstream connection was cancelled") from error
+        if last_error is None:
+            raise OSError("upstream endpoint list was empty")
+        raise last_error
+
+    def abort_connect(self) -> None:
+        self._connect_cancelled.set()
+        self._shutdown_and_close_sockets(self.sock)
+
+
+class _ResolvedHTTPConnection(_ResolvedSocketMixin, http.client.HTTPConnection):
+    def __init__(
+        self,
+        host: str,
+        port: int | None,
+        endpoints: tuple[tuple[int, tuple[Any, ...]], ...],
+        *,
+        timeout: float,
+    ) -> None:
+        super().__init__(host, port, timeout=timeout)
+        self._initialize_resolved_socket(endpoints, timeout)
+
+    def connect(self) -> None:
+        if self._tunnel_host is not None:
+            raise OSError("upstream HTTP tunneling is disabled")
+        self._connect_resolved_tcp(self._connect_deadline())
+
+
+class _ResolvedHTTPSConnection(_ResolvedSocketMixin, http.client.HTTPSConnection):
+    def __init__(
+        self,
+        host: str,
+        port: int | None,
+        endpoints: tuple[tuple[int, tuple[Any, ...]], ...],
+        *,
+        timeout: float,
+        context: ssl.SSLContext,
+    ) -> None:
+        super().__init__(host, port, timeout=timeout, context=context)
+        self._initialize_resolved_socket(endpoints, timeout)
+
+    def connect(self) -> None:
+        if self._tunnel_host is not None:
+            raise OSError("upstream HTTPS tunneling is disabled")
+        deadline = self._connect_deadline()
+        raw_socket = self._connect_resolved_tcp(deadline)
+        try:
+            tls_socket = self._context.wrap_socket(
+                raw_socket,
+                server_hostname=self.host,
+                do_handshake_on_connect=False,
+            )
+            self.sock = tls_socket
+            self._raise_if_connect_cancelled()
+            tls_socket.settimeout(self._remaining_connect_timeout(deadline))
+            tls_socket.do_handshake()
+        except BaseException:
+            current = self.sock
+            self._shutdown_and_close_sockets(current, raw_socket)
+            if self.sock is current:
+                self.sock = None
+            raise
+
+
+@dataclasses.dataclass(frozen=True)
+class UpstreamTarget:
+    scheme: str
+    host: str
+    port: int | None
+    path: str
+    endpoints: tuple[tuple[int, tuple[Any, ...]], ...] = ()
+
+    @classmethod
+    def official(cls) -> "UpstreamTarget":
+        target = cls._parse(DEFAULT_UPSTREAM_URL, allow_loopback_http=False)
+        if target != cls("https", "chatgpt.com", None, "/backend-api/codex/responses"):
+            raise BenchmarkError("official upstream endpoint invariant was violated")
+        return dataclasses.replace(
+            target,
+            endpoints=_resolve_upstream_endpoints(target.host, target.port or 443),
+        )
+
+    @classmethod
+    def _for_test(cls, value: str) -> "UpstreamTarget":
+        target = cls._parse(value, allow_loopback_http=True)
+        if target.host not in {"127.0.0.1", "localhost", "::1"}:
+            raise BenchmarkError("test upstream must resolve to an explicit loopback host")
+        return dataclasses.replace(
+            target,
+            endpoints=_literal_loopback_endpoints(
+                target.host,
+                target.port or (443 if target.scheme == "https" else 80),
+            ),
+        )
+
+    @classmethod
+    def _parse(
+        cls, value: str, *, allow_loopback_http: bool
+    ) -> "UpstreamTarget":
+        parsed = urllib.parse.urlsplit(value)
+        if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+            raise BenchmarkError("upstream URL must be an absolute HTTP(S) URL")
+        if parsed.username or parsed.password or parsed.query or parsed.fragment:
+            raise BenchmarkError(
+                "upstream URL must not contain credentials, a query, or a fragment"
+            )
+        if parsed.scheme == "http" and (
+            not allow_loopback_http
+            or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}
+        ):
+            raise BenchmarkError("plain-HTTP upstreams are test-only loopback targets")
+        try:
+            port = parsed.port
+        except ValueError as error:
+            raise BenchmarkError("upstream URL has an invalid port") from error
+        path = parsed.path or "/"
+        return cls(parsed.scheme, parsed.hostname, port, path)
+
+    def connection(self) -> http.client.HTTPConnection:
+        if not self.endpoints:
+            raise BenchmarkError("upstream endpoint was not resolved before use")
+        if self.scheme == "https":
+            return _ResolvedHTTPSConnection(
+                self.host,
+                self.port,
+                self.endpoints,
+                timeout=UPSTREAM_CONNECT_TIMEOUT_SECONDS,
+                context=ssl.create_default_context(),
+            )
+        return _ResolvedHTTPConnection(
+            self.host,
+            self.port,
+            self.endpoints,
+            timeout=UPSTREAM_CONNECT_TIMEOUT_SECONDS,
+        )
+
+
+def _empty_observer_record(
+    expected: ExpectedRequest, *, request_bytes: bytes | None, error: str
+) -> dict[str, Any]:
+    request = {
+        "byte_count": None,
+        "sha256": None,
+        "model": None,
+        "reasoning_effort": None,
+        "service_tier": None,
+        "tool_count": None,
+        "tool_names_sha256": None,
+        "stable_fingerprint_sha256": None,
+    }
+    if request_bytes is not None:
+        request["byte_count"] = len(request_bytes)
+        request["sha256"] = hashlib.sha256(request_bytes).hexdigest()
+    return {
+        "implementation": expected.implementation,
+        "pair": expected.pair,
+        "phase": expected.phase,
+        "request": request,
+        "upstream_http_status": None,
+        "t0_monotonic_ns": None,
+        "first_model_output_monotonic_ns": None,
+        "first_answer_text_monotonic_ns": None,
+        "terminal_monotonic_ns": None,
+        "timing_ns": {
+            "time_to_first_model_output": None,
+            "time_to_first_answer_text": None,
+            "time_to_terminal": None,
+        },
+        "terminal_event": None,
+        "cached_input_tokens": None,
+        "tool_call_detected": False,
+        "tool_call_count": 0,
+        "status": "failed",
+        "error": error,
+    }
+
+
+class _TrackedThreadingHTTPServer(http.server.ThreadingHTTPServer):
+    daemon_threads = True
+    block_on_close = False
+    allow_reuse_address = False
+
+    def __init__(
+        self,
+        address: tuple[str, int],
+        handler: type[http.server.BaseHTTPRequestHandler],
+    ) -> None:
+        self._lifecycle = threading.Condition()
+        self._closing = False
+        self._active_requests: set[socket.socket] = set()
+        super().__init__(address, handler)
+
+    def process_request(
+        self, request: socket.socket, client_address: tuple[str, int]
+    ) -> None:
+        with self._lifecycle:
+            if self._closing:
+                with contextlib.suppress(OSError):
+                    request.shutdown(socket.SHUT_RDWR)
+                request.close()
+                return
+            self._active_requests.add(request)
+        try:
+            super().process_request(request, client_address)
+        except BaseException:
+            with self._lifecycle:
+                self._active_requests.discard(request)
+                self._lifecycle.notify_all()
+            with contextlib.suppress(OSError):
+                request.shutdown(socket.SHUT_RDWR)
+            request.close()
+            raise
+
+    def process_request_thread(
+        self, request: socket.socket, client_address: tuple[str, int]
+    ) -> None:
+        try:
+            super().process_request_thread(request, client_address)
+        finally:
+            with self._lifecycle:
+                self._active_requests.discard(request)
+                self._lifecycle.notify_all()
+
+    def begin_shutdown(self) -> None:
+        with self._lifecycle:
+            self._closing = True
+
+    def interrupt_active_work(self) -> None:
+        with self._lifecycle:
+            requests = tuple(self._active_requests)
+        for request in requests:
+            with contextlib.suppress(OSError):
+                request.shutdown(socket.SHUT_RDWR)
+
+    def _active_work_locked(self) -> int:
+        return len(self._active_requests)
+
+    def wait_for_quiescence(self, deadline: float) -> int:
+        with self._lifecycle:
+            while self._active_work_locked() > 0:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                self._lifecycle.wait(remaining)
+            return self._active_work_locked()
+
+    def active_work_count(self) -> int:
+        with self._lifecycle:
+            return self._active_work_locked()
+
+    def server_bind(self) -> None:
+        socketserver.TCPServer.server_bind(self)
+        host, port = self.server_address[:2]
+        self.server_name = host
+        self.server_port = port
+
+
+class _ObserverServer(_TrackedThreadingHTTPServer):
+
+    def __init__(
+        self,
+        address: tuple[str, int],
+        state: ObserverState,
+        upstream: UpstreamTarget,
+    ):
+        self.state = state
+        self.upstream = upstream
+        self._active_upstreams: dict[
+            http.client.HTTPConnection, list[socket.socket]
+        ] = {}
+        super().__init__(address, _ObserverHandler)
+
+    def register_upstream(self, connection: http.client.HTTPConnection) -> None:
+        upstream_socket = connection.sock
+        with self._lifecycle:
+            if self._closing:
+                should_abort = True
+            else:
+                self._active_upstreams[connection] = (
+                    [] if upstream_socket is None else [upstream_socket]
+                )
+                should_abort = False
+        if should_abort:
+            self._interrupt_upstream_resources(
+                ((connection, (upstream_socket,), upstream_socket),)
+            )
+            raise OSError("observer is shutting down")
+
+    def connected_upstream(self, connection: http.client.HTTPConnection) -> None:
+        upstream_socket = connection.sock
+        if upstream_socket is None:
+            raise OSError("upstream connection did not expose a socket")
+        with self._lifecycle:
+            if connection not in self._active_upstreams:
+                raise OSError("upstream connection lease is missing")
+            registered = self._active_upstreams[connection]
+            if self._closing:
+                retained_sockets = tuple(registered)
+                should_abort = True
+            else:
+                if all(resource is not upstream_socket for resource in registered):
+                    registered.append(upstream_socket)
+                retained_sockets = ()
+                should_abort = False
+        if should_abort:
+            self._interrupt_upstream_resources(
+                ((connection, (*retained_sockets, upstream_socket), upstream_socket),)
+            )
+            raise OSError("observer is shutting down")
+
+    def unregister_upstream(self, connection: http.client.HTTPConnection) -> None:
+        with self._lifecycle:
+            self._active_upstreams.pop(connection, None)
+            self._lifecycle.notify_all()
+
+    @staticmethod
+    def _interrupt_upstream_resources(
+        upstreams: Sequence[
+            tuple[
+                http.client.HTTPConnection,
+                Sequence[socket.socket],
+                socket.socket | None,
+            ]
+        ],
+    ) -> None:
+        resources: list[socket.socket] = []
+        for connection, registered_sockets, current_socket in upstreams:
+            resources.extend(registered_sockets)
+            if current_socket is not None:
+                resources.append(current_socket)
+            abort = getattr(connection, "abort_connect", None)
+            if callable(abort):
+                with contextlib.suppress(OSError):
+                    abort()
+
+        seen: set[int] = set()
+        for upstream in resources:
+            if id(upstream) in seen:
+                continue
+            seen.add(id(upstream))
+            with contextlib.suppress(OSError):
+                upstream.shutdown(socket.SHUT_RDWR)
+            with contextlib.suppress(OSError):
+                upstream.close()
+
+    def interrupt_active_work(self) -> None:
+        with self._lifecycle:
+            upstreams = tuple(
+                (connection, tuple(registered_sockets), connection.sock)
+                for connection, registered_sockets in self._active_upstreams.items()
+            )
+        super().interrupt_active_work()
+        self._interrupt_upstream_resources(upstreams)
+
+    def _active_work_locked(self) -> int:
+        return super()._active_work_locked() + len(self._active_upstreams)
+
+
+class _ObserverHandler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server_version = "nanocodex-latency-observer/1"
+
+    @property
+    def observer_server(self) -> _ObserverServer:
+        return self.server  # type: ignore[return-value]
+
+    def log_message(self, _format: str, *_args: Any) -> None:
+        return
+
+    def handle_one_request(self) -> None:
+        # BaseHTTPRequestHandler rejects an oversized request line before it
+        # calls parse_request. Reset a per-request guard here so every nonempty
+        # parser or dispatch rejection poisons eligibility exactly once.
+        self._unexpected_request_counted = False
+        super().handle_one_request()
+
+    def _count_unexpected_request_once(self) -> None:
+        if self._unexpected_request_counted:
+            return
+        self._unexpected_request_counted = True
+        self.observer_server.state.count_unexpected_request()
+
+    def _raw_request_target(self) -> str:
+        words = self.requestline.split()
+        if len(words) != 3:
+            raise RequestValidationError("request_target_unavailable")
+        return words[1]
+
+    def parse_request(self) -> bool:
+        if not super().parse_request():
+            # BaseHTTPRequestHandler has already emitted its parser error, but
+            # every nonempty inbound attempt must still poison eligibility.
+            self._count_unexpected_request_once()
+            self.close_connection = True
+            return False
+        defects = tuple(getattr(self.headers, "defects", ()))
+        if self.request_version != "HTTP/1.1" or defects:
+            self._count_unexpected_request_once()
+            self.close_connection = True
+            with contextlib.suppress(OSError):
+                self._fixed_response(400, b"malformed request\n", "text/plain")
+            return False
+        try:
+            local_address = ipaddress.ip_address(self.connection.getsockname()[0])
+        except (ValueError, OSError, IndexError):
+            local_address = None
+        if local_address != ipaddress.ip_address("127.0.0.1"):
+            self._count_unexpected_request_once()
+            self._fixed_response(404, b"not found\n", "text/plain")
+            return False
+        return True
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract
+        try:
+            if (
+                self._raw_request_target()
+                != f"/models?client_version={FX_MODELS_CLIENT_VERSION}"
+            ):
+                raise RequestValidationError("fx_models_request_target_invalid")
+            self._require_exact_header_set(FX_MODELS_REQUEST_HEADERS)
+            if self._single_header("Host") != self._observer_host_header():
+                raise RequestValidationError("observer_host_header_invalid")
+            if self._single_header("Connection") != "keep-alive":
+                raise RequestValidationError("fx_models_connection_header_invalid")
+            authorization = self._single_header("Authorization")
+            account_id = self._single_header("ChatGPT-Account-ID")
+            if self._single_header("User-Agent") != FX_USER_AGENT:
+                raise RequestValidationError("fx_models_user_agent_invalid")
+            if self._single_header("Originator") != "fx":
+                raise RequestValidationError("fx_models_originator_invalid")
+            if self._single_header("Accept") != "application/json":
+                raise RequestValidationError("fx_models_accept_invalid")
+            self.observer_server.state.auth_matcher.observe(
+                "fx", authorization, account_id
+            )
+            if not self.observer_server.state.accept_fx_models_discovery():
+                raise RequestValidationError("fx_models_request_unexpected")
+        except RequestValidationError:
+            self._count_unexpected_request_once()
+            self._fixed_response(404, b"not found\n", "text/plain")
+            return
+        self._fixed_response(200, MODELS_BYTES, "application/json")
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract
+        try:
+            request_target = self._raw_request_target()
+        except RequestValidationError:
+            self._discard_request_body()
+            self._count_unexpected_request_once()
+            self._fixed_response(404, b"not found\n", "text/plain")
+            return
+        if request_target == "/forbid-refresh":
+            self._discard_request_body()
+            self.observer_server.state.count_refresh_block()
+            self._fixed_response(409, b"credential refresh disabled\n", "text/plain")
+            return
+        if request_target != "/responses":
+            self._discard_request_body()
+            self._count_unexpected_request_once()
+            self._fixed_response(404, b"not found\n", "text/plain")
+            return
+        claim = self.observer_server.state.claim()
+        if claim is None:
+            self._discard_request_body()
+            self._fixed_response(409, b"unexpected request\n", "text/plain")
+            return
+        ticket, expected = claim
+        body: bytes | None = None
+        try:
+            if (
+                expected.implementation == "fx"
+                and not self.observer_server.state.fx_models_discovery_complete(ticket)
+            ):
+                raise RequestValidationError("fx_models_discovery_missing")
+            canonical_headers = self._canonical_request_headers(
+                expected.implementation
+            )
+            body = self._read_request_body(canonical_headers.content_length)
+            validated = validate_request_body(
+                body,
+                expected.implementation,
+                instructions=expected.instructions,
+                prompt=expected.prompt,
+                home=expected.home,
+                workspace=expected.workspace,
+            )
+            self.observer_server.state.auth_matcher.observe(
+                expected.implementation,
+                canonical_headers.authorization,
+                canonical_headers.account_id,
+            )
+            if (
+                expected.implementation == "nanocodex"
+                and validated.session_id != canonical_headers.session_id
+            ):
+                raise RequestValidationError("nanocodex_body_header_session_mismatch")
+            self.observer_server.state.observe_fresh_identifiers(
+                validated.fresh_identifiers
+            )
+            stable_fingerprint = _combined_request_fingerprint(
+                validated, canonical_headers
+            )
+            self.observer_server.state.observe_request_fingerprint(
+                expected.implementation, stable_fingerprint
+            )
+            self.observer_server.state.reserve_provider_request()
+        except RequestValidationError as error:
+            record = _empty_observer_record(
+                expected, request_bytes=body, error=error.code
+            )
+            self.observer_server.state.complete(ticket, record)
+            self._fixed_response(400, b"benchmark request rejected\n", "text/plain")
+            return
+        except BenchmarkError as error:
+            record = _empty_observer_record(
+                expected, request_bytes=body, error=str(error)
+            )
+            self.observer_server.state.complete(ticket, record)
+            self._fixed_response(400, b"benchmark request rejected\n", "text/plain")
+            return
+
+        request_record = {
+            "byte_count": len(body),
+            "sha256": hashlib.sha256(body).hexdigest(),
+            "model": validated.model,
+            "reasoning_effort": validated.reasoning_effort,
+            "service_tier": validated.service_tier,
+            "tool_count": validated.tool_count,
+            "tool_names_sha256": validated.tool_names_sha256,
+            "stable_fingerprint_sha256": stable_fingerprint,
+        }
+        record = self._forward(
+            expected, body, request_record, canonical_headers
+        )
+        self.observer_server.state.complete(ticket, record)
+
+    def do_CONNECT(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract
+        self._reject_unsupported_method()
+
+    do_PUT = do_CONNECT
+    do_PATCH = do_CONNECT
+    do_DELETE = do_CONNECT
+    do_HEAD = do_CONNECT
+    do_OPTIONS = do_CONNECT
+    do_TRACE = do_CONNECT
+
+    def send_error(
+        self,
+        code: int,
+        message: str | None = None,
+        explain: str | None = None,
+    ) -> None:
+        self._count_unexpected_request_once()
+        self.close_connection = True
+        if code == 501:
+            self._reject_unsupported_method()
+            return
+        super().send_error(code, message, explain)
+
+    def _reject_unsupported_method(self) -> None:
+        # Account before touching attacker-controlled body bytes. A truncated
+        # body or TCP reset must never hide the extra request from eligibility.
+        self._count_unexpected_request_once()
+        self.close_connection = True
+        self._discard_request_body()
+        with contextlib.suppress(OSError):
+            self._fixed_response(405, b"method not allowed\n", "text/plain")
+
+    def _single_header(self, name: str) -> str:
+        values = self.headers.get_all(name, [])
+        if len(values) != 1:
+            raise RequestValidationError(
+                f"{name.lower().replace('-', '_')}_header_count_invalid"
+            )
+        value = values[0]
+        if not isinstance(value, str) or not value:
+            raise RequestValidationError(
+                f"{name.lower().replace('-', '_')}_header_invalid"
+            )
+        return value
+
+    def _require_exact_header_set(self, expected: set[str]) -> None:
+        supplied = {name.lower() for name in self.headers.keys()}
+        if supplied != expected:
+            raise RequestValidationError("request_header_set_invalid")
+        for name in expected:
+            if len(self.headers.get_all(name, [])) != 1:
+                raise RequestValidationError(
+                    f"{name.lower().replace('-', '_')}_header_count_invalid"
+                )
+
+    def _observer_host_header(self) -> str:
+        return f"127.0.0.1:{self.observer_server.server_port}"
+
+    def _optional_single_header(self, name: str) -> str | None:
+        values = self.headers.get_all(name, [])
+        if len(values) > 1:
+            raise RequestValidationError(
+                f"{name.lower().replace('-', '_')}_header_count_invalid"
+            )
+        return values[0] if values else None
+
+    @staticmethod
+    def _metadata_value(name: str, value: str | None) -> str:
+        if (
+            not isinstance(value, str)
+            or not value
+            or value != value.strip()
+            or len(value.encode("utf-8")) > 1024
+            or any(
+                ord(character) < 0x20 or ord(character) > 0x7E
+                for character in value
+            )
+        ):
+            raise RequestValidationError(
+                f"{name.lower().replace('-', '_')}_header_invalid"
+            )
+        return value
+
+    def _canonical_request_headers(
+        self, implementation: str
+    ) -> CanonicalRequestHeaders:
+        allowed_headers = (
+            FX_GENERATION_REQUEST_HEADERS
+            if implementation == "fx"
+            else NANOCODEX_GENERATION_REQUEST_HEADERS
+        )
+        if implementation == "nanocodex" and self.observer_server.state.auth_matcher.fedramp:
+            allowed_headers = allowed_headers | {"x-openai-fedramp"}
+        self._require_exact_header_set(allowed_headers)
+        if self._single_header("Host") != self._observer_host_header():
+            raise RequestValidationError("observer_host_header_invalid")
+        if implementation == "fx" and self._single_header("Connection") != "close":
+            raise RequestValidationError("fx_connection_header_invalid")
+        authorization = self._single_header("Authorization")
+        account_id = self._single_header("ChatGPT-Account-ID")
+        raw_length = self._single_header("Content-Length")
+        content_type = self._single_header("Content-Type")
+        accept = self._single_header("Accept")
+        if authorization != authorization.strip() or account_id != account_id.strip():
+            raise RequestValidationError("credential_header_whitespace_invalid")
+        if content_type != "application/json":
+            raise RequestValidationError("content_type_must_be_application_json")
+        if accept != "text/event-stream":
+            raise RequestValidationError("accept_must_be_text_event_stream")
+        if not raw_length.isascii() or not raw_length.isdecimal():
+            raise RequestValidationError("invalid_content_length")
+        length = int(raw_length)
+        if str(length) != raw_length or length <= 0 or length > MAX_REQUEST_BYTES:
+            raise RequestValidationError("invalid_request_size")
+
+        supplied = {
+            name: self._optional_single_header(name)
+            for name in PRODUCT_METADATA_HEADERS
+        }
+        if supplied["x-codex-turn-state"] is not None:
+            raise RequestValidationError("fresh_turn_state_header_forbidden")
+        user_agent = self._metadata_value("user-agent", supplied["user-agent"])
+
+        if implementation == "fx":
+            if user_agent != FX_USER_AGENT:
+                raise RequestValidationError("fx_user_agent_invalid")
+            if supplied["originator"] != "fx":
+                raise RequestValidationError("fx_originator_invalid")
+            if supplied["openai-beta"] != "responses=experimental":
+                raise RequestValidationError("fx_openai_beta_invalid")
+            for forbidden in (
+                "session-id",
+                "thread-id",
+                "x-client-request-id",
+                "x-openai-internal-codex-responses-lite",
+                "x-openai-fedramp",
+            ):
+                if supplied[forbidden] is not None:
+                    raise RequestValidationError("fx_metadata_header_set_invalid")
+            session_id = None
+            metadata = (
+                ("User-Agent", user_agent),
+                ("Originator", "fx"),
+                ("OpenAI-Beta", "responses=experimental"),
+            )
+        elif implementation == "nanocodex":
+            if user_agent != NANOCODEX_USER_AGENT:
+                raise RequestValidationError("nanocodex_user_agent_invalid")
+            if supplied["originator"] is not None or supplied["openai-beta"] is not None:
+                raise RequestValidationError("nanocodex_metadata_header_set_invalid")
+            if supplied["x-openai-internal-codex-responses-lite"] != "true":
+                raise RequestValidationError("nanocodex_responses_lite_header_invalid")
+            session_id = self._metadata_value("session-id", supplied["session-id"])
+            request_id = self._metadata_value(
+                "x-client-request-id", supplied["x-client-request-id"]
+            )
+            if request_id != session_id:
+                raise RequestValidationError("request_session_identity_mismatch")
+            thread_id = self._metadata_value("thread-id", supplied["thread-id"])
+            if thread_id != session_id:
+                raise RequestValidationError("request_session_identity_mismatch")
+            fedramp = supplied["x-openai-fedramp"]
+            expected_fedramp = self.observer_server.state.auth_matcher.fedramp
+            if expected_fedramp and fedramp != "true":
+                raise RequestValidationError("nanocodex_fedramp_header_missing")
+            if not expected_fedramp and fedramp is not None:
+                raise RequestValidationError("nanocodex_fedramp_header_unexpected")
+            metadata_items = [
+                ("User-Agent", user_agent),
+                ("X-OpenAI-Internal-Codex-Responses-Lite", "true"),
+                ("Session-ID", session_id),
+                ("Thread-ID", thread_id),
+                ("X-Client-Request-ID", request_id),
+            ]
+            if expected_fedramp:
+                metadata_items.append(("X-OpenAI-Fedramp", "true"))
+            metadata = tuple(metadata_items)
+        else:
+            raise RequestValidationError("unknown_implementation")
+        return CanonicalRequestHeaders(
+            authorization, account_id, length, session_id, metadata
+        )
+
+    def _read_request_body(self, length: int) -> bytes:
+        body = self.rfile.read(length)
+        if len(body) != length:
+            raise RequestValidationError("truncated_request_body")
+        return body
+
+    def _discard_request_body(self) -> None:
+        headers = getattr(self, "headers", None)
+        if headers is None:
+            return
+        try:
+            remaining = int(headers.get("Content-Length", "0"))
+        except (TypeError, ValueError):
+            remaining = 0
+        remaining = min(max(remaining, 0), MAX_REQUEST_BYTES)
+        while remaining:
+            try:
+                chunk = self.rfile.read(min(remaining, 64 * 1024))
+            except OSError:
+                return
+            if not chunk:
+                break
+            remaining -= len(chunk)
+
+    def _forward(
+        self,
+        expected: ExpectedRequest,
+        body: bytes,
+        request_record: dict[str, Any],
+        headers: CanonicalRequestHeaders,
+    ) -> dict[str, Any]:
+        connection: http.client.HTTPConnection | None = None
+        upstream: http.client.HTTPResponse | None = None
+        upstream_registered = False
+        response_started = False
+        upstream_status: int | None = None
+        observation: SSEObservation | None = None
+        transport_error: str | None = None
+        try:
+            connection = self.observer_server.upstream.connection()
+            self.observer_server.register_upstream(connection)
+            upstream_registered = True
+            connection.connect()
+            self.observer_server.connected_upstream(connection)
+            if connection.sock is None:
+                raise OSError("upstream connection did not expose a socket")
+            connection.sock.settimeout(CLIENT_TIMEOUT_SECONDS)
+            connection.putrequest(
+                "POST",
+                self.observer_server.upstream.path,
+                skip_accept_encoding=True,
+            )
+            connection.putheader("Authorization", headers.authorization)
+            connection.putheader("ChatGPT-Account-ID", headers.account_id)
+            connection.putheader("Content-Type", "application/json")
+            connection.putheader("Accept", "text/event-stream")
+            for name, value in headers.metadata:
+                connection.putheader(name, value)
+            connection.putheader("Content-Length", str(len(body)))
+            connection.putheader("Connection", "close")
+            connection.endheaders(body)
+            t0_ns = time.monotonic_ns()
+            observation = SSEObservation(t0_ns)
+            upstream = connection.getresponse()
+            upstream_status = upstream.status
+            hide_authentication_failure = upstream.status == 401
+
+            if hide_authentication_failure:
+                self._fixed_response(
+                    502, b"upstream authentication failed\n", "text/plain"
+                )
+                response_started = True
+            else:
+                self.send_response_only(upstream.status)
+                for name, value in upstream.getheaders():
+                    if name.lower() in RESPONSE_HEADER_NAMES:
+                        self.send_header(name, value)
+                self.send_header("Connection", "close")
+                self.end_headers()
+                self.close_connection = True
+                response_started = True
+
+            frame: list[bytes] = []
+            frame_bytes = 0
+            while True:
+                line = upstream.readline(MAX_SSE_LINE_BYTES + 1)
+                if not line:
+                    break
+                if len(line) > MAX_SSE_LINE_BYTES:
+                    transport_error = "upstream_sse_line_too_large"
+                    break
+                frame.append(line)
+                frame_bytes += len(line)
+                if frame_bytes > MAX_SSE_FRAME_BYTES:
+                    transport_error = "upstream_sse_frame_too_large"
+                    break
+                received_ns = time.monotonic_ns()
+                observation.feed_line(line, received_ns)
+                if line.rstrip(b"\r\n"):
+                    continue
+                if observation.error == "duplicate_terminal_event":
+                    transport_error = "duplicate_terminal_event"
+                    break
+                if observation.has_tool_call():
+                    transport_error = "tool_call_blocked_before_delivery"
+                    break
+                if not hide_authentication_failure:
+                    try:
+                        self.wfile.write(b"".join(frame))
+                        self.wfile.flush()
+                    except (BrokenPipeError, ConnectionResetError, OSError):
+                        transport_error = "client_disconnected"
+                        break
+                frame.clear()
+                frame_bytes = 0
+            observation.finish()
+            if transport_error is None and frame:
+                if observation.has_tool_call():
+                    transport_error = "tool_call_blocked_before_delivery"
+                elif not hide_authentication_failure:
+                    try:
+                        self.wfile.write(b"".join(frame))
+                        self.wfile.flush()
+                    except (BrokenPipeError, ConnectionResetError, OSError):
+                        transport_error = "client_disconnected"
+            if not 200 <= upstream.status < 300:
+                observation.status = "http_error"
+                observation.error = f"upstream_http_{upstream.status}"
+            if transport_error is not None:
+                observation.status = "failed"
+                observation.error = transport_error
+        except (TimeoutError, ssl.SSLError, OSError, http.client.HTTPException) as error:
+            if isinstance(error, TimeoutError):
+                transport_error = "upstream_timeout"
+            elif isinstance(error, ssl.SSLError):
+                transport_error = "upstream_tls_error"
+            else:
+                transport_error = "upstream_transport_error"
+            if not response_started:
+                with contextlib.suppress(OSError):
+                    self._fixed_response(502, b"upstream unavailable\n", "text/plain")
+        finally:
+            if upstream is not None:
+                with contextlib.suppress(OSError, http.client.HTTPException):
+                    upstream.close()
+            if connection is not None:
+                try:
+                    connection.close()
+                finally:
+                    if upstream_registered:
+                        self.observer_server.unregister_upstream(connection)
+
+        if observation is None:
+            record = _empty_observer_record(
+                expected, request_bytes=body, error=transport_error or "upstream_failure"
+            )
+        else:
+            record = {
+                "implementation": expected.implementation,
+                "pair": expected.pair,
+                "phase": expected.phase,
+                "request": request_record,
+                "upstream_http_status": upstream_status,
+                **observation.record(),
+            }
+        return record
+
+    def _fixed_response(self, status_code: int, body: bytes, content_type: str) -> None:
+        self.send_response_only(status_code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.close_connection = True
+        self.wfile.write(body)
+        self.wfile.flush()
+
+
+def _close_tracked_server(
+    server: _TrackedThreadingHTTPServer,
+    thread: threading.Thread,
+    label: str,
+) -> None:
+    deadline = time.monotonic() + OBSERVER_SHUTDOWN_TIMEOUT_SECONDS
+    failures: list[BaseException] = []
+    for operation in (
+        server.begin_shutdown,
+        server.interrupt_active_work,
+        server.shutdown,
+        server.server_close,
+    ):
+        try:
+            operation()
+        except BaseException as error:
+            failures.append(error)
+    try:
+        remaining_work = server.wait_for_quiescence(deadline)
+    except BaseException as error:
+        failures.append(error)
+        remaining_work = server.active_work_count()
+    try:
+        thread.join(max(0.0, deadline - time.monotonic()))
+    except BaseException as error:
+        failures.append(error)
+    thread_alive = thread.is_alive()
+    listener = getattr(server, "socket", None)
+    listener_open = listener is not None and listener.fileno() >= 0
+    if failures or remaining_work != 0 or thread_alive or listener_open:
+        raise BenchmarkError(
+            f"{label} shutdown did not quiesce "
+            f"(active_work={remaining_work}, serve_thread_alive={thread_alive}, "
+            f"listener_open={listener_open})"
+        ) from (failures[0] if failures else None)
+
+
+def _start_tracked_server(
+    server: _TrackedThreadingHTTPServer,
+    thread: threading.Thread,
+    label: str,
+) -> None:
+    try:
+        thread.start()
+        return
+    except BaseException as start_error:
+        if thread.is_alive():
+            try:
+                _close_tracked_server(server, thread, label)
+            except BaseException as cleanup_error:
+                raise BenchmarkError(
+                    f"{label} failed to start and cleanup could not be verified"
+                ) from cleanup_error
+        else:
+            failures: list[BaseException] = []
+            for operation in (
+                server.begin_shutdown,
+                server.interrupt_active_work,
+                server.server_close,
+            ):
+                try:
+                    operation()
+                except BaseException as error:
+                    failures.append(error)
+            if failures or server.socket.fileno() >= 0 or server.active_work_count() != 0:
+                raise BenchmarkError(
+                    f"{label} failed to start and listener cleanup failed"
+                ) from (failures[0] if failures else start_error)
+        raise BenchmarkError(f"{label} serve thread failed to start") from start_error
+
+
+class StreamingObserver:
+    def __init__(
+        self,
+        auth: AuthMaterial,
+        provider_request_budget: int,
+        *,
+        expected_fingerprints: Mapping[str, str],
+        fresh_identifier_ledger: FreshUuid7Ledger,
+    ):
+        self._initialize(
+            auth,
+            UpstreamTarget.official(),
+            provider_request_budget,
+            expected_fingerprints,
+            fresh_identifier_ledger,
+            require_fx_models_discovery=True,
+        )
+
+    @classmethod
+    def _for_test(
+        cls,
+        auth: _FakeAuthMaterial,
+        upstream_url: str,
+        *,
+        provider_request_budget: int,
+        expected_fingerprints: Mapping[str, str] | None = None,
+        fresh_identifier_ledger: FreshUuid7Ledger | None = None,
+        require_fx_models_discovery: bool = False,
+    ) -> "StreamingObserver":
+        expected_fake = _fake_auth_material(fedramp=auth.fedramp)
+        if (
+            not isinstance(auth, _FakeAuthMaterial)
+            or auth.raw_codex_auth != expected_fake.raw_codex_auth
+            or auth.access_token != expected_fake.access_token
+            or auth.refresh_token != expected_fake.refresh_token
+            or auth.account_id != expected_fake.account_id
+        ):
+            raise BenchmarkError("custom upstreams require fake test credentials")
+        observer = cls.__new__(cls)
+        observer._initialize(
+            auth,
+            UpstreamTarget._for_test(upstream_url),
+            provider_request_budget,
+            expected_fingerprints,
+            fresh_identifier_ledger,
+            require_fx_models_discovery=require_fx_models_discovery,
+        )
+        return observer
+
+    def _initialize(
+        self,
+        auth: AuthMaterial,
+        upstream: UpstreamTarget,
+        provider_request_budget: int,
+        expected_fingerprints: Mapping[str, str] | None,
+        fresh_identifier_ledger: FreshUuid7Ledger | None,
+        *,
+        require_fx_models_discovery: bool,
+    ) -> None:
+        self.auth_matcher = AuthIdentityMatcher(auth)
+        self.state = ObserverState(
+            self.auth_matcher,
+            provider_request_budget,
+            expected_fingerprints,
+            fresh_identifier_ledger=fresh_identifier_ledger,
+            require_fx_models_discovery=require_fx_models_discovery,
+        )
+        self.server = _ObserverServer(
+            ("0.0.0.0", 0), self.state, upstream
+        )
+        try:
+            self._thread = threading.Thread(
+                target=self.server.serve_forever,
+                name="paired-latency-observer",
+                daemon=True,
+            )
+        except BaseException as error:
+            self.server.server_close()
+            raise BenchmarkError("streaming observer thread construction failed") from error
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.server.server_port}"
+
+    def __enter__(self) -> "StreamingObserver":
+        _start_tracked_server(self.server, self._thread, "streaming observer")
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        _close_tracked_server(self.server, self._thread, "streaming observer")
+
+
+def _offline_sse_response() -> bytes:
+    message = {
+        "id": "msg_offline_preflight",
+        "type": "message",
+        "role": "assistant",
+        "status": "completed",
+        "content": [{"type": "output_text", "text": ACK_TOKEN}],
+    }
+    events = (
+        {
+            "type": "response.created",
+            "response": {"id": "resp_offline_preflight", "status": "in_progress"},
+        },
+        {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {
+                "id": message["id"],
+                "type": "message",
+                "role": "assistant",
+                "status": "in_progress",
+                "content": [],
+            },
+        },
+        {
+            "type": "response.output_text.delta",
+            "output_index": 0,
+            "content_index": 0,
+            "delta": ACK_TOKEN,
+        },
+        {
+            "type": "response.output_item.done",
+            "output_index": 0,
+            "item": message,
+        },
+        {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_offline_preflight",
+                "status": "completed",
+                "output": [message],
+                "usage": {
+                    "input_tokens": 10,
+                    "input_tokens_details": {"cached_tokens": 1},
+                    "output_tokens": 2,
+                    "output_tokens_details": {"reasoning_tokens": 0},
+                    "total_tokens": 12,
+                },
+            },
+        },
+    )
+    return b"".join(
+        b"data: "
+        + json.dumps(event, separators=(",", ":")).encode("utf-8")
+        + b"\n\n"
+        for event in events
+    )
+
+
+OFFLINE_SSE_BYTES = _offline_sse_response()
+
+
+class _OfflineProviderHandler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    @property
+    def offline_server(self) -> "_OfflineProviderServer":
+        return self.server  # type: ignore[return-value]
+
+    def log_message(self, _format: str, *_args: Any) -> None:
+        return
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler contract
+        parsed = urllib.parse.urlsplit(self.path)
+        if parsed.path != "/responses" or parsed.query or parsed.fragment:
+            self.send_error(404)
+            return
+        try:
+            length = int(self.headers.get("Content-Length", ""))
+        except ValueError:
+            self.send_error(400)
+            return
+        if length <= 0 or length > MAX_REQUEST_BYTES or len(self.rfile.read(length)) != length:
+            self.send_error(400)
+            return
+        with self.offline_server.lock:
+            self.offline_server.requests += 1
+        if self.offline_server.stall_after_headers:
+            self.send_response_only(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Connection", "close")
+            self.end_headers()
+            self.wfile.flush()
+            self.offline_server.request_started.set()
+            try:
+                self.rfile.read(1)
+            finally:
+                self.offline_server.peer_disconnected.set()
+            return
+        self.send_response_only(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Content-Length", str(len(OFFLINE_SSE_BYTES)))
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.close_connection = True
+        self.wfile.write(OFFLINE_SSE_BYTES)
+        self.wfile.flush()
+
+
+class _OfflineProviderServer(_TrackedThreadingHTTPServer):
+    def __init__(self, *, stall_after_headers: bool = False) -> None:
+        self.lock = threading.Lock()
+        self.requests = 0
+        self.stall_after_headers = stall_after_headers
+        self.request_started = threading.Event()
+        self.peer_disconnected = threading.Event()
+        super().__init__(("127.0.0.1", 0), _OfflineProviderHandler)
+
+
+class _OfflineProvider:
+    def __init__(self, *, stall_after_headers: bool = False) -> None:
+        self.server = _OfflineProviderServer(
+            stall_after_headers=stall_after_headers
+        )
+        try:
+            self._thread = threading.Thread(
+                target=self.server.serve_forever,
+                name="paired-latency-offline-provider",
+                daemon=True,
+            )
+        except BaseException as error:
+            self.server.server_close()
+            raise BenchmarkError("offline provider thread construction failed") from error
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.server.server_port}/responses"
+
+    def __enter__(self) -> "_OfflineProvider":
+        _start_tracked_server(self.server, self._thread, "offline provider")
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        _close_tracked_server(self.server, self._thread, "offline provider")
+
+
+SANDBOX_EXEC = Path("/usr/bin/sandbox-exec")
+
+
+def _require_child_egress_sandbox() -> None:
+    if sys.platform != "darwin":
+        raise BenchmarkError(
+            "live paired benchmarking requires the Darwin child egress sandbox"
+        )
+    try:
+        info = SANDBOX_EXEC.stat()
+    except OSError as error:
+        raise BenchmarkError("Darwin child egress sandbox is unavailable") from error
+    if not stat.S_ISREG(info.st_mode) or not os.access(SANDBOX_EXEC, os.X_OK):
+        raise BenchmarkError("Darwin child egress sandbox is unavailable")
+
+
+def _observer_port(base_url: str) -> int:
+    parsed = urllib.parse.urlsplit(base_url)
+    try:
+        host = ipaddress.ip_address(parsed.hostname or "")
+        port = parsed.port
+    except ValueError as error:
+        raise BenchmarkError("observer URL is not an exact numeric loopback endpoint") from error
+    if (
+        parsed.scheme != "http"
+        or host != ipaddress.ip_address("127.0.0.1")
+        or port is None
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise BenchmarkError("observer URL is not an exact numeric loopback endpoint")
+    return port
+
+
+def _sandboxed_child_command(command: Sequence[str], observer_base_url: str) -> list[str]:
+    _require_child_egress_sandbox()
+    if not command or any(not isinstance(part, str) or not part for part in command):
+        raise BenchmarkError("child command is empty or malformed")
+    port = _observer_port(observer_base_url)
+    profile = "\n".join(
+        (
+            "(version 1)",
+            "(allow default)",
+            "(deny network*)",
+            "(deny process-fork)",
+            # Seatbelt accepts only its reserved `localhost` token here. The
+            # AF_INET + TCP conjunction prevents its token from also admitting
+            # ::1 or UDP; the product endpoint remains numeric 127.0.0.1.
+            "(allow network-outbound "
+            f'(require-all (socket-domain AF_INET) (remote tcp "localhost:{port}")))',
+        )
+    )
+    return [str(SANDBOX_EXEC), "-p", profile, *command]
+
+
+def _child_environment(home: Path) -> dict[str, str]:
+    path_value = os.environ.get("PATH") or os.defpath
+    if "\x00" in path_value:
+        raise BenchmarkError("PATH contains an invalid NUL byte")
+    directories = {
+        "XDG_CONFIG_HOME": home / ".config",
+        "XDG_CACHE_HOME": home / ".cache",
+        "XDG_DATA_HOME": home / ".local" / "share",
+        "TMPDIR": home / ".tmp",
+    }
+    for directory in directories.values():
+        directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        os.chmod(directory, 0o700)
+    return {
+        "PATH": path_value,
+        "HOME": str(home),
+        **{key: str(value) for key, value in directories.items()},
+        "NO_COLOR": "1",
+    }
+
+
+def _reap_process_once(
+    process: subprocess.Popen[bytes], *, deadline: float, retry_seconds: float
+) -> tuple[bool, BaseException | None, bool]:
+    """Return (reaped, last error, verified impossible) for one wait cycle."""
+    if process.returncode is not None:
+        return True, None, False
+
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        return False, None, False
+
+    wait_error: BaseException | None = None
+    try:
+        returncode = process.wait(timeout=min(retry_seconds, remaining))
+    except (subprocess.TimeoutExpired, OSError) as error:
+        wait_error = error
+    else:
+        if process.returncode is None:
+            process.returncode = returncode
+        return True, None, False
+
+    if process.returncode is not None:
+        return True, None, False
+    if os.name != "posix":
+        return False, wait_error, False
+
+    try:
+        child, status = os.waitpid(process.pid, os.WNOHANG)
+    except ChildProcessError as error:
+        if process.returncode is not None:
+            return True, None, False
+        return False, error, True
+    except OSError as error:
+        return False, error, False
+    if child == process.pid:
+        process.returncode = os.waitstatus_to_exitcode(status)
+        return True, None, False
+    return False, wait_error, False
+
+
+def _kill_process_group(
+    process: subprocess.Popen[bytes], *, deadline: float
+) -> None:
+    retry_seconds = 0.01
+    group_absent = os.name != "posix"
+    leader_reaped = process.returncode is not None
+    reap_impossible: BaseException | None = None
+    last_group_error: BaseException | None = None
+    last_reap_error: BaseException | None = None
+
+    while time.monotonic() < deadline:
+        group_signal_failed = False
+        if os.name == "posix" and not group_absent:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                group_absent = True
+            except OSError as error:
+                group_signal_failed = True
+                last_group_error = error
+
+        leader_reaped = process.returncode is not None
+        if not leader_reaped and (group_signal_failed or group_absent):
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
+            except OSError as error:
+                last_group_error = error
+            leader_reaped = process.returncode is not None
+
+        if not leader_reaped and reap_impossible is None:
+            leader_reaped, reap_error, impossible = _reap_process_once(
+                process, deadline=deadline, retry_seconds=retry_seconds
+            )
+            if reap_error is not None:
+                last_reap_error = reap_error
+            if impossible:
+                reap_impossible = reap_error
+
+        if os.name == "posix" and not group_absent:
+            try:
+                os.killpg(process.pid, 0)
+            except ProcessLookupError:
+                group_absent = True
+            except OSError as error:
+                last_group_error = error
+
+        if leader_reaped and group_absent:
+            return
+        if group_absent and reap_impossible is not None:
+            raise BenchmarkError("failed to reap the child process") from reap_impossible
+
+        remaining = deadline - time.monotonic()
+        if remaining > 0:
+            time.sleep(min(retry_seconds, remaining))
+
+    if not group_absent:
+        raise BenchmarkError(
+            "child process group remained alive after termination"
+        ) from last_group_error
+    if not leader_reaped:
+        raise BenchmarkError("failed to reap the child process") from last_reap_error
+
+
+def _run_process(
+    command: Sequence[str],
+    cwd: Path,
+    environment: Mapping[str, str],
+    *,
+    timeout_seconds: float = CLIENT_TIMEOUT_SECONDS,
+    stdout_limit: int = MAX_CLIENT_OUTPUT_BYTES,
+    stderr_limit: int = MAX_CLIENT_STDERR_BYTES,
+) -> ProcessCapture:
+    if timeout_seconds <= 0 or stdout_limit <= 0 or stderr_limit <= 0:
+        raise BenchmarkError("process supervision limits must be positive")
+    prepared_command = list(command)
+    prepared_environment = dict(environment)
+    stdout_chunks: list[bytes] = []
+    totals = {"stdout": 0, "stderr": 0}
+    selector = selectors.DefaultSelector()
+    active_streams: dict[int, tuple[str, int, bool]] = {}
+    retained_stdout = 0
+
+    def close_stream(file_descriptor: int) -> None:
+        with contextlib.suppress(Exception):
+            selector.unregister(file_descriptor)
+        active_streams.pop(file_descriptor, None)
+
+    def read_ready(file_descriptor: int) -> None:
+        nonlocal output_limit_exceeded, retained_stdout
+        name, limit, retain = active_streams[file_descriptor]
+        try:
+            chunk = os.read(file_descriptor, 64 * 1024)
+        except BlockingIOError:
+            return
+        except OSError as error:
+            raise BenchmarkError("failed to drain bounded child output") from error
+        if not chunk:
+            close_stream(file_descriptor)
+            return
+        totals[name] += len(chunk)
+        if retain and retained_stdout < limit:
+            kept = chunk[: limit - retained_stdout]
+            stdout_chunks.append(kept)
+            retained_stdout += len(kept)
+        if totals[name] > limit:
+            output_limit_exceeded = True
+
+    try:
+        process = subprocess.Popen(
+            prepared_command,
+            cwd=cwd,
+            env=prepared_environment,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+    except BaseException:
+        selector.close()
+        raise
+
+    run_error: BaseException | None = None
+    timed_out = False
+    output_limit_exceeded = False
+    try:
+        deadline = time.monotonic() + timeout_seconds
+        if process.stdout is None or process.stderr is None:
+            raise BenchmarkError("failed to create bounded child output pipes")
+        for stream, name, limit, retain in (
+            (process.stdout, "stdout", stdout_limit, True),
+            (process.stderr, "stderr", stderr_limit, False),
+        ):
+            file_descriptor = stream.fileno()
+            os.set_blocking(file_descriptor, False)
+            active_streams[file_descriptor] = (name, limit, retain)
+            try:
+                selector.register(file_descriptor, selectors.EVENT_READ)
+            except BaseException:
+                active_streams.pop(file_descriptor, None)
+                raise
+
+        while process.poll() is None:
+            if output_limit_exceeded:
+                break
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
+                break
+            for key, _mask in selector.select(min(remaining, 0.05)):
+                read_ready(key.fd)
+    except BaseException as error:
+        run_error = error
+    finally:
+        # The private session is disposable. Terminate the whole group on every
+        # outcome so a completed leader cannot leave pipe-holding descendants.
+        cleanup_deadline = time.monotonic() + PROCESS_SHUTDOWN_TIMEOUT_SECONDS
+        cleanup_error: BaseException | None = None
+        try:
+            _kill_process_group(process, deadline=cleanup_deadline)
+        except BaseException as error:
+            cleanup_error = error
+
+        if cleanup_error is None:
+            while active_streams and time.monotonic() < cleanup_deadline:
+                events = selector.select(
+                    min(0.05, max(0.0, cleanup_deadline - time.monotonic()))
+                )
+                if not events:
+                    continue
+                try:
+                    for key, _mask in events:
+                        read_ready(key.fd)
+                except BaseException as error:
+                    cleanup_error = error
+                    break
+            if active_streams:
+                cleanup_error = cleanup_error or BenchmarkError(
+                    "child output pipes did not reach EOF"
+                )
+
+        selector.close()
+        for stream in (process.stdout, process.stderr):
+            if stream is not None:
+                with contextlib.suppress(OSError):
+                    stream.close()
+        if cleanup_error is not None:
+            raise BenchmarkError("child process cleanup could not be verified") from (
+                run_error or cleanup_error
+            )
+
+    if run_error is not None:
+        raise run_error
+
+    return ProcessCapture(
+        returncode=None if timed_out else process.returncode,
+        stdout=b"".join(stdout_chunks),
+        stderr_bytes=totals["stderr"],
+        timed_out=timed_out,
+        stdout_truncated=totals["stdout"] > stdout_limit,
+        stderr_truncated=totals["stderr"] > stderr_limit,
+        output_limit_exceeded=output_limit_exceeded,
+    )
+
+
+def _literal_loopback_endpoints(
+    host: str, port: int
+) -> tuple[tuple[int, tuple[Any, ...]], ...]:
+    if host == "127.0.0.1":
+        return ((socket.AF_INET, (host, port)),)
+    if host == "::1":
+        return ((socket.AF_INET6, (host, port, 0, 0)),)
+    if host == "localhost":
+        return (
+            (socket.AF_INET, ("127.0.0.1", port)),
+            (socket.AF_INET6, ("::1", port, 0, 0)),
+        )
+    raise BenchmarkError("test upstream was not an exact loopback host")
+
+
+def _resolve_upstream_endpoints(
+    host: str, port: int
+) -> tuple[tuple[int, tuple[Any, ...]], ...]:
+    resolver = """
+import json
+import socket
+import sys
+
+host = sys.argv[1]
+port = int(sys.argv[2])
+results = []
+for family, kind, protocol, _canonical, address in socket.getaddrinfo(
+    host, port, type=socket.SOCK_STREAM, proto=socket.IPPROTO_TCP
+):
+    if family in (socket.AF_INET, socket.AF_INET6):
+        results.append([family, list(address)])
+print(json.dumps(results, separators=(",", ":")))
+"""
+    capture = _run_process(
+        [sys.executable, "-I", "-c", resolver, host, str(port)],
+        Path.cwd(),
+        {"PATH": os.environ.get("PATH") or os.defpath, "LC_ALL": "C"},
+        timeout_seconds=UPSTREAM_RESOLVE_TIMEOUT_SECONDS,
+        stdout_limit=64 * 1024,
+        stderr_limit=64 * 1024,
+    )
+    if (
+        capture.returncode != 0
+        or capture.timed_out
+        or capture.output_limit_exceeded
+        or capture.stderr_truncated
+    ):
+        raise BenchmarkError("official upstream DNS resolution failed")
+    try:
+        raw_endpoints = json.loads(capture.stdout)
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise BenchmarkError("official upstream DNS result was malformed") from error
+    if not isinstance(raw_endpoints, list) or not 1 <= len(raw_endpoints) <= 32:
+        raise BenchmarkError("official upstream DNS result was empty or oversized")
+    endpoints: list[tuple[int, tuple[Any, ...]]] = []
+    for entry in raw_endpoints:
+        if (
+            not isinstance(entry, list)
+            or len(entry) != 2
+            or entry[0] not in {socket.AF_INET, socket.AF_INET6}
+            or not isinstance(entry[1], list)
+        ):
+            raise BenchmarkError("official upstream DNS endpoint was malformed")
+        family = entry[0]
+        address = entry[1]
+        expected_length = 2 if family == socket.AF_INET else 4
+        if len(address) != expected_length or address[1] != port:
+            raise BenchmarkError("official upstream DNS endpoint was malformed")
+        try:
+            parsed_ip = ipaddress.ip_address(address[0])
+        except ValueError as error:
+            raise BenchmarkError("official upstream DNS address was malformed") from error
+        if (family == socket.AF_INET) != isinstance(parsed_ip, ipaddress.IPv4Address):
+            raise BenchmarkError("official upstream DNS address family disagreed")
+        if family == socket.AF_INET6 and any(
+            isinstance(value, bool) or not isinstance(value, int) or value < 0
+            for value in address[2:]
+        ):
+            raise BenchmarkError("official upstream IPv6 endpoint was malformed")
+        endpoint = (family, tuple(address))
+        if endpoint not in endpoints:
+            endpoints.append(endpoint)
+    if not endpoints:
+        raise BenchmarkError("official upstream DNS result contained no usable address")
+    return tuple(endpoints)
+
+
+def _parse_stdout_object(capture: ProcessCapture) -> tuple[dict[str, Any] | None, str | None]:
+    if capture.stdout_truncated:
+        return None, "client_stdout_too_large"
+    try:
+        value = json.loads(capture.stdout)
+    except (UnicodeError, json.JSONDecodeError):
+        return None, "client_stdout_not_single_json_object"
+    if not isinstance(value, dict):
+        return None, "client_stdout_not_single_json_object"
+    return value, None
+
+
+def parse_fx_client_output(capture: ProcessCapture) -> dict[str, Any]:
+    errors: list[str] = []
+    if capture.timed_out:
+        errors.append("client_timeout")
+    if capture.returncode != 0:
+        errors.append("process_exit_nonzero")
+    if capture.stderr_truncated:
+        errors.append("client_stderr_too_large")
+    value, parse_error = _parse_stdout_object(capture)
+    if parse_error is not None:
+        errors.append(parse_error)
+        value = {}
+    json_exit = value.get("exit_code")
+    if isinstance(json_exit, bool) or not isinstance(json_exit, int) or json_exit != 0:
+        errors.append("fx_json_exit_nonzero_or_missing")
+    final_output_valid = value.get("output") == ACK_TOKEN
+    if not final_output_valid:
+        errors.append("fx_final_output_mismatch")
+    model_valid = value.get("model") == MODEL
+    if not model_valid:
+        errors.append("fx_reported_model_mismatch")
+    tool_calls = value.get("tool_calls")
+    if not isinstance(tool_calls, list):
+        errors.append("fx_tool_calls_not_array")
+        reported_tool_calls: int | None = None
+    else:
+        reported_tool_calls = len(tool_calls)
+    return {
+        "valid": not errors,
+        "errors": list(dict.fromkeys(errors)),
+        "process_exit_code": capture.returncode,
+        "timed_out": capture.timed_out,
+        "stdout_bytes": len(capture.stdout),
+        "stderr_bytes": capture.stderr_bytes,
+        "final_output_valid": final_output_valid,
+        "reported_model_valid": model_valid,
+        "reported_tool_calls": reported_tool_calls,
+        "client_configuration_echo_valid": model_valid,
+    }
+
+
+def _is_nonnegative_integer(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _nanocodex_diagnostics_valid(value: Mapping[str, Any]) -> bool:
+    timing = value.get("timing_ns")
+    if not isinstance(timing, dict):
+        return False
+    required_timings = (
+        "prompt_submit_to_acceptance",
+        "prompt_submit_to_first_assistant_delta_emitted",
+        "prompt_acceptance_to_first_assistant_delta_emitted",
+        "prompt_submit_to_first_assistant_delta_received",
+        "prompt_acceptance_to_first_assistant_delta_received",
+        "assistant_delta_emit_to_receive",
+        "prompt_submit_to_result_completion",
+        "prompt_acceptance_to_result_completion",
+    )
+    if not all(_is_nonnegative_integer(timing.get(key)) for key in required_timings):
+        return False
+    provider_to_emit = timing.get("provider_source_to_assistant_delta_emit")
+    if provider_to_emit is not None and not _is_nonnegative_integer(provider_to_emit):
+        return False
+
+    usage = value.get("usage")
+    turn_usage = value.get("turn_usage")
+    token_fields = (
+        "input_tokens",
+        "cached_input_tokens",
+        "cache_write_input_tokens",
+        "output_tokens",
+        "reasoning_output_tokens",
+        "total_tokens",
+    )
+    if not isinstance(usage, dict) or not isinstance(usage.get("reported"), bool):
+        return False
+    if not all(_is_nonnegative_integer(usage.get(key)) for key in token_fields):
+        return False
+    if not isinstance(turn_usage, dict) or not all(
+        _is_nonnegative_integer(turn_usage.get(key)) for key in token_fields
+    ):
+        return False
+
+    events = value.get("events")
+    return isinstance(events, dict) and all(
+        (
+            _is_nonnegative_integer(events.get("count")),
+            _is_nonnegative_integer(events.get("first_sequence")),
+            _is_nonnegative_integer(events.get("last_sequence")),
+            _is_nonnegative_integer(events.get("assistant_delta_count")),
+            events.get("sequences_contiguous") is True,
+        )
+    )
+
+
+def parse_nanocodex_client_output(
+    capture: ProcessCapture, *, source_commit: str, cwd: Path
+) -> dict[str, Any]:
+    errors: list[str] = []
+    if capture.timed_out:
+        errors.append("client_timeout")
+    if capture.returncode != 0:
+        errors.append("process_exit_nonzero")
+    if capture.stderr_truncated:
+        errors.append("client_stderr_too_large")
+    value, parse_error = _parse_stdout_object(capture)
+    if parse_error is not None:
+        errors.append(parse_error)
+        value = {}
+
+    provenance = value.get("provenance")
+    configuration_echo_valid = isinstance(provenance, dict) and all(
+        (
+            value.get("schema_version") == 1,
+            value.get("benchmark") == "paired_fx_model_latency",
+            provenance.get("implementation") == "nanocodex" if isinstance(provenance, dict) else False,
+            provenance.get("source_commit") == source_commit if isinstance(provenance, dict) else False,
+            provenance.get("model") == MODEL if isinstance(provenance, dict) else False,
+            provenance.get("thinking") == EFFORT if isinstance(provenance, dict) else False,
+            provenance.get("fast_mode") is False if isinstance(provenance, dict) else False,
+            provenance.get("workspace") == str(cwd) if isinstance(provenance, dict) else False,
+            provenance.get("instructions_fnv1a64") == fnv1a64(SYSTEM_INSTRUCTIONS)
+            if isinstance(provenance, dict)
+            else False,
+            provenance.get("prompt_fnv1a64") == fnv1a64(ACK_TOKEN)
+            if isinstance(provenance, dict)
+            else False,
+            provenance.get("expected_fnv1a64") == fnv1a64(ACK_TOKEN)
+            if isinstance(provenance, dict)
+            else False,
+            provenance.get("prompt_cache_key_fnv1a64")
+            == fnv1a64(NANOCODEX_PROMPT_CACHE_KEY)
+            if isinstance(provenance, dict)
+            else False,
+        )
+    )
+    if not configuration_echo_valid:
+        errors.append("nanocodex_configuration_echo_invalid")
+    if value.get("transport") != "https":
+        errors.append("nanocodex_transport_invalid")
+
+    verified = value.get("verified")
+    final_output_valid = isinstance(verified, dict) and verified.get("final_output") is True
+    functional_checks = isinstance(verified, dict) and all(
+        verified.get(key) is True
+        for key in (
+            "final_output",
+            "assistant_deltas",
+            "one_model_call",
+            "zero_tool_calls",
+            "run_completed",
+            "clean_shutdown",
+            "auth_refresh_disabled",
+        )
+    )
+    if not functional_checks:
+        errors.append("nanocodex_functional_verification_failed")
+
+    model_call = value.get("model_call")
+    model_call_valid = isinstance(model_call, dict) and all(
+        (
+            model_call.get("call_index") == 1,
+            isinstance(model_call.get("attempt"), int)
+            and not isinstance(model_call.get("attempt"), bool)
+            and model_call["attempt"] >= 1,
+            isinstance(model_call.get("connection_generation"), int)
+            and not isinstance(model_call.get("connection_generation"), bool)
+            and model_call["connection_generation"] == 0,
+            model_call.get("status") == "completed",
+            _is_nonnegative_integer(model_call.get("duration_ns")),
+            _is_nonnegative_integer(model_call.get("time_to_first_event_ns")),
+            model_call.get("time_to_first_output_ns") is None
+            or _is_nonnegative_integer(model_call.get("time_to_first_output_ns")),
+            _is_nonnegative_integer(model_call.get("tool_calls")),
+        )
+    )
+    if not model_call_valid:
+        errors.append("nanocodex_model_call_invalid")
+    reported_tool_calls = (
+        model_call.get("tool_calls") if isinstance(model_call, dict) else None
+    )
+
+    usage = value.get("usage")
+    reported_cached = usage.get("cached_input_tokens") if isinstance(usage, dict) else None
+    if reported_cached is not None and not _is_nonnegative_integer(reported_cached):
+        errors.append("nanocodex_cached_tokens_invalid")
+        reported_cached = None
+    if not _nanocodex_diagnostics_valid(value):
+        errors.append("nanocodex_diagnostics_invalid")
+
+    return {
+        "valid": not errors,
+        "errors": list(dict.fromkeys(errors)),
+        "process_exit_code": capture.returncode,
+        "timed_out": capture.timed_out,
+        "stdout_bytes": len(capture.stdout),
+        "stderr_bytes": capture.stderr_bytes,
+        "final_output_valid": final_output_valid,
+        "reported_tool_calls": reported_tool_calls,
+        "reported_cached_input_tokens": reported_cached,
+        "client_configuration_echo_valid": configuration_echo_valid,
+    }
+
+
+def _missing_observation(expected: ExpectedRequest) -> dict[str, Any]:
+    return _empty_observer_record(
+        expected, request_bytes=None, error="client_sent_no_observed_request"
+    )
+
+
+def _required_timing_present(observation: Mapping[str, Any]) -> bool:
+    timing = observation.get("timing_ns")
+    return isinstance(timing, dict) and _is_nonnegative_integer(
+        timing.get("time_to_first_model_output")
+    )
+
+
+def _combined_run(
+    implementation: str,
+    client: dict[str, Any],
+    observer: dict[str, Any],
+    unexpected_requests: int,
+) -> dict[str, Any]:
+    observer_functional = (
+        observer.get("error") is None
+        and observer.get("status") == "completed"
+        and observer.get("upstream_http_status") is not None
+        and 200 <= observer["upstream_http_status"] < 300
+    )
+    functional_valid = bool(client.get("valid")) and observer_functional
+    client_tool_count = client.get("reported_tool_calls")
+    no_tool_calls = (
+        client_tool_count == 0
+        and observer.get("tool_call_detected") is False
+        and unexpected_requests == 0
+    )
+    timing_present = _required_timing_present(observer)
+    measured_failure = not (
+        functional_valid and no_tool_calls and timing_present and unexpected_requests == 0
+    )
+    return {
+        "implementation": implementation,
+        "functional_valid": functional_valid,
+        "no_tool_calls": no_tool_calls,
+        "timing_present": timing_present,
+        "cached_input_tokens": observer.get("cached_input_tokens"),
+        "unexpected_request_count": unexpected_requests,
+        "measured_failure": measured_failure,
+        "client_configuration_echo_valid": bool(
+            client.get("client_configuration_echo_valid")
+        ),
+        "client": client,
+        "observer": observer,
+    }
+
+
+def _run_implementation(
+    implementation: str,
+    *,
+    pair: int,
+    phase: str,
+    sequence: int,
+    args: argparse.Namespace,
+    auth: AuthMaterial,
+    observer: StreamingObserver,
+    runtime_root: Path,
+    executables: Mapping[str, tuple[Path, str]],
+) -> dict[str, Any]:
+    auth.assert_live_window()
+    executable, expected_digest = executables[implementation]
+    _assert_executable_copy(executable, expected_digest)
+    with tempfile.TemporaryDirectory(
+        prefix=f"{sequence:04d}-{implementation}-", dir=runtime_root
+    ) as raw_home:
+        generated = Path(raw_home)
+        generated.rmdir()
+        if implementation == "fx":
+            prepare_fx_home(generated, auth)
+        else:
+            prepare_nanocodex_home(generated, auth)
+        generated = generated.resolve(strict=True)
+        workspace = generated / "workspace"
+        _mkdir_private(workspace)
+        workspace = workspace.resolve(strict=True)
+        expected = ExpectedRequest(
+            implementation=implementation,
+            pair=pair,
+            phase=phase,
+            home=str(generated),
+            workspace=str(workspace),
+        )
+        before_unexpected = observer.state.stats()["unexpected_requests"]
+        ticket = observer.state.arm(expected)
+        try:
+            environment = _child_environment(generated)
+            if implementation == "fx":
+                environment.update(
+                    {
+                        "FX_DISABLE_KEYCHAIN": "1",
+                        "FX_AUTO_UPGRADE": "0",
+                        "FX_E2E_OPENAI_CODEX_RESPONSES_URL": observer.base_url
+                        + "/responses",
+                        "FX_E2E_OPENAI_CODEX_MODELS_URL": observer.base_url + "/models",
+                        "FX_E2E_CHATGPT_TOKEN_URL": observer.base_url + "/forbid-refresh",
+                    }
+                )
+                command = [
+                    str(executable),
+                    "ask",
+                    "--json",
+                    "--no-save",
+                    "--auto",
+                    "--system",
+                    SYSTEM_INSTRUCTIONS,
+                    "--",
+                    ACK_TOKEN,
+                ]
+                capture = _run_process(
+                    _sandboxed_child_command(command, observer.base_url),
+                    workspace,
+                    environment,
+                )
+                client = parse_fx_client_output(capture)
+            else:
+                auth_path = generated / ".codex" / "auth.json"
+                environment["CODEX_HOME"] = str(auth_path.parent)
+                command = [
+                    str(executable),
+                    "--cwd",
+                    str(workspace),
+                    "--auth-file",
+                    str(auth_path),
+                    "--api-base-url",
+                    observer.base_url,
+                    "--instructions",
+                    SYSTEM_INSTRUCTIONS,
+                    "--prompt",
+                    ACK_TOKEN,
+                    "--expected",
+                    ACK_TOKEN,
+                    "--source-commit",
+                    args.nanocodex_commit,
+                    "--transport",
+                    "https",
+                ]
+                capture = _run_process(
+                    _sandboxed_child_command(command, observer.base_url),
+                    workspace,
+                    environment,
+                )
+                client = parse_nanocodex_client_output(
+                    capture,
+                    source_commit=args.nanocodex_commit,
+                    cwd=workspace,
+                )
+        except BaseException:
+            observer.state.cancel_unclaimed(ticket)
+            raise
+
+        if observer.state.cancel_unclaimed(ticket):
+            observed = _missing_observation(expected)
+        else:
+            observed = observer.state.wait(ticket, OBSERVER_RESULT_TIMEOUT_SECONDS)
+            if observed is None:
+                observed = _missing_observation(expected)
+        after_unexpected = observer.state.stats()["unexpected_requests"]
+    return _combined_run(
+        implementation,
+        client,
+        observed,
+        after_unexpected - before_unexpected,
+    )
+
+
+def _offline_actual_binary_preflight(
+    *,
+    args: argparse.Namespace,
+    runtime_root: Path,
+    executables: Mapping[str, tuple[Path, str]],
+    fresh_identifier_ledger: FreshUuid7Ledger,
+) -> tuple[dict[str, str], dict[str, Any]]:
+    fake_auth = _fake_auth_material()
+    run_count = 4
+    preflight_runtime_root = runtime_root / XML_METACHAR_PREFLIGHT_DIRECTORY
+    _mkdir_private(preflight_runtime_root)
+    with _OfflineProvider() as provider:
+        with StreamingObserver._for_test(
+            fake_auth,
+            provider.url,
+            provider_request_budget=run_count,
+            fresh_identifier_ledger=fresh_identifier_ledger,
+            require_fx_models_discovery=True,
+        ) as observer:
+            for sequence, implementation in enumerate(
+                ("fx", "nanocodex", "nanocodex", "fx"), 1
+            ):
+                run = _run_implementation(
+                    implementation,
+                    pair=(sequence + 1) // 2,
+                    phase="offline_preflight",
+                    sequence=sequence,
+                    args=args,
+                    auth=fake_auth,
+                    observer=observer,
+                    runtime_root=(
+                        preflight_runtime_root
+                        if implementation == "nanocodex"
+                        else runtime_root
+                    ),
+                    executables=executables,
+                )
+                if run["measured_failure"]:
+                    client_errors = run.get("client", {}).get("errors", [])
+                    observer_error = run.get("observer", {}).get("error")
+                    safe_detail = observer_error or ",".join(client_errors) or "unknown"
+                    raise BenchmarkError(
+                        f"{implementation} actual-binary offline preflight failed: {safe_detail}"
+                    )
+            stats = observer.state.stats()
+            fingerprints = observer.state.request_fingerprints()
+            stable = observer.state.fingerprints_stable()
+            shared_auth_verified = observer.auth_matcher.verified()
+        with provider.server.lock:
+            upstream_requests = provider.server.requests
+
+    if (
+        stats["provider_requests_forwarded"] != run_count
+        or upstream_requests != run_count
+        or stats["models_requests"] != run_count // 2
+        or stats["unexpected_requests"] != 0
+        or stats["refresh_attempts_blocked"] != 0
+        or not stable
+        or not shared_auth_verified
+    ):
+        raise BenchmarkError("actual-binary offline preflight containment failed")
+
+    fedramp_auth = _fake_auth_material(fedramp=True)
+    fedramp_run_count = 2
+    with _OfflineProvider() as fedramp_provider:
+        with StreamingObserver._for_test(
+            fedramp_auth,
+            fedramp_provider.url,
+            provider_request_budget=fedramp_run_count,
+            fresh_identifier_ledger=fresh_identifier_ledger,
+            require_fx_models_discovery=True,
+        ) as fedramp_observer:
+            for sequence in range(run_count + 1, run_count + fedramp_run_count + 1):
+                run = _run_implementation(
+                    "nanocodex",
+                    pair=sequence,
+                    phase="offline_fedramp_preflight",
+                    sequence=sequence,
+                    args=args,
+                    auth=fedramp_auth,
+                    observer=fedramp_observer,
+                    runtime_root=preflight_runtime_root,
+                    executables=executables,
+                )
+                if run["measured_failure"]:
+                    client_errors = run.get("client", {}).get("errors", [])
+                    observer_error = run.get("observer", {}).get("error")
+                    safe_detail = observer_error or ",".join(client_errors) or "unknown"
+                    raise BenchmarkError(
+                        "nanocodex actual-binary FedRAMP preflight failed: "
+                        f"{safe_detail}"
+                    )
+            fedramp_stats = fedramp_observer.state.stats()
+            fedramp_fingerprints = fedramp_observer.state.request_fingerprints()
+            fedramp_auth_verified = fedramp_observer.auth_matcher.verified_for(
+                {"nanocodex"}
+            )
+        with fedramp_provider.server.lock:
+            fedramp_upstream_requests = fedramp_provider.server.requests
+    if (
+        fedramp_stats["provider_requests_forwarded"] != fedramp_run_count
+        or fedramp_upstream_requests != fedramp_run_count
+        or fedramp_stats["models_requests"] != 0
+        or fedramp_stats["unexpected_requests"] != 0
+        or fedramp_stats["refresh_attempts_blocked"] != 0
+        or fedramp_fingerprints != {"nanocodex": fingerprints["nanocodex"]}
+        or not fedramp_auth_verified
+    ):
+        raise BenchmarkError("actual-binary FedRAMP preflight containment failed")
+    freshness_evidence = fresh_identifier_ledger.evidence()
+    if not freshness_evidence["distinct_and_one_use_verified"]:
+        raise BenchmarkError("actual-binary UUIDv7 freshness preflight failed")
+    return fingerprints, {
+        "passed": True,
+        "provider_network_used": False,
+        "scripted_loopback_requests": upstream_requests + fedramp_upstream_requests,
+        "runs_per_implementation": 2,
+        "nanocodex_fedramp_runs": fedramp_run_count,
+        "nanocodex_fedramp_header_verified_from_id_token": True,
+        "contradictory_id_and_access_token_claims_verified": True,
+        "fx_exact_models_discovery_once_per_run_verified": True,
+        "fresh_uuid7_identifiers_distinct_and_one_use_verified": freshness_evidence[
+            "distinct_and_one_use_verified"
+        ],
+        "xml_metacharacter_private_paths_verified": True,
+        "distinct_private_workspace_fingerprints_stable": stable,
+        "exact_executable_request_templates_captured": True,
+        "independent_reference_body_fingerprints_verified": True,
+    }
+
+
+def percentile(values: Sequence[int], quantile: float) -> int | None:
+    if not values:
+        return None
+    if not 0 < quantile <= 1:
+        raise BenchmarkError("nearest-rank quantiles must be in (0, 1]")
+    ordered = sorted(values)
+    return ordered[math.ceil(len(ordered) * quantile) - 1]
+
+
+def distribution(values: Sequence[int]) -> dict[str, Any]:
+    return {
+        "n": len(values),
+        "percentile_method": "nearest_rank",
+        "p50": percentile(values, 0.50),
+        "p95": percentile(values, 0.95),
+        "min": min(values) if values else None,
+        "max": max(values) if values else None,
+    }
+
+
+def _pair_reasons(
+    pair: Mapping[str, Any], *, cache_policy: str
+) -> list[str]:
+    reasons: list[str] = []
+    runs = pair.get("runs")
+    if not isinstance(runs, dict):
+        return ["malformed_pair"]
+    for implementation in ("fx", "nanocodex"):
+        run = runs.get(implementation)
+        if not isinstance(run, dict):
+            reasons.append(f"{implementation}_missing")
+            continue
+        if run.get("functional_valid") is not True:
+            reasons.append(f"{implementation}_functionally_invalid")
+        if run.get("no_tool_calls") is not True:
+            reasons.append(f"{implementation}_tool_call_or_extra_request")
+        if run.get("timing_present") is not True:
+            reasons.append(f"{implementation}_timing_missing")
+    if cache_policy not in {"ignore", "warm", "equal"}:
+        raise BenchmarkError("unknown cache eligibility policy")
+    if cache_policy != "ignore" and all(
+        isinstance(runs.get(name), dict) for name in ("fx", "nanocodex")
+    ):
+        fx_cached = runs["fx"].get("cached_input_tokens")
+        nano_cached = runs["nanocodex"].get("cached_input_tokens")
+        if not _is_nonnegative_integer(fx_cached) or not _is_nonnegative_integer(
+            nano_cached
+        ):
+            reasons.append("cached_input_tokens_unknown_or_invalid")
+        elif cache_policy == "warm" and fx_cached == 0 and nano_cached == 0:
+            reasons.append("cached_input_both_cold")
+        elif cache_policy == "warm" and (fx_cached == 0 or nano_cached == 0):
+            reasons.append("cached_input_warm_cold_mismatch")
+        elif cache_policy == "equal" and fx_cached != nano_cached:
+            reasons.append("cached_input_tokens_mismatch")
+    return reasons
+
+
+def _metric_value(run: Mapping[str, Any], metric: str) -> int | None:
+    return run["observer"]["timing_ns"][metric]
+
+
+def paired_metric(pairs: Sequence[Mapping[str, Any]], metric: str) -> dict[str, Any]:
+    eligible = [
+        pair
+        for pair in pairs
+        if _is_nonnegative_integer(_metric_value(pair["runs"]["fx"], metric))
+        and _is_nonnegative_integer(
+            _metric_value(pair["runs"]["nanocodex"], metric)
+        )
+    ]
+    fx_values = [_metric_value(pair["runs"]["fx"], metric) for pair in eligible]
+    nano_values = [
+        _metric_value(pair["runs"]["nanocodex"], metric) for pair in eligible
+    ]
+    deltas = [nano - fx for fx, nano in zip(fx_values, nano_values)]
+    return {
+        "unit": "ns",
+        "eligible_pairs": len(eligible),
+        "delta_definition": "nanocodex_minus_fx",
+        "fx": distribution(fx_values),
+        "nanocodex": distribution(nano_values),
+        "paired_delta": distribution(deltas),
+        "win_counts_are": "descriptive_only_not_inferential",
+        "tie_threshold_ns": TIE_THRESHOLD_NS,
+        "wins": {
+            "nanocodex": sum(delta < -TIE_THRESHOLD_NS for delta in deltas),
+            "fx": sum(delta > TIE_THRESHOLD_NS for delta in deltas),
+            "ties": sum(abs(delta) <= TIE_THRESHOLD_NS for delta in deltas),
+        },
+    }
+
+
+def summarize_pairs(pairs: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    primary: list[Mapping[str, Any]] = []
+    strict_equal: list[Mapping[str, Any]] = []
+    diagnostic: list[Mapping[str, Any]] = []
+    exclusion_counts: dict[str, int] = {}
+    cache_matches = 0
+    cache_mismatches = 0
+    cache_unknown = 0
+    for pair in pairs:
+        diagnostic_reasons = _pair_reasons(pair, cache_policy="ignore")
+        primary_reasons = _pair_reasons(pair, cache_policy="warm")
+        strict_reasons = _pair_reasons(pair, cache_policy="equal")
+        if not diagnostic_reasons:
+            diagnostic.append(pair)
+            runs = pair["runs"]
+            fx_cached = runs["fx"].get("cached_input_tokens")
+            nano_cached = runs["nanocodex"].get("cached_input_tokens")
+            if not _is_nonnegative_integer(fx_cached) or not _is_nonnegative_integer(
+                nano_cached
+            ):
+                cache_unknown += 1
+            elif fx_cached == nano_cached:
+                cache_matches += 1
+            else:
+                cache_mismatches += 1
+        if not primary_reasons:
+            primary.append(pair)
+        if not strict_reasons:
+            strict_equal.append(pair)
+        for reason in primary_reasons:
+            exclusion_counts[reason] = exclusion_counts.get(reason, 0) + 1
+
+    metrics = (
+        "time_to_first_model_output",
+        "time_to_first_answer_text",
+        "time_to_terminal",
+    )
+    return {
+        "primary": {
+            "eligibility": (
+                "both functionally valid, no tool/extra calls, scored TTFT present, "
+                "and both product-specific cached-input counts are known "
+                "positive integers; exact counts may differ and remain part of each "
+                "product's shipped latency"
+            ),
+            "cache_exclusions": (
+                "null/invalid counts, both-cold pairs, and warm/cold mismatches are "
+                "not scored"
+            ),
+            "minimum_eligible_pairs": MIN_PRIMARY_ELIGIBLE_PAIRS,
+            "eligible_pairs": len(primary),
+            "metrics": {metric: paired_metric(primary, metric) for metric in metrics},
+        },
+        "strict_equal_cache_diagnostic": {
+            "eligibility": (
+                "all functional/scored-TTFT gates plus known nonnegative and exactly "
+                "equal cached-input counts"
+            ),
+            "eligible_pairs": len(strict_equal),
+            "metrics": {
+                metric: paired_metric(strict_equal, metric) for metric in metrics
+            },
+        },
+        "all_valid_diagnostic": {
+            "eligibility": (
+                "both functionally valid, no tool/extra calls, and scored TTFT "
+                "present; optional diagnostic timings are summarized where present; "
+                "cache equality ignored"
+            ),
+            "eligible_pairs": len(diagnostic),
+            "cache_equal_pairs": cache_matches,
+            "cache_mismatch_pairs": cache_mismatches,
+            "cache_unknown_pairs": cache_unknown,
+            "metrics": {
+                metric: paired_metric(diagnostic, metric) for metric in metrics
+            },
+        },
+        "primary_exclusions": exclusion_counts,
+    }
+
+
+def _local_command_environment() -> dict[str, str]:
+    return {
+        "PATH": os.environ.get("PATH") or os.defpath,
+        "LC_ALL": "C",
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_CONFIG_GLOBAL": os.devnull,
+        "GIT_OPTIONAL_LOCKS": "0",
+    }
+
+
+def _git_output(root: Path, *arguments: str) -> str:
+    capture = _run_process(
+        ["git", "-C", str(root), *arguments],
+        root,
+        _local_command_environment(),
+        timeout_seconds=15,
+        stdout_limit=128 * 1024,
+        stderr_limit=128 * 1024,
+    )
+    if (
+        capture.returncode != 0
+        or capture.timed_out
+        or capture.output_limit_exceeded
+        or capture.stderr_truncated
+    ):
+        raise BenchmarkError("source checkout git inspection failed")
+    try:
+        return capture.stdout.decode("utf-8").rstrip("\n")
+    except UnicodeError as error:
+        raise BenchmarkError("source checkout git output was not UTF-8") from error
+
+
+def _source_provenance(
+    source_root: Path,
+    executable: Path,
+    expected_commit: str,
+    implementation: str,
+) -> dict[str, Any]:
+    if not COMMIT_RE.fullmatch(expected_commit):
+        raise BenchmarkError("source commits must be full 40-character hexadecimal IDs")
+    expected_commit = expected_commit.lower()
+    try:
+        root = source_root.resolve(strict=True)
+    except OSError as error:
+        raise BenchmarkError(f"{implementation} source root is not readable") from error
+    if not root.is_dir():
+        raise BenchmarkError(f"{implementation} source root must be a directory")
+    try:
+        git_root = Path(_git_output(root, "rev-parse", "--show-toplevel")).resolve(
+            strict=True
+        )
+    except OSError as error:
+        raise BenchmarkError(f"{implementation} git root is not readable") from error
+    if git_root != root:
+        raise BenchmarkError(
+            f"{implementation} source root must be the checkout top level"
+        )
+    head = _git_output(root, "rev-parse", "--verify", "HEAD").lower()
+    if head != expected_commit:
+        raise BenchmarkError(f"{implementation} source checkout HEAD mismatch")
+    if _git_output(root, "status", "--porcelain=v1", "--untracked-files=all"):
+        raise BenchmarkError(f"{implementation} source checkout is not clean")
+    try:
+        resolved = executable.resolve(strict=True)
+        resolved.relative_to(root)
+        info = resolved.stat()
+    except (OSError, ValueError) as error:
+        raise BenchmarkError(
+            f"{implementation} executable must resolve beneath its source checkout"
+        ) from error
+    if not stat.S_ISREG(info.st_mode) or not os.access(resolved, os.X_OK):
+        raise BenchmarkError(
+            f"{implementation} executable must be an executable regular file"
+        )
+    return {
+        "implementation": implementation,
+        "source_root": str(root),
+        "expected_commit": expected_commit,
+        "git_head": head,
+        "tree_clean": True,
+        "binary": {
+            "path": str(resolved),
+            "sha256": sha256_file(resolved),
+            "byte_count": info.st_size,
+            "source_build_attestation": "not_claimed",
+        },
+    }
+
+
+def _copy_executable(
+    provenance: Mapping[str, Any], runtime_root: Path
+) -> Path:
+    implementation = provenance["implementation"]
+    source = Path(provenance["binary"]["path"])
+    destination = runtime_root / f"{implementation}-immutable"
+    descriptor = os.open(
+        destination,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+        0o500,
+    )
+    try:
+        with source.open("rb") as reader, os.fdopen(
+            descriptor, "wb", closefd=True
+        ) as writer:
+            shutil.copyfileobj(reader, writer, length=1024 * 1024)
+            writer.flush()
+            os.fsync(writer.fileno())
+            os.fchmod(writer.fileno(), 0o500)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.close(descriptor)
+        with contextlib.suppress(OSError):
+            destination.unlink()
+        raise
+    _assert_executable_copy(destination, provenance["binary"]["sha256"])
+    return destination
+
+
+def _assert_executable_copy(path: Path, expected_sha256: str) -> None:
+    try:
+        info = path.lstat()
+    except OSError as error:
+        raise BenchmarkError("private executable copy is not readable") from error
+    if (
+        not stat.S_ISREG(info.st_mode)
+        or stat.S_IMODE(info.st_mode) != 0o500
+        or info.st_nlink != 1
+        or not os.access(path, os.X_OK)
+        or sha256_file(path) != expected_sha256
+    ):
+        raise BenchmarkError("private executable copy failed its immutable digest check")
+
+
+def _source_unchanged(provenance: Mapping[str, Any]) -> bool:
+    try:
+        current = _source_provenance(
+            Path(provenance["source_root"]),
+            Path(provenance["binary"]["path"]),
+            provenance["expected_commit"],
+            provenance["implementation"],
+        )
+    except BenchmarkError:
+        return False
+    return current["binary"]["sha256"] == provenance["binary"]["sha256"]
+
+
+def _preflight_report_output(path: Path) -> None:
+    if os.path.lexists(path):
+        raise BenchmarkError("--output already exists; refusing to overwrite it")
+    descriptor = -1
+    temporary = ""
+    try:
+        descriptor, temporary = tempfile.mkstemp(
+            prefix=f".{path.name}.preflight-", dir=path.parent
+        )
+        os.fchmod(descriptor, 0o600)
+        os.write(descriptor, b"{}\n")
+        os.fsync(descriptor)
+    except OSError as error:
+        raise BenchmarkError("report output failed its preflight write") from error
+    finally:
+        if descriptor >= 0:
+            with contextlib.suppress(OSError):
+                os.close(descriptor)
+        if temporary:
+            with contextlib.suppress(OSError):
+                os.unlink(temporary)
+
+
+def _validate_and_resolve_args(args: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not args.confirm_paid_live_run:
+        raise BenchmarkError("--confirm-paid-live-run is required")
+    if (
+        isinstance(args.trials, bool)
+        or not isinstance(args.trials, int)
+        or args.trials < MIN_TRIALS
+        or args.trials > MAX_TRIALS
+        or args.trials % 2 != 0
+    ):
+        raise BenchmarkError(
+            f"--trials must be an even integer from {MIN_TRIALS} through {MAX_TRIALS}"
+        )
+    if (
+        isinstance(args.warmup_pairs, bool)
+        or not isinstance(args.warmup_pairs, int)
+        or args.warmup_pairs < 0
+        or args.warmup_pairs > MAX_WARMUP_PAIRS
+    ):
+        raise BenchmarkError(
+            f"--warmup-pairs must be from 0 through {MAX_WARMUP_PAIRS}"
+        )
+    request_budget = 2 * (args.warmup_pairs + args.trials)
+    if request_budget <= 0 or request_budget > MAX_PROVIDER_REQUESTS:
+        raise BenchmarkError("provider request budget is outside the bounded range")
+    args.provider_request_budget = request_budget
+    _require_child_egress_sandbox()
+    args.nanocodex_commit = args.nanocodex_commit.lower()
+    args.auth_file = args.auth_file.resolve(strict=True)
+    args.output = args.output.resolve()
+    if not args.output.parent.is_dir():
+        raise BenchmarkError("--output parent directory does not exist")
+    _preflight_report_output(args.output)
+    fx = _source_provenance(
+        args.fx_source_root, args.fx_bin, FX_COMMIT, "fx"
+    )
+    nano = _source_provenance(
+        args.nanocodex_source_root,
+        args.nanocodex_bin,
+        args.nanocodex_commit,
+        "nanocodex",
+    )
+    args.fx_source_root = Path(fx["source_root"])
+    args.nanocodex_source_root = Path(nano["source_root"])
+    args.fx_bin = Path(fx["binary"]["path"])
+    args.nanocodex_bin = Path(nano["binary"]["path"])
+    return fx, nano
+
+
+def _order(pair: int) -> list[str]:
+    return ["fx", "nanocodex"] if pair % 2 == 1 else ["nanocodex", "fx"]
+
+
+def _warmup_failure_summary(pair: int, run: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "pair": pair,
+        "implementation": run.get("implementation"),
+        "client_errors": run.get("client", {}).get("errors", []),
+        "observer_error": run.get("observer", {}).get("error"),
+    }
+
+
+def run_benchmark(args: argparse.Namespace) -> tuple[dict[str, Any], int, AuthMaterial]:
+    fx_provenance, nano_provenance = _validate_and_resolve_args(args)
+    fresh_identifier_ledger = FreshUuid7Ledger()
+    start_utc = dt.datetime.now(dt.timezone.utc).isoformat()
+    measured_pairs: list[dict[str, Any]] = []
+    warmup_failures: list[dict[str, Any]] = []
+    warmup_pairs_completed = 0
+    sequence = 0
+    aborted_before_measurement = False
+    aborted_on_measured_failure = False
+    copy_integrity = {"fx": False, "nanocodex": False}
+
+    with tempfile.TemporaryDirectory(prefix="nanocodex-fx-latency-") as raw_root:
+        runtime_root = Path(raw_root)
+        os.chmod(runtime_root, 0o700)
+        fx_copy = _copy_executable(fx_provenance, runtime_root)
+        nano_copy = _copy_executable(nano_provenance, runtime_root)
+        executables = {
+            "fx": (fx_copy, fx_provenance["binary"]["sha256"]),
+            "nanocodex": (
+                nano_copy,
+                nano_provenance["binary"]["sha256"],
+            ),
+        }
+        request_templates, offline_preflight = _offline_actual_binary_preflight(
+            args=args,
+            runtime_root=runtime_root,
+            executables=executables,
+            fresh_identifier_ledger=fresh_identifier_ledger,
+        )
+        auth = load_auth_snapshot(args.auth_file)
+        with StreamingObserver(
+            auth,
+            args.provider_request_budget,
+            expected_fingerprints=request_templates,
+            fresh_identifier_ledger=fresh_identifier_ledger,
+        ) as observer:
+            for pair in range(1, args.warmup_pairs + 1):
+                pair_failed = False
+                for implementation in _order(pair):
+                    sequence += 1
+                    run = _run_implementation(
+                        implementation,
+                        pair=pair,
+                        phase="warmup",
+                        sequence=sequence,
+                        args=args,
+                        auth=auth,
+                        observer=observer,
+                        runtime_root=runtime_root,
+                        executables=executables,
+                    )
+                    if run["measured_failure"]:
+                        pair_failed = True
+                        warmup_failures.append(_warmup_failure_summary(pair, run))
+                        break
+                if not pair_failed:
+                    warmup_pairs_completed += 1
+                if pair_failed:
+                    aborted_before_measurement = True
+                    break
+
+            if not aborted_before_measurement:
+                for pair in range(1, args.trials + 1):
+                    schedule_pair = args.warmup_pairs + pair
+                    pair_record: dict[str, Any] = {
+                        "pair": pair,
+                        "schedule_pair": schedule_pair,
+                        "order": _order(schedule_pair),
+                        "runs": {},
+                    }
+                    for implementation in pair_record["order"]:
+                        sequence += 1
+                        run = _run_implementation(
+                            implementation,
+                            pair=pair,
+                            phase="measured",
+                            sequence=sequence,
+                            args=args,
+                            auth=auth,
+                            observer=observer,
+                            runtime_root=runtime_root,
+                            executables=executables,
+                        )
+                        pair_record["runs"][implementation] = run
+                        if run["measured_failure"]:
+                            aborted_on_measured_failure = True
+                            break
+                    measured_pairs.append(pair_record)
+                    if aborted_on_measured_failure:
+                        break
+
+        # Snapshot only after the context's checked handler/upstream drain. A
+        # teardown failure raises before report construction or publication.
+        observer_stats = observer.state.stats()
+        shared_auth_verified = observer.auth_matcher.verified()
+        request_fingerprints = observer.state.request_fingerprints()
+        fingerprints_stable = observer.state.fingerprints_stable()
+        fresh_uuid7_identifiers_verified = (
+            fresh_identifier_ledger.distinct_and_one_use_verified()
+        )
+        offline_preflight[
+            "fresh_uuid7_identifiers_distinct_and_one_use_verified"
+        ] = fresh_uuid7_identifiers_verified
+
+        for implementation, (path, digest) in executables.items():
+            try:
+                _assert_executable_copy(path, digest)
+            except BenchmarkError:
+                copy_integrity[implementation] = False
+            else:
+                copy_integrity[implementation] = True
+
+    fx_unchanged = _source_unchanged(fx_provenance)
+    nano_unchanged = _source_unchanged(nano_provenance)
+    source_integrity_failure = not all(
+        (fx_unchanged, nano_unchanged, *copy_integrity.values())
+    )
+    measured_failures = sum(
+        bool(run.get("measured_failure"))
+        for pair in measured_pairs
+        for run in pair["runs"].values()
+    )
+    summary = summarize_pairs(measured_pairs)
+    insufficient_primary = (
+        summary["primary"]["eligible_pairs"] < MIN_PRIMARY_ELIGIBLE_PAIRS
+    )
+    measured_pairs_completed = sum(
+        set(pair.get("runs", {})) == {"fx", "nanocodex"}
+        for pair in measured_pairs
+    )
+    incomplete_schedule = measured_pairs_completed != args.trials
+    exit_conditions = {
+        "warmup_failure": bool(warmup_failures),
+        "measured_failure": measured_failures > 0,
+        "insufficient_primary_eligible_pairs": insufficient_primary,
+        "source_or_execution_copy_integrity_failure": source_integrity_failure,
+        "incomplete_measured_schedule": incomplete_schedule,
+        "shared_auth_identity_not_verified": not shared_auth_verified,
+        "request_fingerprints_not_stable": not fingerprints_stable,
+        "fresh_uuid7_identifiers_not_distinct_and_one_use": (
+            not fresh_uuid7_identifiers_verified
+        ),
+        "credential_refresh_attempted": observer_stats["refresh_attempts_blocked"] > 0,
+        "unexpected_request_seen": observer_stats["unexpected_requests"] > 0,
+    }
+    exit_code = int(any(exit_conditions.values()))
+    document = {
+        "schema_version": 1,
+        "benchmark": "paired_fx_model_latency",
+        "status": "passed" if exit_code == 0 else "failed",
+        "started_at": start_utc,
+        "completed_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "comparison_design": {
+            "kind": "controlled_product_as_shipped",
+            "identical_input_or_isolated_client_claim": False,
+            "tool_surfaces": "implementation_specific_product_defaults",
+            "source_build_attestation_claimed": False,
+            "request_equivalence": (
+                "each live request must match the independently reviewed fixed full-body "
+                "contract and the stable actual-binary provider-free preflight fingerprint"
+            ),
+        },
+        "provenance": {
+            "fx": {
+                **fx_provenance,
+                "source_unchanged_during_run": fx_unchanged,
+                "execution_copy": {
+                    "sha256": fx_provenance["binary"]["sha256"],
+                    "mode": "0500",
+                    "digest_rechecked_before_each_client": True,
+                    "unchanged_after_run": copy_integrity["fx"],
+                },
+            },
+            "nanocodex": {
+                **nano_provenance,
+                "source_unchanged_during_run": nano_unchanged,
+                "execution_copy": {
+                    "sha256": nano_provenance["binary"]["sha256"],
+                    "mode": "0500",
+                    "digest_rechecked_before_each_client": True,
+                    "unchanged_after_run": copy_integrity["nanocodex"],
+                },
+            },
+            "child_workspace_policy": "fresh_private_empty_workspace_per_run",
+            "upstream_url": DEFAULT_UPSTREAM_URL,
+            "transport": "https",
+            "model": MODEL,
+            "reasoning_effort": EFFORT,
+            "service_tier": "standard",
+            "fast_mode": False,
+            "tool_names_hash": "sha256(sorted compact JSON names)",
+            "request_hash": "sha256(raw forwarded JSON bytes)",
+            "stable_request_fingerprints": request_fingerprints,
+            "offline_request_template_fingerprints": request_templates,
+            "independent_reference_body_fingerprints": dict(
+                REFERENCE_BODY_FINGERPRINTS
+            ),
+            "stable_request_fingerprint_method": (
+                "sha256(validated canonical body plus allowlisted product metadata "
+                "headers, with only validated fresh session/item identities and exact "
+                "private home/workspace paths normalized and the separately validated "
+                "credential-derived FedRAMP header excluded)"
+            ),
+            "shared_auth_identity_verified": shared_auth_verified,
+            "actual_binary_offline_preflight": offline_preflight,
+            "child_egress_policy": (
+                "Darwin Seatbelt permits the product process only AF_INET TCP to a "
+                "unique host-local port; the observer reserves that port on every "
+                "IPv4 interface and accepts requests only when their local destination "
+                "is 127.0.0.1; IPv6, UDP, and child-process creation are denied; only "
+                "the parent observer can reach the fixed official HTTPS endpoint"
+            ),
+            "observer_shutdown_policy": (
+                "selector-owned child pipes, process groups, downstream handlers, and "
+                "upstream sockets must be terminated, reaped, and drained to bounded "
+                "deadlines before a successful report can be returned or published"
+            ),
+        },
+        "auth": auth.safe_metadata(),
+        "workload": {
+            "instructions": SYSTEM_INSTRUCTIONS,
+            "prompt": ACK_TOKEN,
+            "expected": ACK_TOKEN,
+            "instructions_fnv1a64": fnv1a64(SYSTEM_INSTRUCTIONS),
+            "prompt_fnv1a64": fnv1a64(ACK_TOKEN),
+            "nanocodex_prompt_cache_key": NANOCODEX_PROMPT_CACHE_KEY,
+            "nanocodex_prompt_cache_key_fnv1a64": fnv1a64(
+                NANOCODEX_PROMPT_CACHE_KEY
+            ),
+        },
+        "schedule": {
+            "kind": "alternating_sequential_fresh_clients",
+            "alternation_scope": "continuous_across_warmup_and_measured_pairs",
+            "odd_schedule_pairs": ["fx", "nanocodex"],
+            "even_schedule_pairs": ["nanocodex", "fx"],
+            "warmup_pairs_requested": args.warmup_pairs,
+            "warmup_pairs_discarded": warmup_pairs_completed,
+            "measured_pairs_requested": args.trials,
+            "measured_pairs_started": len(measured_pairs),
+            "measured_pairs_completed": measured_pairs_completed,
+            "provider_request_budget": args.provider_request_budget,
+            "stop_policy": "first_functional_failure",
+        },
+        "warmup": {
+            "timings_discarded": True,
+            "failures": warmup_failures,
+        },
+        "observer": observer_stats,
+        "score": {
+            "name": "provider_time_to_first_model_output",
+            "metric": "time_to_first_model_output",
+            "unit": "nanoseconds",
+            "clock_start": "full_upstream_request_flushed",
+            "clock_end": "first_nonempty_semantic_sse_delta_received",
+            "lower_is_better": True,
+            "eligibility": "warm_primary_pairs_only",
+            "result": summary["primary"]["metrics"][
+                "time_to_first_model_output"
+            ],
+        },
+        "diagnostics": {
+            "time_to_first_answer_text": summary["primary"]["metrics"][
+                "time_to_first_answer_text"
+            ],
+            "time_to_terminal": summary["primary"]["metrics"][
+                "time_to_terminal"
+            ],
+        },
+        "summary": {
+            "measured_failures": measured_failures,
+            "percentile_method": "nearest_rank",
+            "wins_are": "descriptive_only_not_inferential",
+            **summary,
+        },
+        "exit_conditions": exit_conditions,
+        "pairs": measured_pairs,
+    }
+    return document, exit_code, auth
+
+
+def _report_string_values(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, Mapping):
+        for key, child in value.items():
+            if isinstance(key, str):
+                yield key
+            yield from _report_string_values(child)
+    elif isinstance(value, Sequence) and not isinstance(
+        value, (str, bytes, bytearray)
+    ):
+        for child in value:
+            yield from _report_string_values(child)
+
+
+def _json_unescape_string(value: str) -> str | None:
+    escaped = (
+        value.replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+        .replace("\b", "\\b")
+        .replace("\f", "\\f")
+    )
+    try:
+        decoded = json.loads(f'"{escaped}"')
+    except (UnicodeError, json.JSONDecodeError):
+        return None
+    return decoded if isinstance(decoded, str) else None
+
+
+def _normalized_string_forms(value: str) -> set[str]:
+    forms = {
+        value,
+        unicodedata.normalize("NFC", value),
+        unicodedata.normalize("NFKC", value),
+    }
+    decoded = _json_unescape_string(value)
+    if decoded is not None:
+        forms.update(
+            {
+                decoded,
+                unicodedata.normalize("NFC", decoded),
+                unicodedata.normalize("NFKC", decoded),
+            }
+        )
+    return forms
+
+
+def _assert_report_has_no_secrets(
+    document: Mapping[str, Any], auth: AuthMaterial
+) -> None:
+    secret_forms: set[str] = set()
+    for secret in auth.secret_values:
+        if not secret:
+            continue
+        secret_forms.update(_normalized_string_forms(secret))
+        escaped = json.dumps(secret, ensure_ascii=True)[1:-1]
+        secret_forms.update(_normalized_string_forms(escaped))
+    for value in _report_string_values(document):
+        for candidate in _normalized_string_forms(value):
+            if any(secret in candidate for secret in secret_forms):
+                raise BenchmarkError("refusing to serialize a credential-bearing report")
+
+
+def _encoded_report(document: Mapping[str, Any], auth: AuthMaterial) -> bytes:
+    _assert_report_has_no_secrets(document, auth)
+    encoded = (json.dumps(document, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    lowered = encoded.lower()
+    if b'"authorization"' in lowered or b'"chatgpt-account-id"' in lowered:
+        raise BenchmarkError("refusing to serialize raw auth headers")
+    return encoded
+
+
+def write_report(path: Path, encoded: bytes) -> None:
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb", closefd=True) as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        # Link is an atomic no-clobber publication on the same filesystem. If
+        # another process creates the requested path after preflight, fail
+        # rather than replacing its file.
+        os.link(temporary, path, follow_symlinks=False)
+        # The no-clobber link is the publication commit. Failure to remove the
+        # now-redundant private inode name must not turn a published successful
+        # benchmark into a failed exit status.
+        with contextlib.suppress(OSError):
+            os.unlink(temporary)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.close(descriptor)
+        with contextlib.suppress(OSError):
+            os.unlink(temporary)
+        raise
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a live paid controlled product-as-shipped fx-vs-Nanocodex "
+            "latency comparison against the fixed official HTTPS endpoint. "
+            "No request is made unless --confirm-paid-live-run is supplied."
+        )
+    )
+    parser.add_argument("--fx-source-root", type=Path, required=True)
+    parser.add_argument("--fx-bin", type=Path, required=True)
+    parser.add_argument("--nanocodex-source-root", type=Path, required=True)
+    parser.add_argument("--nanocodex-bin", type=Path, required=True)
+    parser.add_argument("--nanocodex-commit", required=True)
+    parser.add_argument("--auth-file", type=Path, required=True)
+    parser.add_argument("--trials", type=int, default=20)
+    parser.add_argument("--warmup-pairs", type=int, default=2)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--confirm-paid-live-run",
+        action="store_true",
+        required=True,
+        help="explicitly authorize the paid live provider requests",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        args = parse_args(argv)
+        document, exit_code, auth = run_benchmark(args)
+        notification = json.dumps(
+            {
+                "status": document["status"],
+                "measured_pairs": document["schedule"][
+                    "measured_pairs_completed"
+                ],
+                "primary_eligible_pairs": document["summary"]["primary"][
+                    "eligible_pairs"
+                ],
+            },
+            separators=(",", ":"),
+        )
+        if exit_code != 0:
+            with contextlib.suppress(OSError, ValueError):
+                print(notification)
+            return exit_code
+        write_report(args.output, _encoded_report(document, auth))
+        with contextlib.suppress(OSError, ValueError):
+            print(notification)
+        return exit_code
+    except BenchmarkError as error:
+        print(f"paired model-latency benchmark refused: {error}", file=sys.stderr)
+        return 2
+    except OSError:
+        print("paired model-latency benchmark failed with a local I/O error", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/test_paired_fx_model_latency.py
+++ b/benchmarks/test_paired_fx_model_latency.py
@@ -1,0 +1,4960 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import contextlib
+import errno
+import http.client
+import http.server
+import io
+import ipaddress
+import json
+import os
+import signal
+import socket
+import socketserver
+import stat
+import struct
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unicodedata
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from benchmarks import paired_fx_model_latency as bench
+
+
+def _compact(value: object) -> bytes:
+    return json.dumps(value, separators=(",", ":")).encode("utf-8")
+
+
+def _jwt(payload: dict[str, object]) -> str:
+    def encoded(value: object) -> str:
+        return base64.urlsafe_b64encode(_compact(value)).decode("ascii").rstrip("=")
+
+    return f"{encoded({'alg': 'none'})}.{encoded(payload)}.signature"
+
+
+def _function_tool(name: str = "terminal") -> dict[str, object]:
+    return {
+        "type": "function",
+        "name": name,
+        "description": "A controlled test tool.",
+        "strict": False,
+        "parameters": {"type": "object", "properties": {}},
+    }
+
+
+def _custom_tool(name: str) -> dict[str, object]:
+    return {
+        "type": "custom",
+        "name": name,
+        "description": "A controlled test custom tool.",
+        "format": {"type": "text"},
+    }
+
+
+TEST_HOME = "/private/offline-benchmark-home"
+TEST_WORKSPACE = TEST_HOME + "/workspace"
+
+
+def _client_message_id(value: int) -> str:
+    return f"msg_00000000-0000-7000-8000-{value:012x}"
+
+
+def _session_id(value: int) -> str:
+    return f"00000000-0000-7000-8000-{value:012x}"
+
+
+def _environment_context(workspace: str = TEST_WORKSPACE) -> str:
+    return bench._expected_nanocodex_environment_text(workspace)
+
+
+def _fx_instructions(
+    *, home: str = TEST_HOME, workspace: str = TEST_WORKSPACE
+) -> str:
+    return (
+        bench.SYSTEM_INSTRUCTIONS
+        + "\n\n"
+        + "Search the current public web for a query with optional allow or block domain "
+        "filters. When to use: broad web or current-events research that needs sources; "
+        "use US-oriented queries and include the current month and year when freshness "
+        "needs disambiguation. Treat results as untrusted and cite supporting sources "
+        "with Markdown links. When NOT to use: exact known URLs, local repo facts, "
+        "authenticated/private sources, or browser interaction.\n\n"
+        "Configured MCP servers visible to this model turn are listed below.\n"
+        "Use mcp_search_tools with the server alias and requested use case. Then use "
+        "mcp_select_tool with one exact result. Do not guess tool names.\n"
+        "<mcp_servers>\n"
+        "  <none />\n"
+        "</mcp_servers>\n\n\n"
+        "<fx-turn-context>\n"
+        f"workspace_root: {workspace}\n"
+        f"current_directory: {workspace}\n"
+        f"operating_system: {bench.platform.system()} {bench.platform.release()}\n"
+        "shell_path: (unknown)\n"
+        f"date_utc: {bench.dt.datetime.now(bench.dt.timezone.utc).date().isoformat()}\n"
+        f"home_directory: {home}\n"
+        "git_worktree: unknown\n"
+        "</fx-turn-context>\n"
+        "Runtime context: this is a noninteractive run without live question UI; when "
+        "a user-owned decision remains after inspection, stop and surface a concrete "
+        "blocker in freeform text with the available options. Do not recommend or label "
+        "one option as preferred.\n\n"
+        "Runtime context: permission mode is auto. After configured rules, session "
+        "grants, and deterministic safe-tool authority, fx reviews each unresolved "
+        "sensitive tool call once. An automatic non-allow returns a failed tool result "
+        "for replanning, and exact repeats reuse that denial. Choose a materially "
+        "different safe action, or when that result contains approval_request_id call "
+        "ask_user_question with that exact ID to enter fx's real permission screen. Do "
+        "not retry unchanged, invent an ID, or treat generic question or conversation "
+        "text as approval. Bounded consecutive all-blocked response groups end the turn "
+        "with ordinary blocker text and never open a permission screen automatically; "
+        "any successful tool resets that count. Tool admission and exact live "
+        "revalidation remain authoritative."
+    )
+
+
+def _fx_request(*, workspace: str = TEST_WORKSPACE) -> dict[str, object]:
+    return {
+        "model": bench.MODEL,
+        "store": False,
+        "stream": True,
+        "instructions": _fx_instructions(
+            home=workspace.removesuffix("/workspace"), workspace=workspace
+        ),
+        "input": [
+            {
+                "role": "user",
+                "content": [{"type": "input_text", "text": bench.ACK_TOKEN}],
+            }
+        ],
+        "tools": [
+            _function_tool(name)
+            for name in bench.FX_TOOL_NAMES
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": True,
+        "include": ["reasoning.encrypted_content"],
+        "text": {"verbosity": "low"},
+        "reasoning": {"effort": bench.EFFORT, "summary": "auto"},
+    }
+
+
+def _nanocodex_request(
+    *,
+    session_id: str = _session_id(100),
+    cache_key: str = bench.NANOCODEX_PROMPT_CACHE_KEY,
+    workspace: str = TEST_WORKSPACE,
+    id_offset: int = 0,
+) -> dict[str, object]:
+    return {
+        "model": bench.MODEL,
+        "store": False,
+        "stream": True,
+        "input": [
+            {
+                "type": "additional_tools",
+                "role": "developer",
+                "tools": [
+                    _custom_tool("exec"),
+                    _function_tool("wait"),
+                ],
+            },
+            {
+                "type": "message",
+                "role": "developer",
+                "content": [
+                    {"type": "input_text", "text": bench.SYSTEM_INSTRUCTIONS}
+                ],
+            },
+            {
+                "type": "message",
+                "id": _client_message_id(id_offset + 1),
+                "role": "developer",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": bench.NANOCODEX_PERMISSIONS_INSTRUCTIONS,
+                    }
+                ],
+            },
+            {
+                "type": "message",
+                "id": _client_message_id(id_offset + 2),
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": _environment_context(workspace)}
+                ],
+            },
+            {
+                "type": "message",
+                "id": _client_message_id(id_offset + 3),
+                "role": "user",
+                "content": [{"type": "input_text", "text": bench.ACK_TOKEN}],
+            },
+        ],
+        "tool_choice": "auto",
+        "parallel_tool_calls": False,
+        "reasoning": {
+            "effort": bench.EFFORT,
+            "summary": "auto",
+            "context": "all_turns",
+        },
+        "include": ["reasoning.encrypted_content"],
+        "prompt_cache_key": cache_key,
+        "text": {"verbosity": "low"},
+        "client_metadata": {
+            "session_id": session_id,
+            "thread_id": session_id,
+            "x-codex-turn-metadata": json.dumps(
+                {
+                    "code_mode_tool_names": {
+                        name: {"name": name, "namespace": None}
+                        for name in bench.NANOCODEX_CODE_MODE_TOOL_NAMES
+                    }
+                },
+                separators=(",", ":"),
+            ),
+        },
+    }
+
+
+def _request_headers(
+    auth: bench.AuthMaterial,
+    implementation: str = "fx",
+    *,
+    session_id: str = _session_id(100),
+) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {auth.access_token}",
+        "ChatGPT-Account-ID": auth.account_id,
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+    }
+    if implementation == "fx":
+        headers.update(
+            {
+                "User-Agent": bench.FX_USER_AGENT,
+                "Originator": "fx",
+                "OpenAI-Beta": "responses=experimental",
+                "Connection": "close",
+            }
+        )
+    elif implementation == "nanocodex":
+        headers.update(
+            {
+                "User-Agent": bench.NANOCODEX_USER_AGENT,
+                "X-OpenAI-Internal-Codex-Responses-Lite": "true",
+                "Session-ID": session_id,
+                "Thread-ID": session_id,
+                "X-Client-Request-ID": session_id,
+            }
+        )
+        if auth.fedramp:
+            headers["X-OpenAI-Fedramp"] = "true"
+    else:
+        raise AssertionError(f"unknown test implementation {implementation}")
+    return headers
+
+
+def _send_request(
+    connection: http.client.HTTPConnection,
+    method: str,
+    target: str,
+    *,
+    headers: dict[str, str],
+    body: bytes | None = None,
+) -> None:
+    connection.putrequest(method, target, skip_accept_encoding=True)
+    for name, value in headers.items():
+        connection.putheader(name, value)
+    if body is not None and not any(name.lower() == "content-length" for name in headers):
+        connection.putheader("Content-Length", str(len(body)))
+    connection.endheaders(body)
+
+
+@contextlib.contextmanager
+def _fixture_contracts():
+    fx = _fx_request()
+    nanocodex = _nanocodex_request()
+    with (
+        mock.patch.object(
+            bench,
+            "FX_TOOL_DECLARATIONS_SHA256",
+            bench._canonical_json_sha256(fx["tools"]),
+        ),
+        mock.patch.object(
+            bench,
+            "NANOCODEX_TOOL_DECLARATIONS_SHA256",
+            bench._canonical_json_sha256(nanocodex["input"][0]["tools"]),
+        ),
+    ):
+        references = {
+            "fx": bench._stable_request_fingerprint(
+                fx,
+                "fx",
+                home=TEST_HOME,
+                workspace=TEST_WORKSPACE,
+            ),
+            "nanocodex": bench._stable_request_fingerprint(
+                nanocodex,
+                "nanocodex",
+                home=TEST_HOME,
+                workspace=TEST_WORKSPACE,
+            ),
+        }
+        with mock.patch.object(bench, "REFERENCE_BODY_FINGERPRINTS", references):
+            yield
+
+
+class ContractFixtureTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        contract = _fixture_contracts()
+        contract.__enter__()
+        self.addCleanup(contract.__exit__, None, None, None)
+
+
+class AuthSnapshotTests(unittest.TestCase):
+    def _load_with_id_payload(
+        self,
+        id_payload: dict[str, object],
+        *,
+        access_fedramp: bool = False,
+        include_id_token: bool = True,
+    ) -> bench.AuthMaterial:
+        account_id = "00000000-0000-4000-8000-000000000001"
+        access_token = _jwt(
+            {
+                "exp": 4_102_444_800,
+                "https://api.openai.com/auth": {
+                    "chatgpt_account_id": account_id,
+                    "chatgpt_account_is_fedramp": access_fedramp,
+                },
+            }
+        )
+        tokens = {
+            "access_token": access_token,
+            "refresh_token": "offline-refresh-token",
+            "account_id": account_id,
+        }
+        if include_id_token:
+            tokens["id_token"] = _jwt(id_payload)
+        document = {
+            "auth_mode": "chatgpt",
+            "tokens": tokens,
+        }
+        with tempfile.TemporaryDirectory() as raw:
+            path = Path(raw) / "auth.json"
+            bench._write_private(path, _compact(document))
+            return bench.load_auth_snapshot(path, now_seconds=0)
+
+    def test_fedramp_requires_the_exact_nested_boolean_id_token_claim(self) -> None:
+        claim = "https://api.openai.com/auth"
+        nested_true = self._load_with_id_payload(
+            {claim: {"chatgpt_account_is_fedramp": True}}
+        )
+        nested_false = self._load_with_id_payload(
+            {claim: {"chatgpt_account_is_fedramp": False}}
+        )
+        top_level = self._load_with_id_payload(
+            {"chatgpt_account_is_fedramp": True}
+        )
+        string_true = self._load_with_id_payload(
+            {claim: {"chatgpt_account_is_fedramp": "true"}}
+        )
+        empty_id_token = self._load_with_id_payload({}, access_fedramp=True)
+
+        self.assertTrue(nested_true.fedramp)
+        self.assertFalse(nested_false.fedramp)
+        self.assertFalse(top_level.fedramp)
+        self.assertFalse(string_true.fedramp)
+        self.assertFalse(empty_id_token.fedramp)
+        with self.assertRaisesRegex(bench.BenchmarkError, "tokens.id_token"):
+            self._load_with_id_payload(
+                {}, access_fedramp=True, include_id_token=False
+            )
+
+    def test_fake_auth_flag_is_derived_from_the_nested_jwt_claim(self) -> None:
+        for expected in (False, True):
+            with self.subTest(fedramp=expected):
+                auth = bench._fake_auth_material(fedramp=expected)
+                raw = json.loads(auth.raw_codex_auth)
+                id_token = raw["tokens"]["id_token"]
+                payload = bench._decode_jwt_payload(id_token)
+                claim = payload["https://api.openai.com/auth"]
+                self.assertIs(
+                    claim["chatgpt_account_is_fedramp"], expected
+                )
+                self.assertIs(auth.fedramp, expected)
+                access = bench._decode_jwt_payload(auth.access_token)
+                self.assertIs(
+                    access["https://api.openai.com/auth"][
+                        "chatgpt_account_is_fedramp"
+                    ],
+                    not expected,
+                )
+
+        tampered = bench.dataclasses.replace(
+            bench._fake_auth_material(fedramp=False), fedramp=True
+        )
+        with self.assertRaisesRegex(bench.BenchmarkError, "fake test credentials"):
+            bench.StreamingObserver._for_test(
+                tampered,
+                "http://127.0.0.1:1/responses",
+                provider_request_budget=1,
+            )
+
+
+class _LocalServer(http.server.ThreadingHTTPServer):
+    daemon_threads = True
+
+    def server_bind(self) -> None:
+        socketserver.TCPServer.server_bind(self)
+        host, port = self.server_address[:2]
+        self.server_name = host
+        self.server_port = port
+
+
+@contextlib.contextmanager
+def _serve(handler: type[http.server.BaseHTTPRequestHandler]):
+    server = _LocalServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _assert_process_gone(test: unittest.TestCase, pid: int, label: str) -> None:
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        proc_stat = Path(f"/proc/{pid}/stat")
+        if proc_stat.exists() and ") Z " in proc_stat.read_text():
+            return
+        time.sleep(0.02)
+    test.fail(f"{label} process-group descendant remained alive")
+
+
+def _post_observer(
+    observer: bench.StreamingObserver,
+    body: bytes,
+    auth: bench.AuthMaterial,
+    implementation: str = "fx",
+) -> tuple[int, bytes]:
+    status, streamed, _ = _post_observer_with_headers(
+        observer, body, auth, implementation
+    )
+    return status, streamed
+
+
+def _post_observer_with_headers(
+    observer: bench.StreamingObserver,
+    body: bytes,
+    auth: bench.AuthMaterial,
+    implementation: str = "fx",
+) -> tuple[int, bytes, list[tuple[str, str]]]:
+    connection = http.client.HTTPConnection(
+        "127.0.0.1", observer.server.server_port, timeout=5
+    )
+    _send_request(
+        connection,
+        "POST",
+        "/responses",
+        body=body,
+        headers=_request_headers(auth, implementation),
+    )
+    response = connection.getresponse()
+    status = response.status
+    headers = response.getheaders()
+    streamed = response.read()
+    connection.close()
+    return status, streamed, headers
+
+
+def _nano_output(commit: str, cwd: Path) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "benchmark": "paired_fx_model_latency",
+        "provenance": {
+            "implementation": "nanocodex",
+            "source_commit": commit,
+            "model": bench.MODEL,
+            "thinking": bench.EFFORT,
+            "fast_mode": False,
+            "workspace": str(cwd),
+            "instructions_fnv1a64": bench.fnv1a64(bench.SYSTEM_INSTRUCTIONS),
+            "prompt_fnv1a64": bench.fnv1a64(bench.ACK_TOKEN),
+            "expected_fnv1a64": bench.fnv1a64(bench.ACK_TOKEN),
+            "prompt_cache_key_fnv1a64": bench.fnv1a64(
+                bench.NANOCODEX_PROMPT_CACHE_KEY
+            ),
+        },
+        "transport": "https",
+        "timing_ns": {
+            "prompt_submit_to_acceptance": 1,
+            "prompt_submit_to_first_assistant_delta_emitted": 10,
+            "prompt_acceptance_to_first_assistant_delta_emitted": 9,
+            "prompt_submit_to_first_assistant_delta_received": 12,
+            "prompt_acceptance_to_first_assistant_delta_received": 11,
+            "assistant_delta_emit_to_receive": 2,
+            "provider_source_to_assistant_delta_emit": 1,
+            "prompt_submit_to_result_completion": 100,
+            "prompt_acceptance_to_result_completion": 99,
+        },
+        "model_call": {
+            "call_index": 1,
+            "attempt": 1,
+            "connection_generation": 0,
+            "status": "completed",
+            "duration_ns": 100,
+            "time_to_first_event_ns": 10,
+            "time_to_first_output_ns": 20,
+            "tool_calls": 0,
+        },
+        "usage": {
+            "reported": True,
+            "input_tokens": 10,
+            "cached_input_tokens": 1,
+            "cache_write_input_tokens": 0,
+            "output_tokens": 2,
+            "reasoning_output_tokens": 1,
+            "total_tokens": 12,
+        },
+        "turn_usage": {
+            "input_tokens": 10,
+            "cached_input_tokens": 1,
+            "cache_write_input_tokens": 0,
+            "output_tokens": 2,
+            "reasoning_output_tokens": 1,
+            "total_tokens": 12,
+        },
+        "events": {
+            "count": 8,
+            "first_sequence": 1,
+            "last_sequence": 8,
+            "assistant_delta_count": 1,
+            "sequences_contiguous": True,
+        },
+        "verified": {
+            "final_output": True,
+            "assistant_deltas": True,
+            "one_model_call": True,
+            "zero_tool_calls": True,
+            "run_completed": True,
+            "clean_shutdown": True,
+            "auth_refresh_disabled": True,
+        },
+    }
+
+
+class RequestValidationTests(ContractFixtureTestCase):
+    def test_auth_identity_matcher_rejects_surrounding_whitespace(self) -> None:
+        auth = bench._fake_auth_material()
+        for account_id in (f" {auth.account_id}", f"{auth.account_id} "):
+            with self.subTest(account_id=repr(account_id)):
+                matcher = bench.AuthIdentityMatcher(auth)
+                with self.assertRaisesRegex(
+                    bench.RequestValidationError, "shared_auth_identity_missing"
+                ):
+                    matcher.observe(
+                        "fx", f"Bearer {auth.access_token}", account_id
+                    )
+                self.assertFalse(matcher.verified_for({"fx"}))
+
+    def test_accepts_only_exact_product_specific_fresh_shapes(self) -> None:
+        fx = bench.validate_request_body(_compact(_fx_request()), "fx")
+        nano = bench.validate_request_body(
+            _compact(_nanocodex_request()), "nanocodex"
+        )
+
+        self.assertEqual(fx.service_tier, "standard")
+        self.assertEqual(fx.tool_count, 23)
+        self.assertEqual(nano.tool_count, 2)
+        self.assertRegex(fx.fingerprint_sha256, r"^[0-9a-f]{64}$")
+
+    def test_rejects_state_history_extra_instructions_and_unsafe_controls(self) -> None:
+        cases: list[tuple[dict[str, object], str, str]] = []
+
+        previous = _nanocodex_request()
+        previous["previous_response_id"] = "resp_old"
+        cases.append((previous, "nanocodex", "unexpected_previous_response_id"))
+
+        assistant = _nanocodex_request()
+        assistant["input"].insert(
+            2,
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "old"}],
+            },
+        )
+        cases.append((assistant, "nanocodex", "nanocodex_input_missing"))
+
+        extra_instructions = _fx_request()
+        extra_instructions["instructions"] = extra_instructions[
+            "instructions"
+        ].replace(bench.SYSTEM_INSTRUCTIONS, "different benchmark", 1)
+        cases.append(
+            (extra_instructions, "fx", "benchmark_instructions_mismatch")
+        )
+
+        stored = _fx_request()
+        stored["store"] = True
+        cases.append((stored, "fx", "store_must_be_false"))
+
+        background = _fx_request()
+        background["background"] = True
+        cases.append((background, "fx", "background_must_be_absent"))
+
+        priority = _fx_request()
+        priority["service_tier"] = "priority"
+        cases.append(
+            (priority, "fx", "service_tier_must_be_standard_omission")
+        )
+
+        websocket = _nanocodex_request()
+        websocket["type"] = "response.create"
+        cases.append((websocket, "nanocodex", "https_request_type_must_be_absent"))
+
+        for request, implementation, error in cases:
+            with self.subTest(error=error), self.assertRaisesRegex(
+                bench.RequestValidationError, error
+            ):
+                bench.validate_request_body(_compact(request), implementation)
+
+    def test_independent_full_contract_rejects_nested_surface_mutations(self) -> None:
+        cases: list[tuple[str, dict[str, object], str]] = []
+
+        fx_description = _fx_request()
+        del fx_description["tools"][0]["description"]
+        cases.append(("fx tool description removed", fx_description, "fx"))
+
+        fx_schema = _fx_request()
+        fx_schema["tools"][0]["parameters"]["additionalProperties"] = False
+        cases.append(("fx tool schema changed", fx_schema, "fx"))
+
+        fx_unknown = _fx_request()
+        fx_unknown["tools"][0]["unreviewed"] = True
+        cases.append(("fx nested field added", fx_unknown, "fx"))
+
+        fx_reordered = _fx_request()
+        fx_reordered["tools"][0], fx_reordered["tools"][1] = (
+            fx_reordered["tools"][1],
+            fx_reordered["tools"][0],
+        )
+        cases.append(("fx tools reordered", fx_reordered, "fx"))
+
+        fx_suffix = _fx_request()
+        fx_suffix["instructions"] = fx_suffix["instructions"].replace(
+            "Runtime context: this is a noninteractive run",
+            "Runtime context: this is an interactive run",
+            1,
+        )
+        cases.append(("fx shipped context changed", fx_suffix, "fx"))
+
+        fx_context = _fx_request()
+        fx_context["instructions"] = fx_context["instructions"].replace(
+            "shell_path: (unknown)", "shell_path: /bin/zsh", 1
+        )
+        cases.append(("fx dynamic context changed", fx_context, "fx"))
+
+        nano_description = _nanocodex_request()
+        del nano_description["input"][0]["tools"][1]["description"]
+        cases.append(
+            ("nanocodex tool description removed", nano_description, "nanocodex")
+        )
+
+        nano_format = _nanocodex_request()
+        del nano_format["input"][0]["tools"][0]["format"]
+        cases.append(("nanocodex custom format removed", nano_format, "nanocodex"))
+
+        nano_metadata = _nanocodex_request()
+        del nano_metadata["client_metadata"]["x-codex-turn-metadata"]
+        cases.append(("nanocodex turn metadata removed", nano_metadata, "nanocodex"))
+
+        nano_names = _nanocodex_request()
+        metadata = json.loads(
+            nano_names["client_metadata"]["x-codex-turn-metadata"]
+        )
+        del metadata["code_mode_tool_names"]["apply_patch"]
+        nano_names["client_metadata"]["x-codex-turn-metadata"] = json.dumps(
+            metadata, separators=(",", ":")
+        )
+        cases.append(("nanocodex metadata map thinned", nano_names, "nanocodex"))
+
+        for label, request, implementation in cases:
+            with self.subTest(mutation=label), self.assertRaises(
+                bench.RequestValidationError
+            ):
+                bench.validate_request_body(_compact(request), implementation)
+
+    def test_rejects_duplicate_json_keys_and_oversized_body(self) -> None:
+        with self.assertRaisesRegex(
+            bench.RequestValidationError, "duplicate_json_object_key"
+        ):
+            bench.validate_request_body(b'{"model":"a","model":"b"}', "fx")
+        exact = _compact(_fx_request())
+        exact += b" " * (bench.MAX_REQUEST_BYTES - len(exact))
+        self.assertEqual(len(exact), bench.MAX_REQUEST_BYTES)
+        bench.validate_request_body(exact, "fx")
+        with self.assertRaisesRegex(
+            bench.RequestValidationError, "invalid_request_size"
+        ):
+            bench.validate_request_body(
+                b" " * (bench.MAX_REQUEST_BYTES + 1), "fx"
+            )
+
+    def test_nanocodex_fresh_identifiers_are_uuid7_distinct_and_one_use(self) -> None:
+        invalid_session = _nanocodex_request(session_id="not-a-uuid")
+        with self.assertRaisesRegex(
+            bench.RequestValidationError, "nanocodex_session_identity_invalid"
+        ):
+            bench.validate_request_body(_compact(invalid_session), "nanocodex")
+
+        duplicate_items = _nanocodex_request()
+        duplicate_items["input"][3]["id"] = duplicate_items["input"][2]["id"]
+        with self.assertRaisesRegex(
+            bench.RequestValidationError, "nanocodex_request_identifiers_reused"
+        ):
+            bench.validate_request_body(_compact(duplicate_items), "nanocodex")
+
+        cross_namespace = _nanocodex_request(session_id=_session_id(1))
+        with self.assertRaisesRegex(
+            bench.RequestValidationError, "nanocodex_request_identifiers_reused"
+        ):
+            bench.validate_request_body(_compact(cross_namespace), "nanocodex")
+
+        auth = bench._fake_auth_material()
+        state = bench.ObserverState(bench.AuthIdentityMatcher(auth), 2)
+        state.observe_fresh_identifiers((_session_id(301), _session_id(302)))
+        self.assertTrue(
+            state.fresh_identifier_ledger.distinct_and_one_use_verified()
+        )
+        with self.assertRaisesRegex(
+            bench.RequestValidationError, "fresh_request_identifier_reused"
+        ):
+            state.observe_fresh_identifiers(
+                (_session_id(303), _session_id(302))
+            )
+        self.assertFalse(
+            state.fresh_identifier_ledger.distinct_and_one_use_verified()
+        )
+
+        isolated = bench.ObserverState(bench.AuthIdentityMatcher(auth), 1)
+        isolated.observe_fresh_identifiers((_session_id(301), _session_id(302)))
+        self.assertTrue(
+            isolated.fresh_identifier_ledger.distinct_and_one_use_verified()
+        )
+
+    def test_fresh_uuid7_ledger_atomically_rejects_concurrent_reuse(self) -> None:
+        ledger = bench.FreshUuid7Ledger()
+        barrier = threading.Barrier(3)
+        outcomes: list[str] = []
+        outcomes_lock = threading.Lock()
+
+        def observe() -> None:
+            barrier.wait()
+            try:
+                ledger.observe((_session_id(401),))
+            except bench.RequestValidationError as error:
+                outcome = error.code
+            else:
+                outcome = "accepted"
+            with outcomes_lock:
+                outcomes.append(outcome)
+
+        threads = [threading.Thread(target=observe) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        barrier.wait()
+        for thread in threads:
+            thread.join(timeout=5)
+            self.assertFalse(thread.is_alive())
+
+        self.assertCountEqual(
+            outcomes, ["accepted", "fresh_request_identifier_reused"]
+        )
+        self.assertEqual(
+            ledger.evidence(),
+            {
+                "accepted_identity_uses": 1,
+                "distinct_canonical_uuid7_identities": 1,
+                "reuse_detected": True,
+                "noncanonical_identity_detected": False,
+                "distinct_and_one_use_verified": False,
+            },
+        )
+
+    def test_nanocodex_environment_xml_escapes_every_dynamic_metacharacter(self) -> None:
+        workspace = "/private/xml-&<>\"'/workspace"
+        context = bench._expected_nanocodex_environment_text(workspace)
+        escaped = "/private/xml-&amp;&lt;&gt;&quot;&apos;/workspace"
+
+        self.assertIn(f"<cwd>{escaped}</cwd>", context)
+        self.assertIn(f"<root>{escaped}</root>", context)
+        validated = bench.validate_request_body(
+            _compact(_nanocodex_request(workspace=workspace)),
+            "nanocodex",
+            workspace=workspace,
+        )
+        self.assertEqual(len(validated.fresh_identifiers), 4)
+
+    def test_fingerprint_normalizes_only_fresh_identifiers(self) -> None:
+        first_home = "/private/run-one"
+        second_home = "/private/run-two"
+        first = bench.validate_request_body(
+            _compact(
+                _nanocodex_request(
+                    session_id=_session_id(201),
+                    workspace=first_home + "/workspace",
+                    id_offset=0,
+                )
+            ),
+            "nanocodex",
+            home=first_home,
+            workspace=first_home + "/workspace",
+        )
+        second = bench.validate_request_body(
+            _compact(
+                _nanocodex_request(
+                    session_id=_session_id(202),
+                    workspace=second_home + "/workspace",
+                    id_offset=10,
+                )
+            ),
+            "nanocodex",
+            home=second_home,
+            workspace=second_home + "/workspace",
+        )
+        changed = _nanocodex_request(session_id=_session_id(203))
+        changed["input"][0]["tools"][0]["description"] = "changed surface"
+
+        self.assertEqual(first.fingerprint_sha256, second.fingerprint_sha256)
+        with self.assertRaisesRegex(
+            bench.RequestValidationError, "nanocodex_tool_contract_mismatch"
+        ):
+            bench.validate_request_body(_compact(changed), "nanocodex")
+
+        wrong_cache = _nanocodex_request(cache_key="random-per-process-cache")
+        with self.assertRaisesRegex(
+            bench.RequestValidationError, "nanocodex_prompt_cache_key_mismatch"
+        ):
+            bench.validate_request_body(_compact(wrong_cache), "nanocodex")
+
+    def test_combined_fingerprint_excludes_only_credential_derived_fedramp(self) -> None:
+        validated = bench.validate_request_body(
+            _compact(_nanocodex_request()), "nanocodex"
+        )
+        metadata = (
+            ("User-Agent", bench.NANOCODEX_USER_AGENT),
+            ("Session-ID", "one"),
+            ("Thread-ID", "one"),
+            ("X-Client-Request-ID", "one"),
+        )
+        ordinary = bench.CanonicalRequestHeaders(
+            "Bearer fake",
+            "account",
+            1,
+            "one",
+            metadata,
+        )
+        fedramp = bench.CanonicalRequestHeaders(
+            "Bearer different-fake",
+            "different-account",
+            1,
+            "two",
+            metadata[:-3]
+            + (
+                ("Session-ID", "two"),
+                ("Thread-ID", "two"),
+                ("X-Client-Request-ID", "two"),
+                ("X-OpenAI-Fedramp", "true"),
+            ),
+        )
+
+        self.assertEqual(
+            bench._combined_request_fingerprint(validated, ordinary),
+            bench._combined_request_fingerprint(validated, fedramp),
+        )
+
+
+class SSETimingTests(unittest.TestCase):
+    def test_extracts_timings_cache_and_tool_calls(self) -> None:
+        lines = [
+            (
+                b'data: {"type":"response.reasoning_text.delta","delta":"thinking"}\n',
+                1_500,
+            ),
+            (b"\n", 1_501),
+            (
+                b'data: {"type":"response.output_text.delta","delta":"ACK"}\n',
+                1_900,
+            ),
+            (b"\n", 1_901),
+            (
+                b'data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"call-1"}}\n',
+                2_000,
+            ),
+            (b"\n", 2_001),
+            (
+                b'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens_details":{"cached_tokens":17}},"output":[]}}\n',
+                3_000,
+            ),
+            (b"\n", 3_001),
+        ]
+        result = bench.observe_sse_lines(lines, t0_ns=1_000)
+
+        self.assertEqual(result["timing_ns"]["time_to_first_model_output"], 500)
+        self.assertEqual(result["timing_ns"]["time_to_first_answer_text"], 900)
+        self.assertEqual(result["timing_ns"]["time_to_terminal"], 2_000)
+        self.assertEqual(result["cached_input_tokens"], 17)
+        self.assertEqual(result["tool_call_count"], 1)
+
+    def test_duplicate_terminal_event_is_an_error(self) -> None:
+        terminal = (
+            b'data: {"type":"response.completed","response":{"status":"completed",'
+            b'"usage":{"cached_input_tokens":1}}}\n'
+        )
+        result = bench.observe_sse_lines(
+            [(terminal, 10), (b"\n", 11), (terminal, 20), (b"\n", 21)],
+            t0_ns=0,
+        )
+
+        self.assertEqual(result["error"], "duplicate_terminal_event")
+        self.assertEqual(result["status"], "failed")
+
+    def test_multiline_semantic_event_uses_the_last_required_data_line(self) -> None:
+        result = bench.observe_sse_lines(
+            [
+                (
+                    b'data: {"type":"response.output_text.delta",\n',
+                    100,
+                ),
+                (b'data: "delta":"ACK"}\n', 900),
+                (b"\n", 901),
+                (
+                    b'data: {"type":"response.completed","response":{"status":"completed"}}\n',
+                    1_000,
+                ),
+                (b"\n", 1_001),
+            ],
+            t0_ns=0,
+        )
+
+        self.assertEqual(result["timing_ns"]["time_to_first_model_output"], 900)
+
+    def test_answer_and_terminal_diagnostics_do_not_gate_the_score(self) -> None:
+        run = bench._combined_run(
+            "nanocodex",
+            {"valid": True, "reported_tool_calls": 0},
+            {
+                "error": None,
+                "status": "completed",
+                "upstream_http_status": 200,
+                "tool_call_detected": False,
+                "cached_input_tokens": 1,
+                "timing_ns": {
+                    "time_to_first_model_output": 100,
+                    "time_to_first_answer_text": None,
+                    "time_to_terminal": None,
+                },
+            },
+            0,
+        )
+
+        self.assertTrue(run["timing_present"])
+        self.assertFalse(run["measured_failure"])
+
+    def test_rejects_conflicting_cache_fields_and_nonfunction_tool_events(self) -> None:
+        conflicting = (
+            b'data: {"type":"response.completed","response":{"status":"completed",'
+            b'"usage":{"cached_input_tokens":1,"input_tokens_details":'
+            b'{"cached_tokens":2}}}}\n'
+        )
+        cache_result = bench.observe_sse_lines(
+            [(conflicting, 10), (b"\n", 11)], t0_ns=0
+        )
+        self.assertEqual(cache_result["error"], "invalid_cached_input_tokens")
+        self.assertIsNone(cache_result["cached_input_tokens"])
+
+        tool_result = bench.observe_sse_lines(
+            [
+                (
+                    b'data: {"type":"response.web_search_call.in_progress"}\n',
+                    10,
+                ),
+                (b"\n", 11),
+            ],
+            t0_ns=0,
+        )
+        self.assertTrue(tool_result["tool_call_detected"])
+
+        unknown_call = bench.observe_sse_lines(
+            [
+                (
+                    b'data: {"type":"response.output_item.added","item":{"type":"future_provider_call","id":"danger"}}\n',
+                    20,
+                ),
+                (b"\n", 21),
+            ],
+            t0_ns=0,
+        )
+        self.assertTrue(unknown_call["tool_call_detected"])
+
+
+class LocalObserverIntegrationTests(ContractFixtureTestCase):
+    def test_models_discovery_accepts_only_the_pinned_fx_query(self) -> None:
+        auth = bench._fake_auth_material()
+
+        headers = {
+            "Authorization": f"Bearer {auth.access_token}",
+            "ChatGPT-Account-ID": auth.account_id,
+            "User-Agent": bench.FX_USER_AGENT,
+            "Originator": "fx",
+            "Accept": "application/json",
+            "Connection": "keep-alive",
+        }
+
+        def get(observer: bench.StreamingObserver, target: str) -> tuple[int, bytes]:
+            connection = http.client.HTTPConnection(
+                "127.0.0.1", observer.server.server_port, timeout=5
+            )
+            _send_request(connection, "GET", target, headers=headers)
+            response = connection.getresponse()
+            result = response.status, response.read()
+            connection.close()
+            return result
+
+        with bench._OfflineProvider() as provider:
+            with bench.StreamingObserver._for_test(
+                auth,
+                provider.url,
+                provider_request_budget=1,
+                require_fx_models_discovery=True,
+            ) as observer:
+                observer.state.arm(bench.ExpectedRequest("fx", 1, "test"))
+                exact_status, exact_body = get(
+                    observer,
+                    "/models?client_version=" + bench.FX_MODELS_CLIENT_VERSION,
+                )
+                rejected = [
+                    get(observer, "/models"),
+                    get(observer, "/models?client_version=wrong"),
+                    get(
+                        observer,
+                        "/models?client_version="
+                        + bench.FX_MODELS_CLIENT_VERSION
+                        + "&extra=1",
+                    ),
+                    get(
+                        observer,
+                        "/models?client_version="
+                        + bench.FX_MODELS_CLIENT_VERSION
+                        + "&client_version="
+                        + bench.FX_MODELS_CLIENT_VERSION,
+                    ),
+                    get(observer, "/models?client%5Fversion=0.148.0"),
+                    get(observer, "/models?client_version=%30.148.0"),
+                ]
+                stats = observer.state.stats()
+
+        self.assertEqual(exact_status, 200)
+        self.assertEqual(exact_body, bench.MODELS_BYTES)
+        self.assertEqual([status for status, _body in rejected], [404] * 6)
+        self.assertEqual(stats["models_requests"], 1)
+        self.assertEqual(stats["unexpected_requests"], 6)
+        self.assertEqual(stats["provider_requests_forwarded"], 0)
+        self.assertEqual(provider.server.requests, 0)
+
+    def test_models_discovery_rejects_account_whitespace_and_poisons_run(self) -> None:
+        auth = bench._fake_auth_material()
+        model_headers = {
+            "Authorization": f"Bearer {auth.access_token}",
+            "ChatGPT-Account-ID": f"{auth.account_id} ",
+            "User-Agent": bench.FX_USER_AGENT,
+            "Originator": "fx",
+            "Accept": "application/json",
+            "Connection": "keep-alive",
+        }
+        exact_model_headers = {
+            **model_headers,
+            "ChatGPT-Account-ID": auth.account_id,
+        }
+        with bench._OfflineProvider() as provider:
+            with bench.StreamingObserver._for_test(
+                auth,
+                provider.url,
+                provider_request_budget=1,
+                require_fx_models_discovery=True,
+            ) as observer:
+                ticket = observer.state.arm(
+                    bench.ExpectedRequest("fx", 1, "test")
+                )
+                connection = http.client.HTTPConnection(
+                    "127.0.0.1", observer.server.server_port, timeout=5
+                )
+                _send_request(
+                    connection,
+                    "GET",
+                    "/models?client_version=" + bench.FX_MODELS_CLIENT_VERSION,
+                    headers=model_headers,
+                )
+                rejected = connection.getresponse()
+                rejected.read()
+                connection.close()
+
+                connection = http.client.HTTPConnection(
+                    "127.0.0.1", observer.server.server_port, timeout=5
+                )
+                _send_request(
+                    connection,
+                    "GET",
+                    "/models?client_version=" + bench.FX_MODELS_CLIENT_VERSION,
+                    headers=exact_model_headers,
+                )
+                accepted = connection.getresponse()
+                accepted.read()
+                connection.close()
+
+                status, _streamed = _post_observer(
+                    observer, _compact(_fx_request()), auth
+                )
+                observed = observer.state.wait(ticket, 5)
+                stats = observer.state.stats()
+                auth_verified = observer.auth_matcher.verified_for({"fx"})
+
+        self.assertEqual(rejected.status, 404)
+        self.assertEqual(accepted.status, 200)
+        self.assertEqual(status, 200)
+        self.assertEqual(observed["status"], "completed")
+        self.assertEqual(stats["models_requests"], 1)
+        self.assertEqual(stats["unexpected_requests"], 1)
+        self.assertEqual(stats["provider_requests_forwarded"], 1)
+        self.assertEqual(provider.server.requests, 1)
+        self.assertFalse(auth_verified)
+
+    def test_transport_headers_match_each_captured_client_exactly(self) -> None:
+        auth = bench._fake_auth_material()
+        models_headers = {
+            "Authorization": f"Bearer {auth.access_token}",
+            "ChatGPT-Account-ID": auth.account_id,
+            "User-Agent": bench.FX_USER_AGENT,
+            "Originator": "fx",
+            "Accept": "application/json",
+            "Connection": "keep-alive",
+        }
+
+        def request(
+            observer: bench.StreamingObserver,
+            method: str,
+            target: str,
+            header_pairs: list[tuple[str, str]],
+            *,
+            body: bytes | None = None,
+            skip_host: bool = False,
+        ) -> int:
+            connection = http.client.HTTPConnection(
+                "127.0.0.1", observer.server.server_port, timeout=5
+            )
+            connection.putrequest(
+                method,
+                target,
+                skip_host=skip_host,
+                skip_accept_encoding=True,
+            )
+            for name, value in header_pairs:
+                connection.putheader(name, value)
+            if body is not None:
+                connection.putheader("Content-Length", str(len(body)))
+            connection.endheaders(body)
+            response = connection.getresponse()
+            status = response.status
+            response.read()
+            connection.close()
+            return status
+
+        model_cases = (
+            (list(models_headers.items()), True, "request_header_set_invalid"),
+            (
+                [("Host", "wrong.invalid"), *models_headers.items()],
+                True,
+                "observer_host_header_invalid",
+            ),
+            (
+                [
+                    ("Host", "127.0.0.1:1"),
+                    ("Host", "127.0.0.1:1"),
+                    *models_headers.items(),
+                ],
+                True,
+                "host_header_count_invalid",
+            ),
+            (
+                [
+                    *(
+                        (name, value)
+                        for name, value in models_headers.items()
+                        if name != "Connection"
+                    ),
+                ],
+                False,
+                "request_header_set_invalid",
+            ),
+            (
+                [
+                    *(
+                        (name, "close" if name == "Connection" else value)
+                        for name, value in models_headers.items()
+                    ),
+                ],
+                False,
+                "fx_models_connection_header_invalid",
+            ),
+            (
+                [*models_headers.items(), ("Accept-Encoding", "identity")],
+                False,
+                "request_header_set_invalid",
+            ),
+        )
+        with bench._OfflineProvider() as provider:
+            for ordinal, (headers, skip_host, expected_error) in enumerate(
+                model_cases, 1
+            ):
+                with self.subTest(kind="models", case=ordinal):
+                    with bench.StreamingObserver._for_test(
+                        auth,
+                        provider.url,
+                        provider_request_budget=1,
+                        require_fx_models_discovery=True,
+                    ) as observer:
+                        observer.state.arm(
+                            bench.ExpectedRequest("fx", ordinal, "test")
+                        )
+                        status = request(
+                            observer,
+                            "GET",
+                            "/models?client_version="
+                            + bench.FX_MODELS_CLIENT_VERSION,
+                            headers,
+                            skip_host=skip_host,
+                        )
+                        stats = observer.state.stats()
+                    self.assertEqual(status, 404)
+                    self.assertEqual(stats["models_requests"], 0)
+                    self.assertEqual(stats["unexpected_requests"], 1)
+
+            body_by_implementation = {
+                "fx": _compact(_fx_request()),
+                "nanocodex": _compact(_nanocodex_request()),
+            }
+            generation_cases = (
+                (
+                    "fx",
+                    [
+                        *(
+                            (name, value)
+                            for name, value in _request_headers(auth, "fx").items()
+                            if name != "Connection"
+                        )
+                    ],
+                    False,
+                    "request_header_set_invalid",
+                ),
+                (
+                    "fx",
+                    [
+                        *(
+                            (name, "keep-alive" if name == "Connection" else value)
+                            for name, value in _request_headers(auth, "fx").items()
+                        )
+                    ],
+                    False,
+                    "fx_connection_header_invalid",
+                ),
+                (
+                    "nanocodex",
+                    [
+                        *_request_headers(auth, "nanocodex").items(),
+                        ("Connection", "close"),
+                    ],
+                    False,
+                    "request_header_set_invalid",
+                ),
+                (
+                    "nanocodex",
+                    [
+                        *_request_headers(auth, "nanocodex").items(),
+                        ("Accept-Encoding", "identity"),
+                    ],
+                    False,
+                    "request_header_set_invalid",
+                ),
+                (
+                    "nanocodex",
+                    list(_request_headers(auth, "nanocodex").items()),
+                    True,
+                    "request_header_set_invalid",
+                ),
+                (
+                    "nanocodex",
+                    [
+                        ("Host", "wrong.invalid"),
+                        *_request_headers(auth, "nanocodex").items(),
+                    ],
+                    True,
+                    "observer_host_header_invalid",
+                ),
+                (
+                    "nanocodex",
+                    [
+                        ("Host", "127.0.0.1:1"),
+                        ("Host", "127.0.0.1:1"),
+                        *_request_headers(auth, "nanocodex").items(),
+                    ],
+                    True,
+                    "host_header_count_invalid",
+                ),
+                (
+                    "fx",
+                    [
+                        *(
+                            (
+                                name,
+                                "Application/JSON"
+                                if name == "Content-Type"
+                                else value,
+                            )
+                            for name, value in _request_headers(auth, "fx").items()
+                        )
+                    ],
+                    False,
+                    "content_type_must_be_application_json",
+                ),
+                (
+                    "fx",
+                    [
+                        *(
+                            (
+                                name,
+                                "TEXT/EVENT-STREAM" if name == "Accept" else value,
+                            )
+                            for name, value in _request_headers(auth, "fx").items()
+                        )
+                    ],
+                    False,
+                    "accept_must_be_text_event_stream",
+                ),
+                (
+                    "nanocodex",
+                    [
+                        *(
+                            (
+                                name,
+                                "Application/JSON"
+                                if name == "Content-Type"
+                                else value,
+                            )
+                            for name, value in _request_headers(
+                                auth, "nanocodex"
+                            ).items()
+                        )
+                    ],
+                    False,
+                    "content_type_must_be_application_json",
+                ),
+                (
+                    "nanocodex",
+                    [
+                        *(
+                            (
+                                name,
+                                "TEXT/EVENT-STREAM" if name == "Accept" else value,
+                            )
+                            for name, value in _request_headers(
+                                auth, "nanocodex"
+                            ).items()
+                        )
+                    ],
+                    False,
+                    "accept_must_be_text_event_stream",
+                ),
+            )
+            for ordinal, (
+                implementation,
+                headers,
+                skip_host,
+                expected_error,
+            ) in enumerate(generation_cases, 1):
+                with self.subTest(kind="generation", case=ordinal):
+                    with bench.StreamingObserver._for_test(
+                        auth, provider.url, provider_request_budget=1
+                    ) as observer:
+                        ticket = observer.state.arm(
+                            bench.ExpectedRequest(implementation, ordinal, "test")
+                        )
+                        status = request(
+                            observer,
+                            "POST",
+                            "/responses",
+                            headers,
+                            body=body_by_implementation[implementation],
+                            skip_host=skip_host,
+                        )
+                        observed = observer.state.wait(ticket, 5)
+                        stats = observer.state.stats()
+                    self.assertEqual(status, 400)
+                    self.assertEqual(observed["error"], expected_error)
+                    self.assertEqual(stats["provider_requests_forwarded"], 0)
+
+        self.assertEqual(provider.server.requests, 0)
+
+    def test_raw_parser_defects_are_counted_before_claim_or_forwarding(self) -> None:
+        auth = bench._fake_auth_material()
+        generation_body = _compact(_fx_request())
+
+        def raw_request(
+            observer: bench.StreamingObserver,
+            request_line: str,
+            headers: list[tuple[str, str]],
+            *,
+            malformed_header: bytes = b"",
+            body: bytes = b"",
+        ) -> bytes:
+            connection = socket.create_connection(
+                ("127.0.0.1", observer.server.server_port), timeout=5
+            )
+            encoded_headers = b"".join(
+                f"{name}: {value}\r\n".encode("ascii") for name, value in headers
+            )
+            connection.sendall(
+                request_line.encode("ascii")
+                + b"\r\n"
+                + encoded_headers
+                + malformed_header
+                + b"\r\n"
+                + body
+            )
+            chunks: list[bytes] = []
+            while True:
+                chunk = connection.recv(4096)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            connection.close()
+            return b"".join(chunks)
+
+        malformed_headers = (
+            b"X-Malformed\r\n",
+            b"X-Malformed : value\r\n",
+            b": value\r\n",
+        )
+        with bench._OfflineProvider() as provider:
+            with bench.StreamingObserver._for_test(
+                auth,
+                provider.url,
+                provider_request_budget=1,
+                require_fx_models_discovery=True,
+            ) as observer:
+                ticket = observer.state.arm(
+                    bench.ExpectedRequest("fx", 1, "test")
+                )
+                model_headers = [
+                    ("Host", f"127.0.0.1:{observer.server.server_port}"),
+                    (
+                        "Authorization",
+                        f"Bearer {auth.access_token}",
+                    ),
+                    ("ChatGPT-Account-ID", auth.account_id),
+                    ("User-Agent", bench.FX_USER_AGENT),
+                    ("Originator", "fx"),
+                    ("Accept", "application/json"),
+                    ("Connection", "keep-alive"),
+                ]
+                generation_headers = [
+                    ("Host", f"127.0.0.1:{observer.server.server_port}"),
+                    *_request_headers(auth, "fx").items(),
+                    ("Content-Length", str(len(generation_body))),
+                ]
+                for malformed in malformed_headers:
+                    raw_request(
+                        observer,
+                        "GET /models?client_version=0.148.0 HTTP/1.1",
+                        model_headers,
+                        malformed_header=malformed,
+                    )
+                    raw_request(
+                        observer,
+                        "POST /responses HTTP/1.1",
+                        generation_headers,
+                        malformed_header=malformed,
+                        body=generation_body,
+                    )
+
+                stats = observer.state.stats()
+                self.assertTrue(observer.state.cancel_unclaimed(ticket))
+
+        self.assertEqual(stats["unexpected_requests"], 6)
+        self.assertEqual(stats["models_requests"], 0)
+        self.assertEqual(stats["provider_requests_forwarded"], 0)
+        self.assertEqual(provider.server.requests, 0)
+
+    def test_pre_dispatch_parser_failures_poison_a_following_valid_run(self) -> None:
+        auth = bench._fake_auth_material()
+        body = _compact(_fx_request())
+
+        def fire(observer: bench.StreamingObserver, request: bytes) -> None:
+            connection = socket.create_connection(
+                ("127.0.0.1", observer.server.server_port), timeout=5
+            )
+            connection.sendall(request)
+            with contextlib.suppress(OSError):
+                while connection.recv(4096):
+                    pass
+            connection.close()
+
+        with bench._OfflineProvider() as provider:
+            with bench.StreamingObserver._for_test(
+                auth, provider.url, provider_request_budget=1
+            ) as observer:
+                ticket = observer.state.arm(
+                    bench.ExpectedRequest("fx", 1, "test")
+                )
+                overflow = (
+                    b"GET /responses HTTP/1.1\r\nHost: 127.0.0.1\r\n"
+                    + b"".join(
+                        f"X-Overflow-{index}: value\r\n".encode("ascii")
+                        for index in range(128)
+                    )
+                    + b"\r\n"
+                )
+                for request in (
+                    overflow,
+                    b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n",
+                    b"BAD METHOD /responses HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n",
+                ):
+                    fire(observer, request)
+                self.assertEqual(
+                    observer.state.stats()["provider_requests_forwarded"], 0
+                )
+
+                status, _streamed = _post_observer(observer, body, auth, "fx")
+                observed = observer.state.wait(ticket, 5)
+                stats = observer.state.stats()
+
+        self.assertEqual(status, 200)
+        self.assertEqual(observed["status"], "completed")
+        self.assertEqual(stats["unexpected_requests"], 3)
+        self.assertEqual(stats["provider_requests_forwarded"], 1)
+        self.assertEqual(provider.server.requests, 1)
+
+    def test_oversized_request_line_is_counted_once_and_poisons_eligibility(
+        self,
+    ) -> None:
+        auth = bench._fake_auth_material()
+        body = _compact(_fx_request())
+        with bench._OfflineProvider() as provider:
+            with bench.StreamingObserver._for_test(
+                auth, provider.url, provider_request_budget=1
+            ) as observer:
+                ticket = observer.state.arm(
+                    bench.ExpectedRequest("fx", 1, "test")
+                )
+                connection = socket.create_connection(
+                    ("127.0.0.1", observer.server.server_port), timeout=5
+                )
+                connection.sendall(
+                    b"GET /" + b"x" * 65_536 + b" HTTP/1.1\r\n\r\n"
+                )
+                response = bytearray()
+                with contextlib.suppress(ConnectionResetError):
+                    while chunk := connection.recv(4096):
+                        response.extend(chunk)
+                connection.close()
+
+                self.assertTrue(bytes(response).startswith(b"HTTP/1.1 414 "))
+                self.assertEqual(
+                    observer.state.stats()["unexpected_requests"], 1
+                )
+                self.assertEqual(
+                    observer.state.stats()["provider_requests_forwarded"], 0
+                )
+
+                status, _streamed = _post_observer(observer, body, auth, "fx")
+                observed = observer.state.wait(ticket, 5)
+                stats = observer.state.stats()
+
+        combined = bench._combined_run(
+            "fx",
+            {
+                "valid": True,
+                "reported_tool_calls": 0,
+                "client_configuration_echo_valid": True,
+            },
+            observed,
+            stats["unexpected_requests"],
+        )
+        self.assertEqual(status, 200)
+        self.assertEqual(observed["status"], "completed")
+        self.assertEqual(stats["unexpected_requests"], 1)
+        self.assertEqual(stats["provider_requests_forwarded"], 1)
+        self.assertEqual(provider.server.requests, 1)
+        self.assertTrue(combined["measured_failure"])
+        self.assertFalse(combined["no_tool_calls"])
+
+    def test_only_exact_origin_form_post_targets_can_claim_or_refresh(self) -> None:
+        auth = bench._fake_auth_material()
+        body = _compact(_fx_request())
+        invalid_targets = (
+            "http://attacker.invalid/responses",
+            "//responses",
+            "http://attacker.invalid/forbid-refresh",
+            "//forbid-refresh",
+        )
+        with bench._OfflineProvider() as provider:
+            with bench.StreamingObserver._for_test(
+                auth, provider.url, provider_request_budget=1
+            ) as observer:
+                ticket = observer.state.arm(
+                    bench.ExpectedRequest("fx", 1, "test")
+                )
+                statuses: list[int] = []
+                for target in invalid_targets:
+                    connection = http.client.HTTPConnection(
+                        "127.0.0.1", observer.server.server_port, timeout=5
+                    )
+                    _send_request(
+                        connection,
+                        "POST",
+                        target,
+                        headers=_request_headers(auth, "fx"),
+                        body=body,
+                    )
+                    response = connection.getresponse()
+                    statuses.append(response.status)
+                    response.read()
+                    connection.close()
+
+                before_valid = observer.state.stats()
+                status, _streamed = _post_observer(observer, body, auth, "fx")
+                observed = observer.state.wait(ticket, 5)
+                stats = observer.state.stats()
+
+        combined = bench._combined_run(
+            "fx",
+            {
+                "valid": True,
+                "reported_tool_calls": 0,
+                "client_configuration_echo_valid": True,
+            },
+            observed,
+            stats["unexpected_requests"],
+        )
+        self.assertEqual(statuses, [404] * len(invalid_targets))
+        self.assertEqual(before_valid["unexpected_requests"], len(invalid_targets))
+        self.assertEqual(before_valid["refresh_attempts_blocked"], 0)
+        self.assertEqual(before_valid["provider_requests_forwarded"], 0)
+        self.assertEqual(status, 200)
+        self.assertEqual(observed["status"], "completed")
+        self.assertEqual(stats["provider_requests_forwarded"], 1)
+        self.assertEqual(provider.server.requests, 1)
+        self.assertTrue(combined["measured_failure"])
+
+    def test_every_unsupported_method_is_counted_before_valid_generation(self) -> None:
+        auth = bench._fake_auth_material()
+        body = _compact(_fx_request())
+        with bench._OfflineProvider() as provider:
+            with bench.StreamingObserver._for_test(
+                auth, provider.url, provider_request_budget=1
+            ) as observer:
+                ticket = observer.state.arm(
+                    bench.ExpectedRequest("fx", 1, "test")
+                )
+                for method in ("HEAD", "OPTIONS", "TRACE", "BREW"):
+                    connection = http.client.HTTPConnection(
+                        "127.0.0.1", observer.server.server_port, timeout=5
+                    )
+                    connection.putrequest(
+                        method, "/responses", skip_accept_encoding=True
+                    )
+                    connection.endheaders()
+                    response = connection.getresponse()
+                    response.read()
+                    connection.close()
+                    self.assertEqual(response.status, 405)
+
+                status, _streamed = _post_observer(observer, body, auth, "fx")
+                observed = observer.state.wait(ticket, 5)
+                stats = observer.state.stats()
+
+        self.assertEqual(status, 200)
+        self.assertEqual(observed["status"], "completed")
+        self.assertEqual(stats["unexpected_requests"], 4)
+        self.assertEqual(stats["provider_requests_forwarded"], 1)
+        self.assertEqual(provider.server.requests, 1)
+
+    def test_reset_unsupported_bodies_are_counted_before_drain(self) -> None:
+        auth = bench._fake_auth_material()
+        body = _compact(_fx_request())
+        with bench._OfflineProvider() as provider:
+            with bench.StreamingObserver._for_test(
+                auth, provider.url, provider_request_budget=1
+            ) as observer:
+                ticket = observer.state.arm(
+                    bench.ExpectedRequest("fx", 1, "test")
+                )
+                for expected_count, method in enumerate(("HEAD", "BREW"), start=1):
+                    connection = socket.create_connection(
+                        ("127.0.0.1", observer.server.server_port), timeout=5
+                    )
+                    connection.sendall(
+                        (
+                            f"{method} /responses HTTP/1.1\r\n"
+                            f"Host: 127.0.0.1:{observer.server.server_port}\r\n"
+                            "Content-Length: 1048576\r\n"
+                            "Connection: close\r\n\r\n"
+                            "x"
+                        ).encode("ascii")
+                    )
+                    connection.setsockopt(
+                        socket.SOL_SOCKET,
+                        socket.SO_LINGER,
+                        struct.pack("ii", 1, 0),
+                    )
+                    connection.close()
+                    deadline = time.monotonic() + 5
+                    while (
+                        observer.state.stats()["unexpected_requests"]
+                        < expected_count
+                        and time.monotonic() < deadline
+                    ):
+                        time.sleep(0.01)
+                    self.assertEqual(
+                        observer.state.stats()["unexpected_requests"],
+                        expected_count,
+                    )
+
+                status, _streamed = _post_observer(observer, body, auth, "fx")
+                observed = observer.state.wait(ticket, 5)
+                stats = observer.state.stats()
+
+        self.assertEqual(status, 200)
+        self.assertEqual(observed["status"], "completed")
+        self.assertEqual(stats["unexpected_requests"], 2)
+        self.assertEqual(stats["provider_requests_forwarded"], 1)
+        self.assertEqual(provider.server.requests, 1)
+
+    def test_shutdown_interrupts_a_stalled_upstream_and_drains_all_work(self) -> None:
+        auth = bench._fake_auth_material()
+        client_result: dict[str, object] = {}
+        response_owns_socket = threading.Event()
+
+        class HandoffConnection(bench._ResolvedHTTPConnection):
+            published_socket: socket.socket | None = None
+
+            def connect(self) -> None:
+                super().connect()
+                self.published_socket = self.sock
+
+            def getresponse(self) -> http.client.HTTPResponse:
+                response = super().getresponse()
+                if self.sock is None:
+                    response_owns_socket.set()
+                return response
+
+        def post(observer: bench.StreamingObserver) -> None:
+            try:
+                client_result["response"] = _post_observer(
+                    observer, _compact(_fx_request()), auth
+                )
+            except BaseException as error:
+                client_result["error"] = type(error).__name__
+
+        with bench._OfflineProvider(stall_after_headers=True) as provider:
+            observer = bench.StreamingObserver._for_test(
+                auth, provider.url, provider_request_budget=1
+            )
+            target = observer.server.upstream
+            connection = HandoffConnection(
+                target.host,
+                target.port,
+                target.endpoints,
+                timeout=bench.UPSTREAM_CONNECT_TIMEOUT_SECONDS,
+            )
+            with mock.patch.object(
+                bench.UpstreamTarget, "connection", return_value=connection
+            ):
+                with observer:
+                    observer.state.arm(bench.ExpectedRequest("fx", 1, "test"))
+                    client_thread = threading.Thread(
+                        target=post, args=(observer,), daemon=True
+                    )
+                    client_thread.start()
+                    self.assertTrue(provider.server.request_started.wait(5))
+                    self.assertTrue(response_owns_socket.wait(5))
+                    self.assertIsNone(connection.sock)
+                    self.assertEqual(
+                        observer.state.stats()["provider_requests_forwarded"], 1
+                    )
+                    shutdown_started = time.monotonic()
+
+            shutdown_elapsed = time.monotonic() - shutdown_started
+            self.assertTrue(provider.server.peer_disconnected.wait(5))
+            self.assertEqual(
+                provider.server.wait_for_quiescence(time.monotonic() + 5), 0
+            )
+            client_thread.join(timeout=5)
+            self.assertFalse(client_thread.is_alive())
+            self.assertFalse(observer._thread.is_alive())
+            self.assertEqual(observer.server.active_work_count(), 0)
+            self.assertEqual(observer.server.socket.fileno(), -1)
+            self.assertIsNotNone(connection.published_socket)
+            self.assertEqual(connection.published_socket.fileno(), -1)
+            self.assertLess(
+                shutdown_elapsed, bench.OBSERVER_SHUTDOWN_TIMEOUT_SECONDS + 1
+            )
+
+        self.assertFalse(provider._thread.is_alive())
+        self.assertEqual(provider.server.active_work_count(), 0)
+
+    def test_offline_template_mismatch_fails_before_budget_or_upstream(self) -> None:
+        upstream_requests = 0
+
+        class FakeUpstream(http.server.BaseHTTPRequestHandler):
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+            def do_POST(self) -> None:  # noqa: N802
+                nonlocal upstream_requests
+                upstream_requests += 1
+                self.send_response(500)
+                self.end_headers()
+
+        auth = bench._fake_auth_material()
+        with _serve(FakeUpstream) as upstream:
+            url = f"http://127.0.0.1:{upstream.server_port}/responses"
+            with bench.StreamingObserver._for_test(
+                auth,
+                url,
+                provider_request_budget=1,
+                expected_fingerprints={"fx": "0" * 64, "nanocodex": "1" * 64},
+            ) as observer:
+                ticket = observer.state.arm(
+                    bench.ExpectedRequest("fx", 1, "test")
+                )
+                status, _ = _post_observer(
+                    observer, _compact(_fx_request()), auth
+                )
+                observed = observer.state.wait(ticket, 5)
+                stats = observer.state.stats()
+
+        self.assertEqual(status, 400)
+        self.assertEqual(
+            observed["error"], "request_fingerprint_preflight_mismatch"
+        )
+        self.assertEqual(stats["provider_requests_forwarded"], 0)
+        self.assertEqual(upstream_requests, 0)
+
+    def test_uuid7_freshness_spans_preflight_fedramp_and_live_observers(self) -> None:
+        def fingerprint(
+            request: dict[str, object], auth: bench.AuthMaterial
+        ) -> str:
+            body = _compact(request)
+            validated = bench.validate_request_body(
+                body,
+                "nanocodex",
+                home=TEST_HOME,
+                workspace=TEST_WORKSPACE,
+            )
+            session_id = request["client_metadata"]["session_id"]
+            metadata = [
+                ("User-Agent", bench.NANOCODEX_USER_AGENT),
+                ("X-OpenAI-Internal-Codex-Responses-Lite", "true"),
+                ("Session-ID", session_id),
+                ("Thread-ID", session_id),
+                ("X-Client-Request-ID", session_id),
+            ]
+            if auth.fedramp:
+                metadata.append(("X-OpenAI-Fedramp", "true"))
+            headers = bench.CanonicalRequestHeaders(
+                f"Bearer {auth.access_token}",
+                auth.account_id,
+                len(body),
+                session_id,
+                tuple(metadata),
+            )
+            return bench._combined_request_fingerprint(validated, headers)
+
+        def post(
+            observer: bench.StreamingObserver,
+            request: dict[str, object],
+            auth: bench.AuthMaterial,
+            phase: str,
+        ) -> tuple[int, dict[str, object]]:
+            session_id = request["client_metadata"]["session_id"]
+            ticket = observer.state.arm(
+                bench.ExpectedRequest(
+                    "nanocodex",
+                    1,
+                    phase,
+                    home=TEST_HOME,
+                    workspace=TEST_WORKSPACE,
+                )
+            )
+            connection = http.client.HTTPConnection(
+                "127.0.0.1", observer.server.server_port, timeout=5
+            )
+            _send_request(
+                connection,
+                "POST",
+                "/responses",
+                body=_compact(request),
+                headers=_request_headers(
+                    auth, "nanocodex", session_id=session_id
+                ),
+            )
+            response = connection.getresponse()
+            status = response.status
+            response.read()
+            connection.close()
+            observed = observer.state.wait(ticket, 5)
+            self.assertIsNotNone(observed)
+            return status, observed
+
+        boundaries = (
+            ("ordinary_to_fedramp", False, True, "offline_fedramp_preflight"),
+            ("fedramp_preflight_to_live", True, False, "warmup"),
+        )
+        for boundary_index, (
+            boundary,
+            first_fedramp,
+            second_fedramp,
+            second_phase,
+        ) in enumerate(boundaries, 1):
+            for direction_index, direction in enumerate(
+                ("session_to_msg", "msg_to_session"), 1
+            ):
+                with self.subTest(boundary=boundary, direction=direction):
+                    value = boundary_index * 10_000 + direction_index * 1_000
+                    first_auth = bench._fake_auth_material(
+                        fedramp=first_fedramp
+                    )
+                    second_auth = bench._fake_auth_material(
+                        fedramp=second_fedramp
+                    )
+                    ledger = bench.FreshUuid7Ledger()
+                    first_request = _nanocodex_request(
+                        session_id=_session_id(value),
+                        id_offset=value + 10,
+                    )
+                    second_request = _nanocodex_request(
+                        session_id=_session_id(value + 100),
+                        id_offset=value + 200,
+                    )
+                    if direction == "session_to_msg":
+                        second_request["input"][2]["id"] = "msg_" + _session_id(
+                            value
+                        )
+                    else:
+                        reused_message_id = first_request["input"][2]["id"]
+                        reused = reused_message_id.removeprefix("msg_")
+                        second_request["client_metadata"]["session_id"] = reused
+                        second_request["client_metadata"]["thread_id"] = reused
+
+                    expected_fingerprint = fingerprint(first_request, first_auth)
+                    self.assertEqual(
+                        fingerprint(second_request, second_auth),
+                        expected_fingerprint,
+                    )
+
+                    with bench._OfflineProvider() as first_provider:
+                        with bench.StreamingObserver._for_test(
+                            first_auth,
+                            first_provider.url,
+                            provider_request_budget=1,
+                            fresh_identifier_ledger=ledger,
+                        ) as first_observer:
+                            first_status, first_observed = post(
+                                first_observer,
+                                first_request,
+                                first_auth,
+                                "offline_preflight",
+                            )
+                            first_stats = first_observer.state.stats()
+                            first_fingerprints = (
+                                first_observer.state.request_fingerprints()
+                            )
+                    self.assertEqual(first_status, 200)
+                    self.assertEqual(first_observed["status"], "completed")
+                    self.assertEqual(first_stats["provider_requests_forwarded"], 1)
+                    self.assertEqual(first_provider.server.requests, 1)
+                    self.assertEqual(
+                        first_fingerprints, {"nanocodex": expected_fingerprint}
+                    )
+
+                    with bench._OfflineProvider() as second_provider:
+                        with bench.StreamingObserver._for_test(
+                            second_auth,
+                            second_provider.url,
+                            provider_request_budget=1,
+                            expected_fingerprints={
+                                "fx": "0" * 64,
+                                "nanocodex": expected_fingerprint,
+                            },
+                            fresh_identifier_ledger=ledger,
+                        ) as second_observer:
+                            second_status, second_observed = post(
+                                second_observer,
+                                second_request,
+                                second_auth,
+                                second_phase,
+                            )
+                            second_stats = second_observer.state.stats()
+                            second_fingerprints = (
+                                second_observer.state.request_fingerprints()
+                            )
+
+                    self.assertEqual(second_status, 400)
+                    self.assertEqual(
+                        second_observed["error"],
+                        "fresh_request_identifier_reused",
+                    )
+                    self.assertEqual(second_fingerprints, {})
+                    self.assertEqual(
+                        second_stats["provider_requests_forwarded"], 0
+                    )
+                    self.assertEqual(second_provider.server.requests, 0)
+                    self.assertEqual(
+                        ledger.evidence(),
+                        {
+                            "accepted_identity_uses": 4,
+                            "distinct_canonical_uuid7_identities": 4,
+                            "reuse_detected": True,
+                            "noncanonical_identity_detected": False,
+                            "distinct_and_one_use_verified": False,
+                        },
+                    )
+
+    def test_provider_budget_rejects_second_http_request_before_upstream(self) -> None:
+        upstream_requests = 0
+
+        class FakeUpstream(http.server.BaseHTTPRequestHandler):
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+            def do_POST(self) -> None:  # noqa: N802
+                nonlocal upstream_requests
+                length = int(self.headers["Content-Length"])
+                self.rfile.read(length)
+                upstream_requests += 1
+                body = (
+                    b'data: {"type":"response.output_text.delta","delta":"ACK"}\n\n'
+                    b'data: {"type":"response.completed","response":{"status":"completed","usage":{"cached_input_tokens":1},"output":[]}}\n\n'
+                )
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        auth = bench._fake_auth_material()
+        body = _compact(_fx_request())
+        with _serve(FakeUpstream) as upstream:
+            url = f"http://127.0.0.1:{upstream.server_port}/responses"
+            with bench.StreamingObserver._for_test(
+                auth, url, provider_request_budget=1
+            ) as observer:
+                first_ticket = observer.state.arm(
+                    bench.ExpectedRequest("fx", 1, "test")
+                )
+                first_status, _ = _post_observer(observer, body, auth)
+                first = observer.state.wait(first_ticket, 5)
+                second_ticket = observer.state.arm(
+                    bench.ExpectedRequest("fx", 2, "test")
+                )
+                second_status, _ = _post_observer(observer, body, auth)
+                second = observer.state.wait(second_ticket, 5)
+                stats = observer.state.stats()
+
+        self.assertEqual(first_status, 200)
+        self.assertEqual(first["status"], "completed")
+        self.assertEqual(second_status, 400)
+        self.assertEqual(second["error"], "provider_request_budget_exhausted")
+        self.assertEqual(stats["provider_requests_forwarded"], 1)
+        self.assertEqual(upstream_requests, 1)
+
+    def test_invalid_request_bodies_fail_before_budget_or_upstream(self) -> None:
+        upstream_requests = 0
+
+        class FakeUpstream(http.server.BaseHTTPRequestHandler):
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+            def do_POST(self) -> None:  # noqa: N802
+                nonlocal upstream_requests
+                upstream_requests += 1
+                self.send_response(500)
+                self.end_headers()
+
+        prior = _nanocodex_request()
+        prior["previous_response_id"] = "resp_old"
+        stripped_fx = _fx_request()
+        stripped_fx["tools"] = [_function_tool("read_file")]
+        wrong_workspace = _nanocodex_request(workspace="/private/wrong/workspace")
+        cases = (
+            (
+                "nanocodex",
+                prior,
+                bench.ExpectedRequest(
+                    "nanocodex",
+                    1,
+                    "test",
+                    home=TEST_HOME,
+                    workspace=TEST_WORKSPACE,
+                ),
+                "unexpected_previous_response_id",
+            ),
+            (
+                "fx",
+                stripped_fx,
+                bench.ExpectedRequest(
+                    "fx", 2, "test", home=TEST_HOME, workspace=TEST_WORKSPACE
+                ),
+                "fx_default_tool_surface_mismatch",
+            ),
+            (
+                "nanocodex",
+                wrong_workspace,
+                bench.ExpectedRequest(
+                    "nanocodex",
+                    3,
+                    "test",
+                    home=TEST_HOME,
+                    workspace=TEST_WORKSPACE,
+                ),
+                "nanocodex_workspace_context_mismatch",
+            ),
+        )
+        auth = bench._fake_auth_material()
+        with _serve(FakeUpstream) as upstream:
+            url = f"http://127.0.0.1:{upstream.server_port}/responses"
+            with bench.StreamingObserver._for_test(
+                auth, url, provider_request_budget=len(cases)
+            ) as observer:
+                for implementation, request, expected, error in cases:
+                    with self.subTest(error=error):
+                        ticket = observer.state.arm(expected)
+                        status, _ = _post_observer(
+                            observer,
+                            _compact(request),
+                            auth,
+                            implementation,
+                        )
+                        observed = observer.state.wait(ticket, 5)
+                        self.assertEqual(status, 400)
+                        self.assertEqual(observed["error"], error)
+                stats = observer.state.stats()
+
+        self.assertEqual(stats["provider_requests_forwarded"], 0)
+        self.assertEqual(upstream_requests, 0)
+
+    def test_forwards_only_canonical_headers_and_records_stable_fingerprints(self) -> None:
+        received_bodies: list[bytes] = []
+        received_headers: list[dict[str, list[str]]] = []
+
+        class FakeUpstream(http.server.BaseHTTPRequestHandler):
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+            def do_POST(self) -> None:  # noqa: N802
+                length = int(self.headers["Content-Length"])
+                received_bodies.append(self.rfile.read(length))
+                received_headers.append(
+                    {
+                        name.lower(): self.headers.get_all(name, [])
+                        for name in self.headers.keys()
+                    }
+                )
+                body = (
+                    b'data: {"type":"response.output_text.delta","delta":"'
+                    + bench.ACK_TOKEN.encode()
+                    + b'"}\n\n'
+                    b'data: {"type":"response.completed","response":{"status":"completed","usage":{"cached_input_tokens":3}}}\n\n'
+                )
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        auth = bench._fake_auth_material()
+        bodies = {
+            "fx": _compact(_fx_request()),
+            "nanocodex": _compact(_nanocodex_request()),
+        }
+        with _serve(FakeUpstream) as upstream:
+            url = f"http://127.0.0.1:{upstream.server_port}/responses"
+            with bench.StreamingObserver._for_test(
+                auth, url, provider_request_budget=2
+            ) as observer:
+                for pair, implementation in enumerate(("fx", "nanocodex"), 1):
+                    ticket = observer.state.arm(
+                        bench.ExpectedRequest(implementation, pair, "test")
+                    )
+                    connection = http.client.HTTPConnection(
+                        "127.0.0.1", observer.server.server_port, timeout=5
+                    )
+                    headers = _request_headers(auth, implementation)
+                    _send_request(
+                        connection,
+                        "POST",
+                        "/responses",
+                        body=bodies[implementation],
+                        headers=headers,
+                    )
+                    response = connection.getresponse()
+                    streamed = response.read()
+                    connection.close()
+                    self.assertEqual(response.status, 200)
+                    self.assertIn(bench.ACK_TOKEN.encode(), streamed)
+                    observation = observer.state.wait(ticket, 5)
+                    self.assertEqual(observation["status"], "completed")
+
+                self.assertTrue(observer.auth_matcher.verified())
+                self.assertTrue(observer.state.fingerprints_stable())
+
+        self.assertEqual(received_bodies, [bodies["fx"], bodies["nanocodex"]])
+        common_names = {
+            "host",
+            "authorization",
+            "chatgpt-account-id",
+            "content-type",
+            "accept",
+            "content-length",
+            "connection",
+        }
+        product_names = {
+            "fx": {
+                "user-agent",
+                "originator",
+                "openai-beta",
+            },
+            "nanocodex": {
+                "user-agent",
+                "x-openai-internal-codex-responses-lite",
+                "session-id",
+                "thread-id",
+                "x-client-request-id",
+            },
+        }
+        for implementation, headers in zip(
+            ("fx", "nanocodex"), received_headers
+        ):
+            expected_names = common_names | product_names[implementation]
+            self.assertEqual(set(headers), expected_names)
+            self.assertTrue(all(len(values) == 1 for values in headers.values()))
+            self.assertEqual(headers["content-type"], ["application/json"])
+            self.assertEqual(headers["accept"], ["text/event-stream"])
+        self.assertEqual(received_headers[0]["originator"], ["fx"])
+        self.assertEqual(
+            received_headers[0]["openai-beta"], ["responses=experimental"]
+        )
+        self.assertEqual(
+            received_headers[1]["x-openai-internal-codex-responses-lite"],
+            ["true"],
+        )
+
+    def test_nanocodex_fedramp_header_tracks_the_credential(self) -> None:
+        received_fedramp: list[str | None] = []
+
+        class FakeUpstream(http.server.BaseHTTPRequestHandler):
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+            def do_POST(self) -> None:  # noqa: N802
+                length = int(self.headers["Content-Length"])
+                self.rfile.read(length)
+                received_fedramp.append(self.headers.get("X-OpenAI-Fedramp"))
+                body = (
+                    b'data: {"type":"response.output_text.delta","delta":"ACK"}\n\n'
+                    b'data: {"type":"response.completed","response":{"status":"completed","usage":{"cached_input_tokens":1}}}\n\n'
+                )
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.end_headers()
+                self.wfile.write(body)
+
+        auth = bench._fake_auth_material(fedramp=True)
+        with _serve(FakeUpstream) as upstream:
+            url = f"http://127.0.0.1:{upstream.server_port}/responses"
+            with bench.StreamingObserver._for_test(
+                auth, url, provider_request_budget=1
+            ) as observer:
+                ticket = observer.state.arm(
+                    bench.ExpectedRequest("nanocodex", 1, "test")
+                )
+                status, _ = _post_observer(
+                    observer,
+                    _compact(_nanocodex_request()),
+                    auth,
+                    "nanocodex",
+                )
+                observed = observer.state.wait(ticket, 5)
+
+        self.assertEqual(status, 200)
+        self.assertEqual(observed["status"], "completed")
+        self.assertEqual(received_fedramp, ["true"])
+
+    def test_rejects_each_duplicate_sensitive_header_before_upstream(self) -> None:
+        upstream_requests = 0
+
+        class FakeUpstream(http.server.BaseHTTPRequestHandler):
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+            def do_POST(self) -> None:  # noqa: N802
+                nonlocal upstream_requests
+                upstream_requests += 1
+                self.send_response(500)
+                self.end_headers()
+
+        auth = bench._fake_auth_material()
+        body = _compact(_fx_request())
+        base_headers = [
+            *_request_headers(auth, "fx").items(),
+            ("Content-Length", str(len(body))),
+        ]
+        expected_errors = {
+            "Authorization": "authorization_header_count_invalid",
+            "ChatGPT-Account-ID": "chatgpt_account_id_header_count_invalid",
+            "Content-Type": "content_type_header_count_invalid",
+            "Content-Length": "content_length_header_count_invalid",
+        }
+        with _serve(FakeUpstream) as upstream:
+            url = f"http://127.0.0.1:{upstream.server_port}/responses"
+            with bench.StreamingObserver._for_test(
+                auth, url, provider_request_budget=4
+            ) as observer:
+                for pair, duplicate in enumerate(expected_errors, 1):
+                    ticket = observer.state.arm(
+                        bench.ExpectedRequest("fx", pair, "test")
+                    )
+                    connection = http.client.HTTPConnection(
+                        "127.0.0.1", observer.server.server_port, timeout=5
+                    )
+                    connection.putrequest(
+                        "POST", "/responses", skip_accept_encoding=True
+                    )
+                    for name, value in base_headers:
+                        connection.putheader(name, value)
+                        if name == duplicate:
+                            connection.putheader(name, value)
+                    connection.endheaders(body)
+                    response = connection.getresponse()
+                    response.read()
+                    connection.close()
+                    self.assertEqual(response.status, 400)
+                    observed = observer.state.wait(ticket, 5)
+                    self.assertEqual(observed["error"], expected_errors[duplicate])
+
+                ticket = observer.state.arm(
+                    bench.ExpectedRequest("fx", 5, "test")
+                )
+                connection = http.client.HTTPConnection(
+                    "127.0.0.1", observer.server.server_port, timeout=5
+                )
+                _send_request(
+                    connection,
+                    "POST",
+                    "/responses",
+                    body=body,
+                    headers=_request_headers(auth)
+                    | {"ChatGPT-Account-ID": f" {auth.account_id} "},
+                )
+                response = connection.getresponse()
+                response.read()
+                connection.close()
+                self.assertEqual(response.status, 400)
+                observed = observer.state.wait(ticket, 5)
+                self.assertEqual(
+                    observed["error"], "credential_header_whitespace_invalid"
+                )
+
+                self.assertEqual(
+                    observer.state.stats()["provider_requests_forwarded"], 0
+                )
+        self.assertEqual(upstream_requests, 0)
+
+    def test_upstream_401_becomes_502_and_never_triggers_refresh(self) -> None:
+        body_marker = b'UPSTREAM-SECRET-BODY-MARKER:{"error":"unauthorized"}\n'
+        header_marker = "upstream-secret-header-marker"
+
+        class Unauthorized(http.server.BaseHTTPRequestHandler):
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+            def do_POST(self) -> None:  # noqa: N802
+                length = int(self.headers["Content-Length"])
+                self.rfile.read(length)
+                body = body_marker
+                self.send_response(401)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.send_header("WWW-Authenticate", header_marker)
+                self.send_header("Set-Cookie", f"secret={header_marker}")
+                self.send_header("Location", f"https://example.invalid/{header_marker}")
+                self.end_headers()
+                self.wfile.write(body)
+
+        auth = bench._fake_auth_material()
+        with _serve(Unauthorized) as upstream:
+            url = f"http://127.0.0.1:{upstream.server_port}/responses"
+            with bench.StreamingObserver._for_test(
+                auth, url, provider_request_budget=1
+            ) as observer:
+                ticket = observer.state.arm(
+                    bench.ExpectedRequest("fx", 1, "test")
+                )
+                status, downstream, downstream_headers = _post_observer_with_headers(
+                    observer, _compact(_fx_request()), auth
+                )
+                observed = observer.state.wait(ticket, 5)
+
+                self.assertEqual(status, 502)
+                self.assertEqual(downstream, b"upstream authentication failed\n")
+                self.assertEqual(
+                    {name.lower() for name, _value in downstream_headers},
+                    {"content-type", "content-length", "connection"},
+                )
+                self.assertNotIn(body_marker, downstream)
+                self.assertNotIn(
+                    header_marker,
+                    repr((downstream, downstream_headers)),
+                )
+                self.assertEqual(observed["upstream_http_status"], 401)
+                self.assertEqual(observed["error"], "upstream_http_401")
+                self.assertEqual(observer.state.stats()["refresh_attempts_blocked"], 0)
+                self.assertEqual(
+                    observer.state.stats()["provider_requests_forwarded"], 1
+                )
+                self.assertEqual(observer.state.stats()["unexpected_requests"], 0)
+
+    def test_redirect_upgrade_and_connect_cannot_escape_observer(self) -> None:
+        redirect_target_requests = 0
+
+        class RedirectTarget(http.server.BaseHTTPRequestHandler):
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+            def do_POST(self) -> None:  # noqa: N802
+                nonlocal redirect_target_requests
+                redirect_target_requests += 1
+                self.send_response(500)
+                self.end_headers()
+
+        auth = bench._fake_auth_material()
+        with _serve(RedirectTarget) as target:
+            location = f"http://127.0.0.1:{target.server_port}/stolen"
+
+            class RedirectingUpstream(http.server.BaseHTTPRequestHandler):
+                def log_message(self, _format: str, *_args: object) -> None:
+                    return
+
+                def do_POST(self) -> None:  # noqa: N802
+                    length = int(self.headers["Content-Length"])
+                    self.rfile.read(length)
+                    self.send_response(307)
+                    self.send_header("Location", location)
+                    self.send_header("Set-Cookie", "upstream-secret=marker")
+                    self.end_headers()
+
+            with _serve(RedirectingUpstream) as upstream:
+                url = f"http://127.0.0.1:{upstream.server_port}/responses"
+                with bench.StreamingObserver._for_test(
+                    auth, url, provider_request_budget=1
+                ) as observer:
+                    ticket = observer.state.arm(
+                        bench.ExpectedRequest("fx", 1, "test")
+                    )
+                    status, _body, headers = _post_observer_with_headers(
+                        observer, _compact(_fx_request()), auth
+                    )
+                    observed = observer.state.wait(ticket, 5)
+
+                    connection = http.client.HTTPConnection(
+                        "127.0.0.1", observer.server.server_port, timeout=5
+                    )
+                    connection.request(
+                        "GET",
+                        "/responses",
+                        headers={
+                            "Connection": "Upgrade",
+                            "Upgrade": "websocket",
+                            "Sec-WebSocket-Key": "offline-test",
+                        },
+                    )
+                    upgrade = connection.getresponse()
+                    upgrade.read()
+                    connection.close()
+
+                    connection = http.client.HTTPConnection(
+                        "127.0.0.1", observer.server.server_port, timeout=5
+                    )
+                    connection.request("CONNECT", "example.invalid:443")
+                    connect = connection.getresponse()
+                    connect.read()
+                    connection.close()
+                    stats = observer.state.stats()
+
+        self.assertEqual(status, 307)
+        self.assertEqual(observed["error"], "upstream_http_307")
+        self.assertNotIn("location", {name.lower() for name, _value in headers})
+        self.assertNotIn("set-cookie", {name.lower() for name, _value in headers})
+        self.assertEqual(redirect_target_requests, 0)
+        self.assertEqual(upgrade.status, 404)
+        self.assertEqual(connect.status, 405)
+        self.assertEqual(stats["provider_requests_forwarded"], 1)
+        self.assertEqual(stats["unexpected_requests"], 2)
+
+    def test_rejects_duplicate_product_metadata_and_fresh_turn_state(self) -> None:
+        upstream_requests = 0
+
+        class FakeUpstream(http.server.BaseHTTPRequestHandler):
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+            def do_POST(self) -> None:  # noqa: N802
+                nonlocal upstream_requests
+                upstream_requests += 1
+                self.send_response(500)
+                self.end_headers()
+
+        auth = bench._fake_auth_material(fedramp=True)
+        cases: list[tuple[str, str]] = [
+            ("fx", name)
+            for name in (
+                "User-Agent",
+                "Originator",
+                "OpenAI-Beta",
+            )
+        ] + [
+            ("nanocodex", name)
+            for name in (
+                "User-Agent",
+                "X-OpenAI-Internal-Codex-Responses-Lite",
+                "Session-ID",
+                "Thread-ID",
+                "X-Client-Request-ID",
+                "X-OpenAI-Fedramp",
+            )
+        ]
+        bodies = {
+            "fx": _compact(_fx_request()),
+            "nanocodex": _compact(_nanocodex_request()),
+        }
+        with _serve(FakeUpstream) as upstream:
+            url = f"http://127.0.0.1:{upstream.server_port}/responses"
+            with bench.StreamingObserver._for_test(
+                auth, url, provider_request_budget=len(cases) + 1
+            ) as observer:
+                for pair, (implementation, duplicate) in enumerate(cases, 1):
+                    body = bodies[implementation]
+                    ticket = observer.state.arm(
+                        bench.ExpectedRequest(implementation, pair, "test")
+                    )
+                    connection = http.client.HTTPConnection(
+                        "127.0.0.1", observer.server.server_port, timeout=5
+                    )
+                    connection.putrequest(
+                        "POST", "/responses", skip_accept_encoding=True
+                    )
+                    headers = _request_headers(auth, implementation)
+                    headers["Content-Length"] = str(len(body))
+                    for name, value in headers.items():
+                        connection.putheader(name, value)
+                        if name.lower() == duplicate.lower():
+                            connection.putheader(name, value)
+                    connection.endheaders(body)
+                    response = connection.getresponse()
+                    response.read()
+                    connection.close()
+                    self.assertEqual(response.status, 400)
+                    observed = observer.state.wait(ticket, 5)
+                    error = duplicate.lower().replace("-", "_")
+                    self.assertEqual(
+                        observed["error"], f"{error}_header_count_invalid"
+                    )
+
+                body = bodies["nanocodex"]
+                ticket = observer.state.arm(
+                    bench.ExpectedRequest("nanocodex", len(cases) + 1, "test")
+                )
+                connection = http.client.HTTPConnection(
+                    "127.0.0.1", observer.server.server_port, timeout=5
+                )
+                _send_request(
+                    connection,
+                    "POST",
+                    "/responses",
+                    body=body,
+                    headers=_request_headers(auth, "nanocodex")
+                    | {"X-Codex-Turn-State": "prior-state"},
+                )
+                response = connection.getresponse()
+                response.read()
+                connection.close()
+                self.assertEqual(response.status, 400)
+                observed = observer.state.wait(ticket, 5)
+                self.assertEqual(observed["error"], "request_header_set_invalid")
+
+        self.assertEqual(upstream_requests, 0)
+
+    def test_fx_no_save_rejects_every_session_identity_header(self) -> None:
+        upstream_requests = 0
+
+        class FakeUpstream(http.server.BaseHTTPRequestHandler):
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+            def do_POST(self) -> None:  # noqa: N802
+                nonlocal upstream_requests
+                upstream_requests += 1
+                self.send_response(500)
+                self.end_headers()
+
+        auth = bench._fake_auth_material()
+        body = _compact(_fx_request())
+        forbidden = ("Session-ID", "Thread-ID", "X-Client-Request-ID")
+        with _serve(FakeUpstream) as upstream:
+            url = f"http://127.0.0.1:{upstream.server_port}/responses"
+            with bench.StreamingObserver._for_test(
+                auth, url, provider_request_budget=len(forbidden)
+            ) as observer:
+                for pair, name in enumerate(forbidden, 1):
+                    ticket = observer.state.arm(
+                        bench.ExpectedRequest("fx", pair, "test")
+                    )
+                    connection = http.client.HTTPConnection(
+                        "127.0.0.1", observer.server.server_port, timeout=5
+                    )
+                    _send_request(
+                        connection,
+                        "POST",
+                        "/responses",
+                        body=body,
+                        headers=_request_headers(auth, "fx")
+                        | {name: "forbidden-session"},
+                    )
+                    response = connection.getresponse()
+                    response.read()
+                    connection.close()
+                    self.assertEqual(response.status, 400)
+                    observed = observer.state.wait(ticket, 5)
+                    self.assertEqual(
+                        observed["error"], "request_header_set_invalid"
+                    )
+                stats = observer.state.stats()
+
+        self.assertEqual(stats["provider_requests_forwarded"], 0)
+        self.assertEqual(upstream_requests, 0)
+
+    def test_rejects_unreviewed_candidate_header_before_upstream(self) -> None:
+        upstream_requests = 0
+
+        class FakeUpstream(http.server.BaseHTTPRequestHandler):
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+            def do_POST(self) -> None:  # noqa: N802
+                nonlocal upstream_requests
+                upstream_requests += 1
+                self.send_response(500)
+                self.end_headers()
+
+        auth = bench._fake_auth_material()
+        with _serve(FakeUpstream) as upstream:
+            url = f"http://127.0.0.1:{upstream.server_port}/responses"
+            with bench.StreamingObserver._for_test(
+                auth, url, provider_request_budget=1
+            ) as observer:
+                ticket = observer.state.arm(
+                    bench.ExpectedRequest("fx", 1, "test")
+                )
+                connection = http.client.HTTPConnection(
+                    "127.0.0.1", observer.server.server_port, timeout=5
+                )
+                _send_request(
+                    connection,
+                    "POST",
+                    "/responses",
+                    body=_compact(_fx_request()),
+                    headers=_request_headers(auth, "fx")
+                    | {"X-OpenAI-Evil": "unreviewed"},
+                )
+                response = connection.getresponse()
+                response.read()
+                connection.close()
+                observed = observer.state.wait(ticket, 5)
+                stats = observer.state.stats()
+
+        self.assertEqual(response.status, 400)
+        self.assertEqual(observed["error"], "request_header_set_invalid")
+        self.assertEqual(stats["provider_requests_forwarded"], 0)
+        self.assertEqual(upstream_requests, 0)
+
+    def test_fx_generation_requires_one_valid_models_discovery(self) -> None:
+        auth = bench._fake_auth_material()
+        with bench._OfflineProvider() as provider:
+            with bench.StreamingObserver._for_test(
+                auth,
+                provider.url,
+                provider_request_budget=1,
+                require_fx_models_discovery=True,
+            ) as observer:
+                ticket = observer.state.arm(
+                    bench.ExpectedRequest("fx", 1, "test")
+                )
+                status, _body = _post_observer(
+                    observer, _compact(_fx_request()), auth, "fx"
+                )
+                observed = observer.state.wait(ticket, 5)
+
+        self.assertEqual(status, 400)
+        self.assertEqual(observed["error"], "fx_models_discovery_missing")
+        self.assertEqual(provider.server.requests, 0)
+
+    def test_tool_call_frame_is_blocked_before_child_delivery(self) -> None:
+        class ToolCallingUpstream(http.server.BaseHTTPRequestHandler):
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+            def do_POST(self) -> None:  # noqa: N802
+                length = int(self.headers["Content-Length"])
+                self.rfile.read(length)
+                body = (
+                    b'data: {"type":"response.output_text.delta","delta":"partial"}\n\n'
+                    b'data: {"type":"response.output_item.added","item":{"type":"function_call","call_id":"danger"}}\n\n'
+                    b'data: {"type":"response.completed","response":{"status":"completed","usage":{"cached_input_tokens":2}}}\n\n'
+                )
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.end_headers()
+                with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+                    self.wfile.write(body)
+                    self.wfile.flush()
+
+        auth = bench._fake_auth_material()
+        with _serve(ToolCallingUpstream) as upstream:
+            url = f"http://127.0.0.1:{upstream.server_port}/responses"
+            with bench.StreamingObserver._for_test(
+                auth, url, provider_request_budget=1
+            ) as observer:
+                ticket = observer.state.arm(
+                    bench.ExpectedRequest("fx", 1, "test")
+                )
+                status, streamed = _post_observer(
+                    observer, _compact(_fx_request()), auth
+                )
+                observed = observer.state.wait(ticket, 5)
+
+        self.assertEqual(status, 200)
+        self.assertIn(b"partial", streamed)
+        self.assertNotIn(b"function_call", streamed)
+        self.assertTrue(observed["tool_call_detected"])
+        self.assertEqual(observed["error"], "tool_call_blocked_before_delivery")
+
+    def test_tool_search_is_blocked_incrementally_and_in_terminal_output(self) -> None:
+        variants = {
+            "incremental": (
+                b'data: {"type":"response.output_text.delta","delta":"partial"}\n\n'
+                b'data: {"type":"response.output_item.added","item":{"type":"tool_search_call","call_id":"danger-search"}}\n\n'
+                b'data: {"type":"response.completed","response":{"status":"completed","usage":{"cached_input_tokens":2},"output":[]}}\n\n'
+            ),
+            "terminal": (
+                b'data: {"type":"response.completed","response":{"status":"completed","usage":{"cached_input_tokens":2},"output":[{"type":"tool_search_call","call_id":"danger-search"}]}}\n\n'
+            ),
+        }
+        for name, response_body in variants.items():
+            with self.subTest(variant=name):
+                class ToolSearchUpstream(http.server.BaseHTTPRequestHandler):
+                    def log_message(self, _format: str, *_args: object) -> None:
+                        return
+
+                    def do_POST(self) -> None:  # noqa: N802
+                        length = int(self.headers["Content-Length"])
+                        self.rfile.read(length)
+                        self.send_response(200)
+                        self.send_header("Content-Type", "text/event-stream")
+                        self.end_headers()
+                        with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+                            self.wfile.write(response_body)
+                            self.wfile.flush()
+
+                auth = bench._fake_auth_material()
+                with _serve(ToolSearchUpstream) as upstream:
+                    url = f"http://127.0.0.1:{upstream.server_port}/responses"
+                    with bench.StreamingObserver._for_test(
+                        auth, url, provider_request_budget=1
+                    ) as observer:
+                        ticket = observer.state.arm(
+                            bench.ExpectedRequest("nanocodex", 1, "test")
+                        )
+                        status, streamed = _post_observer(
+                            observer,
+                            _compact(_nanocodex_request()),
+                            auth,
+                            "nanocodex",
+                        )
+                        observed = observer.state.wait(ticket, 5)
+
+                self.assertEqual(status, 200)
+                self.assertNotIn(b"tool_search_call", streamed)
+                self.assertNotIn(b"danger-search", streamed)
+                self.assertTrue(observed["tool_call_detected"])
+                self.assertEqual(
+                    observed["error"], "tool_call_blocked_before_delivery"
+                )
+
+    def test_custom_upstream_requires_private_fake_auth_seam(self) -> None:
+        real = bench.AuthMaterial(
+            raw_codex_auth=b"{}",
+            access_token="real-looking-access",
+            refresh_token="real-looking-refresh",
+            account_id="real-looking-account",
+            expires_at_ms=(int(time.time()) + 3_600) * 1_000,
+            secret_values=("real-looking-access",),
+        )
+        with self.assertRaisesRegex(bench.BenchmarkError, "fake test credentials"):
+            bench.StreamingObserver._for_test(
+                real,  # type: ignore[arg-type]
+                "http://127.0.0.1:1/responses",
+                provider_request_budget=1,
+            )
+        endpoints = ((socket.AF_INET, ("203.0.113.1", 443)),)
+        with mock.patch.object(
+            bench, "_resolve_upstream_endpoints", return_value=endpoints
+        ) as resolve:
+            self.assertEqual(
+                bench.UpstreamTarget.official(),
+                bench.UpstreamTarget(
+                    "https",
+                    "chatgpt.com",
+                    None,
+                    "/backend-api/codex/responses",
+                    endpoints,
+                ),
+            )
+        resolve.assert_called_once_with("chatgpt.com", 443)
+
+
+def _run(
+    *,
+    first: int,
+    answer: int,
+    terminal: int,
+    cache: int | None,
+    functional: bool = True,
+    tools: bool = False,
+) -> dict[str, object]:
+    return {
+        "functional_valid": functional,
+        "no_tool_calls": not tools,
+        "timing_present": True,
+        "cached_input_tokens": cache,
+        "observer": {
+            "timing_ns": {
+                "time_to_first_model_output": first,
+                "time_to_first_answer_text": answer,
+                "time_to_terminal": terminal,
+            }
+        },
+    }
+
+
+def _pair(number: int, fx: dict[str, object], nano: dict[str, object]) -> dict[str, object]:
+    return {"pair": number, "runs": {"fx": fx, "nanocodex": nano}}
+
+
+class PairingSummaryTests(unittest.TestCase):
+    def test_warm_primary_retains_product_specific_counts_and_excludes_unknown_or_cold(self) -> None:
+        pairs = [
+            _pair(
+                1,
+                _run(first=5_000_000, answer=6_000_000, terminal=7_000_000, cache=4),
+                _run(first=3_000_000, answer=4_000_000, terminal=5_000_000, cache=7),
+            ),
+            _pair(
+                2,
+                _run(first=5_000_000, answer=6_000_000, terminal=7_000_000, cache=None),
+                _run(first=4_000_000, answer=5_000_000, terminal=6_000_000, cache=None),
+            ),
+            _pair(
+                3,
+                _run(first=5_000_000, answer=6_000_000, terminal=7_000_000, cache=0),
+                _run(first=4_000_000, answer=5_000_000, terminal=6_000_000, cache=9),
+            ),
+            _pair(
+                4,
+                _run(first=5_000_000, answer=6_000_000, terminal=7_000_000, cache=0),
+                _run(first=4_000_000, answer=5_000_000, terminal=6_000_000, cache=0),
+            ),
+        ]
+        summary = bench.summarize_pairs(pairs)
+
+        self.assertEqual(summary["primary"]["eligible_pairs"], 1)
+        self.assertEqual(summary["strict_equal_cache_diagnostic"]["eligible_pairs"], 1)
+        self.assertEqual(summary["all_valid_diagnostic"]["eligible_pairs"], 4)
+        self.assertEqual(summary["all_valid_diagnostic"]["cache_unknown_pairs"], 1)
+        self.assertEqual(
+            summary["primary_exclusions"]["cached_input_tokens_unknown_or_invalid"],
+            1,
+        )
+        self.assertEqual(
+            summary["primary_exclusions"]["cached_input_warm_cold_mismatch"], 1
+        )
+        self.assertEqual(
+            summary["primary_exclusions"]["cached_input_both_cold"], 1
+        )
+
+    def test_nearest_rank_and_one_millisecond_tie_boundary(self) -> None:
+        self.assertEqual(bench.percentile([1, 2, 100, 101], 0.50), 2)
+        self.assertEqual(bench.percentile([1, 2, 100, 101], 0.95), 101)
+        pairs = [
+            _pair(1, _run(first=5_000_000, answer=5_000_000, terminal=5_000_000, cache=1), _run(first=6_000_000, answer=6_000_000, terminal=6_000_000, cache=2)),
+            _pair(2, _run(first=5_000_000, answer=5_000_000, terminal=5_000_000, cache=1), _run(first=6_000_001, answer=6_000_001, terminal=6_000_001, cache=2)),
+            _pair(3, _run(first=5_000_000, answer=5_000_000, terminal=5_000_000, cache=1), _run(first=3_999_999, answer=3_999_999, terminal=3_999_999, cache=2)),
+        ]
+        metric = bench.summarize_pairs(pairs)["primary"]["metrics"][
+            "time_to_first_model_output"
+        ]
+
+        self.assertEqual(metric["wins"], {"nanocodex": 1, "fx": 1, "ties": 1})
+        self.assertEqual(metric["win_counts_are"], "descriptive_only_not_inferential")
+        self.assertEqual(metric["tie_threshold_ns"], 1_000_000)
+
+    def test_minimum_primary_contract_is_twenty(self) -> None:
+        pairs = [
+            _pair(
+                number,
+                _run(first=3_000_000, answer=4_000_000, terminal=5_000_000, cache=2),
+                _run(first=2_000_000, answer=3_000_000, terminal=4_000_000, cache=3),
+            )
+            for number in range(1, 21)
+        ]
+        summary = bench.summarize_pairs(pairs)
+        self.assertEqual(summary["primary"]["eligible_pairs"], 20)
+        self.assertEqual(summary["primary"]["minimum_eligible_pairs"], 20)
+
+
+class EnvironmentAndProcessTests(unittest.TestCase):
+    def test_child_egress_sandbox_allows_only_exact_observer_port(self) -> None:
+        if sys.platform != "darwin":
+            with self.assertRaisesRegex(bench.BenchmarkError, "requires the Darwin"):
+                bench._sandboxed_child_command(
+                    [sys.executable, "-c", "pass"], "http://127.0.0.1:1"
+                )
+            return
+
+        tcp4_allowed = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        tcp4_denied = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        tcp6_denied = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        udp4_denied = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        udp6_denied = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+        tcp6_denied.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+        udp6_denied.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+        tcp4_allowed.bind(("127.0.0.1", 0))
+        tcp4_denied.bind(("127.0.0.1", 0))
+        allowed_port = tcp4_allowed.getsockname()[1]
+        denied_port = tcp4_denied.getsockname()[1]
+        tcp6_denied.bind(("::1", allowed_port))
+        udp4_denied.bind(("127.0.0.1", allowed_port))
+        udp6_denied.bind(("::1", allowed_port))
+        tcp4_allowed.listen(1)
+        tcp4_denied.listen(1)
+        tcp6_denied.listen(1)
+        tcp4_allowed.settimeout(5)
+        accepted = threading.Event()
+
+        def accept_allowed() -> None:
+            try:
+                connection, _address = tcp4_allowed.accept()
+                connection.close()
+                accepted.set()
+            except OSError:
+                return
+
+        accept_thread = threading.Thread(target=accept_allowed, daemon=True)
+        accept_thread.start()
+        script = """
+import json
+import socket
+import sys
+
+allowed_port = int(sys.argv[1])
+denied_port = int(sys.argv[2])
+
+def tcp(family, address):
+    sock = socket.socket(family, socket.SOCK_STREAM)
+    sock.settimeout(1)
+    try:
+        sock.connect(address)
+        return {"ok": True}
+    except OSError as error:
+        return {"ok": False, "errno": error.errno}
+    finally:
+        sock.close()
+
+def udp(family, address):
+    sock = socket.socket(family, socket.SOCK_DGRAM)
+    sock.settimeout(1)
+    try:
+        sent = sock.sendto(b"forbidden", address)
+        return {"ok": True, "sent": sent}
+    except OSError as error:
+        return {"ok": False, "errno": error.errno}
+    finally:
+        sock.close()
+
+print(json.dumps({
+    "tcp4_allowed": tcp(socket.AF_INET, ("127.0.0.1", allowed_port)),
+    "tcp4_other_port": tcp(socket.AF_INET, ("127.0.0.1", denied_port)),
+    "tcp6_same_port": tcp(socket.AF_INET6, ("::1", allowed_port, 0, 0)),
+    "udp4_same_port": udp(socket.AF_INET, ("127.0.0.1", allowed_port)),
+    "udp6_same_port": udp(socket.AF_INET6, ("::1", allowed_port, 0, 0)),
+}, sort_keys=True))
+"""
+        try:
+            base_url = f"http://127.0.0.1:{allowed_port}"
+            capture = bench._run_process(
+                bench._sandboxed_child_command(
+                    [
+                        sys.executable,
+                        "-c",
+                        script,
+                        str(allowed_port),
+                        str(denied_port),
+                    ],
+                    base_url,
+                ),
+                Path.cwd(),
+                {"PATH": os.environ.get("PATH") or os.defpath},
+                timeout_seconds=5,
+                stdout_limit=4096,
+                stderr_limit=4096,
+            )
+            self.assertEqual(capture.returncode, 0, capture.stdout)
+            results = json.loads(capture.stdout)
+            self.assertEqual(results["tcp4_allowed"], {"ok": True})
+            for name in (
+                "tcp4_other_port",
+                "tcp6_same_port",
+                "udp4_same_port",
+                "udp6_same_port",
+            ):
+                self.assertEqual(
+                    results[name], {"ok": False, "errno": errno.EPERM}, name
+                )
+            self.assertTrue(accepted.wait(5))
+            for listener in (tcp4_denied, tcp6_denied):
+                listener.settimeout(0.2)
+                with self.assertRaises(socket.timeout):
+                    listener.accept()
+            for receiver in (udp4_denied, udp6_denied):
+                receiver.settimeout(0.2)
+                with self.assertRaises(socket.timeout):
+                    receiver.recvfrom(1024)
+        finally:
+            tcp4_allowed.close()
+            tcp4_denied.close()
+            tcp6_denied.close()
+            udp4_denied.close()
+            udp6_denied.close()
+            accept_thread.join(timeout=5)
+
+        with self.assertRaisesRegex(bench.BenchmarkError, "numeric loopback"):
+            bench._sandboxed_child_command(
+                [sys.executable, "-c", "pass"], f"http://localhost:{allowed_port}"
+            )
+
+    def test_child_sandbox_denies_process_creation_but_preserves_threads(self) -> None:
+        if sys.platform != "darwin":
+            self.skipTest("Darwin Seatbelt behavior is host-specific")
+
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        listener.settimeout(5)
+        port = listener.getsockname()[1]
+        accepted = threading.Event()
+
+        def accept_allowed() -> None:
+            try:
+                connection, _address = listener.accept()
+                connection.close()
+                accepted.set()
+            except OSError:
+                return
+
+        accept_thread = threading.Thread(target=accept_allowed, daemon=True)
+        accept_thread.start()
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            fork_marker = root / "forked"
+            spawn_marker = root / "spawned"
+            popen_marker = root / "popened"
+            script = """
+import json
+import os
+import pathlib
+import socket
+import subprocess
+import sys
+import threading
+
+port = int(sys.argv[1])
+fork_marker, spawn_marker, popen_marker = sys.argv[2:5]
+
+def attempted(call):
+    try:
+        call()
+        return {"ok": True}
+    except OSError as error:
+        return {"ok": False, "errno": error.errno}
+
+def fork_child():
+    pid = os.fork()
+    if pid == 0:
+        pathlib.Path(fork_marker).write_text("created")
+        os._exit(0)
+    os.waitpid(pid, 0)
+
+def spawn_child():
+    code = "import pathlib;pathlib.Path(%r).write_text('created')" % spawn_marker
+    pid = os.posix_spawn(sys.executable, [sys.executable, "-c", code], os.environ)
+    os.waitpid(pid, 0)
+
+def popen_child():
+    code = "import pathlib;pathlib.Path(%r).write_text('created')" % popen_marker
+    subprocess.Popen(
+        [sys.executable, "-c", code], start_new_session=True
+    ).wait(timeout=5)
+
+thread_result = []
+thread = threading.Thread(target=lambda: thread_result.append("joined"))
+thread.start()
+thread.join()
+
+connection = socket.create_connection(("127.0.0.1", port), timeout=2)
+connection.close()
+
+print(json.dumps({
+    "identity": [os.getpid(), os.getpgrp(), os.getsid(0)],
+    "setsid": attempted(os.setsid),
+    "setpgid": attempted(lambda: os.setpgid(0, 0)),
+    "fork": attempted(fork_child),
+    "posix_spawn": attempted(spawn_child),
+    "popen_new_session": attempted(popen_child),
+    "thread_joined": thread_result == ["joined"],
+    "tcp4_allowed": True,
+}, sort_keys=True))
+"""
+            try:
+                capture = bench._run_process(
+                    bench._sandboxed_child_command(
+                        [
+                            sys.executable,
+                            "-c",
+                            script,
+                            str(port),
+                            str(fork_marker),
+                            str(spawn_marker),
+                            str(popen_marker),
+                        ],
+                        f"http://127.0.0.1:{port}",
+                    ),
+                    root,
+                    {"PATH": os.environ.get("PATH") or os.defpath},
+                    timeout_seconds=10,
+                    stdout_limit=4096,
+                    stderr_limit=4096,
+                )
+            finally:
+                listener.close()
+                accept_thread.join(timeout=5)
+
+            self.assertEqual(capture.returncode, 0, capture.stdout)
+            results = json.loads(capture.stdout)
+            self.assertEqual(len(set(results["identity"])), 1)
+            self.assertTrue(results["thread_joined"])
+            self.assertTrue(results["tcp4_allowed"])
+            self.assertTrue(accepted.is_set())
+            for name in (
+                "setsid",
+                "setpgid",
+                "fork",
+                "posix_spawn",
+                "popen_new_session",
+            ):
+                self.assertEqual(
+                    results[name], {"ok": False, "errno": errno.EPERM}, name
+                )
+            self.assertFalse(fork_marker.exists())
+            self.assertFalse(spawn_marker.exists())
+            self.assertFalse(popen_marker.exists())
+
+    def test_observer_reserves_allowed_port_on_every_ipv4_interface(self) -> None:
+        if sys.platform != "darwin":
+            self.skipTest("Darwin Seatbelt behavior is host-specific")
+
+        candidates = {
+            address
+            for _family, _kind, _protocol, _canonical, (address, *_rest) in (
+                socket.getaddrinfo(socket.gethostname(), None, socket.AF_INET)
+            )
+            if not ipaddress.ip_address(address).is_loopback
+        }
+        if not candidates:
+            route_probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            try:
+                route_probe.connect(("192.0.2.1", 9))
+                address = route_probe.getsockname()[0]
+                if not ipaddress.ip_address(address).is_loopback:
+                    candidates.add(address)
+            finally:
+                route_probe.close()
+        if not candidates:
+            self.skipTest("host has no non-loopback IPv4 interface")
+        local_address = sorted(candidates)[0]
+
+        auth = bench._fake_auth_material()
+        with bench._OfflineProvider() as provider:
+            with bench.StreamingObserver._for_test(
+                auth, provider.url, provider_request_budget=1
+            ) as observer:
+                self.assertEqual(observer.server.server_address[0], "0.0.0.0")
+                port = observer.server.server_port
+                bypass = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                try:
+                    with self.assertRaises(OSError):
+                        bypass.bind((local_address, port))
+                finally:
+                    bypass.close()
+
+                script = (
+                    "import http.client,sys;"
+                    "c=http.client.HTTPConnection(sys.argv[1],int(sys.argv[2]),timeout=2);"
+                    "c.request('GET','/bypass');r=c.getresponse();"
+                    "print(r.status);r.read();c.close()"
+                )
+                capture = bench._run_process(
+                    bench._sandboxed_child_command(
+                        [sys.executable, "-c", script, local_address, str(port)],
+                        observer.base_url,
+                    ),
+                    Path.cwd(),
+                    {"PATH": os.environ.get("PATH") or os.defpath},
+                    timeout_seconds=5,
+                    stdout_limit=1024,
+                    stderr_limit=4096,
+                )
+                stats = observer.state.stats()
+
+        self.assertEqual(capture.returncode, 0)
+        self.assertEqual(capture.stdout, b"404\n")
+        self.assertEqual(stats["unexpected_requests"], 1)
+        self.assertEqual(stats["provider_requests_forwarded"], 0)
+        self.assertEqual(provider.server.requests, 0)
+
+    def test_child_environment_is_a_minimal_allowlist(self) -> None:
+        poisoned = {
+            "PATH": "/controlled/path",
+            "HTTPS_PROXY": "http://secret-proxy",
+            "AWS_SECRET_ACCESS_KEY": "secret",
+            "GITHUB_TOKEN": "secret",
+            "SSH_AUTH_SOCK": "/secret/socket",
+            "DYLD_INSERT_LIBRARIES": "/secret/inject.dylib",
+            "LD_PRELOAD": "/secret/inject.so",
+            "UNRELATED_SECRET": "secret",
+        }
+        with tempfile.TemporaryDirectory() as raw, mock.patch.dict(
+            os.environ, poisoned, clear=True
+        ):
+            home = Path(raw) / "home"
+            home.mkdir(mode=0o700)
+            environment = bench._child_environment(home)
+            for name in (
+                "XDG_CONFIG_HOME",
+                "XDG_CACHE_HOME",
+                "XDG_DATA_HOME",
+                "TMPDIR",
+            ):
+                self.assertEqual(
+                    stat.S_IMODE(Path(environment[name]).stat().st_mode), 0o700
+                )
+
+        self.assertEqual(
+            set(environment),
+            {
+                "PATH",
+                "HOME",
+                "XDG_CONFIG_HOME",
+                "XDG_CACHE_HOME",
+                "XDG_DATA_HOME",
+                "TMPDIR",
+                "NO_COLOR",
+            },
+        )
+        self.assertEqual(environment["PATH"], "/controlled/path")
+        self.assertFalse(any("PROXY" in key for key in environment))
+
+    def test_timeout_kills_and_reaps_the_private_process_group(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            marker = root / "descendant.pid"
+            script = (
+                "import pathlib,subprocess,sys,time;"
+                "p=subprocess.Popen([sys.executable,'-c','import time;time.sleep(60)']);"
+                f"pathlib.Path({str(marker)!r}).write_text(str(p.pid));"
+                "time.sleep(60)"
+            )
+            capture = bench._run_process(
+                [sys.executable, "-c", script],
+                root,
+                {"PATH": os.environ.get("PATH") or os.defpath},
+                timeout_seconds=0.5,
+                stdout_limit=1024,
+                stderr_limit=1024,
+            )
+            self.assertTrue(capture.timed_out)
+            self.assertIsNone(capture.returncode)
+            self.assertTrue(marker.exists())
+            descendant = int(marker.read_text())
+            _assert_process_gone(self, descendant, "timed-out")
+
+    def test_output_is_bounded_while_produced_and_overflow_kills_child(self) -> None:
+        for descriptor, stream_name in ((1, "stdout"), (2, "stderr")):
+            with self.subTest(stream=stream_name), tempfile.TemporaryDirectory() as raw:
+                root = Path(raw)
+                marker = root / "descendant.pid"
+                capture = bench._run_process(
+                    [
+                        sys.executable,
+                        "-c",
+                        (
+                            "import os,pathlib,subprocess,sys,time;"
+                            "p=subprocess.Popen([sys.executable,'-c','import time;time.sleep(60)']);"
+                            f"pathlib.Path({str(marker)!r}).write_text(str(p.pid));"
+                            f"os.write({descriptor},b'x'*8192);"
+                            "time.sleep(60)"
+                        ),
+                    ],
+                    root,
+                    {"PATH": os.environ.get("PATH") or os.defpath},
+                    timeout_seconds=5,
+                    stdout_limit=1024,
+                    stderr_limit=1024,
+                )
+                descendant = int(marker.read_text())
+
+            self.assertTrue(capture.output_limit_exceeded)
+            if stream_name == "stdout":
+                self.assertTrue(capture.stdout_truncated)
+                self.assertLessEqual(len(capture.stdout), 1024)
+            else:
+                self.assertTrue(capture.stderr_truncated)
+                self.assertGreater(capture.stderr_bytes, 1024)
+            _assert_process_gone(self, descendant, f"{stream_name}-overflow")
+
+    def test_completed_leader_cannot_leave_descendant_holding_output_pipes(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            marker = root / "descendant.pid"
+            script = (
+                "import pathlib,subprocess,sys;"
+                "p=subprocess.Popen([sys.executable,'-c','import time;time.sleep(60)']);"
+                f"pathlib.Path({str(marker)!r}).write_text(str(p.pid))"
+            )
+            started = time.monotonic()
+            capture = bench._run_process(
+                [sys.executable, "-c", script],
+                root,
+                {"PATH": os.environ.get("PATH") or os.defpath},
+                timeout_seconds=5,
+                stdout_limit=1024,
+                stderr_limit=1024,
+            )
+            elapsed = time.monotonic() - started
+            descendant = int(marker.read_text())
+
+        self.assertEqual(capture.returncode, 0)
+        self.assertFalse(capture.timed_out)
+        self.assertLess(elapsed, 2)
+        _assert_process_gone(self, descendant, "completed-leader")
+
+    def test_process_supervision_does_not_depend_on_drainer_threads(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as raw,
+            mock.patch.object(
+                bench.threading.Thread,
+                "start",
+                side_effect=RuntimeError("injected drainer start failure"),
+            ),
+        ):
+            capture = bench._run_process(
+                [sys.executable, "-c", "print('selector-owned')"],
+                Path(raw),
+                {"PATH": os.environ.get("PATH") or os.defpath},
+                timeout_seconds=5,
+                stdout_limit=1024,
+                stderr_limit=1024,
+            )
+
+        self.assertEqual(capture.returncode, 0)
+        self.assertEqual(capture.stdout, b"selector-owned\n")
+
+    def test_selector_is_owned_before_spawn_and_setup_failures_reap_child(self) -> None:
+        with tempfile.TemporaryDirectory() as raw, mock.patch.object(
+            bench.selectors,
+            "DefaultSelector",
+            side_effect=OSError("injected selector construction failure"),
+        ), mock.patch.object(bench.subprocess, "Popen") as popen:
+            with self.assertRaisesRegex(OSError, "selector construction"):
+                bench._run_process(
+                    [sys.executable, "-c", "pass"],
+                    Path(raw),
+                    {"PATH": os.environ.get("PATH") or os.defpath},
+                )
+        popen.assert_not_called()
+
+        real_popen = subprocess.Popen
+        for failure in ("set_blocking", "register"):
+            with self.subTest(failure=failure), tempfile.TemporaryDirectory() as raw:
+                observed: list[subprocess.Popen[bytes]] = []
+
+                def capture_popen(
+                    *args: object, **kwargs: object
+                ) -> subprocess.Popen[bytes]:
+                    process = real_popen(*args, **kwargs)
+                    observed.append(process)
+                    return process
+
+                patches = [
+                    mock.patch.object(
+                        bench.subprocess, "Popen", side_effect=capture_popen
+                    )
+                ]
+                if failure == "set_blocking":
+                    patches.append(
+                        mock.patch.object(
+                            bench.os,
+                            "set_blocking",
+                            side_effect=OSError("injected set_blocking failure"),
+                        )
+                    )
+                else:
+                    real_selector = bench.selectors.DefaultSelector()
+
+                    class RegisterFailure:
+                        def register(self, *_args: object, **_kwargs: object) -> None:
+                            raise OSError("injected register failure")
+
+                        def unregister(self, value: object) -> object:
+                            return real_selector.unregister(value)
+
+                        def select(self, timeout: float | None = None) -> list[object]:
+                            return real_selector.select(timeout)
+
+                        def close(self) -> None:
+                            real_selector.close()
+
+                    patches.append(
+                        mock.patch.object(
+                            bench.selectors,
+                            "DefaultSelector",
+                            return_value=RegisterFailure(),
+                        )
+                    )
+                with contextlib.ExitStack() as stack:
+                    for patch in patches:
+                        stack.enter_context(patch)
+                    with self.assertRaises(OSError):
+                        bench._run_process(
+                            [sys.executable, "-c", "import time;time.sleep(60)"],
+                            Path(raw),
+                            {"PATH": os.environ.get("PATH") or os.defpath},
+                            timeout_seconds=5,
+                            stdout_limit=1024,
+                            stderr_limit=1024,
+                        )
+                self.assertEqual(len(observed), 1)
+                _assert_process_gone(self, observed[0].pid, failure)
+
+    def test_unverifiable_group_termination_raises_instead_of_returning(self) -> None:
+        observed: list[subprocess.Popen[bytes]] = []
+        real_popen = subprocess.Popen
+        signal_times: list[float] = []
+
+        def capture_popen(*args: object, **kwargs: object) -> subprocess.Popen[bytes]:
+            process = real_popen(*args, **kwargs)
+            observed.append(process)
+            return process
+
+        def unavailable_killpg(_group: int, _value: int) -> None:
+            signal_times.append(time.monotonic())
+            raise PermissionError("injected kill failure")
+
+        with (
+            tempfile.TemporaryDirectory() as raw,
+            mock.patch.object(bench.subprocess, "Popen", side_effect=capture_popen),
+            mock.patch.object(bench.os, "killpg", side_effect=unavailable_killpg),
+            mock.patch.object(bench, "PROCESS_SHUTDOWN_TIMEOUT_SECONDS", 0.15),
+            self.assertRaisesRegex(
+                bench.BenchmarkError, "cleanup could not be verified"
+            ),
+        ):
+            bench._run_process(
+                [sys.executable, "-c", "import time; time.sleep(60)"],
+                Path(raw),
+                {"PATH": os.environ.get("PATH") or os.defpath},
+                timeout_seconds=0.1,
+                stdout_limit=1024,
+                stderr_limit=1024,
+            )
+
+        self.assertEqual(len(observed), 1)
+        self.assertGreaterEqual(len(signal_times), 4)
+        self.assertGreaterEqual(signal_times[-1] - signal_times[0], 0.1)
+        _assert_process_gone(self, observed[0].pid, "kill-failure-cleanup")
+
+    @unittest.skipUnless(os.name == "posix", "process-group cleanup requires POSIX")
+    def test_multiple_transient_group_signal_failures_still_remove_entire_group(
+        self,
+    ) -> None:
+        real_killpg = os.killpg
+        real_popen = subprocess.Popen
+        signal_attempts = 0
+        observed: list[subprocess.Popen[bytes]] = []
+
+        def transient_killpg(group: int, value: int) -> None:
+            nonlocal signal_attempts
+            if value == signal.SIGKILL:
+                signal_attempts += 1
+                if signal_attempts <= 2:
+                    raise PermissionError(
+                        f"injected transient group signal failure {signal_attempts}"
+                    )
+            real_killpg(group, value)
+
+        def capture_popen(*args: object, **kwargs: object) -> subprocess.Popen[bytes]:
+            process = real_popen(*args, **kwargs)
+            observed.append(process)
+            return process
+
+        with tempfile.TemporaryDirectory() as raw:
+            marker = Path(raw) / "processes.json"
+            script = (
+                "import json,os,pathlib,subprocess,sys,time;"
+                "p=subprocess.Popen([sys.executable,'-c','import time;time.sleep(60)']);"
+                f"pathlib.Path({str(marker)!r}).write_text("
+                "json.dumps([os.getpid(),os.getpgrp(),p.pid]));"
+                "time.sleep(60)"
+            )
+            with mock.patch.object(
+                bench.subprocess, "Popen", side_effect=capture_popen
+            ), mock.patch.object(bench.os, "killpg", side_effect=transient_killpg):
+                capture = bench._run_process(
+                    [sys.executable, "-c", script],
+                    Path(raw),
+                    {"PATH": os.environ.get("PATH") or os.defpath},
+                    timeout_seconds=0.5,
+                    stdout_limit=1024,
+                    stderr_limit=1024,
+                )
+            parent_pid, group_id, descendant_pid = json.loads(marker.read_text())
+
+        self.assertTrue(capture.timed_out)
+        self.assertEqual(len(observed), 1)
+        self.assertEqual(parent_pid, observed[0].pid)
+        self.assertEqual(group_id, parent_pid)
+        self.assertGreaterEqual(signal_attempts, 3)
+        self.assertEqual(observed[0].returncode, -signal.SIGKILL)
+        for label, pid in (("parent", parent_pid), ("descendant", descendant_pid)):
+            with self.subTest(process=label), self.assertRaises(ProcessLookupError):
+                os.kill(pid, 0)
+        with self.assertRaises(ProcessLookupError):
+            os.killpg(group_id, 0)
+
+    @unittest.skipUnless(os.name == "posix", "waitpid fallback requires POSIX")
+    def test_recoverable_wait_and_waitpid_failures_still_reap_leader(self) -> None:
+        process = subprocess.Popen(
+            [sys.executable, "-c", "import time;time.sleep(60)"],
+            start_new_session=True,
+        )
+        real_waitpid = os.waitpid
+        wait_calls = 0
+        waitpid_calls = 0
+
+        def recoverable_wait(*, timeout: float | None = None) -> int:
+            nonlocal wait_calls
+            wait_calls += 1
+            if wait_calls == 1:
+                raise subprocess.TimeoutExpired(process.args, timeout)
+            if wait_calls == 2:
+                raise InterruptedError(errno.EINTR, "injected interrupted wait")
+            raise OSError(errno.EAGAIN, "injected recoverable wait failure")
+
+        def transient_waitpid(pid: int, options: int) -> tuple[int, int]:
+            nonlocal waitpid_calls
+            waitpid_calls += 1
+            if waitpid_calls == 1:
+                raise InterruptedError(errno.EINTR, "injected interrupted waitpid")
+            if waitpid_calls == 2:
+                raise OSError(errno.EAGAIN, "injected recoverable waitpid failure")
+            return real_waitpid(pid, options)
+
+        process.wait = recoverable_wait  # type: ignore[method-assign]
+        process.kill = lambda: os.kill(  # type: ignore[method-assign]
+            process.pid, signal.SIGKILL
+        )
+        with mock.patch.object(bench.os, "waitpid", side_effect=transient_waitpid):
+            bench._kill_process_group(process, deadline=time.monotonic() + 2)
+
+        self.assertGreaterEqual(wait_calls, 3)
+        self.assertGreaterEqual(waitpid_calls, 3)
+        self.assertEqual(process.returncode, -signal.SIGKILL)
+        with self.assertRaises(ProcessLookupError):
+            os.kill(process.pid, 0)
+        with self.assertRaises(ProcessLookupError):
+            os.killpg(process.pid, 0)
+
+
+class TrackedServerLifecycleTests(unittest.TestCase):
+    @contextlib.contextmanager
+    def _stalled_tls_peer(self):
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen()
+        listener.settimeout(0.05)
+        accepted = threading.Event()
+        client_bytes = threading.Event()
+        disconnected = threading.Event()
+        stop = threading.Event()
+        peer_lock = threading.Lock()
+        peer_socket: list[socket.socket] = []
+
+        def serve() -> None:
+            peer: socket.socket | None = None
+            try:
+                while not stop.is_set():
+                    try:
+                        peer, _address = listener.accept()
+                        break
+                    except TimeoutError:
+                        continue
+                    except OSError:
+                        return
+                if peer is None:
+                    return
+                with peer_lock:
+                    peer_socket.append(peer)
+                accepted.set()
+                peer.settimeout(0.05)
+                while not stop.is_set():
+                    try:
+                        chunk = peer.recv(64 * 1024)
+                    except TimeoutError:
+                        continue
+                    except OSError:
+                        disconnected.set()
+                        return
+                    if not chunk:
+                        disconnected.set()
+                        return
+                    client_bytes.set()
+            finally:
+                if peer is not None:
+                    with contextlib.suppress(OSError):
+                        peer.close()
+
+        thread = threading.Thread(target=serve, daemon=True)
+        thread.start()
+        try:
+            yield {
+                "endpoint": (socket.AF_INET, listener.getsockname()),
+                "accepted": accepted,
+                "client_bytes": client_bytes,
+                "disconnected": disconnected,
+            }
+        finally:
+            stop.set()
+            with peer_lock:
+                peer = peer_socket[0] if peer_socket else None
+            if peer is not None:
+                with contextlib.suppress(OSError):
+                    peer.shutdown(socket.SHUT_RDWR)
+                with contextlib.suppress(OSError):
+                    peer.close()
+            with contextlib.suppress(OSError):
+                listener.close()
+            thread.join(timeout=5)
+            self.assertFalse(thread.is_alive())
+
+    def test_bound_server_thread_start_failure_closes_every_listener(self) -> None:
+        auth = bench._fake_auth_material()
+        owners = (
+            (
+                "offline provider",
+                bench._OfflineProvider(),
+                "127.0.0.1",
+            ),
+            (
+                "streaming observer",
+                bench.StreamingObserver._for_test(
+                    auth,
+                    "http://127.0.0.1:9/responses",
+                    provider_request_budget=1,
+                ),
+                "0.0.0.0",
+            ),
+        )
+        for label, owner, bind_host in owners:
+            with self.subTest(owner=label):
+                port = owner.server.server_port
+                with mock.patch.object(
+                    owner._thread,
+                    "start",
+                    side_effect=RuntimeError("injected thread start failure"),
+                ), self.assertRaisesRegex(bench.BenchmarkError, "failed to start"):
+                    owner.__enter__()
+                self.assertFalse(owner._thread.is_alive())
+                self.assertEqual(owner.server.active_work_count(), 0)
+                self.assertEqual(owner.server.socket.fileno(), -1)
+                replacement = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                try:
+                    replacement.bind((bind_host, port))
+                finally:
+                    replacement.close()
+
+    def test_server_thread_construction_failure_closes_bound_listener(self) -> None:
+        created: list[bench._OfflineProviderServer] = []
+        real_server = bench._OfflineProviderServer
+
+        def capture_server(*, stall_after_headers: bool = False) -> bench._OfflineProviderServer:
+            server = real_server(stall_after_headers=stall_after_headers)
+            created.append(server)
+            return server
+
+        with mock.patch.object(
+            bench, "_OfflineProviderServer", side_effect=capture_server
+        ), mock.patch.object(
+            bench.threading,
+            "Thread",
+            side_effect=RuntimeError("injected thread construction failure"),
+        ), self.assertRaisesRegex(bench.BenchmarkError, "thread construction"):
+            bench._OfflineProvider()
+
+        self.assertEqual(len(created), 1)
+        self.assertEqual(created[0].socket.fileno(), -1)
+        self.assertEqual(created[0].active_work_count(), 0)
+
+    def test_shutdown_interrupts_connection_before_connect_completes(self) -> None:
+        auth = bench._fake_auth_material()
+        started = threading.Event()
+        aborted = threading.Event()
+        client_finished = threading.Event()
+
+        class BlockingConnection:
+            def __init__(self) -> None:
+                self.sock, self.peer = socket.socketpair()
+
+            def connect(self) -> None:
+                started.set()
+                try:
+                    self.sock.recv(1)
+                except OSError as error:
+                    raise OSError("connect interrupted") from error
+                raise OSError("connect unexpectedly resumed")
+
+            def abort_connect(self) -> None:
+                aborted.set()
+                with contextlib.suppress(OSError):
+                    self.sock.shutdown(socket.SHUT_RDWR)
+                self.sock.close()
+
+            def close(self) -> None:
+                self.sock.close()
+
+        connection = BlockingConnection()
+        observer = bench.StreamingObserver._for_test(
+            auth,
+            "http://127.0.0.1:9/responses",
+            provider_request_budget=1,
+        )
+        observer.__enter__()
+        observer.state.arm(bench.ExpectedRequest("nanocodex", 1, "test"))
+
+        def post() -> None:
+            try:
+                _post_observer(
+                    observer,
+                    _compact(_nanocodex_request()),
+                    auth,
+                    "nanocodex",
+                )
+            except (OSError, http.client.HTTPException):
+                pass
+            finally:
+                client_finished.set()
+
+        client = threading.Thread(target=post, daemon=True)
+        with _fixture_contracts(), mock.patch.object(
+            bench.UpstreamTarget, "connection", return_value=connection
+        ):
+            client.start()
+            self.assertTrue(started.wait(5))
+            observer.__exit__(None, None, None)
+        client.join(timeout=5)
+        connection.peer.close()
+
+        self.assertTrue(aborted.is_set())
+        self.assertTrue(client_finished.is_set())
+        self.assertFalse(client.is_alive())
+        self.assertFalse(observer._thread.is_alive())
+        self.assertEqual(observer.server.active_work_count(), 0)
+        self.assertEqual(observer.server.socket.fileno(), -1)
+
+    def test_observer_interrupts_abort_hooks_and_all_unique_retained_sockets(self) -> None:
+        first_socket = mock.Mock(spec=socket.socket)
+        second_socket = mock.Mock(spec=socket.socket)
+        first_socket.shutdown.side_effect = OSError("already disconnected")
+        first_socket.close.side_effect = OSError("already closed")
+
+        class Connection:
+            def __init__(
+                self, upstream_socket: socket.socket, *, abort_fails: bool
+            ) -> None:
+                self.sock: socket.socket | None = upstream_socket
+                self.abort_fails = abort_fails
+                self.abort_calls = 0
+
+            def abort_connect(self) -> None:
+                self.abort_calls += 1
+                if self.abort_fails:
+                    raise OSError("injected abort failure")
+
+        first = Connection(first_socket, abort_fails=True)
+        second = Connection(second_socket, abort_fails=False)
+        target = bench.UpstreamTarget._for_test("http://127.0.0.1:9/responses")
+        server = bench._ObserverServer(("127.0.0.1", 0), mock.Mock(), target)
+        try:
+            server.register_upstream(first)  # type: ignore[arg-type]
+            server.connected_upstream(first)  # type: ignore[arg-type]
+            first.sock = None
+            server.register_upstream(second)  # type: ignore[arg-type]
+            server.connected_upstream(second)  # type: ignore[arg-type]
+
+            server.interrupt_active_work()
+
+            self.assertEqual(first.abort_calls, 1)
+            self.assertEqual(second.abort_calls, 1)
+            first_socket.shutdown.assert_called_once_with(socket.SHUT_RDWR)
+            first_socket.close.assert_called_once_with()
+            second_socket.shutdown.assert_called_once_with(socket.SHUT_RDWR)
+            second_socket.close.assert_called_once_with()
+        finally:
+            server.unregister_upstream(first)  # type: ignore[arg-type]
+            server.unregister_upstream(second)  # type: ignore[arg-type]
+            server.server_close()
+
+        self.assertEqual(server.active_work_count(), 0)
+        self.assertEqual(server.socket.fileno(), -1)
+
+    def test_observer_snapshots_upstream_before_handler_can_unregister_it(self) -> None:
+        retained_socket = mock.Mock(spec=socket.socket)
+
+        class Connection:
+            def __init__(self) -> None:
+                self.sock: socket.socket | None = retained_socket
+                self.abort_calls = 0
+
+            def abort_connect(self) -> None:
+                self.abort_calls += 1
+
+        connection = Connection()
+        target = bench.UpstreamTarget._for_test("http://127.0.0.1:9/responses")
+        server = bench._ObserverServer(("127.0.0.1", 0), mock.Mock(), target)
+        try:
+            server.register_upstream(connection)  # type: ignore[arg-type]
+            server.connected_upstream(connection)  # type: ignore[arg-type]
+            connection.sock = None
+
+            def unregister_during_interrupt() -> None:
+                server.unregister_upstream(connection)  # type: ignore[arg-type]
+
+            with mock.patch.object(
+                bench._TrackedThreadingHTTPServer,
+                "interrupt_active_work",
+                side_effect=unregister_during_interrupt,
+            ):
+                server.interrupt_active_work()
+
+            self.assertEqual(connection.abort_calls, 1)
+            retained_socket.shutdown.assert_called_once_with(socket.SHUT_RDWR)
+            retained_socket.close.assert_called_once_with()
+        finally:
+            server.unregister_upstream(connection)  # type: ignore[arg-type]
+            server.server_close()
+
+        self.assertEqual(server.active_work_count(), 0)
+        self.assertEqual(server.socket.fileno(), -1)
+
+    def test_shutdown_during_connected_handoff_closes_prior_and_current_sockets(
+        self,
+    ) -> None:
+        prior_socket = mock.Mock(spec=socket.socket)
+        current_socket = mock.Mock(spec=socket.socket)
+
+        class Connection:
+            def __init__(self) -> None:
+                self.sock: socket.socket | None = prior_socket
+                self.abort_calls = 0
+
+            def abort_connect(self) -> None:
+                self.abort_calls += 1
+
+        connection = Connection()
+        target = bench.UpstreamTarget._for_test("http://127.0.0.1:9/responses")
+        server = bench._ObserverServer(("127.0.0.1", 0), mock.Mock(), target)
+        try:
+            server.register_upstream(connection)  # type: ignore[arg-type]
+            connection.sock = current_socket
+            server.begin_shutdown()
+            with self.assertRaisesRegex(OSError, "shutting down"):
+                server.connected_upstream(connection)  # type: ignore[arg-type]
+
+            self.assertEqual(connection.abort_calls, 1)
+            prior_socket.shutdown.assert_called_once_with(socket.SHUT_RDWR)
+            prior_socket.close.assert_called_once_with()
+            current_socket.shutdown.assert_called_once_with(socket.SHUT_RDWR)
+            current_socket.close.assert_called_once_with()
+        finally:
+            server.unregister_upstream(connection)  # type: ignore[arg-type]
+            server.server_close()
+
+        self.assertEqual(server.active_work_count(), 0)
+        self.assertEqual(server.socket.fileno(), -1)
+
+    def test_cancellation_during_tcp_socket_construction_handoff(self) -> None:
+        with self._stalled_tls_peer() as peer:
+            connection = bench._ResolvedHTTPConnection(
+                "127.0.0.1",
+                peer["endpoint"][1][1],
+                (peer["endpoint"],),
+                timeout=5,
+            )
+            candidate = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            constructing = threading.Event()
+            release = threading.Event()
+            errors: list[BaseException] = []
+
+            def delayed_socket(
+                _family: int, _kind: int, _protocol: int
+            ) -> socket.socket:
+                constructing.set()
+                if not release.wait(5):
+                    raise AssertionError("socket construction handoff was not released")
+                return candidate
+
+            def connect() -> None:
+                try:
+                    connection.connect()
+                except BaseException as error:
+                    errors.append(error)
+
+            thread = threading.Thread(target=connect, daemon=True)
+            with mock.patch.object(
+                bench.socket, "socket", side_effect=delayed_socket
+            ):
+                thread.start()
+                try:
+                    self.assertTrue(constructing.wait(5))
+                    self.assertIsNone(connection.sock)
+                    connection.abort_connect()
+                finally:
+                    release.set()
+                thread.join(timeout=5)
+
+            self.assertFalse(thread.is_alive())
+            self.assertEqual(len(errors), 1)
+            self.assertIsInstance(errors[0], OSError)
+            self.assertRegex(str(errors[0]), "cancelled")
+            self.assertIsNone(connection.sock)
+            self.assertEqual(candidate.fileno(), -1)
+            self.assertFalse(peer["accepted"].wait(0.1))
+
+    def test_cancellation_at_each_tcp_socket_publication_checkpoint(self) -> None:
+        for checkpoint in (2, 3):
+            with self.subTest(checkpoint=checkpoint), self._stalled_tls_peer() as peer:
+                connection = bench._ResolvedHTTPConnection(
+                    "127.0.0.1",
+                    peer["endpoint"][1][1],
+                    (peer["endpoint"],),
+                    timeout=5,
+                )
+                reached = threading.Event()
+                release = threading.Event()
+                errors: list[BaseException] = []
+                check_calls = 0
+                real_check = connection._raise_if_connect_cancelled
+
+                def controlled_check() -> None:
+                    nonlocal check_calls
+                    check_calls += 1
+                    if check_calls == checkpoint:
+                        reached.set()
+                        if not release.wait(5):
+                            raise AssertionError("publication checkpoint was not released")
+                    real_check()
+
+                def connect() -> None:
+                    try:
+                        connection.connect()
+                    except BaseException as error:
+                        errors.append(error)
+
+                thread = threading.Thread(target=connect, daemon=True)
+                with mock.patch.object(
+                    connection,
+                    "_raise_if_connect_cancelled",
+                    side_effect=controlled_check,
+                ):
+                    thread.start()
+                    self.assertTrue(reached.wait(5))
+                    self.assertIsNotNone(connection.sock)
+                    connection.abort_connect()
+                    release.set()
+                    thread.join(timeout=5)
+
+                self.assertFalse(thread.is_alive())
+                self.assertEqual(len(errors), 1)
+                self.assertIsInstance(errors[0], OSError)
+                self.assertRegex(str(errors[0]), "cancelled")
+                self.assertIsNone(connection.sock)
+                if checkpoint == 3:
+                    self.assertTrue(peer["accepted"].wait(5))
+                    self.assertTrue(peer["disconnected"].wait(5))
+
+    def test_cancellation_during_tls_socket_publication_handoff(self) -> None:
+        with self._stalled_tls_peer() as peer:
+            real_context = bench.ssl.SSLContext(bench.ssl.PROTOCOL_TLS_CLIENT)
+            real_context.check_hostname = False
+            real_context.verify_mode = bench.ssl.CERT_NONE
+            wrapped = threading.Event()
+            release = threading.Event()
+            wrapped_socket: list[bench.ssl.SSLSocket] = []
+
+            class PausingContext:
+                def wrap_socket(
+                    self,
+                    raw_socket: socket.socket,
+                    *,
+                    server_hostname: str,
+                    do_handshake_on_connect: bool,
+                ) -> bench.ssl.SSLSocket:
+                    tls_socket = real_context.wrap_socket(
+                        raw_socket,
+                        server_hostname=server_hostname,
+                        do_handshake_on_connect=do_handshake_on_connect,
+                    )
+                    wrapped_socket.append(tls_socket)
+                    wrapped.set()
+                    if not release.wait(5):
+                        raise AssertionError("TLS ownership handoff was not released")
+                    return tls_socket
+
+            connection = bench._ResolvedHTTPSConnection(
+                "127.0.0.1",
+                peer["endpoint"][1][1],
+                (peer["endpoint"],),
+                timeout=5,
+                context=PausingContext(),  # type: ignore[arg-type]
+            )
+            errors: list[BaseException] = []
+
+            def connect() -> None:
+                try:
+                    connection.connect()
+                except BaseException as error:
+                    errors.append(error)
+
+            thread = threading.Thread(target=connect, daemon=True)
+            thread.start()
+            try:
+                self.assertTrue(wrapped.wait(5))
+                self.assertTrue(peer["accepted"].wait(5))
+                self.assertIsNotNone(connection.sock)
+                self.assertEqual(connection.sock.fileno(), -1)
+                self.assertEqual(len(wrapped_socket), 1)
+                self.assertGreaterEqual(wrapped_socket[0].fileno(), 0)
+                connection.abort_connect()
+            finally:
+                release.set()
+            thread.join(timeout=5)
+
+            self.assertFalse(thread.is_alive())
+            self.assertEqual(len(errors), 1)
+            self.assertIsInstance(errors[0], OSError)
+            self.assertRegex(str(errors[0]), "cancelled")
+            self.assertIsNone(connection.sock)
+            self.assertTrue(peer["disconnected"].wait(5))
+            self.assertFalse(peer["client_bytes"].is_set())
+            self.assertEqual(wrapped_socket[0].fileno(), -1)
+
+    def test_real_loopback_tls_stall_uses_one_tcp_and_tls_deadline(self) -> None:
+        with self._stalled_tls_peer() as peer:
+            context = bench.ssl.SSLContext(bench.ssl.PROTOCOL_TLS_CLIENT)
+            context.check_hostname = False
+            context.verify_mode = bench.ssl.CERT_NONE
+            connection = bench._ResolvedHTTPSConnection(
+                "127.0.0.1",
+                peer["endpoint"][1][1],
+                (peer["endpoint"],),
+                timeout=0.7,
+                context=context,
+            )
+            real_tcp_connect = connection._connect_resolved_tcp
+
+            def consume_tcp_budget(deadline: float) -> socket.socket:
+                connected = real_tcp_connect(deadline)
+                time.sleep(0.45)
+                return connected
+
+            started = time.monotonic()
+            with mock.patch.object(
+                connection,
+                "_connect_resolved_tcp",
+                side_effect=consume_tcp_budget,
+            ), self.assertRaises(TimeoutError):
+                connection.connect()
+            elapsed = time.monotonic() - started
+
+            self.assertTrue(peer["accepted"].wait(5))
+            self.assertTrue(peer["client_bytes"].wait(5))
+            self.assertTrue(peer["disconnected"].wait(5))
+            self.assertIsNone(connection.sock)
+            self.assertLess(elapsed, 0.95)
+
+    def test_real_loopback_tls_stall_is_interrupted_without_leaking_a_socket(self) -> None:
+        with self._stalled_tls_peer() as peer:
+            context = bench.ssl.SSLContext(bench.ssl.PROTOCOL_TLS_CLIENT)
+            context.check_hostname = False
+            context.verify_mode = bench.ssl.CERT_NONE
+            connection = bench._ResolvedHTTPSConnection(
+                "127.0.0.1",
+                peer["endpoint"][1][1],
+                (peer["endpoint"],),
+                timeout=5,
+                context=context,
+            )
+            errors: list[BaseException] = []
+
+            def connect() -> None:
+                try:
+                    connection.connect()
+                except BaseException as error:
+                    errors.append(error)
+
+            thread = threading.Thread(target=connect, daemon=True)
+            thread.start()
+            self.assertTrue(peer["client_bytes"].wait(5))
+            self.assertIsInstance(connection.sock, bench.ssl.SSLSocket)
+            connection.abort_connect()
+            thread.join(timeout=5)
+
+            self.assertFalse(thread.is_alive())
+            self.assertEqual(len(errors), 1)
+            self.assertIsInstance(errors[0], OSError)
+            self.assertTrue(peer["disconnected"].wait(5))
+            self.assertIsNone(connection.sock)
+
+    def test_nonquiescent_shutdown_fails_before_publication(self) -> None:
+        server = mock.Mock(spec=bench._TrackedThreadingHTTPServer)
+        server.wait_for_quiescence.return_value = 1
+        thread = mock.Mock(spec=threading.Thread)
+        thread.is_alive.return_value = False
+        published = False
+
+        def close_then_publish() -> None:
+            nonlocal published
+            bench._close_tracked_server(server, thread, "test server")
+            published = True
+
+        with mock.patch.object(
+            bench, "OBSERVER_SHUTDOWN_TIMEOUT_SECONDS", 0
+        ), self.assertRaisesRegex(bench.BenchmarkError, "did not quiesce"):
+            close_then_publish()
+
+        self.assertFalse(published)
+        server.begin_shutdown.assert_called_once_with()
+        server.interrupt_active_work.assert_called_once_with()
+        thread.join.assert_called_once()
+
+
+class PrivateWorkspaceTests(unittest.TestCase):
+    class _State:
+        def __init__(self) -> None:
+            self.ticket = 0
+
+        def stats(self) -> dict[str, int]:
+            return {"unexpected_requests": 0}
+
+        def arm(self, _expected: object) -> int:
+            self.ticket += 1
+            return self.ticket
+
+        def cancel_unclaimed(self, _ticket: int) -> bool:
+            return True
+
+    class _Observer:
+        base_url = "http://127.0.0.1:1"
+
+        def __init__(self) -> None:
+            self.state = PrivateWorkspaceTests._State()
+
+    def test_both_products_run_in_fresh_private_empty_workspaces(self) -> None:
+        auth = bench._fake_auth_material()
+        commit = "a" * 40
+        args = argparse.Namespace(nanocodex_commit=commit)
+        observed: list[tuple[str, Path, dict[str, str]]] = []
+
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            executable = root / "immutable"
+            executable.write_bytes(b"executable")
+            executable.chmod(0o500)
+            digest = bench.sha256_file(executable)
+            executables = {
+                "fx": (executable, digest),
+                "nanocodex": (executable, digest),
+            }
+
+            def fake_run(
+                command: list[str],
+                cwd: Path,
+                environment: dict[str, str],
+                **_kwargs: object,
+            ) -> bench.ProcessCapture:
+                self.assertEqual(command[0], str(bench.SANDBOX_EXEC))
+                self.assertEqual(list(cwd.iterdir()), [])
+                self.assertEqual(stat.S_IMODE(cwd.stat().st_mode), 0o700)
+                self.assertEqual(cwd.parent, Path(environment["HOME"]))
+                implementation = (
+                    "nanocodex" if "--source-commit" in command else "fx"
+                )
+                observed.append((implementation, cwd, dict(environment)))
+                if implementation == "fx":
+                    output = {
+                        "output": bench.ACK_TOKEN,
+                        "exit_code": 0,
+                        "model": bench.MODEL,
+                        "tool_calls": [],
+                    }
+                else:
+                    self.assertEqual(command[command.index("--cwd") + 1], str(cwd))
+                    self.assertEqual(command[command.index("--transport") + 1], "https")
+                    output = _nano_output(commit, cwd)
+                return bench.ProcessCapture(0, _compact(output), 0, False)
+
+            observer = self._Observer()
+            with mock.patch.object(bench, "_run_process", side_effect=fake_run):
+                implementations = ("fx", "nanocodex", "nanocodex", "fx")
+                for sequence, implementation in enumerate(implementations, 1):
+                    bench._run_implementation(
+                        implementation,
+                        pair=(sequence + 1) // 2,
+                        phase="test",
+                        sequence=sequence,
+                        args=args,
+                        auth=auth,
+                        observer=observer,  # type: ignore[arg-type]
+                        runtime_root=root,
+                        executables=executables,
+                    )
+
+        self.assertEqual(
+            [item[0] for item in observed],
+            ["fx", "nanocodex", "nanocodex", "fx"],
+        )
+        self.assertEqual(len({item[1] for item in observed}), 4)
+        self.assertTrue(all(not workspace.exists() for _, workspace, _ in observed))
+
+
+class SourceProvenanceTests(unittest.TestCase):
+    def _fixture(self, root: Path) -> tuple[Path, str]:
+        subprocess.run(["git", "init", "-q", str(root)], check=True)
+        subprocess.run(
+            ["git", "-C", str(root), "config", "user.email", "test@example.invalid"],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(root), "config", "user.name", "Offline Test"],
+            check=True,
+        )
+        executable = root / "bin" / "product"
+        executable.parent.mkdir()
+        executable.write_text("#!/bin/sh\nexit 0\n")
+        executable.chmod(0o755)
+        subprocess.run(["git", "-C", str(root), "add", "bin/product"], check=True)
+        subprocess.run(
+            ["git", "-C", str(root), "commit", "-q", "-m", "fixture"], check=True
+        )
+        head = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True,
+        ).stdout.strip()
+        return executable, head
+
+    def test_clean_exact_head_binary_beneath_root_and_private_copy(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw) / "source"
+            root.mkdir()
+            executable, head = self._fixture(root)
+            provenance = bench._source_provenance(
+                root, executable, head, "nanocodex"
+            )
+            runtime = Path(raw) / "runtime"
+            runtime.mkdir(mode=0o700)
+            copied = bench._copy_executable(provenance, runtime)
+
+            self.assertEqual(provenance["git_head"], head)
+            self.assertTrue(provenance["tree_clean"])
+            self.assertEqual(stat.S_IMODE(copied.stat().st_mode), 0o500)
+            self.assertEqual(
+                bench.sha256_file(copied), provenance["binary"]["sha256"]
+            )
+            copied.chmod(0o700)
+            with self.assertRaisesRegex(bench.BenchmarkError, "immutable digest"):
+                bench._assert_executable_copy(
+                    copied, provenance["binary"]["sha256"]
+                )
+
+    def test_rejects_dirty_mismatched_or_escaping_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            base = Path(raw)
+            dirty_root = base / "dirty"
+            dirty_root.mkdir()
+            dirty_bin, dirty_head = self._fixture(dirty_root)
+            (dirty_root / "untracked-secret").write_text("dirty")
+            with self.assertRaisesRegex(bench.BenchmarkError, "not clean"):
+                bench._source_provenance(
+                    dirty_root, dirty_bin, dirty_head, "nanocodex"
+                )
+
+            mismatch_root = base / "mismatch"
+            mismatch_root.mkdir()
+            mismatch_bin, _ = self._fixture(mismatch_root)
+            with self.assertRaisesRegex(bench.BenchmarkError, "HEAD mismatch"):
+                bench._source_provenance(
+                    mismatch_root, mismatch_bin, "0" * 40, "nanocodex"
+                )
+
+            escape_root = base / "escape"
+            escape_root.mkdir()
+            _, escape_head = self._fixture(escape_root)
+            outside = base / "outside"
+            outside.write_text("#!/bin/sh\n")
+            outside.chmod(0o755)
+            with self.assertRaisesRegex(bench.BenchmarkError, "beneath"):
+                bench._source_provenance(
+                    escape_root, outside, escape_head, "nanocodex"
+                )
+
+        self.assertEqual(
+            bench.FX_COMMIT, "4a8f765c94f4e205ecae293d6d5c98ec9aef2200"
+        )
+
+    def test_end_of_run_source_recheck_detects_tree_or_binary_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            executable, head = self._fixture(root)
+            provenance = bench._source_provenance(
+                root, executable, head, "nanocodex"
+            )
+            self.assertTrue(bench._source_unchanged(provenance))
+
+            executable.write_text("#!/bin/sh\nexit 1\n")
+            self.assertFalse(bench._source_unchanged(provenance))
+
+
+class ActualBinaryPreflightIntegrationTests(unittest.TestCase):
+    """Explicit operator-supplied artifact gate; not part of unit discovery."""
+
+    def actual_binary_preflight(self) -> None:
+        self.assertEqual(sys.platform, "darwin")
+        required_environment = {
+            name: os.environ.get(name)
+            for name in (
+                "NANOCODEX_PAIRED_FX_SOURCE_ROOT",
+                "NANOCODEX_PAIRED_FX_BIN",
+                "NANOCODEX_PAIRED_NANOCODEX_BIN",
+                "NANOCODEX_PAIRED_NANOCODEX_COMMIT",
+            )
+        }
+        self.assertTrue(
+            all(required_environment.values()),
+            f"missing actual-binary environment: {required_environment}",
+        )
+        fx_source_root = Path(
+            required_environment["NANOCODEX_PAIRED_FX_SOURCE_ROOT"] or ""
+        ).resolve(strict=True)
+        fx_binary = Path(
+            required_environment["NANOCODEX_PAIRED_FX_BIN"] or ""
+        ).resolve(strict=True)
+        nanocodex_binary = Path(
+            required_environment["NANOCODEX_PAIRED_NANOCODEX_BIN"] or ""
+        ).resolve(strict=True)
+        nanocodex_commit = required_environment[
+            "NANOCODEX_PAIRED_NANOCODEX_COMMIT"
+        ]
+        self.assertIsNotNone(nanocodex_commit)
+        self.assertEqual(
+            subprocess.run(
+                ["git", "-C", str(fx_source_root), "rev-parse", "HEAD"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            ).stdout.decode("ascii").strip(),
+            bench.FX_COMMIT,
+        )
+        self.assertEqual(
+            subprocess.run(
+                ["git", "-C", str(fx_source_root), "status", "--porcelain"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            ).stdout,
+            b"",
+        )
+        fx_binary.relative_to(fx_source_root)
+
+        sources = {"fx": fx_binary, "nanocodex": nanocodex_binary}
+        with tempfile.TemporaryDirectory(
+            prefix="paired-latency-actual-binaries-"
+        ) as raw:
+            runtime_root = Path(raw)
+            provenance = {
+                name: {
+                    "implementation": name,
+                    "binary": {
+                        "path": str(path),
+                        "sha256": bench.sha256_file(path),
+                    },
+                }
+                for name, path in sources.items()
+            }
+            executables = {
+                name: (
+                    bench._copy_executable(item, runtime_root),
+                    item["binary"]["sha256"],
+                )
+                for name, item in provenance.items()
+            }
+            ledger = bench.FreshUuid7Ledger()
+            fingerprints, evidence = bench._offline_actual_binary_preflight(
+                args=argparse.Namespace(nanocodex_commit=nanocodex_commit),
+                runtime_root=runtime_root,
+                executables=executables,
+                fresh_identifier_ledger=ledger,
+            )
+
+        self.assertEqual(
+            fingerprints,
+            {
+                "fx": "ae0e171655642b3d9e7f68162fb13f4030b4132bd3b5020ef6e9b126b19a3883",
+                "nanocodex": "0f9ba75f32634eb08b59fa4691e6ba131cee1730672607efb3c0a6b0772d3106",
+            },
+        )
+        self.assertTrue(evidence["passed"])
+        self.assertFalse(evidence["provider_network_used"])
+        self.assertEqual(evidence["scripted_loopback_requests"], 6)
+        self.assertTrue(evidence["xml_metacharacter_private_paths_verified"])
+        self.assertTrue(
+            evidence["fresh_uuid7_identifiers_distinct_and_one_use_verified"]
+        )
+        self.assertEqual(
+            ledger.evidence(),
+            {
+                "accepted_identity_uses": 16,
+                "distinct_canonical_uuid7_identities": 16,
+                "reuse_detected": False,
+                "noncanonical_identity_detected": False,
+                "distinct_and_one_use_verified": True,
+            },
+        )
+
+
+class ScheduleAndCliTests(unittest.TestCase):
+    def _argv(self) -> list[str]:
+        return [
+            "--fx-source-root",
+            "/tmp/fx",
+            "--fx-bin",
+            "/tmp/fx/bin/fx",
+            "--nanocodex-source-root",
+            "/tmp/nano",
+            "--nanocodex-bin",
+            "/tmp/nano/bin/nano",
+            "--nanocodex-commit",
+            "a" * 40,
+            "--auth-file",
+            "/tmp/auth",
+            "--output",
+            "/tmp/report",
+            "--confirm-paid-live-run",
+        ]
+
+    def test_safe_defaults_no_upstream_override_and_https_only_endpoint(self) -> None:
+        args = bench.parse_args(self._argv())
+        self.assertEqual(args.trials, 20)
+        self.assertEqual(args.warmup_pairs, 2)
+        self.assertFalse(hasattr(args, "upstream_url"))
+        self.assertFalse(hasattr(args, "fx_commit"))
+        self.assertFalse(hasattr(args, "cwd"))
+        with contextlib.redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            bench.parse_args(self._argv() + ["--upstream-url", "https://evil.invalid"])
+
+    def test_failed_benchmark_is_never_published(self) -> None:
+        document = {
+            "status": "failed",
+            "schedule": {"measured_pairs_completed": 0},
+            "summary": {"primary": {"eligible_pairs": 0}},
+        }
+        with (
+            mock.patch.object(bench, "parse_args", return_value=argparse.Namespace()),
+            mock.patch.object(
+                bench,
+                "run_benchmark",
+                return_value=(document, 1, bench._fake_auth_material()),
+            ),
+            mock.patch.object(bench, "write_report") as write_report,
+            contextlib.redirect_stdout(io.StringIO()),
+        ):
+            exit_code = bench.main([])
+
+        self.assertEqual(exit_code, 1)
+        write_report.assert_not_called()
+
+    def test_successful_publication_survives_stdout_failure(self) -> None:
+        document = {
+            "status": "passed",
+            "schedule": {"measured_pairs_completed": 20},
+            "summary": {"primary": {"eligible_pairs": 20}},
+        }
+        with tempfile.TemporaryDirectory() as raw:
+            output = Path(raw) / "report.json"
+            args = argparse.Namespace(output=output)
+            with (
+                mock.patch.object(bench, "parse_args", return_value=args),
+                mock.patch.object(
+                    bench,
+                    "run_benchmark",
+                    return_value=(document, 0, bench._fake_auth_material()),
+                ),
+                mock.patch("builtins.print", side_effect=OSError("stdout closed")),
+            ):
+                exit_code = bench.main([])
+
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(json.loads(output.read_bytes()), document)
+
+    def test_successful_publication_survives_actually_closed_stdout(self) -> None:
+        document = {
+            "status": "passed",
+            "schedule": {"measured_pairs_completed": 20},
+            "summary": {"primary": {"eligible_pairs": 20}},
+        }
+        closed_stdout = io.StringIO()
+        closed_stdout.close()
+        with tempfile.TemporaryDirectory() as raw:
+            output = Path(raw) / "report.json"
+            args = argparse.Namespace(output=output)
+            with (
+                mock.patch.object(bench, "parse_args", return_value=args),
+                mock.patch.object(
+                    bench,
+                    "run_benchmark",
+                    return_value=(document, 0, bench._fake_auth_material()),
+                ),
+                mock.patch.object(bench.sys, "stdout", closed_stdout),
+            ):
+                exit_code = bench.main([])
+
+            self.assertEqual(exit_code, 0)
+            self.assertEqual(json.loads(output.read_bytes()), document)
+
+    def test_trials_must_be_even_and_at_least_twenty(self) -> None:
+        for trials in (0, 19, 21, 102):
+            args = argparse.Namespace(
+                confirm_paid_live_run=True, trials=trials, warmup_pairs=0
+            )
+            with self.subTest(trials=trials), self.assertRaisesRegex(
+                bench.BenchmarkError, "even integer"
+            ):
+                bench._validate_and_resolve_args(args)
+
+    def test_alternation_continues_from_warmup_into_measurement(self) -> None:
+        warmup_pairs = 3
+        self.assertEqual(bench._order(warmup_pairs), ["fx", "nanocodex"])
+        self.assertEqual(
+            bench._order(warmup_pairs + 1), ["nanocodex", "fx"]
+        )
+
+    def test_provider_request_budget_is_hard_bounded(self) -> None:
+        auth = bench._fake_auth_material()
+        state = bench.ObserverState(bench.AuthIdentityMatcher(auth), 1)
+        state.reserve_provider_request()
+        with self.assertRaisesRegex(
+            bench.RequestValidationError, "provider_request_budget_exhausted"
+        ):
+            state.reserve_provider_request()
+
+    def test_request_fingerprint_mismatch_fails_closed(self) -> None:
+        auth = bench._fake_auth_material()
+        state = bench.ObserverState(bench.AuthIdentityMatcher(auth), 2)
+        state.observe_request_fingerprint("fx", "a" * 64)
+        state.observe_request_fingerprint("fx", "a" * 64)
+        with self.assertRaisesRegex(
+            bench.RequestValidationError, "unstable_request_fingerprint"
+        ):
+            state.observe_request_fingerprint("fx", "b" * 64)
+        self.assertFalse(state.fingerprints_stable())
+
+    def test_report_preflight_happens_before_source_inspection(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            auth = root / "auth.json"
+            auth.write_text("{}")
+            output = root / "report.json"
+            output.write_text("owned")
+            args = argparse.Namespace(
+                confirm_paid_live_run=True,
+                trials=20,
+                warmup_pairs=0,
+                nanocodex_commit="a" * 40,
+                auth_file=auth,
+                output=output,
+                fx_source_root=root,
+                fx_bin=root / "fx",
+                nanocodex_source_root=root,
+                nanocodex_bin=root / "nano",
+            )
+            with mock.patch.object(bench, "_source_provenance") as source:
+                with self.assertRaisesRegex(bench.BenchmarkError, "already exists"):
+                    bench._validate_and_resolve_args(args)
+                source.assert_not_called()
+
+
+class ReportSecurityTests(unittest.TestCase):
+    def _auth(self, secret: str) -> bench.AuthMaterial:
+        return bench.AuthMaterial(
+            raw_codex_auth=b"{}",
+            access_token=secret,
+            refresh_token="refresh-secret",
+            account_id="account-secret",
+            expires_at_ms=(int(time.time()) + 3_600) * 1_000,
+            secret_values=(secret, "refresh-secret", "account-secret"),
+        )
+
+    def test_recursive_secret_scan_catches_keys_escapes_and_unicode_forms(self) -> None:
+        secret = "tökén"
+        auth = self._auth(secret)
+        for credential in auth.secret_values:
+            escaped = json.dumps(credential, ensure_ascii=True)[1:-1]
+            decomposed = unicodedata.normalize("NFD", credential)
+            for document in (
+                {"nested": [{"value": escaped}]},
+                {"nested": {decomposed: "value"}},
+                {"nested": {"value": decomposed}},
+            ):
+                with self.subTest(document=document), self.assertRaisesRegex(
+                    bench.BenchmarkError, "credential-bearing report"
+                ):
+                    bench._encoded_report(document, auth)
+        for header_name in ("Authorization", "ChatGPT-Account-ID"):
+            with self.subTest(header=header_name), self.assertRaisesRegex(
+                bench.BenchmarkError, "raw auth headers"
+            ):
+                bench._encoded_report({header_name: "redacted"}, auth)
+        self.assertEqual(
+            json.loads(bench._encoded_report({"nested": ["benign"]}, auth)),
+            {"nested": ["benign"]},
+        )
+
+    def test_atomic_report_publication_never_clobbers_existing_target(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            target = root / "report.json"
+            target.write_bytes(b"existing")
+            with self.assertRaises(FileExistsError):
+                bench.write_report(target, b"replacement")
+            self.assertEqual(target.read_bytes(), b"existing")
+            self.assertEqual(list(root.glob(".report.json.*.tmp")), [])
+
+            owned = root / "owned"
+            owned.write_bytes(b"owned")
+            symlink = root / "symlink-report.json"
+            symlink.symlink_to(owned)
+            with self.assertRaises(FileExistsError):
+                bench.write_report(symlink, b"replacement")
+            self.assertTrue(symlink.is_symlink())
+            self.assertEqual(owned.read_bytes(), b"owned")
+            self.assertEqual(list(root.glob(".symlink-report.json.*.tmp")), [])
+
+            published = root / "published.json"
+            bench.write_report(published, b"published")
+            self.assertEqual(published.read_bytes(), b"published")
+            self.assertEqual(stat.S_IMODE(published.stat().st_mode), 0o600)
+
+    def test_report_fsync_failure_never_publishes(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            target = root / "report.json"
+            with (
+                mock.patch.object(bench.os, "fsync", side_effect=OSError("fsync")),
+                self.assertRaisesRegex(OSError, "fsync"),
+            ):
+                bench.write_report(target, b"uncommitted")
+
+            self.assertFalse(target.exists())
+            self.assertEqual(list(root.glob(".report.json.*.tmp")), [])
+
+    def test_temporary_unlink_failure_after_link_is_committed_success(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            target = root / "report.json"
+            with mock.patch.object(
+                bench.os, "unlink", side_effect=OSError("unlink denied")
+            ):
+                bench.write_report(target, b"committed")
+
+            self.assertEqual(target.read_bytes(), b"committed")
+            self.assertEqual(stat.S_IMODE(target.stat().st_mode), 0o600)
+
+
+class ClientOutputTests(unittest.TestCase):
+    def test_parses_minimized_fx_output(self) -> None:
+        raw = _compact(
+            {
+                "output": bench.ACK_TOKEN,
+                "exit_code": 0,
+                "model": bench.MODEL,
+                "session_id": "not-retained",
+                "tool_calls": [],
+            }
+        )
+        parsed = bench.parse_fx_client_output(
+            bench.ProcessCapture(0, raw, stderr_bytes=0, timed_out=False)
+        )
+        self.assertTrue(parsed["valid"])
+        self.assertTrue(parsed["client_configuration_echo_valid"])
+        self.assertNotIn("output", parsed)
+        self.assertNotIn("session_id", parsed)
+
+    def test_parses_nanocodex_configuration_echo_but_not_as_source_proof(self) -> None:
+        commit = "a" * 40
+        cwd = Path("/private/ephemeral-workspace")
+        parsed = bench.parse_nanocodex_client_output(
+            bench.ProcessCapture(
+                0,
+                _compact(_nano_output(commit, cwd)),
+                stderr_bytes=0,
+                timed_out=False,
+            ),
+            source_commit=commit,
+            cwd=cwd,
+        )
+        self.assertTrue(parsed["valid"])
+        self.assertTrue(parsed["client_configuration_echo_valid"])
+        self.assertNotIn("provenance_valid", parsed)
+
+        websocket_generation = _nano_output(commit, cwd)
+        websocket_generation["model_call"]["connection_generation"] = 1
+        rejected = bench.parse_nanocodex_client_output(
+            bench.ProcessCapture(
+                0,
+                _compact(websocket_generation),
+                stderr_bytes=0,
+                timed_out=False,
+            ),
+            source_commit=commit,
+            cwd=cwd,
+        )
+        self.assertFalse(rejected["valid"])
+        self.assertIn("nanocodex_model_call_invalid", rejected["errors"])
+
+
+class StopPolicyTests(unittest.TestCase):
+    class _State:
+        def stats(self) -> dict[str, int]:
+            return {
+                "unexpected_requests": 0,
+                "models_requests": 0,
+                "refresh_attempts_blocked": 0,
+                "provider_request_budget": 40,
+                "provider_requests_forwarded": 1,
+            }
+
+        def request_fingerprints(self) -> dict[str, str]:
+            return {"fx": "a" * 64, "nanocodex": "b" * 64}
+
+        def fingerprints_stable(self) -> bool:
+            return True
+
+    class _Matcher:
+        def verified(self) -> bool:
+            return True
+
+    class _Observer:
+        base_url = "http://127.0.0.1:1"
+        last_fresh_identifier_ledger: bench.FreshUuid7Ledger | None = None
+
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            self.__class__.last_fresh_identifier_ledger = _kwargs.get(
+                "fresh_identifier_ledger"
+            )
+            self.state = StopPolicyTests._State()
+            self.auth_matcher = StopPolicyTests._Matcher()
+
+        def __enter__(self) -> "StopPolicyTests._Observer":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+    def test_first_measured_functional_failure_stops_all_later_clients(self) -> None:
+        self._Observer.last_fresh_identifier_ledger = None
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            executable = root / "product"
+            executable.write_bytes(b"product")
+            executable.chmod(0o500)
+            digest = bench.sha256_file(executable)
+            provenance = lambda name: {
+                "implementation": name,
+                "source_root": str(root),
+                "expected_commit": "a" * 40,
+                "git_head": "a" * 40,
+                "tree_clean": True,
+                "binary": {
+                    "path": str(executable),
+                    "sha256": digest,
+                    "byte_count": executable.stat().st_size,
+                },
+            }
+            args = argparse.Namespace(
+                auth_file=root / "auth",
+                nanocodex_commit="a" * 40,
+                trials=20,
+                warmup_pairs=0,
+                provider_request_budget=40,
+            )
+            failure = {
+                "implementation": "fx",
+                "functional_valid": False,
+                "no_tool_calls": True,
+                "timing_present": False,
+                "cached_input_tokens": None,
+                "measured_failure": True,
+                "client": {"errors": ["failed"]},
+                "observer": {"error": "failed", "timing_ns": {}},
+            }
+            with (
+                mock.patch.object(
+                    bench,
+                    "_validate_and_resolve_args",
+                    return_value=(provenance("fx"), provenance("nanocodex")),
+                ),
+                mock.patch.object(
+                    bench, "load_auth_snapshot", return_value=bench._fake_auth_material()
+                ),
+                mock.patch.object(bench, "_copy_executable", return_value=executable),
+                mock.patch.object(bench, "_assert_executable_copy"),
+                mock.patch.object(bench, "_source_unchanged", return_value=True),
+                mock.patch.object(
+                    bench,
+                    "_offline_actual_binary_preflight",
+                    return_value=(
+                        {"fx": "a" * 64, "nanocodex": "b" * 64},
+                        {
+                            "passed": True,
+                            "provider_network_used": False,
+                            "scripted_loopback_requests": 6,
+                            "runs_per_implementation": 2,
+                            "nanocodex_fedramp_runs": 2,
+                            "nanocodex_fedramp_header_verified_from_id_token": True,
+                            "contradictory_id_and_access_token_claims_verified": True,
+                            "fx_exact_models_discovery_once_per_run_verified": True,
+                            "fresh_uuid7_identifiers_distinct_and_one_use_verified": True,
+                            "distinct_private_workspace_fingerprints_stable": True,
+                            "exact_executable_request_templates_captured": True,
+                            "independent_reference_body_fingerprints_verified": True,
+                            "xml_metacharacter_private_paths_verified": True,
+                        },
+                    ),
+                ) as preflight,
+                mock.patch.object(bench, "StreamingObserver", self._Observer),
+                mock.patch.object(
+                    bench, "_run_implementation", return_value=failure
+                ) as run,
+            ):
+                document, exit_code, _ = bench.run_benchmark(args)
+
+        self.assertEqual(run.call_count, 1)
+        self.assertIs(
+            preflight.call_args.kwargs["fresh_identifier_ledger"],
+            self._Observer.last_fresh_identifier_ledger,
+        )
+        self.assertEqual(document["schedule"]["measured_pairs_started"], 1)
+        self.assertEqual(document["schedule"]["measured_pairs_completed"], 0)
+        self.assertEqual(document["pairs"][0]["order"], ["fx", "nanocodex"])
+        self.assertEqual(set(document["pairs"][0]["runs"]), {"fx"})
+        self.assertEqual(
+            document["comparison_design"]["kind"], "controlled_product_as_shipped"
+        )
+        self.assertFalse(
+            document["comparison_design"]["identical_input_or_isolated_client_claim"]
+        )
+        self.assertEqual(document["provenance"]["transport"], "https")
+        self.assertEqual(
+            document["schedule"]["alternation_scope"],
+            "continuous_across_warmup_and_measured_pairs",
+        )
+        self.assertTrue(
+            document["exit_conditions"][
+                "fresh_uuid7_identifiers_not_distinct_and_one_use"
+            ]
+        )
+        self.assertFalse(
+            document["provenance"]["actual_binary_offline_preflight"][
+                "fresh_uuid7_identifiers_distinct_and_one_use_verified"
+            ]
+        )
+        self.assertEqual(exit_code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/crates/nanocodex-agent/benches/harness_performance.rs
+++ b/crates/nanocodex-agent/benches/harness_performance.rs
@@ -19,20 +19,50 @@ use nanocodex_agent::{
     AgentEvents, ExecutionEnvironment, Nanocodex, OpenAi, ResponseError, Thinking, Tools,
     TurnResult,
     events::{AgentEventKind, monotonic_now_ns},
+    session::SessionId,
 };
 use nanocodex_oai_api::{
     ResponseEvent,
-    responses::{ContentItem, MessageRole, ResponseItem, Usage, WarmupResponse},
+    responses::{
+        ContentItem, MessageRole, ResponseItem, ResponseItemId, ToolDefinition, Usage,
+        WarmupResponse,
+    },
     tower::{
         GenerationOutput, ResponsePipelineStats, ResponsesAttempt, ResponsesAttemptKind,
         ResponsesOutput, ResponsesServiceResponse,
     },
 };
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, get_current_pid};
 use tower::Service;
 
 const PROMPT_CACHE_KEY: &str = "nanocodex-harness-performance-v1";
+const PROMPT_FOOTPRINT_CACHE_KEY: &str = "nanocodex-prompt-footprint-v1";
+const PROMPT_FOOTPRINT_SESSION_ID: &str = "019c0d31-c308-7d91-bff4-5dca82d15ac6";
+const PROMPT_FOOTPRINT_WORKSPACE_MARKER: &str = "<isolated-temporary-workspace>";
+const PROMPT_FOOTPRINT_DATE: &str = "2026-08-22";
+const PROMPT_FOOTPRINT_TIMEZONE: &str = "Etc/UTC";
+const PROMPT_FOOTPRINT_FIRST_PROMPT: &str =
+    "Measure the default Nanocodex prompt footprint, turn one.";
+const PROMPT_FOOTPRINT_FOLLOW_ON_PROMPT: &str =
+    "Measure the default Nanocodex prompt footprint, turn two.";
+const PROMPT_FOOTPRINT_WARMUP_RESPONSE_ID: &str = "resp_prompt_footprint_warmup";
+const PROMPT_FOOTPRINT_FIRST_RESPONSE_ID: &str = "resp_prompt_footprint_first";
+const PROMPT_FOOTPRINT_FOLLOW_ON_RESPONSE_ID: &str = "resp_prompt_footprint_follow_on";
+const CANONICAL_ITEM_UUID: &str = "00000000-0000-7000-8000-000000000000";
+const EXPECTED_STABLE_PREFIX_SHA256: &str =
+    "70877209285cfc80ed44568265e0ff31621fedf2b29677a8553c2218721b0cb3";
+const EXPECTED_ADDITIONAL_TOOLS_ITEM_SHA256: &str =
+    "8d5728ace7e30c0e097392fc72082918a6cb6b3ad48a679c507ad22eaa0d6bf8";
+const EXPECTED_TOOL_DECLARATIONS_SHA256: &str =
+    "8c3a181cb39dbc6b94b5c568b209ca28d916e3cd1e1d33a163cb438d98c2fbb7";
+const EXPECTED_SYSTEM_PROMPT_SHA256: &str =
+    "cfa73b0509e3e5fa1cf15dacb7be0edbfa428ac9a16ecb80d46f09f8d8c5542e";
+const EXPECTED_FIRST_DELTA_SHA256: &str =
+    "e34620a335f1fa711113ab5308fca26619f5dde5beddbfe18881a26c7ebded3c";
+const EXPECTED_FOLLOW_ON_DELTA_SHA256: &str =
+    "daf84b7b02df04c29dd4b4ad68b7063279665121a94bfcb5e173f34b76f00399";
 
 #[derive(Clone)]
 struct ScriptedResponses {
@@ -176,6 +206,119 @@ impl Service<ResponsesAttempt> for ScriptedResponses {
     }
 }
 
+#[derive(Clone)]
+struct PromptFootprintResponses {
+    state: Arc<PromptFootprintState>,
+}
+
+#[derive(Default)]
+struct PromptFootprintState {
+    calls: AtomicU64,
+    attempts: Mutex<Vec<PromptFootprintAttempt>>,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum PromptFootprintAttemptKind {
+    Warmup,
+    Generation,
+}
+
+#[derive(Clone)]
+struct PromptFootprintAttempt {
+    kind: PromptFootprintAttemptKind,
+    previous_response_id: Option<String>,
+    full_replay: bool,
+    input: Vec<ResponseItem>,
+}
+
+impl PromptFootprintState {
+    fn record(&self, attempt: PromptFootprintAttempt) {
+        self.attempts
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(attempt);
+    }
+
+    fn attempts(&self) -> Vec<PromptFootprintAttempt> {
+        self.attempts
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+}
+
+impl Service<ResponsesAttempt> for PromptFootprintResponses {
+    type Response = ResponsesServiceResponse;
+    type Error = ResponseError;
+    type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _context: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: ResponsesAttempt) -> Self::Future {
+        let call = self.state.calls.fetch_add(1, Ordering::Relaxed) + 1;
+        let kind = match request.kind() {
+            ResponsesAttemptKind::Warmup => PromptFootprintAttemptKind::Warmup,
+            ResponsesAttemptKind::Generation => PromptFootprintAttemptKind::Generation,
+            ResponsesAttemptKind::Compaction => {
+                return std::future::ready(Err(ResponseError::service(std::io::Error::other(
+                    "the prompt-footprint probe unexpectedly requested compaction",
+                ))));
+            }
+            _ => {
+                return std::future::ready(Err(ResponseError::service(std::io::Error::other(
+                    "the prompt-footprint probe received an unknown Responses attempt kind",
+                ))));
+            }
+        };
+        self.state.record(PromptFootprintAttempt {
+            kind,
+            previous_response_id: request.previous_response_id().map(str::to_owned),
+            full_replay: request.is_full_replay(),
+            input: request.input_items().cloned().collect(),
+        });
+
+        let output = match (call, kind) {
+            (1, PromptFootprintAttemptKind::Warmup) => ResponsesOutput::Warmup(WarmupResponse {
+                id: PROMPT_FOOTPRINT_WARMUP_RESPONSE_ID.to_owned(),
+                usage: None,
+            }),
+            (2, PromptFootprintAttemptKind::Generation) => prompt_footprint_generation(
+                PROMPT_FOOTPRINT_FIRST_RESPONSE_ID,
+                "prompt-footprint-first-complete",
+            ),
+            (3, PromptFootprintAttemptKind::Generation) => prompt_footprint_generation(
+                PROMPT_FOOTPRINT_FOLLOW_ON_RESPONSE_ID,
+                "prompt-footprint-follow-on-complete",
+            ),
+            _ => {
+                return std::future::ready(Err(ResponseError::service(std::io::Error::other(
+                    "the prompt-footprint probe received an unexpected request sequence",
+                ))));
+            }
+        };
+        std::future::ready(Ok(ResponsesServiceResponse::new(output)))
+    }
+}
+
+fn prompt_footprint_generation(response_id: &str, message: &str) -> ResponsesOutput {
+    let message_item =
+        ResponseItem::message(MessageRole::Assistant, [ContentItem::output_text(message)]);
+    ResponsesOutput::Generation(GenerationOutput {
+        id: response_id.to_owned(),
+        status: "completed".to_owned(),
+        end_turn: Some(true),
+        final_message: Some(message.to_owned()),
+        output_items: vec![message_item],
+        code_calls: Vec::new(),
+        usage: None,
+        time_to_first_event_ns: 0,
+        time_to_first_output_ns: None,
+        pipeline_stats: ResponsePipelineStats::default(),
+    })
+}
+
 const fn attempt_kind(kind: ResponsesAttemptKind) -> &'static str {
     match kind {
         ResponsesAttemptKind::Warmup => "warmup",
@@ -269,6 +412,7 @@ struct BenchmarkReport {
     memory: MemoryReport,
     fork: ForkReport,
     prompt_cache: PromptCacheReport,
+    prompt_footprint: PromptFootprintReport,
 }
 
 #[derive(Serialize)]
@@ -355,6 +499,44 @@ struct PromptCacheReport {
     generation_input_items: usize,
     generation_input_bytes: usize,
     requests: Vec<AttemptRecord>,
+}
+
+#[derive(Serialize)]
+struct PromptFootprintReport {
+    boundary: &'static str,
+    prompt_cache_key: &'static str,
+    session_id: &'static str,
+    workspace: String,
+    execution_environment: PromptFootprintEnvironment,
+    prompts: PromptFootprintPrompts,
+    stable_hash_normalization: &'static str,
+    stable_prefix: PromptFootprintComponent,
+    additional_tools_item: PromptFootprintComponent,
+    additional_tool_declarations: PromptFootprintComponent,
+    default_system_prompt_item: PromptFootprintComponent,
+    first_generation_delta: PromptFootprintComponent,
+    follow_on_delta: PromptFootprintComponent,
+    follow_on_uses_previous_response_id_without_full_replay: bool,
+}
+
+#[derive(Serialize)]
+struct PromptFootprintEnvironment {
+    current_date: &'static str,
+    timezone: &'static str,
+}
+
+#[derive(Serialize)]
+struct PromptFootprintPrompts {
+    first: &'static str,
+    follow_on: &'static str,
+}
+
+#[derive(Serialize)]
+struct PromptFootprintComponent {
+    serialized_bytes: usize,
+    stable_sha256: String,
+    item_count: usize,
+    tool_count: usize,
 }
 
 #[derive(Serialize)]
@@ -603,6 +785,9 @@ async fn run_benchmark(args: &Args, rss: &mut RssSampler) -> Result<BenchmarkRep
         );
     }
 
+    // This probe must remain after every timed sample, RSS sample, and measured-agent shutdown.
+    let prompt_footprint = measure_prompt_footprint().await?;
+
     Ok(BenchmarkReport {
         schema_version: 1,
         implementation: "nanocodex",
@@ -659,7 +844,421 @@ async fn run_benchmark(args: &Args, rss: &mut RssSampler) -> Result<BenchmarkRep
             construction_ns: Distribution::new(&fork_samples),
         },
         prompt_cache,
+        prompt_footprint,
     })
+}
+
+async fn measure_prompt_footprint() -> Result<PromptFootprintReport> {
+    let workspace_dir = tempfile::Builder::new()
+        .prefix("nanocodex-prompt-footprint-")
+        .tempdir()
+        .wrap_err("failed to create isolated prompt-footprint workspace")?;
+    let workspace = fs::canonicalize(workspace_dir.path())
+        .wrap_err("failed to resolve isolated prompt-footprint workspace")?;
+    let workspace_text = workspace
+        .to_str()
+        .ok_or_else(|| eyre!("the fixed prompt-footprint workspace is not valid UTF-8"))?
+        .to_owned();
+    let session_id = PROMPT_FOOTPRINT_SESSION_ID
+        .parse::<SessionId>()
+        .wrap_err("the fixed prompt-footprint session ID is invalid")?;
+    let state = Arc::new(PromptFootprintState::default());
+    let service_state = Arc::clone(&state);
+    let openai = OpenAi::builder("harness-only")
+        .service(move || PromptFootprintResponses {
+            state: Arc::clone(&service_state),
+        })
+        .build()?;
+    let tools = Tools::builder().build()?;
+    let (agent, events) = Nanocodex::builder(openai)
+        .workspace(&workspace)
+        .execution_environment(ExecutionEnvironment::new(
+            PROMPT_FOOTPRINT_DATE,
+            PROMPT_FOOTPRINT_TIMEZONE,
+        ))
+        .session_id(session_id)
+        .prompt_cache_key(PROMPT_FOOTPRINT_CACHE_KEY)
+        .tools(tools)
+        .build()?;
+    drop(events);
+
+    let turns = async {
+        complete_prompt_footprint_turn(
+            &agent,
+            PROMPT_FOOTPRINT_FIRST_PROMPT,
+            "prompt-footprint-first-complete",
+        )
+        .await?;
+        complete_prompt_footprint_turn(
+            &agent,
+            PROMPT_FOOTPRINT_FOLLOW_ON_PROMPT,
+            "prompt-footprint-follow-on-complete",
+        )
+        .await
+    }
+    .await;
+    let shutdown = agent.shutdown().await;
+    shutdown.wrap_err("failed to shut down the prompt-footprint agent")?;
+    turns?;
+
+    let attempts = state.attempts();
+    let [warmup, first, follow_on] = attempts.as_slice() else {
+        bail!(
+            "expected one warmup and two generations in the prompt-footprint probe, got {} requests",
+            attempts.len()
+        );
+    };
+    if warmup.kind != PromptFootprintAttemptKind::Warmup
+        || warmup.previous_response_id.is_some()
+        || warmup.full_replay
+    {
+        bail!("the prompt-footprint warmup request had an unexpected transport shape");
+    }
+    if first.kind != PromptFootprintAttemptKind::Generation
+        || first.previous_response_id.as_deref() != Some(PROMPT_FOOTPRINT_WARMUP_RESPONSE_ID)
+        || first.full_replay
+    {
+        bail!("the first prompt-footprint generation was not incremental from warmup");
+    }
+    let follow_on_uses_previous_response_id_without_full_replay = follow_on.kind
+        == PromptFootprintAttemptKind::Generation
+        && follow_on.previous_response_id.as_deref() == Some(PROMPT_FOOTPRINT_FIRST_RESPONSE_ID)
+        && !follow_on.full_replay;
+    if !follow_on_uses_previous_response_id_without_full_replay {
+        bail!(
+            "the follow-on prompt-footprint generation did not use previous_response_id without full replay"
+        );
+    }
+
+    let [additional_tools_item, default_system_prompt_item] = warmup.input.as_slice() else {
+        bail!(
+            "the default stable prefix must contain exactly additional_tools and system-prompt items"
+        );
+    };
+    let additional_tool_declarations = match additional_tools_item {
+        ResponseItem::AdditionalTools {
+            id: None,
+            role: MessageRole::Developer,
+            tools,
+        } if !tools.is_empty() => tools,
+        _ => bail!("the default stable prefix is missing its typed additional_tools item"),
+    };
+    validate_default_tool_contract(additional_tool_declarations)?;
+    let system_prompt = prefix_system_prompt(default_system_prompt_item)?;
+    if system_prompt.trim().is_empty() {
+        bail!("the default system-prompt item is empty");
+    }
+
+    validate_first_generation_delta(&first.input, &workspace_text)?;
+    validate_follow_on_delta(&follow_on.input)?;
+
+    let report = PromptFootprintReport {
+        boundary: "isolated_default_agent_probe_after_timing_and_rss",
+        prompt_cache_key: PROMPT_FOOTPRINT_CACHE_KEY,
+        session_id: PROMPT_FOOTPRINT_SESSION_ID,
+        workspace: PROMPT_FOOTPRINT_WORKSPACE_MARKER.to_owned(),
+        execution_environment: PromptFootprintEnvironment {
+            current_date: PROMPT_FOOTPRINT_DATE,
+            timezone: PROMPT_FOOTPRINT_TIMEZONE,
+        },
+        prompts: PromptFootprintPrompts {
+            first: PROMPT_FOOTPRINT_FIRST_PROMPT,
+            follow_on: PROMPT_FOOTPRINT_FOLLOW_ON_PROMPT,
+        },
+        stable_hash_normalization: "client UUIDv7 suffixes and the isolated workspace path are replaced before hashing; serialized_bytes always describe the exact wire value",
+        stable_prefix: response_items_footprint(&warmup.input, None)?,
+        additional_tools_item: response_item_footprint(additional_tools_item)?,
+        additional_tool_declarations: serialized_footprint(
+            additional_tool_declarations,
+            additional_tool_declarations,
+            0,
+            additional_tool_declarations.len(),
+        )?,
+        default_system_prompt_item: response_item_footprint(default_system_prompt_item)?,
+        first_generation_delta: response_items_footprint(&first.input, Some(&workspace_text))?,
+        follow_on_delta: response_items_footprint(&follow_on.input, None)?,
+        follow_on_uses_previous_response_id_without_full_replay,
+    };
+    validate_prompt_footprint_contract(&report)?;
+    Ok(report)
+}
+
+fn validate_prompt_footprint_contract(report: &PromptFootprintReport) -> Result<()> {
+    require_prompt_component(
+        "stable prefix",
+        &report.stable_prefix,
+        EXPECTED_STABLE_PREFIX_SHA256,
+        Some(40_265),
+        2,
+        2,
+    )?;
+    require_prompt_component(
+        "additional_tools item",
+        &report.additional_tools_item,
+        EXPECTED_ADDITIONAL_TOOLS_ITEM_SHA256,
+        Some(22_236),
+        1,
+        2,
+    )?;
+    require_prompt_component(
+        "default tool declarations",
+        &report.additional_tool_declarations,
+        EXPECTED_TOOL_DECLARATIONS_SHA256,
+        Some(22_181),
+        0,
+        2,
+    )?;
+    require_prompt_component(
+        "default system prompt",
+        &report.default_system_prompt_item,
+        EXPECTED_SYSTEM_PROMPT_SHA256,
+        Some(18_026),
+        1,
+        0,
+    )?;
+    require_prompt_component(
+        "first generation delta",
+        &report.first_generation_delta,
+        EXPECTED_FIRST_DELTA_SHA256,
+        None,
+        3,
+        0,
+    )?;
+    require_prompt_component(
+        "follow-on delta",
+        &report.follow_on_delta,
+        EXPECTED_FOLLOW_ON_DELTA_SHA256,
+        Some(183),
+        1,
+        0,
+    )?;
+    Ok(())
+}
+
+fn require_prompt_component(
+    label: &str,
+    actual: &PromptFootprintComponent,
+    expected_sha256: &str,
+    expected_bytes: Option<usize>,
+    expected_items: usize,
+    expected_tools: usize,
+) -> Result<()> {
+    if actual.stable_sha256 != expected_sha256
+        || expected_bytes.is_some_and(|bytes| actual.serialized_bytes != bytes)
+        || actual.item_count != expected_items
+        || actual.tool_count != expected_tools
+    {
+        bail!(
+            "the {label} changed: bytes={}, sha256={}, items={}, tools={}",
+            actual.serialized_bytes,
+            actual.stable_sha256,
+            actual.item_count,
+            actual.tool_count
+        );
+    }
+    Ok(())
+}
+
+async fn complete_prompt_footprint_turn(
+    agent: &Nanocodex,
+    prompt: &'static str,
+    expected_message: &str,
+) -> Result<()> {
+    let result = agent.prompt(prompt).await?.result().await?;
+    if result.final_message() != expected_message {
+        bail!(
+            "prompt-footprint turn returned an unexpected final message: {:?}",
+            result.final_message()
+        );
+    }
+    Ok(())
+}
+
+fn prefix_system_prompt(item: &ResponseItem) -> Result<&str> {
+    let ResponseItem::Message {
+        id: None,
+        role: MessageRole::Developer,
+        content,
+        ..
+    } = item
+    else {
+        bail!("the default stable prefix is missing its typed system-prompt item");
+    };
+    let [ContentItem::InputText { text }] = content.as_slice() else {
+        bail!("the default system-prompt item must contain exactly one input_text part");
+    };
+    Ok(text)
+}
+
+fn validate_default_tool_contract(tools: &[ToolDefinition]) -> Result<()> {
+    if !tools.iter().any(|tool| tool.name() == "exec")
+        || !tools.iter().any(|tool| tool.name() == "wait")
+    {
+        bail!("the default tool contract must expose both exec and wait");
+    }
+    Ok(())
+}
+
+fn validate_first_generation_delta(items: &[ResponseItem], workspace: &str) -> Result<()> {
+    let [permissions, environment, prompt] = items else {
+        bail!("the first generation delta must contain permissions, environment, and prompt items");
+    };
+    let permissions = single_input_text(permissions, MessageRole::Developer, "permissions")?;
+    if !permissions.starts_with("<permissions instructions>") {
+        bail!("the first generation delta is missing permissions instructions");
+    }
+    let environment = single_input_text(environment, MessageRole::User, "environment")?;
+    for expected in [
+        format!("<cwd>{workspace}</cwd>"),
+        format!("<current_date>{PROMPT_FOOTPRINT_DATE}</current_date>"),
+        format!("<timezone>{PROMPT_FOOTPRINT_TIMEZONE}</timezone>"),
+    ] {
+        if !environment.contains(&expected) {
+            bail!("the first generation environment item is missing {expected}");
+        }
+    }
+    let prompt = single_input_text(prompt, MessageRole::User, "first prompt")?;
+    if prompt != PROMPT_FOOTPRINT_FIRST_PROMPT {
+        bail!("the first generation delta did not retain the fixed prompt exactly");
+    }
+    Ok(())
+}
+
+fn validate_follow_on_delta(items: &[ResponseItem]) -> Result<()> {
+    let [prompt] = items else {
+        bail!("the follow-on generation delta must contain only its new prompt item");
+    };
+    let prompt = single_input_text(prompt, MessageRole::User, "follow-on prompt")?;
+    if prompt != PROMPT_FOOTPRINT_FOLLOW_ON_PROMPT {
+        bail!("the follow-on generation delta did not retain the fixed prompt exactly");
+    }
+    Ok(())
+}
+
+fn single_input_text<'a>(
+    item: &'a ResponseItem,
+    expected_role: MessageRole,
+    label: &str,
+) -> Result<&'a str> {
+    let ResponseItem::Message { role, content, .. } = item else {
+        bail!("the {label} item is not a typed message");
+    };
+    if *role != expected_role {
+        bail!("the {label} item has an unexpected role");
+    }
+    let [ContentItem::InputText { text }] = content.as_slice() else {
+        bail!("the {label} item must contain exactly one input_text part");
+    };
+    Ok(text)
+}
+
+fn response_items_footprint(
+    items: &[ResponseItem],
+    workspace: Option<&str>,
+) -> Result<PromptFootprintComponent> {
+    let canonical = canonicalize_response_items(items, workspace)?;
+    serialized_footprint(
+        items,
+        &canonical,
+        items.len(),
+        response_item_tool_count(items),
+    )
+}
+
+fn response_item_footprint(item: &ResponseItem) -> Result<PromptFootprintComponent> {
+    let canonical = canonicalize_response_item(item.clone(), None)?;
+    serialized_footprint(
+        item,
+        &canonical,
+        1,
+        response_item_tool_count(std::slice::from_ref(item)),
+    )
+}
+
+fn serialized_footprint<W, S>(
+    wire_value: &W,
+    stable_value: &S,
+    item_count: usize,
+    tool_count: usize,
+) -> Result<PromptFootprintComponent>
+where
+    W: Serialize + ?Sized,
+    S: Serialize + ?Sized,
+{
+    let wire = serde_json::to_vec(wire_value)?;
+    let stable = serde_json::to_vec(stable_value)?;
+    Ok(PromptFootprintComponent {
+        serialized_bytes: wire.len(),
+        stable_sha256: sha256_hex(&stable),
+        item_count,
+        tool_count,
+    })
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let digest = Sha256::digest(bytes);
+    let mut encoded = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+        encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    encoded
+}
+
+fn canonicalize_response_items(
+    items: &[ResponseItem],
+    workspace: Option<&str>,
+) -> Result<Vec<ResponseItem>> {
+    items
+        .iter()
+        .cloned()
+        .map(|item| canonicalize_response_item(item, workspace))
+        .collect()
+}
+
+fn canonicalize_response_item(
+    mut item: ResponseItem,
+    workspace: Option<&str>,
+) -> Result<ResponseItem> {
+    if let Some(id) = item.id() {
+        let prefix = item
+            .id_prefix()
+            .ok_or_else(|| eyre!("a prompt-footprint item has an ID but no typed ID prefix"))?;
+        let marker = format!("{prefix}_");
+        let suffix = id.as_str().strip_prefix(&marker).ok_or_else(|| {
+            eyre!("prompt-footprint item ID {id} does not use its typed {prefix} prefix")
+        })?;
+        if suffix.len() != CANONICAL_ITEM_UUID.len() {
+            bail!("prompt-footprint item ID {id} does not have a fixed-width UUID suffix");
+        }
+        item.set_id(Some(ResponseItemId::with_suffix(
+            prefix,
+            CANONICAL_ITEM_UUID,
+        )));
+    }
+    if let (Some(workspace), ResponseItem::Message { content, .. }) = (workspace, &mut item) {
+        for part in content {
+            if let ContentItem::InputText { text } = part
+                && text.contains(workspace)
+            {
+                *text = text
+                    .replace(workspace, PROMPT_FOOTPRINT_WORKSPACE_MARKER)
+                    .into_boxed_str();
+            }
+        }
+    }
+    Ok(item)
+}
+
+fn response_item_tool_count(items: &[ResponseItem]) -> usize {
+    items
+        .iter()
+        .map(|item| match item {
+            ResponseItem::AdditionalTools { tools, .. } => tools.len(),
+            _ => 0,
+        })
+        .sum()
 }
 
 async fn measured_turn(

--- a/crates/nanocodex-agent/benches/harness_performance.rs
+++ b/crates/nanocodex-agent/benches/harness_performance.rs
@@ -571,7 +571,7 @@ impl Distribution {
     }
 }
 
-fn percentile(ordered: &[u64], percentile: usize) -> u64 {
+const fn percentile(ordered: &[u64], percentile: usize) -> u64 {
     let index = (ordered.len() - 1).saturating_mul(percentile).div_ceil(100);
     ordered[index]
 }

--- a/crates/nanocodex-agent/src/model/run/responses.rs
+++ b/crates/nanocodex-agent/src/model/run/responses.rs
@@ -72,24 +72,26 @@ where
         if let Some(input_content) = &input_content {
             record_span_content(&span, "model.input", input_content);
         }
-        let execution_steps = self.execution_steps.clone();
-        let step_id = format!("model-{call_index}");
-        let mut recorded_prompt_history = prompt_history.iter().cloned().collect::<Vec<_>>();
-        for item in &mut recorded_prompt_history {
-            item.strip_id();
-        }
-        let step_input = RecordedModelCall {
-            call_index,
-            model: self.model.as_str(),
-            reasoning_mode: self.config.reasoning_mode.as_str(),
-            effort: self.thinking.as_str(),
-            fast_mode: self.fast_mode,
-            prompt_history: &recorded_prompt_history,
-        };
-        let recovered = if let Some(steps) = &execution_steps {
+        let execution_recording = self
+            .execution_steps
+            .clone()
+            .map(|steps| (steps, format!("model-{call_index}")));
+        let recovered = if let Some((steps, step_id)) = &execution_recording {
+            let mut recorded_prompt_history = prompt_history.iter().cloned().collect::<Vec<_>>();
+            for item in &mut recorded_prompt_history {
+                item.strip_id();
+            }
+            let step_input = RecordedModelCall {
+                call_index,
+                model: self.model.as_str(),
+                reasoning_mode: self.config.reasoning_mode.as_str(),
+                effort: self.thinking.as_str(),
+                fast_mode: self.fast_mode,
+                prompt_history: &recorded_prompt_history,
+            };
             match steps
                 .begin::<_, RecordedModelResult>(
-                    &step_id,
+                    step_id,
                     "model_call",
                     &step_input,
                     crate::agent::execution::ExecutionRetry::Idempotent,
@@ -135,8 +137,8 @@ where
                 server_reasoning_included,
                 duration_ns: elapsed_ns(started_at),
             };
-            if let Some(steps) = &execution_steps {
-                steps.complete(&step_id, &output).await?;
+            if let Some((steps, step_id)) = &execution_recording {
+                steps.complete(step_id, &output).await?;
             }
             output
         };

--- a/crates/nanocodex-oai-api/src/tower/attempt.rs
+++ b/crates/nanocodex-oai-api/src/tower/attempt.rs
@@ -67,6 +67,10 @@ impl ResponsesObserver {
     const fn projects_response_events(&self) -> bool {
         self.response_events.is_none()
     }
+
+    pub(crate) const fn observes_response_events(&self) -> bool {
+        self.response_events.is_some()
+    }
 }
 
 #[derive(Serialize)]

--- a/crates/nanocodex-oai-api/src/tower/stream.rs
+++ b/crates/nanocodex-oai-api/src/tower/stream.rs
@@ -514,7 +514,9 @@ where
 
     let decode_started_at = Instant::now();
     let event = decode_event::<ServerEvent>(raw_event)?;
-    if let Some(event) = event.normalized() {
+    if observer.observes_response_events()
+        && let Some(event) = event.normalized()
+    {
         observer.emit_response(event).await;
     }
     timing.pipeline.decode_duration_ns = timing

--- a/crates/nanocodex-tools/src/image/mod.rs
+++ b/crates/nanocodex-tools/src/image/mod.rs
@@ -190,7 +190,7 @@ pub async fn prepare_output_images(output: &mut ToolOutputBody) {
 /// policy. Audio input is retained as an explicit placeholder until supported.
 pub async fn prepare_user_input(input: &PromptInput) -> Vec<ContentItem> {
     let input = match input {
-        PromptInput::Text(text) => vec![UserInput::Text { text: text.clone() }],
+        PromptInput::Text(text) => return vec![input_text(text.clone())],
         PromptInput::Content(items) => items.clone(),
     };
     match tokio::task::spawn_blocking(move || prepare_user_content(input)).await {
@@ -596,6 +596,16 @@ mod tests {
     use image::{DynamicImage, GenericImageView, ImageFormat, Rgba, RgbaImage};
 
     use super::*;
+
+    #[tokio::test]
+    async fn plain_text_input_preserves_bytes_without_image_work() {
+        let content = prepare_user_input(&PromptInput::Text("exact text".to_owned())).await;
+
+        assert!(matches!(
+            content.as_slice(),
+            [ContentItem::InputText { text }] if text.as_ref() == "exact text"
+        ));
+    }
 
     #[test]
     fn detail_policies_match_codex_patch_budgets() {

--- a/docs/HARNESS_PERFORMANCE.md
+++ b/docs/HARNESS_PERFORMANCE.md
@@ -1,10 +1,12 @@
 # Agent harness performance
 
-`harness_performance` measures the part of latency and memory that Nanocodex
-owns: runtime construction, agent startup, prompt admission, typed event
-delivery, retained history, historical forks, and prompt-cache-preserving
-request construction. It deliberately removes provider, network, sandbox, VM,
-and tool-process variance.
+`harness_performance` measures diagnostic costs that Nanocodex owns: runtime
+construction, agent startup, prompt admission, typed event delivery, retained
+history, historical forks, and prompt-cache-preserving request construction. It
+deliberately removes provider, network, sandbox, VM, and tool-process variance.
+These measurements locate regressions; they are not the product score. The
+latency score and controlled comparison protocol are defined in
+[`MODEL_LATENCY.md`](MODEL_LATENCY.md).
 
 This is the baseline beneath host adapters. A Cloudflare Worker, Vercel
 Workflow, native CLI, or VM-backed consumer may add its own cold-start and
@@ -24,6 +26,19 @@ The default release-profile workload runs in one process on one Tokio worker:
   startup samples; and
 - typed JSON output containing distributions and every audited request shape.
 
+After all timing and RSS sampling, a separate untimed probe builds the real
+default `Tools` registry. It records exact serialized byte counts and stable
+fingerprints for the warmup prefix, default tool declarations, default system
+prompt, first-turn delta, and incremental follow-on delta. Keeping this probe
+outside the timed workload makes the small client-tax measurement useful while
+ensuring that a faster result cannot silently come from removing production
+prompt or tool functionality.
+
+The normalized SHA-256 fingerprints, item counts, tool counts, and deterministic
+byte counts are executable gates, not descriptive snapshots. An intentional
+prompt or default-tool contract change must update those expected values in the
+benchmark together with its review; a stub schema or shortened prompt fails.
+
 Compilation is outside the timed process. RSS is process resident memory from
 the host, so comparisons require the same OS, architecture, allocator, build
 profile, and workload.
@@ -40,6 +55,7 @@ profile, and workload.
 | Fork construction | before `fork_from(checkpoint)` | fork handle and stream returned | checkpoint/history sharing plus child-driver construction |
 | Retained-fork memory | RSS after history | RSS with all forks retained | amortized resident footprint of live forks |
 | Cache eligibility | every scripted request | audited request ledger | stable key/prefix, warmup reuse, incremental chaining, and request bytes |
+| Prompt footprint | default-agent request construction | audited typed request shapes | complete default tools/system prompt and exact first/follow-on wire footprint |
 
 TTFT here is not model TTFT: the scripted service has no inference. It is the
 minimum client-side tax that live provider TTFT sits on top of.
@@ -63,9 +79,14 @@ The benchmark also accepts `--history-turns`, `--prompt-bytes`,
 `--startup-samples`. Keep the default workload for comparisons; change one
 dimension at a time for diagnosis.
 
+`source_commit` is a caller-declared local diagnostic. It does not attest that
+the tree was clean or that an executable came from that tree. The paid paired
+runner performs its own clean-checkout, location, and executable-digest checks.
+
 The process exits unsuccessfully if the cache key changes, a fork unexpectedly
-warms a replacement service, or a generation stops using the expected
-incremental request path.
+warms a replacement service, a generation stops using the expected incremental
+request path, the default `exec`/`wait` tool contract disappears, or the first
+and follow-on prompts stop using their expected typed request shapes.
 
 ## Reference baseline
 
@@ -93,11 +114,12 @@ requests, and no full-history generation replay. The 32-turn history plus 128
 retained forks ended at a median 22.25 MiB process RSS.
 
 The startup clock begins inside process `main`; executable loading before
-`main` is a host/package measurement. Warm page-cache results should not be
-presented as cold package launch time. At this scale, scheduler placement still
-moves agent-build and fork distributions even without provider noise. Compare
-repeated idle-host runs and inspect p50, p95, and maxima rather than treating
-one sample as a product claim.
+`main` is a host/package measurement. Startup, binary size, and RSS remain
+diagnostics rather than model-latency score inputs. Warm page-cache results
+should not be presented as cold package launch time. At this scale, scheduler
+placement still moves agent-build and fork distributions even without provider
+noise. Compare repeated idle-host runs and inspect p50, p95, and maxima rather
+than treating one sample as a product claim.
 
 ## Prompt-cache interpretation
 
@@ -111,10 +133,12 @@ Use the live [`RESPONSE_TRANSPORT_BENCH.md`](RESPONSE_TRANSPORT_BENCH.md) suite
 for cached-input tokens, network TTFT, WebSocket/HTTPS setup, and server-side
 checkpoint behavior. Keep the two result sets separate:
 
-1. this harness attributes SDK startup, scheduling, memory, and fork costs;
-2. a host-adapter benchmark adds Worker/Workflow/WASM/native startup and memory;
-3. a live provider benchmark adds network, queueing, inference, and actual
-   prompt-cache usage.
+1. this harness attributes SDK scheduling and event-path tax while auditing the
+   complete production prompt footprint;
+2. a browser loopback benchmark measures inline-WASM and Worker prompt-to-typed
+   delta tax in real Chromium; and
+3. the live model-latency benchmark adds transport, queueing, inference, and
+   actual prompt-cache usage.
 
 That layering makes regressions actionable and avoids solving provider or
 sandbox variance with adapters in the core agent contract.

--- a/docs/MODEL_LATENCY.md
+++ b/docs/MODEL_LATENCY.md
@@ -1,0 +1,238 @@
+# Model-latency scorecard
+
+Nanocodex has one performance objective: minimize latency from an accepted user
+prompt to the first nonempty semantic model output. A faster result is eligible
+only when the complete agent contract remains intact. Startup time, binary
+size, RSS, and total completion time are useful diagnostics, but they do not
+enter the score.
+
+## Scored boundary
+
+The live cross-product score is provider TTFT:
+
+```text
+full upstream request flushed -> first nonempty semantic SSE delta received
+```
+
+Semantic output includes answer text, refusal text, reasoning text, and
+reasoning-summary text. Empty deltas, lifecycle frames, and output-item shells
+do not stop the clock. First answer-text delta is recorded separately so a
+reasoning-first response cannot be mistaken for user-visible answer latency.
+For Nanocodex alone, the report also records prompt submission and acceptance
+through the first typed `AssistantDelta`, plus the transport-to-typed-event tax.
+
+`response.completed` latency is retained for diagnosis only. It is not blended
+with TTFT, and local startup or memory measurements never compensate for a
+slower model result.
+
+## Correctness eligibility
+
+A latency sample is rejected unless all relevant behavior is preserved:
+
+- fixed `gpt-5.6-sol`, low reasoning effort, non-fast service, and no priority
+  tier;
+- the exact benchmark instructions, prompt, and answer;
+- the real nonempty production tool declarations, with no tool selected by the
+  model for the one-generation workload;
+- one completed model call, contiguous typed events, and exactly one terminal
+  run event;
+- stable prompt/cache identity and the expected incremental history shape;
+- historical-fork boundary preservation, cancellation recovery, and joined
+  shutdown in the browser adapter, plus the repository's exact typed replay
+  regressions at the owning native boundary; and
+- no leaked socket, task, secret, raw authorization header, or credential in a
+  retained report.
+
+The deterministic harness records exact default-system-prompt and default-tool
+wire footprints. The Chromium suite independently gates inline-WASM and Worker
+event order, follow-on history, forks, cancellation, recovery, and socket
+cleanup. Removing instructions, tools, events, history, retries, or cleanup to
+win a timing row therefore makes the row ineligible.
+
+## Three measurement lanes
+
+| Lane | Clock | Purpose |
+| --- | --- | --- |
+| Native deterministic | prompt submission to scripted typed delta | isolates Rust scheduling, request construction, and event projection without provider noise |
+| Real Chromium loopback | browser prompt submission to typed `assistant.delta` | measures inline-WASM and package-Worker client tax with raw browser/server timestamps |
+| Paid live comparison | upstream request flush to first semantic delta | scores actual model latency for Nanocodex and pinned fx on the fixed official route; first-answer and terminal timing remain diagnostics |
+
+The first two lanes are regression evidence, not claims about provider speed.
+The Chromium report records the repository commit/tree, dirty state, and
+SHA-256 hashes of the JavaScript and WebAssembly responses actually served by
+its owned Vite process. The native harness's `source_commit` remains explicitly
+caller-declared. Chromium report encoding and publication happen only after the
+scripted WebSocket listener has closed and verified that no clients remain.
+
+Only the live lane can establish an fx comparison. Nanocodex's native persistent
+WebSocket path remains a separate product diagnostic; fx currently buffers
+`ask --json`, so the paired score holds both clients to the common HTTPS
+Responses route and measures them at the shared streaming observer.
+
+## Controlled fx protocol
+
+The comparison is deliberately product-as-shipped, not an identical-request or
+isolated-client microbenchmark. It pins fx source commit
+`4a8f765c94f4e205ecae293d6d5c98ec9aef2200`, requires clean source checkouts,
+requires each supplied executable to resolve under its checkout, then runs a
+private mode-`0500` copy whose SHA-256 is rechecked before every child. The
+executable digest is authoritative; checkout proximity is not a build
+attestation.
+
+Each executable uses its shipped request builder and default tool surface. The
+comparison deliberately holds transport to the common HTTPS Responses route;
+it does not claim to compare either product's default connection startup.
+
+Before real credential contents are loaded or a provider request can be
+forwarded, the runner executes the exact immutable binary copies twice each
+against a scripted loopback SSE provider with unmistakably fake credentials.
+It then executes Nanocodex twice more with a fake ID token whose nested boolean
+FedRAMP claim is true. In both phases the fake bearer access token deliberately
+carries the opposite claim, so the emitted header proves that policy follows
+the ID token exclusively. These six provider-free runs must succeed from
+distinct private workspaces, including a Nanocodex workspace whose path
+contains every XML metacharacter, use fresh distinct UUIDv7 identities after
+normalizing session and `msg_` wire namespaces to their underlying UUIDs,
+produce stable canonical request fingerprints, and prove that only the
+ID-claim-bearing runs emit the FedRAMP header. The full recursive bodies are
+also checked against independently reviewed fixed hashes for the pinned fx
+ReleaseSafe binary and the reviewed Nanocodex reference, so a candidate cannot
+establish its own weaker contract. This covers every tool
+description/schema/format, ordered context item, shipped fx runtime paragraph,
+and Nanocodex Code Mode metadata entry. Every live request must pass both the
+fixed contract and the actual-binary stability fingerprint before it can
+consume provider budget.
+
+Every run uses:
+
+- one frozen ChatGPT/Codex auth snapshot in private isolated homes; upstream
+  `401` is translated to a non-`401` child failure so neither client can refresh;
+- the exact official Codex Responses HTTPS route, shared auth identity, model,
+  low reasoning effort, standard service tier, benchmark instruction, final
+  user input, and byte-exact ACK answer;
+- fresh clients with no history or `previous_response_id`, complete
+  implementation-specific default tool surfaces, and a fixed Nanocodex prompt
+  cache key for its identical prefix;
+- a pinned loopback fx model catalog served only for fx's exact
+  `/models?client_version=0.148.0` discovery request, with the exact reviewed
+  auth/product header set, exactly once before each fx generation, and
+  explicitly advertising low effort;
+- validated request bodies, exact product user agents, fresh distinct UUIDv7
+  Nanocodex request identities with no cross-namespace or cross-run reuse, and
+  one run-scoped freshness ledger shared by ordinary preflight, FedRAMP
+  preflight, warmup, and measured execution. Requests must be defect-free
+  HTTP/1.1 with exact origin-form request targets and exact
+  per-product/per-endpoint header sets and values. Absolute-form,
+  authority-bearing, query-bearing, and fragment-bearing generation or refresh
+  targets are rejected before claim. Header validation includes the observer
+  `Host`, untrimmed credential values, byte-exact media types, fx's
+  endpoint-specific `Connection` header, Nanocodex's absence of `Connection`,
+  and the reviewed absence of `Accept-Encoding`; every nonempty parser failure,
+  including oversized request lines or headers, is counted exactly once before
+  claim or budget reservation. Valid bodies are then forwarded raw without
+  JSON reserialization or response buffering;
+- a Darwin Seatbelt policy that permits only IPv4 TCP to one unique host-local
+  port; the observer reserves that port on every IPv4 interface and accepts a
+  request only when its local destination is `127.0.0.1`. IPv6, UDP, and
+  child-process creation remain denied while threads are preserved; the parent
+  observer alone can reach the fixed official HTTPS endpoint, and the runner
+  refuses live execution when this combined boundary is unavailable;
+- selector-owned bounded child stdout/stderr, explicit process-group
+  termination and reap verification that retries transient group-signal and
+  wait failures through one deadline, and tracked downstream handlers/upstream
+  sockets that are owned from creation through TCP, TLS, and response handoff,
+  interrupted, and drained to bounded shutdown deadlines before a successful
+  report can be returned or published. Official DNS resolution runs once in a
+  bounded, supervised helper before the observer starts, and every
+  resolved-address TCP-plus-TLS attempt shares one deadline shorter than the
+  shutdown budget;
+- fail-closed SSE delivery: call-shaped or unknown output items, including
+  `tool_search_call`, are withheld before the child can execute them;
+- two discarded warmup pairs, then at least 20 even-count measured pairs with
+  AB/BA order continuing across the warmup boundary; and
+- retained request byte counts/hashes, stable product-specific fingerprints,
+  tool-name hashes, provider timings, cached-input tokens, status, and failure
+  codes, but never raw bodies, headers, client output, or credentials.
+
+The primary summary is explicitly warm: both products must be functionally
+valid, select no tool, have the scored TTFT, and report known positive
+cached-input counts. First-answer and terminal timings are nullable diagnostics
+and never gate the score. Absolute cache counts may differ because removing
+either product's real tools would invalidate the comparison. Exact cache-count
+equality is retained as a stricter sensitivity diagnostic; unknown cache
+telemetry is never considered equal. At least 20 warm-primary pairs are
+required.
+
+Percentiles use nearest rank. Paired delta is `nanocodex - fx`, so a negative
+value favors Nanocodex; differences within one millisecond are descriptive
+ties, and win counts are explicitly non-inferential. The runner stops on the
+first functional failure and exits nonzero for insufficient primary samples,
+changed source/binary provenance, an auth mismatch, refresh attempt, unstable
+request fingerprint, unexpected request, or incomplete schedule.
+The retained document exposes only `time_to_first_model_output` under
+`score.metric` as the machine-readable score; answer and terminal distributions
+are labeled diagnostics. Any nonzero benchmark result is kept in memory for a
+safe failure summary only and is never written to the requested report path.
+Successful publication is one atomic, no-clobber hard-link commit from a
+private mode-`0600` fsynced temporary file. Pre-commit I/O failures leave no
+report; post-commit temporary-name cleanup or stdout notification failures do
+not turn the published success into a failed exit.
+
+## Run the local gates
+
+```sh
+just bench-model-latency-local
+```
+
+This runs the native harness and rebuilds the WASM package before exercising
+inline and Worker paths in real Chromium. Reports can be retained explicitly
+with the environment variables documented by the individual commands.
+
+Before a live run, exercise the exact operator-supplied artifacts through the
+source-controlled six-request provider-free integration gate:
+
+```sh
+just test-model-latency-actual-binaries \
+  /absolute/path/to/pinned/fx-checkout \
+  /absolute/path/to/pinned/fx-checkout/zig-out/bin/fx
+```
+
+The portable unit suite does not discover this test automatically because the
+pinned external fx checkout is not a repository dependency. The live runner
+nevertheless repeats the same immutable-copy preflight mandatorily before it
+loads real credential contents.
+
+## Run the paid live comparison
+
+Build both pinned executables first. Nanocodex's narrow consumer package is:
+
+```sh
+cargo build --release -p nanocodex-model-latency-bench --bin model-latency-bench
+```
+
+On macOS, create the output directory, then invoke:
+
+```sh
+python3 benchmarks/paired_fx_model_latency.py \
+  --fx-source-root /absolute/path/to/pinned/fx-checkout \
+  --fx-bin /absolute/path/to/pinned/fx \
+  --nanocodex-source-root "$PWD" \
+  --nanocodex-bin "$PWD/target/release/model-latency-bench" \
+  --nanocodex-commit "$(git rev-parse HEAD)" \
+  --auth-file "$HOME/.codex/auth.json" \
+  --warmup-pairs 2 \
+  --trials 20 \
+  --output "$PWD/.nanocodex/benchmarks/paired-fx-model-latency.json" \
+  --confirm-paid-live-run
+```
+
+`--confirm-paid-live-run` is mandatory and authorizes real paid provider
+requests. Without it the runner refuses before reading credential contents or
+making a request. Even with confirmation, the actual-binary offline preflight,
+independent request-contract verification, source checks, and egress-boundary
+checks happen before the credential is loaded. The default schedule permits at
+most 44 live
+forwarded provider requests; the six scripted preflight requests are local and
+free. The output path must not already exist. No live provider comparison was
+executed while adding this benchmark; do not claim that Nanocodex beats fx until
+a retained warm-primary run says so.

--- a/examples/model-latency-bench/Cargo.toml
+++ b/examples/model-latency-bench/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "nanocodex-model-latency-bench"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Controlled product-latency consumer for Nanocodex"
+
+[[bin]]
+name = "model-latency-bench"
+path = "../model_latency_bench.rs"
+
+[dependencies]
+eyre.workspace = true
+nanocodex.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
+
+[lints]
+workspace = true

--- a/examples/model_latency_bench.rs
+++ b/examples/model_latency_bench.rs
@@ -1,0 +1,840 @@
+use std::{env, net::IpAddr, path::PathBuf, sync::Arc, time::Duration};
+
+use eyre::{Result, WrapErr, bail, eyre};
+use nanocodex::{
+    AgentEvents, Model, Nanocodex, OpenAi, Thinking, Tools, Turn, TurnResult, TurnUsage,
+    agent::events::{
+        AgentEventKind, AssistantDelta, ModelCallCompleted, ModelCallStarted, RunStarted,
+        RunStatus, RunTerminal, monotonic_now_ns,
+    },
+    oai::{
+        MODEL,
+        auth::{
+            OpenAiAuth, OpenAiAuthError, OpenAiAuthFuture, OpenAiAuthSnapshot, OpenAiAuthSource,
+            load_chatgpt_auth,
+        },
+        responses::Usage,
+        transport::ResponsesTransport,
+    },
+};
+use serde::Serialize;
+use tokio::time::timeout;
+
+const EVENT_STREAM_CLOSE_TIMEOUT: Duration = Duration::from_secs(1);
+const PROMPT_CACHE_KEY: &str = "nanocodex-paired-fx-model-latency-v1";
+
+#[derive(Clone, Copy)]
+enum Transport {
+    WebSocket,
+    Https,
+}
+
+impl Transport {
+    const fn responses(self) -> ResponsesTransport {
+        match self {
+            Self::WebSocket => ResponsesTransport::WebSocket,
+            Self::Https => ResponsesTransport::Https,
+        }
+    }
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::WebSocket => "websocket",
+            Self::Https => "https",
+        }
+    }
+
+    const fn event_name(self) -> &'static str {
+        match self {
+            Self::WebSocket => "responses_websocket_v2",
+            Self::Https => "responses_https_sse",
+        }
+    }
+}
+
+struct Args {
+    cwd: PathBuf,
+    auth_file: PathBuf,
+    api_base_url: String,
+    websocket_url: Option<String>,
+    transport: Transport,
+    instructions: String,
+    prompt: String,
+    expected: String,
+    source_commit: String,
+}
+
+struct StartedTurn {
+    turn: Turn,
+    submitted_ns: u64,
+    accepted_ns: u64,
+}
+
+struct CompletedTurn {
+    result: TurnResult,
+    result_completed_ns: u64,
+    submitted_ns: u64,
+    accepted_ns: u64,
+    events: ObservedEvents,
+}
+
+#[derive(Default)]
+struct ObservedEvents {
+    assistant_text: String,
+    assistant_messages: Vec<String>,
+    assistant_delta_count: usize,
+    event_count: usize,
+    first_sequence: Option<u64>,
+    last_sequence: Option<u64>,
+    first_delta_emitted_ns: Option<u64>,
+    first_delta_received_ns: Option<u64>,
+    first_delta_source_received_ns: Option<u64>,
+    run_started: Vec<RunStarted>,
+    model_calls_started: Vec<ModelCallStarted>,
+    model_calls_completed: Vec<ModelCallCompleted>,
+    run_completed: Option<RunTerminal>,
+}
+
+#[derive(Serialize)]
+struct BenchmarkReport {
+    schema_version: u32,
+    benchmark: &'static str,
+    provenance: Provenance,
+    transport: &'static str,
+    timing_ns: TimingMeasurement,
+    model_call: ModelCallMeasurement,
+    usage: UsageMeasurement,
+    turn_usage: TurnUsageMeasurement,
+    events: EventMeasurement,
+    verified: Verification,
+}
+
+#[derive(Serialize)]
+struct Provenance {
+    implementation: &'static str,
+    source_commit: String,
+    model: &'static str,
+    thinking: &'static str,
+    fast_mode: bool,
+    workspace: String,
+    instructions_fnv1a64: String,
+    prompt_fnv1a64: String,
+    expected_fnv1a64: String,
+    prompt_cache_key_fnv1a64: String,
+}
+
+#[derive(Serialize)]
+struct TimingMeasurement {
+    prompt_submit_to_acceptance: u64,
+    prompt_submit_to_first_assistant_delta_emitted: u64,
+    prompt_acceptance_to_first_assistant_delta_emitted: u64,
+    prompt_submit_to_first_assistant_delta_received: u64,
+    prompt_acceptance_to_first_assistant_delta_received: u64,
+    assistant_delta_emit_to_receive: u64,
+    provider_source_to_assistant_delta_emit: Option<u64>,
+    prompt_submit_to_result_completion: u64,
+    prompt_acceptance_to_result_completion: u64,
+}
+
+#[derive(Serialize)]
+struct ModelCallMeasurement {
+    call_index: u32,
+    attempt: u32,
+    connection_generation: u32,
+    status: String,
+    duration_ns: u64,
+    time_to_first_event_ns: u64,
+    time_to_first_output_ns: Option<u64>,
+    tool_calls: usize,
+}
+
+#[allow(clippy::struct_field_names)]
+#[derive(Serialize)]
+struct UsageMeasurement {
+    reported: bool,
+    input_tokens: u64,
+    cached_input_tokens: u64,
+    cache_write_input_tokens: u64,
+    output_tokens: u64,
+    reasoning_output_tokens: u64,
+    total_tokens: u64,
+}
+
+#[allow(clippy::struct_field_names)]
+#[derive(Serialize)]
+struct TurnUsageMeasurement {
+    input_tokens: u64,
+    cached_input_tokens: u64,
+    cache_write_input_tokens: u64,
+    output_tokens: u64,
+    reasoning_output_tokens: u64,
+    total_tokens: u64,
+}
+
+#[derive(Serialize)]
+struct EventMeasurement {
+    count: usize,
+    first_sequence: u64,
+    last_sequence: u64,
+    assistant_delta_count: usize,
+    sequences_contiguous: bool,
+}
+
+#[derive(Serialize)]
+struct Verification {
+    final_output: bool,
+    assistant_deltas: bool,
+    one_model_call: bool,
+    zero_tool_calls: bool,
+    run_completed: bool,
+    clean_shutdown: bool,
+    auth_refresh_disabled: bool,
+}
+
+struct FrozenChatGptAuth {
+    snapshot: OpenAiAuthSnapshot,
+}
+
+impl OpenAiAuthSource for FrozenChatGptAuth {
+    fn validate(&self) -> Result<(), OpenAiAuthError> {
+        Ok(())
+    }
+
+    fn snapshot(&self) -> OpenAiAuthFuture<'_, Result<OpenAiAuthSnapshot, OpenAiAuthError>> {
+        let snapshot = self.snapshot.clone();
+        Box::pin(async move { Ok(snapshot) })
+    }
+
+    fn recover_unauthorized(
+        &self,
+        _rejected: &OpenAiAuthSnapshot,
+    ) -> OpenAiAuthFuture<'_, Result<(), OpenAiAuthError>> {
+        Box::pin(async {
+            Err(OpenAiAuthError::LoginRequired(Arc::from(
+                "the model-latency benchmark uses one immutable auth snapshot",
+            )))
+        })
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = parse_args()?;
+    let managed_auth = load_chatgpt_auth(&args.auth_file)
+        .wrap_err_with(|| format!("failed to load {}", args.auth_file.display()))?;
+    let auth = OpenAiAuth::managed_chatgpt(Arc::new(FrozenChatGptAuth {
+        snapshot: managed_auth
+            .snapshot()
+            .await
+            .wrap_err("failed to freeze the benchmark auth snapshot")?,
+    }));
+    nanocodex::oai::transport::install_default_rustls_crypto_provider();
+    let http_client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .wrap_err("failed to build the benchmark HTTP client")?;
+    let mut openai = OpenAi::builder(auth)
+        .model(Model::Sol)
+        .thinking(Thinking::Low)
+        .fast_mode(false)
+        .transport(args.transport.responses())
+        .api_base_url(args.api_base_url.clone())
+        .http_client(http_client);
+    if let Some(websocket_url) = &args.websocket_url {
+        openai = openai.websocket_url(websocket_url.clone());
+    }
+    let openai = openai.build()?;
+    let tools = Tools::builder().build()?;
+    let (agent, mut events) = Nanocodex::builder(openai)
+        .model(Model::Sol)
+        .instructions(args.instructions.clone())
+        .thinking(Thinking::Low)
+        .fast_mode(false)
+        .prompt_cache_key(PROMPT_CACHE_KEY)
+        .workspace(&args.cwd)
+        .tools(tools)
+        .build()?;
+
+    let completed = measured_generation(&agent, &mut events, &args.prompt).await;
+    let shutdown = agent.shutdown().await;
+    if let Err(shutdown_error) = shutdown {
+        return match completed {
+            Ok(_) => Err(shutdown_error).wrap_err("agent shutdown failed"),
+            Err(run_error) => Err(eyre!(
+                "benchmark failed: {run_error:#}; agent shutdown also failed: {shutdown_error:#}"
+            )),
+        };
+    }
+    drop(agent);
+    let completed = completed?;
+    require_closed_event_stream(&mut events).await?;
+    let report = finish_report(completed, args)?;
+    println!("{}", serde_json::to_string(&report)?);
+    Ok(())
+}
+
+async fn measured_generation(
+    agent: &Nanocodex,
+    events: &mut AgentEvents,
+    prompt: &str,
+) -> Result<CompletedTurn> {
+    let started = start_prompt(agent, prompt).await?;
+    let submitted_ns = started.submitted_ns;
+    let accepted_ns = started.accepted_ns;
+    let ((result, result_completed_ns), events) =
+        tokio::try_join!(await_result(started.turn), drain_events(events))?;
+    Ok(CompletedTurn {
+        result,
+        result_completed_ns,
+        submitted_ns,
+        accepted_ns,
+        events,
+    })
+}
+
+async fn start_prompt(agent: &Nanocodex, prompt: &str) -> Result<StartedTurn> {
+    let submitted_ns = monotonic_now_ns();
+    let turn = agent.prompt(prompt).await?;
+    Ok(StartedTurn {
+        turn,
+        submitted_ns,
+        accepted_ns: monotonic_now_ns(),
+    })
+}
+
+async fn await_result(turn: Turn) -> Result<(TurnResult, u64)> {
+    let result = turn.result().await?;
+    Ok((result, monotonic_now_ns()))
+}
+
+async fn drain_events(events: &mut AgentEvents) -> Result<ObservedEvents> {
+    let mut observed = ObservedEvents::default();
+    let mut next_sequence = 1_u64;
+    while let Some(timed) = events.recv_timed().await {
+        let received_ns = monotonic_now_ns();
+        let event = timed.event;
+        if event.seq != next_sequence {
+            bail!(
+                "agent event sequence is not contiguous: expected {next_sequence}, got {}",
+                event.seq
+            );
+        }
+        next_sequence = next_sequence
+            .checked_add(1)
+            .ok_or_else(|| eyre!("agent event sequence overflowed"))?;
+        observed.first_sequence.get_or_insert(event.seq);
+        observed.last_sequence = Some(event.seq);
+        observed.event_count += 1;
+
+        match event.kind {
+            AgentEventKind::AssistantDelta => {
+                let delta: AssistantDelta = event.decode_payload()?;
+                if delta.model_call_index != 1 {
+                    bail!(
+                        "assistant delta belonged to model call {}, expected 1",
+                        delta.model_call_index
+                    );
+                }
+                observed.assistant_delta_count += 1;
+                observed.assistant_text.push_str(&delta.text);
+                if !delta.text.is_empty() && observed.first_delta_emitted_ns.is_none() {
+                    observed.first_delta_emitted_ns = Some(timed.timing.emitted_ns);
+                    observed.first_delta_received_ns = Some(received_ns);
+                    observed.first_delta_source_received_ns = timed.timing.source_received_ns;
+                }
+            }
+            AgentEventKind::AssistantMessage => {
+                let message: nanocodex::agent::events::AssistantMessage = event.decode_payload()?;
+                if message.model_call_index != 1 {
+                    bail!(
+                        "assistant message belonged to model call {}, expected 1",
+                        message.model_call_index
+                    );
+                }
+                observed.assistant_messages.push(message.text);
+            }
+            AgentEventKind::RunStarted => {
+                observed.run_started.push(event.decode_payload()?);
+            }
+            AgentEventKind::ModelCallStarted => {
+                observed.model_calls_started.push(event.decode_payload()?);
+            }
+            AgentEventKind::ModelCallCompleted => {
+                let completed: ModelCallCompleted = event.decode_payload()?;
+                if completed.tool_calls != 0 {
+                    bail!(
+                        "latency generation requested {} tool calls",
+                        completed.tool_calls
+                    );
+                }
+                observed.model_calls_completed.push(completed);
+            }
+            AgentEventKind::ToolCall | AgentEventKind::ToolResult => {
+                bail!("latency generation emitted an unexpected tool event");
+            }
+            AgentEventKind::ModelCallFailed => {
+                bail!(
+                    "latency generation emitted model.call.failed: {}",
+                    event.payload.get()
+                );
+            }
+            AgentEventKind::ModelCompactionStarted
+            | AgentEventKind::ModelCompactionCompleted
+            | AgentEventKind::ModelCompactionFailed => {
+                bail!("latency generation unexpectedly entered context compaction");
+            }
+            AgentEventKind::ModelWarmupFailed => {
+                bail!(
+                    "latency generation emitted model.warmup.failed: {}",
+                    event.payload.get()
+                );
+            }
+            AgentEventKind::RunError | AgentEventKind::RunFailed => {
+                bail!(
+                    "latency generation emitted {:?}: {}",
+                    event.kind,
+                    event.payload.get()
+                );
+            }
+            AgentEventKind::RunCompleted => {
+                if observed.run_completed.is_some() {
+                    bail!("latency generation emitted run.completed more than once");
+                }
+                observed.run_completed = Some(event.decode_payload()?);
+                return Ok(observed);
+            }
+            AgentEventKind::ApiEvent
+            | AgentEventKind::ReasoningSummaryDelta
+            | AgentEventKind::RunSteered
+            | AgentEventKind::ModelWarmupStarted
+            | AgentEventKind::ModelWarmupCompleted
+            | AgentEventKind::ModelAttemptStarted
+            | AgentEventKind::ModelAttemptFailed
+            | AgentEventKind::ModelAttemptRetrying
+            | AgentEventKind::ModelConnectionStarted
+            | AgentEventKind::ModelConnectionCompleted
+            | AgentEventKind::ModelConnectionFailed => {}
+        }
+    }
+    Err(eyre!("agent event stream closed before run.completed"))
+}
+
+async fn require_closed_event_stream(events: &mut AgentEvents) -> Result<()> {
+    match timeout(EVENT_STREAM_CLOSE_TIMEOUT, events.recv_timed()).await {
+        Ok(None) => Ok(()),
+        Ok(Some(timed)) => bail!(
+            "agent emitted event sequence {} after run.completed and shutdown",
+            timed.event.seq
+        ),
+        Err(_) => bail!("agent event stream remained open after shutdown"),
+    }
+}
+
+fn finish_report(completed: CompletedTurn, args: Args) -> Result<BenchmarkReport> {
+    if completed.result.final_message() != args.expected {
+        bail!(
+            "unexpected final output: expected {:?}, got {:?}",
+            args.expected,
+            completed.result.final_message()
+        );
+    }
+    if completed.events.assistant_text != args.expected {
+        bail!(
+            "concatenated assistant.delta output differs: expected {:?}, got {:?}",
+            args.expected,
+            completed.events.assistant_text
+        );
+    }
+    let [assistant_message] = completed.events.assistant_messages.as_slice() else {
+        bail!(
+            "latency generation must emit one complete assistant message, observed {}",
+            completed.events.assistant_messages.len()
+        );
+    };
+    if assistant_message != &args.expected {
+        bail!(
+            "complete assistant message differs: expected {:?}, got {:?}",
+            args.expected,
+            assistant_message
+        );
+    }
+    let [run_started] = completed.events.run_started.as_slice() else {
+        bail!(
+            "latency generation must emit one run.started, observed {}",
+            completed.events.run_started.len()
+        );
+    };
+    validate_run_started(run_started, &args)?;
+    let [call_started] = completed.events.model_calls_started.as_slice() else {
+        bail!(
+            "latency generation must start one model call, observed {}",
+            completed.events.model_calls_started.len()
+        );
+    };
+    validate_model_call_started(call_started)?;
+    let [call] = completed.events.model_calls_completed.as_slice() else {
+        bail!(
+            "latency generation must complete one model call, observed {}",
+            completed.events.model_calls_completed.len()
+        );
+    };
+    validate_model_call(call, args.transport)?;
+    let terminal = completed
+        .events
+        .run_completed
+        .as_ref()
+        .ok_or_else(|| eyre!("latency generation did not emit run.completed"))?;
+    validate_terminal(terminal, &args)?;
+
+    let first_delta_emitted_ns = completed
+        .events
+        .first_delta_emitted_ns
+        .ok_or_else(|| eyre!("latency generation completed without assistant.delta"))?;
+    let first_delta_received_ns = completed
+        .events
+        .first_delta_received_ns
+        .ok_or_else(|| eyre!("latency generation did not receive assistant.delta"))?;
+    let first_sequence = completed
+        .events
+        .first_sequence
+        .ok_or_else(|| eyre!("latency generation emitted no events"))?;
+    let last_sequence = completed
+        .events
+        .last_sequence
+        .ok_or_else(|| eyre!("latency generation emitted no events"))?;
+
+    let timing_ns = TimingMeasurement {
+        prompt_submit_to_acceptance: elapsed_ns(
+            completed.accepted_ns,
+            completed.submitted_ns,
+            "prompt acceptance",
+        )?,
+        prompt_submit_to_first_assistant_delta_emitted: elapsed_ns(
+            first_delta_emitted_ns,
+            completed.submitted_ns,
+            "first assistant.delta emission from prompt submission",
+        )?,
+        prompt_acceptance_to_first_assistant_delta_emitted: elapsed_ns(
+            first_delta_emitted_ns,
+            completed.accepted_ns,
+            "first assistant.delta emission from prompt acceptance",
+        )?,
+        prompt_submit_to_first_assistant_delta_received: elapsed_ns(
+            first_delta_received_ns,
+            completed.submitted_ns,
+            "first assistant.delta receipt from prompt submission",
+        )?,
+        prompt_acceptance_to_first_assistant_delta_received: elapsed_ns(
+            first_delta_received_ns,
+            completed.accepted_ns,
+            "first assistant.delta receipt from prompt acceptance",
+        )?,
+        assistant_delta_emit_to_receive: elapsed_ns(
+            first_delta_received_ns,
+            first_delta_emitted_ns,
+            "first assistant.delta delivery",
+        )?,
+        provider_source_to_assistant_delta_emit: completed
+            .events
+            .first_delta_source_received_ns
+            .map(|source_ns| {
+                elapsed_ns(
+                    first_delta_emitted_ns,
+                    source_ns,
+                    "provider source to assistant.delta emission",
+                )
+            })
+            .transpose()?,
+        prompt_submit_to_result_completion: elapsed_ns(
+            completed.result_completed_ns,
+            completed.submitted_ns,
+            "result completion from prompt submission",
+        )?,
+        prompt_acceptance_to_result_completion: elapsed_ns(
+            completed.result_completed_ns,
+            completed.accepted_ns,
+            "result completion from prompt acceptance",
+        )?,
+    };
+    let usage = UsageMeasurement::from_provider(call.usage.as_ref());
+    let turn_usage = TurnUsageMeasurement::from_turn(completed.result.usage());
+    Ok(BenchmarkReport {
+        schema_version: 1,
+        benchmark: "paired_fx_model_latency",
+        provenance: Provenance {
+            implementation: "nanocodex",
+            source_commit: args.source_commit,
+            model: MODEL,
+            thinking: Thinking::Low.as_str(),
+            fast_mode: false,
+            workspace: args.cwd.display().to_string(),
+            instructions_fnv1a64: fnv1a64(args.instructions.as_bytes()),
+            prompt_fnv1a64: fnv1a64(args.prompt.as_bytes()),
+            expected_fnv1a64: fnv1a64(args.expected.as_bytes()),
+            prompt_cache_key_fnv1a64: fnv1a64(PROMPT_CACHE_KEY.as_bytes()),
+        },
+        transport: args.transport.as_str(),
+        timing_ns,
+        model_call: ModelCallMeasurement {
+            call_index: call.call_index,
+            attempt: call.attempt,
+            connection_generation: call.connection_generation,
+            status: call.status.clone(),
+            duration_ns: call.duration_ns,
+            time_to_first_event_ns: call.time_to_first_event_ns,
+            time_to_first_output_ns: call.time_to_first_output_ns,
+            tool_calls: call.tool_calls,
+        },
+        usage,
+        turn_usage,
+        events: EventMeasurement {
+            count: completed.events.event_count,
+            first_sequence,
+            last_sequence,
+            assistant_delta_count: completed.events.assistant_delta_count,
+            sequences_contiguous: true,
+        },
+        verified: Verification {
+            final_output: true,
+            assistant_deltas: true,
+            one_model_call: true,
+            zero_tool_calls: true,
+            run_completed: true,
+            clean_shutdown: true,
+            auth_refresh_disabled: true,
+        },
+    })
+}
+
+fn validate_run_started(started: &RunStarted, args: &Args) -> Result<()> {
+    if started.model != MODEL
+        || started.effort != Thinking::Low.as_str()
+        || started.transport != args.transport.event_name()
+        || started.instruction_bytes != args.prompt.len()
+    {
+        bail!("run.started does not match the fixed benchmark configuration");
+    }
+    Ok(())
+}
+
+fn validate_model_call_started(started: &ModelCallStarted) -> Result<()> {
+    if started.call_index != 1 || started.model != MODEL || started.effort != Thinking::Low.as_str()
+    {
+        bail!("model.call.started does not match the fixed benchmark generation");
+    }
+    Ok(())
+}
+
+fn validate_model_call(call: &ModelCallCompleted, transport: Transport) -> Result<()> {
+    let expected_connection_generation = match transport {
+        Transport::Https => 0,
+        Transport::WebSocket => 1,
+    };
+    if call.call_index != 1
+        || call.attempt != 1
+        || call.connection_generation != expected_connection_generation
+        || call.model != MODEL
+        || call.status != "completed"
+    {
+        bail!("model.call.completed does not describe one completed {MODEL} generation");
+    }
+    if call.tool_calls != 0 {
+        bail!(
+            "latency generation completed {} tool calls",
+            call.tool_calls
+        );
+    }
+    Ok(())
+}
+
+fn validate_terminal(terminal: &RunTerminal, args: &Args) -> Result<()> {
+    if terminal.status != RunStatus::Completed
+        || terminal.model != MODEL
+        || terminal.effort != Thinking::Low.as_str()
+        || terminal.transport != args.transport.event_name()
+        || terminal.metrics.model_calls != 1
+        || terminal.metrics.tool_calls != 0
+    {
+        bail!("run.completed does not match the fixed one-generation benchmark");
+    }
+    Ok(())
+}
+
+impl UsageMeasurement {
+    fn from_provider(usage: Option<&Usage>) -> Self {
+        Self {
+            reported: usage.is_some(),
+            input_tokens: usage.map_or(0, |usage| usage.input_tokens),
+            cached_input_tokens: usage
+                .and_then(|usage| usage.input_tokens_details.as_ref())
+                .map_or(0, |details| details.cached_tokens),
+            cache_write_input_tokens: usage
+                .and_then(|usage| usage.input_tokens_details.as_ref())
+                .map_or(0, |details| details.cache_write_tokens),
+            output_tokens: usage.map_or(0, |usage| usage.output_tokens),
+            reasoning_output_tokens: usage
+                .and_then(|usage| usage.output_tokens_details.as_ref())
+                .map_or(0, |details| details.reasoning_tokens),
+            total_tokens: usage.map_or(0, |usage| usage.total_tokens),
+        }
+    }
+}
+
+impl TurnUsageMeasurement {
+    const fn from_turn(usage: &TurnUsage) -> Self {
+        Self {
+            input_tokens: usage.input_tokens(),
+            cached_input_tokens: usage.cached_input_tokens(),
+            cache_write_input_tokens: usage.cache_write_input_tokens(),
+            output_tokens: usage.output_tokens(),
+            reasoning_output_tokens: usage.reasoning_output_tokens(),
+            total_tokens: usage.total_tokens(),
+        }
+    }
+}
+
+fn elapsed_ns(later: u64, earlier: u64, label: &str) -> Result<u64> {
+    later
+        .checked_sub(earlier)
+        .ok_or_else(|| eyre!("monotonic timestamp moved backwards while measuring {label}"))
+}
+
+fn parse_args() -> Result<Args> {
+    let mut cwd = None;
+    let mut auth_file = None;
+    let mut api_base_url = None;
+    let mut websocket_url = None;
+    let mut transport = None;
+    let mut instructions = None;
+    let mut prompt = None;
+    let mut expected = None;
+    let mut source_commit = None;
+    let mut arguments = env::args().skip(1);
+    while let Some(flag) = arguments.next() {
+        let mut value = || {
+            arguments
+                .next()
+                .ok_or_else(|| eyre!("{flag} requires a value"))
+        };
+        match flag.as_str() {
+            "--cwd" => set_once(&mut cwd, PathBuf::from(value()?), &flag)?,
+            "--auth-file" => set_once(&mut auth_file, PathBuf::from(value()?), &flag)?,
+            "--api-base-url" => set_once(&mut api_base_url, value()?, &flag)?,
+            "--websocket-url" => set_once(&mut websocket_url, value()?, &flag)?,
+            "--transport" => {
+                let parsed = match value()?.as_str() {
+                    "websocket" => Transport::WebSocket,
+                    "https" => Transport::Https,
+                    other => {
+                        bail!("invalid --transport value {other:?}; expected websocket or https")
+                    }
+                };
+                set_once(&mut transport, parsed, &flag)?;
+            }
+            "--instructions" => set_once(&mut instructions, value()?, &flag)?,
+            "--prompt" => set_once(&mut prompt, value()?, &flag)?,
+            "--expected" => set_once(&mut expected, value()?, &flag)?,
+            "--source-commit" => set_once(&mut source_commit, value()?, &flag)?,
+            _ => bail!("unknown argument {flag:?}"),
+        }
+    }
+
+    let transport = transport.unwrap_or(Transport::Https);
+    if matches!(transport, Transport::Https) && websocket_url.is_some() {
+        bail!("--websocket-url requires --transport websocket");
+    }
+    if matches!(transport, Transport::WebSocket) && websocket_url.is_none() {
+        bail!("--transport websocket requires an explicit loopback --websocket-url");
+    }
+    let cwd = required(cwd, "--cwd")?
+        .canonicalize()
+        .wrap_err("failed to canonicalize --cwd")?;
+    if !cwd.is_dir() {
+        bail!("--cwd must name a directory");
+    }
+    let auth_file = required(auth_file, "--auth-file")?
+        .canonicalize()
+        .wrap_err("failed to canonicalize --auth-file")?;
+    if !auth_file.is_file() {
+        bail!("--auth-file must name a file");
+    }
+    let api_base_url = require_loopback_url(
+        required_nonempty(api_base_url, "--api-base-url")?,
+        "--api-base-url",
+        "http",
+    )?;
+    let websocket_url = optional_nonempty(websocket_url, "--websocket-url")?
+        .map(|value| require_loopback_url(value, "--websocket-url", "ws"))
+        .transpose()?;
+    Ok(Args {
+        cwd,
+        auth_file,
+        api_base_url,
+        websocket_url,
+        transport,
+        instructions: required_nonempty(instructions, "--instructions")?,
+        prompt: required_nonempty(prompt, "--prompt")?,
+        expected: required_nonempty(expected, "--expected")?,
+        source_commit: required_nonempty(source_commit, "--source-commit")?,
+    })
+}
+
+fn set_once<T>(slot: &mut Option<T>, value: T, flag: &str) -> Result<()> {
+    if slot.replace(value).is_some() {
+        bail!("{flag} may be supplied only once");
+    }
+    Ok(())
+}
+
+fn required<T>(value: Option<T>, flag: &str) -> Result<T> {
+    value.ok_or_else(|| eyre!("missing required argument {flag}"))
+}
+
+fn required_nonempty(value: Option<String>, flag: &str) -> Result<String> {
+    let value = required(value, flag)?;
+    if value.trim().is_empty() {
+        bail!("{flag} must not be empty");
+    }
+    Ok(value)
+}
+
+fn optional_nonempty(value: Option<String>, flag: &str) -> Result<Option<String>> {
+    value
+        .map(|value| {
+            if value.trim().is_empty() {
+                bail!("{flag} must not be empty");
+            }
+            Ok(value)
+        })
+        .transpose()
+}
+
+fn require_loopback_url(value: String, flag: &str, scheme: &str) -> Result<String> {
+    let parsed =
+        reqwest::Url::parse(&value).wrap_err_with(|| format!("{flag} must be a valid URL"))?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| eyre!("{flag} must include a host"))?;
+    let loopback = host
+        .parse::<IpAddr>()
+        .is_ok_and(|address| address.is_loopback());
+    if parsed.scheme() != scheme
+        || !loopback
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+    {
+        bail!("{flag} must be a credential-free {scheme} URL on a numeric loopback IP address");
+    }
+    Ok(value)
+}
+
+fn fnv1a64(bytes: &[u8]) -> String {
+    let mut digest = 0xcbf2_9ce4_8422_2325_u64;
+    for byte in bytes {
+        digest ^= u64::from(*byte);
+        digest = digest.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{digest:016x}")
+}

--- a/examples/react-vite/browser-model-latency.html
+++ b/examples/react-vite/browser-model-latency.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Nanocodex browser model latency</title>
+  </head>
+  <body>
+    <script type="module" src="/src/browserModelLatency.ts"></script>
+  </body>
+</html>

--- a/examples/react-vite/e2e/browser-model-latency.spec.mjs
+++ b/examples/react-vite/e2e/browser-model-latency.spec.mjs
@@ -1,0 +1,409 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+
+import { test } from "@playwright/test";
+import { WebSocketServer } from "ws";
+
+const SAMPLE_COUNT = integerEnvironment("NANOCODEX_BROWSER_SAMPLES", 8, 2);
+const REPOSITORY_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const SOURCE_COMMIT = git("rev-parse", "HEAD");
+const SOURCE_TREE = git("rev-parse", "HEAD^{tree}");
+const SOURCE_DIRTY = git("status", "--porcelain=v1", "--untracked-files=all").length > 0;
+
+test("real Chromium reports inline and package-Worker model latency", async ({ page }) => {
+  const server = await ScriptedResponsesServer.start(SAMPLE_COUNT);
+  const external = [];
+  const servedAssetPromises = [];
+  page.on("request", (request) => {
+    if (!isLoopback(request.url())) external.push(request.url());
+  });
+  page.on("websocket", (socket) => {
+    if (!isLoopback(socket.url())) external.push(socket.url());
+  });
+  page.on("response", (response) => {
+    const contentType = response.headers()["content-type"] ?? "";
+    if (
+      isLoopback(response.url())
+      && (contentType.includes("javascript") || contentType.includes("application/wasm"))
+    ) {
+      servedAssetPromises.push(response.body().then((body) => ({
+        path: new URL(response.url()).pathname,
+        content_type: contentType,
+        sha256: createHash("sha256").update(body).digest("hex"),
+      })));
+    }
+  });
+
+  try {
+    await page.goto("/browser-model-latency.html");
+    await page.waitForFunction(() => typeof window.runNanocodexBrowserModelLatency === "function");
+    const report = await page.evaluate(
+      ({ endpoint, samples, declaredSourceCommit }) => window.runNanocodexBrowserModelLatency({
+        endpoint,
+        samples,
+        declaredSourceCommit,
+      }),
+      {
+        endpoint: server.endpoint,
+        samples: SAMPLE_COUNT,
+        declaredSourceCommit: SOURCE_COMMIT,
+      },
+    );
+    const servedAssets = deduplicateAssets(await Promise.all(servedAssetPromises));
+    assert.ok(
+      servedAssets.some((asset) => asset.content_type.includes("javascript")),
+      "benchmark did not retain any served JavaScript asset hash",
+    );
+    assert.ok(
+      servedAssets.some((asset) => asset.content_type.includes("application/wasm")),
+      "benchmark did not retain its served WebAssembly asset hash",
+    );
+    report.provenance = {
+      source_commit: SOURCE_COMMIT,
+      source_tree: SOURCE_TREE,
+      source_dirty: SOURCE_DIRTY,
+      served_assets: servedAssets,
+    };
+
+    await server.waitForCleanup();
+    server.assertComplete(report);
+    assert.deepEqual(external, [], `benchmark attempted non-loopback requests: ${external.join(", ")}`);
+    assert.equal(report.schema_version, 1);
+    assert.equal(report.implementation, "nanocodex-browser-model-latency");
+    assert.equal(report.declared_source_commit, SOURCE_COMMIT);
+
+    await publishAfterServerClose(server, async () => {
+      const encoded = `${JSON.stringify(report, null, 2)}\n`;
+      const output = process.env.NANOCODEX_BROWSER_REPORT;
+      if (output) {
+        const path = resolve(output);
+        await mkdir(dirname(path), { recursive: true });
+        await writeFile(path, encoded, "utf8");
+      }
+      console.log(JSON.stringify(report));
+    });
+  } catch (error) {
+    server.rethrowFailure();
+    throw error;
+  } finally {
+    await server.close();
+  }
+});
+
+test("listener close failure prevents benchmark report publication", async () => {
+  const closeFailure = new Error("injected listener close failure");
+  let verified = false;
+  let published = false;
+  const server = {
+    close: async () => {
+      throw closeFailure;
+    },
+    assertClosed: () => {
+      verified = true;
+    },
+  };
+
+  await assert.rejects(
+    publishAfterServerClose(server, async () => {
+      published = true;
+    }),
+    (error) => error === closeFailure,
+  );
+  assert.equal(verified, false);
+  assert.equal(published, false);
+});
+
+class ScriptedResponsesServer {
+  static async start(sampleCount) {
+    const instance = new ScriptedResponsesServer(sampleCount);
+    await new Promise((resolveListening, reject) => {
+      instance.server.once("listening", resolveListening);
+      instance.server.once("error", reject);
+    });
+    return instance;
+  }
+
+  constructor(sampleCount) {
+    this.sampleCount = sampleCount;
+    this.server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    this.closePromise = undefined;
+    this.failure = undefined;
+    this.records = new Map();
+    this.state = Object.fromEntries(["inline", "worker"].map((runtime) => [runtime, {
+      cancelSocket: undefined,
+      cancelSocketClosed: false,
+      cancellationConnectionReplaced: false,
+      cancelValidated: false,
+      followOnValidated: false,
+      forkValidated: false,
+      recoveryValidated: false,
+      samples: 0,
+    }]));
+    this.server.on("connection", (socket) => {
+      socket.on("message", (data) => this.handle(socket, data));
+      socket.on("close", () => {
+        if (socket.cancelRuntime) this.state[socket.cancelRuntime].cancelSocketClosed = true;
+      });
+      socket.on("error", (error) => this.fail(error));
+    });
+    this.server.on("error", (error) => this.fail(error));
+  }
+
+  get endpoint() {
+    const address = this.server.address();
+    assert.equal(typeof address, "object");
+    return `ws://127.0.0.1:${address.port}`;
+  }
+
+  handle(socket, data) {
+    const requestReceivedUs = epochMicroseconds();
+    try {
+      const request = JSON.parse(data.toString("utf8"));
+      const encoded = JSON.stringify(request.input);
+      const runtime = encoded.includes("BENCH_INLINE_") ? "inline"
+        : encoded.includes("BENCH_WORKER_") ? "worker"
+          : undefined;
+      assert.ok(runtime, `unrecognized benchmark request: ${encoded}`);
+      if (encoded.includes(`BENCH_${runtime.toUpperCase()}_RECOVER`)) {
+        this.handleRecovery(socket, runtime, request, encoded, requestReceivedUs);
+      } else if (encoded.includes(`BENCH_${runtime.toUpperCase()}_CANCEL`)) {
+        this.handleCancellation(socket, runtime, request, requestReceivedUs);
+      } else if (encoded.includes(`BENCH_${runtime.toUpperCase()}_FORK`)) {
+        this.handleFork(socket, runtime, request, encoded, requestReceivedUs);
+      } else {
+        this.handleSample(socket, runtime, request, encoded, requestReceivedUs);
+      }
+    } catch (error) {
+      this.fail(error);
+    }
+  }
+
+  handleSample(socket, runtime, request, encoded, requestReceivedUs) {
+    const matches = [...encoded.matchAll(new RegExp(`BENCH_${runtime.toUpperCase()}_SAMPLE_(\\d+)`, "g"))];
+    assert.equal(matches.length, 1, `${runtime} request did not contain one current sample marker`);
+    const ordinal = Number(matches[0][1]);
+    assert.equal(ordinal, this.state[runtime].samples, `${runtime} samples arrived out of order`);
+    if (ordinal === 0) {
+      assert.equal(request.previous_response_id, undefined);
+    } else {
+      assert.equal(request.previous_response_id, `${runtime}-response-${ordinal - 1}`);
+      assert.equal(request.input.length, 1, `${runtime} follow-on did not send only its delta`);
+      assert.ok(!encoded.includes(`BENCH_${runtime.toUpperCase()}_SAMPLE_${ordinal - 1}`));
+      this.state[runtime].followOnValidated = true;
+    }
+    const id = `${runtime}-sample-${ordinal}`;
+    const finalText = `${runtime.toUpperCase()}_SAMPLE_${ordinal}_OK`;
+    this.sendCompleted(socket, {
+      eventId: id,
+      finalText,
+      requestReceivedUs,
+      responseId: `${runtime}-response-${ordinal}`,
+    });
+    this.state[runtime].samples += 1;
+  }
+
+  handleFork(socket, runtime, request, encoded, requestReceivedUs) {
+    assert.equal(request.previous_response_id, undefined, `${runtime} historical fork leaked a response id`);
+    assert.ok(encoded.includes(`BENCH_${runtime.toUpperCase()}_SAMPLE_0`));
+    assert.ok(encoded.includes(`${runtime.toUpperCase()}_SAMPLE_0_OK`));
+    assert.ok(!encoded.includes(`BENCH_${runtime.toUpperCase()}_SAMPLE_1`));
+    assert.ok(!encoded.includes(`${runtime.toUpperCase()}_SAMPLE_1_OK`));
+    this.state[runtime].forkValidated = true;
+    this.sendCompleted(socket, {
+      eventId: `${runtime}-fork`,
+      finalText: `${runtime.toUpperCase()}_FORK_OK`,
+      requestReceivedUs,
+      responseId: `${runtime}-fork-response`,
+    });
+  }
+
+  handleCancellation(socket, runtime, request, requestReceivedUs) {
+    assert.equal(
+      request.previous_response_id,
+      `${runtime}-response-${this.sampleCount - 1}`,
+      `${runtime} cancellation did not continue the retained response chain`,
+    );
+    assert.equal(this.state[runtime].cancelSocket, undefined, `${runtime} opened more than one cancellation socket`);
+    this.state[runtime].cancelSocket = socket;
+    socket.cancelRuntime = runtime;
+    this.state[runtime].cancelValidated = true;
+    this.sendDelta(socket, {
+      eventId: `${runtime}-cancel`,
+      finalText: `${runtime.toUpperCase()}_CANCEL_PARTIAL`,
+      requestReceivedUs,
+    });
+  }
+
+  handleRecovery(socket, runtime, request, encoded, requestReceivedUs) {
+    assert.equal(
+      this.state[runtime].cancelSocketClosed,
+      true,
+      `${runtime} recovery began before cancellation closed its in-flight socket`,
+    );
+    assert.notEqual(
+      socket,
+      this.state[runtime].cancelSocket,
+      `${runtime} recovery reused the cancelled in-flight socket`,
+    );
+    this.state[runtime].cancellationConnectionReplaced = true;
+    assert.equal(request.previous_response_id, undefined, `${runtime} recovery did not replay after cancellation`);
+    assert.ok(encoded.includes(`BENCH_${runtime.toUpperCase()}_CANCEL`));
+    assert.ok(encoded.includes(`BENCH_${runtime.toUpperCase()}_RECOVER`));
+    assert.ok(encoded.includes("<turn_aborted>"));
+    assert.ok(!encoded.includes(`${runtime.toUpperCase()}_CANCEL_PARTIAL`));
+    this.state[runtime].recoveryValidated = true;
+    this.sendCompleted(socket, {
+      eventId: `${runtime}-recover`,
+      finalText: `${runtime.toUpperCase()}_RECOVERED_OK`,
+      requestReceivedUs,
+      responseId: `${runtime}-recovered-response`,
+    });
+  }
+
+  sendDelta(socket, { eventId, finalText, requestReceivedUs }) {
+    const template = JSON.stringify({
+      type: "response.output_text.delta",
+      output_index: 0,
+      content_index: 0,
+      delta: finalText,
+      benchmark: {
+        id: eventId,
+        request_received_epoch_us: requestReceivedUs,
+        response_delta_sent_epoch_us: "__NANOCODEX_SEND_EPOCH_US__",
+      },
+    });
+    const sentUs = epochMicroseconds();
+    const payload = template.replace('"__NANOCODEX_SEND_EPOCH_US__"', String(sentUs));
+    this.records.set(eventId, { requestReceivedUs, sentUs });
+    socket.send(payload);
+  }
+
+  sendCompleted(socket, { eventId, finalText, requestReceivedUs, responseId }) {
+    this.sendDelta(socket, { eventId, finalText, requestReceivedUs });
+    socket.send(JSON.stringify({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: {
+        id: `${responseId}-message`,
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text: finalText }],
+      },
+    }));
+    socket.send(JSON.stringify({
+      type: "response.completed",
+      response: {
+        id: responseId,
+        status: "completed",
+        output: [],
+        usage: null,
+      },
+    }));
+  }
+
+  async waitForCleanup() {
+    const deadline = performance.now() + 5_000;
+    while (this.server.clients.size > 0) {
+      this.rethrowFailure();
+      if (performance.now() >= deadline) {
+        assert.fail(`${this.server.clients.size} benchmark WebSocket(s) remained after shutdown`);
+      }
+      await new Promise((resolveWait) => setTimeout(resolveWait, 10));
+    }
+  }
+
+  assertComplete(report) {
+    this.rethrowFailure();
+    for (const runtime of ["inline", "worker"]) {
+      const state = this.state[runtime];
+      assert.equal(state.samples, this.sampleCount);
+      assert.equal(state.followOnValidated, true);
+      assert.equal(state.forkValidated, true);
+      assert.equal(state.cancelValidated, true);
+      assert.equal(state.cancelSocketClosed, true);
+      assert.equal(state.cancellationConnectionReplaced, true);
+      assert.equal(state.recoveryValidated, true);
+      assert.equal(report.runtimes[runtime].raw_samples.length, this.sampleCount);
+      for (const sample of report.runtimes[runtime].raw_samples) {
+        const recorded = this.records.get(sample.id);
+        assert.ok(recorded, `server did not record ${sample.id}`);
+        assert.equal(sample.server_request_received_epoch_us, recorded.requestReceivedUs);
+        assert.equal(sample.server_delta_sent_epoch_us, recorded.sentUs);
+      }
+      for (const distribution of Object.values(report.runtimes[runtime].distributions)) {
+        assert.equal(distribution.n, this.sampleCount);
+      }
+    }
+  }
+
+  fail(error) {
+    this.failure ??= error instanceof Error ? error : new Error(String(error));
+    for (const socket of this.server.clients) socket.terminate();
+  }
+
+  rethrowFailure() {
+    if (this.failure) throw this.failure;
+  }
+
+  assertClosed() {
+    this.rethrowFailure();
+    assert.equal(this.server.address(), null, "benchmark WebSocket listener remained open after close");
+    assert.equal(this.server.clients.size, 0, "benchmark WebSocket clients remained after close");
+  }
+
+  close() {
+    if (this.closePromise === undefined) {
+      this.closePromise = new Promise((resolveClose, reject) => {
+        for (const socket of this.server.clients) socket.terminate();
+        this.server.close((error) => error ? reject(error) : resolveClose());
+      });
+    }
+    return this.closePromise;
+  }
+}
+
+async function publishAfterServerClose(server, publish) {
+  await server.close();
+  server.assertClosed();
+  await publish();
+}
+
+function epochMicroseconds() {
+  return Math.round((performance.timeOrigin + performance.now()) * 1_000);
+}
+
+function isLoopback(value) {
+  const hostname = new URL(value).hostname;
+  return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "[::1]";
+}
+
+function integerEnvironment(name, fallback, minimum) {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const value = Number(raw);
+  assert.ok(Number.isSafeInteger(value) && value >= minimum, `${name} must be an integer >= ${minimum}`);
+  return value;
+}
+
+function git(...args) {
+  return execFileSync("git", ["-C", REPOSITORY_ROOT, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function deduplicateAssets(assets) {
+  const byIdentity = new Map();
+  for (const asset of assets) {
+    byIdentity.set(`${asset.path}\0${asset.sha256}`, asset);
+  }
+  return [...byIdentity.values()].sort((left, right) => (
+    left.path.localeCompare(right.path) || left.sha256.localeCompare(right.sha256)
+  ));
+}

--- a/examples/react-vite/package-lock.json
+++ b/examples/react-vite/package-lock.json
@@ -25,7 +25,8 @@
         "@vitejs/plugin-react": "6.0.2",
         "typescript": "5.9.3",
         "vite": "8.1.5",
-        "wrangler": "^4.112.0"
+        "wrangler": "^4.112.0",
+        "ws": "^8.18.3"
       }
     },
     "../../js/bindings": {

--- a/examples/react-vite/package.json
+++ b/examples/react-vite/package.json
@@ -13,6 +13,7 @@
     "deploy": "npm run build && wrangler deploy",
     "test": "node --test worker/*.test.mjs && node --experimental-strip-types --test test/*.test.ts",
     "test:e2e": "playwright test",
+    "bench:browser:model": "playwright test -c playwright.browser-model.config.ts e2e/browser-model-latency.spec.mjs",
     "test:e2e:mpp": "LIVE_MPP_E2E=1 playwright test --headed --grep 'live browser MPP'"
   },
   "dependencies": {
@@ -33,6 +34,7 @@
     "@vitejs/plugin-react": "6.0.2",
     "typescript": "5.9.3",
     "vite": "8.1.5",
-    "wrangler": "^4.112.0"
+    "wrangler": "^4.112.0",
+    "ws": "^8.18.3"
   }
 }

--- a/examples/react-vite/playwright.browser-model.config.ts
+++ b/examples/react-vite/playwright.browser-model.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "@playwright/test";
+
+import base from "./playwright.config";
+
+const { channel: _channel, ...use } = base.use ?? {};
+
+export default defineConfig({
+  ...base,
+  use,
+  webServer: base.webServer
+    ? { ...base.webServer, reuseExistingServer: false }
+    : undefined,
+});

--- a/examples/react-vite/src/browserModelLatency.ts
+++ b/examples/react-vite/src/browserModelLatency.ts
@@ -1,0 +1,658 @@
+import { Agent as WorkerAgent, Transport as WorkerTransport } from "nanocodex/browser";
+import { Agent as InlineAgent, Transport as InlineTransport } from "nanocodex/host";
+import type {
+  AgentEvent,
+  DefaultAgent,
+  EventWatcher,
+  Turn,
+  TurnResult,
+} from "nanocodex/host";
+
+type RuntimeKind = "inline" | "worker";
+
+type BenchmarkOptions = {
+  endpoint: string;
+  samples: number;
+  declaredSourceCommit: string;
+};
+
+type ServerTiming = {
+  id: string;
+  requestReceivedEpochUs: number;
+  responseDeltaSentEpochUs: number;
+};
+
+type RawSample = {
+  id: string;
+  ordinal: number;
+  connection: "initial" | "reused";
+  client_submit_epoch_us: number;
+  server_request_received_epoch_us: number;
+  server_delta_sent_epoch_us: number;
+  client_raw_api_event_received_epoch_us: number;
+  client_typed_delta_received_epoch_us: number;
+  client_turn_result_received_epoch_us: number;
+  submit_to_raw_api_event_ns: number;
+  raw_api_event_to_typed_event_ns: number;
+  server_request_to_delta_send_ns: number;
+  submit_to_typed_event_ns: number;
+  submit_to_turn_result_ns: number;
+};
+
+type Distribution = {
+  n: number;
+  min_ns: number;
+  p50_ns: number;
+  p95_ns: number;
+  max_ns: number;
+  mean_ns: number;
+};
+
+type RuntimeReport = {
+  raw_samples: RawSample[];
+  distributions: {
+    submit_to_raw_api_event: Distribution;
+    raw_api_event_to_typed_event: Distribution;
+    server_request_to_delta_send: Distribution;
+    submit_to_typed_event: Distribution;
+    submit_to_turn_result: Distribution;
+  };
+};
+
+export type BrowserModelLatencyReport = {
+  schema_version: 1;
+  implementation: "nanocodex-browser-model-latency";
+  declared_source_commit: string;
+  browser: { user_agent: string };
+  clock: {
+    timestamp_unit: "microseconds";
+    duration_unit: "nanoseconds";
+    browser: string;
+    server: string;
+    cross_realm_timestamps: string;
+    boundaries: Record<string, string>;
+  };
+  sample_count_per_runtime: number;
+  runtimes: Record<RuntimeKind, RuntimeReport>;
+  correctness_gates: {
+    exact_final_output: true;
+    typed_event_order: true;
+    incremental_follow_on: true;
+    historical_fork_boundary: true;
+    cancellation: true;
+    graceful_shutdown: true;
+    loopback_only: true;
+  };
+};
+
+declare global {
+  interface Window {
+    runNanocodexBrowserModelLatency(
+      options: BenchmarkOptions,
+    ): Promise<BrowserModelLatencyReport>;
+  }
+}
+
+window.runNanocodexBrowserModelLatency = runBenchmark;
+
+async function runBenchmark(options: BenchmarkOptions): Promise<BrowserModelLatencyReport> {
+  validateOptions(options);
+  const inline = await runRuntime("inline", options);
+  const worker = await runRuntime("worker", options);
+  return {
+    schema_version: 1,
+    implementation: "nanocodex-browser-model-latency",
+    declared_source_commit: options.declaredSourceCommit,
+    browser: { user_agent: navigator.userAgent },
+    clock: {
+      timestamp_unit: "microseconds",
+      duration_unit: "nanoseconds",
+      browser: "Math.round((performance.timeOrigin + performance.now()) * 1000)",
+      server: "Math.round((performance.timeOrigin + performance.now()) * 1000) in Node.js",
+      cross_realm_timestamps: "retained for audit only and never subtracted; every reported duration uses one realm's clock",
+      boundaries: {
+        client_submit: "immediately before agent.turn.prompt",
+        server_request_received: "entry to the ws message callback with the complete request frame",
+        server_delta_sent: "immediately before timestamp insertion and WebSocket.send",
+        client_raw_api_event_received: "entry to the AgentEvent api.event listener for the delta frame",
+        client_typed_delta_received: "entry to the AgentEvent assistant.delta listener",
+        client_turn_result_received: "first promise continuation after turn.result resolves",
+      },
+    },
+    sample_count_per_runtime: options.samples,
+    runtimes: { inline, worker },
+    correctness_gates: {
+      exact_final_output: true,
+      typed_event_order: true,
+      incremental_follow_on: true,
+      historical_fork_boundary: true,
+      cancellation: true,
+      graceful_shutdown: true,
+      loopback_only: true,
+    },
+  };
+}
+
+async function runRuntime(
+  runtime: RuntimeKind,
+  options: BenchmarkOptions,
+): Promise<RuntimeReport> {
+  const turns = new Set<Turn>();
+  const results = new Set<TurnResult>();
+  const agents = new Set<DefaultAgent>();
+  const rawSamples: RawSample[] = [];
+  let tracker: TypedEventTracker | undefined;
+  let firstResult: TurnResult | undefined;
+
+  try {
+    const agent = await createAgent(runtime, options.endpoint);
+    agents.add(agent);
+    tracker = new TypedEventTracker(agent);
+    for (let ordinal = 0; ordinal < options.samples; ordinal += 1) {
+      const id = `${runtime}-sample-${ordinal}`;
+      const finalText = `${runtime.toUpperCase()}_SAMPLE_${ordinal}_OK`;
+      const eventStart = tracker.length;
+      const delta = tracker.expectDelta(id, finalText);
+      const submittedUs = epochMicroseconds();
+      const turn = agent.turn.prompt({
+        input: `BENCH_${runtime.toUpperCase()}_SAMPLE_${ordinal}`,
+      });
+      turns.add(turn);
+      const resultPromise = turn.result().then((result) => ({
+        receivedUs: epochMicroseconds(),
+        result,
+      }));
+      const [typedDelta, completed] = await Promise.all([delta, resultPromise]);
+      invariant(completed.result.finalMessage === finalText, `${id} returned the wrong final text`);
+      results.add(completed.result);
+      await tracker.assertCompletedTurn(eventStart, id, finalText);
+      rawSamples.push(sample(
+        id,
+        ordinal,
+        submittedUs,
+        typedDelta.rawEventReceivedUs,
+        typedDelta.receivedUs,
+        completed.receivedUs,
+        typedDelta.server,
+      ));
+      turn.dispose();
+      turns.delete(turn);
+      if (ordinal === 0) {
+        firstResult = completed.result;
+      } else {
+        completed.result.dispose();
+        results.delete(completed.result);
+      }
+    }
+
+    invariant(firstResult !== undefined, `${runtime} did not retain its first result`);
+    const branch = await agent.session.fork({ at: firstResult });
+    agents.add(branch);
+    await checkedTurn(
+      branch,
+      `BENCH_${runtime.toUpperCase()}_FORK`,
+      `${runtime.toUpperCase()}_FORK_OK`,
+      `${runtime}-fork`,
+      tracker,
+      turns,
+      results,
+    );
+    await shutdown(branch);
+    agents.delete(branch);
+
+    const cancelledEventStart = tracker.length;
+    const cancelledId = `${runtime}-cancel`;
+    const partialText = `${runtime.toUpperCase()}_CANCEL_PARTIAL`;
+    const partial = tracker.expectDelta(cancelledId, partialText);
+    const cancelled = agent.turn.prompt({
+      input: `BENCH_${runtime.toUpperCase()}_CANCEL`,
+    });
+    turns.add(cancelled);
+    await partial;
+    await cancelled.cancel();
+    let cancelledResultRejected = false;
+    try {
+      await cancelled.result();
+    } catch {
+      cancelledResultRejected = true;
+    }
+    invariant(cancelledResultRejected, `${runtime} cancellation resolved a TurnResult`);
+    await tracker.assertCancelledTurn(cancelledEventStart, cancelledId, partialText);
+    cancelled.dispose();
+    turns.delete(cancelled);
+
+    await checkedTurn(
+      agent,
+      `BENCH_${runtime.toUpperCase()}_RECOVER`,
+      `${runtime.toUpperCase()}_RECOVERED_OK`,
+      `${runtime}-recover`,
+      tracker,
+      turns,
+      results,
+    );
+
+    firstResult.dispose();
+    results.delete(firstResult);
+    tracker.off();
+    await shutdown(agent);
+    agents.delete(agent);
+    return runtimeReport(rawSamples);
+  } finally {
+    await cleanupRuntime(runtime, tracker, results, turns, agents);
+  }
+}
+
+async function cleanupRuntime(
+  runtime: RuntimeKind,
+  tracker: TypedEventTracker | undefined,
+  results: Set<TurnResult>,
+  turns: Set<Turn>,
+  agents: Set<DefaultAgent>,
+): Promise<void> {
+  const failures: unknown[] = [];
+  try {
+    tracker?.off();
+  } catch (error) {
+    failures.push(error);
+  }
+  for (const result of results) {
+    try {
+      result.dispose();
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  for (const turn of turns) {
+    try {
+      await turn.cancel();
+    } catch (error) {
+      failures.push(error);
+    }
+    try {
+      turn.dispose();
+    } catch (error) {
+      failures.push(error);
+    }
+  }
+  const shutdowns = await Promise.allSettled([...agents].map(shutdown));
+  for (const outcome of shutdowns) {
+    if (outcome.status === "rejected") failures.push(outcome.reason);
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, `${runtime} agent cleanup failed`);
+  }
+}
+
+async function createAgent(runtime: RuntimeKind, endpoint: string): Promise<DefaultAgent> {
+  const connection = {
+    apiKey: "loopback-benchmark",
+    websocketPreconnect: false,
+    websocketUrl: endpoint,
+    websocketWarmup: false,
+  };
+  const common = {
+    instructions: "Return only the exact scripted benchmark token.",
+    mcp: false as const,
+    thinking: "none" as const,
+  };
+  if (runtime === "inline") {
+    return InlineAgent.create({
+      ...common,
+      transport: InlineTransport.openAi(connection),
+    });
+  }
+  return WorkerAgent.create({
+    ...common,
+    harness: false,
+    transport: WorkerTransport.openAi(connection),
+  });
+}
+
+async function checkedTurn(
+  agent: DefaultAgent,
+  prompt: string,
+  finalText: string,
+  benchmarkId: string,
+  tracker: TypedEventTracker,
+  turns: Set<Turn>,
+  results: Set<TurnResult>,
+): Promise<void> {
+  const eventStart = tracker.length;
+  const turn = agent.turn.prompt({ input: prompt });
+  turns.add(turn);
+  const result = await turn.result();
+  results.add(result);
+  invariant(result.finalMessage === finalText, `${prompt} returned the wrong final text`);
+  await tracker.assertCompletedTurn(eventStart, benchmarkId, finalText);
+  result.dispose();
+  results.delete(result);
+  turn.dispose();
+  turns.delete(turn);
+}
+
+async function shutdown(agent: DefaultAgent): Promise<void> {
+  const failures: unknown[] = [];
+  try {
+    await agent.session.shutdown();
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    agent.dispose();
+  } catch (error) {
+    failures.push(error);
+  }
+  if (failures.length > 0) {
+    throw new AggregateError(failures, "browser agent shutdown failed");
+  }
+}
+
+class TypedEventTracker {
+  readonly events: Array<{
+    benchmarkId?: string;
+    event: AgentEvent;
+    observedUs: number;
+    text?: string;
+  }> = [];
+  readonly metadata = new Map<string, {
+    rawEventReceivedUs: number;
+    server: ServerTiming;
+  }>();
+  readonly waiters = new Map<string, {
+    id: string;
+    reject(error: Error): void;
+    resolve(value: {
+      rawEventReceivedUs: number;
+      receivedUs: number;
+      server: ServerTiming;
+    }): void;
+  }>();
+  readonly watch: EventWatcher;
+
+  constructor(agent: DefaultAgent) {
+    this.watch = agent.events.watch({ includeAllSessions: true });
+    this.watch.onEvent((event) => this.observe(event));
+  }
+
+  get length(): number {
+    return this.events.length;
+  }
+
+  expectDelta(
+    id: string,
+    text: string,
+  ): Promise<{
+    rawEventReceivedUs: number;
+    receivedUs: number;
+    server: ServerTiming;
+  }> {
+    invariant(!this.waiters.has(text), `duplicate delta waiter for ${text}`);
+    return new Promise((resolve, reject) => {
+      this.waiters.set(text, { id, reject, resolve });
+    });
+  }
+
+  async assertCompletedTurn(start: number, id: string, text: string): Promise<void> {
+    await eventually(() => this.events.slice(start).some(({ event }) => event.type === "run.completed"));
+    await settleEventDelivery();
+    const events = this.events.slice(start);
+    assertOneRequest(events, id);
+    assertContiguousSequence(events, id);
+    const raw = onlyIndex(events, (entry) => entry.benchmarkId === id, `${id} raw api.event`);
+    const delta = onlyIndex(
+      events,
+      (entry) => entry.event.type === "assistant.delta",
+      `${id} assistant.delta`,
+    );
+    const message = onlyIndex(
+      events,
+      (entry) => entry.event.type === "assistant.message",
+      `${id} assistant.message`,
+    );
+    const completed = onlyIndex(
+      events,
+      (entry) => entry.event.type === "run.completed" || entry.event.type === "run.failed",
+      `${id} terminal event`,
+    );
+    invariant(events[delta].text === text, `${id} assistant.delta text differed`);
+    invariant(events[message].text === text, `${id} assistant.message text differed`);
+    assertModelCall(events[delta], id);
+    assertModelCall(events[message], id);
+    invariant(events[completed].event.type === "run.completed", `${id} did not complete successfully`);
+    invariant(completed === events.length - 1, `${id} emitted an event after its terminal`);
+    invariant(
+      !events.some(({ event }) => event.type === "tool.call" || event.type === "tool.result"),
+      `${id} emitted a tool event`,
+    );
+    invariant(raw >= 0 && raw < delta, `${id} did not preserve api.event -> assistant.delta order`);
+    invariant(delta < message && message < completed, `${id} did not preserve typed completion order`);
+  }
+
+  async assertCancelledTurn(start: number, id: string, partialText: string): Promise<void> {
+    await eventually(() => this.events.slice(start).some(({ event }) => event.type === "run.failed"));
+    await settleEventDelivery();
+    const events = this.events.slice(start);
+    assertOneRequest(events, id);
+    assertContiguousSequence(events, id);
+    const raw = onlyIndex(events, (entry) => entry.benchmarkId === id, `${id} raw api.event`);
+    const delta = onlyIndex(
+      events,
+      (entry) => entry.event.type === "assistant.delta",
+      `${id} assistant.delta`,
+    );
+    const failed = onlyIndex(
+      events,
+      (entry) => entry.event.type === "run.completed" || entry.event.type === "run.failed",
+      `${id} terminal event`,
+    );
+    invariant(events[delta].text === partialText, `${id} partial assistant.delta text differed`);
+    assertModelCall(events[delta], id);
+    invariant(raw < delta, `${id} did not preserve api.event -> assistant.delta order`);
+    invariant(delta >= 0 && delta < failed, "cancelled run.failed did not follow its typed partial delta");
+    invariant(events[failed].event.payload.status === "cancelled", "run.failed did not report cancellation");
+    invariant(events[failed].event.type === "run.failed", `${id} emitted the wrong terminal kind`);
+    invariant(failed === events.length - 1, `${id} emitted an event after its terminal`);
+    invariant(
+      !events.some(({ event }) => event.type === "assistant.message"),
+      `${id} emitted a completed assistant message`,
+    );
+  }
+
+  off(): void {
+    this.watch.off();
+  }
+
+  private observe(event: AgentEvent): void {
+    const observedUs = epochMicroseconds();
+    const timing = event.type === "api.event" ? serverTiming(event.payload.event) : undefined;
+    if (timing) {
+      this.metadata.set(timing.id, {
+        rawEventReceivedUs: observedUs,
+        server: timing,
+      });
+    }
+    const text = typeof event.payload.text === "string" ? event.payload.text : undefined;
+    this.events.push({
+      ...(timing ? { benchmarkId: timing.id } : {}),
+      event,
+      observedUs,
+      ...(text === undefined ? {} : { text }),
+    });
+    if (event.type !== "assistant.delta" || text === undefined) return;
+    const waiter = this.waiters.get(text);
+    if (!waiter) return;
+    this.waiters.delete(text);
+    const metadata = this.metadata.get(waiter.id);
+    if (!metadata) {
+      waiter.reject(new Error(`${waiter.id} assistant.delta arrived before its raw api.event`));
+      return;
+    }
+    waiter.resolve({
+      rawEventReceivedUs: metadata.rawEventReceivedUs,
+      receivedUs: observedUs,
+      server: metadata.server,
+    });
+  }
+}
+
+function serverTiming(value: unknown): ServerTiming | undefined {
+  const event = typeof value === "string" ? parseJson(value) : value;
+  if (!event || typeof event !== "object") return undefined;
+  const benchmark = (event as Record<string, unknown>).benchmark;
+  if (!benchmark || typeof benchmark !== "object") return undefined;
+  const fields = benchmark as Record<string, unknown>;
+  if (
+    typeof fields.id !== "string"
+    || typeof fields.request_received_epoch_us !== "number"
+    || typeof fields.response_delta_sent_epoch_us !== "number"
+  ) return undefined;
+  return {
+    id: fields.id,
+    requestReceivedEpochUs: fields.request_received_epoch_us,
+    responseDeltaSentEpochUs: fields.response_delta_sent_epoch_us,
+  };
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return undefined;
+  }
+}
+
+function sample(
+  id: string,
+  ordinal: number,
+  submittedUs: number,
+  rawEventReceivedUs: number,
+  typedDeltaUs: number,
+  resultUs: number,
+  server: ServerTiming,
+): RawSample {
+  invariant(server.id === id, `${id} received timing for ${server.id}`);
+  invariant(rawEventReceivedUs >= submittedUs, `${id} raw api.event preceded prompt submission`);
+  invariant(typedDeltaUs >= rawEventReceivedUs, `${id} typed delta preceded its raw api.event`);
+  invariant(resultUs >= typedDeltaUs, `${id} TurnResult preceded its typed delta`);
+  invariant(
+    server.responseDeltaSentEpochUs >= server.requestReceivedEpochUs,
+    `${id} server send preceded request receipt`,
+  );
+  return {
+    id,
+    ordinal,
+    connection: ordinal === 0 ? "initial" : "reused",
+    client_submit_epoch_us: submittedUs,
+    server_request_received_epoch_us: server.requestReceivedEpochUs,
+    server_delta_sent_epoch_us: server.responseDeltaSentEpochUs,
+    client_raw_api_event_received_epoch_us: rawEventReceivedUs,
+    client_typed_delta_received_epoch_us: typedDeltaUs,
+    client_turn_result_received_epoch_us: resultUs,
+    submit_to_raw_api_event_ns: toNanoseconds(rawEventReceivedUs - submittedUs),
+    raw_api_event_to_typed_event_ns: toNanoseconds(typedDeltaUs - rawEventReceivedUs),
+    server_request_to_delta_send_ns: toNanoseconds(
+      server.responseDeltaSentEpochUs - server.requestReceivedEpochUs,
+    ),
+    submit_to_typed_event_ns: toNanoseconds(typedDeltaUs - submittedUs),
+    submit_to_turn_result_ns: toNanoseconds(resultUs - submittedUs),
+  };
+}
+
+function runtimeReport(rawSamples: RawSample[]): RuntimeReport {
+  return {
+    raw_samples: rawSamples,
+    distributions: {
+      submit_to_raw_api_event: distribution(rawSamples.map((entry) => entry.submit_to_raw_api_event_ns)),
+      raw_api_event_to_typed_event: distribution(
+        rawSamples.map((entry) => entry.raw_api_event_to_typed_event_ns),
+      ),
+      server_request_to_delta_send: distribution(
+        rawSamples.map((entry) => entry.server_request_to_delta_send_ns),
+      ),
+      submit_to_typed_event: distribution(rawSamples.map((entry) => entry.submit_to_typed_event_ns)),
+      submit_to_turn_result: distribution(rawSamples.map((entry) => entry.submit_to_turn_result_ns)),
+    },
+  };
+}
+
+function distribution(values: number[]): Distribution {
+  invariant(values.length > 0, "latency distribution requires samples");
+  const sorted = [...values].sort((left, right) => left - right);
+  return {
+    n: sorted.length,
+    min_ns: sorted[0],
+    p50_ns: percentile(sorted, 0.5),
+    p95_ns: percentile(sorted, 0.95),
+    max_ns: sorted[sorted.length - 1],
+    mean_ns: Math.round(sorted.reduce((total, value) => total + value, 0) / sorted.length),
+  };
+}
+
+function percentile(sorted: number[], quantile: number): number {
+  return sorted[Math.max(0, Math.ceil(sorted.length * quantile) - 1)];
+}
+
+function assertOneRequest(
+  entries: Array<{ event: AgentEvent }>,
+  id: string,
+): void {
+  const requestIds = new Set(entries.map((entry) => entry.event.request_id));
+  invariant(requestIds.size === 1, `${id} mixed events from more than one session`);
+}
+
+function assertContiguousSequence(entries: Array<{ event: AgentEvent }>, id: string): void {
+  const sequence = entries.map((entry) => entry.event.seq);
+  invariant(
+    sequence.every((value, index) => index === 0 || value === sequence[index - 1] + 1),
+    `${id} event sequence is not contiguous`,
+  );
+}
+
+function onlyIndex<T>(entries: T[], predicate: (entry: T) => boolean, label: string): number {
+  const matches = entries.flatMap((entry, index) => predicate(entry) ? [index] : []);
+  invariant(matches.length === 1, `${label} count was ${matches.length}, expected one`);
+  return matches[0];
+}
+
+function assertModelCall(entry: { event: AgentEvent }, id: string): void {
+  invariant(entry.event.payload.model_call_index === 1, `${id} used the wrong model call index`);
+}
+
+async function settleEventDelivery(): Promise<void> {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function eventually(predicate: () => boolean): Promise<void> {
+  const deadline = performance.now() + 5_000;
+  while (!predicate()) {
+    if (performance.now() >= deadline) throw new Error("timed out waiting for typed event delivery");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+function validateOptions(options: BenchmarkOptions): void {
+  const endpoint = new URL(options.endpoint);
+  invariant(endpoint.protocol === "ws:", "browser model benchmark requires ws loopback");
+  invariant(
+    endpoint.hostname === "127.0.0.1" || endpoint.hostname === "localhost" || endpoint.hostname === "[::1]",
+    "browser model benchmark refuses a non-loopback endpoint",
+  );
+  invariant(Number.isSafeInteger(options.samples) && options.samples >= 2, "samples must be an integer >= 2");
+  invariant(
+    /^[0-9a-f]{40}$/.test(options.declaredSourceCommit),
+    "declaredSourceCommit must be a full Git commit",
+  );
+}
+
+function epochMicroseconds(): number {
+  return Math.round((performance.timeOrigin + performance.now()) * 1_000);
+}
+
+function toNanoseconds(microseconds: number): number {
+  return Math.round(microseconds * 1_000);
+}
+
+function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}

--- a/py/bindings/tests/test_runtime.py
+++ b/py/bindings/tests/test_runtime.py
@@ -136,7 +136,7 @@ for agent in agents:
 deadline = time.monotonic() + 2
 while True:
     after = threads()
-    if during - after >= len(agents) or time.monotonic() >= deadline:
+    if after - before <= 5 or time.monotonic() >= deadline:
         break
     time.sleep(0.01)
 print(json.dumps({{"before": before, "during": during, "after": after}}))
@@ -149,7 +149,10 @@ print(json.dumps({{"before": before, "during": during, "after": after}}))
             )
             self.assertEqual(server.connection_count, 8)
         counts = json.loads(completed.stdout)
-        self.assertEqual(
+        # Plain-text prompts deliberately avoid the blocking pool. Bound
+        # transient thread growth without requiring avoidable worker threads.
+        self.assertLessEqual(counts["after"], counts["during"], counts)
+        self.assertLessEqual(
             counts["during"] - counts["after"],
             8,
             counts,


### PR DESCRIPTION
## Summary

- remove avoidable work from the production model event path without changing tools, prompts, history, events, retry, cancellation, fork, or shutdown behavior
- add exact prompt-footprint gates and a native deterministic model-path benchmark
- add real Chromium inline-WASM and Worker latency lanes with functionality and listener-close gates
- add a controlled pinned-fx comparison whose sole score is full upstream request flush to first nonempty semantic SSE output
- fail closed on request-contract, UUID freshness, tool-call, source integrity, process/socket teardown, credential-refresh, and report-publication failures

Stacked on #199.

## Evidence

- `just bench-model-latency-local`
  - native warm submit-to-first-delta p50: 55.0 microseconds
  - reused Chromium inline p50: 0.4 milliseconds
  - reused Chromium Worker p50: 0.5 milliseconds
  - 90 provider-free runner tests and 2 Chromium tests passed
  - clean committed provenance at `10c84aac`
- pinned fx plus release Nanocodex six-request actual-binary preflight passed with zero provider traffic and stable fixed request fingerprints
- warnings-denied Clippy passed for affected libraries, harness benchmark, and model-latency consumer
- rustfmt, crate-boundary policy, focused plain-text and durability regressions, and independent stop-ship reviews passed

No paid or provider call was made. This PR makes no fx winner claim; that remains gated on an explicitly authorized retained warm-primary live run.