### PR TITLE
test(web): assert terminal behavior at its owner

### DIFF
--- a/js/terminal/test/components.test.mjs
+++ b/js/terminal/test/components.test.mjs
@@ -63,7 +63,9 @@ test("controller-backed terminal remains caller-owned when no Agent is attached"
 test("composer keeps send stable while exposing stop separately", async () => {
   assert.equal(terminalComposerAction(true, ""), "stop");
   assert.equal(terminalComposerAction(true, "steer"), "send");
+  const changes = [];
   const submissions = [];
+  const textareaNode = { value: "ship it" };
   let cancelled = 0;
   let renderer;
   await act(async () => {
@@ -73,14 +75,19 @@ test("composer keeps send stable while exposing stop separately", async () => {
       running: true,
       status: "ready",
       onCancel() { cancelled += 1; },
-      onChange() {},
+      onChange(value) { changes.push(value); },
       onSubmit(value) { submissions.push(value); },
-    }));
+    }), {
+      createNodeMock(element) {
+        return element.type === "textarea" ? textareaNode : {};
+      },
+    });
   });
   const form = renderer.root.findByType("form");
   await act(async () => form.props.onSubmit({ preventDefault() {} }));
   assert.deepEqual(submissions, ["ship it"]);
   const textarea = renderer.root.findByType("textarea");
