### PR TITLE
feat(browser): add isolated native authentication flows

### DIFF
--- a/bin/nanocodex/src/browser.rs
+++ b/bin/nanocodex/src/browser.rs
@@ -3,8 +3,9 @@ use std::path::{Path, PathBuf};
 use clap::{Args, ValueEnum};
 use eyre::{Result, WrapErr, eyre};
 use nanocodex_browser::{
-    BraveSession, BraveSessionError, Browser, BrowserProfileKind, BrowserStorageState, BrowserTool,
-    FirefoxCookieSource, SafariCookieSource, VirtualAuthenticator,
+    BraveSession, BraveSessionError, Browser, BrowserCookieAuthorization, BrowserProfileKind,
+    BrowserStorageState, BrowserTool, FirefoxCookieSource, HostPasskeyAuthenticator,
+    SafariCookieSource, VirtualAuthenticator,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -30,6 +31,22 @@ enum CookieSourceKind {
     None,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+enum CookieAuthorizationKind {
+    #[default]
+    Background,
+    Interactive,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+enum PasskeyKind {
+    #[default]
+    Virtual,
+    Host,
+    #[value(alias = "false", alias = "off")]
+    None,
+}
+
 enum CookieSource {
     Chromium(BraveSession),
     State(BrowserStorageState),
@@ -41,16 +58,17 @@ pub(crate) struct BrowserArgs {
     /// Select the private browser exposed to Code Mode as `tools.browser`.
     ///
     /// By default, Nanocodex uses a dedicated automation browser on macOS. On
-    /// other platforms it prefers Brave, falls back to another installed
-    /// Chromium-family browser, and disables browser tools when none is
-    /// available. Pass `brave` to require the standard Brave installation,
-    /// `chromium` to skip Brave, or `none` to disable browser tools.
+    /// other platforms it prefers Brave and falls back to another installed
+    /// Chromium-family browser. Pass `brave` to deliberately use the standard
+    /// Brave application with a private profile, `chromium` to use normal
+    /// private browser discovery, or `none` to disable browser tools. Bare
+    /// `--browser` selects private browser discovery.
     #[arg(
         long,
         env = "NANOCODEX_BROWSER",
         value_enum,
         num_args = 0..=1,
-        default_missing_value = "brave",
+        default_missing_value = "chromium",
         require_equals = true
     )]
     browser: Option<BrowserKind>,
@@ -72,6 +90,31 @@ pub(crate) struct BrowserArgs {
     #[cfg_attr(not(target_os = "macos"), arg(default_value = "all"))]
     cookies: Option<CookieSourceKind>,
 
+    /// Permit a visible temporary browser when macOS must authorize cookie decryption.
+    ///
+    /// `interactive` retries a failed background import with a copied temporary
+    /// profile. It never opens the ordinary source profile or its tabs.
+    #[arg(
+        long = "cookie-auth",
+        env = "NANOCODEX_BROWSER_COOKIE_AUTH",
+        value_enum,
+        default_value = "background"
+    )]
+    cookie_authorization: CookieAuthorizationKind,
+
+    /// Select passkeys owned by Nanocodex or interactively use the macOS host authenticator.
+    ///
+    /// `virtual` persists automation-only passkeys in the Nanocodex state
+    /// directory. `host` exposes explicit start/resume browser actions that use
+    /// a temporary visible desktop browser and the normal Touch ID/iPhone UI.
+    #[arg(
+        long,
+        env = "NANOCODEX_BROWSER_PASSKEYS",
+        value_enum,
+        default_value = "virtual"
+    )]
+    passkeys: PasskeyKind,
+
     /// Chrome or Chromium executable used by the browser tool.
     #[arg(long, env = "NANOCODEX_BROWSER_EXECUTABLE", value_name = "PATH")]
     browser_executable: Option<PathBuf>,
@@ -82,6 +125,8 @@ impl Default for BrowserArgs {
         Self {
             browser: None,
             cookies: Some(default_cookie_source()),
+            cookie_authorization: CookieAuthorizationKind::Background,
+            passkeys: PasskeyKind::Virtual,
             browser_executable: None,
         }
     }
