### PR TITLE
feat(managed): host Android phone tools for managed agents

### DIFF
--- a/services/managed/src/device-host-protocol.ts
+++ b/services/managed/src/device-host-protocol.ts
@@ -1,0 +1,240 @@
+export const DEVICE_HOST_PROTOCOL_VERSION = 1 as const;
+export const DEVICE_HOST_LEASE_MS = 60_000;
+export const DEVICE_TOOL_CALL_TIMEOUT_MS = 120_000;
+export const MAX_DEVICE_HOST_MESSAGE_BYTES = 256 * 1024;
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const IDENTIFIER = /^[A-Za-z0-9._:-]{1,128}$/;
+const encoder = new TextEncoder();
+
+export type DeviceHostCommand =
+  | {
+    type: "attach";
+    protocol_version: typeof DEVICE_HOST_PROTOCOL_VERSION;
+    host_id: string;
+    catalog_version: number;
+  }
+  | {
+    type: "ping";
+    lease_id: string;
+    epoch: number;
+    nonce?: string;
+  }
+  | {
+    type: "device_tool_result";
+    lease_id: string;
+    epoch: number;
+    call_id: string;
+    success: boolean;
+    output: unknown;
+  };
+
+export type DeviceHostServerMessage =
+  | {
+    type: "lease";
+    protocol_version: typeof DEVICE_HOST_PROTOCOL_VERSION;
+    lease_id: string;
+    epoch: number;
+    expires_at: number;
+    catalog_version: number;
+  }
+  | {
+    type: "pong";
+    lease_id: string;
+    epoch: number;
+    expires_at: number;
+    nonce?: string;
+  }
+  | {
+    type: "device_tool_call";
+    lease_id: string;
+    epoch: number;
+    call_id: string;
+    tool: "phone";
+    operation: string;
+    arguments: Record<string, unknown>;
+  }
+  | {
+    type: "ack";
+    lease_id: string;
+    epoch: number;
+    call_id: string;
+    state: "completed";
+  }
+  | {
+    type: "fenced";
+    epoch: number;
+    reason: string;
+  }
+  | {
+    type: "error";
+    code: string;
+    message: string;
+  };
+
+export type DeviceToolInput = {
+  operation: string;
+  arguments: Record<string, unknown>;
+};
+
+export type DeviceToolOutput =
+  | { ok: true; status: "completed"; output: unknown }
+  | { ok: false; status: "failed"; output: unknown }
+  | { ok: false; status: "unavailable"; message: string }
+  | { ok: false; status: "ambiguous"; message: string };
+
+export function matchesDeviceHostLease(
+  holder: { hostId?: string; leaseId?: string; epoch?: number },
+  state: {
+    host_id: string | null;
+    lease_id: string | null;
+    epoch: number;
+    lease_expires_at: number;
+  },
+  now: number,
+): boolean {
+  return holder.hostId !== undefined
+    && holder.hostId === state.host_id
+    && holder.leaseId !== undefined
+    && holder.leaseId === state.lease_id
+    && holder.epoch !== undefined
+    && holder.epoch === state.epoch
+    && state.lease_expires_at >= now;
+}
+
+export function parseDeviceHostCommand(encoded: string): DeviceHostCommand {
+  if (encoder.encode(encoded).byteLength > MAX_DEVICE_HOST_MESSAGE_BYTES) {
+    throw new DeviceHostProtocolError(
+      "message_too_large",
+      `device-host messages are limited to ${MAX_DEVICE_HOST_MESSAGE_BYTES} bytes`,
+    );
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(encoded);
+  } catch {
+    throw new DeviceHostProtocolError("invalid_json", "device-host messages must be JSON objects");
+  }
+  const command = objectValue(value, "device-host message");
+  if (command.type === "attach") {
+    exactKeys(command, ["type", "protocol_version", "host_id", "catalog_version"]);
+    if (command.protocol_version !== DEVICE_HOST_PROTOCOL_VERSION) {
+      throw new DeviceHostProtocolError("unsupported_version", "unsupported device-host protocol version");
+    }
+    return {
+      type: "attach",
+      protocol_version: DEVICE_HOST_PROTOCOL_VERSION,
+      host_id: uuid(command.host_id, "host_id"),
+      catalog_version: boundedInteger(command.catalog_version, 1, 2_147_483_647, "catalog_version"),
+    };
+  }
+  if (command.type === "ping") {
+    exactKeys(command, ["type", "lease_id", "epoch", "nonce"]);
+    if (command.nonce !== undefined
+      && (typeof command.nonce !== "string" || command.nonce.length > 128)) {
+      throw new DeviceHostProtocolError("invalid_nonce", "ping nonce must be at most 128 characters");
+    }
+    return {
+      type: "ping",
+      lease_id: uuid(command.lease_id, "lease_id"),
+      epoch: boundedInteger(command.epoch, 1, Number.MAX_SAFE_INTEGER, "epoch"),
+      ...(command.nonce === undefined ? {} : { nonce: command.nonce }),
+    };
+  }
+  if (command.type === "device_tool_result") {
+    exactKeys(command, ["type", "lease_id", "epoch", "call_id", "success", "output"]);
+    if (typeof command.success !== "boolean" || !Object.hasOwn(command, "output")) {
+      throw new DeviceHostProtocolError(
+        "invalid_result",
+        "device_tool_result requires boolean success and an output value",
+      );
+    }
+    return {
+      type: "device_tool_result",
+      lease_id: uuid(command.lease_id, "lease_id"),
+      epoch: boundedInteger(command.epoch, 1, Number.MAX_SAFE_INTEGER, "epoch"),
+      call_id: identifier(command.call_id, "call_id"),
+      success: command.success,
+      output: command.output,
+    };
+  }
+  throw new DeviceHostProtocolError("unknown_command", "unsupported device-host command");
+}
+
+export function parseDeviceToolInput(value: unknown): DeviceToolInput {
+  const input = objectValue(value, "phone input");
+  exactKeys(input, ["operation", "arguments"]);
+  const operation = identifier(input.operation, "operation");
+  const args = input.arguments === undefined ? {} : objectValue(input.arguments, "phone arguments");
+  const encoded = JSON.stringify(args);
+  if (encoder.encode(encoded).byteLength > MAX_DEVICE_HOST_MESSAGE_BYTES / 2) {
+    throw new DeviceHostProtocolError(
+      "arguments_too_large",
+      `phone arguments are limited to ${MAX_DEVICE_HOST_MESSAGE_BYTES / 2} bytes`,
+    );
+  }
+  return { operation, arguments: args };
+}
+
+export function deviceToolResult(success: boolean, output: unknown): DeviceToolOutput {
+  return success
+    ? { ok: true, status: "completed", output }
+    : { ok: false, status: "failed", output };
+}
+
+export function deviceToolUnavailable(message = "No Android device host is currently attached."): DeviceToolOutput {
+  return { ok: false, status: "unavailable", message };
+}
+
+export function deviceToolAmbiguous(message: string): DeviceToolOutput {
+  return { ok: false, status: "ambiguous", message };
+}
+
+function uuid(value: unknown, name: string): string {
+  if (typeof value !== "string" || !UUID_V4.test(value)) {
+    throw new DeviceHostProtocolError("invalid_identity", `${name} must be a lowercase UUID v4`);
+  }
+  return value;
+}
+
+function identifier(value: unknown, name: string): string {
+  if (typeof value !== "string" || !IDENTIFIER.test(value)) {
+    throw new DeviceHostProtocolError(
+      "invalid_identifier",
+      `${name} must be 1-128 letters, numbers, dots, underscores, colons, or hyphens`,
+    );
+  }
+  return value;
+}
+
+function boundedInteger(value: unknown, minimum: number, maximum: number, name: string): number {
+  if (!Number.isSafeInteger(value) || Number(value) < minimum || Number(value) > maximum) {
+    throw new DeviceHostProtocolError(
+      "invalid_integer",
+      `${name} must be an integer from ${minimum} through ${maximum}`,
+    );
+  }
+  return Number(value);
+}
+
+function objectValue(value: unknown, name: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new DeviceHostProtocolError("invalid_message", `${name} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function exactKeys(value: Record<string, unknown>, allowed: readonly string[]): void {
+  const fields = new Set(allowed);
+  if (Object.keys(value).some((key) => !fields.has(key))) {
+    throw new DeviceHostProtocolError("invalid_message", "device-host message has unsupported fields");
+  }
+}
+
+export class DeviceHostProtocolError extends Error {
+  constructor(readonly code: string, message: string) {
+    super(message);
+  }
+}
+
+export class DeviceHostAmbiguousError extends Error {}

--- a/services/managed/src/index.ts
+++ b/services/managed/src/index.ts
@@ -74,6 +74,20 @@ import {
   validatePromptInput,
 } from "./protocol";
 import {
+  DEVICE_HOST_LEASE_MS,
+  DEVICE_TOOL_CALL_TIMEOUT_MS,
+  DeviceHostAmbiguousError,
+  DeviceHostProtocolError,
+  deviceToolAmbiguous,
+  deviceToolResult,
+  deviceToolUnavailable,
+  matchesDeviceHostLease,
+  parseDeviceHostCommand,
+  parseDeviceToolInput,
+  type DeviceHostCommand,
+  type DeviceHostServerMessage,
+} from "./device-host-protocol";
+import {
   classifyTurnFailure,
   materializeTurnTerminal,
   type TurnTerminal,
@@ -158,6 +172,31 @@ type SessionRow = {
   completed_turns: number;
   last_active: number;
   stream_error: string | null;
+};
+
+type DeviceHostAttachment = {
+  kind: "device-host";
+  sessionId: string;
+  hostId?: string;
+  leaseId?: string;
+  epoch?: number;
+};
+
+type DeviceHostStateRow = {
+  epoch: number;
+  host_id: string | null;
+  catalog_version: number | null;
+  lease_id: string | null;
+  lease_expires_at: number;
+};
+
+type PendingDeviceToolCall = {
+  leaseId: string;
+  epoch: number;
+  deadlineAt: number;
+  timeout?: ReturnType<typeof setTimeout>;
+  resolve(result: { success: boolean; output: unknown }): void;
+  reject(error: Error): void;
 };
 
 type SessionInitializationOwnership = {
@@ -527,7 +566,7 @@ export default {
     const sessionHeaders = new Headers(request.headers);
     sessionHeaders.set(SESSION_OWNER_ASSERTION, principal.userId);
     const publicOrigin = `public_origin=${encodeURIComponent(url.origin)}`;
-    if (resource === "ws") {
+    if (resource === "ws" || resource === "device-host") {
       if (request.method !== "GET" || request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
         return new Response("Expected WebSocket upgrade", { status: 426 });
       }
@@ -535,7 +574,7 @@ export default {
         return json({ error: "forbidden_origin" }, { status: 403 });
       }
       return stub.fetch(
-        `https://session.internal/socket?${publicOrigin}`,
+        `https://session.internal/${resource === "ws" ? "socket" : "device-host"}?${publicOrigin}`,
         new Request(request, { headers: sessionHeaders }),
       );
     }
