### PR TITLE
fix(connect): scope account awareness to managed agents

### DIFF
--- a/js/bindings/tools/browser/browserShell.mjs
+++ b/js/bindings/tools/browser/browserShell.mjs
@@ -33,9 +33,7 @@ const AGENT_INSTRUCTIONS = `You are working in a persistent browser filesystem r
 Use exec_command for bash commands such as ls, cat, find, grep, git, curl, wget, and python3. The
 shell and Python runtime execute entirely in browser sandboxes, so they have no host process or PTY.
 curl, wget, and the gh compatibility command use one thread-scoped, same-origin egress gateway.
-Call accountInfo for the current identities, stablecoin balances, and app authorization boundaries,
-then use gh or curl normally; accountInfo is a tool, not a shell command. Destination policy,
-spend limits, and connected-account credentials stay outside the browser runtime. The
+Destination policy and connected-account credentials stay outside the browser runtime. The
 clang, clang++, gcc, g++, cc, and c++ compile C/C++ sources to WASI WebAssembly in a lazy worker.
 Browser SSH is noninteractive and requires a wss:// endpoint that carries raw SSH because browsers
 cannot open TCP sockets. The repository's only publish branch is nanocodex;

--- a/services/managed/src/account-info.ts
+++ b/services/managed/src/account-info.ts
@@ -1,3 +1,5 @@
+import type { PromptInput } from "nanocodex";
+
 const CONNECTOR_IDS = ["github", "gmail", "gdrive"] as const;
 
 type ConnectorId = typeof CONNECTOR_IDS[number];
@@ -53,6 +55,21 @@ export async function accountInfo(
   } catch {
     return emptyInfo("unavailable");
   }
+}
+
+export function withInitialAccountInfo(input: PromptInput, info: AccountInfo): PromptInput {
+  const explanation = [
+    "The managed runtime already resolved the following non-secret accountInfo snapshot for",
+    "this agent. Use it as the current connected-account context. Do not call accountInfo",
+    "again unless the task requires state refreshed after this first prompt.",
+  ].join(" ");
+  const context = {
+    type: "text" as const,
+    text: `${explanation}\n\n<account_info>\n${JSON.stringify(info)}\n</account_info>`,
+  };
+  return typeof input === "string"
+    ? [context, { type: "text", text: input }]
+    : [context, ...input];
 }
 
 function emptyInfo(status: "disabled" | "unavailable"): AccountInfo {

--- a/services/managed/src/index.ts
+++ b/services/managed/src/index.ts
@@ -70,7 +70,7 @@ import {
   unbindAgentCredential,
 } from "./credentials";
 import { routeBrowserEgress } from "./browser-egress";
-import { accountInfo } from "./account-info";
+import { accountInfo, type AccountInfo, withInitialAccountInfo } from "./account-info";
 import { routeConnectorRequest } from "./connectors";
 import {
   attachAgent,
@@ -103,6 +103,7 @@ const encoder = new TextEncoder();
 const ENCODED_PONG = JSON.stringify({ type: "pong" });
 const SESSION_DELETING_KEY = "nanocodex:session-deleting";
 const SESSION_DELETION_GENERATION_KEY = "nanocodex:session-deletion-generation";
+const INITIAL_ACCOUNT_CONTEXT_KEY = "nanocodex:initial-account-context";
 const CREDENTIAL_BINDING_KEY = "nanocodex:credential-binding";
 const CLEANUP_RETRY_ATTEMPT_KEY = "nanocodex:cleanup-retry-attempt";
 const CREDENTIAL_BINDING_PREPARE_TIMEOUT_MS = 60_000;
@@ -146,6 +147,11 @@ type SessionStatusRow = {
   last_active: number;
   stream_error: string | null;
 };
+
+type InitialAccountContext = Readonly<{
+  turn_id: string;
+  account: AccountInfo;
+}>;
 
 type ManagedTurnState =
   | "accepted"
@@ -571,6 +577,7 @@ export class NanocodexSession extends DurableComputerSession {
   readonly #pendingTurnIds = new Set<string>();
   readonly #turnInputs = new Map<string, PromptInput>();
   readonly #admissionTasks = new Map<string, Promise<ManagedTurnRow>>();
+  #initialAccountContextTask?: Promise<InitialAccountContext | undefined>;
   readonly #cancellationTasks = new Map<string, Promise<void>>();
   readonly #inFlight = new Set<Promise<unknown>>();
   #recoveryTask?: Promise<void>;
@@ -1409,8 +1416,12 @@ export class NanocodexSession extends DurableComputerSession {
     try {
       const agent = await this.#ensureAgent();
       if (this.#deleting || this.#agent !== agent) throw retryableError("agent became unavailable during admission");
+      const initialAccountContext = await this.#initialAccountContext();
+      const modelInput = initialAccountContext?.turn_id === row.id
+        ? withInitialAccountInfo(input, initialAccountContext.account)
+        : input;
       this.#eventTurnQueue.push(row.id);
-      turn = agent.turn.prompt({ id: row.id, input });
+      turn = agent.turn.prompt({ id: row.id, input: modelInput });
       this.#turns.set(row.id, turn);
       const durableId = await turn.accepted();
       if (durableId !== undefined && durableId !== row.id) {
@@ -1563,11 +1574,13 @@ export class NanocodexSession extends DurableComputerSession {
       }
       await transaction.delete(CREDENTIAL_BINDING_KEY);
       await transaction.delete(CLEANUP_RETRY_ATTEMPT_KEY);
+      await transaction.delete(INITIAL_ACCOUNT_CONTEXT_KEY);
       await transaction.delete(SESSION_DELETING_KEY);
       await transaction.deleteAlarm();
     });
     this.#assertDeletionGeneration(generation);
     this.#credentialBinding = undefined;
+    this.#initialAccountContextTask = undefined;
     this.#deleting = false;
   }
 
@@ -1777,6 +1790,29 @@ export class NanocodexSession extends DurableComputerSession {
       console.error("superseded Nanocodex agent shutdown failed", errorMessage(error));
     }));
     return shutdown;
+  }
+
+  #initialAccountContext(): Promise<InitialAccountContext | undefined> {
+    return this.#initialAccountContextTask ??= this.#loadInitialAccountContext();
+  }
+
+  async #loadInitialAccountContext(): Promise<InitialAccountContext | undefined> {
+    const retained = await this.ctx.storage.get<InitialAccountContext>(
+      INITIAL_ACCOUNT_CONTEXT_KEY,
+    );
+    if (retained) return retained;
+    const session = this.#session();
+    if (!session || session.runtime_profile === "multiplayer") return undefined;
+    const first = this.ctx.storage.sql.exec<{ id: string }>(
+      "SELECT id FROM managed_turns ORDER BY created_at, id LIMIT 1",
+    ).toArray()[0];
+    if (!first) return undefined;
+    const prepared = {
+      turn_id: first.id,
+      account: await accountInfo(this.env.NANOCODEX, session.owner_id, true),
+    } satisfies InitialAccountContext;
+    await this.ctx.storage.put(INITIAL_ACCOUNT_CONTEXT_KEY, prepared);
+    return prepared;
   }
 
   async #createAgent(): Promise<CloudflareAgent.Agent> {

--- a/services/managed/test/account-info.test.ts
+++ b/services/managed/test/account-info.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { accountInfo } from "../src/account-info";
+import { accountInfo, withInitialAccountInfo } from "../src/account-info";
 
 describe("account info", () => {
   it("reports authenticated connector names and display labels only", async () => {
@@ -52,5 +52,27 @@ describe("account info", () => {
       authorizations: [],
     });
     expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("prepends a resolved snapshot to the first model prompt", () => {
+    const info = {
+      status: "ready" as const,
+      authenticated: ["github" as const],
+      accounts: { github: "Nano Cat (nanocat)" },
+      identity: {},
+      stablecoins: [] as const,
+      authorizations: [] as const,
+    };
+
+    expect(withInitialAccountInfo("inspect my repositories", info)).toEqual([
+      {
+        type: "text",
+        text: [
+          "The managed runtime already resolved the following non-secret accountInfo snapshot for this agent. Use it as the current connected-account context. Do not call accountInfo again unless the task requires state refreshed after this first prompt.",
+          `<account_info>\n${JSON.stringify(info)}\n</account_info>`,
+        ].join("\n\n"),
+      },
+      { type: "text", text: "inspect my repositories" },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- resolve the non-secret accountInfo snapshot when a managed Connect agent is created
- embed that snapshot in the agent context inherited by clean spawned children
- reserve the runtime accountInfo tool for explicit refreshes
- remove managed-account guidance from generic browser agents

## Verification

- node --test test/cloud-connect.test.mjs test/browser-harness.test.mjs
- Connect playground production build
- host-managed browser pass on the local Connect playground with no page, console, or network failures