@@ -95,6 +140,8 @@ impl BrowserArgs {
     pub(crate) fn disable(&mut self) {
         self.browser = Some(BrowserKind::None);
         self.cookies = Some(CookieSourceKind::None);
+        self.cookie_authorization = CookieAuthorizationKind::Background;
+        self.passkeys = PasskeyKind::None;
         self.browser_executable = None;
     }
 
@@ -113,6 +160,19 @@ impl BrowserArgs {
         matches!(self.browser, Some(BrowserKind::Brave))
     }
 
+    #[cfg(test)]
+    pub(crate) const fn uses_interactive_cookie_authorization(&self) -> bool {
+        matches!(
+            self.cookie_authorization,
+            CookieAuthorizationKind::Interactive
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn uses_host_passkeys(&self) -> bool {
+        matches!(self.passkeys, PasskeyKind::Host)
+    }
+
     pub(crate) fn configure(&self, workspace: &Path) -> Result<Option<ConfiguredBrowser>> {
         if self.browser == Some(BrowserKind::None) {
             if self.cookies.is_some_and(|source| {
@@ -122,6 +182,14 @@ impl BrowserArgs {
             }
             if self.browser_executable.is_some() {
                 return Err(eyre!("--browser-executable requires an enabled browser"));
+            }
+            if self.cookie_authorization == CookieAuthorizationKind::Interactive {
+                return Err(eyre!(
+                    "--cookie-auth=interactive requires an enabled browser"
+                ));
+            }
+            if self.passkeys == PasskeyKind::Host {
+                return Err(eyre!("--passkeys=host requires an enabled browser"));
             }
             return Ok(None);
         }
@@ -133,11 +201,17 @@ impl BrowserArgs {
         else {
             return Ok(None);
         };
-        let virtual_authenticator = VirtualAuthenticator::platform_passkey()
-            .credential_store(default_virtual_credential_store()?);
-        let mut builder = Browser::builder()
-            .file_root(workspace)
-            .virtual_authenticator(virtual_authenticator);
+        let mut builder = Browser::builder().file_root(workspace);
+        builder = match self.passkeys {
+            PasskeyKind::Virtual => builder.virtual_authenticator(
+                VirtualAuthenticator::platform_passkey()
+                    .credential_store(default_virtual_credential_store()?),
+            ),
+            PasskeyKind::Host => {
+                builder.host_passkey_authenticator(standard_host_passkey_authenticator()?)
+            }
+            PasskeyKind::None => builder,
+        };
         if let Some(executable) = launch.executable {
             builder = builder.executable(executable);
         }
@@ -146,9 +220,29 @@ impl BrowserArgs {
             .filter(|source| *source != CookieSourceKind::None)
         {
             builder = match cookie_source(source, launch.kind)? {
-                CookieSource::Chromium(source) => builder.cookie_source(source.copy_all_cookies()),
-                CookieSource::State(state) => builder.storage_state(state),
+                CookieSource::Chromium(source) => {
+                    builder.cookie_source(source.copy_all_cookies().cookie_authorization(
+                        match self.cookie_authorization {
+                            CookieAuthorizationKind::Background => {
+                                BrowserCookieAuthorization::Background
+                            }
+                            CookieAuthorizationKind::Interactive => {
+                                BrowserCookieAuthorization::Interactive
+                            }
+                        },
+                    ))
+                }
+                CookieSource::State(state) => {
+                    if self.cookie_authorization == CookieAuthorizationKind::Interactive {
+                        return Err(eyre!(
+                            "--cookie-auth=interactive requires a Chromium-family cookie source"
+                        ));
+                    }
+                    builder.storage_state(state)
+                }
             };
+        } else if self.cookie_authorization == CookieAuthorizationKind::Interactive {
+            return Err(eyre!("--cookie-auth=interactive requires browser cookies"));
         }
         let browser = builder
             .build()
@@ -170,6 +264,32 @@ fn default_virtual_credential_store() -> Result<PathBuf> {
         return Err(eyre!("NANOCODEX_DIR cannot be empty"));
     }
     Ok(root.join("browser/passkeys.json"))
+}
+
+fn standard_host_passkey_authenticator() -> Result<HostPasskeyAuthenticator> {
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err(eyre!(
+            "--passkeys=host is currently supported only on macOS"
+        ))
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        for kind in [
+            BrowserProfileKind::Brave,
+            BrowserProfileKind::Chrome,
+            BrowserProfileKind::Edge,
+            BrowserProfileKind::Chromium,
+        ] {
+            if let Ok(session) = BraveSession::standard_for(kind) {
+                return Ok(HostPasskeyAuthenticator::new(session.executable()));
+            }
+        }
+        Err(eyre!(
+            "--passkeys=host requires an installed Brave, Chrome, Edge, or Chromium application"
+        ))
+    }
 }
 
 struct BrowserLaunch {
@@ -432,6 +552,8 @@ mod tests {
         let browser = BrowserArgs {
             browser: Some(super::BrowserKind::Chromium),
             cookies: None,
+            cookie_authorization: super::CookieAuthorizationKind::Background,
+            passkeys: super::PasskeyKind::Virtual,
             browser_executable: None,
         }
         .configure(workspace.path())
@@ -459,6 +581,8 @@ mod tests {
         let disabled = BrowserArgs {
             browser: Some(super::BrowserKind::None),
             cookies: Some(super::CookieSourceKind::None),
+            cookie_authorization: super::CookieAuthorizationKind::Background,
+            passkeys: super::PasskeyKind::None,
             browser_executable: None,
         }
         .configure(workspace.path())
@@ -468,6 +592,8 @@ mod tests {
         let cookies = BrowserArgs {
             browser: Some(super::BrowserKind::None),
             cookies: Some(super::CookieSourceKind::Chrome),
+            cookie_authorization: super::CookieAuthorizationKind::Background,
+            passkeys: super::PasskeyKind::None,
             browser_executable: None,
         }
         .configure(workspace.path())
@@ -478,6 +604,8 @@ mod tests {
         let executable = BrowserArgs {
             browser: Some(super::BrowserKind::None),
             cookies: Some(super::CookieSourceKind::All),
+            cookie_authorization: super::CookieAuthorizationKind::Background,
+            passkeys: super::PasskeyKind::None,
             browser_executable: Some("/tmp/chromium".into()),
         }
         .configure(workspace.path())

--- a/bin/nanocodex/src/config.rs
+++ b/bin/nanocodex/src/config.rs
@@ -259,6 +259,16 @@ impl AgentArgs {
         self.browser.uses_brave()
     }
 
+    #[cfg(test)]
+    pub(crate) const fn uses_interactive_browser_cookie_authorization(&self) -> bool {
+        self.browser.uses_interactive_cookie_authorization()
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn uses_host_browser_passkeys(&self) -> bool {
+        self.browser.uses_host_passkeys()
+    }
+
     pub(crate) fn thinking(&self) -> Thinking {
         self.model_policy.thinking.unwrap_or_default()
     }

--- a/bin/nanocodex/src/main.rs
+++ b/bin/nanocodex/src/main.rs
@@ -329,12 +329,14 @@ mod tests {
         assert!(tui.agent.browser_enabled());
         #[cfg(target_os = "macos")]
         assert!(!tui.agent.copies_all_browser_cookies());
+        #[cfg(target_os = "macos")]
+        assert!(!tui.agent.uses_brave_browser());
         #[cfg(not(target_os = "macos"))]
         assert!(tui.agent.copies_all_browser_cookies());
 
         let tui = Cli::try_parse_from(["nanocodex", "--browser"]).unwrap();
         assert!(tui.agent.browser_enabled());
-        assert!(tui.agent.uses_brave_browser());
+        assert!(!tui.agent.uses_brave_browser());
 
         let brave =
             Cli::try_parse_from(["nanocodex", "--browser=brave", "--cookies=true"]).unwrap();
@@ -348,6 +350,16 @@ mod tests {
 
         let all_cookies = Cli::try_parse_from(["nanocodex", "--cookies=all"]).unwrap();
         assert!(all_cookies.agent.browser_enabled());
+
+        let interactive = Cli::try_parse_from(["nanocodex", "--cookie-auth=interactive"]).unwrap();
+        assert!(
+            interactive
+                .agent
+                .uses_interactive_browser_cookie_authorization()
+        );
+
+        let host_passkeys = Cli::try_parse_from(["nanocodex", "--passkeys=host"]).unwrap();
+        assert!(host_passkeys.agent.uses_host_browser_passkeys());
 
         let no_cookies = Cli::try_parse_from(["nanocodex", "--cookies=none"]).unwrap();
         assert!(no_cookies.agent.browser_enabled());

--- a/crates/experimental/nanocodex-browser/README.md
+++ b/crates/experimental/nanocodex-browser/README.md
@@ -43,7 +43,9 @@ can register the same value with `.tool(browser)`.
 install an isolated virtual platform authenticator by default, so passkey
 registration and sign-in work unattended inside the private browser session.
 Low-level `Browser::builder()` consumers retain explicit control through
-`.virtual_authenticator(...)`.
+`.virtual_authenticator(...)`. On macOS, callers may instead configure
+`.host_passkey_authenticator(...)` for explicit user-approved access to the
+system passkey UI.
 
 For isolation, one non-cloneable VM owner keeps the disposable browser alive
 and gives the agent a tool handle:
@@ -211,17 +213,22 @@ actions return a typed unsupported error; there is no Chromium fallback.
 - Viewport- and element-targeted screenshots, pixel-level visual diffs,
   PDF, visual/session/performance traces, video, CPU profiles, coverage, heap
   inspection, accessibility/axe, Lighthouse, and CrUX actions.
-- Harness-owned cookies/storage, virtual passkeys, allowlisted source-browser handoff,
+- Harness-owned cookies/storage, virtual passkeys, explicit host-passkey handoff,
   upload roots, browser egress policy, remote CDP, and libkrun VM composition.
 - Pinned Chromium mobile profiles, verified audit matrices, and an explicit
   real-Safari Appium/XCUITest backend with Xcode device discovery.
 
-The Nanocodex CLI prefers a private Brave session and falls back to an
-installed Chrome, Chromium, or Edge when Brave is not installed. If none is
-available, the CLI starts without browser tools. It copies a standard desktop
-browser profile's complete cookie database by default. `all`
-auto-detects the source; `brave`, `chrome`, `chromium`, `edge`, `firefox`, and
-`safari` select it explicitly.
+The Nanocodex CLI default and bare `--browser` use private automation-browser
+discovery with a fresh temporary profile. On macOS this selects a dedicated
+chrome-headless-shell or Chrome for Testing installation, not the user's Brave
+or Chrome application. `--browser=brave` remains an explicit request to launch
+the standard Brave application with a private profile. Cookie import defaults
+to `none` on macOS so unattended startup never opens the login Keychain, and
+to `all` on other platforms. `all` auto-detects the source; `brave`, `chrome`,
+`chromium`, `edge`, `firefox`, and `safari` select it explicitly. When
+requested on macOS, Chromium-family cookie decryption may briefly use the
+source browser's Keychain identity, but that bounded broker exits before the
+long-lived automation session starts.
 
 The CLI's virtual platform authenticator persists testing passkeys across
 browser and Nanocodex restarts in `$NANOCODEX_DIR/browser/passkeys.json`, or
@@ -233,6 +240,21 @@ to inspect non-secret metadata, `passkey_use` to expose one saved credential,
 `passkey_new` to create against an empty authenticator, and `passkey_auto` to
 restore normal automatic credential selection. Selection never deletes the
 other credentials in the persisted store.
+
+Pass `--passkeys=host` on macOS to use passkeys from the host authenticator
+without exporting them. The browser tool first navigates headlessly as usual.
+At a passkey gate it calls `host_passkey_start`, which opens the same page in a
+visible Brave, Chrome, Edge, or Chromium application backed by a new temporary
+profile. Complete the ceremony with Touch ID or an iPhone and leave that window
+open. A subsequent `host_passkey_resume` imports the resulting cookies, closes
+the temporary window, and continues in the private headless session. The
+ordinary desktop-browser profile is never opened, and passkey private keys and
+user handles never enter Nanocodex or browser-tool output. Host and virtual
+passkey modes are mutually exclusive.
+
+```console
+nanocodex --passkeys=host
+```
 
 Pass `none` to either option to disable the browser or cookie-copy default:
 
@@ -253,9 +275,19 @@ binary-cookie decoder may require granting the Nanocodex process macOS access
 to Safari's sandboxed profile. Source profiles are never mutated, and cookie
 values remain outside the model-callable browser schema. The `exec` contract
 advertises `tools.browser` with a compact summary; its complete action guidance
-remains runtime-only in `ALL_TOOLS`. The default cookie mode deliberately gives
-the agent authenticated access to every site represented in the selected
-profile.
+remains runtime-only in `ALL_TOOLS`. Selecting `all` deliberately gives the
+agent authenticated access to every site represented in the selected profile.
+
+On macOS, if a populated Chromium-family store cannot be decrypted in the
+background, rerun with `--cookie-auth=interactive`. Nanocodex first tries the
+invisible broker, then opens one visible window backed only by a fresh copied
+temporary profile. Approve the Keychain prompt within two minutes; the broker
+exports the cookies and closes before the dedicated automation browser starts.
+The ordinary source profile and its tabs are never opened or controlled.
+
+```console
+nanocodex --cookies=brave --cookie-auth=interactive
+```
 
 ## Current boundaries
 

--- a/crates/experimental/nanocodex-browser/src/lib.rs
+++ b/crates/experimental/nanocodex-browser/src/lib.rs
@@ -89,7 +89,9 @@ pub use ios::{
     BrowserIosDeviceSelector, BrowserIosError, IosBrowser,
 };
 pub use native::{BrowserBuildError, BrowserError};
-pub use session::{BraveSession, BraveSessionError, BrowserProfileKind};
+pub use session::{
+    BraveSession, BraveSessionError, BrowserCookieAuthorization, BrowserProfileKind,
+};
 
 const TOOL_DESCRIPTION: &str = r#"Control one server-managed browser session.
 
@@ -215,6 +217,11 @@ non-secret credential metadata. Before a WebAuthn ceremony, use `passkey_use`
 to expose one saved credential, `passkey_new` to expose an empty authenticator
 for registration, or `passkey_auto` to expose every saved credential and let
 the relying party choose. Persisted private keys never enter tool output.
+When host passkeys are explicitly configured, call `host_passkey_start` on the
+page that needs authentication. Complete the passkey ceremony in the isolated
+visible browser without closing it, then call `host_passkey_resume` to transfer
+the authenticated cookies back into this headless session. The host credential
+never enters Nanocodex or the tool output.
 Use `matched_styles`, `force_pseudo_state`, and `event_listeners` for authored
 CSS and listener provenance. The debugger actions expose source-mapped
 breakpoints, exception policy, pause stacks/scopes, resume, and stepping;
@@ -763,6 +770,10 @@ pub enum BrowserAction {
     PasskeyNew,
     /// Expose every persisted passkey and let the relying party choose.
     PasskeyAuto,
+    /// Open the active page in an isolated visible browser that can use host passkeys.
+    HostPasskeyStart,
+    /// Import the completed host-passkey session and close its visible browser.
+    HostPasskeyResume,
     /// Evaluate JavaScript in the active page.
     Evaluate {
         /// JavaScript expression to evaluate.
@@ -886,6 +897,8 @@ impl BrowserAction {
             Self::PasskeyUse { .. } => BrowserActionName::PasskeyUse,
             Self::PasskeyNew => BrowserActionName::PasskeyNew,
             Self::PasskeyAuto => BrowserActionName::PasskeyAuto,
+            Self::HostPasskeyStart => BrowserActionName::HostPasskeyStart,
+            Self::HostPasskeyResume => BrowserActionName::HostPasskeyResume,
             Self::Evaluate { .. } => BrowserActionName::Evaluate,
         }
     }
@@ -1002,6 +1015,8 @@ pub enum BrowserActionName {
     PasskeyUse,
     PasskeyNew,
     PasskeyAuto,
+    HostPasskeyStart,
+    HostPasskeyResume,
     Evaluate,
 }
 
@@ -2008,6 +2023,32 @@ pub enum BrowserGate {
     JsChallenge { evidence: String },
     /// The page visibly denies access.
     AccessDenied { evidence: String },
+}
+
+/// Explicit access to passkeys provided by the host operating system.
+///
+/// The configured desktop browser is launched only for a model-requested,
+/// user-visible authorization handoff. It receives an isolated temporary
+/// profile and never opens the user's ordinary browser profile. Credential
+/// material remains inside the host authenticator; only resulting browser
+/// cookies are synchronized back into the managed headless session.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HostPasskeyAuthenticator {
+    executable: std::path::PathBuf,
+}
+
+impl HostPasskeyAuthenticator {
+    /// Selects the signed desktop browser application used for host passkey UI.
+    #[must_use]
+    pub fn new(executable: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            executable: executable.into(),
+        }
+    }
+
+    pub(crate) fn executable(&self) -> &std::path::Path {
+        &self.executable
+    }
 }
 
 /// A virtual platform passkey authenticator owned by the browser session.
@@ -3291,7 +3332,9 @@ fn recording_result(
         | BrowserAction::NetworkRoute { .. }
         | BrowserAction::RemoveNetworkRoute { .. }
         | BrowserAction::ClearNetworkRoutes
-        | BrowserAction::SetOffline { .. } => BrowserActionResult::Action {
+        | BrowserAction::SetOffline { .. }
+        | BrowserAction::HostPasskeyStart
+        | BrowserAction::HostPasskeyResume => BrowserActionResult::Action {
             sequence,
             action: action.name(),
             executed,
@@ -3319,65 +3362,6 @@ pub struct Browser {
     inner: Arc<native::NativeBrowser>,
 }
 
-/// A validated authentication handoff that has not opened the user's Brave yet.
-///
-/// This is a harness operation, not a model-callable [`BrowserAction`]. Opening
-/// consumes this value so callers cannot accidentally open arbitrary pages or
-/// resume a handoff that was never presented to the user.
-pub struct BraveAuthHandoff {
-    browser: Browser,
-    url: url::Url,
-}
-
-/// An authentication page opened in the user's ordinary Brave profile.
-///
-/// After the user completes the passkey or other authentication gate, call
-/// [`resume`](Self::resume) to take a fresh allowlisted cookie snapshot and
-/// reopen the protected URL in the dedicated browser. A local browser is
-/// relaunched with the new snapshot; a remote CDP browser receives refreshed
-/// cookies without restarting.
-pub struct OpenedBraveAuthHandoff {
-    browser: Browser,
-    url: url::Url,
-}
-
-impl BraveAuthHandoff {
-    /// Opens only the validated protected URL in the user's ordinary Brave.
-    ///
-    /// The passkey ceremony remains entirely in the user's browser. Nanocodex
-    /// does not receive credential material or control the visible page.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if Brave cannot be started or the URL is no longer
-    /// allowed by this browser's session policy.
-    pub fn open(self) -> Result<OpenedBraveAuthHandoff, BrowserError> {
-        self.browser.inner.open_auth_handoff(&self.url)?;
-        Ok(OpenedBraveAuthHandoff {
-            browser: self.browser,
-            url: self.url,
-        })
-    }
-}
-
-impl OpenedBraveAuthHandoff {
-    /// Refreshes the private headless session after the caller observes that
-    /// the user has completed authentication.
-    ///
-    /// A fresh filtered cookie snapshot is copied from Brave and the protected
-    /// URL is reopened before this future completes. A locally launched
-    /// browser discards its old private process and profile. A remote CDP
-    /// browser remains alive and receives a replacement cookie set.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the session cannot be refreshed, the fresh snapshot
-    /// cannot be prepared, or the protected page cannot be reopened.
-    pub async fn resume(self) -> Result<(), BrowserError> {
-        self.browser.inner.resume_auth_handoff(self.url).await
-    }
-}
-
 /// Configuration for one isolated [`Browser`] session.
 #[derive(Clone, Debug, Default)]
 pub struct BrowserBuilder {
@@ -3386,6 +3370,7 @@ pub struct BrowserBuilder {
     brave_session: Option<BraveSession>,
     launch_brave_executable: bool,
     virtual_authenticator: Option<VirtualAuthenticator>,
+    host_passkey_authenticator: Option<HostPasskeyAuthenticator>,
     react_diagnostics: Option<ReactDiagnostics>,
     egress_policy: Option<BrowserEgressPolicy>,
     file_root: Option<std::path::PathBuf>,
@@ -3446,6 +3431,16 @@ impl BrowserBuilder {
     #[must_use]
     pub fn virtual_authenticator(mut self, virtual_authenticator: VirtualAuthenticator) -> Self {
         self.virtual_authenticator = Some(virtual_authenticator);
+        self
+    }
+
+    /// Enables explicit interactive use of the host operating system's passkeys.
+    ///
+    /// The selected application receives a fresh isolated profile for each
+    /// handoff. This policy cannot be combined with a virtual authenticator.
+    #[must_use]
+    pub fn host_passkey_authenticator(mut self, authenticator: HostPasskeyAuthenticator) -> Self {
+        self.host_passkey_authenticator = Some(authenticator);
         self
     }
 
@@ -3588,6 +3583,22 @@ impl BrowserBuilder {
                 message: "the virtual credential store path cannot be empty".to_owned(),
             });
         }
+        if self.virtual_authenticator.is_some() && self.host_passkey_authenticator.is_some() {
+            return Err(BrowserBuildError::Configuration {
+                message: "host and virtual passkey authenticators cannot be enabled together"
+                    .to_owned(),
+            });
+        }
+        if let Some(authenticator) = &self.host_passkey_authenticator
+            && !authenticator.executable().is_file()
+        {
+            return Err(BrowserBuildError::Configuration {
+                message: format!(
+                    "host passkey browser executable is unavailable: {}",
+                    authenticator.executable().display()
+                ),
+            });
+        }
         if let Some(client) = &self.crux_client {
             if client.api_key.is_empty() {
                 return Err(BrowserBuildError::Configuration {
@@ -3635,6 +3646,7 @@ impl BrowserBuilder {
                 self.brave_session,
                 self.launch_brave_executable,
                 self.virtual_authenticator,
+                self.host_passkey_authenticator,
                 self.react_diagnostics,
                 egress_policy,
                 file_root,
@@ -3853,26 +3865,6 @@ impl Browser {
         validate_storage_state(&state)
             .map_err(|message| BrowserError::Configuration { message })?;
         self.inner.restore_storage_state(state).await
-    }
-
-    /// Prepares an explicit user authentication handoff for an allowlisted URL.
-    ///
-    /// This is available only for browsers configured with
-    /// [`BrowserBuilder::brave_session`]. It never becomes part of the browser
-    /// tool schema, so a model cannot open arbitrary pages in the user's
-    /// browser. The caller decides when to open the page and when authentication
-    /// has completed.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error when no Brave session is configured or the URL's exact
-    /// origin is outside that session's allowlist.
-    pub fn auth_handoff(&self, url: url::Url) -> Result<BraveAuthHandoff, BrowserError> {
-        self.inner.validate_auth_handoff(&url)?;
-        Ok(BraveAuthHandoff {
-            browser: self.clone(),
-            url,
-        })
     }
 
     /// Returns public metadata for credentials in the virtual authenticator.

--- a/crates/experimental/nanocodex-browser/src/native.rs
+++ b/crates/experimental/nanocodex-browser/src/native.rs
@@ -90,16 +90,17 @@ use url::Url;
 use crate::{
     BraveSession, BraveSessionError, BrowserAction, BrowserActionName, BrowserActionOutcome,
     BrowserActionResult, BrowserAfterAction, BrowserClickOptions, BrowserConsoleEntry,
-    BrowserCookie, BrowserCookieSameSite, BrowserCruxClient, BrowserDialog, BrowserDialogKind,
-    BrowserDocumentReadyState, BrowserDomDocument, BrowserDomLayout, BrowserDomNode,
-    BrowserDomRect, BrowserDomSnapshot, BrowserDownload, BrowserEgressPolicy,
-    BrowserElementContext, BrowserElementReference, BrowserFrame, BrowserGate, BrowserHttpHeader,
-    BrowserImageArtifact, BrowserNetworkBodyKind, BrowserNetworkCallFrame, BrowserNetworkContext,
-    BrowserNetworkInitiator, BrowserNetworkRequest, BrowserNetworkTiming, BrowserOriginStorage,
-    BrowserPageError, BrowserPageState, BrowserPasskeyMode, BrowserPostActionSnapshot,
-    BrowserReactEvent, BrowserReactStatus, BrowserStorageState, BrowserTab, BrowserTarget,
-    BrowserTargetIndex, BrowserWebSocketDirection, BrowserWebSocketMessage, MAX_VIEWPORT_DIMENSION,
-    ReactDiagnostics, VirtualAuthenticator, VirtualCredential,
+    BrowserCookie, BrowserCookieAuthorization, BrowserCookieSameSite, BrowserCruxClient,
+    BrowserDialog, BrowserDialogKind, BrowserDocumentReadyState, BrowserDomDocument,
+    BrowserDomLayout, BrowserDomNode, BrowserDomRect, BrowserDomSnapshot, BrowserDownload,
+    BrowserEgressPolicy, BrowserElementContext, BrowserElementReference, BrowserFrame, BrowserGate,
+    BrowserHttpHeader, BrowserImageArtifact, BrowserNetworkBodyKind, BrowserNetworkCallFrame,
+    BrowserNetworkContext, BrowserNetworkInitiator, BrowserNetworkRequest, BrowserNetworkTiming,
+    BrowserOriginStorage, BrowserPageError, BrowserPageState, BrowserPasskeyMode,
+    BrowserPostActionSnapshot, BrowserReactEvent, BrowserReactStatus, BrowserStorageState,
+    BrowserTab, BrowserTarget, BrowserTargetIndex, BrowserWebSocketDirection,
+    BrowserWebSocketMessage, HostPasskeyAuthenticator, MAX_VIEWPORT_DIMENSION, ReactDiagnostics,
+    VirtualAuthenticator, VirtualCredential,
     features::{
         BrowserColorScheme, BrowserContext, BrowserDeviceDescriptor, BrowserDevicePreset,
         BrowserMobileAudit, BrowserMobileAuditSample, BrowserMobileFinding,
@@ -114,6 +115,8 @@ use credential_store::VirtualCredentialStore;
 const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(25);
 const DEFAULT_NAVIGATION_TIMEOUT: Duration = Duration::from_secs(5);
 const BROWSER_LAUNCH_TIMEOUT: Duration = Duration::from_secs(10);
+const COOKIE_AUTHORIZATION_TIMEOUT: Duration = Duration::from_secs(120);
+const COOKIE_AUTHORIZATION_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const SESSION_DISCARD_TIMEOUT: Duration = Duration::from_secs(3);
 const MAIN_CONTEXT_RETRY_TIMEOUT: Duration = Duration::from_secs(2);
 const MAX_EXPLICIT_WAIT: Duration = Duration::from_secs(30);
@@ -156,6 +159,7 @@ pub(crate) struct NativeBrowser {
     brave_session: Option<BraveSession>,
     launch_brave_executable: bool,
     virtual_authenticator: Option<VirtualAuthenticator>,
+    host_passkey_authenticator: Option<HostPasskeyAuthenticator>,
     react_diagnostics: Option<ReactDiagnostics>,
     egress_policy: Option<BrowserEgressPolicy>,
     file_root: Option<PathBuf>,
@@ -422,6 +426,8 @@ struct Session {
     virtual_authenticator: Option<VirtualAuthenticator>,
     virtual_credential_store: Option<VirtualCredentialStore>,
     passkey_mode: BrowserPasskeyMode,
+    host_passkey_authenticator: Option<HostPasskeyAuthenticator>,
+    host_passkey_broker: Option<HostPasskeyBroker>,
     react_diagnostics_enabled: bool,
     authenticators: HashMap<String, InstalledAuthenticator>,
     closed_targets: HashSet<String>,
@@ -448,6 +454,15 @@ struct Session {
     lighthouse_executable: Option<PathBuf>,
     crux_client: Option<BrowserCruxClient>,
     poisoned: Arc<AtomicBool>,
+}
+
+struct HostPasskeyBroker {
+    browser: Chromium,
+    page: Page,
+    handler: JoinHandle<()>,
+    launcher: tokio::process::Child,
+    _profile: TempDir,
+    return_url: Url,
 }
 
 struct ActionLease {
@@ -917,6 +932,9 @@ fn trace_browser_configuration(owner: &NativeBrowser) {
         "braveSession": owner.brave_session.as_ref().map(BraveSession::trace_value),
         "launchBraveExecutable": owner.launch_brave_executable,
         "virtualAuthenticator": owner.virtual_authenticator.is_some(),
+        "hostPasskeyAuthenticator": owner.host_passkey_authenticator.as_ref().map(|authenticator| {
+            serde_json::json!({ "executable": authenticator.executable() })
+        }),
         "reactDiagnostics": owner.react_diagnostics.map(|diagnostics| {
             serde_json::json!({
                 "includeProfilingHooks": diagnostics.include_profiling_hooks(),
@@ -947,6 +965,7 @@ impl Session {
         let brave_session = owner.brave_session.as_ref();
         let launch_brave_executable = owner.launch_brave_executable;
         let virtual_authenticator = owner.virtual_authenticator.clone();
+        let host_passkey_authenticator = owner.host_passkey_authenticator.clone();
         let virtual_credential_store = virtual_authenticator
             .as_ref()
             .and_then(VirtualAuthenticator::credential_store_path)
@@ -1081,6 +1100,8 @@ impl Session {
             virtual_authenticator,
             virtual_credential_store,
             passkey_mode: BrowserPasskeyMode::Auto,
+            host_passkey_authenticator,
+            host_passkey_broker: None,
             react_diagnostics_enabled: react_diagnostics.is_some(),
             authenticators: HashMap::new(),
             closed_targets: HashSet::new(),
@@ -1114,6 +1135,10 @@ impl Session {
 
     async fn close(mut self) -> Result<(), BrowserError> {
         let credential_sync = self.synchronize_virtual_credentials().await;
+        let host_passkey_shutdown = match self.host_passkey_broker.take() {
+            Some(mut broker) => broker.close().await,
+            None => Ok(()),
+        };
         self.network_observer.abort();
         for task in &self.browser_tasks {
             task.abort();
@@ -1123,6 +1148,7 @@ impl Session {
         }
         let close = close_chromium(&mut self.browser, &self.handler).await;
         credential_sync?;
+        host_passkey_shutdown?;
         close
     }
 
@@ -1154,17 +1180,6 @@ impl Session {
                 );
             }
         }
-        Ok(())
-    }
-
-    async fn refresh_remote_cookies(
-        &mut self,
-        runtime_dir: &Path,
-        brave_session: &BraveSession,
-    ) -> Result<(), BrowserError> {
-        let cookies = export_profile_cookies(runtime_dir, brave_session).await?;
-        trace_serialized("session.refreshed_brave_cookies", &cookies);
-        replace_browser_cookies(&self.browser, cookies).await?;
         Ok(())
     }
 
@@ -2005,6 +2020,160 @@ impl Session {
             credentials: self.persisted_virtual_credentials()?,
         })
     }
+
+    async fn start_host_passkey_authorization(&mut self) -> Result<(), BrowserError> {
+        let authenticator = self
+            .host_passkey_authenticator
+            .as_ref()
+            .ok_or(BrowserError::HostPasskeyAuthenticatorNotConfigured)?;
+        if self.host_passkey_broker.is_some() {
+            return Err(BrowserError::HostPasskeyAuthorizationActive);
+        }
+        let raw_url = self.page.url().await?.unwrap_or_default();
+        validate_url(&raw_url)?;
+        let url = Url::parse(&raw_url)?;
+        self.validate_navigation(&url)?;
+        let cookies = self
+            .browser
+            .get_cookies()
+            .await?
+            .into_iter()
+            .filter_map(cookie_param)
+            .collect();
+        self.host_passkey_broker = Some(
+            HostPasskeyBroker::launch(&self.output_dir, authenticator.executable(), url, cookies)
+                .await?,
+        );
+        Ok(())
+    }
+
+    async fn resume_host_passkey_authorization(&mut self) -> Result<(), BrowserError> {
+        let mut broker = self
+            .host_passkey_broker
+            .take()
+            .ok_or(BrowserError::HostPasskeyAuthorizationNotActive)?;
+        let cookies = broker
+            .browser
+            .get_cookies()
+            .await
+            .map_err(BrowserError::from)
+            .map(|cookies| {
+                cookies
+                    .into_iter()
+                    .filter_map(cookie_param)
+                    .collect::<Vec<_>>()
+            });
+        let return_url = broker
+            .page
+            .url()
+            .await
+            .map_err(BrowserError::from)
+            .map(|url| {
+                url.and_then(|url| Url::parse(&url).ok())
+                    .unwrap_or_else(|| broker.return_url.clone())
+            });
+        let shutdown = broker.close().await;
+        let cookies = cookies?;
+        let return_url = return_url?;
+        shutdown?;
+        self.validate_navigation(&return_url)?;
+        replace_browser_cookies(&self.browser, cookies).await?;
+        navigate(&self.page, return_url.as_str()).await?;
+        self.refs.clear();
+        Ok(())
+    }
+}
+
+impl HostPasskeyBroker {
+    #[cfg(target_os = "macos")]
+    async fn launch(
+        runtime_dir: &Path,
+        executable: &Path,
+        return_url: Url,
+        cookies: Vec<CookieParam>,
+    ) -> Result<Self, BrowserError> {
+        let application =
+            macos_application_bundle(executable).ok_or_else(|| BrowserError::Configuration {
+                message: format!(
+                    "host passkeys require a macOS application bundle; {} is not inside one",
+                    executable.display()
+                ),
+            })?;
+        let profile = tempfile::Builder::new()
+            .prefix("nanocodex-host-passkey-")
+            .tempdir_in(runtime_dir)?;
+        let mut command = tokio::process::Command::new("/usr/bin/open");
+        command
+            .args(host_passkey_broker_arguments(application, profile.path()))
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true);
+        let mut launcher = command.spawn()?;
+        let endpoint = wait_for_macos_broker_endpoint(profile.path(), &mut launcher).await?;
+        let (browser, mut events) = Chromium::connect(endpoint.as_str()).await?;
+        let handler = tokio::spawn(async move {
+            while let Some(event) = events.next().await {
+                if let Err(error) = event {
+                    warn!(
+                        target: "nanocodex_browser",
+                        %error,
+                        "host passkey broker handler stopped"
+                    );
+                    break;
+                }
+            }
+        });
+        replace_browser_cookies(&browser, cookies).await?;
+        let page = match browser.pages().await?.into_iter().next() {
+            Some(page) => page,
+            None => browser.new_page("about:blank").await?,
+        };
+        navigate(&page, return_url.as_str()).await?;
+        info!(
+            target: "nanocodex_browser",
+            url = return_url.as_str(),
+            "opened isolated browser for host passkey authorization"
+        );
+        Ok(Self {
+            browser,
+            page,
+            handler,
+            launcher,
+            _profile: profile,
+            return_url,
+        })
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    async fn launch(
+        _runtime_dir: &Path,
+        _executable: &Path,
+        _return_url: Url,
+        _cookies: Vec<CookieParam>,
+    ) -> Result<Self, BrowserError> {
+        Err(BrowserError::HostPasskeyAuthenticatorUnsupported)
+    }
+
+    async fn close(&mut self) -> Result<(), BrowserError> {
+        let close = self
+            .browser
+            .close()
+            .await
+            .map(drop)
+            .map_err(BrowserError::from);
+        self.handler.abort();
+        let launcher_shutdown = match timeout(SESSION_DISCARD_TIMEOUT, self.launcher.wait()).await {
+            Ok(result) => result.map(drop).map_err(BrowserError::from),
+            Err(_) => {
+                self.launcher.kill().await?;
+                self.launcher.wait().await?;
+                Ok(())
+            }
+        };
+        close?;
+        launcher_shutdown
+    }
 }
 
 fn virtual_credential_metadata(credential: &Credential) -> VirtualCredential {
@@ -2096,17 +2265,65 @@ async fn export_profile_cookies(
     runtime_dir: &Path,
     brave_session: &BraveSession,
 ) -> Result<Vec<CookieParam>, BrowserError> {
+    let (source_cookie_count, cookies) = export_profile_cookies_once(
+        runtime_dir,
+        brave_session,
+        CookieBrokerPresentation::Background,
+    )
+    .await?;
+    if source_cookie_count > 0
+        && cookies.is_empty()
+        && brave_session.cookie_authorization_policy() == BrowserCookieAuthorization::Interactive
+    {
+        warn!(
+            target: "nanocodex_browser",
+            source_cookie_count,
+            timeout_seconds = COOKIE_AUTHORIZATION_TIMEOUT.as_secs(),
+            "opening a visible temporary browser for cookie authorization"
+        );
+        let (interactive_source_count, cookies) = export_profile_cookies_once(
+            runtime_dir,
+            brave_session,
+            CookieBrokerPresentation::Interactive,
+        )
+        .await?;
+        return finish_profile_cookie_export(brave_session, interactive_source_count, cookies);
+    }
+    finish_profile_cookie_export(brave_session, source_cookie_count, cookies)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CookieBrokerPresentation {
+    Background,
+    Interactive,
+}
+
+async fn export_profile_cookies_once(
+    runtime_dir: &Path,
+    brave_session: &BraveSession,
+    presentation: CookieBrokerPresentation,
+) -> Result<(i64, Vec<Cookie>), BrowserError> {
     let broker_profile = tempfile::Builder::new()
         .prefix("brave-cookie-broker-")
         .tempdir_in(runtime_dir)?;
-    brave_session.prepare(broker_profile.path()).await?;
+    let source_cookie_count = brave_session.prepare(broker_profile.path()).await?;
 
-    let config = profile_launch_config(
-        BrowserConfig::builder()
-            .user_data_dir(broker_profile.path())
-            .new_headless_mode(),
-    )
-    .chrome_executable(brave_session.executable());
+    #[cfg(target_os = "macos")]
+    if presentation == CookieBrokerPresentation::Interactive {
+        let cookies = export_profile_cookies_interactive_macos(
+            broker_profile.path(),
+            brave_session.executable(),
+        )
+        .await?;
+        return Ok((source_cookie_count, cookies));
+    }
+
+    let config = BrowserConfig::builder().user_data_dir(broker_profile.path());
+    let config = match presentation {
+        CookieBrokerPresentation::Background => config.new_headless_mode(),
+        CookieBrokerPresentation::Interactive => config.with_head().window_size(960, 640),
+    };
+    let config = profile_launch_config(config).chrome_executable(brave_session.executable());
     let (mut browser, mut events) = Chromium::launch(build_config(config)?).await?;
     let handler = tokio::spawn(async move {
         while let Some(event) = events.next().await {
@@ -2121,17 +2338,221 @@ async fn export_profile_cookies(
         }
     });
 
-    let exported = browser.get_cookies().await.map_err(BrowserError::from);
+    let exported = match presentation {
+        CookieBrokerPresentation::Background => {
+            browser.get_cookies().await.map_err(BrowserError::from)
+        }
+        CookieBrokerPresentation::Interactive => timeout(COOKIE_AUTHORIZATION_TIMEOUT, async {
+            loop {
+                let cookies = browser.get_cookies().await?;
+                if !cookies.is_empty() {
+                    return Ok::<Vec<Cookie>, CdpError>(cookies);
+                }
+                tokio::time::sleep(COOKIE_AUTHORIZATION_POLL_INTERVAL).await;
+            }
+        })
+        .await
+        .map_err(|_| BrowserError::ProfileCookieAuthorizationTimedOut {
+            seconds: COOKIE_AUTHORIZATION_TIMEOUT.as_secs(),
+        })?
+        .map_err(BrowserError::from),
+    };
     let shutdown = close_chromium(&mut browser, &handler).await;
     let cookies = exported?;
     shutdown?;
 
+    Ok((source_cookie_count, cookies))
+}
+
+#[cfg(target_os = "macos")]
+async fn export_profile_cookies_interactive_macos(
+    broker_profile: &Path,
+    executable: &Path,
+) -> Result<Vec<Cookie>, BrowserError> {
+    let application = macos_application_bundle(executable).ok_or_else(|| {
+        BrowserError::Configuration {
+            message: format!(
+                "interactive cookie authorization requires a macOS application bundle; {} is not inside one",
+                executable.display()
+            ),
+        }
+    })?;
+    let mut launcher = tokio::process::Command::new("/usr/bin/open")
+        .args(interactive_cookie_broker_arguments(
+            application,
+            broker_profile,
+        ))
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()?;
+
+    let endpoint = timeout(BROWSER_LAUNCH_TIMEOUT, async {
+        let active_port = broker_profile.join("DevToolsActivePort");
+        loop {
+            if let Ok(contents) = tokio::fs::read_to_string(&active_port).await {
+                let port = contents
+                    .lines()
+                    .next()
+                    .and_then(|line| line.parse::<u16>().ok())
+                    .filter(|port| *port != 0)
+                    .ok_or_else(|| BrowserError::Configuration {
+                        message: format!(
+                            "interactive cookie broker wrote an invalid {}",
+                            active_port.display()
+                        ),
+                    })?;
+                return Ok(format!("http://127.0.0.1:{port}"));
+            }
+            if let Some(status) = launcher.try_wait()? {
+                return Err(BrowserError::Configuration {
+                    message: format!(
+                        "interactive cookie broker exited before DevTools was ready: {status}"
+                    ),
+                });
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .map_err(|_| BrowserError::Configuration {
+        message: format!(
+            "interactive cookie broker did not expose DevTools within {} seconds",
+            BROWSER_LAUNCH_TIMEOUT.as_secs()
+        ),
+    })??;
+
+    let (mut browser, mut events) = Chromium::connect(endpoint.as_str()).await?;
+    let handler = tokio::spawn(async move {
+        while let Some(event) = events.next().await {
+            if let Err(error) = event {
+                warn!(
+                    target: "nanocodex_browser",
+                    %error,
+                    "interactive cookie broker handler stopped"
+                );
+                break;
+            }
+        }
+    });
+    let exported = timeout(COOKIE_AUTHORIZATION_TIMEOUT, async {
+        loop {
+            let cookies = browser.get_cookies().await?;
+            if !cookies.is_empty() {
+                return Ok::<Vec<Cookie>, CdpError>(cookies);
+            }
+            tokio::time::sleep(COOKIE_AUTHORIZATION_POLL_INTERVAL).await;
+        }
+    })
+    .await
+    .map_err(|_| BrowserError::ProfileCookieAuthorizationTimedOut {
+        seconds: COOKIE_AUTHORIZATION_TIMEOUT.as_secs(),
+    })?
+    .map_err(BrowserError::from);
+    let close = browser.close().await.map(drop).map_err(BrowserError::from);
+    handler.abort();
+    let launcher_shutdown = match timeout(SESSION_DISCARD_TIMEOUT, launcher.wait()).await {
+        Ok(result) => result.map(drop).map_err(BrowserError::from),
+        Err(_) => {
+            launcher.kill().await?;
+            launcher.wait().await?;
+            Ok(())
+        }
+    };
+    let cookies = exported?;
+    close?;
+    launcher_shutdown?;
+    Ok(cookies)
+}
+
+#[cfg(target_os = "macos")]
+fn macos_application_bundle(executable: &Path) -> Option<&Path> {
+    executable
+        .ancestors()
+        .find(|path| path.extension().is_some_and(|extension| extension == "app"))
+}
+
+#[cfg(target_os = "macos")]
+fn interactive_cookie_broker_arguments(
+    application: &Path,
+    broker_profile: &Path,
+) -> Vec<std::ffi::OsString> {
+    [
+        "-n".into(),
+        "-W".into(),
+        "-a".into(),
+        application.as_os_str().to_owned(),
+        "--args".into(),
+        format!("--user-data-dir={}", broker_profile.display()).into(),
+        "--profile-directory=Default".into(),
+        "--remote-debugging-port=0".into(),
+        "--no-first-run".into(),
+        "about:blank".into(),
+    ]
+    .into()
+}
+
+#[cfg(target_os = "macos")]
+fn host_passkey_broker_arguments(
+    application: &Path,
+    broker_profile: &Path,
+) -> Vec<std::ffi::OsString> {
+    interactive_cookie_broker_arguments(application, broker_profile)
+}
+
+#[cfg(target_os = "macos")]
+async fn wait_for_macos_broker_endpoint(
+    broker_profile: &Path,
+    launcher: &mut tokio::process::Child,
+) -> Result<String, BrowserError> {
+    timeout(BROWSER_LAUNCH_TIMEOUT, async {
+        let active_port = broker_profile.join("DevToolsActivePort");
+        loop {
+            if let Ok(contents) = tokio::fs::read_to_string(&active_port).await {
+                let port = contents
+                    .lines()
+                    .next()
+                    .and_then(|line| line.parse::<u16>().ok())
+                    .filter(|port| *port != 0)
+                    .ok_or_else(|| BrowserError::Configuration {
+                        message: format!("browser wrote an invalid {}", active_port.display()),
+                    })?;
+                return Ok(format!("http://127.0.0.1:{port}"));
+            }
+            if let Some(status) = launcher.try_wait()? {
+                return Err(BrowserError::Configuration {
+                    message: format!("browser exited before DevTools was ready: {status}"),
+                });
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .map_err(|_| BrowserError::Configuration {
+        message: format!(
+            "browser did not expose DevTools within {} seconds",
+            BROWSER_LAUNCH_TIMEOUT.as_secs()
+        ),
+    })?
+}
+
+fn finish_profile_cookie_export(
+    brave_session: &BraveSession,
+    source_cookie_count: i64,
+    cookies: Vec<Cookie>,
+) -> Result<Vec<CookieParam>, BrowserError> {
     let cookies = allowed_cookie_params(
         cookies,
         (!brave_session.copies_all_cookies()).then(|| brave_session.allowed_origins()),
     );
+    if source_cookie_count > 0 && cookies.is_empty() {
+        return Err(BrowserError::ProfileCookieExportUnavailable {
+            source_cookie_count,
+        });
+    }
     info!(
         target: "nanocodex_browser",
+        source_cookie_count,
         browser_cookie_count = cookies.len(),
         browser_cookie_origin_count = brave_session.allowed_origins().len(),
         browser_cookie_all_origins = brave_session.copies_all_cookies(),
@@ -2789,6 +3210,7 @@ impl NativeBrowser {
         brave_session: Option<BraveSession>,
         launch_brave_executable: bool,
         virtual_authenticator: Option<VirtualAuthenticator>,
+        host_passkey_authenticator: Option<HostPasskeyAuthenticator>,
         react_diagnostics: Option<ReactDiagnostics>,
         egress_policy: Option<BrowserEgressPolicy>,
         file_root: Option<PathBuf>,
@@ -2809,6 +3231,7 @@ impl NativeBrowser {
             brave_session,
             launch_brave_executable,
             virtual_authenticator,
+            host_passkey_authenticator,
             react_diagnostics,
             egress_policy,
             file_root,
@@ -3064,84 +3487,6 @@ impl NativeBrowser {
         Ok(())
     }
 
-    pub(crate) fn open_auth_handoff(&self, url: &Url) -> Result<(), BrowserError> {
-        let session = self
-            .brave_session
-            .as_ref()
-            .ok_or(BrowserError::BraveSessionNotConfigured)?;
-        session.open_handoff(url)?;
-        info!(
-            target: "nanocodex_browser",
-            url = url.as_str(),
-            "opened authentication handoff in ordinary Brave"
-        );
-        Ok(())
-    }
-
-    pub(crate) fn validate_auth_handoff(&self, url: &Url) -> Result<(), BrowserError> {
-        let session = self
-            .brave_session
-            .as_ref()
-            .ok_or(BrowserError::BraveSessionNotConfigured)?;
-        session.validate_handoff_url(url)?;
-        Ok(())
-    }
-
-    pub(crate) async fn resume_auth_handoff(&self, url: Url) -> Result<(), BrowserError> {
-        let span = info_span!(
-            target: "nanocodex_browser",
-            "browser.auth_handoff.resume"
-        );
-        async {
-            let mut state = self.state.lock().await;
-            if state.closed {
-                return Err(BrowserError::Closed);
-            }
-            let brave_session = self
-                .brave_session
-                .as_ref()
-                .ok_or(BrowserError::BraveSessionNotConfigured)?;
-            brave_session.validate_handoff_url(&url)?;
-            if self.cdp_endpoint.is_some() {
-                if let Some(session) = state.session.as_mut() {
-                    session
-                        .refresh_remote_cookies(self.runtime_dir.path(), brave_session)
-                        .await?;
-                } else {
-                    state.session = Some(Session::launch(self).await?);
-                }
-            } else {
-                if let Some(session) = state.session.take() {
-                    session.close().await?;
-                }
-                let profile = self.runtime_dir.path().join("profile");
-                match tokio::fs::remove_dir_all(&profile).await {
-                    Ok(()) => {}
-                    Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-                    Err(error) => return Err(error.into()),
-                }
-                state.session = Some(Session::launch(self).await?);
-            }
-            let session = state
-                .session
-                .as_mut()
-                .ok_or(BrowserError::SessionUnavailable)?;
-            validate_url(url.as_str())?;
-            session.validate_navigation(&url)?;
-            navigate(&session.page, url.as_str()).await?;
-            session.sync_virtual_authenticators().await?;
-            session.refs.clear();
-            info!(
-                target: "nanocodex_browser",
-                url = url.as_str(),
-                "resumed private headless browser after authentication handoff"
-            );
-            Ok(())
-        }
-        .instrument(span)
-        .await
-    }
-
     pub(crate) async fn virtual_credentials(&self) -> Result<Vec<VirtualCredential>, BrowserError> {
         let mut state = self.state.lock().await;
         if state.closed {
@@ -3235,6 +3580,17 @@ async fn execute_action(
             session.passkey_mode = BrowserPasskeyMode::Auto;
             session.apply_passkey_mode().await?;
             session.passkeys_result(sequence, BrowserActionName::PasskeyAuto)
+        }
+        BrowserAction::HostPasskeyStart => {
+            session.start_host_passkey_authorization().await?;
+            Ok(action_result(sequence, BrowserActionName::HostPasskeyStart))
+        }
+        BrowserAction::HostPasskeyResume => {
+            session.resume_host_passkey_authorization().await?;
+            Ok(action_result(
+                sequence,
+                BrowserActionName::HostPasskeyResume,
+            ))
         }
         BrowserAction::Snapshot {
             interactive,
@@ -6975,6 +7331,14 @@ pub enum BrowserError {
     BraveSession(#[from] BraveSessionError),
     #[error("browser configuration is invalid: {message}")]
     Configuration { message: String },
+    #[error(
+        "the source profile contains {source_cookie_count} selected cookies, but its browser exported none; unlock the source browser's credential storage and retry"
+    )]
+    ProfileCookieExportUnavailable { source_cookie_count: i64 },
+    #[error(
+        "interactive source-profile cookie authorization did not complete within {seconds} seconds"
+    )]
+    ProfileCookieAuthorizationTimedOut { seconds: u64 },
     #[error("browser action input is {bytes} bytes, above the {maximum}-byte limit")]
     ActionInputTooLarge { bytes: u64, maximum: u64 },
     #[error("browser action result is {bytes} bytes, above the {maximum}-byte limit")]
@@ -7202,10 +7566,16 @@ pub enum BrowserError {
     AmbiguousVirtualCredential { credential_id: String },
     #[error("virtual credential store {} is invalid: {message}", path.display())]
     VirtualCredentialStore { path: PathBuf, message: String },
-    #[error("this browser was not configured with an authenticated Brave session")]
-    BraveSessionNotConfigured,
     #[error("the virtual authenticator is not ready; navigate to a page first")]
     VirtualAuthenticatorNotReady,
+    #[error("this browser was not configured to use host passkeys")]
+    HostPasskeyAuthenticatorNotConfigured,
+    #[error("host passkeys are currently supported only on macOS")]
+    HostPasskeyAuthenticatorUnsupported,
+    #[error("a host passkey authorization browser is already open")]
+    HostPasskeyAuthorizationActive,
+    #[error("no host passkey authorization browser is open")]
+    HostPasskeyAuthorizationNotActive,
     #[error("selector `{selector}` was not found before the browser timeout")]
     SelectorTimeout { selector: String },
     #[error("selector `{selector}` did not reach state {state:?} before the browser timeout")]
@@ -7933,6 +8303,62 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
+    fn interactive_cookie_broker_uses_only_the_copied_profile() {
+        let executable =
+            std::path::Path::new("/Applications/Brave Browser.app/Contents/MacOS/Brave Browser");
+        let application = super::macos_application_bundle(executable).unwrap();
+        let copied_profile = std::path::Path::new("/private/tmp/brave-cookie-broker-test");
+        let arguments = super::interactive_cookie_broker_arguments(application, copied_profile)
+            .into_iter()
+            .map(|argument| argument.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            application,
+            std::path::Path::new("/Applications/Brave Browser.app")
+        );
+        assert!(
+            arguments
+                .iter()
+                .any(|argument| argument == "--user-data-dir=/private/tmp/brave-cookie-broker-test")
+        );
+        assert!(!arguments.iter().any(|argument| {
+            argument.contains("Library/Application Support/BraveSoftware/Brave-Browser")
+                || argument.contains("use-mock-keychain")
+                || argument.contains("password-store=basic")
+                || argument.contains("enable-automation")
+        }));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn host_passkey_broker_uses_an_isolated_real_keychain_profile() {
+        let executable =
+            std::path::Path::new("/Applications/Brave Browser.app/Contents/MacOS/Brave Browser");
+        let application = super::macos_application_bundle(executable).unwrap();
+        let isolated_profile = std::path::Path::new("/private/tmp/nanocodex-host-passkey-test");
+        let arguments = super::host_passkey_broker_arguments(application, isolated_profile)
+            .into_iter()
+            .map(|argument| argument.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+
+        assert!(
+            arguments
+                .iter()
+                .any(|argument| argument
+                    == "--user-data-dir=/private/tmp/nanocodex-host-passkey-test")
+        );
+        assert!(!arguments.iter().any(|argument| {
+            argument.contains("Library/Application Support/BraveSoftware/Brave-Browser")
+                || argument.contains("headless")
+                || argument.contains("use-mock-keychain")
+                || argument.contains("password-store=basic")
+                || argument.contains("enable-automation")
+        }));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
     fn explicit_automation_executable_remains_caller_owned() {
         let explicit = std::path::PathBuf::from("/caller/selected/chrome");
         assert_eq!(
@@ -8262,22 +8688,6 @@ mod tests {
             .await?;
         let BrowserActionResult::Evaluation { value, .. } = result else {
             return Err(std::io::Error::other("expected evaluation result").into());
-        };
-        assert_eq!(value.as_bool(), Some(true));
-
-        seed_brave_cookie(&executable, &source_profile, "refreshed").await?;
-        browser
-            .inner
-            .resume_auth_handoff(url::Url::parse("https://example.com")?)
-            .await?;
-        let result = browser
-            .execute(BrowserAction::Evaluate {
-                expression: "document.cookie.includes('nanocodex_cookie_bridge=refreshed')"
-                    .to_owned(),
-            })
-            .await?;
-        let BrowserActionResult::Evaluation { value, .. } = result else {
-            return Err(std::io::Error::other("expected refreshed evaluation result").into());
         };
         assert_eq!(value.as_bool(), Some(true));
 

--- a/crates/experimental/nanocodex-browser/src/session.rs
+++ b/crates/experimental/nanocodex-browser/src/session.rs
@@ -1,6 +1,5 @@
 use std::{
     path::{Component, Path, PathBuf},
-    process::{Command, Stdio},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -17,6 +16,17 @@ pub enum BrowserProfileKind {
     Chrome,
     Chromium,
     Edge,
+}
+
+/// How a Chromium-family cookie source may access its encrypted cookie store.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum BrowserCookieAuthorization {
+    /// Import cookies without opening a visible browser or credential prompt.
+    #[default]
+    Background,
+    /// If background import cannot decrypt a populated store, open one visible
+    /// temporary copied profile so the user can authorize Keychain access.
+    Interactive,
 }
 
 impl BrowserProfileKind {
@@ -47,6 +57,7 @@ pub struct BraveSession {
     allowed_origins: Vec<Url>,
     copy_all_cookies: bool,
     include_site_data: bool,
+    cookie_authorization: BrowserCookieAuthorization,
 }
 
 impl BraveSession {
@@ -145,6 +156,7 @@ impl BraveSession {
             allowed_origins: Vec::new(),
             copy_all_cookies: false,
             include_site_data: false,
+            cookie_authorization: BrowserCookieAuthorization::Background,
         }
     }
 
@@ -186,6 +198,16 @@ impl BraveSession {
         self
     }
 
+    /// Allows an explicit visible authorization retry for encrypted cookies.
+    ///
+    /// The retry launches the source browser executable with a copied temporary
+    /// profile. It never opens or mutates the ordinary source profile.
+    #[must_use]
+    pub const fn cookie_authorization(mut self, authorization: BrowserCookieAuthorization) -> Self {
+        self.cookie_authorization = authorization;
+        self
+    }
+
     /// Returns the source browser executable selected by this session.
     #[must_use]
     pub fn executable(&self) -> &Path {
@@ -204,6 +226,10 @@ impl BraveSession {
         self.copy_all_cookies
     }
 
+    pub(crate) const fn cookie_authorization_policy(&self) -> BrowserCookieAuthorization {
+        self.cookie_authorization
+    }
+
     pub(crate) fn trace_value(&self) -> serde_json::Value {
         serde_json::json!({
             "executable": self.executable,
@@ -212,49 +238,14 @@ impl BraveSession {
             "allowedOrigins": self.allowed_origins,
             "copyAllCookies": self.copy_all_cookies,
             "includeSiteData": self.include_site_data,
+            "cookieAuthorization": format!("{:?}", self.cookie_authorization),
         })
-    }
-
-    pub(crate) fn validate_handoff_url(&self, url: &Url) -> Result<(), BraveSessionError> {
-        if self.copy_all_cookies
-            && matches!(url.scheme(), "http" | "https")
-            && url.host_str().is_some()
-        {
-            return Ok(());
-        }
-        if self
-            .allowed_origins
-            .iter()
-            .any(|allowed| allowed.origin() == url.origin())
-        {
-            return Ok(());
-        }
-        Err(BraveSessionError::HandoffOriginNotAllowed { url: url.clone() })
-    }
-
-    pub(crate) fn open_handoff(&self, url: &Url) -> Result<(), BraveSessionError> {
-        self.validate_handoff_url(url)?;
-        let mut child = Command::new(&self.executable)
-            .arg(format!("--user-data-dir={}", self.user_data_dir.display()))
-            .arg(format!(
-                "--profile-directory={}",
-                self.profile_directory.display()
-            ))
-            .arg(url.as_str())
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()?;
-        std::thread::spawn(move || {
-            let _ = child.wait();
-        });
-        Ok(())
     }
 
     pub(crate) async fn prepare(
         &self,
         target_user_data_dir: &Path,
-    ) -> Result<(), BraveSessionError> {
+    ) -> Result<i64, BraveSessionError> {
         self.validate()?;
         let source_profile = self.user_data_dir.join(&self.profile_directory);
         if self.include_site_data
@@ -286,7 +277,7 @@ impl BraveSession {
                 .map(str::to_owned)
                 .collect::<Vec<_>>()
         });
-        tokio::task::spawn_blocking(move || {
+        let cookie_count = tokio::task::spawn_blocking(move || {
             snapshot_cookies(&source_cookies, &target_cookies, allowed_hosts.as_deref())
         })
         .await
@@ -305,7 +296,7 @@ impl BraveSession {
             .await
             .map_err(BraveSessionError::SnapshotTask)??;
         }
-        Ok(())
+        Ok(cookie_count)
     }
 
     pub(crate) fn validate(&self) -> Result<(), BraveSessionError> {
@@ -355,7 +346,7 @@ fn snapshot_cookies(
     source: &Path,
     target: &Path,
     allowed_hosts: Option<&[String]>,
-) -> Result<(), BraveSessionError> {
+) -> Result<i64, BraveSessionError> {
     let source = Connection::open_with_flags(
         source,
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
@@ -398,7 +389,7 @@ fn snapshot_cookies(
         [temporary_cookie_expiry()?],
     )?;
     transaction.commit()?;
-    Ok(())
+    Ok(target.query_row("SELECT COUNT(*) FROM cookies", [], |row| row.get(0))?)
 }
 
 pub(crate) fn cookie_applies_to(cookie_host: &str, allowed_host: &str) -> bool {
@@ -465,8 +456,6 @@ pub enum BraveSessionError {
     MissingAllowedOrigin,
     #[error("profile session origin must contain only a scheme, host, and optional port: {origin}")]
     InvalidOrigin { origin: Url },
-    #[error("authentication handoff URL is outside the profile session allowlist: {url}")]
-    HandoffOriginNotAllowed { url: Url },
     #[error("source cookie database is unavailable under {profile}")]
     CookiesUnavailable { profile: PathBuf },
     #[error(
@@ -493,6 +482,18 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
+    fn interactive_cookie_authorization_is_explicit_session_policy() {
+        let session = super::BraveSession::new("/brave", "/profile")
+            .cookie_authorization(super::BrowserCookieAuthorization::Interactive);
+
+        assert_eq!(
+            session.cookie_authorization_policy(),
+            super::BrowserCookieAuthorization::Interactive
+        );
+        assert_eq!(session.trace_value()["cookieAuthorization"], "Interactive");
+    }
+
+    #[test]
     fn cookie_domains_are_filtered_by_request_applicability() {
         assert!(super::cookie_applies_to(
             ".example.com",
@@ -507,31 +508,6 @@ mod tests {
             "console.example.com"
         ));
         assert!(!super::cookie_applies_to("notexample.com", "example.com"));
-    }
-
-    #[test]
-    fn handoff_is_limited_to_an_allowed_exact_origin() -> Result<(), Box<dyn Error>> {
-        let session = super::BraveSession::new("/brave", "/profile")
-            .allow_origin(url::Url::parse("https://admin.example.com")?);
-
-        assert!(
-            session
-                .validate_handoff_url(&url::Url::parse(
-                    "https://admin.example.com/passkey?return=%2F"
-                )?)
-                .is_ok()
-        );
-        assert!(
-            session
-                .validate_handoff_url(&url::Url::parse("https://example.com")?)
-                .is_err()
-        );
-        assert!(
-            session
-                .validate_handoff_url(&url::Url::parse("http://admin.example.com")?)
-                .is_err()
-        );
-        Ok(())
     }
 
     #[test]

--- a/crates/experimental/nanocodex-browser/src/tests.rs
+++ b/crates/experimental/nanocodex-browser/src/tests.rs
@@ -22,8 +22,8 @@ use super::{
     BrowserOrientation, BrowserOriginStorage, BrowserPasskeyMode, BrowserPerformanceInsight,
     BrowserPostActionSnapshot, BrowserPseudoClass, BrowserReactEventKind, BrowserReducedMotion,
     BrowserRouteHeader, BrowserRouteResponse, BrowserStorageState, BrowserTarget, BrowserTool,
-    BrowserViewport, BrowserWaitForSelectorState, IosBrowser, ReactDiagnostics,
-    VirtualAuthenticator, browser_tool_builder,
+    BrowserViewport, BrowserWaitForSelectorState, HostPasskeyAuthenticator, IosBrowser,
+    ReactDiagnostics, VirtualAuthenticator, browser_tool_builder,
 };
 
 #[test]
@@ -32,6 +32,25 @@ fn browser_tool_enables_virtual_platform_passkeys() {
         browser_tool_builder().virtual_authenticator,
         Some(VirtualAuthenticator::platform_passkey())
     );
+}
+
+#[test]
+fn host_and_virtual_passkey_policies_are_mutually_exclusive() -> Result<()> {
+    let directory = tempfile::tempdir()?;
+    let executable = directory.path().join("desktop-browser");
+    std::fs::write(&executable, [])?;
+    let error = Browser::builder()
+        .virtual_authenticator(VirtualAuthenticator::platform_passkey())
+        .host_passkey_authenticator(HostPasskeyAuthenticator::new(executable))
+        .build()
+        .err()
+        .ok_or_else(|| eyre!("expected mutually exclusive passkey policies"))?;
+    assert!(matches!(
+        error,
+        BrowserBuildError::Configuration { ref message }
+            if message == "host and virtual passkey authenticators cannot be enabled together"
+    ));
+    Ok(())
 }
 
 #[test]
@@ -337,16 +356,6 @@ async fn virtual_authenticator_is_reused_when_returning_to_a_tab() -> Result<()>
     Ok(())
 }
 
-#[test]
-fn authentication_handoff_requires_an_authenticated_brave_session() -> Result<()> {
-    let browser = Browser::new()?;
-    assert!(matches!(
-        browser.auth_handoff(url::Url::parse("https://example.com")?),
-        Err(BrowserError::BraveSessionNotConfigured)
-    ));
-    Ok(())
-}
-
 #[tokio::test]
 async fn code_mode_calls_record_browser_actions_in_order() -> Result<()> {
     let (browser, recording) = BrowserTool::recording();
@@ -460,6 +469,8 @@ fn recording_browser_exposes_model_controlled_passkey_modes() -> Result<()> {
     })?;
     let fresh = recording.record(BrowserAction::PasskeyNew)?;
     let automatic = recording.record(BrowserAction::PasskeyAuto)?;
+    let host_started = recording.record(BrowserAction::HostPasskeyStart)?;
+    let host_resumed = recording.record(BrowserAction::HostPasskeyResume)?;
 
     assert!(matches!(
         listed,
@@ -493,6 +504,20 @@ fn recording_browser_exposes_model_controlled_passkey_modes() -> Result<()> {
         BrowserActionResult::Passkeys {
             action: BrowserActionName::PasskeyAuto,
             mode: BrowserPasskeyMode::Auto,
+            ..
+        }
+    ));
+    assert!(matches!(
+        host_started,
+        BrowserActionResult::Action {
+            action: BrowserActionName::HostPasskeyStart,
+            ..
+        }
+    ));
+    assert!(matches!(
+        host_resumed,
+        BrowserActionResult::Action {
+            action: BrowserActionName::HostPasskeyResume,
             ..
         }
     ));
@@ -645,6 +670,8 @@ async fn code_mode_description_exposes_browser_action_schema() -> Result<()> {
     assert!(description.contains(r#"action: "passkey_use""#));
     assert!(description.contains(r#"action: "passkey_new""#));
     assert!(description.contains(r#"action: "passkey_auto""#));
+    assert!(description.contains(r#"action: "host_passkey_start""#));
+    assert!(description.contains(r#"action: "host_passkey_resume""#));
     assert!(description.contains(r#"action: "export_har""#));
     assert!(description.contains(r#"action: "list_frames""#));
     assert!(description.contains(r#"action: "list_tabs""#));
@@ -661,7 +688,6 @@ async fn code_mode_description_exposes_browser_action_schema() -> Result<()> {
     assert!(description.contains(r#"by: "role""#));
     assert!(description.contains("Promise.all"));
     assert!(description.contains("Promise<{"));
-    assert!(!description.contains("auth_handoff"));
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- default macOS automation to dedicated chrome-headless-shell or Chrome for Testing discovery with an isolated profile
- add explicit interactive cookie decryption through a copied temporary profile
- add opt-in host passkey start/resume actions while keeping credentials inside the OS authenticator
- remove the older ordinary-profile Brave authentication handoff
- wire CLI flags, public types, documentation, and focused regressions

## Validation
- `cargo fmt --all`
- `cargo check -p nanocodex-browser -p nanocodex-bin`
- `cargo test -p nanocodex-browser passkey` (4 passed; 1 environment-dependent test ignored)
- `git diff --check`

## Residual manual validation
A live Keychain/Touch ID ceremony is intentionally not automated; it requires a signed installed macOS browser and user authorization.