@@ -706,6 +745,7 @@ export class NanocodexSession extends DurableComputerSession {
   readonly #admissionTasks = new Map<string, Promise<ManagedTurnRow>>();
   #initialAccountContextTask?: Promise<InitialAccountContext | undefined>;
   readonly #cancellationTasks = new Map<string, Promise<void>>();
+  readonly #pendingDeviceToolCalls = new Map<string, PendingDeviceToolCall>();
   readonly #realtimeOperations = new Map<string, Promise<unknown>>();
   #realtimeOperationTail: Promise<void> = Promise.resolve();
   readonly #inFlight = new Set<Promise<unknown>>();
@@ -783,6 +823,31 @@ export class NanocodexSession extends DurableComputerSession {
         voice_session_id TEXT NOT NULL,
         updated_at INTEGER NOT NULL
       );
+      CREATE TABLE IF NOT EXISTS device_host_state (
+        singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+        epoch INTEGER NOT NULL DEFAULT 0,
+        host_id TEXT,
+        catalog_version INTEGER,
+        lease_id TEXT,
+        lease_expires_at INTEGER NOT NULL DEFAULT 0
+      );
+      INSERT OR IGNORE INTO device_host_state (singleton) VALUES (1);
+      CREATE TABLE IF NOT EXISTS device_tool_calls (
+        call_id TEXT PRIMARY KEY,
+        lease_id TEXT NOT NULL,
+        epoch INTEGER NOT NULL,
+        state TEXT NOT NULL CHECK (state IN ('dispatched', 'completed', 'ambiguous')),
+        operation TEXT NOT NULL,
+        arguments_json TEXT NOT NULL,
+        result_json TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      UPDATE device_tool_calls
+      SET state = 'ambiguous',
+          result_json = '{"ok":false,"status":"ambiguous","message":"device host lifecycle restarted after dispatch"}',
+          updated_at = unixepoch('subsec') * 1000
+      WHERE state = 'dispatched';
     `);
     this.#eventLog = new DurableEventLog<StreamMessage>(this.ctx.storage);
     this.#eventArchive = new ManagedEventArchive<StreamMessage>(
@@ -1103,6 +1168,8 @@ export class NanocodexSession extends DurableComputerSession {
     }
     if (request.method === "GET" && url.pathname === "/socket")
       return this.#upgrade();
+    if (request.method === "GET" && url.pathname === "/device-host")
+      return this.#upgradeDeviceHost();
     const realtimeRoute = url.pathname.match(
       /^\/realtime\/(start|delegate|stop)$/,
     );
@@ -1300,6 +1367,11 @@ export class NanocodexSession extends DurableComputerSession {
       closeSocket(socket, 1009, "message exceeds 1 MiB");
       return;
     }
+    const attachment = socket.deserializeAttachment() as DeviceHostAttachment | { sessionId?: string } | null;
+    if (attachment && "kind" in attachment && attachment.kind === "device-host") {
+      await this.#dispatchDeviceHost(socket, attachment, message);
+      return;
+    }
     let command: ClientCommand;
     try {
       command = parseCommand(message);
@@ -1312,10 +1384,12 @@ export class NanocodexSession extends DurableComputerSession {
   }
 
   webSocketClose(socket: WebSocket, code: number, reason: string): void {
+    this.#retireDeviceHost(socket, reason || "peer closed");
     closeSocket(socket, code, reason || "peer closed");
   }
 
   webSocketError(socket: WebSocket): void {
+    this.#retireDeviceHost(socket, "WebSocket failed");
     closeSocket(socket, 1011, "WebSocket failed");
   }
 
@@ -1394,6 +1468,275 @@ export class NanocodexSession extends DurableComputerSession {
     });
     return new Response(null, { status: 101, webSocket: client });
   }
+
+  #upgradeDeviceHost(): Response {
+    if (this.#deleting) return new Response("Agent is being deleted", { status: 409 });
+    const session = this.#sessionStatus();
+    if (!session) return new Response("Unknown session", { status: 404 });
+    if (this.#session()?.runtime_profile !== "managed") {
+      return new Response("Device hosting is unavailable for multiplayer agents", { status: 409 });
+    }
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair);
+    server.serializeAttachment({
+      kind: "device-host",
+      sessionId: session.session_id,
+    } satisfies DeviceHostAttachment);
+    this.ctx.acceptWebSocket(server, ["device-host"]);
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  async #dispatchDeviceHost(
+    socket: WebSocket,
+    attachment: DeviceHostAttachment,
+    encoded: string,
+  ): Promise<void> {
+    let command: DeviceHostCommand;
+    try {
+      command = parseDeviceHostCommand(encoded);
+    } catch (error) {
+      const protocol = error instanceof DeviceHostProtocolError
+        ? error
+        : new DeviceHostProtocolError("invalid_message", errorMessage(error));
+      this.#sendDeviceHost(socket, { type: "error", code: protocol.code, message: protocol.message });
+      return;
+    }
+    try {
+      if (command.type === "attach") {
+        this.#claimDeviceHost(socket, attachment, command.host_id, command.catalog_version);
+        return;
+      }
+      this.#requireDeviceHostLease(socket, attachment, command.lease_id, command.epoch);
+      if (command.type === "ping") {
+        this.#renewDeviceHostLease(socket, command);
+      } else {
+        this.#completeDeviceToolCall(socket, command);
+      }
+    } catch (error) {
+      const protocol = error instanceof DeviceHostProtocolError
+        ? error
+        : new DeviceHostProtocolError("device_host_failed", errorMessage(error));
+      if (protocol.code !== "stale_lease") {
+        this.#sendDeviceHost(socket, { type: "error", code: protocol.code, message: protocol.message });
+      }
+    }
+  }
+
+  #claimDeviceHost(
+    socket: WebSocket,
+    attachment: DeviceHostAttachment,
+    hostId: string,
+    catalogVersion: number,
+  ): void {
+    if (attachment.hostId || attachment.leaseId || attachment.epoch) {
+      throw new DeviceHostProtocolError("already_attached", "this socket already holds a device-host lease");
+    }
+    const current = this.#deviceHostState();
+    if (current.epoch >= Number.MAX_SAFE_INTEGER) {
+      throw new DeviceHostProtocolError("lease_exhausted", "the device-host lease epoch is exhausted");
+    }
+    const epoch = current.epoch + 1;
+    const leaseId = crypto.randomUUID();
+    const expiresAt = Date.now() + DEVICE_HOST_LEASE_MS;
+    this.ctx.storage.sql.exec(
+      `UPDATE device_host_state
+       SET epoch = ?, host_id = ?, catalog_version = ?, lease_id = ?, lease_expires_at = ?
+       WHERE singleton = 1`,
+      epoch,
+      hostId,
+      catalogVersion,
+      leaseId,
+      expiresAt,
+    );
+    for (const candidate of this.ctx.getWebSockets("device-host")) {
+      if (candidate === socket) continue;
+      const candidateAttachment = candidate.deserializeAttachment() as DeviceHostAttachment | null;
+      if (candidateAttachment?.kind !== "device-host" || !candidateAttachment.leaseId) continue;
+      try {
+        this.#sendDeviceHost(candidate, {
+          type: "fenced",
+          epoch,
+          reason: "a newer Android device host acquired the agent lease",
+        });
+      } catch { /* Closing the old socket is itself the authoritative fence. */ }
+      this.#retireDeviceHost(candidate, "replaced by a newer device host");
+      closeSocket(candidate, 1008, "device-host lease replaced");
+    }
+    socket.serializeAttachment({
+      ...attachment,
+      hostId,
+      leaseId,
+      epoch,
+    } satisfies DeviceHostAttachment);
+    try {
+      this.#sendDeviceHost(socket, {
+        type: "lease",
+        protocol_version: 1,
+        lease_id: leaseId,
+        epoch,
+        expires_at: expiresAt,
+        catalog_version: catalogVersion,
+      });
+    } catch {
+      this.#retireDeviceHost(socket, "lease delivery failed");
+      closeSocket(socket, 1011, "device-host lease delivery failed");
+    }
+  }
+
+  #requireDeviceHostLease(
+    socket: WebSocket,
+    attachment: DeviceHostAttachment,
+    leaseId: string,
+    epoch: number,
+  ): DeviceHostStateRow {
+    const state = this.#deviceHostState();
+    if (attachment.leaseId !== leaseId
+      || attachment.epoch !== epoch
+      || !matchesDeviceHostLease(attachment, state, Date.now())) {
+      try {
+        this.#sendDeviceHost(socket, {
+          type: "fenced",
+          epoch: state.epoch,
+          reason: "the device-host lease is stale or expired",
+        });
+      } catch { /* Closing the stale socket is itself the authoritative fence. */ }
+      this.#retireDeviceHost(socket, "stale or expired lease");
+      closeSocket(socket, 1008, "stale device-host lease");
+      throw new DeviceHostProtocolError("stale_lease", "the device-host lease is stale or expired");
+    }
+    return state;
+  }
+
+  #renewDeviceHostLease(
+    socket: WebSocket,
+    command: Extract<DeviceHostCommand, { type: "ping" }>,
+  ): void {
+    const expiresAt = Date.now() + DEVICE_HOST_LEASE_MS;
+    this.ctx.storage.sql.exec(
+      `UPDATE device_host_state SET lease_expires_at = ?
+       WHERE singleton = 1 AND lease_id = ? AND epoch = ?`,
+      expiresAt,
+      command.lease_id,
+      command.epoch,
+    );
+    this.#sendDeviceHost(socket, {
+      type: "pong",
+      lease_id: command.lease_id,
+      epoch: command.epoch,
+      expires_at: expiresAt,
+      ...(command.nonce === undefined ? {} : { nonce: command.nonce }),
+    });
+  }
+
+  #completeDeviceToolCall(
+    socket: WebSocket,
+    command: Extract<DeviceHostCommand, { type: "device_tool_result" }>,
+  ): void {
+    const pending = this.#pendingDeviceToolCalls.get(command.call_id);
+    if (!pending || pending.leaseId !== command.lease_id || pending.epoch !== command.epoch) {
+      throw new DeviceHostProtocolError("unknown_call", "device tool call is not pending for this lease");
+    }
+    const stored = JSON.stringify(deviceToolResult(command.success, command.output));
+    this.ctx.storage.sql.exec(
+      `UPDATE device_tool_calls
+       SET state = 'completed', result_json = ?, updated_at = ?
+       WHERE call_id = ? AND lease_id = ? AND epoch = ? AND state = 'dispatched'`,
+      stored,
+      Date.now(),
+      command.call_id,
+      command.lease_id,
+      command.epoch,
+    );
+    if (pending.timeout !== undefined) clearTimeout(pending.timeout);
+    this.#pendingDeviceToolCalls.delete(command.call_id);
+    pending.resolve({ success: command.success, output: command.output });
+    this.#sendDeviceHost(socket, {
+      type: "ack",
+      lease_id: command.lease_id,
+      epoch: command.epoch,
+      call_id: command.call_id,
+      state: "completed",
+    });
+  }
+
+  #retireDeviceHost(socket: WebSocket, reason: string): void {
+    const attachment = socket.deserializeAttachment() as DeviceHostAttachment | null;
+    if (attachment?.kind !== "device-host" || !attachment.leaseId || !attachment.epoch) return;
+    const ambiguousMessage = `Android device outcome is ambiguous after disconnect: ${reason}`;
+    const ambiguous = deviceToolAmbiguous(ambiguousMessage);
+    this.ctx.storage.transactionSync(() => {
+      this.ctx.storage.sql.exec(
+        `UPDATE device_tool_calls
+         SET state = 'ambiguous', result_json = ?, updated_at = ?
+         WHERE lease_id = ? AND epoch = ? AND state = 'dispatched'`,
+        JSON.stringify(ambiguous),
+        Date.now(),
+        attachment.leaseId,
+        attachment.epoch,
+      );
+      this.ctx.storage.sql.exec(
+        `UPDATE device_host_state
+         SET host_id = NULL, catalog_version = NULL, lease_id = NULL, lease_expires_at = 0
+         WHERE singleton = 1 AND lease_id = ? AND epoch = ?`,
+        attachment.leaseId,
+        attachment.epoch,
+      );
+    });
+    for (const [callId, pending] of this.#pendingDeviceToolCalls) {
+      if (pending.leaseId !== attachment.leaseId || pending.epoch !== attachment.epoch) continue;
+      if (pending.timeout !== undefined) clearTimeout(pending.timeout);
+      this.#pendingDeviceToolCalls.delete(callId);
+      pending.reject(new DeviceHostAmbiguousError(ambiguousMessage));
+    }
+  }
+
+  #deviceHostState(): DeviceHostStateRow {
+    const state = this.ctx.storage.sql.exec<DeviceHostStateRow>(
+      `SELECT epoch, host_id, catalog_version, lease_id, lease_expires_at
+       FROM device_host_state WHERE singleton = 1`,
+    ).toArray()[0];
+    if (!state) throw new Error("device-host state is missing");
+    return state;
+  }
+
+  #sendDeviceHost(socket: WebSocket, message: DeviceHostServerMessage): void {
+    socket.send(JSON.stringify(message));
+  }
+
+  #armDeviceToolExpiry(callId: string, pending: PendingDeviceToolCall, expiresAt: number): void {
+    if (pending.timeout !== undefined) clearTimeout(pending.timeout);
+    pending.timeout = setTimeout(() => {
+      const current = this.#pendingDeviceToolCalls.get(callId);
+      if (current !== pending) return;
+      const state = this.#deviceHostState();
+      if (state.lease_id === pending.leaseId
+        && state.epoch === pending.epoch
+        && state.lease_expires_at > Date.now()
+        && pending.deadlineAt > Date.now()) {
+        this.#armDeviceToolExpiry(
+          callId,
+          pending,
+          Math.min(state.lease_expires_at, pending.deadlineAt),
+        );
+        return;
+      }
+      const ambiguousMessage = "Android device did not return a result before its lease or call deadline expired";
+      const ambiguous = deviceToolAmbiguous(ambiguousMessage);
+      this.ctx.storage.sql.exec(
+        `UPDATE device_tool_calls
+         SET state = 'ambiguous', result_json = ?, updated_at = ?
+         WHERE call_id = ? AND lease_id = ? AND epoch = ? AND state = 'dispatched'`,
+        JSON.stringify(ambiguous),
+        Date.now(),
+        callId,
+        pending.leaseId,
+        pending.epoch,
+      );
+      this.#pendingDeviceToolCalls.delete(callId);
+      pending.reject(new DeviceHostAmbiguousError(ambiguousMessage));
+    }, Math.max(1, expiresAt - Date.now()));
+  }
+
 
   async #dispatch(socket: WebSocket, command: ClientCommand): Promise<void> {
     if (this.#deleting) {
@@ -2814,6 +3157,95 @@ export class NanocodexSession extends DurableComputerSession {
     return prepared;
   }
 
+  async #executePhone(input: unknown, context: { callId: string }): Promise<unknown> {
+    let phone;
+    try {
+      phone = parseDeviceToolInput(input);
+    } catch (error) {
+      return {
+        ok: false,
+        status: "failed",
+        output: {
+          code: error instanceof DeviceHostProtocolError ? error.code : "invalid_phone_input",
+          message: errorMessage(error),
+        },
+      };
+    }
+    const state = this.#deviceHostState();
+    const socket = this.ctx.getWebSockets("device-host").find((candidate) => {
+      if (candidate.readyState !== WebSocket.OPEN) return false;
+      const attachment = candidate.deserializeAttachment() as DeviceHostAttachment | null;
+      return attachment?.kind === "device-host"
+        && matchesDeviceHostLease(attachment, state, Date.now());
+    });
+    if (!socket || !state.lease_id || !state.host_id || state.lease_expires_at < Date.now()) {
+      if (socket) {
+        try {
+          this.#sendDeviceHost(socket, {
+            type: "fenced",
+            epoch: state.epoch,
+            reason: "the device-host lease expired before tool dispatch",
+          });
+        } catch { /* Closing the expired socket is itself the authoritative fence. */ }
+        this.#retireDeviceHost(socket, "lease expired before dispatch");
+        closeSocket(socket, 1008, "device-host lease expired");
+      }
+      return deviceToolUnavailable();
+    }
+    const now = Date.now();
+    try {
+      this.ctx.storage.sql.exec(
+        `INSERT INTO device_tool_calls
+           (call_id, lease_id, epoch, state, operation, arguments_json, created_at, updated_at)
+         VALUES (?, ?, ?, 'dispatched', ?, ?, ?, ?)`,
+        context.callId,
+        state.lease_id,
+        state.epoch,
+        phone.operation,
+        JSON.stringify(phone.arguments),
+        now,
+        now,
+      );
+    } catch (error) {
+      return deviceToolAmbiguous(`Phone call could not be admitted without risking replay: ${errorMessage(error)}`);
+    }
+    const result = new Promise<{ success: boolean; output: unknown }>((resolve, reject) => {
+      const pending: PendingDeviceToolCall = {
+        leaseId: state.lease_id!,
+        epoch: state.epoch,
+        deadlineAt: now + DEVICE_TOOL_CALL_TIMEOUT_MS,
+        resolve,
+        reject,
+      };
+      this.#pendingDeviceToolCalls.set(context.callId, pending);
+      this.#armDeviceToolExpiry(
+        context.callId,
+        pending,
+        Math.min(state.lease_expires_at, pending.deadlineAt),
+      );
+    });
+    try {
+      this.#sendDeviceHost(socket, {
+        type: "device_tool_call",
+        lease_id: state.lease_id,
+        epoch: state.epoch,
+        call_id: context.callId,
+        tool: "phone",
+        operation: phone.operation,
+        arguments: phone.arguments,
+      });
+    } catch (error) {
+      this.#retireDeviceHost(socket, `dispatch failed: ${errorMessage(error)}`);
+    }
+    try {
+      const completed = await result;
+      return deviceToolResult(completed.success, completed.output);
+    } catch (error) {
+      return deviceToolAmbiguous(errorMessage(error));
+    }
+  }
+
+
   async #createAgent(): Promise<CloudflareAgent.Agent> {
     const constructionStartedAt = performance.now();
     const session = this.#session();
@@ -2862,11 +3294,28 @@ export class NanocodexSession extends DurableComputerSession {
           ].join("\n\n")
           : [
             "You are Nanocodex running as a durable managed agent on Cloudflare Workers.",
+            "The phone tool's current attached Android device is the authority for phone state and phone actions. A missing device host means the phone is unavailable; there is no cloud fallback.",
+            "Never claim that a phone action happened unless the phone tool returned ok=true and status=completed. Report failed, unavailable, and ambiguous phone outcomes accurately.",
             "Your /workspace filesystem is durable Cloudflare Computer storage backed by this agent's Durable Object.",
             "Call accountInfo to see the current identities, stablecoin balances, and app authorization boundaries, then use gh or curl normally through transparent authenticated egress. accountInfo is a tool, not a shell command.",
           ].join("\n\n"),
         tools: [
           execCommand,
+          ...(multiplayer ? [] : [{
+            name: "phone",
+            description: "Read current phone state or perform a phone operation on the currently attached Android device. This has no cloud fallback; inspect ok and status before claiming success.",
+            supportsParallelToolCalls: false,
+            parameters: {
+              type: "object",
+              properties: {
+                operation: { type: "string", minLength: 1, maxLength: 128 },
+                arguments: { type: "object" },
+              },
+              required: ["operation"],
+              additionalProperties: false,
+            },
+            handler: (input: unknown, context: { callId: string }) => this.#executePhone(input, context),
+          }]),
           ...(multiplayer ? [] : [{
             name: "accountInfo",
             description: "Report account authentication, stablecoin balances, and app authorization boundaries. Never returns credentials.",

--- a/services/managed/test/device-host-protocol.test.ts
+++ b/services/managed/test/device-host-protocol.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEVICE_HOST_PROTOCOL_VERSION,
+  MAX_DEVICE_HOST_MESSAGE_BYTES,
+  deviceToolAmbiguous,
+  deviceToolResult,
+  deviceToolUnavailable,
+  matchesDeviceHostLease,
+  parseDeviceHostCommand,
+  parseDeviceToolInput,
+} from "../src/device-host-protocol";
+
+const HOST_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const LEASE_ID = "22222222-2222-4222-8222-222222222222";
+
+describe("Android device-host protocol", () => {
+  it("strictly parses v1 attach, ping, and device results", () => {
+    expect(parseDeviceHostCommand(JSON.stringify({
+      type: "attach",
+      protocol_version: DEVICE_HOST_PROTOCOL_VERSION,
+      host_id: HOST_ID,
+      catalog_version: 1,
+    }))).toEqual({
+      type: "attach",
+      protocol_version: 1,
+      host_id: HOST_ID,
+      catalog_version: 1,
+    });
+    expect(parseDeviceHostCommand(JSON.stringify({
+      type: "ping",
+      lease_id: LEASE_ID,
+      epoch: 7,
+      nonce: "heartbeat-7",
+    }))).toEqual({
+      type: "ping",
+      lease_id: LEASE_ID,
+      epoch: 7,
+      nonce: "heartbeat-7",
+    });
+    expect(parseDeviceHostCommand(JSON.stringify({
+      type: "device_tool_result",
+      lease_id: LEASE_ID,
+      epoch: 7,
+      call_id: "phone-call:1",
+      success: false,
+      output: { code: "permission_denied", remediation: "grant calendar access" },
+    }))).toMatchObject({ type: "device_tool_result", success: false });
+
+    expect(() => parseDeviceHostCommand(JSON.stringify({
+      type: "attach",
+      protocol_version: 1,
+      host_id: HOST_ID,
+      catalog_version: 1,
+      credential: "must-not-be-accepted",
+    }))).toThrow("unsupported fields");
+    expect(() => parseDeviceHostCommand(JSON.stringify({
+      type: "attach",
+      protocol_version: 2,
+      host_id: HOST_ID,
+      catalog_version: 1,
+    }))).toThrow("unsupported device-host protocol version");
+  });
+
+  it("enforces message, identity, catalog, operation, and object bounds", () => {
+    expect(() => parseDeviceHostCommand("x".repeat(MAX_DEVICE_HOST_MESSAGE_BYTES + 1)))
+      .toThrow("limited");
+    expect(() => parseDeviceHostCommand(JSON.stringify({
+      type: "attach",
+      protocol_version: 1,
+      host_id: HOST_ID.toUpperCase(),
+      catalog_version: 1,
+    }))).toThrow("lowercase UUID v4");
+    expect(() => parseDeviceHostCommand(JSON.stringify({
+      type: "attach",
+      protocol_version: 1,
+      host_id: HOST_ID,
+      catalog_version: 0,
+    }))).toThrow("catalog_version");
+    expect(parseDeviceToolInput({ operation: "calendar.list" })).toEqual({
+      operation: "calendar.list",
+      arguments: {},
+    });
+    expect(() => parseDeviceToolInput({ operation: "calendar.list", arguments: [] }))
+      .toThrow("phone arguments must be an object");
+    expect(() => parseDeviceToolInput({ operation: "calendar/list" }))
+      .toThrow("operation must be");
+  });
+
+  it("fences stale identities, epochs, and expired leases", () => {
+    const state = {
+      host_id: HOST_ID,
+      lease_id: LEASE_ID,
+      epoch: 9,
+      lease_expires_at: 20_000,
+    };
+    expect(matchesDeviceHostLease({ hostId: HOST_ID, leaseId: LEASE_ID, epoch: 9 }, state, 19_999))
+      .toBe(true);
+    expect(matchesDeviceHostLease({ hostId: HOST_ID, leaseId: LEASE_ID, epoch: 8 }, state, 19_999))
+      .toBe(false);
+    expect(matchesDeviceHostLease({ hostId: HOST_ID, leaseId: LEASE_ID, epoch: 9 }, state, 20_001))
+      .toBe(false);
+    expect(matchesDeviceHostLease({ hostId: HOST_ID, leaseId: crypto.randomUUID(), epoch: 9 }, state, 19_999))
+      .toBe(false);
+  });
+
+  it("keeps failed, offline, and ambiguous device outcomes structured", () => {
+    expect(deviceToolResult(false, { code: "not_allowed" })).toEqual({
+      ok: false,
+      status: "failed",
+      output: { code: "not_allowed" },
+    });
+    expect(deviceToolUnavailable()).toEqual({
+      ok: false,
+      status: "unavailable",
+      message: "No Android device host is currently attached.",
+    });
+    expect(deviceToolAmbiguous("disconnected after dispatch")).toEqual({
+      ok: false,
+      status: "ambiguous",
+      message: "disconnected after dispatch",
+    });
+  });
+});

--- a/services/managed/test/device-host.test.ts
+++ b/services/managed/test/device-host.test.ts
@@ -1,0 +1,151 @@
+import { env, SELF } from "cloudflare:test";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import type { Env } from "../src/index";
+
+const testEnv = env as unknown as Env;
+const USER_ID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+const API_KEY = `ncx_live_${"d".repeat(12)}_${"h".repeat(43)}`;
+const createdAgents = new Set<string>();
+
+beforeAll(async () => seedApiKey());
+
+afterAll(async () => {
+  await Promise.all([...createdAgents].map(async (agentId) => {
+    await authenticatedFetch(`https://example.test/v1/agents/${agentId}`, { method: "DELETE" });
+  }));
+});
+
+describe("managed Android device host", () => {
+  it("authenticates the endpoint and monotonically fences a replaced host", async () => {
+    const agentId = await createAgent();
+    const endpoint = `https://example.test/v1/agents/${agentId}/device-host`;
+
+    const unauthenticated = await SELF.fetch(endpoint, {
+      headers: { upgrade: "websocket" },
+    });
+    expect(unauthenticated.status).toBe(401);
+
+    const first = await upgrade(endpoint);
+    const firstLeaseMessage = nextMessage(first);
+    first.send(JSON.stringify({
+      type: "attach",
+      protocol_version: 1,
+      host_id: "11111111-1111-4111-8111-111111111111",
+      catalog_version: 1,
+    }));
+    const firstLease = await firstLeaseMessage as {
+      type: string;
+      lease_id: string;
+      epoch: number;
+      expires_at: number;
+    };
+    expect(firstLease).toMatchObject({ type: "lease", epoch: 1 });
+    expect(firstLease.expires_at).toBeGreaterThan(Date.now());
+
+    const pongMessage = nextMessage(first);
+    first.send(JSON.stringify({
+      type: "ping",
+      lease_id: firstLease.lease_id,
+      epoch: firstLease.epoch,
+      nonce: "device-heartbeat",
+    }));
+    expect(await pongMessage).toMatchObject({
+      type: "pong",
+      lease_id: firstLease.lease_id,
+      epoch: 1,
+      nonce: "device-heartbeat",
+    });
+
+    const fencedMessage = nextMessage(first);
+    const second = await upgrade(endpoint);
+    const secondLeaseMessage = nextMessage(second);
+    second.send(JSON.stringify({
+      type: "attach",
+      protocol_version: 1,
+      host_id: "22222222-2222-4222-8222-222222222222",
+      catalog_version: 3,
+    }));
+    expect(await fencedMessage).toMatchObject({
+      type: "fenced",
+      epoch: 2,
+    });
+    expect(await secondLeaseMessage).toMatchObject({
+      type: "lease",
+      epoch: 2,
+      catalog_version: 3,
+    });
+    second.close(1000, "test complete");
+  });
+
+});
+
+async function createAgent(): Promise<string> {
+  const created = await authenticatedFetch("https://example.test/v1/agents", { method: "POST" });
+  expect(created.status).toBe(201);
+  const { agent_id: agentId } = await created.json<{ agent_id: string }>();
+  createdAgents.add(agentId);
+  return agentId;
+}
+
+async function upgrade(endpoint: string): Promise<WebSocket> {
+  const response = await authenticatedFetch(endpoint, {
+    headers: { upgrade: "websocket" },
+  });
+  expect(response.status).toBe(101);
+  expect(response.webSocket).toBeTruthy();
+  response.webSocket!.accept();
+  return response.webSocket!;
+}
+
+function nextMessage(socket: WebSocket): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("timed out waiting for device-host message")), 2_000);
+    socket.addEventListener("message", (event) => {
+      clearTimeout(timeout);
+      try {
+        resolve(JSON.parse(String(event.data)) as Record<string, unknown>);
+      } catch (error) {
+        reject(error);
+      }
+    }, { once: true });
+  });
+}
+
+async function authenticatedFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const request = new Request(input, init);
+  const headers = new Headers(request.headers);
+  headers.set("authorization", `Bearer ${API_KEY}`);
+  return SELF.fetch(new Request(request, { headers }));
+}
+
+async function seedApiKey(): Promise<void> {
+  const digestBytes = new Uint8Array(
+    await crypto.subtle.digest("SHA-256", new TextEncoder().encode(API_KEY)),
+  );
+  let binary = "";
+  for (const byte of digestBytes) binary += String.fromCharCode(byte);
+  const digest = btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+  const account = testEnv.NANOCODEX_USERS.getByName(USER_ID);
+  const provisioned = await account.fetch("https://user.internal/account", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ id: USER_ID, persistent: true }),
+  });
+  expect(provisioned.ok).toBe(true);
+  const key = testEnv.NANOCODEX_API_KEYS.getByName(digest);
+  await key.fetch("https://api-key.internal/record", { method: "DELETE" });
+  const record = await key.fetch("https://api-key.internal/record", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      id: "d".repeat(12),
+      label: "device-host-test",
+      prefix: API_KEY.slice(0, "ncx_live_".length + 12),
+      createdAt: Date.now(),
+      digest,
+      userId: USER_ID,
+    }),
+  });
+  expect(record.status).toBe(201);
+}