+  textareaNode.value = "live native input";
   let prevented = 0;
   await act(async () => textarea.props.onKeyDown({
     nativeEvent: {
@@ -91,20 +98,21 @@ test("composer keeps send stable while exposing stop separately", async () => {
     },
     preventDefault() { prevented += 1; },
   }));
-  assert.deepEqual(submissions, ["ship it", "ship it"]);
+  assert.deepEqual(submissions, ["ship it", "live native input"]);
   assert.equal(prevented, 1);
   await act(async () => textarea.props.onCompositionStart());
   await act(async () => textarea.props.onKeyDown({
     nativeEvent: {
-      isComposing: true,
+      isComposing: false,
       key: "Enter",
       keyCode: 229,
       shiftKey: false,
     },
     preventDefault() { prevented += 1; },
   }));
-  await act(async () => textarea.props.onCompositionEnd({ currentTarget: { value: "ship it" } }));
-  assert.deepEqual(submissions, ["ship it", "ship it"]);
+  await act(async () => textarea.props.onCompositionEnd({ currentTarget: { value: "composed input" } }));
+  assert.deepEqual(changes, ["composed input"]);
+  assert.deepEqual(submissions, ["ship it", "live native input"]);
   assert.equal(prevented, 1);
   assert.deepEqual(
     renderer.root.findAllByType("button").map((button) => button.props["aria-label"]),
@@ -126,6 +134,53 @@ test("composer keeps send stable while exposing stop separately", async () => {
     ["Stop response", "Send message"],
   );
   assert.equal(renderer.root.findByProps({ "aria-label": "Send message" }).props.disabled, false);
+  await act(async () => renderer.root.findByProps({ "aria-label": "Stop response" }).props.onClick());
+  assert.equal(cancelled, 1);
+  await act(async () => renderer.unmount());
+});
+
+test("welcome is replaced by the first visible durable or voice entry", async () => {
+  const props = {
+    canLoadOlder: false,
+    composer: null,
+    entries: [],
+    inactiveMessage: "",
+    isLoadingOlder: false,
+    mode: "full",
+    status: "ready",
+    welcome: "Welcome to Nanocodex",
+    onLoadOlder: async () => false,
+  };
+  let renderer;
+  await act(async () => {
+    renderer = TestRenderer.create(React.createElement(TerminalTranscriptSurface, props), {
+      createNodeMock(element) {
+        return element.type === "div"
+          ? { clientHeight: 300, firstElementChild: null, scrollHeight: 300, scrollTop: 0 }
+          : {};
+      },
+    });
+  });
+  assert.equal(renderer.root.findAllByProps({ className: "agent-terminal-markdown is-assistant is-welcome" }).length, 1);
+
+  await act(async () => renderer.update(React.createElement(TerminalTranscriptSurface, {
+    ...props,
+    entries: [{ id: "durable", kind: "assistant", text: "Ready", streaming: false }],
+  })));
+  assert.equal(renderer.root.findAllByProps({ className: "agent-terminal-markdown is-assistant is-welcome" }).length, 0);
+
+  await act(async () => renderer.update(React.createElement(TerminalTranscriptSurface, {
+    ...props,
+    voiceEntries: [{
+      id: "voice",
+      kind: "user",
+      source: "voice",
+      streaming: false,
+      text: "Hello",
+    }],
+  })));
+  assert.equal(renderer.root.findAllByProps({ className: "agent-terminal-markdown is-assistant is-welcome" }).length, 0);
+  assert.equal(renderer.root.findAllByProps({ "data-source": "voice" }).length, 1);
   await act(async () => renderer.unmount());
 });
 

--- a/web/test/agentBundleBoundary.test.ts
+++ b/web/test/agentBundleBoundary.test.ts
@@ -38,15 +38,15 @@ test("Vite owns one static application graph without manual module loaders", () 
   assert.match(managedRuntime, /Agent,[\s\S]*?from "nanocodex\/managed"/);
 });
 
-test("the authenticated terminal consumes the public React hooks directly", () => {
-  assert.match(terminal, /import \{[\s\S]*?createConfig,[\s\S]*?useNanocodex,[\s\S]*?useVoice,[\s\S]*?\} from "nanocodex-react"/);
+test("the website owns browser Agent creation while the shared terminal owns voice", () => {
+  assert.match(terminal, /import \{[\s\S]*?createConfig,[\s\S]*?useNanocodex,[\s\S]*?\} from "nanocodex-react"/);
   assert.match(terminal, /const agentConfig = useMemo\(\(\) => createConfig\(\{/);
   assert.match(
     terminal,
     /useNanocodex\(\{ config: agentConfig, threadId \}\)/,
   );
-  assert.match(terminal, /useVoice\(agent, \{[\s\S]*?beforeAgentTurn: beforeLocalTurn,[\s\S]*?enabled: mode !== "hidden"/);
-  assert.match(terminal, /useVoice\(managed, \{ enabled: mode !== "hidden" \}\)/);
+  assert.match(terminal, /<AgentTerminalView[\s\S]*?voice[\s\S]*?voiceOptions=\{\{ beforeAgentTurn: beforeLocalTurn \}\}/);
+  assert.match(terminal, /export const ManagedAgentTerminal[\s\S]*?<AgentTerminalView[\s\S]*?voice/);
   assert.doesNotMatch(terminal, /NanocodexProvider|prepareAgent|preload/);
 });
 

--- a/web/test/agentExperience.test.ts
+++ b/web/test/agentExperience.test.ts
@@ -7,7 +7,6 @@ import { browserMcpConfiguration } from "../src/browserMcp.ts";
 const terminal = source("../src/AgentTerminal.tsx");
 const connectTerminal = source("../connect-playground/src/ConnectAgentExperience.tsx");
 const terminalView = source("../../js/terminal/src/AgentTerminalView.tsx");
-const terminalPresentation = source("../../js/terminal/src/TerminalTranscriptSurface.tsx");
 const dock = source("../src/ArtifactDock.tsx");
 const terminalCss = [
   source("../src/AgentTerminal.css"),
@@ -45,12 +44,6 @@ test("the landing terminal is ephemeral while the Agent demo is managed-durable 
   assert.match(experience, /landing[\s\S]*?\? hasCredential[\s\S]*?<AgentTerminal[\s\S]*?: hasCredential && managedConversationId[\s\S]*?<ManagedAgentTerminal/);
   assert.match(experience, /runtime="managed"/);
   assert.doesNotMatch(experience, /activeRuntime|agent-runtime-switch|Local browser|Managed durable|localConversations/);
-});
-
-test("the landing welcome is replaced atomically by the first transcript entry", () => {
-  assert.match(terminalPresentation, /const visibleWelcome = entries\.length === 0 \? welcome : undefined/);
-  assert.match(terminalPresentation, /\{visibleWelcome \? <article[\s\S]*?\{visibleWelcome\}/);
-  assert.doesNotMatch(terminalPresentation, /welcomeDismissed|setWelcomeDismissed/);
 });
 
 test("the Connect terminal enables package-owned voice from final-output permission", () => {

--- a/web/test/browserAgentCapabilities.test.ts
+++ b/web/test/browserAgentCapabilities.test.ts
@@ -61,18 +61,6 @@ test("the terminal fails before thread or Worker creation and exposes the capabi
   assert.match(session, /if \(capabilityError\) return "browser unsupported"/);
 });
 
-test("coarse-pointer Safari keeps native IME composition separate from send", () => {
-  const terminal = source("../../js/terminal/src/AgentTerminalView.tsx");
-  const composer = source("../../js/terminal/src/TerminalComposer.tsx");
-  assert.match(composer, /<textarea[\s\S]*?enterKeyHint="send"/);
-  assert.match(composer, /onCompositionStart=\{\(\) => \{ composing\.current = true; \}\}/);
-  assert.match(composer, /onCompositionEnd=\{\(\) => \{ composing\.current = false; \}\}/);
-  assert.match(composer, /isSubmitKeyEvent\(event\.nativeEvent, composing\.current\)/);
-  assert.match(composer, /!event\.isComposing/);
-  assert.match(composer, /event\.keyCode !== 229/);
-  assert.match(terminal, /submitPrompt\(controller, submittedPrompts\.current, input, submittedAt\)/);
-});
-
 function source(path: string): string {
   return readFileSync(new URL(path, import.meta.url), "utf8");
 }

--- a/web/test/mobileLayout.test.ts
+++ b/web/test/mobileLayout.test.ts
@@ -183,12 +183,11 @@ test("touch terminals use one native IME-safe composer and one contextual action
   assert.equal(matches(terminal, /<TerminalComposer\b/g), 1);
   assert.match(touchComposer, /<textarea[\s\S]*?aria-label="Message Nanocodex"/);
   assert.doesNotMatch(touchComposer, /placeholder="Message Nanocodex"/);
-  assert.match(touchComposer, /value=\{draft\}[\s\S]*?onChange=\{\(event\) => onChange\(event\.currentTarget\.value\)\}/);
-  assert.match(touchComposer, /onCompositionStart=\{\(\) => \{ composing\.current = true; \}\}/);
-  assert.match(touchComposer, /isSubmitKeyEvent\(event\.nativeEvent, composing\.current\)/);
-  assert.match(touchComposer, /onSubmit\(draft\)/);
   assert.match(touchComposer, /terminalComposerAction\(running, draft\)/);
-  assert.match(touchComposer, /\{action === "stop" \? \([\s\S]*?aria-label="Stop response"[\s\S]*?<Square[\s\S]*?\) : \([\s\S]*?aria-label="Send message"[\s\S]*?<ArrowUp/);
+  assert.match(touchComposer, /aria-label="Stop response"/);
+  assert.match(touchComposer, /<Square aria-hidden="true"/);
+  assert.match(touchComposer, /aria-label="Send message"/);
+  assert.match(touchComposer, /<ArrowUp aria-hidden="true"/);
   assert.equal(matches(touchComposer, /className="agent-touch-actions"/g), 1);
   assert.match(touchComposer, /className="agent-touch-actions">\s*\{controls\}[\s\S]*?aria-label="Send message"/);
   assert.match(terminal, /className="agent-voice-button"[\s\S]*?aria-label=\{engaged \? "Stop voice" : "Start voice"\}/);
@@ -222,8 +221,6 @@ test("touch terminals use one native IME-safe composer and one contextual action
   assert.match(action, /background:\s*transparent/);
   assert.match(action, /border-radius:\s*0/);
   assert.match(terminalPresentationCss, /\.agent-touch-composer\.is-running \.agent-touch-actions button \{[\s\S]*?color:\s*var\(--terminal-muted/);
-  assert.match(terminal, /submitPrompt\(controller, submittedPrompts\.current, input, submittedAt\)/);
-  assert.match(terminal, /controller\.cancel\(\)/);
 });
 
 test("the phone transcript owns the remaining workspace and native vertical gestures", () => {


### PR DESCRIPTION
Unblocks the production deployment by replacing four stale web source-regex contracts with behavior coverage in the reusable terminal package. Covers live textarea submission, IME composition fencing, cancellation, and durable/voice welcome replacement.\n\nFocused verification:\n- `npm test --prefix js/terminal` (6/6)\n- focused web architecture/layout tests (33/33)