### PR TITLE
feat(js): add reusable Vite integration

### DIFF
--- a/examples/react-vite/src/worker.ts
+++ b/examples/react-vite/src/worker.ts
@@ -78,22 +78,8 @@ async function createAgent(data: StartMessage) {
   return {
     agent: await Agent.create({
       ...common,
-      transport: Transport.openAi({
-        apiKey: "worker-managed",
-        websocketUrl: workerEndpoint(),
-        createWebSocket: (endpoint: string, sessionId: string) => {
-          const url = new URL(endpoint);
-          url.searchParams.set("session_id", sessionId);
-          return new WebSocket(url);
-        },
-      }),
     }),
   };
-}
-
-function workerEndpoint(): string {
-  const protocol = self.location.protocol === "https:" ? "wss:" : "ws:";
-  return `${protocol}//${self.location.host}/api/responses`;
 }
 
 function errorMessage(error: unknown): string {

--- a/examples/react-vite/vite.config.ts
+++ b/examples/react-vite/vite.config.ts
@@ -1,12 +1,12 @@
-import { cloudflare } from "@cloudflare/vite-plugin";
 import react from "@vitejs/plugin-react";
 import { fileURLToPath } from "node:url";
+import { nanocodex } from "nanocodex/vite/cloudflare";
 import { defineConfig } from "vite";
 
 const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
 
 export default defineConfig({
-  plugins: [react(), cloudflare()],
+  plugins: [react(), nanocodex()],
   build: {
     manifest: true,
   },

--- a/examples/react-vite/worker/index.mjs
+++ b/examples/react-vite/worker/index.mjs
@@ -1,5 +1,5 @@
 import {
-  DEFAULT_RESPONSES_UPGRADE_URL,
+  modelConnection,
   upstreamHeaders,
   validateWebSocketRequest,
 } from "./protocol.mjs";
@@ -8,10 +8,12 @@ export default {
   async fetch(request, env) {
     const rejection = validateWebSocketRequest(request);
     if (rejection) return rejection;
-    if (!env.OPENAI_API_KEY) return new Response("Worker secret is not configured", { status: 500 });
+    const connection = modelConnection(env);
+    if (connection instanceof Response) return connection;
+    const sessionId = new URL(request.url).searchParams.get("session_id");
 
-    const upstreamResponse = await fetch(DEFAULT_RESPONSES_UPGRADE_URL, {
-      headers: upstreamHeaders(env.OPENAI_API_KEY, new URL(request.url).searchParams.get("session_id")),
+    const upstreamResponse = await fetch(connection.url, {
+      headers: upstreamHeaders(connection.credential, sessionId),
     });
     const upstream = upstreamResponse.webSocket;
     if (!upstream) {
@@ -24,6 +26,7 @@ export default {
     upstream.accept();
     server.accept();
     bridge(server, upstream);
+    server.send(JSON.stringify({ type: "nanocodex.proxy.ready" }));
 
     return new Response(null, { status: 101, webSocket: client });
   },

--- a/examples/react-vite/worker/protocol.mjs
+++ b/examples/react-vite/worker/protocol.mjs
@@ -1,4 +1,5 @@
 export const DEFAULT_RESPONSES_UPGRADE_URL = "https://api.openai.com/v1/responses";
+export const CHATGPT_RESPONSES_PATH = "/backend-api/codex/responses";
 
 const RESPONSES_WEBSOCKETS_BETA = "responses_websockets=2026-02-06";
 
@@ -15,18 +16,89 @@ export function validateWebSocketRequest(request) {
   return undefined;
 }
 
-export function upstreamHeaders(apiKey, sessionId) {
+export function upstreamHeaders(credential, sessionId) {
+  const bearer = credential.kind === "chatgpt" ? credential.accessToken : credential.apiKey;
   return {
     Upgrade: "websocket",
-    Authorization: `Bearer ${apiKey}`,
+    Authorization: `Bearer ${bearer}`,
     "OpenAI-Beta": RESPONSES_WEBSOCKETS_BETA,
+    originator: "codex_cli_rs",
     "x-openai-internal-codex-responses-lite": "true",
     "session-id": sessionId,
     "thread-id": sessionId,
     "x-client-request-id": sessionId,
     "x-responsesapi-include-timing-metrics": "true",
-    "User-Agent": "nanocodex-react-vite/0.1.0",
+    "User-Agent": "codex_cli_rs/0.0.0",
+    ...(credential.kind === "chatgpt" ? {
+      "ChatGPT-Account-ID": credential.accountId,
+      ...(credential.fedramp ? { "X-OpenAI-Fedramp": "true" } : {}),
+    } : {}),
   };
+}
+
+export function modelConnection(env) {
+  const local = localChatGptCredential(env);
+  if (local instanceof Response) return local;
+  if (local) {
+    const endpoint = localEgressUrl(env.NANOCODEX_DEV_CHATGPT_EGRESS_URL);
+    if (endpoint instanceof Response) return endpoint;
+    return {
+      credential: local,
+      url: new URL(`.${CHATGPT_RESPONSES_PATH}`, endpoint).href,
+    };
+  }
+  if (typeof env.OPENAI_API_KEY !== "string" || !env.OPENAI_API_KEY.trim()) {
+    return new Response("Worker credential is not configured", { status: 500 });
+  }
+  return {
+    credential: { kind: "api_key", apiKey: env.OPENAI_API_KEY.trim() },
+    url: DEFAULT_RESPONSES_UPGRADE_URL,
+  };
+}
+
+function localChatGptCredential(env) {
+  if (env.ENVIRONMENT !== "development") return undefined;
+  const values = [
+    env.NANOCODEX_DEV_CHATGPT_ACCESS_TOKEN,
+    env.NANOCODEX_DEV_CHATGPT_ACCOUNT_ID,
+    env.NANOCODEX_DEV_CHATGPT_FEDRAMP,
+    env.NANOCODEX_DEV_CHATGPT_EXPIRES_AT,
+    env.NANOCODEX_DEV_CHATGPT_EGRESS_URL,
+    env.NANOCODEX_DEV_CHATGPT_SESSION_ID,
+  ];
+  if (values.every((value) => typeof value !== "string" || !value.trim())) return undefined;
+  const accessToken = env.NANOCODEX_DEV_CHATGPT_ACCESS_TOKEN?.trim();
+  const accountId = env.NANOCODEX_DEV_CHATGPT_ACCOUNT_ID?.trim();
+  const fedramp = env.NANOCODEX_DEV_CHATGPT_FEDRAMP?.trim().toLowerCase();
+  const expiresAt = Number(env.NANOCODEX_DEV_CHATGPT_EXPIRES_AT);
+  if (!accessToken || !accountId || !["true", "false"].includes(fedramp) || !Number.isSafeInteger(expiresAt)) {
+    return new Response("Local ChatGPT credential is incomplete", { status: 500 });
+  }
+  if (expiresAt <= Date.now() + 5 * 60_000) {
+    return new Response("Local ChatGPT login expires too soon; run codex login", { status: 503 });
+  }
+  return { kind: "chatgpt", accessToken, accountId, fedramp: fedramp === "true" };
+}
+
+function localEgressUrl(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    return new Response("Local ChatGPT egress is unavailable", { status: 500 });
+  }
+  if (
+    url.protocol !== "http:"
+    || url.hostname !== "127.0.0.1"
+    || url.username
+    || url.password
+    || !/^\/[A-Za-z0-9_-]{43}\/$/.test(url.pathname)
+    || url.search
+    || url.hash
+  ) {
+    return new Response("Local ChatGPT egress is invalid", { status: 500 });
+  }
+  return url;
 }
 
 function sameOrigin(request, url) {

--- a/examples/react-vite/worker/protocol.test.mjs
+++ b/examples/react-vite/worker/protocol.test.mjs
@@ -1,16 +1,50 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { upstreamHeaders, validateWebSocketRequest } from "./protocol.mjs";
+import { modelConnection, upstreamHeaders, validateWebSocketRequest } from "./protocol.mjs";
 
 test("the Worker adds the secret and stable session headers upstream", () => {
-  const headers = upstreamHeaders("worker-secret", "browser-session");
+  const headers = upstreamHeaders({ kind: "api_key", apiKey: "worker-secret" }, "browser-session");
   assert.equal(headers.Authorization, "Bearer worker-secret");
   assert.equal(headers.Upgrade, "websocket");
   assert.equal(headers["OpenAI-Beta"], "responses_websockets=2026-02-06");
   assert.equal(headers["x-openai-internal-codex-responses-lite"], "true");
   assert.equal(headers["session-id"], "browser-session");
   assert.equal(headers["thread-id"], "browser-session");
+});
+
+test("local Vite auth keeps ChatGPT credentials behind the Worker", () => {
+  const expiresAt = Date.now() + 60 * 60_000;
+  const connection = modelConnection({
+    ENVIRONMENT: "development",
+    NANOCODEX_DEV_CHATGPT_ACCESS_TOKEN: "local-access",
+    NANOCODEX_DEV_CHATGPT_ACCOUNT_ID: "account-123",
+    NANOCODEX_DEV_CHATGPT_FEDRAMP: "false",
+    NANOCODEX_DEV_CHATGPT_EXPIRES_AT: String(expiresAt),
+    NANOCODEX_DEV_CHATGPT_EGRESS_URL: `http://127.0.0.1:43123/${"e".repeat(43)}/`,
+    NANOCODEX_DEV_CHATGPT_SESSION_ID: "s".repeat(43),
+  });
+  assert.equal(connection.url,
+    `http://127.0.0.1:43123/${"e".repeat(43)}/backend-api/codex/responses`);
+  const headers = upstreamHeaders(connection.credential, "browser-session");
+  assert.equal(headers.Authorization, "Bearer local-access");
+  assert.equal(headers["ChatGPT-Account-ID"], "account-123");
+  assert.equal(Object.hasOwn(headers, "X-OpenAI-Fedramp"), false);
+});
+
+test("production ignores local Vite credential bindings", () => {
+  const connection = modelConnection({
+    ENVIRONMENT: "production",
+    OPENAI_API_KEY: "production-key",
+    NANOCODEX_DEV_CHATGPT_ACCESS_TOKEN: "must-be-ignored",
+    NANOCODEX_DEV_CHATGPT_ACCOUNT_ID: "must-be-ignored",
+    NANOCODEX_DEV_CHATGPT_FEDRAMP: "false",
+    NANOCODEX_DEV_CHATGPT_EXPIRES_AT: String(Date.now() + 60 * 60_000),
+    NANOCODEX_DEV_CHATGPT_EGRESS_URL: `http://127.0.0.1:43123/${"e".repeat(43)}/`,
+    NANOCODEX_DEV_CHATGPT_SESSION_ID: "s".repeat(43),
+  });
+  assert.equal(connection.credential.kind, "api_key");
+  assert.equal(connection.credential.apiKey, "production-key");
 });
 
 test("the Worker accepts only same-origin WebSocket upgrades with valid sessions", () => {

--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -340,19 +340,43 @@ const agent = await Agent.create({
 ```
 
 `browser(...)` runs in a browser Worker because OPFS is a browser capability;
-use the individual factories in server-side Cloudflare Workers. Vite consumers
-install the package-owned SSH compatibility adapter in both page and nested
-Worker plugin graphs:
+use the individual factories in server-side Cloudflare Workers. An ordinary
+Vite browser app needs one plugin. `vite dev` reads the current ChatGPT
+subscription from the developer's Codex auth file on the server, owns the
+same-origin `/api/responses` socket, and installs compatibility in both page
+and nested Worker graphs:
 
 ```js
-import { nanocodexTools } from "nanocodex/tools/vite";
+import { nanocodex } from "nanocodex/vite";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [nanocodexTools()],
-  worker: { format: "es", plugins: () => [nanocodexTools()] },
+  plugins: [nanocodex()],
+  worker: { format: "es" },
 });
 ```
+
+Cloudflare applications use the combined entry instead of installing a second
+Cloudflare plugin:
+
+```js
+import { nanocodex } from "nanocodex/vite/cloudflare";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react(), nanocodex()],
+});
+```
+
+In development, the application Worker remains the sole browser credential
+broker. Nanocodex gives workerd only the current access-token snapshot and a
+capability-scoped loopback egress; it never imports the host process
+environment. `vite build` does not read local auth or include those bindings,
+so the application's production authentication and agent ownership remain
+unchanged. The refresh token, ID token, full auth document, and credentials
+never enter browser code or responses. `nanocodex()` already includes the
+legacy `nanocodexTools()` compatibility plugin; do not install both.
 
 The browser composition includes `render_artifact` as a normal typed tool. For
 other hosts, compose the same factory with any workspace implementing the

--- a/js/bindings/package-lock.json
+++ b/js/bindings/package-lock.json
@@ -35,6 +35,18 @@
       },
       "engines": {
         "node": ">=22.13.0"
+      },
+      "peerDependencies": {
+        "@cloudflare/vite-plugin": ">=1.47.0",
+        "vite": ">=6.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/vite-plugin": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/@adraffy/ens-normalize": {

--- a/js/bindings/package.json
+++ b/js/bindings/package.json
@@ -39,6 +39,14 @@
       "types": "./browser/realtimePrompt.d.mts",
       "import": "./browser/realtimePrompt.mjs"
     },
+    "./vite": {
+      "types": "./vite/index.d.mts",
+      "import": "./vite/index.mjs"
+    },
+    "./vite/cloudflare": {
+      "types": "./vite/cloudflare.d.mts",
+      "import": "./vite/cloudflare.mjs"
+    },
     "./workspace": {
       "types": "./runtime/workspace.d.mts",
       "import": "./runtime/workspace.mjs"
@@ -120,6 +128,7 @@
     "pkg-web",
     "runtime",
     "tools",
+    "vite",
     "internal.mjs",
     "index.d.mts",
     "index.mjs",
@@ -163,6 +172,18 @@
     "pkg-pr-new": "0.0.79",
     "quickjs-emscripten-core": "0.32.0",
     "typescript": "5.9.3"
+  },
+  "peerDependencies": {
+    "@cloudflare/vite-plugin": ">=1.47.0",
+    "vite": ">=6.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@cloudflare/vite-plugin": {
+      "optional": true
+    },
+    "vite": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=22.13.0"

--- a/js/bindings/scripts/check-package.mjs
+++ b/js/bindings/scripts/check-package.mjs
@@ -79,6 +79,10 @@ const requiredFiles = [
   "tools/browser/index.d.mts",
   "tools/vite.mjs",
   "tools/vite.d.mts",
+  "vite/index.mjs",
+  "vite/index.d.mts",
+  "vite/cloudflare.mjs",
+  "vite/cloudflare.d.mts",
   "wasm.d.mts",
   "pkg-web/nanocodex.js",
   "pkg-web/nanocodex.d.ts",
@@ -126,6 +130,8 @@ export async function checkPackage(packageRoot = root) {
   assert.equal(packageJson.exports?.["./tools/artifact"]?.import, "./tools/artifact.mjs");
   assert.equal(packageJson.exports?.["./tools/browser"]?.import, "./tools/browser/index.mjs");
   assert.equal(packageJson.exports?.["./tools/vite"]?.import, "./tools/vite.mjs");
+  assert.equal(packageJson.exports?.["./vite"]?.import, "./vite/index.mjs");
+  assert.equal(packageJson.exports?.["./vite/cloudflare"]?.import, "./vite/cloudflare.mjs");
   assert.equal(packageJson.exports?.["./wasm"]?.import, "./pkg-web/nanocodex_bg.wasm");
   checkDocumentedBrowserVersion(readme, packageJson.version);
 

--- a/js/bindings/test/package.test.mjs
+++ b/js/bindings/test/package.test.mjs
@@ -88,6 +88,7 @@ test("the packed package ships and resolves every public entry point", async () 
       import { dataset as aggregateDataset, web } from "nanocodex/tools";
       import { dataset } from "nanocodex/tools/dataset";
       import { nanocodexTools } from "nanocodex/tools/vite";
+      import { nanocodex } from "nanocodex/vite";
       import { Agent as NodeAgent, Subagents as NodeSubagents, Transport as NodeTransport, Workspace as NodeWorkspace } from "nanocodex/node";
       import * as nodeExports from "nanocodex/node";
       import { Subagents as BrowserSubagents, Workspace as BrowserWorkspace } from "nanocodex/browser";
@@ -172,6 +173,9 @@ test("the packed package ships and resolves every public entry point", async () 
       const sprintfCompatibility = nanocodexTools().resolveId("sprintf-js", "/consumer.js");
       assert.match(sprintfCompatibility, /browserSprintf\.mjs$/);
       assert.equal(nanocodexTools().resolveId("sprintf-js", sprintfCompatibility), null);
+      const vitePlugin = nanocodex({ chatGpt: false });
+      assert.equal(vitePlugin.name, "nanocodex");
+      assert.match(vitePlugin.resolveId("node:zlib"), /browserZlib\.mjs$/);
       const [{ gzipSync, gunzipSync }, { sprintf }] = await Promise.all([
         import(sprintfCompatibility.replace(/browserSprintf\.mjs$/, "browserZlib.mjs")),
         import(sprintfCompatibility),

--- a/js/bindings/test/types.test-d.mts
+++ b/js/bindings/test/types.test-d.mts
@@ -51,6 +51,7 @@ import {
 } from "../tools/dataset.mjs";
 import { browser as browserTools } from "../tools/browser/index.mjs";
 import { nanocodexTools } from "../tools/vite.mjs";
+import { nanocodex } from "../vite/index.mjs";
 import {
   createMemoryDurabilityStore,
   durabilityRevision,
@@ -377,6 +378,9 @@ async function check() {
     tools: [...browserRuntime.tools, ...BrowserSubagents.create()],
   });
   nanocodexTools().resolveId("node-rsa");
+  nanocodex().resolveId("node-rsa");
+  // @ts-expect-error Cloudflare composition is selected by the dedicated subpath.
+  nanocodex({ chatGpt: { worker: true } });
   // @ts-expect-error Rust extensions must come from a branded constructor.
   await Agent.create({ transport: Transport.openAi({ apiKey }), tools: [{ maxConcurrency: 8 }] });
   // @ts-expect-error function-backed MPP transports cannot cross the package Worker boundary.

--- a/js/bindings/test/vite.test.mjs
+++ b/js/bindings/test/vite.test.mjs
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import WebSocket, { WebSocketServer } from "ws";
+
+import { readCodexSubscription } from "../vite/codex-auth-file.mjs";
+import { createNanocodexCloudflarePlugins } from "../vite/cloudflare-plugin.mjs";
+import { startChatGptWorkerEgress } from "../vite/chatgpt-egress.mjs";
+
+test("one Vite plugin gives Cloudflare only exact development Worker bindings", async () => {
+  const fixture = await authFixture();
+  const sentinelName = "NANOCODEX_TEST_UNRELATED_HOST_SECRET";
+  const previousSentinel = process.env[sentinelName];
+  process.env[sentinelName] = "must-not-enter-workerd";
+  let cloudflareOptions;
+  const plugins = createNanocodexCloudflarePlugins({
+    chatGpt: { authFile: fixture.path },
+    cloudflare: { config: () => ({ vars: { APPLICATION_VAR: "kept" } }) },
+  }, (options) => {
+    cloudflareOptions = options;
+    return [{ name: "vite-plugin-cloudflare" }];
+  });
+  const plugin = plugins[0];
+  try {
+    const config = await plugin.config({
+      worker: {},
+    }, { command: "serve" });
+    const customized = cloudflareOptions.config({ vars: { FROM_WRANGLER: "kept-too" } });
+    assert.equal(customized.vars.APPLICATION_VAR, "kept");
+    assert.equal(customized.vars.ENVIRONMENT, "development");
+    assert.equal(customized.vars.NANOCODEX_DEV_CHATGPT_ACCESS_TOKEN, fixture.accessToken);
+    assert.equal(customized.vars.NANOCODEX_DEV_CHATGPT_ACCOUNT_ID, "account-123");
+    assert.match(customized.vars.NANOCODEX_DEV_CHATGPT_EGRESS_URL,
+      /^http:\/\/127\.0\.0\.1:\d+\/[A-Za-z0-9_-]{43}\/$/);
+    assert.match(customized.vars.NANOCODEX_DEV_CHATGPT_SESSION_ID, /^[A-Za-z0-9_-]{43}$/);
+    assert.equal(Object.hasOwn(customized.vars, sentinelName), false);
+    assert.equal(process.env[sentinelName], "must-not-enter-workerd");
+    assert.equal(config.worker.plugins().filter(({ name }) => name === "nanocodex-tools").length, 1);
+  } finally {
+    await plugin.closeBundle();
+    await fixture.close();
+    if (previousSentinel === undefined) delete process.env[sentinelName];
+    else process.env[sentinelName] = previousSentinel;
+  }
+});
+
+test("production builds neither read local auth nor start development egress", async () => {
+  let cloudflareOptions;
+  const [plugin] = createNanocodexCloudflarePlugins({
+    chatGpt: { authFile: "/definitely/missing/nanocodex-auth.json" },
+  }, (options) => {
+    cloudflareOptions = options;
+    return [];
+  });
+  const config = await plugin.config({ plugins: [] }, { command: "build" });
+  assert.equal(cloudflareOptions.config({ vars: { PRODUCTION: "yes" } }), undefined);
+  assert.equal(typeof config.worker.plugins, "function");
+  await plugin.closeBundle();
+});
+
+test("the Codex auth reader selects current subscription fields but never refresh data", async () => {
+  const fixture = await authFixture();
+  try {
+    const auth = await readCodexSubscription(fixture.path);
+    assert.equal(auth.accessToken, fixture.accessToken);
+    assert.equal(auth.accountId, "account-123");
+    assert.equal(auth.fedramp, false);
+    assert.equal(Object.hasOwn(auth, "refreshToken"), false);
+    assert.equal(Object.hasOwn(auth, "idToken"), false);
+
+    if (process.platform !== "win32") {
+      await chmod(fixture.path, 0o644);
+      await assert.rejects(readCodexSubscription(fixture.path), /group or other users/);
+    }
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("worker egress is loopback-only, fixed to ChatGPT, and forwards bounded HTTP and WebSockets", async () => {
+  const upstreamHttp = [];
+  const upstreamServer = createServer();
+  const upstreamWebSockets = new WebSocketServer({ noServer: true });
+  let upstreamHeaders;
+  upstreamServer.on("upgrade", (request, socket, head) => {
+    upstreamHeaders = request.headers;
+    upstreamWebSockets.handleUpgrade(request, socket, head, (connection) => {
+      connection.on("message", (data) => connection.send(data));
+    });
+  });
+  await listen(upstreamServer);
+  const upstreamAddress = upstreamServer.address();
+  assert(upstreamAddress && typeof upstreamAddress !== "string");
+  const egress = await startChatGptWorkerEgress({
+    fetchImpl: async (url, init) => {
+      upstreamHttp.push({ url, headers: new Headers(init.headers) });
+      return new Response("ok", { status: 200, headers: { "content-type": "text/plain" } });
+    },
+    openUpstream(_fixedUrl, options) {
+      return new WebSocket(`ws://127.0.0.1:${upstreamAddress.port}/responses`, options);
+    },
+  });
+  try {
+    const response = await fetch(new URL("backend-api/codex/alpha/search", egress.url), {
+      headers: { authorization: "Bearer fake-access", "chatgpt-account-id": "account-123" },
+    });
+    assert.equal(await response.text(), "ok");
+    assert.equal(upstreamHttp[0].url, "https://chatgpt.com/backend-api/codex/alpha/search");
+    assert.equal(upstreamHttp[0].headers.get("authorization"), "Bearer fake-access");
+
+    const websocketUrl = new URL("backend-api/codex/responses", egress.url);
+    websocketUrl.protocol = "ws:";
+    const downstream = new WebSocket(websocketUrl, {
+      headers: { authorization: "Bearer fake-access", "chatgpt-account-id": "account-123" },
+    });
+    await once(downstream, "open");
+    downstream.send("one-worker-path");
+    const [message] = await once(downstream, "message");
+    assert.equal(message.toString(), "one-worker-path");
+    assert.equal(upstreamHeaders.authorization, "Bearer fake-access");
+    assert.equal(upstreamHeaders["chatgpt-account-id"], "account-123");
+    downstream.close();
+
+    const bypass = new URL(egress.url);
+    bypass.pathname = "/backend-api/codex/alpha/search";
+    assert.equal((await fetch(bypass)).status, 404);
+  } finally {
+    await egress.close();
+    for (const connection of upstreamWebSockets.clients) connection.terminate();
+    await close(upstreamServer);
+  }
+});
+
+async function authFixture() {
+  const directory = await mkdtemp(join(tmpdir(), "nanocodex-vite-auth-"));
+  const path = join(directory, "auth.json");
+  const expiresAt = Math.floor(Date.now() / 1_000) + 3_600;
+  const accountClaims = {
+    "https://api.openai.com/auth": {
+      chatgpt_account_id: "account-123",
+      chatgpt_account_is_fedramp: false,
+    },
+  };
+  const accessToken = jwt({ exp: expiresAt, ...accountClaims });
+  await writeFile(path, JSON.stringify({
+    auth_mode: "chatgpt",
+    tokens: {
+      access_token: accessToken,
+      account_id: "account-123",
+      id_token: jwt(accountClaims),
+      refresh_token: "must-never-leave-this-file",
+    },
+  }), { mode: 0o600 });
+  return {
+    accessToken,
+    path,
+    close: () => rm(directory, { recursive: true, force: true }),
+  };
+}
+
+function jwt(payload) {
+  return [
+    Buffer.from('{"alg":"none"}').toString("base64url"),
+    Buffer.from(JSON.stringify(payload)).toString("base64url"),
+    "signature",
+  ].join(".");
+}
+
+function once(target, event) {
+  return new Promise((resolve, reject) => {
+    target.once(event, (...values) => resolve(values));
+    target.once("error", reject);
+  });
+}
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+}

--- a/js/bindings/vite/chatgpt-egress.mjs
+++ b/js/bindings/vite/chatgpt-egress.mjs
@@ -1,0 +1,263 @@
+import { randomBytes } from "node:crypto";
+import { createServer } from "node:http";
+import { Readable } from "node:stream";
+
+import WebSocket, { WebSocketServer } from "ws";
+
+const CHATGPT_HOST = "chatgpt.com";
+const CHATGPT_PATH_PREFIX = "/backend-api/codex/";
+const MAX_BUFFERED_BYTES = 32 * 1024 * 1024;
+
+export async function startChatGptWorkerEgress(options = {}) {
+  const capability = options.capability ?? randomBytes(32).toString("base64url");
+  if (!/^[A-Za-z0-9_-]{43}$/.test(capability)) {
+    throw new TypeError("ChatGPT development egress capability must be 43 base64url characters");
+  }
+  const localPrefix = `/${capability}`;
+  const sockets = new Set();
+  const upstreams = new Set();
+  const downstreamServer = new WebSocketServer({
+    noServer: true,
+    maxPayload: MAX_BUFFERED_BYTES,
+    perMessageDeflate: false,
+  });
+  const server = createServer((request, response) => {
+    void proxyHttpRequest(request, response, options.fetchImpl ?? fetch, localPrefix);
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+  server.on("upgrade", (request, socket, head) => {
+    proxyWebSocketUpgrade({
+      downstreamServer,
+      head,
+      openUpstream: options.openUpstream,
+      localPrefix,
+      request,
+      socket,
+      upstreams,
+    });
+  });
+  server.on("clientError", (_error, socket) => {
+    socket.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
+  });
+
+  await new Promise((resolve, reject) => {
+    const onError = (error) => reject(error);
+    server.once("error", onError);
+    server.listen(options.port ?? 0, "127.0.0.1", () => {
+      server.off("error", onError);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("ChatGPT development egress did not bind TCP");
+
+  let closed = false;
+  return Object.freeze({
+    url: `http://127.0.0.1:${address.port}${localPrefix}/`,
+    async close() {
+      if (closed) return;
+      closed = true;
+      for (const socket of downstreamServer.clients) socket.terminate();
+      for (const socket of upstreams) socket.terminate();
+      for (const socket of sockets) socket.destroy();
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    },
+  });
+}
+
+async function proxyHttpRequest(request, response, fetchImpl, localPrefix) {
+  const upstreamPath = allowedUpstreamPath(request.url, localPrefix);
+  if (!safeLoopbackRequest(request) || upstreamPath === undefined) {
+    response.writeHead(404, noStoreHeaders("text/plain; charset=utf-8"));
+    response.end("Not found\n");
+    return;
+  }
+  try {
+    const method = request.method ?? "GET";
+    const upstream = await fetchImpl(`https://${CHATGPT_HOST}${upstreamPath}`, {
+      method,
+      headers: upstreamHttpHeaders(request),
+      body: method === "GET" || method === "HEAD"
+        ? undefined
+        : Readable.toWeb(request),
+      duplex: "half",
+      redirect: "manual",
+    });
+    const headers = new Headers(upstream.headers);
+    headers.delete("content-encoding");
+    headers.delete("content-length");
+    headers.set("cache-control", "no-store");
+    response.writeHead(upstream.status, upstream.statusText, Object.fromEntries(headers));
+    if (upstream.body) Readable.fromWeb(upstream.body).pipe(response);
+    else response.end();
+  } catch {
+    if (!response.headersSent) response.writeHead(502, noStoreHeaders("text/plain; charset=utf-8"));
+    response.end("ChatGPT development egress failed\n");
+  }
+}
+
+function proxyWebSocketUpgrade({ downstreamServer, head, localPrefix, openUpstream, request, socket, upstreams }) {
+  socket.on("error", () => {});
+  const upstreamPath = allowedUpstreamPath(request.url, localPrefix);
+  if (!safeLoopbackRequest(request) || upstreamPath === undefined) {
+    rejectUpgrade(socket, 404, "Not found");
+    return;
+  }
+  const upstreamOptions = {
+    handshakeTimeout: 15_000,
+    headers: upstreamWebSocketHeaders(request),
+    maxPayload: MAX_BUFFERED_BYTES,
+    perMessageDeflate: false,
+  };
+  const upstream = openUpstream
+    ? openUpstream(`wss://${CHATGPT_HOST}${upstreamPath}`, upstreamOptions)
+    : new WebSocket(`wss://${CHATGPT_HOST}${upstreamPath}`, upstreamOptions);
+  upstreams.add(upstream);
+  upstream.once("close", () => upstreams.delete(upstream));
+  let settled = false;
+  upstream.once("open", () => {
+    if (settled || socket.destroyed) {
+      upstream.terminate();
+      return;
+    }
+    settled = true;
+    try {
+      downstreamServer.handleUpgrade(request, socket, head, (downstream) => {
+        bridge(downstream, upstream);
+      });
+    } catch {
+      upstream.terminate();
+      rejectUpgrade(socket, 502, "WebSocket upgrade failed");
+    }
+  });
+  upstream.once("unexpected-response", (_request, response) => {
+    response.resume();
+    if (settled || socket.destroyed) return;
+    settled = true;
+    rejectUpgrade(socket, safeStatus(response.statusCode), "ChatGPT WebSocket rejected");
+    upstream.terminate();
+  });
+  upstream.once("error", () => {
+    if (settled || socket.destroyed) return;
+    settled = true;
+    rejectUpgrade(socket, 502, "ChatGPT WebSocket failed");
+  });
+  socket.once("close", () => {
+    if (!settled && upstream.readyState !== WebSocket.CLOSED) upstream.terminate();
+  });
+}
+
+function bridge(left, right) {
+  let closed = false;
+  const relay = (source, destination) => (data, isBinary) => {
+    if (closed || destination.readyState !== WebSocket.OPEN) return;
+    if (destination.bufferedAmount + data.byteLength > MAX_BUFFERED_BYTES) {
+      closed = true;
+      source.close(1013, "relay backpressure limit");
+      destination.close(1013, "relay backpressure limit");
+      return;
+    }
+    destination.send(data, { binary: isBinary, compress: false }, (error) => {
+      if (error && !closed) {
+        closed = true;
+        source.terminate();
+        destination.terminate();
+      }
+    });
+  };
+  left.on("message", relay(left, right));
+  right.on("message", relay(right, left));
+  left.once("close", (code) => closePeer(right, code));
+  right.once("close", (code) => closePeer(left, code));
+  left.once("error", () => right.terminate());
+  right.once("error", () => left.terminate());
+}
+
+function upstreamHttpHeaders(request) {
+  const headers = new Headers();
+  for (const name of [
+    "accept",
+    "authorization",
+    "chatgpt-account-id",
+    "content-type",
+    "openai-alpha",
+    "originator",
+    "session-id",
+    "thread-id",
+    "user-agent",
+    "x-oai-attestation",
+    "x-openai-fedramp",
+    "x-session-id",
+  ]) {
+    const value = request.headers[name];
+    if (typeof value === "string") headers.set(name, value);
+  }
+  return headers;
+}
+
+function upstreamWebSocketHeaders(request) {
+  const allowed = new Set([
+    "authorization",
+    "chatgpt-account-id",
+    "openai-beta",
+    "originator",
+    "session-id",
+    "thread-id",
+    "user-agent",
+    "x-client-request-id",
+    "x-openai-fedramp",
+    "x-openai-internal-codex-responses-lite",
+    "x-responsesapi-include-timing-metrics",
+  ]);
+  return Object.fromEntries(
+    Object.entries(request.headers).flatMap(([name, value]) =>
+      value === undefined || !allowed.has(name) ? [] : [[name, value]]),
+  );
+}
+
+function safeLoopbackRequest(request) {
+  const address = request.socket.remoteAddress;
+  return address === "127.0.0.1" || address === "::1" || address === "::ffff:127.0.0.1";
+}
+
+function allowedUpstreamPath(path, localPrefix) {
+  if (typeof path !== "string") return undefined;
+  try {
+    const url = new URL(path, "http://127.0.0.1");
+    const expectedPrefix = `${localPrefix}${CHATGPT_PATH_PREFIX}`;
+    if (!url.pathname.startsWith(expectedPrefix)) return undefined;
+    return `${url.pathname.slice(localPrefix.length)}${url.search}`;
+  } catch {
+    return undefined;
+  }
+}
+
+function closePeer(peer, code) {
+  if (peer.readyState === WebSocket.OPEN) peer.close(safeCloseCode(code), "relay peer closed");
+  else if (peer.readyState === WebSocket.CONNECTING) peer.terminate();
+}
+
+function safeCloseCode(code) {
+  const standard = code >= 1000 && code <= 1014 && ![1004, 1005, 1006].includes(code);
+  return standard || (code >= 3000 && code <= 4999) ? code : 1011;
+}
+
+function safeStatus(status) {
+  return Number.isInteger(status) && status >= 400 && status <= 599 ? status : 502;
+}
+
+function rejectUpgrade(socket, status, message) {
+  if (socket.destroyed || socket.writableEnded) return;
+  const body = `${message}\n`;
+  socket.end(
+    `HTTP/1.1 ${status} ${message}\r\nContent-Type: text/plain\r\nCache-Control: no-store\r\n`
+    + `Content-Length: ${Buffer.byteLength(body)}\r\nConnection: close\r\n\r\n${body}`,
+  );
+}
+
+function noStoreHeaders(contentType) {
+  return { "cache-control": "no-store", "content-type": contentType };
+}

--- a/js/bindings/vite/chatgpt-subscription.mjs
+++ b/js/bindings/vite/chatgpt-subscription.mjs
@@ -1,0 +1,451 @@
+import { isIP } from "node:net";
+
+import WebSocket, { WebSocketServer } from "ws";
+
+import { defaultCodexAuthFile, readCodexSubscription } from "./codex-auth-file.mjs";
+
+const CHATGPT_RESPONSES_URL = "wss://chatgpt.com/backend-api/codex/responses";
+const DEFAULT_RESPONSES_PATH = "/api/responses";
+const DEFAULT_STATUS_PATH = "/api/auth/chatgpt";
+const MAX_BUFFERED_BYTES = 32 * 1024 * 1024;
+const MAX_HEADER_BYTES = 16 * 1024;
+const SESSION_ID_PATTERN = /^[A-Za-z0-9._:-]{1,200}$/;
+const FORBIDDEN_DOWNSTREAM_HEADERS = new Set([
+  "authorization",
+  "chatgpt-account-id",
+  "openai-beta",
+  "originator",
+  "proxy-authorization",
+  "session-id",
+  "thread-id",
+  "x-client-request-id",
+  "x-openai-fedramp",
+  "x-openai-internal-codex-responses-lite",
+  "x-responsesapi-include-timing-metrics",
+]);
+
+export function chatGptSubscription(options = {}) {
+  return createChatGptSubscriptionPlugin(options, {
+    WebSocketImpl: WebSocket,
+    readAuth: readCodexSubscription,
+    upstreamUrl: CHATGPT_RESPONSES_URL,
+  });
+}
+
+/** Internal dependency seam used by provider-free tests. Not package-exported. */
+export function createChatGptSubscriptionPlugin(options = {}, dependencies) {
+  const responsesPath = exactPath(options.responsesPath ?? DEFAULT_RESPONSES_PATH, "responsesPath");
+  const statusPath = options.statusPath === false
+    ? false
+    : exactPath(options.statusPath ?? DEFAULT_STATUS_PATH, "statusPath");
+  const authFile = options.authFile === undefined
+    ? defaultCodexAuthFile()
+    : resolveAuthFile(options.authFile);
+  const minimumTokenTtlMs = options.minimumTokenTtlMs ?? 5 * 60_000;
+  if (!Number.isSafeInteger(minimumTokenTtlMs) || minimumTokenTtlMs < 0) {
+    throw new TypeError("minimumTokenTtlMs must be a non-negative integer");
+  }
+  if (options.onEvent !== undefined && typeof options.onEvent !== "function") {
+    throw new TypeError("onEvent must be a function");
+  }
+
+  return {
+    name: "nanocodex-chatgpt-subscription",
+    apply: "serve",
+    enforce: "pre",
+    async configureServer(vite) {
+      const server = vite.httpServer;
+      if (!server) throw new Error("Nanocodex local ChatGPT auth requires a Vite HTTP server");
+      const downstreamServer = new WebSocketServer({
+        noServer: true,
+        maxPayload: MAX_BUFFERED_BYTES,
+        perMessageDeflate: false,
+      });
+      const downstreams = new Set();
+      const upstreams = new Set();
+      let closed = false;
+      const emit = (type, detail = {}) => {
+        try { options.onEvent?.(Object.freeze({ type, ...detail })); } catch (error) {
+          vite.config.logger.warn(`[nanocodex] local ChatGPT observer failed: ${errorMessage(error)}`);
+        }
+      };
+      const loadAuth = () => dependencies.readAuth(authFile, { minimumTtlMs: minimumTokenTtlMs });
+
+      if (statusPath !== false) {
+        vite.middlewares.use((request, response, next) => {
+          let url;
+          try {
+            url = new URL(request.url ?? "/", "http://127.0.0.1");
+          } catch {
+            next();
+            return;
+          }
+          if (url.pathname !== statusPath || url.search || request.method !== "GET") {
+            next();
+            return;
+          }
+          if (!safeSameOriginRequest(request)) {
+            response.writeHead(403, noStoreHeaders("text/plain; charset=utf-8"));
+            response.end("Forbidden\n");
+            return;
+          }
+          void loadAuth().then(
+            (auth) => {
+              const body = JSON.stringify({
+                state: "authenticated",
+                expiresAt: auth.expiresAt,
+                managedLocally: true,
+              });
+              response.writeHead(200, {
+                ...noStoreHeaders("application/json; charset=utf-8"),
+                "content-length": Buffer.byteLength(body),
+              });
+              response.end(body);
+            },
+            () => next(),
+          );
+        });
+      }
+
+      const onUpgrade = (request, socket, head) => {
+        const parsed = parseUpgrade(request, responsesPath);
+        if (parsed === undefined) return;
+        if (parsed instanceof Error) {
+          rejectHttpUpgrade(socket, errorStatus(parsed), errorMessage(parsed));
+          return;
+        }
+        if (closed) {
+          rejectHttpUpgrade(socket, 503, "Development server is closing");
+          return;
+        }
+        try {
+          downstreamServer.handleUpgrade(request, socket, head, (downstream) => {
+            downstreams.add(downstream);
+            downstream.once("close", () => downstreams.delete(downstream));
+            void connectUpstream({
+              authFile,
+              dependencies,
+              downstream,
+              emit,
+              loadAuth,
+              sessionId: parsed.sessionId,
+              upstreams,
+            });
+          });
+        } catch {
+          rejectHttpUpgrade(socket, 502, "WebSocket upgrade failed");
+        }
+      };
+      server.prependListener("upgrade", onUpgrade);
+
+      const close = () => {
+        if (closed) return;
+        closed = true;
+        server.removeListener("upgrade", onUpgrade);
+        for (const socket of downstreams) socket.terminate();
+        for (const socket of upstreams) socket.terminate();
+        downstreamServer.close();
+      };
+      server.once("close", close);
+
+      try {
+        const auth = await loadAuth();
+        emit("auth.ready", { expiresAt: auth.expiresAt });
+        vite.config.logger.info(
+          `[nanocodex] local ChatGPT subscription ready from ${authFile}`,
+        );
+      } catch (error) {
+        emit("auth.unavailable", { kind: authErrorKind(error) });
+        vite.config.logger.info(
+          `[nanocodex] local ChatGPT subscription unavailable; run \`codex login\` (${errorMessage(error)})`,
+        );
+      }
+    },
+  };
+}
+
+async function connectUpstream({ dependencies, downstream, emit, loadAuth, sessionId, upstreams }) {
+  let auth;
+  try {
+    auth = await loadAuth();
+  } catch (error) {
+    emit("auth.unavailable", { kind: authErrorKind(error) });
+    rejectWebSocket(downstream, authErrorKind(error) === "expired" ? 401 : 503,
+      "Local ChatGPT login unavailable; run `codex login` and retry");
+    return;
+  }
+  if (downstream.readyState !== WebSocket.OPEN) return;
+
+  const upstream = new dependencies.WebSocketImpl(dependencies.upstreamUrl, {
+    handshakeTimeout: 8_000,
+    headers: upstreamHeaders(auth, sessionId),
+    maxPayload: MAX_BUFFERED_BYTES,
+    perMessageDeflate: false,
+  });
+  upstreams.add(upstream);
+  upstream.once("close", () => upstreams.delete(upstream));
+  let opened = false;
+  let readySent = false;
+  let settled = false;
+
+  const fail = (status, message) => {
+    if (settled) return;
+    settled = true;
+    emit("upstream.rejected", { status });
+    rejectWebSocket(downstream, status, message);
+    if (upstream.readyState !== WebSocket.CLOSED) upstream.terminate();
+  };
+  upstream.once("unexpected-response", (_request, response) => {
+    response.resume();
+    fail(normalizeProviderStatus(response.statusCode), providerFailure(response.statusCode));
+  });
+  upstream.once("error", () => {
+    if (!opened) fail(502, "ChatGPT WebSocket connection failed");
+  });
+  upstream.once("open", () => {
+    if (settled || downstream.readyState !== WebSocket.OPEN) {
+      upstream.terminate();
+      return;
+    }
+    opened = true;
+    settled = true;
+    const pending = [];
+    let pendingBytes = 0;
+    const bufferUntilReady = (data, isBinary) => {
+      pendingBytes += data.byteLength;
+      if (pendingBytes > MAX_BUFFERED_BYTES) {
+        downstream.close(1013, "relay backpressure limit");
+        upstream.close(1013, "relay backpressure limit");
+        return;
+      }
+      pending.push([data, isBinary]);
+    };
+    upstream.on("message", bufferUntilReady);
+    downstream.send(JSON.stringify({ type: "nanocodex.proxy.ready" }), { compress: false }, (error) => {
+      if (error) {
+        downstream.terminate();
+        upstream.terminate();
+        return;
+      }
+      readySent = true;
+      upstream.off("message", bufferUntilReady);
+      bridge(downstream, upstream, emit, pending);
+      emit("connection.ready");
+    });
+  });
+  downstream.once("close", () => {
+    if (!readySent && upstream.readyState !== WebSocket.CLOSED) upstream.terminate();
+  });
+}
+
+function bridge(downstream, upstream, emit, pendingUpstreamMessages = []) {
+  let closed = false;
+  const relay = (source, destination, type) => (data, isBinary) => {
+    if (closed || destination.readyState !== WebSocket.OPEN) return;
+    if (isBinary) {
+      closed = true;
+      source.close(1003, "text frames required");
+      destination.close(1003, "text frames required");
+      return;
+    }
+    const byteLength = data.byteLength;
+    if (destination.bufferedAmount + byteLength > MAX_BUFFERED_BYTES) {
+      closed = true;
+      source.close(1013, "relay backpressure limit");
+      destination.close(1013, "relay backpressure limit");
+      return;
+    }
+    destination.send(data, { binary: false, compress: false }, (error) => {
+      if (error && !closed) {
+        closed = true;
+        source.terminate();
+        destination.terminate();
+      }
+    });
+    emit(type, { byteLength });
+  };
+  const relayDownstream = relay(downstream, upstream, "request.forwarded");
+  const relayUpstream = relay(upstream, downstream, "response.forwarded");
+  downstream.on("message", relayDownstream);
+  upstream.on("message", relayUpstream);
+  for (const [data, isBinary] of pendingUpstreamMessages) relayUpstream(data, isBinary);
+  downstream.once("close", (code) => {
+    emit("connection.closed", { side: "browser", code });
+    closePeer(upstream, code);
+  });
+  upstream.once("close", (code) => {
+    emit("connection.closed", { side: "provider", code });
+    closePeer(downstream, code);
+  });
+  downstream.once("error", () => upstream.terminate());
+  upstream.once("error", () => downstream.terminate());
+}
+
+function parseUpgrade(request, responsesPath) {
+  let url;
+  try {
+    url = new URL(request.url ?? "/", "http://127.0.0.1");
+  } catch {
+    return new Error("Bad request");
+  }
+  if (url.pathname !== responsesPath) return undefined;
+  if (request.method !== "GET") return statusError(405, "Method not allowed");
+  if (!safeSameOriginRequest(request)) return statusError(403, "Forbidden");
+  if (headerBytes(request) > MAX_HEADER_BYTES) return statusError(431, "Request headers too large");
+  if (request.headers["sec-websocket-protocol"] !== undefined) {
+    return statusError(400, "WebSocket subprotocols are not supported");
+  }
+  for (const name of FORBIDDEN_DOWNSTREAM_HEADERS) {
+    if (request.headers[name] !== undefined) return statusError(400, "Credential headers are not accepted");
+  }
+  const entries = [...url.searchParams.entries()];
+  if (entries.length !== 1 || entries[0][0] !== "session_id" || !SESSION_ID_PATTERN.test(entries[0][1])) {
+    return statusError(400, "Invalid session");
+  }
+  return { sessionId: entries[0][1] };
+}
+
+function safeSameOriginRequest(request) {
+  if (!isLoopbackAddress(request.socket.remoteAddress)) return false;
+  const hosts = rawHeaderValues(request, "host");
+  const origins = rawHeaderValues(request, "origin");
+  if (hosts.length !== 1 || origins.length !== 1) return false;
+  let origin;
+  try {
+    origin = new URL(origins[0]);
+  } catch {
+    return false;
+  }
+  const protocol = request.socket.encrypted === true ? "https:" : "http:";
+  return origin.protocol === protocol
+    && origin.host === hosts[0]
+    && origin.pathname === "/"
+    && !origin.search
+    && !origin.hash
+    && isLoopbackHostname(origin.hostname);
+}
+
+function rawHeaderValues(request, expectedName) {
+  const values = [];
+  for (let index = 0; index < request.rawHeaders.length; index += 2) {
+    if (request.rawHeaders[index]?.toLowerCase() === expectedName) {
+      values.push(request.rawHeaders[index + 1] ?? "");
+    }
+  }
+  return values;
+}
+
+function headerBytes(request) {
+  return request.rawHeaders.reduce((total, value) => total + Buffer.byteLength(value), 0);
+}
+
+function upstreamHeaders(auth, sessionId) {
+  return {
+    Authorization: `Bearer ${auth.accessToken}`,
+    "ChatGPT-Account-ID": auth.accountId,
+    "OpenAI-Beta": "responses_websockets=2026-02-06",
+    originator: "codex_cli_rs",
+    "x-openai-internal-codex-responses-lite": "true",
+    "session-id": sessionId,
+    "thread-id": sessionId,
+    "x-client-request-id": sessionId,
+    "x-responsesapi-include-timing-metrics": "true",
+    "User-Agent": "codex_cli_rs/0.0.0",
+    ...(auth.fedramp ? { "X-OpenAI-Fedramp": "true" } : {}),
+  };
+}
+
+function providerFailure(status) {
+  if (status === 401 || status === 403) {
+    return "ChatGPT rejected the local login; run `codex login` and retry";
+  }
+  if (status === 429) return "ChatGPT rate limit reached";
+  return "ChatGPT WebSocket upgrade failed";
+}
+
+function normalizeProviderStatus(status) {
+  return Number.isInteger(status) && status >= 400 && status <= 599 ? status : 502;
+}
+
+function rejectWebSocket(socket, status, error) {
+  if (socket.readyState !== WebSocket.OPEN) return;
+  socket.send(JSON.stringify({ type: "nanocodex.proxy.rejected", status, error }), { compress: false }, () => {
+    if (socket.readyState === WebSocket.OPEN) socket.close(status === 429 ? 1013 : 1011, "connection rejected");
+  });
+}
+
+function closePeer(peer, code) {
+  if (peer.readyState === WebSocket.OPEN) peer.close(safeCloseCode(code), "relay peer closed");
+  else if (peer.readyState === WebSocket.CONNECTING) peer.terminate();
+}
+
+function safeCloseCode(code) {
+  const standard = code >= 1000 && code <= 1014 && ![1004, 1005, 1006].includes(code);
+  return standard || (code >= 3000 && code <= 4999) ? code : 1011;
+}
+
+function rejectHttpUpgrade(socket, status, message) {
+  if (socket.destroyed || socket.writableEnded) return;
+  const body = `${message}\n`;
+  socket.once("error", () => {});
+  socket.end(
+    `HTTP/1.1 ${status} ${message}\r\nContent-Type: text/plain\r\nCache-Control: no-store\r\n`
+    + `Content-Length: ${Buffer.byteLength(body)}\r\nConnection: close\r\n\r\n${body}`,
+  );
+}
+
+function noStoreHeaders(contentType) {
+  return {
+    "cache-control": "no-store",
+    "content-type": contentType,
+    "x-content-type-options": "nosniff",
+  };
+}
+
+function exactPath(value, name) {
+  if (typeof value !== "string" || !value.startsWith("/") || value.startsWith("//")) {
+    throw new TypeError(`${name} must be an absolute URL path`);
+  }
+  const url = new URL(value, "http://nanocodex.invalid");
+  if (url.pathname !== value || url.search || url.hash) {
+    throw new TypeError(`${name} must not contain a query or fragment`);
+  }
+  return value;
+}
+
+function resolveAuthFile(value) {
+  if (value instanceof URL) {
+    if (value.protocol !== "file:") throw new TypeError("authFile URL must use file:");
+    return decodeURIComponent(value.pathname);
+  }
+  if (typeof value !== "string" || !value.trim()) throw new TypeError("authFile must be a path or file URL");
+  return value;
+}
+
+function isLoopbackAddress(address) {
+  if (address === "::1") return true;
+  const normalized = address?.startsWith("::ffff:") ? address.slice(7) : address;
+  return isLoopbackHostname(normalized ?? "");
+}
+
+function isLoopbackHostname(hostname) {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (normalized === "localhost" || normalized === "::1") return true;
+  return isIP(normalized) === 4 && normalized.split(".", 1)[0] === "127";
+}
+
+function statusError(status, message) {
+  return Object.assign(new Error(message), { status });
+}
+
+function errorStatus(error) {
+  return Number.isInteger(error.status) ? error.status : 400;
+}
+
+function authErrorKind(error) {
+  return typeof error?.kind === "string" ? error.kind : "invalid";
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/js/bindings/vite/cloudflare-plugin.mjs
+++ b/js/bindings/vite/cloudflare-plugin.mjs
@@ -1,0 +1,37 @@
+import { createNanocodexVitePlugin } from "./plugin.mjs";
+
+/** Internal dependency seam used by provider-free tests. Not package-exported. */
+export function createNanocodexCloudflarePlugins(options, cloudflare) {
+  let devBindings;
+  const core = createNanocodexVitePlugin(
+    { chatGpt: options.chatGpt },
+    {
+      target: "cloudflare",
+      setDevBindings(value) {
+        devBindings = value;
+      },
+    },
+  );
+  return [core, ...cloudflare(withDevBindings(options.cloudflare ?? {}, () => devBindings))];
+}
+
+function withDevBindings(options, getDevBindings) {
+  const userConfig = options.config;
+  return {
+    ...options,
+    config(workerConfig) {
+      const customized = typeof userConfig === "function"
+        ? userConfig(workerConfig)
+        : userConfig;
+      const bindings = getDevBindings();
+      if (!bindings) return customized;
+      return {
+        ...(customized ?? {}),
+        vars: {
+          ...(customized?.vars ?? {}),
+          ...bindings,
+        },
+      };
+    },
+  };
+}

--- a/js/bindings/vite/cloudflare.d.mts
+++ b/js/bindings/vite/cloudflare.d.mts
@@ -1,0 +1,14 @@
+import type { PluginConfig } from "@cloudflare/vite-plugin";
+import type { PluginOption } from "vite";
+
+import type { NanocodexChatGptViteOptions } from "./index.mjs";
+
+export type NanocodexCloudflareViteOptions = Readonly<{
+  /** Cloudflare Vite plugin options. Nanocodex adds only exact development credential bindings. */
+  cloudflare?: PluginConfig | undefined;
+  /** Local ChatGPT subscription support is on by default; pass false to disable it. */
+  chatGpt?: Pick<NanocodexChatGptViteOptions, "authFile"> | false | undefined;
+}>;
+
+/** One call installs browser shims, local subscription brokering, and the Cloudflare Worker plugin. */
+export function nanocodex(options?: NanocodexCloudflareViteOptions): PluginOption[];

--- a/js/bindings/vite/cloudflare.mjs
+++ b/js/bindings/vite/cloudflare.mjs
@@ -1,0 +1,32 @@
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { createNanocodexCloudflarePlugins } from "./cloudflare-plugin.mjs";
+
+const projectUrl = pathToFileURL(resolve(process.cwd(), "package.json"));
+const cloudflareModule = await import(await resolveProjectImport("@cloudflare/vite-plugin"));
+const { cloudflare } = cloudflareModule;
+
+/** One-call Nanocodex and Cloudflare integration for development and deployment. */
+export function nanocodex(options = {}) {
+  return createNanocodexCloudflarePlugins(options, cloudflare);
+}
+
+async function resolveProjectImport(packageName) {
+  const projectRequire = createRequire(projectUrl);
+  for (const modulesDirectory of projectRequire.resolve.paths(packageName) ?? []) {
+    const packageFile = resolve(modulesDirectory, packageName, "package.json");
+    try {
+      const manifest = JSON.parse(await readFile(packageFile, "utf8"));
+      const target = manifest.exports?.["."]?.import ?? manifest.module;
+      if (typeof target === "string") {
+        return pathToFileURL(resolve(packageFile, "..", target)).href;
+      }
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+  }
+  throw new Error(`${packageName} must be installed by the Vite application`);
+}

--- a/js/bindings/vite/codex-auth-file.mjs
+++ b/js/bindings/vite/codex-auth-file.mjs
@@ -1,0 +1,158 @@
+import { createHash } from "node:crypto";
+import { open } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+const MAX_AUTH_FILE_BYTES = 64 * 1024;
+const DEFAULT_MINIMUM_TTL_MS = 5 * 60_000;
+
+export function defaultCodexAuthFile(environment = process.env) {
+  const explicit = nonEmpty(environment.NANOCODEX_AUTH_FILE)
+    ?? nonEmpty(environment.NANOCODEX_CODEX_AUTH_FILE);
+  if (explicit !== undefined) return resolve(explicit);
+  const codexHome = nonEmpty(environment.CODEX_HOME);
+  return resolve(codexHome === undefined ? join(homedir(), ".codex", "auth.json") : join(codexHome, "auth.json"));
+}
+
+export async function readCodexSubscription(path, options = {}) {
+  const authPath = resolve(path);
+  const minimumTtlMs = options.minimumTtlMs ?? DEFAULT_MINIMUM_TTL_MS;
+  if (!Number.isSafeInteger(minimumTtlMs) || minimumTtlMs < 0) {
+    throw new TypeError("minimumTtlMs must be a non-negative integer");
+  }
+
+  let file;
+  try {
+    file = await open(authPath, "r");
+  } catch (error) {
+    throw authError("missing", `cannot open Codex auth file: ${errorMessage(error)}`);
+  }
+
+  let encoded;
+  try {
+    const metadata = await file.stat();
+    if (!metadata.isFile()) throw new Error(`Codex auth path is not a file: ${authPath}`);
+    if (metadata.size > MAX_AUTH_FILE_BYTES) {
+      throw new Error(`Codex auth file exceeds ${MAX_AUTH_FILE_BYTES} bytes`);
+    }
+    if (process.platform !== "win32" && (metadata.mode & 0o077) !== 0) {
+      throw authError("insecure", "Codex auth file must not be accessible by group or other users");
+    }
+    encoded = await file.readFile();
+  } catch (error) {
+    if (error?.code === "NANOCODEX_AUTH_INSECURE") throw error;
+    throw authError("invalid", `cannot read Codex auth file: ${errorMessage(error)}`);
+  } finally {
+    await file.close();
+  }
+  if (encoded.byteLength > MAX_AUTH_FILE_BYTES) {
+    throw authError("invalid", `Codex auth file exceeds ${MAX_AUTH_FILE_BYTES} bytes`);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(encoded.toString("utf8"));
+  } catch (error) {
+    throw authError("invalid", `cannot parse Codex auth file: ${errorMessage(error)}`);
+  }
+  if (!isRecord(parsed) || parsed.auth_mode !== "chatgpt" || !isRecord(parsed.tokens)) {
+    throw authError("missing", "Codex auth file does not contain a ChatGPT subscription login");
+  }
+
+  const accessToken = requiredString(parsed.tokens.access_token, "access token");
+  const idClaims = jwtPayload(optionalString(parsed.tokens.id_token));
+  const accessClaims = jwtPayload(accessToken);
+  const idAuth = nestedRecord(idClaims, "https://api.openai.com/auth");
+  const accessAuth = nestedRecord(accessClaims, "https://api.openai.com/auth");
+  const accountIds = [
+    optionalString(parsed.tokens.account_id),
+    optionalString(idAuth?.chatgpt_account_id),
+    optionalString(accessAuth?.chatgpt_account_id),
+  ].filter((value) => value !== undefined);
+  const accountId = accountIds[0];
+  if (accountId === undefined) {
+    throw authError("invalid", "Codex auth file is missing the ChatGPT account ID");
+  }
+  if (accountIds.some((candidate) => candidate !== accountId)) {
+    throw authError("invalid", "Codex auth file contains conflicting ChatGPT account IDs");
+  }
+
+  const expiresAt = typeof accessClaims?.exp === "number" && Number.isFinite(accessClaims.exp)
+    ? accessClaims.exp * 1_000
+    : undefined;
+  if (expiresAt === undefined || expiresAt <= Date.now() + minimumTtlMs) {
+    throw authError("expired", "Codex access token expires too soon; run `codex login` and retry");
+  }
+
+  const fedrampClaims = [
+    optionalBoolean(idAuth?.chatgpt_account_is_fedramp),
+    optionalBoolean(accessAuth?.chatgpt_account_is_fedramp),
+  ].filter((value) => value !== undefined);
+  if (fedrampClaims.some((candidate) => candidate !== fedrampClaims[0])) {
+    throw authError("invalid", "Codex auth file contains conflicting FedRAMP claims");
+  }
+
+  return Object.freeze({
+    accessToken,
+    accountId,
+    fedramp: fedrampClaims[0] ?? false,
+    expiresAt,
+    revision: createHash("sha256")
+      .update(accessToken)
+      .update("\0")
+      .update(accountId)
+      .digest("base64url"),
+  });
+}
+
+function jwtPayload(token) {
+  if (token === undefined) return undefined;
+  const encoded = token.split(".")[1];
+  if (!encoded) return undefined;
+  try {
+    const value = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"));
+    return isRecord(value) ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function nestedRecord(value, key) {
+  const nested = value?.[key];
+  return isRecord(nested) ? nested : undefined;
+}
+
+function requiredString(value, name) {
+  const normalized = optionalString(value);
+  if (normalized === undefined) {
+    throw authError("invalid", `Codex auth file is missing the ${name}`);
+  }
+  return normalized;
+}
+
+function optionalString(value) {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function optionalBoolean(value) {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function nonEmpty(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function authError(kind, message) {
+  return Object.assign(new Error(message), {
+    code: `NANOCODEX_AUTH_${kind.toUpperCase()}`,
+    kind,
+  });
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/js/bindings/vite/index.d.mts
+++ b/js/bindings/vite/index.d.mts
@@ -1,0 +1,23 @@
+export type NanocodexChatGptViteOptions = Readonly<{
+  /** Defaults to NANOCODEX_AUTH_FILE, NANOCODEX_CODEX_AUTH_FILE, CODEX_HOME/auth.json, then ~/.codex/auth.json. */
+  authFile?: string | URL | undefined;
+  /** Same-origin host-managed WebSocket path. Defaults to /api/responses. */
+  responsesPath?: `/${string}` | undefined;
+}>;
+
+export type NanocodexViteOptions = Readonly<{
+  /** Local ChatGPT subscription support is on by default; pass false to disable it. */
+  chatGpt?: NanocodexChatGptViteOptions | false | undefined;
+}>;
+
+export type NanocodexVitePlugin = Readonly<{
+  name: "nanocodex";
+  enforce: "pre";
+  resolveId(source: string, importer?: string): string | null;
+  config(config: unknown, environment: Readonly<{ command: "build" | "serve" }>): unknown | Promise<unknown>;
+  configureServer(server: unknown): void | Promise<void>;
+  closeBundle(): void | Promise<void>;
+}>;
+
+/** Complete local integration for an ordinary Vite browser application. */
+export function nanocodex(options?: NanocodexViteOptions): NanocodexVitePlugin;

--- a/js/bindings/vite/index.mjs
+++ b/js/bindings/vite/index.mjs
@@ -1,0 +1,6 @@
+import { createNanocodexVitePlugin } from "./plugin.mjs";
+
+/** Browser compatibility plus a same-origin local ChatGPT endpoint for ordinary Vite apps. */
+export function nanocodex(options = {}) {
+  return createNanocodexVitePlugin(options, { target: "vite" });
+}

--- a/js/bindings/vite/plugin.mjs
+++ b/js/bindings/vite/plugin.mjs
@@ -1,0 +1,102 @@
+import { randomBytes } from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+import { nanocodexTools } from "../tools/vite.mjs";
+import { chatGptSubscription } from "./chatgpt-subscription.mjs";
+import { defaultCodexAuthFile, readCodexSubscription } from "./codex-auth-file.mjs";
+import { startChatGptWorkerEgress } from "./chatgpt-egress.mjs";
+
+export function createNanocodexVitePlugin(options, integration) {
+  const tools = nanocodexTools();
+  const chatGpt = options.chatGpt ?? {};
+  const direct = integration.target === "vite" && chatGpt !== false
+    ? chatGptSubscription(chatGpt)
+    : undefined;
+  let workerAuth;
+  let egress;
+  let cleanupPromise;
+
+  const cleanup = () => cleanupPromise ??= (async () => {
+    try {
+      await egress?.close();
+    } finally {
+      egress = undefined;
+      workerAuth = undefined;
+      integration.setDevBindings?.(undefined);
+    }
+  })();
+
+  return {
+    name: "nanocodex",
+    enforce: "pre",
+    resolveId: tools.resolveId,
+    async config(config, environment) {
+      const nestedWorker = workerPlugins(config.worker?.plugins);
+      if (
+        integration.target !== "cloudflare"
+        || environment.command !== "serve"
+        || chatGpt === false
+      ) {
+        if (integration.target === "cloudflare") await cleanup();
+        integration.setDevBindings?.(undefined);
+        return { worker: { plugins: nestedWorker } };
+      }
+
+      await cleanup();
+      cleanupPromise = undefined;
+      try {
+        const configuredAuthFile = chatGpt.authFile === undefined
+          ? defaultCodexAuthFile()
+          : chatGpt.authFile;
+        const authFile = configuredAuthFile instanceof URL
+          ? fileURLToPath(configuredAuthFile)
+          : configuredAuthFile;
+        workerAuth = await readCodexSubscription(authFile);
+        egress = await startChatGptWorkerEgress();
+        integration.setDevBindings(Object.freeze({
+          ENVIRONMENT: "development",
+          NANOCODEX_DEV_CHATGPT_ACCESS_TOKEN: workerAuth.accessToken,
+          NANOCODEX_DEV_CHATGPT_ACCOUNT_ID: workerAuth.accountId,
+          NANOCODEX_DEV_CHATGPT_FEDRAMP: String(workerAuth.fedramp),
+          NANOCODEX_DEV_CHATGPT_EXPIRES_AT: String(workerAuth.expiresAt),
+          NANOCODEX_DEV_CHATGPT_EGRESS_URL: egress.url,
+          NANOCODEX_DEV_CHATGPT_SESSION_ID: randomBytes(32).toString("base64url"),
+        }));
+      } catch (error) {
+        await cleanup();
+        throw new Error(
+          `Nanocodex local ChatGPT setup failed: ${errorMessage(error)}. Run \`codex login\` and retry.`,
+        );
+      }
+      return { worker: { plugins: nestedWorker } };
+    },
+    async configureServer(vite) {
+      if (integration.target === "vite") {
+        await direct?.configureServer(vite);
+        return;
+      }
+      if (!workerAuth) return;
+      vite.config.logger.info(
+        `[nanocodex] local ChatGPT subscription ready through the application Worker (expires ${new Date(workerAuth.expiresAt).toISOString()})`,
+      );
+      vite.httpServer?.once("close", () => { void cleanup(); });
+    },
+    async closeBundle() {
+      await cleanup();
+    },
+  };
+}
+
+function workerPlugins(existing) {
+  return () => {
+    const configured = typeof existing === "function" ? existing() : [];
+    const plugins = (configured ?? []).flat(Infinity).filter(Boolean);
+    return plugins.some((plugin) => plugin?.name === "nanocodex-tools")
+      ? plugins
+      : [nanocodexTools(), ...plugins];
+  };
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}


### PR DESCRIPTION
## Summary
- publish `nanocodex/vite` and `nanocodex/vite/cloudflare` entrypoints with matching types and package checks
- provide same-origin local ChatGPT subscription proxying from Codex auth without exposing refresh credentials
- capability-scope Cloudflare development egress to loopback and fixed ChatGPT Codex routes
- adopt the reusable integration in the React/Vite Cloudflare example while retaining production `OPENAI_API_KEY` fallback

## Validation
- `node --test js/bindings/test/vite.test.mjs`
- `npm run test:typecheck --prefix js/bindings`
- `npm run check:package --prefix js/bindings`
- `node --test js/bindings/test/package.test.mjs`
- `npm test --prefix examples/react-vite`
- `npm run build --prefix examples/react-vite`
- Node syntax checks and `git diff --check`

## Scope
Stale website-specific auth/session changes from the source worktree are intentionally omitted. The current production passkey, managed-agent, credential-broker, and deployment-health architecture is unchanged.