--- a/services/managed/test/device-host.test.ts
+++ b/services/managed/test/device-host.test.ts
@@ -78,6 +78,84 @@ describe("managed Android device host", () => {
     second.close(1000, "test complete");
   });
 
+  it("executes a managed agent phone call on the attached device host", async () => {
+    const agentId = await createAgent();
+    const host = await upgrade(`https://example.test/v1/agents/${agentId}/device-host`);
+    const leaseMessage = nextMessage(host);
+    host.send(JSON.stringify({
+      type: "attach",
+      protocol_version: 1,
+      host_id: "33333333-3333-4333-8333-333333333333",
+      catalog_version: 3,
+    }));
+    const lease = await leaseMessage as {
+      lease_id: string;
+      epoch: number;
+    };
+
+    const deviceCallMessage = nextMessage(host);
+    const started = await authenticatedFetch(
+      `https://example.test/v1/agents/${agentId}/turns`,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "idempotency-key": "request-managed-phone",
+        },
+        body: JSON.stringify({ id: "turn-managed-phone", input: "E2E_MANAGED_PHONE" }),
+      },
+    );
+    expect(started.status).toBe(202);
+
+    const deviceCall = await deviceCallMessage as {
+      type: string;
+      lease_id: string;
+      epoch: number;
+      call_id: string;
+      tool: string;
+      operation: string;
+      arguments: Record<string, unknown>;
+    };
+    expect(deviceCall).toMatchObject({
+      type: "device_tool_call",
+      lease_id: lease.lease_id,
+      epoch: lease.epoch,
+      call_id: "managed-phone",
+      tool: "phone",
+      operation: "device.location.current",
+      arguments: { provider: "precise" },
+    });
+
+    const ackMessage = nextMessage(host);
+    host.send(JSON.stringify({
+      type: "device_tool_result",
+      lease_id: lease.lease_id,
+      epoch: lease.epoch,
+      call_id: deviceCall.call_id,
+      success: true,
+      output: {
+        ok: true,
+        operation: deviceCall.operation,
+        latitude: 37.8715,
+        longitude: -122.273,
+      },
+    }));
+    expect(await ackMessage).toMatchObject({
+      type: "ack",
+      lease_id: lease.lease_id,
+      epoch: lease.epoch,
+      call_id: "managed-phone",
+      state: "completed",
+    });
+
+    const terminal = await waitForTurn(agentId, "turn-managed-phone");
+    expect(terminal).toMatchObject({
+      type: "turn_completed",
+      final_message: "MANAGED_PHONE_OK",
+    });
+    host.close(1000, "test complete");
+  });
+
 });
 
 async function createAgent(): Promise<string> {
@@ -117,6 +195,20 @@ async function authenticatedFetch(input: RequestInfo | URL, init?: RequestInit):
   const headers = new Headers(request.headers);
   headers.set("authorization", `Bearer ${API_KEY}`);
   return SELF.fetch(new Request(request, { headers }));
+}
+
+async function waitForTurn(agentId: string, turnId: string): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + 10_000;
+  do {
+    const response = await authenticatedFetch(
+      `https://example.test/v1/agents/${agentId}/turns/${turnId}`,
+    );
+    expect(response.status).toBe(200);
+    const view = await response.json<{ terminal?: Record<string, unknown> }>();
+    if (view.terminal) return view.terminal;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  } while (Date.now() < deadline);
+  throw new Error(`timed out waiting for ${turnId}`);
 }
 
 async function seedApiKey(): Promise<void> {

--- a/services/managed/vitest.config.ts
+++ b/services/managed/vitest.config.ts
@@ -201,8 +201,32 @@ export default {
       const multiplayerConnectorOutput = input.find((item) => (
         item?.type === "function_call_output" && item.call_id === "multiplayer-no-connectors"
       ));
+      const phoneOutput = input.find((item) => (
+        item?.type === "function_call_output" && item.call_id === "managed-phone"
+      ));
       pendingResponse = setTimeout(() => {
         pendingResponse = undefined;
+        if (phoneOutput) {
+          const output = String(phoneOutput.output);
+          const valid = output.includes('"ok":true')
+            && output.includes('"status":"completed"')
+            && output.includes('"operation":"device.location.current"')
+            && output.includes('"latitude":37.8715');
+          server.send(JSON.stringify({
+            type: "response.completed",
+            response: {
+              id: crypto.randomUUID(),
+              status: "completed",
+              output: [{
+                type: "message",
+                role: "assistant",
+                content: [{ type: "output_text", text: valid ? "MANAGED_PHONE_OK" : "MANAGED_PHONE_BAD" }],
+              }],
+              usage: null,
+            },
+          }));
+          return;
+        }
         if (multiplayerConnectorOutput) {
           const output = String(multiplayerConnectorOutput.output);
           const valid = output.includes("MULTIPLAYER_RUNTIME_OK")
@@ -315,6 +339,26 @@ export default {
                 name: "exec_command",
                 arguments: JSON.stringify({
                   cmd: "printf 'MULTIPLAYER_RUNTIME_OK\\n' > /workspace/multiplayer.txt; cat /workspace/multiplayer.txt; gh api repos/gakonst/nanocodex",
+                }),
+              }],
+              usage: null,
+            },
+          }));
+          return;
+        }
+        if (text.includes("E2E_MANAGED_PHONE")) {
+          server.send(JSON.stringify({
+            type: "response.completed",
+            response: {
+              id: crypto.randomUUID(),
+              status: "completed",
+              output: [{
+                type: "function_call",
+                call_id: "managed-phone",
+                name: "phone",
+                arguments: JSON.stringify({
+                  operation: "device.location.current",
+                  arguments: { provider: "precise" },
                 }),
               }],
               usage: null,


### PR DESCRIPTION
Adds an authenticated, fenced Android device-host WebSocket to each private managed agent and registers the managed `phone` tool. Includes lease, ambiguity, duplicate-call, and a complete mocked model-to-device-to-model E2E test.\n\nValidated with managed typecheck, focused Vitest (6 tests), and Wrangler production dry build.