### PR TITLE
fix(deploy): allow staged X OAuth credentials

### DIFF
--- a/services/egress/README.md
+++ b/services/egress/README.md
@@ -140,8 +140,10 @@ npm ci
 npm run check
 ```
 
-Production deployment accepts the encryption key, private readiness probe
-token, and the GitHub/Google/X OAuth application client IDs and secrets. The
+Production deployment requires the encryption key, private readiness probe
+token, and the GitHub/Google OAuth application client IDs and secrets. X OAuth
+application credentials are optional, but its client ID and secret must be
+configured together. The
 deployment input names are `NANOCODEX_GITHUB_OAUTH_CLIENT_ID`,
 `NANOCODEX_GITHUB_OAUTH_CLIENT_SECRET`, `NANOCODEX_GOOGLE_OAUTH_CLIENT_ID`,
 `NANOCODEX_GOOGLE_OAUTH_CLIENT_SECRET`, `NANOCODEX_X_OAUTH_CLIENT_ID`, and

--- a/services/egress/scripts/production-broker.mjs
+++ b/services/egress/scripts/production-broker.mjs
@@ -19,10 +19,13 @@ export function productionBrokerSecrets(environment) {
     "NANOCODEX_GOOGLE_OAUTH_CLIENT_ID");
   const googleClientSecret = required(environment.NANOCODEX_GOOGLE_OAUTH_CLIENT_SECRET,
     "NANOCODEX_GOOGLE_OAUTH_CLIENT_SECRET");
-  const xClientId = required(environment.NANOCODEX_X_OAUTH_CLIENT_ID,
+  const xClientId = optional(environment.NANOCODEX_X_OAUTH_CLIENT_ID,
     "NANOCODEX_X_OAUTH_CLIENT_ID");
-  const xClientSecret = required(environment.NANOCODEX_X_OAUTH_CLIENT_SECRET,
+  const xClientSecret = optional(environment.NANOCODEX_X_OAUTH_CLIENT_SECRET,
     "NANOCODEX_X_OAUTH_CLIENT_SECRET");
+  if ((xClientId === undefined) !== (xClientSecret === undefined)) {
+    throw new Error("X OAuth application credentials must be configured together");
+  }
   if (!/^[A-Za-z0-9_-]{43}$/.test(encryptionKey)) {
     throw new Error("NANOCODEX_CREDENTIAL_ENCRYPTION_KEY must be a 32-byte base64url value");
   }
@@ -36,9 +39,11 @@ export function productionBrokerSecrets(environment) {
     GITHUB_OAUTH_CLIENT_SECRET: githubClientSecret,
     GOOGLE_OAUTH_CLIENT_ID: googleClientId,
     GOOGLE_OAUTH_CLIENT_SECRET: googleClientSecret,
-    X_OAUTH_CLIENT_ID: xClientId,
-    X_OAUTH_CLIENT_SECRET: xClientSecret,
   };
+  if (xClientId !== undefined && xClientSecret !== undefined) {
+    secrets.X_OAUTH_CLIENT_ID = xClientId;
+    secrets.X_OAUTH_CLIENT_SECRET = xClientSecret;
+  }
   const previousEncryptionKey = environment.NANOCODEX_CREDENTIAL_ENCRYPTION_KEY_PREVIOUS;
   if (previousEncryptionKey !== undefined) {
     const previous = required(previousEncryptionKey,
@@ -164,6 +169,11 @@ function required(value, name) {
     throw new Error(`${name} is required and must be one line`);
   }
   return value;
+}
+
+function optional(value, name) {
+  if (value === undefined || value === "") return undefined;
+  return required(value, name);
 }
 
 function run(args, env) {

--- a/services/egress/test/production-broker.node.mjs
+++ b/services/egress/test/production-broker.node.mjs
@@ -66,6 +66,33 @@ test("production deployment accepts an optional previous encryption key for rota
   }), /PREVIOUS must be a 32-byte base64url value/);
 });
 
+test("production deployment treats X OAuth as an optional atomic pair", () => {
+  const {
+    NANOCODEX_X_OAUTH_CLIENT_ID: _xId,
+    NANOCODEX_X_OAUTH_CLIENT_SECRET: _xSecret,
+    ...withoutX
+  } = connectorSecrets;
+  const secrets = productionBrokerSecrets({
+    NANOCODEX_CREDENTIAL_ENCRYPTION_KEY: encryptionKey,
+    NANOCODEX_BROKER_PROBE_TOKEN: probeToken,
+    ...withoutX,
+  });
+  assert.equal("X_OAUTH_CLIENT_ID" in secrets, false);
+  assert.equal("X_OAUTH_CLIENT_SECRET" in secrets, false);
+  assert.throws(() => productionBrokerSecrets({
+    NANOCODEX_CREDENTIAL_ENCRYPTION_KEY: encryptionKey,
+    NANOCODEX_BROKER_PROBE_TOKEN: probeToken,
+    ...withoutX,
+    NANOCODEX_X_OAUTH_CLIENT_ID: "x-client-id",
+  }), /X OAuth application credentials must be configured together/);
+  assert.throws(() => productionBrokerSecrets({
+    NANOCODEX_CREDENTIAL_ENCRYPTION_KEY: encryptionKey,
+    NANOCODEX_BROKER_PROBE_TOKEN: probeToken,
+    ...withoutX,
+    NANOCODEX_X_OAUTH_CLIENT_SECRET: "x-client-secret",
+  }), /X OAuth application credentials must be configured together/);
+});
+
 test("production deployment requires a full immutable Git revision", () => {
   assert.equal(productionRevision({ TARGET_SHA: "a".repeat(40) }), "a".repeat(40));
   assert.throws(() => productionRevision({ TARGET_SHA: "abc123" }), /full lowercase Git commit SHA/);

--- a/services/managed/scripts/production-rollout.mjs
+++ b/services/managed/scripts/production-rollout.mjs
@@ -84,8 +84,12 @@ export function assertProductionPreflight(environment) {
   requireConfigured(environment, "NANOCODEX_GITHUB_OAUTH_CLIENT_SECRET_CONFIGURED");
   requireConfigured(environment, "NANOCODEX_GOOGLE_OAUTH_CLIENT_ID_CONFIGURED");
   requireConfigured(environment, "NANOCODEX_GOOGLE_OAUTH_CLIENT_SECRET_CONFIGURED");
-  requireConfigured(environment, "NANOCODEX_X_OAUTH_CLIENT_ID_CONFIGURED");
-  requireConfigured(environment, "NANOCODEX_X_OAUTH_CLIENT_SECRET_CONFIGURED");
+  requireOptionalConfiguredPair(
+    environment,
+    "NANOCODEX_X_OAUTH_CLIENT_ID_CONFIGURED",
+    "NANOCODEX_X_OAUTH_CLIENT_SECRET_CONFIGURED",
+    "X OAuth application credentials",
+  );
   requireConfigured(environment, "NANOCODEX_GIT_TOKEN_CONFIGURED");
   const adminToken = requiredSecret(environment, "NANOCODEX_ADMIN_TOKEN");
   assertTokenStrength(adminToken, "NANOCODEX_ADMIN_TOKEN");
@@ -626,6 +630,14 @@ function requiredBrokerProbeToken(environment) {
 function requireConfigured(environment, name) {
   if (environment[name] !== "true") {
     throw new Error(`${name.replace(/_CONFIGURED$/, "")} is required for production rollout`);
+  }
+}
+
+function requireOptionalConfiguredPair(environment, left, right, label) {
+  const leftConfigured = environment[left] === "true";
+  const rightConfigured = environment[right] === "true";
+  if (leftConfigured !== rightConfigured) {
+    throw new Error(`${label} must be configured together for production rollout`);
   }
 }
 

--- a/services/managed/test-node/production-rollout.test.mjs
+++ b/services/managed/test-node/production-rollout.test.mjs
@@ -53,8 +53,6 @@ test("production preflight requires only deployment and application boundary inp
     "NANOCODEX_GITHUB_OAUTH_CLIENT_SECRET_CONFIGURED",
     "NANOCODEX_GOOGLE_OAUTH_CLIENT_ID_CONFIGURED",
     "NANOCODEX_GOOGLE_OAUTH_CLIENT_SECRET_CONFIGURED",
-    "NANOCODEX_X_OAUTH_CLIENT_ID_CONFIGURED",
-    "NANOCODEX_X_OAUTH_CLIENT_SECRET_CONFIGURED",
   ]) {
     const missing = preflightEnvironment();
     delete missing[name];
@@ -63,6 +61,28 @@ test("production preflight requires only deployment and application boundary inp
   const weak = preflightEnvironment();
   weak.NANOCODEX_ADMIN_TOKEN = "short";
   assert.throws(() => assertProductionPreflight(weak), /at least 32 bytes/);
+});
+
+test("production preflight treats X OAuth as an optional atomic pair", () => {
+  const absent = preflightEnvironment();
+  absent.NANOCODEX_X_OAUTH_CLIENT_ID_CONFIGURED = "false";
+  absent.NANOCODEX_X_OAUTH_CLIENT_SECRET_CONFIGURED = "false";
+  assert.doesNotThrow(() => assertProductionPreflight(absent));
+
+  for (const configured of [
+    ["true", "false"],
+    ["false", "true"],
+  ]) {
+    const partial = preflightEnvironment();
+    [
+      partial.NANOCODEX_X_OAUTH_CLIENT_ID_CONFIGURED,
+      partial.NANOCODEX_X_OAUTH_CLIENT_SECRET_CONFIGURED,
+    ] = configured;
+    assert.throws(
+      () => assertProductionPreflight(partial),
+      /X OAuth application credentials must be configured together/,
+    );
+  }
 });
 
 test("production rollout accepts only a clean checkout of the selected master revision", () => {


### PR DESCRIPTION
Unblocks production when X OAuth is not provisioned while preserving strict atomic-pair validation. GitHub and Google remain mandatory; X is included only when both client ID and secret exist, and partial configuration fails closed.\n\nFocused verification:\n- managed production rollout tests: 12/12\n- egress production broker tests: 8/8