### PR TITLE
fix(js): reject credentialed tool redirects

### DIFF
--- a/js/bindings/test/tools.test.mjs
+++ b/js/bindings/test/tools.test.mjs
@@ -47,6 +47,7 @@ test("web forwards the complete command object through a caller-owned host adapt
     session_id: "session-1",
   });
   assert.equal(requests[0].init.headers.authorization, "Bearer host");
+  assert.equal(requests[0].init.redirect, "error");
   assert.equal(requests[0].init.signal, context.signal);
   assert.deepEqual(tool.parameters.properties.search_query.items.required, ["q"]);
   assert.deepEqual(tool.parameters.properties.response_length.enum, ["short", "medium", "long"]);

--- a/js/bindings/tools/standard.mjs
+++ b/js/bindings/tools/standard.mjs
@@ -201,6 +201,9 @@ function jsonRequester(options, defaultUrl) {
       method: "POST",
       headers,
       body: JSON.stringify(body),
+      // These adapters commonly carry caller-owned bearer credentials.
+      // Never let fetch forward them to a redirect target.
+      redirect: "error",
       signal,
     });
     const payload = await response.json().catch(() => undefined);


### PR DESCRIPTION
JSON-backed standard tools can carry caller-owned bearer credentials. Prevent fetch from following redirects so those headers cannot be forwarded to another origin.

- set `redirect: "error"` on shared JSON tool requests
- cover the authenticated adapter request options

Validation:
- `node --test test/tools.test.mjs`
- `git diff --check`