### PR TITLE
refactor(durability): replace journals with total state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,23 @@ jobs:
     name: Node and browser bindings
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_DB: nanocodex_test
+          POSTGRES_PASSWORD: nanocodex_test
+          POSTGRES_USER: nanocodex_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U nanocodex_test -d nanocodex_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://nanocodex_test:nanocodex_test@127.0.0.1:5432/nanocodex_test
+      NANOCODEX_LIVE_POSTGRES: "1"
     permissions:
       contents: read
     steps:

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ your application
   ├─ cheap Nanocodex command handle ── prompt / steer / cancel / fork
   ├─ optional typed events ─────────── UI / persistence / telemetry
   ├─ caller-defined tools ──────────── your data and capabilities
-  ├─ optional durability layer ─────── journal / replay / recovery / stores
+  ├─ optional durability layer ─────── total state / recovery / stores
   └─ private driver
        ├─ ordered turns and typed committed history
        ├─ persistent OpenAI Responses WebSocket + typed retries
@@ -181,11 +181,15 @@ breaking stay composable without introducing a second retry owner.
 
 ### Durable execution is optional and Rust-owned
 
-`nanocodex-durability` adds an append-only journal, typed reduction and
+`nanocodex-durability` adds a replace-in-place total execution state and
 recovery policy, operation deduplication, effect replay, and session
 checkpoints. It includes memory, SQLite, and Postgres stores, plus a
 host-provided store contract whose only requirement is atomic load and
-compare-and-append. Rust owns the journal format and every recovery decision.
+fenced compare-and-replace. Rust owns the state format and every recovery decision.
+Model calls, warmup, compaction, and tools share one effect admission result:
+execute, replay an exact output, or persist an explicit unknown outcome without
+repeating an at-most-once effect. Live attempts are fenced in-memory
+capabilities, not a second durable state machine.
 
 The layer implements the agent's neutral execution-policy seam; the core agent
 does not depend on it. Lower-level consumers can use `DurableSession` directly
@@ -615,7 +619,7 @@ tracing, and benchmark gates; stable crates never depend on them.
 | --- | --- | --- |
 | [`nanocodex`](crates/nanocodex/README.md) | Stable, published | Thin Alloy-style facade and canonical imports; no runtime implementation. |
 | [`nanocodex-agent`](crates/nanocodex-agent/README.md) | Stable, published | Owned driver, turns/results/events, history policy, snapshots, compaction, branches, and cancellation. |
-| [`nanocodex-durability`](crates/nanocodex-durability/README.md) | Stable, source/Git-only, optional | Append-only execution journal, deduplication, replay and recovery policy, checkpoints, and memory/SQLite/Postgres/host stores. |
+| [`nanocodex-durability`](crates/nanocodex-durability/README.md) | Stable, source/Git-only, optional | Total execution state, deduplication, recovery policy, staged outcomes, checkpoints, and memory/SQLite/Postgres/host stores. |
 | [`nanocodex-oai-api`](crates/nanocodex-oai-api/README.md) | Stable, published | OpenAI auth, typed Responses and Realtime boundaries, persistent transports, managed context, retry, pricing, and Tower client. |
 | [`nanocodex-tools`](crates/nanocodex-tools/README.md) | Stable, published | Tool contract, standard tools, shell/process lifecycle, Code Mode, deferred search, MCP, and remote dispatch. |
 | [`nanocodex-subagents`](crates/nanocodex-subagents/README.md) | Source/Git-only optional workspace extension | Task-tree lifecycle and the seven canonical child-agent tools above the core. |

--- a/crates/experimental/nanocodex-browser/src/tests.rs
+++ b/crates/experimental/nanocodex-browser/src/tests.rs
@@ -3181,7 +3181,9 @@ fn execution_text(output: &ToolOutputBody) -> Result<&str> {
         .rev()
         .find_map(|content| match content {
             ToolOutputContent::InputText { text } => Some(text.as_str()),
-            ToolOutputContent::InputImage { .. } | ToolOutputContent::InputAudio { .. } => None,
+            ToolOutputContent::InputImage { .. }
+            | ToolOutputContent::InputAudio { .. }
+            | ToolOutputContent::EncryptedContent { .. } => None,
         })
         .ok_or_else(|| eyre!("missing Code Mode text output"))
 }

--- a/crates/nanocodex-agent/src/agent/driver/mod.rs
+++ b/crates/nanocodex-agent/src/agent/driver/mod.rs
@@ -1271,10 +1271,6 @@ where
                         checkpoint,
                     ));
                     match error.execution_policy_disposition() {
-                        Some(crate::ExecutionPolicyDisposition::Blocked) => {
-                            self.execution.release_turn(execution_turn).await;
-                            (model.emit_terminal("failed").and(Err(error)), false, None)
-                        }
                         Some(crate::ExecutionPolicyDisposition::Reopen) => {
                             (model.emit_terminal("failed").and(Err(error)), false, None)
                         }
@@ -1306,10 +1302,6 @@ where
                     }
                 }
                 Err(error) => match error.execution_policy_disposition() {
-                    Some(crate::ExecutionPolicyDisposition::Blocked) => {
-                        self.execution.release_turn(execution_turn).await;
-                        (model.emit_terminal("failed").and(Err(error)), false, None)
-                    }
                     Some(crate::ExecutionPolicyDisposition::Reopen) => {
                         (model.emit_terminal("failed").and(Err(error)), false, None)
                     }

--- a/crates/nanocodex-agent/src/agent/driver/mod.rs
+++ b/crates/nanocodex-agent/src/agent/driver/mod.rs
@@ -384,7 +384,66 @@ where
                     );
                     drop(parent);
                     let compact_started = web_time::Instant::now();
-                    if let Err(error) = self.execution.authorize_compaction().await {
+                    let compact_base_checkpoint = latest_fork_checkpoint.clone();
+                    let admitted = self
+                        .execution
+                        .admit_compaction(
+                            compact_base_checkpoint.as_deref(),
+                            thread_model,
+                            default_thinking,
+                            default_fast_mode,
+                            self.workspace.as_deref(),
+                        )
+                        .await;
+                    let (compaction_operation_id, admission) = match admitted {
+                        Ok(admitted) => admitted,
+                        Err(error) => {
+                            let reopen = matches!(
+                                error.execution_policy_disposition(),
+                                Some(crate::ExecutionPolicyDisposition::Reopen)
+                            );
+                            span.record("status", "failed");
+                            span.record("otel.status_code", "ERROR");
+                            span.record(
+                                "duration_ns",
+                                u64::try_from(compact_started.elapsed().as_nanos())
+                                    .unwrap_or(u64::MAX),
+                            );
+                            drop(result.send(Err(error)));
+                            if reopen {
+                                begin_shutdown(
+                                    &mut self.commands,
+                                    &mut queued_turns,
+                                    default_thinking,
+                                    default_fast_mode,
+                                )
+                                .await;
+                                commands_open = false;
+                            }
+                            continue;
+                        }
+                    };
+                    if !matches!(admission, AdmittedExecution::Execute) {
+                        let error = NanocodexError::InvalidExecutionPolicy(
+                            "standalone compaction identity resolved to an unexpected terminal operation"
+                                .to_owned(),
+                        );
+                        span.record("status", "failed");
+                        span.record("otel.status_code", "ERROR");
+                        span.record(
+                            "duration_ns",
+                            u64::try_from(compact_started.elapsed().as_nanos()).unwrap_or(u64::MAX),
+                        );
+                        drop(result.send(Err(error)));
+                        continue;
+                    }
+                    let execution_turn = self
+                        .execution
+                        .start_compaction(default_thinking, compaction_operation_id.clone());
+                    if let Err(error) = execution_turn.begin().await {
+                        if let Some(operation_id) = &compaction_operation_id {
+                            self.execution.release_claim(operation_id).await;
+                        }
                         let reopen = matches!(
                             error.execution_policy_disposition(),
                             Some(crate::ExecutionPolicyDisposition::Reopen)
@@ -408,8 +467,7 @@ where
                         }
                         continue;
                     }
-                    let compact_base_checkpoint = latest_fork_checkpoint.clone();
-                    let execution_turn = self.execution.start_compaction(default_thinking);
+                    let execution_steps = execution_turn.steps();
                     let mut compact_replaced = false;
                     let (cancel_compaction, mut cancel_compaction_rx) = oneshot::channel();
                     let mut cancel_compaction = Some(cancel_compaction);
@@ -421,6 +479,7 @@ where
                                 default_fast_mode,
                                 logical_turn_index,
                                 &mut cancel_compaction_rx,
+                                execution_steps,
                             )
                             .instrument(span.clone()),
                     );
@@ -680,7 +739,10 @@ where
                                 execution_turn.replaced()
                             } else {
                                 execution_turn.interrupted()
-                            };
+                            }
+                            .retain_pending_attempt(
+                                "standalone compaction was interrupted before durable settlement",
+                            );
                             let persisted = self
                                 .execution
                                 .persist(&checkpoint, execution_turn)
@@ -688,8 +750,6 @@ where
                                 .await;
                             match persisted {
                                 Ok(()) => {
-                                    compact_checkpoint_committed = true;
-                                    latest_fork_checkpoint = Some(checkpoint);
                                     model.replace_client(ResponsesClient::new((self
                                         .spawner
                                         .service_factory)(
@@ -706,27 +766,16 @@ where
                                 thread_model,
                                 checkpoint,
                             ));
-                            let retryable = error
-                                .responses_error()
-                                .is_some_and(|source| source.retry_advice().is_some())
-                                || matches!(
-                                    error.execution_policy_disposition(),
-                                    Some(crate::ExecutionPolicyDisposition::Retry)
-                                );
                             let persisted = self
                                 .execution
                                 .persist(
                                     &checkpoint,
-                                    execution_turn.failed(error.to_string(), retryable),
+                                    execution_turn.failed(error.to_string(), true),
                                 )
                                 .instrument(span.clone())
                                 .await;
                             match persisted {
-                                Ok(()) => {
-                                    compact_checkpoint_committed = true;
-                                    latest_fork_checkpoint = Some(checkpoint);
-                                    Err(error)
-                                }
+                                Ok(()) => Err(error),
                                 Err(error) => Err(error),
                             }
                         }

--- a/crates/nanocodex-agent/src/agent/execution/mod.rs
+++ b/crates/nanocodex-agent/src/agent/execution/mod.rs
@@ -54,7 +54,8 @@ pub enum ExecutionAdmission {
 pub enum ExecutionRetry {
     /// An interrupted effect may be executed again.
     Idempotent,
-    /// An interrupted effect has an ambiguous outcome and must not be repeated.
+    /// An interrupted effect has an unknown external outcome and must not be
+    /// repeated.
     Never,
 }
 
@@ -64,6 +65,9 @@ pub enum ExecutionStepAdmission {
     Execute,
     /// Reuse the exact JSON output retained by a prior attempt.
     Replay(String),
+    /// Do not repeat an interrupted at-most-once effect whose outcome is unknown.
+    /// The caller must commit an explicit unknown result before continuing.
+    Unknown,
 }
 
 /// Serializable result retained at a completed agent boundary.
@@ -105,15 +109,11 @@ pub trait ExecutionPolicy: Send + Sync {
         })
     }
 
-    /// Fences a model-only external effect immediately before it begins. The
-    /// default fails closed so omission cannot authorize an effect.
-    fn authorize_model_effect<'a>(
-        &'a self,
-        _kind: &'static str,
-    ) -> ExecutionFuture<'a, Result<()>> {
+    /// Fences a standalone checkpoint effect immediately before it begins.
+    fn fence_checkpoint_effect<'a>(&'a self) -> ExecutionFuture<'a, Result<()>> {
         Box::pin(async {
             Err(NanocodexError::ExecutionPolicyCapabilityUnsupported {
-                capability: "authorize_model_effect",
+                capability: "fence_checkpoint_effect",
             })
         })
     }
@@ -223,15 +223,11 @@ pub trait ExecutionPolicy: Send + Sync {
         })
     }
 
-    /// Fences a model-only external effect immediately before it begins. The
-    /// default fails closed.
-    fn authorize_model_effect<'a>(
-        &'a self,
-        _kind: &'static str,
-    ) -> ExecutionFuture<'a, Result<()>> {
+    /// Fences a standalone checkpoint effect immediately before it begins.
+    fn fence_checkpoint_effect<'a>(&'a self) -> ExecutionFuture<'a, Result<()>> {
         Box::pin(async {
             Err(NanocodexError::ExecutionPolicyCapabilityUnsupported {
-                capability: "authorize_model_effect",
+                capability: "fence_checkpoint_effect",
             })
         })
     }
@@ -488,7 +484,7 @@ impl Execution {
 
     pub(crate) async fn authorize_compaction(&self) -> Result<()> {
         if let Some(policy) = &self.policy {
-            policy.authorize_model_effect("compaction").await?;
+            policy.fence_checkpoint_effect().await?;
         }
         Ok(())
     }
@@ -548,17 +544,6 @@ impl Execution {
             .await
     }
 
-    pub(crate) async fn release_turn(&self, turn: ExecutionTurn) {
-        let ExecutionTurn {
-            policy,
-            operation_id,
-            ..
-        } = turn;
-        if let (Some(policy), Some(operation_id)) = (policy, operation_id) {
-            policy.release(operation_id).await;
-        }
-    }
-
     #[cfg(not(target_family = "wasm"))]
     pub(crate) async fn flush(&self) -> Result<()> {
         self.platform.flush().await
@@ -597,18 +582,10 @@ pub(crate) struct ExecutionSteps {
 pub(crate) enum ExecutionStep<O> {
     Execute,
     Replay(O),
+    Unknown,
 }
 
 impl ExecutionSteps {
-    /// Durably authorizes an operation-owned model effect immediately before
-    /// entering the transport.
-    ///
-    /// Authorization fences owners that were already stale. Once it returns,
-    /// takeover can still fence the result but cannot retract an in-flight call.
-    pub(crate) async fn authorize_model_effect(&self, kind: &'static str) -> Result<()> {
-        self.policy.authorize_model_effect(kind).await
-    }
-
     pub(crate) async fn begin<I, O>(
         &self,
         step_id: impl Into<String>,
@@ -633,6 +610,7 @@ impl ExecutionSteps {
         {
             ExecutionStepAdmission::Execute => Ok(ExecutionStep::Execute),
             ExecutionStepAdmission::Replay(output) => Ok(ExecutionStep::Replay(decode(&output)?)),
+            ExecutionStepAdmission::Unknown => Ok(ExecutionStep::Unknown),
         }
     }
 
@@ -778,10 +756,18 @@ async fn cancel_with_reclaim(
         .await
         .map_err(reopen_after_cancel_retry)?;
     match admission {
-        ExecutionAdmission::Execute => policy
-            .cancel(operation_id, snapshot)
-            .await
-            .map_err(reopen_after_cancel_retry),
+        ExecutionAdmission::Execute => {
+            if snapshot.is_some() {
+                policy
+                    .begin_attempt(operation_id.clone())
+                    .await
+                    .map_err(reopen_after_cancel_retry)?;
+            }
+            policy
+                .cancel(operation_id, snapshot)
+                .await
+                .map_err(reopen_after_cancel_retry)
+        }
         ExecutionAdmission::Cancelled => Ok(()),
         ExecutionAdmission::Completed { .. } | ExecutionAdmission::Failed { .. } => {
             Err(NanocodexError::InvalidExecutionPolicy(format!(

--- a/crates/nanocodex-agent/src/agent/execution/mod.rs
+++ b/crates/nanocodex-agent/src/agent/execution/mod.rs
@@ -9,6 +9,7 @@ mod platform;
 use std::{future::Future, pin::Pin, sync::Arc};
 
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use sha2::{Digest, Sha256};
 
 use crate::{
     NanocodexError, Result,
@@ -68,6 +69,16 @@ pub enum ExecutionStepAdmission {
     /// Do not repeat an interrupted at-most-once effect whose outcome is unknown.
     /// The caller must commit an explicit unknown result before continuing.
     Unknown,
+}
+
+/// Authoritative durable result of reconciling one step during cancellation.
+pub enum ExecutionStepReconciliation {
+    /// The effect boundary was never committed or its execution permit was
+    /// definitely not observed, so no synthetic output was retained.
+    NotStarted,
+    /// The exact retained output, whether committed by the effect itself or by
+    /// cancellation while an at-most-once effect remained pending.
+    Completed(String),
 }
 
 /// Serializable result retained at a completed agent boundary.
@@ -170,6 +181,23 @@ pub trait ExecutionPolicy: Send + Sync {
         step_id: String,
         output_json: String,
     ) -> ExecutionFuture<'a, Result<()>>;
+
+    /// Atomically inspects and settles one at-most-once step during explicit
+    /// cancellation. Policies that durably retain `Never` steps must override
+    /// this method. The default fails closed so omission cannot falsely claim
+    /// that an authorized effect did not start.
+    fn reconcile_cancelled_step<'a>(
+        &'a self,
+        _operation_id: String,
+        _step_id: String,
+        _unknown_output_json: String,
+    ) -> ExecutionFuture<'a, Result<ExecutionStepReconciliation>> {
+        Box::pin(async {
+            Err(NanocodexError::ExecutionPolicyCapabilityUnsupported {
+                capability: "reconcile_cancelled_step",
+            })
+        })
+    }
 
     /// Atomically commits a terminal turn output and its resumable boundary.
     fn complete<'a>(
@@ -276,6 +304,22 @@ pub trait ExecutionPolicy: Send + Sync {
         step_id: String,
         output_json: String,
     ) -> ExecutionFuture<'a, Result<()>>;
+    /// Atomically inspects and settles one at-most-once step during explicit
+    /// cancellation. Policies that durably retain `Never` steps must override
+    /// this method. The default fails closed so omission cannot falsely claim
+    /// that an authorized effect did not start.
+    fn reconcile_cancelled_step<'a>(
+        &'a self,
+        _operation_id: String,
+        _step_id: String,
+        _unknown_output_json: String,
+    ) -> ExecutionFuture<'a, Result<ExecutionStepReconciliation>> {
+        Box::pin(async {
+            Err(NanocodexError::ExecutionPolicyCapabilityUnsupported {
+                capability: "reconcile_cancelled_step",
+            })
+        })
+    }
     /// Commits a terminal turn and resumable boundary.
     fn complete<'a>(
         &'a self,
@@ -398,6 +442,24 @@ pub(crate) enum AdmittedExecution {
     Cancelled,
 }
 
+#[derive(Serialize)]
+struct StandaloneCompactionInput {
+    kind: &'static str,
+    base_checkpoint: Option<StandaloneCompactionBase>,
+    model: &'static str,
+    effort: &'static str,
+    fast_mode: bool,
+    workspace: Option<String>,
+}
+
+#[derive(Serialize)]
+struct StandaloneCompactionBase {
+    lineage_id: String,
+    prompt_cache_key: String,
+    workspace: String,
+    history: Vec<nanocodex_oai_api::responses::ResponseItem>,
+}
+
 impl Execution {
     #[cfg(not(target_family = "wasm"))]
     pub(crate) const fn info(&self) -> Option<&RolloutInfo> {
@@ -471,22 +533,64 @@ impl Execution {
         }
     }
 
+    pub(crate) async fn admit_compaction(
+        &self,
+        base_checkpoint: Option<&CommittedSession>,
+        model: nanocodex_oai_api::Model,
+        effort: nanocodex_oai_api::Thinking,
+        fast_mode: bool,
+        workspace: Option<&str>,
+    ) -> Result<(Option<String>, AdmittedExecution)> {
+        let Some(policy) = &self.policy else {
+            return Ok((None, AdmittedExecution::Execute));
+        };
+        policy.fence_checkpoint_effect().await?;
+        let base_checkpoint = base_checkpoint.map(|checkpoint| {
+            let mut history = checkpoint.model().snapshot_history();
+            for item in &mut history {
+                item.strip_id();
+            }
+            StandaloneCompactionBase {
+                lineage_id: checkpoint.lineage_id().to_owned(),
+                prompt_cache_key: checkpoint.model().prompt_cache_key().to_owned(),
+                workspace: checkpoint.model().workspace().to_owned(),
+                history,
+            }
+        });
+        let input = StandaloneCompactionInput {
+            kind: "standalone_compaction",
+            base_checkpoint,
+            model: model.as_str(),
+            effort: effort.as_str(),
+            fast_mode,
+            workspace: workspace.map(str::to_owned),
+        };
+        let input_json = encode(&input)?;
+        let digest = Sha256::digest(input_json.as_bytes());
+        let digest = digest
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        let candidate_operation_id = format!("standalone-compaction-{digest}");
+        let (operation_id, admission) = policy
+            .admit_automatic(candidate_operation_id, input_json)
+            .await?;
+        Ok((Some(operation_id), map_admission(admission)))
+    }
+
     #[cfg_attr(target_family = "wasm", allow(clippy::missing_const_for_fn))]
-    pub(crate) fn start_compaction(&self, effort: nanocodex_oai_api::Thinking) -> ExecutionTurn {
+    pub(crate) fn start_compaction(
+        &self,
+        effort: nanocodex_oai_api::Thinking,
+        operation_id: Option<String>,
+    ) -> ExecutionTurn {
         ExecutionTurn {
             platform: self.platform.start_compaction(effort),
             policy: self.policy.clone(),
-            operation_id: None,
+            operation_id,
             operation_input: None,
             outcome: ExecutionOutcome::Started,
         }
-    }
-
-    pub(crate) async fn authorize_compaction(&self) -> Result<()> {
-        if let Some(policy) = &self.policy {
-            policy.fence_checkpoint_effect().await?;
-        }
-        Ok(())
     }
 
     pub(crate) async fn persist(
@@ -511,12 +615,15 @@ impl Execution {
         checkpoint: &CommittedSession,
         turn: ExecutionTurn,
     ) -> Result<()> {
-        if let Some(policy) = &self.policy {
-            policy.commit_checkpoint(checkpoint.snapshot()).await?;
-        }
-        self.platform
-            .persist_compaction(checkpoint, turn.platform)
-            .await;
+        let ExecutionTurn {
+            platform,
+            policy,
+            operation_id,
+            operation_input,
+            outcome,
+        } = turn;
+        persist_operation(policy, operation_id, operation_input, outcome, checkpoint).await?;
+        self.platform.persist_compaction(checkpoint, platform).await;
         Ok(())
     }
 
@@ -585,6 +692,11 @@ pub(crate) enum ExecutionStep<O> {
     Unknown,
 }
 
+pub(crate) enum ReconciledExecutionStep<O> {
+    NotStarted,
+    Completed(O),
+}
+
 impl ExecutionSteps {
     pub(crate) async fn begin<I, O>(
         &self,
@@ -622,6 +734,30 @@ impl ExecutionSteps {
         self.policy
             .complete_step(self.operation_id.clone(), step_id.into(), encode(output)?)
             .await
+    }
+
+    pub(crate) async fn reconcile_cancelled<O>(
+        &self,
+        step_id: impl Into<String>,
+        unknown_output: &O,
+    ) -> Result<ReconciledExecutionStep<O>>
+    where
+        O: DeserializeOwned + Serialize,
+    {
+        match self
+            .policy
+            .reconcile_cancelled_step(
+                self.operation_id.clone(),
+                step_id.into(),
+                encode(unknown_output)?,
+            )
+            .await?
+        {
+            ExecutionStepReconciliation::NotStarted => Ok(ReconciledExecutionStep::NotStarted),
+            ExecutionStepReconciliation::Completed(output) => {
+                Ok(ReconciledExecutionStep::Completed(decode(&output)?))
+            }
+        }
     }
 }
 
@@ -667,6 +803,10 @@ impl ExecutionTurn {
     #[cfg_attr(target_family = "wasm", allow(clippy::missing_const_for_fn))]
     pub(crate) fn completed_without_message(mut self) -> Self {
         self.platform = self.platform.completed_without_message();
+        self.outcome = ExecutionOutcome::Completed(ExecutionOutput {
+            final_message: String::new(),
+            usage: TurnUsage::default(),
+        });
         self
     }
 
@@ -687,6 +827,14 @@ impl ExecutionTurn {
         self.outcome = ExecutionOutcome::Failed {
             error: error.into(),
             retryable,
+        };
+        self
+    }
+
+    pub(crate) fn retain_pending_attempt(mut self, error: impl Into<String>) -> Self {
+        self.outcome = ExecutionOutcome::Failed {
+            error: error.into(),
+            retryable: true,
         };
         self
     }

--- a/crates/nanocodex-agent/src/agent/execution/native.rs
+++ b/crates/nanocodex-agent/src/agent/execution/native.rs
@@ -4,7 +4,9 @@ use tracing::error;
 
 use crate::{
     NanocodexError, Result,
-    rollout::{RolloutConfig, RolloutInfo, RolloutOrigin, RolloutRecorder, RolloutTurn},
+    rollout::{
+        RolloutConfig, RolloutCreate, RolloutInfo, RolloutOrigin, RolloutRecorder, RolloutTurn,
+    },
     session::CommittedSession,
 };
 
@@ -47,16 +49,18 @@ impl Config {
             })?;
         let recorder = RolloutRecorder::create(
             &runtime,
-            config,
-            session_id,
-            prompt_cache_key,
-            &cwd,
-            instructions,
-            RolloutOrigin {
-                kind: origin_kind,
-                parent_thread_id: parent_session_id,
+            RolloutCreate {
+                config,
+                thread_id: session_id,
+                prompt_cache_key,
+                cwd: &cwd,
+                instructions,
+                origin: RolloutOrigin {
+                    kind: origin_kind,
+                    parent_thread_id: parent_session_id,
+                },
+                resume_history_len,
             },
-            resume_history_len,
         )
         .map_err(|source| NanocodexError::InitializeRollout {
             codex_home: config.codex_home().to_path_buf(),

--- a/crates/nanocodex-agent/src/agent/mod.rs
+++ b/crates/nanocodex-agent/src/agent/mod.rs
@@ -146,7 +146,7 @@ use driver::{AgentDriver, AgentOrigin, BranchSpawner, DriverShutdown};
 #[cfg(feature = "openai")]
 use execution::{Execution, ExecutionConfig};
 #[cfg(feature = "openai")]
-pub(crate) use execution::{ExecutionStep, ExecutionSteps};
+pub(crate) use execution::{ExecutionStep, ExecutionSteps, ReconciledExecutionStep};
 #[cfg(feature = "openai")]
 pub(crate) use executor::{AgentFactory, AgentSend};
 #[cfg(feature = "openai")]

--- a/crates/nanocodex-agent/src/error.rs
+++ b/crates/nanocodex-agent/src/error.rs
@@ -12,8 +12,6 @@ pub use nanocodex_oai_api::transport::ResponsesError;
 pub enum ExecutionPolicyDisposition {
     /// The same live policy owner may safely retry the operation.
     Retry,
-    /// The operation remains pending but automatic execution is blocked.
-    Blocked,
     /// This policy owner must stop and be rebuilt from authoritative state.
     Reopen,
     /// The operation cannot be retried automatically.

--- a/crates/nanocodex-agent/src/model/run/lifecycle.rs
+++ b/crates/nanocodex-agent/src/model/run/lifecycle.rs
@@ -252,12 +252,14 @@ where
             request_prefix: &recorded_request_prefix,
         };
         if let Some(steps) = &self.execution_steps {
+            // A reopened durable step cannot prove that the provider did not
+            // observe the request. Live in-attempt retries remain client-owned.
             match steps
                 .begin::<_, WarmupExecution>(
                     "warmup",
                     "warmup",
                     &recorded,
-                    crate::agent::execution::ExecutionRetry::Idempotent,
+                    crate::agent::execution::ExecutionRetry::Never,
                 )
                 .await?
             {
@@ -265,7 +267,7 @@ where
                 crate::agent::ExecutionStep::Execute => {}
                 crate::agent::ExecutionStep::Unknown => {
                     return Err(NanocodexError::InvalidAttemptState {
-                        detail: "idempotent warmup was recovered as unknown",
+                        detail: "warmup provider outcome is unknown after durable recovery; refusing to resubmit",
                     });
                 }
             }
@@ -388,21 +390,27 @@ where
             prompt_history: &recorded_prompt_history,
         };
         let recovered = if let Some(steps) = &execution_steps {
+            // A reopened durable step cannot prove that the provider did not
+            // observe the request. Live in-attempt retries remain client-owned.
             match steps
                 .begin::<_, RecordedCompactionResult>(
                     &step_id,
                     "compaction",
                     &step_input,
-                    crate::agent::execution::ExecutionRetry::Idempotent,
+                    crate::agent::execution::ExecutionRetry::Never,
                 )
                 .await?
             {
                 crate::agent::ExecutionStep::Execute => None,
                 crate::agent::ExecutionStep::Replay(output) => Some(output),
                 crate::agent::ExecutionStep::Unknown => {
-                    return Err(NanocodexError::InvalidAttemptState {
-                        detail: "idempotent compaction was recovered as unknown",
-                    });
+                    let error = NanocodexError::InvalidAttemptState {
+                        detail: "compaction provider outcome is unknown after durable recovery; refusing to resubmit",
+                    };
+                    span.record("status", "failed");
+                    span.record("otel.status_code", "ERROR");
+                    span.record("duration_ns", elapsed_ns(started_at));
+                    return self.compaction_failed(after_model_call_index, started_at, error);
                 }
             }
         } else {

--- a/crates/nanocodex-agent/src/model/run/lifecycle.rs
+++ b/crates/nanocodex-agent/src/model/run/lifecycle.rs
@@ -1,11 +1,27 @@
 use super::*;
 
+#[derive(Deserialize, Serialize)]
 pub(super) struct WarmupExecution {
     pub(super) response_id: String,
     pub(super) attempt: u32,
     pub(super) connection_generation: u32,
     pub(super) usage: Option<Usage>,
     pub(super) server_reasoning_included: bool,
+}
+
+#[derive(Serialize)]
+struct RecordedWarmupCall<'a> {
+    model: &'a str,
+    model_id_prefix: Option<&'a str>,
+    reasoning_mode: &'a str,
+    effort: &'a str,
+    fast_mode: bool,
+    store_responses: bool,
+    transport: &'a str,
+    websocket_url: &'a str,
+    api_base_url: &'a str,
+    prompt_cache_key: &'a str,
+    request_prefix: &'a [ResponseItem],
 }
 
 pub(super) struct WarmupOutcome {
@@ -218,8 +234,41 @@ where
         factory: &ResponsesAttemptFactory,
         span: &tracing::Span,
     ) -> Result<WarmupExecution> {
+        let mut recorded_request_prefix = factory.profile().prefix().to_vec();
+        for item in &mut recorded_request_prefix {
+            item.strip_id();
+        }
+        let recorded = RecordedWarmupCall {
+            model: self.model.as_str(),
+            model_id_prefix: self.config.model_id_prefix.as_deref(),
+            reasoning_mode: self.config.reasoning_mode.as_str(),
+            effort: self.thinking.as_str(),
+            fast_mode: self.fast_mode,
+            store_responses: self.config.store_responses,
+            transport: self.config.responses_transport.as_str(),
+            websocket_url: &self.config.websocket_url,
+            api_base_url: &self.config.api_base_url,
+            prompt_cache_key: factory.profile().prompt_cache_key(),
+            request_prefix: &recorded_request_prefix,
+        };
         if let Some(steps) = &self.execution_steps {
-            steps.authorize_model_effect("warmup").await?;
+            match steps
+                .begin::<_, WarmupExecution>(
+                    "warmup",
+                    "warmup",
+                    &recorded,
+                    crate::agent::execution::ExecutionRetry::Idempotent,
+                )
+                .await?
+            {
+                crate::agent::ExecutionStep::Replay(output) => return Ok(output),
+                crate::agent::ExecutionStep::Execute => {}
+                crate::agent::ExecutionStep::Unknown => {
+                    return Err(NanocodexError::InvalidAttemptState {
+                        detail: "idempotent warmup was recovered as unknown",
+                    });
+                }
+            }
         }
         let success = self
             .client
@@ -237,13 +286,17 @@ where
                 detail: "warmup returned a non-warmup response",
             });
         };
-        Ok(WarmupExecution {
+        let output = WarmupExecution {
             response_id: response.id,
             attempt,
             connection_generation,
             usage: response.usage,
             server_reasoning_included,
-        })
+        };
+        if let Some(steps) = &self.execution_steps {
+            steps.complete("warmup", &output).await?;
+        }
+        Ok(output)
     }
 
     pub(super) fn warmup_failed<T>(
@@ -346,6 +399,11 @@ where
             {
                 crate::agent::ExecutionStep::Execute => None,
                 crate::agent::ExecutionStep::Replay(output) => Some(output),
+                crate::agent::ExecutionStep::Unknown => {
+                    return Err(NanocodexError::InvalidAttemptState {
+                        detail: "idempotent compaction was recovered as unknown",
+                    });
+                }
             }
         } else {
             None

--- a/crates/nanocodex-agent/src/model/run/mod.rs
+++ b/crates/nanocodex-agent/src/model/run/mod.rs
@@ -411,11 +411,16 @@ impl<S> ModelRun<S> {
 }
 
 pub(crate) fn prepare_checkpoint(
-    checkpoint: ModelCheckpoint,
+    mut checkpoint: ModelCheckpoint,
     config: &ModelConfig,
     tools: &Tools,
     context_source: ContextSource,
 ) -> PreparedCheckpoint {
+    // Unstored response IDs are scoped to the live transport connection. A fork
+    // owns a fresh client, so it must replay client-owned history instead.
+    if !config.store_responses {
+        checkpoint.conversation.reset_for_full_request();
+    }
     let runtime = tool_runtime(checkpoint.workspace(), config, tools);
     let selected_agents_md = context_source
         .project_instructions(checkpoint.workspace())

--- a/crates/nanocodex-agent/src/model/run/mod.rs
+++ b/crates/nanocodex-agent/src/model/run/mod.rs
@@ -411,16 +411,11 @@ impl<S> ModelRun<S> {
 }
 
 pub(crate) fn prepare_checkpoint(
-    mut checkpoint: ModelCheckpoint,
+    checkpoint: ModelCheckpoint,
     config: &ModelConfig,
     tools: &Tools,
     context_source: ContextSource,
 ) -> PreparedCheckpoint {
-    // Unstored response IDs are scoped to the live transport connection. A fork
-    // owns a fresh client, so it must replay client-owned history instead.
-    if !config.store_responses {
-        checkpoint.conversation.reset_for_full_request();
-    }
     let runtime = tool_runtime(checkpoint.workspace(), config, tools);
     let selected_agents_md = context_source
         .project_instructions(checkpoint.workspace())
@@ -440,6 +435,11 @@ pub(crate) fn prepare_resumed_checkpoint(
     session_id: &str,
     context_source: ContextSource,
 ) -> Result<PreparedCheckpoint> {
+    // Unstored response IDs are scoped to the live transport connection. A fork
+    // owns a fresh client, so it must replay client-owned history instead.
+    if !config.store_responses {
+        checkpoint.conversation.reset_for_full_request();
+    }
     checkpoint.global_instructions = context_source
         .global_instructions()
         .or(checkpoint.global_instructions);

--- a/crates/nanocodex-agent/src/model/run/mod.rs
+++ b/crates/nanocodex-agent/src/model/run/mod.rs
@@ -435,11 +435,6 @@ pub(crate) fn prepare_resumed_checkpoint(
     session_id: &str,
     context_source: ContextSource,
 ) -> Result<PreparedCheckpoint> {
-    // Unstored response IDs are scoped to the live transport connection. A fork
-    // owns a fresh client, so it must replay client-owned history instead.
-    if !config.store_responses {
-        checkpoint.conversation.reset_for_full_request();
-    }
     checkpoint.global_instructions = context_source
         .global_instructions()
         .or(checkpoint.global_instructions);

--- a/crates/nanocodex-agent/src/model/run/responses.rs
+++ b/crates/nanocodex-agent/src/model/run/responses.rs
@@ -121,6 +121,11 @@ where
             {
                 crate::agent::ExecutionStep::Execute => None,
                 crate::agent::ExecutionStep::Replay(output) => Some(output),
+                crate::agent::ExecutionStep::Unknown => {
+                    return Err(NanocodexError::InvalidAttemptState {
+                        detail: "idempotent model call was recovered as unknown",
+                    });
+                }
             }
         } else {
             None

--- a/crates/nanocodex-agent/src/model/run/responses.rs
+++ b/crates/nanocodex-agent/src/model/run/responses.rs
@@ -110,21 +110,31 @@ where
             prompt_history: &recorded_prompt_history,
         };
         let recovered = if let Some(steps) = &execution_steps {
+            // A reopened durable step cannot distinguish a provider rejection
+            // from a submitted-and-billing-uncertain request. The live client
+            // still owns safe retries within this one uninterrupted attempt.
             match steps
                 .begin::<_, RecordedModelResult>(
                     &step_id,
                     "model_call",
                     &step_input,
-                    crate::agent::execution::ExecutionRetry::Idempotent,
+                    crate::agent::execution::ExecutionRetry::Never,
                 )
                 .await?
             {
                 crate::agent::ExecutionStep::Execute => None,
                 crate::agent::ExecutionStep::Replay(output) => Some(output),
                 crate::agent::ExecutionStep::Unknown => {
-                    return Err(NanocodexError::InvalidAttemptState {
-                        detail: "idempotent model call was recovered as unknown",
-                    });
+                    span.record("status", "failed");
+                    span.record("otel.status_code", "ERROR");
+                    span.record("duration_ns", elapsed_ns(started_at));
+                    return self.model_call_failed(
+                        call_index,
+                        started_at,
+                        NanocodexError::InvalidAttemptState {
+                            detail: "model call provider outcome is unknown after durable recovery; refusing to resubmit",
+                        },
+                    );
                 }
             }
         } else {

--- a/crates/nanocodex-agent/src/model/run/tool_calls.rs
+++ b/crates/nanocodex-agent/src/model/run/tool_calls.rs
@@ -181,23 +181,30 @@ where
                     let started_at = active.started_at;
                     let step_id = format!("tool-{call_index}-{}", call.call_id);
                     let unavailable = unsupported_tool_message(tools, &call).is_some();
+                    let retry = if matches!(active.kind, CodeCallKind::ToolSearch) {
+                        crate::agent::execution::ExecutionRetry::Idempotent
+                    } else {
+                        crate::agent::execution::ExecutionRetry::Never
+                    };
+                    let mut unknown = false;
                     let recovered = if let Some(steps) = &execution_steps {
                         match steps
-                            .begin::<_, CompletedToolCall>(
-                                &step_id,
-                                "tool_call",
-                                &call,
-                                crate::agent::execution::ExecutionRetry::Never,
-                            )
+                            .begin::<_, CompletedToolCall>(&step_id, "tool_call", &call, retry)
                             .await?
                         {
                             crate::agent::ExecutionStep::Execute => None,
                             crate::agent::ExecutionStep::Replay(output) => Some(output),
+                            crate::agent::ExecutionStep::Unknown => {
+                                unknown = true;
+                                None
+                            }
                         }
                     } else {
                         None
                     };
-                    let (result, executed) = if let Some(completed) = recovered {
+                    let (result, persist_result) = if unknown {
+                        (Ok(Self::unknown_recovered_tool_call(&active)), true)
+                    } else if let Some(completed) = recovered {
                         if unavailable {
                             (Ok(Self::unavailable_recovered_tool_call(&active)), false)
                         } else {
@@ -257,7 +264,7 @@ where
                     };
                     match result {
                         Ok(mut completed) => {
-                            if executed {
+                            if persist_result {
                                 completed.work_duration_ns =
                                     Self::completed_tool_work_duration(&active);
                                 if let Some(steps) = &execution_steps {
@@ -459,6 +466,38 @@ where
             tool: active.name.clone(),
             success: false,
             duration_ns,
+            work_duration_ns: 0,
+            output,
+            structured_result,
+            metadata: None,
+            response_items: vec![response_item],
+        }
+    }
+
+    fn unknown_recovered_tool_call(active: &ActiveToolCall) -> CompletedToolCall {
+        let output = ToolOutputBody::Text(format!(
+            "The prior `{}` tool execution stopped after durable authorization and may or may not have been dispatched. Its external outcome is unknown, so Nanocodex did not repeat it. Inspect the current state before deciding whether another tool call is safe.",
+            active.name
+        ));
+        let structured_result = serde_json::json!({
+            "status": "unknown",
+            "recovered": true,
+            "replayed": false,
+            "tool": active.name.as_str(),
+        });
+        record_tool_span_terminal(&active.span, "failed", "ERROR", 0, &output);
+        let response_item = match active.kind {
+            CodeCallKind::Custom => custom_tool_output(active.call_id.clone(), output.clone()),
+            CodeCallKind::Function => function_tool_output(active.call_id.clone(), output.clone()),
+            CodeCallKind::ToolSearch => {
+                unreachable!("retry-safe tool search cannot recover with an unknown outcome")
+            }
+        };
+        CompletedToolCall {
+            call_id: active.call_id.clone(),
+            tool: active.name.clone(),
+            success: false,
+            duration_ns: 0,
             work_duration_ns: 0,
             output,
             structured_result,

--- a/crates/nanocodex-agent/src/model/run/tool_calls.rs
+++ b/crates/nanocodex-agent/src/model/run/tool_calls.rs
@@ -5,6 +5,8 @@ pub(super) struct ActiveToolCall {
     pub(super) call_id: String,
     pub(super) name: String,
     pub(super) kind: CodeCallKind,
+    pub(super) execution_step_id: String,
+    pub(super) execution_retry: crate::agent::execution::ExecutionRetry,
     pub(super) started_at: Instant,
     pub(super) shell_abort_format: bool,
     pub(super) completion: Arc<Mutex<Option<CompletedToolCall>>>,
@@ -181,11 +183,7 @@ where
                     let started_at = active.started_at;
                     let step_id = format!("tool-{call_index}-{}", call.call_id);
                     let unavailable = unsupported_tool_message(tools, &call).is_some();
-                    let retry = if matches!(active.kind, CodeCallKind::ToolSearch) {
-                        crate::agent::execution::ExecutionRetry::Idempotent
-                    } else {
-                        crate::agent::execution::ExecutionRetry::Never
-                    };
+                    let retry = active.execution_retry;
                     let mut unknown = false;
                     let recovered = if let Some(steps) = &execution_steps {
                         match steps
@@ -203,7 +201,15 @@ where
                         None
                     };
                     let (result, persist_result) = if unknown {
-                        (Ok(Self::unknown_recovered_tool_call(&active)), true)
+                        let completed = Self::unknown_recovered_tool_call(&active);
+                        record_tool_span_terminal(
+                            &active.span,
+                            "failed",
+                            "ERROR",
+                            completed.duration_ns,
+                            &completed.output,
+                        );
+                        (Ok(completed), true)
                     } else if let Some(completed) = recovered {
                         if unavailable {
                             (Ok(Self::unavailable_recovered_tool_call(&active)), false)
@@ -343,6 +349,12 @@ where
             call_id: call.call_id.clone(),
             name: qualified_name,
             kind: call.kind,
+            execution_step_id: format!("tool-{call_index}-{}", call.call_id),
+            execution_retry: if matches!(call.kind, CodeCallKind::ToolSearch) {
+                crate::agent::execution::ExecutionRetry::Idempotent
+            } else {
+                crate::agent::execution::ExecutionRetry::Never
+            },
             started_at,
             shell_abort_format: call.namespace.is_none()
                 && matches!(call.name.as_str(), "shell_command" | "unified_exec"),
@@ -474,7 +486,7 @@ where
         }
     }
 
-    fn unknown_recovered_tool_call(active: &ActiveToolCall) -> CompletedToolCall {
+    pub(super) fn unknown_recovered_tool_call(active: &ActiveToolCall) -> CompletedToolCall {
         let output = ToolOutputBody::Text(format!(
             "The prior `{}` tool execution stopped after durable authorization and may or may not have been dispatched. Its external outcome is unknown, so Nanocodex did not repeat it. Inspect the current state before deciding whether another tool call is safe.",
             active.name
@@ -485,7 +497,6 @@ where
             "replayed": false,
             "tool": active.name.as_str(),
         });
-        record_tool_span_terminal(&active.span, "failed", "ERROR", 0, &output);
         let response_item = match active.kind {
             CodeCallKind::Custom => custom_tool_output(active.call_id.clone(), output.clone()),
             CodeCallKind::Function => function_tool_output(active.call_id.clone(), output.clone()),

--- a/crates/nanocodex-agent/src/model/run/turn.rs
+++ b/crates/nanocodex-agent/src/model/run/turn.rs
@@ -13,8 +13,9 @@ where
         fast_mode: bool,
         logical_turn: u64,
         cancel: &mut tokio::sync::oneshot::Receiver<()>,
+        execution_steps: Option<ExecutionSteps>,
     ) -> Result<ModelCompactOutcome> {
-        self.execution_steps = None;
+        self.execution_steps = execution_steps;
         self.thinking = thinking;
         self.fast_mode = fast_mode;
         self.started_at = Instant::now();
@@ -240,7 +241,7 @@ where
                 if let Some(tools) = &self.active_tools {
                     tools.cancel_turn().await;
                 }
-                let checkpoint = self.commit_interrupted_checkpoint()?;
+                let checkpoint = self.commit_cancelled_checkpoint().await?;
                 let error = NanocodexError::TurnCancelled;
                 let message = error.to_string();
                 self.events
@@ -618,6 +619,48 @@ where
             false,
             self.global_instructions.clone(),
         ))
+    }
+
+    async fn commit_cancelled_checkpoint(&mut self) -> Result<ModelCheckpoint> {
+        if let Some(steps) = self.execution_steps.clone() {
+            for call in &self.active_tool_calls {
+                if call.execution_retry != crate::agent::execution::ExecutionRetry::Never {
+                    continue;
+                }
+                let mut unknown = Self::unknown_recovered_tool_call(call);
+                let work_duration_ns = Self::completed_tool_work_duration(call);
+                unknown.duration_ns = elapsed_ns(call.started_at);
+                unknown.work_duration_ns = work_duration_ns;
+                let reconciled = steps
+                    .reconcile_cancelled(&call.execution_step_id, &unknown)
+                    .await?;
+                let crate::agent::ReconciledExecutionStep::Completed(completed) = reconciled else {
+                    continue;
+                };
+                let mut retained = call
+                    .completion
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if retained.is_none() {
+                    if completed
+                        .structured_result
+                        .get("status")
+                        .is_some_and(|status| status == "unknown")
+                    {
+                        record_tool_span_terminal(
+                            &call.span,
+                            "failed",
+                            "ERROR",
+                            completed.duration_ns,
+                            &completed.output,
+                        );
+                    }
+                    Self::emit_completed_tool_result(&self.events, &completed)?;
+                }
+                retained.replace(completed);
+            }
+        }
+        self.commit_interrupted_checkpoint()
     }
 
     pub(super) fn checkpoint_from_session(

--- a/crates/nanocodex-agent/src/rollout/mod.rs
+++ b/crates/nanocodex-agent/src/rollout/mod.rs
@@ -7,7 +7,7 @@ mod tests;
 
 pub use load::{DurableSession, RolloutSessionInfo, RolloutTranscriptItem};
 pub use store::RolloutInfo;
-pub(crate) use store::{RolloutOrigin, RolloutRecorder, RolloutTurn};
+pub(crate) use store::{RolloutCreate, RolloutOrigin, RolloutRecorder, RolloutTurn};
 
 use std::{
     fs::File,

--- a/crates/nanocodex-agent/src/rollout/store/mod.rs
+++ b/crates/nanocodex-agent/src/rollout/store/mod.rs
@@ -37,6 +37,16 @@ pub(crate) struct RolloutOrigin<'a> {
     pub(crate) parent_thread_id: Option<&'a str>,
 }
 
+pub(crate) struct RolloutCreate<'a> {
+    pub(crate) config: &'a RolloutConfig,
+    pub(crate) thread_id: &'a str,
+    pub(crate) prompt_cache_key: &'a str,
+    pub(crate) cwd: &'a Path,
+    pub(crate) instructions: &'a str,
+    pub(crate) origin: RolloutOrigin<'a>,
+    pub(crate) resume_history_len: Option<usize>,
+}
+
 enum RolloutCommand {
     Commit {
         commit: Box<RolloutCommit>,
@@ -183,16 +193,16 @@ impl RolloutTurn {
 }
 
 impl RolloutRecorder {
-    pub(crate) fn create(
-        runtime: &Handle,
-        config: &RolloutConfig,
-        thread_id: &str,
-        prompt_cache_key: &str,
-        cwd: &Path,
-        instructions: &str,
-        origin: RolloutOrigin<'_>,
-        resume_history_len: Option<usize>,
-    ) -> io::Result<Self> {
+    pub(crate) fn create(runtime: &Handle, request: RolloutCreate<'_>) -> io::Result<Self> {
+        let RolloutCreate {
+            config,
+            thread_id,
+            prompt_cache_key,
+            cwd,
+            instructions,
+            origin,
+            resume_history_len,
+        } = request;
         if let Some(path) = &config.resume_path {
             let history_len = resume_history_len.ok_or_else(|| {
                 io::Error::new(

--- a/crates/nanocodex-agent/src/rollout/tests.rs
+++ b/crates/nanocodex-agent/src/rollout/tests.rs
@@ -182,16 +182,18 @@ fn set_modified(path: &Path, seconds: u64) {
 fn recorder(home: &Path) -> RolloutRecorder {
     RolloutRecorder::create(
         &Handle::current(),
-        &RolloutConfig::new(home),
-        "019c0d31-c308-7d91-bff4-5dca82d15ac6",
-        "durable-cache",
-        Path::new("/worktree"),
-        "base instructions",
-        RolloutOrigin {
-            kind: "root",
-            parent_thread_id: None,
+        RolloutCreate {
+            config: &RolloutConfig::new(home),
+            thread_id: "019c0d31-c308-7d91-bff4-5dca82d15ac6",
+            prompt_cache_key: "durable-cache",
+            cwd: Path::new("/worktree"),
+            instructions: "base instructions",
+            origin: RolloutOrigin {
+                kind: "root",
+                parent_thread_id: None,
+            },
+            resume_history_len: None,
         },
-        None,
     )
     .expect("create rollout")
 }
@@ -604,17 +606,19 @@ async fn resumed_writer_repairs_a_rollout_behind_the_durable_boundary() {
     let config = RolloutConfig::new(home.path()).resumed(path.clone());
     let resumed = RolloutRecorder::create(
         &Handle::current(),
-        &config,
-        "019c0d31-c308-7d91-bff4-5dca82d15ac6",
-        "durable-cache",
-        Path::new("/worktree"),
-        "base instructions",
-        RolloutOrigin {
-            kind: "resume",
-            parent_thread_id: None,
+        RolloutCreate {
+            config: &config,
+            thread_id: "019c0d31-c308-7d91-bff4-5dca82d15ac6",
+            prompt_cache_key: "durable-cache",
+            cwd: Path::new("/worktree"),
+            instructions: "base instructions",
+            origin: RolloutOrigin {
+                kind: "resume",
+                parent_thread_id: None,
+            },
+            // The durable snapshot already contains `two`, but its rollout append failed.
+            resume_history_len: Some(2),
         },
-        // The durable snapshot already contains `two`, but its rollout append failed.
-        Some(2),
     )
     .expect("resume rollout");
     resumed
@@ -683,16 +687,18 @@ async fn fork_metadata_retains_parent_identity() {
     let parent = "019c0d31-c308-7d91-bff4-5dca82d15ac5";
     let recorder = RolloutRecorder::create(
         &Handle::current(),
-        &RolloutConfig::new(home.path()),
-        "019c0d31-c308-7d91-bff4-5dca82d15ac6",
-        "durable-cache",
-        Path::new("/worktree"),
-        "base instructions",
-        RolloutOrigin {
-            kind: "fork",
-            parent_thread_id: Some(parent),
+        RolloutCreate {
+            config: &RolloutConfig::new(home.path()),
+            thread_id: "019c0d31-c308-7d91-bff4-5dca82d15ac6",
+            prompt_cache_key: "durable-cache",
+            cwd: Path::new("/worktree"),
+            instructions: "base instructions",
+            origin: RolloutOrigin {
+                kind: "fork",
+                parent_thread_id: Some(parent),
+            },
+            resume_history_len: None,
         },
-        None,
     )
     .expect("create fork rollout");
 

--- a/crates/nanocodex-agent/tests/it/model/context.rs
+++ b/crates/nanocodex-agent/tests/it/model/context.rs
@@ -129,9 +129,9 @@ async fn fork_replaces_or_removes_changed_agents_md_once() -> Result<()> {
         let (stream, _) = listener.accept().await?;
         let mut replacement = accept_async(stream).await?;
         let replaced = next_json(&mut replacement).await?;
-        assert!(replaced.get("previous_response_id").is_none());
+        assert_eq!(replaced["previous_response_id"], "resp-root");
         let replaced = replaced.to_string();
-        assert!(replaced.contains("creation-time agents"));
+        assert!(!replaced.contains("creation-time agents"));
         assert!(replaced.contains(
             "These AGENTS.md instructions replace all previously provided AGENTS.md instructions."
         ));
@@ -145,9 +145,9 @@ async fn fork_replaces_or_removes_changed_agents_md_once() -> Result<()> {
         let (stream, _) = listener.accept().await?;
         let mut removal = accept_async(stream).await?;
         let removed = next_json(&mut removal).await?;
-        assert!(removed.get("previous_response_id").is_none());
+        assert_eq!(removed["previous_response_id"], "resp-root");
         let removed = removed.to_string();
-        assert!(removed.contains("creation-time agents"));
+        assert!(!removed.contains("creation-time agents"));
         assert!(
             removed.contains("The previously provided AGENTS.md instructions no longer apply.")
         );
@@ -222,9 +222,9 @@ async fn fork_reloads_a_changed_global_agents_source_once() -> Result<()> {
         let (stream, _) = listener.accept().await?;
         let mut fork = accept_async(stream).await?;
         let replaced = next_json(&mut fork).await?;
-        assert!(replaced.get("previous_response_id").is_none());
+        assert_eq!(replaced["previous_response_id"], "resp-root");
         let replaced = replaced.to_string();
-        assert!(replaced.contains("original global agents"));
+        assert!(!replaced.contains("original global agents"));
         assert!(replaced.contains("replacement global agents"));
         assert_eq!(
             replaced.matches("replace all previously provided").count(),

--- a/crates/nanocodex-agent/tests/it/model/recovery/durable_provider.rs
+++ b/crates/nanocodex-agent/tests/it/model/recovery/durable_provider.rs
@@ -1,0 +1,322 @@
+use std::{
+    future::{Ready, ready},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU32, Ordering},
+    },
+    task::{Context, Poll},
+};
+
+use nanocodex_agent::{
+    NanocodexError,
+    execution::{
+        ExecutionAdmission, ExecutionFuture, ExecutionOutput, ExecutionPolicy, ExecutionRetry,
+        ExecutionStepAdmission,
+    },
+    session::SessionSnapshot,
+};
+use nanocodex_oai_api::{
+    responses::{ContentItem, MessageRole, ResponseItem, ResponseItemId, WarmupResponse},
+    tower::{
+        CompactionOutput, GenerationOutput, ResponsePipelineStats, ResponsesAttempt,
+        ResponsesAttemptKind, ResponsesOutput, ResponsesServiceResponse,
+    },
+};
+use tower::Service;
+
+use super::*;
+
+#[derive(Clone)]
+struct ProviderProbe {
+    calls: Arc<AtomicU32>,
+}
+
+impl Service<ResponsesAttempt> for ProviderProbe {
+    type Response = ResponsesServiceResponse;
+    type Error = ResponseError;
+    type Future = Ready<std::result::Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        _context: &mut Context<'_>,
+    ) -> Poll<std::result::Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: ResponsesAttempt) -> Self::Future {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        let output = match request.kind() {
+            ResponsesAttemptKind::Warmup => ResponsesOutput::Warmup(WarmupResponse {
+                id: "resp-warmup".to_owned(),
+                usage: None,
+            }),
+            ResponsesAttemptKind::Generation => ResponsesOutput::Generation(GenerationOutput {
+                id: "resp-generation".to_owned(),
+                status: "completed".to_owned(),
+                end_turn: Some(true),
+                final_message: Some("provider was called".to_owned()),
+                output_items: vec![ResponseItem::message(
+                    MessageRole::Assistant,
+                    [ContentItem::output_text("provider was called")],
+                )],
+                code_calls: Vec::new(),
+                usage: None,
+                time_to_first_event_ns: 0,
+                time_to_first_output_ns: None,
+                pipeline_stats: ResponsePipelineStats::default(),
+            }),
+            ResponsesAttemptKind::Compaction => ResponsesOutput::Compaction(CompactionOutput {
+                id: "resp-compaction".to_owned(),
+                status: "completed".to_owned(),
+                item: ResponseItem::Compaction {
+                    id: Some(ResponseItemId::from("cmp-provider")),
+                    encrypted_content: "opaque-summary".into(),
+                    created_by: None,
+                    internal_chat_message_metadata_passthrough: None,
+                },
+                usage: None,
+                time_to_first_event_ns: 0,
+                time_to_first_output_ns: None,
+                pipeline_stats: ResponsePipelineStats::default(),
+            }),
+            _ => panic!("provider recovery probe received an unsupported attempt kind"),
+        };
+        ready(Ok(ResponsesServiceResponse::new(output)))
+    }
+}
+
+struct PendingProviderStep {
+    pending_kind: &'static str,
+    admissions: Mutex<Vec<(String, ExecutionRetry)>>,
+}
+
+impl PendingProviderStep {
+    fn new(pending_kind: &'static str) -> Self {
+        Self {
+            pending_kind,
+            admissions: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn assert_recovered_at_most_once(&self) {
+        assert_eq!(
+            self.admissions.lock().unwrap().as_slice(),
+            [(self.pending_kind.to_owned(), ExecutionRetry::Never)]
+        );
+    }
+
+    fn clear_admissions(&self) {
+        self.admissions.lock().unwrap().clear();
+    }
+}
+
+impl ExecutionPolicy for PendingProviderStep {
+    fn admit<'a>(
+        &'a self,
+        _operation_id: String,
+        _input_json: String,
+    ) -> ExecutionFuture<'a, nanocodex_agent::Result<ExecutionAdmission>> {
+        Box::pin(async { Ok(ExecutionAdmission::Execute) })
+    }
+
+    fn admit_automatic<'a>(
+        &'a self,
+        candidate_operation_id: String,
+        _input_json: String,
+    ) -> ExecutionFuture<'a, nanocodex_agent::Result<(String, ExecutionAdmission)>> {
+        Box::pin(async move { Ok((candidate_operation_id, ExecutionAdmission::Execute)) })
+    }
+
+    fn release<'a>(&'a self, _operation_id: String) -> ExecutionFuture<'a, ()> {
+        Box::pin(async {})
+    }
+
+    fn begin_attempt<'a>(
+        &'a self,
+        _operation_id: String,
+    ) -> ExecutionFuture<'a, nanocodex_agent::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn begin_step<'a>(
+        &'a self,
+        _operation_id: String,
+        _step_id: String,
+        kind: String,
+        _input_json: String,
+        retry: ExecutionRetry,
+    ) -> ExecutionFuture<'a, nanocodex_agent::Result<ExecutionStepAdmission>> {
+        Box::pin(async move {
+            self.admissions.lock().unwrap().push((kind.clone(), retry));
+            if kind == self.pending_kind && retry == ExecutionRetry::Never {
+                Ok(ExecutionStepAdmission::Unknown)
+            } else {
+                Ok(ExecutionStepAdmission::Execute)
+            }
+        })
+    }
+
+    fn complete_step<'a>(
+        &'a self,
+        _operation_id: String,
+        _step_id: String,
+        _output_json: String,
+    ) -> ExecutionFuture<'a, nanocodex_agent::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn complete<'a>(
+        &'a self,
+        _operation_id: String,
+        _snapshot: SessionSnapshot,
+        _output: ExecutionOutput,
+    ) -> ExecutionFuture<'a, nanocodex_agent::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn fail_attempt<'a>(
+        &'a self,
+        _operation_id: String,
+        _error: String,
+    ) -> ExecutionFuture<'a, nanocodex_agent::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn fail<'a>(
+        &'a self,
+        _operation_id: String,
+        _snapshot: SessionSnapshot,
+        _error: String,
+    ) -> ExecutionFuture<'a, nanocodex_agent::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+#[tokio::test]
+async fn execution_policy_cancellation_reconciliation_defaults_fail_closed() {
+    let policy = PendingProviderStep::new("tool_call");
+    let outcome = policy
+        .reconcile_cancelled_step(
+            "turn-1".to_owned(),
+            "tool-1".to_owned(),
+            r#"{"status":"unknown"}"#.to_owned(),
+        )
+        .await;
+
+    assert!(matches!(
+        outcome,
+        Err(NanocodexError::ExecutionPolicyCapabilityUnsupported {
+            capability: "reconcile_cancelled_step"
+        })
+    ));
+}
+
+async fn assert_pending_provider_step_is_not_repeated(
+    kind: &'static str,
+    transport: ResponsesTransport,
+    expected_detail: &'static str,
+) -> Result<()> {
+    let provider_calls = Arc::new(AtomicU32::new(0));
+    let service_calls = Arc::clone(&provider_calls);
+    let policy = Arc::new(PendingProviderStep::new(kind));
+    let openai = OpenAi::builder("test-key")
+        .transport(transport)
+        .service(move || ProviderProbe {
+            calls: Arc::clone(&service_calls),
+        })
+        .build()?;
+    let workspace = tempfile::tempdir()?;
+    let (agent, events) = Nanocodex::builder(openai)
+        .workspace(workspace.path())
+        .execution_policy(policy.clone())
+        .build()?;
+    drop(events);
+
+    let error = agent
+        .prompt("recover the interrupted provider step")
+        .await?
+        .await
+        .expect_err("an EffectPending provider step must fail closed");
+    assert!(matches!(
+        error,
+        NanocodexError::InvalidAttemptState { detail } if detail == expected_detail
+    ));
+    assert_eq!(
+        provider_calls.load(Ordering::Relaxed),
+        0,
+        "durable recovery must not submit the provider request again"
+    );
+    policy.assert_recovered_at_most_once();
+    agent.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn pending_model_call_recovery_does_not_call_the_provider_again() -> Result<()> {
+    assert_pending_provider_step_is_not_repeated(
+        "model_call",
+        ResponsesTransport::Https,
+        "model call provider outcome is unknown after durable recovery; refusing to resubmit",
+    )
+    .await
+}
+
+#[tokio::test]
+async fn pending_warmup_recovery_does_not_call_the_provider_again() -> Result<()> {
+    assert_pending_provider_step_is_not_repeated(
+        "warmup",
+        ResponsesTransport::WebSocket,
+        "warmup provider outcome is unknown after durable recovery; refusing to resubmit",
+    )
+    .await
+}
+
+#[tokio::test]
+async fn pending_compaction_recovery_does_not_call_the_provider_again() -> Result<()> {
+    let provider_calls = Arc::new(AtomicU32::new(0));
+    let service_calls = Arc::clone(&provider_calls);
+    let policy = Arc::new(PendingProviderStep::new("compaction"));
+    let openai = OpenAi::builder("test-key")
+        .transport(ResponsesTransport::Https)
+        .service(move || ProviderProbe {
+            calls: Arc::clone(&service_calls),
+        })
+        .build()?;
+    let workspace = tempfile::tempdir()?;
+    let (agent, events) = Nanocodex::builder(openai)
+        .workspace(workspace.path())
+        .context_window_tokens(1)
+        .execution_policy(policy.clone())
+        .build()?;
+    drop(events);
+
+    assert_eq!(
+        agent
+            .prompt("establish context that requires compaction")
+            .await?
+            .await?
+            .final_message(),
+        "provider was called"
+    );
+    assert_eq!(provider_calls.swap(0, Ordering::Relaxed), 1);
+    policy.clear_admissions();
+
+    let error = agent
+        .prompt("recover the pending compaction")
+        .await?
+        .await
+        .expect_err("an EffectPending compaction must fail closed");
+    assert!(matches!(
+        error,
+        NanocodexError::InvalidAttemptState { detail }
+            if detail == "compaction provider outcome is unknown after durable recovery; refusing to resubmit"
+    ));
+    assert_eq!(
+        provider_calls.load(Ordering::Relaxed),
+        0,
+        "compaction recovery must not submit the provider request again"
+    );
+    policy.assert_recovered_at_most_once();
+    agent.shutdown().await?;
+    Ok(())
+}

--- a/crates/nanocodex-agent/tests/it/model/recovery/mod.rs
+++ b/crates/nanocodex-agent/tests/it/model/recovery/mod.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 mod compaction;
+mod durable_provider;
 mod failures;
 mod normalization;
 mod reconnect;

--- a/crates/nanocodex-agent/tests/it/model/transport/websocket.rs
+++ b/crates/nanocodex-agent/tests/it/model/transport/websocket.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[tokio::test]
-async fn websocket_ephemeral_chains_on_connection_and_replays_a_fresh_fork() -> Result<()> {
+async fn websocket_ephemeral_chains_a_fresh_fork_from_its_checkpoint() -> Result<()> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let endpoint = format!("ws://{}", listener.local_addr()?);
     let server = tokio::spawn(async move {
@@ -24,12 +24,11 @@ async fn websocket_ephemeral_chains_on_connection_and_replays_a_fresh_fork() -> 
 
         let (stream, _) = listener.accept().await?;
         let mut branch = accept_async(stream).await?;
-        let replay = next_json(&mut branch).await?;
-        assert_eq!(replay["store"], false);
-        assert!(replay.get("previous_response_id").is_none());
-        let replay = replay.to_string();
-        assert!(replay.contains("first prompt"));
-        assert!(replay.contains("branch prompt"));
+        let request = next_json(&mut branch).await?;
+        assert_eq!(request["store"], false);
+        assert_eq!(request["previous_response_id"], "resp-first");
+        assert_eq!(request["input"].as_array().map(Vec::len), Some(1));
+        assert_eq!(request["input"][0]["content"][0]["text"], "branch prompt");
         send_final(&mut branch, "resp-branch").await
     });
 

--- a/crates/nanocodex-durability/Cargo.toml
+++ b/crates/nanocodex-durability/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 readme = "README.md"
 keywords.workspace = true
 categories.workspace = true
-description = "Portable durable execution journal and stores for Nanocodex"
+description = "Portable durable execution state and stores for Nanocodex"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/nanocodex-durability/README.md
+++ b/crates/nanocodex-durability/README.md
@@ -127,10 +127,14 @@ Only a definite `NotCommitted` replacement may be retried on the same owner.
 owner acquisition and loading the complete current state before deciding what
 ran.
 
-Each external effect follows an intent/effect/settlement boundary. Step state is
-`effect_pending`, `outcome_ready`, or `completed`. Settlement first stages the
-complete result, then materializes it in a second commit. A crash after staging
-replays the staged result without invoking the effect again. An unfinished
-at-most-once effect becomes `Unknown`; an idempotent effect may be retried with
-the exact stable identity and input. Operation terminals atomically carry their
-checkpoint and replay receipt.
+Each external effect follows an intent/effect/settlement boundary. A start
+commits `effect_pending`; settlement atomically replaces it with `completed`
+and the exact output. A crash before settlement uses the declared recovery
+policy, while a crash after settlement replays the output without invoking the
+effect again. An unfinished at-most-once effect becomes `Unknown`; an
+idempotent effect may be retried with the exact stable identity and input.
+Operation terminals atomically carry their checkpoint and replay receipt.
+
+Unlike a store that stages an output separately from source-ordered transcript
+placement, this store owns one opaque total state. A second materialization
+write would add latency without adding a recovery boundary.

--- a/crates/nanocodex-durability/README.md
+++ b/crates/nanocodex-durability/README.md
@@ -1,13 +1,14 @@
 # nanocodex-durability
 
 `nanocodex-durability` is the portable durable-execution boundary used by
-Nanocodex agents. Rust owns the journal format, optimistic revision protocol,
-state reduction, deduplication, checkpoint selection, and recovery decisions.
-Hosts provide only atomic journal loading and compare-and-append.
+Nanocodex agents. Rust owns one complete current-state value, its optimistic
+revision protocol, deduplication, checkpoint selection, and every recovery
+decision. Hosts atomically load and replace opaque state. There is no event-log
+replay during recovery.
 
 See [the end-to-end durability model and correctness review](../../docs/DURABILITY.md)
-for the Rust state machine, Agent/WASM/application consumption, crash matrix,
-and current implementation gaps.
+for the Rust state machine, Agent/WASM/application consumption, and crash
+matrix.
 
 This crate is an optional layer over `nanocodex-agent`: durability depends on
 the agent, never the reverse. It implements the agent's neutral execution
@@ -23,7 +24,7 @@ nanocodex-oai-api <- nanocodex-tools <- nanocodex-agent
                                   nanocodex-durability
 ```
 
-Construct only the layer an application needs, or attach the journal after the
+Construct only the layer an application needs, or attach durable state after the
 OpenAI client and tool registry have been composed into an agent:
 
 ```rust,ignore
@@ -35,10 +36,10 @@ let openai = OpenAi::new(std::env::var("OPENAI_API_KEY")?)?;
 let tools = Tools::builder().without_defaults().build()?;
 
 let store = MemoryStore::new()?;
-let journal = DurableSession::open(store, "agent-123").await?;
+let state = DurableSession::open(store, "agent-123").await?;
 let (agent, events) = Nanocodex::builder(openai)
     .tools(tools)
-    .durability(journal)
+    .durability(state)
     .await?
     .build()?;
 
@@ -61,10 +62,15 @@ The crate includes an in-memory store on every target and optional native
 SQLite and Postgres stores. JavaScript runtimes implement the same small store
 contract through the Nanocodex WASM host bridge.
 
-Operations are durable accepted units of work. Steps are replayable boundaries
-inside an operation. An unfinished step is classified from its retry policy:
-retry-safe steps can start another attempt, while an unfinished unsafe step is
-reported as ambiguous and is never silently repeated.
+Operations are durable accepted units of work. Steps cover every external
+effect inside an operation: model calls, warmup, automatic compaction, and
+tools. Beginning a step returns `Execute`, `Replay(output)`, or `Unknown`.
+`Unknown` means an at-most-once start committed without a completion, so the
+effect is never silently repeated. The Agent adapter commits one structured
+failed tool result for that uncertainty and continues the model loop.
+Standalone compaction uses the same owner boundary: it commits a
+`checkpoint_effect_started` fence before provider entry and commits the new
+checkpoint only after the transform completes.
 
 Completed tool outputs are replayed only while the recovered agent still owns
 the named tool. If a deployment removes a runtime-owned tool, recovery emits an
@@ -82,12 +88,12 @@ use nanocodex_durability::{Admission, DurableSession, MemoryStore};
 
 # async fn example() -> nanocodex_durability::Result<()> {
 let store = MemoryStore::new()?;
-let journal = DurableSession::open(store.clone(), "agent-123").await?;
+let state = DurableSession::open(store.clone(), "agent-123").await?;
 
-match journal.admit_typed::<_, String, String>("request-7", &"hello").await? {
+match state.admit_typed::<_, String, String>("request-7", &"hello").await? {
     Admission::Accepted | Admission::Pending => {
-        journal.begin_attempt("request-7").await?;
-        journal.complete("request-7", &"checkpoint", &"answer").await?;
+        state.begin_attempt("request-7").await?;
+        state.complete("request-7", &"checkpoint", &"answer").await?;
     }
     Admission::Completed { checkpoint, output } => {
         assert_eq!((checkpoint, output), ("checkpoint".to_owned(), "answer".to_owned()));
@@ -103,18 +109,28 @@ match journal.admit_typed::<_, String, String>("request-7", &"hello").await? {
 
 Enable `sqlite` and open `SqliteStore` for a directly owned native connection.
 Enable `postgres` and pass a driven `tokio_postgres::Client` to
-`PostgresStore::new`. Both implement the exact same `JournalStore` contract.
+`PostgresStore::new`. Both implement the exact same `StateStore` contract.
 
-The host contract has only two operations:
+The logical host contract has only two operations:
 
-- `acquire_owner(journal_id, owner_id)` atomically advances the persisted owner
-  fence and returns that token with one coherent journal snapshot.
-- `append(journal_id, owner_token, expected_revision, payload)` checks owner
-  authority before revision and atomically appends the opaque payload.
+- `acquire(state_id, owner_id)` atomically advances the persisted owner
+  fence and returns that token with one coherent current-state value.
+- `replace(state_id, owner_token, expected_revision, payload)` checks authority
+  before revision, installs the complete replacement, and advances the revision
+  in one transaction.
 
-Hosts do not deserialize entries, snapshots, model outputs, or tool results.
+Hosts do not deserialize state, snapshots, model outputs, or tool results.
 Rust owns those types and all recovery decisions.
 
-Only a definite `NotCommitted` append may be retried on the same owner.
+Only a definite `NotCommitted` replacement may be retried on the same owner.
 `Fenced`, revision `Conflict`, and unknown `Backend` outcomes require a fresh
-owner acquisition and complete journal reduction before deciding what ran.
+owner acquisition and loading the complete current state before deciding what
+ran.
+
+Each external effect follows an intent/effect/settlement boundary. Step state is
+`effect_pending`, `outcome_ready`, or `completed`. Settlement first stages the
+complete result, then materializes it in a second commit. A crash after staging
+replays the staged result without invoking the effect again. An unfinished
+at-most-once effect becomes `Unknown`; an idempotent effect may be retried with
+the exact stable identity and input. Operation terminals atomically carry their
+checkpoint and replay receipt.

--- a/crates/nanocodex-durability/src/agent.rs
+++ b/crates/nanocodex-durability/src/agent.rs
@@ -4,13 +4,15 @@ use nanocodex_agent::{
     ExecutionPolicyDisposition, NanocodexBuilder, NanocodexError, Result as AgentResult,
     execution::{
         ExecutionAdmission, ExecutionFuture, ExecutionOutput, ExecutionPolicy, ExecutionRetry,
-        ExecutionStepAdmission,
+        ExecutionStepAdmission, ExecutionStepReconciliation,
     },
     session::SessionSnapshot,
 };
 use serde_json::value::RawValue;
 
-use crate::{Admission, BeginStep, DurableSession, Error, RetryPolicy, session::DurableOwner};
+use crate::{
+    Admission, BeginStep, DurableSession, Error, ReconciledStep, RetryPolicy, session::DurableOwner,
+};
 
 /// Fluent builder extension that attaches portable durability to an agent.
 pub trait DurableAgentExt: Sized {
@@ -191,6 +193,28 @@ impl ExecutionPolicy for DurableExecution {
                 .complete_step(operation_id, step_id, &output)
                 .await
                 .map_err(agent_error)
+        })
+    }
+
+    fn reconcile_cancelled_step<'a>(
+        &'a self,
+        operation_id: String,
+        step_id: String,
+        unknown_output_json: String,
+    ) -> ExecutionFuture<'a, AgentResult<ExecutionStepReconciliation>> {
+        Box::pin(async move {
+            let unknown_output = raw(unknown_output_json)?;
+            match self
+                .owner
+                .reconcile_cancelled_step(operation_id, step_id, &unknown_output)
+                .await
+            {
+                Ok(ReconciledStep::NotStarted) => Ok(ExecutionStepReconciliation::NotStarted),
+                Ok(ReconciledStep::Completed(output)) => Ok(
+                    ExecutionStepReconciliation::Completed(output.json().to_owned()),
+                ),
+                Err(error) => Err(agent_error(error)),
+            }
         })
     }
 

--- a/crates/nanocodex-durability/src/agent.rs
+++ b/crates/nanocodex-durability/src/agent.rs
@@ -12,18 +12,17 @@ use serde_json::value::RawValue;
 
 use crate::{Admission, BeginStep, DurableSession, Error, RetryPolicy, session::DurableOwner};
 
-/// Fluent compatibility extension that attaches portable durability to an
-/// otherwise independent agent builder.
+/// Fluent builder extension that attaches portable durability to an agent.
 pub trait DurableAgentExt: Sized {
-    /// Restores the journal's latest checkpoint and installs its execution
+    /// Restores the state's latest checkpoint and installs its execution
     /// policy at the agent's neutral lifecycle seam.
-    fn durability(self, journal: DurableSession) -> impl Future<Output = AgentResult<Self>>;
+    fn durability(self, state: DurableSession) -> impl Future<Output = AgentResult<Self>>;
 }
 
 impl<F> DurableAgentExt for NanocodexBuilder<F> {
-    async fn durability(self, journal: DurableSession) -> AgentResult<Self> {
-        let mut builder = self.default_prompt_cache_key(journal.journal_id().to_owned());
-        let (owner, checkpoint) = journal.acquire_agent().await.map_err(agent_error)?;
+    async fn durability(self, state: DurableSession) -> AgentResult<Self> {
+        let mut builder = self.default_prompt_cache_key(state.state_id().to_owned());
+        let (owner, checkpoint) = state.acquire_agent().await.map_err(agent_error)?;
         if let Some(checkpoint) = checkpoint {
             let restored = checkpoint
                 .decode::<SessionSnapshot>()
@@ -34,7 +33,7 @@ impl<F> DurableAgentExt for NanocodexBuilder<F> {
                     != checkpoint.json()
             {
                 return Err(NanocodexError::InvalidSessionSnapshot(
-                    "configured resume snapshot does not match the durability journal".to_owned(),
+                    "configured resume snapshot does not match the durability state".to_owned(),
                 ));
             }
             builder = builder.resume(restored);
@@ -51,7 +50,7 @@ impl<F> DurableAgentExt for NanocodexBuilder<F> {
                 .take()
                 .ok_or_else(|| {
                     NanocodexError::InvalidExecutionPolicy(
-                        "a durability-attached builder can build only one agent; attach durability again to reopen the journal"
+                        "a durability-attached builder can build only one agent; attach durability again to reopen the state"
                             .to_owned(),
                     )
                 })?;
@@ -82,13 +81,10 @@ impl ExecutionPolicy for DurableExecution {
         })
     }
 
-    fn authorize_model_effect<'a>(
-        &'a self,
-        kind: &'static str,
-    ) -> ExecutionFuture<'a, AgentResult<()>> {
+    fn fence_checkpoint_effect<'a>(&'a self) -> ExecutionFuture<'a, AgentResult<()>> {
         Box::pin(async move {
             self.owner
-                .authorize_model_effect(kind)
+                .fence_checkpoint_effect()
                 .await
                 .map_err(agent_error)
         })
@@ -168,16 +164,18 @@ impl ExecutionPolicy for DurableExecution {
     ) -> ExecutionFuture<'a, AgentResult<ExecutionStepAdmission>> {
         Box::pin(async move {
             let input = raw(input_json)?;
-            self.owner
+            match self
+                .owner
                 .begin_step(operation_id, step_id, kind, &input, map_retry(retry))
                 .await
-                .map(|admission| match admission {
-                    BeginStep::Execute => ExecutionStepAdmission::Execute,
-                    BeginStep::Replay(output) => {
-                        ExecutionStepAdmission::Replay(output.json().to_owned())
-                    }
-                })
-                .map_err(agent_error)
+            {
+                Ok(BeginStep::Execute) => Ok(ExecutionStepAdmission::Execute),
+                Ok(BeginStep::Replay(output)) => {
+                    Ok(ExecutionStepAdmission::Replay(output.json().to_owned()))
+                }
+                Ok(BeginStep::Unknown) => Ok(ExecutionStepAdmission::Unknown),
+                Err(error) => Err(agent_error(error)),
+            }
         })
     }
 
@@ -269,7 +267,6 @@ fn agent_error(error: Error) -> NanocodexError {
         Error::Store(crate::StoreError::NotCommitted(_))
         | Error::OperationBlocked { .. }
         | Error::OperationActive { .. } => ExecutionPolicyDisposition::Retry,
-        Error::AmbiguousStep { .. } => ExecutionPolicyDisposition::Blocked,
         Error::Store(
             crate::StoreError::Fenced
             | crate::StoreError::Conflict { .. }
@@ -296,18 +293,11 @@ mod tests {
                 ExecutionPolicyDisposition::Retry,
             ),
             (
-                Error::AmbiguousStep {
-                    operation_id: "turn".to_owned(),
-                    step_id: "tool".to_owned(),
-                },
-                ExecutionPolicyDisposition::Blocked,
-            ),
-            (
                 Error::Store(crate::StoreError::Fenced),
                 ExecutionPolicyDisposition::Reopen,
             ),
             (
-                Error::InvalidJournal("broken".to_owned()),
+                Error::InvalidState("broken".to_owned()),
                 ExecutionPolicyDisposition::Fatal,
             ),
         ];

--- a/crates/nanocodex-durability/src/lib.rs
+++ b/crates/nanocodex-durability/src/lib.rs
@@ -3,19 +3,15 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod agent;
-mod journal;
 mod memory;
 #[cfg(all(feature = "postgres", not(target_family = "wasm")))]
 mod postgres;
 mod session;
 #[cfg(all(feature = "sqlite", not(target_family = "wasm")))]
 mod sqlite;
+mod state;
 mod store;
 
-pub use journal::{
-    EncodedPayload, Entry, JournalState, OperationState, OperationStatus, RetryPolicy, StepState,
-    StepStatus,
-};
 pub use memory::MemoryStore;
 #[cfg(all(feature = "postgres", not(target_family = "wasm")))]
 #[cfg_attr(
@@ -27,9 +23,12 @@ pub use session::{Admission, AutomaticAdmission, BeginStep, DurableSession};
 #[cfg(all(feature = "sqlite", not(target_family = "wasm")))]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "sqlite", not(target_family = "wasm")))))]
 pub use sqlite::SqliteStore;
+pub use state::{
+    DurableState, EncodedPayload, OperationState, OperationStatus, RetryPolicy, StepState,
+    StepStatus, Transition,
+};
 pub use store::{
-    JournalStore, OwnedJournal, OwnerId, OwnerToken, StoreError, StoreFuture, StoredBatch,
-    StoredJournal,
+    OwnedState, OwnerId, OwnerToken, StateStore, StoreError, StoreFuture, StoredState,
 };
 
 /// Result returned by durability operations.
@@ -41,18 +40,18 @@ pub enum Error {
     /// The host store rejected or failed an operation.
     #[error(transparent)]
     Store(#[from] StoreError),
-    /// A stored journal batch could not be decoded.
-    #[error("durability journal batch {revision} is invalid: {source}")]
+    /// Stored state could not be decoded.
+    #[error("durability state at revision {revision} is invalid: {source}")]
     Decode {
-        /// Revision containing the invalid batch.
+        /// Revision containing the invalid state transition.
         revision: u64,
         /// JSON decoding failure.
         #[source]
         source: serde_json::Error,
     },
-    /// An entry violated the append-only journal state machine.
-    #[error("invalid durability journal: {0}")]
-    InvalidJournal(String),
+    /// Retained state violated the durability state machine.
+    #[error("invalid durability state: {0}")]
+    InvalidState(String),
     /// An operation ID was reused with different input.
     #[error("durable operation `{operation_id}` already has different input")]
     OperationConflict {
@@ -75,14 +74,6 @@ pub enum Error {
         /// Missing step.
         step_id: String,
     },
-    /// A step may have performed external side effects before the worker died.
-    #[error("durable step `{step_id}` in operation `{operation_id}` has an ambiguous outcome")]
-    AmbiguousStep {
-        /// Owning operation.
-        operation_id: String,
-        /// Ambiguous step.
-        step_id: String,
-    },
     /// A terminal operation cannot be changed.
     #[error("durable operation `{operation_id}` is already terminal")]
     OperationTerminal {
@@ -95,8 +86,8 @@ pub enum Error {
         /// Active operation identity.
         operation_id: String,
     },
-    /// A direct journal caller attempted to mutate state while an Agent owns it.
-    #[error("durability journal has a live authoritative model owner")]
+    /// A direct state caller attempted to mutate state while an Agent owns it.
+    #[error("durability state has a live authoritative model owner")]
     ModelOwnerActive,
     /// A superseded Agent attempted to use its stale model-owner capability.
     #[error("durability model owner was fenced by a newer owner")]
@@ -117,6 +108,12 @@ pub enum Error {
     #[error("durable operation `{operation_id}` already has an active attempt")]
     AttemptActive {
         /// Operation with a live attempt.
+        operation_id: String,
+    },
+    /// Active cancellation omitted the safe interrupted checkpoint.
+    #[error("active durable operation `{operation_id}` cancellation requires a checkpoint")]
+    CancellationCheckpointRequired {
+        /// Active operation that cannot be cancelled without a checkpoint.
         operation_id: String,
     },
     /// A native owner task was created without an active Tokio runtime.

--- a/crates/nanocodex-durability/src/lib.rs
+++ b/crates/nanocodex-durability/src/lib.rs
@@ -19,7 +19,7 @@ pub use memory::MemoryStore;
     doc(cfg(all(feature = "postgres", not(target_family = "wasm"))))
 )]
 pub use postgres::PostgresStore;
-pub use session::{Admission, AutomaticAdmission, BeginStep, DurableSession};
+pub use session::{Admission, AutomaticAdmission, BeginStep, DurableSession, ReconciledStep};
 #[cfg(all(feature = "sqlite", not(target_family = "wasm")))]
 #[cfg_attr(docsrs, doc(cfg(all(feature = "sqlite", not(target_family = "wasm")))))]
 pub use sqlite::SqliteStore;

--- a/crates/nanocodex-durability/src/memory.rs
+++ b/crates/nanocodex-durability/src/memory.rs
@@ -4,28 +4,18 @@ use tokio::sync::{mpsc, oneshot};
 
 #[cfg(not(target_family = "wasm"))]
 use crate::Error;
-use crate::{
-    JournalStore, OwnedJournal, OwnerId, OwnerToken, StoreError, StoreFuture, StoredBatch,
-    StoredJournal,
-};
+use crate::{OwnedState, OwnerId, OwnerToken, StateStore, StoreError, StoreFuture, StoredState};
 
 const COMMAND_CAPACITY: usize = 64;
 
 enum Command {
     AcquireOwner {
-        journal_id: String,
+        state_id: String,
         owner_id: OwnerId,
-        result: oneshot::Sender<Result<OwnedJournal, StoreError>>,
+        result: oneshot::Sender<Result<OwnedState, StoreError>>,
     },
-    Append {
-        journal_id: String,
-        owner: OwnerToken,
-        expected_revision: u64,
-        payload: String,
-        result: oneshot::Sender<Result<u64, StoreError>>,
-    },
-    Compact {
-        journal_id: String,
+    Replace {
+        state_id: String,
         owner: OwnerToken,
         expected_revision: u64,
         payload: String,
@@ -35,7 +25,7 @@ enum Command {
 
 /// Process-local store useful for tests and ephemeral native or WASM sessions.
 ///
-/// One spawned task owns all journal maps. Clones are command handles, allowing
+/// One spawned task owns all state maps. Clones are command handles, allowing
 /// a new [`crate::DurableSession`] driver to reopen the same process-local data
 /// without exposing shared mutable state.
 #[derive(Clone)]
@@ -48,17 +38,17 @@ impl MemoryStore {
     pub fn new() -> crate::Result<Self> {
         let (commands, mut receiver) = mpsc::channel(COMMAND_CAPACITY);
         let driver = async move {
-            let mut journals = HashMap::<String, StoredJournal>::new();
+            let mut states = HashMap::<String, StoredState>::new();
             let mut owners = HashMap::<String, OwnerToken>::new();
             while let Some(command) = receiver.recv().await {
                 match command {
                     Command::AcquireOwner {
-                        journal_id,
+                        state_id,
                         owner_id,
                         result,
                     } => {
                         let fence = owners
-                            .get(&journal_id)
+                            .get(&state_id)
                             .map_or(Some(1), |owner| owner.fence().checked_add(1));
                         let outcome = fence
                             .ok_or_else(|| {
@@ -68,72 +58,41 @@ impl MemoryStore {
                             })
                             .map(|fence| {
                                 let owner = OwnerToken::new(owner_id, fence);
-                                owners.insert(journal_id.clone(), owner.clone());
-                                OwnedJournal {
+                                owners.insert(state_id.clone(), owner.clone());
+                                OwnedState {
                                     owner,
-                                    journal: journals.get(&journal_id).cloned().unwrap_or_default(),
+                                    state: states.get(&state_id).cloned().unwrap_or_default(),
                                 }
                             });
                         drop(result.send(outcome));
                     }
-                    Command::Append {
-                        journal_id,
+                    Command::Replace {
+                        state_id,
                         owner,
                         expected_revision,
                         payload,
                         result,
                     } => {
-                        let outcome = if owners.get(&journal_id) != Some(&owner) {
+                        let outcome = if owners.get(&state_id) != Some(&owner) {
                             Err(StoreError::Fenced)
                         } else {
-                            let journal = journals.entry(journal_id).or_default();
-                            if journal.revision != expected_revision {
+                            let state = states.entry(state_id).or_default();
+                            if state.revision != expected_revision {
                                 Err(StoreError::Conflict {
                                     expected: expected_revision,
-                                    actual: journal.revision,
+                                    actual: state.revision,
                                 })
                             } else {
-                                match journal.revision.checked_add(1) {
+                                match state.revision.checked_add(1) {
                                     Some(revision) => {
-                                        journal.batches.push(StoredBatch { revision, payload });
-                                        journal.revision = revision;
+                                        state.payload = Some(payload);
+                                        state.revision = revision;
                                         Ok(revision)
                                     }
                                     None => Err(StoreError::NotCommitted(
                                         "in-memory durability revision overflow".to_owned(),
                                     )),
                                 }
-                            }
-                        };
-                        drop(result.send(outcome));
-                    }
-                    Command::Compact {
-                        journal_id,
-                        owner,
-                        expected_revision,
-                        payload,
-                        result,
-                    } => {
-                        let outcome = if owners.get(&journal_id) != Some(&owner) {
-                            Err(StoreError::Fenced)
-                        } else {
-                            let journal = journals.entry(journal_id).or_default();
-                            if journal.revision != expected_revision {
-                                Err(StoreError::Conflict {
-                                    expected: expected_revision,
-                                    actual: journal.revision,
-                                })
-                            } else if expected_revision == 0 {
-                                Err(StoreError::NotCommitted(
-                                    "cannot compact an empty in-memory durability journal"
-                                        .to_owned(),
-                                ))
-                            } else {
-                                journal.batches = vec![StoredBatch {
-                                    revision: expected_revision,
-                                    payload,
-                                }];
-                                Ok(expected_revision)
                             }
                         };
                         drop(result.send(outcome));
@@ -146,17 +105,17 @@ impl MemoryStore {
     }
 }
 
-impl JournalStore for MemoryStore {
-    fn acquire_owner<'a>(
+impl StateStore for MemoryStore {
+    fn acquire<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner_id: OwnerId,
-    ) -> StoreFuture<'a, Result<OwnedJournal, StoreError>> {
+    ) -> StoreFuture<'a, Result<OwnedState, StoreError>> {
         Box::pin(async move {
             let (result, receiver) = oneshot::channel();
             self.commands
                 .send(Command::AcquireOwner {
-                    journal_id: journal_id.to_owned(),
+                    state_id: state_id.to_owned(),
                     owner_id,
                     result,
                 })
@@ -166,9 +125,9 @@ impl JournalStore for MemoryStore {
         })
     }
 
-    fn append<'a>(
+    fn replace<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner: &'a OwnerToken,
         expected_revision: u64,
         payload: &'a str,
@@ -176,31 +135,8 @@ impl JournalStore for MemoryStore {
         Box::pin(async move {
             let (result, receiver) = oneshot::channel();
             self.commands
-                .send(Command::Append {
-                    journal_id: journal_id.to_owned(),
-                    owner: owner.clone(),
-                    expected_revision,
-                    payload: payload.to_owned(),
-                    result,
-                })
-                .await
-                .map_err(|_| stopped())?;
-            receiver.await.map_err(|_| stopped())?
-        })
-    }
-
-    fn compact<'a>(
-        &'a mut self,
-        journal_id: &'a str,
-        owner: &'a OwnerToken,
-        expected_revision: u64,
-        payload: &'a str,
-    ) -> StoreFuture<'a, Result<u64, StoreError>> {
-        Box::pin(async move {
-            let (result, receiver) = oneshot::channel();
-            self.commands
-                .send(Command::Compact {
-                    journal_id: journal_id.to_owned(),
+                .send(Command::Replace {
+                    state_id: state_id.to_owned(),
                     owner: owner.clone(),
                     expected_revision,
                     payload: payload.to_owned(),
@@ -238,68 +174,43 @@ mod tests {
     async fn acquisition_fences_stale_writer_before_revision_check() {
         let mut first = MemoryStore::new().unwrap();
         let mut second = first.clone();
-        let first_owned = first
-            .acquire_owner("journal", OwnerId::new())
-            .await
-            .unwrap();
+        let first_owned = first.acquire("state", OwnerId::new()).await.unwrap();
         assert_eq!(first_owned.owner.fence(), 1);
         first
-            .append("journal", &first_owned.owner, 0, "first")
+            .replace("state", &first_owned.owner, 0, "first")
             .await
             .unwrap();
 
-        let second_owned = second
-            .acquire_owner("journal", OwnerId::new())
-            .await
-            .unwrap();
+        let second_owned = second.acquire("state", OwnerId::new()).await.unwrap();
         assert_eq!(second_owned.owner.fence(), 2);
-        assert_eq!(second_owned.journal.revision, 1);
-        assert_eq!(second_owned.journal.batches[0].payload, "first");
+        assert_eq!(second_owned.state.revision, 1);
+        assert_eq!(second_owned.state.payload.as_deref(), Some("first"));
         assert_eq!(
             first
-                .append("journal", &first_owned.owner, u64::MAX, "stale")
+                .replace("state", &first_owned.owner, u64::MAX, "stale")
                 .await,
             Err(StoreError::Fenced)
         );
     }
 
     #[tokio::test]
-    async fn compaction_keeps_revision_and_fence_while_replacing_batches() {
+    async fn replace_overwrites_the_complete_value_and_advances_revision() {
         let mut store = MemoryStore::new().unwrap();
-        let owned = store
-            .acquire_owner("journal", OwnerId::new())
+        let owned = store.acquire("state", OwnerId::new()).await.unwrap();
+        store
+            .replace("state", &owned.owner, 0, "first")
             .await
             .unwrap();
         store
-            .append("journal", &owned.owner, 0, "first")
+            .replace("state", &owned.owner, 1, "second")
             .await
             .unwrap();
-        store
-            .append("journal", &owned.owner, 1, "second")
-            .await
-            .unwrap();
+        let reopened = store.acquire("state", OwnerId::new()).await.unwrap();
+        assert_eq!(reopened.state.revision, 2);
+        assert_eq!(reopened.state.payload.as_deref(), Some("second"));
         assert_eq!(
             store
-                .compact("journal", &owned.owner, 2, "checkpoint")
-                .await,
-            Ok(2)
-        );
-
-        let reopened = store
-            .acquire_owner("journal", OwnerId::new())
-            .await
-            .unwrap();
-        assert_eq!(reopened.journal.revision, 2);
-        assert_eq!(
-            reopened.journal.batches,
-            vec![StoredBatch {
-                revision: 2,
-                payload: "checkpoint".to_owned(),
-            }]
-        );
-        assert_eq!(
-            store
-                .compact("journal", &owned.owner, u64::MAX, "stale")
+                .replace("state", &owned.owner, u64::MAX, "stale")
                 .await,
             Err(StoreError::Fenced)
         );

--- a/crates/nanocodex-durability/src/postgres.rs
+++ b/crates/nanocodex-durability/src/postgres.rs
@@ -1,55 +1,39 @@
-use tokio_postgres::{Client, Transaction, error::SqlState, types::ToSql};
+use tokio_postgres::Client;
 
-use crate::{
-    JournalStore, OwnedJournal, OwnerId, OwnerToken, StoreError, StoreFuture, StoredBatch,
-    StoredJournal,
-};
+use crate::{OwnedState, OwnerId, OwnerToken, StateStore, StoreError, StoreFuture, StoredState};
 
-// The shared Postgres schema retains the complete u64 range for JavaScript
-// adapters. Native revisions deliberately stop at the signed 64-bit ceiling.
-const MAX_NATIVE_REVISION: u64 = i64::MAX as u64;
-const MAX_U64_DECIMAL: &str = "18446744073709551615";
-const ABOVE_MAX_U64_DECIMAL: &str = "18446744073709551616";
-
-const POSTGRES_SCHEMA: &str = "CREATE TABLE IF NOT EXISTS nanocodex_journals (
-       journal_id TEXT PRIMARY KEY,
-       revision NUMERIC(20, 0) NOT NULL
-         CHECK (revision >= 0 AND revision <= 18446744073709551615)
-     );
-     CREATE TABLE IF NOT EXISTS nanocodex_journal_batches (
-       journal_id TEXT NOT NULL REFERENCES nanocodex_journals(journal_id),
-       revision NUMERIC(20, 0) NOT NULL
-         CHECK (revision > 0 AND revision <= 18446744073709551615),
-       payload TEXT NOT NULL,
-       PRIMARY KEY (journal_id, revision)
-     );
-     CREATE TABLE IF NOT EXISTS nanocodex_journal_owners (
-       journal_id TEXT PRIMARY KEY,
+const POSTGRES_SCHEMA: &str = "CREATE TABLE IF NOT EXISTS nanocodex_durable_owners (
+       state_id TEXT PRIMARY KEY,
        owner_id TEXT NOT NULL,
        fence NUMERIC(20, 0) NOT NULL
          CHECK (fence >= 1 AND fence <= 18446744073709551615)
+     );
+     CREATE TABLE IF NOT EXISTS nanocodex_durable_states (
+       state_id TEXT PRIMARY KEY,
+       revision NUMERIC(20, 0) NOT NULL
+         CHECK (revision >= 1 AND revision <= 18446744073709551615),
+       payload TEXT NOT NULL
      );";
 
-/// Postgres-backed journal store.
+/// Postgres-backed state store.
 pub struct PostgresStore {
     client: Client,
 }
 
 impl PostgresStore {
-    /// Initializes the current journal schema using a caller-driven Postgres client.
+    /// Initializes the current state schema using a caller-driven Postgres client.
     pub async fn new(client: Client) -> Result<Self, StoreError> {
         let mut store = Self { client };
         let transaction = store.client.transaction().await.map_err(backend)?;
         transaction
             .query(
                 "SELECT pg_advisory_xact_lock(hashtextextended(
-                   current_database() || ':' || current_schema() || ':nanocodex-durability', 0
+                   current_database() || ':' || current_schema() || ':nanocodex-durability-v2', 0
                  ))",
                 &[],
             )
             .await
             .map_err(backend)?;
-        upgrade_released_schema(&transaction).await?;
         transaction
             .batch_execute(POSTGRES_SCHEMA)
             .await
@@ -60,24 +44,24 @@ impl PostgresStore {
     }
 }
 
-impl JournalStore for PostgresStore {
-    fn acquire_owner<'a>(
+impl StateStore for PostgresStore {
+    fn acquire<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner_id: OwnerId,
-    ) -> StoreFuture<'a, Result<OwnedJournal, StoreError>> {
+    ) -> StoreFuture<'a, Result<OwnedState, StoreError>> {
         Box::pin(async move {
             let transaction = self.client.transaction().await.map_err(backend)?;
             let row = transaction
                 .query_opt(
-                    "INSERT INTO nanocodex_journal_owners (journal_id, owner_id, fence)
+                    "INSERT INTO nanocodex_durable_owners (state_id, owner_id, fence)
                      VALUES ($1, $2, 1)
-                     ON CONFLICT (journal_id) DO UPDATE
+                     ON CONFLICT (state_id) DO UPDATE
                      SET owner_id = excluded.owner_id,
-                         fence = nanocodex_journal_owners.fence + 1
-                     WHERE nanocodex_journal_owners.fence < 18446744073709551615
+                         fence = nanocodex_durable_owners.fence + 1
+                     WHERE nanocodex_durable_owners.fence < 18446744073709551615
                      RETURNING fence::text",
-                    &[&journal_id, &owner_id.as_str()],
+                    &[&state_id, &owner_id.as_str()],
                 )
                 .await
                 .map_err(backend)?
@@ -85,45 +69,31 @@ impl JournalStore for PostgresStore {
                     StoreError::NotCommitted("Postgres durability owner fence overflow".to_owned())
                 })?;
             let fence = parse_u64(&row.get::<_, String>(0), "Postgres owner fence")?;
-            let revision = transaction
+            let state = transaction
                 .query_opt(
-                    "SELECT revision::text FROM nanocodex_journals WHERE journal_id = $1",
-                    &[&journal_id],
+                    "SELECT revision::text, payload
+                     FROM nanocodex_durable_states WHERE state_id = $1",
+                    &[&state_id],
                 )
                 .await
                 .map_err(backend)?
-                .map_or_else(
-                    || Ok(0),
-                    |row| parse_u64(&row.get::<_, String>(0), "Postgres journal revision"),
-                )?;
-            let rows = transaction
-                .query(
-                    "SELECT revision::text, payload FROM nanocodex_journal_batches
-                     WHERE journal_id = $1 ORDER BY revision",
-                    &[&journal_id],
-                )
-                .await
-                .map_err(backend)?;
-            let batches = rows
-                .into_iter()
                 .map(|row| {
-                    let revision = row.get::<_, String>(0);
-                    Ok(StoredBatch {
-                        revision: parse_u64(&revision, "Postgres batch revision")?,
-                        payload: row.get(1),
+                    Ok(StoredState {
+                        revision: parse_u64(&row.get::<_, String>(0), "Postgres state revision")?,
+                        payload: Some(row.get(1)),
                     })
                 })
-                .collect::<Result<Vec<_>, StoreError>>()?;
-            let journal = StoredJournal { revision, batches };
+                .transpose()?
+                .unwrap_or_default();
             let owner = OwnerToken::new(owner_id, fence);
             transaction.commit().await.map_err(backend)?;
-            Ok(OwnedJournal { owner, journal })
+            Ok(OwnedState { owner, state })
         })
     }
 
-    fn append<'a>(
+    fn replace<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner: &'a OwnerToken,
         expected_revision: u64,
         payload: &'a str,
@@ -132,42 +102,34 @@ impl JournalStore for PostgresStore {
             let transaction = self.client.transaction().await.map_err(backend)?;
             let retained_owner = transaction
                 .query_opt(
-                    "SELECT owner_id, fence::text FROM nanocodex_journal_owners
-                     WHERE journal_id = $1 FOR UPDATE",
-                    &[&journal_id],
+                    "SELECT owner_id, fence::text FROM nanocodex_durable_owners
+                     WHERE state_id = $1 FOR UPDATE",
+                    &[&state_id],
                 )
                 .await
                 .map_err(backend)?;
-            let owns_journal = match retained_owner {
+            let owns_state = match retained_owner {
                 Some(row) => {
-                    let owner_id = row.get::<_, String>(0);
-                    let fence = row.get::<_, String>(1);
-                    owner_id == owner.owner_id().as_str()
-                        && parse_u64(&fence, "Postgres owner fence")? == owner.fence()
+                    row.get::<_, String>(0) == owner.owner_id().as_str()
+                        && parse_u64(&row.get::<_, String>(1), "Postgres owner fence")?
+                            == owner.fence()
                 }
                 None => false,
             };
-            if !owns_journal {
+            if !owns_state {
                 return Err(StoreError::Fenced);
             }
-            transaction
-                .execute(
-                    "INSERT INTO nanocodex_journals (journal_id, revision) VALUES ($1, 0)
-                     ON CONFLICT (journal_id) DO NOTHING",
-                    &[&journal_id],
-                )
-                .await
-                .map_err(backend)?;
             let actual = transaction
-                .query_one(
-                    "SELECT revision::text FROM nanocodex_journals
-                     WHERE journal_id = $1 FOR UPDATE",
-                    &[&journal_id],
+                .query_opt(
+                    "SELECT revision::text FROM nanocodex_durable_states
+                     WHERE state_id = $1 FOR UPDATE",
+                    &[&state_id],
                 )
                 .await
                 .map_err(backend)?
-                .get::<_, String>(0);
-            let actual = parse_u64(&actual, "Postgres journal revision")?;
+                .map_or(Ok(0), |row| {
+                    parse_u64(&row.get::<_, String>(0), "Postgres state revision")
+                })?;
             if actual != expected_revision {
                 return Err(StoreError::Conflict {
                     expected: expected_revision,
@@ -177,19 +139,14 @@ impl JournalStore for PostgresStore {
             let revision = actual.checked_add(1).ok_or_else(|| {
                 StoreError::NotCommitted("Postgres durability revision overflow".to_owned())
             })?;
-            let native_revision = native_revision(revision)?;
+            let revision_text = revision.to_string();
             transaction
                 .execute(
-                    "INSERT INTO nanocodex_journal_batches (journal_id, revision, payload)
-                     VALUES ($1, $2::bigint, $3)",
-                    &[&journal_id, &native_revision, &payload],
-                )
-                .await
-                .map_err(backend)?;
-            transaction
-                .execute(
-                    "UPDATE nanocodex_journals SET revision = $2::bigint WHERE journal_id = $1",
-                    &[&journal_id, &native_revision],
+                    "INSERT INTO nanocodex_durable_states (state_id, revision, payload)
+                     VALUES ($1, $2::numeric, $3)
+                     ON CONFLICT (state_id) DO UPDATE
+                     SET revision = excluded.revision, payload = excluded.payload",
+                    &[&state_id, &revision_text, &payload],
                 )
                 .await
                 .map_err(backend)?;
@@ -199,710 +156,141 @@ impl JournalStore for PostgresStore {
     }
 }
 
-fn backend(error: tokio_postgres::Error) -> StoreError {
-    StoreError::Backend(error.to_string())
-}
-
-#[derive(Clone, Copy)]
-struct ColumnSpec {
-    name: &'static str,
-    type_name: &'static str,
-    not_null: bool,
-    numeric_shape: Option<(i32, i32)>,
-}
-
-const fn text_not_null(name: &'static str) -> ColumnSpec {
-    ColumnSpec {
-        name,
-        type_name: "text",
-        not_null: true,
-        numeric_shape: None,
-    }
-}
-
-const fn u64_numeric(name: &'static str) -> ColumnSpec {
-    ColumnSpec {
-        name,
-        type_name: "numeric",
-        not_null: true,
-        numeric_shape: Some((20, 0)),
-    }
-}
-
-const fn released_bigint(name: &'static str) -> ColumnSpec {
-    ColumnSpec {
-        name,
-        type_name: "int8",
-        not_null: true,
-        numeric_shape: None,
-    }
-}
-
-async fn upgrade_released_schema(transaction: &Transaction<'_>) -> Result<(), StoreError> {
-    if !is_released_schema(transaction).await? {
-        return Ok(());
-    }
-
-    transaction
-        .batch_execute(
-            "ALTER TABLE nanocodex_journals
-               DROP CONSTRAINT nanocodex_journals_revision_check;
-             ALTER TABLE nanocodex_journal_batches
-               DROP CONSTRAINT nanocodex_journal_batches_revision_check;
-             ALTER TABLE nanocodex_journals
-               ALTER COLUMN revision TYPE NUMERIC(20, 0) USING revision::numeric;
-             ALTER TABLE nanocodex_journal_batches
-               ALTER COLUMN revision TYPE NUMERIC(20, 0) USING revision::numeric;
-             ALTER TABLE nanocodex_journals
-               ADD CONSTRAINT nanocodex_journals_revision_check
-               CHECK (revision >= 0 AND revision <= 18446744073709551615);
-             ALTER TABLE nanocodex_journal_batches
-               ADD CONSTRAINT nanocodex_journal_batches_revision_check
-               CHECK (revision > 0 AND revision <= 18446744073709551615);",
-        )
-        .await
-        .map_err(backend)
-}
-
-async fn is_released_schema(transaction: &Transaction<'_>) -> Result<bool, StoreError> {
-    let relations = transaction
-        .query_one(
-            "SELECT to_regclass('nanocodex_journals') IS NOT NULL,
-                    to_regclass('nanocodex_journal_batches') IS NOT NULL,
-                    to_regclass('nanocodex_journal_owners') IS NOT NULL",
-            &[],
-        )
-        .await
-        .map_err(backend)?;
-    if !relations.get::<_, bool>(0) || !relations.get::<_, bool>(1) {
-        return Ok(false);
-    }
-    let owners_exist = relations.get::<_, bool>(2);
-    if !table_matches(
-        transaction,
-        "nanocodex_journals",
-        &[text_not_null("journal_id"), released_bigint("revision")],
-        &["journal_id"],
-    )
-    .await?
-        || !table_matches(
-            transaction,
-            "nanocodex_journal_batches",
-            &[
-                text_not_null("journal_id"),
-                released_bigint("revision"),
-                text_not_null("payload"),
-            ],
-            &["journal_id", "revision"],
-        )
-        .await?
-        || !has_canonical_foreign_key(&foreign_keys(transaction).await?)
-    {
-        return Ok(false);
-    }
-
-    let checks = check_specs(transaction).await?;
-    let checks_match = checks
-        == if owners_exist {
-            vec![
-                CheckSpec {
-                    table: "nanocodex_journal_batches".to_owned(),
-                    column: Some("revision".to_owned()),
-                },
-                CheckSpec {
-                    table: "nanocodex_journal_owners".to_owned(),
-                    column: Some("fence".to_owned()),
-                },
-                CheckSpec {
-                    table: "nanocodex_journals".to_owned(),
-                    column: Some("revision".to_owned()),
-                },
-            ]
-        } else {
-            vec![
-                CheckSpec {
-                    table: "nanocodex_journal_batches".to_owned(),
-                    column: Some("revision".to_owned()),
-                },
-                CheckSpec {
-                    table: "nanocodex_journals".to_owned(),
-                    column: Some("revision".to_owned()),
-                },
-            ]
-        };
-    if !checks_match || (owners_exist && !is_current_empty_owner_table(transaction).await?) {
-        return Ok(false);
-    }
-
-    Ok(released_checks(transaction).await?
-        == [
-            ReleasedCheck {
-                table: "nanocodex_journal_batches".to_owned(),
-                name: "nanocodex_journal_batches_revision_check".to_owned(),
-                expression: "revision>0".to_owned(),
-            },
-            ReleasedCheck {
-                table: "nanocodex_journals".to_owned(),
-                name: "nanocodex_journals_revision_check".to_owned(),
-                expression: "revision>=0".to_owned(),
-            },
-        ])
-}
-
-async fn is_current_empty_owner_table(transaction: &Transaction<'_>) -> Result<bool, StoreError> {
-    if !table_matches(
-        transaction,
-        "nanocodex_journal_owners",
-        &[
-            text_not_null("journal_id"),
-            text_not_null("owner_id"),
-            u64_numeric("fence"),
-        ],
-        &["journal_id"],
-    )
-    .await?
-        || transaction
-            .query_one(
-                "SELECT EXISTS (SELECT 1 FROM nanocodex_journal_owners)",
-                &[],
-            )
-            .await
-            .map_err(backend)?
-            .get::<_, bool>(0)
-    {
-        return Ok(false);
-    }
-
-    let probe = uuid::Uuid::now_v7().simple().to_string();
-    transaction
-        .batch_execute("SAVEPOINT nanocodex_owner_schema_boundaries")
-        .await
-        .map_err(backend)?;
-    let validation = validate_owner_numeric_boundaries(transaction, &probe).await;
-    transaction
-        .batch_execute(
-            "ROLLBACK TO SAVEPOINT nanocodex_owner_schema_boundaries;
-             RELEASE SAVEPOINT nanocodex_owner_schema_boundaries",
-        )
-        .await
-        .map_err(backend)?;
-    Ok(validation.is_ok())
-}
-
-#[derive(Debug, PartialEq, Eq)]
-struct ReleasedCheck {
-    table: String,
-    name: String,
-    expression: String,
-}
-
-async fn released_checks(transaction: &Transaction<'_>) -> Result<Vec<ReleasedCheck>, StoreError> {
-    transaction
-        .query(
-            "SELECT retained_table.relname, retained_constraint.conname,
-                    pg_get_expr(retained_constraint.conbin, retained_constraint.conrelid)
-             FROM pg_constraint AS retained_constraint
-             JOIN pg_class AS retained_table
-               ON retained_table.oid = retained_constraint.conrelid
-             JOIN pg_namespace AS retained_schema
-               ON retained_schema.oid = retained_table.relnamespace
-             WHERE retained_schema.nspname = current_schema()
-               AND retained_table.relname IN (
-                 'nanocodex_journals',
-                 'nanocodex_journal_batches'
-               )
-               AND retained_constraint.contype = 'c'
-               AND retained_constraint.convalidated
-               AND NOT retained_constraint.connoinherit
-             ORDER BY retained_table.relname, retained_constraint.oid",
-            &[],
-        )
-        .await
-        .map_err(backend)
-        .map(|rows| {
-            rows.into_iter()
-                .map(|row| ReleasedCheck {
-                    table: row.get(0),
-                    name: row.get(1),
-                    expression: normalize_check_expression(&row.get::<_, String>(2)),
-                })
-                .collect()
-        })
-}
-
-fn normalize_check_expression(expression: &str) -> String {
-    expression
-        .chars()
-        .filter(|character| !character.is_ascii_whitespace() && !matches!(character, '(' | ')'))
-        .collect::<String>()
-}
-
-async fn validate_schema(transaction: &Transaction<'_>) -> Result<(), StoreError> {
-    validate_table(
-        transaction,
-        "nanocodex_journals",
-        &[text_not_null("journal_id"), u64_numeric("revision")],
-        &["journal_id"],
-    )
-    .await?;
-    validate_table(
-        transaction,
-        "nanocodex_journal_batches",
-        &[
-            text_not_null("journal_id"),
-            u64_numeric("revision"),
-            text_not_null("payload"),
-        ],
-        &["journal_id", "revision"],
-    )
-    .await?;
-    validate_table(
-        transaction,
-        "nanocodex_journal_owners",
-        &[
-            text_not_null("journal_id"),
-            text_not_null("owner_id"),
-            u64_numeric("fence"),
-        ],
-        &["journal_id"],
-    )
-    .await?;
-    validate_foreign_keys(transaction).await?;
-    validate_numeric_checks(transaction).await
-}
-
-async fn validate_table(
-    transaction: &Transaction<'_>,
-    table: &str,
-    expected_columns: &[ColumnSpec],
-    expected_primary_key: &[&str],
-) -> Result<(), StoreError> {
-    let columns = table_columns(transaction, table).await?;
-    if columns.len() != expected_columns.len() {
-        return Err(incompatible_schema(format!(
-            "`{table}` must contain exactly {} columns, found {}",
-            expected_columns.len(),
-            columns.len()
-        )));
-    }
-    for (actual, expected) in columns.iter().zip(expected_columns) {
-        if actual.name != expected.name
-            || actual.type_name != expected.type_name
-            || actual.not_null != expected.not_null
-            || actual.numeric_shape != expected.numeric_shape
-        {
-            return Err(incompatible_schema(format!(
-                "`{table}.{}` has an incompatible column shape",
-                expected.name
-            )));
-        }
-    }
-    if table_primary_key(transaction, table).await? != expected_primary_key {
-        return Err(incompatible_schema(format!(
-            "`{table}` has an incompatible PRIMARY KEY"
-        )));
-    }
-    Ok(())
-}
-
-struct ColumnShape {
-    name: String,
-    type_name: String,
-    not_null: bool,
-    numeric_shape: Option<(i32, i32)>,
-}
-
-async fn table_matches(
-    transaction: &Transaction<'_>,
-    table: &str,
-    expected_columns: &[ColumnSpec],
-    expected_primary_key: &[&str],
-) -> Result<bool, StoreError> {
-    let columns = table_columns(transaction, table).await?;
-    if columns.len() != expected_columns.len() {
-        return Ok(false);
-    }
-    if columns
-        .iter()
-        .zip(expected_columns)
-        .any(|(actual, expected)| {
-            actual.name != expected.name
-                || actual.type_name != expected.type_name
-                || actual.not_null != expected.not_null
-                || actual.numeric_shape != expected.numeric_shape
-        })
-    {
-        return Ok(false);
-    }
-    Ok(table_primary_key(transaction, table).await? == expected_primary_key)
-}
-
-async fn table_columns(
-    transaction: &Transaction<'_>,
-    table: &str,
-) -> Result<Vec<ColumnShape>, StoreError> {
-    transaction
-        .query(
-            "SELECT attribute.attname, type.typname, attribute.attnotnull,
-                    CASE WHEN type.typname = 'numeric' AND attribute.atttypmod >= 0
-                         THEN ((attribute.atttypmod - 4) >> 16) & 65535 END,
-                    CASE WHEN type.typname = 'numeric' AND attribute.atttypmod >= 0
-                         THEN (attribute.atttypmod - 4) & 65535 END
-             FROM pg_attribute AS attribute
-             JOIN pg_type AS type ON type.oid = attribute.atttypid
-             WHERE attribute.attrelid = $1::text::regclass
-               AND attribute.attnum > 0
-               AND NOT attribute.attisdropped
-             ORDER BY attribute.attnum",
-            &[&table],
-        )
-        .await
-        .map_err(backend)?
-        .into_iter()
-        .map(|row| {
-            let numeric_shape = match (row.get(3), row.get(4)) {
-                (Some(precision), Some(scale)) => Some((precision, scale)),
-                (None, None) => None,
-                _ => {
-                    return Err(incompatible_schema(
-                        "incomplete numeric metadata".to_owned(),
-                    ));
-                }
-            };
-            Ok(ColumnShape {
-                name: row.get(0),
-                type_name: row.get(1),
-                not_null: row.get(2),
-                numeric_shape,
-            })
-        })
-        .collect::<Result<Vec<_>, StoreError>>()
-}
-
-async fn table_primary_key(
-    transaction: &Transaction<'_>,
-    table: &str,
-) -> Result<Vec<String>, StoreError> {
-    let primary_key = transaction
-        .query(
-            "SELECT attribute.attname
-             FROM pg_index AS index
-             CROSS JOIN LATERAL unnest(index.indkey)
-               WITH ORDINALITY AS key(attnum, position)
-             JOIN pg_attribute AS attribute
-               ON attribute.attrelid = index.indrelid
-              AND attribute.attnum = key.attnum
-             WHERE index.indrelid = $1::text::regclass
-               AND index.indisprimary
-             ORDER BY key.position",
-            &[&table],
-        )
-        .await
-        .map_err(backend)?
-        .into_iter()
-        .map(|row| row.get::<_, String>(0))
-        .collect::<Vec<_>>();
-    Ok(primary_key)
-}
-
-async fn validate_foreign_keys(transaction: &Transaction<'_>) -> Result<(), StoreError> {
-    let foreign_keys = foreign_keys(transaction).await?;
-    if !has_canonical_foreign_key(&foreign_keys) {
-        return Err(incompatible_schema(
-            "`nanocodex_journal_batches` has an incompatible foreign key".to_owned(),
-        ));
-    }
-    Ok(())
-}
-
-async fn foreign_keys(transaction: &Transaction<'_>) -> Result<Vec<ForeignKeySpec>, StoreError> {
+async fn validate_schema(transaction: &tokio_postgres::Transaction<'_>) -> Result<(), StoreError> {
     let rows = transaction
         .query(
-            "SELECT source_attribute.attname,
-                    target_schema.nspname = current_schema(),
-                    target_table.relname, target_attribute.attname,
-                    retained_constraint.condeferrable,
-                    retained_constraint.condeferred
-             FROM pg_constraint AS retained_constraint
-             CROSS JOIN LATERAL unnest(retained_constraint.conkey, retained_constraint.confkey)
-               WITH ORDINALITY AS key(source_attnum, target_attnum, position)
-             JOIN pg_attribute AS source_attribute
-               ON source_attribute.attrelid = retained_constraint.conrelid
-              AND source_attribute.attnum = key.source_attnum
-             JOIN pg_class AS target_table ON target_table.oid = retained_constraint.confrelid
-             JOIN pg_namespace AS target_schema ON target_schema.oid = target_table.relnamespace
-             JOIN pg_attribute AS target_attribute
-               ON target_attribute.attrelid = retained_constraint.confrelid
-              AND target_attribute.attnum = key.target_attnum
-             WHERE retained_constraint.conrelid = 'nanocodex_journal_batches'::regclass
-               AND retained_constraint.contype = 'f'
-             ORDER BY retained_constraint.oid, key.position",
+            "SELECT table_name, column_name, data_type, is_nullable,
+                    numeric_precision, numeric_scale
+             FROM information_schema.columns
+             WHERE table_schema = current_schema()
+               AND table_name IN ('nanocodex_durable_owners', 'nanocodex_durable_states')
+             ORDER BY table_name, ordinal_position",
             &[],
         )
         .await
-        .map_err(backend)?
+        .map_err(backend)?;
+    let actual = rows
         .into_iter()
-        .map(|row| ForeignKeySpec {
-            source_column: row.get(0),
-            target_in_current_schema: row.get(1),
-            target_table: row.get(2),
-            target_column: row.get(3),
-            deferrable: row.get(4),
-            initially_deferred: row.get(5),
+        .map(|row| {
+            (
+                row.get::<_, String>(0),
+                row.get::<_, String>(1),
+                row.get::<_, String>(2),
+                row.get::<_, String>(3),
+                row.get::<_, Option<i32>>(4),
+                row.get::<_, Option<i32>>(5),
+            )
         })
         .collect::<Vec<_>>();
-    Ok(rows)
-}
-
-#[derive(Debug, PartialEq, Eq)]
-struct ForeignKeySpec {
-    source_column: String,
-    target_in_current_schema: bool,
-    target_table: String,
-    target_column: String,
-    deferrable: bool,
-    initially_deferred: bool,
-}
-
-fn has_canonical_foreign_key(foreign_keys: &[ForeignKeySpec]) -> bool {
-    foreign_keys
-        == [ForeignKeySpec {
-            source_column: "journal_id".to_owned(),
-            target_in_current_schema: true,
-            target_table: "nanocodex_journals".to_owned(),
-            target_column: "journal_id".to_owned(),
-            deferrable: false,
-            initially_deferred: false,
-        }]
-}
-
-async fn check_specs(transaction: &Transaction<'_>) -> Result<Vec<CheckSpec>, StoreError> {
-    let checks = transaction
-        .query(
-            "SELECT retained_table.relname, attribute.attname
-             FROM pg_constraint AS retained_constraint
-             JOIN pg_class AS retained_table
-               ON retained_table.oid = retained_constraint.conrelid
-             JOIN pg_namespace AS retained_schema
-               ON retained_schema.oid = retained_table.relnamespace
-             LEFT JOIN pg_attribute AS attribute
-               ON attribute.attrelid = retained_constraint.conrelid
-              AND retained_constraint.conkey = ARRAY[attribute.attnum]::smallint[]
-             WHERE retained_schema.nspname = current_schema()
-               AND retained_table.relname IN (
-                 'nanocodex_journals',
-                 'nanocodex_journal_batches',
-                 'nanocodex_journal_owners'
-               )
-               AND retained_constraint.contype = 'c'
-             ORDER BY retained_table.relname, retained_constraint.oid",
-            &[],
-        )
-        .await
-        .map_err(backend)?
-        .into_iter()
-        .map(|row| CheckSpec {
-            table: row.get(0),
-            column: row.get(1),
+    let expected = vec![
+        (
+            "nanocodex_durable_owners",
+            "state_id",
+            "text",
+            "NO",
+            None,
+            None,
+        ),
+        (
+            "nanocodex_durable_owners",
+            "owner_id",
+            "text",
+            "NO",
+            None,
+            None,
+        ),
+        (
+            "nanocodex_durable_owners",
+            "fence",
+            "numeric",
+            "NO",
+            Some(20),
+            Some(0),
+        ),
+        (
+            "nanocodex_durable_states",
+            "state_id",
+            "text",
+            "NO",
+            None,
+            None,
+        ),
+        (
+            "nanocodex_durable_states",
+            "revision",
+            "numeric",
+            "NO",
+            Some(20),
+            Some(0),
+        ),
+        (
+            "nanocodex_durable_states",
+            "payload",
+            "text",
+            "NO",
+            None,
+            None,
+        ),
+    ];
+    if actual.len() != expected.len()
+        || actual.iter().zip(expected).any(|(actual, expected)| {
+            actual.0 != expected.0
+                || actual.1 != expected.1
+                || actual.2 != expected.2
+                || actual.3 != expected.3
+                || actual.4 != expected.4
+                || actual.5 != expected.5
         })
-        .collect::<Vec<_>>();
-    Ok(checks)
-}
-
-async fn validate_numeric_checks(transaction: &Transaction<'_>) -> Result<(), StoreError> {
-    let checks = check_specs(transaction).await?;
-    for (table, column) in canonical_numeric_checks() {
-        if !checks
-            .iter()
-            .any(|check| check.table == table && check.column.as_deref() == Some(column))
-        {
-            return Err(incompatible_schema(format!(
-                "`{table}.{column}` must have a single-column CHECK constraint"
-            )));
-        }
-    }
-    if !has_canonical_numeric_checks(&checks) {
-        return Err(incompatible_schema(
-            "the journal tables have incompatible CHECK constraints".to_owned(),
+    {
+        return Err(StoreError::Backend(
+            "incompatible Postgres durability schema; recreate the two nanocodex_durable_* tables"
+                .to_owned(),
         ));
     }
-
-    let probe = uuid::Uuid::now_v7().simple().to_string();
-    transaction
-        .batch_execute("SAVEPOINT nanocodex_schema_boundaries")
-        .await
-        .map_err(backend)?;
-    let validation = validate_numeric_boundaries(transaction, &probe).await;
-    transaction
-        .batch_execute(
-            "ROLLBACK TO SAVEPOINT nanocodex_schema_boundaries;
-             RELEASE SAVEPOINT nanocodex_schema_boundaries",
+    let primary_keys = transaction
+        .query(
+            "SELECT tc.table_name, kcu.column_name, kcu.ordinal_position
+             FROM information_schema.table_constraints AS tc
+             JOIN information_schema.key_column_usage AS kcu
+               ON tc.constraint_catalog = kcu.constraint_catalog
+              AND tc.constraint_schema = kcu.constraint_schema
+              AND tc.constraint_name = kcu.constraint_name
+             WHERE tc.table_schema = current_schema()
+               AND tc.constraint_type = 'PRIMARY KEY'
+               AND tc.table_name IN ('nanocodex_durable_owners', 'nanocodex_durable_states')
+             ORDER BY tc.table_name, kcu.ordinal_position",
+            &[],
         )
         .await
         .map_err(backend)?;
-    validation
-}
-
-#[derive(Debug, PartialEq, Eq)]
-struct CheckSpec {
-    table: String,
-    column: Option<String>,
-}
-
-const fn canonical_numeric_checks() -> [(&'static str, &'static str); 3] {
-    [
-        ("nanocodex_journal_batches", "revision"),
-        ("nanocodex_journal_owners", "fence"),
-        ("nanocodex_journals", "revision"),
-    ]
-}
-
-fn has_canonical_numeric_checks(checks: &[CheckSpec]) -> bool {
-    checks.len() == canonical_numeric_checks().len()
-        && checks
+    let primary_keys = primary_keys
+        .into_iter()
+        .map(|row| {
+            (
+                row.get::<_, String>(0),
+                row.get::<_, String>(1),
+                row.get::<_, i32>(2),
+            )
+        })
+        .collect::<Vec<_>>();
+    let expected_primary_keys = [
+        ("nanocodex_durable_owners", "state_id", 1),
+        ("nanocodex_durable_states", "state_id", 1),
+    ];
+    if primary_keys.len() != expected_primary_keys.len()
+        || primary_keys
             .iter()
-            .zip(canonical_numeric_checks())
-            .all(|(actual, (table, column))| {
-                actual.table == table && actual.column.as_deref() == Some(column)
+            .zip(expected_primary_keys)
+            .any(|(actual, expected)| {
+                actual.0 != expected.0 || actual.1 != expected.1 || actual.2 != expected.2
             })
-}
-
-async fn validate_numeric_boundaries(
-    transaction: &Transaction<'_>,
-    probe: &str,
-) -> Result<(), StoreError> {
-    validate_owner_numeric_boundaries(transaction, probe).await?;
-    for (suffix, revision) in [
-        ("journal-min", "0"),
-        ("journal-interior", "1"),
-        ("journal-max", MAX_U64_DECIMAL),
-    ] {
-        transaction
-            .execute(
-                "INSERT INTO nanocodex_journals (journal_id, revision)
-                 VALUES ($1, $2::text::numeric)",
-                &[&format!("{probe}-{suffix}"), &revision],
-            )
-            .await
-            .map_err(|error| incompatible_schema(format!("journal bounds rejected: {error}")))?;
-    }
-    let batch_journal = format!("{probe}-journal-min");
-    for revision in ["1", "2", MAX_U64_DECIMAL] {
-        transaction
-            .execute(
-                "INSERT INTO nanocodex_journal_batches (journal_id, revision, payload)
-                 VALUES ($1, $2::text::numeric, 'schema-validator')",
-                &[&batch_journal, &revision],
-            )
-            .await
-            .map_err(|error| incompatible_schema(format!("batch bounds rejected: {error}")))?;
-    }
-
-    for (label, statement, id, value) in [
-        (
-            "negative journal revision",
-            "INSERT INTO nanocodex_journals (journal_id, revision)
-             VALUES ($1, $2::text::numeric)",
-            format!("{probe}-journal-negative"),
-            "-1",
-        ),
-        (
-            "journal revision above u64",
-            "INSERT INTO nanocodex_journals (journal_id, revision)
-             VALUES ($1, $2::text::numeric)",
-            format!("{probe}-journal-overflow"),
-            ABOVE_MAX_U64_DECIMAL,
-        ),
-    ] {
-        expect_check_violation(transaction, label, statement, &[&id, &value]).await?;
-    }
-    for (label, value) in [
-        ("batch revision zero", "0"),
-        ("batch revision above u64", ABOVE_MAX_U64_DECIMAL),
-    ] {
-        expect_check_violation(
-            transaction,
-            label,
-            "INSERT INTO nanocodex_journal_batches (journal_id, revision, payload)
-             VALUES ($1, $2::text::numeric, 'schema-validator')",
-            &[&batch_journal, &value],
-        )
-        .await?;
+    {
+        return Err(StoreError::Backend(
+            "incompatible Postgres durability primary keys; each state_id must be the sole primary key"
+                .to_owned(),
+        ));
     }
     Ok(())
-}
-
-async fn validate_owner_numeric_boundaries(
-    transaction: &Transaction<'_>,
-    probe: &str,
-) -> Result<(), StoreError> {
-    for (suffix, fence) in [
-        ("owner-min", "1"),
-        ("owner-interior", "2"),
-        ("owner-max", MAX_U64_DECIMAL),
-    ] {
-        transaction
-            .execute(
-                "INSERT INTO nanocodex_journal_owners (journal_id, owner_id, fence)
-                 VALUES ($1, 'schema-validator', $2::text::numeric)",
-                &[&format!("{probe}-{suffix}"), &fence],
-            )
-            .await
-            .map_err(|error| incompatible_schema(format!("owner bounds rejected: {error}")))?;
-    }
-
-    for (label, statement, id, value) in [
-        (
-            "owner fence zero",
-            "INSERT INTO nanocodex_journal_owners (journal_id, owner_id, fence)
-             VALUES ($1, 'schema-validator', $2::text::numeric)",
-            format!("{probe}-owner-zero"),
-            "0",
-        ),
-        (
-            "owner fence above u64",
-            "INSERT INTO nanocodex_journal_owners (journal_id, owner_id, fence)
-             VALUES ($1, 'schema-validator', $2::text::numeric)",
-            format!("{probe}-owner-overflow"),
-            ABOVE_MAX_U64_DECIMAL,
-        ),
-    ] {
-        expect_check_violation(transaction, label, statement, &[&id, &value]).await?;
-    }
-    Ok(())
-}
-
-async fn expect_check_violation(
-    transaction: &Transaction<'_>,
-    label: &str,
-    statement: &str,
-    params: &[&(dyn ToSql + Sync)],
-) -> Result<(), StoreError> {
-    transaction
-        .batch_execute("SAVEPOINT nanocodex_schema_check")
-        .await
-        .map_err(backend)?;
-    let result = transaction.execute(statement, params).await;
-    transaction
-        .batch_execute(
-            "ROLLBACK TO SAVEPOINT nanocodex_schema_check;
-             RELEASE SAVEPOINT nanocodex_schema_check",
-        )
-        .await
-        .map_err(backend)?;
-    match result {
-        Err(error) if error.code() == Some(&SqlState::CHECK_VIOLATION) => Ok(()),
-        Err(error) => Err(incompatible_schema(format!(
-            "{label} failed for the wrong reason: {error}"
-        ))),
-        Ok(_) => Err(incompatible_schema(format!(
-            "{label} was accepted by its CHECK constraint"
-        ))),
-    }
-}
-
-fn incompatible_schema(detail: String) -> StoreError {
-    StoreError::Backend(format!("incompatible Postgres durability schema: {detail}"))
 }
 
 fn parse_u64(value: &str, label: &str) -> Result<u64, StoreError> {
@@ -911,488 +299,17 @@ fn parse_u64(value: &str, label: &str) -> Result<u64, StoreError> {
         .map_err(|error| StoreError::Backend(format!("invalid {label}: {error}")))
 }
 
-fn native_revision(value: u64) -> Result<i64, StoreError> {
-    debug_assert_eq!(MAX_NATIVE_REVISION, i64::MAX as u64);
-    i64::try_from(value)
-        .map_err(|_| StoreError::NotCommitted("Postgres durability revision overflow".to_owned()))
+fn backend(error: tokio_postgres::Error) -> StoreError {
+    StoreError::Backend(error.to_string())
 }
 
 #[cfg(test)]
 mod tests {
-    use tokio_postgres::NoTls;
-
     use super::*;
-    use crate::{Admission, DurableSession};
 
     #[test]
-    fn signed_64_bit_revision_ceiling_fails_closed() {
-        assert_eq!(native_revision(MAX_NATIVE_REVISION), Ok(i64::MAX));
-        assert_eq!(
-            native_revision(MAX_NATIVE_REVISION + 1),
-            Err(StoreError::NotCommitted(
-                "Postgres durability revision overflow".to_owned()
-            ))
-        );
-    }
-
-    #[test]
-    fn foreign_key_shape_requires_current_schema_and_immediate_enforcement() {
-        let canonical = || ForeignKeySpec {
-            source_column: "journal_id".to_owned(),
-            target_in_current_schema: true,
-            target_table: "nanocodex_journals".to_owned(),
-            target_column: "journal_id".to_owned(),
-            deferrable: false,
-            initially_deferred: false,
-        };
-        assert!(has_canonical_foreign_key(&[canonical()]));
-
-        let mut wrong_schema = canonical();
-        wrong_schema.target_in_current_schema = false;
-        assert!(!has_canonical_foreign_key(&[wrong_schema]));
-
-        let mut deferrable = canonical();
-        deferrable.deferrable = true;
-        assert!(!has_canonical_foreign_key(&[deferrable]));
-
-        let mut initially_deferred = canonical();
-        initially_deferred.initially_deferred = true;
-        assert!(!has_canonical_foreign_key(&[initially_deferred]));
-    }
-
-    #[test]
-    fn numeric_check_shape_rejects_extra_constraints() {
-        let mut checks = canonical_numeric_checks()
-            .into_iter()
-            .map(|(table, column)| CheckSpec {
-                table: table.to_owned(),
-                column: Some(column.to_owned()),
-            })
-            .collect::<Vec<_>>();
-        assert!(has_canonical_numeric_checks(&checks));
-
-        checks.insert(
-            2,
-            CheckSpec {
-                table: "nanocodex_journal_owners".to_owned(),
-                column: Some("owner_id".to_owned()),
-            },
-        );
-        assert!(!has_canonical_numeric_checks(&checks));
-    }
-
-    async fn connect_test_client(url: &str) -> Client {
-        let (client, connection) = tokio_postgres::connect(url, NoTls).await.unwrap();
-        tokio::spawn(async move {
-            connection.await.unwrap();
-        });
-        client
-    }
-
-    #[tokio::test]
-    #[ignore = "requires NANOCODEX_TEST_POSTGRES_URL"]
-    async fn real_postgres_rejects_bad_schema_and_reopens_shared_numeric_schema() {
-        let url = std::env::var("NANOCODEX_TEST_POSTGRES_URL").unwrap();
-
-        let malformed_schema = format!("nanocodex_test_{}", uuid::Uuid::now_v7().simple());
-        let malformed = connect_test_client(&url).await;
-        malformed
-            .batch_execute(&format!(
-                "CREATE SCHEMA {malformed_schema};
-                 SET search_path TO {malformed_schema};
-                 CREATE TABLE nanocodex_journal_owners (
-                   journal_id TEXT PRIMARY KEY,
-                   owner_id TEXT NOT NULL,
-                   fence BIGINT NOT NULL CHECK (fence >= 1)
-                 );"
-            ))
-            .await
-            .unwrap();
-        let error = match PostgresStore::new(malformed).await {
-            Ok(_) => panic!("incompatible ownership schema was accepted"),
-            Err(error) => error,
-        };
-        assert!(
-            error
-                .to_string()
-                .contains("`nanocodex_journal_owners.fence` has an incompatible column shape"),
-            "unexpected schema error: {error}"
-        );
-        let cleanup = connect_test_client(&url).await;
-        cleanup
-            .batch_execute(&format!("DROP SCHEMA {malformed_schema} CASCADE"))
-            .await
-            .unwrap();
-        drop(cleanup);
-
-        let ceiling_schema = format!("nanocodex_test_{}", uuid::Uuid::now_v7().simple());
-        let client = connect_test_client(&url).await;
-        client
-            .batch_execute(&format!(
-                "CREATE SCHEMA {ceiling_schema};
-                 SET search_path TO {ceiling_schema};
-                 CREATE TABLE nanocodex_journal_owners (
-                   journal_id TEXT PRIMARY KEY,
-                   owner_id TEXT NOT NULL,
-                   fence NUMERIC(20, 0) NOT NULL
-                     CHECK (fence >= 1 AND fence <= 18446744073709551615)
-                 );
-                 CREATE TABLE nanocodex_journals (
-                   journal_id TEXT PRIMARY KEY,
-                   revision NUMERIC(20, 0) NOT NULL
-                     CHECK (revision >= 0 AND revision <= 18446744073709551615)
-                 );
-                 CREATE TABLE nanocodex_journal_batches (
-                   journal_id TEXT NOT NULL REFERENCES nanocodex_journals(journal_id),
-                   revision NUMERIC(20, 0) NOT NULL
-                     CHECK (revision > 0 AND revision <= 18446744073709551615),
-                   payload TEXT NOT NULL,
-                   PRIMARY KEY (journal_id, revision)
-                 )"
-            ))
-            .await
-            .unwrap();
-        let mut store = PostgresStore::new(client).await.unwrap();
-        let owned = store
-            .acquire_owner("journal", OwnerId::new())
-            .await
-            .unwrap();
-        store
-            .client
-            .execute(
-                "INSERT INTO nanocodex_journals (journal_id, revision) VALUES ($1, $2::bigint)",
-                &[&"journal", &i64::MAX],
-            )
-            .await
-            .unwrap();
-        assert!(matches!(
-            store
-                .append("journal", &owned.owner, MAX_NATIVE_REVISION, "overflow")
-                .await,
-            Err(StoreError::NotCommitted(message))
-                if message == "Postgres durability revision overflow"
-        ));
-        assert_eq!(
-            store
-                .client
-                .query_one(
-                    "SELECT revision::text FROM nanocodex_journals
-                     WHERE journal_id = 'journal'",
-                    &[],
-                )
-                .await
-                .unwrap()
-                .get::<_, String>(0),
-            i64::MAX.to_string()
-        );
-        store
-            .acquire_owner("owner-ceiling", OwnerId::new())
-            .await
-            .unwrap();
-        store
-            .client
-            .batch_execute(
-                "UPDATE nanocodex_journal_owners
-                 SET fence = 18446744073709551614 WHERE journal_id = 'owner-ceiling'",
-            )
-            .await
-            .unwrap();
-        let max_owner = OwnerId::new();
-        let max_owned = store
-            .acquire_owner("owner-ceiling", max_owner.clone())
-            .await
-            .unwrap();
-        assert_eq!(max_owned.owner.fence(), u64::MAX);
-        assert!(matches!(
-            store.acquire_owner("owner-ceiling", OwnerId::new()).await,
-            Err(StoreError::NotCommitted(message))
-                if message == "Postgres durability owner fence overflow"
-        ));
-        assert_eq!(
-            store
-                .client
-                .query_one(
-                    "SELECT fence::text FROM nanocodex_journal_owners
-                     WHERE journal_id = 'owner-ceiling'",
-                    &[],
-                )
-                .await
-                .unwrap()
-                .get::<_, String>(0),
-            u64::MAX.to_string()
-        );
-        drop(store);
-        let reopened = connect_test_client(&url).await;
-        reopened
-            .batch_execute(&format!("SET search_path TO {ceiling_schema}"))
-            .await
-            .unwrap();
-        let mut reopened = PostgresStore::new(reopened).await.unwrap();
-        let reopened_journal = reopened
-            .acquire_owner("journal", OwnerId::new())
-            .await
-            .unwrap();
-        assert_eq!(reopened_journal.journal.revision, MAX_NATIVE_REVISION);
-        assert!(matches!(
-            reopened
-                .append(
-                    "journal",
-                    &reopened_journal.owner,
-                    MAX_NATIVE_REVISION,
-                    "overflow"
-                )
-                .await,
-            Err(StoreError::NotCommitted(message))
-                if message == "Postgres durability revision overflow"
-        ));
-        drop(reopened);
-        let cleanup = connect_test_client(&url).await;
-        cleanup
-            .batch_execute(&format!("DROP SCHEMA {ceiling_schema} CASCADE"))
-            .await
-            .unwrap();
-    }
-
-    #[tokio::test]
-    #[ignore = "requires NANOCODEX_TEST_POSTGRES_URL"]
-    async fn real_postgres_rejects_released_schema_with_unsafe_owner_residue() {
-        let url = std::env::var("NANOCODEX_TEST_POSTGRES_URL").unwrap();
-
-        for (case, owners_sql, expected_owner_rows) in [
-            (
-                "nonempty",
-                "CREATE TABLE nanocodex_journal_owners (
-                   journal_id TEXT PRIMARY KEY,
-                   owner_id TEXT NOT NULL,
-                   fence NUMERIC(20, 0) NOT NULL
-                     CHECK (fence >= 1 AND fence <= 18446744073709551615)
-                 );
-                 INSERT INTO nanocodex_journal_owners (journal_id, owner_id, fence)
-                 VALUES ('released-journal', 'unknown-owner', 7);",
-                1_i64,
-            ),
-            (
-                "malformed",
-                "CREATE TABLE nanocodex_journal_owners (
-                   journal_id TEXT PRIMARY KEY,
-                   owner_id TEXT NOT NULL,
-                   fence NUMERIC(20, 0) NOT NULL
-                     CHECK (fence >= 2 AND fence <= 18446744073709551615)
-                 );",
-                0_i64,
-            ),
-        ] {
-            let schema = format!("nanocodex_test_{}", uuid::Uuid::now_v7().simple());
-            let client = connect_test_client(&url).await;
-            client
-                .batch_execute(&format!(
-                    "CREATE SCHEMA {schema};
-                     SET search_path TO {schema};
-                     CREATE TABLE nanocodex_journals (
-                       journal_id TEXT PRIMARY KEY,
-                       revision BIGINT NOT NULL CHECK (revision >= 0)
-                     );
-                     CREATE TABLE nanocodex_journal_batches (
-                       journal_id TEXT NOT NULL REFERENCES nanocodex_journals(journal_id),
-                       revision BIGINT NOT NULL CHECK (revision > 0),
-                       payload TEXT NOT NULL,
-                       PRIMARY KEY (journal_id, revision)
-                     );
-                     {owners_sql}
-                     INSERT INTO nanocodex_journals (journal_id, revision)
-                     VALUES ('released-journal', 1);
-                     INSERT INTO nanocodex_journal_batches (journal_id, revision, payload)
-                     VALUES ('released-journal', 1, 'retained-payload');"
-                ))
-                .await
-                .unwrap();
-
-            let error = match PostgresStore::new(client).await {
-                Ok(_) => panic!("released schema with {case} owners was accepted"),
-                Err(error) => error,
-            };
-            assert!(
-                error
-                    .to_string()
-                    .contains("incompatible Postgres durability schema"),
-                "unexpected {case} owner error: {error}"
-            );
-
-            let audit = connect_test_client(&url).await;
-            audit
-                .batch_execute(&format!("SET search_path TO {schema}"))
-                .await
-                .unwrap();
-            let revision_types = audit
-                .query(
-                    "SELECT data_type
-                     FROM information_schema.columns
-                     WHERE table_schema = current_schema()
-                       AND column_name = 'revision'
-                       AND table_name IN ('nanocodex_journals', 'nanocodex_journal_batches')
-                     ORDER BY table_name",
-                    &[],
-                )
-                .await
-                .unwrap();
-            assert_eq!(revision_types.len(), 2);
-            assert!(
-                revision_types
-                    .iter()
-                    .all(|row| row.get::<_, String>(0) == "bigint")
-            );
-            assert_eq!(
-                audit
-                    .query_one("SELECT count(*) FROM nanocodex_journal_owners", &[],)
-                    .await
-                    .unwrap()
-                    .get::<_, i64>(0),
-                expected_owner_rows
-            );
-            assert_eq!(
-                audit
-                    .query_one(
-                        "SELECT payload FROM nanocodex_journal_batches
-                         WHERE journal_id = 'released-journal' AND revision = 1",
-                        &[],
-                    )
-                    .await
-                    .unwrap()
-                    .get::<_, String>(0),
-                "retained-payload"
-            );
-            audit
-                .batch_execute(&format!("DROP SCHEMA {schema} CASCADE"))
-                .await
-                .unwrap();
-        }
-    }
-
-    #[tokio::test]
-    #[ignore = "requires NANOCODEX_TEST_POSTGRES_URL"]
-    async fn real_postgres_upgrades_and_replays_the_released_bigint_schema() {
-        let url = std::env::var("NANOCODEX_TEST_POSTGRES_URL").unwrap();
-        let schema = format!("nanocodex_test_{}", uuid::Uuid::now_v7().simple());
-        let client = connect_test_client(&url).await;
-        client
-            .batch_execute(&format!(
-                r#"CREATE SCHEMA {schema};
-                 SET search_path TO {schema};
-                 CREATE TABLE nanocodex_journals (
-                   journal_id TEXT PRIMARY KEY,
-                   revision BIGINT NOT NULL CHECK (revision >= 0)
-                 );
-                 CREATE TABLE nanocodex_journal_batches (
-                   journal_id TEXT NOT NULL REFERENCES nanocodex_journals(journal_id),
-                   revision BIGINT NOT NULL CHECK (revision > 0),
-                   payload TEXT NOT NULL,
-                   PRIMARY KEY (journal_id, revision)
-                 );
-                 CREATE TABLE nanocodex_journal_owners (
-                   journal_id TEXT PRIMARY KEY,
-                   owner_id TEXT NOT NULL,
-                   fence NUMERIC(20, 0) NOT NULL
-                     CHECK (fence >= 1 AND fence <= 18446744073709551615)
-                 );
-                 INSERT INTO nanocodex_journals (journal_id, revision)
-                 VALUES ('released-journal', 4);
-                 INSERT INTO nanocodex_journal_batches (journal_id, revision, payload) VALUES
-                   ('released-journal', 1, '{{"operation_accepted":{{"operation_id":"legacy-turn","input":"prompt"}}}}'),
-                   ('released-journal', 2, '{{"step_started":{{"operation_id":"legacy-turn","step_id":"tool-1","kind":"tool","input":"charge","retry":"idempotent"}}}}'),
-                   ('released-journal', 3, '{{"step_completed":{{"operation_id":"legacy-turn","step_id":"tool-1","output":"receipt"}}}}'),
-                   ('released-journal', 4, '{{"operation_completed":{{"operation_id":"legacy-turn","checkpoint":{{"version":7}},"output":{{"message":"legacy done"}}}}}}');"#
-            ))
-            .await
-            .unwrap();
-
-        let session = DurableSession::open(
-            PostgresStore::new(client).await.unwrap(),
-            "released-journal",
-        )
-        .await
-        .unwrap();
-        let replay = session
-            .admit_typed::<_, serde_json::Value, serde_json::Value>("legacy-turn", &"prompt")
-            .await
-            .unwrap();
-        assert!(matches!(
-            replay,
-            Admission::Completed { checkpoint, output }
-                if checkpoint == serde_json::json!({"version": 7})
-                    && output == serde_json::json!({"message": "legacy done"})
-        ));
-        assert_eq!(session.state().await.unwrap().revision(), 4);
-        drop(session);
-
-        let audit = connect_test_client(&url).await;
-        audit
-            .batch_execute(&format!("SET search_path TO {schema}"))
-            .await
-            .unwrap();
-        let shapes = audit
-            .query(
-                "SELECT table_name, data_type, numeric_precision, numeric_scale
-                 FROM information_schema.columns
-                 WHERE table_schema = current_schema()
-                   AND column_name = 'revision'
-                   AND table_name IN ('nanocodex_journals', 'nanocodex_journal_batches')
-                 ORDER BY table_name",
-                &[],
-            )
-            .await
-            .unwrap();
-        assert_eq!(shapes.len(), 2);
-        for shape in shapes {
-            assert_eq!(shape.get::<_, String>(1), "numeric");
-            assert_eq!(shape.get::<_, Option<i32>>(2), Some(20));
-            assert_eq!(shape.get::<_, Option<i32>>(3), Some(0));
-        }
-        assert_eq!(
-            audit
-                .query_one(
-                    "SELECT count(*) FROM nanocodex_journal_batches
-                     WHERE journal_id = 'released-journal'",
-                    &[],
-                )
-                .await
-                .unwrap()
-                .get::<_, i64>(0),
-            4
-        );
-        drop(audit);
-
-        let reopened = connect_test_client(&url).await;
-        reopened
-            .batch_execute(&format!("SET search_path TO {schema}"))
-            .await
-            .unwrap();
-        let mut reopened = PostgresStore::new(reopened).await.unwrap();
-        let released = reopened
-            .acquire_owner("released-journal", OwnerId::new())
-            .await
-            .unwrap();
-        assert_eq!(released.owner.fence(), 2);
-        assert_eq!(released.journal.revision, 4);
-        assert_eq!(released.journal.batches.len(), 4);
-        let probe = reopened
-            .acquire_owner("append-probe", OwnerId::new())
-            .await
-            .unwrap();
-        reopened
-            .append(
-                "append-probe",
-                &probe.owner,
-                0,
-                r#"{"model_effect_started":{"kind":"probe"}}"#,
-            )
-            .await
-            .unwrap();
-        drop(reopened);
-
-        let cleanup = connect_test_client(&url).await;
-        cleanup
-            .batch_execute(&format!("DROP SCHEMA {schema} CASCADE"))
-            .await
-            .unwrap();
+    fn counters_reject_negative_and_oversized_text() {
+        assert!(parse_u64("-1", "counter").is_err());
+        assert!(parse_u64("18446744073709551616", "counter").is_err());
     }
 }

--- a/crates/nanocodex-durability/src/session.rs
+++ b/crates/nanocodex-durability/src/session.rs
@@ -703,9 +703,7 @@ impl Driver {
     ) -> Result<(String, StoredAdmission)> {
         if let Some((pending_id, operation)) = self
             .state
-            .pending_operations()
-            .into_iter()
-            .find(|(pending_id, _)| !self.claimed.contains_key(*pending_id))
+            .first_pending_operation_where(|pending_id| !self.claimed.contains_key(pending_id))
         {
             if operation.input != input {
                 return Err(Error::OperationBlocked {
@@ -782,16 +780,6 @@ impl Driver {
                 StepStatus::Completed(output) => {
                     return Ok(StoredBeginStep::Replay(output.clone()));
                 }
-                StepStatus::OutcomeReady(output) => {
-                    let output = output.clone();
-                    self.apply(Transition::StepCompleted {
-                        operation_id,
-                        step_id,
-                        output: output.clone(),
-                    })
-                    .await?;
-                    return Ok(StoredBeginStep::Replay(output));
-                }
                 StepStatus::EffectPending if retry == RetryPolicy::Never => {
                     return Ok(StoredBeginStep::Unknown);
                 }
@@ -833,26 +821,7 @@ impl Driver {
             StepStatus::Completed(_) => Err(Error::InvalidState(format!(
                 "step `{step_id}` in operation `{operation_id}` already completed"
             ))),
-            StepStatus::OutcomeReady(staged) => {
-                if staged != output {
-                    return Err(Error::InvalidState(format!(
-                        "step `{step_id}` in operation `{operation_id}` changed its staged outcome"
-                    )));
-                }
-                self.apply(Transition::StepCompleted {
-                    operation_id,
-                    step_id,
-                    output,
-                })
-                .await
-            }
             StepStatus::EffectPending => {
-                self.apply(Transition::StepOutcomeReady {
-                    operation_id: operation_id.clone(),
-                    step_id: step_id.clone(),
-                    output: output.clone(),
-                })
-                .await?;
                 self.apply(Transition::StepCompleted {
                     operation_id,
                     step_id,
@@ -951,9 +920,9 @@ impl Driver {
             Error::InvalidState("state revision exceeded the u64 range".to_owned())
         })?;
         let mut next = self.state.clone();
-        next.apply_transition(expected_revision, &entry)?;
+        next.apply_transition(expected_revision, entry)?;
         if let Some(limit) = self.terminal_receipt_limit {
-            next.retain_terminal_receipts(limit);
+            let _ = next.retain_terminal_receipts(limit);
         }
         self.persist(next).await
     }
@@ -968,7 +937,7 @@ impl Driver {
                 next.revision()
             )));
         }
-        let payload = next.checkpoint_payload(None)?;
+        let payload = next.checkpoint_payload()?;
         let revision = match self
             .store
             .replace(&self.state_id, &self.owner, self.state.revision(), &payload)
@@ -999,10 +968,8 @@ impl Driver {
         let Some(limit) = self.terminal_receipt_limit else {
             return Ok(());
         };
-        let before = self.state.checkpoint_payload(None)?;
         let mut next = self.state.clone();
-        next.retain_terminal_receipts(limit);
-        if next.checkpoint_payload(None)? == before {
+        if !next.retain_terminal_receipts(limit) {
             return Ok(());
         }
         let revision = self.state.revision().checked_add(1).ok_or_else(|| {

--- a/crates/nanocodex-durability/src/session.rs
+++ b/crates/nanocodex-durability/src/session.rs
@@ -76,6 +76,16 @@ pub enum BeginStep<O = EncodedPayload> {
     Unknown,
 }
 
+/// Authoritative result of reconciling an at-most-once step during explicit
+/// cancellation.
+#[derive(Clone, Debug)]
+pub enum ReconciledStep<O = EncodedPayload> {
+    /// The effect definitely did not start, so no output was invented.
+    NotStarted,
+    /// The exact durable output retained for the step.
+    Completed(O),
+}
+
 enum StoredAdmission {
     Accepted,
     Pending,
@@ -126,6 +136,50 @@ enum StoredBeginStep {
     Execute,
     Replay(EncodedPayload),
     Unknown,
+}
+
+enum StoredReconciledStep {
+    NotStarted,
+    Completed(EncodedPayload),
+}
+
+const STEP_HANDOFF_WAITING: u8 = 0;
+const STEP_HANDOFF_AUTHORIZED: u8 = 1;
+const STEP_HANDOFF_ABANDONED: u8 = 2;
+
+struct StepStartHandoff {
+    state: Arc<AtomicU8>,
+    resolved: bool,
+}
+
+impl StepStartHandoff {
+    fn new() -> Self {
+        Self {
+            state: Arc::new(AtomicU8::new(STEP_HANDOFF_WAITING)),
+            resolved: false,
+        }
+    }
+
+    fn shared(&self) -> Arc<AtomicU8> {
+        Arc::clone(&self.state)
+    }
+
+    fn authorize(&mut self) {
+        self.state.store(STEP_HANDOFF_AUTHORIZED, Ordering::Release);
+        self.resolved = true;
+    }
+
+    fn disarm(&mut self) {
+        self.resolved = true;
+    }
+}
+
+impl Drop for StepStartHandoff {
+    fn drop(&mut self) {
+        if !self.resolved {
+            self.state.store(STEP_HANDOFF_ABANDONED, Ordering::Release);
+        }
+    }
 }
 
 #[derive(Clone, Eq, PartialEq)]
@@ -182,6 +236,7 @@ enum Command {
         kind: String,
         input: EncodedPayload,
         retry: RetryPolicy,
+        handoff: Arc<AtomicU8>,
         result: oneshot::Sender<Result<StoredBeginStep>>,
     },
     CompleteStep {
@@ -190,6 +245,13 @@ enum Command {
         step_id: String,
         output: EncodedPayload,
         result: oneshot::Sender<Result<()>>,
+    },
+    ReconcileCancelledStep {
+        caller: Caller,
+        operation_id: String,
+        step_id: String,
+        unknown_output: EncodedPayload,
+        result: oneshot::Sender<Result<StoredReconciledStep>>,
     },
     Complete {
         caller: Caller,
@@ -241,6 +303,7 @@ struct Driver {
     active_agent_generation: Option<u64>,
     claimed: HashMap<String, Caller>,
     running: HashSet<String>,
+    step_start_handoffs: HashMap<(String, String), Arc<AtomicU8>>,
     poisoned: bool,
     commands: mpsc::Receiver<Command>,
     releases: mpsc::UnboundedReceiver<ReleaseSignal>,
@@ -326,6 +389,7 @@ impl Driver {
                         self.active_agent_generation = None;
                         self.claimed.clear();
                         self.running.clear();
+                        self.step_start_handoffs.clear();
                     }
                 }
                 Command::Admit {
@@ -407,8 +471,10 @@ impl Driver {
                     kind,
                     input,
                     retry,
+                    handoff,
                     result,
                 } => {
+                    let handoff_key = (operation_id.clone(), step_id.clone());
                     let outcome = match self.authorize(&caller) {
                         Ok(()) => {
                             self.begin_step(&caller, operation_id, step_id, kind, input, retry)
@@ -416,7 +482,12 @@ impl Driver {
                         }
                         Err(error) => Err(error),
                     };
+                    let started_never = retry == RetryPolicy::Never
+                        && matches!(&outcome, Ok(StoredBeginStep::Execute));
                     drop(result.send(outcome));
+                    if started_never {
+                        self.step_start_handoffs.insert(handoff_key, handoff);
+                    }
                 }
                 Command::CompleteStep {
                     caller,
@@ -425,10 +496,35 @@ impl Driver {
                     output,
                     result,
                 } => {
+                    let handoff_key = (operation_id.clone(), step_id.clone());
                     let outcome = match self.authorize(&caller) {
                         Ok(()) => {
                             self.complete_step(&caller, operation_id, step_id, output)
                                 .await
+                        }
+                        Err(error) => Err(error),
+                    };
+                    if outcome.is_ok() {
+                        self.step_start_handoffs.remove(&handoff_key);
+                    }
+                    drop(result.send(outcome));
+                }
+                Command::ReconcileCancelledStep {
+                    caller,
+                    operation_id,
+                    step_id,
+                    unknown_output,
+                    result,
+                } => {
+                    let outcome = match self.authorize(&caller) {
+                        Ok(()) => {
+                            self.reconcile_cancelled_step(
+                                &caller,
+                                operation_id,
+                                step_id,
+                                unknown_output,
+                            )
+                            .await
                         }
                         Err(error) => Err(error),
                     };
@@ -562,12 +658,25 @@ impl Driver {
                 }
                 Command::FenceCheckpointEffect { caller, result } => {
                     let outcome = match self.authorize(&caller) {
+                        Ok(()) if self.state.checkpoint_effect_pending() => {
+                            Err(Error::InvalidState(
+                                "standalone checkpoint provider outcome is unknown after durable recovery; refusing to resubmit"
+                                    .to_owned(),
+                            ))
+                        }
                         Ok(()) => match self.state.first_pending_operation() {
+                            Some((pending_id, _))
+                                if pending_id.starts_with("standalone-compaction-") =>
+                            {
+                                Ok(())
+                            }
                             Some((pending_id, _)) => Err(Error::OperationBlocked {
                                 operation_id: "standalone-checkpoint".to_owned(),
                                 pending_id: pending_id.to_owned(),
                             }),
-                            None => self.apply(Transition::CheckpointEffectStarted).await,
+                            None => {
+                                Ok(())
+                            }
                         },
                         Err(error) => Err(error),
                     };
@@ -587,6 +696,7 @@ impl Driver {
                     self.active_agent_generation = None;
                     self.claimed.clear();
                     self.running.clear();
+                    self.step_start_handoffs.clear();
                 }
                 release.state.finish();
             }
@@ -601,6 +711,7 @@ impl Driver {
                     .retain(|_, caller| caller != &Caller::Direct(caller_id.clone()));
                 for operation_id in released {
                     self.running.remove(&operation_id);
+                    self.clear_step_start_handoffs(&operation_id);
                 }
             }
         }
@@ -644,6 +755,7 @@ impl Driver {
         self.state = state;
         self.claimed.clear();
         self.running.clear();
+        self.step_start_handoffs.clear();
         self.next_agent_generation = generation;
         self.active_agent_generation = Some(generation);
         Ok(AgentAcquisition {
@@ -832,6 +944,73 @@ impl Driver {
         }
     }
 
+    async fn reconcile_cancelled_step(
+        &mut self,
+        caller: &Caller,
+        operation_id: String,
+        step_id: String,
+        unknown_output: EncodedPayload,
+    ) -> Result<StoredReconciledStep> {
+        self.require_claimed(caller, &operation_id)?;
+        self.require_running(&operation_id)?;
+        let key = (operation_id.clone(), step_id.clone());
+        let Some((retry, status)) = self
+            .state
+            .operation(&operation_id)
+            .and_then(|operation| operation.steps.get(&step_id))
+            .map(|step| (step.retry, step.status.clone()))
+        else {
+            self.step_start_handoffs.remove(&key);
+            return Ok(StoredReconciledStep::NotStarted);
+        };
+        if retry != RetryPolicy::Never {
+            return Err(Error::InvalidState(format!(
+                "step `{step_id}` in operation `{operation_id}` is not an at-most-once effect"
+            )));
+        }
+        match status {
+            StepStatus::Completed(output) => {
+                self.step_start_handoffs.remove(&key);
+                Ok(StoredReconciledStep::Completed(output))
+            }
+            StepStatus::EffectPending => {
+                let handoff = self
+                    .step_start_handoffs
+                    .get(&key)
+                    .map_or(STEP_HANDOFF_AUTHORIZED, |handoff| {
+                        handoff.load(Ordering::Acquire)
+                    });
+                match handoff {
+                    STEP_HANDOFF_ABANDONED => {
+                        self.apply(Transition::StepAbandoned {
+                            operation_id,
+                            step_id,
+                        })
+                        .await?;
+                        self.step_start_handoffs.remove(&key);
+                        Ok(StoredReconciledStep::NotStarted)
+                    }
+                    STEP_HANDOFF_AUTHORIZED => {
+                        self.apply(Transition::StepCompleted {
+                            operation_id,
+                            step_id,
+                            output: unknown_output.clone(),
+                        })
+                        .await?;
+                        self.step_start_handoffs.remove(&key);
+                        Ok(StoredReconciledStep::Completed(unknown_output))
+                    }
+                    STEP_HANDOFF_WAITING => Err(Error::InvalidState(format!(
+                        "step `{step_id}` in operation `{operation_id}` cancellation raced an unresolved execution handoff"
+                    ))),
+                    state => Err(Error::InvalidState(format!(
+                        "step `{step_id}` in operation `{operation_id}` has invalid execution handoff state {state}"
+                    ))),
+                }
+            }
+        }
+    }
+
     async fn complete(
         &mut self,
         caller: &Caller,
@@ -905,6 +1084,7 @@ impl Driver {
         self.require_claimed(caller, operation_id)?;
         self.claimed.remove(operation_id);
         self.running.remove(operation_id);
+        self.clear_step_start_handoffs(operation_id);
         Ok(())
     }
 
@@ -912,7 +1092,13 @@ impl Driver {
         if self.claimed.get(operation_id) == Some(caller) {
             self.claimed.remove(operation_id);
             self.running.remove(operation_id);
+            self.clear_step_start_handoffs(operation_id);
         }
+    }
+
+    fn clear_step_start_handoffs(&mut self, operation_id: &str) {
+        self.step_start_handoffs
+            .retain(|(candidate, _), _| candidate != operation_id);
     }
 
     async fn apply(&mut self, entry: Transition) -> Result<()> {
@@ -1114,6 +1300,7 @@ impl DurableSession {
             active_agent_generation: None,
             claimed: HashMap::new(),
             running: HashSet::new(),
+            step_start_handoffs: HashMap::new(),
             poisoned: false,
             commands: receiver,
             releases: release_receiver,
@@ -1392,6 +1579,7 @@ impl DurableSession {
         retry: RetryPolicy,
     ) -> Result<StoredBeginStep> {
         let (result, receiver) = oneshot::channel();
+        let mut handoff = StepStartHandoff::new();
         self.send(Command::BeginStep {
             caller: Caller::Direct(self.caller_id.clone()),
             operation_id,
@@ -1399,10 +1587,17 @@ impl DurableSession {
             kind,
             input,
             retry,
+            handoff: handoff.shared(),
             result,
         })
         .await?;
-        receive(receiver).await
+        let outcome = receive(receiver).await?;
+        if matches!(&outcome, StoredBeginStep::Execute) {
+            handoff.authorize();
+        } else {
+            handoff.disarm();
+        }
+        Ok(outcome)
     }
 
     /// Commits a step output for future replay.
@@ -1422,6 +1617,29 @@ impl DurableSession {
         })
         .await?;
         receive(receiver).await
+    }
+
+    /// Reconciles an at-most-once step for explicit cancellation and returns
+    /// the exact output selected by durable state.
+    pub async fn reconcile_cancelled_step<T: Serialize + ?Sized>(
+        &self,
+        operation_id: impl Into<String>,
+        step_id: impl Into<String>,
+        unknown_output: &T,
+    ) -> Result<ReconciledStep> {
+        let (result, receiver) = oneshot::channel();
+        self.send(Command::ReconcileCancelledStep {
+            caller: Caller::Direct(self.caller_id.clone()),
+            operation_id: operation_id.into(),
+            step_id: step_id.into(),
+            unknown_output: EncodedPayload::encode(unknown_output)?,
+            result,
+        })
+        .await?;
+        match receive(receiver).await? {
+            StoredReconciledStep::NotStarted => Ok(ReconciledStep::NotStarted),
+            StoredReconciledStep::Completed(output) => Ok(ReconciledStep::Completed(output)),
+        }
     }
 
     /// Atomically terminalizes an operation with its checkpoint and result.
@@ -1642,6 +1860,7 @@ impl DurableOwner {
         I: Serialize + ?Sized,
     {
         let (result, receiver) = oneshot::channel();
+        let mut handoff = StepStartHandoff::new();
         self.send(Command::BeginStep {
             caller: self.caller()?,
             operation_id,
@@ -1649,10 +1868,17 @@ impl DurableOwner {
             kind,
             input: EncodedPayload::encode(input)?,
             retry,
+            handoff: handoff.shared(),
             result,
         })
         .await?;
-        match receive(receiver).await? {
+        let outcome = receive(receiver).await?;
+        if matches!(&outcome, StoredBeginStep::Execute) {
+            handoff.authorize();
+        } else {
+            handoff.disarm();
+        }
+        match outcome {
             StoredBeginStep::Execute => Ok(BeginStep::Execute),
             StoredBeginStep::Replay(output) => Ok(BeginStep::Replay(output)),
             StoredBeginStep::Unknown => Ok(BeginStep::Unknown),
@@ -1675,6 +1901,27 @@ impl DurableOwner {
         })
         .await?;
         receive(receiver).await
+    }
+
+    pub(crate) async fn reconcile_cancelled_step<T: Serialize + ?Sized>(
+        &self,
+        operation_id: String,
+        step_id: String,
+        unknown_output: &T,
+    ) -> Result<ReconciledStep> {
+        let (result, receiver) = oneshot::channel();
+        self.send(Command::ReconcileCancelledStep {
+            caller: self.caller()?,
+            operation_id,
+            step_id,
+            unknown_output: EncodedPayload::encode(unknown_output)?,
+            result,
+        })
+        .await?;
+        match receive(receiver).await? {
+            StoredReconciledStep::NotStarted => Ok(ReconciledStep::NotStarted),
+            StoredReconciledStep::Completed(output) => Ok(ReconciledStep::Completed(output)),
+        }
     }
 
     pub(crate) async fn complete<C: Serialize + ?Sized, O: Serialize + ?Sized>(
@@ -2033,6 +2280,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rejected_step_completion_cannot_erase_an_unresolved_execution_handoff() {
+        let store = MemoryStore::new().unwrap();
+        let session = DurableSession::open(store, "rejected-step-completion-handoff")
+            .await
+            .unwrap();
+        let foreign = session.clone();
+        session.admit("turn-1", &"prompt").await.unwrap();
+        session.begin_attempt("turn-1").await.unwrap();
+
+        let mut handoff = StepStartHandoff::new();
+        let (result, receiver) = oneshot::channel();
+        session
+            .send(Command::BeginStep {
+                caller: Caller::Direct(session.caller_id.clone()),
+                operation_id: "turn-1".to_owned(),
+                step_id: "tool-1".to_owned(),
+                kind: "tool_call".to_owned(),
+                input: EncodedPayload::encode(&"effect").unwrap(),
+                retry: RetryPolicy::Never,
+                handoff: handoff.shared(),
+                result,
+            })
+            .await
+            .unwrap();
+        assert!(matches!(
+            receive(receiver).await,
+            Ok(StoredBeginStep::Execute)
+        ));
+
+        assert!(matches!(
+            foreign
+                .complete_step("turn-1", "tool-1", &"stale output")
+                .await,
+            Err(Error::OperationNotClaimed { .. })
+        ));
+        let error = session
+            .reconcile_cancelled_step("turn-1", "tool-1", &"unknown")
+            .await
+            .expect_err("a rejected caller must leave the unresolved handoff fenced");
+        assert!(error.to_string().contains("unresolved execution handoff"));
+        handoff.disarm();
+    }
+
+    #[tokio::test]
     async fn direct_mutation_cannot_bypass_a_live_model_owner() {
         let store = MemoryStore::new().unwrap();
         let session = DurableSession::open(store, "direct-owner-bypass")
@@ -2387,21 +2678,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn standalone_checkpoint_intent_survives_a_cold_reopen() {
+    async fn standalone_checkpoint_fence_is_read_only_across_a_cold_reopen() {
         let store = MemoryStore::new().unwrap();
         let session = DurableSession::open(store.clone(), "checkpoint-intent-reopen")
             .await
             .unwrap();
         let (owner, _) = session.acquire_agent().await.unwrap();
+        let revision = session.state().await.unwrap().revision();
         owner.fence_checkpoint_effect().await.unwrap();
-        assert!(session.state().await.unwrap().checkpoint_effect_pending());
+        assert_eq!(session.state().await.unwrap().revision(), revision);
+        assert!(!session.state().await.unwrap().checkpoint_effect_pending());
         owner.shutdown().await.unwrap();
         drop(session);
 
         let reopened = DurableSession::open(store, "checkpoint-intent-reopen")
             .await
             .unwrap();
-        assert!(reopened.state().await.unwrap().checkpoint_effect_pending());
+        assert!(!reopened.state().await.unwrap().checkpoint_effect_pending());
         let (owner, _) = reopened.acquire_agent().await.unwrap();
         owner.fence_checkpoint_effect().await.unwrap();
         owner.commit_checkpoint(&7_u32).await.unwrap();

--- a/crates/nanocodex-durability/src/session.rs
+++ b/crates/nanocodex-durability/src/session.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{
         Arc,
         atomic::{AtomicU8, AtomicUsize, Ordering},
@@ -10,13 +10,12 @@ use serde::{Serialize, de::DeserializeOwned};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::{
-    EncodedPayload, Entry, Error, JournalState, JournalStore, OperationStatus, OwnerId, OwnerToken,
-    Result, RetryPolicy, StepStatus, StoreError, StoredJournal, journal::RetainedCheckpoint,
+    DurableState, EncodedPayload, Error, OperationStatus, OwnerId, OwnerToken, Result, RetryPolicy,
+    StateStore, StepStatus, StoreError, StoredState, Transition, state::RetainedCheckpoint,
 };
 
 const COMMAND_CAPACITY: usize = 64;
 const RELEASE_BURST_LIMIT: usize = 32;
-const COMPACTION_BATCH_THRESHOLD: usize = 64;
 
 /// Result of submitting one idempotent operation.
 #[derive(Clone, Debug)]
@@ -71,6 +70,10 @@ pub enum BeginStep<O = EncodedPayload> {
     Execute,
     /// A prior attempt completed; use this stored output instead of executing.
     Replay(O),
+    /// A prior owner crossed an at-most-once effect boundary without retaining
+    /// its output. The caller must persist an explicit unknown result and must
+    /// not repeat the effect.
+    Unknown,
 }
 
 enum StoredAdmission {
@@ -122,6 +125,7 @@ impl StoredAdmission {
 enum StoredBeginStep {
     Execute,
     Replay(EncodedPayload),
+    Unknown,
 }
 
 #[derive(Clone, Eq, PartialEq)]
@@ -137,7 +141,7 @@ struct AgentAcquisition {
 
 enum Command {
     State {
-        result: oneshot::Sender<JournalState>,
+        result: oneshot::Sender<DurableState>,
     },
     LatestCheckpoint {
         result: oneshot::Sender<Option<EncodedPayload>>,
@@ -169,7 +173,7 @@ enum Command {
     BeginAttempt {
         caller: Caller,
         operation_id: String,
-        result: oneshot::Sender<Result<u32>>,
+        result: oneshot::Sender<Result<()>>,
     },
     BeginStep {
         caller: Caller,
@@ -204,7 +208,6 @@ enum Command {
     FailAttempt {
         caller: Caller,
         operation_id: String,
-        error: String,
         result: oneshot::Sender<Result<()>>,
     },
     Cancel {
@@ -213,7 +216,7 @@ enum Command {
         checkpoint: Option<EncodedPayload>,
         result: oneshot::Sender<Result<()>>,
     },
-    Compact {
+    PruneReceipts {
         caller: Caller,
         result: oneshot::Sender<Result<()>>,
     },
@@ -222,24 +225,22 @@ enum Command {
         checkpoint: EncodedPayload,
         result: oneshot::Sender<Result<()>>,
     },
-    AuthorizeModelEffect {
+    FenceCheckpointEffect {
         caller: Caller,
-        kind: String,
         result: oneshot::Sender<Result<()>>,
     },
 }
 
 struct Driver {
-    store: Box<dyn JournalStore>,
-    journal_id: Arc<str>,
-    state: JournalState,
-    retained_batches: usize,
+    store: Box<dyn StateStore>,
+    state_id: Arc<str>,
+    state: DurableState,
     terminal_receipt_limit: Option<usize>,
     owner: OwnerToken,
     next_agent_generation: u64,
     active_agent_generation: Option<u64>,
     claimed: HashMap<String, Caller>,
-    exact_retries: HashMap<String, Entry>,
+    running: HashSet<String>,
     poisoned: bool,
     commands: mpsc::Receiver<Command>,
     releases: mpsc::UnboundedReceiver<ReleaseSignal>,
@@ -324,6 +325,7 @@ impl Driver {
                     {
                         self.active_agent_generation = None;
                         self.claimed.clear();
+                        self.running.clear();
                     }
                 }
                 Command::Admit {
@@ -464,32 +466,12 @@ impl Driver {
                 Command::FailAttempt {
                     caller,
                     operation_id,
-                    error,
                     result,
                 } => {
                     let outcome = match self.authorize(&caller) {
                         Ok(()) => {
                             let outcome = match self.require_claimed(&caller, &operation_id) {
-                                Ok(()) => {
-                                    let entry = Entry::AttemptFailed {
-                                        operation_id: operation_id.clone(),
-                                        error,
-                                    };
-                                    match self.require_active_attempt(&operation_id).and_then(
-                                        |()| self.require_exact_retry(&operation_id, &entry),
-                                    ) {
-                                        Ok(()) => {
-                                            let outcome = self.append(entry.clone()).await;
-                                            self.track_terminal_attempt(
-                                                &operation_id,
-                                                entry,
-                                                &outcome,
-                                            );
-                                            outcome
-                                        }
-                                        Err(error) => Err(error),
-                                    }
-                                }
+                                Ok(()) => self.require_running(&operation_id),
                                 Err(error) => Err(error),
                             };
                             if finishing_attempt_releases_claim(&outcome) {
@@ -511,19 +493,31 @@ impl Driver {
                         Ok(()) => {
                             let outcome = match self.require_claimed(&caller, &operation_id) {
                                 Ok(()) => {
-                                    let proposed = Entry::OperationCancelled {
-                                        operation_id: operation_id.clone(),
-                                        checkpoint,
-                                    };
-                                    match self.terminal_retry_entry(&operation_id, proposed) {
-                                        Ok(entry) => {
-                                            let outcome = self.append_terminal(entry.clone()).await;
-                                            self.track_terminal_attempt(
-                                                &operation_id,
-                                                entry,
-                                                &outcome,
-                                            );
-                                            outcome
+                                    let admissible = match checkpoint.as_ref() {
+                                        Some(_) => self.require_running(&operation_id),
+                                        None if self.running.contains(&operation_id) => {
+                                            Err(Error::CancellationCheckpointRequired {
+                                                operation_id: operation_id.clone(),
+                                            })
+                                        }
+                                        None => Ok(()),
+                                    }
+                                    .and_then(|()| {
+                                        self.state
+                                            .operation(&operation_id)
+                                            .filter(|operation| !operation.status.is_terminal())
+                                            .ok_or_else(|| Error::OperationTerminal {
+                                                operation_id: operation_id.clone(),
+                                            })
+                                            .map(|_| ())
+                                    });
+                                    match admissible {
+                                        Ok(()) => {
+                                            self.apply_terminal(Transition::OperationCancelled {
+                                                operation_id: operation_id.clone(),
+                                                checkpoint,
+                                            })
+                                            .await
                                         }
                                         Err(error) => Err(error),
                                     }
@@ -539,9 +533,9 @@ impl Driver {
                     };
                     drop(result.send(outcome));
                 }
-                Command::Compact { caller, result } => {
+                Command::PruneReceipts { caller, result } => {
                     let outcome = match self.authorize(&caller) {
-                        Ok(()) => self.compact_retained(true).await,
+                        Ok(()) => self.prune_retained(true).await,
                         Err(error) => Err(error),
                     };
                     drop(result.send(outcome));
@@ -558,7 +552,7 @@ impl Driver {
                                 pending_id: pending_id.to_owned(),
                             }),
                             None => {
-                                self.append_terminal(Entry::CheckpointCommitted { checkpoint })
+                                self.apply_terminal(Transition::CheckpointCommitted { checkpoint })
                                     .await
                             }
                         },
@@ -566,22 +560,15 @@ impl Driver {
                     };
                     drop(result.send(outcome));
                 }
-                Command::AuthorizeModelEffect {
-                    caller,
-                    kind,
-                    result,
-                } => {
+                Command::FenceCheckpointEffect { caller, result } => {
                     let outcome = match self.authorize(&caller) {
-                        Ok(()) if kind == "compaction" => {
-                            match self.state.first_pending_operation() {
-                                Some((pending_id, _)) => Err(Error::OperationBlocked {
-                                    operation_id: "standalone-compaction".to_owned(),
-                                    pending_id: pending_id.to_owned(),
-                                }),
-                                None => self.append(Entry::ModelEffectStarted { kind }).await,
-                            }
-                        }
-                        Ok(()) => self.append(Entry::ModelEffectStarted { kind }).await,
+                        Ok(()) => match self.state.first_pending_operation() {
+                            Some((pending_id, _)) => Err(Error::OperationBlocked {
+                                operation_id: "standalone-checkpoint".to_owned(),
+                                pending_id: pending_id.to_owned(),
+                            }),
+                            None => self.apply(Transition::CheckpointEffectStarted).await,
+                        },
                         Err(error) => Err(error),
                     };
                     drop(result.send(outcome));
@@ -599,12 +586,22 @@ impl Driver {
                 if self.active_agent_generation == Some(release.generation) {
                     self.active_agent_generation = None;
                     self.claimed.clear();
+                    self.running.clear();
                 }
                 release.state.finish();
             }
             ReleaseSignal::Direct(caller_id) => {
+                let released = self
+                    .claimed
+                    .iter()
+                    .filter(|(_, caller)| *caller == &Caller::Direct(caller_id.clone()))
+                    .map(|(operation_id, _)| operation_id.clone())
+                    .collect::<Vec<_>>();
                 self.claimed
                     .retain(|_, caller| caller != &Caller::Direct(caller_id.clone()));
+                for operation_id in released {
+                    self.running.remove(&operation_id);
+                }
             }
         }
     }
@@ -619,11 +616,7 @@ impl Driver {
     }
 
     async fn acquire_agent(&mut self) -> Result<AgentAcquisition> {
-        let acquired = match self
-            .store
-            .acquire_owner(&self.journal_id, OwnerId::new())
-            .await
-        {
+        let acquired = match self.store.acquire(&self.state_id, OwnerId::new()).await {
             Ok(acquired) => acquired,
             Err(error @ StoreError::NotCommitted(_)) => return Err(error.into()),
             Err(error) => {
@@ -631,7 +624,7 @@ impl Driver {
                 return Err(error.into());
             }
         };
-        let state = match reduce(acquired.journal) {
+        let state = match reduce(acquired.state) {
             Ok(state) => state,
             Err(error) => {
                 self.poisoned = true;
@@ -642,7 +635,7 @@ impl Driver {
             Some(generation) => generation,
             None => {
                 self.poisoned = true;
-                return Err(Error::InvalidJournal(
+                return Err(Error::InvalidState(
                     "model-owner generation exceeded the u64 range".to_owned(),
                 ));
             }
@@ -650,7 +643,7 @@ impl Driver {
         self.owner = acquired.owner;
         self.state = state;
         self.claimed.clear();
-        self.exact_retries.clear();
+        self.running.clear();
         self.next_agent_generation = generation;
         self.active_agent_generation = Some(generation);
         Ok(AgentAcquisition {
@@ -672,27 +665,8 @@ impl Driver {
             if self.claimed.contains_key(&operation_id) {
                 return Err(Error::OperationActive { operation_id });
             }
-            if matches!(caller, Caller::Agent(_))
-                && let Some(entry @ Entry::AttemptFailed { .. }) =
-                    self.exact_retries.get(&operation_id).cloned()
-            {
-                self.append(entry).await?;
-                self.exact_retries.remove(&operation_id);
-            }
             let operation = self.state.operation(&operation_id).ok_or_else(|| {
-                Error::InvalidJournal(format!("operation `{operation_id}` disappeared"))
-            })?;
-            if matches!(operation.status, OperationStatus::Pending)
-                && operation.active_attempt
-                && !self.exact_retries.contains_key(&operation_id)
-            {
-                self.append(Entry::AttemptReleased {
-                    operation_id: operation_id.clone(),
-                })
-                .await?;
-            }
-            let operation = self.state.operation(&operation_id).ok_or_else(|| {
-                Error::InvalidJournal(format!("operation `{operation_id}` disappeared"))
+                Error::InvalidState(format!("operation `{operation_id}` disappeared"))
             })?;
             return match &operation.status {
                 OperationStatus::Pending => {
@@ -712,7 +686,7 @@ impl Driver {
                 OperationStatus::Cancelled { .. } => Ok(StoredAdmission::Cancelled),
             };
         }
-        self.append(Entry::OperationAccepted {
+        self.apply(Transition::OperationAccepted {
             operation_id: operation_id.clone(),
             input,
         })
@@ -752,7 +726,7 @@ impl Driver {
         Ok((candidate_operation_id, admission))
     }
 
-    async fn begin_attempt(&mut self, caller: &Caller, operation_id: String) -> Result<u32> {
+    async fn begin_attempt(&mut self, caller: &Caller, operation_id: String) -> Result<()> {
         self.require_claimed(caller, &operation_id)?;
         if let Some((pending_id, _)) = self.state.first_pending_operation()
             && pending_id != operation_id
@@ -763,25 +737,16 @@ impl Driver {
             });
         }
         let operation = self.state.operation(&operation_id).ok_or_else(|| {
-            Error::InvalidJournal(format!("operation `{operation_id}` was not accepted"))
+            Error::InvalidState(format!("operation `{operation_id}` was not accepted"))
         })?;
         if operation.status.is_terminal() {
             return Err(Error::OperationTerminal { operation_id });
         }
-        if self.exact_retries.contains_key(&operation_id) {
-            if !operation.active_attempt {
-                return Err(Error::AttemptNotStarted { operation_id });
-            }
-            return Ok(operation.attempts);
+        if self.running.contains(&operation_id) {
+            return Err(Error::AttemptActive { operation_id });
         }
-        self.append(Entry::AttemptStarted {
-            operation_id: operation_id.clone(),
-        })
-        .await?;
-        Ok(self
-            .state
-            .operation(&operation_id)
-            .map_or(0, |operation| operation.attempts))
+        self.running.insert(operation_id.clone());
+        Ok(())
     }
 
     async fn begin_step(
@@ -802,19 +767,14 @@ impl Driver {
                 pending_id: pending_id.to_owned(),
             });
         }
-        let operation = self.state.operation(&operation_id).ok_or_else(|| {
-            Error::InvalidJournal(format!("operation `{operation_id}` was not accepted"))
-        })?;
-        if !operation.active_attempt {
-            return Err(Error::AttemptNotStarted { operation_id });
-        }
+        self.require_running(&operation_id)?;
         if let Some(step) = self
             .state
             .operation(&operation_id)
             .and_then(|operation| operation.steps.get(&step_id))
         {
             if step.kind != kind || step.input != input || step.retry != retry {
-                return Err(Error::InvalidJournal(format!(
+                return Err(Error::InvalidState(format!(
                     "step `{step_id}` in operation `{operation_id}` changed definition"
                 )));
             }
@@ -822,24 +782,30 @@ impl Driver {
                 StepStatus::Completed(output) => {
                     return Ok(StoredBeginStep::Replay(output.clone()));
                 }
-                StepStatus::Started if retry == RetryPolicy::Never => {
-                    return Err(Error::AmbiguousStep {
+                StepStatus::OutcomeReady(output) => {
+                    let output = output.clone();
+                    self.apply(Transition::StepCompleted {
                         operation_id,
                         step_id,
-                    });
+                        output: output.clone(),
+                    })
+                    .await?;
+                    return Ok(StoredBeginStep::Replay(output));
                 }
-                StepStatus::Started => {}
+                StepStatus::EffectPending if retry == RetryPolicy::Never => {
+                    return Ok(StoredBeginStep::Unknown);
+                }
+                StepStatus::EffectPending => {}
             }
         }
-        let entry = Entry::StepStarted {
+        let entry = Transition::StepStarted {
             operation_id: operation_id.clone(),
             step_id,
             kind,
             input,
             retry,
         };
-        self.require_exact_retry(&operation_id, &entry)?;
-        self.append(entry).await?;
+        self.apply(entry).await?;
         Ok(StoredBeginStep::Execute)
     }
 
@@ -861,19 +827,40 @@ impl Driver {
                 step_id,
             });
         };
-        if matches!(step.status, StepStatus::Completed(_)) {
-            return Err(Error::InvalidJournal(format!(
+        let status = step.status.clone();
+        self.require_running(&operation_id)?;
+        match status {
+            StepStatus::Completed(_) => Err(Error::InvalidState(format!(
                 "step `{step_id}` in operation `{operation_id}` already completed"
-            )));
+            ))),
+            StepStatus::OutcomeReady(staged) => {
+                if staged != output {
+                    return Err(Error::InvalidState(format!(
+                        "step `{step_id}` in operation `{operation_id}` changed its staged outcome"
+                    )));
+                }
+                self.apply(Transition::StepCompleted {
+                    operation_id,
+                    step_id,
+                    output,
+                })
+                .await
+            }
+            StepStatus::EffectPending => {
+                self.apply(Transition::StepOutcomeReady {
+                    operation_id: operation_id.clone(),
+                    step_id: step_id.clone(),
+                    output: output.clone(),
+                })
+                .await?;
+                self.apply(Transition::StepCompleted {
+                    operation_id,
+                    step_id,
+                    output,
+                })
+                .await
+            }
         }
-        self.require_active_attempt(&operation_id)?;
-        let entry = Entry::StepCompleted {
-            operation_id: operation_id.clone(),
-            step_id,
-            output,
-        };
-        self.require_exact_retry(&operation_id, &entry)?;
-        self.append(entry).await
     }
 
     async fn complete(
@@ -884,15 +871,13 @@ impl Driver {
         output: EncodedPayload,
     ) -> Result<()> {
         self.require_claimed(caller, &operation_id)?;
-        self.require_active_attempt(&operation_id)?;
-        let proposed = Entry::OperationCompleted {
+        self.require_running(&operation_id)?;
+        let entry = Transition::OperationCompleted {
             operation_id: operation_id.clone(),
             checkpoint,
             output,
         };
-        let entry = self.terminal_retry_entry(&operation_id, proposed)?;
-        let outcome = self.append_terminal(entry.clone()).await;
-        self.track_terminal_attempt(&operation_id, entry, &outcome);
+        let outcome = self.apply_terminal(entry).await;
         if finishing_attempt_releases_claim(&outcome) {
             self.release_claim_if_owned(caller, &operation_id);
         }
@@ -907,15 +892,13 @@ impl Driver {
         error: String,
     ) -> Result<()> {
         self.require_claimed(caller, &operation_id)?;
-        self.require_active_attempt(&operation_id)?;
-        let proposed = Entry::OperationFailed {
+        self.require_running(&operation_id)?;
+        let entry = Transition::OperationFailed {
             operation_id: operation_id.clone(),
             checkpoint,
             error,
         };
-        let entry = self.terminal_retry_entry(&operation_id, proposed)?;
-        let outcome = self.append_terminal(entry.clone()).await;
-        self.track_terminal_attempt(&operation_id, entry, &outcome);
+        let outcome = self.apply_terminal(entry).await;
         if finishing_attempt_releases_claim(&outcome) {
             self.release_claim_if_owned(caller, &operation_id);
         }
@@ -932,60 +915,16 @@ impl Driver {
         }
     }
 
-    fn require_exact_retry(&self, operation_id: &str, entry: &Entry) -> Result<()> {
-        if let Some(expected) = self.exact_retries.get(operation_id)
-            && expected != entry
-        {
-            return Err(Error::InvalidJournal(format!(
-                "operation `{operation_id}` must retry its definitely uncommitted mutation exactly"
-            )));
-        }
-        Ok(())
-    }
-
-    fn terminal_retry_entry(&self, operation_id: &str, proposed: Entry) -> Result<Entry> {
-        let Some(expected) = self.exact_retries.get(operation_id) else {
-            return Ok(proposed);
-        };
-        let compatible = match (expected, &proposed) {
-            (
-                Entry::OperationCompleted {
-                    output: expected, ..
-                },
-                Entry::OperationCompleted {
-                    output: proposed, ..
-                },
-            ) => expected == proposed,
-            (
-                Entry::OperationFailed {
-                    error: expected, ..
-                },
-                Entry::OperationFailed {
-                    error: proposed, ..
-                },
-            ) => expected == proposed,
-            (Entry::OperationCancelled { .. }, Entry::OperationCancelled { .. }) => true,
-            _ => false,
-        };
-        if compatible {
-            Ok(expected.clone())
-        } else {
-            Err(Error::InvalidJournal(format!(
-                "operation `{operation_id}` must retry its definitely uncommitted terminal mutation exactly"
-            )))
-        }
-    }
-
-    fn require_active_attempt(&self, operation_id: &str) -> Result<()> {
+    fn require_running(&self, operation_id: &str) -> Result<()> {
         let operation = self.state.operation(operation_id).ok_or_else(|| {
-            Error::InvalidJournal(format!("operation `{operation_id}` was not accepted"))
+            Error::InvalidState(format!("operation `{operation_id}` was not accepted"))
         })?;
         if operation.status.is_terminal() {
             return Err(Error::OperationTerminal {
                 operation_id: operation_id.to_owned(),
             });
         }
-        if !operation.active_attempt {
+        if !self.running.contains(operation_id) {
             return Err(Error::AttemptNotStarted {
                 operation_id: operation_id.to_owned(),
             });
@@ -993,44 +932,46 @@ impl Driver {
         Ok(())
     }
 
-    fn track_terminal_attempt(&mut self, operation_id: &str, entry: Entry, outcome: &Result<()>) {
-        match outcome {
-            Err(Error::Store(StoreError::NotCommitted(_))) => {
-                self.exact_retries.insert(operation_id.to_owned(), entry);
-            }
-            Ok(()) => {
-                self.exact_retries.remove(operation_id);
-            }
-            Err(_) => {}
-        }
-    }
-
     fn release_claim(&mut self, caller: &Caller, operation_id: &str) -> Result<()> {
         self.require_claimed(caller, operation_id)?;
         self.claimed.remove(operation_id);
+        self.running.remove(operation_id);
         Ok(())
     }
 
     fn release_claim_if_owned(&mut self, caller: &Caller, operation_id: &str) {
         if self.claimed.get(operation_id) == Some(caller) {
             self.claimed.remove(operation_id);
+            self.running.remove(operation_id);
         }
     }
 
-    async fn append(&mut self, entry: Entry) -> Result<()> {
+    async fn apply(&mut self, entry: Transition) -> Result<()> {
         let expected_revision = self.state.revision().checked_add(1).ok_or_else(|| {
-            Error::InvalidJournal("journal revision exceeded the u64 range".to_owned())
+            Error::InvalidState("state revision exceeded the u64 range".to_owned())
         })?;
-        self.state.validate_batch(expected_revision, &entry)?;
-        let payload = serde_json::to_string(&entry)?;
+        let mut next = self.state.clone();
+        next.apply_transition(expected_revision, &entry)?;
+        if let Some(limit) = self.terminal_receipt_limit {
+            next.retain_terminal_receipts(limit);
+        }
+        self.persist(next).await
+    }
+
+    async fn persist(&mut self, next: DurableState) -> Result<()> {
+        let expected_revision = self.state.revision().checked_add(1).ok_or_else(|| {
+            Error::InvalidState("state revision exceeded the u64 range".to_owned())
+        })?;
+        if next.revision() != expected_revision {
+            return Err(Error::InvalidState(format!(
+                "next current state has revision {}, expected {expected_revision}",
+                next.revision()
+            )));
+        }
+        let payload = next.checkpoint_payload(None)?;
         let revision = match self
             .store
-            .append(
-                &self.journal_id,
-                &self.owner,
-                self.state.revision(),
-                &payload,
-            )
+            .replace(&self.state_id, &self.owner, self.state.revision(), &payload)
             .await
         {
             Ok(revision) => revision,
@@ -1042,59 +983,33 @@ impl Driver {
         };
         if revision != expected_revision {
             self.poisoned = true;
-            return Err(Error::InvalidJournal(format!(
-                "store returned revision {revision} after appending expected revision {expected_revision}"
+            return Err(Error::InvalidState(format!(
+                "store returned revision {revision} after replacing expected revision {expected_revision}"
             )));
         }
-        if let Err(error) = self.state.apply_batch(revision, &entry) {
-            self.poisoned = true;
-            return Err(error);
-        }
-        self.retained_batches = self.retained_batches.saturating_add(1);
+        self.state = next;
         Ok(())
     }
 
-    async fn append_terminal(&mut self, entry: Entry) -> Result<()> {
-        self.append(entry).await?;
-        if self.retained_batches < COMPACTION_BATCH_THRESHOLD {
-            return Ok(());
-        }
-        match self.compact_retained(false).await {
-            Err(Error::Store(StoreError::NotCommitted(_))) => Ok(()),
-            outcome => outcome,
-        }
+    async fn apply_terminal(&mut self, entry: Transition) -> Result<()> {
+        self.apply(entry).await
     }
 
-    async fn compact_retained(&mut self, explicit: bool) -> Result<()> {
-        if self.retained_batches == 0 || (!explicit && self.retained_batches == 1) {
+    async fn prune_retained(&mut self, _explicit: bool) -> Result<()> {
+        let Some(limit) = self.terminal_receipt_limit else {
+            return Ok(());
+        };
+        let before = self.state.checkpoint_payload(None)?;
+        let mut next = self.state.clone();
+        next.retain_terminal_receipts(limit);
+        if next.checkpoint_payload(None)? == before {
             return Ok(());
         }
-        let revision = self.state.revision();
-        let payload = self.state.checkpoint_payload(self.terminal_receipt_limit)?;
-        match self
-            .store
-            .compact(&self.journal_id, &self.owner, revision, &payload)
-            .await
-        {
-            Ok(compacted_revision) if compacted_revision == revision => {
-                if let Some(limit) = self.terminal_receipt_limit {
-                    self.state.retain_terminal_receipts(limit);
-                }
-                self.retained_batches = 1;
-                Ok(())
-            }
-            Ok(compacted_revision) => {
-                self.poisoned = true;
-                Err(Error::InvalidJournal(format!(
-                    "store compacted revision {compacted_revision} while retaining revision {revision}"
-                )))
-            }
-            Err(error @ StoreError::NotCommitted(_)) => Err(error.into()),
-            Err(error) => {
-                self.poisoned = true;
-                Err(error.into())
-            }
-        }
+        let revision = self.state.revision().checked_add(1).ok_or_else(|| {
+            Error::InvalidState("state revision exceeded the u64 range".to_owned())
+        })?;
+        next.advance_revision(revision)?;
+        self.persist(next).await
     }
 }
 
@@ -1105,47 +1020,37 @@ const fn finishing_attempt_releases_claim(outcome: &Result<()>) -> bool {
     )
 }
 
-fn reduce(stored: StoredJournal) -> Result<JournalState> {
-    let mut state = JournalState::default();
-    for batch in stored.batches {
-        match serde_json::from_str::<RetainedCheckpoint>(&batch.payload) {
-            Ok(RetainedCheckpoint {
-                nanocodex_journal_state,
-            }) if state.revision() == 0 => {
-                state = JournalState::from_checkpoint(batch.revision, nanocodex_journal_state)?;
-            }
-            Ok(_) => {
-                return Err(Error::InvalidJournal(
-                    "a compacted journal checkpoint must be the first retained batch".to_owned(),
-                ));
-            }
-            Err(_) => {
-                let entry = serde_json::from_str::<Entry>(&batch.payload).map_err(|source| {
-                    Error::Decode {
-                        revision: batch.revision,
-                        source,
-                    }
-                })?;
-                state.apply_replayed_batch(batch.revision, &entry)?;
-            }
-        }
+fn reduce(stored: StoredState) -> Result<DurableState> {
+    let Some(payload) = stored.payload else {
+        return if stored.revision == 0 {
+            Ok(DurableState::default())
+        } else {
+            Err(Error::InvalidState(format!(
+                "store reported revision {} without a payload",
+                stored.revision
+            )))
+        };
+    };
+    if stored.revision == 0 {
+        return Err(Error::InvalidState(
+            "store retained a payload at revision zero".to_owned(),
+        ));
     }
-    if state.revision() != stored.revision {
-        return Err(Error::InvalidJournal(format!(
-            "store reported revision {}, but batches reduce to {}",
-            stored.revision,
-            state.revision()
-        )));
-    }
-    Ok(state)
+    let RetainedCheckpoint {
+        nanocodex_durable_state,
+    } = serde_json::from_str(&payload).map_err(|source| Error::Decode {
+        revision: stored.revision,
+        source,
+    })?;
+    DurableState::from_checkpoint(stored.revision, nanocodex_durable_state)
 }
 
-/// Cheap command handle for an owned durable-journal driver.
+/// Cheap command handle for an owned durable-state driver.
 ///
-/// The spawned driver is the sole owner of the reduced journal state and all
+/// The spawned driver is the sole owner of the reduced state state and all
 /// live operation claims. Clones only enqueue commands and await typed replies.
 pub struct DurableSession {
-    journal_id: Arc<str>,
+    state_id: Arc<str>,
     commands: mpsc::Sender<Command>,
     releases: mpsc::UnboundedSender<ReleaseSignal>,
     caller_id: OwnerId,
@@ -1155,7 +1060,7 @@ pub struct DurableSession {
 impl Clone for DurableSession {
     fn clone(&self) -> Self {
         Self {
-            journal_id: Arc::clone(&self.journal_id),
+            state_id: Arc::clone(&self.state_id),
             commands: self.commands.clone(),
             releases: self.releases.clone(),
             caller_id: OwnerId::new(),
@@ -1176,11 +1081,11 @@ impl Drop for DurableSession {
 
 impl DurableSession {
     /// Loads and validates a durable session, then spawns its owning driver.
-    pub async fn open<S>(store: S, journal_id: impl Into<String>) -> Result<Self>
+    pub async fn open<S>(store: S, state_id: impl Into<String>) -> Result<Self>
     where
-        S: JournalStore + 'static,
+        S: StateStore + 'static,
     {
-        Self::open_inner(store, journal_id.into(), None).await
+        Self::open_inner(store, state_id.into(), None).await
     }
 
     /// Loads a durable session whose compacted checkpoint retains at most the
@@ -1191,22 +1096,22 @@ impl DurableSession {
     /// model checkpoint are always retained.
     pub async fn open_with_terminal_receipt_limit<S>(
         store: S,
-        journal_id: impl Into<String>,
+        state_id: impl Into<String>,
         limit: usize,
     ) -> Result<Self>
     where
-        S: JournalStore + 'static,
+        S: StateStore + 'static,
     {
-        Self::open_inner(store, journal_id.into(), Some(limit)).await
+        Self::open_inner(store, state_id.into(), Some(limit)).await
     }
 
-    /// Compacts the retained journal into one current-state checkpoint.
+    /// Removes old terminal replay receipts from the complete retained state.
     ///
-    /// This lets an embedding host reduce a large recovered journal before it
+    /// This lets an embedding host reduce a large recovered state before it
     /// allocates the model and tool runtime that will consume the checkpoint.
-    pub async fn compact(&self) -> Result<()> {
+    pub async fn prune_receipts(&self) -> Result<()> {
         let (result, receiver) = oneshot::channel();
-        self.send(Command::Compact {
+        self.send(Command::PruneReceipts {
             caller: Caller::Direct(self.caller_id.clone()),
             result,
         })
@@ -1216,40 +1121,38 @@ impl DurableSession {
 
     async fn open_inner<S>(
         mut store: S,
-        journal_id: String,
+        state_id: String,
         terminal_receipt_limit: Option<usize>,
     ) -> Result<Self>
     where
-        S: JournalStore + 'static,
+        S: StateStore + 'static,
     {
-        if journal_id.trim().is_empty() {
-            return Err(Error::InvalidJournal(
-                "journal identity must not be empty".to_owned(),
+        if state_id.trim().is_empty() {
+            return Err(Error::InvalidState(
+                "state identity must not be empty".to_owned(),
             ));
         }
-        let acquired = store.acquire_owner(&journal_id, OwnerId::new()).await?;
-        let retained_batches = acquired.journal.batches.len();
-        let state = reduce(acquired.journal)?;
-        let journal_id = Arc::<str>::from(journal_id);
+        let acquired = store.acquire(&state_id, OwnerId::new()).await?;
+        let state = reduce(acquired.state)?;
+        let state_id = Arc::<str>::from(state_id);
         let (commands, receiver) = mpsc::channel(COMMAND_CAPACITY);
         let (releases, release_receiver) = mpsc::unbounded_channel();
         spawn_driver(Driver {
             store: Box::new(store),
-            journal_id: Arc::clone(&journal_id),
+            state_id: Arc::clone(&state_id),
             state,
-            retained_batches,
             terminal_receipt_limit,
             owner: acquired.owner,
             next_agent_generation: 0,
             active_agent_generation: None,
             claimed: HashMap::new(),
-            exact_retries: HashMap::new(),
+            running: HashSet::new(),
             poisoned: false,
             commands: receiver,
             releases: release_receiver,
         })?;
         Ok(Self {
-            journal_id,
+            state_id,
             commands,
             releases,
             caller_id: OwnerId::new(),
@@ -1257,21 +1160,21 @@ impl DurableSession {
         })
     }
 
-    /// Stable host-store journal identity.
+    /// Stable host-store state identity.
     #[must_use]
-    pub fn journal_id(&self) -> &str {
-        &self.journal_id
+    pub fn state_id(&self) -> &str {
+        &self.state_id
     }
 
     /// Copies the current reduced state from the owning driver.
-    pub async fn state(&self) -> Result<JournalState> {
+    pub async fn state(&self) -> Result<DurableState> {
         let (result, receiver) = oneshot::channel();
         self.send(Command::State { result }).await?;
         receiver.await.map_err(|_| Error::DriverStopped)
     }
 
     /// Copies the latest terminal checkpoint from the owning driver without
-    /// cloning the rest of the reduced journal.
+    /// cloning the rest of the reduced state.
     pub async fn latest_checkpoint(&self) -> Result<Option<EncodedPayload>> {
         let (result, receiver) = oneshot::channel();
         self.send(Command::LatestCheckpoint { result }).await?;
@@ -1292,7 +1195,7 @@ impl DurableSession {
     }
 
     /// Durably accepts and claims an operation, retaining terminal payloads in
-    /// their encoded journal form.
+    /// their encoded state form.
     pub async fn admit<I>(&self, operation_id: impl Into<String>, input: &I) -> Result<Admission>
     where
         I: Serialize + ?Sized,
@@ -1320,7 +1223,7 @@ impl DurableSession {
     }
 
     /// Durably admits automatically identified work, retaining terminal
-    /// payloads in their encoded journal form.
+    /// payloads in their encoded state form.
     ///
     /// The candidate identity is used for new work. If the oldest unclaimed
     /// pending operation has identical input, that operation is reclaimed and
@@ -1427,7 +1330,7 @@ impl DurableSession {
         Ok(admission)
     }
 
-    /// Releases a live claim without changing durable journal state.
+    /// Releases a live claim without changing durable state state.
     pub async fn release(&self, operation_id: impl Into<String>) -> Result<()> {
         let (result, receiver) = oneshot::channel();
         self.send(Command::Release {
@@ -1443,8 +1346,8 @@ impl DurableSession {
         outcome
     }
 
-    /// Records that an accepted operation is beginning another attempt.
-    pub async fn begin_attempt(&self, operation_id: impl Into<String>) -> Result<u32> {
+    /// Claims an accepted operation for one live execution attempt.
+    pub async fn begin_attempt(&self, operation_id: impl Into<String>) -> Result<()> {
         let (result, receiver) = oneshot::channel();
         self.send(Command::BeginAttempt {
             caller: Caller::Direct(self.caller_id.clone()),
@@ -1456,7 +1359,7 @@ impl DurableSession {
     }
 
     /// Begins or replays one stable step, retaining replay output in its
-    /// encoded journal form.
+    /// encoded state form.
     pub async fn begin_step<I>(
         &self,
         operation_id: impl Into<String>,
@@ -1480,6 +1383,7 @@ impl DurableSession {
         {
             StoredBeginStep::Execute => Ok(BeginStep::Execute),
             StoredBeginStep::Replay(output) => Ok(BeginStep::Replay(output)),
+            StoredBeginStep::Unknown => Ok(BeginStep::Unknown),
         }
     }
 
@@ -1508,6 +1412,7 @@ impl DurableSession {
         {
             StoredBeginStep::Execute => Ok(BeginStep::Execute),
             StoredBeginStep::Replay(output) => Ok(BeginStep::Replay(output.decode()?)),
+            StoredBeginStep::Unknown => Ok(BeginStep::Unknown),
         }
     }
 
@@ -1598,17 +1503,20 @@ impl DurableSession {
         outcome
     }
 
-    /// Records a failed attempt while leaving the operation retryable.
+    /// Ends the live attempt while leaving the durable operation pending.
+    ///
+    /// The diagnostic is intentionally not persisted: attempts are live
+    /// scheduling state, while accepted input, effects, and terminals are the
+    /// durable protocol.
     pub async fn fail_attempt(
         &self,
         operation_id: impl Into<String>,
-        error: impl Into<String>,
+        _error: impl Into<String>,
     ) -> Result<()> {
         let (result, receiver) = oneshot::channel();
         self.send(Command::FailAttempt {
             caller: Caller::Direct(self.caller_id.clone()),
             operation_id: operation_id.into(),
-            error: error.into(),
             result,
         })
         .await?;
@@ -1620,6 +1528,9 @@ impl DurableSession {
     }
 
     /// Explicitly terminalizes an operation as cancelled.
+    ///
+    /// This is valid only before an attempt starts. Active Agent cancellation
+    /// commits its safe interrupted checkpoint through the execution policy.
     pub async fn cancel(&self, operation_id: impl Into<String>) -> Result<()> {
         let (result, receiver) = oneshot::channel();
         self.send(Command::Cancel {
@@ -1741,7 +1652,7 @@ impl DurableOwner {
         receive(receiver).await
     }
 
-    pub(crate) async fn begin_attempt(&self, operation_id: String) -> Result<u32> {
+    pub(crate) async fn begin_attempt(&self, operation_id: String) -> Result<()> {
         let (result, receiver) = oneshot::channel();
         self.send(Command::BeginAttempt {
             caller: self.caller()?,
@@ -1777,6 +1688,7 @@ impl DurableOwner {
         match receive(receiver).await? {
             StoredBeginStep::Execute => Ok(BeginStep::Execute),
             StoredBeginStep::Replay(output) => Ok(BeginStep::Replay(output)),
+            StoredBeginStep::Unknown => Ok(BeginStep::Unknown),
         }
     }
 
@@ -1834,12 +1746,11 @@ impl DurableOwner {
         receive(receiver).await
     }
 
-    pub(crate) async fn fail_attempt(&self, operation_id: String, error: String) -> Result<()> {
+    pub(crate) async fn fail_attempt(&self, operation_id: String, _error: String) -> Result<()> {
         let (result, receiver) = oneshot::channel();
         self.send(Command::FailAttempt {
             caller: self.caller()?,
             operation_id,
-            error,
             result,
         })
         .await?;
@@ -1876,11 +1787,10 @@ impl DurableOwner {
         receive(receiver).await
     }
 
-    pub(crate) async fn authorize_model_effect(&self, kind: &str) -> Result<()> {
+    pub(crate) async fn fence_checkpoint_effect(&self) -> Result<()> {
         let (result, receiver) = oneshot::channel();
-        self.send(Command::AuthorizeModelEffect {
+        self.send(Command::FenceCheckpointEffect {
             caller: self.caller()?,
-            kind: kind.to_owned(),
             result,
         })
         .await?;
@@ -1910,7 +1820,7 @@ impl DurableOwner {
             Err(OWNER_RELEASED) => return Ok(()),
             Err(OWNER_RELEASING) => {}
             Ok(_) | Err(_) => {
-                return Err(Error::InvalidJournal(
+                return Err(Error::InvalidState(
                     "durable owner entered an invalid release state".to_owned(),
                 ));
             }
@@ -2021,51 +1931,6 @@ mod tests {
 
     use super::*;
     use crate::MemoryStore;
-
-    #[derive(Clone)]
-    struct FailCompactionOnce {
-        inner: MemoryStore,
-        failed: Arc<std::sync::atomic::AtomicBool>,
-    }
-
-    impl JournalStore for FailCompactionOnce {
-        fn acquire_owner<'a>(
-            &'a mut self,
-            journal_id: &'a str,
-            owner_id: OwnerId,
-        ) -> crate::StoreFuture<'a, std::result::Result<crate::OwnedJournal, StoreError>> {
-            self.inner.acquire_owner(journal_id, owner_id)
-        }
-
-        fn append<'a>(
-            &'a mut self,
-            journal_id: &'a str,
-            owner: &'a OwnerToken,
-            expected_revision: u64,
-            payload: &'a str,
-        ) -> crate::StoreFuture<'a, std::result::Result<u64, StoreError>> {
-            self.inner
-                .append(journal_id, owner, expected_revision, payload)
-        }
-
-        fn compact<'a>(
-            &'a mut self,
-            journal_id: &'a str,
-            owner: &'a OwnerToken,
-            expected_revision: u64,
-            payload: &'a str,
-        ) -> crate::StoreFuture<'a, std::result::Result<u64, StoreError>> {
-            if !self.failed.swap(true, Ordering::SeqCst) {
-                return Box::pin(async {
-                    Err(StoreError::NotCommitted(
-                        "injected explicit compaction response loss".to_owned(),
-                    ))
-                });
-            }
-            self.inner
-                .compact(journal_id, owner, expected_revision, payload)
-        }
-    }
 
     #[cfg(not(target_family = "wasm"))]
     #[test]
@@ -2180,7 +2045,7 @@ mod tests {
             Err(Error::ModelOwnerFenced)
         ));
         assert!(matches!(
-            older.authorize_model_effect("compaction").await,
+            older.fence_checkpoint_effect().await,
             Err(Error::ModelOwnerFenced)
         ));
         assert_eq!(session.state().await.unwrap().revision(), revision);
@@ -2277,12 +2142,11 @@ mod tests {
         ));
         let state = session.state().await.unwrap();
         assert_eq!(state.revision(), revision);
-        assert!(state.operation("turn-1").unwrap().active_attempt);
         claimant.complete("turn-1", &1, &"done").await.unwrap();
     }
 
     #[tokio::test]
-    async fn owner_shutdown_observes_a_dead_journal_driver() {
+    async fn owner_shutdown_observes_a_dead_state_driver() {
         let (commands, receiver) = mpsc::channel(1);
         drop(receiver);
         let (releases, _release_receiver) = mpsc::unbounded_channel();
@@ -2326,6 +2190,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn queued_cancellation_cannot_publish_an_unexecuted_checkpoint() {
+        let store = MemoryStore::new().unwrap();
+        let session = DurableSession::open(store, "queued-cancel-checkpoint")
+            .await
+            .unwrap();
+        let (owner, _) = session.acquire_agent().await.unwrap();
+        owner
+            .admit_typed::<_, u32, String>("turn-1".to_owned(), &"one")
+            .await
+            .unwrap();
+        owner
+            .admit_typed::<_, u32, String>("turn-2".to_owned(), &"two")
+            .await
+            .unwrap();
+        owner.begin_attempt("turn-1".to_owned()).await.unwrap();
+        assert!(matches!(
+            owner.cancel("turn-2".to_owned(), Some(&99_u32)).await,
+            Err(Error::AttemptNotStarted { .. })
+        ));
+        owner
+            .cancel("turn-2".to_owned(), None::<&u32>)
+            .await
+            .unwrap();
+        owner
+            .complete("turn-1".to_owned(), &1_u32, &"done")
+            .await
+            .unwrap();
+        owner.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn terminal_boundary_compacts_the_prefix_without_rewinding_revision() {
         let store = MemoryStore::new().unwrap();
         let session = DurableSession::open(store.clone(), "bounded-prefix")
@@ -2351,12 +2246,11 @@ mod tests {
 
         let mut inspector = store.clone();
         let compacted = inspector
-            .acquire_owner("bounded-prefix", OwnerId::new())
+            .acquire("bounded-prefix", OwnerId::new())
             .await
             .unwrap();
-        assert_eq!(compacted.journal.revision, 66);
-        assert_eq!(compacted.journal.batches.len(), 1);
-        assert_eq!(compacted.journal.batches[0].revision, 66);
+        assert_eq!(compacted.state.revision, 44);
+        assert!(compacted.state.payload.is_some());
 
         let reopened = DurableSession::open(store, "bounded-prefix").await.unwrap();
         assert!(matches!(
@@ -2368,7 +2262,7 @@ mod tests {
                 output
             }) if output == "output-0"
         ));
-        assert_eq!(reopened.state().await.unwrap().revision(), 66);
+        assert_eq!(reopened.state().await.unwrap().revision(), 44);
     }
 
     #[tokio::test]
@@ -2418,14 +2312,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn explicit_zero_retention_compaction_propagates_not_committed_then_retries() {
-        let inner = MemoryStore::new().unwrap();
-        let store = FailCompactionOnce {
-            inner: inner.clone(),
-            failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-        };
+    async fn zero_retention_is_atomic_with_terminal_state() {
+        let store = MemoryStore::new().unwrap();
         let session =
-            DurableSession::open_with_terminal_receipt_limit(store, "explicit-zero-retention", 0)
+            DurableSession::open_with_terminal_receipt_limit(store.clone(), "zero-retention", 0)
                 .await
                 .unwrap();
         assert!(matches!(
@@ -2435,22 +2325,14 @@ mod tests {
         session.begin_attempt("turn-1").await.unwrap();
         session.complete("turn-1", &1_u32, &"done").await.unwrap();
 
-        assert!(matches!(
-            session.compact().await,
-            Err(Error::Store(StoreError::NotCommitted(message)))
-                if message == "injected explicit compaction response loss"
-        ));
-        assert!(session.state().await.unwrap().operation("turn-1").is_some());
-
-        session.compact().await.unwrap();
         assert!(session.state().await.unwrap().operation("turn-1").is_none());
-        let mut inspector = inner;
-        let compacted = inspector
-            .acquire_owner("explicit-zero-retention", OwnerId::new())
+        let mut inspector = store;
+        let retained = inspector
+            .acquire("zero-retention", OwnerId::new())
             .await
             .unwrap();
-        assert_eq!(compacted.journal.revision, 3);
-        assert_eq!(compacted.journal.batches.len(), 1);
+        assert_eq!(retained.state.revision, 2);
+        assert!(retained.state.payload.is_some());
     }
 
     #[tokio::test]
@@ -2465,7 +2347,7 @@ mod tests {
         ));
         session.begin_attempt("turn-1").await.unwrap();
         session.complete("turn-1", &1_u32, &"done").await.unwrap();
-        session.compact().await.unwrap();
+        session.prune_receipts().await.unwrap();
         drop(session);
 
         let reopened = DurableSession::open_with_terminal_receipt_limit(
@@ -2483,7 +2365,7 @@ mod tests {
                 .operation("turn-1")
                 .is_some()
         );
-        reopened.compact().await.unwrap();
+        reopened.prune_receipts().await.unwrap();
         assert!(
             reopened
                 .state()
@@ -2496,11 +2378,11 @@ mod tests {
 
         let mut inspector = store;
         let retained = inspector
-            .acquire_owner("rewrite-one-checkpoint", OwnerId::new())
+            .acquire("rewrite-one-checkpoint", OwnerId::new())
             .await
             .unwrap();
-        assert_eq!(retained.journal.revision, 3);
-        assert_eq!(retained.journal.batches.len(), 1);
+        assert_eq!(retained.state.revision, 3);
+        assert!(retained.state.payload.is_some());
     }
 
     #[tokio::test]
@@ -2535,5 +2417,28 @@ mod tests {
                 .unwrap(),
             2
         );
+    }
+
+    #[tokio::test]
+    async fn standalone_checkpoint_intent_survives_a_cold_reopen() {
+        let store = MemoryStore::new().unwrap();
+        let session = DurableSession::open(store.clone(), "checkpoint-intent-reopen")
+            .await
+            .unwrap();
+        let (owner, _) = session.acquire_agent().await.unwrap();
+        owner.fence_checkpoint_effect().await.unwrap();
+        assert!(session.state().await.unwrap().checkpoint_effect_pending());
+        owner.shutdown().await.unwrap();
+        drop(session);
+
+        let reopened = DurableSession::open(store, "checkpoint-intent-reopen")
+            .await
+            .unwrap();
+        assert!(reopened.state().await.unwrap().checkpoint_effect_pending());
+        let (owner, _) = reopened.acquire_agent().await.unwrap();
+        owner.fence_checkpoint_effect().await.unwrap();
+        owner.commit_checkpoint(&7_u32).await.unwrap();
+        assert!(!reopened.state().await.unwrap().checkpoint_effect_pending());
+        owner.shutdown().await.unwrap();
     }
 }

--- a/crates/nanocodex-durability/src/sqlite.rs
+++ b/crates/nanocodex-durability/src/sqlite.rs
@@ -2,22 +2,19 @@ use std::path::Path;
 
 use rusqlite::{Connection, OptionalExtension as _, TransactionBehavior, params};
 
-use crate::{
-    JournalStore, OwnedJournal, OwnerId, OwnerToken, StoreError, StoreFuture, StoredBatch,
-    StoredJournal,
-};
+use crate::{OwnedState, OwnerId, OwnerToken, StateStore, StoreError, StoreFuture, StoredState};
 
 // SQLite INTEGER revisions deliberately stop at the signed 64-bit SQL ceiling.
 // Owner fences use a textual encoding so the public u64 token remains lossless.
 const MAX_SQL_REVISION: u64 = i64::MAX as u64;
 
-/// SQLite-backed journal store.
+/// SQLite-backed state store.
 pub struct SqliteStore {
     connection: Connection,
 }
 
 impl SqliteStore {
-    /// Opens a SQLite database and initializes the current journal schema.
+    /// Opens a SQLite database and initializes the current state schema.
     pub fn open(path: impl AsRef<Path>) -> Result<Self, StoreError> {
         let connection = Connection::open(path).map_err(backend)?;
         Self::from_connection(connection)
@@ -28,34 +25,29 @@ impl SqliteStore {
         connection
             .execute_batch(
                 "PRAGMA foreign_keys = ON;
-                 CREATE TABLE IF NOT EXISTS nanocodex_journals (
-                   journal_id TEXT PRIMARY KEY,
-                   revision INTEGER NOT NULL CHECK (revision >= 0)
-                 );
-                 CREATE TABLE IF NOT EXISTS nanocodex_journal_batches (
-                   journal_id TEXT NOT NULL,
-                   revision INTEGER NOT NULL CHECK (revision > 0),
-                   payload TEXT NOT NULL,
-                   PRIMARY KEY (journal_id, revision),
-                   FOREIGN KEY (journal_id) REFERENCES nanocodex_journals(journal_id)
-                 );
-                 CREATE TABLE IF NOT EXISTS nanocodex_journal_owners (
-                   journal_id TEXT PRIMARY KEY,
+                 CREATE TABLE IF NOT EXISTS nanocodex_durable_owners (
+                   state_id TEXT PRIMARY KEY,
                    owner_id TEXT NOT NULL,
                    fence TEXT NOT NULL
+                 );
+                 CREATE TABLE IF NOT EXISTS nanocodex_durable_states (
+                   state_id TEXT PRIMARY KEY,
+                   revision INTEGER NOT NULL CHECK (revision > 0),
+                   payload TEXT NOT NULL
                  );",
             )
             .map_err(backend)?;
         validate_owner_schema(&connection)?;
+        validate_state_schema(&connection)?;
         Ok(Self { connection })
     }
 
-    fn acquire_owner_transactional(
+    fn acquire_transactional(
         &mut self,
-        journal_id: &str,
+        state_id: &str,
         owner_id: OwnerId,
         after_begin: impl FnOnce(),
-    ) -> Result<OwnedJournal, StoreError> {
+    ) -> Result<OwnedState, StoreError> {
         let transaction = self
             .connection
             .transaction_with_behavior(TransactionBehavior::Immediate)
@@ -63,8 +55,8 @@ impl SqliteStore {
         after_begin();
         let retained_fence = transaction
             .query_row(
-                "SELECT fence FROM nanocodex_journal_owners WHERE journal_id = ?1",
-                [journal_id],
+                "SELECT fence FROM nanocodex_durable_owners WHERE state_id = ?1",
+                [state_id],
                 |row| row.get::<_, String>(0),
             )
             .optional()
@@ -80,22 +72,22 @@ impl SqliteStore {
         };
         transaction
             .execute(
-                "INSERT INTO nanocodex_journal_owners (journal_id, owner_id, fence)
+                "INSERT INTO nanocodex_durable_owners (state_id, owner_id, fence)
                  VALUES (?1, ?2, ?3)
-                 ON CONFLICT (journal_id) DO UPDATE
+                 ON CONFLICT (state_id) DO UPDATE
                  SET owner_id = excluded.owner_id, fence = excluded.fence",
-                params![journal_id, owner_id.as_str(), fence.to_string()],
+                params![state_id, owner_id.as_str(), fence.to_string()],
             )
             .map_err(backend)?;
-        let journal = load_journal(&transaction, journal_id)?;
+        let state = load_state(&transaction, state_id)?;
         let owner = OwnerToken::new(owner_id, fence);
         transaction.commit().map_err(backend)?;
-        Ok(OwnedJournal { owner, journal })
+        Ok(OwnedState { owner, state })
     }
 
-    fn append_transactional(
+    fn replace_transactional(
         &mut self,
-        journal_id: &str,
+        state_id: &str,
         owner: &OwnerToken,
         expected_revision: u64,
         payload: &str,
@@ -108,35 +100,31 @@ impl SqliteStore {
         after_begin();
         let retained_owner = transaction
             .query_row(
-                "SELECT owner_id, fence FROM nanocodex_journal_owners WHERE journal_id = ?1",
-                [journal_id],
+                "SELECT owner_id, fence FROM nanocodex_durable_owners WHERE state_id = ?1",
+                [state_id],
                 |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
             )
             .optional()
             .map_err(backend)?;
-        let owns_journal = match retained_owner {
+        let owns_state = match retained_owner {
             Some((owner_id, fence)) => {
                 owner_id == owner.owner_id().as_str()
                     && parse_u64(&fence, "SQLite owner fence")? == owner.fence()
             }
             None => false,
         };
-        if !owns_journal {
+        if !owns_state {
             return Err(StoreError::Fenced);
         }
-        transaction
-            .execute(
-                "INSERT OR IGNORE INTO nanocodex_journals (journal_id, revision) VALUES (?1, 0)",
-                [journal_id],
-            )
-            .map_err(backend)?;
         let actual = transaction
             .query_row(
-                "SELECT revision FROM nanocodex_journals WHERE journal_id = ?1",
-                [journal_id],
+                "SELECT revision FROM nanocodex_durable_states WHERE state_id = ?1",
+                [state_id],
                 |row| row.get::<_, i64>(0),
             )
-            .map_err(backend)?;
+            .optional()
+            .map_err(backend)?
+            .unwrap_or(0);
         let actual = to_u64(actual)?;
         if actual != expected_revision {
             return Err(StoreError::Conflict {
@@ -150,15 +138,11 @@ impl SqliteStore {
         let sql_revision = sql_counter(revision, "SQLite durability revision overflow")?;
         transaction
             .execute(
-                "INSERT INTO nanocodex_journal_batches (journal_id, revision, payload)
-                 VALUES (?1, ?2, ?3)",
-                params![journal_id, sql_revision, payload],
-            )
-            .map_err(backend)?;
-        transaction
-            .execute(
-                "UPDATE nanocodex_journals SET revision = ?2 WHERE journal_id = ?1",
-                params![journal_id, sql_revision],
+                "INSERT INTO nanocodex_durable_states (state_id, revision, payload)
+                 VALUES (?1, ?2, ?3)
+                 ON CONFLICT (state_id) DO UPDATE
+                 SET revision = excluded.revision, payload = excluded.payload",
+                params![state_id, sql_revision, payload],
             )
             .map_err(backend)?;
         transaction.commit().map_err(backend)?;
@@ -166,32 +150,31 @@ impl SqliteStore {
     }
 }
 
-impl JournalStore for SqliteStore {
-    fn acquire_owner<'a>(
+impl StateStore for SqliteStore {
+    fn acquire<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner_id: OwnerId,
-    ) -> StoreFuture<'a, Result<OwnedJournal, StoreError>> {
-        let result = self.acquire_owner_transactional(journal_id, owner_id, || {});
+    ) -> StoreFuture<'a, Result<OwnedState, StoreError>> {
+        let result = self.acquire_transactional(state_id, owner_id, || {});
         Box::pin(async move { result })
     }
 
-    fn append<'a>(
+    fn replace<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner: &'a OwnerToken,
         expected_revision: u64,
         payload: &'a str,
     ) -> StoreFuture<'a, Result<u64, StoreError>> {
-        let result =
-            self.append_transactional(journal_id, owner, expected_revision, payload, || {});
+        let result = self.replace_transactional(state_id, owner, expected_revision, payload, || {});
         Box::pin(async move { result })
     }
 }
 
 fn validate_owner_schema(connection: &Connection) -> Result<(), StoreError> {
     let mut statement = connection
-        .prepare("PRAGMA table_info('nanocodex_journal_owners')")
+        .prepare("PRAGMA table_info('nanocodex_durable_owners')")
         .map_err(backend)?;
     let columns = statement
         .query_map([], |row| {
@@ -206,10 +189,17 @@ fn validate_owner_schema(connection: &Connection) -> Result<(), StoreError> {
         .collect::<rusqlite::Result<Vec<_>>>()
         .map_err(backend)?;
     let expected = [
-        ("journal_id", "TEXT", false, 1),
+        ("state_id", "TEXT", false, 1),
         ("owner_id", "TEXT", true, 0),
         ("fence", "TEXT", true, 0),
     ];
+    if columns.len() != expected.len() {
+        return Err(incompatible_owner_schema(format!(
+            "expected exactly {} columns, found {}",
+            expected.len(),
+            columns.len()
+        )));
+    }
     for (name, declared_type, not_null, primary_key) in expected {
         let Some((_, actual_type, actual_not_null, actual_primary_key)) =
             columns.iter().find(|(actual_name, ..)| actual_name == name)
@@ -236,54 +226,91 @@ fn validate_owner_schema(connection: &Connection) -> Result<(), StoreError> {
     }
     if columns
         .iter()
-        .any(|(name, _, _, primary_key)| name != "journal_id" && *primary_key != 0)
+        .any(|(name, _, _, primary_key)| name != "state_id" && *primary_key != 0)
     {
         return Err(incompatible_owner_schema(
-            "the PRIMARY KEY must contain only `journal_id`".to_owned(),
+            "the PRIMARY KEY must contain only `state_id`".to_owned(),
         ));
+    }
+    Ok(())
+}
+
+fn validate_state_schema(connection: &Connection) -> Result<(), StoreError> {
+    let mut statement = connection
+        .prepare("PRAGMA table_info('nanocodex_durable_states')")
+        .map_err(backend)?;
+    let columns = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, bool>(3)?,
+                row.get::<_, i64>(5)?,
+            ))
+        })
+        .map_err(backend)?
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(backend)?;
+    let expected = [
+        ("state_id", "TEXT", false, 1),
+        ("revision", "INTEGER", true, 0),
+        ("payload", "TEXT", true, 0),
+    ];
+    if columns.len() != expected.len() {
+        return Err(incompatible_state_schema(format!(
+            "expected exactly {} columns, found {}",
+            expected.len(),
+            columns.len()
+        )));
+    }
+    for (name, declared_type, not_null, primary_key) in expected {
+        let Some((_, actual_type, actual_not_null, actual_primary_key)) =
+            columns.iter().find(|(actual_name, ..)| actual_name == name)
+        else {
+            return Err(incompatible_state_schema(format!(
+                "missing required `{name}` column"
+            )));
+        };
+        if !actual_type.eq_ignore_ascii_case(declared_type)
+            || (not_null && !actual_not_null)
+            || *actual_primary_key != primary_key
+        {
+            return Err(incompatible_state_schema(format!(
+                "`{name}` has an incompatible column shape"
+            )));
+        }
     }
     Ok(())
 }
 
 fn incompatible_owner_schema(detail: String) -> StoreError {
     StoreError::Backend(format!(
-        "incompatible SQLite `nanocodex_journal_owners` schema: {detail}; recreate the table with the current schema"
+        "incompatible SQLite `nanocodex_durable_owners` schema: {detail}; recreate the table with the current schema"
     ))
 }
 
-fn load_journal(connection: &Connection, journal_id: &str) -> Result<StoredJournal, StoreError> {
-    let revision = connection
+fn incompatible_state_schema(detail: String) -> StoreError {
+    StoreError::Backend(format!(
+        "incompatible SQLite `nanocodex_durable_states` schema: {detail}; recreate the table with the current schema"
+    ))
+}
+
+fn load_state(connection: &Connection, state_id: &str) -> Result<StoredState, StoreError> {
+    let retained = connection
         .query_row(
-            "SELECT revision FROM nanocodex_journals WHERE journal_id = ?1",
-            [journal_id],
-            |row| row.get::<_, i64>(0),
+            "SELECT revision, payload FROM nanocodex_durable_states WHERE state_id = ?1",
+            [state_id],
+            |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?)),
         )
         .optional()
-        .map_err(backend)?
-        .unwrap_or(0);
-    let revision = to_u64(revision)?;
-    let mut statement = connection
-        .prepare(
-            "SELECT revision, payload FROM nanocodex_journal_batches
-             WHERE journal_id = ?1 ORDER BY revision",
-        )
         .map_err(backend)?;
-    let batches = statement
-        .query_map([journal_id], |row| {
-            Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?))
-        })
-        .map_err(backend)?
-        .collect::<rusqlite::Result<Vec<_>>>()
-        .map_err(backend)?
-        .into_iter()
-        .map(|(revision, payload)| {
-            Ok(StoredBatch {
-                revision: to_u64(revision)?,
-                payload,
-            })
-        })
-        .collect::<Result<Vec<_>, StoreError>>()?;
-    Ok(StoredJournal { revision, batches })
+    match retained {
+        Some((revision, payload)) => Ok(StoredState {
+            revision: to_u64(revision)?,
+            payload: Some(payload),
+        }),
+        None => Ok(StoredState::default()),
+    }
 }
 
 fn backend(error: rusqlite::Error) -> StoreError {
@@ -321,15 +348,15 @@ mod tests {
         Connection::open(path)
             .unwrap()
             .query_row(
-                "SELECT owner_id, fence FROM nanocodex_journal_owners WHERE journal_id = 'journal'",
+                "SELECT owner_id, fence FROM nanocodex_durable_owners WHERE state_id = 'state'",
                 [],
                 |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .unwrap()
     }
 
-    fn retained_journal(path: &Path) -> StoredJournal {
-        load_journal(&Connection::open(path).unwrap(), "journal").unwrap()
+    fn retained_state(path: &Path) -> StoredState {
+        load_state(&Connection::open(path).unwrap(), "state").unwrap()
     }
 
     fn assert_contender_waits<T>(started: mpsc::Receiver<()>, handle: &thread::JoinHandle<T>) {
@@ -349,7 +376,22 @@ mod tests {
             Err(error) => error,
         };
         let message = error.to_string();
-        assert!(message.contains("incompatible SQLite `nanocodex_journal_owners` schema"));
+        assert!(message.contains("incompatible SQLite `nanocodex_durable_owners` schema"));
+        assert!(
+            message.contains(expected_detail),
+            "unexpected error: {message}"
+        );
+    }
+
+    fn assert_state_schema_error(create_state: &str, expected_detail: &str) {
+        let connection = Connection::open_in_memory().unwrap();
+        connection.execute_batch(create_state).unwrap();
+        let error = match SqliteStore::from_connection(connection) {
+            Ok(_) => panic!("incompatible state schema was accepted"),
+            Err(error) => error,
+        };
+        let message = error.to_string();
+        assert!(message.contains("incompatible SQLite `nanocodex_durable_states` schema"));
         assert!(
             message.contains(expected_detail),
             "unexpected error: {message}"
@@ -359,40 +401,73 @@ mod tests {
     #[test]
     fn initialization_rejects_malformed_preexisting_owner_tables() {
         assert_schema_error(
-            "CREATE TABLE nanocodex_journal_owners (journal_id TEXT PRIMARY KEY)",
-            "missing required `owner_id` column",
+            "CREATE TABLE nanocodex_durable_owners (state_id TEXT PRIMARY KEY)",
+            "expected exactly 3 columns",
         );
         assert_schema_error(
-            "CREATE TABLE nanocodex_journal_owners (
-               journal_id TEXT PRIMARY KEY,
+            "CREATE TABLE nanocodex_durable_owners (
+               state_id TEXT PRIMARY KEY,
                owner_id TEXT NOT NULL,
                fence INTEGER NOT NULL
              )",
             "`fence` must be declared TEXT",
         );
         assert_schema_error(
-            "CREATE TABLE nanocodex_journal_owners (
-               journal_id TEXT,
+            "CREATE TABLE nanocodex_durable_owners (
+               state_id TEXT,
                owner_id TEXT NOT NULL,
                fence TEXT NOT NULL
              )",
-            "`journal_id` has an incompatible PRIMARY KEY constraint",
+            "`state_id` has an incompatible PRIMARY KEY constraint",
         );
         assert_schema_error(
-            "CREATE TABLE nanocodex_journal_owners (
-               journal_id TEXT PRIMARY KEY,
+            "CREATE TABLE nanocodex_durable_owners (
+               state_id TEXT PRIMARY KEY,
                owner_id TEXT,
                fence TEXT NOT NULL
              )",
             "`owner_id` has an incompatible NOT NULL constraint",
         );
         assert_schema_error(
-            "CREATE TABLE nanocodex_journal_owners (
-               journal_id TEXT PRIMARY KEY,
+            "CREATE TABLE nanocodex_durable_owners (
+               state_id TEXT PRIMARY KEY,
                owner_id TEXT NOT NULL,
                fence TEXT
              )",
             "`fence` has an incompatible NOT NULL constraint",
+        );
+    }
+
+    #[test]
+    fn initialization_rejects_malformed_preexisting_state_tables() {
+        assert_state_schema_error(
+            "CREATE TABLE nanocodex_durable_states (state_id TEXT PRIMARY KEY)",
+            "expected exactly 3 columns",
+        );
+        assert_state_schema_error(
+            "CREATE TABLE nanocodex_durable_states (
+               state_id TEXT PRIMARY KEY,
+               revision TEXT NOT NULL,
+               payload TEXT NOT NULL
+             )",
+            "`revision` has an incompatible column shape",
+        );
+        assert_state_schema_error(
+            "CREATE TABLE nanocodex_durable_states (
+               state_id TEXT,
+               revision INTEGER NOT NULL,
+               payload TEXT NOT NULL
+             )",
+            "`state_id` has an incompatible column shape",
+        );
+        assert_state_schema_error(
+            "CREATE TABLE nanocodex_durable_states (
+               state_id TEXT PRIMARY KEY,
+               revision INTEGER NOT NULL,
+               payload TEXT,
+               extra TEXT
+             )",
+            "expected exactly 3 columns",
         );
     }
 
@@ -408,7 +483,7 @@ mod tests {
         let mut second_store = open_concurrent_store(&path);
         let first_id = first_owner;
         let first = thread::spawn(move || {
-            first_store.acquire_owner_transactional("journal", first_id, || {
+            first_store.acquire_transactional("state", first_id, || {
                 locked_tx.send(()).unwrap();
                 release_rx.recv().unwrap();
             })
@@ -419,7 +494,7 @@ mod tests {
         let second_id = second_owner.clone();
         let second = thread::spawn(move || {
             started_tx.send(()).unwrap();
-            second_store.acquire_owner_transactional("journal", second_id, || {})
+            second_store.acquire_transactional("state", second_id, || {})
         });
         assert_contender_waits(started_rx, &second);
         release_tx.send(()).unwrap();
@@ -432,22 +507,22 @@ mod tests {
             retained_owner(&path),
             (second_owner.as_str().to_owned(), "2".to_owned())
         );
-        assert_eq!(retained_journal(&path), StoredJournal::default());
+        assert_eq!(retained_state(&path), StoredState::default());
 
         let mut stale = open_concurrent_store(&path);
         assert_eq!(
-            stale.append_transactional("journal", &first.owner, 0, "stale", || {}),
+            stale.replace_transactional("state", &first.owner, 0, "stale", || {}),
             Err(StoreError::Fenced)
         );
     }
 
     #[test]
-    fn acquire_then_stale_append_is_fenced_before_revision_comparison() {
+    fn acquire_then_stale_replace_is_fenced_before_revision_comparison() {
         let file = tempfile::NamedTempFile::new().unwrap();
         let path = file.path().to_owned();
         let mut seeded = open_concurrent_store(&path);
         let old = seeded
-            .acquire_owner_transactional("journal", OwnerId::new(), || {})
+            .acquire_transactional("state", OwnerId::new(), || {})
             .unwrap();
         drop(seeded);
 
@@ -455,10 +530,10 @@ mod tests {
         let (locked_tx, locked_rx) = mpsc::channel();
         let (release_tx, release_rx) = mpsc::channel();
         let mut acquire_store = open_concurrent_store(&path);
-        let mut append_store = open_concurrent_store(&path);
+        let mut replace_store = open_concurrent_store(&path);
         let acquire_id = new_owner.clone();
         let acquire = thread::spawn(move || {
-            acquire_store.acquire_owner_transactional("journal", acquire_id, || {
+            acquire_store.acquire_transactional("state", acquire_id, || {
                 locked_tx.send(()).unwrap();
                 release_rx.recv().unwrap();
             })
@@ -467,40 +542,40 @@ mod tests {
 
         let (started_tx, started_rx) = mpsc::channel();
         let old_owner = old.owner;
-        let append = thread::spawn(move || {
+        let replace = thread::spawn(move || {
             started_tx.send(()).unwrap();
-            append_store.append_transactional("journal", &old_owner, 99, "stale", || {})
+            replace_store.replace_transactional("state", &old_owner, 99, "stale", || {})
         });
-        assert_contender_waits(started_rx, &append);
+        assert_contender_waits(started_rx, &replace);
         release_tx.send(()).unwrap();
 
         let acquired = acquire.join().unwrap().unwrap();
-        assert_eq!(append.join().unwrap(), Err(StoreError::Fenced));
+        assert_eq!(replace.join().unwrap(), Err(StoreError::Fenced));
         assert_eq!(acquired.owner.fence(), 2);
         assert_eq!(
             retained_owner(&path),
             (new_owner.as_str().to_owned(), "2".to_owned())
         );
-        assert_eq!(retained_journal(&path), StoredJournal::default());
+        assert_eq!(retained_state(&path), StoredState::default());
     }
 
     #[test]
-    fn append_then_acquire_commits_before_fencing_the_writer() {
+    fn replace_then_acquire_commits_before_fencing_the_writer() {
         let file = tempfile::NamedTempFile::new().unwrap();
         let path = file.path().to_owned();
         let mut seeded = open_concurrent_store(&path);
         let old = seeded
-            .acquire_owner_transactional("journal", OwnerId::new(), || {})
+            .acquire_transactional("state", OwnerId::new(), || {})
             .unwrap();
         drop(seeded);
 
         let (locked_tx, locked_rx) = mpsc::channel();
         let (release_tx, release_rx) = mpsc::channel();
-        let mut append_store = open_concurrent_store(&path);
+        let mut replace_store = open_concurrent_store(&path);
         let mut acquire_store = open_concurrent_store(&path);
         let old_owner = old.owner.clone();
-        let append = thread::spawn(move || {
-            append_store.append_transactional("journal", &old_owner, 0, "committed", || {
+        let replace = thread::spawn(move || {
+            replace_store.replace_transactional("state", &old_owner, 0, "committed", || {
                 locked_tx.send(()).unwrap();
                 release_rx.recv().unwrap();
             })
@@ -512,36 +587,36 @@ mod tests {
         let acquire_id = new_owner.clone();
         let acquire = thread::spawn(move || {
             started_tx.send(()).unwrap();
-            acquire_store.acquire_owner_transactional("journal", acquire_id, || {})
+            acquire_store.acquire_transactional("state", acquire_id, || {})
         });
         assert_contender_waits(started_rx, &acquire);
         release_tx.send(()).unwrap();
 
-        assert_eq!(append.join().unwrap(), Ok(1));
+        assert_eq!(replace.join().unwrap(), Ok(1));
         let acquired = acquire.join().unwrap().unwrap();
         assert_eq!(acquired.owner.fence(), 2);
-        assert_eq!(acquired.journal.revision, 1);
-        assert_eq!(acquired.journal.batches[0].payload, "committed");
+        assert_eq!(acquired.state.revision, 1);
+        assert_eq!(acquired.state.payload.as_deref(), Some("committed"));
         assert_eq!(
             retained_owner(&path),
             (new_owner.as_str().to_owned(), "2".to_owned())
         );
-        assert_eq!(retained_journal(&path), acquired.journal);
+        assert_eq!(retained_state(&path), acquired.state);
 
         let mut stale = open_concurrent_store(&path);
         assert_eq!(
-            stale.append_transactional("journal", &old.owner, 999, "stale", || {}),
+            stale.replace_transactional("state", &old.owner, 999, "stale", || {}),
             Err(StoreError::Fenced)
         );
     }
 
     #[test]
-    fn concurrent_same_revision_appends_commit_exactly_one_batch() {
+    fn concurrent_same_revision_replacements_commit_exactly_one_value() {
         let file = tempfile::NamedTempFile::new().unwrap();
         let path = file.path().to_owned();
         let mut seeded = open_concurrent_store(&path);
         let owned = seeded
-            .acquire_owner_transactional("journal", OwnerId::new(), || {})
+            .acquire_transactional("state", OwnerId::new(), || {})
             .unwrap();
         drop(seeded);
 
@@ -551,7 +626,7 @@ mod tests {
         let mut second_store = open_concurrent_store(&path);
         let first_owner = owned.owner.clone();
         let first = thread::spawn(move || {
-            first_store.append_transactional("journal", &first_owner, 0, "first", || {
+            first_store.replace_transactional("state", &first_owner, 0, "first", || {
                 locked_tx.send(()).unwrap();
                 release_rx.recv().unwrap();
             })
@@ -562,7 +637,7 @@ mod tests {
         let second_owner = owned.owner.clone();
         let second = thread::spawn(move || {
             started_tx.send(()).unwrap();
-            second_store.append_transactional("journal", &second_owner, 0, "second", || {})
+            second_store.replace_transactional("state", &second_owner, 0, "second", || {})
         });
         assert_contender_waits(started_rx, &second);
         release_tx.send(()).unwrap();
@@ -580,91 +655,73 @@ mod tests {
             (owned.owner.owner_id().as_str().to_owned(), "1".to_owned())
         );
         assert_eq!(
-            retained_journal(&path),
-            StoredJournal {
+            retained_state(&path),
+            StoredState {
                 revision: 1,
-                batches: vec![StoredBatch {
-                    revision: 1,
-                    payload: "first".to_owned(),
-                }],
+                payload: Some("first".to_owned()),
             }
         );
     }
 
     #[tokio::test]
-    async fn reopen_fences_stale_owner_and_preserves_legacy_batches() {
+    async fn old_journal_tables_are_ignored() {
         let file = tempfile::NamedTempFile::new().unwrap();
         let connection = Connection::open(file.path()).unwrap();
         connection
             .execute_batch(
                 "CREATE TABLE nanocodex_journals (
-                   journal_id TEXT PRIMARY KEY,
+                   state_id TEXT PRIMARY KEY,
                    revision INTEGER NOT NULL CHECK (revision >= 0)
                  );
                  CREATE TABLE nanocodex_journal_batches (
-                   journal_id TEXT NOT NULL,
+                   state_id TEXT NOT NULL,
                    revision INTEGER NOT NULL CHECK (revision > 0),
                    payload TEXT NOT NULL,
-                   PRIMARY KEY (journal_id, revision),
-                   FOREIGN KEY (journal_id) REFERENCES nanocodex_journals(journal_id)
+                   PRIMARY KEY (state_id, revision),
+                   FOREIGN KEY (state_id) REFERENCES nanocodex_journals(state_id)
                  );
-                 INSERT INTO nanocodex_journals VALUES ('journal', 1);
-                 INSERT INTO nanocodex_journal_batches VALUES ('journal', 1, 'legacy');",
+                 INSERT INTO nanocodex_journals VALUES ('state', 1);
+                 INSERT INTO nanocodex_journal_batches VALUES ('state', 1, 'retained');",
             )
             .unwrap();
         let mut first = SqliteStore::from_connection(connection).unwrap();
-        let first_owned = first
-            .acquire_owner("journal", OwnerId::new())
-            .await
-            .unwrap();
+        let first_owned = first.acquire("state", OwnerId::new()).await.unwrap();
         assert_eq!(first_owned.owner.fence(), 1);
-        assert_eq!(first_owned.journal.batches[0].payload, "legacy");
+        assert_eq!(first_owned.state, StoredState::default());
         drop(first);
 
         let mut second = SqliteStore::open(file.path()).unwrap();
-        let second_owned = second
-            .acquire_owner("journal", OwnerId::new())
-            .await
-            .unwrap();
+        let second_owned = second.acquire("state", OwnerId::new()).await.unwrap();
         assert_eq!(second_owned.owner.fence(), 2);
         assert_eq!(
             second
-                .append("journal", &first_owned.owner, 0, "stale")
+                .replace("state", &first_owned.owner, 0, "stale")
                 .await,
             Err(StoreError::Fenced)
         );
     }
 
     #[tokio::test]
-    async fn authority_survives_without_journal_content() {
+    async fn authority_survives_without_state_content() {
         let file = tempfile::NamedTempFile::new().unwrap();
         let mut store = SqliteStore::open(file.path()).unwrap();
-        let first = store
-            .acquire_owner("journal", OwnerId::new())
-            .await
-            .unwrap();
+        let first = store.acquire("state", OwnerId::new()).await.unwrap();
         store
-            .append("journal", &first.owner, 0, "content")
+            .replace("state", &first.owner, 0, "content")
             .await
             .unwrap();
         drop(store);
 
         let connection = Connection::open(file.path()).unwrap();
         connection
-            .execute("DELETE FROM nanocodex_journal_batches", [])
-            .unwrap();
-        connection
-            .execute("DELETE FROM nanocodex_journals", [])
+            .execute("DELETE FROM nanocodex_durable_states", [])
             .unwrap();
         drop(connection);
 
         let mut reopened = SqliteStore::open(file.path()).unwrap();
-        let acquired = reopened
-            .acquire_owner("journal", OwnerId::new())
-            .await
-            .unwrap();
+        let acquired = reopened.acquire("state", OwnerId::new()).await.unwrap();
         assert_eq!(acquired.owner.fence(), 2);
-        assert_eq!(acquired.journal, StoredJournal::default());
+        assert_eq!(acquired.state, StoredState::default());
     }
 
     #[tokio::test]
@@ -675,27 +732,27 @@ mod tests {
         store
             .connection
             .execute(
-                "INSERT INTO nanocodex_journal_owners (journal_id, owner_id, fence)
+                "INSERT INTO nanocodex_durable_owners (state_id, owner_id, fence)
                  VALUES (?1, ?2, ?3)",
-                params!["journal", prior_owner.as_str(), (u64::MAX - 1).to_string()],
+                params!["state", prior_owner.as_str(), (u64::MAX - 1).to_string()],
             )
             .unwrap();
 
         let installed_owner = OwnerId::new();
         let installed = store
-            .acquire_owner("journal", installed_owner.clone())
+            .acquire("state", installed_owner.clone())
             .await
             .unwrap();
         assert_eq!(installed.owner.fence(), u64::MAX);
         assert!(matches!(
-            store.acquire_owner("journal", OwnerId::new()).await,
+            store.acquire("state", OwnerId::new()).await,
             Err(StoreError::NotCommitted(_))
         ));
         let retained = store
             .connection
             .query_row(
-                "SELECT owner_id, fence FROM nanocodex_journal_owners WHERE journal_id = ?1",
-                ["journal"],
+                "SELECT owner_id, fence FROM nanocodex_durable_owners WHERE state_id = ?1",
+                ["state"],
                 |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
             )
             .unwrap();
@@ -709,21 +766,19 @@ mod tests {
     async fn revision_above_signed_64_bit_ceiling_is_not_committed() {
         let mut store =
             SqliteStore::from_connection(Connection::open_in_memory().unwrap()).unwrap();
-        let owned = store
-            .acquire_owner("journal", OwnerId::new())
-            .await
-            .unwrap();
+        let owned = store.acquire("state", OwnerId::new()).await.unwrap();
         store
             .connection
             .execute(
-                "INSERT INTO nanocodex_journals (journal_id, revision) VALUES (?1, ?2)",
-                params!["journal", i64::MAX],
+                "INSERT INTO nanocodex_durable_states (state_id, revision, payload)
+                 VALUES (?1, ?2, ?3)",
+                params!["state", i64::MAX, "retained"],
             )
             .unwrap();
 
         assert!(matches!(
             store
-                .append("journal", &owned.owner, MAX_SQL_REVISION, "overflow")
+                .replace("state", &owned.owner, MAX_SQL_REVISION, "overflow")
                 .await,
             Err(StoreError::NotCommitted(message))
                 if message == "SQLite durability revision overflow"
@@ -732,7 +787,7 @@ mod tests {
             store
                 .connection
                 .query_row(
-                    "SELECT revision FROM nanocodex_journals WHERE journal_id = 'journal'",
+                    "SELECT revision FROM nanocodex_durable_states WHERE state_id = 'state'",
                     [],
                     |row| row.get::<_, i64>(0),
                 )
@@ -740,15 +795,11 @@ mod tests {
             i64::MAX
         );
         assert_eq!(
-            store
-                .connection
-                .query_row(
-                    "SELECT count(*) FROM nanocodex_journal_batches",
-                    [],
-                    |row| { row.get::<_, i64>(0) }
-                )
-                .unwrap(),
-            0
+            load_state(&store.connection, "state")
+                .unwrap()
+                .payload
+                .as_deref(),
+            Some("retained")
         );
     }
 }

--- a/crates/nanocodex-durability/src/state.rs
+++ b/crates/nanocodex-durability/src/state.rs
@@ -85,16 +85,6 @@ pub enum Transition {
         /// Opaque typed output returned during replay.
         output: EncodedPayload,
     },
-    /// A step effect settled and its output is durable but has not yet crossed
-    /// the source-ordered materialization boundary.
-    StepOutcomeReady {
-        /// Accepted operation identity.
-        operation_id: String,
-        /// Stable step identity within the operation.
-        step_id: String,
-        /// Complete canonical effect output.
-        output: EncodedPayload,
-    },
     /// An operation completed and advanced the durable session checkpoint.
     OperationCompleted {
         /// Accepted operation identity.
@@ -177,9 +167,7 @@ impl OperationStatus {
 pub enum StepStatus {
     /// The intent committed and the external effect has an unknown outcome.
     EffectPending,
-    /// The external effect settled and its complete output is staged durably.
-    OutcomeReady(EncodedPayload),
-    /// The staged output crossed the operation's materialization boundary.
+    /// The external effect's exact output settled durably.
     Completed(EncodedPayload),
 }
 
@@ -236,6 +224,19 @@ pub(crate) struct RetainedCheckpoint {
     pub(crate) nanocodex_durable_state: DurableCheckpoint,
 }
 
+#[derive(serde::Serialize)]
+struct DurableCheckpointRef<'a> {
+    format: u8,
+    operations: &'a BTreeMap<String, OperationState>,
+    latest_checkpoint: Option<&'a EncodedPayload>,
+    checkpoint_effect_pending: bool,
+}
+
+#[derive(serde::Serialize)]
+struct RetainedCheckpointRef<'a> {
+    nanocodex_durable_state: DurableCheckpointRef<'a>,
+}
+
 impl DurableState {
     /// Current optimistic store revision.
     #[must_use]
@@ -269,9 +270,16 @@ impl DurableState {
     }
 
     pub(crate) fn first_pending_operation(&self) -> Option<(&str, &OperationState)> {
+        self.first_pending_operation_where(|_| true)
+    }
+
+    pub(crate) fn first_pending_operation_where(
+        &self,
+        mut predicate: impl FnMut(&str) -> bool,
+    ) -> Option<(&str, &OperationState)> {
         self.operations
             .iter()
-            .filter(|(_, operation)| !operation.status.is_terminal())
+            .filter(|(id, operation)| !operation.status.is_terminal() && predicate(id.as_str()))
             .min_by_key(|(_, operation)| operation.accepted_order)
             .map(|(id, operation)| (id.as_str(), operation))
     }
@@ -291,27 +299,22 @@ impl DurableState {
         self.checkpoint_effect_pending
     }
 
-    pub(crate) fn checkpoint_payload(
-        &self,
-        terminal_receipt_limit: Option<usize>,
-    ) -> Result<String> {
-        let mut operations = self.operations.clone();
-        if let Some(limit) = terminal_receipt_limit {
-            Self::retain_terminal_operations(&mut operations, limit);
-        }
-        serde_json::to_string(&RetainedCheckpoint {
-            nanocodex_durable_state: DurableCheckpoint {
+    pub(crate) fn checkpoint_payload(&self) -> Result<String> {
+        serde_json::to_string(&RetainedCheckpointRef {
+            nanocodex_durable_state: DurableCheckpointRef {
                 format: STATE_FORMAT,
-                operations,
-                latest_checkpoint: self.latest_checkpoint().cloned(),
+                operations: &self.operations,
+                latest_checkpoint: self.latest_checkpoint(),
                 checkpoint_effect_pending: self.checkpoint_effect_pending,
             },
         })
         .map_err(Error::InvalidPayload)
     }
 
-    pub(crate) fn retain_terminal_receipts(&mut self, limit: usize) {
+    pub(crate) fn retain_terminal_receipts(&mut self, limit: usize) -> bool {
+        let before = self.operations.len();
         Self::retain_terminal_operations(&mut self.operations, limit);
+        self.operations.len() != before
     }
 
     fn retain_terminal_operations(operations: &mut BTreeMap<String, OperationState>, limit: usize) {
@@ -420,8 +423,8 @@ impl DurableState {
         self.validate(entry)
     }
 
-    pub(crate) fn apply_transition(&mut self, revision: u64, entry: &Transition) -> Result<()> {
-        self.validate_transition(revision, entry)?;
+    pub(crate) fn apply_transition(&mut self, revision: u64, entry: Transition) -> Result<()> {
+        self.validate_transition(revision, &entry)?;
         self.apply(revision, entry)?;
         self.revision = revision;
         Ok(())
@@ -470,10 +473,7 @@ impl DurableState {
                             "step `{step_id}` in operation `{operation_id}` changed definition"
                         )));
                     }
-                    if matches!(
-                        step.status,
-                        StepStatus::OutcomeReady(_) | StepStatus::Completed(_)
-                    ) {
+                    if matches!(step.status, StepStatus::Completed(_)) {
                         return Err(Error::InvalidState(format!(
                             "settled step `{step_id}` in operation `{operation_id}` restarted"
                         )));
@@ -490,10 +490,10 @@ impl DurableState {
                     }
                 }
             }
-            Transition::StepOutcomeReady {
+            Transition::StepCompleted {
                 operation_id,
                 step_id,
-                ..
+                output: _,
             } => {
                 ensure_nonempty(step_id, "step ID")?;
                 self.ensure_prior_operations_terminal(operation_id)?;
@@ -503,35 +503,11 @@ impl DurableState {
                         "step `{step_id}` in operation `{operation_id}` completed before start"
                     ))
                 })?;
-                if !matches!(step.status, StepStatus::EffectPending) {
-                    return Err(Error::InvalidState(format!(
-                        "step `{step_id}` in operation `{operation_id}` produced more than one outcome"
-                    )));
-                }
-            }
-            Transition::StepCompleted {
-                operation_id,
-                step_id,
-                output,
-            } => {
-                ensure_nonempty(step_id, "step ID")?;
-                self.ensure_prior_operations_terminal(operation_id)?;
-                let operation = self.pending_operation(operation_id)?;
-                let step = operation.steps.get(step_id).ok_or_else(|| {
-                    Error::InvalidState(format!(
-                        "step `{step_id}` in operation `{operation_id}` materialized before start"
-                    ))
-                })?;
                 match &step.status {
-                    StepStatus::OutcomeReady(staged) if staged == output => {}
-                    StepStatus::OutcomeReady(_) => {
+                    StepStatus::EffectPending => {}
+                    StepStatus::Completed(_) => {
                         return Err(Error::InvalidState(format!(
-                            "step `{step_id}` in operation `{operation_id}` changed its staged outcome"
-                        )));
-                    }
-                    _ => {
-                        return Err(Error::InvalidState(format!(
-                            "step `{step_id}` in operation `{operation_id}` materialized before its outcome was ready"
+                            "step `{step_id}` in operation `{operation_id}` completed more than once"
                         )));
                     }
                 }
@@ -577,21 +553,16 @@ impl DurableState {
         Ok(())
     }
 
-    fn apply(&mut self, revision: u64, entry: &Transition) -> Result<()> {
+    fn apply(&mut self, revision: u64, entry: Transition) -> Result<()> {
         match entry {
             Transition::OperationAccepted {
                 operation_id,
                 input,
             } => {
-                if self.operations.contains_key(operation_id) {
-                    return Err(Error::InvalidState(format!(
-                        "operation `{operation_id}` was accepted more than once"
-                    )));
-                }
                 self.operations.insert(
-                    operation_id.clone(),
+                    operation_id,
                     OperationState {
-                        input: input.clone(),
+                        input,
                         status: OperationStatus::Pending,
                         steps: BTreeMap::new(),
                         accepted_order: revision,
@@ -605,21 +576,8 @@ impl DurableState {
                 input,
                 retry,
             } => {
-                let operation = self.pending_operation_mut(operation_id)?;
-                if let Some(step) = operation.steps.get_mut(step_id) {
-                    if step.kind != *kind || step.input != *input || step.retry != *retry {
-                        return Err(Error::InvalidState(format!(
-                            "step `{step_id}` in operation `{operation_id}` changed definition"
-                        )));
-                    }
-                    if matches!(
-                        step.status,
-                        StepStatus::OutcomeReady(_) | StepStatus::Completed(_)
-                    ) {
-                        return Err(Error::InvalidState(format!(
-                            "settled step `{step_id}` in operation `{operation_id}` restarted"
-                        )));
-                    }
+                let operation = self.pending_operation_mut(&operation_id)?;
+                if let Some(step) = operation.steps.get_mut(&step_id) {
                     step.attempts = step.attempts.checked_add(1).ok_or_else(|| {
                         Error::InvalidState(format!(
                             "step `{step_id}` in operation `{operation_id}` exceeded the attempt counter range"
@@ -627,103 +585,71 @@ impl DurableState {
                     })?;
                 } else {
                     operation.steps.insert(
-                        step_id.clone(),
+                        step_id,
                         StepState {
-                            kind: kind.clone(),
-                            input: input.clone(),
-                            retry: *retry,
+                            kind,
+                            input,
+                            retry,
                             status: StepStatus::EffectPending,
                             attempts: 1,
                         },
                     );
                 }
             }
-            Transition::StepOutcomeReady {
-                operation_id,
-                step_id,
-                output,
-            } => {
-                let operation = self.pending_operation_mut(operation_id)?;
-                let step = operation.steps.get_mut(step_id).ok_or_else(|| {
-                    Error::InvalidState(format!(
-                        "step `{step_id}` in operation `{operation_id}` completed before start"
-                    ))
-                })?;
-                if !matches!(step.status, StepStatus::EffectPending) {
-                    return Err(Error::InvalidState(format!(
-                        "step `{step_id}` in operation `{operation_id}` produced more than one outcome"
-                    )));
-                }
-                step.status = StepStatus::OutcomeReady(output.clone());
-            }
             Transition::StepCompleted {
                 operation_id,
                 step_id,
                 output,
             } => {
-                let operation = self.pending_operation_mut(operation_id)?;
-                let step = operation.steps.get_mut(step_id).ok_or_else(|| {
+                let operation = self.pending_operation_mut(&operation_id)?;
+                let step = operation.steps.get_mut(&step_id).ok_or_else(|| {
                     Error::InvalidState(format!(
-                        "step `{step_id}` in operation `{operation_id}` materialized before start"
+                        "step `{step_id}` in operation `{operation_id}` completed before start"
                     ))
                 })?;
-                match &step.status {
-                    StepStatus::OutcomeReady(staged) if staged == output => {
-                        step.status = StepStatus::Completed(output.clone());
-                    }
-                    _ => {
-                        return Err(Error::InvalidState(format!(
-                            "step `{step_id}` in operation `{operation_id}` materialized without its exact staged outcome"
-                        )));
-                    }
-                }
+                step.status = StepStatus::Completed(output);
             }
             Transition::OperationCompleted {
                 operation_id,
                 checkpoint,
                 output,
             } => {
-                self.ensure_prior_operations_terminal(operation_id)?;
-                let operation = self.pending_operation_mut(operation_id)?;
+                let operation = self.pending_operation_mut(&operation_id)?;
                 operation.status = OperationStatus::Completed {
                     checkpoint: checkpoint.clone(),
-                    output: output.clone(),
+                    output,
                 };
-                self.latest_checkpoint = Some((revision, checkpoint.clone()));
+                self.latest_checkpoint = Some((revision, checkpoint));
             }
             Transition::OperationFailed {
                 operation_id,
                 checkpoint,
                 error,
             } => {
-                self.ensure_prior_operations_terminal(operation_id)?;
-                let operation = self.pending_operation_mut(operation_id)?;
+                let operation = self.pending_operation_mut(&operation_id)?;
                 operation.status = OperationStatus::Failed {
                     checkpoint: checkpoint.clone(),
-                    error: error.clone(),
+                    error,
                 };
-                self.latest_checkpoint = Some((revision, checkpoint.clone()));
+                self.latest_checkpoint = Some((revision, checkpoint));
             }
             Transition::OperationCancelled {
                 operation_id,
                 checkpoint,
             } => {
-                if checkpoint.is_some() {
-                    self.ensure_prior_operations_terminal(operation_id)?;
-                }
-                let operation = self.pending_operation_mut(operation_id)?;
+                let operation = self.pending_operation_mut(&operation_id)?;
                 operation.status = OperationStatus::Cancelled {
                     checkpoint: checkpoint.clone(),
                 };
                 if let Some(checkpoint) = checkpoint {
-                    self.latest_checkpoint = Some((revision, checkpoint.clone()));
+                    self.latest_checkpoint = Some((revision, checkpoint));
                 }
             }
             Transition::CheckpointEffectStarted => {
                 self.checkpoint_effect_pending = true;
             }
             Transition::CheckpointCommitted { checkpoint } => {
-                self.latest_checkpoint = Some((revision, checkpoint.clone()));
+                self.latest_checkpoint = Some((revision, checkpoint));
                 self.checkpoint_effect_pending = false;
             }
         }
@@ -777,7 +703,6 @@ impl Transition {
             Self::OperationAccepted { operation_id, .. }
             | Self::StepStarted { operation_id, .. }
             | Self::StepCompleted { operation_id, .. }
-            | Self::StepOutcomeReady { operation_id, .. }
             | Self::OperationCompleted { operation_id, .. }
             | Self::OperationFailed { operation_id, .. }
             | Self::OperationCancelled { operation_id, .. } => Some(operation_id),

--- a/crates/nanocodex-durability/src/state.rs
+++ b/crates/nanocodex-durability/src/state.rs
@@ -1,35 +1,35 @@
 use std::collections::BTreeMap;
 
-use serde::{Serialize, de::DeserializeOwned};
-use serde_json::value::RawValue;
-
 use crate::{Error, Result};
+use serde::{Serialize, de::DeserializeOwned};
 
-/// A typed value erased only for storage in a heterogeneous journal.
+const STATE_FORMAT: u8 = 1;
+
+/// A typed value erased only for storage in a heterogeneous state.
 ///
 /// The wrapper preserves the original JSON representation. Consumers recover
-/// concrete Rust types with [`Self::decode`]; hosts treat the containing batch
+/// concrete Rust types with [`Self::decode`]; hosts treat the containing state
 /// as opaque bytes.
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[serde(transparent)]
-pub struct EncodedPayload(Box<RawValue>);
+pub struct EncodedPayload(String);
 
 impl EncodedPayload {
     pub(crate) fn encode<T: Serialize + ?Sized>(value: &T) -> Result<Self> {
-        serde_json::value::to_raw_value(value)
+        serde_json::to_string(value)
             .map(Self)
             .map_err(Error::InvalidPayload)
     }
 
     /// Decodes this payload into its expected concrete type.
     pub fn decode<T: DeserializeOwned>(&self) -> Result<T> {
-        serde_json::from_str(self.0.get()).map_err(Error::InvalidPayload)
+        serde_json::from_str(&self.0).map_err(Error::InvalidPayload)
     }
 
     /// Returns the exact retained JSON text.
     #[must_use]
     pub fn json(&self) -> &str {
-        self.0.get()
+        &self.0
     }
 }
 
@@ -52,35 +52,16 @@ pub enum RetryPolicy {
     Idempotent,
 }
 
-/// One Rust-owned durable journal entry.
+/// One Rust-owned durable state entry.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Entry {
-    /// The authoritative owner durably authorized a model-only external effect.
-    ///
-    /// This append is the effect-start linearization point. A later owner may
-    /// fence the stale result, but cannot retract a request that was already
-    /// authorized and entered the transport.
-    ModelEffectStarted {
-        /// Stable semantic effect kind used for recovery diagnostics.
-        kind: String,
-    },
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum Transition {
     /// A host-visible operation was durably accepted.
     OperationAccepted {
         /// Caller-provided idempotency identity.
         operation_id: String,
         /// Opaque typed input encoded by the Rust consumer.
         input: EncodedPayload,
-    },
-    /// A new execution attempt began for an accepted operation.
-    AttemptStarted {
-        /// Accepted operation identity.
-        operation_id: String,
-    },
-    /// A live attempt lost its claim before reaching a terminal mutation.
-    AttemptReleased {
-        /// Accepted operation identity.
-        operation_id: String,
     },
     /// A replayable step began.
     StepStarted {
@@ -104,12 +85,15 @@ pub enum Entry {
         /// Opaque typed output returned during replay.
         output: EncodedPayload,
     },
-    /// An execution attempt failed without terminalizing its operation.
-    AttemptFailed {
+    /// A step effect settled and its output is durable but has not yet crossed
+    /// the source-ordered materialization boundary.
+    StepOutcomeReady {
         /// Accepted operation identity.
         operation_id: String,
-        /// Stable diagnostic failure string.
-        error: String,
+        /// Stable step identity within the operation.
+        step_id: String,
+        /// Complete canonical effect output.
+        output: EncodedPayload,
     },
     /// An operation completed and advanced the durable session checkpoint.
     OperationCompleted {
@@ -138,6 +122,8 @@ pub enum Entry {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         checkpoint: Option<EncodedPayload>,
     },
+    /// A retry-safe standalone checkpoint effect crossed its store fence.
+    CheckpointEffectStarted,
     /// A model-only boundary, such as explicit standalone compaction, advanced
     /// the resumable session without terminalizing an operation.
     CheckpointCommitted {
@@ -148,7 +134,7 @@ pub enum Entry {
 
 /// Reduced status of one operation.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub enum OperationStatus {
     /// Accepted work may be attempted or resumed.
     Pending,
@@ -189,14 +175,17 @@ impl OperationStatus {
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StepStatus {
-    /// A start exists without a corresponding completion.
-    Started,
-    /// The step has a replayable output.
+    /// The intent committed and the external effect has an unknown outcome.
+    EffectPending,
+    /// The external effect settled and its complete output is staged durably.
+    OutcomeReady(EncodedPayload),
+    /// The staged output crossed the operation's materialization boundary.
     Completed(EncodedPayload),
 }
 
 /// Reduced durable step state.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct StepState {
     /// Semantic kind recorded by the caller.
     pub kind: String,
@@ -212,6 +201,7 @@ pub struct StepState {
 
 /// Reduced durable operation state.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct OperationState {
     /// Original opaque operation input.
     pub input: EncodedPayload,
@@ -219,36 +209,34 @@ pub struct OperationState {
     pub status: OperationStatus,
     /// Ordered durable steps by identity.
     pub steps: BTreeMap<String, StepState>,
-    /// Number of execution attempts.
-    pub attempts: u32,
-    /// Whether the latest begun attempt may still mutate this operation.
-    pub active_attempt: bool,
-    /// Most recent non-terminal failure, when any.
-    pub last_error: Option<String>,
     pub(crate) accepted_order: u64,
 }
 
-/// Complete state reduced from an append-only journal.
+/// Complete state reduced from an complete retained state.
 #[derive(Clone, Debug, Default)]
-pub struct JournalState {
+pub struct DurableState {
     revision: u64,
     operations: BTreeMap<String, OperationState>,
     latest_checkpoint: Option<(u64, EncodedPayload)>,
+    checkpoint_effect_pending: bool,
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]
-pub(crate) struct JournalCheckpoint {
-    version: u8,
+#[serde(deny_unknown_fields)]
+pub(crate) struct DurableCheckpoint {
+    format: u8,
     operations: BTreeMap<String, OperationState>,
     latest_checkpoint: Option<EncodedPayload>,
+    checkpoint_effect_pending: bool,
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct RetainedCheckpoint {
-    pub(crate) nanocodex_journal_state: JournalCheckpoint,
+    pub(crate) nanocodex_durable_state: DurableCheckpoint,
 }
 
-impl JournalState {
+impl DurableState {
     /// Current optimistic store revision.
     #[must_use]
     pub const fn revision(&self) -> u64 {
@@ -296,6 +284,13 @@ impl JournalState {
             .map(|(_, checkpoint)| checkpoint)
     }
 
+    /// Returns whether a retry-safe standalone checkpoint effect has committed
+    /// its intent but not its settlement.
+    #[must_use]
+    pub const fn checkpoint_effect_pending(&self) -> bool {
+        self.checkpoint_effect_pending
+    }
+
     pub(crate) fn checkpoint_payload(
         &self,
         terminal_receipt_limit: Option<usize>,
@@ -305,10 +300,11 @@ impl JournalState {
             Self::retain_terminal_operations(&mut operations, limit);
         }
         serde_json::to_string(&RetainedCheckpoint {
-            nanocodex_journal_state: JournalCheckpoint {
-                version: 1,
+            nanocodex_durable_state: DurableCheckpoint {
+                format: STATE_FORMAT,
                 operations,
                 latest_checkpoint: self.latest_checkpoint().cloned(),
+                checkpoint_effect_pending: self.checkpoint_effect_pending,
             },
         })
         .map_err(Error::InvalidPayload)
@@ -334,16 +330,16 @@ impl JournalState {
         });
     }
 
-    pub(crate) fn from_checkpoint(revision: u64, checkpoint: JournalCheckpoint) -> Result<Self> {
+    pub(crate) fn from_checkpoint(revision: u64, checkpoint: DurableCheckpoint) -> Result<Self> {
         if revision == 0 {
-            return Err(Error::InvalidJournal(
-                "a compacted journal checkpoint must have a positive revision".to_owned(),
+            return Err(Error::InvalidState(
+                "a compacted state checkpoint must have a positive revision".to_owned(),
             ));
         }
-        if checkpoint.version != 1 {
-            return Err(Error::InvalidJournal(format!(
-                "unsupported compacted journal checkpoint version {}",
-                checkpoint.version
+        if checkpoint.format != STATE_FORMAT {
+            return Err(Error::InvalidState(format!(
+                "unsupported state format {}",
+                checkpoint.format
             )));
         }
         let mut accepted_orders = std::collections::BTreeSet::new();
@@ -353,40 +349,70 @@ impl JournalState {
                 || operation.accepted_order > revision
                 || !accepted_orders.insert(operation.accepted_order)
             {
-                return Err(Error::InvalidJournal(format!(
+                return Err(Error::InvalidState(format!(
                     "operation `{operation_id}` has an invalid compacted acceptance order"
-                )));
-            }
-            if operation.status.is_terminal() && operation.active_attempt {
-                return Err(Error::InvalidJournal(format!(
-                    "terminal operation `{operation_id}` retained an active attempt"
                 )));
             }
             for (step_id, step) in &operation.steps {
                 ensure_nonempty(step_id, "step ID")?;
                 ensure_nonempty(&step.kind, "step kind")?;
                 if step.attempts == 0 {
-                    return Err(Error::InvalidJournal(format!(
+                    return Err(Error::InvalidState(format!(
                         "step `{step_id}` in operation `{operation_id}` has no committed start"
                     )));
                 }
+                if step.retry == RetryPolicy::Never && step.attempts != 1 {
+                    return Err(Error::InvalidState(format!(
+                        "at-most-once step `{step_id}` in operation `{operation_id}` has more than one committed start"
+                    )));
+                }
+            }
+            if matches!(
+                &operation.status,
+                OperationStatus::Cancelled { checkpoint: None }
+            ) && !operation.steps.is_empty()
+            {
+                return Err(Error::InvalidState(format!(
+                    "started operation `{operation_id}` was cancelled without a checkpoint"
+                )));
             }
         }
-        Ok(Self {
+        let state = Self {
             revision,
             operations: checkpoint.operations,
             latest_checkpoint: checkpoint
                 .latest_checkpoint
                 .map(|checkpoint| (revision, checkpoint)),
-        })
+            checkpoint_effect_pending: checkpoint.checkpoint_effect_pending,
+        };
+        if state.checkpoint_effect_pending
+            && let Some((pending_id, _)) = state.first_pending_operation()
+        {
+            return Err(Error::InvalidState(format!(
+                "standalone checkpoint effect crossed pending operation `{pending_id}`"
+            )));
+        }
+        for (operation_id, operation) in &state.operations {
+            if matches!(
+                &operation.status,
+                OperationStatus::Completed { .. }
+                    | OperationStatus::Failed { .. }
+                    | OperationStatus::Cancelled {
+                        checkpoint: Some(_)
+                    }
+            ) {
+                state.ensure_prior_operations_terminal(operation_id)?;
+            }
+        }
+        Ok(state)
     }
 
-    pub(crate) fn validate_batch(&self, revision: u64, entry: &Entry) -> Result<()> {
+    pub(crate) fn validate_transition(&self, revision: u64, entry: &Transition) -> Result<()> {
         let expected_revision = self.revision.checked_add(1).ok_or_else(|| {
-            Error::InvalidJournal("journal revision exceeded the u64 range".to_owned())
+            Error::InvalidState("state revision exceeded the u64 range".to_owned())
         })?;
         if revision != expected_revision {
-            return Err(Error::InvalidJournal(format!(
+            return Err(Error::InvalidState(format!(
                 "expected revision {}, found {revision}",
                 expected_revision
             )));
@@ -394,116 +420,40 @@ impl JournalState {
         self.validate(entry)
     }
 
-    pub(crate) fn apply_batch(&mut self, revision: u64, entry: &Entry) -> Result<()> {
-        self.validate_batch(revision, entry)?;
+    pub(crate) fn apply_transition(&mut self, revision: u64, entry: &Transition) -> Result<()> {
+        self.validate_transition(revision, entry)?;
         self.apply(revision, entry)?;
         self.revision = revision;
         Ok(())
     }
 
-    pub(crate) fn apply_replayed_batch(&mut self, revision: u64, entry: &Entry) -> Result<()> {
+    pub(crate) fn advance_revision(&mut self, revision: u64) -> Result<()> {
         let expected_revision = self.revision.checked_add(1).ok_or_else(|| {
-            Error::InvalidJournal("journal revision exceeded the u64 range".to_owned())
+            Error::InvalidState("state revision exceeded the u64 range".to_owned())
         })?;
         if revision != expected_revision {
-            return Err(Error::InvalidJournal(format!(
+            return Err(Error::InvalidState(format!(
                 "expected revision {}, found {revision}",
                 expected_revision
             )));
         }
-        self.validate_replayed(entry)?;
-        self.apply(revision, entry)?;
         self.revision = revision;
         Ok(())
     }
 
-    fn validate_replayed(&self, entry: &Entry) -> Result<()> {
+    fn validate(&self, entry: &Transition) -> Result<()> {
         if let Some(operation_id) = entry.operation_id() {
             ensure_nonempty(operation_id, "operation ID")?;
         }
         match entry {
-            Entry::AttemptStarted { operation_id } | Entry::AttemptFailed { operation_id, .. } => {
-                self.pending_operation(operation_id)?;
-            }
-            Entry::StepStarted {
-                operation_id,
-                step_id,
-                kind,
-                input,
-                retry,
-            } => {
-                ensure_nonempty(step_id, "step ID")?;
-                ensure_nonempty(kind, "step kind")?;
-                let operation = self.pending_operation(operation_id)?;
-                if let Some(step) = operation.steps.get(step_id) {
-                    if step.kind != *kind || step.input != *input || step.retry != *retry {
-                        return Err(Error::InvalidJournal(format!(
-                            "step `{step_id}` in operation `{operation_id}` changed definition"
-                        )));
-                    }
-                    if matches!(step.status, StepStatus::Completed(_)) {
-                        return Err(Error::InvalidJournal(format!(
-                            "completed step `{step_id}` in operation `{operation_id}` restarted"
-                        )));
-                    }
-                }
-            }
-            Entry::StepCompleted {
-                operation_id,
-                step_id,
-                ..
-            } => {
-                ensure_nonempty(step_id, "step ID")?;
-                let operation = self.pending_operation(operation_id)?;
-                let step = operation.steps.get(step_id).ok_or_else(|| {
-                    Error::InvalidJournal(format!(
-                        "step `{step_id}` in operation `{operation_id}` completed before start"
-                    ))
-                })?;
-                if matches!(step.status, StepStatus::Completed(_)) {
-                    return Err(Error::InvalidJournal(format!(
-                        "step `{step_id}` in operation `{operation_id}` completed more than once"
-                    )));
-                }
-            }
-            Entry::OperationCompleted { operation_id, .. }
-            | Entry::OperationFailed { operation_id, .. } => {
-                self.ensure_prior_operations_terminal(operation_id)?;
-                self.pending_operation(operation_id)?;
-            }
-            _ => return self.validate(entry),
-        }
-        Ok(())
-    }
-
-    fn validate(&self, entry: &Entry) -> Result<()> {
-        if let Some(operation_id) = entry.operation_id() {
-            ensure_nonempty(operation_id, "operation ID")?;
-        }
-        match entry {
-            Entry::OperationAccepted { operation_id, .. } => {
+            Transition::OperationAccepted { operation_id, .. } => {
                 if self.operations.contains_key(operation_id) {
-                    return Err(Error::InvalidJournal(format!(
+                    return Err(Error::InvalidState(format!(
                         "operation `{operation_id}` was accepted more than once"
                     )));
                 }
             }
-            Entry::AttemptStarted { operation_id } => {
-                self.ensure_prior_operations_terminal(operation_id)?;
-                let operation = self.pending_operation(operation_id)?;
-                if operation.active_attempt {
-                    return Err(Error::AttemptActive {
-                        operation_id: operation_id.clone(),
-                    });
-                }
-            }
-            Entry::AttemptReleased { operation_id } => {
-                self.active_attempt(operation_id)?;
-            }
-            Entry::AttemptFailed { operation_id, .. } => {
-                self.attempted_operation(operation_id)?;
-            }
-            Entry::StepStarted {
+            Transition::StepStarted {
                 operation_id,
                 step_id,
                 kind,
@@ -512,62 +462,124 @@ impl JournalState {
             } => {
                 ensure_nonempty(step_id, "step ID")?;
                 ensure_nonempty(kind, "step kind")?;
-                let operation = self.attempted_operation(operation_id)?;
+                self.ensure_prior_operations_terminal(operation_id)?;
+                let operation = self.pending_operation(operation_id)?;
                 if let Some(step) = operation.steps.get(step_id) {
                     if step.kind != *kind || step.input != *input || step.retry != *retry {
-                        return Err(Error::InvalidJournal(format!(
+                        return Err(Error::InvalidState(format!(
                             "step `{step_id}` in operation `{operation_id}` changed definition"
                         )));
                     }
-                    if matches!(step.status, StepStatus::Completed(_)) {
-                        return Err(Error::InvalidJournal(format!(
-                            "completed step `{step_id}` in operation `{operation_id}` restarted"
+                    if matches!(
+                        step.status,
+                        StepStatus::OutcomeReady(_) | StepStatus::Completed(_)
+                    ) {
+                        return Err(Error::InvalidState(format!(
+                            "settled step `{step_id}` in operation `{operation_id}` restarted"
+                        )));
+                    }
+                    if step.retry == RetryPolicy::Never {
+                        return Err(Error::InvalidState(format!(
+                            "at-most-once step `{step_id}` in operation `{operation_id}` restarted"
                         )));
                     }
                 }
             }
-            Entry::StepCompleted {
+            Transition::StepOutcomeReady {
                 operation_id,
                 step_id,
                 ..
             } => {
                 ensure_nonempty(step_id, "step ID")?;
-                let operation = self.attempted_operation(operation_id)?;
+                self.ensure_prior_operations_terminal(operation_id)?;
+                let operation = self.pending_operation(operation_id)?;
                 let step = operation.steps.get(step_id).ok_or_else(|| {
-                    Error::InvalidJournal(format!(
+                    Error::InvalidState(format!(
                         "step `{step_id}` in operation `{operation_id}` completed before start"
                     ))
                 })?;
-                if matches!(step.status, StepStatus::Completed(_)) {
-                    return Err(Error::InvalidJournal(format!(
-                        "step `{step_id}` in operation `{operation_id}` completed more than once"
+                if !matches!(step.status, StepStatus::EffectPending) {
+                    return Err(Error::InvalidState(format!(
+                        "step `{step_id}` in operation `{operation_id}` produced more than one outcome"
                     )));
                 }
             }
-            Entry::OperationCompleted { operation_id, .. }
-            | Entry::OperationFailed { operation_id, .. } => {
-                self.attempted_operation(operation_id)?;
-            }
-            Entry::OperationCancelled { operation_id, .. } => {
+            Transition::StepCompleted {
+                operation_id,
+                step_id,
+                output,
+            } => {
+                ensure_nonempty(step_id, "step ID")?;
+                self.ensure_prior_operations_terminal(operation_id)?;
                 let operation = self.pending_operation(operation_id)?;
-                if operation.attempts > 0 {
-                    self.ensure_prior_operations_terminal(operation_id)?;
+                let step = operation.steps.get(step_id).ok_or_else(|| {
+                    Error::InvalidState(format!(
+                        "step `{step_id}` in operation `{operation_id}` materialized before start"
+                    ))
+                })?;
+                match &step.status {
+                    StepStatus::OutcomeReady(staged) if staged == output => {}
+                    StepStatus::OutcomeReady(_) => {
+                        return Err(Error::InvalidState(format!(
+                            "step `{step_id}` in operation `{operation_id}` changed its staged outcome"
+                        )));
+                    }
+                    _ => {
+                        return Err(Error::InvalidState(format!(
+                            "step `{step_id}` in operation `{operation_id}` materialized before its outcome was ready"
+                        )));
+                    }
                 }
             }
-            Entry::ModelEffectStarted { kind } => ensure_nonempty(kind, "model effect kind")?,
-            Entry::CheckpointCommitted { .. } => {}
+            Transition::OperationCompleted { operation_id, .. } => {
+                self.ensure_prior_operations_terminal(operation_id)?;
+                let operation = self.pending_operation(operation_id)?;
+                if operation
+                    .steps
+                    .values()
+                    .any(|step| !matches!(step.status, StepStatus::Completed(_)))
+                {
+                    return Err(Error::InvalidState(format!(
+                        "operation `{operation_id}` completed with an unfinished step"
+                    )));
+                }
+            }
+            Transition::OperationFailed { operation_id, .. } => {
+                self.ensure_prior_operations_terminal(operation_id)?;
+                self.pending_operation(operation_id)?;
+            }
+            Transition::OperationCancelled {
+                operation_id,
+                checkpoint,
+            } => {
+                let operation = self.pending_operation(operation_id)?;
+                if checkpoint.is_some() {
+                    self.ensure_prior_operations_terminal(operation_id)?;
+                } else if !operation.steps.is_empty() {
+                    return Err(Error::InvalidState(format!(
+                        "started operation `{operation_id}` was cancelled without a checkpoint"
+                    )));
+                }
+            }
+            Transition::CheckpointEffectStarted | Transition::CheckpointCommitted { .. } => {
+                if let Some((pending_id, _)) = self.first_pending_operation() {
+                    return Err(Error::InvalidState(format!(
+                        "standalone checkpoint effect crossed pending operation `{pending_id}`"
+                    )));
+                }
+            }
         }
         Ok(())
     }
 
-    fn apply(&mut self, revision: u64, entry: &Entry) -> Result<()> {
+    fn apply(&mut self, revision: u64, entry: &Transition) -> Result<()> {
         match entry {
-            Entry::OperationAccepted {
+            Transition::OperationAccepted {
                 operation_id,
                 input,
             } => {
                 if self.operations.contains_key(operation_id) {
-                    return Err(Error::InvalidJournal(format!(
+                    return Err(Error::InvalidState(format!(
                         "operation `{operation_id}` was accepted more than once"
                     )));
                 }
@@ -577,23 +589,11 @@ impl JournalState {
                         input: input.clone(),
                         status: OperationStatus::Pending,
                         steps: BTreeMap::new(),
-                        attempts: 0,
-                        active_attempt: false,
-                        last_error: None,
                         accepted_order: revision,
                     },
                 );
             }
-            Entry::AttemptStarted { operation_id } => {
-                let operation = self.pending_operation_mut(operation_id)?;
-                operation.attempts = operation.attempts.saturating_add(1);
-                operation.active_attempt = true;
-                operation.last_error = None;
-            }
-            Entry::AttemptReleased { operation_id } => {
-                self.pending_operation_mut(operation_id)?.active_attempt = false;
-            }
-            Entry::StepStarted {
+            Transition::StepStarted {
                 operation_id,
                 step_id,
                 kind,
@@ -603,13 +603,16 @@ impl JournalState {
                 let operation = self.pending_operation_mut(operation_id)?;
                 if let Some(step) = operation.steps.get_mut(step_id) {
                     if step.kind != *kind || step.input != *input || step.retry != *retry {
-                        return Err(Error::InvalidJournal(format!(
+                        return Err(Error::InvalidState(format!(
                             "step `{step_id}` in operation `{operation_id}` changed definition"
                         )));
                     }
-                    if matches!(step.status, StepStatus::Completed(_)) {
-                        return Err(Error::InvalidJournal(format!(
-                            "completed step `{step_id}` in operation `{operation_id}` restarted"
+                    if matches!(
+                        step.status,
+                        StepStatus::OutcomeReady(_) | StepStatus::Completed(_)
+                    ) {
+                        return Err(Error::InvalidState(format!(
+                            "settled step `{step_id}` in operation `{operation_id}` restarted"
                         )));
                     }
                     step.attempts = step.attempts.saturating_add(1);
@@ -620,75 +623,86 @@ impl JournalState {
                             kind: kind.clone(),
                             input: input.clone(),
                             retry: *retry,
-                            status: StepStatus::Started,
+                            status: StepStatus::EffectPending,
                             attempts: 1,
                         },
                     );
                 }
             }
-            Entry::StepCompleted {
+            Transition::StepOutcomeReady {
                 operation_id,
                 step_id,
                 output,
             } => {
                 let operation = self.pending_operation_mut(operation_id)?;
                 let step = operation.steps.get_mut(step_id).ok_or_else(|| {
-                    Error::InvalidJournal(format!(
+                    Error::InvalidState(format!(
                         "step `{step_id}` in operation `{operation_id}` completed before start"
                     ))
                 })?;
-                if matches!(step.status, StepStatus::Completed(_)) {
-                    return Err(Error::InvalidJournal(format!(
-                        "step `{step_id}` in operation `{operation_id}` completed more than once"
+                if !matches!(step.status, StepStatus::EffectPending) {
+                    return Err(Error::InvalidState(format!(
+                        "step `{step_id}` in operation `{operation_id}` produced more than one outcome"
                     )));
                 }
-                step.status = StepStatus::Completed(output.clone());
+                step.status = StepStatus::OutcomeReady(output.clone());
             }
-            Entry::AttemptFailed {
+            Transition::StepCompleted {
                 operation_id,
-                error,
+                step_id,
+                output,
             } => {
                 let operation = self.pending_operation_mut(operation_id)?;
-                operation.active_attempt = false;
-                operation.last_error = Some(error.clone());
+                let step = operation.steps.get_mut(step_id).ok_or_else(|| {
+                    Error::InvalidState(format!(
+                        "step `{step_id}` in operation `{operation_id}` materialized before start"
+                    ))
+                })?;
+                match &step.status {
+                    StepStatus::OutcomeReady(staged) if staged == output => {
+                        step.status = StepStatus::Completed(output.clone());
+                    }
+                    _ => {
+                        return Err(Error::InvalidState(format!(
+                            "step `{step_id}` in operation `{operation_id}` materialized without its exact staged outcome"
+                        )));
+                    }
+                }
             }
-            Entry::OperationCompleted {
+            Transition::OperationCompleted {
                 operation_id,
                 checkpoint,
                 output,
             } => {
                 self.ensure_prior_operations_terminal(operation_id)?;
                 let operation = self.pending_operation_mut(operation_id)?;
-                operation.active_attempt = false;
                 operation.status = OperationStatus::Completed {
                     checkpoint: checkpoint.clone(),
                     output: output.clone(),
                 };
                 self.latest_checkpoint = Some((revision, checkpoint.clone()));
             }
-            Entry::OperationFailed {
+            Transition::OperationFailed {
                 operation_id,
                 checkpoint,
                 error,
             } => {
                 self.ensure_prior_operations_terminal(operation_id)?;
                 let operation = self.pending_operation_mut(operation_id)?;
-                operation.active_attempt = false;
                 operation.status = OperationStatus::Failed {
                     checkpoint: checkpoint.clone(),
                     error: error.clone(),
                 };
                 self.latest_checkpoint = Some((revision, checkpoint.clone()));
             }
-            Entry::OperationCancelled {
+            Transition::OperationCancelled {
                 operation_id,
                 checkpoint,
             } => {
-                if self.pending_operation(operation_id)?.attempts > 0 {
+                if checkpoint.is_some() {
                     self.ensure_prior_operations_terminal(operation_id)?;
                 }
                 let operation = self.pending_operation_mut(operation_id)?;
-                operation.active_attempt = false;
                 operation.status = OperationStatus::Cancelled {
                     checkpoint: checkpoint.clone(),
                 };
@@ -696,9 +710,12 @@ impl JournalState {
                     self.latest_checkpoint = Some((revision, checkpoint.clone()));
                 }
             }
-            Entry::ModelEffectStarted { .. } => {}
-            Entry::CheckpointCommitted { checkpoint } => {
+            Transition::CheckpointEffectStarted => {
+                self.checkpoint_effect_pending = true;
+            }
+            Transition::CheckpointCommitted { checkpoint } => {
                 self.latest_checkpoint = Some((revision, checkpoint.clone()));
+                self.checkpoint_effect_pending = false;
             }
         }
         Ok(())
@@ -706,10 +723,10 @@ impl JournalState {
 
     fn pending_operation_mut(&mut self, operation_id: &str) -> Result<&mut OperationState> {
         let operation = self.operations.get_mut(operation_id).ok_or_else(|| {
-            Error::InvalidJournal(format!("operation `{operation_id}` was not accepted"))
+            Error::InvalidState(format!("operation `{operation_id}` was not accepted"))
         })?;
         if operation.status.is_terminal() {
-            return Err(Error::InvalidJournal(format!(
+            return Err(Error::InvalidState(format!(
                 "terminal operation `{operation_id}` was changed"
             )));
         }
@@ -718,26 +735,11 @@ impl JournalState {
 
     fn pending_operation(&self, operation_id: &str) -> Result<&OperationState> {
         let operation = self.operations.get(operation_id).ok_or_else(|| {
-            Error::InvalidJournal(format!("operation `{operation_id}` was not accepted"))
+            Error::InvalidState(format!("operation `{operation_id}` was not accepted"))
         })?;
         if operation.status.is_terminal() {
-            return Err(Error::InvalidJournal(format!(
+            return Err(Error::InvalidState(format!(
                 "terminal operation `{operation_id}` was changed"
-            )));
-        }
-        Ok(operation)
-    }
-
-    fn attempted_operation(&self, operation_id: &str) -> Result<&OperationState> {
-        self.ensure_prior_operations_terminal(operation_id)?;
-        self.active_attempt(operation_id)
-    }
-
-    fn active_attempt(&self, operation_id: &str) -> Result<&OperationState> {
-        let operation = self.pending_operation(operation_id)?;
-        if !operation.active_attempt {
-            return Err(Error::InvalidJournal(format!(
-                "operation `{operation_id}` does not have an active attempt"
             )));
         }
         Ok(operation)
@@ -745,14 +747,14 @@ impl JournalState {
 
     fn ensure_prior_operations_terminal(&self, operation_id: &str) -> Result<()> {
         let operation = self.operations.get(operation_id).ok_or_else(|| {
-            Error::InvalidJournal(format!("operation `{operation_id}` was not accepted"))
+            Error::InvalidState(format!("operation `{operation_id}` was not accepted"))
         })?;
         if let Some((pending_id, _)) = self.operations.iter().find(|(id, candidate)| {
             candidate.accepted_order < operation.accepted_order
                 && !candidate.status.is_terminal()
                 && id.as_str() != operation_id
         }) {
-            return Err(Error::InvalidJournal(format!(
+            return Err(Error::InvalidState(format!(
                 "operation `{operation_id}` completed before `{pending_id}`"
             )));
         }
@@ -760,26 +762,24 @@ impl JournalState {
     }
 }
 
-impl Entry {
+impl Transition {
     fn operation_id(&self) -> Option<&str> {
         match self {
             Self::OperationAccepted { operation_id, .. }
-            | Self::AttemptStarted { operation_id }
-            | Self::AttemptReleased { operation_id }
             | Self::StepStarted { operation_id, .. }
             | Self::StepCompleted { operation_id, .. }
-            | Self::AttemptFailed { operation_id, .. }
+            | Self::StepOutcomeReady { operation_id, .. }
             | Self::OperationCompleted { operation_id, .. }
             | Self::OperationFailed { operation_id, .. }
             | Self::OperationCancelled { operation_id, .. } => Some(operation_id),
-            Self::ModelEffectStarted { .. } | Self::CheckpointCommitted { .. } => None,
+            Self::CheckpointEffectStarted | Self::CheckpointCommitted { .. } => None,
         }
     }
 }
 
 fn ensure_nonempty(value: &str, name: &str) -> Result<()> {
     if value.trim().is_empty() {
-        return Err(Error::InvalidJournal(format!("{name} must not be empty")));
+        return Err(Error::InvalidState(format!("{name} must not be empty")));
     }
     Ok(())
 }

--- a/crates/nanocodex-durability/src/state.rs
+++ b/crates/nanocodex-durability/src/state.rs
@@ -76,6 +76,14 @@ pub enum Transition {
         /// Recovery policy if completion is missing.
         retry: RetryPolicy,
     },
+    /// A newly started at-most-once step was not observed by its executor, so
+    /// its effect boundary is removed before any external dispatch can occur.
+    StepAbandoned {
+        /// Accepted operation identity.
+        operation_id: String,
+        /// Stable step identity within the operation.
+        step_id: String,
+    },
     /// A replayable step completed.
     StepCompleted {
         /// Accepted operation identity.
@@ -512,6 +520,27 @@ impl DurableState {
                     }
                 }
             }
+            Transition::StepAbandoned {
+                operation_id,
+                step_id,
+            } => {
+                ensure_nonempty(step_id, "step ID")?;
+                self.ensure_prior_operations_terminal(operation_id)?;
+                let operation = self.pending_operation(operation_id)?;
+                let step = operation.steps.get(step_id).ok_or_else(|| {
+                    Error::InvalidState(format!(
+                        "step `{step_id}` in operation `{operation_id}` was abandoned before start"
+                    ))
+                })?;
+                if step.retry != RetryPolicy::Never
+                    || !matches!(step.status, StepStatus::EffectPending)
+                    || step.attempts != 1
+                {
+                    return Err(Error::InvalidState(format!(
+                        "step `{step_id}` in operation `{operation_id}` cannot be abandoned after effect authorization"
+                    )));
+                }
+            }
             Transition::OperationCompleted { operation_id, .. } => {
                 self.ensure_prior_operations_terminal(operation_id)?;
                 let operation = self.pending_operation(operation_id)?;
@@ -609,6 +638,14 @@ impl DurableState {
                 })?;
                 step.status = StepStatus::Completed(output);
             }
+            Transition::StepAbandoned {
+                operation_id,
+                step_id,
+            } => {
+                self.pending_operation_mut(&operation_id)?
+                    .steps
+                    .remove(&step_id);
+            }
             Transition::OperationCompleted {
                 operation_id,
                 checkpoint,
@@ -702,6 +739,7 @@ impl Transition {
         match self {
             Self::OperationAccepted { operation_id, .. }
             | Self::StepStarted { operation_id, .. }
+            | Self::StepAbandoned { operation_id, .. }
             | Self::StepCompleted { operation_id, .. }
             | Self::OperationCompleted { operation_id, .. }
             | Self::OperationFailed { operation_id, .. }

--- a/crates/nanocodex-durability/src/state.rs
+++ b/crates/nanocodex-durability/src/state.rs
@@ -483,6 +483,11 @@ impl DurableState {
                             "at-most-once step `{step_id}` in operation `{operation_id}` restarted"
                         )));
                     }
+                    if step.attempts == u32::MAX {
+                        return Err(Error::InvalidState(format!(
+                            "step `{step_id}` in operation `{operation_id}` exceeded the attempt counter range"
+                        )));
+                    }
                 }
             }
             Transition::StepOutcomeReady {
@@ -615,7 +620,11 @@ impl DurableState {
                             "settled step `{step_id}` in operation `{operation_id}` restarted"
                         )));
                     }
-                    step.attempts = step.attempts.saturating_add(1);
+                    step.attempts = step.attempts.checked_add(1).ok_or_else(|| {
+                        Error::InvalidState(format!(
+                            "step `{step_id}` in operation `{operation_id}` exceeded the attempt counter range"
+                        ))
+                    })?;
                 } else {
                     operation.steps.insert(
                         step_id.clone(),

--- a/crates/nanocodex-durability/src/store.rs
+++ b/crates/nanocodex-durability/src/store.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, pin::Pin};
 
-/// Fresh, unguessable identity proposed by a journal owner.
+/// Fresh, unguessable identity proposed by a state owner.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(transparent)]
 pub struct OwnerId(String);
@@ -10,7 +10,6 @@ impl OwnerId {
     pub fn new() -> Self {
         Self(uuid::Uuid::now_v7().to_string())
     }
-
     /// Returns the encoded owner identity.
     pub fn as_str(&self) -> &str {
         &self.0
@@ -35,43 +34,32 @@ impl OwnerToken {
     pub const fn new(owner_id: OwnerId, fence: u64) -> Self {
         Self { owner_id, fence }
     }
-
     /// Returns the identity installed by this acquisition.
     pub const fn owner_id(&self) -> &OwnerId {
         &self.owner_id
     }
-
     /// Returns the monotonically increasing fencing generation.
     pub const fn fence(&self) -> u64 {
         self.fence
     }
 }
 
-/// One encoded append batch returned by a host store.
-#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct StoredBatch {
-    /// Monotonic journal revision assigned to this batch.
-    pub revision: u64,
-    /// Rust-owned JSON payload. Hosts must retain it byte-for-byte.
-    pub payload: String,
-}
-
-/// Complete encoded journal returned by a host store.
+/// Complete opaque durable state retained by a host store.
 #[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct StoredJournal {
-    /// Current compare-and-append revision.
+pub struct StoredState {
+    /// Current compare-and-replace revision.
     pub revision: u64,
-    /// Ordered append batches.
-    pub batches: Vec<StoredBatch>,
+    /// Rust-owned JSON payload. `None` is valid only at revision zero.
+    pub payload: Option<String>,
 }
 
-/// One owner acquisition and the journal snapshot read in the same transaction.
+/// One owner acquisition and its same-transaction state snapshot.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct OwnedJournal {
+pub struct OwnedState {
     /// Newly installed owner authority.
     pub owner: OwnerToken,
-    /// Self-consistent journal contents observed by that acquisition.
-    pub journal: StoredJournal,
+    /// Self-consistent state observed by that acquisition.
+    pub state: StoredState,
 }
 
 /// Host-store failure.
@@ -81,11 +69,11 @@ pub struct OwnedJournal {
 /// state or resolving the structural conflict.
 #[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
 pub enum StoreError {
-    /// A newer or different owner holds authority for this journal.
-    #[error("durability journal owner was fenced")]
+    /// A newer or different owner holds authority for this state.
+    #[error("durability state owner was fenced")]
     Fenced,
-    /// Another writer advanced the journal.
-    #[error("durability journal revision conflict: expected {expected}, found {actual}")]
+    /// Another writer advanced the state.
+    #[error("durability state revision conflict: expected {expected}, found {actual}")]
     Conflict {
         /// Revision supplied by the caller.
         expected: u64,
@@ -95,100 +83,60 @@ pub enum StoreError {
     /// The host guarantees that the requested operation made no durable change.
     #[error("durability store operation was not committed: {0}")]
     NotCommitted(String),
-    /// The selected storage backend failed.
-    ///
-    /// A mutation returning this variant has an unknown outcome. The session
-    /// owner stops and must be reopened from the host journal.
+    /// The selected storage backend failed. Mutation outcome is unknown.
     #[error("durability store failed: {0}")]
     Backend(String),
 }
 
-/// Boxed host operation used by [`JournalStore`].
+/// Boxed host operation used by [`StateStore`].
 #[cfg(not(target_family = "wasm"))]
 pub type StoreFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
-/// Boxed host operation used by [`JournalStore`].
+/// Boxed host operation used by [`StateStore`].
 #[cfg(target_family = "wasm")]
 pub type StoreFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 
 /// Minimal host-owned persistence contract.
 ///
-/// `acquire_owner` must atomically increment retained fencing authority, install
-/// the supplied identity, and load one self-consistent journal. `append` must
-/// check that authority before comparing the journal revision in the same
-/// transaction, retain the payload, and advance the revision by one.
+/// `acquire` atomically installs a fresh fencing owner and returns the complete
+/// state from the same transaction. `replace` verifies that owner and the
+/// expected revision, then atomically replaces the complete opaque payload and
+/// advances the revision by exactly one.
 #[cfg(not(target_family = "wasm"))]
-pub trait JournalStore: Send {
-    /// Acquires exclusive authority and loads one complete journal.
-    fn acquire_owner<'a>(
+pub trait StateStore: Send {
+    /// Acquires exclusive authority and loads one complete state.
+    fn acquire<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner_id: OwnerId,
-    ) -> StoreFuture<'a, Result<OwnedJournal, StoreError>>;
+    ) -> StoreFuture<'a, Result<OwnedState, StoreError>>;
 
-    /// Atomically appends one opaque Rust-owned batch.
-    fn append<'a>(
+    /// Atomically replaces the complete opaque state.
+    fn replace<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner: &'a OwnerToken,
         expected_revision: u64,
         payload: &'a str,
     ) -> StoreFuture<'a, Result<u64, StoreError>>;
-
-    /// Atomically replaces the retained batch prefix with one equivalent
-    /// checkpoint at the unchanged current revision.
-    fn compact<'a>(
-        &'a mut self,
-        _journal_id: &'a str,
-        _owner: &'a OwnerToken,
-        _expected_revision: u64,
-        _payload: &'a str,
-    ) -> StoreFuture<'a, Result<u64, StoreError>> {
-        Box::pin(async {
-            Err(StoreError::NotCommitted(
-                "durability store does not support journal compaction".to_owned(),
-            ))
-        })
-    }
 }
 
 /// Minimal host-owned persistence contract.
-///
-/// `acquire_owner` must atomically increment retained fencing authority, install
-/// the supplied identity, and load one self-consistent journal. `append` must
-/// check that authority before comparing the journal revision in the same
-/// transaction, retain the payload, and advance the revision by one.
 #[cfg(target_family = "wasm")]
-pub trait JournalStore {
-    /// Acquires exclusive authority and loads one complete journal.
-    fn acquire_owner<'a>(
+pub trait StateStore {
+    /// Acquires exclusive authority and loads one complete state.
+    fn acquire<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner_id: OwnerId,
-    ) -> StoreFuture<'a, Result<OwnedJournal, StoreError>>;
+    ) -> StoreFuture<'a, Result<OwnedState, StoreError>>;
 
-    /// Atomically appends one opaque Rust-owned batch.
-    fn append<'a>(
+    /// Atomically replaces the complete opaque state.
+    fn replace<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner: &'a OwnerToken,
         expected_revision: u64,
         payload: &'a str,
     ) -> StoreFuture<'a, Result<u64, StoreError>>;
-
-    /// Atomically replaces the retained batch prefix with one equivalent
-    /// checkpoint at the unchanged current revision.
-    fn compact<'a>(
-        &'a mut self,
-        _journal_id: &'a str,
-        _owner: &'a OwnerToken,
-        _expected_revision: u64,
-        _payload: &'a str,
-    ) -> StoreFuture<'a, Result<u64, StoreError>> {
-        Box::pin(async {
-            Err(StoreError::NotCommitted(
-                "durability store does not support journal compaction".to_owned(),
-            ))
-        })
-    }
 }

--- a/crates/nanocodex-durability/tests/agent.rs
+++ b/crates/nanocodex-durability/tests/agent.rs
@@ -1413,7 +1413,7 @@ async fn queued_developer_context_waits_for_an_exact_id_retry_to_terminalize() -
     let store = crate::MemoryStore::new()?;
     let failing = FailReplaceOnce {
         inner: store.clone(),
-        expected_revision: 6,
+        expected_revision: 4,
         failed: Arc::new(AtomicBool::new(false)),
     };
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -1457,7 +1457,7 @@ async fn queued_developer_context_waits_for_an_exact_id_retry_to_terminalize() -
     let first = turn
         .result()
         .await
-        .expect_err("the first model-step completion must be retryable");
+        .expect_err("the first model-step settlement must be retryable");
     assert!(first.to_string().contains("injected replacement failure"));
     assert!(
         !append.is_finished(),
@@ -1473,8 +1473,8 @@ async fn queued_developer_context_waits_for_an_exact_id_retry_to_terminalize() -
     append.await??;
     assert_eq!(
         generations.load(Ordering::SeqCst),
-        1,
-        "a staged model outcome must materialize without repeating the provider effect",
+        2,
+        "a definitely uncommitted idempotent model settlement must retry the provider effect",
     );
     let checkpoint = state
         .latest_checkpoint()
@@ -1555,7 +1555,7 @@ async fn cold_reopen_recovers_idle_routed_prompt_without_a_second_model_call() -
     let store = crate::MemoryStore::new()?;
     let failing_store = FailReplaceOnce {
         inner: store.clone(),
-        expected_revision: 7,
+        expected_revision: 5,
         failed: Arc::new(AtomicBool::new(false)),
     };
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -2084,7 +2084,7 @@ async fn failed_completed_compaction_persistence_restores_the_committed_live_bou
     let store = MemoryStore::new()?;
     let failing = FailReplaceOnce {
         inner: store.clone(),
-        expected_revision: 8,
+        expected_revision: 6,
         failed: Arc::new(AtomicBool::new(false)),
     };
     let openai = || {
@@ -2432,7 +2432,7 @@ async fn assert_cold_model_replay_forces_full_history(store_responses: bool) -> 
     let store = crate::MemoryStore::new()?;
     let failing_store = FailReplaceOnce {
         inner: store.clone(),
-        expected_revision: 7,
+        expected_revision: 5,
         failed: Arc::new(AtomicBool::new(false)),
     };
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -2657,7 +2657,7 @@ async fn portable_state_replays_a_completed_model_step_after_terminal_commit_fai
     let store = crate::MemoryStore::new()?;
     let failing_store = FailReplaceOnce {
         inner: store.clone(),
-        expected_revision: 7,
+        expected_revision: 5,
         failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -2727,7 +2727,7 @@ async fn exact_id_retry_reclaims_a_definitely_uncommitted_terminal_replace() -> 
     let store = crate::MemoryStore::new()?;
     let failing_store = FailReplaceOnce {
         inner: store,
-        expected_revision: 7,
+        expected_revision: 5,
         failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -2779,7 +2779,7 @@ async fn portable_state_continues_after_an_ambiguous_tool_without_repeating_it()
     let store = crate::MemoryStore::new()?;
     let failing_store = FailReplaceOnce {
         inner: store.clone(),
-        expected_revision: 8,
+        expected_revision: 6,
         failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -2880,7 +2880,7 @@ async fn changed_tool_profile_blocks_replay_after_spawn_without_creating_a_ghost
     let store = crate::MemoryStore::new()?;
     let failing_store = FailReplaceOnce {
         inner: store.clone(),
-        expected_revision: 9,
+        expected_revision: 7,
         failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));

--- a/crates/nanocodex-durability/tests/agent.rs
+++ b/crates/nanocodex-durability/tests/agent.rs
@@ -24,8 +24,8 @@ use nanocodex_agent::{
 use serde_json::json;
 
 use nanocodex_durability::{
-    DurableAgentExt, DurableSession, MemoryStore, OwnedState, OwnerId, OwnerToken, StateStore,
-    StoreError, StoreFuture,
+    DurableAgentExt, DurableSession, MemoryStore, OperationStatus, OwnedState, OwnerId, OwnerToken,
+    RetryPolicy, StateStore, StepStatus, StoreError, StoreFuture,
 };
 
 fn temporary_workspace(label: &str) -> Result<PathBuf> {
@@ -185,6 +185,10 @@ struct CountingDurableTool {
     calls: Arc<std::sync::atomic::AtomicUsize>,
 }
 
+struct BlockingDurableTool {
+    started: Arc<tokio::sync::Notify>,
+}
+
 struct EphemeralSpawnTool {
     calls: Arc<std::sync::atomic::AtomicUsize>,
 }
@@ -210,6 +214,30 @@ impl nanocodex_agent::Tool for CountingDurableTool {
     ) -> nanocodex_tools::ToolResult {
         self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         Ok(nanocodex_tools::ToolOutput::text("counted"))
+    }
+}
+
+#[nanocodex_tools::contract::async_trait]
+impl nanocodex_agent::Tool for BlockingDurableTool {
+    fn definition(&self) -> nanocodex_tools::ToolDefinition {
+        nanocodex_tools::ToolDefinition::function(
+            "count_once",
+            "Block after crossing the durable at-most-once effect boundary.",
+            json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        )
+    }
+
+    async fn execute(
+        &self,
+        _input: nanocodex_tools::ToolInput,
+        _context: nanocodex_tools::ToolContext<'_>,
+    ) -> nanocodex_tools::ToolResult {
+        self.started.notify_one();
+        std::future::pending().await
     }
 }
 
@@ -276,6 +304,12 @@ struct GatedWarmupService {
 
 #[derive(Clone)]
 struct DurableCompactionService;
+
+#[derive(Clone)]
+struct PendingStandaloneCompactionService {
+    compactions: Arc<std::sync::atomic::AtomicUsize>,
+    started: Arc<tokio::sync::Notify>,
+}
 
 #[derive(Clone)]
 struct AutomaticCompactionService {
@@ -660,6 +694,35 @@ impl tower::Service<nanocodex_oai_api::tower::ResponsesAttempt> for DurableCompa
 
     fn call(&mut self, request: nanocodex_oai_api::tower::ResponsesAttempt) -> Self::Future {
         std::future::ready(Ok(successful_attempt(request.kind())))
+    }
+}
+
+impl tower::Service<nanocodex_oai_api::tower::ResponsesAttempt>
+    for PendingStandaloneCompactionService
+{
+    type Response = nanocodex_oai_api::tower::ResponsesServiceResponse;
+    type Error = ResponseError;
+    type Future =
+        Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(
+        &mut self,
+        _context: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::result::Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: nanocodex_oai_api::tower::ResponsesAttempt) -> Self::Future {
+        use nanocodex_oai_api::tower::ResponsesAttemptKind;
+        let kind = request.kind();
+        match kind {
+            ResponsesAttemptKind::Compaction => {
+                self.compactions.fetch_add(1, Ordering::SeqCst);
+                self.started.notify_one();
+                Box::pin(std::future::pending())
+            }
+            kind => Box::pin(async move { Ok(successful_attempt(kind)) }),
+        }
     }
 }
 
@@ -1344,6 +1407,18 @@ async fn execution_policy_authority_defaults_fail_closed() -> Result<()> {
             capability: "cancel"
         })
     ));
+    assert!(matches!(
+        ExecutionPolicy::reconcile_cancelled_step(
+            policy.as_ref(),
+            "turn".to_owned(),
+            "tool".to_owned(),
+            "{}".to_owned(),
+        )
+        .await,
+        Err(NanocodexError::ExecutionPolicyCapabilityUnsupported {
+            capability: "reconcile_cancelled_step"
+        })
+    ));
     assert_eq!(releases.load(Ordering::SeqCst), 0);
     assert_eq!(generations.load(Ordering::SeqCst), 0);
 
@@ -1409,7 +1484,8 @@ async fn developer_context_during_an_active_turn_acks_only_after_durable_commit(
 }
 
 #[tokio::test]
-async fn queued_developer_context_waits_for_an_exact_id_retry_to_terminalize() -> Result<()> {
+async fn queued_developer_context_waits_for_unknown_provider_recovery_to_terminalize() -> Result<()>
+{
     let store = crate::MemoryStore::new()?;
     let failing = FailReplaceOnce {
         inner: store.clone(),
@@ -1468,13 +1544,18 @@ async fn queued_developer_context_waits_for_an_exact_id_retry_to_terminalize() -
         .prompt(PromptRequest::new("retry before developer context").request_id("retry-turn"))
         .await?
         .result()
-        .await?;
-    assert_eq!(recovered.final_message(), "durably replayed");
+        .await
+        .expect_err("a settled provider effect without a durable result must remain unknown");
+    assert!(
+        recovered
+            .to_string()
+            .contains("provider outcome is unknown after durable recovery; refusing to resubmit")
+    );
     append.await??;
     assert_eq!(
         generations.load(Ordering::SeqCst),
-        2,
-        "a definitely uncommitted idempotent model settlement must retry the provider effect",
+        1,
+        "durable recovery must not repeat a provider effect whose outcome may have been billed",
     );
     let checkpoint = state
         .latest_checkpoint()
@@ -1960,6 +2041,157 @@ async fn independent_session_takeover_fences_standalone_compaction_before_execut
 }
 
 #[tokio::test]
+async fn cold_reopen_refuses_to_resubmit_a_pending_standalone_compaction() -> Result<()> {
+    let store = MemoryStore::new()?;
+    let compactions = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let started = Arc::new(tokio::sync::Notify::new());
+    let openai = || {
+        let compactions = Arc::clone(&compactions);
+        let started = Arc::clone(&started);
+        OpenAi::builder("test-key")
+            .service(move || PendingStandaloneCompactionService {
+                compactions: Arc::clone(&compactions),
+                started: Arc::clone(&started),
+            })
+            .build()
+    };
+    let workspace = temporary_workspace("standalone-compaction-cold-reopen")?;
+    let state_id = "standalone-compaction-cold-reopen";
+    let state = DurableSession::open(store.clone(), state_id).await?;
+    let (agent, events) = Nanocodex::builder(openai()?)
+        .workspace(&workspace)
+        .durability(state)
+        .await?
+        .build()?;
+    agent
+        .prompt("seed compaction input")
+        .await?
+        .result()
+        .await?;
+
+    let compacting = tokio::spawn({
+        let agent = agent.clone();
+        async move { agent.compact().await }
+    });
+    started.notified().await;
+    assert_eq!(compactions.load(Ordering::SeqCst), 1);
+    agent.shutdown().await?;
+    assert!(matches!(
+        compacting.await?,
+        Err(NanocodexError::TurnCancelled)
+    ));
+    drop((agent, events));
+
+    let reopened = DurableSession::open(store, state_id).await?;
+    let retained = reopened.state().await?;
+    let compaction = retained
+        .pending_operations()
+        .into_iter()
+        .find(|(_, operation)| {
+            operation
+                .steps
+                .values()
+                .any(|step| step.kind == "compaction")
+        })
+        .ok_or_else(|| eyre!("pending standalone compaction receipt was not retained"))?
+        .1;
+    let provider_step = compaction
+        .steps
+        .values()
+        .find(|step| step.kind == "compaction")
+        .ok_or_else(|| eyre!("pending compaction has no provider step"))?;
+    assert_eq!(provider_step.retry, RetryPolicy::Never);
+    assert!(matches!(provider_step.status, StepStatus::EffectPending));
+    assert_eq!(provider_step.attempts, 1);
+    drop(retained);
+
+    let (resumed, resumed_events) = Nanocodex::builder(openai()?)
+        .workspace(&workspace)
+        .durability(reopened)
+        .await?
+        .build()?;
+    let error = resumed
+        .compact()
+        .await
+        .expect_err("a cold pending provider effect must fail closed");
+    let detail = error.to_string();
+    assert!(
+        detail.contains(
+            "compaction provider outcome is unknown after durable recovery; refusing to resubmit"
+        ),
+        "unexpected cold-recovery error: {detail}"
+    );
+    assert_eq!(
+        compactions.load(Ordering::SeqCst),
+        1,
+        "cold recovery must preserve one provider call"
+    );
+
+    resumed.shutdown().await?;
+    drop((resumed, resumed_events));
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn live_replacement_refuses_to_resubmit_a_pending_standalone_compaction() -> Result<()> {
+    let store = MemoryStore::new()?;
+    let compactions = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let started = Arc::new(tokio::sync::Notify::new());
+    let openai = OpenAi::builder("test-key")
+        .service({
+            let compactions = Arc::clone(&compactions);
+            let started = Arc::clone(&started);
+            move || PendingStandaloneCompactionService {
+                compactions: Arc::clone(&compactions),
+                started: Arc::clone(&started),
+            }
+        })
+        .build()?;
+    let workspace = temporary_workspace("standalone-compaction-live-replacement")?;
+    let state = DurableSession::open(store, "standalone-compaction-live-replacement").await?;
+    let (agent, events) = Nanocodex::builder(openai)
+        .workspace(&workspace)
+        .durability(state)
+        .await?
+        .build()?;
+    agent
+        .prompt("seed compaction input")
+        .await?
+        .result()
+        .await?;
+
+    let first = tokio::spawn({
+        let agent = agent.clone();
+        async move { agent.compact().await }
+    });
+    started.notified().await;
+    assert_eq!(compactions.load(Ordering::SeqCst), 1);
+    let replacement = agent
+        .compact()
+        .await
+        .expect_err("replacement must reconcile the pending provider effect as Unknown");
+    let detail = replacement.to_string();
+    assert!(
+        detail.contains(
+            "compaction provider outcome is unknown after durable recovery; refusing to resubmit"
+        ),
+        "unexpected replacement error: {detail}"
+    );
+    assert!(matches!(first.await?, Err(NanocodexError::TurnCancelled)));
+    assert_eq!(
+        compactions.load(Ordering::SeqCst),
+        1,
+        "same-live replacement must preserve one provider call"
+    );
+
+    agent.shutdown().await?;
+    drop((agent, events));
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn takeover_after_warmup_authorization_fences_the_result_not_the_in_flight_call() -> Result<()>
 {
     let store = crate::MemoryStore::new()?;
@@ -2196,6 +2428,125 @@ async fn active_cancel_reclaims_a_definitely_uncommitted_terminal_before_follow_
             .is_some_and(|operation| operation.status.is_terminal()),
         "the exact cancellation retry must commit before the follow-on runs"
     );
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn active_cancel_settles_a_pending_never_retry_tool_as_unknown() -> Result<()> {
+    let store = MemoryStore::new()?;
+    let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let tool_started = Arc::new(tokio::sync::Notify::new());
+    let openai = OpenAi::builder("test-key")
+        .service({
+            let generations = Arc::clone(&generations);
+            move || DurableToolService {
+                generations: Arc::clone(&generations),
+            }
+        })
+        .build()?;
+    let tools = Tools::builder()
+        .without_defaults()
+        .tool(BlockingDurableTool {
+            started: Arc::clone(&tool_started),
+        })
+        .build()?;
+    let workspace = temporary_workspace("active-cancel-pending-never-tool")?;
+    let state_id = "active-cancel-pending-never-tool";
+    let state = DurableSession::open(store.clone(), state_id).await?;
+    let (agent, mut events) = Nanocodex::builder(openai)
+        .workspace(&workspace)
+        .session_id(test_session_id())
+        .tools(tools)
+        .durability(state)
+        .await?
+        .build()?;
+    let turn = agent
+        .prompt(PromptRequest::new("run the blocker").request_id("cancel-never-tool"))
+        .await?;
+    tool_started.notified().await;
+
+    turn.cancel().await?;
+    assert!(matches!(
+        turn.result().await,
+        Err(NanocodexError::TurnCancelled)
+    ));
+    let cancellation_events = std::iter::from_fn(|| events.try_recv_timed()).collect::<Vec<_>>();
+    let tool_results = cancellation_events
+        .iter()
+        .enumerate()
+        .filter(|(_, event)| event.event.kind == AgentEventKind::ToolResult)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        tool_results.len(),
+        1,
+        "cancellation must emit the reconciled durable result exactly once"
+    );
+    let (tool_result_index, tool_result) = tool_results[0];
+    let tool_result = tool_result.event.decode_payload::<serde_json::Value>()?;
+    assert_eq!(tool_result["call_id"], "call-count-once");
+    assert_eq!(tool_result["status"], "failed");
+    assert_eq!(tool_result["structured_result"]["status"], "unknown");
+    let emitted_duration_ns = tool_result["duration_ns"]
+        .as_u64()
+        .expect("the Unknown tool result retains its elapsed duration");
+    assert!(
+        emitted_duration_ns > 0,
+        "active cancellation must not reset elapsed tool work"
+    );
+    let run_error_index = cancellation_events
+        .iter()
+        .position(|event| event.event.kind == AgentEventKind::RunError)
+        .expect("explicit cancellation emits RunError");
+    assert!(
+        tool_result_index < run_error_index,
+        "the authoritative tool result must precede the cancellation error"
+    );
+    agent.shutdown().await?;
+    drop((agent, events));
+
+    let reopened = DurableSession::open(store, state_id).await?;
+    let state = reopened.state().await?;
+    let operation = state
+        .operation("cancel-never-tool")
+        .expect("cancelled operation remains retained");
+    let checkpoint = match &operation.status {
+        OperationStatus::Cancelled {
+            checkpoint: Some(checkpoint),
+        } => checkpoint,
+        status => panic!("expected terminal cancellation checkpoint, found {status:?}"),
+    };
+    assert!(
+        operation
+            .steps
+            .values()
+            .all(|step| matches!(step.status, StepStatus::Completed(_))),
+        "terminal cancellation must not retain an unfinished step"
+    );
+    let tool_step = operation
+        .steps
+        .values()
+        .find(|step| step.kind == "tool_call")
+        .expect("the never-retry tool step remains retained");
+    let StepStatus::Completed(output) = &tool_step.status else {
+        unreachable!("all operation steps were asserted completed")
+    };
+    let unknown: serde_json::Value = output.decode()?;
+    assert_eq!(unknown["structured_result"]["status"], "unknown");
+    assert_eq!(unknown["structured_result"]["recovered"], true);
+    assert_eq!(unknown["structured_result"]["replayed"], false);
+    assert_eq!(unknown["duration_ns"], emitted_duration_ns);
+    let retained_work_duration_ns = unknown["work_duration_ns"]
+        .as_u64()
+        .expect("the Unknown tool result retains its execution duration");
+    assert!(retained_work_duration_ns > 0);
+    assert!(retained_work_duration_ns <= emitted_duration_ns);
+    assert!(unknown.to_string().contains("external outcome is unknown"));
+    assert!(
+        checkpoint.json().contains("external outcome is unknown"),
+        "the cancelled checkpoint must contain the same Unknown tool response"
+    );
+
     std::fs::remove_dir_all(workspace)?;
     Ok(())
 }

--- a/crates/nanocodex-durability/tests/agent.rs
+++ b/crates/nanocodex-durability/tests/agent.rs
@@ -24,7 +24,7 @@ use nanocodex_agent::{
 use serde_json::json;
 
 use nanocodex_durability::{
-    DurableAgentExt, DurableSession, JournalStore, MemoryStore, OwnedJournal, OwnerId, OwnerToken,
+    DurableAgentExt, DurableSession, MemoryStore, OwnedState, OwnerId, OwnerToken, StateStore,
     StoreError, StoreFuture,
 };
 
@@ -39,7 +39,7 @@ fn test_session_id() -> SessionId {
 }
 
 #[derive(Clone)]
-struct FailAppendOnce {
+struct FailReplaceOnce {
     inner: crate::MemoryStore,
     expected_revision: u64,
     failed: Arc<std::sync::atomic::AtomicBool>,
@@ -53,33 +53,40 @@ struct FailEntryOnce {
     failed: Arc<AtomicBool>,
 }
 
-impl crate::JournalStore for FailEntryOnce {
-    fn acquire_owner<'a>(
+impl crate::StateStore for FailEntryOnce {
+    fn acquire<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner_id: crate::OwnerId,
-    ) -> crate::StoreFuture<'a, std::result::Result<crate::OwnedJournal, crate::StoreError>> {
-        self.inner.acquire_owner(journal_id, owner_id)
+    ) -> crate::StoreFuture<'a, std::result::Result<crate::OwnedState, crate::StoreError>> {
+        self.inner.acquire(state_id, owner_id)
     }
 
-    fn append<'a>(
+    fn replace<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner: &'a crate::OwnerToken,
         expected_revision: u64,
         payload: &'a str,
     ) -> crate::StoreFuture<'a, std::result::Result<u64, crate::StoreError>> {
-        let matches_entry = payload.contains(self.entry_tag)
-            && payload.contains(&format!("\"operation_id\":\"{}\"", self.operation_id));
+        let state: serde_json::Value = serde_json::from_str(payload)
+            .expect("durability fault injection receives a complete state value");
+        let operation_status =
+            &state["nanocodex_durable_state"]["operations"][self.operation_id]["status"];
+        let matches_entry = match self.entry_tag {
+            "\"operation_cancelled\"" => operation_status.get("cancelled").is_some(),
+            "\"operation_completed\"" => operation_status.get("completed").is_some(),
+            other => payload.contains(other),
+        };
         if matches_entry && !self.failed.swap(true, Ordering::SeqCst) {
             return Box::pin(async {
                 Err(crate::StoreError::NotCommitted(
-                    "injected entry append failure".to_owned(),
+                    "injected state replacement failure".to_owned(),
                 ))
             });
         }
         self.inner
-            .append(journal_id, owner, expected_revision, payload)
+            .replace(state_id, owner, expected_revision, payload)
     }
 }
 
@@ -90,50 +97,52 @@ struct GateCompactionAuthorization {
     release: Arc<tokio::sync::Notify>,
 }
 
-impl crate::JournalStore for GateCompactionAuthorization {
-    fn acquire_owner<'a>(
+impl crate::StateStore for GateCompactionAuthorization {
+    fn acquire<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner_id: crate::OwnerId,
-    ) -> crate::StoreFuture<'a, std::result::Result<crate::OwnedJournal, crate::StoreError>> {
-        self.inner.acquire_owner(journal_id, owner_id)
+    ) -> crate::StoreFuture<'a, std::result::Result<crate::OwnedState, crate::StoreError>> {
+        self.inner.acquire(state_id, owner_id)
     }
 
-    fn append<'a>(
+    fn replace<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner: &'a crate::OwnerToken,
         expected_revision: u64,
         payload: &'a str,
     ) -> crate::StoreFuture<'a, std::result::Result<u64, crate::StoreError>> {
-        if payload.contains("\"step_started\"") && payload.contains("\"kind\":\"compaction\"") {
+        if payload.contains("\"status\":\"effect_pending\"")
+            && payload.contains("\"kind\":\"compaction\"")
+        {
             let started = Arc::clone(&self.started);
             let release = Arc::clone(&self.release);
             return Box::pin(async move {
                 started.notify_one();
                 release.notified().await;
                 self.inner
-                    .append(journal_id, owner, expected_revision, payload)
+                    .replace(state_id, owner, expected_revision, payload)
                     .await
             });
         }
         self.inner
-            .append(journal_id, owner, expected_revision, payload)
+            .replace(state_id, owner, expected_revision, payload)
     }
 }
 
-impl crate::JournalStore for FailAppendOnce {
-    fn acquire_owner<'a>(
+impl crate::StateStore for FailReplaceOnce {
+    fn acquire<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner_id: crate::OwnerId,
-    ) -> crate::StoreFuture<'a, std::result::Result<crate::OwnedJournal, crate::StoreError>> {
-        self.inner.acquire_owner(journal_id, owner_id)
+    ) -> crate::StoreFuture<'a, std::result::Result<crate::OwnedState, crate::StoreError>> {
+        self.inner.acquire(state_id, owner_id)
     }
 
-    fn append<'a>(
+    fn replace<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner: &'a crate::OwnerToken,
         expected_revision: u64,
         payload: &'a str,
@@ -143,12 +152,12 @@ impl crate::JournalStore for FailAppendOnce {
         {
             return Box::pin(async {
                 Err(crate::StoreError::NotCommitted(
-                    "injected append failure".to_owned(),
+                    "injected replacement failure".to_owned(),
                 ))
             });
         }
         self.inner
-            .append(journal_id, owner, expected_revision, payload)
+            .replace(state_id, owner, expected_revision, payload)
     }
 }
 
@@ -927,7 +936,9 @@ impl tower::Service<nanocodex_oai_api::tower::ResponsesAttempt> for DurableToolS
 
     fn call(&mut self, request: nanocodex_oai_api::tower::ResponsesAttempt) -> Self::Future {
         use nanocodex_oai_api::{
-            responses::WarmupResponse,
+            responses::{
+                ContentItem, FunctionOutputBody, MessageRole, ResponseItem, WarmupResponse,
+            },
             tower::{
                 CodeCall, CodeCallKind, GenerationOutput, ResponsePipelineStats,
                 ResponsesAttemptKind, ResponsesOutput, ResponsesServiceResponse,
@@ -939,33 +950,67 @@ impl tower::Service<nanocodex_oai_api::tower::ResponsesAttempt> for DurableToolS
                 usage: None,
             }),
             ResponsesAttemptKind::Generation => {
-                self.generations
+                let generation = self
+                    .generations
                     .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                let item = serde_json::from_value(json!({
-                    "type": "function_call",
-                    "call_id": "call-count-once",
-                    "name": "count_once",
-                    "arguments": "{}"
-                }))
-                .expect("durable tool call item decodes");
-                ResponsesOutput::Generation(GenerationOutput {
-                    id: "durable-tool-response".to_owned(),
-                    status: "completed".to_owned(),
-                    end_turn: Some(false),
-                    final_message: None,
-                    output_items: vec![item],
-                    code_calls: vec![CodeCall {
-                        call_id: "call-count-once".to_owned(),
-                        name: "count_once".to_owned(),
-                        namespace: None,
-                        input: "{}".to_owned(),
-                        kind: CodeCallKind::Function,
-                    }],
-                    usage: None,
-                    time_to_first_event_ns: 0,
-                    time_to_first_output_ns: None,
-                    pipeline_stats: ResponsePipelineStats::default(),
-                })
+                if generation == 0 {
+                    let item = serde_json::from_value(json!({
+                        "type": "function_call",
+                        "call_id": "call-count-once",
+                        "name": "count_once",
+                        "arguments": "{}"
+                    }))
+                    .expect("durable tool call item decodes");
+                    ResponsesOutput::Generation(GenerationOutput {
+                        id: "durable-tool-response".to_owned(),
+                        status: "completed".to_owned(),
+                        end_turn: Some(false),
+                        final_message: None,
+                        output_items: vec![item],
+                        code_calls: vec![CodeCall {
+                            call_id: "call-count-once".to_owned(),
+                            name: "count_once".to_owned(),
+                            namespace: None,
+                            input: "{}".to_owned(),
+                            kind: CodeCallKind::Function,
+                        }],
+                        usage: None,
+                        time_to_first_event_ns: 0,
+                        time_to_first_output_ns: None,
+                        pipeline_stats: ResponsePipelineStats::default(),
+                    })
+                } else {
+                    let recovered_output = request.input_items().find_map(|item| match item {
+                        ResponseItem::FunctionCallOutput {
+                            call_id,
+                            output: FunctionOutputBody::Text(output),
+                            ..
+                        } if &**call_id == "call-count-once" => Some(output.as_ref()),
+                        _ => None,
+                    });
+                    assert!(
+                        recovered_output
+                            .expect("recovery must include the synthetic tool result")
+                            .contains("external outcome is unknown")
+                    );
+                    ResponsesOutput::Generation(GenerationOutput {
+                        id: "durable-tool-recovered-response".to_owned(),
+                        status: "completed".to_owned(),
+                        end_turn: Some(true),
+                        final_message: Some("recovered without repeating the tool".to_owned()),
+                        output_items: vec![ResponseItem::message(
+                            MessageRole::Assistant,
+                            [ContentItem::output_text(
+                                "recovered without repeating the tool",
+                            )],
+                        )],
+                        code_calls: Vec::new(),
+                        usage: None,
+                        time_to_first_event_ns: 0,
+                        time_to_first_output_ns: None,
+                        pipeline_stats: ResponsePipelineStats::default(),
+                    })
+                }
             }
             kind => panic!("unexpected durable tool attempt: {kind:?}"),
         };
@@ -1048,7 +1093,7 @@ impl tower::Service<nanocodex_oai_api::tower::ResponsesAttempt> for ReplayContin
                             item["type"] == "function_call"
                                 && item["call_id"] == "call-replay-fence"
                         })
-                        .expect("full replay retains the journaled model output");
+                        .expect("full replay retains the durable model output");
                     let tool_index = input
                         .iter()
                         .position(|item| {
@@ -1136,7 +1181,7 @@ impl tower::Service<nanocodex_oai_api::tower::ResponsesAttempt> for DurableRepla
 #[tokio::test]
 async fn durability_attached_builder_is_safe_single_use_across_clones() -> Result<()> {
     let store = MemoryStore::new()?;
-    let journal = DurableSession::open(store, "single-use-builder").await?;
+    let state = DurableSession::open(store, "single-use-builder").await?;
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let openai = OpenAi::builder("test-key")
         .service({
@@ -1149,7 +1194,7 @@ async fn durability_attached_builder_is_safe_single_use_across_clones() -> Resul
     let workspace = temporary_workspace("durability-single-use-builder")?;
     let builder = Nanocodex::builder(openai)
         .workspace(&workspace)
-        .durability(journal)
+        .durability(state)
         .await?;
     let duplicate = builder.clone();
 
@@ -1167,10 +1212,10 @@ async fn durability_attached_builder_is_safe_single_use_across_clones() -> Resul
 }
 
 #[tokio::test]
-async fn configured_durability_automatically_journals_plain_prompts() -> Result<()> {
+async fn configured_durability_automatically_persists_plain_prompts() -> Result<()> {
     let store = crate::MemoryStore::new()?;
-    let journal = crate::DurableSession::open(store, "automatic-prompt").await?;
-    let journal_state = journal.clone();
+    let state = crate::DurableSession::open(store, "automatic-prompt").await?;
+    let durable_state = state.clone();
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let openai = OpenAi::builder("test-key")
         .service({
@@ -1184,11 +1229,11 @@ async fn configured_durability_automatically_journals_plain_prompts() -> Result<
     let builder = Nanocodex::builder(openai)
         .workspace(&workspace)
         .session_id(test_session_id())
-        .durability(journal)
+        .durability(state)
         .await?;
     let (agent, events) = builder.build()?;
 
-    let turn = agent.prompt("journal this automatically").await?;
+    let turn = agent.prompt("state this automatically").await?;
     let generated_request_id = turn
         .request_id()
         .ok_or_else(|| eyre!("automatic durable request ID is missing"))?
@@ -1196,7 +1241,7 @@ async fn configured_durability_automatically_journals_plain_prompts() -> Result<
     let result = turn.result().await?;
     assert_eq!(result.final_message(), "durably replayed");
     assert_eq!(result.request_id(), Some(generated_request_id.as_str()));
-    let state = journal_state.state().await?;
+    let state = durable_state.state().await?;
     assert_eq!(state.operations().len(), 1);
     let generated_id = state
         .operations()
@@ -1205,7 +1250,7 @@ async fn configured_durability_automatically_journals_plain_prompts() -> Result<
         .ok_or_else(|| eyre!("automatic durable operation is missing"))?;
     assert_eq!(generated_id, &generated_request_id);
     assert!(generated_request_id.parse::<SessionId>().is_ok());
-    assert!(journal_state.latest_checkpoint().await?.is_some());
+    assert!(durable_state.latest_checkpoint().await?.is_some());
 
     agent.shutdown().await?;
     drop((agent, events));
@@ -1216,7 +1261,7 @@ async fn configured_durability_automatically_journals_plain_prompts() -> Result<
 #[tokio::test]
 async fn acknowledged_developer_context_survives_a_cold_reopen() -> Result<()> {
     let store = crate::MemoryStore::new()?;
-    let journal = crate::DurableSession::open(store.clone(), "durable-developer-context").await?;
+    let state = crate::DurableSession::open(store.clone(), "durable-developer-context").await?;
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let openai = || {
         let generations = Arc::clone(&generations);
@@ -1229,7 +1274,7 @@ async fn acknowledged_developer_context_survives_a_cold_reopen() -> Result<()> {
     let workspace = temporary_workspace("durable-developer-context")?;
     let (agent, events) = Nanocodex::builder(openai()?)
         .workspace(&workspace)
-        .durability(journal.clone())
+        .durability(state.clone())
         .await?
         .build()?;
 
@@ -1239,7 +1284,7 @@ async fn acknowledged_developer_context_survives_a_cold_reopen() -> Result<()> {
     agent.shutdown().await?;
     drop((agent, events));
 
-    let retained = journal
+    let retained = state
         .latest_checkpoint()
         .await?
         .ok_or_else(|| eyre!("developer context was acknowledged without a checkpoint"))?;
@@ -1290,7 +1335,7 @@ async fn execution_policy_authority_defaults_fail_closed() -> Result<()> {
     assert!(matches!(
         agent.compact().await,
         Err(NanocodexError::ExecutionPolicyCapabilityUnsupported {
-            capability: "authorize_model_effect"
+            capability: "fence_checkpoint_effect"
         })
     ));
     assert!(matches!(
@@ -1311,7 +1356,7 @@ async fn execution_policy_authority_defaults_fail_closed() -> Result<()> {
 #[tokio::test]
 async fn developer_context_during_an_active_turn_acks_only_after_durable_commit() -> Result<()> {
     let store = crate::MemoryStore::new()?;
-    let journal = crate::DurableSession::open(store, "active-developer-context").await?;
+    let state = crate::DurableSession::open(store, "active-developer-context").await?;
     let started = Arc::new(AtomicBool::new(false));
     let openai = OpenAi::builder("test-key")
         .service({
@@ -1324,7 +1369,7 @@ async fn developer_context_during_an_active_turn_acks_only_after_durable_commit(
     let workspace = temporary_workspace("active-developer-context")?;
     let (agent, events) = Nanocodex::builder(openai)
         .workspace(&workspace)
-        .durability(journal.clone())
+        .durability(state.clone())
         .await?
         .build()?;
     let turn = agent.prompt("hold this turn open").await?;
@@ -1351,7 +1396,7 @@ async fn developer_context_during_an_active_turn_acks_only_after_durable_commit(
     ));
     append.await??;
     assert!(
-        journal
+        state
             .latest_checkpoint()
             .await?
             .is_some_and(|checkpoint| checkpoint.json().contains("active durable marker"))
@@ -1366,9 +1411,9 @@ async fn developer_context_during_an_active_turn_acks_only_after_durable_commit(
 #[tokio::test]
 async fn queued_developer_context_waits_for_an_exact_id_retry_to_terminalize() -> Result<()> {
     let store = crate::MemoryStore::new()?;
-    let failing = FailAppendOnce {
+    let failing = FailReplaceOnce {
         inner: store.clone(),
-        expected_revision: 4,
+        expected_revision: 6,
         failed: Arc::new(AtomicBool::new(false)),
     };
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -1387,10 +1432,10 @@ async fn queued_developer_context_waits_for_an_exact_id_retry_to_terminalize() -
             .build()
     };
     let workspace = temporary_workspace("developer-context-retry-barrier")?;
-    let journal = DurableSession::open(failing, "developer-context-retry-barrier").await?;
+    let state = DurableSession::open(failing, "developer-context-retry-barrier").await?;
     let (agent, events) = Nanocodex::builder(openai()?)
         .workspace(&workspace)
-        .durability(journal.clone())
+        .durability(state.clone())
         .await?
         .build()?;
 
@@ -1413,7 +1458,7 @@ async fn queued_developer_context_waits_for_an_exact_id_retry_to_terminalize() -
         .result()
         .await
         .expect_err("the first model-step completion must be retryable");
-    assert!(first.to_string().contains("injected append failure"));
+    assert!(first.to_string().contains("injected replacement failure"));
     assert!(
         !append.is_finished(),
         "developer context must remain unacknowledged while the operation is pending"
@@ -1426,8 +1471,12 @@ async fn queued_developer_context_waits_for_an_exact_id_retry_to_terminalize() -
         .await?;
     assert_eq!(recovered.final_message(), "durably replayed");
     append.await??;
-    assert_eq!(generations.load(Ordering::SeqCst), 2);
-    let checkpoint = journal
+    assert_eq!(
+        generations.load(Ordering::SeqCst),
+        1,
+        "a staged model outcome must materialize without repeating the provider effect",
+    );
+    let checkpoint = state
         .latest_checkpoint()
         .await?
         .ok_or_else(|| eyre!("developer acknowledgment omitted its checkpoint"))?;
@@ -1453,8 +1502,8 @@ async fn queued_developer_context_waits_for_an_exact_id_retry_to_terminalize() -
 #[tokio::test]
 async fn idle_routed_prompt_is_durably_admitted_and_checkpointed() -> Result<()> {
     let store = crate::MemoryStore::new()?;
-    let journal = crate::DurableSession::open(store, "automatic-routed-prompt").await?;
-    let journal_state = journal.clone();
+    let state = crate::DurableSession::open(store, "automatic-routed-prompt").await?;
+    let durable_state = state.clone();
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let openai = OpenAi::builder("test-key")
         .service({
@@ -1468,11 +1517,11 @@ async fn idle_routed_prompt_is_durably_admitted_and_checkpointed() -> Result<()>
     let (agent, events) = Nanocodex::builder(openai)
         .workspace(&workspace)
         .session_id(test_session_id())
-        .durability(journal)
+        .durability(state)
         .await?
         .build()?;
 
-    let turn = match agent.route_prompt("journal this routed prompt").await? {
+    let turn = match agent.route_prompt("state this routed prompt").await? {
         PromptRoute::Started(turn) => turn,
         PromptRoute::Steered => return Err(eyre!("idle durable input unexpectedly steered")),
     };
@@ -1486,13 +1535,13 @@ async fn idle_routed_prompt_is_durably_admitted_and_checkpointed() -> Result<()>
         .request_id()
         .ok_or_else(|| eyre!("routed durable result is missing its request ID"))?;
     assert_eq!(accepted_request_id, request_id);
-    let state = journal_state.state().await?;
+    let state = durable_state.state().await?;
     assert!(
         state
             .operation(request_id)
             .is_some_and(|operation| operation.status.is_terminal())
     );
-    assert!(journal_state.latest_checkpoint().await?.is_some());
+    assert!(durable_state.latest_checkpoint().await?.is_some());
     assert_eq!(generations.load(Ordering::SeqCst), 1);
 
     agent.shutdown().await?;
@@ -1504,9 +1553,9 @@ async fn idle_routed_prompt_is_durably_admitted_and_checkpointed() -> Result<()>
 #[tokio::test]
 async fn cold_reopen_recovers_idle_routed_prompt_without_a_second_model_call() -> Result<()> {
     let store = crate::MemoryStore::new()?;
-    let failing_store = FailAppendOnce {
+    let failing_store = FailReplaceOnce {
         inner: store.clone(),
-        expected_revision: 5,
+        expected_revision: 7,
         failed: Arc::new(AtomicBool::new(false)),
     };
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -1520,11 +1569,11 @@ async fn cold_reopen_recovers_idle_routed_prompt_without_a_second_model_call() -
     };
     let workspace = temporary_workspace("routed-durability-cold-reopen")?;
 
-    let journal = crate::DurableSession::open(failing_store, "routed-cold-reopen").await?;
+    let state = crate::DurableSession::open(failing_store, "routed-cold-reopen").await?;
     let (first, first_events) = Nanocodex::builder(openai()?)
         .workspace(&workspace)
         .session_id(test_session_id())
-        .durability(journal)
+        .durability(state)
         .await?
         .build()?;
     let first_turn = match first.route_prompt("recover routed input").await? {
@@ -1534,16 +1583,20 @@ async fn cold_reopen_recovers_idle_routed_prompt_without_a_second_model_call() -
     let first_error = first_turn
         .result()
         .await
-        .expect_err("the injected terminal append must fail the routed attempt");
-    assert!(first_error.to_string().contains("injected append failure"));
+        .expect_err("the injected terminal replacement must fail the routed attempt");
+    assert!(
+        first_error
+            .to_string()
+            .contains("injected replacement failure")
+    );
     first.shutdown().await?;
     drop((first, first_events));
 
-    let journal = crate::DurableSession::open(store, "routed-cold-reopen").await?;
+    let state = crate::DurableSession::open(store, "routed-cold-reopen").await?;
     let (reopened, reopened_events) = Nanocodex::builder(openai()?)
         .workspace(&workspace)
         .session_id(test_session_id())
-        .durability(journal.clone())
+        .durability(state.clone())
         .await?
         .build()?;
     let recovered_turn = match reopened.route_prompt("recover routed input").await? {
@@ -1555,9 +1608,9 @@ async fn cold_reopen_recovers_idle_routed_prompt_without_a_second_model_call() -
     assert_eq!(
         generations.load(Ordering::SeqCst),
         1,
-        "cold recovery must replay the journaled model output",
+        "cold recovery must replay the durable model output",
     );
-    assert!(journal.latest_checkpoint().await?.is_some());
+    assert!(state.latest_checkpoint().await?.is_some());
 
     reopened.shutdown().await?;
     drop((reopened, reopened_events));
@@ -1568,7 +1621,7 @@ async fn cold_reopen_recovers_idle_routed_prompt_without_a_second_model_call() -
 #[tokio::test]
 async fn active_routed_input_is_retained_in_the_durable_checkpoint() -> Result<()> {
     let store = crate::MemoryStore::new()?;
-    let journal = crate::DurableSession::open(store, "active-routed-input").await?;
+    let state = crate::DurableSession::open(store, "active-routed-input").await?;
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let started = Arc::new(AtomicBool::new(false));
     let release_first = Arc::new(tokio::sync::Notify::new());
@@ -1591,7 +1644,7 @@ async fn active_routed_input_is_retained_in_the_durable_checkpoint() -> Result<(
     let (agent, events) = Nanocodex::builder(openai)
         .workspace(&workspace)
         .session_id(test_session_id())
-        .durability(journal.clone())
+        .durability(state.clone())
         .await?
         .build()?;
 
@@ -1610,7 +1663,7 @@ async fn active_routed_input_is_retained_in_the_durable_checkpoint() -> Result<(
     assert_eq!(turn.result().await?.final_message(), "steer retained");
     assert!(observed_steer.load(Ordering::Acquire));
     assert_eq!(generations.load(Ordering::SeqCst), 2);
-    let checkpoint = journal
+    let checkpoint = state
         .latest_checkpoint()
         .await?
         .ok_or_else(|| eyre!("active routed turn did not commit a checkpoint"))?
@@ -1626,9 +1679,9 @@ async fn active_routed_input_is_retained_in_the_durable_checkpoint() -> Result<(
 #[tokio::test]
 async fn shutdown_reclaims_a_definitely_uncommitted_queued_terminalization() -> Result<()> {
     let store = crate::MemoryStore::new()?;
-    let failing = FailAppendOnce {
+    let failing = FailReplaceOnce {
         inner: store.clone(),
-        expected_revision: 6,
+        expected_revision: 8,
         failed: Arc::new(AtomicBool::new(false)),
     };
     let started = Arc::new(AtomicBool::new(false));
@@ -1641,10 +1694,10 @@ async fn shutdown_reclaims_a_definitely_uncommitted_queued_terminalization() -> 
         })
         .build()?;
     let workspace = temporary_workspace("durable-shutdown-failure")?;
-    let journal = DurableSession::open(failing, "shutdown-failure").await?;
+    let state = DurableSession::open(failing, "shutdown-failure").await?;
     let (agent, events) = Nanocodex::builder(openai)
         .workspace(&workspace)
-        .durability(journal)
+        .durability(state)
         .await?
         .build()?;
     let active = agent
@@ -1684,7 +1737,7 @@ async fn shutdown_reclaims_a_definitely_uncommitted_queued_terminalization() -> 
 #[tokio::test]
 async fn durable_terminal_replays_emit_one_terminal_without_model_execution() -> Result<()> {
     let store = crate::MemoryStore::new()?;
-    let journal = crate::DurableSession::open(store, "terminal-replay-events").await?;
+    let state = crate::DurableSession::open(store, "terminal-replay-events").await?;
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let openai = || {
         let generations = Arc::clone(&generations);
@@ -1698,7 +1751,7 @@ async fn durable_terminal_replays_emit_one_terminal_without_model_execution() ->
 
     let (seed, seed_events) = Nanocodex::builder(openai()?)
         .workspace(&workspace)
-        .durability(journal.clone())
+        .durability(state.clone())
         .await?
         .build()?;
     let completed = seed
@@ -1714,18 +1767,18 @@ async fn durable_terminal_replays_emit_one_terminal_without_model_execution() ->
     drop((seed, seed_events));
 
     let failed_prompt = Prompt::from("failed replay");
-    journal.admit("failed-replay", &failed_prompt).await?;
-    journal.begin_attempt("failed-replay").await?;
-    journal
+    state.admit("failed-replay", &failed_prompt).await?;
+    state.begin_attempt("failed-replay").await?;
+    state
         .fail("failed-replay", &snapshot, "retained failure")
         .await?;
     let cancelled_prompt = Prompt::from("cancelled replay");
-    journal.admit("cancelled-replay", &cancelled_prompt).await?;
-    journal.cancel("cancelled-replay").await?;
+    state.admit("cancelled-replay", &cancelled_prompt).await?;
+    state.cancel("cancelled-replay").await?;
 
     let (resumed, mut events) = Nanocodex::builder(openai()?)
         .workspace(&workspace)
-        .durability(journal)
+        .durability(state)
         .await?
         .build()?;
 
@@ -1793,7 +1846,7 @@ fn assert_replay_terminal(
 #[tokio::test]
 async fn newer_agent_acquisition_fences_an_older_live_model_before_execution() -> Result<()> {
     let store = crate::MemoryStore::new()?;
-    let journal = crate::DurableSession::open(store, "fenced-live-agents").await?;
+    let state = crate::DurableSession::open(store, "fenced-live-agents").await?;
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let openai = || {
         let generations = Arc::clone(&generations);
@@ -1807,12 +1860,12 @@ async fn newer_agent_acquisition_fences_an_older_live_model_before_execution() -
 
     let (older, older_events) = Nanocodex::builder(openai()?)
         .workspace(&workspace)
-        .durability(journal.clone())
+        .durability(state.clone())
         .await?
         .build()?;
     let (newer, newer_events) = Nanocodex::builder(openai()?)
         .workspace(&workspace)
-        .durability(journal.clone())
+        .durability(state.clone())
         .await?
         .build()?;
 
@@ -1855,11 +1908,53 @@ async fn newer_agent_acquisition_fences_an_older_live_model_before_execution() -
         .await?;
     assert_eq!(result.final_message(), "durably replayed");
     assert_eq!(generations.load(std::sync::atomic::Ordering::SeqCst), 1);
-    assert_eq!(journal.state().await?.operations().len(), 1);
+    assert_eq!(state.state().await?.operations().len(), 1);
 
-    older.shutdown().await?;
+    let _ = older.shutdown().await;
     newer.shutdown().await?;
     drop((older, older_events, newer, newer_events));
+    std::fs::remove_dir_all(workspace)?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn independent_session_takeover_fences_standalone_compaction_before_execution() -> Result<()>
+{
+    let store = crate::MemoryStore::new()?;
+    let state = crate::DurableSession::open(store.clone(), "independent-compaction-fence").await?;
+    let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let openai = OpenAi::builder("test-key")
+        .service({
+            let generations = Arc::clone(&generations);
+            move || DurableReplayService {
+                generations: Arc::clone(&generations),
+            }
+        })
+        .build()?;
+    let workspace = temporary_workspace("independent-compaction-fence")?;
+    let (older, events) = Nanocodex::builder(openai)
+        .workspace(&workspace)
+        .durability(state)
+        .await?
+        .build()?;
+
+    let takeover = crate::DurableSession::open(store, "independent-compaction-fence").await?;
+    let error = older
+        .compact()
+        .await
+        .expect_err("the independently fenced owner must not enter compaction");
+    assert_eq!(
+        error.execution_policy_disposition(),
+        Some(ExecutionPolicyDisposition::Reopen)
+    );
+    assert_eq!(
+        generations.load(std::sync::atomic::Ordering::SeqCst),
+        0,
+        "store-fenced compaction must fail before calling the model service",
+    );
+
+    let _ = older.shutdown().await;
+    drop((older, events, takeover));
     std::fs::remove_dir_all(workspace)?;
     Ok(())
 }
@@ -1868,7 +1963,7 @@ async fn newer_agent_acquisition_fences_an_older_live_model_before_execution() -
 async fn takeover_after_warmup_authorization_fences_the_result_not_the_in_flight_call() -> Result<()>
 {
     let store = crate::MemoryStore::new()?;
-    let journal = DurableSession::open(store, "warmup-authorization-takeover").await?;
+    let state = DurableSession::open(store, "warmup-authorization-takeover").await?;
     let warmups = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let started = Arc::new(tokio::sync::Notify::new());
@@ -1890,7 +1985,7 @@ async fn takeover_after_warmup_authorization_fences_the_result_not_the_in_flight
     let workspace = temporary_workspace("warmup-authorization-takeover")?;
     let (older, older_events) = Nanocodex::builder(openai()?)
         .workspace(&workspace)
-        .durability(journal.clone())
+        .durability(state.clone())
         .await?
         .build()?;
     let turn = older.prompt("authorize warmup then take over").await?;
@@ -1899,7 +1994,7 @@ async fn takeover_after_warmup_authorization_fences_the_result_not_the_in_flight
 
     let (newer, newer_events) = Nanocodex::builder(openai()?)
         .workspace(&workspace)
-        .durability(journal)
+        .durability(state)
         .await?
         .build()?;
     release.notify_one();
@@ -1924,7 +2019,7 @@ async fn takeover_after_warmup_authorization_fences_the_result_not_the_in_flight
 #[tokio::test]
 async fn sequential_model_owners_preserve_history_and_cache_lineage() -> Result<()> {
     let store = crate::MemoryStore::new()?;
-    let journal = crate::DurableSession::open(store, "sequential-model-owners").await?;
+    let state = crate::DurableSession::open(store, "sequential-model-owners").await?;
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let openai = || {
         let generations = Arc::clone(&generations);
@@ -1938,11 +2033,11 @@ async fn sequential_model_owners_preserve_history_and_cache_lineage() -> Result<
 
     let (first, first_events) = Nanocodex::builder(openai()?)
         .workspace(&workspace)
-        .durability(journal.clone())
+        .durability(state.clone())
         .await?
         .build()?;
     first.prompt("first retained turn").await?.result().await?;
-    let first_checkpoint = journal
+    let first_checkpoint = state
         .latest_checkpoint()
         .await?
         .ok_or_else(|| eyre!("first owner did not commit a checkpoint"))?
@@ -1957,7 +2052,7 @@ async fn sequential_model_owners_preserve_history_and_cache_lineage() -> Result<
 
     let (second, second_events) = Nanocodex::builder(openai()?)
         .workspace(&workspace)
-        .durability(journal.clone())
+        .durability(state.clone())
         .await?
         .build()?;
     second
@@ -1965,7 +2060,7 @@ async fn sequential_model_owners_preserve_history_and_cache_lineage() -> Result<
         .await?
         .result()
         .await?;
-    let second_checkpoint = journal
+    let second_checkpoint = state
         .latest_checkpoint()
         .await?
         .ok_or_else(|| eyre!("second owner did not commit a checkpoint"))?
@@ -1987,9 +2082,9 @@ async fn sequential_model_owners_preserve_history_and_cache_lineage() -> Result<
 async fn failed_completed_compaction_persistence_restores_the_committed_live_boundary() -> Result<()>
 {
     let store = MemoryStore::new()?;
-    let failing = FailAppendOnce {
+    let failing = FailReplaceOnce {
         inner: store.clone(),
-        expected_revision: 7,
+        expected_revision: 8,
         failed: Arc::new(AtomicBool::new(false)),
     };
     let openai = || {
@@ -1998,10 +2093,10 @@ async fn failed_completed_compaction_persistence_restores_the_committed_live_bou
             .build()
     };
     let workspace = temporary_workspace("completed-compaction-rollback")?;
-    let journal = DurableSession::open(failing, "completed-compaction-rollback").await?;
+    let state = DurableSession::open(failing, "completed-compaction-rollback").await?;
     let (agent, events) = Nanocodex::builder(openai()?)
         .workspace(&workspace)
-        .durability(journal)
+        .durability(state)
         .await?
         .build()?;
     agent
@@ -2014,8 +2109,8 @@ async fn failed_completed_compaction_persistence_restores_the_committed_live_bou
     let error = agent
         .compact()
         .await
-        .expect_err("the completed compaction checkpoint append must fail once");
-    assert!(error.to_string().contains("injected append failure"));
+        .expect_err("the completed compaction checkpoint replacement must fail once");
+    assert!(error.to_string().contains("injected replacement failure"));
     assert_eq!(
         serde_json::to_value(agent.context().await?.history())?,
         committed_history,
@@ -2066,10 +2161,10 @@ async fn active_cancel_reclaims_a_definitely_uncommitted_terminal_before_follow_
         })
         .build()?;
     let workspace = temporary_workspace("active-cancel-not-committed")?;
-    let journal = DurableSession::open(failing, "active-cancel-not-committed").await?;
+    let state = DurableSession::open(failing, "active-cancel-not-committed").await?;
     let (agent, events) = Nanocodex::builder(openai)
         .workspace(&workspace)
-        .durability(journal)
+        .durability(state)
         .await?
         .build()?;
     let turn = agent
@@ -2130,10 +2225,10 @@ async fn queued_cancel_reclaims_a_definitely_uncommitted_terminal_before_follow_
         })
         .build()?;
     let workspace = temporary_workspace("queued-cancel-not-committed")?;
-    let journal = DurableSession::open(failing, "queued-cancel-not-committed").await?;
+    let state = DurableSession::open(failing, "queued-cancel-not-committed").await?;
     let (agent, events) = Nanocodex::builder(openai)
         .workspace(&workspace)
-        .durability(journal)
+        .durability(state)
         .await?
         .build()?;
     let active = agent
@@ -2188,10 +2283,10 @@ async fn automatic_compaction_replays_a_after_terminal_not_committed_instead_of_
         })
         .build()?;
     let workspace = temporary_workspace("automatic-compaction-terminal-retry")?;
-    let journal = DurableSession::open(failing, "automatic-compaction-terminal-retry").await?;
+    let state = DurableSession::open(failing, "automatic-compaction-terminal-retry").await?;
     let (agent, events) = Nanocodex::builder(openai)
         .workspace(&workspace)
-        .durability(journal)
+        .durability(state)
         .await?
         .build()?;
     agent
@@ -2200,16 +2295,24 @@ async fn automatic_compaction_replays_a_after_terminal_not_committed_instead_of_
         .result()
         .await?;
 
-    let first = agent
+    let first = match agent
         .prompt(
             PromptRequest::new("reuse the exact compaction")
                 .request_id("compaction-terminal-retry"),
         )
-        .await?
-        .result()
         .await
-        .expect_err("the first terminal append must be definitely uncommitted");
-    assert!(first.to_string().contains("injected entry append failure"));
+    {
+        Ok(turn) => turn
+            .result()
+            .await
+            .expect_err("the first terminal write must be definitely uncommitted"),
+        Err(error) => error,
+    };
+    assert!(
+        first
+            .to_string()
+            .contains("injected state replacement failure")
+    );
     assert_eq!(compactions.load(Ordering::SeqCst), 1);
     assert_eq!(generations.load(Ordering::SeqCst), 2);
 
@@ -2266,10 +2369,10 @@ async fn takeover_during_automatic_compaction_authorization_fences_before_provid
             .build()
     };
     let workspace = temporary_workspace("automatic-compaction-takeover")?;
-    let older_journal = DurableSession::open(gated, "automatic-compaction-takeover").await?;
+    let older_state = DurableSession::open(gated, "automatic-compaction-takeover").await?;
     let (older, older_events) = Nanocodex::builder(openai()?)
         .workspace(&workspace)
-        .durability(older_journal)
+        .durability(older_state)
         .await?
         .build()?;
     older
@@ -2285,10 +2388,10 @@ async fn takeover_during_automatic_compaction_authorization_fences_before_provid
         .await?;
     authorization_started.notified().await;
 
-    let newer_journal = DurableSession::open(store, "automatic-compaction-takeover").await?;
+    let newer_state = DurableSession::open(store, "automatic-compaction-takeover").await?;
     let (newer, newer_events) = Nanocodex::builder(openai()?)
         .workspace(&workspace)
-        .durability(newer_journal)
+        .durability(newer_state)
         .await?
         .build()?;
     authorization_release.notify_one();
@@ -2327,9 +2430,9 @@ async fn takeover_during_automatic_compaction_authorization_fences_before_provid
 
 async fn assert_cold_model_replay_forces_full_history(store_responses: bool) -> Result<()> {
     let store = crate::MemoryStore::new()?;
-    let failing_store = FailAppendOnce {
+    let failing_store = FailReplaceOnce {
         inner: store.clone(),
-        expected_revision: 5,
+        expected_revision: 7,
         failed: Arc::new(AtomicBool::new(false)),
     };
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -2356,15 +2459,15 @@ async fn assert_cold_model_replay_forces_full_history(store_responses: bool) -> 
     } else {
         "ephemeral"
     };
-    let journal_id = format!("cold-model-replay-{suffix}");
-    let workspace = temporary_workspace(&journal_id)?;
+    let state_id = format!("cold-model-replay-{suffix}");
+    let workspace = temporary_workspace(&state_id)?;
 
-    let journal = crate::DurableSession::open(failing_store, journal_id.clone()).await?;
+    let state = crate::DurableSession::open(failing_store, state_id.clone()).await?;
     let (first, first_events) = Nanocodex::builder(openai()?)
         .workspace(&workspace)
         .session_id(test_session_id())
         .tools(tools()?)
-        .durability(journal)
+        .durability(state)
         .await?
         .build()?;
     let error = first
@@ -2375,19 +2478,19 @@ async fn assert_cold_model_replay_forces_full_history(store_responses: bool) -> 
         .await?
         .result()
         .await
-        .expect_err("the injected tool-step append must fail the first owner");
-    assert!(error.to_string().contains("injected append failure"));
+        .expect_err("the injected tool-step replacement must fail the first owner");
+    assert!(error.to_string().contains("injected replacement failure"));
     assert_eq!(generations.load(Ordering::SeqCst), 1);
     assert_eq!(tool_calls.load(Ordering::SeqCst), 0);
     first.shutdown().await?;
     drop((first, first_events));
 
-    let journal = crate::DurableSession::open(store, journal_id).await?;
+    let state = crate::DurableSession::open(store, state_id).await?;
     let (reopened, reopened_events) = Nanocodex::builder(openai()?)
         .workspace(&workspace)
         .session_id(test_session_id())
         .tools(tools()?)
-        .durability(journal)
+        .durability(state)
         .await?
         .build()?;
     let result = reopened
@@ -2549,12 +2652,12 @@ async fn abandoned_routed_terminal_replay_emits_no_terminal_event() -> Result<()
 }
 
 #[tokio::test]
-async fn portable_journal_replays_a_completed_model_step_after_terminal_commit_failure()
--> Result<()> {
+async fn portable_state_replays_a_completed_model_step_after_terminal_commit_failure() -> Result<()>
+{
     let store = crate::MemoryStore::new()?;
-    let failing_store = FailAppendOnce {
+    let failing_store = FailReplaceOnce {
         inner: store.clone(),
-        expected_revision: 5,
+        expected_revision: 7,
         failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -2567,11 +2670,11 @@ async fn portable_journal_replays_a_completed_model_step_after_terminal_commit_f
             .build()
     };
     let workspace = temporary_workspace("portable-durability-model-replay")?;
-    let journal = crate::DurableSession::open(failing_store, "portable-model-replay").await?;
+    let state = crate::DurableSession::open(failing_store, "portable-model-replay").await?;
     let builder = Nanocodex::builder(openai()?)
         .workspace(&workspace)
         .session_id(test_session_id())
-        .durability(journal)
+        .durability(state)
         .await?;
     let (agent, mut events) = builder.build()?;
     let first_turn = agent.prompt("replay this exact turn").await?;
@@ -2582,8 +2685,8 @@ async fn portable_journal_replays_a_completed_model_step_after_terminal_commit_f
     let error = first_turn
         .result()
         .await
-        .expect_err("the injected terminal append must fail the first attempt");
-    assert!(error.to_string().contains("injected append failure"));
+        .expect_err("the injected terminal replacement must fail the first attempt");
+    assert!(error.to_string().contains("injected replacement failure"));
     let terminals = std::iter::from_fn(|| events.try_recv_timed())
         .filter(|event| event.event.kind.is_terminal())
         .collect::<Vec<_>>();
@@ -2596,11 +2699,11 @@ async fn portable_journal_replays_a_completed_model_step_after_terminal_commit_f
     agent.shutdown().await?;
     drop((agent, events));
 
-    let journal = crate::DurableSession::open(store, "portable-model-replay").await?;
+    let state = crate::DurableSession::open(store, "portable-model-replay").await?;
     let builder = Nanocodex::builder(openai()?)
         .workspace(&workspace)
         .session_id(test_session_id())
-        .durability(journal)
+        .durability(state)
         .await?;
     let (resumed, resumed_events) = builder.build()?;
     let recovered_turn = resumed.prompt("replay this exact turn").await?;
@@ -2611,7 +2714,7 @@ async fn portable_journal_replays_a_completed_model_step_after_terminal_commit_f
     assert_eq!(
         generations.load(std::sync::atomic::Ordering::SeqCst),
         1,
-        "the recovered operation must use the Rust-journaled model output",
+        "the recovered operation must use the Rust-durable model output",
     );
     resumed.shutdown().await?;
     drop((resumed, resumed_events));
@@ -2620,11 +2723,11 @@ async fn portable_journal_replays_a_completed_model_step_after_terminal_commit_f
 }
 
 #[tokio::test]
-async fn exact_id_retry_reclaims_a_definitely_uncommitted_terminal_append() -> Result<()> {
+async fn exact_id_retry_reclaims_a_definitely_uncommitted_terminal_replace() -> Result<()> {
     let store = crate::MemoryStore::new()?;
-    let failing_store = FailAppendOnce {
+    let failing_store = FailReplaceOnce {
         inner: store,
-        expected_revision: 5,
+        expected_revision: 7,
         failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -2637,11 +2740,11 @@ async fn exact_id_retry_reclaims_a_definitely_uncommitted_terminal_append() -> R
             .build()?
     };
     let workspace = temporary_workspace("portable-durability-live-retry")?;
-    let journal = crate::DurableSession::open(failing_store, "portable-model-live-retry").await?;
+    let state = crate::DurableSession::open(failing_store, "portable-model-live-retry").await?;
     let builder = Nanocodex::builder(openai)
         .workspace(&workspace)
         .session_id(test_session_id())
-        .durability(journal)
+        .durability(state)
         .await?;
     let (agent, events) = builder.build()?;
 
@@ -2650,8 +2753,8 @@ async fn exact_id_retry_reclaims_a_definitely_uncommitted_terminal_append() -> R
         .await?
         .result()
         .await
-        .expect_err("the injected terminal append must fail the first attempt");
-    assert!(first.to_string().contains("injected append failure"));
+        .expect_err("the injected terminal replacement must fail the first attempt");
+    assert!(first.to_string().contains("injected replacement failure"));
 
     let recovered = agent
         .prompt(PromptRequest::new("replay this exact turn").request_id("exact-live-retry"))
@@ -2662,7 +2765,7 @@ async fn exact_id_retry_reclaims_a_definitely_uncommitted_terminal_append() -> R
     assert_eq!(
         generations.load(std::sync::atomic::Ordering::SeqCst),
         1,
-        "the live owner must roll back before replaying the journaled model output",
+        "the live owner must roll back before replaying the durable model output",
     );
 
     agent.shutdown().await?;
@@ -2672,11 +2775,11 @@ async fn exact_id_retry_reclaims_a_definitely_uncommitted_terminal_append() -> R
 }
 
 #[tokio::test]
-async fn portable_journal_refuses_to_repeat_a_tool_with_an_ambiguous_completion() -> Result<()> {
+async fn portable_state_continues_after_an_ambiguous_tool_without_repeating_it() -> Result<()> {
     let store = crate::MemoryStore::new()?;
-    let failing_store = FailAppendOnce {
+    let failing_store = FailReplaceOnce {
         inner: store.clone(),
-        expected_revision: 6,
+        expected_revision: 8,
         failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -2698,12 +2801,12 @@ async fn portable_journal_refuses_to_repeat_a_tool_with_an_ambiguous_completion(
             .build()
     };
     let workspace = temporary_workspace("portable-durability-ambiguous-tool")?;
-    let journal = crate::DurableSession::open(failing_store, "ambiguous-tool").await?;
+    let state = crate::DurableSession::open(failing_store, "ambiguous-tool").await?;
     let builder = Nanocodex::builder(openai()?)
         .workspace(&workspace)
         .session_id(test_session_id())
         .tools(tools()?)
-        .durability(journal)
+        .durability(state)
         .await?;
     let (agent, events) = builder.build()?;
     let first_turn = agent
@@ -2713,32 +2816,61 @@ async fn portable_journal_refuses_to_repeat_a_tool_with_an_ambiguous_completion(
     let first = first_turn
         .result()
         .await
-        .expect_err("the injected tool completion append must fail");
-    assert!(first.to_string().contains("injected append failure"));
+        .expect_err("the injected tool completion replacement must fail");
+    assert!(first.to_string().contains("injected replacement failure"));
     agent.shutdown().await?;
     drop((agent, events));
 
-    let journal = crate::DurableSession::open(store, "ambiguous-tool").await?;
+    let state = crate::DurableSession::open(store.clone(), "ambiguous-tool").await?;
     let builder = Nanocodex::builder(openai()?)
         .workspace(&workspace)
         .session_id(test_session_id())
         .tools(tools()?)
-        .durability(journal)
+        .durability(state)
         .await?;
     let (resumed, resumed_events) = builder.build()?;
     let recovered_turn = resumed
         .prompt(PromptRequest::new("run the counter").request_id("turn-1"))
         .await?;
     assert_eq!(recovered_turn.request_id(), Some("turn-1"));
-    let recovered = recovered_turn
-        .result()
-        .await
-        .expect_err("an unsafe unfinished tool must remain ambiguous");
-    assert!(recovered.to_string().contains("ambiguous outcome"));
+    let recovered = recovered_turn.result().await?;
+    assert_eq!(
+        recovered.final_message(),
+        "recovered without repeating the tool"
+    );
     assert_eq!(tool_calls.load(std::sync::atomic::Ordering::SeqCst), 1);
-    assert_eq!(generations.load(std::sync::atomic::Ordering::SeqCst), 1);
+    assert_eq!(generations.load(std::sync::atomic::Ordering::SeqCst), 2);
     resumed.shutdown().await?;
     drop((resumed, resumed_events));
+
+    let state = crate::DurableSession::open(store, "ambiguous-tool").await?;
+    let builder = Nanocodex::builder(openai()?)
+        .workspace(&workspace)
+        .session_id(test_session_id())
+        .tools(tools()?)
+        .durability(state)
+        .await?;
+    let (reopened, reopened_events) = builder.build()?;
+    let replayed = reopened
+        .prompt(PromptRequest::new("run the counter").request_id("turn-1"))
+        .await?
+        .result()
+        .await?;
+    assert_eq!(
+        replayed.final_message(),
+        "recovered without repeating the tool"
+    );
+    assert_eq!(generations.load(std::sync::atomic::Ordering::SeqCst), 2);
+    let next = reopened
+        .prompt(PromptRequest::new("continue").request_id("turn-2"))
+        .await?
+        .result()
+        .await?;
+    assert_eq!(next.final_message(), "recovered without repeating the tool");
+    assert_eq!(tool_calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    assert_eq!(generations.load(std::sync::atomic::Ordering::SeqCst), 3);
+    reopened.shutdown().await?;
+    drop((reopened, reopened_events));
     std::fs::remove_dir_all(workspace)?;
     Ok(())
 }
@@ -2746,9 +2878,9 @@ async fn portable_journal_refuses_to_repeat_a_tool_with_an_ambiguous_completion(
 #[tokio::test]
 async fn changed_tool_profile_blocks_replay_after_spawn_without_creating_a_ghost() -> Result<()> {
     let store = crate::MemoryStore::new()?;
-    let failing_store = FailAppendOnce {
+    let failing_store = FailReplaceOnce {
         inner: store.clone(),
-        expected_revision: 7,
+        expected_revision: 9,
         failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
@@ -2768,12 +2900,12 @@ async fn changed_tool_profile_blocks_replay_after_spawn_without_creating_a_ghost
             calls: Arc::clone(&spawn_calls),
         })
         .build()?;
-    let journal = crate::DurableSession::open(failing_store, "spawn-recovery").await?;
+    let state = crate::DurableSession::open(failing_store, "spawn-recovery").await?;
     let builder = Nanocodex::builder(openai()?)
         .workspace(&workspace)
         .session_id(test_session_id())
         .tools(first_tools)
-        .durability(journal)
+        .durability(state)
         .await?;
     let (agent, events) = builder.build()?;
 
@@ -2783,7 +2915,7 @@ async fn changed_tool_profile_blocks_replay_after_spawn_without_creating_a_ghost
         .result()
         .await
         .expect_err("the injected crash boundary must stop before the wait model call");
-    assert!(first.to_string().contains("injected append failure"));
+    assert!(first.to_string().contains("injected replacement failure"));
     assert_eq!(
         spawn_calls.load(std::sync::atomic::Ordering::SeqCst),
         1,
@@ -2797,13 +2929,13 @@ async fn changed_tool_profile_blocks_replay_after_spawn_without_creating_a_ghost
     agent.shutdown().await?;
     drop((agent, events));
 
-    let journal = crate::DurableSession::open(store, "spawn-recovery").await?;
+    let state = crate::DurableSession::open(store, "spawn-recovery").await?;
     let recovered_tools = Tools::builder().without_defaults().build()?;
     let builder = Nanocodex::builder(openai()?)
         .workspace(&workspace)
         .session_id(test_session_id())
         .tools(recovered_tools)
-        .durability(journal)
+        .durability(state)
         .await?;
     let (recovered, recovered_events) = builder.build()?;
     let error = recovered
@@ -2833,7 +2965,7 @@ async fn changed_tool_profile_blocks_replay_after_spawn_without_creating_a_ghost
 #[tokio::test]
 async fn attached_execution_policy_spawns_a_nondurable_clean_child() -> Result<()> {
     let store = crate::MemoryStore::new()?;
-    let journal = crate::DurableSession::open(store, "spawn-policy").await?;
+    let state = crate::DurableSession::open(store, "spawn-policy").await?;
     let service_factories = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let generations = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let openai = OpenAi::builder("test-key")
@@ -2852,7 +2984,7 @@ async fn attached_execution_policy_spawns_a_nondurable_clean_child() -> Result<(
     let builder = Nanocodex::builder(openai)
         .workspace(&workspace)
         .session_id(test_session_id())
-        .durability(journal)
+        .durability(state)
         .await?;
     let (agent, events) = builder.build()?;
 

--- a/crates/nanocodex-durability/tests/session.rs
+++ b/crates/nanocodex-durability/tests/session.rs
@@ -202,7 +202,7 @@ async fn replays_completed_operations_and_steps_after_reopen() {
     };
     assert_eq!(checkpoint, Checkpoint { version: 1 });
     assert_eq!(output.message, "done");
-    assert_eq!(reopened.state().await.unwrap().revision(), 5);
+    assert_eq!(reopened.state().await.unwrap().revision(), 4);
 }
 
 #[tokio::test]

--- a/crates/nanocodex-durability/tests/session.rs
+++ b/crates/nanocodex-durability/tests/session.rs
@@ -360,6 +360,38 @@ async fn rejects_noncanonical_checkpoint_fields() {
 }
 
 #[tokio::test]
+async fn rejects_retry_attempt_counter_overflow_without_advancing_state() {
+    let revision = u64::from(u32::MAX);
+    let payload = format!(
+        r#"{{"nanocodex_durable_state":{{"format":1,"operations":{{"turn":{{"input":"\"prompt\"","status":"pending","steps":{{"model":{{"kind":"model","input":"\"retry\"","retry":"idempotent","status":"effect_pending","attempts":{}}}}},"accepted_order":1}}}},"latest_checkpoint":null,"checkpoint_effect_pending":false}}}}"#,
+        u32::MAX,
+    );
+    let session = DurableSession::open(
+        SeededStore {
+            state: StoredState {
+                revision,
+                payload: Some(payload),
+            },
+        },
+        "attempt-overflow",
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        session.admit("turn", &"prompt").await,
+        Ok(Admission::Pending)
+    ));
+    session.begin_attempt("turn").await.unwrap();
+
+    let error = session
+        .begin_step("turn", "model", "model", &"retry", RetryPolicy::Idempotent)
+        .await
+        .expect_err("attempt overflow must not silently saturate");
+    assert!(matches!(error, Error::InvalidState(_)));
+    assert_eq!(session.state().await.unwrap().revision(), revision);
+}
+
+#[tokio::test]
 async fn rejects_the_deleted_journal_state_envelope() {
     let payload = r#"{"nanocodex_journal_state":{"format":1,"operations":{},"latest_checkpoint":null,"checkpoint_effect_pending":false}}"#;
     let error = match DurableSession::open(seeded_store(&[payload]), "deleted-state-envelope").await

--- a/crates/nanocodex-durability/tests/session.rs
+++ b/crates/nanocodex-durability/tests/session.rs
@@ -1,6 +1,6 @@
 use nanocodex_durability::{
     Admission, BeginStep, DurableSession, Error, MemoryStore, OwnedState, OwnerId, OwnerToken,
-    RetryPolicy, StateStore, StoreError, StoreFuture, StoredState,
+    ReconciledStep, RetryPolicy, StateStore, StepStatus, StoreError, StoreFuture, StoredState,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::{
@@ -46,6 +46,67 @@ struct NotCommittedOnceStore {
 
 struct SeededStore {
     state: StoredState,
+}
+
+#[derive(Clone, Copy)]
+enum StepGateMoment {
+    BeforeStartCommit,
+    AfterCompletionCommit,
+}
+
+struct StepGateStore {
+    inner: MemoryStore,
+    moment: StepGateMoment,
+    entered: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Notify>,
+    used: Arc<AtomicBool>,
+}
+
+impl StateStore for StepGateStore {
+    fn acquire<'a>(
+        &'a mut self,
+        state_id: &'a str,
+        owner_id: OwnerId,
+    ) -> StoreFuture<'a, Result<OwnedState, StoreError>> {
+        self.inner.acquire(state_id, owner_id)
+    }
+
+    fn replace<'a>(
+        &'a mut self,
+        state_id: &'a str,
+        owner: &'a OwnerToken,
+        expected_revision: u64,
+        payload: &'a str,
+    ) -> StoreFuture<'a, Result<u64, StoreError>> {
+        let matches = match self.moment {
+            StepGateMoment::BeforeStartCommit => payload.contains("\"status\":\"effect_pending\""),
+            StepGateMoment::AfterCompletionCommit => payload.contains("\"status\":{\"completed\":"),
+        };
+        if matches && !self.used.swap(true, Ordering::SeqCst) {
+            let entered = Arc::clone(&self.entered);
+            let release = Arc::clone(&self.release);
+            return match self.moment {
+                StepGateMoment::BeforeStartCommit => Box::pin(async move {
+                    entered.notify_one();
+                    release.notified().await;
+                    self.inner
+                        .replace(state_id, owner, expected_revision, payload)
+                        .await
+                }),
+                StepGateMoment::AfterCompletionCommit => Box::pin(async move {
+                    let revision = self
+                        .inner
+                        .replace(state_id, owner, expected_revision, payload)
+                        .await?;
+                    entered.notify_one();
+                    release.notified().await;
+                    Ok(revision)
+                }),
+            };
+        }
+        self.inner
+            .replace(state_id, owner, expected_revision, payload)
+    }
 }
 
 impl StateStore for SeededStore {
@@ -271,6 +332,256 @@ async fn refuses_to_repeat_an_ambiguous_unsafe_step() {
             .await,
         Ok(BeginStep::Unknown)
     ));
+    let ReconciledStep::Completed(output) = reopened
+        .reconcile_cancelled_step("turn-1", "tool-1", &"unknown after reopen")
+        .await
+        .unwrap()
+    else {
+        panic!("a cold pending at-most-once effect must reconcile as unknown")
+    };
+    assert_eq!(output.decode::<String>().unwrap(), "unknown after reopen");
+}
+
+#[tokio::test]
+async fn cancellation_reconciliation_does_not_invent_unknown_before_begin_is_observed() {
+    let inner = MemoryStore::new().unwrap();
+    let entered = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    let session = Arc::new(
+        DurableSession::open(
+            StepGateStore {
+                inner,
+                moment: StepGateMoment::BeforeStartCommit,
+                entered: Arc::clone(&entered),
+                release: Arc::clone(&release),
+                used: Arc::new(AtomicBool::new(false)),
+            },
+            "cancel-before-begin-observed",
+        )
+        .await
+        .unwrap(),
+    );
+    session.admit("turn-1", &"run tool").await.unwrap();
+    session.begin_attempt("turn-1").await.unwrap();
+    let revision_before_absent = session.state().await.unwrap().revision();
+    assert!(matches!(
+        session
+            .reconcile_cancelled_step("turn-1", "tool-absent", &"unknown")
+            .await
+            .unwrap(),
+        ReconciledStep::NotStarted
+    ));
+    assert_eq!(
+        session.state().await.unwrap().revision(),
+        revision_before_absent,
+        "an absent step must not create a durable transition"
+    );
+
+    let beginning = tokio::spawn({
+        let session = Arc::clone(&session);
+        async move {
+            session
+                .begin_step(
+                    "turn-1",
+                    "tool-1",
+                    "tool_call",
+                    &"effect",
+                    RetryPolicy::Never,
+                )
+                .await
+        }
+    });
+    entered.notified().await;
+    beginning.abort();
+    assert!(beginning.await.unwrap_err().is_cancelled());
+    release.notify_one();
+
+    assert!(matches!(
+        session
+            .reconcile_cancelled_step("turn-1", "tool-1", &"unknown")
+            .await
+            .unwrap(),
+        ReconciledStep::NotStarted
+    ));
+    assert!(
+        session
+            .state()
+            .await
+            .unwrap()
+            .operation("turn-1")
+            .unwrap()
+            .steps
+            .is_empty(),
+        "an unobserved execution permit must leave no durable step"
+    );
+}
+
+#[tokio::test]
+async fn cancellation_reconciliation_completes_an_authorized_pending_step_once_as_unknown() {
+    let session = DurableSession::open(
+        MemoryStore::new().unwrap(),
+        "cancel-authorized-pending-step",
+    )
+    .await
+    .unwrap();
+    session.admit("turn-1", &"run tool").await.unwrap();
+    session.begin_attempt("turn-1").await.unwrap();
+    assert!(matches!(
+        session
+            .begin_step(
+                "turn-1",
+                "tool-1",
+                "tool_call",
+                &"effect",
+                RetryPolicy::Never,
+            )
+            .await
+            .unwrap(),
+        BeginStep::Execute
+    ));
+
+    let ReconciledStep::Completed(output) = session
+        .reconcile_cancelled_step("turn-1", "tool-1", &"unknown")
+        .await
+        .unwrap()
+    else {
+        panic!("an authorized pending effect must settle as unknown")
+    };
+    assert_eq!(output.decode::<String>().unwrap(), "unknown");
+    let revision_after_completion = session.state().await.unwrap().revision();
+    let ReconciledStep::Completed(replayed) = session
+        .reconcile_cancelled_step("turn-1", "tool-1", &"different unknown")
+        .await
+        .unwrap()
+    else {
+        panic!("a settled effect must replay its first authoritative output")
+    };
+    assert_eq!(replayed.decode::<String>().unwrap(), "unknown");
+    assert_eq!(
+        session.state().await.unwrap().revision(),
+        revision_after_completion,
+        "reconciling a completed step must not append a second completion"
+    );
+    assert!(matches!(
+        session
+            .state()
+            .await
+            .unwrap()
+            .operation("turn-1")
+            .unwrap()
+            .steps["tool-1"]
+            .status,
+        StepStatus::Completed(_)
+    ));
+}
+
+#[tokio::test]
+async fn cancellation_reconciliation_does_not_overtake_a_live_begin_handoff() {
+    let entered = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    let session = Arc::new(
+        DurableSession::open(
+            StepGateStore {
+                inner: MemoryStore::new().unwrap(),
+                moment: StepGateMoment::BeforeStartCommit,
+                entered: Arc::clone(&entered),
+                release: Arc::clone(&release),
+                used: Arc::new(AtomicBool::new(false)),
+            },
+            "cancel-live-begin-handoff",
+        )
+        .await
+        .unwrap(),
+    );
+    session.admit("turn-1", &"run tool").await.unwrap();
+    session.begin_attempt("turn-1").await.unwrap();
+    let beginning = tokio::spawn({
+        let session = Arc::clone(&session);
+        async move {
+            session
+                .begin_step(
+                    "turn-1",
+                    "tool-1",
+                    "tool_call",
+                    &"effect",
+                    RetryPolicy::Never,
+                )
+                .await
+        }
+    });
+    entered.notified().await;
+    tokio::spawn({
+        let release = Arc::clone(&release);
+        async move {
+            tokio::task::yield_now().await;
+            release.notify_one();
+        }
+    });
+
+    let error = session
+        .reconcile_cancelled_step("turn-1", "tool-1", &"unknown")
+        .await
+        .expect_err("a live execution permit cannot be reclassified by cancellation");
+    assert!(error.to_string().contains("unresolved execution handoff"));
+    assert!(matches!(
+        beginning.await.unwrap().unwrap(),
+        BeginStep::Execute
+    ));
+}
+
+#[tokio::test]
+async fn cancellation_reconciliation_retains_completion_committed_before_its_reply_is_observed() {
+    let inner = MemoryStore::new().unwrap();
+    let entered = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    let session = Arc::new(
+        DurableSession::open(
+            StepGateStore {
+                inner,
+                moment: StepGateMoment::AfterCompletionCommit,
+                entered: Arc::clone(&entered),
+                release: Arc::clone(&release),
+                used: Arc::new(AtomicBool::new(false)),
+            },
+            "cancel-after-completion-commit",
+        )
+        .await
+        .unwrap(),
+    );
+    session.admit("turn-1", &"run tool").await.unwrap();
+    session.begin_attempt("turn-1").await.unwrap();
+    session
+        .begin_step(
+            "turn-1",
+            "tool-1",
+            "tool_call",
+            &"effect",
+            RetryPolicy::Never,
+        )
+        .await
+        .unwrap();
+
+    let completing = tokio::spawn({
+        let session = Arc::clone(&session);
+        async move {
+            session
+                .complete_step("turn-1", "tool-1", &"real output")
+                .await
+        }
+    });
+    entered.notified().await;
+    completing.abort();
+    assert!(completing.await.unwrap_err().is_cancelled());
+    release.notify_one();
+
+    let ReconciledStep::Completed(output) = session
+        .reconcile_cancelled_step("turn-1", "tool-1", &"unknown")
+        .await
+        .unwrap()
+    else {
+        panic!("the durable real output must remain authoritative")
+    };
+    assert_eq!(output.decode::<String>().unwrap(), "real output");
 }
 
 #[tokio::test]

--- a/crates/nanocodex-durability/tests/session.rs
+++ b/crates/nanocodex-durability/tests/session.rs
@@ -1,6 +1,6 @@
 use nanocodex_durability::{
-    Admission, BeginStep, DurableSession, Error, JournalStore, MemoryStore, OwnedJournal, OwnerId,
-    OwnerToken, RetryPolicy, StoreError, StoreFuture, StoredBatch, StoredJournal,
+    Admission, BeginStep, DurableSession, Error, MemoryStore, OwnedState, OwnerId, OwnerToken,
+    RetryPolicy, StateStore, StoreError, StoreFuture, StoredState,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::{
@@ -45,51 +45,51 @@ struct NotCommittedOnceStore {
 }
 
 struct SeededStore {
-    journal: StoredJournal,
+    state: StoredState,
 }
 
-impl JournalStore for SeededStore {
-    fn acquire_owner<'a>(
+impl StateStore for SeededStore {
+    fn acquire<'a>(
         &'a mut self,
-        _journal_id: &'a str,
+        _state_id: &'a str,
         owner_id: OwnerId,
-    ) -> StoreFuture<'a, Result<OwnedJournal, StoreError>> {
-        let journal = self.journal.clone();
+    ) -> StoreFuture<'a, Result<OwnedState, StoreError>> {
+        let state = self.state.clone();
         Box::pin(async move {
-            Ok(OwnedJournal {
+            Ok(OwnedState {
                 owner: OwnerToken::new(owner_id, 1),
-                journal,
+                state,
             })
         })
     }
 
-    fn append<'a>(
+    fn replace<'a>(
         &'a mut self,
-        _journal_id: &'a str,
+        _state_id: &'a str,
         _owner: &'a OwnerToken,
         _expected_revision: u64,
         _payload: &'a str,
     ) -> StoreFuture<'a, Result<u64, StoreError>> {
         Box::pin(async {
             Err(StoreError::Backend(
-                "the seeded legacy store is read-only".to_owned(),
+                "the seeded store is read-only".to_owned(),
             ))
         })
     }
 }
 
-impl JournalStore for NotCommittedOnceStore {
-    fn acquire_owner<'a>(
+impl StateStore for NotCommittedOnceStore {
+    fn acquire<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner_id: OwnerId,
-    ) -> StoreFuture<'a, Result<OwnedJournal, StoreError>> {
-        self.inner.acquire_owner(journal_id, owner_id)
+    ) -> StoreFuture<'a, Result<OwnedState, StoreError>> {
+        self.inner.acquire(state_id, owner_id)
     }
 
-    fn append<'a>(
+    fn replace<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner: &'a OwnerToken,
         expected_revision: u64,
         payload: &'a str,
@@ -97,27 +97,27 @@ impl JournalStore for NotCommittedOnceStore {
         if expected_revision == self.fail_at_revision && !self.failed.swap(true, Ordering::SeqCst) {
             return Box::pin(async {
                 Err(StoreError::NotCommitted(
-                    "injected retryable append failure".to_owned(),
+                    "injected retryable replacement failure".to_owned(),
                 ))
             });
         }
         self.inner
-            .append(journal_id, owner, expected_revision, payload)
+            .replace(state_id, owner, expected_revision, payload)
     }
 }
 
-impl JournalStore for CommitThenFailStore {
-    fn acquire_owner<'a>(
+impl StateStore for CommitThenFailStore {
+    fn acquire<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner_id: OwnerId,
-    ) -> StoreFuture<'a, Result<OwnedJournal, StoreError>> {
-        self.inner.acquire_owner(journal_id, owner_id)
+    ) -> StoreFuture<'a, Result<OwnedState, StoreError>> {
+        self.inner.acquire(state_id, owner_id)
     }
 
-    fn append<'a>(
+    fn replace<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner: &'a OwnerToken,
         expected_revision: u64,
         payload: &'a str,
@@ -125,11 +125,11 @@ impl JournalStore for CommitThenFailStore {
         Box::pin(async move {
             let revision = self
                 .inner
-                .append(journal_id, owner, expected_revision, payload)
+                .replace(state_id, owner, expected_revision, payload)
                 .await?;
             if expected_revision == self.fail_after_revision {
                 return Err(StoreError::Backend(
-                    "append response was lost after commit".to_owned(),
+                    "replacement response was lost after commit".to_owned(),
                 ));
             }
             Ok(revision)
@@ -159,7 +159,7 @@ async fn replays_completed_operations_and_steps_after_reopen() {
             .await,
         Ok(Admission::Accepted)
     ));
-    assert_eq!(session.begin_attempt("turn-1").await.unwrap(), 1);
+    session.begin_attempt("turn-1").await.unwrap();
     assert!(matches!(
         session
             .begin_step_typed::<_, ModelOutput>(
@@ -232,7 +232,6 @@ async fn failed_operations_replay_their_error_and_do_not_block_follow_on_work() 
     assert_eq!(error, "invalid image");
 
     session.admit("turn-2", &"continue").await.unwrap();
-    session.begin_attempt("turn-2").await.unwrap();
     session.cancel("turn-2").await.unwrap();
 
     let reopened = DurableSession::open(store, "failed-session").await.unwrap();
@@ -270,7 +269,7 @@ async fn refuses_to_repeat_an_ambiguous_unsafe_step() {
         reopened
             .begin_step("turn-1", "tool-1", "tool", &"charge", RetryPolicy::Never)
             .await,
-        Err(Error::AmbiguousStep { .. })
+        Ok(BeginStep::Unknown)
     ));
 }
 
@@ -289,100 +288,197 @@ async fn queues_admission_but_serializes_attempts() {
     session.begin_attempt("turn-2").await.unwrap();
 }
 
-#[tokio::test]
-async fn reopens_a_seeded_legacy_journal_with_repeated_attempt_starts() {
-    let batches = [
-        r#"{"operation_accepted":{"operation_id":"legacy-turn","input":"prompt"}}"#,
-        r#"{"attempt_started":{"operation_id":"legacy-turn"}}"#,
-        r#"{"attempt_started":{"operation_id":"legacy-turn"}}"#,
-        r#"{"operation_completed":{"operation_id":"legacy-turn","checkpoint":{"version":7},"output":{"message":"legacy done"}}}"#,
-    ]
-    .into_iter()
-    .enumerate()
-    .map(|(index, payload)| StoredBatch {
-        revision: u64::try_from(index + 1).unwrap(),
-        payload: payload.to_owned(),
-    })
-    .collect();
-    let session = DurableSession::open(
-        SeededStore {
-            journal: StoredJournal {
-                revision: 4,
-                batches,
-            },
-        },
-        "legacy-repeated-attempts",
-    )
-    .await
-    .unwrap();
-
-    let state = session.state().await.unwrap();
-    let operation = state.operation("legacy-turn").unwrap();
-    assert_eq!(operation.attempts, 2);
-    assert!(matches!(
-        &operation.status,
-        nanocodex_durability::OperationStatus::Completed { checkpoint, output }
-            if checkpoint.decode::<Checkpoint>().unwrap() == Checkpoint { version: 7 }
-                && output.decode::<TurnOutput>().unwrap().message == "legacy done"
-    ));
-}
-
-fn seeded_legacy_store(payloads: &[&str]) -> SeededStore {
-    let batches = payloads
-        .iter()
-        .enumerate()
-        .map(|(index, payload)| StoredBatch {
-            revision: u64::try_from(index + 1).unwrap(),
-            payload: (*payload).to_owned(),
-        })
-        .collect::<Vec<_>>();
+fn seeded_store(payloads: &[&str]) -> SeededStore {
+    assert_eq!(payloads.len(), 1, "durable state has no replay history");
     SeededStore {
-        journal: StoredJournal {
-            revision: u64::try_from(batches.len()).unwrap(),
-            batches,
+        state: StoredState {
+            revision: 1,
+            payload: Some(payloads[0].to_owned()),
         },
     }
 }
 
 #[tokio::test]
-async fn reopens_a_seeded_legacy_step_start_without_an_attempt_start() {
-    let session = DurableSession::open(
-        seeded_legacy_store(&[
-            r#"{"operation_accepted":{"operation_id":"legacy-turn","input":"prompt"}}"#,
-            r#"{"step_started":{"operation_id":"legacy-turn","step_id":"tool-1","kind":"tool","input":"charge","retry":"idempotent"}}"#,
-        ]),
-        "legacy-step-start",
+async fn rejects_every_inconsistent_store_state_shape() {
+    for (name, state) in [
+        (
+            "payload-at-zero",
+            StoredState {
+                revision: 0,
+                payload: Some("{}".to_owned()),
+            },
+        ),
+        (
+            "missing-at-nonzero",
+            StoredState {
+                revision: 1,
+                payload: None,
+            },
+        ),
+    ] {
+        let error = match DurableSession::open(SeededStore { state }, name).await {
+            Ok(_) => panic!("inconsistent retained state was accepted"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, Error::InvalidState(_)));
+    }
+}
+
+#[tokio::test]
+async fn rejects_unknown_outer_state_fields() {
+    let error = match DurableSession::open(
+        seeded_store(&[r#"{"nanocodex_durable_state":{"format":1,"operations":{},"latest_checkpoint":null,"checkpoint_effect_pending":false},"unknown":true}"#]),
+        "unknown-outer-field",
     )
     .await
-    .unwrap();
+    {
+        Ok(_) => panic!("unknown retained state field was accepted"),
+        Err(error) => error,
+    };
+    assert!(matches!(error, Error::Decode { revision: 1, .. }));
+}
+
+#[tokio::test]
+async fn rejects_noncanonical_checkpoint_fields() {
+    let payload = r#"{"nanocodex_durable_state":{"format":1,"operations":{},"latest_checkpoint":null,"checkpoint_effect_pending":false,"generation":1}}"#;
+    let error = match DurableSession::open(
+        SeededStore {
+            state: StoredState {
+                revision: 1,
+                payload: Some(payload.to_owned()),
+            },
+        },
+        "noncanonical-checkpoint",
+    )
+    .await
+    {
+        Ok(_) => panic!("checkpoint fields must match the current protocol exactly"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(error, Error::Decode { revision: 1, .. }));
+}
+
+#[tokio::test]
+async fn rejects_the_deleted_journal_state_envelope() {
+    let payload = r#"{"nanocodex_journal_state":{"format":1,"operations":{},"latest_checkpoint":null,"checkpoint_effect_pending":false}}"#;
+    let error = match DurableSession::open(seeded_store(&[payload]), "deleted-state-envelope").await
+    {
+        Ok(_) => panic!("the current-state protocol must not adopt old state state"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(error, Error::Decode { revision: 1, .. }));
+}
+
+#[tokio::test]
+async fn rejects_noncanonical_transition_shape() {
+    let error = match DurableSession::open(
+        seeded_store(&[r#"{"operation_accepted":{"operation_id":"turn","input":"prompt"}}"#]),
+        "noncanonical-entry",
+    )
+    .await
+    {
+        Ok(_) => panic!("state entries must use the current tagged shape"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(error, Error::Decode { revision: 1, .. }));
+}
+
+#[tokio::test]
+async fn rejects_a_checkpoint_terminal_that_crosses_pending_work() {
+    let payload = r#"{"nanocodex_durable_state":{"format":1,"operations":{"turn-1":{"input":"\"first\"","status":"pending","steps":{},"accepted_order":1},"turn-2":{"input":"\"second\"","status":{"completed":{"checkpoint":"\"crossed\"","output":"\"done\""}},"steps":{},"accepted_order":2}},"latest_checkpoint":"\"crossed\"","checkpoint_effect_pending":false}}"#;
+    let error = match DurableSession::open(
+        SeededStore {
+            state: StoredState {
+                revision: 2,
+                payload: Some(payload.to_owned()),
+            },
+        },
+        "crossed-checkpoint-terminal",
+    )
+    .await
+    {
+        Ok(_) => panic!("checkpoint-bearing terminals must preserve operation order"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(error, Error::InvalidState(_)));
+}
+
+#[tokio::test]
+async fn rejects_a_checkpoint_effect_that_crosses_pending_work() {
+    let payload = r#"{"nanocodex_durable_state":{"format":1,"operations":{"turn":{"input":"\"prompt\"","status":"pending","steps":{},"accepted_order":1}},"latest_checkpoint":null,"checkpoint_effect_pending":true}}"#;
+    let error =
+        match DurableSession::open(seeded_store(&[payload]), "crossed-checkpoint-effect").await {
+            Ok(_) => panic!("standalone checkpoint effects must not cross pending operations"),
+            Err(error) => error,
+        };
+
+    assert!(matches!(error, Error::InvalidState(_)));
+}
+
+#[tokio::test]
+async fn rejects_a_restarted_at_most_once_step() {
+    let payload = r#"{"nanocodex_durable_state":{"format":1,"operations":{"turn":{"input":"\"prompt\"","status":"pending","steps":{"tool-1":{"kind":"tool","input":"\"charge\"","retry":"never","status":"effect_pending","attempts":2}},"accepted_order":1}},"latest_checkpoint":null,"checkpoint_effect_pending":false}}"#;
+    let error =
+        match DurableSession::open(seeded_store(&[payload]), "restarted-at-most-once-step").await {
+            Ok(_) => panic!("at-most-once steps must have one committed start"),
+            Err(error) => error,
+        };
+
+    assert!(matches!(error, Error::InvalidState(_)));
+}
+
+#[tokio::test]
+async fn reopens_a_seeded_step_start() {
+    let store = MemoryStore::new().unwrap();
+    let session = DurableSession::open(store.clone(), "seeded-step-start")
+        .await
+        .unwrap();
+    session.admit("turn", &"prompt").await.unwrap();
+    session.begin_attempt("turn").await.unwrap();
+    session
+        .begin_step("turn", "tool-1", "tool", &"charge", RetryPolicy::Idempotent)
+        .await
+        .unwrap();
+    drop(session);
+    let session = DurableSession::open(store, "seeded-step-start")
+        .await
+        .unwrap();
 
     let state = session.state().await.unwrap();
-    let operation = state.operation("legacy-turn").unwrap();
-    assert_eq!(operation.attempts, 0);
-    assert!(!operation.active_attempt);
+    let operation = state.operation("turn").unwrap();
     assert!(matches!(
         operation.steps.get("tool-1").map(|step| &step.status),
-        Some(nanocodex_durability::StepStatus::Started)
+        Some(nanocodex_durability::StepStatus::EffectPending)
     ));
 }
 
 #[tokio::test]
-async fn reopens_a_seeded_legacy_step_completion_without_an_attempt_start() {
-    let session = DurableSession::open(
-        seeded_legacy_store(&[
-            r#"{"operation_accepted":{"operation_id":"legacy-turn","input":"prompt"}}"#,
-            r#"{"step_started":{"operation_id":"legacy-turn","step_id":"tool-1","kind":"tool","input":"charge","retry":"idempotent"}}"#,
-            r#"{"step_completed":{"operation_id":"legacy-turn","step_id":"tool-1","output":"receipt"}}"#,
-        ]),
-        "legacy-step-completion",
-    )
-    .await
-    .unwrap();
+async fn reopens_a_seeded_step_completion() {
+    let store = MemoryStore::new().unwrap();
+    let session = DurableSession::open(store.clone(), "seeded-step-completion")
+        .await
+        .unwrap();
+    session.admit("turn", &"prompt").await.unwrap();
+    session.begin_attempt("turn").await.unwrap();
+    session
+        .begin_step("turn", "tool-1", "tool", &"charge", RetryPolicy::Idempotent)
+        .await
+        .unwrap();
+    session
+        .complete_step("turn", "tool-1", &"receipt")
+        .await
+        .unwrap();
+    drop(session);
+    let session = DurableSession::open(store, "seeded-step-completion")
+        .await
+        .unwrap();
 
     let state = session.state().await.unwrap();
-    let operation = state.operation("legacy-turn").unwrap();
-    assert_eq!(operation.attempts, 0);
-    assert!(!operation.active_attempt);
+    let operation = state.operation("turn").unwrap();
     assert!(matches!(
         operation.steps.get("tool-1").map(|step| &step.status),
         Some(nanocodex_durability::StepStatus::Completed(output))
@@ -391,72 +487,65 @@ async fn reopens_a_seeded_legacy_step_completion_without_an_attempt_start() {
 }
 
 #[tokio::test]
-async fn reopens_a_seeded_legacy_attempt_failure_without_an_attempt_start() {
-    let session = DurableSession::open(
-        seeded_legacy_store(&[
-            r#"{"operation_accepted":{"operation_id":"legacy-turn","input":"prompt"}}"#,
-            r#"{"attempt_failed":{"operation_id":"legacy-turn","error":"temporary"}}"#,
-        ]),
-        "legacy-attempt-failure",
-    )
-    .await
-    .unwrap();
-
-    let state = session.state().await.unwrap();
-    let operation = state.operation("legacy-turn").unwrap();
-    assert_eq!(operation.attempts, 0);
-    assert!(!operation.active_attempt);
-    assert_eq!(operation.last_error.as_deref(), Some("temporary"));
-}
-
-#[tokio::test]
-async fn reopens_a_seeded_legacy_completion_without_an_attempt_start() {
-    let session = DurableSession::open(
-        seeded_legacy_store(&[
-            r#"{"operation_accepted":{"operation_id":"legacy-turn","input":"prompt"}}"#,
-            r#"{"operation_completed":{"operation_id":"legacy-turn","checkpoint":{"version":7},"output":{"message":"legacy done"}}}"#,
-        ]),
-        "legacy-completion",
-    )
-    .await
-    .unwrap();
+async fn reopens_a_seeded_completion() {
+    let store = MemoryStore::new().unwrap();
+    let session = DurableSession::open(store.clone(), "seeded-completion")
+        .await
+        .unwrap();
+    session.admit("turn", &"prompt").await.unwrap();
+    session.begin_attempt("turn").await.unwrap();
+    session
+        .complete(
+            "turn",
+            &Checkpoint { version: 7 },
+            &TurnOutput {
+                message: "done".to_owned(),
+            },
+        )
+        .await
+        .unwrap();
+    drop(session);
+    let session = DurableSession::open(store, "seeded-completion")
+        .await
+        .unwrap();
 
     let replay = session
-        .admit_typed::<_, Checkpoint, TurnOutput>("legacy-turn", &"prompt")
+        .admit_typed::<_, Checkpoint, TurnOutput>("turn", &"prompt")
         .await
         .unwrap();
     assert!(matches!(
         replay,
         Admission::Completed { checkpoint, output }
-            if checkpoint == Checkpoint { version: 7 } && output.message == "legacy done"
+            if checkpoint == Checkpoint { version: 7 } && output.message == "done"
     ));
-    let state = session.state().await.unwrap();
-    assert_eq!(state.operation("legacy-turn").unwrap().attempts, 0);
 }
 
 #[tokio::test]
-async fn reopens_a_seeded_legacy_terminal_failure_without_an_attempt_start() {
-    let session = DurableSession::open(
-        seeded_legacy_store(&[
-            r#"{"operation_accepted":{"operation_id":"legacy-turn","input":"prompt"}}"#,
-            r#"{"operation_failed":{"operation_id":"legacy-turn","checkpoint":{"version":8},"error":"legacy failure"}}"#,
-        ]),
-        "legacy-terminal-failure",
-    )
-    .await
-    .unwrap();
+async fn reopens_a_seeded_terminal_failure() {
+    let store = MemoryStore::new().unwrap();
+    let session = DurableSession::open(store.clone(), "seeded-terminal-failure")
+        .await
+        .unwrap();
+    session.admit("turn", &"prompt").await.unwrap();
+    session.begin_attempt("turn").await.unwrap();
+    session
+        .fail("turn", &Checkpoint { version: 8 }, "failure")
+        .await
+        .unwrap();
+    drop(session);
+    let session = DurableSession::open(store, "seeded-terminal-failure")
+        .await
+        .unwrap();
 
     let replay = session
-        .admit_typed::<_, Checkpoint, TurnOutput>("legacy-turn", &"prompt")
+        .admit_typed::<_, Checkpoint, TurnOutput>("turn", &"prompt")
         .await
         .unwrap();
     assert!(matches!(
         replay,
         Admission::Failed { checkpoint, error }
-            if checkpoint == Checkpoint { version: 8 } && error == "legacy failure"
+            if checkpoint == Checkpoint { version: 8 } && error == "failure"
     ));
-    let state = session.state().await.unwrap();
-    assert_eq!(state.operation("legacy-turn").unwrap().attempts, 0);
 }
 
 #[tokio::test]
@@ -481,7 +570,32 @@ async fn queued_unstarted_operation_can_cancel_behind_a_pending_predecessor() {
 }
 
 #[tokio::test]
-async fn definitely_uncommitted_terminal_append_reopens_the_exact_claim_for_retry() {
+async fn active_operation_cancellation_requires_a_checkpoint() {
+    let store = MemoryStore::new().unwrap();
+    let session = DurableSession::open(store, "active-cancel-checkpoint")
+        .await
+        .unwrap();
+    session.admit("turn-1", &"one").await.unwrap();
+    session.begin_attempt("turn-1").await.unwrap();
+
+    assert!(matches!(
+        session.cancel("turn-1").await,
+        Err(Error::CancellationCheckpointRequired { operation_id }) if operation_id == "turn-1"
+    ));
+    assert!(matches!(
+        session
+            .state()
+            .await
+            .unwrap()
+            .operation("turn-1")
+            .unwrap()
+            .status,
+        nanocodex_durability::OperationStatus::Pending
+    ));
+}
+
+#[tokio::test]
+async fn definitely_uncommitted_terminal_replace_reopens_the_exact_claim_for_retry() {
     let store = MemoryStore::new().unwrap();
     let failed = Arc::new(AtomicBool::new(false));
     let session = DurableSession::open(
@@ -519,7 +633,7 @@ async fn definitely_uncommitted_completion_reopens_the_exact_claim_for_retry() {
     let session = DurableSession::open(
         NotCommittedOnceStore {
             inner: store,
-            fail_at_revision: 2,
+            fail_at_revision: 1,
             failed: Arc::new(AtomicBool::new(false)),
         },
         "retry-completion-claim",
@@ -536,32 +650,26 @@ async fn definitely_uncommitted_completion_reopens_the_exact_claim_for_retry() {
         session.admit("turn-1", &"prompt").await,
         Ok(Admission::Pending)
     ));
+    session.begin_attempt("turn-1").await.unwrap();
     session.complete("turn-1", &1, &"answer").await.unwrap();
 }
 
 #[tokio::test]
-async fn definitely_uncommitted_attempt_failure_reopens_the_exact_claim_for_retry() {
+async fn attempt_failure_releases_the_claim_without_a_durable_write() {
     let store = MemoryStore::new().unwrap();
-    let session = DurableSession::open(
-        NotCommittedOnceStore {
-            inner: store,
-            fail_at_revision: 2,
-            failed: Arc::new(AtomicBool::new(false)),
-        },
-        "retry-attempt-failure-claim",
-    )
-    .await
-    .unwrap();
+    let session = DurableSession::open(store, "retry-attempt-failure-claim")
+        .await
+        .unwrap();
     session.admit("turn-1", &"prompt").await.unwrap();
     session.begin_attempt("turn-1").await.unwrap();
-    assert!(matches!(
-        session.fail_attempt("turn-1", "temporary").await,
-        Err(Error::Store(StoreError::NotCommitted(_)))
-    ));
+    let revision = session.state().await.unwrap().revision();
+    session.fail_attempt("turn-1", "temporary").await.unwrap();
+    assert_eq!(session.state().await.unwrap().revision(), revision);
     assert!(matches!(
         session.admit("turn-1", &"prompt").await,
         Ok(Admission::Pending)
     ));
+    session.begin_attempt("turn-1").await.unwrap();
     session.fail_attempt("turn-1", "temporary").await.unwrap();
     assert!(matches!(
         session.admit("turn-1", &"prompt").await,
@@ -819,7 +927,7 @@ async fn automatic_admission_reclaims_multiple_queued_operations_in_order() {
 }
 
 #[tokio::test]
-async fn rejects_invalid_transitions_before_the_host_append() {
+async fn rejects_invalid_transitions_before_the_host_replace() {
     let store = MemoryStore::new().unwrap();
     let session = DurableSession::open(store.clone(), "session")
         .await
@@ -836,12 +944,12 @@ async fn rejects_invalid_transitions_before_the_host_append() {
 }
 
 #[tokio::test]
-async fn stops_a_stale_owner_when_an_append_outcome_is_ambiguous() {
+async fn stops_a_stale_owner_when_a_replace_outcome_is_ambiguous() {
     let store = MemoryStore::new().unwrap();
     let session = DurableSession::open(
         CommitThenFailStore {
             inner: store.clone(),
-            fail_after_revision: 2,
+            fail_after_revision: 1,
         },
         "session",
     )
@@ -864,7 +972,7 @@ async fn stops_a_stale_owner_when_an_append_outcome_is_ambiguous() {
 
 #[cfg(feature = "sqlite")]
 #[tokio::test]
-async fn sqlite_compare_and_append_survives_reopen() {
+async fn sqlite_compare_and_replace_survives_reopen() {
     use nanocodex_durability::SqliteStore;
 
     let directory = tempfile::tempdir().unwrap();

--- a/crates/nanocodex-managed/src/driver.rs
+++ b/crates/nanocodex-managed/src/driver.rs
@@ -389,7 +389,7 @@ where
         };
         let terminal = matches!(
             turn.state,
-            TurnState::Blocked | TurnState::Completed | TurnState::Cancelled | TurnState::Failed
+            TurnState::Completed | TurnState::Cancelled | TurnState::Failed
         ) || turn.terminal.is_some();
         let turn_id = turn.turn_id.clone();
         if turn
@@ -556,10 +556,6 @@ where
             ManagedEventData::TurnCancelled { id } => {
                 self.complete(&id, |_| Err(NanocodexError::TurnCancelled));
             }
-            ManagedEventData::TurnBlocked { id, error } => {
-                let outcome = turn_error(id.clone(), "blocked", error);
-                self.complete(&id, |_| Err(outcome));
-            }
             ManagedEventData::TurnFailed { id, error } => {
                 let outcome = turn_error(id.clone(), "failed", error);
                 self.complete(&id, |_| Err(outcome));
@@ -665,7 +661,6 @@ fn retained_result(
             ))
         }
         ManagedEventData::TurnCancelled { .. } => Err(NanocodexError::TurnCancelled),
-        ManagedEventData::TurnBlocked { id, error } => Err(turn_error(id, "blocked", error)),
         ManagedEventData::TurnFailed { id, error } => Err(turn_error(id, "failed", error)),
         _ => {
             return Err(backend_error(ManagedError::InvalidResponse(

--- a/crates/nanocodex-managed/src/types.rs
+++ b/crates/nanocodex-managed/src/types.rs
@@ -341,10 +341,6 @@ pub enum TurnState {
     Accepted,
     /// Cancellation was requested.
     Cancelling,
-    /// Execution failed transiently and may retry.
-    Retryable,
-    /// Execution is blocked on an unavailable capability.
-    Blocked,
     /// Execution completed successfully.
     Completed,
     /// Execution was cancelled.
@@ -505,13 +501,6 @@ pub enum ManagedEventData {
         /// Retryable failure detail.
         error: String,
     },
-    /// A turn is blocked on an unavailable capability.
-    TurnBlocked {
-        /// Stable managed turn identifier.
-        id: String,
-        /// Blocking failure detail.
-        error: String,
-    },
     /// A turn failed terminally.
     TurnFailed {
         /// Stable managed turn identifier.
@@ -638,13 +627,6 @@ impl ManagedEventData {
                     error: value.error,
                 })
             }
-            "turn_blocked" => {
-                let value: Failure = decode_raw(raw)?;
-                Ok(Self::TurnBlocked {
-                    id: value.id,
-                    error: value.error,
-                })
-            }
             "turn_failed" => {
                 let value: Failure = decode_raw(raw)?;
                 Ok(Self::TurnFailed {
@@ -699,7 +681,6 @@ impl ManagedEventData {
             | Self::TurnCompleted { id, .. }
             | Self::TurnCancelled { id }
             | Self::TurnRetryable { id, .. }
-            | Self::TurnBlocked { id, .. }
             | Self::TurnFailed { id, .. } => Some(id),
             Self::AgentCreated { .. } | Self::Event { .. } | Self::StreamFailed { .. } => None,
         }
@@ -718,11 +699,6 @@ impl ManagedEventData {
                 state: "cancelled".to_owned(),
                 message: "managed turn was cancelled".to_owned(),
             })),
-            Self::TurnBlocked { id, error } if id == turn_id => Some(Err(ManagedError::Turn {
-                turn_id: id.clone(),
-                state: "blocked".to_owned(),
-                message: error.clone(),
-            })),
             Self::TurnFailed { id, error } if id == turn_id => Some(Err(ManagedError::Turn {
                 turn_id: id.clone(),
                 state: "failed".to_owned(),
@@ -740,7 +716,6 @@ impl ManagedEventData {
             Self::TurnCompleted { .. } => "turn_completed",
             Self::TurnCancelled { .. } => "turn_cancelled",
             Self::TurnRetryable { .. } => "turn_retryable",
-            Self::TurnBlocked { .. } => "turn_blocked",
             Self::TurnFailed { .. } => "turn_failed",
             Self::Event { .. } => "event",
             Self::StreamFailed { .. } => "stream_failed",

--- a/crates/nanocodex-oai-api/src/transport/api_error.rs
+++ b/crates/nanocodex-oai-api/src/transport/api_error.rs
@@ -15,13 +15,14 @@ pub(super) fn retryable_api_error(event: &str) -> Option<(&'static str, Option<D
                 return None;
             }
             match discriminator {
+                Some("server_is_overloaded" | "slow_down") => "api_overload",
                 Some("rate_limit_exceeded") => "api_rate_limit",
                 Some("server_error" | "websocket_connection_limit_reached") => "api_server",
                 _ => "api_failed",
             }
         }
         _ => match discriminator {
-            Some("server_is_overloaded" | "slow_down") => return None,
+            Some("server_is_overloaded" | "slow_down") => "api_overload",
             Some("server_error" | "websocket_connection_limit_reached") => "api_server",
             Some("rate_limit_exceeded") => "api_rate_limit",
             _ => return None,
@@ -52,8 +53,6 @@ fn is_terminal_response_failure(code: &str) -> bool {
             | "misalignment_policy_violation"
             | "invalid_prompt"
             | "bio_policy"
-            | "server_is_overloaded"
-            | "slow_down"
     )
 }
 
@@ -167,22 +166,35 @@ mod tests {
     }
 
     #[test]
-    fn overload_failures_are_terminal() {
+    fn overload_failures_are_retryable_and_retain_server_delay() {
         for code in ["server_is_overloaded", "slow_down"] {
-            let failed = format!(
-                r#"{{
-                    "type": "response.failed",
-                    "response": {{ "error": {{ "code": "{code}" }} }}
-                }}"#
-            );
-            let error = format!(
-                r#"{{
-                    "type": "error",
-                    "error": {{ "code": "{code}" }}
-                }}"#
-            );
-            assert_eq!(retryable_api_error(&failed), None, "failed: {code}");
-            assert_eq!(retryable_api_error(&error), None, "error: {code}");
+            for discriminator in ["code", "type"] {
+                let failed = format!(
+                    r#"{{
+                        "type": "response.failed",
+                        "response": {{
+                            "error": {{ "{discriminator}": "{code}", "retry_after": 1.25 }}
+                        }}
+                    }}"#
+                );
+                let error = format!(
+                    r#"{{
+                        "type": "error",
+                        "error": {{ "{discriminator}": "{code}" }},
+                        "headers": {{ "Retry-After": "2.5" }}
+                    }}"#
+                );
+                assert_eq!(
+                    retryable_api_error(&failed),
+                    Some(("api_overload", Some(Duration::from_millis(1_250)))),
+                    "failed: {discriminator}={code}"
+                );
+                assert_eq!(
+                    retryable_api_error(&error),
+                    Some(("api_overload", Some(Duration::from_millis(2_500)))),
+                    "error: {discriminator}={code}"
+                );
+            }
         }
     }
 

--- a/crates/nanocodex-subagents/src/runtime.rs
+++ b/crates/nanocodex-subagents/src/runtime.rs
@@ -217,7 +217,7 @@ impl TurnSteer {
 }
 
 impl RegistryState {
-    fn next_access(&mut self) -> u64 {
+    const fn next_access(&mut self) -> u64 {
         self.next_access = self.next_access.wrapping_add(1);
         self.next_access
     }

--- a/docs/DURABILITY.md
+++ b/docs/DURABILITY.md
@@ -1,496 +1,202 @@
-# Durability model and correctness review
+# Durability model
 
-Status: implemented and verified, 2026-08-24.
+Nanocodex has one durability protocol. Rust owns it. Hosts store one opaque,
+complete current-state value, and application layers project those facts for
+their own APIs. Recovery loads one total state value.
 
-This document records the end-to-end durability contract after closing findings
-D-01 through D-98. The central rule is:
+The protocol protects the entire execution lifecycle: prompt admission, model
+requests, warmup, compaction, tool effects, checkpoint commits, cancellation,
+terminal results, and recovery. It is not a tool-only mechanism.
 
-> An accepted operation is not finished until its authoritative Rust journal
-> transition and checkpoint are committed. Everything outside that journal is
-> an ingress ledger or projection recoverable from the same operation identity.
+## Authority
 
-## 1. Boundaries and sources of truth
+| Layer | Durable responsibility | Never authoritative for |
+|---|---|---|
+| `nanocodex-durability` | Total state format, FIFO admission, effect recovery, checkpoints, terminals | Provider or application policy |
+| State store | Atomic owner acquisition and compare-and-replace of one opaque value | State decoding or recovery decisions |
+| Agent adapter | Stable IDs and typed inputs/outputs for model, compaction, warmup, and tool steps | Storage semantics |
+| Managed Durable Object | Inbox, cancellation intent, retry deadline, terminal/event projection | Whether an inner effect may replay |
 
-| State | Owner | Purpose | Authority |
-| --- | --- | --- | --- |
-| Rust execution journal | `nanocodex-durability` | Admission, FIFO execution, effect replay, terminals, and resumable checkpoints | Authoritative for whether model/tool work may execute |
-| `SessionSnapshot` | `nanocodex-agent` | Typed history, model configuration, response chain, and completed tool progress | Authoritative model state only after the journal commits it |
-| Managed/local ingress and transcript rows | Application | Retain exact external IDs and inputs before Agent admission; present history | Authoritative for application delivery, never proof of a Rust terminal |
+There is no second durable attempt state. A driver owns live operation claims
+and running attempts in memory under its fenced owner capability. Losing the
+driver loses those claims; it does not require a state mutation to release
+them.
 
-The host store owns atomic storage but treats Rust journal batches as opaque,
-byte-preserved JSON. The Rust reducer alone interprets operations, steps,
-checkpoints, and recovery policy.
+## Store contract
 
-The browser has two separate origin-local databases: the Worker-owned Rust
-journal and the UI transcript. The transcript is an ingress ledger and
-projection; it is not a second execution authority. Likewise, managed
-`managed_turns` rows instruct recovery of the Cloudflare Agent's Rust journal
-and do not replace it.
+A store implements two operations:
 
-## 2. Fenced host-store contract
+1. `acquire(state_id, owner_id)` atomically advances the owner fence and
+   returns the new token with one coherent state value.
+2. `replace(state_id, owner_token, expected_revision, payload)` first checks
+   the owner token, then the expected revision, and atomically replaces the old
+   opaque Rust payload with the complete new value while advancing the revision.
 
-`JournalStore` has two operations:
+There is exactly zero or one retained payload. Multiple historical batches are
+corruption and are rejected. Receipt retention is a normal state transition,
+not log-prefix compaction. Hosts never deserialize state.
 
-1. `acquire_owner(journal_id, owner_id)` atomically increments the persisted
-   monotonic fence, installs the proposed owner identity, and returns an
-   `OwnedJournal { owner: OwnerToken, journal }` read from that same snapshot.
-2. `append(journal_id, owner, expected_revision, payload)` atomically checks
-   the complete `OwnerToken` **before** checking the revision, appends one
-   byte-preserved payload, and advances the revision by one.
+This is a hard cutover. The envelope is `nanocodex_durable_state`; the former
+`nanocodex_journal_state` envelope and individual event batches are rejected.
+There is no adoption, migration, or compatibility reader for old durable data.
 
-Owner authority and journal revision are separate. Authority is not a lease:
-it has no TTL, heartbeat, or expiry. Every successful acquisition immediately
-replaces the prior authority by increasing its persisted fence. Consequently,
-the last opener wins and every prior opener becomes stale, even if its expected
-revision happens to match.
+Store results have exact meanings:
 
-The contract is implemented by Memory, native SQLite, Postgres, browser
-IndexedDB, and Cloudflare Durable Object SQLite. Native SQL acquisition also
-fixes the former mixed-snapshot load race by acquiring authority and reading
-the revision/batches inside one transaction.
+| Result | Meaning | Same-owner retry |
+|---|---|---|
+| success | Mutation committed at the returned revision | Not needed |
+| `NotCommitted` | Store guarantees no mutation occurred | Allowed |
+| `Fenced` / `Conflict` | This owner or revision is stale | Forbidden |
+| backend/transport error | Commit outcome is not proven | Forbidden; reacquire and reload |
 
-Owner fences use the complete `u64` domain in every backend. Journal revisions
-use `u64` in the Rust contract, Memory, IndexedDB, Cloudflare SQLite text
-adapters, and the JavaScript Postgres adapter. Native Rust SQLite/Postgres
-journal revisions deliberately stop at signed SQL `INTEGER`/`BIGINT`
-`i64::MAX`; an attempted successor returns definite `NotCommitted` without a
-write. This backend limit is explicit rather than an accidental conversion.
+## Total restart state
 
-| Store outcome | Commit knowledge | Required action |
-| --- | --- | --- |
-| appended | Batch committed exactly once | Apply it to the live reducer |
-| `NotCommitted` | Store guarantees no durable mutation | The same owner may retry |
-| `Fenced` | A newer owner replaced this owner | Stop and reopen |
-| `Conflict` | Authoritative revision differs | Stop and reopen |
-| `Backend` | Mutation outcome may be unknown | Stop and reopen |
+Every committed revision is independently decodable. It contains all retained
+operations, each operation's full step states, the latest resumable checkpoint,
+and whether a standalone checkpoint effect is currently in its uncertain
+window. A stored revision never depends on an earlier revision.
 
-Only `NotCommitted` permits an in-place retry. `Fenced`, `Conflict`, and
-`Backend` poison the live durability driver; a fresh acquisition and complete
-journal reduction are required before deciding what happened.
+## Operation state
 
-Evidence:
+The durable operation state machine is intentionally small:
 
-- `crates/nanocodex-durability/src/store.rs`
-- `crates/nanocodex-durability/src/{memory,sqlite,postgres}.rs`
-- `js/bindings/browser/indexeddb-durability-store.mjs`
-- `js/bindings/cloudflare/Agent.mjs`
-- store regressions
-  `acquisition_fences_stale_writer_before_revision_check`,
-  `IndexedDB durability atomically increments concurrent owner acquisitions`,
-  `PostgreSQL retains owner fences separately and checks them before revisions`,
-  and `Cloudflare durability owns schema setup and atomic SQLite adaptation`
-
-## 3. Journal and execution authorization
-
-The journal records:
-
-```text
-OperationAccepted(id, input)
-AttemptStarted(id)
-StepStarted(id, step_id, kind, input, retry_policy)
-StepCompleted(id, step_id, output)
-AttemptFailed(id, error)
-OperationCompleted(id, checkpoint, output)
-OperationFailed(id, checkpoint, error)
-OperationCancelled(id, optional_checkpoint)
-CheckpointCommitted(checkpoint)
+```mermaid
+stateDiagram-v2
+    [*] --> Pending: OperationAccepted
+    Pending --> Completed: OperationCompleted
+    Pending --> Failed: OperationFailed
+    Pending --> Cancelled: OperationCancelled
 ```
 
-Admission is idempotent by exact operation ID and encoded input. Pending work
-is recovered in acceptance order; completed, failed, and cancelled submissions
-replay their retained terminal without repeating model or tool work.
+Acceptance stores the exact operation ID and typed input. A duplicate with the
+same input returns the existing state; the same ID with different input is an
+error. Pending operations execute FIFO. Completion and failure atomically carry
+the new resumable checkpoint. Cancellation may carry a safe interrupted
+checkpoint.
 
-Many operations may be admitted, but an execution step is authorized only when
-all of these are true:
+Attempt starts, releases, and transient failures are live scheduling facts,
+not durable facts.
 
-- the caller still owns that operation's process-local claim;
-- the operation is the oldest pending operation;
-- an attempt has started; and
-- the recorded step definition is byte-identical.
+## Effect state
 
-Every `DurableSession` clone receives a distinct caller identity. An Agent
-receives a generation-scoped `DurableOwner`; acquiring a new Agent generation
-invalidates the older generation and its claims. These process-local checks
-close clone/caller ABA and accidental cross-claim mutation. They complement,
-but do not replace, the persisted host-store fence that excludes stale
-processes, Workers, tabs, and Durable Object incarnations.
+Every operation-owned external effect uses a stable step ID and records its
+normalized input before dispatch. This includes:
 
-Admission result delivery uses an acknowledgement handoff. If the receiver is
-cancelled before acknowledging ownership, the driver releases exactly the
-claim it granted, so an ownerless live claim cannot strand FIFO recovery.
-Each clone tracks only claims that it can actually own. Dropping a clone with
-no claim emits no release traffic; dropping a claimant uses an unbounded
-release lane, and the driver drains that lane in bounded batches so reclamation
-cannot be lost or starve normal commands.
+- model generation;
+- WebSocket warmup;
+- automatic compaction;
+- tool execution.
 
-Durable steps retain their definition before the effect. A completed step
-replays its output. An unfinished idempotent step may run again; an unfinished
-`Never` step remains `AmbiguousStep` and is never repeated automatically.
-Model-step identity includes the complete continuation-relevant semantic
-profile: model and model prefix, reasoning and effort controls, fast/store and
-transport configuration, endpoints, durable prompt-cache key, immutable
-request prefix (including instructions and tool definitions), and typed prompt
-history. A changed configuration therefore rejects replay instead of applying
-an old result under new semantics.
+Beginning a step returns exactly one value:
 
-That strict identity belongs to an unfinished effect, not to the lifetime of a
-completed thread. A cold reopen from a committed `SessionSnapshot` keeps its
-typed conversation, model, workspace, lineage, and prompt-cache key, then
-rebuilds the request prefix from the current runtime. This lets deployments
-change instructions or tool schemas without stranding the thread. Historical
-tool calls and outputs remain inert typed history; only current handlers may
-execute on subsequent turns.
+| Admission | Durable evidence | Caller action |
+|---|---|---|
+| `Execute` | No prior start, or an unfinished retry-safe start | Dispatch once and commit output |
+| `Replay(output)` | An outcome is staged or materialized | Finish materialization if needed, then reuse the exact output; do not dispatch |
+| `Unknown` | An unfinished at-most-once start exists | Do not dispatch; commit an explicit unknown result |
 
-The durable model-effect append is the authorization linearization point. A
-newer owner can fence the old owner before that append or fence its result
-afterward, but cannot retract a provider call that was already authorized and
-is in flight. Warmup and ordinary generation both cross this boundary; warmup
-is not a durability bypass. Custom `ExecutionPolicy` implementations that omit
-model authorization, checkpoint commit, or cancellation support fail closed
-with an explicit unsupported-capability error.
+`Unknown` is data, not an operation-level exception. An interrupted unsafe tool
+therefore becomes one structured failed tool result, is committed as that
+step's output, and returns control to the model. The message says the effect
+*may* have run because a committed start proves authorization, not handler
+entry or external settlement.
 
-## 4. Checkpoints, cancellation, terminals, and shutdown
+Retry-safe model and compaction steps may execute again only with the same
+stable identity and normalized input. Successful dispatch uses two settlement
+transitions: `effect_pending -> outcome_ready -> completed`. If the second
+commit is lost, recovery materializes the already-staged result without
+repeating the effect. Completed results always replay.
 
-Completed and failed operations atomically retain their `SessionSnapshot` with
-the terminal. Active cancellation now commits its safe interrupted checkpoint;
-queued cancellation commits without a new model checkpoint and may terminalize
-behind an active predecessor because it never started model work. Successful
-standalone compaction commits `CheckpointCommitted`, so a cold reopen restores
-the compacted history even if no later prompt ran.
+Standalone compaction is a retry-safe checkpoint transform. It commits
+`CheckpointEffectStarted` through the current owner immediately before provider
+entry, then commits the resulting checkpoint. It cannot run while an accepted
+operation is pending.
 
-Automatic pre-turn and mid-turn compaction is part of the owning operation,
-not an unjournaled provider side effect. It records a stable idempotent step,
-authorizes the provider call against the current owner immediately before the
-effect, and replays the retained compaction output after a crash. A takeover
-before provider entry fences the old owner; a terminal append that is definitely
-not committed reclaims the same operation and reuses completed compaction rather
-than compacting again or allowing later work to overtake it.
+## Checkpoints and terminals
 
-The model run returns terminal data without publishing a contractual terminal
-event. The Agent driver first commits the journal transition and only then
-emits `completed`, `failed`, or `cancelled`. Replayed completed, failed, and
-cancelled admissions emit the corresponding terminal without executing the
-model, but only after the caller receives prompt acceptance. Dropping
-acceptance cannot create an orphan contractual terminal. A failed append emits
-no false terminal.
+The checkpoint inside `OperationCompleted` or `OperationFailed` and that
+operation's terminal result are one state replacement. A crash cannot expose a
+new checkpoint without its terminal receipt or a terminal receipt without its
+checkpoint.
 
-Shutdown drains accepted work and reports settlement/terminalization failures
-instead of returning success while an accepted cancellation or terminal failed
-to commit.
+Standalone developer-context and compaction boundaries use
+`CheckpointCommitted`. They are rejected while an operation is pending, so a
+standalone checkpoint cannot jump over FIFO work.
 
-The crash rules are therefore:
+## Cancellation
 
-| Boundary | Recovered state and action |
-| --- | --- |
-| Before acceptance commit | No operation; submit stable ID/input |
-| After acceptance, before attempt | Pending; reclaim exact ID/input |
-| After attempt, before a step | Pending; start another attempt |
-| After idempotent step start | Pending; repeat the same step identity |
-| After unsafe step start | Pending and ambiguous; reconcile manually |
-| After step completion | Replay retained output without repeating effect |
-| Terminal append returns `NotCommitted` | Pending; same owner may retry |
-| Terminal append returns `Fenced`, `Conflict`, or `Backend` | Live owner stops; reopen before deciding |
-| Terminal committed but projection missed | Replay terminal and repair projection |
-| Active cancellation committed | Restore exact safe interrupted checkpoint |
-| Standalone compaction committed | Restore the compacted checkpoint |
+Cancellation is durable intent at the application boundary and a terminal
+state fact at the Rust boundary.
 
-## 5. Public recovery dispositions and consumers
+Managed cancellation may reserve an exact not-yet-admitted turn ID. Matching
+admission consumes that reservation into `cancelling` before any model or tool
+work starts. Active cancellation commits `OperationCancelled` before the API
+reports completion. A definite `NotCommitted` may retry; any unknown store
+outcome requires owner reacquisition and loading authoritative state.
 
-`ExecutionPolicyDisposition` preserves action, not wording:
+## Managed projection
 
-| Disposition | Examples | Caller action |
-| --- | --- | --- |
-| `Retry` | `NotCommitted`, retryable transport, predecessor/active-owner wait | Retry only on the still-valid owner when allowed |
-| `Blocked` | `AmbiguousStep` | Keep nonterminal and require reconciliation |
-| `Reopen` | `Fenced`, `Conflict`, `Backend`, poisoned/stopped owner | Dispose the stale Agent, acquire the journal again, and resubmit exact ID/input |
-| `Fatal` | Invalid journal, changed step definition, invalid request | Fail closed; do not loop or reinterpret retained state |
+The Managed Durable Object has only these persisted turn states:
 
-WASM exposes stale-authority failures as `reopen_required`. The managed
-controller rebuilds its Agent; the local controller retains an actionable
-reload state for a fresh wrapper. Both keep the exact operation pending for
-recovery and never retry a poisoned handle.
+- `accepted`
+- `cancelling`
+- `completed`
+- `cancelled`
+- `failed`
 
-The local transcript allocates an atomic per-thread monotonic sequence, stores
-the exact Rust operation ID and prompt before admission, and recovers rows in
-that order. It no longer infers completion by matching prompt text against
-compactable model context. Duplicate prompt text cannot alias an older turn.
-Later recovery publishes its updated history before admitting newer work, and
-blocked/reopen states are actionable. If transcript ingress persistence fails,
-Rust admission is not attempted.
+Transient infrastructure failure does not create another state. The row stays
+`accepted` or `cancelling` with `error`, `attempt_count`, and an absolute
+`retry_at`. `turn_retryable` is a control event describing that schedule, not a
+terminal or a separate source of truth.
 
-Transcript persistence does not serialize remote execution. Each local runtime
-has a process-local FIFO only; no browser Web Lock is held across model I/O.
-Independent tabs may race to recover the same ingress row, and the persisted
-Rust owner fence decides which Agent can execute. A retained-recovery display
-deadline relinquishes only the UI observer. It never cancels or disposes a Turn
-whose durable outcome is unknown; late settlement remains observed and newer
-model effects stay behind the retained barrier.
+The Durable Object commits the turn row and `turn_accepted` cursor before
+returning HTTP 202. It commits a terminal row and terminal event cursor in the
+same SQLite transaction. SSE live publication only wakes readers; replay from
+the durable cursor is authoritative.
 
-Terminal transcript transitions are absorbing. A stale tab cannot replace a
-winner's `completed` or `failed` row with `reopen_required`, and live/recovery
-callers consume the authoritative transition returned by IndexedDB. Storage
-retains every unfinished row plus the newest 100 terminal rows and physically
-deletes older terminals in the same write transaction. Malformed retained rows
-fail closed instead of disappearing from recovery, and observer callbacks are
-isolated from admission.
+## Crash matrix
 
-Managed creation uses a durable credential-binding saga. The session Durable
-Object records binding ownership before external bind/initialize work, commits
-the binding active only after account attachment, and retains deletion markers
-until unbind, detach, workspace cleanup, and local-state deletion all finish.
-Every ownership RPC has a hard caller deadline independent of abort cooperation;
-deletion therefore cannot wait forever on a nonsettling service binding.
-Cleanup first retires the one-shot agent and subject identities in their
-authoritative account/directory rows. A delayed attach or bind that arrives
-after its caller timed out is rejected by that permanent tombstone instead of
-resurrecting ownership. Cleanup retries use persisted capped exponential
-backoff with jitter. Subject mappings are sharded one Durable Object per
-subject; a retained pre-sharding session installs an active ownership marker
-from authoritative `session_state` and idempotently rebinds the current shard
-before constructing any model transport. Retryable keyed creation stages retain
-and refresh the same preparation lease; keyless legacy creates compensate
-immediately, while the durable watchdog owns abandoned keyed preparations.
-Deletion commits that durable marker and alarm before the irreversible local
-tombstone, so reconstruction always owns unfinished external cleanup.
+| Crash point | Recovered fact | Result |
+|---|---|---|
+| Before acceptance commit | No operation | Caller may submit normally |
+| After acceptance, before effect start | Pending operation | New owner claims and executes |
+| After retry-safe effect start | `effect_pending` retry-safe step | Execute again with the same identity and input |
+| After unsafe effect start | Started at-most-once step | `Unknown`; never redispatch |
+| After effect returns, before staged settlement | `effect_pending` | Apply the configured safe/unsafe recovery rule |
+| After outcome staging | `outcome_ready` | Materialize and replay exact output; never redispatch |
+| After materialization | `completed` | Replay exact output |
+| During terminal replacement with `NotCommitted` | Pending operation | Same valid owner may retry |
+| During terminal replacement with unknown outcome | Unknown store result | Reacquire, reload, then decide |
+| After terminal commit | Terminal operation | Replay terminal; no execution |
+| After managed terminal transaction, before SSE send | Terminal row/event | Cursor replay delivers it |
 
-Managed turn cancellation is itself durable work. One `turn_cancelling` intent
-is committed before acknowledgement. Control or reconstruction failure updates
-that row's attempt count, error, and absolute `retry_at`; duplicate requests,
-reconstruction, and alarms cannot run cancellation before that deadline. A due
-cancellation can target a still-live Turn, and alarm selection takes the
-minimum cancellation deadline rather than replacing it with idle shutdown.
+## Invariants
 
-## 6. Closed findings
+1. Persist before dispatch.
+2. Never infer a commit from a transport error.
+3. Never retry on a stale owner.
+4. Never automatically repeat an unfinished at-most-once effect.
+5. Never represent uncertainty as a permanent thread-wide block.
+6. Never split a checkpoint from its terminal receipt.
+7. Never let managed projection override Rust effect recovery.
+8. Keep live ownership out of persistent state.
 
-All review findings D-01 through D-98 are closed in the current implementation.
+These invariants are exercised against memory, SQLite, Postgres, WASM host
+stores, and Cloudflare Durable Object integration. A backend-specific failure
+must map into the same store result meanings; it must not invent recovery
+policy.
 
-| Finding | Implemented closure | Regression evidence |
-| --- | --- | --- |
-| D-01 stale model-owner checkpoint | Persisted monotonic owner fences plus one generation-scoped Agent owner prevent stale model execution and checkpoint regression | `newer_agent_acquisition_fences_an_older_live_model_before_execution`; `sequential_model_owners_preserve_history_and_cache_lineage` |
-| D-02 cancellation lost checkpoint | Active cancellation journals the safe interrupted snapshot and checkpoint selection includes it | `ExecutionOutcome::Interrupted` passes `Some(checkpoint.snapshot())`; cancellation/reopen lifecycle coverage |
-| D-03 terminal preceded commit | Driver commits execution policy before emitting contractual terminal; failed terminal append emits none | `portable_journal_replays_a_completed_model_step_after_terminal_commit_failure` |
-| D-04 native load mixed snapshots | `acquire_owner` installs authority and reads the journal in one SQLite/Postgres transaction | store acquisition implementations and owner-fence store regressions |
-| D-05 stale JS owner retried forever | WASM maps fenced/conflict/backend/stopped owner to `reopen_required`; managed/local replace the Agent | `a fenced durability owner requires reopening instead of retrying the stale Agent`; managed/local reopen tests; two-tab browser gate below |
-| D-06 queued cancellation/shutdown contradiction | Never-started queued work can cancel out of order; shutdown accumulates uncommitted settlement failures | `queued_unstarted_operation_can_cancel_behind_a_pending_predecessor`; `shutdown_reports_a_queued_terminalization_that_did_not_commit` |
-| D-07 policy disposition collapsed | Typed `ExecutionPolicyDisposition` drives retry, blocked, reopen, and fatal behavior end to end | `durability_errors_preserve_their_required_recovery_action`; binding and controller disposition tables |
-| D-08 prompt-text reconciliation alias | Local recovery uses exact retained operation IDs and does not infer terminality from prompt text | `recovers a newer identical pending prompt by exact durable ID` |
-| D-09 replay emitted no terminal | Durable terminal replay emits one typed terminal without model execution | `durable_terminal_replays_emit_one_terminal_without_model_execution` |
-| D-10 claims were advisory | Distinct caller identities and Agent generations authorize every mutation and release | `cloned_handle_cannot_mutate_another_handles_claim` |
-| D-11 transcript ordering/status gaps | Atomic per-thread sequence, post-recovery history projection, and actionable reopen state | `orders same-millisecond prompts by the durable per-thread sequence`; `later recovery publishes the recovered answer before admitting newer work`; `projects reopen-required recovery as actionable history and blocks newer admission` |
-| D-12 steps bypassed FIFO/attempt/claim | Driver and reducer require claimed oldest operation and a started attempt before step authorization | direct-session transition/FIFO tests, including `queues_admission_but_serializes_attempts` and pre-append invalid-transition coverage |
-| D-13 cancelled admission leaked a claim | Two-phase acknowledgement releases unaccepted claims for direct and automatic admission | acknowledgement handoff in `session.rs` and cancellation-safe admission coverage |
-| D-14 local ingress failed open | Transcript ID/input commit is mandatory before Rust prompt admission | `prompt ingress fails closed and a later persisted prompt is not blocked` |
-| D-15 routed prompt bypassed durability | Idle `route_prompt` performs the same automatic journal admission as `prompt`; active routing remains steering | routed prompt completion, cold-reopen, and active-steering regressions |
-| D-16 stale transcript downgrade | IndexedDB terminal transitions are conditional and absorbing; callers use the authoritative returned row | two-runtime winner-before-stale-fence barriers, including a live turn |
-| D-17 JavaScript numeric precision | Numeric revisions/fences are accepted only when nonnegative safe integers; exact decimal strings preserve the complete `u64` domain | unsafe-number rejection and exact-string binding tests |
-| D-18 cold step replay reused dead response ID | Journal-replayed model output remains typed history but invalidates transport continuation and forces full replay | `cold_model_step_replay_never_reuses_the_replaced_transport_chain`, with store off/on |
-| D-19 replay terminal preceded acceptance | Replayed terminals publish only after acceptance delivery succeeds for both queued prompts and idle routed prompts | `abandoned_terminal_replay_acceptance_emits_no_terminal_event` and `abandoned_routed_terminal_replay_emits_no_terminal_event` |
-| D-20 managed transient became terminal/unscheduled | Disposed/startup/HTTP 5xx failures stay retryable; alarm scheduling occurs after admission-task removal | real HTTP 503 → retryable → alarm/resubmission → one completion Worker test |
-| D-21 persistent backend races/schema ambiguity | Real SQLite multi-connection lock-order tests prove fencing/CAS; SQLite and Postgres reject malformed owner schemas at initialization | SQLite backend race tests and configured PostgreSQL 18 test |
-| D-22 transcript retention/corruption | Older terminal rows are deleted, all unfinished rows remain recoverable, malformed rows and session sequence metadata block admission, v1 sessions migrate to exact sequencing, and the oldest barrier remains visible | real fake-IndexedDB retention/corruption/migration tests and history projection regression |
-| D-23 definitely-uncommitted terminal retained claim | Exact-ID terminal retry releases and then reclaims the same operation; a committed model step replays once instead of repeating the effect | `exact_id_retry_reclaims_a_definitely_uncommitted_terminal_append`; direct-session definite-`NotCommitted` regressions |
-| D-24 developer checkpoint overtook pending retry | Developer context remains unacknowledged and uncommitted until the preceding pending operation terminalizes | `queued_developer_context_waits_for_an_exact_id_retry_to_terminalize`; active developer checkpoint regression |
-| D-25 compaction failure escaped or exposed uncommitted state | Standalone compaction failures stay inside the driver; failed checkpoint persistence restores the previously committed model state | `failed_completed_compaction_persistence_restores_the_committed_live_boundary` |
-| D-26 warmup bypassed model authorization | Warmup crosses the same durable model-effect authorization boundary as generation; takeover can fence its result | `takeover_after_warmup_authorization_fences_the_result_not_the_in_flight_call` |
-| D-27 shutdown/release was cancellation-unsafe | Owner shutdown has explicit active/releasing/released state and a shared completion; Drop keeps the release lane armed | `cancelled_shutdown_keeps_the_drop_release_lane_armed`; concurrent graceful-shutdown binding regression |
-| D-28 policy defaults and clone release traffic failed open/liveness | Authority-bearing `ExecutionPolicy` defaults fail closed; only claim-owning clones release and bounded fair draining prevents command starvation | `execution_policy_authority_defaults_fail_closed`; `clone_drop_churn_and_claim_release_bursts_do_not_starve_commands` |
-| D-29 transcript migration could lose unindexed rows or block startup | Upgrade scans the object store, bounds retained terminals per thread, and aborts the whole version change on an unorderable row; initialization is lazy and surfaces an actionable storage error | fake-IndexedDB 5,000-row bounded migration and unindexed-row preservation regressions |
-| D-30 managed create/delete lifecycle races | Durable binding ownership, tracked bind/attach work, shutdown-before-admission drain, and persisted cleanup backoff make create/delete compensating and restartable | managed watchdog, stalled admission, cleanup retry, and retained pre-marker rebind Worker tests |
-| D-31 provider throttling caused retry storms or rejected usable credentials | `Retry-After` or capped exponential jitter is persisted before body disposal; ordinary acquisition keeps an unexpired token while recovery and expiry fail closed | real broker Durable Object alarm/cancellation/backoff tests |
-| D-32 active cancel acknowledged an uncommitted terminal | Active cancellation returns success only after `OperationCancelled` commits; a definite `NotCommitted` remains recoverable and any ambiguous store outcome requires reopen | `active_cancel_acknowledges_only_a_committed_operation_cancelled_entry` |
-| D-33 automatic compaction was neither replayable nor freshly authorized | Pre/mid-turn compaction is an operation-owned idempotent durable step with stable input, retained output, and a fresh owner authorization immediately before provider entry | `automatic_compaction_replays_a_after_terminal_not_committed_instead_of_running_b`; `takeover_during_automatic_compaction_authorization_fences_before_provider_entry` |
-| D-34 duplicate JavaScript construction fenced the live owner before failing | Stable session IDs are atomically reserved before raw Agent construction; failed construction releases, successful construction adopts, and duplicate/concurrent construction never touches durability authority | duplicate stable-session and concurrent-creation binding regressions |
-| D-35 managed terminals and history had projection/cursor gaps | Outer terminal events survive retained history and reload without duplicating raw assistant output; history snapshot completion establishes the exact cursor before the live watcher attaches | managed outer-terminal projection and delayed-page-snapshot attachment regressions |
-| D-36 retained managed lifecycle could lose cleanup or accepted siblings | Legacy deletion derives binding ownership from authoritative session state; deletion supersedes cold construction; controller-driven reopen keeps accepted siblings retryable; replay-only raw terminals are attributed before following work; infrastructure retry has no arbitrary terminal attempt count | direct legacy delete, deletion-versus-construction, accepted-sibling reopen, replay-only terminal, and former-eight-attempt Worker regressions |
-| D-37 hung local recovery blocked the UI forever | Retained exact-ID recovery has a bounded observer deadline and an actionable nonterminal `reopen_required` barrier; it does not cancel an ambiguously live Turn, newer model effects remain blocked, and late settlement is observed and disposed | `bounds hung retained recovery without admitting newer model work` |
-| D-38 browser sockets and compiler runs leaked after disposal | CONNECTING sockets are owned immediately and closed on disposal; compiler run trees and directory metadata are removed in `finally` while declared outputs survive | CONNECTING-socket and successful/failed compiler run-tree regressions; repeated large-memfs measurement |
-| D-39 localhost shutdown orphaned relays, Vite, and setup children | Signal ownership is installed before setup, every detached process group is tracked, repeated signals escalate, and the Vite child exits when parent IPC disappears | dev-local parent-disconnect, descendant, repeated-signal, publisher, and abrupt-orchestrator regressions |
-| D-40 response-body disposal could overwrite egress protocol outcomes | Best-effort cancellation cannot replace 401 recovery or 429 classification; device-login start/poll/exchange disposes every pending and non-success body | rejecting-body 401/429 and device-login body-lifecycle regressions |
-| D-41 Worker failure leaked the page-side session reservation | Worker close invalidates every page-side root/child wrapper, releases its reservation, rejects pending work once, and permits immediate same-session reconstruction | Worker pending-RPC crash followed by same-session replacement; complete Worker Agent suite |
-| D-42 durable developer context was retained but could be omitted from the next model delta | Acknowledged developer messages commit their checkpoint while preserving the unsent model delta across live and cold reconstruction; only a completed provider response advances that boundary | adapter developer-context model-input regression; `acknowledged_developer_context_survives_a_cold_reopen` |
-| D-43 cloned builders could construct two owners from one durability route | Durable attachment is consumed atomically across every builder clone; the loser fails before host acquisition and cannot fence the live Agent | `durability_attached_builder_is_safe_single_use_across_clones`; duplicate/concurrent JavaScript stable-session construction suites |
-| D-44 persistent host schemas could look compatible while changing authority semantics | Native and JavaScript Postgres validation now pins schema, column types/defaults/nullability, exact CHECK constraints, primary keys, immediate same-schema foreign keys, and the absence of extra constraints before any mutation | PGlite/native schema suites covering cross-schema and deferred FKs, missing/extra CHECK constraints, mixed legacy counters, and counter exhaustion |
-| D-45 browser-host cleanup could lose not-yet-registered sockets or run twice | The host owns socket factories and preconnects from invocation through registration, aborts never-resolving construction, closes late CONNECTING sockets, isolates cleanup failures, and returns one promise for reentrant disposal | complete browser-host lifecycle suite, including direct/MPP late-open and reentrant cleanup |
-| D-46 a stopped fenced Agent lost its recovery disposition | Driver shutdown records whether it owned an execution policy; every stopped command path returns typed `ExecutionPolicyOwnerStopped`, which WASM/controller policy maps to `reopen_required` rather than an ordinary stopped failure | core stopped-error distinction and stale-owner subsequent-prompt reopen regressions |
-| D-47 a remounted local terminal could replay a stale one-shot history cache | Every new history subscription reloads the authoritative IndexedDB transcript after initialization; visible/focus/pageshow refresh is a fallback when a suspended tab misses its best-effort broadcast | continuously attached cross-tab propagation, missed-broadcast foreground recovery, and dispose/commit/reattach same-wrapper regressions |
-| D-48 Windows local shutdown could only kill process leaders, not prove descendant cleanup | Local development fails closed on Windows until it has a Job Object owner; supported Unix hosts retain verified process-group shutdown | platform-contract and process-group lifecycle regressions |
-| D-49 local optimistic prompt IDs differed from authoritative transcript IDs | Every local Turn exposes its durable transcript-row identity, including prompts queued behind a running turn, so history reconciliation replaces rather than duplicates the optimistic row | immediate and queued prompt projection regressions; real two-tab browser pass |
-| D-50 Cloudflare public disposal retained stale lifecycle authority | Lifecycle authority follows the exposed Agent's actual release observer; public disposal permits a fenced replacement while joined shutdown remains exclusive until completion | dispose/recreate/destroy and in-flight shutdown regressions |
-| D-51 throwing Worker cleanup could strand construction and its session reservation | Prewarm rejection settles before best-effort cleanup, cleanup failures are isolated and reported, and failed construction always releases the stable-session reservation | throwing-terminator followed by same-session replacement regression |
-| D-52 JavaScript PostgreSQL schema probes admitted sampled values outside `u64` | Validation probes negative, zero where forbidden, adjacent overflow, and farther overflow boundaries for every authority/revision counter before accepting retained schemas | mock predicates and real PGlite malformed-CHECK regressions |
-| D-53 same-isolate restore could reuse an ambiguously consumed refresh token | Every decrypted durable credential passes one restoration installer that quarantines `in_flight` refresh state, including restoration after persistence failure | post-provider persistence-failure and second-request regression |
-| D-54 one slow subject shard blocked every tenant behind a singleton queue | Directory ordering is keyed per subject; shard I/O no longer owns a cross-tenant tail, and unbind reconciles the shard before deleting authoritative legacy metadata | stalled-subject concurrency, rollback unbind, reconciliation-failure, and malformed throttle regressions |
-| D-55 retained local history duplicated the matching live assistant result | History reconciliation pairs the authoritative assistant with its exact durable user row and removes the matching live projection before result settlement | reducer regression and real completed local browser turn |
-| D-56 browser network restoration left managed SSE half open after durable completion | A browser `online` transition replaces the shared connection from every subscriber's exact cursor, and response-reader failures reconnect instead of terminally ending subscribers | controlled half-open/reader-failure regressions and real offline-complete-reconnect browser turn |
-| D-57 a prompt rejected before `run.started` remained at the head of the transcript queue and consumed the next run admission | Turn completion removes its exact optimistic prompt identity whether or not admission was observed; later runs cannot inherit failed projection state | reducer regression plus consecutive offline-failure/online-success browser turn |
-| D-58 repeated localhost shutdown could mistake an inaccessible reused process-group ID for an owned live descendant and report a fatal `EPERM` after cleanup succeeded | Local groups run under the orchestrator uid; `EPERM` therefore proves that the numeric group is no longer the owned group and must never be targeted | injected reused-group regression plus real stack shutdown and port-release check |
-| D-59 a browser Web Lock serialized cross-tab transcript processing across remote model I/O | Local coordination is process-local only; independent tabs race at the ingress boundary and the persisted Rust owner fence remains the sole cross-tab execution authority | `a stalled tab cannot hold cross-tab transcript processing across model I/O`; real two-tab fence pass |
-| D-60 a local recovery display timeout cancelled a Turn whose durable outcome was still unknown | Timeout relinquishes the observer without sending cancellation or disposal; the retained row remains a barrier and late settlement is observed and released | timeout cancellation-count and late-disposal regressions |
-| D-61 managed history startup could detach permanently or outlive its page | Initial history keeps retrying after its actionable error, wakes immediately on `online`, and every page request is owned by the subscriber's abort signal | managed initial-history retry, online recovery, and detach-abort regressions |
-| D-62 transcript reconciliation used globally colliding presentation IDs and adjacency-derived ownership | User, assistant, reasoning, tool, plan, steer, and error projections carry durable turn identity; history keys are turn-scoped and queued hydration cannot move one turn's answer behind another | local exact-result, queued A/B rebase, same-tab managed, and cross-turn ID-collision regressions |
-| D-63 managed cancellation ignored its persisted retry deadline | The cancelling row owns backoff across direct control failure, reconstruction, duplicate requests, active Turns, and alarms; only one intent event is emitted | real Durable Object HTTP-503 reconstruction, premature duplicate/alarm, and due-time retry regression |
-| D-64 Evals failures became permanently inert after navigation remount | The shared query client retains normal failed-query remount retry, while explicit retry remains available in the rendered failure state | QueryObserver failure-remount-success regression and Evals route tests |
-| D-65 wildcard localhost ownership let two development servers answer one port and cross-connect HMR | The local orchestrator probes both loopback families before setup, defaults to explicit `127.0.0.1`, and fails actionably if either family already owns the selected port | dual-family occupied-port regressions; canonical stack cold-start on explicit port 5183 |
-| D-66 duplicate managed submissions bypassed an admission retry deadline | The authoritative admission boundary reloads the row and refuses `retryable` work before its persisted absolute `retry_at`; it preserves the same alarm | real Durable Object fake-clock duplicate-POST, premature-alarm, and exact-deadline regression |
-| D-67 raw local Rust events could associate an older recovered run with the newest optimistic prompt | The local wrapper tags every live event with the exact durable turn active at admission, and the reducer removes only the queued row matching that ID; FIFO remains only for non-durable events | wrapper exact-ID event regression, unmatched-old-run reducer regression, and two-tab A/B browser pass |
-| D-68 a managed history fetch could ignore abort and blackhole startup forever | Each initial and older-page attempt owns an online wakeup and hard deadline raced independently of fetch cooperation; subscriber detachment aborts the same attempt | never-settling loader deadline, online recovery, and detach regressions |
-| D-69 terminal detachment left managed result subscribers and online listeners live | Every active terminal turn observer is disposed on detach; managed disposal aborts its local request/SSE signal without cancelling the authoritative server turn | active-turn terminal-detach and managed-observer-abort regressions |
-| D-70 history prepend renumbered live reasoning/tool identities and could place tool work after its retained answer | Managed raw projections derive presentation identity from the durable event cursor, and reconciliation inserts live turn activity before that turn's retained final assistant | cursor-renumber reasoning regression, live-tool ordering regression, and exact browser row-order check |
-| D-71 non-contiguous retained/live groups for one turn dropped late activity | Transcript reconciliation globally coalesces groups by durable turn ID while preserving each turn's first-seen order | non-contiguous same-turn merge and retained/live prepend regressions |
-| D-72 a retained terminal error and its buffered live terminal rendered twice | Failure projection detects an existing error for the terminal event's durable turn even after active state has detached | retained-plus-buffered terminal error deduplication regression |
-| D-73 presentation abort cancelled managed prompt/cancel mutations | Mutation submission owns its own lifetime; `Turn.result({ signal })` aborts only that observer and leaves the authoritative request running | held prompt, cancel-signal, and observer-detach binding/runtime regressions |
-| D-74 a half-open managed SSE could retain subscribers forever without throwing | Each reader wait has a 45-second inactivity deadline, safely above the server's 15-second keepalive, and reconnects from the exact adopted cursor | fake-clock inactive-reader reconnect regression |
-| D-75 route detachment shut down a browser Agent with accepted durable work | Config tracks accepted Turns independently of presentation subscribers and retires the Agent only after the result settles | active-turn unsubscribe/shutdown regression and route-switch browser gate |
-| D-76 credential ownership RPCs and deletion drain could never settle | Bind, rebind, unbind, attach, detach, create phases, compensation, and drain all use real raced deadlines even when a callee ignores `AbortSignal` | nonsettling create-bind, cold-rebind, account-attach, and cleanup regressions |
-| D-77 a lost outer create-commit response could leave an attached orphan | Any non-confirmed commit response enters authoritative session cleanup; account and subject tombstones reject every late one-shot generation | post-inner-commit response-loss, late attach, failed shard reconciliation, and rollback-broker regressions |
-| D-78 the route-lifetime presentation wrapper hid later Worker failure callbacks | Runtime Agents are mapped to their presented wrappers solely for identity comparison while failure cleanup still disposes the real Worker Agent | silent Worker heartbeat failure/replacement regression, repeated 20 times, plus complete binding gate |
-| D-79 recovery snapshot and buffered live events duplicated a terminal | History establishes the authoritative snapshot before recovery can flush live events, and retained/live terminal reconciliation is by durable turn identity | local recovery snapshot/buffer exact-once regression and route-detach browser pass |
-| D-80 raw policy diagnostics escaped through old retained assistants | Live Rust policy diagnostics are tracing-only; retained errors and legacy assistant-shaped diagnostics are normalized on every read to one actionable disposition without operation or step IDs | `normalizes legacy raw durability assistants from context and initialized transcripts`; ambiguous-tool regression; retained browser replay |
-| D-81 World collision lookup dominated cold main-thread work | Static blocked tiles are precomputed once instead of rescanned for every query | browser CPU profile: `townBlocked` about 95.72 ms self before and 1.53 ms after; World TBT 0 ms |
-| D-82 legacy replay rejected repeated attempt markers or attemptless work | Replay accepts the historical shapes already emitted, while live mutation still requires one claimed oldest operation and one current attempt | repeated-`AttemptStarted` and prior-attemptless replay regressions |
-| D-83 definitely-uncommitted cancellation stranded its claim | A noncommitted terminal releases exact ownership and permits deterministic reclaim; committed cancellation remains absorbing | Rust `NotCommitted` cancellation and exact-ID reclaim regressions |
-| D-84 latest-event reconnect lost control cursor state | SSE adopts and reconnects from the exact latest cursor, with the first canonical terminal absorbing later duplicates and rejecting contradictions | managed latest-cursor, conflicting-terminal, and reconnect regressions |
-| D-85 cancellation inherited an already-aborted prompt observer | Prompt, cancel, and control mutations own independent lifetimes; aborting a result observer never aborts the authoritative mutation | held prompt and cancel-signal regressions |
-| D-86 Config refresh or subscriber loss destroyed live browser work | Config queues/coalesces replacement until every accepted Turn lease settles; explicit destruction remains the force boundary | active-turn refresh/unsubscribe and replacement regressions |
-| D-87 `Turn.agent` escaped the presented lease owner | Presented Turns recursively point at the presented Agent, so prompts reached through `Turn.agent` acquire the same generation lease | recursive `Turn.agent` binding regressions and complete binding gate |
-| D-88 a non-cooperative stream could wedge or grow without bound | Fetch, reader cancellation, SSE frames, paused queues, and terminal caches have independent hard deadlines and byte/count caps | nonsettling reader/cancel, oversized frame, paused queue, and terminal-cache regressions |
-| D-89 local steering could execute before durable reservation or disappear on crash | Steering is reserved first, transitions to accepted/rejected after dispatch, is capped, and a retained unproved dispatch blocks prompt recovery rather than replaying either input | steer persistence/cap/failure and unresolved-steer recovery regressions |
-| D-90 pre-admission local cancellation was ephemeral | Cancellation intent is committed before Rust admission and then absorbed or forwarded exactly once in FIFO order | pre-admission cancel, reload, and cancellation-status regressions |
-| D-91 managed retention split turns or orphaned suffixes | Retention groups complete turns by durable identity and compactly retains prompt plus terminal for oversized groups | grouped-retention, oversized-turn, and orphan-suffix regressions |
-| D-92 non-cooperative initial history blocked startup forever | One bounded history generation owns each request; timeout returns control while the still-settling request prevents overlap, and retry starts only after it is safe | bounded noncooperative history and retry regressions |
-| D-93 shard I/O and response-body cancellation had no hard boundary | Every ownership/shard call and response-body cancel is raced against a real deadline and stale post-I/O authority is revalidated | nonsettling shard, body-cancel, and late-result regressions |
-| D-94 two shards or a late bind could disagree about ownership | One revision-fenced shard CAS is authoritative; tombstones win, disagreement is repaired, and legacy authority is checked again after I/O | subject-sharding CAS, tombstone repair, and stale-generation regressions |
-| D-95 room initialization and receipt/quota calls could hang | Multiplayer initialization, allocation receipts, and quota ownership have one-shot deadlines and cannot publish after their generation retires | nonsettling room initialize/receipt/quota regressions and two-tab room browser flow |
-| D-96 deletion could time out and later resurrect a managed Agent | Deletion is phase-bounded, persists attempt generation/retry state, and fences every post-await runtime/event-watcher publication; stale constructed Agents shut down directly | deletion-runtime generation and late-construction regressions |
-| D-97 released PostgreSQL authority schemas could not open safely | Serialized advisory-lock initialization converts released `BIGINT` journal/batch counters to `NUMERIC` in place, preserves rows, and accepts only an exact empty current owner table residue | three ignored real-PostgreSQL-16 upgrade/residue/schema tests plus all-feature gate |
-| D-98 browser bootstrap could replay historical diagnostic text as a completed answer | Known policy-text assistants override even an explicit legacy completed status to a safe blocked projection; raw text is never treated as model output or repeated | legacy context and initialized-transcript projection regression plus real retained browser state |
+## Relationship to Pi `dev`
 
-Additional recovery coverage proves completed model-step replay after a failed
-terminal commit, ambiguous tool refusal, changed tool-profile rejection, and
-exact history/cache lineage across sequential owners.
+The execution core deliberately follows Pi's harness boundaries: a total
+replace-in-place restart state, separate acceptance and driving, fenced single
+ownership, intent/effect/settlement, staged tool outcomes, durable cancellation,
+and atomic terminal checkpoint/result publication.
 
-The adversarial gate repeatedly ran the complete 25-case Rust durable-Agent
-suite 100 times, the local runtime race suite 100 times, and the
-IndexedDB/Cloudflare store suites 100 times. Managed Miniflare tests exercise
-concurrent duplicates, alarm/admission overlap, concrete cursor reconnect, and
-HTTP 503 recovery against real Durable Object SQLite semantics.
-
-## 7. Browser verification
-
-On 2026-08-24 the real local application was exercised in two independent tabs
-at:
-
-`http://127.0.0.1:5183/agent?thread=11111111-2222-4333-8444-555555555555`
-
-The newer tab fenced the older owner. The stale tab submitted
-`Reply with exactly FINAL_STALE_RECOVERY_OK`; the prompt was retained as
-`reopen_required` with actionable reload text and made no model call. Reloading
-acquired fresh authority, recovered the exact retained prompt, and rendered
-`FINAL_STALE_RECOVERY_OK` exactly once. The authoritative IndexedDB row changed
-to `completed`. The replacement
-WebSocket contained exactly the recovered generation and a later mobile turn;
-there was no generation for the fenced submission before reload.
-
-The same integrated build also performed a real curl-style GET to
-`https://api.github.com` through the browser agent and observed `200 OK`, sent
-and completed a turn through native touch controls under an iPhone 15 Pro
-profile, and completed a managed-durable turn followed by a page reload. Local
-and managed outputs survived their respective reloads. The complete pass had
-zero uncaught page errors and zero error/warning console entries. Expected MCP
-transport negotiation and runtime-switch aborts remained visible as canceled
-requests; they did not become durability failures or user-visible errors.
-The transcript v4 upgrade is separately exercised with real IndexedDB-shaped
-data: a 5,000-row migration retains the newest 100 terminals per thread and all
-unfinished work, while a row that cannot participate in ordered recovery aborts
-the version change and preserves the old database rather than deleting evidence.
-
-A final lifecycle pass reproduced the former projection gap without involving
-the model: the receiving terminal detached, another tab committed while no
-journal observer existed, and the same memoized local wrapper reattached. Its
-first snapshot now reloads IndexedDB and contains the missed prompt and answer
-exactly once. A fresh two-tab browser run then projected each tab's completion
-into the other tab without reload. Browser foregrounding also rereads
-authoritative history, so suspended tabs do not depend on BroadcastChannel
-delivery being durable.
-
-The mobile managed path was reloaded at iPhone SE geometry, retained a
-313-pixel transcript viewport, submitted `MOBILE_TOUCH_OK` through native
-touch/IME controls, survived an offline failure and reconnect, and retained
-the final output after reload. The embedded and axe audits had zero violations
-after naming the compact account trigger and making the decorative conversation
-backdrop non-interactive.
-
-The final cold-stack pass repeated the ownership paths after D-79 through D-98.
-A local tool turn and a managed tool turn each finished while the complete Agent
-document was detached, returned exactly once, and remained exactly once after a
-full reload. Two independent local tabs converged on `TAB_A_FINAL_OK` and
-`TAB_B_FINAL_OK`; the stale tab showed an actionable recovery notice rather
-than a policy diagnostic. Cancellation suppressed the requested final output,
-and a mid-turn steering input produced `STEERING_ACCEPTED_OK` once before and
-after reload. A previously retained raw ambiguous-effect assistant was read as
-the safe “outcome could not be proved” disposition without its operation or
-step IDs. Managed native touch/IME produced `MOBILE_TOUCH_IME_OK` once.
-
-The same browser session created a Multiplayer room, synchronized a human
-message across two tabs, completed one room-agent turn, reloaded both clients,
-and deleted the room. World movement/interact, Changelog-to-commit navigation,
-commit search/diff, docs navigation, Evals, and Source file selection completed
-with zero uncaught page errors. Every canonical direct route had zero horizontal
-overflow. The iPhone SE, iPhone 15 Pro, Pixel 8, and Galaxy S24 layout matrix had
-zero application layout findings after the 360-pixel header fix; the harness's
-remaining `screen` mismatch is an emulation-provider limitation, while viewport
-and document geometry matched. Deterministic and axe audits reported zero
-violations (axe retained only an indeterminate xterm contrast check).
-
-## 8. Reference comparison
-
-The pi-mono review informed three invariants but did not supply a complete
-execution implementation to copy. Its `dev` runtime2 checkpoint `c77ab55`
-commits implemented admission events after state, restores exact open operation
-inventory, and its SQLite backend uses a fenced writer lease. Those are
-consistent with Nanocodex's commit-before-projection, exact-ID recovery, and
-persisted-owner rules.
-
-At that checkpoint pi runtime2 still had no public drive, terminal settlement,
-abort/resume, or automatic recovery supervisor. Its JSONL backend also had only
-process-local writer exclusion. Nanocodex therefore adopted the useful
-invariants, not pi's incomplete lifecycle or weaker JSONL authority model.
-
-## 9. Remaining limitations and operating risks
-
-- Ownership is deliberate last-opener-wins fencing, not mutual exclusion. A
-  second legitimate opener causes an immediate ownership handoff and forces
-  the older Agent to reopen on its next mutation.
-- There is no lease, TTL, or heartbeat. Authority does not expire; availability
-  comes from opening a new owner, which increments the fence.
-- Owner fences are `u64`. Journal revisions are `u64` except in the native Rust
-  SQLite/Postgres adapters, whose signed SQL counters stop at `i64::MAX`.
-  Exhaustion fails without committing; there is no wraparound or automatic
-  reset.
-- The outer managed/local transcript is an exact ingress ledger and UI
-  projection, not execution authority. Application projection repair still
-  depends on resubmitting its retained ID/input to the Rust journal.
-- Terminal transcript storage is bounded, and admission fails closed at 32
-  unfinished rows per local thread. Unfinished rows are never pruned because
-  dropping one would lose accepted work; recovery or an explicit replacement
-  remains required before admitting more.
-- Browser durability is origin-local IndexedDB durability. It survives page and
-  Worker replacement in that origin, but it is not remote, cross-browser, or
-  cross-device durability.
-- Cold reopen retains the durable prompt-cache key (defaulting to journal ID)
-  but intentionally omits provider response IDs. Its first model request
-  replays complete client-owned typed history and may be larger than a warm
-  `previous_response_id` continuation.
-- Provider cache-hit rate and first-request cost after cold durable reopen still
-  require the paired live benchmark described in `PROMPT_CACHE_REVIEW.md`.
-- A malformed retained browser snapshot still fails closed. Instruction and
-  tool-definition drift at a completed boundary is deploy-compatible: the new
-  runtime rebinds its current request prefix while retaining authoritative
-  history. Drift during an unfinished recorded model step remains a semantic
-  conflict and must not replay an old result under the new profile.
-- Native SQLite/Postgres and JavaScript Postgres validate existing owner-table
-  schemas eagerly and exactly. The generic JavaScript SQLite/Cloudflare adapter
-  relies on its first acquire/append statement to reject incompatible
-  pre-existing owner state. That remains fail-closed for authority but turns a
-  bad Cloudflare deployment into a later availability/configuration failure
-  rather than an eager startup diagnostic.
+This crate is not a clone of Pi's complete session database. Pi also defines
+immutable conversation entries, mutable bound values/lists, an append-only
+usage ledger, assistant-frame persistence, lanes/navigation, and operation
+cleanup. Nanocodex keeps conversation data inside its typed agent checkpoint
+and scopes this crate to execution recovery. Claiming those storage subsystems
+were copied would be false; the shared durability invariants are the part
+implemented here.

--- a/docs/DURABILITY.md
+++ b/docs/DURABILITY.md
@@ -69,6 +69,14 @@ This is a cutover protocol, not live replication or a distributed transaction:
 Importing the same archive into multiple destinations creates competing clones;
 only one destination may become live.
 
+The Cloudflare adapter exposes this protocol directly as
+`CloudflareAgent.exportDurabilityState(owner)` and
+`CloudflareAgent.importDurabilityState(owner, archive)`. Export requires an
+inactive Agent. Import requires a pristine Durable Object and is exactly
+idempotent for a byte-identical archive, so a lost success response can be
+retried. A fresh runtime session ID is created at the destination while the
+archive's stable state ID remains unchanged.
+
 Archives can contain conversation and tool state and are not encrypted by this
 API. Applications own transport encryption, access control, retention, and
 deletion. An ambiguous destination commit must be reconciled by loading the

--- a/docs/DURABILITY.md
+++ b/docs/DURABILITY.md
@@ -126,7 +126,7 @@ Beginning a step returns exactly one value:
 | Admission | Durable evidence | Caller action |
 |---|---|---|
 | `Execute` | No prior start, or an unfinished retry-safe start | Dispatch once and commit output |
-| `Replay(output)` | An outcome is staged or materialized | Finish materialization if needed, then reuse the exact output; do not dispatch |
+| `Replay(output)` | A completed output is durable | Reuse the exact output; do not dispatch |
 | `Unknown` | An unfinished at-most-once start exists | Do not dispatch; commit an explicit unknown result |
 
 `Unknown` is data, not an operation-level exception. An interrupted unsafe tool
@@ -136,10 +136,10 @@ step's output, and returns control to the model. The message says the effect
 entry or external settlement.
 
 Retry-safe model and compaction steps may execute again only with the same
-stable identity and normalized input. Successful dispatch uses two settlement
-transitions: `effect_pending -> outcome_ready -> completed`. If the second
-commit is lost, recovery materializes the already-staged result without
-repeating the effect. Completed results always replay.
+stable identity and normalized input. Successful dispatch settles in one
+replacement: `effect_pending -> completed(output)`. That replacement is the
+materialization boundary because the output and all operation state share one
+opaque total-state payload. Completed results always replay.
 
 Standalone compaction is a retry-safe checkpoint transform. It commits
 `CheckpointEffectStarted` through the current owner immediately before provider
@@ -196,9 +196,8 @@ the durable cursor is authoritative.
 | After acceptance, before effect start | Pending operation | New owner claims and executes |
 | After retry-safe effect start | `effect_pending` retry-safe step | Execute again with the same identity and input |
 | After unsafe effect start | Started at-most-once step | `Unknown`; never redispatch |
-| After effect returns, before staged settlement | `effect_pending` | Apply the configured safe/unsafe recovery rule |
-| After outcome staging | `outcome_ready` | Materialize and replay exact output; never redispatch |
-| After materialization | `completed` | Replay exact output |
+| After effect returns, before settlement | `effect_pending` | Apply the configured safe/unsafe recovery rule |
+| After settlement | `completed(output)` | Replay exact output; never redispatch |
 | During terminal replacement with `NotCommitted` | Pending operation | Same valid owner may retry |
 | During terminal replacement with unknown outcome | Unknown store result | Reacquire, reload, then decide |
 | After terminal commit | Terminal operation | Replay terminal; no execution |
@@ -222,10 +221,10 @@ policy.
 
 ## Relationship to Pi `dev`
 
-The execution core deliberately follows Pi's harness boundaries: a total
-replace-in-place restart state, separate acceptance and driving, fenced single
-ownership, intent/effect/settlement, staged tool outcomes, durable cancellation,
-and atomic terminal checkpoint/result publication.
+The execution core deliberately follows Pi's harness boundaries: a complete
+current restart state after every transition, separate acceptance and driving,
+fenced single ownership, intent/effect/settlement, durable cancellation, and
+atomic terminal checkpoint/result publication.
 
 This crate is not a clone of Pi's complete session database. Pi also defines
 immutable conversation entries, mutable bound values/lists, an append-only
@@ -234,3 +233,11 @@ cleanup. Nanocodex keeps conversation data inside its typed agent checkpoint
 and scopes this crate to execution recovery. Claiming those storage subsystems
 were copied would be false; the shared durability invariants are the part
 implemented here.
+
+Pi's `outcome_ready` state is necessary because finalized parallel tool output
+is staged separately before source-ordered entry placement. Nanocodex has no
+second authoritative transcript store: the replay output lives in the same
+total-state replacement as its step status. Therefore its minimal equivalent
+is the single `effect_pending -> completed(output)` settlement above. This
+preserves the crash boundary while removing one full payload serialization and
+one backend transaction from every successful external effect.

--- a/docs/DURABILITY.md
+++ b/docs/DURABILITY.md
@@ -24,7 +24,7 @@ them.
 
 ## Store contract
 
-A store implements two operations:
+The live store protocol implements two operations:
 
 1. `acquire(state_id, owner_id)` atomically advances the owner fence and
    returns the new token with one coherent state value.
@@ -39,6 +39,40 @@ not log-prefix compaction. Hosts never deserialize state.
 This is a hard cutover. The envelope is `nanocodex_durable_state`; the former
 `nanocodex_journal_state` envelope and individual event batches are rejected.
 There is no adoption, migration, or compatibility reader for old durable data.
+
+## Provider portability
+
+The JavaScript memory, SQLite, Cloudflare Durable Object SQLite, and PostgreSQL
+adapters also implement an offline transfer extension. `exportDurabilityState`
+acquires a fresh owner fence at the source and returns one JSON-safe archive
+containing the stable state ID, exact revision, and opaque total-state payload.
+`importDurabilityState` installs that exact revision into an empty destination
+and creates a fence before any destination agent can acquire it.
+
+The state ID is part of the agent's durable identity and must not be rewritten.
+The storage provider and physical database may change; the logical agent ID
+does not. This lets the same Rust/WASM agent move, for example, from a
+Cloudflare Worker Durable Object to Vercel with PostgreSQL and back again.
+Completed operation IDs still replay their committed terminal results without
+calling the model, while newly accepted operations continue from the imported
+checkpoint. The first new model request after rehydration carries the committed
+history and does not depend on a provider-owned previous-response handle.
+
+This is a cutover protocol, not live replication or a distributed transaction:
+
+1. stop accepting work and shut down the source agent;
+2. export once, which fences any stale source writer;
+3. transfer the archive as sensitive application data;
+4. import into an empty destination under the archive's unchanged state ID;
+5. start the destination agent and never resume the old source.
+
+Importing the same archive into multiple destinations creates competing clones;
+only one destination may become live.
+
+Archives can contain conversation and tool state and are not encrypted by this
+API. Applications own transport encryption, access control, retention, and
+deletion. An ambiguous destination commit must be reconciled by loading the
+destination; blindly resuming the source can create split-brain execution.
 
 Store results have exact meanings:
 

--- a/docs/MILLION_USER_ARCHITECTURE.md
+++ b/docs/MILLION_USER_ARCHITECTURE.md
@@ -8,11 +8,11 @@ split between live coordination state and retained history.
 
 The initial instrumented Worker test proved four things:
 
-- one ordinary completed managed turn populated the append-only Rust durability
-  journal, the managed cursor log, and the managed turn receipt;
+- one ordinary completed managed turn replaced the single opaque Rust durable
+  state, populated the managed cursor log, and stored the managed turn receipt;
 - the same raw model/tool event content was retained in both the Cloudflare SDK
   event table and the managed cursor table;
-- the runtime journal ID is derived from the adapter's retained
+- the runtime state ID is derived from the adapter's retained
   `nanocodex_cloudflare_agent.session_id`, not the public managed agent ID; and
 - SQLite database size materially exceeds known JSON payload bytes, so indexes,
   workspace state, and page overhead must stay visible as an unattributed
@@ -31,13 +31,13 @@ The current implementation:
 - fixes `Agent.extend()` so nested adapter actions such as `events.connect` and
   `turn.route` are actually merged at runtime instead of existing only in the
   type declarations;
-- compacts 64 or more terminal Rust journal batches into one fenced checkpoint
-  batch without rewinding the revision, while retaining exact completed-ID
-  replay receipts and every unresolved operation; and
+- prunes old terminal receipts by replacing the complete fenced Rust state,
+  without rewinding the revision, while retaining the selected completed-ID
+  replay window and every unresolved operation; and
 - prevents a cold alarm from taking the idle-shutdown path while SQLite still
   owns accepted, cancelling, or retryable work. A real browser detach/reconnect
   run exposed this race: the outer turn remained accepted while repeated idle
-  shutdowns fenced admission before the first journal revision. The corrected
+  shutdowns fenced admission before the first state revision. The corrected
   run recovered that same accepted turn and committed its terminal after the
   browser re-authorized the reconnect.
 - seals old managed cursor events into immutable, checksum-verified R2
@@ -79,7 +79,7 @@ The hot durability head is now bounded by explicit policy. Model checkpoints,
 unresolved operations, ambiguous steps, recent exact receipts, recent managed
 events, and the small manifest head remain in SQLite. Closed cursor history and
 old exact receipts are immutable R2 data. The durable workspace remains a
-separate caller-visible storage budget; it is not journal history and is never
+separate caller-visible storage budget; it is not runtime state history and is never
 silently moved or expired.
 
 ## Production scale evidence
@@ -122,7 +122,7 @@ The governing rule is simple:
 
 > Every independently operating identity routes directly to its own atom of
 > coordination. No product request consults a global directory, allocator,
-> quota actor, journal owner, or deployment owner.
+> quota actor, durable-state owner, or deployment owner.
 
 ## Current topology
 
@@ -144,7 +144,7 @@ The governing rule is simple:
                   |                                      |                   |
                   v                                      v                   v
        +----------------------+              +------------------+   +------------------+
-       | Fixed-name auth DOs  |              | UserAccountDO    |   | NanocodexSession |
+       | Fixed-name auth DOs  |              | UserAccountDO    |   | DurableAgentSession |
        | account / webauthn / |              | keyed by user    |   | keyed by agent   |
        | account-link state   |              +------------------+   +---------+--------+
        +----------------------+              | one SQL row per  |             |
@@ -160,9 +160,8 @@ The governing rule is simple:
                  |  managed_realtime_operations pending + recent exact    |
                  |  archive manifests          bounded R2 ownership heads |
                  |  nanocodex_cloudflare_events disabled for managed mode |
-                 |  nanocodex_journal_owners   current fence              |
-                 |  nanocodex_journals         current revision           |
-                 |  nanocodex_journal_batches  checkpoint + recent tail   |
+                 |  nanocodex_durable_owners   current fence              |
+                 |  nanocodex_durable_states   one complete current state |
                  |  workspace / Computer state                            |
                  +--------------------------------------------------------+
                                                                           |
@@ -197,8 +196,8 @@ Current source anchors:
 - `services/managed/src/durable-events.ts` owns managed cursor replay;
 - `js/bindings/cloudflare/Agent.mjs` installs the raw AgentEvent projection;
 - `js/bindings/cloudflare/event-socket.mjs` retains raw AgentEvents;
-- `js/bindings/runtime/durability-store.mjs` retains and reloads journal
-  batches; and
+- `js/bindings/runtime/durability-store.mjs` retains and reloads one complete
+  current-state value; and
 - `services/egress/src/egress.ts` and `services/egress/src/broker.ts` route to
   and own the direct one-subject state machines.
 
@@ -218,19 +217,18 @@ churn is unbounded today. Deleting tombstones without another permanent
 anti-resurrection proof would reintroduce the race, so any compaction must first
 replace their semantic role rather than merely expire rows.
 
-### Durability journal
+### Durable state
 
-`nanocodex_journal_batches` stores one payload for every journal revision.
-Acquisition loads every retained batch in revision order and reduces the whole
-journal in memory. Terminal entries carry safe resumable checkpoints and
-results, so retained bytes can grow faster than the number of turns when those
-checkpoints are large.
+`nanocodex_durable_states` stores exactly one complete Rust-owned payload per
+agent. Acquisition reads that value in the same transaction that installs a
+new owner fence. Every replacement advances its revision; no historical
+storage prefix is loaded or reduced.
 
-The managed policy now compacts a terminal prefix after 64 retained batches
-and keeps only unresolved operations plus the 512 newest exact receipts in the
-live and stored Rust state. The outer managed receipt archive preserves older
-API replay identities. The latest checkpoint itself can still grow with the
-model's retained conversation and remains an explicit hot-head budget.
+The managed policy keeps unresolved operations plus the 512 newest exact
+receipts in the live and stored Rust state. The outer managed receipt archive
+preserves older API replay identities. The latest checkpoint itself can still
+grow with the model's retained conversation and remains an explicit hot-head
+budget.
 
 ### Managed turns and idempotency
 
@@ -262,7 +260,7 @@ opens.
 ### Workspace
 
 The retained Computer filesystem shares the session's Durable Object storage.
-It is not loaded as part of journal recovery, but it contributes independently
+It is not loaded as part of execution recovery, but it contributes independently
 to the per-agent SQLite size and requires its own retention policy.
 
 ## Remaining target topology
@@ -293,7 +291,7 @@ to the per-agent SQLite size and requires its own retention policy.
  | AgentDO(agent ID) -- sole authoritative owner                                    |
  |                                                                                  |
  | SQLite coordination head                                                         |
- |   owner epoch + journal fence                                                     |
+ |   owner epoch + durable-state fence                                               |
  |   latest resumable model checkpoint                                               |
  |   unresolved operations and tool steps                                            |
  |   bounded recent idempotency/terminal receipts                                    |
@@ -324,9 +322,9 @@ owner epoch. Egress verifies the capability statelessly and routes directly to
 
 ## SQLite and R2 boundary
 
-R2 should not become the live journal.
+R2 should not become the live execution state.
 
-The live journal needs atomic revision comparison, current-owner fencing,
+The live state needs atomic revision comparison, current-owner fencing,
 ordered admission, exact unresolved-operation state, and a checkpoint commit
 that agrees with the accepted terminal. Agent-local SQLite already owns those
 properties with the lowest coordination cost.
@@ -345,12 +343,12 @@ Keep only what is required to execute or recover the next operation:
 - unresolved operations and ambiguous tool steps;
 - a bounded recent idempotency and terminal-replay window;
 - recent events needed for reconnect-to-live delivery;
-- the next journal revision and event cursor;
+- the next state revision and event cursor;
 - a bounded recent segment window and immutable archive-index root; and
 - workspace metadata and actively retained files.
 
 Cold Agent construction reads this bounded head only. It never scans R2 and
-never replays the complete lifetime journal.
+never replays a lifetime mutation log because no such log exists.
 
 ### Immutable history body in R2
 
@@ -429,14 +427,14 @@ terminal boundary or from its own alarm.
 R2 should not preserve accidental duplication forever. The order of work is:
 
 1. **Implemented for owned tables:** measure bytes and rows independently for
-   journal batches, managed events, raw AgentEvents, turn receipts, realtime
+   the single Rust state, managed events, raw AgentEvents, turn receipts, realtime
    receipts, and the SQLite remainder. Computer workspace bytes are still part
    of the visible remainder and need a first-class Computer accounting API.
 2. **Implemented:** remove the second full event projection or make the managed
    stream a typed view over one canonical retained event log.
-3. **Implemented for capable stores:** teach the durability journal to
-   checkpoint and discard a closed prefix while retaining the latest
-   checkpoint, unresolved work, and a caller-selected recent replay window.
+3. **Implemented:** replace the total Rust state after pruning terminal
+   receipts, retaining the latest checkpoint, unresolved work, and a
+   caller-selected recent replay window.
 4. **Implemented:** keep recent reconnect and idempotency data locally and move
    older exact receipts to deterministic immutable R2 objects.
 5. **Implemented:** move closed managed-event prefixes into bounded immutable
@@ -448,13 +446,13 @@ Deletion is preferable to moving redundant data.
 
 Emit these dimensions per agent without requiring a global actor:
 
-- journal batch count and encoded bytes;
+- total-state row count and encoded bytes;
 - latest checkpoint bytes and checkpoint growth per completed turn;
 - managed event rows/bytes;
 - raw AgentEvent rows/bytes;
 - managed-turn rows, input bytes, and terminal bytes;
 - workspace file count and retained bytes;
-- cold journal load and reducer time;
+- cold state load and decode time;
 - cold Agent construction and restored upstream-connect time;
 - history-page latency from local SQLite and R2;
 - sealed segment size, upload duration, and compaction duration; and
@@ -470,7 +468,7 @@ them for cold-start and storage cost rather than guesswork.
 Decisions:
 
 - AgentDO SQLite remains the sole live durability authority.
-- R2 stores immutable historical bodies, never the mutable journal head.
+- R2 stores immutable application history, never the mutable execution state.
 - The latest complete resumable checkpoint remains local.
 - Every segment is agent-namespaced and content-addressed.
 - Every AgentDO compacts itself; there is no global compactor.

--- a/docs/PRODUCTION_PERFORMANCE_REVIEW.md
+++ b/docs/PRODUCTION_PERFORMANCE_REVIEW.md
@@ -16,7 +16,7 @@ model latency dominates time to first token.
 
 The normal live prompt-cache path is also structurally sound: one agent keeps a
 stable cache lineage and uses `previous_response_id` for compatible incremental
-requests. Portable durability now defaults the cache key to the stable journal
+requests. Portable durability now defaults the cache key to the stable state
 ID. Cold reopen retains that key but deliberately omits the remote response ID,
 so the first request replays complete client-owned typed history. Durable model
 steps bind that key, instructions, tools, model, request controls, immutable
@@ -309,7 +309,7 @@ Live managed Worker logs repeatedly emitted:
 
 ```text
 managed agent prewarm failed
-Nanocodex durability journal is already active: cloudflare:01a02eba-...
+Nanocodex durability state is already active: cloudflare:01a02eba-...
 ```
 
 Observed behavior:
@@ -330,7 +330,7 @@ Two boundaries interacted to produce the storm in the measured deployment:
    subscriber remains. The next alarm clears and retries the failed promise.
    This bypasses the bounded exponential turn retry policy.
 2. The deployed durability path relied on a process-local strong map keyed by
-   journal ID. Explicit shutdown released it, but Durable Object incarnation
+   state ID. Explicit shutdown released it, but Durable Object incarnation
    loss had no authoritative cross-incarnation stale-writer boundary.
 
 The stale owner may originate from Durable Object incarnation loss or a
@@ -340,15 +340,15 @@ rollback boundary through final decoration and awaiting session shutdown.
 
 The correctness fix is store-authoritative rather than process-local.
 Memory, SQLite, Postgres, IndexedDB, and Cloudflare Durable Object storage now
-persist a monotonic fence separately from the journal revision.
-`acquire_owner` installs the new authority and reads one journal snapshot in the
-same transaction. Every append checks the complete owner token before the
+persist a monotonic fence separately from the state revision. `acquire`
+installs the new authority and reads the one total state in the same
+transaction. Every `replace` checks the complete owner token before the
 revision. A newer opener therefore fences every older Agent before it can
 regress history or cache lineage.
 
 This authority is non-expiring and is not a lease: there is no heartbeat or
 TTL. Acquisition is last-opener-wins ownership handoff. `Fenced`, `Conflict`,
-and unknown `Backend` outcomes require a fresh Agent and full journal reopen;
+and unknown `Backend` outcomes require a fresh Agent and full state reload;
 only a definite `NotCommitted` result is safe to retry on the same owner.
 
 ### Correct fix boundary
@@ -357,8 +357,8 @@ only a definite `NotCommitted` result is safe to retry on the same owner.
    decoration setup. Every failure before publication awaits
    `agent.session.shutdown()`.
 2. **Implemented:** persist a monotonic owner fence in every host store,
-   atomically return its same-snapshot `OwnedJournal`, and check authority
-   before revision on every append.
+   atomically return its same-snapshot `OwnedState`, and check authority before
+   revision on every replacement.
 3. **Implemented:** remove fixed one-second passive retry. One attempt per
    subscriber transition is sufficient; real turns already own bounded typed
    retry. Structural ownership errors enter actionable `reopen_required` state
@@ -497,7 +497,7 @@ Current browser performance marks are useful but incomplete:
 - Provider usage is not split into total, cached, and cache-write input tokens
   in this production comparison.
 - There is no retained measurement of first-request bytes after direct
-  snapshot, portable-journal, or Codex-rollout recovery.
+  snapshot, portable-state, or Codex-rollout recovery.
 
 Add runtime-labelled switch, acceptance, run-start, first-token, history-visible,
 and completion timings before the next comparative performance pass. Add a
@@ -515,13 +515,13 @@ review are implemented:
    effort controls, fast/store and transport configuration, endpoints, and
    typed history. Any semantic change rejects replay.
 2. Active cancellation commits its safe interrupted checkpoint to the portable
-   journal, preserving restored history and cache prefix.
+   durable state, preserving restored history and cache prefix.
 3. Successful standalone compaction commits a model-only portable checkpoint,
    preserving the smaller replacement history across a cold reopen.
-4. Durable attachment defaults the prompt-cache key to journal ID. Sequential
+4. Durable attachment defaults the prompt-cache key to state ID. Sequential
    owners retain it; cold reopen sends full typed history without a retained
    provider response ID.
-5. A journal-replayed model step explicitly invalidates its old transport
+5. A state-replayed model step explicitly invalidates its old transport
    response ID. The next model/compaction request is a full typed-history replay
    under both `store(false)` and `store(true)`.
 6. Idle routed prompts now pass through durable admission; terminal replay

--- a/examples/vercel-workflows/README.md
+++ b/examples/vercel-workflows/README.md
@@ -54,9 +54,11 @@ transaction-scoped PostgreSQL advisory lock serializes schema creation across
 cold instances. Revisions are
 `NUMERIC(20,0)` values read and written as unsigned decimal strings, preserving
 Rust's complete `u64` range. Compare-and-replace conditionally advances the
-revision and replaces the opaque state in one transaction. A rejected `COMMIT` is an
-unknown outcome: the adapter throws, Rust poisons and stops that live state
-owner, and a new step reloads the database before doing more work.
+revision and replaces the opaque state in one transaction. If a `COMMIT`
+response is lost, the adapter discards that connection and retries the exact
+idempotent request on a fresh connection. It returns the committed revision,
+a normal conflict/fence result, or a retry-safe availability error—never an
+ambiguous write outcome.
 
 The browser keeps its agent transcript in application code: an `@wterm/react`
 terminal fed by a small ANSI renderer over the replayable, client-safe Workflow

--- a/examples/vercel-workflows/README.md
+++ b/examples/vercel-workflows/README.md
@@ -6,7 +6,7 @@ Vercel Workflows and native Vercel Function WebSockets.
 Each Workflow run is one agent session:
 
 - a typed Workflow hook accepts prompts and processes them sequentially;
-- each Function step opens the same application-owned PostgreSQL journal through
+- each Function step opens the same application-owned PostgreSQL state store through
   the `DATABASE_URL` injected by a Vercel Marketplace database integration;
 - every accepted prompt, typed agent event, and terminal result is appended to
   the Workflow's resumable stream;
@@ -32,7 +32,7 @@ browser B ─ WebSocket Function ─┘             │
                                               ▼
                                   Nanocodex WASM Function step
                                      ├─ Responses WebSocket → OpenAI
-                                     ├─ atomic journal append → PostgreSQL
+                                     ├─ atomic state replace → PostgreSQL
                                      └─ named persistent Vercel Sandbox
                                           └─ files, commands, preview domains
 
@@ -43,8 +43,8 @@ browser terminal ─ controller PTY WebSocket ─ same named Vercel Sandbox
 The WebSocket connection itself is disposable and bounded by the Vercel
 Function duration. The browser reconnects automatically. Workflow durably owns
 prompt serialization and the replayable client event stream; PostgreSQL stores
-the opaque Rust journal at model, tool, and terminal boundaries. A replacement
-Function step reconstructs the agent from that journal, so Rust/WASM retains
+the opaque Rust total state at model, tool, and terminal boundaries. A replacement
+Function step reconstructs the agent from that state, so Rust/WASM retains
 deduplication, checkpoint reconstruction, and recovery policy without a second
 JavaScript state machine.
 
@@ -53,16 +53,16 @@ and immediately registers the pool with `attachDatabasePool`. A fixed
 transaction-scoped PostgreSQL advisory lock serializes schema creation across
 cold instances. Revisions are
 `NUMERIC(20,0)` values read and written as unsigned decimal strings, preserving
-Rust's complete `u64` range. Compare-and-append conditionally advances the head
-and inserts the opaque batch in one transaction. A rejected `COMMIT` is an
-unknown outcome: the adapter throws, Rust poisons and stops that live journal
+Rust's complete `u64` range. Compare-and-replace conditionally advances the
+revision and replaces the opaque state in one transaction. A rejected `COMMIT` is an
+unknown outcome: the adapter throws, Rust poisons and stops that live state
 owner, and a new step reloads the database before doing more work.
 
 The browser keeps its agent transcript in application code: an `@wterm/react`
 terminal fed by a small ANSI renderer over the replayable, client-safe Workflow
 event stream. That consumer boundary is the replacement seam: an application
 can render the snapshot with xterm.js or ordinary React without changing the
-headless Nanocodex agent, its durable journal, or its transport. The example
+headless Nanocodex agent, its durable state, or its transport. The example
 keeps the adapter local because UI frameworks and terminal renderers consume
 Agent events directly rather than defining a core UI abstraction.
 
@@ -88,7 +88,7 @@ Workflow socket never carries terminal bytes.
 
 These lifetimes are intentionally different:
 
-- PostgreSQL retains the opaque Rust journal and committed conversation state;
+- PostgreSQL retains the opaque Rust total state and committed conversation state;
 - the Workflow actor serializes prompts and retains replayable client events;
 - the named persistent Sandbox retains files across VM stop/resume;
 - each terminal attachment owns one ephemeral login shell; reconnecting requests
@@ -116,7 +116,7 @@ npx vercel env pull examples/vercel-workflows/.env.local
 ```
 
 Importing or building the application does not open a database connection. The
-first durability load or append creates the pool and current schema.
+first durability load or replacement creates the pool and current schema.
 
 For API-key authentication, use Vercel CLI's local runtime because native
 WebSocket upgrades require Vercel's Function adapter:
@@ -243,9 +243,14 @@ normal lifecycle.
 The focused durability tests run the production PostgreSQL SQL against PGlite,
 a deterministic WASM PostgreSQL build. They cover schema-lock acquisition,
 expected-revision conflicts, numeric load order, the exact `u64` maximum,
-confirmed rollback, commit ambiguity, and recreation from the retained journal
-without requiring external credentials. Live multi-session contention remains
-a deployment smoke against the selected Marketplace provider.
+confirmed rollback, commit ambiguity, and recreation from the retained state
+without requiring external credentials. The portability test additionally runs
+a real Nanocodex WASM agent through Cloudflare SQLite → Vercel PostgreSQL →
+Cloudflare SQLite. It verifies exact revision transfer, duplicate terminal
+replay without a model call, full-history provider requests without stale
+previous-response handles, and continued execution after both cutovers. Live
+multi-session contention remains a deployment smoke against the selected
+Marketplace provider.
 
 References:
 

--- a/examples/vercel-workflows/README.md
+++ b/examples/vercel-workflows/README.md
@@ -240,17 +240,20 @@ experimental. Connections are expected to close when a Function reaches its
 maximum duration; automatic cursor-based reconnection is part of the demo's
 normal lifecycle.
 
-The focused durability tests run the production PostgreSQL SQL against PGlite,
-a deterministic WASM PostgreSQL build. They cover schema-lock acquisition,
+The focused deterministic durability tests run the PostgreSQL adapter against
+PGlite. A separate CI test runs the same adapter through a real `pg.Pool`
+connected to PostgreSQL 17. Together they cover schema-lock acquisition,
 expected-revision conflicts, numeric load order, the exact `u64` maximum,
 confirmed rollback, commit ambiguity, and recreation from the retained state
-without requiring external credentials. The portability test additionally runs
-a real Nanocodex WASM agent through Cloudflare SQLite → Vercel PostgreSQL →
-Cloudflare SQLite. It verifies exact revision transfer, duplicate terminal
-replay without a model call, full-history provider requests without stale
-previous-response handles, and continued execution after both cutovers. Live
-multi-session contention remains a deployment smoke against the selected
-Marketplace provider.
+without requiring external credentials. The portability tests additionally run
+a real Nanocodex WASM agent through the Cloudflare SQLite and PostgreSQL store
+contracts, and run the managed Cloudflare HTTP API inside the Workers runtime
+with actual Durable Object SQLite. They verify exact revision transfer, fresh
+runtime identities, duplicate terminal replay without a model call,
+full-history provider requests without stale previous-response handles, and
+continued execution after cutover. Only the OpenAI Responses endpoint is
+simulated. Live PostgreSQL CAS, fencing, import conflict, and continuation are
+mandatory in CI; Marketplace deployment remains an environment-specific smoke.
 
 References:
 

--- a/examples/vercel-workflows/app/api/durability/export/route.ts
+++ b/examples/vercel-workflows/app/api/durability/export/route.ts
@@ -1,4 +1,4 @@
-import { exportDurabilityState } from "nanocodex/durability";
+import { durabilityRevision, exportDurabilityStatePage } from "nanocodex/durability";
 
 import { hasBearerToken } from "@/lib/bearer-auth";
 import { postgresDurabilityStore } from "@/workflows/postgres-durability";
@@ -14,17 +14,32 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
   try {
-    const body = await request.json() as { state_id?: unknown };
+    const body = await request.json() as {
+      state_id?: unknown;
+      from?: unknown;
+      to?: unknown;
+      cursor?: unknown;
+      limit?: unknown;
+    };
     if (!body || typeof body !== "object" || Array.isArray(body)
-      || Object.keys(body).some((key) => key !== "state_id")
-      || typeof body.state_id !== "string" || !body.state_id.trim()) {
+      || Object.keys(body).some((key) => !["state_id", "from", "to", "cursor", "limit"].includes(key))
+      || typeof body.state_id !== "string" || !body.state_id.trim()
+      || (typeof body.from !== "string" && typeof body.from !== "number")
+      || (body.to !== undefined && typeof body.to !== "string" && typeof body.to !== "number")
+      || (body.cursor !== undefined && typeof body.cursor !== "string")
+      || (body.limit !== undefined && typeof body.limit !== "number")) {
       return Response.json(
-        { error: { code: "invalid_request", message: "state_id is required" } },
+        { error: { code: "invalid_request", message: "state_id and from are required" } },
         { status: 400, headers: { "cache-control": "no-store" } },
       );
     }
     return Response.json(
-      await exportDurabilityState(postgresDurabilityStore(), body.state_id),
+      await exportDurabilityStatePage(postgresDurabilityStore(), body.state_id, {
+        from: durabilityRevision(body.from),
+        to: body.to === undefined ? undefined : durabilityRevision(body.to),
+        cursor: body.cursor,
+        limit: body.limit,
+      }),
       { headers: { "cache-control": "no-store" } },
     );
   } catch (error) {

--- a/examples/vercel-workflows/app/api/durability/export/route.ts
+++ b/examples/vercel-workflows/app/api/durability/export/route.ts
@@ -1,6 +1,8 @@
 import { durabilityRevision, exportDurabilityStatePage } from "nanocodex/durability";
+import type { DurabilityExportPageRequest } from "nanocodex/durability";
 
 import { hasBearerToken } from "@/lib/bearer-auth";
+import { errorResponse, RequestError } from "@/lib/validation";
 import { postgresDurabilityStore } from "@/workflows/postgres-durability";
 
 export const runtime = "nodejs";
@@ -14,39 +16,83 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
   try {
-    const body = await request.json() as {
-      state_id?: unknown;
-      from?: unknown;
-      to?: unknown;
-      cursor?: unknown;
-      limit?: unknown;
-    };
-    if (!body || typeof body !== "object" || Array.isArray(body)
-      || Object.keys(body).some((key) => !["state_id", "from", "to", "cursor", "limit"].includes(key))
-      || typeof body.state_id !== "string" || !body.state_id.trim()
-      || (typeof body.from !== "string" && typeof body.from !== "number")
-      || (body.to !== undefined && typeof body.to !== "string" && typeof body.to !== "number")
-      || (body.cursor !== undefined && typeof body.cursor !== "string")
-      || (body.limit !== undefined && typeof body.limit !== "number")) {
-      return Response.json(
-        { error: { code: "invalid_request", message: "state_id and from are required" } },
-        { status: 400, headers: { "cache-control": "no-store" } },
-      );
-    }
+    const body = parseExportRequest(await request.json());
     return Response.json(
       await exportDurabilityStatePage(postgresDurabilityStore(), body.state_id, {
-        from: durabilityRevision(body.from),
-        to: body.to === undefined ? undefined : durabilityRevision(body.to),
+        from: body.from,
+        ...(body.fromDigest === undefined ? {} : { fromDigest: body.fromDigest }),
+        to: body.to,
         cursor: body.cursor,
         limit: body.limit,
       }),
       { headers: { "cache-control": "no-store" } },
     );
   } catch (error) {
+    if (error instanceof RequestError) return errorResponse(error);
     const message = error instanceof Error ? error.message : String(error);
     return Response.json(
       { error: { code: "durability_export_failed", message } },
       { status: 500, headers: { "cache-control": "no-store" } },
     );
   }
+}
+
+type ExportRequest = DurabilityExportPageRequest & Readonly<{ state_id: string }>;
+
+function parseExportRequest(value: unknown): ExportRequest {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw invalidRequest("durability export body must be a JSON object");
+  }
+  const body = value as Record<string, unknown>;
+  const fields = ["state_id", "from", "fromDigest", "to", "cursor", "limit"];
+  if (Object.keys(body).some((key) => !fields.includes(key))) {
+    throw invalidRequest("durability export body contains an unknown field");
+  }
+  if (typeof body.state_id !== "string" || !body.state_id.trim()) {
+    throw invalidRequest("state_id must be a non-empty string");
+  }
+
+  const from = parseRevision(body.from, "from");
+  const to = body.to === undefined ? undefined : parseRevision(body.to, "to");
+  const fromDigest = body.fromDigest;
+  if (fromDigest !== undefined
+    && (typeof fromDigest !== "string" || !/^sha256:[0-9a-f]{64}$/.test(fromDigest))) {
+    throw invalidRequest("fromDigest must be a SHA-256 durability state digest");
+  }
+  if (from !== "0" && fromDigest === undefined) {
+    throw invalidRequest("fromDigest is required when from is nonzero");
+  }
+  if (body.cursor !== undefined
+    && (typeof body.cursor !== "string" || !/^v1:(0|[1-9][0-9]*)$/.test(body.cursor))) {
+    throw invalidRequest("cursor is invalid");
+  }
+  if (body.limit !== undefined
+    && (!Number.isSafeInteger(body.limit) || (body.limit as number) < 1
+      || (body.limit as number) > 1024 * 1024)) {
+    throw invalidRequest("limit must be an integer from 1 to 1048576");
+  }
+
+  return {
+    state_id: body.state_id,
+    from,
+    ...(fromDigest === undefined ? {} : { fromDigest }),
+    to,
+    cursor: body.cursor as string | undefined,
+    limit: body.limit as number | undefined,
+  };
+}
+
+function parseRevision(value: unknown, field: string): ReturnType<typeof durabilityRevision> {
+  if (typeof value !== "string" && typeof value !== "number") {
+    throw invalidRequest(`${field} must be an unsigned 64-bit decimal revision`);
+  }
+  try {
+    return durabilityRevision(value);
+  } catch {
+    throw invalidRequest(`${field} must be an unsigned 64-bit decimal revision`);
+  }
+}
+
+function invalidRequest(message: string): RequestError {
+  return new RequestError("invalid_request", message);
 }

--- a/examples/vercel-workflows/app/api/durability/export/route.ts
+++ b/examples/vercel-workflows/app/api/durability/export/route.ts
@@ -1,0 +1,37 @@
+import { exportDurabilityState } from "nanocodex/durability";
+
+import { hasBearerToken } from "@/lib/bearer-auth";
+import { postgresDurabilityStore } from "@/workflows/postgres-durability";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request): Promise<Response> {
+  const expected = process.env.NANOCODEX_ADMIN_TOKEN?.trim();
+  if (expected && !hasBearerToken(request, expected)) {
+    return Response.json(
+      { error: { code: "unauthorized", message: "durability export token was rejected" } },
+      { status: 401, headers: { "cache-control": "no-store" } },
+    );
+  }
+  try {
+    const body = await request.json() as { state_id?: unknown };
+    if (!body || typeof body !== "object" || Array.isArray(body)
+      || Object.keys(body).some((key) => key !== "state_id")
+      || typeof body.state_id !== "string" || !body.state_id.trim()) {
+      return Response.json(
+        { error: { code: "invalid_request", message: "state_id is required" } },
+        { status: 400, headers: { "cache-control": "no-store" } },
+      );
+    }
+    return Response.json(
+      await exportDurabilityState(postgresDurabilityStore(), body.state_id),
+      { headers: { "cache-control": "no-store" } },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return Response.json(
+      { error: { code: "durability_export_failed", message } },
+      { status: 500, headers: { "cache-control": "no-store" } },
+    );
+  }
+}

--- a/examples/vercel-workflows/app/api/sessions/route.ts
+++ b/examples/vercel-workflows/app/api/sessions/route.ts
@@ -2,6 +2,7 @@ import { start } from "workflow/api";
 
 import { hasBearerToken } from "@/lib/bearer-auth";
 import { nanocodexActor } from "@/workflows/nanocodex-actor";
+import type { DurabilityPortableStateArchive } from "nanocodex/durability";
 
 export const runtime = "nodejs";
 
@@ -13,9 +14,15 @@ export async function POST(request: Request): Promise<Response> {
     );
   }
   try {
-    const run = await start(nanocodexActor);
+    const archive = await optionalDurabilityArchive(request);
+    const run = archive === undefined
+      ? await start(nanocodexActor)
+      : await start(nanocodexActor, [archive]);
     return Response.json(
-      { session_id: run.runId },
+      {
+        session_id: run.runId,
+        durability_id: archive?.stateId ?? run.runId,
+      },
       { status: 201, headers: { "cache-control": "no-store" } },
     );
   } catch (error) {
@@ -25,6 +32,20 @@ export async function POST(request: Request): Promise<Response> {
       { status: 500, headers: { "cache-control": "no-store" } },
     );
   }
+}
+
+async function optionalDurabilityArchive(
+  request: Request,
+): Promise<DurabilityPortableStateArchive | undefined> {
+  const encoded = await request.text();
+  if (!encoded.trim()) return undefined;
+  const body = JSON.parse(encoded) as { durability?: unknown };
+  if (!body || typeof body !== "object" || Array.isArray(body)
+    || Object.keys(body).some((key) => key !== "durability")
+    || body.durability === undefined) {
+    throw new TypeError("session creation body must contain only durability");
+  }
+  return body.durability as DurabilityPortableStateArchive;
 }
 
 function authorizedToCreate(request: Request): boolean {

--- a/examples/vercel-workflows/test/cloudflare-durability-storage.ts
+++ b/examples/vercel-workflows/test/cloudflare-durability-storage.ts
@@ -1,0 +1,122 @@
+import type { CloudflareDurableObjectStorage } from "nanocodex/durability/cloudflare";
+
+type OwnerRow = { owner_id: string; fence: string };
+type StateRow = { revision: string; payload: string };
+type ChunkHeadRow = { revision: string; chunk_count: number };
+type ChunkRow = {
+  stateId: string;
+  revision: string;
+  chunk_index: number;
+  payload: string;
+};
+
+/** In-memory Durable Object SQLite boundary used by the portability integration test. */
+export function cloudflareDurabilityStorage(): CloudflareDurableObjectStorage {
+  const owners = new Map<string, OwnerRow>();
+  const states = new Map<string, StateRow>();
+  const heads = new Map<string, ChunkHeadRow>();
+  const chunks: ChunkRow[] = [];
+  const storage = {
+    sql: {
+      exec(sql: string, ...args: unknown[]) {
+        const stateId = args[0] as string;
+        let rows: unknown[];
+        if (sql.startsWith("CREATE TABLE")) {
+          rows = [];
+        } else if (sql.startsWith("PRAGMA table_info")) {
+          rows = pragmaRows(sql);
+        } else if (sql.startsWith("SELECT owner_id, fence FROM nanocodex_durable_owners")) {
+          const stored = owners.get(stateId);
+          rows = stored ? [stored] : [];
+        } else if (sql.startsWith("INSERT INTO nanocodex_durable_owners")) {
+          owners.set(stateId, { owner_id: args[1] as string, fence: args[2] as string });
+          rows = [];
+        } else if (sql.startsWith("SELECT revision, payload FROM nanocodex_durable_states")) {
+          const stored = states.get(stateId);
+          rows = stored ? [stored] : [];
+        } else if (sql.startsWith("INSERT INTO nanocodex_durable_states")) {
+          states.set(stateId, { revision: args[1] as string, payload: args[2] as string });
+          rows = [];
+        } else if (sql.startsWith("DELETE FROM nanocodex_durable_chunk_heads")) {
+          heads.delete(stateId);
+          rows = [];
+        } else if (sql.startsWith("INSERT INTO nanocodex_durable_chunk_heads")) {
+          heads.set(stateId, { revision: args[1] as string, chunk_count: args[2] as number });
+          rows = [];
+        } else if (sql.startsWith("SELECT revision, chunk_count FROM nanocodex_durable_chunk_heads")) {
+          const stored = heads.get(stateId);
+          rows = stored ? [stored] : [];
+        } else if (sql.startsWith("DELETE FROM nanocodex_durable_state_chunks")) {
+          removeChunks(chunks, stateId);
+          rows = [];
+        } else if (sql.startsWith("INSERT INTO nanocodex_durable_state_chunks")) {
+          chunks.push({
+            stateId,
+            revision: args[1] as string,
+            chunk_index: args[2] as number,
+            payload: args[3] as string,
+          });
+          rows = [];
+        } else if (sql.startsWith(
+          "SELECT revision, chunk_index, payload FROM nanocodex_durable_state_chunks",
+        )) {
+          rows = chunks.filter((chunk) => chunk.stateId === stateId);
+        } else {
+          throw new Error(`unexpected Cloudflare durability SQL: ${sql}`);
+        }
+        return { toArray: () => rows };
+      },
+    },
+    transactionSync<Result>(callback: () => Result): Result {
+      const snapshot = {
+        owners: new Map(owners),
+        states: new Map(states),
+        heads: new Map(heads),
+        chunks: chunks.map((chunk) => ({ ...chunk })),
+      };
+      try {
+        return callback();
+      } catch (error) {
+        restoreMap(owners, snapshot.owners);
+        restoreMap(states, snapshot.states);
+        restoreMap(heads, snapshot.heads);
+        chunks.splice(0, chunks.length, ...snapshot.chunks);
+        throw error;
+      }
+    },
+  };
+  return storage as unknown as CloudflareDurableObjectStorage;
+}
+
+function pragmaRows(sql: string): object[] {
+  if (sql.includes("nanocodex_durable_owners")) {
+    return columns([["state_id", "TEXT", 0, 1], ["owner_id", "TEXT", 1, 0], ["fence", "TEXT", 1, 0]]);
+  }
+  if (sql.includes("nanocodex_durable_states")) {
+    return columns([["state_id", "TEXT", 0, 1], ["revision", "TEXT", 1, 0], ["payload", "TEXT", 1, 0]]);
+  }
+  if (sql.includes("nanocodex_durable_chunk_heads")) {
+    return columns([["state_id", "TEXT", 0, 1], ["revision", "TEXT", 1, 0], ["chunk_count", "INTEGER", 1, 0]]);
+  }
+  return columns([
+    ["state_id", "TEXT", 1, 1],
+    ["revision", "TEXT", 1, 2],
+    ["chunk_index", "INTEGER", 1, 3],
+    ["payload", "TEXT", 1, 0],
+  ]);
+}
+
+function columns(shapes: Array<[string, string, number, number]>): object[] {
+  return shapes.map(([name, type, notnull, pk], cid) => ({ cid, name, type, notnull, pk }));
+}
+
+function removeChunks(chunks: ChunkRow[], stateId: string): void {
+  for (let index = chunks.length - 1; index >= 0; index -= 1) {
+    if (chunks[index]!.stateId === stateId) chunks.splice(index, 1);
+  }
+}
+
+function restoreMap<Key, Value>(target: Map<Key, Value>, source: Map<Key, Value>): void {
+  target.clear();
+  for (const [key, value] of source) target.set(key, value);
+}

--- a/examples/vercel-workflows/test/durability-export-route.test.ts
+++ b/examples/vercel-workflows/test/durability-export-route.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  exportDurabilityStatePage: vi.fn(),
+  postgresDurabilityStore: vi.fn(),
+}));
+
+vi.mock("nanocodex/durability", async (importOriginal) => ({
+  ...await importOriginal<typeof import("nanocodex/durability")>(),
+  exportDurabilityStatePage: mocks.exportDurabilityStatePage,
+}));
+vi.mock("@/workflows/postgres-durability", () => ({
+  postgresDurabilityStore: mocks.postgresDurabilityStore,
+}));
+
+import { POST } from "../app/api/durability/export/route";
+
+const FROM_DIGEST = `sha256:${"1".repeat(64)}`;
+const ZERO_DIGEST = `sha256:${"2".repeat(64)}`;
+const store = { acquire: vi.fn() };
+
+describe("durability export route", () => {
+  beforeEach(() => {
+    delete process.env.NANOCODEX_ADMIN_TOKEN;
+    mocks.exportDurabilityStatePage.mockReset();
+    mocks.postgresDurabilityStore.mockReset();
+    mocks.postgresDurabilityStore.mockReturnValue(store);
+  });
+
+  it("consumes and exposes the exact nonzero from-state lineage digest", async () => {
+    const page = exportPage("7", FROM_DIGEST);
+    mocks.exportDurabilityStatePage.mockResolvedValue(page);
+
+    const response = await post({
+      state_id: "portable-agent",
+      from: "7",
+      fromDigest: FROM_DIGEST,
+      to: "9",
+      cursor: "v1:12",
+      limit: 97,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    await expect(response.json()).resolves.toEqual(page);
+    expect(mocks.exportDurabilityStatePage).toHaveBeenCalledWith(store, "portable-agent", {
+      from: "7",
+      fromDigest: FROM_DIGEST,
+      to: "9",
+      cursor: "v1:12",
+      limit: 97,
+    });
+  });
+
+  it("preserves revision-zero export requests without a supplied digest", async () => {
+    const page = exportPage("0", ZERO_DIGEST);
+    mocks.exportDurabilityStatePage.mockResolvedValue(page);
+
+    const response = await post({ state_id: "portable-agent", from: 0 });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(page);
+    expect(mocks.exportDurabilityStatePage).toHaveBeenCalledWith(store, "portable-agent", {
+      from: "0",
+      to: undefined,
+      cursor: undefined,
+      limit: undefined,
+    });
+  });
+
+  it.each([
+    [{ state_id: "portable-agent", from: "7" }, "fromDigest is required"],
+    [{ state_id: "portable-agent", from: "7", fromDigest: "sha256:not-a-digest" }, "fromDigest must be"],
+    [{ state_id: "portable-agent", from: "nope", fromDigest: FROM_DIGEST }, "from must be"],
+    [{ state_id: "portable-agent", from: "0", extra: true }, "unknown field"],
+  ])("rejects invalid lineage requests before opening the store", async (body, message) => {
+    const response = await post(body);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: { code: "invalid_request", message: expect.stringContaining(message) },
+    });
+    expect(mocks.postgresDurabilityStore).not.toHaveBeenCalled();
+    expect(mocks.exportDurabilityStatePage).not.toHaveBeenCalled();
+  });
+});
+
+function post(body: unknown): Promise<Response> {
+  return POST(new Request("https://example.test/api/durability/export", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  }));
+}
+
+function exportPage(from: string, fromDigest: string) {
+  return {
+    format: "nanocodex-durability-state-page-v1",
+    stateId: "portable-agent",
+    from,
+    fromDigest,
+    to: "9",
+    cursor: "v1:0",
+    nextCursor: null,
+    payloadLength: 6,
+    payload: "opaque",
+  } as const;
+}

--- a/examples/vercel-workflows/test/postgres-durability.test.ts
+++ b/examples/vercel-workflows/test/postgres-durability.test.ts
@@ -1,7 +1,17 @@
+import { readFile } from "node:fs/promises";
+
 import { PGlite } from "@electric-sql/pglite";
 import { describe, expect, it } from "vitest";
+import { WebSocketServer, type RawData, type WebSocket } from "ws";
 
-import { durabilityRevision } from "nanocodex/durability";
+import {
+  DurabilityImportConflictError,
+  durabilityRevision,
+  exportDurabilityState,
+  importDurabilityState,
+  type DurabilityPortableStateArchive,
+} from "nanocodex/durability";
+import { createCloudflareDurabilityStore } from "nanocodex/durability/cloudflare";
 import {
   createPostgresDurabilityStore,
   type PostgresDurabilityClient,
@@ -10,10 +20,13 @@ import {
   type PostgresDurabilityRow,
   UnknownPostgresCommitOutcomeError,
 } from "nanocodex/durability/postgres";
+import { Agent, Transport } from "nanocodex/node";
+import { cloudflareDurabilityStorage } from "./cloudflare-durability-storage";
 import { postgresDurabilityStore } from "../workflows/postgres-durability";
 
 const MAX_REVISION = durabilityRevision("18446744073709551615");
 const BEFORE_MAX_REVISION = durabilityRevision("18446744073709551614");
+type NodeAgent = Awaited<ReturnType<typeof Agent.create>>;
 
 describe("Vercel PostgreSQL durability store", () => {
   it("does not require DATABASE_URL until the application store is requested", () => {
@@ -144,6 +157,32 @@ describe("Vercel PostgreSQL durability store", () => {
     }
   });
 
+  it("admits exactly one concurrent portable import into an empty PostgreSQL target", async () => {
+    const pool = new PGlitePool();
+    try {
+      const stores = [
+        createPostgresDurabilityStore(pool.asPostgresPool()),
+        createPostgresDurabilityStore(pool.asPostgresPool()),
+      ];
+      const attempts = await Promise.allSettled(stores.map((store) => store.importState(
+        "portable-race",
+        { revision: durabilityRevision("23"), payload: "one-exact-import" },
+      )));
+      expect(attempts.filter(({ status }) => status === "fulfilled")).toHaveLength(1);
+      const rejected = attempts.find(({ status }) => status === "rejected");
+      expect(rejected).toMatchObject({ status: "rejected" });
+      if (rejected?.status === "rejected") {
+        expect(rejected.reason).toBeInstanceOf(DurabilityImportConflictError);
+      }
+      await expect(stores[0]!.load("portable-race")).resolves.toEqual({
+        revision: durabilityRevision("23"),
+        payload: "one-exact-import",
+      });
+    } finally {
+      await pool.close();
+    }
+  });
+
   it("preserves the complete unsigned-u64 decimal range without JS numbers", async () => {
     const pool = new PGlitePool();
     try {
@@ -232,7 +271,244 @@ describe("Vercel PostgreSQL durability store", () => {
       await pool.close();
     }
   });
+
+  it("moves one live agent Cloudflare → Vercel Postgres → Cloudflare without replaying turns", async () => {
+    const module = await readFile(
+      new URL("../../../js/bindings/pkg-web/nanocodex_bg.wasm", import.meta.url),
+    );
+    const server = await startResponsesServer();
+    const pool = new PGlitePool();
+    const source = createCloudflareDurabilityStore(cloudflareDurabilityStorage());
+    const postgres = createPostgresDurabilityStore(pool.asPostgresPool());
+    const returned = createCloudflareDurabilityStore(cloudflareDurabilityStorage());
+    const sessionId = "018f1f9a-7b3c-7a70-8000-000000000070";
+    const stateId = "portable-managed-agent";
+    let agent: NodeAgent | undefined;
+
+    try {
+      agent = await Agent.create({
+        module,
+        sessionId,
+        thinking: "none",
+        transport: Transport.openAi({ apiKey: "test-key", websocketUrl: server.url }),
+        durability: source,
+        durabilityId: stateId,
+      });
+      const sourceScenario = answerNext(
+        server,
+        "cloudflare-response",
+        "COMMITTED ON CLOUDFLARE",
+        { inputs: ["commit this turn on Cloudflare"] },
+      );
+      const cloudflareTurn = agent.turn.prompt({
+        id: "turn-cloudflare",
+        input: "commit this turn on Cloudflare",
+      });
+      const cloudflareResult = await cloudflareTurn.result();
+      expect(cloudflareResult.finalMessage).toBe("COMMITTED ON CLOUDFLARE");
+      cloudflareResult.dispose();
+      cloudflareTurn.dispose();
+      await sourceScenario;
+      await shutdownAgent(agent);
+      agent = undefined;
+
+      const cloudflareArchive = jsonRoundTrip(await exportDurabilityState(source, stateId));
+      await expect(importDurabilityState(postgres, cloudflareArchive)).resolves.toEqual({
+        revision: cloudflareArchive.revision,
+        payload: cloudflareArchive.payload,
+      });
+
+      agent = await Agent.create({
+        module,
+        sessionId,
+        thinking: "none",
+        transport: Transport.openAi({ apiKey: "test-key", websocketUrl: server.url }),
+        durability: postgres,
+        durabilityId: stateId,
+      });
+      const replayedCloudflareTurn = agent.turn.prompt({
+        id: "turn-cloudflare",
+        input: "commit this turn on Cloudflare",
+      });
+      const replayedCloudflare = await replayedCloudflareTurn.result();
+      expect(replayedCloudflare.finalMessage).toBe("COMMITTED ON CLOUDFLARE");
+      expect(server.connections).toBe(1);
+      replayedCloudflare.dispose();
+      replayedCloudflareTurn.dispose();
+
+      const postgresScenario = answerNext(
+        server,
+        "postgres-response",
+        "COMMITTED ON POSTGRES",
+        {
+          inputs: [
+            "commit this turn on Cloudflare",
+            "COMMITTED ON CLOUDFLARE",
+            "continue this same agent on Vercel Postgres",
+          ],
+        },
+      );
+      const postgresTurn = agent.turn.prompt({
+        id: "turn-postgres",
+        input: "continue this same agent on Vercel Postgres",
+      });
+      const postgresResult = await postgresTurn.result();
+      expect(postgresResult.finalMessage).toBe("COMMITTED ON POSTGRES");
+      postgresResult.dispose();
+      postgresTurn.dispose();
+      await postgresScenario;
+      await shutdownAgent(agent);
+      agent = undefined;
+
+      const postgresArchive = jsonRoundTrip(await exportDurabilityState(postgres, stateId));
+      expect(BigInt(postgresArchive.revision)).toBeGreaterThan(BigInt(cloudflareArchive.revision));
+      await importDurabilityState(returned, postgresArchive);
+
+      agent = await Agent.create({
+        module,
+        sessionId,
+        thinking: "none",
+        transport: Transport.openAi({ apiKey: "test-key", websocketUrl: server.url }),
+        durability: returned,
+        durabilityId: stateId,
+      });
+      const replayedPostgresTurn = agent.turn.prompt({
+        id: "turn-postgres",
+        input: "continue this same agent on Vercel Postgres",
+      });
+      const replayedPostgres = await replayedPostgresTurn.result();
+      expect(replayedPostgres.finalMessage).toBe("COMMITTED ON POSTGRES");
+      expect(server.connections).toBe(2);
+      replayedPostgres.dispose();
+      replayedPostgresTurn.dispose();
+
+      const returnScenario = answerNext(
+        server,
+        "returned-response",
+        "RUNNING AGAIN ON CLOUDFLARE",
+        {
+          inputs: [
+            "COMMITTED ON CLOUDFLARE",
+            "continue this same agent on Vercel Postgres",
+            "COMMITTED ON POSTGRES",
+            "prove the imported agent can keep running on Cloudflare",
+          ],
+        },
+      );
+      const returnTurn = agent.turn.prompt({
+        id: "turn-returned",
+        input: "prove the imported agent can keep running on Cloudflare",
+      });
+      const returnResult = await returnTurn.result();
+      expect(returnResult.finalMessage).toBe("RUNNING AGAIN ON CLOUDFLARE");
+      expect(server.connections).toBe(3);
+      returnResult.dispose();
+      returnTurn.dispose();
+      await returnScenario;
+      expect(BigInt((await returned.load(stateId)).revision)).toBeGreaterThan(
+        BigInt(postgresArchive.revision),
+      );
+    } finally {
+      try {
+        if (agent) await shutdownAgent(agent);
+      } finally {
+        try {
+          await server.close();
+        } finally {
+          await pool.close();
+        }
+      }
+    }
+  }, 30_000);
 });
+
+function jsonRoundTrip(archive: DurabilityPortableStateArchive): DurabilityPortableStateArchive {
+  return JSON.parse(JSON.stringify(archive)) as DurabilityPortableStateArchive;
+}
+
+async function shutdownAgent(agent: NodeAgent): Promise<void> {
+  try {
+    await agent.session.shutdown();
+  } finally {
+    agent.dispose();
+  }
+}
+
+async function answerNext(
+  server: ResponsesServer,
+  responseId: string,
+  message: string,
+  expected: Readonly<{ inputs: readonly string[] }>,
+): Promise<void> {
+  const socket = await server.nextConnection();
+  const request = await nextMessage(socket);
+  socket.send(JSON.stringify({
+    type: "response.completed",
+    response: {
+      id: responseId,
+      status: "completed",
+      output: [{
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: message }],
+      }],
+      usage: null,
+    },
+  }));
+  const input = JSON.stringify(request.input);
+  for (const text of expected.inputs) expect(input).toContain(text);
+  expect(request.previous_response_id).toBeUndefined();
+}
+
+type ResponsesServer = Readonly<{
+  connections: number;
+  url: string;
+  nextConnection(): Promise<WebSocket>;
+  close(): Promise<void>;
+}>;
+
+async function startResponsesServer(): Promise<ResponsesServer> {
+  const websocketServer = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await new Promise<void>((resolve, reject) => {
+    websocketServer.once("listening", resolve);
+    websocketServer.once("error", reject);
+  });
+  const queued: WebSocket[] = [];
+  const waiters: Array<(socket: WebSocket) => void> = [];
+  let connections = 0;
+  websocketServer.on("connection", (socket) => {
+    connections += 1;
+    const resolve = waiters.shift();
+    if (resolve) resolve(socket);
+    else queued.push(socket);
+  });
+  return Object.freeze({
+    get connections() { return connections; },
+    get url() {
+      const address = websocketServer.address();
+      if (!address || typeof address === "string") throw new Error("Responses server is not listening");
+      return `ws://127.0.0.1:${address.port}`;
+    },
+    nextConnection() {
+      const socket = queued.shift();
+      return socket ? Promise.resolve(socket) : new Promise((resolve) => waiters.push(resolve));
+    },
+    close() {
+      for (const socket of websocketServer.clients) socket.terminate();
+      return new Promise<void>((resolve, reject) => {
+        websocketServer.close((error) => error ? reject(error) : resolve());
+      });
+    },
+  });
+}
+
+function nextMessage(socket: WebSocket): Promise<Record<string, unknown>> {
+  return new Promise((resolve) => {
+    socket.once("message", (data: RawData) => {
+      resolve(JSON.parse(data.toString("utf8")) as Record<string, unknown>);
+    });
+  });
+}
 
 type InjectedFailure = { pattern: RegExp; timing: "before" | "after" };
 

--- a/examples/vercel-workflows/test/postgres-durability.test.ts
+++ b/examples/vercel-workflows/test/postgres-durability.test.ts
@@ -7,9 +7,9 @@ import { WebSocketServer, type RawData, type WebSocket } from "ws";
 import {
   DurabilityImportConflictError,
   durabilityRevision,
-  exportDurabilityState,
-  importDurabilityState,
-  type DurabilityPortableStateArchive,
+  exportDurabilityStatePage,
+  importDurabilityStatePages,
+  type DurabilityPortableStatePage,
 } from "nanocodex/durability";
 import { createCloudflareDurabilityStore } from "nanocodex/durability/cloudflare";
 import {
@@ -18,7 +18,6 @@ import {
   type PostgresDurabilityPool,
   type PostgresDurabilityQueryResult,
   type PostgresDurabilityRow,
-  UnknownPostgresCommitOutcomeError,
 } from "nanocodex/durability/postgres";
 import { Agent, Transport } from "nanocodex/node";
 import { cloudflareDurabilityStorage } from "./cloudflare-durability-storage";
@@ -218,7 +217,7 @@ describe("Vercel PostgreSQL durability store", () => {
     }
   });
 
-  it("throws on an unknown COMMIT outcome and reloads the retained commit", async () => {
+  it("reconciles a lost COMMIT response to one definitive successful write", async () => {
     const pool = new PGlitePool({ failCommitAfter: 3 });
     try {
       const first = createPostgresDurabilityStore(pool.asPostgresPool());
@@ -228,7 +227,7 @@ describe("Vercel PostgreSQL durability store", () => {
         fence: owner.fence,
         expectedRevision: durabilityRevision("0"),
         payload: "committed-before-disconnect",
-      })).rejects.toBeInstanceOf(UnknownPostgresCommitOutcomeError);
+      })).resolves.toEqual({ status: "replaced", revision: durabilityRevision("1") });
 
       const recreated = createPostgresDurabilityStore(pool.asPostgresPool());
       await expect(recreated.acquire("unknown", { ownerId: "recreated-owner" })).resolves.toEqual({
@@ -323,10 +322,11 @@ describe("Vercel PostgreSQL durability store", () => {
       await shutdownAgent(agent);
       agent = undefined;
 
-      const cloudflareArchive = jsonRoundTrip(await exportDurabilityState(source, stateId));
-      await expect(importDurabilityState(postgres, cloudflareArchive)).resolves.toEqual({
-        revision: cloudflareArchive.revision,
-        payload: cloudflareArchive.payload,
+      const cloudflarePages = await exportPages(source, stateId, durabilityRevision("0"));
+      const cloudflareTo = cloudflarePages[0]!.to;
+      await expect(importDurabilityStatePages(postgres, jsonRoundTrip(cloudflarePages))).resolves.toEqual({
+        revision: cloudflareTo,
+        payload: cloudflarePages.map((page) => page.payload).join(""),
       });
 
       agent = await Agent.create({
@@ -369,10 +369,13 @@ describe("Vercel PostgreSQL durability store", () => {
       await shutdownAgent(agent);
       agent = undefined;
 
-      const postgresArchive = jsonRoundTrip(await exportDurabilityState(postgres, stateId));
-      expect(BigInt(postgresArchive.revision)).toBeGreaterThan(BigInt(cloudflareArchive.revision));
-      expect(postgresArchive.payload).toContain("opaque-portable-summary");
-      await importDurabilityState(returned, postgresArchive);
+      const postgresPages = await exportPages(postgres, stateId, cloudflareTo);
+      const postgresTo = postgresPages[0]!.to;
+      expect(BigInt(postgresTo)).toBeGreaterThan(BigInt(cloudflareTo));
+      expect(postgresPages.map((page) => page.payload).join(""))
+        .toContain("opaque-portable-summary");
+      await importDurabilityStatePages(returned, jsonRoundTrip(cloudflarePages));
+      await importDurabilityStatePages(returned, jsonRoundTrip(postgresPages));
 
       agent = await Agent.create({
         module,
@@ -417,7 +420,7 @@ describe("Vercel PostgreSQL durability store", () => {
       expect(server.connections).toBe(3);
       await returnScenario;
       expect(BigInt((await returned.load(stateId)).revision)).toBeGreaterThan(
-        BigInt(postgresArchive.revision),
+        BigInt(postgresTo),
       );
     } finally {
       try {
@@ -433,8 +436,30 @@ describe("Vercel PostgreSQL durability store", () => {
   }, 30_000);
 });
 
-function jsonRoundTrip(archive: DurabilityPortableStateArchive): DurabilityPortableStateArchive {
-  return JSON.parse(JSON.stringify(archive)) as DurabilityPortableStateArchive;
+async function exportPages(
+  store: Parameters<typeof exportDurabilityStatePage>[0],
+  stateId: string,
+  from: ReturnType<typeof durabilityRevision>,
+): Promise<DurabilityPortableStatePage[]> {
+  const pages: DurabilityPortableStatePage[] = [];
+  let cursor: string | undefined;
+  let to: ReturnType<typeof durabilityRevision> | undefined;
+  do {
+    const page = await exportDurabilityStatePage(store, stateId, {
+      from,
+      to,
+      cursor,
+      limit: 97,
+    });
+    pages.push(page);
+    to = page.to;
+    cursor = page.nextCursor ?? undefined;
+  } while (cursor !== undefined);
+  return pages;
+}
+
+function jsonRoundTrip(pages: DurabilityPortableStatePage[]): DurabilityPortableStatePage[] {
+  return JSON.parse(JSON.stringify(pages)) as DurabilityPortableStatePage[];
 }
 
 async function shutdownAgent(agent: NodeAgent): Promise<void> {

--- a/examples/vercel-workflows/test/postgres-durability.test.ts
+++ b/examples/vercel-workflows/test/postgres-durability.test.ts
@@ -215,7 +215,7 @@ describe("Vercel PostgreSQL durability store", () => {
         fence: owner.fence,
         expectedRevision: durabilityRevision("0"),
         payload: "never-started",
-      })).resolves.toEqual({ status: "not_committed", message: "injected query failure" });
+      })).rejects.toThrow("injected query failure");
 
       pool.failNextAfter(/^INSERT INTO nanocodex_durable_states/);
       await expect(store.replace("failures", {

--- a/examples/vercel-workflows/test/postgres-durability.test.ts
+++ b/examples/vercel-workflows/test/postgres-durability.test.ts
@@ -1,10 +1,7 @@
 import { PGlite } from "@electric-sql/pglite";
 import { describe, expect, it } from "vitest";
 
-import {
-  type DurabilityFence,
-  durabilityRevision,
-} from "nanocodex/durability";
+import { durabilityRevision } from "nanocodex/durability";
 import {
   createPostgresDurabilityStore,
   type PostgresDurabilityClient,
@@ -39,8 +36,8 @@ describe("Vercel PostgreSQL durability store", () => {
         first.load("schema-a"),
         second.load("schema-b"),
       ])).resolves.toEqual([
-        { revision: durabilityRevision("0"), batches: [] },
-        { revision: durabilityRevision("0"), batches: [] },
+        { revision: durabilityRevision("0"), payload: null },
+        { revision: durabilityRevision("0"), payload: null },
       ]);
       expect(pool.clientQueries.filter((query) => query.startsWith(
         "SELECT pg_advisory_xact_lock",
@@ -50,138 +47,33 @@ describe("Vercel PostgreSQL durability store", () => {
     }
   });
 
-  it("reopens the canonical native schema with structurally compatible numeric counters", async () => {
+  it("reopens one complete state with a higher owner fence", async () => {
     const pool = new PGlitePool();
     try {
-      await pool.query(
-        `CREATE TABLE nanocodex_journals (
-           journal_id TEXT PRIMARY KEY,
-           revision NUMERIC(20, 0) NOT NULL
-             CHECK (revision >= 0 AND revision <= 18446744073709551615)
-         )`,
-      );
-      await pool.query(
-        `CREATE TABLE nanocodex_journal_batches (
-           journal_id TEXT NOT NULL REFERENCES nanocodex_journals(journal_id),
-           revision NUMERIC(20, 0) NOT NULL
-             CHECK (revision > 0 AND revision <= 18446744073709551615),
-           payload TEXT NOT NULL,
-           PRIMARY KEY (journal_id, revision)
-         )`,
-      );
-      await pool.query(
-        `CREATE TABLE nanocodex_journal_owners (
-           journal_id TEXT PRIMARY KEY,
-           owner_id TEXT NOT NULL,
-           fence NUMERIC(20, 0) NOT NULL
-             CHECK (fence >= 1 AND fence <= 18446744073709551615)
-         )`,
-      );
-
-      const columns = await pool.query<{
-        table_name: string;
-        column_name: string;
-        data_type: string;
-        is_nullable: "YES" | "NO";
-        numeric_precision: number | null;
-        numeric_scale: number | null;
-      }>(
-        `SELECT table_name, column_name, data_type, is_nullable,
-                numeric_precision, numeric_scale
-           FROM information_schema.columns
-          WHERE table_schema = current_schema()
-            AND table_name IN (
-              'nanocodex_journals',
-              'nanocodex_journal_batches',
-              'nanocodex_journal_owners'
-            )
-          ORDER BY table_name, ordinal_position`,
-      );
-      expect(columns.rows).toEqual([
-        {
-          table_name: "nanocodex_journal_batches",
-          column_name: "journal_id",
-          data_type: "text",
-          is_nullable: "NO",
-          numeric_precision: null,
-          numeric_scale: null,
-        },
-        {
-          table_name: "nanocodex_journal_batches",
-          column_name: "revision",
-          data_type: "numeric",
-          is_nullable: "NO",
-          numeric_precision: 20,
-          numeric_scale: 0,
-        },
-        {
-          table_name: "nanocodex_journal_batches",
-          column_name: "payload",
-          data_type: "text",
-          is_nullable: "NO",
-          numeric_precision: null,
-          numeric_scale: null,
-        },
-        {
-          table_name: "nanocodex_journal_owners",
-          column_name: "journal_id",
-          data_type: "text",
-          is_nullable: "NO",
-          numeric_precision: null,
-          numeric_scale: null,
-        },
-        {
-          table_name: "nanocodex_journal_owners",
-          column_name: "owner_id",
-          data_type: "text",
-          is_nullable: "NO",
-          numeric_precision: null,
-          numeric_scale: null,
-        },
-        {
-          table_name: "nanocodex_journal_owners",
-          column_name: "fence",
-          data_type: "numeric",
-          is_nullable: "NO",
-          numeric_precision: 20,
-          numeric_scale: 0,
-        },
-        {
-          table_name: "nanocodex_journals",
-          column_name: "journal_id",
-          data_type: "text",
-          is_nullable: "NO",
-          numeric_precision: null,
-          numeric_scale: null,
-        },
-        {
-          table_name: "nanocodex_journals",
-          column_name: "revision",
-          data_type: "numeric",
-          is_nullable: "NO",
-          numeric_precision: 20,
-          numeric_scale: 0,
-        },
-      ]);
-
       const first = createPostgresDurabilityStore(pool.asPostgresPool());
-      const owner = await first.acquire("shared", { ownerId: "native-reopener" });
-      await expect(first.append("shared", {
+      const owner = await first.acquire("shared", { ownerId: "first-owner" });
+      expect(owner).toEqual({
+        ownerId: "first-owner",
+        fence: durabilityRevision("1"),
+        revision: durabilityRevision("0"),
+        payload: null,
+      });
+      await expect(first.replace("shared", {
         ownerId: owner.ownerId,
         fence: owner.fence,
         expectedRevision: owner.revision,
         payload: "written-by-js",
-      })).resolves.toEqual({ status: "appended", revision: durabilityRevision("1") });
+      })).resolves.toEqual({ status: "replaced", revision: durabilityRevision("1") });
 
       const reopened = createPostgresDurabilityStore(pool.asPostgresPool());
-      await expect(reopened.acquire("shared", { ownerId: "second-reopener" })).resolves.toEqual({
-        ownerId: "second-reopener",
+      await expect(reopened.acquire("shared", { ownerId: "second-owner" })).resolves.toEqual({
+        ownerId: "second-owner",
         fence: durabilityRevision("2"),
         revision: durabilityRevision("1"),
-        batches: [{ revision: durabilityRevision("1"), payload: "written-by-js" }],
+        payload: "written-by-js",
       });
       await expect(pool.query(
-        `INSERT INTO nanocodex_journal_owners (journal_id, owner_id, fence)
+        `INSERT INTO nanocodex_durable_owners (state_id, owner_id, fence)
          VALUES ('invalid-zero-fence', 'invalid', 0)`,
       )).rejects.toThrow();
     } finally {
@@ -189,7 +81,7 @@ describe("Vercel PostgreSQL durability store", () => {
     }
   });
 
-  it("rejects missing numeric CHECK constraints before mutation even when PGlite accepts u64 + 1", async () => {
+  it("ignores retained journal tables during the hard cutover", async () => {
     const pool = new PGlitePool();
     try {
       await pool.query(
@@ -199,280 +91,22 @@ describe("Vercel PostgreSQL durability store", () => {
          )`,
       );
       await pool.query(
-        `CREATE TABLE nanocodex_journal_batches (
-           journal_id TEXT NOT NULL REFERENCES nanocodex_journals(journal_id),
-           revision NUMERIC(20, 0) NOT NULL,
-           payload TEXT NOT NULL,
-           PRIMARY KEY (journal_id, revision)
-         )`,
+        `INSERT INTO nanocodex_journals (journal_id, revision) VALUES ('legacy', 7)`,
       );
-      await pool.query(
-        `CREATE TABLE nanocodex_journal_owners (
-           journal_id TEXT PRIMARY KEY,
-           owner_id TEXT NOT NULL,
-           fence NUMERIC(20, 0) NOT NULL
-         )`,
-      );
-      await expect(pool.query(
-        `INSERT INTO nanocodex_journals (journal_id, revision)
-         VALUES ('accepted-overflow', 18446744073709551616)`,
-      )).resolves.toEqual({ rows: [] });
-
       const store = createPostgresDurabilityStore(pool.asPostgresPool());
-      await expect(store.acquire("must-not-mutate", { ownerId: "rejected-owner" })).rejects.toThrow(
-        "`nanocodex_journal_batches.revision` must have a single-column CHECK constraint",
-      );
-      await expect(pool.query(
-        "SELECT journal_id FROM nanocodex_journal_owners WHERE journal_id = 'must-not-mutate'",
-      )).resolves.toEqual({ rows: [] });
-    } finally {
-      await pool.close();
-    }
-  });
-
-  it("rejects a batches foreign key into a same-named table in another schema", async () => {
-    const pool = new PGlitePool();
-    try {
-      await pool.query("CREATE SCHEMA alternate");
-      await pool.query(
-        `CREATE TABLE alternate.nanocodex_journals (
-           journal_id TEXT PRIMARY KEY,
-           revision NUMERIC(20, 0) NOT NULL
-         )`,
-      );
-      await createDurabilitySchema(pool, {
-        reference: "alternate.nanocodex_journals(journal_id)",
+      await expect(store.load("legacy")).resolves.toEqual({
+        revision: durabilityRevision("0"),
+        payload: null,
       });
-
-      const store = createPostgresDurabilityStore(pool.asPostgresPool());
-      await expect(store.acquire("must-not-mutate", { ownerId: "rejected-owner" })).rejects.toThrow(
-        "`nanocodex_journal_batches` has an incompatible foreign key",
-      );
       await expect(pool.query(
-        "SELECT journal_id FROM nanocodex_journal_owners WHERE journal_id = 'must-not-mutate'",
-      )).resolves.toEqual({ rows: [] });
+        "SELECT revision::text AS revision FROM nanocodex_journals WHERE journal_id = 'legacy'",
+      )).resolves.toEqual({ rows: [{ revision: "7" }] });
     } finally {
       await pool.close();
     }
   });
 
-  it("rejects a deferred batches foreign key", async () => {
-    const pool = new PGlitePool();
-    try {
-      await createDurabilitySchema(pool, {
-        foreignKeyMode: "DEFERRABLE INITIALLY DEFERRED",
-      });
-
-      const store = createPostgresDurabilityStore(pool.asPostgresPool());
-      await expect(store.acquire("must-not-mutate", { ownerId: "rejected-owner" })).rejects.toThrow(
-        "`nanocodex_journal_batches` has an incompatible foreign key",
-      );
-      await expect(pool.query(
-        "SELECT journal_id FROM nanocodex_journal_owners WHERE journal_id = 'must-not-mutate'",
-      )).resolves.toEqual({ rows: [] });
-    } finally {
-      await pool.close();
-    }
-  });
-
-  it("rejects an extra owner CHECK constraint", async () => {
-    const pool = new PGlitePool();
-    try {
-      await createDurabilitySchema(pool, {
-        ownerExtraCheck: "CHECK (owner_id <> '')",
-      });
-
-      const store = createPostgresDurabilityStore(pool.asPostgresPool());
-      await expect(store.acquire("must-not-mutate", { ownerId: "rejected-owner" })).rejects.toThrow(
-        "the journal tables have incompatible CHECK constraints",
-      );
-      await expect(pool.query(
-        "SELECT journal_id FROM nanocodex_journal_owners WHERE journal_id = 'must-not-mutate'",
-      )).resolves.toEqual({ rows: [] });
-    } finally {
-      await pool.close();
-    }
-  });
-
-  it.each([
-    {
-      name: "owner fence",
-      schema: { ownerCheck: "fence IN (1, 18446744073709551615)" },
-      error: "owner bounds rejected",
-    },
-    {
-      name: "journal revision",
-      schema: { journalCheck: "revision IN (0, 18446744073709551615)" },
-      error: "journal bounds rejected",
-    },
-    {
-      name: "batch revision",
-      schema: { batchCheck: "revision IN (1, 18446744073709551615)" },
-      error: "batch bounds rejected",
-    },
-  ])("rejects endpoint-only $name CHECK semantics", async ({ schema, error }) => {
-    const pool = new PGlitePool();
-    try {
-      await createDurabilitySchema(pool, schema);
-
-      const store = createPostgresDurabilityStore(pool.asPostgresPool());
-      await expect(store.acquire("must-not-mutate", { ownerId: "rejected-owner" })).rejects.toThrow(error);
-      await expect(pool.query(
-        "SELECT journal_id FROM nanocodex_journal_owners WHERE journal_id = 'must-not-mutate'",
-      )).resolves.toEqual({ rows: [] });
-    } finally {
-      await pool.close();
-    }
-  });
-
-  it.each([
-    {
-      name: "negative owner fence",
-      schema: { ownerCheck: "fence <> 0 AND fence <= 18446744073709551615" },
-      error: "negative owner fence was accepted by its CHECK constraint",
-    },
-    {
-      name: "negative batch revision",
-      schema: { batchCheck: "revision <> 0 AND revision <= 18446744073709551615" },
-      error: "negative batch revision was accepted by its CHECK constraint",
-    },
-    {
-      name: "journal revision above the adjacent overflow sample",
-      schema: { journalCheck: "revision >= 0 AND revision <> 18446744073709551616" },
-      error: "journal revision farther above u64 was accepted by its CHECK constraint",
-    },
-  ])("rejects CHECK semantics admitting $name", async ({ schema, error }) => {
-    const pool = new PGlitePool();
-    try {
-      await createDurabilitySchema(pool, schema);
-
-      const store = createPostgresDurabilityStore(pool.asPostgresPool());
-      await expect(store.acquire("must-not-mutate", { ownerId: "rejected-owner" })).rejects.toThrow(error);
-      await expect(pool.query(
-        "SELECT journal_id FROM nanocodex_journal_owners WHERE journal_id = 'must-not-mutate'",
-      )).resolves.toEqual({ rows: [] });
-    } finally {
-      await pool.close();
-    }
-  });
-
-  it.each([
-    {
-      name: "reversed batch primary key",
-      reference: "nanocodex_journals(journal_id)",
-      primaryKey: "revision, journal_id",
-      error: "journal tables have incompatible PRIMARY KEY constraints",
-    },
-    {
-      name: "batch foreign key targeting owners",
-      reference: "nanocodex_journal_owners(journal_id)",
-      primaryKey: "journal_id, revision",
-      error: "`nanocodex_journal_batches` has an incompatible foreign key",
-    },
-  ])("rejects $name before owner mutation", async ({ reference, primaryKey, error }) => {
-    const pool = new PGlitePool();
-    try {
-      await pool.query(
-        `CREATE TABLE nanocodex_journals (
-           journal_id TEXT PRIMARY KEY,
-           revision NUMERIC(20, 0) NOT NULL
-             CHECK (revision >= 0 AND revision <= 18446744073709551615)
-         )`,
-      );
-      await pool.query(
-        `CREATE TABLE nanocodex_journal_owners (
-           journal_id TEXT PRIMARY KEY,
-           owner_id TEXT NOT NULL,
-           fence NUMERIC(20, 0) NOT NULL
-             CHECK (fence >= 1 AND fence <= 18446744073709551615)
-         )`,
-      );
-      await pool.query(
-        `CREATE TABLE nanocodex_journal_batches (
-           journal_id TEXT NOT NULL REFERENCES ${reference},
-           revision NUMERIC(20, 0) NOT NULL
-             CHECK (revision > 0 AND revision <= 18446744073709551615),
-           payload TEXT NOT NULL,
-           PRIMARY KEY (${primaryKey})
-         )`,
-      );
-
-      const store = createPostgresDurabilityStore(pool.asPostgresPool());
-      await expect(store.acquire("must-not-mutate", { ownerId: "rejected-owner" })).rejects.toThrow(error);
-      await expect(pool.query(
-        "SELECT journal_id FROM nanocodex_journal_owners WHERE journal_id = 'must-not-mutate'",
-      )).resolves.toEqual({ rows: [] });
-    } finally {
-      await pool.close();
-    }
-  });
-
-  it("rejects mixed legacy BIGINT journals before acquiring or appending", async () => {
-    const pool = new PGlitePool();
-    try {
-      await pool.query(
-        `CREATE TABLE nanocodex_journals (
-           journal_id TEXT PRIMARY KEY,
-           revision BIGINT NOT NULL CHECK (revision >= 0)
-         )`,
-      );
-      await pool.query(
-        `CREATE TABLE nanocodex_journal_batches (
-           journal_id TEXT NOT NULL REFERENCES nanocodex_journals(journal_id),
-           revision BIGINT NOT NULL CHECK (revision > 0),
-           payload TEXT NOT NULL,
-           PRIMARY KEY (journal_id, revision)
-         )`,
-      );
-      await pool.query(
-        `CREATE TABLE nanocodex_journal_owners (
-           journal_id TEXT PRIMARY KEY,
-           owner_id TEXT NOT NULL,
-           fence NUMERIC(20, 0) NOT NULL
-             CHECK (fence >= 1 AND fence <= 18446744073709551615)
-         )`,
-      );
-      await pool.query(
-        `INSERT INTO nanocodex_journals (journal_id, revision)
-         VALUES ('retained', 1)`,
-      );
-      await pool.query(
-        `INSERT INTO nanocodex_journal_batches (journal_id, revision, payload)
-         VALUES ('retained', 1, 'legacy')`,
-      );
-
-      const store = createPostgresDurabilityStore(pool.asPostgresPool());
-      await expect(store.acquire("retained", { ownerId: "must-not-acquire" })).rejects.toThrow(
-        "incompatible Postgres durability schema: `nanocodex_journal_batches.revision` has an incompatible column shape",
-      );
-      await expect(store.append("retained", {
-        ownerId: "must-not-append",
-        fence: "1" as DurabilityFence,
-        expectedRevision: durabilityRevision("1"),
-        payload: "must-not-write",
-      })).rejects.toThrow(
-        "incompatible Postgres durability schema: `nanocodex_journal_batches.revision` has an incompatible column shape",
-      );
-
-      await expect(pool.query(
-        "SELECT journal_id, owner_id, fence::text AS fence FROM nanocodex_journal_owners",
-      )).resolves.toEqual({ rows: [] });
-      await expect(pool.query(
-        `SELECT journal.revision::text AS revision,
-                batch.revision::text AS batch_revision,
-                batch.payload
-           FROM nanocodex_journals AS journal
-           JOIN nanocodex_journal_batches AS batch USING (journal_id)
-          WHERE journal.journal_id = 'retained'`,
-      )).resolves.toEqual({
-        rows: [{ revision: "1", batch_revision: "1", payload: "legacy" }],
-      });
-    } finally {
-      await pool.close();
-    }
-  });
-
-  it("chooses one of many independent CAS contenders and reloads numeric batch order", async () => {
+  it("chooses one of many independent complete-state CAS contenders", async () => {
     const pool = new PGlitePool();
     try {
       const stores = Array.from(
@@ -481,14 +115,14 @@ describe("Vercel PostgreSQL durability store", () => {
       );
       await Promise.all(stores.map((store, index) => store.load(`schema-${index}`)));
       const owner = await stores[0]!.acquire("race", { ownerId: "race-owner" });
-      const contenders = await Promise.all(stores.map((store, index) => store.append("race", {
-          ownerId: owner.ownerId,
-          fence: owner.fence,
-          expectedRevision: durabilityRevision("0"),
-          payload: `batch-1-${index}`,
-        })));
-      expect(contenders.filter((result) => result.status === "appended")).toEqual([
-        { status: "appended", revision: durabilityRevision("1") },
+      const contenders = await Promise.all(stores.map((store, index) => store.replace("race", {
+        ownerId: owner.ownerId,
+        fence: owner.fence,
+        expectedRevision: durabilityRevision("0"),
+        payload: `state-${index}`,
+      })));
+      expect(contenders.filter((result) => result.status === "replaced")).toEqual([
+        { status: "replaced", revision: durabilityRevision("1") },
       ]);
       expect(contenders.filter((result) => result.status === "conflict")).toEqual(
         Array.from({ length: 15 }, () => ({
@@ -496,36 +130,15 @@ describe("Vercel PostgreSQL durability store", () => {
           actualRevision: durabilityRevision("1"),
         })),
       );
-      const winner = contenders.findIndex((result) => result.status === "appended");
-      const firstPayload = `batch-1-${winner}`;
-      await expect(pool.query<{ batch_count: string }>(
-        `SELECT count(*)::text AS batch_count
-           FROM nanocodex_journal_batches
-          WHERE journal_id = $1`,
-        ["race"],
-      )).resolves.toEqual({ rows: [{ batch_count: "1" }] });
-
-      const store = stores[0]!;
-      for (let revision = 1n; revision < 10n; revision += 1n) {
-        await expect(store.append("race", {
-          ownerId: owner.ownerId,
-          fence: owner.fence,
-          expectedRevision: durabilityRevision(revision),
-          payload: `batch-${revision + 1n}`,
-        })).resolves.toEqual({
-          status: "appended",
-          revision: durabilityRevision(revision + 1n),
-        });
-      }
-
-      const recreated = createPostgresDurabilityStore(pool.asPostgresPool());
-      await expect(recreated.load("race")).resolves.toEqual({
-        revision: durabilityRevision("10"),
-        batches: Array.from({ length: 10 }, (_, index) => ({
-          revision: durabilityRevision(BigInt(index + 1)),
-          payload: index === 0 ? firstPayload : `batch-${index + 1}`,
-        })),
+      const winner = contenders.findIndex((result) => result.status === "replaced");
+      await expect(stores[0]!.load("race")).resolves.toEqual({
+        revision: durabilityRevision("1"),
+        payload: `state-${winner}`,
       });
+      await expect(pool.query<{ state_count: string }>(
+        "SELECT count(*)::text AS state_count FROM nanocodex_durable_states WHERE state_id = $1",
+        ["race"],
+      )).resolves.toEqual({ rows: [{ state_count: "1" }] });
     } finally {
       await pool.close();
     }
@@ -537,22 +150,22 @@ describe("Vercel PostgreSQL durability store", () => {
       const store = createPostgresDurabilityStore(pool.asPostgresPool());
       const owner = await store.acquire("u64", { ownerId: "u64-owner" });
       await pool.query(
-        `INSERT INTO nanocodex_journals (journal_id, revision)
-         VALUES ($1, $2::numeric)`,
-        ["u64", BEFORE_MAX_REVISION],
+        `INSERT INTO nanocodex_durable_states (state_id, revision, payload)
+         VALUES ($1, $2::numeric, $3)`,
+        ["u64", BEFORE_MAX_REVISION, "before-max"],
       );
 
-      await expect(store.append("u64", {
+      await expect(store.replace("u64", {
         ownerId: owner.ownerId,
         fence: owner.fence,
         expectedRevision: BEFORE_MAX_REVISION,
-        payload: "max-batch",
-      })).resolves.toEqual({ status: "appended", revision: MAX_REVISION });
+        payload: "max-state",
+      })).resolves.toEqual({ status: "replaced", revision: MAX_REVISION });
       await expect(store.load("u64")).resolves.toEqual({
         revision: MAX_REVISION,
-        batches: [{ revision: MAX_REVISION, payload: "max-batch" }],
+        payload: "max-state",
       });
-      await expect(store.append("u64", {
+      await expect(store.replace("u64", {
         ownerId: owner.ownerId,
         fence: owner.fence,
         expectedRevision: MAX_REVISION,
@@ -561,10 +174,6 @@ describe("Vercel PostgreSQL durability store", () => {
         status: "not_committed",
         message: "PostgreSQL durability revision overflow",
       });
-      expect((await pool.query<{ revision: string }>(
-        `SELECT revision::text AS revision FROM nanocodex_journals WHERE journal_id = $1`,
-        ["u64"],
-      )).rows).toEqual([{ revision: MAX_REVISION }]);
     } finally {
       await pool.close();
     }
@@ -575,7 +184,7 @@ describe("Vercel PostgreSQL durability store", () => {
     try {
       const first = createPostgresDurabilityStore(pool.asPostgresPool());
       const owner = await first.acquire("unknown", { ownerId: "first-owner" });
-      await expect(first.append("unknown", {
+      await expect(first.replace("unknown", {
         ownerId: owner.ownerId,
         fence: owner.fence,
         expectedRevision: durabilityRevision("0"),
@@ -583,24 +192,11 @@ describe("Vercel PostgreSQL durability store", () => {
       })).rejects.toBeInstanceOf(UnknownPostgresCommitOutcomeError);
 
       const recreated = createPostgresDurabilityStore(pool.asPostgresPool());
-      const recreatedOwner = await recreated.acquire("unknown", { ownerId: "recreated-owner" });
-      expect(recreatedOwner).toEqual({
+      await expect(recreated.acquire("unknown", { ownerId: "recreated-owner" })).resolves.toEqual({
         ownerId: "recreated-owner",
         fence: durabilityRevision("2"),
         revision: durabilityRevision("1"),
-        batches: [{
-          revision: durabilityRevision("1"),
-          payload: "committed-before-disconnect",
-        }],
-      });
-      await expect(recreated.append("unknown", {
-        ownerId: recreatedOwner.ownerId,
-        fence: recreatedOwner.fence,
-        expectedRevision: durabilityRevision("0"),
-        payload: "must-not-repeat",
-      })).resolves.toEqual({
-        status: "conflict",
-        actualRevision: durabilityRevision("1"),
+        payload: "committed-before-disconnect",
       });
       expect(pool.releases.filter(Boolean)).toHaveLength(1);
     } finally {
@@ -608,108 +204,37 @@ describe("Vercel PostgreSQL durability store", () => {
     }
   });
 
-  it("returns not_committed when BEGIN is proven not to have written", async () => {
+  it("distinguishes transactions that never began from rolled-back state writes", async () => {
     const pool = new PGlitePool();
     try {
       const store = createPostgresDurabilityStore(pool.asPostgresPool());
-      const owner = await store.acquire("begin-failure", { ownerId: "begin-owner" });
+      const owner = await store.acquire("failures", { ownerId: "failure-owner" });
       pool.failNextBefore(/^BEGIN$/);
-
-      await expect(store.append("begin-failure", {
+      await expect(store.replace("failures", {
         ownerId: owner.ownerId,
         fence: owner.fence,
         expectedRevision: durabilityRevision("0"),
         payload: "never-started",
-      })).resolves.toEqual({
-        status: "not_committed",
-        message: "PostgreSQL transaction did not begin: injected query failure",
-      });
-      await expect(store.load("begin-failure")).resolves.toEqual({
-        revision: durabilityRevision("0"),
-        batches: [],
-      });
-      expect(pool.releases.at(-1)).toBe(true);
-    } finally {
-      await pool.close();
-    }
-  });
+      })).resolves.toEqual({ status: "not_committed", message: "injected query failure" });
 
-  it("returns not_committed after a failed statement is confirmed rolled back", async () => {
-    const pool = new PGlitePool();
-    try {
-      const store = createPostgresDurabilityStore(pool.asPostgresPool());
-      const owner = await store.acquire("rolled-back", { ownerId: "rollback-owner" });
-      pool.failNextAfter(/^INSERT INTO nanocodex_journals/);
-
-      await expect(store.append("rolled-back", {
+      pool.failNextAfter(/^INSERT INTO nanocodex_durable_states/);
+      await expect(store.replace("failures", {
         ownerId: owner.ownerId,
         fence: owner.fence,
         expectedRevision: durabilityRevision("0"),
-        payload: "rolled-back-batch",
-      })).resolves.toEqual({
-        status: "not_committed",
-        message: "PostgreSQL durability append was rolled back: injected query failure",
-      });
-      await expect(store.load("rolled-back")).resolves.toEqual({
+        payload: "rolled-back",
+      })).resolves.toEqual({ status: "not_committed", message: "injected query failure" });
+      await expect(store.load("failures")).resolves.toEqual({
         revision: durabilityRevision("0"),
-        batches: [],
+        payload: null,
       });
-      expect(pool.releases.at(-1)).toBe(false);
     } finally {
       await pool.close();
     }
   });
 });
 
-type DurabilitySchemaOptions = {
-  reference?: string;
-  foreignKeyMode?: string;
-  journalCheck?: string;
-  batchCheck?: string;
-  ownerCheck?: string;
-  ownerExtraCheck?: string;
-};
-
-async function createDurabilitySchema(
-  pool: PGlitePool,
-  options: DurabilitySchemaOptions = {},
-): Promise<void> {
-  const {
-    reference = "nanocodex_journals(journal_id)",
-    foreignKeyMode = "",
-    journalCheck = "revision >= 0 AND revision <= 18446744073709551615",
-    batchCheck = "revision > 0 AND revision <= 18446744073709551615",
-    ownerCheck = "fence >= 1 AND fence <= 18446744073709551615",
-    ownerExtraCheck,
-  } = options;
-  await pool.query(
-    `CREATE TABLE nanocodex_journals (
-       journal_id TEXT PRIMARY KEY,
-       revision NUMERIC(20, 0) NOT NULL CHECK (${journalCheck})
-     )`,
-  );
-  await pool.query(
-    `CREATE TABLE nanocodex_journal_owners (
-       journal_id TEXT PRIMARY KEY,
-       owner_id TEXT NOT NULL,
-       fence NUMERIC(20, 0) NOT NULL CHECK (${ownerCheck})
-       ${ownerExtraCheck === undefined ? "" : `, ${ownerExtraCheck}`}
-     )`,
-  );
-  await pool.query(
-    `CREATE TABLE nanocodex_journal_batches (
-       journal_id TEXT NOT NULL REFERENCES ${reference} ${foreignKeyMode},
-       revision NUMERIC(20, 0) NOT NULL CHECK (${batchCheck}),
-       payload TEXT NOT NULL,
-       PRIMARY KEY (journal_id, revision)
-     )`,
-  );
-}
-
-type InjectedFailure = {
-  pattern: RegExp;
-  timing: "before" | "after";
-};
+type InjectedFailure = { pattern: RegExp; timing: "before" | "after" };
 
 class PGlitePool {
   readonly #database = new PGlite();
@@ -724,34 +249,22 @@ class PGlitePool {
     this.#failCommitAfter = options.failCommitAfter;
   }
 
-  asPostgresPool(): PostgresDurabilityPool {
-    return this;
-  }
-
-  failNextBefore(pattern: RegExp): void {
-    this.#failure = { pattern, timing: "before" };
-  }
-
-  failNextAfter(pattern: RegExp): void {
-    this.#failure = { pattern, timing: "after" };
-  }
+  asPostgresPool(): PostgresDurabilityPool { return this; }
+  failNextBefore(pattern: RegExp): void { this.#failure = { pattern, timing: "before" }; }
+  failNextAfter(pattern: RegExp): void { this.#failure = { pattern, timing: "after" }; }
 
   async query<Row extends PostgresDurabilityRow = PostgresDurabilityRow>(
     text: string,
     values: unknown[] = [],
   ): Promise<PostgresDurabilityQueryResult<Row>> {
     const result = await this.#database.query<Row>(text, [...values]);
-    return {
-      rows: result.rows,
-    };
+    return { rows: result.rows };
   }
 
   async connect(): Promise<PostgresDurabilityClient> {
     const previous = this.#connectionTail;
     let unlock!: () => void;
-    this.#connectionTail = new Promise<void>((resolve) => {
-      unlock = resolve;
-    });
+    this.#connectionTail = new Promise<void>((resolve) => { unlock = resolve; });
     await previous;
     let released = false;
     return {
@@ -761,9 +274,7 @@ class PGlitePool {
       ) => {
         const query = text.trim();
         this.clientQueries.push(query);
-        if (this.#takeFailure(query, "before")) {
-          throw new Error("injected query failure");
-        }
+        if (this.#takeFailure(query, "before")) throw new Error("injected query failure");
         const result = await this.query<Row>(text, values);
         if (text === "COMMIT") {
           this.#commits += 1;
@@ -771,9 +282,7 @@ class PGlitePool {
             throw new Error("connection disappeared after COMMIT was applied");
           }
         }
-        if (this.#takeFailure(query, "after")) {
-          throw new Error("injected query failure");
-        }
+        if (this.#takeFailure(query, "after")) throw new Error("injected query failure");
         return result;
       },
       release: (discard?: Error | boolean) => {

--- a/examples/vercel-workflows/test/postgres-durability.test.ts
+++ b/examples/vercel-workflows/test/postgres-durability.test.ts
@@ -272,7 +272,7 @@ describe("Vercel PostgreSQL durability store", () => {
     }
   });
 
-  it("round-trips one live Agent through the Cloudflare and PostgreSQL store contracts", async () => {
+  it("round-trips one compacted multi-turn Agent through Cloudflare and PostgreSQL", async () => {
     const module = await readFile(
       new URL("../../../js/bindings/pkg-web/nanocodex_bg.wasm", import.meta.url),
     );
@@ -296,20 +296,29 @@ describe("Vercel PostgreSQL durability store", () => {
         durability: source,
         durabilityId: stateId,
       });
-      const sourceScenario = answerNext(
-        server,
-        "cloudflare-response",
-        "COMMITTED ON CLOUDFLARE",
-        { inputs: ["commit this turn on Cloudflare"] },
-      );
-      const cloudflareTurn = agent.turn.prompt({
-        id: "turn-cloudflare",
-        input: "commit this turn on Cloudflare",
-      });
-      const cloudflareResult = await cloudflareTurn.result();
-      expect(cloudflareResult.finalMessage).toBe("COMMITTED ON CLOUDFLARE");
-      cloudflareResult.dispose();
-      cloudflareTurn.dispose();
+      const sourceScenario = (async () => {
+        const socket = await server.nextConnection();
+        await answerMessage(socket, "cloudflare-response-1", "CLOUDFLARE TURN ONE", {
+          inputs: ["first Cloudflare turn"],
+        });
+        await answerMessage(socket, "cloudflare-response-2", "CLOUDFLARE TURN TWO", {
+          inputs: ["second Cloudflare turn"],
+          previousResponseId: "cloudflare-response-1",
+        });
+        await answerCompaction(socket, "cloudflare-compaction", {
+          previousResponseId: "cloudflare-response-2",
+        });
+        await answerMessage(socket, "cloudflare-response-3", "CLOUDFLARE COMPACTED", {
+          inputs: ["opaque-portable-summary", "source after compaction"],
+        });
+      })();
+      await expect(runTurn(agent, "turn-cloudflare-1", "first Cloudflare turn"))
+        .resolves.toBe("CLOUDFLARE TURN ONE");
+      await expect(runTurn(agent, "turn-cloudflare-2", "second Cloudflare turn"))
+        .resolves.toBe("CLOUDFLARE TURN TWO");
+      await agent.session.compact();
+      await expect(runTurn(agent, "turn-cloudflare-3", "source after compaction"))
+        .resolves.toBe("CLOUDFLARE COMPACTED");
       await sourceScenario;
       await shutdownAgent(agent);
       agent = undefined;
@@ -328,42 +337,41 @@ describe("Vercel PostgreSQL durability store", () => {
         durability: postgres,
         durabilityId: stateId,
       });
-      const replayedCloudflareTurn = agent.turn.prompt({
-        id: "turn-cloudflare",
-        input: "commit this turn on Cloudflare",
-      });
-      const replayedCloudflare = await replayedCloudflareTurn.result();
-      expect(replayedCloudflare.finalMessage).toBe("COMMITTED ON CLOUDFLARE");
+      await expect(runTurn(agent, "turn-cloudflare-1", "first Cloudflare turn"))
+        .resolves.toBe("CLOUDFLARE TURN ONE");
+      await expect(runTurn(agent, "turn-cloudflare-2", "second Cloudflare turn"))
+        .resolves.toBe("CLOUDFLARE TURN TWO");
+      await expect(runTurn(agent, "turn-cloudflare-3", "source after compaction"))
+        .resolves.toBe("CLOUDFLARE COMPACTED");
       expect(server.connections).toBe(1);
-      replayedCloudflare.dispose();
-      replayedCloudflareTurn.dispose();
 
-      const postgresScenario = answerNext(
-        server,
-        "postgres-response",
-        "COMMITTED ON POSTGRES",
-        {
+      const postgresScenario = (async () => {
+        const socket = await server.nextConnection();
+        await answerMessage(socket, "postgres-response-1", "POSTGRES TURN ONE", {
           inputs: [
-            "commit this turn on Cloudflare",
-            "COMMITTED ON CLOUDFLARE",
-            "continue this same agent on Vercel Postgres",
+            "opaque-portable-summary",
+            "source after compaction",
+            "CLOUDFLARE COMPACTED",
+            "first Vercel Postgres turn",
           ],
-        },
-      );
-      const postgresTurn = agent.turn.prompt({
-        id: "turn-postgres",
-        input: "continue this same agent on Vercel Postgres",
-      });
-      const postgresResult = await postgresTurn.result();
-      expect(postgresResult.finalMessage).toBe("COMMITTED ON POSTGRES");
-      postgresResult.dispose();
-      postgresTurn.dispose();
+        });
+        await answerMessage(socket, "postgres-response-2", "POSTGRES TURN TWO", {
+          inputs: ["second Vercel Postgres turn"],
+          previousResponseId: "postgres-response-1",
+        });
+      })();
+      await expect(runTurn(agent, "turn-postgres-1", "first Vercel Postgres turn"))
+        .resolves.toBe("POSTGRES TURN ONE");
+      await expect(runTurn(agent, "turn-postgres-2", "second Vercel Postgres turn"))
+        .resolves.toBe("POSTGRES TURN TWO");
       await postgresScenario;
+      expect(server.connections).toBe(2);
       await shutdownAgent(agent);
       agent = undefined;
 
       const postgresArchive = jsonRoundTrip(await exportDurabilityState(postgres, stateId));
       expect(BigInt(postgresArchive.revision)).toBeGreaterThan(BigInt(cloudflareArchive.revision));
+      expect(postgresArchive.payload).toContain("opaque-portable-summary");
       await importDurabilityState(returned, postgresArchive);
 
       agent = await Agent.create({
@@ -374,38 +382,39 @@ describe("Vercel PostgreSQL durability store", () => {
         durability: returned,
         durabilityId: stateId,
       });
-      const replayedPostgresTurn = agent.turn.prompt({
-        id: "turn-postgres",
-        input: "continue this same agent on Vercel Postgres",
-      });
-      const replayedPostgres = await replayedPostgresTurn.result();
-      expect(replayedPostgres.finalMessage).toBe("COMMITTED ON POSTGRES");
+      const replayedTurns = [
+        ["turn-cloudflare-1", "first Cloudflare turn", "CLOUDFLARE TURN ONE"],
+        ["turn-cloudflare-2", "second Cloudflare turn", "CLOUDFLARE TURN TWO"],
+        ["turn-cloudflare-3", "source after compaction", "CLOUDFLARE COMPACTED"],
+        ["turn-postgres-1", "first Vercel Postgres turn", "POSTGRES TURN ONE"],
+        ["turn-postgres-2", "second Vercel Postgres turn", "POSTGRES TURN TWO"],
+      ] as const;
+      for (const [id, input, expected] of replayedTurns) {
+        await expect(runTurn(agent, id, input)).resolves.toBe(expected);
+      }
       expect(server.connections).toBe(2);
-      replayedPostgres.dispose();
-      replayedPostgresTurn.dispose();
 
-      const returnScenario = answerNext(
-        server,
-        "returned-response",
-        "RUNNING AGAIN ON CLOUDFLARE",
-        {
+      const returnScenario = (async () => {
+        const socket = await server.nextConnection();
+        await answerMessage(socket, "returned-response-1", "RETURNED TURN ONE", {
           inputs: [
-            "COMMITTED ON CLOUDFLARE",
-            "continue this same agent on Vercel Postgres",
-            "COMMITTED ON POSTGRES",
-            "prove the imported agent can keep running on Cloudflare",
+            "opaque-portable-summary",
+            "POSTGRES TURN ONE",
+            "second Vercel Postgres turn",
+            "POSTGRES TURN TWO",
+            "first returned Cloudflare turn",
           ],
-        },
-      );
-      const returnTurn = agent.turn.prompt({
-        id: "turn-returned",
-        input: "prove the imported agent can keep running on Cloudflare",
-      });
-      const returnResult = await returnTurn.result();
-      expect(returnResult.finalMessage).toBe("RUNNING AGAIN ON CLOUDFLARE");
+        });
+        await answerMessage(socket, "returned-response-2", "RETURNED TURN TWO", {
+          inputs: ["second returned Cloudflare turn"],
+          previousResponseId: "returned-response-1",
+        });
+      })();
+      await expect(runTurn(agent, "turn-returned-1", "first returned Cloudflare turn"))
+        .resolves.toBe("RETURNED TURN ONE");
+      await expect(runTurn(agent, "turn-returned-2", "second returned Cloudflare turn"))
+        .resolves.toBe("RETURNED TURN TWO");
       expect(server.connections).toBe(3);
-      returnResult.dispose();
-      returnTurn.dispose();
       await returnScenario;
       expect(BigInt((await returned.load(stateId)).revision)).toBeGreaterThan(
         BigInt(postgresArchive.revision),
@@ -436,13 +445,30 @@ async function shutdownAgent(agent: NodeAgent): Promise<void> {
   }
 }
 
-async function answerNext(
-  server: ResponsesServer,
+async function runTurn(
+  agent: NodeAgent,
+  id: string,
+  input: string,
+): Promise<string | undefined> {
+  const turn = agent.turn.prompt({ id, input });
+  try {
+    const result = await turn.result();
+    try {
+      return result.finalMessage;
+    } finally {
+      result.dispose();
+    }
+  } finally {
+    turn.dispose();
+  }
+}
+
+async function answerMessage(
+  socket: WebSocket,
   responseId: string,
   message: string,
-  expected: Readonly<{ inputs: readonly string[] }>,
+  expected: Readonly<{ inputs: readonly string[]; previousResponseId?: string }>,
 ): Promise<void> {
-  const socket = await server.nextConnection();
   const request = await nextMessage(socket);
   socket.send(JSON.stringify({
     type: "response.completed",
@@ -459,7 +485,34 @@ async function answerNext(
   }));
   const input = JSON.stringify(request.input);
   for (const text of expected.inputs) expect(input).toContain(text);
-  expect(request.previous_response_id).toBeUndefined();
+  expect(request.previous_response_id).toBe(expected.previousResponseId);
+}
+
+async function answerCompaction(
+  socket: WebSocket,
+  responseId: string,
+  expected: Readonly<{ previousResponseId?: string }>,
+): Promise<void> {
+  const request = await nextMessage(socket);
+  expect(request.input).toEqual([{ type: "compaction_trigger" }]);
+  expect(request.previous_response_id).toBe(expected.previousResponseId);
+  socket.send(JSON.stringify({
+    type: "response.output_item.done",
+    item: {
+      id: "portable-compaction-item",
+      type: "compaction",
+      encrypted_content: "opaque-portable-summary",
+    },
+  }));
+  socket.send(JSON.stringify({
+    type: "response.completed",
+    response: {
+      id: responseId,
+      status: "completed",
+      output: [],
+      usage: null,
+    },
+  }));
 }
 
 type ResponsesServer = Readonly<{

--- a/examples/vercel-workflows/test/postgres-durability.test.ts
+++ b/examples/vercel-workflows/test/postgres-durability.test.ts
@@ -7,6 +7,7 @@ import { WebSocketServer, type RawData, type WebSocket } from "ws";
 import {
   DurabilityImportConflictError,
   durabilityRevision,
+  durabilityStateDigest,
   exportDurabilityStatePage,
   importDurabilityStatePages,
   type DurabilityPortableStatePage,
@@ -324,10 +325,15 @@ describe("Vercel PostgreSQL durability store", () => {
 
       const cloudflarePages = await exportPages(source, stateId, durabilityRevision("0"));
       const cloudflareTo = cloudflarePages[0]!.to;
-      await expect(importDurabilityStatePages(postgres, jsonRoundTrip(cloudflarePages))).resolves.toEqual({
+      const importedPostgresState = await importDurabilityStatePages(
+        postgres,
+        jsonRoundTrip(cloudflarePages),
+      );
+      expect(importedPostgresState).toEqual({
         revision: cloudflareTo,
         payload: cloudflarePages.map((page) => page.payload).join(""),
       });
+      const cloudflareDigest = await durabilityStateDigest(importedPostgresState);
 
       agent = await Agent.create({
         module,
@@ -369,7 +375,7 @@ describe("Vercel PostgreSQL durability store", () => {
       await shutdownAgent(agent);
       agent = undefined;
 
-      const postgresPages = await exportPages(postgres, stateId, cloudflareTo);
+      const postgresPages = await exportPages(postgres, stateId, cloudflareTo, cloudflareDigest);
       const postgresTo = postgresPages[0]!.to;
       expect(BigInt(postgresTo)).toBeGreaterThan(BigInt(cloudflareTo));
       expect(postgresPages.map((page) => page.payload).join(""))
@@ -440,6 +446,7 @@ async function exportPages(
   store: Parameters<typeof exportDurabilityStatePage>[0],
   stateId: string,
   from: ReturnType<typeof durabilityRevision>,
+  fromDigest?: string,
 ): Promise<DurabilityPortableStatePage[]> {
   const pages: DurabilityPortableStatePage[] = [];
   let cursor: string | undefined;
@@ -447,6 +454,7 @@ async function exportPages(
   do {
     const page = await exportDurabilityStatePage(store, stateId, {
       from,
+      ...(fromDigest === undefined ? {} : { fromDigest }),
       to,
       cursor,
       limit: 97,

--- a/examples/vercel-workflows/test/postgres-durability.test.ts
+++ b/examples/vercel-workflows/test/postgres-durability.test.ts
@@ -272,7 +272,7 @@ describe("Vercel PostgreSQL durability store", () => {
     }
   });
 
-  it("moves one live agent Cloudflare → Vercel Postgres → Cloudflare without replaying turns", async () => {
+  it("round-trips one live Agent through the Cloudflare and PostgreSQL store contracts", async () => {
     const module = await readFile(
       new URL("../../../js/bindings/pkg-web/nanocodex_bg.wasm", import.meta.url),
     );
@@ -281,14 +281,16 @@ describe("Vercel PostgreSQL durability store", () => {
     const source = createCloudflareDurabilityStore(cloudflareDurabilityStorage());
     const postgres = createPostgresDurabilityStore(pool.asPostgresPool());
     const returned = createCloudflareDurabilityStore(cloudflareDurabilityStorage());
-    const sessionId = "018f1f9a-7b3c-7a70-8000-000000000070";
+    const cloudflareSessionId = "018f1f9a-7b3c-7a70-8000-000000000070";
+    const vercelSessionId = "018f1f9a-7b3c-7a70-8000-000000000071";
+    const returnedSessionId = "018f1f9a-7b3c-7a70-8000-000000000072";
     const stateId = "portable-managed-agent";
     let agent: NodeAgent | undefined;
 
     try {
       agent = await Agent.create({
         module,
-        sessionId,
+        sessionId: cloudflareSessionId,
         thinking: "none",
         transport: Transport.openAi({ apiKey: "test-key", websocketUrl: server.url }),
         durability: source,
@@ -320,7 +322,7 @@ describe("Vercel PostgreSQL durability store", () => {
 
       agent = await Agent.create({
         module,
-        sessionId,
+        sessionId: vercelSessionId,
         thinking: "none",
         transport: Transport.openAi({ apiKey: "test-key", websocketUrl: server.url }),
         durability: postgres,
@@ -366,7 +368,7 @@ describe("Vercel PostgreSQL durability store", () => {
 
       agent = await Agent.create({
         module,
-        sessionId,
+        sessionId: returnedSessionId,
         thinking: "none",
         transport: Transport.openAi({ apiKey: "test-key", websocketUrl: server.url }),
         durability: returned,

--- a/examples/vercel-workflows/test/postgres-live.test.ts
+++ b/examples/vercel-workflows/test/postgres-live.test.ts
@@ -9,7 +9,13 @@ import {
   exportDurabilityState,
   importDurabilityState,
 } from "nanocodex/durability";
-import { createPostgresDurabilityStore } from "nanocodex/durability/postgres";
+import {
+  createPostgresDurabilityStore,
+  type PostgresDurabilityClient,
+  type PostgresDurabilityPool,
+  type PostgresDurabilityQueryResult,
+  type PostgresDurabilityRow,
+} from "nanocodex/durability/postgres";
 
 const live = process.env.NANOCODEX_LIVE_POSTGRES === "1";
 const connectionString = process.env.DATABASE_URL;
@@ -79,4 +85,135 @@ describe.runIf(live)("live PostgreSQL durability", () => {
       payload: "stale-source-resurrection",
     })).resolves.toEqual({ status: "fenced" });
   });
+
+  it("serializes two empty-target imports before expected-state validation", async () => {
+    if (!connectionString) throw new Error("DATABASE_URL is required for live PostgreSQL tests");
+    const stateId = `live-import-race-${randomUUID()}`;
+    const firstApplication = `nanocodex-import-first-${randomUUID()}`;
+    const secondApplication = `nanocodex-import-second-${randomUUID()}`;
+    const firstPool = new Pool({
+      application_name: firstApplication,
+      connectionString,
+      max: 1,
+      options: `-c search_path=${schemaB}`,
+    });
+    const secondPool = new Pool({
+      application_name: secondApplication,
+      connectionString,
+      max: 1,
+      options: `-c search_path=${schemaB}`,
+    });
+    const firstLocked = deferred();
+    const releaseFirst = deferred();
+    let firstAttempt: Promise<unknown> | undefined;
+    let secondAttempt: Promise<unknown> | undefined;
+
+    try {
+      const first = createPostgresDurabilityStore(
+        pauseAfterStateLock(firstPool, stateId, firstLocked.resolve, releaseFirst.promise),
+      );
+      const second = createPostgresDurabilityStore(secondPool);
+      await Promise.all([first.load("initialize-first"), second.load("initialize-second")]);
+
+      firstAttempt = Promise.resolve(first.importState(stateId, {
+        revision: durabilityRevision("8"),
+        payload: "first-import",
+      }, {
+        expectedRevision: durabilityRevision("0"),
+        expectedPayload: null,
+      }));
+      await firstLocked.promise;
+      secondAttempt = Promise.resolve(second.importState(stateId, {
+        revision: durabilityRevision("9"),
+        payload: "second-import",
+      }, {
+        expectedRevision: durabilityRevision("0"),
+        expectedPayload: null,
+      }));
+      await waitForAdvisoryLock(secondApplication);
+      releaseFirst.resolve();
+
+      const attempts = await Promise.allSettled([firstAttempt, secondAttempt]);
+      expect(attempts[0]).toEqual({
+        status: "fulfilled",
+        value: { revision: durabilityRevision("8"), payload: "first-import" },
+      });
+      expect(attempts[1]).toMatchObject({ status: "rejected" });
+      if (attempts[1]?.status === "rejected") {
+        expect(attempts[1].reason).toBeInstanceOf(DurabilityImportConflictError);
+        expect(attempts[1].reason).toMatchObject({
+          expectedRevision: durabilityRevision("0"),
+          actualRevision: durabilityRevision("8"),
+        });
+      }
+      await expect(first.load(stateId)).resolves.toEqual({
+        revision: durabilityRevision("8"),
+        payload: "first-import",
+      });
+    } finally {
+      releaseFirst.resolve();
+      await Promise.allSettled([firstAttempt, secondAttempt].filter((attempt) => attempt !== undefined));
+      await Promise.allSettled([firstPool.end(), secondPool.end()]);
+    }
+  });
 });
+
+function pauseAfterStateLock(
+  pool: Pool,
+  stateId: string,
+  locked: () => void,
+  release: Promise<void>,
+): PostgresDurabilityPool {
+  return {
+    async connect(): Promise<PostgresDurabilityClient> {
+      const client = await pool.connect();
+      return {
+        async query<Row extends PostgresDurabilityRow = PostgresDurabilityRow>(
+          text: string,
+          values: unknown[] = [],
+        ): Promise<PostgresDurabilityQueryResult<Row>> {
+          const result = await client.query(text, values);
+          if (text.includes(":nanocodex-durability-v2:state:") && values[0] === stateId) {
+            locked();
+            await release;
+          }
+          return { rows: result.rows as unknown as readonly Row[] };
+        },
+        release(discard?: Error | boolean): void {
+          client.release(discard);
+        },
+      };
+    },
+    async query<Row extends PostgresDurabilityRow = PostgresDurabilityRow>(
+      text: string,
+      values: unknown[] = [],
+    ): Promise<PostgresDurabilityQueryResult<Row>> {
+      const result = await pool.query(text, values);
+      return { rows: result.rows as unknown as readonly Row[] };
+    },
+  };
+}
+
+async function waitForAdvisoryLock(applicationName: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const result = await admin.query<{ waiting: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1 FROM pg_stat_activity
+         WHERE application_name = $1
+           AND wait_event_type = 'Lock'
+           AND wait_event = 'advisory'
+       ) AS waiting`,
+      [applicationName],
+    );
+    if (result.rows[0]?.waiting) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`PostgreSQL client ${JSON.stringify(applicationName)} did not wait for the state lock`);
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((accept) => { resolve = accept; });
+  return { promise, resolve };
+}

--- a/examples/vercel-workflows/test/postgres-live.test.ts
+++ b/examples/vercel-workflows/test/postgres-live.test.ts
@@ -1,0 +1,82 @@
+import { randomUUID } from "node:crypto";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Pool } from "pg";
+
+import {
+  DurabilityImportConflictError,
+  durabilityRevision,
+  exportDurabilityState,
+  importDurabilityState,
+} from "nanocodex/durability";
+import { createPostgresDurabilityStore } from "nanocodex/durability/postgres";
+
+const live = process.env.NANOCODEX_LIVE_POSTGRES === "1";
+const connectionString = process.env.DATABASE_URL;
+const schemaA = `nanocodex_live_a_${randomUUID().replaceAll("-", "")}`;
+const schemaB = `nanocodex_live_b_${randomUUID().replaceAll("-", "")}`;
+let admin: Pool;
+let sourcePool: Pool;
+let destinationPool: Pool;
+
+describe.runIf(live)("live PostgreSQL durability", () => {
+  beforeAll(async () => {
+    if (!connectionString) throw new Error("DATABASE_URL is required for live PostgreSQL tests");
+    admin = new Pool({ connectionString });
+    await admin.query(`CREATE SCHEMA ${schemaA}`);
+    await admin.query(`CREATE SCHEMA ${schemaB}`);
+    sourcePool = new Pool({ connectionString, options: `-c search_path=${schemaA}` });
+    destinationPool = new Pool({ connectionString, options: `-c search_path=${schemaB}` });
+  });
+
+  afterAll(async () => {
+    await Promise.allSettled([sourcePool?.end(), destinationPool?.end()]);
+    if (admin) {
+      await admin.query(`DROP SCHEMA IF EXISTS ${schemaA} CASCADE`);
+      await admin.query(`DROP SCHEMA IF EXISTS ${schemaB} CASCADE`);
+      await admin.end();
+    }
+  });
+
+  it("uses real pg.Pool transactions for fencing, CAS, and portable import", async () => {
+    const stateId = `live-postgres-${randomUUID()}`;
+    const source = createPostgresDurabilityStore(sourcePool);
+    const owner = await source.acquire(stateId, { ownerId: "live-owner" });
+    const contenders = await Promise.all(Array.from({ length: 24 }, (_, index) => (
+      createPostgresDurabilityStore(sourcePool).replace(stateId, {
+        ownerId: owner.ownerId,
+        fence: owner.fence,
+        expectedRevision: owner.revision,
+        payload: `winner-${index}`,
+      })
+    )));
+    expect(contenders.filter(({ status }) => status === "replaced")).toHaveLength(1);
+    expect(contenders.filter(({ status }) => status === "conflict")).toHaveLength(23);
+
+    const retained = await source.load(stateId);
+    expect(retained).toMatchObject({ revision: durabilityRevision("1") });
+    const archive = JSON.parse(JSON.stringify(
+      await exportDurabilityState(source, stateId),
+    ));
+    const destination = createPostgresDurabilityStore(destinationPool);
+    await expect(importDurabilityState(destination, archive)).resolves.toEqual(retained);
+    await expect(importDurabilityState(destination, archive)).rejects.toBeInstanceOf(
+      DurabilityImportConflictError,
+    );
+
+    const reopened = await destination.acquire(stateId, { ownerId: "vercel-workflow-step" });
+    expect(reopened).toMatchObject(retained);
+    await expect(destination.replace(stateId, {
+      ownerId: reopened.ownerId,
+      fence: reopened.fence,
+      expectedRevision: reopened.revision,
+      payload: `${retained.payload}:continued-on-vercel`,
+    })).resolves.toEqual({ status: "replaced", revision: durabilityRevision("2") });
+    await expect(source.replace(stateId, {
+      ownerId: owner.ownerId,
+      fence: owner.fence,
+      expectedRevision: durabilityRevision("1"),
+      payload: "stale-source-resurrection",
+    })).resolves.toEqual({ status: "fenced" });
+  });
+});

--- a/examples/vercel-workflows/test/sessions-route.test.ts
+++ b/examples/vercel-workflows/test/sessions-route.test.ts
@@ -26,7 +26,7 @@ describe("session creation route", () => {
     else process.env.NANOCODEX_ADMIN_TOKEN = originalAdminToken;
   });
 
-  it("uses the Workflow run ID as the only public session identity", async () => {
+  it("uses the Workflow run ID as both identities for a new session", async () => {
     mocks.start.mockResolvedValue({ runId: "wrun_canonical" });
 
     const response = await POST(new Request("https://example.test/api/sessions", {
@@ -34,12 +34,38 @@ describe("session creation route", () => {
     }));
 
     expect(response.status).toBe(201);
-    await expect(response.json()).resolves.toEqual({ session_id: "wrun_canonical" });
+    await expect(response.json()).resolves.toEqual({
+      session_id: "wrun_canonical",
+      durability_id: "wrun_canonical",
+    });
     expect(mocks.start).toHaveBeenCalledOnce();
     expect(mocks.start).toHaveBeenCalledWith(mocks.nanocodexActor);
   });
 
-  it("accepts no compatibility session argument at the actor boundary", () => {
-    expectTypeOf(nanocodexActor).toEqualTypeOf<() => Promise<never>>();
+  it("starts an imported state under a fresh Workflow run identity", async () => {
+    mocks.start.mockResolvedValue({ runId: "wrun_imported" });
+    const durability = {
+      format: "nanocodex-durability-state-v1",
+      stateId: "portable-agent",
+      revision: "9",
+      payload: "opaque",
+    } as const;
+
+    const response = await POST(new Request("https://example.test/api/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ durability }),
+    }));
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      session_id: "wrun_imported",
+      durability_id: "portable-agent",
+    });
+    expect(mocks.start).toHaveBeenCalledWith(mocks.nanocodexActor, [durability]);
+  });
+
+  it("accepts only a portable archive argument at the actor boundary", () => {
+    expectTypeOf(nanocodexActor).toBeFunction();
   });
 });

--- a/examples/vercel-workflows/workflows/nanocodex-actor.ts
+++ b/examples/vercel-workflows/workflows/nanocodex-actor.ts
@@ -179,7 +179,7 @@ export async function runNanocodexTurn(
       try {
         await agent.session.shutdown();
       } catch {
-        // The Rust journal result or typed failure above is authoritative.
+        // The Rust total-state result or typed failure above is authoritative.
       } finally {
         agent.dispose();
       }

--- a/examples/vercel-workflows/workflows/nanocodex-actor.ts
+++ b/examples/vercel-workflows/workflows/nanocodex-actor.ts
@@ -5,6 +5,10 @@ import {
   type DefaultAgent,
   type EventWatcher,
 } from "nanocodex";
+import {
+  importDurabilityState,
+  type DurabilityPortableStateArchive,
+} from "nanocodex/durability";
 import { defineHook, getWorkflowMetadata, getWritable } from "workflow";
 
 import type {
@@ -30,10 +34,13 @@ export function promptHookToken(sessionId: string): string {
   return `nanocodex_actor:${sessionId}`;
 }
 
-export async function nanocodexActor(): Promise<never> {
+export async function nanocodexActor(
+  archive?: DurabilityPortableStateArchive,
+): Promise<never> {
   "use workflow";
 
   const sessionId = getWorkflowMetadata().workflowRunId;
+  const durabilityId = await prepareNanocodexDurability(sessionId, archive);
   const receivePrompt = nanocodexPromptHook.create({
     token: promptHookToken(sessionId),
   });
@@ -42,7 +49,7 @@ export async function nanocodexActor(): Promise<never> {
   await writeSessionEvent({
     type: "ready",
     session_id: sessionId,
-    restored: false,
+    restored: archive !== undefined,
   });
 
   for await (const request of receivePrompt) {
@@ -52,7 +59,7 @@ export async function nanocodexActor(): Promise<never> {
       input: request.input,
       replayed: seen.has(request.id),
     });
-    const outcome = await runNanocodexTurn(sessionId, request);
+    const outcome = await runNanocodexTurn(sessionId, durabilityId, request);
     seen.add(request.id);
     if (!outcome.ok) {
       await writeSessionEvent({
@@ -69,6 +76,17 @@ export async function nanocodexActor(): Promise<never> {
   throw new Error("Nanocodex actor prompt hook closed unexpectedly");
 }
 
+export async function prepareNanocodexDurability(
+  sessionId: string,
+  archive?: DurabilityPortableStateArchive,
+): Promise<string> {
+  "use step";
+
+  if (archive === undefined) return sessionId;
+  await importDurabilityState(postgresDurabilityStore(), archive);
+  return archive.stateId;
+}
+
 export async function writeSessionEvent(event: SessionEvent): Promise<void> {
   "use step";
 
@@ -83,6 +101,7 @@ export async function writeSessionEvent(event: SessionEvent): Promise<void> {
 
 export async function runNanocodexTurn(
   sessionId: string,
+  durabilityId: string,
   request: PromptRequest,
 ): Promise<TurnOutcome> {
   "use step";
@@ -103,7 +122,7 @@ export async function runNanocodexTurn(
       instructions: "You are Nanocodex running as a durable Vercel Workflow actor. Use the sandbox_* tools for code, files, and previews; their /workspace is an isolated persistent Vercel Sandbox for this session.",
       module: await wasmBytes,
       durability,
-      durabilityId: sessionId,
+      durabilityId,
       sessionId,
       toolMode: "direct" as const,
       tools: {

--- a/examples/vercel-workflows/workflows/postgres-durability.ts
+++ b/examples/vercel-workflows/workflows/postgres-durability.ts
@@ -1,12 +1,12 @@
 import { attachDatabasePool } from "@vercel/functions";
-import type { DurabilityStore } from "nanocodex/durability";
+import type { DurabilityPortableStore } from "nanocodex/durability";
 import { createPostgresDurabilityStore } from "nanocodex/durability/postgres";
 import { Pool } from "pg";
 
-let applicationStore: DurabilityStore | undefined;
+let applicationStore: DurabilityPortableStore | undefined;
 
 /** The one application-owned store used by every Vercel Workflow step. */
-export function postgresDurabilityStore(): DurabilityStore {
+export function postgresDurabilityStore(): DurabilityPortableStore {
   if (applicationStore) return applicationStore;
   const connectionString = process.env.DATABASE_URL?.trim();
   if (!connectionString) {

--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -863,19 +863,16 @@ from `nanocodex/durability/postgres`; connection ownership and secret policy
 remain in the application.
 
 The built-in stores can move one stopped agent across providers without
-decoding or rebasing its Rust state:
+decoding or rebasing its Rust state. Cloudflare owners should use the adapter's
+lifecycle-safe export instead of reconstructing its private state ID:
 
 ```js
-import {
-  exportDurabilityState,
-  importDurabilityState,
-} from "nanocodex/durability";
-import { createCloudflareDurabilityStore } from "nanocodex/durability/cloudflare";
+import { Agent as CloudflareAgent } from "nanocodex/cloudflare";
+import { importDurabilityState } from "nanocodex/durability";
 import { createPostgresDurabilityStore } from "nanocodex/durability/postgres";
 
 await cloudflareAgent.session.shutdown();
-const source = createCloudflareDurabilityStore(durableObjectStorage);
-const archive = await exportDurabilityState(source, agentId);
+const archive = await CloudflareAgent.exportDurabilityState(durableObjectOwner);
 
 // Send JSON.stringify(archive) through an authenticated, encrypted operator path.
 const serializedArchive = JSON.stringify(archive);
@@ -900,6 +897,13 @@ same agent Cloudflare → PostgreSQL → Cloudflare, replays committed turn IDs
 without model calls, rebuilds the first new provider request from committed
 history without a previous-response handle, and then continues with new turns
 on each destination.
+
+The managed Cloudflare service exposes the same offline cutover at `POST
+/v1/agents/<agent-id>/durability`; the call permanently closes source admission.
+Create a destination with `POST /v1/agents` and `{ "durability": <archive> }`.
+The Vercel example accepts that same body at `POST /api/sessions` and exports a
+stopped PostgreSQL state through `POST /api/durability/export` with
+`{ "state_id": <durability-id> }`.
 
 Node embedders whose bundler relocates package assets may compile and pass the
 web-target artifact explicitly. The runtime still uses the Node host for

--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -170,7 +170,7 @@ credentials or places its reusable grant bearer in a WebSocket URL.
 ### Durable Cloudflare Agent
 
 `nanocodex/cloudflare` is the standard Durable Object consumer. It keeps the
-host transport, SQLite journal, private runtime identity, event persistence,
+host transport, SQLite durable state, private runtime identity, event persistence,
 hibernatable socket fan-out, and cursor replay inside the adapter:
 
 ```js
@@ -224,15 +224,15 @@ evaluator. Select `toolMode: "code"` only when also supplying an evaluator that
 is explicitly compatible with the deployed Worker runtime. Runtime-owned
 Subagents are installed by default, including on a durable root. Clean children
 use the existing in-memory Rust task tree and are closed with the live root;
-their lifecycles are not reconstructed from the durable journal. Use
+their lifecycles are not reconstructed from durable execution state. Use
 `Subagents.create({ maxConcurrency })` in `tools` only to override the default
 maximum concurrency of 32.
 
 Each Durable Object persists a private runtime identity in its own SQLite
-storage and derives its journal identity from it, so multiple objects in one
+storage and derives its state identity from it, so multiple objects in one
 isolate remain independent and eviction reuses the same identity. Before
 replacing an Agent inside a still-live object, await `agent.session.shutdown()`;
-deleting the Durable Object and its retained event/journal rows remains an
+deleting the Durable Object and its retained event/state rows remains an
 application-owned lifecycle operation.
 
 Internally this constructor uses `Transport.hostManaged` and an exact brokered
@@ -782,7 +782,7 @@ with the same instructions and tool definitions, and release the original
 agent before handing its snapshot to another writer.
 
 For crash recovery inside a turn, provide the generic durability host instead
-of manually persisting snapshots. The host stores opaque Rust journal batches;
+of manually persisting snapshots. The host stores one opaque Rust state value;
 model replay, tool ambiguity, operation deduplication, and checkpoint recovery
 remain in Rust/WASM:
 
@@ -792,12 +792,21 @@ import { Agent, Transport } from "nanocodex/host";
 const agent = await Agent.create({
   transport: Transport.openAi({ apiKey: process.env.OPENAI_API_KEY }),
   durability: {
-    async load(journalId) {
-      return database.loadJournal(journalId);
+    async load(stateId) {
+      return database.loadState(stateId);
     },
-    async append(journalId, { expectedRevision, payload }) {
-      return database.compareAndAppend(journalId, expectedRevision, payload);
-      // { status: "appended", revision: "8" }
+    async acquire(stateId, { ownerId }) {
+      return database.acquireState(stateId, ownerId);
+    },
+    async replace(stateId, { ownerId, fence, expectedRevision, payload }) {
+      return database.compareAndReplace(
+        stateId,
+        ownerId,
+        fence,
+        expectedRevision,
+        payload,
+      );
+      // { status: "replaced", revision: "8" }
       // or { status: "conflict", actualRevision: "8" }
       // or { status: "not_committed", message: "transaction rolled back" }
     },
@@ -805,7 +814,7 @@ const agent = await Agent.create({
   durabilityId: "customer-agent-123",
 });
 
-// Every prompt is journaled because durability is configured. Supply `id`
+// Every prompt is durable because the state store is configured. Supply `id`
 // only when an external retry must identify the same logical operation.
 const turn = agent.turn.prompt({ input: "Build the thing." });
 // const turn = agent.turn.prompt({ id: "request-7", input: "Build the thing." });
@@ -829,7 +838,7 @@ Revisions are unsigned decimal strings so JavaScript preserves Rust's full
 `nanocodex/durability` leaf. Durable step hosts can carry the memory store's
 `snapshot()` into the next step. SQLite hosts provide one transaction query
 adapter and execute the canonical schema; the platform never interprets the
-opaque Rust journal. See `services/managed`,
+opaque Rust state. See `services/managed`,
 `examples/vercel-workflows`, and `examples/rivet-actors` for all three host
 shapes.
 

--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -862,6 +862,45 @@ Vercel and other PostgreSQL hosts use `createPostgresDurabilityStore(pool)`
 from `nanocodex/durability/postgres`; connection ownership and secret policy
 remain in the application.
 
+The built-in stores can move one stopped agent across providers without
+decoding or rebasing its Rust state:
+
+```js
+import {
+  exportDurabilityState,
+  importDurabilityState,
+} from "nanocodex/durability";
+import { createCloudflareDurabilityStore } from "nanocodex/durability/cloudflare";
+import { createPostgresDurabilityStore } from "nanocodex/durability/postgres";
+
+await cloudflareAgent.session.shutdown();
+const source = createCloudflareDurabilityStore(durableObjectStorage);
+const archive = await exportDurabilityState(source, agentId);
+
+// Send JSON.stringify(archive) through an authenticated, encrypted operator path.
+const serializedArchive = JSON.stringify(archive);
+const destination = createPostgresDurabilityStore(vercelPostgresPool);
+await importDurabilityState(destination, JSON.parse(serializedArchive));
+
+const vercelAgent = await Agent.create({
+  module: wasmModule,
+  transport,
+  durability: destination,
+  durabilityId: archive.stateId,
+});
+```
+
+Export fences the old source owner, import refuses a destination that already
+has state, and the exact state ID and revision are retained. Do not use this as
+live replication: stop source admission before export, never resume the source
+after cutover begins, and reconcile the destination after an ambiguous import
+commit. The archive can contain conversation and tool state, so handle it as a
+secret. The Vercel example includes a WASM integration test that executes the
+same agent Cloudflare → PostgreSQL → Cloudflare, replays committed turn IDs
+without model calls, rebuilds the first new provider request from committed
+history without a previous-response handle, and then continues with new turns
+on each destination.
+
 Node embedders whose bundler relocates package assets may compile and pass the
 web-target artifact explicitly. The runtime still uses the Node host for
 WebSockets and Code Mode:

--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -898,8 +898,12 @@ const vercelAgent = await Agent.create({
 });
 ```
 
-`from` is exclusive and `to` is inclusive. Each cursor retry returns the same
-page; import atomically succeeds only if the destination is still at `from`.
+`from` is exclusive and `to` is inclusive. For a nonzero `from`, load the
+destination once, hash that exact state with `durabilityStateDigest`, and repeat
+the short `fromDigest` on every page request; revision zero's null-state digest
+is implied. Each page carries that SHA-256 lineage digest, so import atomically
+succeeds only if the destination still has the exact revision and payload
+selected at `from`.
 Because `to` is one complete Rust state, no intermediate revision log is
 needed. Export fences the old source owner, and PostgreSQL reconciles lost
 COMMIT responses internally by retrying the identical idempotent request, so
@@ -914,10 +918,12 @@ on each destination.
 
 The managed Cloudflare service exposes the same offline cutover at `POST
 /v1/agents/<agent-id>/durability`; the call permanently closes source admission.
-Create a destination with `POST /v1/agents` and `{ "durability": <archive> }`.
+Create a destination with `POST /v1/agents`, an `Idempotency-Key` header, and
+`{ "durability": <archive> }`. The stable key owns resumable receipt adoption.
 The Vercel example accepts that same body at `POST /api/sessions` and exports a
 stopped PostgreSQL state through `POST /api/durability/export` with
-`{ "state_id": <durability-id>, "from": <revision>, "to": <optional-revision>,
+`{ "state_id": <durability-id>, "from": <revision>,
+"fromDigest": <required-for-nonzero-from>, "to": <optional-revision>,
 "cursor": <optional-cursor> }`.
 
 Node embedders whose bundler relocates package assets may compile and pass the

--- a/js/bindings/README.md
+++ b/js/bindings/README.md
@@ -868,31 +868,45 @@ lifecycle-safe export instead of reconstructing its private state ID:
 
 ```js
 import { Agent as CloudflareAgent } from "nanocodex/cloudflare";
-import { importDurabilityState } from "nanocodex/durability";
+import { importDurabilityStatePages } from "nanocodex/durability";
 import { createPostgresDurabilityStore } from "nanocodex/durability/postgres";
 
 await cloudflareAgent.session.shutdown();
-const archive = await CloudflareAgent.exportDurabilityState(durableObjectOwner);
+const pages = [];
+let cursor;
+let to;
+do {
+  const page = await CloudflareAgent.exportDurabilityState(durableObjectOwner, {
+    from: "0", // exclusive destination revision
+    to,        // omit once, then repeat the selected inclusive source revision
+    cursor,
+  });
+  pages.push(page);
+  to = page.to;
+  cursor = page.nextCursor ?? undefined;
+} while (cursor !== undefined);
 
-// Send JSON.stringify(archive) through an authenticated, encrypted operator path.
-const serializedArchive = JSON.stringify(archive);
+// Send the pages through an authenticated, encrypted operator path.
 const destination = createPostgresDurabilityStore(vercelPostgresPool);
-await importDurabilityState(destination, JSON.parse(serializedArchive));
+await importDurabilityStatePages(destination, JSON.parse(JSON.stringify(pages)));
 
 const vercelAgent = await Agent.create({
   module: wasmModule,
   transport,
   durability: destination,
-  durabilityId: archive.stateId,
+  durabilityId: pages[0].stateId,
 });
 ```
 
-Export fences the old source owner, import refuses a destination that already
-has state, and the exact state ID and revision are retained. Do not use this as
-live replication: stop source admission before export, never resume the source
-after cutover begins, and reconcile the destination after an ambiguous import
-commit. The archive can contain conversation and tool state, so handle it as a
-secret. The Vercel example includes a WASM integration test that executes the
+`from` is exclusive and `to` is inclusive. Each cursor retry returns the same
+page; import atomically succeeds only if the destination is still at `from`.
+Because `to` is one complete Rust state, no intermediate revision log is
+needed. Export fences the old source owner, and PostgreSQL reconciles lost
+COMMIT responses internally by retrying the identical idempotent request, so
+the API never reports an ambiguous write outcome. Stop source admission before
+the first page and never resume it after cutover begins. Pages can contain
+conversation and tool state, so handle them as secrets. The Vercel example
+includes a WASM integration test that executes the
 same agent Cloudflare → PostgreSQL → Cloudflare, replays committed turn IDs
 without model calls, rebuilds the first new provider request from committed
 history without a previous-response handle, and then continues with new turns
@@ -903,7 +917,8 @@ The managed Cloudflare service exposes the same offline cutover at `POST
 Create a destination with `POST /v1/agents` and `{ "durability": <archive> }`.
 The Vercel example accepts that same body at `POST /api/sessions` and exports a
 stopped PostgreSQL state through `POST /api/durability/export` with
-`{ "state_id": <durability-id> }`.
+`{ "state_id": <durability-id>, "from": <revision>, "to": <optional-revision>,
+"cursor": <optional-cursor> }`.
 
 Node embedders whose bundler relocates package assets may compile and pass the
 web-target artifact explicitly. The runtime still uses the Node host for

--- a/js/bindings/browser/indexeddb-durability-store.mjs
+++ b/js/bindings/browser/indexeddb-durability-store.mjs
@@ -64,8 +64,6 @@ export function createIndexedDbDurabilityStore(options = {}) {
       requireId(stateId, "durability state ID");
       const ownerId = requireId(request?.ownerId, "durability owner ID");
       const fence = durabilityRevision(request?.fence);
-      const expectedRevision = durabilityRevision(request?.expectedRevision);
-      const payload = requirePayload(request?.payload);
       const db = await open();
       const transaction = db.transaction([OWNERS, STATES], "readwrite");
       const completed = transactionCompletion(transaction);
@@ -76,6 +74,7 @@ export function createIndexedDbDurabilityStore(options = {}) {
           await completed;
           return { status: "fenced" };
         }
+        const expectedRevision = durabilityRevision(request?.expectedRevision);
         const states = transaction.objectStore(STATES);
         const state = storedState(await requestResult(states.get(stateId)), stateId);
         if (state.revision !== expectedRevision) {
@@ -86,6 +85,7 @@ export function createIndexedDbDurabilityStore(options = {}) {
           await completed;
           return { status: "not_committed", message: "IndexedDB durability revision overflow" };
         }
+        const payload = requirePayload(request?.payload);
         const revision = durabilityRevision(BigInt(expectedRevision) + 1n);
         await requestResult(states.put({ stateId, revision, payload }));
         await completed;
@@ -114,7 +114,8 @@ function openDatabase(indexedDb, databaseName, invalidate) {
       const opened = request.result;
       if (settled) return opened.close();
       const stores = Array.from(opened.objectStoreNames).sort();
-      if (stores.length !== 2 || stores[0] !== OWNERS || stores[1] !== STATES) {
+      if (stores.length !== 2 || stores[0] !== OWNERS || stores[1] !== STATES
+        || !validStoreSchema(opened, OWNERS) || !validStoreSchema(opened, STATES)) {
         opened.close();
         return settle(reject, new Error("incompatible IndexedDB durability schema; delete the database"));
       }
@@ -129,6 +130,15 @@ function openDatabase(indexedDb, databaseName, invalidate) {
       callback(value);
     }
   });
+}
+
+function validStoreSchema(database, name) {
+  try {
+    const store = database.transaction([name], "readonly").objectStore(name);
+    return store.keyPath === "stateId" && store.autoIncrement === false;
+  } catch {
+    return false;
+  }
 }
 
 function storedState(value, stateId) {

--- a/js/bindings/browser/indexeddb-durability-store.mjs
+++ b/js/bindings/browser/indexeddb-durability-store.mjs
@@ -1,11 +1,9 @@
 import { durabilityRevision } from "../runtime/durability-store.mjs";
 
-const DATABASE_NAME = "nanocodex-browser-durability-v1";
-const DATABASE_VERSION = 2;
-const OWNERS_STORE = "owners";
-const JOURNALS_STORE = "journals";
-const BATCHES_STORE = "batches";
-const JOURNAL_INDEX = "journalId";
+const DATABASE_NAME = "nanocodex-browser-durability-v2";
+const DATABASE_VERSION = 1;
+const OWNERS = "owners";
+const STATES = "states";
 const MAX_REVISION = "18446744073709551615";
 
 /** Creates the Worker-local IndexedDB durability capability. */
@@ -15,9 +13,7 @@ export function createIndexedDbDurabilityStore(options = {}) {
     throw new TypeError("browser durability requires IndexedDB");
   }
   const databaseName = options.databaseName ?? DATABASE_NAME;
-  if (typeof databaseName !== "string" || !databaseName) {
-    throw new TypeError("browser durability database name must be a non-empty string");
-  }
+  requireId(databaseName, "browser durability database name");
   let database;
   const open = () => {
     if (database) return database;
@@ -32,203 +28,74 @@ export function createIndexedDbDurabilityStore(options = {}) {
   };
 
   return Object.freeze({
-    async load(journalId) {
-      validateJournalId(journalId);
+    async load(stateId) {
+      requireId(stateId, "durability state ID");
       const db = await open();
-      const transaction = db.transaction([JOURNALS_STORE, BATCHES_STORE], "readonly");
-      const completed = transactionCompletion(transaction);
-      const journalRequest = requestResult(transaction.objectStore(JOURNALS_STORE).get(journalId));
-      const batchRequest = requestResult(
-        transaction.objectStore(BATCHES_STORE).index(JOURNAL_INDEX).getAll(journalId),
-      );
-      const [journal, storedBatches] = await Promise.all([
-        journalRequest,
-        batchRequest,
-        completed,
-      ]);
-      const revision = durabilityRevision(journal?.revision ?? "0");
-      const batches = storedBatches.map((batch) => ({
-        revision: durabilityRevision(batch.revision),
-        payload: validatePayload(batch.payload),
-      }));
-      batches.sort((left, right) => compareRevisions(left.revision, right.revision));
-      return Object.freeze({
-        revision,
-        batches: Object.freeze(batches.map((batch) => Object.freeze(batch))),
-      });
+      const transaction = db.transaction([STATES], "readonly");
+      const state = await requestResult(transaction.objectStore(STATES).get(stateId));
+      await transactionCompletion(transaction);
+      return storedState(state, stateId);
     },
 
-    async acquire(journalId, request) {
-      validateJournalId(journalId);
-      const ownerId = validateOwnerId(request?.ownerId);
+    async acquire(stateId, request) {
+      requireId(stateId, "durability state ID");
+      const ownerId = requireId(request?.ownerId, "durability owner ID");
       const db = await open();
-      const transaction = db.transaction(
-        [OWNERS_STORE, JOURNALS_STORE, BATCHES_STORE],
-        "readwrite",
-      );
+      const transaction = db.transaction([OWNERS, STATES], "readwrite");
       const completed = transactionCompletion(transaction);
       try {
-        const outcome = acquireOwner(
-          transaction,
-          transaction.objectStore(OWNERS_STORE),
-          transaction.objectStore(JOURNALS_STORE),
-          transaction.objectStore(BATCHES_STORE),
-          journalId,
-          ownerId,
-        );
-        const [result] = await Promise.all([outcome, completed]);
-        return result;
+        const owners = transaction.objectStore(OWNERS);
+        const previous = await requestResult(owners.get(stateId));
+        const previousFence = previous === undefined ? "0" : storedOwner(previous, stateId).fence;
+        if (previousFence === MAX_REVISION) throw new RangeError("IndexedDB durability fence overflow");
+        const fence = durabilityRevision(BigInt(previousFence) + 1n);
+        await requestResult(owners.put({ stateId, ownerId, fence }));
+        const state = storedState(await requestResult(transaction.objectStore(STATES).get(stateId)), stateId);
+        await completed;
+        return Object.freeze({ ownerId, fence, ...state });
       } catch (error) {
+        try { transaction.abort(); } catch {}
         await completed.catch(() => {});
         throw error;
       }
     },
 
-    async append(journalId, request) {
-      validateJournalId(journalId);
-      const ownerId = validateOwnerId(request?.ownerId);
+    async replace(stateId, request) {
+      requireId(stateId, "durability state ID");
+      const ownerId = requireId(request?.ownerId, "durability owner ID");
       const fence = durabilityRevision(request?.fence);
       const expectedRevision = durabilityRevision(request?.expectedRevision);
-      const payload = validatePayload(request?.payload);
+      const payload = requirePayload(request?.payload);
       const db = await open();
-      const transaction = db.transaction(
-        [OWNERS_STORE, JOURNALS_STORE, BATCHES_STORE],
-        "readwrite",
-      );
+      const transaction = db.transaction([OWNERS, STATES], "readwrite");
       const completed = transactionCompletion(transaction);
-      const owners = transaction.objectStore(OWNERS_STORE);
-      const journals = transaction.objectStore(JOURNALS_STORE);
-      const batches = transaction.objectStore(BATCHES_STORE);
       try {
-        const outcome = compareAndAppend(
-          transaction,
-          owners,
-          journals,
-          batches,
-          journalId,
-          ownerId,
-          fence,
-          expectedRevision,
-          payload,
-        );
-        const [result] = await Promise.all([outcome, completed]);
-        return result;
+        const ownerValue = await requestResult(transaction.objectStore(OWNERS).get(stateId));
+        const owner = ownerValue === undefined ? undefined : storedOwner(ownerValue, stateId);
+        if (owner?.ownerId !== ownerId || durabilityRevision(owner?.fence ?? "0") !== fence) {
+          await completed;
+          return { status: "fenced" };
+        }
+        const states = transaction.objectStore(STATES);
+        const state = storedState(await requestResult(states.get(stateId)), stateId);
+        if (state.revision !== expectedRevision) {
+          await completed;
+          return { status: "conflict", actualRevision: state.revision };
+        }
+        if (expectedRevision === MAX_REVISION) {
+          await completed;
+          return { status: "not_committed", message: "IndexedDB durability revision overflow" };
+        }
+        const revision = durabilityRevision(BigInt(expectedRevision) + 1n);
+        await requestResult(states.put({ stateId, revision, payload }));
+        await completed;
+        return { status: "replaced", revision };
       } catch (error) {
+        try { transaction.abort(); } catch {}
         await completed.catch(() => {});
         throw error;
       }
     },
-  });
-}
-
-function acquireOwner(transaction, owners, journals, batches, journalId, ownerId) {
-  return new Promise((resolve, reject) => {
-    const ownerRequest = owners.get(journalId);
-    ownerRequest.onerror = () => reject(
-      ownerRequest.error ?? new Error("reading durability owner failed"),
-    );
-    ownerRequest.onsuccess = () => {
-      try {
-        const previousFence = durabilityRevision(ownerRequest.result?.fence ?? "0");
-        if (previousFence === MAX_REVISION) {
-          try { transaction.abort(); } catch {}
-          reject(new RangeError("IndexedDB durability fence overflow"));
-          return;
-        }
-        const fence = durabilityRevision(BigInt(previousFence) + 1n);
-        const ownerWrite = requestResult(owners.put({ journalId, ownerId, fence }));
-        const journalRead = requestResult(journals.get(journalId));
-        const batchesRead = requestResult(batches.index(JOURNAL_INDEX).getAll(journalId));
-        Promise.all([ownerWrite, journalRead, batchesRead]).then(
-          ([, journal, storedBatches]) => {
-            try {
-              const revision = durabilityRevision(journal?.revision ?? "0");
-              const loadedBatches = storedBatches.map((batch) => ({
-                revision: durabilityRevision(batch.revision),
-                payload: validatePayload(batch.payload),
-              }));
-              loadedBatches.sort((left, right) => (
-                compareRevisions(left.revision, right.revision)
-              ));
-              resolve(Object.freeze({
-                ownerId,
-                fence,
-                revision,
-                batches: Object.freeze(loadedBatches.map((batch) => Object.freeze(batch))),
-              }));
-            } catch (error) {
-              try { transaction.abort(); } catch {}
-              reject(error);
-            }
-          },
-          reject,
-        );
-      } catch (error) {
-        try { transaction.abort(); } catch {}
-        reject(error);
-      }
-    };
-  });
-}
-
-function compareAndAppend(
-  transaction,
-  owners,
-  journals,
-  batches,
-  journalId,
-  ownerId,
-  fence,
-  expectedRevision,
-  payload,
-) {
-  return new Promise((resolve, reject) => {
-    const ownerRequest = owners.get(journalId);
-    ownerRequest.onerror = () => reject(
-      ownerRequest.error ?? new Error("reading durability owner failed"),
-    );
-    ownerRequest.onsuccess = () => {
-      try {
-        const storedOwner = ownerRequest.result;
-        if (
-          storedOwner?.ownerId !== ownerId
-          || durabilityRevision(storedOwner?.fence ?? "0") !== fence
-        ) {
-          resolve({ status: "fenced" });
-          return;
-        }
-        const journalRequest = journals.get(journalId);
-        journalRequest.onerror = () => reject(
-          journalRequest.error ?? new Error("reading durability revision failed"),
-        );
-        journalRequest.onsuccess = () => {
-          try {
-            const actualRevision = durabilityRevision(journalRequest.result?.revision ?? "0");
-            if (actualRevision !== expectedRevision) {
-              resolve({ status: "conflict", actualRevision });
-              return;
-            }
-            if (actualRevision === MAX_REVISION) {
-              resolve({
-                status: "not_committed",
-                message: "IndexedDB durability revision overflow",
-              });
-              return;
-            }
-            const revision = durabilityRevision(BigInt(actualRevision) + 1n);
-            journals.put({ journalId, revision });
-            batches.add({ journalId, revision, payload });
-            resolve({ status: "appended", revision });
-          } catch (error) {
-            try { transaction.abort(); } catch {}
-            reject(error);
-          }
-        };
-      } catch (error) {
-        try { transaction.abort(); } catch {}
-        reject(error);
-      }
-    };
   });
 }
 
@@ -238,44 +105,60 @@ function openDatabase(indexedDb, databaseName, invalidate) {
     const request = indexedDb.open(databaseName, DATABASE_VERSION);
     request.onupgradeneeded = () => {
       const database = request.result;
-      if (!database.objectStoreNames.contains(OWNERS_STORE)) {
-        database.createObjectStore(OWNERS_STORE, { keyPath: "journalId" });
-      }
-      if (!database.objectStoreNames.contains(JOURNALS_STORE)) {
-        database.createObjectStore(JOURNALS_STORE, { keyPath: "journalId" });
-      }
-      if (!database.objectStoreNames.contains(BATCHES_STORE)) {
-        const batches = database.createObjectStore(BATCHES_STORE, {
-          keyPath: ["journalId", "revision"],
-        });
-        batches.createIndex(JOURNAL_INDEX, "journalId", { unique: false });
-      }
+      database.createObjectStore(OWNERS, { keyPath: "stateId" });
+      database.createObjectStore(STATES, { keyPath: "stateId" });
     };
-    request.onerror = () => {
-      if (settled) return;
-      settled = true;
-      reject(request.error ?? new Error("opening browser durability failed"));
-    };
-    request.onblocked = () => {
-      if (settled) return;
-      settled = true;
-      reject(new Error("opening browser durability was blocked"));
-    };
+    request.onerror = () => settle(reject, request.error ?? new Error("opening browser durability failed"));
+    request.onblocked = () => settle(reject, new Error("opening browser durability was blocked"));
     request.onsuccess = () => {
-      const database = request.result;
-      if (settled) {
-        database.close();
-        return;
+      const opened = request.result;
+      if (settled) return opened.close();
+      const stores = Array.from(opened.objectStoreNames).sort();
+      if (stores.length !== 2 || stores[0] !== OWNERS || stores[1] !== STATES) {
+        opened.close();
+        return settle(reject, new Error("incompatible IndexedDB durability schema; delete the database"));
       }
       settled = true;
-      database.onversionchange = () => {
-        invalidate();
-        database.close();
-      };
-      database.onclose = () => invalidate();
-      resolve(database);
+      opened.onversionchange = () => { invalidate(); opened.close(); };
+      opened.onclose = () => invalidate();
+      resolve(opened);
     };
+    function settle(callback, value) {
+      if (settled) return;
+      settled = true;
+      callback(value);
+    }
   });
+}
+
+function storedState(value, stateId) {
+  if (value === undefined) return Object.freeze({ revision: "0", payload: null });
+  exactRecord(value, ["stateId", "revision", "payload"], "IndexedDB durability state");
+  if (value.stateId !== stateId) throw new TypeError("IndexedDB durability state ID mismatch");
+  return Object.freeze({
+    revision: durabilityRevision(value.revision),
+    payload: requirePayload(value.payload),
+  });
+}
+
+function storedOwner(value, stateId) {
+  exactRecord(value, ["stateId", "ownerId", "fence"], "IndexedDB durability owner");
+  if (value.stateId !== stateId) throw new TypeError("IndexedDB durability owner ID mismatch");
+  return Object.freeze({
+    ownerId: requireId(value.ownerId, "durability owner ID"),
+    fence: durabilityRevision(value.fence),
+  });
+}
+
+function exactRecord(value, expected, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${label} must be an object`);
+  }
+  const actual = Object.keys(value).sort();
+  const required = [...expected].sort();
+  if (actual.length !== required.length || actual.some((key, index) => key !== required[index])) {
+    throw new TypeError(`${label} has an invalid shape`);
+  }
 }
 
 function requestResult(request) {
@@ -288,37 +171,17 @@ function requestResult(request) {
 function transactionCompletion(transaction) {
   return new Promise((resolve, reject) => {
     transaction.oncomplete = () => resolve();
-    transaction.onerror = () => reject(
-      transaction.error ?? new Error("IndexedDB durability transaction failed"),
-    );
-    transaction.onabort = () => reject(
-      transaction.error ?? new Error("IndexedDB durability transaction was aborted"),
-    );
+    transaction.onerror = () => reject(transaction.error ?? new Error("IndexedDB durability transaction failed"));
+    transaction.onabort = () => reject(transaction.error ?? new Error("IndexedDB durability transaction was aborted"));
   });
 }
 
-function validateJournalId(journalId) {
-  if (typeof journalId !== "string" || !journalId) {
-    throw new TypeError("durability journal ID must be a non-empty string");
-  }
+function requireId(value, label) {
+  if (typeof value !== "string" || !value.trim()) throw new TypeError(`${label} must be a non-empty string`);
+  return value;
 }
 
-function validatePayload(payload) {
-  if (typeof payload !== "string") {
-    throw new TypeError("durability batch payload must be a string");
-  }
-  return payload;
-}
-
-function validateOwnerId(ownerId) {
-  if (typeof ownerId !== "string" || !ownerId.trim()) {
-    throw new TypeError("durability owner ID must be a non-empty string");
-  }
-  return ownerId;
-}
-
-function compareRevisions(left, right) {
-  const leftRevision = BigInt(left);
-  const rightRevision = BigInt(right);
-  return leftRevision < rightRevision ? -1 : leftRevision > rightRevision ? 1 : 0;
+function requirePayload(value) {
+  if (typeof value !== "string") throw new TypeError("durability payload must be a string");
+  return value;
 }

--- a/js/bindings/cloudflare/Agent.d.mts
+++ b/js/bindings/cloudflare/Agent.d.mts
@@ -8,6 +8,7 @@ import type {
 } from "../types.mjs";
 import type { CloudflareDurableObjectStorage } from "../runtime/cloudflare-durability-store.mjs";
 import type { Tool as SubagentTool } from "../runtime/subagents.mjs";
+import type { DurabilityPortableStateArchive, DurabilityStoredState } from "../types.mjs";
 
 export type DurableObjectContext = Readonly<{
   storage: CloudflareDurableObjectStorage;
@@ -49,6 +50,17 @@ export type Agent<extended extends object = {}> =
 /** Removes the package-owned durable history for one Cloudflare Agent. */
 export function destroy(owner: DurableObjectOwner): void;
 
+/** Fences and exports this inactive Cloudflare Agent's provider-neutral state. */
+export function exportDurabilityState(
+  owner: DurableObjectOwner,
+): Promise<DurabilityPortableStateArchive>;
+
+/** Imports provider-neutral state into a pristine Cloudflare Agent owner. */
+export function importDurabilityState(
+  owner: DurableObjectOwner,
+  archive: DurabilityPortableStateArchive,
+): Promise<DurabilityStoredState>;
+
 /** Prunes old terminal receipts before constructing the full Agent runtime. */
 export function pruneDurableReceipts(
   owner: DurableObjectOwner,
@@ -66,6 +78,8 @@ export function create(owner: create.Owner, options?: create.Options): Promise<c
 export declare namespace create {
   type Owner = DurableObjectOwner;
   type Options = Readonly<{
+    /** Stable portable state identity. It cannot change after first construction or import. */
+    durabilityId?: string | undefined;
     /**
      * `durable` retains the adapter's resumable event socket. `caller` leaves
      * event retention to the embedding Durable Object and disables connect().

--- a/js/bindings/cloudflare/Agent.d.mts
+++ b/js/bindings/cloudflare/Agent.d.mts
@@ -8,7 +8,12 @@ import type {
 } from "../types.mjs";
 import type { CloudflareDurableObjectStorage } from "../runtime/cloudflare-durability-store.mjs";
 import type { Tool as SubagentTool } from "../runtime/subagents.mjs";
-import type { DurabilityPortableStateArchive, DurabilityStoredState } from "../types.mjs";
+import type {
+  DurabilityExportPageRequest,
+  DurabilityPortableStateArchive,
+  DurabilityPortableStatePage,
+  DurabilityStoredState,
+} from "../types.mjs";
 
 export type DurableObjectContext = Readonly<{
   storage: CloudflareDurableObjectStorage;
@@ -54,6 +59,12 @@ export function destroy(owner: DurableObjectOwner): void;
 export function exportDurabilityState(
   owner: DurableObjectOwner,
 ): Promise<DurabilityPortableStateArchive>;
+
+/** Fences once and exports one resumable page of an exact revision range. */
+export function exportDurabilityState(
+  owner: DurableObjectOwner,
+  request: DurabilityExportPageRequest,
+): Promise<DurabilityPortableStatePage>;
 
 /** Imports provider-neutral state into a pristine Cloudflare Agent owner. */
 export function importDurabilityState(

--- a/js/bindings/cloudflare/Agent.d.mts
+++ b/js/bindings/cloudflare/Agent.d.mts
@@ -49,8 +49,8 @@ export type Agent<extended extends object = {}> =
 /** Removes the package-owned durable history for one Cloudflare Agent. */
 export function destroy(owner: DurableObjectOwner): void;
 
-/** Compacts retained durable history before constructing the full Agent runtime. */
-export function compactDurability(
+/** Prunes old terminal receipts before constructing the full Agent runtime. */
+export function pruneDurableReceipts(
   owner: DurableObjectOwner,
   options?: Readonly<{ terminalReceiptRetention?: number | undefined }>,
 ): Promise<void>;
@@ -73,7 +73,7 @@ export declare namespace create {
     eventPersistence?: "durable" | "caller" | undefined;
     instructions?: string | undefined;
     /**
-     * Bounds terminal receipts retained in the hot Rust journal checkpoint.
+     * Bounds terminal receipts retained in the hot Rust state checkpoint.
      * The caller must preserve older exact-ID results before selecting this.
      */
     terminalReceiptRetention?: number | undefined;

--- a/js/bindings/cloudflare/Agent.mjs
+++ b/js/bindings/cloudflare/Agent.mjs
@@ -9,7 +9,12 @@ import { pruneDurableReceipts as pruneWasmDurableReceipts } from "../pkg-web/nan
 import * as Transport from "../browser/Transport.mjs";
 import { initializeBrowserEngine } from "../browser/engine.mjs";
 import { createCloudflareDurabilityStore } from "../runtime/cloudflare-durability-store.mjs";
-import { durabilityRevision } from "../runtime/durability-store.mjs";
+import {
+  createMemoryDurabilityStore,
+  durabilityRevision,
+  exportDurabilityState as exportPortableState,
+  importDurabilityState as importPortableState,
+} from "../runtime/durability-store.mjs";
 import { cloudflareEgress } from "./egress.mjs";
 import { scopeCloudflareEgress } from "./egress-subject.mjs";
 import {
@@ -31,6 +36,7 @@ const EPHEMERAL_APPLICATION_OPTIONS = new Set([
   "workspace",
 ]);
 const APPLICATION_OPTIONS = new Set([
+  "durabilityId",
   "eventPersistence",
   "instructions",
   "terminalReceiptRetention",
@@ -45,6 +51,8 @@ export function bindAgent(module, hostAgent = HostAgent) {
     create: (owner, options) => create(module, owner, options, hostAgent),
     createEphemeral: (owner, options) => createEphemeral(module, owner, options),
     destroy,
+    exportDurabilityState,
+    importDurabilityState,
     route,
   });
 }
@@ -67,10 +75,9 @@ export function destroy(owner) {
   const storage = context.storage;
   createCloudflareDurabilityStore(storage);
   initializeAgentStorage(storage);
-  const sessionId = storedSessionId(storage);
+  const stateId = storedStateId(storage) ?? legacyStateId(storage);
   storage.transactionSync(() => {
-    if (sessionId !== undefined) {
-      const stateId = `cloudflare:${sessionId}`;
+    if (stateId !== undefined) {
       const retained = storage.sql.exec(
         "SELECT fence FROM nanocodex_durable_owners WHERE state_id = ?",
         stateId,
@@ -102,6 +109,111 @@ export function destroy(owner) {
   });
 }
 
+/** Fences and exports this inactive Cloudflare Agent's provider-neutral state. */
+export async function exportDurabilityState(owner) {
+  const context = reserveInactiveLifecycle(owner, "exporting durability state");
+  try {
+    const storage = context.storage;
+    const durability = createCloudflareDurabilityStore(storage);
+    initializeAgentStorage(storage);
+    const stateId = storedStateId(storage) ?? legacyStateId(storage);
+    if (stateId === undefined) {
+      throw new Error("Cloudflare Agent has no durability state to export");
+    }
+    return await exportPortableState(durability, stateId);
+  } finally {
+    lifecycleFor(context).creating = false;
+  }
+}
+
+/** Imports provider-neutral state into a pristine Cloudflare Agent owner. */
+export async function importDurabilityState(owner, archive) {
+  const context = reserveInactiveLifecycle(owner, "importing durability state");
+  try {
+    const storage = context.storage;
+    const durability = createCloudflareDurabilityStore(storage);
+    initializeAgentStorage(storage);
+    const validationStateId = typeof archive?.stateId === "string" && archive.stateId
+      ? archive.stateId
+      : "nanocodex-invalid-import";
+    const validated = await importPortableState(
+      createMemoryDurabilityStore(validationStateId),
+      archive,
+    );
+    const retainedSessionId = storedSessionId(storage);
+    const retainedStateId = storedStateId(storage);
+    if (retainedSessionId !== undefined || retainedStateId !== undefined) {
+      if (retainedSessionId !== undefined
+        && retainedStateId === archive?.stateId
+        && archive?.format === "nanocodex-durability-state-v1") {
+        const retained = await durability.load(retainedStateId);
+        if (retained.revision === validated.revision
+          && retained.payload === validated.payload) {
+          return retained;
+        }
+      }
+      throw new Error("Cloudflare Agent durability import requires a pristine Durable Object");
+    }
+    const imported = await importPortableState(durability, archive);
+    const sessionId = uuidV7();
+    try {
+      storage.transactionSync(() => {
+        storage.sql.exec(
+          "INSERT INTO nanocodex_cloudflare_agent (singleton, session_id) VALUES (1, ?)",
+          sessionId,
+        );
+        storage.sql.exec(
+          "INSERT INTO nanocodex_cloudflare_durability (singleton, state_id) VALUES (1, ?)",
+          archive.stateId,
+        );
+      });
+    } catch (error) {
+      try {
+        storage.transactionSync(() => {
+          storage.sql.exec(
+            "DELETE FROM nanocodex_durable_chunk_heads WHERE state_id = ?",
+            archive.stateId,
+          );
+          storage.sql.exec(
+            "DELETE FROM nanocodex_durable_state_chunks WHERE state_id = ?",
+            archive.stateId,
+          );
+          storage.sql.exec(
+            "DELETE FROM nanocodex_durable_states WHERE state_id = ?",
+            archive.stateId,
+          );
+          storage.sql.exec(
+            "DELETE FROM nanocodex_durable_owners WHERE state_id = ?",
+            archive.stateId,
+          );
+        });
+      } catch (rollbackError) {
+        throw new AggregateError(
+          [error, rollbackError],
+          "Cloudflare Agent durability import metadata and rollback both failed",
+        );
+      }
+      throw error;
+    }
+    return imported;
+  } finally {
+    lifecycleFor(context).creating = false;
+  }
+}
+
+function reserveInactiveLifecycle(owner, operation) {
+  const context = resolveContext(owner);
+  const lifecycle = lifecycleFor(context);
+  if (lifecycle.creating) {
+    throw new Error("Cloudflare Agent lifecycle operation is already in progress");
+  }
+  if (lifecycle.active !== undefined) {
+    throw new Error(`Cloudflare Agent shutdown must complete before ${operation}`);
+  }
+  lifecycle.creating = true;
+  return context;
+}
+
 /** Prunes old terminal receipts before constructing the full Agent runtime. */
 export async function pruneDurableReceipts(module, owner, options = {}) {
   if (!options || typeof options !== "object" || Array.isArray(options)) {
@@ -126,9 +238,8 @@ export async function pruneDurableReceipts(module, owner, options = {}) {
     const storage = context.storage;
     const durability = createCloudflareDurabilityStore(storage);
     initializeAgentStorage(storage);
-    const sessionId = storedSessionId(storage);
-    if (sessionId === undefined) return;
-    const stateId = `cloudflare:${sessionId}`;
+    const stateId = storedStateId(storage) ?? legacyStateId(storage);
+    if (stateId === undefined) return;
     const routeHost = {};
     const route = (await loadDurabilityRuntime()).own(
       routeHost,
@@ -169,6 +280,7 @@ async function createOwned(module, resolved, options, hostAgent, lifecycle) {
   const { context, egress, subject } = resolved;
   const configured = applicationOptions(options);
   const {
+    durabilityId,
     eventPersistence = "durable",
     [INTERNAL_RUNTIME]: internalRuntime,
     ...agentOptions
@@ -182,7 +294,7 @@ async function createOwned(module, resolved, options, hostAgent, lifecycle) {
     : undefined;
   if (eventPersistence === "caller") clearCloudflareEventSocket(context);
   const durability = createCloudflareDurabilityStore(context.storage);
-  const sessionId = durableSessionId(context.storage);
+  const { sessionId, stateId } = durableIdentity(context.storage, durabilityId);
   const endpoint = cloudflareEgress({
     binding: scopeCloudflareEgress(egress, subject),
   });
@@ -217,7 +329,7 @@ async function createOwned(module, resolved, options, hostAgent, lifecycle) {
       transport,
       sessionId,
       durability,
-      durabilityId: `cloudflare:${sessionId}`,
+      durabilityId: stateId,
     });
     await withTimeout(
       startup.promise,
@@ -368,7 +480,7 @@ function applicationOptions(options) {
   for (const name of Object.keys(options)) {
     if (!APPLICATION_OPTIONS.has(name)) {
       throw new TypeError(
-        `Cloudflare Agent.create does not accept ${name}; only eventPersistence, instructions, terminalReceiptRetention, and tools are configurable`,
+        `Cloudflare Agent.create does not accept ${name}; only durabilityId, eventPersistence, instructions, terminalReceiptRetention, and tools are configurable`,
       );
     }
   }
@@ -404,20 +516,42 @@ function ephemeralApplicationOptions(options) {
   return options;
 }
 
-function durableSessionId(storage) {
+function durableIdentity(storage, configuredStateId) {
   initializeAgentStorage(storage);
-  let sessionId = storedSessionId(storage);
-  if (sessionId !== undefined) return sessionId;
-  const generated = uuidV7();
-  storage.sql.exec(
-    "INSERT OR IGNORE INTO nanocodex_cloudflare_agent (singleton, session_id) VALUES (1, ?)",
-    generated,
-  );
-  sessionId = storedSessionId(storage);
+  if (configuredStateId !== undefined
+    && (typeof configuredStateId !== "string" || !configuredStateId.trim())) {
+    throw new TypeError("Cloudflare Agent durabilityId must be a non-empty string");
+  }
+  const previousSessionId = storedSessionId(storage);
+  const previousStateId = storedStateId(storage);
+  if (previousStateId !== undefined
+    && configuredStateId !== undefined
+    && previousStateId !== configuredStateId) {
+    throw new Error("Cloudflare Agent durabilityId does not match the retained state identity");
+  }
+  const generated = previousSessionId ?? uuidV7();
+  const generatedStateId = previousStateId
+    ?? configuredStateId
+    ?? (previousSessionId === undefined ? generated : `cloudflare:${previousSessionId}`);
+  storage.transactionSync(() => {
+    storage.sql.exec(
+      "INSERT OR IGNORE INTO nanocodex_cloudflare_agent (singleton, session_id) VALUES (1, ?)",
+      generated,
+    );
+    storage.sql.exec(
+      "INSERT OR IGNORE INTO nanocodex_cloudflare_durability (singleton, state_id) VALUES (1, ?)",
+      generatedStateId,
+    );
+  });
+  const sessionId = storedSessionId(storage);
+  const stateId = storedStateId(storage);
   if (typeof sessionId !== "string" || !sessionId) {
     throw new Error("Cloudflare Agent failed to persist its runtime session ID");
   }
-  return sessionId;
+  if (typeof stateId !== "string" || !stateId) {
+    throw new Error("Cloudflare Agent failed to persist its durability state ID");
+  }
+  return { sessionId, stateId };
 }
 
 function initializeAgentStorage(storage) {
@@ -427,12 +561,29 @@ function initializeAgentStorage(storage) {
       session_id TEXT NOT NULL UNIQUE
     )
   `);
+  storage.sql.exec(`
+    CREATE TABLE IF NOT EXISTS nanocodex_cloudflare_durability (
+      singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+      state_id TEXT NOT NULL UNIQUE
+    )
+  `);
 }
 
 function storedSessionId(storage) {
   return storage.sql.exec(
     "SELECT session_id FROM nanocodex_cloudflare_agent WHERE singleton = 1",
   ).toArray()[0]?.session_id;
+}
+
+function storedStateId(storage) {
+  return storage.sql.exec(
+    "SELECT state_id FROM nanocodex_cloudflare_durability WHERE singleton = 1",
+  ).toArray()[0]?.state_id;
+}
+
+function legacyStateId(storage) {
+  const sessionId = storedSessionId(storage);
+  return sessionId === undefined ? undefined : `cloudflare:${sessionId}`;
 }
 
 function uuidV7() {

--- a/js/bindings/cloudflare/Agent.mjs
+++ b/js/bindings/cloudflare/Agent.mjs
@@ -52,7 +52,7 @@ export function bindAgent(module, hostAgent = HostAgent) {
     createEphemeral: (owner, options) => createEphemeral(module, owner, options),
     destroy,
     exportDurabilityState,
-    importDurabilityState,
+    importDurabilityState: (owner, archive) => importDurabilityState(owner, archive, module),
     route,
   });
 }
@@ -127,7 +127,7 @@ export async function exportDurabilityState(owner) {
 }
 
 /** Imports provider-neutral state into a pristine Cloudflare Agent owner. */
-export async function importDurabilityState(owner, archive) {
+export async function importDurabilityState(owner, archive, module) {
   const context = reserveInactiveLifecycle(owner, "importing durability state");
   try {
     const storage = context.storage;
@@ -136,10 +136,25 @@ export async function importDurabilityState(owner, archive) {
     const validationStateId = typeof archive?.stateId === "string" && archive.stateId
       ? archive.stateId
       : "nanocodex-invalid-import";
-    const validated = await importPortableState(
-      createMemoryDurabilityStore(validationStateId),
-      archive,
-    );
+    const validationStore = createMemoryDurabilityStore(validationStateId);
+    const validated = await importPortableState(validationStore, archive);
+    if (module !== undefined) {
+      const routeHost = {};
+      const route = (await loadDurabilityRuntime()).own(
+        routeHost,
+        validationStore,
+        validationStateId,
+      );
+      try {
+        installHostBridge();
+        await initializeBrowserEngine({ module });
+        // Opening the Rust durability session validates the complete canonical
+        // state. Pruning happens only in this throwaway memory copy.
+        await pruneWasmDurableReceipts(route.id, validationStateId, 4_096);
+      } finally {
+        route.abandon();
+      }
+    }
     const retainedSessionId = storedSessionId(storage);
     const retainedStateId = storedStateId(storage);
     if (retainedSessionId !== undefined || retainedStateId !== undefined) {

--- a/js/bindings/cloudflare/Agent.mjs
+++ b/js/bindings/cloudflare/Agent.mjs
@@ -13,6 +13,7 @@ import {
   createMemoryDurabilityStore,
   durabilityRevision,
   exportDurabilityState as exportPortableState,
+  exportDurabilityStatePage as exportPortableStatePage,
   importDurabilityState as importPortableState,
 } from "../runtime/durability-store.mjs";
 import { cloudflareEgress } from "./egress.mjs";
@@ -110,7 +111,7 @@ export function destroy(owner) {
 }
 
 /** Fences and exports this inactive Cloudflare Agent's provider-neutral state. */
-export async function exportDurabilityState(owner) {
+export async function exportDurabilityState(owner, request) {
   const context = reserveInactiveLifecycle(owner, "exporting durability state");
   try {
     const storage = context.storage;
@@ -120,7 +121,9 @@ export async function exportDurabilityState(owner) {
     if (stateId === undefined) {
       throw new Error("Cloudflare Agent has no durability state to export");
     }
-    return await exportPortableState(durability, stateId);
+    return request === undefined
+      ? await exportPortableState(durability, stateId)
+      : await exportPortableStatePage(durability, stateId, request);
   } finally {
     lifecycleFor(context).creating = false;
   }

--- a/js/bindings/cloudflare/Agent.mjs
+++ b/js/bindings/cloudflare/Agent.mjs
@@ -5,7 +5,7 @@ import {
   observeAgentRelease,
   routePrompt,
 } from "../internal.mjs";
-import { compactDurableSession } from "../pkg-web/nanocodex.js";
+import { pruneDurableReceipts as pruneWasmDurableReceipts } from "../pkg-web/nanocodex.js";
 import * as Transport from "../browser/Transport.mjs";
 import { initializeBrowserEngine } from "../browser/engine.mjs";
 import { createCloudflareDurabilityStore } from "../runtime/cloudflare-durability-store.mjs";
@@ -41,7 +41,7 @@ const lifecycles = new WeakMap();
 /** @internal Binds the package-owned module to the public Cloudflare namespace. */
 export function bindAgent(module, hostAgent = HostAgent) {
   return Object.freeze({
-    compactDurability: (owner, options) => compactDurability(module, owner, options),
+    pruneDurableReceipts: (owner, options) => pruneDurableReceipts(module, owner, options),
     create: (owner, options) => create(module, owner, options, hostAgent),
     createEphemeral: (owner, options) => createEphemeral(module, owner, options),
     destroy,
@@ -70,42 +70,42 @@ export function destroy(owner) {
   const sessionId = storedSessionId(storage);
   storage.transactionSync(() => {
     if (sessionId !== undefined) {
-      const journalId = `cloudflare:${sessionId}`;
+      const stateId = `cloudflare:${sessionId}`;
       const retained = storage.sql.exec(
-        "SELECT fence FROM nanocodex_journal_owners WHERE journal_id = ?",
-        journalId,
+        "SELECT fence FROM nanocodex_durable_owners WHERE state_id = ?",
+        stateId,
       ).toArray();
       const fence = durabilityRevision(
         BigInt(durabilityRevision(retained[0]?.fence ?? "0")) + 1n,
       );
       storage.sql.exec(
-        `INSERT INTO nanocodex_journal_owners (journal_id, owner_id, fence) VALUES (?, ?, ?)
-         ON CONFLICT (journal_id) DO UPDATE SET owner_id = excluded.owner_id, fence = excluded.fence`,
-        journalId,
+        `INSERT INTO nanocodex_durable_owners (state_id, owner_id, fence) VALUES (?, ?, ?)
+         ON CONFLICT (state_id) DO UPDATE SET owner_id = excluded.owner_id, fence = excluded.fence`,
+        stateId,
         `destroy:${globalThis.crypto.randomUUID()}`,
         fence,
       );
       storage.sql.exec(
-        "DELETE FROM nanocodex_journal_batch_chunks WHERE journal_id = ?",
-        journalId,
+        "DELETE FROM nanocodex_durable_chunk_heads WHERE state_id = ?",
+        stateId,
       );
       storage.sql.exec(
-        "DELETE FROM nanocodex_journal_batches WHERE journal_id = ?",
-        journalId,
+        "DELETE FROM nanocodex_durable_state_chunks WHERE state_id = ?",
+        stateId,
       );
       storage.sql.exec(
-        "DELETE FROM nanocodex_journals WHERE journal_id = ?",
-        journalId,
+        "DELETE FROM nanocodex_durable_states WHERE state_id = ?",
+        stateId,
       );
     }
     clearCloudflareEventSocket(context);
   });
 }
 
-/** Compacts retained durable history before constructing the full Agent runtime. */
-export async function compactDurability(module, owner, options = {}) {
+/** Prunes old terminal receipts before constructing the full Agent runtime. */
+export async function pruneDurableReceipts(module, owner, options = {}) {
   if (!options || typeof options !== "object" || Array.isArray(options)) {
-    throw new TypeError("Cloudflare durability compaction options must be an object");
+    throw new TypeError("Cloudflare durability receipt-pruning options must be an object");
   }
   const terminalReceiptRetention = options.terminalReceiptRetention ?? 512;
   if (!Number.isSafeInteger(terminalReceiptRetention)
@@ -119,7 +119,7 @@ export async function compactDurability(module, owner, options = {}) {
     throw new Error("Cloudflare Agent lifecycle operation is already in progress");
   }
   if (lifecycle.active !== undefined) {
-    throw new Error("Cloudflare Agent shutdown must complete before compacting durability");
+    throw new Error("Cloudflare Agent shutdown must complete before pruning durability receipts");
   }
   lifecycle.creating = true;
   try {
@@ -128,17 +128,17 @@ export async function compactDurability(module, owner, options = {}) {
     initializeAgentStorage(storage);
     const sessionId = storedSessionId(storage);
     if (sessionId === undefined) return;
-    const journalId = `cloudflare:${sessionId}`;
+    const stateId = `cloudflare:${sessionId}`;
     const routeHost = {};
     const route = (await loadDurabilityRuntime()).own(
       routeHost,
       durability,
-      journalId,
+      stateId,
     );
     try {
       installHostBridge();
       await initializeBrowserEngine({ module });
-      await compactDurableSession(route.id, journalId, terminalReceiptRetention);
+      await pruneWasmDurableReceipts(route.id, stateId, terminalReceiptRetention);
     } finally {
       route.abandon();
     }

--- a/js/bindings/internal.mjs
+++ b/js/bindings/internal.mjs
@@ -516,45 +516,20 @@ const hostBridge = Object.freeze({
     // keeps that lookup instance-scoped for roots and Rust-spawned children.
     return requiredDefinitionHost(definitionHostId).toolDefinitions(sessionId);
   },
-  async durabilityAcquire(routeId, journalId, ownerId) {
-    return (await loadDurabilityRuntime()).acquire(routeId, journalId, ownerId);
+  async durabilityAcquire(routeId, stateId, ownerId) {
+    return (await loadDurabilityRuntime()).acquire(routeId, stateId, ownerId);
   },
-  async durabilityAcquirePage(routeId, journalId, ownerId, afterRevision) {
-    return (await loadDurabilityRuntime()).acquirePage(
-      routeId,
-      journalId,
-      ownerId,
-      afterRevision,
-    );
-  },
-  async durabilityAppend(
+  async durabilityReplace(
     routeId,
-    journalId,
+    stateId,
     ownerId,
     fence,
     expectedRevision,
     payload,
   ) {
-    return (await loadDurabilityRuntime()).append(
+    return (await loadDurabilityRuntime()).replace(
       routeId,
-      journalId,
-      ownerId,
-      fence,
-      expectedRevision,
-      payload,
-    );
-  },
-  async durabilityCompact(
-    routeId,
-    journalId,
-    ownerId,
-    fence,
-    expectedRevision,
-    payload,
-  ) {
-    return (await loadDurabilityRuntime()).compact(
-      routeId,
-      journalId,
+      stateId,
       ownerId,
       fence,
       expectedRevision,

--- a/js/bindings/managed/Agent.d.mts
+++ b/js/bindings/managed/Agent.d.mts
@@ -157,8 +157,6 @@ export type Summary = Readonly<{
 export type TurnState =
   | "accepted"
   | "cancelling"
-  | "retryable"
-  | "blocked"
   | "completed"
   | "cancelled"
   | "failed";
@@ -189,7 +187,6 @@ export type EventData = Readonly<{
   | CompletedEventData
   | { type: "turn_cancelled"; id: string }
   | { type: "turn_retryable"; id: string; error: string }
-  | { type: "turn_blocked"; id: string; error: string }
   | { type: "turn_failed"; id: string; error: string }
   | { type: "event"; event: unknown }
   | { type: "stream_failed"; error: string }
@@ -207,7 +204,6 @@ export type CompletedEventData = Readonly<{
 export type TerminalEventData =
   | CompletedEventData
   | Readonly<{ type: "turn_cancelled"; id: string }>
-  | Readonly<{ type: "turn_blocked"; id: string; error: string }>
   | Readonly<{ type: "turn_failed"; id: string; error: string }>;
 
 export type Event = Readonly<{

--- a/js/bindings/managed/Agent.mjs
+++ b/js/bindings/managed/Agent.mjs
@@ -12,7 +12,6 @@ const UTF8 = new TextEncoder();
 const TERMINAL_TYPES = new Set([
   "turn_completed",
   "turn_cancelled",
-  "turn_blocked",
   "turn_failed",
 ]);
 const TERMINAL_CACHE_CAPACITY = 256;

--- a/js/bindings/runtime/cloudflare-durability-store.d.mts
+++ b/js/bindings/runtime/cloudflare-durability-store.d.mts
@@ -1,7 +1,7 @@
 import type {
   DurabilitySqliteRow,
   DurabilitySqliteValue,
-  DurabilityStore,
+  DurabilityPortableStore,
 } from "../types.mjs";
 
 export type CloudflareDurableObjectStorage = Readonly<{
@@ -23,4 +23,4 @@ export type CloudflareDurableObjectStorage = Readonly<{
  */
 export declare function createCloudflareDurabilityStore(
   storage: CloudflareDurableObjectStorage,
-): DurabilityStore;
+): DurabilityPortableStore;

--- a/js/bindings/runtime/cloudflare-durability-store.d.mts
+++ b/js/bindings/runtime/cloudflare-durability-store.d.mts
@@ -18,8 +18,8 @@ export type CloudflareDurableObjectStorage = Readonly<{
 }>;
 
 /**
- * Initializes and adapts one Durable Object's colocated SQLite journal.
- * Rust owns every opaque batch; the host only provides atomic storage.
+ * Initializes and adapts one Durable Object's colocated SQLite durable state.
+ * Rust owns the opaque total-state payload; the host only provides atomic storage.
  */
 export declare function createCloudflareDurabilityStore(
   storage: CloudflareDurableObjectStorage,

--- a/js/bindings/runtime/cloudflare-durability-store.mjs
+++ b/js/bindings/runtime/cloudflare-durability-store.mjs
@@ -1,25 +1,22 @@
-import {
-  createSqliteDurabilityStore,
-  durabilityRevision,
-  sqliteDurabilitySchema,
-} from "./durability-store.mjs";
+import { createSqliteDurabilityStore, sqliteDurabilitySchema } from "./durability-store.mjs";
 
-const ACQUIRE_PAGE_ROWS = 8;
 const DIRECT_PAYLOAD_BYTES = 1_000_000;
 const PAYLOAD_CHUNK_CODE_UNITS = 256_000;
-const MAX_REVISION = 18_446_744_073_709_551_615n;
 const encoder = new TextEncoder();
 
 const cloudflareDurabilitySchema = Object.freeze([
   ...sqliteDurabilitySchema,
-  `CREATE TABLE IF NOT EXISTS nanocodex_journal_batch_chunks (
-     journal_id TEXT NOT NULL,
+  `CREATE TABLE IF NOT EXISTS nanocodex_durable_chunk_heads (
+     state_id TEXT PRIMARY KEY,
+     revision TEXT NOT NULL,
+     chunk_count INTEGER NOT NULL CHECK (chunk_count > 0)
+   )`,
+  `CREATE TABLE IF NOT EXISTS nanocodex_durable_state_chunks (
+     state_id TEXT NOT NULL,
      revision TEXT NOT NULL,
      chunk_index INTEGER NOT NULL,
      payload TEXT NOT NULL,
-     PRIMARY KEY (journal_id, revision, chunk_index),
-     FOREIGN KEY (journal_id, revision)
-       REFERENCES nanocodex_journal_batches(journal_id, revision)
+     PRIMARY KEY (state_id, revision, chunk_index)
    )`,
 ]);
 
@@ -32,159 +29,113 @@ export function createCloudflareDurabilityStore(storage) {
   ) {
     throw new TypeError("Cloudflare durability requires Durable Object storage with SQLite");
   }
-
-  for (const statement of cloudflareDurabilitySchema) storage.sql.exec(statement);
-  const rawQuery = (sql, args) => {
+  const raw = (sql, args) => {
     const cursor = storage.sql.exec(sql, ...args);
     if (typeof cursor?.[Symbol.iterator] !== "function") return cursor.toArray();
-    const rows = [];
-    for (const row of cursor) rows.push(row);
-    return rows;
+    return [...cursor];
   };
+  for (const statement of cloudflareDurabilitySchema) storage.sql.exec(statement);
+  validateSchema(raw);
   const query = (sql, args) => {
-    if (sql.startsWith("INSERT INTO nanocodex_journal_batches")) {
-      return insertBatch(rawQuery, sql, args);
+    if (sql.startsWith("INSERT INTO nanocodex_durable_states")) {
+      return replaceState(raw, sql, args);
     }
-    if (sql.startsWith("DELETE FROM nanocodex_journal_batches")) {
-      rawQuery(
-        "DELETE FROM nanocodex_journal_batch_chunks WHERE journal_id = ?",
-        [args[0]],
-      );
-    }
-    const rows = rawQuery(sql, args);
-    return sql.includes("SELECT revision, payload FROM nanocodex_journal_batches")
-      ? hydrateBatchPayloads(rawQuery, args[0], rows)
+    const rows = raw(sql, args);
+    return sql.startsWith("SELECT revision, payload FROM nanocodex_durable_states")
+      ? hydrateState(raw, args[0], rows)
       : rows;
   };
-  const store = createSqliteDurabilityStore({
+  return createSqliteDurabilityStore({
     transaction: (callback) => storage.transactionSync(() => callback(query)),
-  });
-  return Object.freeze({
-    ...store,
-    acquirePage(journalId, request) {
-      const ownerId = request?.ownerId;
-      if (typeof ownerId !== "string" || !ownerId) {
-        throw new TypeError("durability owner ID must be a non-empty string");
-      }
-      const afterRevision = request?.afterRevision;
-      if (afterRevision !== undefined) durabilityRevision(afterRevision);
-      return storage.transactionSync(() => {
-        let owner;
-        if (afterRevision === undefined) {
-          const retained = query(
-            "SELECT owner_id, fence FROM nanocodex_journal_owners WHERE journal_id = ?",
-            [journalId],
-          )[0];
-          const previousFence = BigInt(durabilityRevision(retained?.fence ?? "0"));
-          if (previousFence === MAX_REVISION) {
-            throw new RangeError("Cloudflare durability fence overflow");
-          }
-          owner = { ownerId, fence: String(previousFence + 1n) };
-          query(
-            `INSERT INTO nanocodex_journal_owners (journal_id, owner_id, fence) VALUES (?, ?, ?)
-             ON CONFLICT (journal_id) DO UPDATE SET owner_id = excluded.owner_id, fence = excluded.fence`,
-            [journalId, owner.ownerId, owner.fence],
-          );
-        } else {
-          const retained = query(
-            "SELECT owner_id, fence FROM nanocodex_journal_owners WHERE journal_id = ?",
-            [journalId],
-          )[0];
-          if (retained?.owner_id !== ownerId) {
-            throw new Error("Cloudflare durability page owner was fenced");
-          }
-          owner = { ownerId, fence: durabilityRevision(retained.fence) };
-        }
-        const journal = query(
-          "SELECT revision FROM nanocodex_journals WHERE journal_id = ?",
-          [journalId],
-        )[0];
-        const revision = durabilityRevision(journal?.revision ?? "0");
-        const bindings = afterRevision === undefined
-          ? [journalId]
-          : [journalId, afterRevision, afterRevision, afterRevision];
-        const rows = query(
-          afterRevision === undefined
-            ? `SELECT revision, payload FROM nanocodex_journal_batches
-               WHERE journal_id = ? ORDER BY length(revision), revision LIMIT 9`
-            : `SELECT revision, payload FROM nanocodex_journal_batches
-               WHERE journal_id = ? AND (
-                 length(revision) > length(?) OR
-                 (length(revision) = length(?) AND revision > ?)
-               ) ORDER BY length(revision), revision LIMIT 9`,
-          bindings,
-        );
-        const hasMore = rows.length > ACQUIRE_PAGE_ROWS;
-        if (hasMore) rows.pop();
-        return {
-          ...owner,
-          revision,
-          batches: rows,
-          hasMore,
-        };
-      });
-    },
   });
 }
 
-function insertBatch(query, sql, args) {
-  const [journalId, revision, payload] = args;
+function validateSchema(query) {
+  const tables = [
+    ["nanocodex_durable_owners", [
+      ["state_id", "TEXT", 0, 1], ["owner_id", "TEXT", 1, 0], ["fence", "TEXT", 1, 0],
+    ]],
+    ["nanocodex_durable_states", [
+      ["state_id", "TEXT", 0, 1], ["revision", "TEXT", 1, 0], ["payload", "TEXT", 1, 0],
+    ]],
+    ["nanocodex_durable_chunk_heads", [
+      ["state_id", "TEXT", 0, 1], ["revision", "TEXT", 1, 0], ["chunk_count", "INTEGER", 1, 0],
+    ]],
+    ["nanocodex_durable_state_chunks", [
+      ["state_id", "TEXT", 1, 1], ["revision", "TEXT", 1, 2],
+      ["chunk_index", "INTEGER", 1, 3], ["payload", "TEXT", 1, 0],
+    ]],
+  ];
+  for (const [table, expected] of tables) {
+    const rows = query(`PRAGMA table_info('${table}')`, []);
+    const valid = rows.length === expected.length && rows.every((row, index) => {
+      const shape = expected[index];
+      return row.name === shape[0]
+        && String(row.type).toUpperCase() === shape[1]
+        && Number(row.notnull) === shape[2]
+        && Number(row.pk) === shape[3];
+    });
+    if (!valid) {
+      throw new Error(`incompatible Cloudflare durability schema for ${table}; recreate it`);
+    }
+  }
+}
+
+function replaceState(query, sql, [stateId, revision, payload]) {
   if (typeof payload !== "string") {
-    throw new TypeError("durability batch payload must be a string");
+    throw new TypeError("durability state payload must be a string");
   }
+  query("DELETE FROM nanocodex_durable_chunk_heads WHERE state_id = ?", [stateId]);
+  query("DELETE FROM nanocodex_durable_state_chunks WHERE state_id = ?", [stateId]);
   if (encoder.encode(payload).byteLength <= DIRECT_PAYLOAD_BYTES) {
-    return query(sql, args);
+    return query(sql, [stateId, revision, payload]);
   }
-  const result = query(sql, [journalId, revision, ""]);
+  const result = query(sql, [stateId, revision, ""]);
   const chunks = payloadChunks(payload);
+  query(
+    `INSERT INTO nanocodex_durable_chunk_heads (state_id, revision, chunk_count)
+     VALUES (?, ?, ?)`,
+    [stateId, revision, chunks.length],
+  );
   for (let index = 0; index < chunks.length; index += 1) {
     query(
-      `INSERT INTO nanocodex_journal_batch_chunks
-         (journal_id, revision, chunk_index, payload) VALUES (?, ?, ?, ?)`,
-      [journalId, revision, index, chunks[index]],
+      `INSERT INTO nanocodex_durable_state_chunks
+       (state_id, revision, chunk_index, payload) VALUES (?, ?, ?, ?)`,
+      [stateId, revision, index, chunks[index]],
     );
   }
   return result;
 }
 
-function hydrateBatchPayloads(query, journalId, batches) {
-  if (batches.length === 0) return batches;
-  const selected = [...new Set(
-    batches.map((batch) => durabilityRevision(batch.revision)),
-  )];
-  const payloads = new Map();
-  for (let offset = 0; offset < selected.length; offset += 99) {
-    const revisions = selected.slice(offset, offset + 99);
-    const placeholders = revisions.map(() => "?").join(", ");
-    const chunks = query(
-      `SELECT revision, chunk_index, payload FROM nanocodex_journal_batch_chunks
-       WHERE journal_id = ? AND revision IN (${placeholders})
-       ORDER BY length(revision), revision, chunk_index`,
-      [journalId, ...revisions],
-    );
-    for (const chunk of chunks) {
-      const revision = durabilityRevision(chunk.revision);
-      const retained = payloads.get(revision) ?? [];
-      if (chunk.chunk_index !== retained.length || typeof chunk.payload !== "string") {
-        throw new Error(`invalid Cloudflare durability chunks for revision ${revision}`);
-      }
-      retained.push(chunk.payload);
-      payloads.set(revision, retained);
+function hydrateState(query, stateId, rows) {
+  if (rows.length === 0) return rows;
+  if (rows.length !== 1) throw new Error("Cloudflare durability retained duplicate states");
+  const row = rows[0];
+  const head = query(
+    `SELECT revision, chunk_count FROM nanocodex_durable_chunk_heads
+     WHERE state_id = ?`,
+    [stateId],
+  )[0];
+  if (!head) return rows;
+  if (head.revision !== row.revision || row.payload !== "") {
+    throw new Error("invalid Cloudflare durability chunk head");
+  }
+  const chunks = query(
+    `SELECT revision, chunk_index, payload FROM nanocodex_durable_state_chunks
+     WHERE state_id = ? ORDER BY chunk_index`,
+    [stateId],
+  );
+  if (chunks.length !== head.chunk_count) {
+    throw new Error(`missing Cloudflare durability chunks for revision ${row.revision}`);
+  }
+  for (let index = 0; index < chunks.length; index += 1) {
+    const chunk = chunks[index];
+    if (chunk.revision !== row.revision || chunk.chunk_index !== index
+      || typeof chunk.payload !== "string") {
+      throw new Error(`invalid Cloudflare durability chunks for revision ${row.revision}`);
     }
   }
-  return batches.map((batch) => {
-    const chunks = payloads.get(durabilityRevision(batch.revision));
-    if (chunks === undefined) {
-      if (batch.payload === "") {
-        throw new Error(`missing Cloudflare durability chunks for revision ${batch.revision}`);
-      }
-      return batch;
-    }
-    if (batch.payload !== "") {
-      throw new Error(`invalid Cloudflare durability chunk head for revision ${batch.revision}`);
-    }
-    return { ...batch, payload: chunks.join("") };
-  });
+  return [{ ...row, payload: chunks.map((chunk) => chunk.payload).join("") }];
 }
 
 function payloadChunks(payload) {

--- a/js/bindings/runtime/durability-store.d.mts
+++ b/js/bindings/runtime/durability-store.d.mts
@@ -4,6 +4,9 @@ export type {
   DurabilityReplaceRequest,
   DurabilityReplaceResult,
   DurabilityFence,
+  DurabilityExportCursor,
+  DurabilityExportPageRequest,
+  DurabilityPortableStatePage,
   DurabilityPortableStateArchive,
   DurabilityPortableStore,
   DurabilityRevision,
@@ -21,7 +24,13 @@ export declare const sqliteDurabilitySchema: readonly string[];
 
 export declare class DurabilityImportConflictError extends Error {
   override readonly name: "DurabilityImportConflictError";
-  constructor(stateId: string);
+  readonly expectedRevision: import("../types.mjs").DurabilityRevision | undefined;
+  readonly actualRevision: import("../types.mjs").DurabilityRevision | undefined;
+  constructor(
+    stateId: string,
+    expectedRevision?: import("../types.mjs").DurabilityRevision,
+    actualRevision?: import("../types.mjs").DurabilityRevision,
+  );
 }
 
 export declare function durabilityRevision(
@@ -42,6 +51,22 @@ export declare function exportDurabilityState(
 export declare function importDurabilityState(
   store: import("../types.mjs").DurabilityPortableStore,
   archive: import("../types.mjs").DurabilityPortableStateArchive,
+): Promise<import("../types.mjs").DurabilityStoredState>;
+
+/**
+ * Fences the source once and returns a deterministic page of its exact `to` revision.
+ * `from` is exclusive, `to` is inclusive, and `cursor` resumes the same payload export.
+ */
+export declare function exportDurabilityStatePage(
+  store: import("../types.mjs").DurabilityStore,
+  stateId: string,
+  request: import("../types.mjs").DurabilityExportPageRequest,
+): Promise<import("../types.mjs").DurabilityPortableStatePage>;
+
+/** Imports a complete contiguous page set iff the destination is still at `from`. */
+export declare function importDurabilityStatePages(
+  store: import("../types.mjs").DurabilityPortableStore,
+  pages: Iterable<import("../types.mjs").DurabilityPortableStatePage>,
 ): Promise<import("../types.mjs").DurabilityStoredState>;
 
 export declare function createMemoryDurabilityStore(

--- a/js/bindings/runtime/durability-store.d.mts
+++ b/js/bindings/runtime/durability-store.d.mts
@@ -1,10 +1,8 @@
 export type {
-  DurabilityAcquiredJournal,
+  DurabilityAcquiredState,
   DurabilityAcquireRequest,
-  DurabilityAppendRequest,
-  DurabilityAppendResult,
-  DurabilityCompactRequest,
-  DurabilityCompactResult,
+  DurabilityReplaceRequest,
+  DurabilityReplaceResult,
   DurabilityFence,
   DurabilityRevision,
   DurabilitySqliteQuery,
@@ -12,8 +10,7 @@ export type {
   DurabilitySqliteTransaction,
   DurabilitySqliteValue,
   DurabilityStore,
-  DurabilityStoredBatch,
-  DurabilityStoredJournal,
+  DurabilityStoredState,
   MemoryDurabilityStore,
   SqliteDurabilityStoreOptions,
 } from "../types.mjs";
@@ -26,8 +23,8 @@ export declare function durabilityRevision(
 ): import("../types.mjs").DurabilityRevision;
 
 export declare function createMemoryDurabilityStore(
-  journalId: string,
-  initial?: import("../types.mjs").DurabilityStoredJournal,
+  stateId: string,
+  initial?: import("../types.mjs").DurabilityStoredState,
 ): import("../types.mjs").MemoryDurabilityStore;
 
 export declare function createSqliteDurabilityStore(

--- a/js/bindings/runtime/durability-store.d.mts
+++ b/js/bindings/runtime/durability-store.d.mts
@@ -4,6 +4,8 @@ export type {
   DurabilityReplaceRequest,
   DurabilityReplaceResult,
   DurabilityFence,
+  DurabilityPortableStateArchive,
+  DurabilityPortableStore,
   DurabilityRevision,
   DurabilitySqliteQuery,
   DurabilitySqliteRow,
@@ -17,10 +19,30 @@ export type {
 
 export declare const sqliteDurabilitySchema: readonly string[];
 
+export declare class DurabilityImportConflictError extends Error {
+  override readonly name: "DurabilityImportConflictError";
+  constructor(stateId: string);
+}
+
 export declare function durabilityRevision(
   /** Numbers must be nonnegative safe integers; use exact decimal text for larger values. */
   value: string | bigint | number,
 ): import("../types.mjs").DurabilityRevision;
+
+/**
+ * Atomically fences the source owner and exports one coherent JSON-safe state.
+ * Do not resume the source provider after beginning a cutover.
+ */
+export declare function exportDurabilityState(
+  store: import("../types.mjs").DurabilityStore,
+  stateId: string,
+): Promise<import("../types.mjs").DurabilityPortableStateArchive>;
+
+/** Restores an exact archive and its stable state identity into an empty destination. */
+export declare function importDurabilityState(
+  store: import("../types.mjs").DurabilityPortableStore,
+  archive: import("../types.mjs").DurabilityPortableStateArchive,
+): Promise<import("../types.mjs").DurabilityStoredState>;
 
 export declare function createMemoryDurabilityStore(
   stateId: string,
@@ -29,4 +51,4 @@ export declare function createMemoryDurabilityStore(
 
 export declare function createSqliteDurabilityStore(
   options: import("../types.mjs").SqliteDurabilityStoreOptions,
-): import("../types.mjs").DurabilityStore;
+): import("../types.mjs").DurabilityPortableStore;

--- a/js/bindings/runtime/durability-store.d.mts
+++ b/js/bindings/runtime/durability-store.d.mts
@@ -38,6 +38,11 @@ export declare function durabilityRevision(
   value: string | bigint | number,
 ): import("../types.mjs").DurabilityRevision;
 
+/** Returns SHA-256 over the UTF-8 JSON tuple `[revision, payload]`. */
+export declare function durabilityStateDigest(
+  state: import("../types.mjs").DurabilityStoredState,
+): Promise<string>;
+
 /**
  * Atomically fences the source owner and exports one coherent JSON-safe state.
  * Do not resume the source provider after beginning a cutover.
@@ -56,6 +61,7 @@ export declare function importDurabilityState(
 /**
  * Fences the source once and returns a deterministic page of its exact `to` revision.
  * `from` is exclusive, `to` is inclusive, and `cursor` resumes the same payload export.
+ * Nonzero ranges must supply `fromDigest` so every page carries the exact lineage proof.
  */
 export declare function exportDurabilityStatePage(
   store: import("../types.mjs").DurabilityStore,
@@ -63,7 +69,7 @@ export declare function exportDurabilityStatePage(
   request: import("../types.mjs").DurabilityExportPageRequest,
 ): Promise<import("../types.mjs").DurabilityPortableStatePage>;
 
-/** Imports a complete contiguous page set iff the destination is still at `from`. */
+/** Imports a complete contiguous page set iff the destination still has the exact state at `from`. */
 export declare function importDurabilityStatePages(
   store: import("../types.mjs").DurabilityPortableStore,
   pages: Iterable<import("../types.mjs").DurabilityPortableStatePage>,

--- a/js/bindings/runtime/durability-store.mjs
+++ b/js/bindings/runtime/durability-store.mjs
@@ -1,6 +1,8 @@
 const MAX_REVISION = 18_446_744_073_709_551_615n;
 const MAX_REVISION_TEXT = String(MAX_REVISION);
 const PORTABLE_FORMAT = "nanocodex-durability-state-v1";
+const PORTABLE_EXPORT_OWNER = "nanocodex-portable-export";
+const PORTABLE_IMPORT_OWNER = "nanocodex-portable-import";
 
 export const sqliteDurabilitySchema = Object.freeze([
   `CREATE TABLE IF NOT EXISTS nanocodex_durable_owners (
@@ -32,7 +34,7 @@ export async function exportDurabilityState(store, stateId) {
   if (!store || typeof store.acquire !== "function") {
     throw new TypeError("durability export requires a state store");
   }
-  const ownerId = portableOwnerId("export");
+  const ownerId = PORTABLE_EXPORT_OWNER;
   const acquired = await store.acquire(stateId, { ownerId });
   exactObject(
     acquired,
@@ -137,7 +139,7 @@ export function createMemoryDurabilityStore(stateId, initial) {
         throw new DurabilityImportConflictError(selected);
       }
       owner = Object.freeze({
-        ownerId: portableOwnerId("import"),
+        ownerId: PORTABLE_IMPORT_OWNER,
         fence: "1",
       });
       state = next;
@@ -234,7 +236,6 @@ export function createSqliteDurabilityStore(options) {
     importState(stateId, imported) {
       requireId(stateId, "state");
       const state = copyState(imported);
-      const ownerId = portableOwnerId("import");
       return options.transaction((query) => mapMaybePromise(
         query(
           "SELECT owner_id, fence FROM nanocodex_durable_owners WHERE state_id = ?",
@@ -257,7 +258,7 @@ export function createSqliteDurabilityStore(options) {
               return mapMaybePromise(
                 query(
                   "INSERT INTO nanocodex_durable_owners (state_id, owner_id, fence) VALUES (?, ?, ?)",
-                  [stateId, ownerId, "1"],
+                  [stateId, PORTABLE_IMPORT_OWNER, "1"],
                 ),
                 () => state.revision === "0"
                   ? state
@@ -333,14 +334,6 @@ function requirePayload(value) {
     throw new TypeError("durability payload must be a string");
   }
   return value;
-}
-
-function portableOwnerId(kind) {
-  const randomUUID = globalThis.crypto?.randomUUID;
-  if (typeof randomUUID !== "function") {
-    throw new Error("durability portability requires crypto.randomUUID()");
-  }
-  return `nanocodex-${kind}-${randomUUID.call(globalThis.crypto)}`;
 }
 
 function exactRows(rows, maximum, label) {

--- a/js/bindings/runtime/durability-store.mjs
+++ b/js/bindings/runtime/durability-store.mjs
@@ -132,8 +132,6 @@ export function createSqliteDurabilityStore(options) {
       requireId(stateId, "state");
       const ownerId = requireId(request?.ownerId, "owner");
       const fence = durabilityFence(request?.fence);
-      const expectedRevision = durabilityRevision(request?.expectedRevision);
-      const payload = requirePayload(request?.payload);
       return options.transaction((query) => mapMaybePromise(
         query(
           "SELECT owner_id, fence FROM nanocodex_durable_owners WHERE state_id = ?",
@@ -149,6 +147,7 @@ export function createSqliteDurabilityStore(options) {
           ) {
             return { status: "fenced" };
           }
+          const expectedRevision = durabilityRevision(request?.expectedRevision);
           return mapMaybePromise(loadSqliteState(query, stateId), (state) => {
             if (state.revision !== expectedRevision) {
               return { status: "conflict", actualRevision: state.revision };
@@ -156,6 +155,7 @@ export function createSqliteDurabilityStore(options) {
             if (expectedRevision === MAX_REVISION_TEXT) {
               return { status: "not_committed", message: "SQLite durability revision overflow" };
             }
+            const payload = requirePayload(request?.payload);
             const revision = durabilityRevision(BigInt(expectedRevision) + 1n);
             return mapMaybePromise(
               query(

--- a/js/bindings/runtime/durability-store.mjs
+++ b/js/bindings/runtime/durability-store.mjs
@@ -1,8 +1,11 @@
 const MAX_REVISION = 18_446_744_073_709_551_615n;
 const MAX_REVISION_TEXT = String(MAX_REVISION);
 const PORTABLE_FORMAT = "nanocodex-durability-state-v1";
+const PORTABLE_PAGE_FORMAT = "nanocodex-durability-state-page-v1";
 const PORTABLE_EXPORT_OWNER = "nanocodex-portable-export";
 const PORTABLE_IMPORT_OWNER = "nanocodex-portable-import";
+const DEFAULT_EXPORT_PAGE_SIZE = 256 * 1024;
+const MAX_EXPORT_PAGE_SIZE = 1024 * 1024;
 
 export const sqliteDurabilitySchema = Object.freeze([
   `CREATE TABLE IF NOT EXISTS nanocodex_durable_owners (
@@ -22,10 +25,120 @@ export function durabilityRevision(value) {
 }
 
 export class DurabilityImportConflictError extends Error {
-  constructor(stateId) {
-    super(`durability state ${JSON.stringify(stateId)} already exists at the import destination`);
+  constructor(stateId, expectedRevision, actualRevision) {
+    super(expectedRevision === undefined
+      ? `durability state ${JSON.stringify(stateId)} already exists at the import destination`
+      : `durability import expected destination revision ${expectedRevision} for state ${JSON.stringify(stateId)}, but found ${actualRevision}`);
     this.name = "DurabilityImportConflictError";
+    this.expectedRevision = expectedRevision;
+    this.actualRevision = actualRevision;
   }
+}
+
+/** Exports one deterministic page of the exact total state at `to`. */
+export async function exportDurabilityStatePage(store, stateId, request) {
+  requireId(stateId, "state");
+  if (!store || typeof store.acquire !== "function") {
+    throw new TypeError("durability export requires a state store");
+  }
+  const from = durabilityRevision(request?.from);
+  const requestedTo = request?.to === undefined ? undefined : durabilityRevision(request.to);
+  const offset = decodeExportCursor(request?.cursor);
+  const limit = exportPageSize(request?.limit);
+  const acquired = await store.acquire(stateId, { ownerId: PORTABLE_EXPORT_OWNER });
+  exactObject(acquired, ["ownerId", "fence", "revision", "payload"], "durability export acquisition");
+  if (acquired.ownerId !== PORTABLE_EXPORT_OWNER) {
+    throw new TypeError("durability export acquisition returned a different owner ID");
+  }
+  durabilityFence(acquired.fence);
+  const state = copyState({ revision: acquired.revision, payload: acquired.payload });
+  const to = state.revision;
+  if (requestedTo !== undefined && requestedTo !== to) {
+    throw new DurabilityImportConflictError(stateId, requestedTo, to);
+  }
+  if (BigInt(from) >= BigInt(to)) {
+    throw new RangeError("durability export from revision must be less than to revision");
+  }
+  const payload = state.payload ?? "";
+  if (offset > payload.length) throw new TypeError("durability export cursor is out of range");
+  let end = Math.min(offset + limit, payload.length);
+  if (end < payload.length && end > offset && isHighSurrogate(payload.charCodeAt(end - 1))) end -= 1;
+  const nextCursor = end < payload.length ? encodeExportCursor(end) : null;
+  return Object.freeze({
+    format: PORTABLE_PAGE_FORMAT,
+    stateId,
+    from,
+    to,
+    cursor: encodeExportCursor(offset),
+    nextCursor,
+    payloadLength: payload.length,
+    payload: payload.slice(offset, end),
+  });
+}
+
+/** Imports contiguous cursor pages with a CAS guard on the destination's `from` revision. */
+export async function importDurabilityStatePages(store, pages) {
+  if (!store || typeof store.importState !== "function") {
+    throw new TypeError("durability import requires a portable state store");
+  }
+  if (!pages || typeof pages[Symbol.iterator] !== "function") {
+    throw new TypeError("durability import pages must be iterable");
+  }
+  let first;
+  let cursor = encodeExportCursor(0);
+  let payload = "";
+  let complete = false;
+  for (const page of pages) {
+    exactObject(
+      page,
+      ["format", "stateId", "from", "to", "cursor", "nextCursor", "payloadLength", "payload"],
+      "durability export page",
+    );
+    if (page.format !== PORTABLE_PAGE_FORMAT || typeof page.payload !== "string") {
+      throw new TypeError("unsupported durability export page");
+    }
+    if (!Number.isSafeInteger(page.payloadLength) || page.payloadLength < 0) {
+      throw new TypeError("durability export page payload length is invalid");
+    }
+    const identity = {
+      stateId: requireId(page.stateId, "exported state"),
+      from: durabilityRevision(page.from),
+      to: durabilityRevision(page.to),
+      payloadLength: page.payloadLength,
+    };
+    first ??= identity;
+    if (identity.stateId !== first.stateId || identity.from !== first.from
+      || identity.to !== first.to || identity.payloadLength !== first.payloadLength) {
+      throw new TypeError("durability export pages describe different revision ranges");
+    }
+    const offset = decodeExportCursor(page.cursor);
+    if (complete || page.cursor !== cursor || offset !== payload.length) {
+      throw new TypeError("durability export pages are missing, duplicated, or out of order");
+    }
+    payload += page.payload;
+    if (payload.length > first.payloadLength) {
+      throw new TypeError("durability export pages exceed their declared payload length");
+    }
+    if (page.nextCursor === null) {
+      if (payload.length !== first.payloadLength) {
+        throw new TypeError("durability export pages are incomplete");
+      }
+      complete = true;
+    }
+    else {
+      if (page.nextCursor !== encodeExportCursor(payload.length)) {
+        throw new TypeError("durability export page cursor does not match its payload");
+      }
+      cursor = page.nextCursor;
+    }
+  }
+  if (!first || !complete) throw new TypeError("durability export pages are incomplete");
+  if (BigInt(first.from) >= BigInt(first.to)) {
+    throw new RangeError("durability import from revision must be less than to revision");
+  }
+  const state = copyState({ revision: first.to, payload: first.to === "0" ? null : payload });
+  const imported = await store.importState(first.stateId, state, { expectedRevision: first.from });
+  return copyState(imported);
 }
 
 /** Fences a source store and exports one coherent provider-neutral state archive. */
@@ -105,6 +218,7 @@ export function createMemoryDurabilityStore(stateId, initial) {
     acquire(selected, request) {
       select(selected);
       const ownerId = requireId(request?.ownerId, "owner");
+      if (owner?.ownerId === ownerId) return acquiredState(owner, state);
       const previousFence = owner?.fence ?? "0";
       if (previousFence === MAX_REVISION_TEXT) {
         throw new RangeError("in-memory durability fence overflow");
@@ -122,6 +236,11 @@ export function createMemoryDurabilityStore(stateId, initial) {
       if (ownerId !== owner?.ownerId || fence !== owner.fence) return { status: "fenced" };
       const expectedRevision = durabilityRevision(request?.expectedRevision);
       if (expectedRevision !== state.revision) {
+        if (state.revision === nextRevision(expectedRevision)
+          && typeof request?.payload === "string"
+          && state.payload === request.payload) {
+          return { status: "replaced", revision: state.revision };
+        }
         return { status: "conflict", actualRevision: state.revision };
       }
       if (expectedRevision === MAX_REVISION_TEXT) {
@@ -132,15 +251,18 @@ export function createMemoryDurabilityStore(stateId, initial) {
       state = Object.freeze({ revision, payload });
       return { status: "replaced", revision };
     },
-    importState(selected, imported) {
+    importState(selected, imported, options) {
       select(selected);
       const next = copyState(imported);
-      if (owner !== undefined || state.revision !== "0") {
-        throw new DurabilityImportConflictError(selected);
+      const expectedRevision = options?.expectedRevision === undefined
+        ? undefined
+        : durabilityRevision(options.expectedRevision);
+      if (expectedRevision === undefined ? owner !== undefined || state.revision !== "0" : state.revision !== expectedRevision) {
+        throw new DurabilityImportConflictError(selected, expectedRevision, state.revision);
       }
       owner = Object.freeze({
         ownerId: PORTABLE_IMPORT_OWNER,
-        fence: "1",
+        fence: durabilityFence(BigInt(owner?.fence ?? "0") + 1n),
       });
       state = next;
       return state;
@@ -171,6 +293,12 @@ export function createSqliteDurabilityStore(options) {
         (owners) => {
           exactRows(owners, 1, "SQLite durability owner");
           if (owners.length === 1) exactObject(owners[0], ["owner_id", "fence"], "SQLite durability owner");
+          if (owners[0]?.owner_id === ownerId) {
+            return mapMaybePromise(
+              loadSqliteState(query, stateId),
+              (state) => acquiredState({ ownerId, fence: durabilityFence(owners[0].fence) }, state),
+            );
+          }
           const previousFence = durabilityFence(owners[0]?.fence ?? "0");
           if (previousFence === MAX_REVISION_TEXT) {
             throw new RangeError("SQLite durability fence overflow");
@@ -213,6 +341,11 @@ export function createSqliteDurabilityStore(options) {
           const expectedRevision = durabilityRevision(request?.expectedRevision);
           return mapMaybePromise(loadSqliteState(query, stateId), (state) => {
             if (state.revision !== expectedRevision) {
+              if (state.revision === nextRevision(expectedRevision)
+                && typeof request?.payload === "string"
+                && state.payload === request.payload) {
+                return { status: "replaced", revision: state.revision };
+              }
               return { status: "conflict", actualRevision: state.revision };
             }
             if (expectedRevision === MAX_REVISION_TEXT) {
@@ -233,9 +366,12 @@ export function createSqliteDurabilityStore(options) {
         },
       ));
     },
-    importState(stateId, imported) {
+    importState(stateId, imported, importOptions) {
       requireId(stateId, "state");
       const state = copyState(imported);
+      const expectedRevision = importOptions?.expectedRevision === undefined
+        ? undefined
+        : durabilityRevision(importOptions.expectedRevision);
       return options.transaction((query) => mapMaybePromise(
         query(
           "SELECT owner_id, fence FROM nanocodex_durable_owners WHERE state_id = ?",
@@ -246,7 +382,6 @@ export function createSqliteDurabilityStore(options) {
           if (owners.length === 1) {
             exactObject(owners[0], ["owner_id", "fence"], "SQLite durability owner");
           }
-          if (owners.length !== 0) throw new DurabilityImportConflictError(stateId);
           return mapMaybePromise(
             query(
               "SELECT revision, payload FROM nanocodex_durable_states WHERE state_id = ?",
@@ -254,17 +389,31 @@ export function createSqliteDurabilityStore(options) {
             ),
             (states) => {
               exactRows(states, 1, "SQLite durability state");
-              if (states.length !== 0) throw new DurabilityImportConflictError(stateId);
+              const current = states.length === 0
+                ? Object.freeze({ revision: "0", payload: null })
+                : copyState({ revision: states[0].revision, payload: states[0].payload });
+              if (expectedRevision === undefined
+                ? owners.length !== 0 || states.length !== 0
+                : current.revision !== expectedRevision) {
+                throw new DurabilityImportConflictError(stateId, expectedRevision, current.revision);
+              }
+              const previousFence = durabilityFence(owners[0]?.fence ?? "0");
+              if (previousFence === MAX_REVISION_TEXT) throw new RangeError("SQLite durability fence overflow");
+              const fence = durabilityFence(BigInt(previousFence) + 1n);
               return mapMaybePromise(
                 query(
-                  "INSERT INTO nanocodex_durable_owners (state_id, owner_id, fence) VALUES (?, ?, ?)",
-                  [stateId, PORTABLE_IMPORT_OWNER, "1"],
+                  `INSERT INTO nanocodex_durable_owners (state_id, owner_id, fence) VALUES (?, ?, ?)
+                   ON CONFLICT (state_id) DO UPDATE
+                   SET owner_id = excluded.owner_id, fence = excluded.fence`,
+                  [stateId, PORTABLE_IMPORT_OWNER, fence],
                 ),
                 () => state.revision === "0"
                   ? state
                   : mapMaybePromise(
                     query(
-                      "INSERT INTO nanocodex_durable_states (state_id, revision, payload) VALUES (?, ?, ?)",
+                      `INSERT INTO nanocodex_durable_states (state_id, revision, payload) VALUES (?, ?, ?)
+                       ON CONFLICT (state_id) DO UPDATE
+                       SET revision = excluded.revision, payload = excluded.payload`,
                       [stateId, state.revision, state.payload],
                     ),
                     () => state,
@@ -276,6 +425,36 @@ export function createSqliteDurabilityStore(options) {
       ));
     },
   });
+}
+
+function nextRevision(revision) {
+  return revision === MAX_REVISION_TEXT ? undefined : durabilityRevision(BigInt(revision) + 1n);
+}
+
+function exportPageSize(value) {
+  if (value === undefined) return DEFAULT_EXPORT_PAGE_SIZE;
+  if (!Number.isSafeInteger(value) || value < 1 || value > MAX_EXPORT_PAGE_SIZE) {
+    throw new TypeError(`durability export page limit must be an integer from 1 to ${MAX_EXPORT_PAGE_SIZE}`);
+  }
+  return value;
+}
+
+function encodeExportCursor(offset) {
+  return `v1:${offset}`;
+}
+
+function decodeExportCursor(value) {
+  if (value === undefined) return 0;
+  if (typeof value !== "string" || !/^v1:(0|[1-9][0-9]*)$/.test(value)) {
+    throw new TypeError("durability export cursor is invalid");
+  }
+  const offset = Number(value.slice(3));
+  if (!Number.isSafeInteger(offset)) throw new TypeError("durability export cursor is invalid");
+  return offset;
+}
+
+function isHighSurrogate(value) {
+  return value >= 0xd800 && value <= 0xdbff;
 }
 
 function loadSqliteState(query, stateId) {

--- a/js/bindings/runtime/durability-store.mjs
+++ b/js/bindings/runtime/durability-store.mjs
@@ -2,21 +2,15 @@ const MAX_REVISION = 18_446_744_073_709_551_615n;
 const MAX_REVISION_TEXT = String(MAX_REVISION);
 
 export const sqliteDurabilitySchema = Object.freeze([
-  `CREATE TABLE IF NOT EXISTS nanocodex_journal_owners (
-     journal_id TEXT PRIMARY KEY,
+  `CREATE TABLE IF NOT EXISTS nanocodex_durable_owners (
+     state_id TEXT PRIMARY KEY,
      owner_id TEXT NOT NULL,
      fence TEXT NOT NULL
    )`,
-  `CREATE TABLE IF NOT EXISTS nanocodex_journals (
-     journal_id TEXT PRIMARY KEY,
-     revision TEXT NOT NULL
-   )`,
-  `CREATE TABLE IF NOT EXISTS nanocodex_journal_batches (
-     journal_id TEXT NOT NULL,
+  `CREATE TABLE IF NOT EXISTS nanocodex_durable_states (
+     state_id TEXT PRIMARY KEY,
      revision TEXT NOT NULL,
-     payload TEXT NOT NULL,
-     PRIMARY KEY (journal_id, revision),
-     FOREIGN KEY (journal_id) REFERENCES nanocodex_journals(journal_id)
+     payload TEXT NOT NULL
    )`,
 ]);
 
@@ -38,91 +32,58 @@ function durabilityUint64(value, field) {
   if (typeof value !== "string" && typeof value !== "bigint" && typeof value !== "number") {
     throw new TypeError(`durability ${field} must be an unsigned 64-bit decimal string`);
   }
-  const revision = String(value);
-  if (!/^(0|[1-9][0-9]*)$/.test(revision) || BigInt(revision) > MAX_REVISION) {
+  const encoded = String(value);
+  if (!/^(0|[1-9][0-9]*)$/.test(encoded) || BigInt(encoded) > MAX_REVISION) {
     throw new TypeError(`durability ${field} must be an unsigned 64-bit decimal string`);
   }
-  return revision;
+  return encoded;
 }
 
-export function createMemoryDurabilityStore(journalId, initial) {
-  if (typeof journalId !== "string" || !journalId.trim()) {
-    throw new TypeError("durability journal ID must be a non-empty string");
-  }
-  let journal = copyJournal(initial ?? { revision: durabilityRevision(0n), batches: [] });
+export function createMemoryDurabilityStore(stateId, initial) {
+  requireId(stateId, "state");
+  let state = copyState(initial ?? { revision: "0", payload: null });
   let owner;
   const select = (selected) => {
-    if (selected !== journalId) throw new Error(`unknown durability journal: ${selected}`);
+    if (selected !== stateId) throw new Error(`unknown durability state: ${selected}`);
   };
   return Object.freeze({
-    journalId,
+    stateId,
     load(selected) {
       select(selected);
-      return journal;
+      return state;
     },
     acquire(selected, request) {
       select(selected);
-      const ownerId = durabilityOwnerId(request?.ownerId);
-      const previousFence = owner?.fence ?? durabilityFence(0n);
+      const ownerId = requireId(request?.ownerId, "owner");
+      const previousFence = owner?.fence ?? "0";
       if (previousFence === MAX_REVISION_TEXT) {
         throw new RangeError("in-memory durability fence overflow");
       }
-      const fence = durabilityFence(BigInt(previousFence) + 1n);
-      owner = Object.freeze({ ownerId, fence });
-      return acquiredJournal(owner, journal);
-    },
-    append(selected, request) {
-      select(selected);
-      const ownerId = durabilityOwnerId(request?.ownerId);
-      const fence = durabilityFence(request?.fence);
-      if (ownerId !== owner?.ownerId || fence !== owner.fence) {
-        return { status: "fenced" };
-      }
-      const expectedRevision = durabilityRevision(request.expectedRevision);
-      if (expectedRevision !== journal.revision) {
-        return { status: "conflict", actualRevision: journal.revision };
-      }
-      if (journal.revision === MAX_REVISION_TEXT) {
-        return {
-          status: "not_committed",
-          message: "in-memory durability revision overflow",
-        };
-      }
-      const revision = durabilityRevision(BigInt(journal.revision) + 1n);
-      journal = Object.freeze({
-        revision,
-        batches: Object.freeze([...journal.batches, Object.freeze({
-          revision,
-          payload: request.payload,
-        })]),
+      owner = Object.freeze({
+        ownerId,
+        fence: durabilityFence(BigInt(previousFence) + 1n),
       });
-      return { status: "appended", revision };
+      return acquiredState(owner, state);
     },
-    compact(selected, request) {
+    replace(selected, request) {
       select(selected);
-      const ownerId = durabilityOwnerId(request?.ownerId);
+      const ownerId = requireId(request?.ownerId, "owner");
       const fence = durabilityFence(request?.fence);
-      if (ownerId !== owner?.ownerId || fence !== owner.fence) {
-        return { status: "fenced" };
+      if (ownerId !== owner?.ownerId || fence !== owner.fence) return { status: "fenced" };
+      const expectedRevision = durabilityRevision(request?.expectedRevision);
+      if (expectedRevision !== state.revision) {
+        return { status: "conflict", actualRevision: state.revision };
       }
-      const expectedRevision = durabilityRevision(request.expectedRevision);
-      if (expectedRevision !== journal.revision) {
-        return { status: "conflict", actualRevision: journal.revision };
+      if (expectedRevision === MAX_REVISION_TEXT) {
+        return { status: "not_committed", message: "in-memory durability revision overflow" };
       }
-      if (expectedRevision === "0") {
-        return { status: "not_committed", message: "cannot compact an empty journal" };
-      }
-      journal = Object.freeze({
-        revision: expectedRevision,
-        batches: Object.freeze([Object.freeze({
-          revision: expectedRevision,
-          payload: request.payload,
-        })]),
-      });
-      return { status: "compacted", revision: expectedRevision };
+      const payload = requirePayload(request?.payload);
+      const revision = durabilityRevision(BigInt(expectedRevision) + 1n);
+      state = Object.freeze({ revision, payload });
+      return { status: "replaced", revision };
     },
     snapshot() {
-      return journal;
+      return state;
     },
   });
 }
@@ -132,17 +93,21 @@ export function createSqliteDurabilityStore(options) {
     throw new TypeError("SQLite durability requires a transaction function");
   }
   return Object.freeze({
-    load(journalId) {
-      return options.transaction((query) => loadSqliteJournal(query, journalId));
+    load(stateId) {
+      requireId(stateId, "state");
+      return options.transaction((query) => loadSqliteState(query, stateId));
     },
-    acquire(journalId, request) {
-      const ownerId = durabilityOwnerId(request?.ownerId);
+    acquire(stateId, request) {
+      requireId(stateId, "state");
+      const ownerId = requireId(request?.ownerId, "owner");
       return options.transaction((query) => mapMaybePromise(
         query(
-          "SELECT owner_id, fence FROM nanocodex_journal_owners WHERE journal_id = ?",
-          [journalId],
+          "SELECT owner_id, fence FROM nanocodex_durable_owners WHERE state_id = ?",
+          [stateId],
         ),
         (owners) => {
+          exactRows(owners, 1, "SQLite durability owner");
+          if (owners.length === 1) exactObject(owners[0], ["owner_id", "fence"], "SQLite durability owner");
           const previousFence = durabilityFence(owners[0]?.fence ?? "0");
           if (previousFence === MAX_REVISION_TEXT) {
             throw new RangeError("SQLite durability fence overflow");
@@ -150,28 +115,33 @@ export function createSqliteDurabilityStore(options) {
           const fence = durabilityFence(BigInt(previousFence) + 1n);
           return mapMaybePromise(
             query(
-              `INSERT INTO nanocodex_journal_owners (journal_id, owner_id, fence) VALUES (?, ?, ?)
-               ON CONFLICT (journal_id) DO UPDATE SET owner_id = excluded.owner_id, fence = excluded.fence`,
-              [journalId, ownerId, fence],
+              `INSERT INTO nanocodex_durable_owners (state_id, owner_id, fence) VALUES (?, ?, ?)
+               ON CONFLICT (state_id) DO UPDATE
+               SET owner_id = excluded.owner_id, fence = excluded.fence`,
+              [stateId, ownerId, fence],
             ),
             () => mapMaybePromise(
-              loadSqliteJournal(query, journalId),
-              (journal) => acquiredJournal({ ownerId, fence }, journal),
+              loadSqliteState(query, stateId),
+              (state) => acquiredState({ ownerId, fence }, state),
             ),
           );
         },
       ));
     },
-    append(journalId, request) {
-      const ownerId = durabilityOwnerId(request?.ownerId);
+    replace(stateId, request) {
+      requireId(stateId, "state");
+      const ownerId = requireId(request?.ownerId, "owner");
       const fence = durabilityFence(request?.fence);
-      const expectedRevision = durabilityRevision(request.expectedRevision);
+      const expectedRevision = durabilityRevision(request?.expectedRevision);
+      const payload = requirePayload(request?.payload);
       return options.transaction((query) => mapMaybePromise(
         query(
-          "SELECT owner_id, fence FROM nanocodex_journal_owners WHERE journal_id = ?",
-          [journalId],
+          "SELECT owner_id, fence FROM nanocodex_durable_owners WHERE state_id = ?",
+          [stateId],
         ),
         (owners) => {
+          exactRows(owners, 1, "SQLite durability owner");
+          if (owners.length === 1) exactObject(owners[0], ["owner_id", "fence"], "SQLite durability owner");
           const storedOwner = owners[0];
           if (
             storedOwner?.owner_id !== ownerId
@@ -179,116 +149,42 @@ export function createSqliteDurabilityStore(options) {
           ) {
             return { status: "fenced" };
           }
-          return mapMaybePromise(
-            query(
-              "SELECT revision FROM nanocodex_journals WHERE journal_id = ?",
-              [journalId],
-            ),
-            (journals) => {
-              const actualRevision = durabilityRevision(journals[0]?.revision ?? "0");
-              if (actualRevision !== expectedRevision) {
-                return { status: "conflict", actualRevision };
-              }
-              if (expectedRevision === MAX_REVISION_TEXT) {
-                return {
-                  status: "not_committed",
-                  message: "SQLite durability revision overflow",
-                };
-              }
-              const revision = durabilityRevision(BigInt(expectedRevision) + 1n);
-              return mapMaybePromise(
-                query(
-                  `INSERT INTO nanocodex_journals (journal_id, revision) VALUES (?, ?)
-                   ON CONFLICT (journal_id) DO UPDATE SET revision = excluded.revision`,
-                  [journalId, revision],
-                ),
-                () => mapMaybePromise(
-                  query(
-                    "INSERT INTO nanocodex_journal_batches (journal_id, revision, payload) VALUES (?, ?, ?)",
-                    [journalId, revision, request.payload],
-                  ),
-                  () => ({ status: "appended", revision }),
-                ),
-              );
-            },
-          );
-        },
-      ));
-    },
-    compact(journalId, request) {
-      const ownerId = durabilityOwnerId(request?.ownerId);
-      const fence = durabilityFence(request?.fence);
-      const expectedRevision = durabilityRevision(request.expectedRevision);
-      return options.transaction((query) => mapMaybePromise(
-        query(
-          "SELECT owner_id, fence FROM nanocodex_journal_owners WHERE journal_id = ?",
-          [journalId],
-        ),
-        (owners) => {
-          const storedOwner = owners[0];
-          if (
-            storedOwner?.owner_id !== ownerId
-            || durabilityFence(storedOwner?.fence ?? "0") !== fence
-          ) {
-            return { status: "fenced" };
-          }
-          return mapMaybePromise(
-            query(
-              "SELECT revision FROM nanocodex_journals WHERE journal_id = ?",
-              [journalId],
-            ),
-            (journals) => {
-              const actualRevision = durabilityRevision(journals[0]?.revision ?? "0");
-              if (actualRevision !== expectedRevision) {
-                return { status: "conflict", actualRevision };
-              }
-              if (expectedRevision === "0") {
-                return {
-                  status: "not_committed",
-                  message: "cannot compact an empty SQLite durability journal",
-                };
-              }
-              return mapMaybePromise(
-                query(
-                  "DELETE FROM nanocodex_journal_batches WHERE journal_id = ?",
-                  [journalId],
-                ),
-                () => mapMaybePromise(
-                  query(
-                    "INSERT INTO nanocodex_journal_batches (journal_id, revision, payload) VALUES (?, ?, ?)",
-                    [journalId, expectedRevision, request.payload],
-                  ),
-                  () => ({ status: "compacted", revision: expectedRevision }),
-                ),
-              );
-            },
-          );
+          return mapMaybePromise(loadSqliteState(query, stateId), (state) => {
+            if (state.revision !== expectedRevision) {
+              return { status: "conflict", actualRevision: state.revision };
+            }
+            if (expectedRevision === MAX_REVISION_TEXT) {
+              return { status: "not_committed", message: "SQLite durability revision overflow" };
+            }
+            const revision = durabilityRevision(BigInt(expectedRevision) + 1n);
+            return mapMaybePromise(
+              query(
+                `INSERT INTO nanocodex_durable_states (state_id, revision, payload) VALUES (?, ?, ?)
+                 ON CONFLICT (state_id) DO UPDATE
+                 SET revision = excluded.revision, payload = excluded.payload`,
+                [stateId, revision, payload],
+              ),
+              () => ({ status: "replaced", revision }),
+            );
+          });
         },
       ));
     },
   });
 }
 
-function loadSqliteJournal(query, journalId) {
+function loadSqliteState(query, stateId) {
   return mapMaybePromise(
     query(
-      "SELECT revision FROM nanocodex_journals WHERE journal_id = ?",
-      [journalId],
+      "SELECT revision, payload FROM nanocodex_durable_states WHERE state_id = ?",
+      [stateId],
     ),
-    (journals) => mapMaybePromise(
-      query(
-        `SELECT revision, payload FROM nanocodex_journal_batches
-         WHERE journal_id = ? ORDER BY length(revision), revision`,
-        [journalId],
-      ),
-      (batches) => ({
-        revision: durabilityRevision(journals[0]?.revision ?? "0"),
-        batches: batches.map((batch) => ({
-          revision: durabilityRevision(batch.revision),
-          payload: batch.payload,
-        })),
-      }),
-    ),
+    (rows) => {
+      exactRows(rows, 1, "SQLite durability state");
+      if (rows.length === 0) return Object.freeze({ revision: "0", payload: null });
+      exactObject(rows[0], ["revision", "payload"], "SQLite durability state");
+      return copyState({ revision: rows[0].revision, payload: rows[0].payload });
+    },
   );
 }
 
@@ -296,28 +192,58 @@ function mapMaybePromise(value, mapper) {
   return value && typeof value.then === "function" ? value.then(mapper) : mapper(value);
 }
 
-function copyJournal(journal) {
-  return Object.freeze({
-    revision: durabilityRevision(journal.revision),
-    batches: Object.freeze(journal.batches.map((batch) => Object.freeze({
-      revision: durabilityRevision(batch.revision),
-      payload: batch.payload,
-    }))),
-  });
+function copyState(state) {
+  if (!state || typeof state !== "object" || Array.isArray(state)) {
+    throw new TypeError("durability state must be an object");
+  }
+  const keys = Object.keys(state).sort();
+  if (keys.length !== 2 || keys[0] !== "payload" || keys[1] !== "revision") {
+    throw new TypeError("durability state must contain exactly payload and revision");
+  }
+  const revision = durabilityRevision(state.revision);
+  const payload = state.payload === null ? null : requirePayload(state.payload);
+  if ((revision === "0") !== (payload === null)) {
+    throw new TypeError("durability state payload must be null exactly at revision zero");
+  }
+  return Object.freeze({ revision, payload });
 }
 
-function acquiredJournal(owner, journal) {
+function acquiredState(owner, state) {
   return Object.freeze({
     ownerId: owner.ownerId,
     fence: owner.fence,
-    revision: journal.revision,
-    batches: journal.batches,
+    revision: state.revision,
+    payload: state.payload,
   });
 }
 
-function durabilityOwnerId(value) {
+function requireId(value, kind) {
   if (typeof value !== "string" || !value.trim()) {
-    throw new TypeError("durability owner ID must be a non-empty string");
+    throw new TypeError(`durability ${kind} ID must be a non-empty string`);
   }
   return value;
+}
+
+function requirePayload(value) {
+  if (typeof value !== "string") {
+    throw new TypeError("durability payload must be a string");
+  }
+  return value;
+}
+
+function exactRows(rows, maximum, label) {
+  if (!Array.isArray(rows) || rows.length > maximum) {
+    throw new TypeError(`${label} query returned an invalid row set`);
+  }
+}
+
+function exactObject(value, expected, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${label} row must be an object`);
+  }
+  const actual = Object.keys(value).sort();
+  const required = [...expected].sort();
+  if (actual.length !== required.length || actual.some((key, index) => key !== required[index])) {
+    throw new TypeError(`${label} row has an invalid shape`);
+  }
 }

--- a/js/bindings/runtime/durability-store.mjs
+++ b/js/bindings/runtime/durability-store.mjs
@@ -24,11 +24,27 @@ export function durabilityRevision(value) {
   return durabilityUint64(value, "revision");
 }
 
+/** Returns SHA-256 over the UTF-8 JSON tuple `[revision, payload]`. */
+export async function durabilityStateDigest(state) {
+  const exact = copyState(state);
+  const encoded = new TextEncoder().encode(JSON.stringify([exact.revision, exact.payload]));
+  const digest = await globalThis.crypto?.subtle?.digest("SHA-256", encoded);
+  if (digest === undefined) {
+    throw new Error("durability range portability requires Web Crypto SHA-256 support");
+  }
+  return `sha256:${[...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("")}`;
+}
+
 export class DurabilityImportConflictError extends Error {
   constructor(stateId, expectedRevision, actualRevision) {
+    const id = JSON.stringify(stateId);
     super(expectedRevision === undefined
-      ? `durability state ${JSON.stringify(stateId)} already exists at the import destination`
-      : `durability import expected destination revision ${expectedRevision} for state ${JSON.stringify(stateId)}, but found ${actualRevision}`);
+      ? `durability state ${id} already exists at the import destination`
+      : expectedRevision === actualRevision
+        ? `durability import expected the exact destination state at revision ${expectedRevision} for ${id}, but found a different payload lineage`
+        : `durability import expected destination revision ${expectedRevision} for state ${id}, but found ${actualRevision}`);
     this.name = "DurabilityImportConflictError";
     this.expectedRevision = expectedRevision;
     this.actualRevision = actualRevision;
@@ -42,6 +58,16 @@ export async function exportDurabilityStatePage(store, stateId, request) {
     throw new TypeError("durability export requires a state store");
   }
   const from = durabilityRevision(request?.from);
+  let fromDigest;
+  if (request?.fromDigest === undefined) {
+    if (from !== "0") {
+      throw new TypeError("nonzero durability export ranges require a from-state digest");
+    }
+    fromDigest = await durabilityStateDigest({ revision: "0", payload: null });
+  }
+  else {
+    fromDigest = durabilityStateDigestText(request.fromDigest);
+  }
   const requestedTo = request?.to === undefined ? undefined : durabilityRevision(request.to);
   const offset = decodeExportCursor(request?.cursor);
   const limit = exportPageSize(request?.limit);
@@ -68,6 +94,7 @@ export async function exportDurabilityStatePage(store, stateId, request) {
     format: PORTABLE_PAGE_FORMAT,
     stateId,
     from,
+    fromDigest,
     to,
     cursor: encodeExportCursor(offset),
     nextCursor,
@@ -91,7 +118,10 @@ export async function importDurabilityStatePages(store, pages) {
   for (const page of pages) {
     exactObject(
       page,
-      ["format", "stateId", "from", "to", "cursor", "nextCursor", "payloadLength", "payload"],
+      [
+        "format", "stateId", "from", "fromDigest", "to", "cursor", "nextCursor",
+        "payloadLength", "payload",
+      ],
       "durability export page",
     );
     if (page.format !== PORTABLE_PAGE_FORMAT || typeof page.payload !== "string") {
@@ -103,11 +133,13 @@ export async function importDurabilityStatePages(store, pages) {
     const identity = {
       stateId: requireId(page.stateId, "exported state"),
       from: durabilityRevision(page.from),
+      fromDigest: durabilityStateDigestText(page.fromDigest),
       to: durabilityRevision(page.to),
       payloadLength: page.payloadLength,
     };
     first ??= identity;
     if (identity.stateId !== first.stateId || identity.from !== first.from
+      || identity.fromDigest !== first.fromDigest
       || identity.to !== first.to || identity.payloadLength !== first.payloadLength) {
       throw new TypeError("durability export pages describe different revision ranges");
     }
@@ -137,7 +169,15 @@ export async function importDurabilityStatePages(store, pages) {
     throw new RangeError("durability import from revision must be less than to revision");
   }
   const state = copyState({ revision: first.to, payload: first.to === "0" ? null : payload });
-  const imported = await store.importState(first.stateId, state, { expectedRevision: first.from });
+  const current = copyState(await store.load(first.stateId));
+  const currentDigest = await durabilityStateDigest(current);
+  if (current.revision !== first.from || currentDigest !== first.fromDigest) {
+    throw new DurabilityImportConflictError(first.stateId, first.from, current.revision);
+  }
+  const imported = await store.importState(first.stateId, state, {
+    expectedRevision: first.from,
+    expectedPayload: current.payload,
+  });
   return copyState(imported);
 }
 
@@ -257,7 +297,11 @@ export function createMemoryDurabilityStore(stateId, initial) {
       const expectedRevision = options?.expectedRevision === undefined
         ? undefined
         : durabilityRevision(options.expectedRevision);
-      if (expectedRevision === undefined ? owner !== undefined || state.revision !== "0" : state.revision !== expectedRevision) {
+      const expectedPayload = expectedImportPayload(options, expectedRevision);
+      if (expectedRevision === undefined
+        ? owner !== undefined || state.revision !== "0"
+        : state.revision !== expectedRevision
+          || expectedPayload.present && state.payload !== expectedPayload.value) {
         throw new DurabilityImportConflictError(selected, expectedRevision, state.revision);
       }
       owner = Object.freeze({
@@ -372,6 +416,7 @@ export function createSqliteDurabilityStore(options) {
       const expectedRevision = importOptions?.expectedRevision === undefined
         ? undefined
         : durabilityRevision(importOptions.expectedRevision);
+      const expectedPayload = expectedImportPayload(importOptions, expectedRevision);
       return options.transaction((query) => mapMaybePromise(
         query(
           "SELECT owner_id, fence FROM nanocodex_durable_owners WHERE state_id = ?",
@@ -394,7 +439,8 @@ export function createSqliteDurabilityStore(options) {
                 : copyState({ revision: states[0].revision, payload: states[0].payload });
               if (expectedRevision === undefined
                 ? owners.length !== 0 || states.length !== 0
-                : current.revision !== expectedRevision) {
+                : current.revision !== expectedRevision
+                  || expectedPayload.present && current.payload !== expectedPayload.value) {
                 throw new DurabilityImportConflictError(stateId, expectedRevision, current.revision);
               }
               const previousFence = durabilityFence(owners[0]?.fence ?? "0");
@@ -455,6 +501,23 @@ function decodeExportCursor(value) {
 
 function isHighSurrogate(value) {
   return value >= 0xd800 && value <= 0xdbff;
+}
+
+function durabilityStateDigestText(value) {
+  if (typeof value !== "string" || !/^sha256:[0-9a-f]{64}$/.test(value)) {
+    throw new TypeError("durability export page from-state digest is invalid");
+  }
+  return value;
+}
+
+function expectedImportPayload(options, expectedRevision) {
+  const present = options?.expectedPayload !== undefined;
+  if (!present) return { present: false, value: undefined };
+  if (expectedRevision === undefined) {
+    throw new TypeError("durability import expected payload requires an expected revision");
+  }
+  const expected = copyState({ revision: expectedRevision, payload: options.expectedPayload });
+  return { present: true, value: expected.payload };
 }
 
 function loadSqliteState(query, stateId) {

--- a/js/bindings/runtime/durability-store.mjs
+++ b/js/bindings/runtime/durability-store.mjs
@@ -1,5 +1,6 @@
 const MAX_REVISION = 18_446_744_073_709_551_615n;
 const MAX_REVISION_TEXT = String(MAX_REVISION);
+const PORTABLE_FORMAT = "nanocodex-durability-state-v1";
 
 export const sqliteDurabilitySchema = Object.freeze([
   `CREATE TABLE IF NOT EXISTS nanocodex_durable_owners (
@@ -16,6 +17,53 @@ export const sqliteDurabilitySchema = Object.freeze([
 
 export function durabilityRevision(value) {
   return durabilityUint64(value, "revision");
+}
+
+export class DurabilityImportConflictError extends Error {
+  constructor(stateId) {
+    super(`durability state ${JSON.stringify(stateId)} already exists at the import destination`);
+    this.name = "DurabilityImportConflictError";
+  }
+}
+
+/** Fences a source store and exports one coherent provider-neutral state archive. */
+export async function exportDurabilityState(store, stateId) {
+  requireId(stateId, "state");
+  if (!store || typeof store.acquire !== "function") {
+    throw new TypeError("durability export requires a state store");
+  }
+  const ownerId = portableOwnerId("export");
+  const acquired = await store.acquire(stateId, { ownerId });
+  exactObject(
+    acquired,
+    ["ownerId", "fence", "revision", "payload"],
+    "durability export acquisition",
+  );
+  if (acquired.ownerId !== ownerId) {
+    throw new TypeError("durability export acquisition returned a different owner ID");
+  }
+  durabilityFence(acquired.fence);
+  const state = copyState({ revision: acquired.revision, payload: acquired.payload });
+  return Object.freeze({ format: PORTABLE_FORMAT, stateId, ...state });
+}
+
+/** Restores an exact provider-neutral archive into an empty portable store. */
+export async function importDurabilityState(store, archive) {
+  if (!store || typeof store.importState !== "function") {
+    throw new TypeError("durability import requires a portable state store");
+  }
+  exactObject(
+    archive,
+    ["format", "stateId", "revision", "payload"],
+    "durability export archive",
+  );
+  if (archive.format !== PORTABLE_FORMAT) {
+    throw new TypeError(`unsupported durability export format: ${String(archive.format)}`);
+  }
+  requireId(archive.stateId, "exported state");
+  const state = copyState({ revision: archive.revision, payload: archive.payload });
+  const imported = await store.importState(archive.stateId, state);
+  return copyState(imported);
 }
 
 function durabilityFence(value) {
@@ -81,6 +129,19 @@ export function createMemoryDurabilityStore(stateId, initial) {
       const revision = durabilityRevision(BigInt(expectedRevision) + 1n);
       state = Object.freeze({ revision, payload });
       return { status: "replaced", revision };
+    },
+    importState(selected, imported) {
+      select(selected);
+      const next = copyState(imported);
+      if (owner !== undefined || state.revision !== "0") {
+        throw new DurabilityImportConflictError(selected);
+      }
+      owner = Object.freeze({
+        ownerId: portableOwnerId("import"),
+        fence: "1",
+      });
+      state = next;
+      return state;
     },
     snapshot() {
       return state;
@@ -170,6 +231,49 @@ export function createSqliteDurabilityStore(options) {
         },
       ));
     },
+    importState(stateId, imported) {
+      requireId(stateId, "state");
+      const state = copyState(imported);
+      const ownerId = portableOwnerId("import");
+      return options.transaction((query) => mapMaybePromise(
+        query(
+          "SELECT owner_id, fence FROM nanocodex_durable_owners WHERE state_id = ?",
+          [stateId],
+        ),
+        (owners) => {
+          exactRows(owners, 1, "SQLite durability owner");
+          if (owners.length === 1) {
+            exactObject(owners[0], ["owner_id", "fence"], "SQLite durability owner");
+          }
+          if (owners.length !== 0) throw new DurabilityImportConflictError(stateId);
+          return mapMaybePromise(
+            query(
+              "SELECT revision, payload FROM nanocodex_durable_states WHERE state_id = ?",
+              [stateId],
+            ),
+            (states) => {
+              exactRows(states, 1, "SQLite durability state");
+              if (states.length !== 0) throw new DurabilityImportConflictError(stateId);
+              return mapMaybePromise(
+                query(
+                  "INSERT INTO nanocodex_durable_owners (state_id, owner_id, fence) VALUES (?, ?, ?)",
+                  [stateId, ownerId, "1"],
+                ),
+                () => state.revision === "0"
+                  ? state
+                  : mapMaybePromise(
+                    query(
+                      "INSERT INTO nanocodex_durable_states (state_id, revision, payload) VALUES (?, ?, ?)",
+                      [stateId, state.revision, state.payload],
+                    ),
+                    () => state,
+                  ),
+              );
+            },
+          );
+        },
+      ));
+    },
   });
 }
 
@@ -229,6 +333,14 @@ function requirePayload(value) {
     throw new TypeError("durability payload must be a string");
   }
   return value;
+}
+
+function portableOwnerId(kind) {
+  const randomUUID = globalThis.crypto?.randomUUID;
+  if (typeof randomUUID !== "function") {
+    throw new Error("durability portability requires crypto.randomUUID()");
+  }
+  return `nanocodex-${kind}-${randomUUID.call(globalThis.crypto)}`;
 }
 
 function exactRows(rows, maximum, label) {

--- a/js/bindings/runtime/durability.mjs
+++ b/js/bindings/runtime/durability.mjs
@@ -1,23 +1,18 @@
 const hosts = new Map();
 let nextRouteId = 1n;
-const ACQUIRE_PAGE_ROWS = 8;
 
-export function own(host, store, journalId) {
-  if ((store === undefined) !== (journalId === undefined)) {
+export function own(host, store, stateId) {
+  if ((store === undefined) !== (stateId === undefined)) {
     throw new TypeError("durability and durabilityId must be supplied together");
   }
   const routeId = `durability-route-${nextRouteId++}`;
-  bind(routeId, host, store, journalId);
+  hosts.set(routeId, { host, store, stateId, references: 0 });
   return Object.freeze({
     id: routeId,
     abandon: () => abandon(host, routeId),
     retain: () => retain(host, routeId),
     release: () => release(host, routeId),
   });
-}
-
-function bind(routeId, host, store, journalId) {
-  hosts.set(routeId, { host, store, journalId, references: 0 });
 }
 
 export function retain(host, routeId) {
@@ -40,186 +35,118 @@ export function abandon(host, routeId) {
   if (ownership?.host === host && ownership.references === 0) hosts.delete(routeId);
 }
 
-export async function acquire(routeId, journalId, ownerId) {
-  const stored = await requiredRoute(routeId, journalId).store.acquire(
-    journalId,
-    { ownerId },
-  );
-  if (!stored || typeof stored !== "object" || !Array.isArray(stored.batches)) {
-    throw new TypeError("durability.acquire() must return { ownerId, fence, revision, batches }");
+export async function acquire(routeId, stateId, ownerId) {
+  const stored = await requiredRoute(routeId, stateId).store.acquire(stateId, { ownerId });
+  if (!stored || typeof stored !== "object" || Array.isArray(stored)) {
+    throw new TypeError("durability.acquire() must return an acquired state object");
   }
-  const acquiredOwnerId = requiredString(stored.ownerId, "durability owner ID");
+  exactKeys(stored, ["ownerId", "fence", "revision", "payload"], "durability acquired state");
+  const acquiredOwnerId = nonempty(stored.ownerId, "durability owner ID");
   if (acquiredOwnerId !== ownerId) {
     throw new TypeError("durability.acquire() must return the requested owner ID");
   }
-  return JSON.stringify({
-    owner_id: acquiredOwnerId,
-    fence: revision(stored.fence, "durability owner fence"),
-    revision: revision(stored.revision, "durability load revision"),
-    batches: stored.batches.map((batch) => ({
-      revision: revision(batch?.revision, "durability batch revision"),
-      payload: requiredString(batch?.payload, "durability batch payload"),
-    })),
-  });
-}
-
-export async function acquirePage(routeId, journalId, ownerId, afterRevision) {
-  const route = requiredRoute(routeId, journalId);
-  const store = route.store;
-  let stored;
-  if (typeof store.acquirePage === "function") {
-    stored = await store.acquirePage(journalId, {
-      ownerId,
-      ...(afterRevision === "" ? {} : { afterRevision }),
-      limit: ACQUIRE_PAGE_ROWS,
-    });
-  } else {
-    if (afterRevision === "") {
-      route.acquisition = await store.acquire(journalId, { ownerId });
-    }
-    const acquired = route.acquisition;
-    if (!acquired || acquired.ownerId !== ownerId) {
-      throw new Error("durability acquisition page has no retained owner");
-    }
-    const start = afterRevision === ""
-      ? 0
-      : acquired.batches.findIndex((batch) => batch.revision === afterRevision) + 1;
-    if (start <= 0 && afterRevision !== "") {
-      throw new Error("durability acquisition cursor is not retained");
-    }
-    const batches = acquired.batches.slice(start, start + ACQUIRE_PAGE_ROWS);
-    const hasMore = start + batches.length < acquired.batches.length;
-    stored = { ...acquired, batches, hasMore };
-    if (!hasMore) route.acquisition = undefined;
-  }
-  if (!stored || typeof stored !== "object" || !Array.isArray(stored.batches)) {
-    throw new TypeError("durability.acquirePage() must return an acquired journal page");
-  }
-  const acquiredOwnerId = requiredString(stored.ownerId, "durability owner ID");
-  if (acquiredOwnerId !== ownerId) {
-    throw new TypeError("durability.acquirePage() must return the requested owner ID");
-  }
-  if (typeof stored.hasMore !== "boolean") {
-    throw new TypeError("durability.acquirePage() must return hasMore");
+  const retainedRevision = uint64(stored.revision, "durability state revision");
+  const payload = stored.payload === null
+    ? null
+    : string(stored.payload, "durability state payload");
+  if ((retainedRevision === "0") !== (payload === null)) {
+    throw new TypeError("durability.acquire() returned inconsistent revision and payload");
   }
   return JSON.stringify({
     owner_id: acquiredOwnerId,
-    fence: revision(stored.fence, "durability owner fence"),
-    revision: revision(stored.revision, "durability load revision"),
-    batches: stored.batches.map((batch) => ({
-      revision: revision(batch?.revision, "durability batch revision"),
-      payload: requiredString(batch?.payload, "durability batch payload"),
-    })),
-    has_more: stored.hasMore,
+    fence: uint64(stored.fence, "durability owner fence"),
+    revision: retainedRevision,
+    payload,
   });
 }
 
-export async function append(
+export async function replace(
   routeId,
-  journalId,
+  stateId,
   ownerId,
   fence,
   expectedRevision,
   payload,
 ) {
-  const result = await requiredRoute(routeId, journalId).store.append(journalId, {
+  const result = await requiredRoute(routeId, stateId).store.replace(stateId, {
     ownerId,
     fence,
     expectedRevision,
     payload,
   });
-  if (result?.status === "appended") {
+  if (result?.status === "replaced") {
+    exactKeys(result, ["status", "revision"], "durability replaced result");
     return JSON.stringify({
-      status: "appended",
-      revision: revision(result.revision, "durability append revision"),
+      status: "replaced",
+      revision: uint64(result.revision, "durability replace revision"),
     });
   }
   if (result?.status === "conflict") {
+    exactKeys(result, ["status", "actualRevision"], "durability conflict result");
     return JSON.stringify({
       status: "conflict",
-      actual_revision: revision(result.actualRevision, "durability conflict revision"),
+      actual_revision: uint64(result.actualRevision, "durability conflict revision"),
     });
   }
   if (result?.status === "not_committed") {
+    exactKeys(result, ["status", "message"], "durability not-committed result");
     return JSON.stringify({
       status: "not_committed",
-      message: requiredString(result.message, "durability not-committed message"),
+      message: nonempty(result.message, "durability not-committed message"),
     });
   }
   if (result?.status === "fenced") {
+    exactKeys(result, ["status"], "durability fenced result");
     return JSON.stringify({ status: "fenced" });
   }
   throw new TypeError(
-    "durability.append() must return an appended, conflict, fenced, or not_committed result",
+    "durability.replace() must return a replaced, conflict, fenced, or not_committed result",
   );
 }
 
-export async function compact(
-  routeId,
-  journalId,
-  ownerId,
-  fence,
-  expectedRevision,
-  payload,
-) {
-  const store = requiredRoute(routeId, journalId).store;
-  if (typeof store.compact !== "function") {
-    return JSON.stringify({
-      status: "not_committed",
-      message: "durability store does not support journal compaction",
-    });
-  }
-  const result = await store.compact(journalId, {
-    ownerId,
-    fence,
-    expectedRevision,
-    payload,
-  });
-  if (result?.status === "compacted") {
-    return JSON.stringify({
-      status: "compacted",
-      revision: revision(result.revision, "durability compact revision"),
-    });
-  }
-  if (result?.status === "conflict") {
-    return JSON.stringify({
-      status: "conflict",
-      actual_revision: revision(result.actualRevision, "durability conflict revision"),
-    });
-  }
-  if (result?.status === "not_committed") {
-    return JSON.stringify({
-      status: "not_committed",
-      message: requiredString(result.message, "durability not-committed message"),
-    });
-  }
-  if (result?.status === "fenced") return JSON.stringify({ status: "fenced" });
-  throw new TypeError(
-    "durability.compact() must return a compacted, conflict, fenced, or not_committed result",
-  );
-}
-
-function requiredRoute(routeId, journalId) {
+function requiredRoute(routeId, stateId) {
   const route = hosts.get(routeId);
   if (!route) throw new Error(`no Nanocodex host owns durability route: ${routeId}`);
-  if (route.journalId !== journalId) {
-    throw new Error(`Nanocodex durability route does not own journal: ${journalId}`);
+  if (route.stateId !== stateId) {
+    throw new Error(`Nanocodex durability route does not own state: ${stateId}`);
   }
   const store = route.store;
-  if (!store || typeof store.acquire !== "function" || typeof store.append !== "function") {
-    throw new TypeError("the selected Nanocodex host must define a durability store");
+  if (!store || typeof store.acquire !== "function" || typeof store.replace !== "function") {
+    throw new TypeError("the selected Nanocodex host must define a durability state store");
   }
   return route;
 }
 
-function revision(value, name) {
-  if (typeof value !== "string" || !/^(0|[1-9][0-9]*)$/.test(value)) {
-    throw new TypeError(`${name} must be an unsigned decimal string`);
+function uint64(value, name) {
+  if (
+    typeof value !== "string"
+    || !/^(0|[1-9][0-9]*)$/.test(value)
+    || BigInt(value) > 18_446_744_073_709_551_615n
+  ) {
+    throw new TypeError(`${name} must be an unsigned 64-bit decimal string`);
   }
   return value;
 }
 
-function requiredString(value, name) {
+function string(value, name) {
   if (typeof value !== "string") throw new TypeError(`${name} must be a string`);
   return value;
+}
+
+function nonempty(value, name) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new TypeError(`${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function exactKeys(value, expected, name) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${name} must be an object`);
+  }
+  const actual = Object.keys(value).sort();
+  const required = [...expected].sort();
+  if (actual.length !== required.length || actual.some((key, index) => key !== required[index])) {
+    throw new TypeError(`${name} must contain exactly ${required.join(", ")}`);
+  }
 }

--- a/js/bindings/runtime/postgres-durability-store.d.mts
+++ b/js/bindings/runtime/postgres-durability-store.d.mts
@@ -1,4 +1,4 @@
-import type { DurabilityStore } from "../types.mjs";
+import type { DurabilityPortableStore } from "../types.mjs";
 
 /** A PostgreSQL result row. Column values remain owned by the pool implementation. */
 export type PostgresDurabilityRow = Readonly<Record<string, unknown>>;
@@ -64,4 +64,4 @@ export declare class UnknownPostgresCommitOutcomeError extends Error {
  */
 export declare function createPostgresDurabilityStore(
   pool: PostgresDurabilityPool,
-): DurabilityStore;
+): DurabilityPortableStore;

--- a/js/bindings/runtime/postgres-durability-store.d.mts
+++ b/js/bindings/runtime/postgres-durability-store.d.mts
@@ -40,13 +40,11 @@ export type PostgresDurabilityPool = Readonly<{
 }>;
 
 /**
- * Signals that PostgreSQL may have applied COMMIT before the connection failed.
- *
- * Callers must treat this as an unknown write outcome and reload the state;
- * it is never converted to the definite `not_committed` replace result.
+ * PostgreSQL remained unavailable while the adapter retried an idempotent
+ * operation to verify a lost COMMIT response. Retrying the same request is safe.
  */
-export declare class UnknownPostgresCommitOutcomeError extends Error {
-  override readonly name: "UnknownPostgresCommitOutcomeError";
+export declare class PostgresDurabilityUnavailableError extends Error {
+  override readonly name: "PostgresDurabilityUnavailableError";
   constructor(stateId: string, cause: unknown);
 }
 
@@ -55,9 +53,8 @@ export declare class UnknownPostgresCommitOutcomeError extends Error {
  *
  * The schema is initialized lazily under a PostgreSQL transaction advisory
  * lock. Replacements atomically compare and advance the complete opaque state in one
- * transaction. Failures return `not_committed` only when no transaction began
- * or ROLLBACK was confirmed; a failed COMMIT throws
- * {@link UnknownPostgresCommitOutcomeError} instead.
+ * transaction. Lost COMMIT responses are reconciled internally by retrying the
+ * same idempotent operation; callers never receive an ambiguous write result.
  *
  * The supplied pool is structural and caller-owned. Constructing the store
  * does not connect, query, or import a PostgreSQL driver.

--- a/js/bindings/runtime/postgres-durability-store.d.mts
+++ b/js/bindings/runtime/postgres-durability-store.d.mts
@@ -42,20 +42,19 @@ export type PostgresDurabilityPool = Readonly<{
 /**
  * Signals that PostgreSQL may have applied COMMIT before the connection failed.
  *
- * Callers must treat this as an unknown write outcome and reload the journal;
- * it is never converted to the definite `not_committed` append result.
+ * Callers must treat this as an unknown write outcome and reload the state;
+ * it is never converted to the definite `not_committed` replace result.
  */
 export declare class UnknownPostgresCommitOutcomeError extends Error {
   override readonly name: "UnknownPostgresCommitOutcomeError";
-  constructor(journalId: string, cause: unknown);
+  constructor(stateId: string, cause: unknown);
 }
 
 /**
  * Creates a concrete PostgreSQL-backed Nanocodex durability store.
  *
  * The schema is initialized lazily under a PostgreSQL transaction advisory
- * lock. Loads preserve numeric revision order. Appends atomically compare and
- * advance the journal head before inserting the opaque batch in one
+ * lock. Replacements atomically compare and advance the complete opaque state in one
  * transaction. Failures return `not_committed` only when no transaction began
  * or ROLLBACK was confirmed; a failed COMMIT throws
  * {@link UnknownPostgresCommitOutcomeError} instead.

--- a/js/bindings/runtime/postgres-durability-store.mjs
+++ b/js/bindings/runtime/postgres-durability-store.mjs
@@ -4,6 +4,7 @@ import {
 } from "./durability-store.mjs";
 
 const MAX_REVISION = "18446744073709551615";
+const PORTABLE_IMPORT_OWNER = "nanocodex-portable-import";
 const SCHEMA = [
   `CREATE TABLE IF NOT EXISTS nanocodex_durable_owners (
      state_id TEXT PRIMARY KEY,
@@ -318,34 +319,22 @@ async function restoreState(pool, stateId, state) {
     await client.query("BEGIN");
     begun = true;
     const owner = await client.query(
-      `SELECT owner_id, fence::text FROM nanocodex_durable_owners
-       WHERE state_id = $1 FOR UPDATE`,
-      [stateId],
-    );
-    if (owner.rows.length > 1) {
-      throw new Error("PostgreSQL returned duplicate durability owners during import");
-    }
-    if (owner.rows.length !== 0) throw new DurabilityImportConflictError(stateId);
-    const retained = await client.query(
-      `SELECT revision::text FROM nanocodex_durable_states
-       WHERE state_id = $1 FOR UPDATE`,
-      [stateId],
-    );
-    if (retained.rows.length > 1) {
-      throw new Error("PostgreSQL returned duplicate durability states during import");
-    }
-    if (retained.rows.length !== 0) throw new DurabilityImportConflictError(stateId);
-    await client.query(
       `INSERT INTO nanocodex_durable_owners (state_id, owner_id, fence)
-       VALUES ($1, $2, $3::numeric)`,
-      [stateId, portableOwnerId(), "1"],
+       VALUES ($1, $2, 1)
+       ON CONFLICT (state_id) DO NOTHING
+       RETURNING state_id`,
+      [stateId, PORTABLE_IMPORT_OWNER],
     );
+    if (owner.rows.length !== 1) throw new DurabilityImportConflictError(stateId);
     if (state.revision !== "0") {
-      await client.query(
+      const retained = await client.query(
         `INSERT INTO nanocodex_durable_states (state_id, revision, payload)
-         VALUES ($1, $2::numeric, $3)`,
+         VALUES ($1, $2::numeric, $3)
+         ON CONFLICT (state_id) DO NOTHING
+         RETURNING state_id`,
         [stateId, state.revision, state.payload],
       );
+      if (retained.rows.length !== 1) throw new DurabilityImportConflictError(stateId);
     }
     try {
       await client.query("COMMIT");
@@ -408,14 +397,6 @@ function importedState(value) {
     throw new TypeError("imported durability payload must be a string");
   }
   return Object.freeze({ revision, payload });
-}
-
-function portableOwnerId() {
-  const randomUUID = globalThis.crypto?.randomUUID;
-  if (typeof randomUUID !== "function") {
-    throw new Error("durability portability requires crypto.randomUUID()");
-  }
-  return `nanocodex-import-${randomUUID.call(globalThis.crypto)}`;
 }
 
 async function loadStateForUpdate(client, stateId) {

--- a/js/bindings/runtime/postgres-durability-store.mjs
+++ b/js/bindings/runtime/postgres-durability-store.mjs
@@ -5,6 +5,7 @@ import {
 
 const MAX_REVISION = "18446744073709551615";
 const PORTABLE_IMPORT_OWNER = "nanocodex-portable-import";
+const VERIFY_ATTEMPTS = 3;
 const SCHEMA = [
   `CREATE TABLE IF NOT EXISTS nanocodex_durable_owners (
      state_id TEXT PRIMARY KEY,
@@ -20,14 +21,16 @@ const SCHEMA = [
    )`,
 ];
 
-export class UnknownPostgresCommitOutcomeError extends Error {
+export class PostgresDurabilityUnavailableError extends Error {
   constructor(stateId, cause) {
-    super(`PostgreSQL durability COMMIT outcome is unknown for state ${JSON.stringify(stateId)}`, {
+    super(`PostgreSQL durability could not verify state ${JSON.stringify(stateId)}; retrying the identical request is safe`, {
       cause,
     });
-    this.name = "UnknownPostgresCommitOutcomeError";
+    this.name = "PostgresDurabilityUnavailableError";
   }
 }
+
+class CommitVerificationRequired extends Error {}
 
 class InvalidPostgresDurabilityRequestError extends Error {
   constructor(cause) {
@@ -73,11 +76,14 @@ export function createPostgresDurabilityStore(pool) {
         payload: request?.payload,
       });
     },
-    async importState(stateId, imported) {
+    async importState(stateId, imported, options) {
       requireId(stateId);
       const state = importedState(imported);
+      const expectedRevision = options?.expectedRevision === undefined
+        ? undefined
+        : durabilityRevision(options.expectedRevision);
       await ready();
-      return restoreState(pool, stateId, state);
+      return restoreState(pool, stateId, state, expectedRevision);
     },
   });
 }
@@ -197,6 +203,10 @@ async function loadState(queryable, stateId) {
 }
 
 async function acquireState(pool, stateId, ownerId) {
+  return verifyCommit(stateId, () => acquireStateOnce(pool, stateId, ownerId));
+}
+
+async function acquireStateOnce(pool, stateId, ownerId) {
   const client = await pool.connect();
   let begun = false;
   let discard = false;
@@ -207,8 +217,14 @@ async function acquireState(pool, stateId, ownerId) {
       `INSERT INTO nanocodex_durable_owners (state_id, owner_id, fence)
        VALUES ($1, $2, 1)
        ON CONFLICT (state_id) DO UPDATE
-       SET owner_id = excluded.owner_id, fence = nanocodex_durable_owners.fence + 1
-       WHERE nanocodex_durable_owners.fence < 18446744073709551615
+       SET owner_id = excluded.owner_id,
+           fence = CASE
+             WHEN nanocodex_durable_owners.owner_id = excluded.owner_id
+               THEN nanocodex_durable_owners.fence
+             ELSE nanocodex_durable_owners.fence + 1
+           END
+       WHERE nanocodex_durable_owners.owner_id = excluded.owner_id
+          OR nanocodex_durable_owners.fence < 18446744073709551615
        RETURNING fence::text`,
       [stateId, ownerId],
     );
@@ -222,11 +238,11 @@ async function acquireState(pool, stateId, ownerId) {
       begun = false;
     } catch (error) {
       discard = true;
-      throw new UnknownPostgresCommitOutcomeError(stateId, error);
+      throw new CommitVerificationRequired("acquire commit response was lost", { cause: error });
     }
     return Object.freeze({ ownerId, fence, ...state });
   } catch (error) {
-    if (error instanceof UnknownPostgresCommitOutcomeError) throw error;
+    if (error instanceof CommitVerificationRequired) throw error;
     if (begun) {
       try {
         await client.query("ROLLBACK");
@@ -245,6 +261,10 @@ async function acquireState(pool, stateId, ownerId) {
 }
 
 async function replaceState(pool, stateId, request) {
+  return verifyCommit(stateId, () => replaceStateOnce(pool, stateId, request));
+}
+
+async function replaceStateOnce(pool, stateId, request) {
   const client = await pool.connect();
   let begun = false;
   let discard = false;
@@ -268,6 +288,11 @@ async function replaceState(pool, stateId, request) {
     if (state.revision !== expectedRevision) {
       await client.query("ROLLBACK");
       begun = false;
+      if (state.revision === nextRevision(expectedRevision)
+        && typeof request.payload === "string"
+        && state.payload === request.payload) {
+        return { status: "replaced", revision: state.revision };
+      }
       return { status: "conflict", actualRevision: state.revision };
     }
     if (state.revision === MAX_REVISION) {
@@ -289,11 +314,11 @@ async function replaceState(pool, stateId, request) {
       begun = false;
     } catch (error) {
       discard = true;
-      throw new UnknownPostgresCommitOutcomeError(stateId, error);
+      throw new CommitVerificationRequired("replace commit response was lost", { cause: error });
     }
     return { status: "replaced", revision };
   } catch (error) {
-    if (error instanceof UnknownPostgresCommitOutcomeError) throw error;
+    if (error instanceof CommitVerificationRequired) throw error;
     if (begun) {
       try {
         await client.query("ROLLBACK");
@@ -311,41 +336,69 @@ async function replaceState(pool, stateId, request) {
   }
 }
 
-async function restoreState(pool, stateId, state) {
+async function restoreState(pool, stateId, state, expectedRevision) {
+  return verifyCommit(
+    stateId,
+    (attempt) => restoreStateOnce(pool, stateId, state, expectedRevision, attempt > 0),
+  );
+}
+
+async function restoreStateOnce(pool, stateId, state, expectedRevision, reconciling) {
   const client = await pool.connect();
   let begun = false;
   let discard = false;
   try {
     await client.query("BEGIN");
     begun = true;
-    const owner = await client.query(
+    const retainedOwner = await client.query(
+      `SELECT owner_id, fence::text FROM nanocodex_durable_owners
+       WHERE state_id = $1 FOR UPDATE`,
+      [stateId],
+    );
+    const retainedState = await loadStateForUpdate(client, stateId);
+    const owner = retainedOwner.rows[0];
+    if (reconciling
+      && owner?.owner_id === PORTABLE_IMPORT_OWNER
+      && retainedState.revision === state.revision
+      && retainedState.payload === state.payload) {
+      await client.query("ROLLBACK");
+      begun = false;
+      return state;
+    }
+    if (expectedRevision === undefined
+      ? owner !== undefined || retainedState.revision !== "0"
+      : retainedState.revision !== expectedRevision) {
+      throw new DurabilityImportConflictError(stateId, expectedRevision, retainedState.revision);
+    }
+    const claimed = await client.query(
       `INSERT INTO nanocodex_durable_owners (state_id, owner_id, fence)
        VALUES ($1, $2, 1)
-       ON CONFLICT (state_id) DO NOTHING
-       RETURNING state_id`,
+       ON CONFLICT (state_id) DO UPDATE
+       SET owner_id = excluded.owner_id, fence = nanocodex_durable_owners.fence + 1
+       WHERE nanocodex_durable_owners.fence < 18446744073709551615
+       RETURNING fence::text`,
       [stateId, PORTABLE_IMPORT_OWNER],
     );
-    if (owner.rows.length !== 1) throw new DurabilityImportConflictError(stateId);
+    if (claimed.rows.length !== 1) throw new RangeError("PostgreSQL durability fence overflow");
     if (state.revision !== "0") {
-      const retained = await client.query(
+      await client.query(
         `INSERT INTO nanocodex_durable_states (state_id, revision, payload)
          VALUES ($1, $2::numeric, $3)
-         ON CONFLICT (state_id) DO NOTHING
-         RETURNING state_id`,
+         ON CONFLICT (state_id) DO UPDATE
+         SET revision = excluded.revision, payload = excluded.payload`,
         [stateId, state.revision, state.payload],
       );
-      if (retained.rows.length !== 1) throw new DurabilityImportConflictError(stateId);
     }
     try {
       await client.query("COMMIT");
       begun = false;
     } catch (error) {
       discard = true;
-      throw new UnknownPostgresCommitOutcomeError(stateId, error);
+      throw new CommitVerificationRequired("import commit response was lost", { cause: error });
     }
     return state;
   } catch (error) {
-    if (error instanceof UnknownPostgresCommitOutcomeError) throw error;
+    if (error instanceof CommitVerificationRequired) throw error;
     if (begun) {
       try {
         await client.query("ROLLBACK");
@@ -361,6 +414,23 @@ async function restoreState(pool, stateId, state) {
   } finally {
     client.release(discard);
   }
+}
+
+async function verifyCommit(stateId, operation) {
+  let retained;
+  for (let attempt = 0; attempt < VERIFY_ATTEMPTS; attempt += 1) {
+    try {
+      return await operation(attempt);
+    } catch (error) {
+      if (!(error instanceof CommitVerificationRequired)) throw error;
+      retained = error;
+    }
+  }
+  throw new PostgresDurabilityUnavailableError(stateId, retained?.cause ?? retained);
+}
+
+function nextRevision(revision) {
+  return revision === MAX_REVISION ? undefined : durabilityRevision(BigInt(revision) + 1n);
 }
 
 function requestRevision(value) {

--- a/js/bindings/runtime/postgres-durability-store.mjs
+++ b/js/bindings/runtime/postgres-durability-store.mjs
@@ -82,8 +82,9 @@ export function createPostgresDurabilityStore(pool) {
       const expectedRevision = options?.expectedRevision === undefined
         ? undefined
         : durabilityRevision(options.expectedRevision);
+      const expectedPayload = expectedImportPayload(options, expectedRevision);
       await ready();
-      return restoreState(pool, stateId, state, expectedRevision);
+      return restoreState(pool, stateId, state, expectedRevision, expectedPayload);
     },
   });
 }
@@ -336,20 +337,40 @@ async function replaceStateOnce(pool, stateId, request) {
   }
 }
 
-async function restoreState(pool, stateId, state, expectedRevision) {
+async function restoreState(pool, stateId, state, expectedRevision, expectedPayload) {
   return verifyCommit(
     stateId,
-    (attempt) => restoreStateOnce(pool, stateId, state, expectedRevision, attempt > 0),
+    (attempt) => restoreStateOnce(
+      pool,
+      stateId,
+      state,
+      expectedRevision,
+      expectedPayload,
+      attempt > 0,
+    ),
   );
 }
 
-async function restoreStateOnce(pool, stateId, state, expectedRevision, reconciling) {
+async function restoreStateOnce(
+  pool,
+  stateId,
+  state,
+  expectedRevision,
+  expectedPayload,
+  reconciling,
+) {
   const client = await pool.connect();
   let begun = false;
   let discard = false;
   try {
     await client.query("BEGIN");
     begun = true;
+    await client.query(
+      `SELECT pg_advisory_xact_lock(hashtextextended(
+         current_schema() || ':nanocodex-durability-v2:state:' || $1, 0
+       ))`,
+      [stateId],
+    );
     const retainedOwner = await client.query(
       `SELECT owner_id, fence::text FROM nanocodex_durable_owners
        WHERE state_id = $1 FOR UPDATE`,
@@ -367,7 +388,8 @@ async function restoreStateOnce(pool, stateId, state, expectedRevision, reconcil
     }
     if (expectedRevision === undefined
       ? owner !== undefined || retainedState.revision !== "0"
-      : retainedState.revision !== expectedRevision) {
+      : retainedState.revision !== expectedRevision
+        || expectedPayload.present && retainedState.payload !== expectedPayload.value) {
       throw new DurabilityImportConflictError(stateId, expectedRevision, retainedState.revision);
     }
     const claimed = await client.query(
@@ -467,6 +489,16 @@ function importedState(value) {
     throw new TypeError("imported durability payload must be a string");
   }
   return Object.freeze({ revision, payload });
+}
+
+function expectedImportPayload(options, expectedRevision) {
+  const present = options?.expectedPayload !== undefined;
+  if (!present) return { present: false, value: undefined };
+  if (expectedRevision === undefined) {
+    throw new TypeError("durability import expected payload requires an expected revision");
+  }
+  const expected = importedState({ revision: expectedRevision, payload: options.expectedPayload });
+  return { present: true, value: expected.payload };
 }
 
 async function loadStateForUpdate(client, stateId) {

--- a/js/bindings/runtime/postgres-durability-store.mjs
+++ b/js/bindings/runtime/postgres-durability-store.mjs
@@ -25,6 +25,13 @@ export class UnknownPostgresCommitOutcomeError extends Error {
   }
 }
 
+class InvalidPostgresDurabilityRequestError extends Error {
+  constructor(cause) {
+    super("invalid PostgreSQL durability replacement request", { cause });
+    this.name = "InvalidPostgresDurabilityRequestError";
+  }
+}
+
 /** Creates a concrete PostgreSQL-backed Nanocodex durability store. */
 export function createPostgresDurabilityStore(pool) {
   if (!pool || typeof pool.connect !== "function" || typeof pool.query !== "function") {
@@ -54,16 +61,12 @@ export function createPostgresDurabilityStore(pool) {
       requireId(stateId);
       const ownerId = requireOwner(request?.ownerId);
       const fence = durabilityRevision(request?.fence);
-      const expectedRevision = durabilityRevision(request?.expectedRevision);
-      if (typeof request?.payload !== "string") {
-        throw new TypeError("durability payload must be a string");
-      }
       await ready();
       return replaceState(pool, stateId, {
         ownerId,
         fence,
-        expectedRevision,
-        payload: request.payload,
+        expectedRevision: request?.expectedRevision,
+        payload: request?.payload,
       });
     },
   });
@@ -112,8 +115,13 @@ async function initialize(pool) {
         "incompatible Postgres durability primary keys; each state_id must be the sole primary key",
       );
     }
-    await client.query("COMMIT");
-    begun = false;
+    try {
+      await client.query("COMMIT");
+      begun = false;
+    } catch (error) {
+      discard = true;
+      throw error;
+    }
   } catch (error) {
     if (begun) {
       try {
@@ -245,8 +253,9 @@ async function replaceState(pool, stateId, request) {
       begun = false;
       return { status: "fenced" };
     }
+    const expectedRevision = requestRevision(request.expectedRevision);
     const state = await loadStateForUpdate(client, stateId);
-    if (state.revision !== request.expectedRevision) {
+    if (state.revision !== expectedRevision) {
       await client.query("ROLLBACK");
       begun = false;
       return { status: "conflict", actualRevision: state.revision };
@@ -256,13 +265,14 @@ async function replaceState(pool, stateId, request) {
       begun = false;
       return { status: "not_committed", message: "PostgreSQL durability revision overflow" };
     }
+    const payload = requestPayload(request.payload);
     const revision = durabilityRevision(BigInt(state.revision) + 1n);
     await client.query(
       `INSERT INTO nanocodex_durable_states (state_id, revision, payload)
        VALUES ($1, $2::numeric, $3)
        ON CONFLICT (state_id) DO UPDATE
        SET revision = excluded.revision, payload = excluded.payload`,
-      [stateId, revision, request.payload],
+      [stateId, revision, payload],
     );
     try {
       await client.query("COMMIT");
@@ -277,17 +287,35 @@ async function replaceState(pool, stateId, request) {
     if (begun) {
       try {
         await client.query("ROLLBACK");
-        begun = false;
-        return { status: "not_committed", message: message(error) };
       } catch (rollbackError) {
         discard = true;
         throw new AggregateError([error, rollbackError], "PostgreSQL durability replace and rollback both failed");
       }
+      begun = false;
+      if (error instanceof InvalidPostgresDurabilityRequestError) throw error.cause;
+      return { status: "not_committed", message: message(error) };
     }
     throw error;
   } finally {
     client.release(discard);
   }
+}
+
+function requestRevision(value) {
+  try {
+    return durabilityRevision(value);
+  } catch (error) {
+    throw new InvalidPostgresDurabilityRequestError(error);
+  }
+}
+
+function requestPayload(value) {
+  if (typeof value !== "string") {
+    throw new InvalidPostgresDurabilityRequestError(
+      new TypeError("durability payload must be a string"),
+    );
+  }
+  return value;
 }
 
 async function loadStateForUpdate(client, stateId) {

--- a/js/bindings/runtime/postgres-durability-store.mjs
+++ b/js/bindings/runtime/postgres-durability-store.mjs
@@ -1,717 +1,321 @@
 import { durabilityRevision } from "./durability-store.mjs";
 
 const MAX_REVISION = "18446744073709551615";
-const ABOVE_MAX_REVISION = "18446744073709551616";
-const FAR_ABOVE_MAX_REVISION = "18446744073709551617";
-const SCHEMA_ADVISORY_LOCK = "6178124430808978225";
-const ZERO_REVISION = durabilityRevision("0");
-
-const POSTGRES_DURABILITY_COLUMNS = [
-  ["nanocodex_journal_batches", "journal_id", "text", null, null],
-  ["nanocodex_journal_batches", "revision", "numeric", 20, 0],
-  ["nanocodex_journal_batches", "payload", "text", null, null],
-  ["nanocodex_journal_owners", "journal_id", "text", null, null],
-  ["nanocodex_journal_owners", "owner_id", "text", null, null],
-  ["nanocodex_journal_owners", "fence", "numeric", 20, 0],
-  ["nanocodex_journals", "journal_id", "text", null, null],
-  ["nanocodex_journals", "revision", "numeric", 20, 0],
-];
-
-const POSTGRES_DURABILITY_PRIMARY_KEYS = [
-  ["nanocodex_journal_batches", "journal_id"],
-  ["nanocodex_journal_batches", "revision"],
-  ["nanocodex_journal_owners", "journal_id"],
-  ["nanocodex_journals", "journal_id"],
-];
-
-const POSTGRES_DURABILITY_NUMERIC_CHECKS = [
-  ["nanocodex_journal_batches", "revision"],
-  ["nanocodex_journal_owners", "fence"],
-  ["nanocodex_journals", "revision"],
-];
-
-const POSTGRES_DURABILITY_SCHEMA = [
-  `CREATE TABLE IF NOT EXISTS nanocodex_journal_owners (
-     journal_id TEXT PRIMARY KEY,
+const SCHEMA = [
+  `CREATE TABLE IF NOT EXISTS nanocodex_durable_owners (
+     state_id TEXT PRIMARY KEY,
      owner_id TEXT NOT NULL,
      fence NUMERIC(20, 0) NOT NULL
        CHECK (fence >= 1 AND fence <= 18446744073709551615)
    )`,
-  `CREATE TABLE IF NOT EXISTS nanocodex_journals (
-     journal_id TEXT PRIMARY KEY,
+  `CREATE TABLE IF NOT EXISTS nanocodex_durable_states (
+     state_id TEXT PRIMARY KEY,
      revision NUMERIC(20, 0) NOT NULL
-       CHECK (revision >= 0 AND revision <= 18446744073709551615)
-   )`,
-  `CREATE TABLE IF NOT EXISTS nanocodex_journal_batches (
-     journal_id TEXT NOT NULL REFERENCES nanocodex_journals(journal_id),
-     revision NUMERIC(20, 0) NOT NULL
-       CHECK (revision > 0 AND revision <= 18446744073709551615),
-     payload TEXT NOT NULL,
-     PRIMARY KEY (journal_id, revision)
+       CHECK (revision >= 1 AND revision <= 18446744073709551615),
+     payload TEXT NOT NULL
    )`,
 ];
 
 export class UnknownPostgresCommitOutcomeError extends Error {
-  name = "UnknownPostgresCommitOutcomeError";
-
-  constructor(journalId, cause) {
-    super(
-      `PostgreSQL durability COMMIT outcome is unknown for journal ${JSON.stringify(journalId)}`,
-      { cause },
-    );
+  constructor(stateId, cause) {
+    super(`PostgreSQL durability COMMIT outcome is unknown for state ${JSON.stringify(stateId)}`, {
+      cause,
+    });
+    this.name = "UnknownPostgresCommitOutcomeError";
   }
 }
 
+/** Creates a concrete PostgreSQL-backed Nanocodex durability store. */
 export function createPostgresDurabilityStore(pool) {
-  requirePool(pool);
-  let schemaReady;
-
-  const readyPool = async () => {
-    const attempt = schemaReady ??= initializeSchema(pool);
-    try {
-      return await attempt;
-    } catch (error) {
-      if (schemaReady === attempt) schemaReady = undefined;
+  if (!pool || typeof pool.connect !== "function" || typeof pool.query !== "function") {
+    throw new TypeError("PostgreSQL durability requires a connection pool");
+  }
+  let initialized;
+  const ready = () => {
+    initialized ??= initialize(pool).catch((error) => {
+      initialized = undefined;
       throw error;
-    }
+    });
+    return initialized;
   };
-
   return Object.freeze({
-    async load(journalId) {
-      requireJournalId(journalId);
-      return loadJournal(await readyPool(), journalId);
+    async load(stateId) {
+      requireId(stateId);
+      await ready();
+      return loadState(pool, stateId);
     },
-
-    async acquire(journalId, request) {
-      requireJournalId(journalId);
-      const ownerId = requireOwnerId(request?.ownerId);
-      return acquireJournal(await readyPool(), journalId, ownerId);
+    async acquire(stateId, request) {
+      requireId(stateId);
+      const ownerId = requireOwner(request?.ownerId);
+      await ready();
+      return acquireState(pool, stateId, ownerId);
     },
-
-    async append(journalId, request) {
-      requireJournalId(journalId);
-      requireAppendRequest(request);
-      return appendJournal(await readyPool(), journalId, request);
+    async replace(stateId, request) {
+      requireId(stateId);
+      const ownerId = requireOwner(request?.ownerId);
+      const fence = durabilityRevision(request?.fence);
+      const expectedRevision = durabilityRevision(request?.expectedRevision);
+      if (typeof request?.payload !== "string") {
+        throw new TypeError("durability payload must be a string");
+      }
+      await ready();
+      return replaceState(pool, stateId, {
+        ownerId,
+        fence,
+        expectedRevision,
+        payload: request.payload,
+      });
     },
   });
 }
 
-async function acquireJournal(pool, journalId, ownerId) {
+async function initialize(pool) {
   const client = await pool.connect();
-  let transactionStarted = false;
-  let commitAttempted = false;
-  let discardClient = true;
+  let begun = false;
+  let discard = false;
   try {
     await client.query("BEGIN");
-    transactionStarted = true;
-    discardClient = false;
-    const acquired = await client.query(
-      `INSERT INTO nanocodex_journal_owners (journal_id, owner_id, fence)
-       VALUES ($1, $2, 1)
-       ON CONFLICT (journal_id) DO UPDATE
-         SET owner_id = excluded.owner_id,
-             fence = nanocodex_journal_owners.fence + 1
-       WHERE nanocodex_journal_owners.fence < 18446744073709551615
-       RETURNING fence::text AS fence`,
-      [journalId, ownerId],
+    begun = true;
+    await client.query(
+      `SELECT pg_advisory_xact_lock(hashtextextended(
+         current_database() || ':' || current_schema() || ':nanocodex-durability-v2', 0
+       ))`,
     );
-    const row = acquired.rows[0];
-    if (!row) {
-      await rollback(client);
-      transactionStarted = false;
+    for (const statement of SCHEMA) await client.query(statement);
+    const columns = await client.query(
+      `SELECT table_name, column_name, data_type, is_nullable,
+              numeric_precision, numeric_scale
+       FROM information_schema.columns
+       WHERE table_schema = current_schema()
+         AND table_name IN ('nanocodex_durable_owners', 'nanocodex_durable_states')
+       ORDER BY table_name, ordinal_position`,
+    );
+    if (!validColumns(columns.rows)) {
+      throw new Error(
+        "incompatible Postgres durability schema; recreate the two nanocodex_durable_* tables",
+      );
+    }
+    const primaryKeys = await client.query(
+      `SELECT tc.table_name, kcu.column_name, kcu.ordinal_position
+       FROM information_schema.table_constraints AS tc
+       JOIN information_schema.key_column_usage AS kcu
+         ON tc.constraint_catalog = kcu.constraint_catalog
+        AND tc.constraint_schema = kcu.constraint_schema
+        AND tc.constraint_name = kcu.constraint_name
+       WHERE tc.table_schema = current_schema()
+         AND tc.constraint_type = 'PRIMARY KEY'
+         AND tc.table_name IN ('nanocodex_durable_owners', 'nanocodex_durable_states')
+       ORDER BY tc.table_name, kcu.ordinal_position`,
+    );
+    if (!validPrimaryKeys(primaryKeys.rows)) {
+      throw new Error(
+        "incompatible Postgres durability primary keys; each state_id must be the sole primary key",
+      );
+    }
+    await client.query("COMMIT");
+    begun = false;
+  } catch (error) {
+    if (begun) {
+      try {
+        await client.query("ROLLBACK");
+      } catch (rollbackError) {
+        discard = true;
+        throw new AggregateError(
+          [error, rollbackError],
+          "PostgreSQL durability initialization and rollback both failed",
+        );
+      }
+    }
+    throw error;
+  } finally {
+    client.release(discard);
+  }
+}
+
+function validPrimaryKeys(rows) {
+  const expected = [
+    ["nanocodex_durable_owners", "state_id", 1],
+    ["nanocodex_durable_states", "state_id", 1],
+  ];
+  return rows.length === expected.length && rows.every((row, index) =>
+    row.table_name === expected[index][0]
+      && row.column_name === expected[index][1]
+      && row.ordinal_position === expected[index][2]);
+}
+
+function validColumns(rows) {
+  const expected = [
+    ["nanocodex_durable_owners", "state_id", "text", "NO", null, null],
+    ["nanocodex_durable_owners", "owner_id", "text", "NO", null, null],
+    ["nanocodex_durable_owners", "fence", "numeric", "NO", 20, 0],
+    ["nanocodex_durable_states", "state_id", "text", "NO", null, null],
+    ["nanocodex_durable_states", "revision", "numeric", "NO", 20, 0],
+    ["nanocodex_durable_states", "payload", "text", "NO", null, null],
+  ];
+  return rows.length === expected.length && rows.every((row, index) => {
+    const shape = expected[index];
+    return row.table_name === shape[0]
+      && row.column_name === shape[1]
+      && row.data_type === shape[2]
+      && row.is_nullable === shape[3]
+      && (row.numeric_precision ?? null) === shape[4]
+      && (row.numeric_scale ?? null) === shape[5];
+  });
+}
+
+async function loadState(queryable, stateId) {
+  const result = await queryable.query(
+    `SELECT revision::text, payload FROM nanocodex_durable_states WHERE state_id = $1`,
+    [stateId],
+  );
+  if (result.rows.length === 0) return Object.freeze({ revision: "0", payload: null });
+  if (result.rows.length !== 1 || typeof result.rows[0].payload !== "string") {
+    throw new Error(`PostgreSQL returned invalid durability state ${JSON.stringify(stateId)}`);
+  }
+  return Object.freeze({
+    revision: durabilityRevision(result.rows[0].revision),
+    payload: result.rows[0].payload,
+  });
+}
+
+async function acquireState(pool, stateId, ownerId) {
+  const client = await pool.connect();
+  let begun = false;
+  let discard = false;
+  try {
+    await client.query("BEGIN");
+    begun = true;
+    const owner = await client.query(
+      `INSERT INTO nanocodex_durable_owners (state_id, owner_id, fence)
+       VALUES ($1, $2, 1)
+       ON CONFLICT (state_id) DO UPDATE
+       SET owner_id = excluded.owner_id, fence = nanocodex_durable_owners.fence + 1
+       WHERE nanocodex_durable_owners.fence < 18446744073709551615
+       RETURNING fence::text`,
+      [stateId, ownerId],
+    );
+    if (owner.rows.length !== 1) {
       throw new RangeError("PostgreSQL durability fence overflow");
     }
-    const fence = storedFence(row.fence, "acquired owner");
-    const journal = await loadJournal(client, journalId);
-
-    commitAttempted = true;
+    const fence = durabilityRevision(owner.rows[0].fence);
+    const state = await loadState(client, stateId);
     try {
       await client.query("COMMIT");
+      begun = false;
     } catch (error) {
-      discardClient = true;
-      throw new UnknownPostgresCommitOutcomeError(journalId, error);
+      discard = true;
+      throw new UnknownPostgresCommitOutcomeError(stateId, error);
     }
-    transactionStarted = false;
-    return { ownerId, fence, ...journal };
+    return Object.freeze({ ownerId, fence, ...state });
   } catch (error) {
-    if (transactionStarted && !commitAttempted) {
-      discardClient = true;
+    if (error instanceof UnknownPostgresCommitOutcomeError) throw error;
+    if (begun) {
       try {
-        await rollback(client);
-        transactionStarted = false;
-        discardClient = false;
+        await client.query("ROLLBACK");
       } catch (rollbackError) {
+        discard = true;
         throw new AggregateError(
           [error, rollbackError],
-          `PostgreSQL durability acquire and rollback both failed for journal ${JSON.stringify(journalId)}`,
+          "PostgreSQL durability acquire and rollback both failed",
         );
       }
     }
     throw error;
   } finally {
-    client.release(discardClient);
+    client.release(discard);
   }
 }
 
-async function initializeSchema(pool) {
+async function replaceState(pool, stateId, request) {
   const client = await pool.connect();
-  let transactionStarted = false;
-  let commitAttempted = false;
-  let discardClient = true;
+  let begun = false;
+  let discard = false;
   try {
     await client.query("BEGIN");
-    transactionStarted = true;
-    discardClient = false;
-    await client.query(
-      "SELECT pg_advisory_xact_lock($1::bigint)",
-      [SCHEMA_ADVISORY_LOCK],
+    begun = true;
+    const owner = await client.query(
+      `SELECT owner_id, fence::text FROM nanocodex_durable_owners
+       WHERE state_id = $1 FOR UPDATE`,
+      [stateId],
     );
-    for (const statement of POSTGRES_DURABILITY_SCHEMA) {
-      await client.query(statement);
-    }
-    await validateSchema(client);
-    commitAttempted = true;
-    try {
-      await client.query("COMMIT");
-    } catch (error) {
-      discardClient = true;
-      throw error;
-    }
-    transactionStarted = false;
-    return pool;
-  } catch (error) {
-    if (transactionStarted && !commitAttempted) {
-      discardClient = true;
-      try {
-        await rollback(client);
-        transactionStarted = false;
-        discardClient = false;
-      } catch (rollbackError) {
-        throw new AggregateError(
-          [error, rollbackError],
-          "PostgreSQL durability schema initialization and rollback both failed",
-        );
-      }
-    }
-    throw error;
-  } finally {
-    client.release(discardClient);
-  }
-}
-
-async function validateSchema(client) {
-  const columns = await client.query(
-    `SELECT table_name, column_name, data_type, is_nullable,
-            numeric_precision, numeric_scale
-       FROM information_schema.columns
-      WHERE table_schema = current_schema()
-        AND table_name IN (
-          'nanocodex_journals',
-          'nanocodex_journal_batches',
-          'nanocodex_journal_owners'
-        )
-      ORDER BY table_name, ordinal_position`,
-  );
-  if (columns.rows.length !== POSTGRES_DURABILITY_COLUMNS.length) {
-    throw incompatibleSchema(
-      `the three journal tables must contain exactly ${POSTGRES_DURABILITY_COLUMNS.length} columns, found ${columns.rows.length}`,
-    );
-  }
-  for (let index = 0; index < POSTGRES_DURABILITY_COLUMNS.length; index += 1) {
-    const row = columns.rows[index];
-    const [table, column, dataType, precision, scale] = POSTGRES_DURABILITY_COLUMNS[index];
-    if (
-      row?.table_name !== table
-      || row.column_name !== column
-      || row.data_type !== dataType
-      || row.is_nullable !== "NO"
-      || !catalogIntegerEquals(row.numeric_precision, precision)
-      || !catalogIntegerEquals(row.numeric_scale, scale)
-    ) {
-      throw incompatibleSchema(`\`${table}.${column}\` has an incompatible column shape`);
-    }
-  }
-
-  const primaryKeys = await client.query(
-    `SELECT retained_table.relname AS table_name,
-            attribute.attname AS column_name
-       FROM pg_class AS retained_table
-       JOIN pg_namespace AS retained_schema
-         ON retained_schema.oid = retained_table.relnamespace
-       JOIN pg_index AS retained_index
-         ON retained_index.indrelid = retained_table.oid
-       CROSS JOIN LATERAL unnest(retained_index.indkey)
-         WITH ORDINALITY AS key(attnum, position)
-       JOIN pg_attribute AS attribute
-         ON attribute.attrelid = retained_index.indrelid
-        AND attribute.attnum = key.attnum
-      WHERE retained_schema.nspname = current_schema()
-        AND retained_table.relname IN (
-          'nanocodex_journals',
-          'nanocodex_journal_batches',
-          'nanocodex_journal_owners'
-        )
-        AND retained_index.indisprimary
-      ORDER BY retained_table.relname, key.position`,
-  );
-  if (!catalogPairsEqual(primaryKeys.rows, POSTGRES_DURABILITY_PRIMARY_KEYS)) {
-    throw incompatibleSchema("the journal tables have incompatible PRIMARY KEY constraints");
-  }
-
-  const foreignKeys = await client.query(
-    `SELECT source_attribute.attname AS source_column,
-            target_schema.nspname = current_schema() AS target_in_current_schema,
-            target_table.relname AS target_table,
-            target_attribute.attname AS target_column,
-            retained_constraint.condeferrable AS is_deferrable,
-            retained_constraint.condeferred AS is_initially_deferred
-       FROM pg_constraint AS retained_constraint
-       JOIN pg_class AS source_table
-         ON source_table.oid = retained_constraint.conrelid
-       JOIN pg_namespace AS source_schema
-         ON source_schema.oid = source_table.relnamespace
-       CROSS JOIN LATERAL unnest(retained_constraint.conkey, retained_constraint.confkey)
-         WITH ORDINALITY AS key(source_attnum, target_attnum, position)
-       JOIN pg_attribute AS source_attribute
-         ON source_attribute.attrelid = retained_constraint.conrelid
-        AND source_attribute.attnum = key.source_attnum
-       JOIN pg_class AS target_table
-         ON target_table.oid = retained_constraint.confrelid
-       JOIN pg_namespace AS target_schema
-         ON target_schema.oid = target_table.relnamespace
-       JOIN pg_attribute AS target_attribute
-         ON target_attribute.attrelid = retained_constraint.confrelid
-        AND target_attribute.attnum = key.target_attnum
-      WHERE source_schema.nspname = current_schema()
-        AND source_table.relname = 'nanocodex_journal_batches'
-        AND retained_constraint.contype = 'f'
-      ORDER BY retained_constraint.oid, key.position`,
-  );
-  if (
-    foreignKeys.rows.length !== 1
-    || foreignKeys.rows[0]?.source_column !== "journal_id"
-    || foreignKeys.rows[0]?.target_in_current_schema !== true
-    || foreignKeys.rows[0]?.target_table !== "nanocodex_journals"
-    || foreignKeys.rows[0]?.target_column !== "journal_id"
-    || foreignKeys.rows[0]?.is_deferrable !== false
-    || foreignKeys.rows[0]?.is_initially_deferred !== false
-  ) {
-    throw incompatibleSchema("`nanocodex_journal_batches` has an incompatible foreign key");
-  }
-
-  await validateNumericChecks(client);
-}
-
-function catalogPairsEqual(rows, expected) {
-  return rows.length === expected.length && rows.every((row, index) => (
-    row?.table_name === expected[index][0]
-    && row.column_name === expected[index][1]
-  ));
-}
-
-async function validateNumericChecks(client) {
-  const checks = await client.query(
-    `SELECT retained_table.relname AS table_name,
-            attribute.attname AS column_name
-       FROM pg_constraint AS retained_constraint
-       JOIN pg_class AS retained_table
-         ON retained_table.oid = retained_constraint.conrelid
-       JOIN pg_namespace AS retained_schema
-         ON retained_schema.oid = retained_table.relnamespace
-       LEFT JOIN pg_attribute AS attribute
-         ON attribute.attrelid = retained_constraint.conrelid
-        AND retained_constraint.conkey = ARRAY[attribute.attnum]::smallint[]
-      WHERE retained_schema.nspname = current_schema()
-        AND retained_table.relname IN (
-          'nanocodex_journals',
-          'nanocodex_journal_batches',
-          'nanocodex_journal_owners'
-        )
-        AND retained_constraint.contype = 'c'
-      ORDER BY retained_table.relname, retained_constraint.oid`,
-  );
-  const retainedChecks = new Set(
-    checks.rows.map((row) => `${row?.table_name}.${row?.column_name}`),
-  );
-  for (const [table, column] of POSTGRES_DURABILITY_NUMERIC_CHECKS) {
-    if (!retainedChecks.has(`${table}.${column}`)) {
-      throw incompatibleSchema(`\`${table}.${column}\` must have a single-column CHECK constraint`);
-    }
-  }
-  if (!catalogPairsEqual(checks.rows, POSTGRES_DURABILITY_NUMERIC_CHECKS)) {
-    throw incompatibleSchema("the journal tables have incompatible CHECK constraints");
-  }
-
-  const probe = `nanocodex-schema-validator-${globalThis.crypto.randomUUID()}`;
-  await client.query("SAVEPOINT nanocodex_schema_validation");
-  let validationError;
-  try {
-    await validateNumericBoundaries(client, probe);
-  } catch (error) {
-    validationError = error;
-  }
-  try {
-    await client.query("ROLLBACK TO SAVEPOINT nanocodex_schema_validation");
-    await client.query("RELEASE SAVEPOINT nanocodex_schema_validation");
-  } catch (cleanupError) {
-    if (validationError !== undefined) {
-      throw new AggregateError(
-        [validationError, cleanupError],
-        "PostgreSQL durability schema validation and savepoint cleanup both failed",
-      );
-    }
-    throw cleanupError;
-  }
-  if (validationError !== undefined) throw validationError;
-}
-
-async function validateNumericBoundaries(client, probe) {
-  for (const [suffix, fence] of [
-    ["owner-min", "1"],
-    ["owner-interior", "2"],
-    ["owner-max", MAX_REVISION],
-  ]) {
-    await expectBoundaryAccepted(
-      client,
-      "owner bounds",
-      `INSERT INTO nanocodex_journal_owners (journal_id, owner_id, fence)
-       VALUES ($1, 'schema-validator', $2::text::numeric)`,
-      [`${probe}-${suffix}`, fence],
-    );
-  }
-  for (const [suffix, revision] of [
-    ["journal-min", "0"],
-    ["journal-interior", "1"],
-    ["journal-max", MAX_REVISION],
-  ]) {
-    await expectBoundaryAccepted(
-      client,
-      "journal bounds",
-      `INSERT INTO nanocodex_journals (journal_id, revision)
-       VALUES ($1, $2::text::numeric)`,
-      [`${probe}-${suffix}`, revision],
-    );
-  }
-  const batchJournal = `${probe}-journal-min`;
-  for (const revision of ["1", "2", MAX_REVISION]) {
-    await expectBoundaryAccepted(
-      client,
-      "batch bounds",
-      `INSERT INTO nanocodex_journal_batches (journal_id, revision, payload)
-       VALUES ($1, $2::text::numeric, 'schema-validator')`,
-      [batchJournal, revision],
-    );
-  }
-
-  for (const [label, statement, id, value] of [
-    [
-      "negative owner fence",
-      `INSERT INTO nanocodex_journal_owners (journal_id, owner_id, fence)
-       VALUES ($1, 'schema-validator', $2::text::numeric)`,
-      `${probe}-owner-negative`,
-      "-1",
-    ],
-    [
-      "owner fence zero",
-      `INSERT INTO nanocodex_journal_owners (journal_id, owner_id, fence)
-       VALUES ($1, 'schema-validator', $2::text::numeric)`,
-      `${probe}-owner-zero`,
-      "0",
-    ],
-    [
-      "owner fence above u64",
-      `INSERT INTO nanocodex_journal_owners (journal_id, owner_id, fence)
-       VALUES ($1, 'schema-validator', $2::text::numeric)`,
-      `${probe}-owner-overflow`,
-      ABOVE_MAX_REVISION,
-    ],
-    [
-      "owner fence farther above u64",
-      `INSERT INTO nanocodex_journal_owners (journal_id, owner_id, fence)
-       VALUES ($1, 'schema-validator', $2::text::numeric)`,
-      `${probe}-owner-far-overflow`,
-      FAR_ABOVE_MAX_REVISION,
-    ],
-    [
-      "negative journal revision",
-      `INSERT INTO nanocodex_journals (journal_id, revision)
-       VALUES ($1, $2::text::numeric)`,
-      `${probe}-journal-negative`,
-      "-1",
-    ],
-    [
-      "journal revision above u64",
-      `INSERT INTO nanocodex_journals (journal_id, revision)
-       VALUES ($1, $2::text::numeric)`,
-      `${probe}-journal-overflow`,
-      ABOVE_MAX_REVISION,
-    ],
-    [
-      "journal revision farther above u64",
-      `INSERT INTO nanocodex_journals (journal_id, revision)
-       VALUES ($1, $2::text::numeric)`,
-      `${probe}-journal-far-overflow`,
-      FAR_ABOVE_MAX_REVISION,
-    ],
-  ]) {
-    await expectCheckViolation(client, label, statement, [id, value]);
-  }
-  for (const [label, value] of [
-    ["negative batch revision", "-1"],
-    ["batch revision zero", "0"],
-    ["batch revision above u64", ABOVE_MAX_REVISION],
-    ["batch revision farther above u64", FAR_ABOVE_MAX_REVISION],
-  ]) {
-    await expectCheckViolation(
-      client,
-      label,
-      `INSERT INTO nanocodex_journal_batches (journal_id, revision, payload)
-       VALUES ($1, $2::text::numeric, 'schema-validator')`,
-      [batchJournal, value],
-    );
-  }
-}
-
-async function expectBoundaryAccepted(client, label, statement, values) {
-  try {
-    await client.query(statement, values);
-  } catch (error) {
-    throw incompatibleSchema(`${label} rejected: ${errorMessage(error)}`);
-  }
-}
-
-async function expectCheckViolation(client, label, statement, values) {
-  await client.query("SAVEPOINT nanocodex_schema_check");
-  let result;
-  try {
-    await client.query(statement, values);
-    result = { accepted: true };
-  } catch (error) {
-    result = { error };
-  }
-  await client.query("ROLLBACK TO SAVEPOINT nanocodex_schema_check");
-  await client.query("RELEASE SAVEPOINT nanocodex_schema_check");
-  if (result.error?.code === "23514") return;
-  if (result.error !== undefined) {
-    throw incompatibleSchema(`${label} failed for the wrong reason: ${errorMessage(result.error)}`);
-  }
-  throw incompatibleSchema(`${label} was accepted by its CHECK constraint`);
-}
-
-function catalogIntegerEquals(value, expected) {
-  if (expected === null) return value === null;
-  if (typeof value === "number") return Number.isInteger(value) && value === expected;
-  if (typeof value === "bigint") return value === BigInt(expected);
-  return typeof value === "string" && value === String(expected);
-}
-
-function incompatibleSchema(detail) {
-  return new Error(
-    `incompatible Postgres durability schema: ${detail}; recreate the three \`nanocodex_journal_*\` tables with the current schema`,
-  );
-}
-
-async function loadJournal(pool, journalId) {
-  const result = await pool.query(
-    `SELECT journal.revision::text AS head_revision,
-            batch.revision::text AS batch_revision,
-            batch.payload
-       FROM nanocodex_journals AS journal
-       LEFT JOIN nanocodex_journal_batches AS batch
-         ON batch.journal_id = journal.journal_id
-      WHERE journal.journal_id = $1
-      ORDER BY batch.revision ASC`,
-    [journalId],
-  );
-  if (result.rows.length === 0) return { revision: ZERO_REVISION, batches: [] };
-
-  const revision = storedRevision(result.rows[0]?.head_revision, "journal head");
-  const batches = result.rows.flatMap((row, index) => {
-    if (storedRevision(row.head_revision, "journal head") !== revision) {
-      throw new Error(
-        `PostgreSQL returned inconsistent heads while loading journal ${JSON.stringify(journalId)}`,
-      );
-    }
-    if (row.batch_revision === null && row.payload === null && index === 0) return [];
-    if (row.batch_revision === null || row.payload === null) {
-      throw new Error(
-        `PostgreSQL returned an incomplete batch while loading journal ${JSON.stringify(journalId)}`,
-      );
-    }
-    return [{
-      revision: storedRevision(row.batch_revision, "journal batch"),
-      payload: row.payload,
-    }];
-  });
-  return { revision, batches };
-}
-
-async function appendJournal(pool, journalId, request) {
-  const ownerId = requireOwnerId(request.ownerId);
-  const fence = durabilityRevision(request.fence);
-  const expectedRevision = durabilityRevision(request.expectedRevision);
-  let client;
-  try {
-    client = await pool.connect();
-  } catch (error) {
-    return {
-      status: "not_committed",
-      message: `PostgreSQL transaction was not started: ${errorMessage(error)}`,
-    };
-  }
-
-  let transactionStarted = false;
-  let commitAttempted = false;
-  let discardClient = true;
-  try {
-    try {
-      await client.query("BEGIN");
-    } catch (error) {
-      return {
-        status: "not_committed",
-        message: `PostgreSQL transaction did not begin: ${errorMessage(error)}`,
-      };
-    }
-    transactionStarted = true;
-    discardClient = false;
-    const owners = await client.query(
-      `SELECT owner_id, fence::text AS fence
-         FROM nanocodex_journal_owners
-        WHERE journal_id = $1
-        FOR UPDATE`,
-      [journalId],
-    );
-    const storedOwner = owners.rows[0];
-    if (
-      storedOwner?.owner_id !== ownerId
-      || storedFence(storedOwner?.fence, "journal owner") !== fence
-    ) {
-      await rollback(client);
-      transactionStarted = false;
+    const retained = owner.rows[0];
+    if (retained?.owner_id !== request.ownerId
+      || durabilityRevision(retained?.fence ?? "0") !== request.fence) {
+      await client.query("ROLLBACK");
+      begun = false;
       return { status: "fenced" };
     }
-    await client.query(
-      `INSERT INTO nanocodex_journals (journal_id, revision)
-       VALUES ($1, 0)
-       ON CONFLICT (journal_id) DO NOTHING`,
-      [journalId],
-    );
-    const advanced = await client.query(
-      `UPDATE nanocodex_journals
-          SET revision = revision + 1
-        WHERE journal_id = $1
-          AND revision = $2::numeric
-          AND revision < 18446744073709551615
-      RETURNING revision::text AS revision`,
-      [journalId, expectedRevision],
-    );
-
-    const row = advanced.rows[0];
-    if (!row) {
-      const actual = await client.query(
-        `SELECT revision::text AS revision
-           FROM nanocodex_journals
-          WHERE journal_id = $1`,
-        [journalId],
-      );
-      const actualRevision = storedRevision(actual.rows[0]?.revision, "journal head");
-      await rollback(client);
-      transactionStarted = false;
-      if (actualRevision === expectedRevision && actualRevision === MAX_REVISION) {
-        return {
-          status: "not_committed",
-          message: "PostgreSQL durability revision overflow",
-        };
-      }
-      return { status: "conflict", actualRevision };
+    const state = await loadStateForUpdate(client, stateId);
+    if (state.revision !== request.expectedRevision) {
+      await client.query("ROLLBACK");
+      begun = false;
+      return { status: "conflict", actualRevision: state.revision };
     }
-
-    const revision = storedRevision(row.revision, "appended journal");
+    if (state.revision === MAX_REVISION) {
+      await client.query("ROLLBACK");
+      begun = false;
+      return { status: "not_committed", message: "PostgreSQL durability revision overflow" };
+    }
+    const revision = durabilityRevision(BigInt(state.revision) + 1n);
     await client.query(
-      `INSERT INTO nanocodex_journal_batches (journal_id, revision, payload)
-       VALUES ($1, $2::numeric, $3)`,
-      [journalId, revision, request.payload],
+      `INSERT INTO nanocodex_durable_states (state_id, revision, payload)
+       VALUES ($1, $2::numeric, $3)
+       ON CONFLICT (state_id) DO UPDATE
+       SET revision = excluded.revision, payload = excluded.payload`,
+      [stateId, revision, request.payload],
     );
-
-    commitAttempted = true;
     try {
       await client.query("COMMIT");
+      begun = false;
     } catch (error) {
-      discardClient = true;
-      throw new UnknownPostgresCommitOutcomeError(journalId, error);
+      discard = true;
+      throw new UnknownPostgresCommitOutcomeError(stateId, error);
     }
-    transactionStarted = false;
-    return { status: "appended", revision };
+    return { status: "replaced", revision };
   } catch (error) {
-    if (transactionStarted && !commitAttempted) {
-      discardClient = true;
+    if (error instanceof UnknownPostgresCommitOutcomeError) throw error;
+    if (begun) {
       try {
-        await rollback(client);
-        transactionStarted = false;
-        discardClient = false;
+        await client.query("ROLLBACK");
+        begun = false;
+        return { status: "not_committed", message: message(error) };
       } catch (rollbackError) {
-        throw new AggregateError(
-          [error, rollbackError],
-          `PostgreSQL durability append and rollback both failed for journal ${JSON.stringify(journalId)}`,
-        );
+        discard = true;
+        throw new AggregateError([error, rollbackError], "PostgreSQL durability replace and rollback both failed");
       }
-      return {
-        status: "not_committed",
-        message: `PostgreSQL durability append was rolled back: ${errorMessage(error)}`,
-      };
     }
     throw error;
   } finally {
-    client.release(discardClient);
+    client.release(discard);
   }
 }
 
-async function rollback(client) {
-  await client.query("ROLLBACK");
-}
-
-function storedRevision(value, owner) {
-  if (typeof value !== "string") {
-    throw new Error(`PostgreSQL ${owner} revision must be returned as decimal text`);
+async function loadStateForUpdate(client, stateId) {
+  const result = await client.query(
+    `SELECT revision::text, payload FROM nanocodex_durable_states
+     WHERE state_id = $1 FOR UPDATE`,
+    [stateId],
+  );
+  if (result.rows.length === 0) return { revision: "0", payload: null };
+  if (result.rows.length !== 1 || typeof result.rows[0].payload !== "string") {
+    throw new Error("PostgreSQL returned invalid durable state");
   }
-  return durabilityRevision(value);
+  return { revision: durabilityRevision(result.rows[0].revision), payload: result.rows[0].payload };
 }
 
-function storedFence(value, owner) {
-  if (typeof value !== "string") {
-    throw new Error(`PostgreSQL ${owner} fence must be returned as decimal text`);
-  }
-  return durabilityRevision(value);
-}
-
-function requirePool(pool) {
-  if (!pool || typeof pool.connect !== "function" || typeof pool.query !== "function") {
-    throw new TypeError("PostgreSQL durability requires a pool with connect and query methods");
+function requireId(value) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new TypeError("durability state ID must be a non-empty string");
   }
 }
 
-function requireJournalId(journalId) {
-  if (typeof journalId !== "string" || !journalId.trim()) {
-    throw new TypeError("durability journal ID must be a non-empty string");
-  }
-}
-
-function requireAppendRequest(request) {
-  requireOwnerId(request?.ownerId);
-  durabilityRevision(request?.fence);
-  durabilityRevision(request?.expectedRevision);
-  if (typeof request?.payload !== "string") {
-    throw new TypeError("durability batch payload must be a string");
-  }
-}
-
-function requireOwnerId(ownerId) {
-  if (typeof ownerId !== "string" || !ownerId.trim()) {
+function requireOwner(value) {
+  if (typeof value !== "string" || !value.trim()) {
     throw new TypeError("durability owner ID must be a non-empty string");
   }
-  return ownerId;
+  return value;
 }
 
-function errorMessage(error) {
+function message(error) {
   return error instanceof Error ? error.message : String(error);
 }

--- a/js/bindings/runtime/postgres-durability-store.mjs
+++ b/js/bindings/runtime/postgres-durability-store.mjs
@@ -1,4 +1,7 @@
-import { durabilityRevision } from "./durability-store.mjs";
+import {
+  DurabilityImportConflictError,
+  durabilityRevision,
+} from "./durability-store.mjs";
 
 const MAX_REVISION = "18446744073709551615";
 const SCHEMA = [
@@ -68,6 +71,12 @@ export function createPostgresDurabilityStore(pool) {
         expectedRevision: request?.expectedRevision,
         payload: request?.payload,
       });
+    },
+    async importState(stateId, imported) {
+      requireId(stateId);
+      const state = importedState(imported);
+      await ready();
+      return restoreState(pool, stateId, state);
     },
   });
 }
@@ -301,6 +310,70 @@ async function replaceState(pool, stateId, request) {
   }
 }
 
+async function restoreState(pool, stateId, state) {
+  const client = await pool.connect();
+  let begun = false;
+  let discard = false;
+  try {
+    await client.query("BEGIN");
+    begun = true;
+    const owner = await client.query(
+      `SELECT owner_id, fence::text FROM nanocodex_durable_owners
+       WHERE state_id = $1 FOR UPDATE`,
+      [stateId],
+    );
+    if (owner.rows.length > 1) {
+      throw new Error("PostgreSQL returned duplicate durability owners during import");
+    }
+    if (owner.rows.length !== 0) throw new DurabilityImportConflictError(stateId);
+    const retained = await client.query(
+      `SELECT revision::text FROM nanocodex_durable_states
+       WHERE state_id = $1 FOR UPDATE`,
+      [stateId],
+    );
+    if (retained.rows.length > 1) {
+      throw new Error("PostgreSQL returned duplicate durability states during import");
+    }
+    if (retained.rows.length !== 0) throw new DurabilityImportConflictError(stateId);
+    await client.query(
+      `INSERT INTO nanocodex_durable_owners (state_id, owner_id, fence)
+       VALUES ($1, $2, $3::numeric)`,
+      [stateId, portableOwnerId(), "1"],
+    );
+    if (state.revision !== "0") {
+      await client.query(
+        `INSERT INTO nanocodex_durable_states (state_id, revision, payload)
+         VALUES ($1, $2::numeric, $3)`,
+        [stateId, state.revision, state.payload],
+      );
+    }
+    try {
+      await client.query("COMMIT");
+      begun = false;
+    } catch (error) {
+      discard = true;
+      throw new UnknownPostgresCommitOutcomeError(stateId, error);
+    }
+    return state;
+  } catch (error) {
+    if (error instanceof UnknownPostgresCommitOutcomeError) throw error;
+    if (begun) {
+      try {
+        await client.query("ROLLBACK");
+      } catch (rollbackError) {
+        discard = true;
+        throw new AggregateError(
+          [error, rollbackError],
+          "PostgreSQL durability import and rollback both failed",
+        );
+      }
+    }
+    throw error;
+  } finally {
+    client.release(discard);
+  }
+}
+
 function requestRevision(value) {
   try {
     return durabilityRevision(value);
@@ -316,6 +389,33 @@ function requestPayload(value) {
     );
   }
   return value;
+}
+
+function importedState(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("imported durability state must be an object");
+  }
+  const keys = Object.keys(value).sort();
+  if (keys.length !== 2 || keys[0] !== "payload" || keys[1] !== "revision") {
+    throw new TypeError("imported durability state must contain exactly payload and revision");
+  }
+  const revision = durabilityRevision(value.revision);
+  const payload = value.payload;
+  if ((revision === "0") !== (payload === null)) {
+    throw new TypeError("imported durability payload must be null exactly at revision zero");
+  }
+  if (payload !== null && typeof payload !== "string") {
+    throw new TypeError("imported durability payload must be a string");
+  }
+  return Object.freeze({ revision, payload });
+}
+
+function portableOwnerId() {
+  const randomUUID = globalThis.crypto?.randomUUID;
+  if (typeof randomUUID !== "function") {
+    throw new Error("durability portability requires crypto.randomUUID()");
+  }
+  return `nanocodex-import-${randomUUID.call(globalThis.crypto)}`;
 }
 
 async function loadStateForUpdate(client, stateId) {

--- a/js/bindings/src/wasm.rs
+++ b/js/bindings/src/wasm.rs
@@ -15,8 +15,7 @@ use nanocodex::{
     agent::{
         AgentHandle, ExecutionEnvironment, PromptRequest, SpawnOptions,
         durability::{
-            JournalStore, OwnedJournal, OwnerId, OwnerToken, StoreError, StoreFuture, StoredBatch,
-            StoredJournal,
+            OwnedState, OwnerId, OwnerToken, StateStore, StoreError, StoreFuture, StoredState,
         },
         input::{Prompt, UserInput},
         session::{SessionId, SessionSnapshot},
@@ -60,9 +59,9 @@ mod transport;
 
 use transport::JavaScriptResponsesHost;
 
-/// Compacts a durable session before its full Agent runtime is constructed.
-#[wasm_bindgen(js_name = compactDurableSession)]
-pub async fn compact_durable_session(
+/// Prunes old replay receipts before the full Agent runtime is constructed.
+#[wasm_bindgen(js_name = pruneDurableReceipts)]
+pub async fn prune_durable_receipts(
     durability_host_id: &str,
     durability_id: &str,
     terminal_receipt_limit: u32,
@@ -87,7 +86,7 @@ pub async fn compact_durable_session(
     )
     .await
     .map_err(js_error)?;
-    session.compact().await.map_err(js_error)
+    session.prune_receipts().await.map_err(js_error)
 }
 
 #[wasm_bindgen]
@@ -127,32 +126,14 @@ extern "C" {
     #[wasm_bindgen(catch, js_namespace = ["globalThis", "nanocodexHost"], js_name = durabilityAcquire)]
     fn host_durability_acquire(
         route_id: &str,
-        journal_id: &str,
+        state_id: &str,
         owner_id: &str,
     ) -> Result<Promise, JsValue>;
 
-    #[wasm_bindgen(catch, js_namespace = ["globalThis", "nanocodexHost"], js_name = durabilityAcquirePage)]
-    fn host_durability_acquire_page(
+    #[wasm_bindgen(catch, js_namespace = ["globalThis", "nanocodexHost"], js_name = durabilityReplace)]
+    fn host_durability_replace(
         route_id: &str,
-        journal_id: &str,
-        owner_id: &str,
-        after_revision: &str,
-    ) -> Result<Promise, JsValue>;
-
-    #[wasm_bindgen(catch, js_namespace = ["globalThis", "nanocodexHost"], js_name = durabilityAppend)]
-    fn host_durability_append(
-        route_id: &str,
-        journal_id: &str,
-        owner_id: &str,
-        fence: &str,
-        expected_revision: &str,
-        payload: &str,
-    ) -> Result<Promise, JsValue>;
-
-    #[wasm_bindgen(catch, js_namespace = ["globalThis", "nanocodexHost"], js_name = durabilityCompact)]
-    fn host_durability_compact(
-        route_id: &str,
-        journal_id: &str,
+        state_id: &str,
         owner_id: &str,
         fence: &str,
         expected_revision: &str,
@@ -330,140 +311,68 @@ struct JavaScriptDurabilityStore {
 }
 
 #[derive(Deserialize)]
-struct JavaScriptOwnedJournal {
+struct JavaScriptOwnedState {
     owner_id: String,
     fence: String,
     revision: String,
-    batches: Vec<JavaScriptStoredBatch>,
-    has_more: bool,
-}
-
-#[derive(Deserialize)]
-struct JavaScriptStoredBatch {
-    revision: String,
-    payload: String,
+    payload: Option<String>,
 }
 
 #[derive(Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
-enum JavaScriptAppendResult {
-    Appended { revision: String },
+enum JavaScriptReplaceResult {
+    Replaced { revision: String },
     Conflict { actual_revision: String },
     Fenced,
     NotCommitted { message: String },
 }
 
-#[derive(Deserialize)]
-#[serde(tag = "status", rename_all = "snake_case")]
-enum JavaScriptCompactResult {
-    Compacted { revision: String },
-    Conflict { actual_revision: String },
-    Fenced,
-    NotCommitted { message: String },
-}
-
-impl JournalStore for JavaScriptDurabilityStore {
-    fn acquire_owner<'a>(
+impl StateStore for JavaScriptDurabilityStore {
+    fn acquire<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner_id: OwnerId,
-    ) -> StoreFuture<'a, Result<OwnedJournal, StoreError>> {
+    ) -> StoreFuture<'a, Result<OwnedState, StoreError>> {
         Box::pin(async move {
-            let mut after_revision = String::new();
-            let mut acquired_fence = None;
-            let mut acquired_revision = None;
-            let mut batches = Vec::new();
-            loop {
-                let promise = host_durability_acquire_page(
-                    &self.route_id,
-                    journal_id,
-                    owner_id.as_str(),
-                    &after_revision,
-                )
+            let promise = host_durability_acquire(&self.route_id, state_id, owner_id.as_str())
                 .map_err(|error| StoreError::Backend(host_error_message(&error)))?;
-                let value = JsFuture::from(promise)
-                    .await
-                    .map_err(|error| StoreError::Backend(host_error_message(&error)))?;
-                let encoded = value.as_string().ok_or_else(|| {
-                    StoreError::Backend(
-                        "JavaScript durability acquire page returned a non-string".to_owned(),
-                    )
+            let value = JsFuture::from(promise)
+                .await
+                .map_err(|error| StoreError::Backend(host_error_message(&error)))?;
+            let encoded = value.as_string().ok_or_else(|| {
+                StoreError::Backend(
+                    "JavaScript durability acquire returned a non-string".to_owned(),
+                )
+            })?;
+            let stored =
+                serde_json::from_str::<JavaScriptOwnedState>(&encoded).map_err(|error| {
+                    StoreError::Backend(format!("invalid durability acquire result: {error}"))
                 })?;
-                let stored =
-                    serde_json::from_str::<JavaScriptOwnedJournal>(&encoded).map_err(|error| {
-                        StoreError::Backend(format!("invalid durability acquire page: {error}"))
-                    })?;
-                if stored.owner_id != owner_id.as_str() {
-                    return Err(StoreError::Backend(
-                        "JavaScript durability acquire returned a different owner ID".to_owned(),
-                    ));
-                }
-                let fence = parse_revision(&stored.fence)?;
-                let revision = parse_revision(&stored.revision)?;
-                if acquired_fence.is_some_and(|retained| retained != fence)
-                    || acquired_revision.is_some_and(|retained| retained != revision)
-                {
-                    return Err(StoreError::Backend(
-                        "JavaScript durability acquisition changed between pages".to_owned(),
-                    ));
-                }
-                acquired_fence = Some(fence);
-                acquired_revision = Some(revision);
-                let page = stored
-                    .batches
-                    .into_iter()
-                    .map(|batch| {
-                        Ok(StoredBatch {
-                            revision: parse_revision(&batch.revision)?,
-                            payload: batch.payload,
-                        })
-                    })
-                    .collect::<Result<Vec<_>, StoreError>>()?;
-                if page
-                    .windows(2)
-                    .any(|pair| pair[0].revision >= pair[1].revision)
-                    || batches.last().is_some_and(|retained: &StoredBatch| {
-                        page.first()
-                            .is_some_and(|candidate| candidate.revision <= retained.revision)
-                    })
-                {
-                    return Err(StoreError::Backend(
-                        "JavaScript durability acquisition revisions did not advance".to_owned(),
-                    ));
-                }
-                if stored.has_more {
-                    let next = page.last().ok_or_else(|| {
-                        StoreError::Backend(
-                            "JavaScript durability acquisition returned an empty continued page"
-                                .to_owned(),
-                        )
-                    })?;
-                    let next = next.revision.to_string();
-                    if next == after_revision {
-                        return Err(StoreError::Backend(
-                            "JavaScript durability acquisition cursor did not advance".to_owned(),
-                        ));
-                    }
-                    after_revision = next;
-                }
-                batches.extend(page);
-                if !stored.has_more {
-                    break;
-                }
+            if stored.owner_id != owner_id.as_str() {
+                return Err(StoreError::Backend(
+                    "JavaScript durability acquire returned a different owner ID".to_owned(),
+                ));
             }
-            Ok(OwnedJournal {
-                owner: OwnerToken::new(owner_id, acquired_fence.unwrap_or_default()),
-                journal: StoredJournal {
-                    revision: acquired_revision.unwrap_or_default(),
-                    batches,
+            let fence = parse_revision(&stored.fence)?;
+            let revision = parse_revision(&stored.revision)?;
+            if (revision == 0) != stored.payload.is_none() {
+                return Err(StoreError::Backend(
+                    "JavaScript durability acquire returned inconsistent state".to_owned(),
+                ));
+            }
+            Ok(OwnedState {
+                owner: OwnerToken::new(owner_id, fence),
+                state: StoredState {
+                    revision,
+                    payload: stored.payload,
                 },
             })
         })
     }
 
-    fn append<'a>(
+    fn replace<'a>(
         &'a mut self,
-        journal_id: &'a str,
+        state_id: &'a str,
         owner: &'a OwnerToken,
         expected_revision: u64,
         payload: &'a str,
@@ -471,50 +380,9 @@ impl JournalStore for JavaScriptDurabilityStore {
         Box::pin(async move {
             let fence = owner.fence().to_string();
             let expected = expected_revision.to_string();
-            let promise = host_durability_append(
+            let promise = host_durability_replace(
                 &self.route_id,
-                journal_id,
-                owner.owner_id().as_str(),
-                &fence,
-                &expected,
-                payload,
-            )
-            .map_err(|error| StoreError::Backend(host_error_message(&error)))?;
-            let value = JsFuture::from(promise)
-                .await
-                .map_err(|error| StoreError::Backend(host_error_message(&error)))?;
-            let encoded = value.as_string().ok_or_else(|| {
-                StoreError::Backend("JavaScript durability append returned a non-string".to_owned())
-            })?;
-            match serde_json::from_str::<JavaScriptAppendResult>(&encoded).map_err(|error| {
-                StoreError::Backend(format!("invalid durability append result: {error}"))
-            })? {
-                JavaScriptAppendResult::Appended { revision } => parse_revision(&revision),
-                JavaScriptAppendResult::Conflict { actual_revision } => Err(StoreError::Conflict {
-                    expected: expected_revision,
-                    actual: parse_revision(&actual_revision)?,
-                }),
-                JavaScriptAppendResult::Fenced => Err(StoreError::Fenced),
-                JavaScriptAppendResult::NotCommitted { message } => {
-                    Err(StoreError::NotCommitted(message))
-                }
-            }
-        })
-    }
-
-    fn compact<'a>(
-        &'a mut self,
-        journal_id: &'a str,
-        owner: &'a OwnerToken,
-        expected_revision: u64,
-        payload: &'a str,
-    ) -> StoreFuture<'a, Result<u64, StoreError>> {
-        Box::pin(async move {
-            let fence = owner.fence().to_string();
-            let expected = expected_revision.to_string();
-            let promise = host_durability_compact(
-                &self.route_id,
-                journal_id,
+                state_id,
                 owner.owner_id().as_str(),
                 &fence,
                 &expected,
@@ -526,21 +394,21 @@ impl JournalStore for JavaScriptDurabilityStore {
                 .map_err(|error| StoreError::Backend(host_error_message(&error)))?;
             let encoded = value.as_string().ok_or_else(|| {
                 StoreError::Backend(
-                    "JavaScript durability compact returned a non-string".to_owned(),
+                    "JavaScript durability replace returned a non-string".to_owned(),
                 )
             })?;
-            match serde_json::from_str::<JavaScriptCompactResult>(&encoded).map_err(|error| {
-                StoreError::Backend(format!("invalid durability compact result: {error}"))
+            match serde_json::from_str::<JavaScriptReplaceResult>(&encoded).map_err(|error| {
+                StoreError::Backend(format!("invalid durability replace result: {error}"))
             })? {
-                JavaScriptCompactResult::Compacted { revision } => parse_revision(&revision),
-                JavaScriptCompactResult::Conflict { actual_revision } => {
+                JavaScriptReplaceResult::Replaced { revision } => parse_revision(&revision),
+                JavaScriptReplaceResult::Conflict { actual_revision } => {
                     Err(StoreError::Conflict {
                         expected: expected_revision,
                         actual: parse_revision(&actual_revision)?,
                     })
                 }
-                JavaScriptCompactResult::Fenced => Err(StoreError::Fenced),
-                JavaScriptCompactResult::NotCommitted { message } => {
+                JavaScriptReplaceResult::Fenced => Err(StoreError::Fenced),
+                JavaScriptReplaceResult::NotCommitted { message } => {
                     Err(StoreError::NotCommitted(message))
                 }
             }
@@ -1266,25 +1134,24 @@ impl WasmNanocodex {
         if let Some(resume) = config.resume {
             builder = builder.resume(resume);
         }
-        if let (Some(route_id), Some(journal_id)) =
-            (config.durability_host_id, config.durability_id)
+        if let (Some(route_id), Some(state_id)) = (config.durability_host_id, config.durability_id)
         {
             let store = JavaScriptDurabilityStore { route_id };
-            let journal = if let Some(limit) = config.terminal_receipt_retention {
+            let durable_state = if let Some(limit) = config.terminal_receipt_retention {
                 if limit > 4_096 {
                     return Err(js_error(
                         "terminal_receipt_retention must be from 0 through 4096",
                     ));
                 }
                 nanocodex::agent::durability::DurableSession::open_with_terminal_receipt_limit(
-                    store, journal_id, limit,
+                    store, state_id, limit,
                 )
                 .await
             } else {
-                nanocodex::agent::durability::DurableSession::open(store, journal_id).await
+                nanocodex::agent::durability::DurableSession::open(store, state_id).await
             }
             .map_err(js_error)?;
-            builder = builder.durability(journal).await.map_err(js_error)?;
+            builder = builder.durability(durable_state).await.map_err(js_error)?;
         }
         let (inner, events) = builder.build().map_err(js_error)?;
         Ok(Self::from_parts(inner, events, subagents))
@@ -2699,7 +2566,6 @@ const fn execution_policy_failure_code(
 
     match disposition {
         ExecutionPolicyDisposition::Retry => "retryable",
-        ExecutionPolicyDisposition::Blocked => "blocked",
         ExecutionPolicyDisposition::Reopen => "reopen_required",
         ExecutionPolicyDisposition::Fatal => "failed",
     }
@@ -2927,7 +2793,7 @@ fn validate(config: &WasmConfig) -> Result<(), JsValue> {
     if config
         .durability_id
         .as_deref()
-        .is_some_and(|journal_id| journal_id.trim().is_empty())
+        .is_some_and(|state_id| state_id.trim().is_empty())
     {
         return Err(js_error("durability_id must not be empty"));
     }

--- a/js/bindings/test/client.test.mjs
+++ b/js/bindings/test/client.test.mjs
@@ -22,50 +22,50 @@ import {
   retain as retainDurabilityHost,
 } from "../runtime/durability.mjs";
 
-test("the memory durability store carries opaque Rust batches across host steps", () => {
-  const store = createMemoryDurabilityStore("journal-1");
-  assert.deepEqual(store.load("journal-1"), { revision: "0", batches: [] });
-  assert.deepEqual(store.acquire("journal-1", { ownerId: "owner-1" }), {
+test("the memory durability store replaces one complete opaque state", () => {
+  const store = createMemoryDurabilityStore("state-1");
+  assert.deepEqual(store.load("state-1"), { revision: "0", payload: null });
+  assert.deepEqual(store.acquire("state-1", { ownerId: "owner-1" }), {
     ownerId: "owner-1",
     fence: "1",
     revision: "0",
-    batches: [],
+    payload: null,
   });
-  assert.deepEqual(store.append("journal-1", {
+  assert.deepEqual(store.replace("state-1", {
     ownerId: "owner-1",
     fence: "1",
     expectedRevision: "0",
     payload: "{\"entry\":1}",
-  }), { status: "appended", revision: "1" });
-  assert.deepEqual(store.acquire("journal-1", { ownerId: "owner-2" }), {
+  }), { status: "replaced", revision: "1" });
+  assert.deepEqual(store.acquire("state-1", { ownerId: "owner-2" }), {
     ownerId: "owner-2",
     fence: "2",
     revision: "1",
-    batches: [{ revision: "1", payload: "{\"entry\":1}" }],
+    payload: "{\"entry\":1}",
   });
-  assert.deepEqual(store.append("journal-1", {
+  assert.deepEqual(store.replace("state-1", {
     ownerId: "owner-1",
     fence: "1",
     expectedRevision: "0",
     payload: "stale",
   }), { status: "fenced" });
-  assert.deepEqual(store.append("journal-1", {
+  assert.deepEqual(store.replace("state-1", {
     ownerId: "owner-2",
     fence: "2",
     expectedRevision: "0",
     payload: "conflicting",
   }), { status: "conflict", actualRevision: "1" });
-  assert.deepEqual(store.compact("journal-1", {
+  assert.deepEqual(store.replace("state-1", {
     ownerId: "owner-2",
     fence: "2",
     expectedRevision: "1",
-    payload: "{\"nanocodex_journal_state\":{}}",
-  }), { status: "compacted", revision: "1" });
+    payload: "{\"nanocodex_durable_state\":{}}",
+  }), { status: "replaced", revision: "2" });
   assert.deepEqual(store.snapshot(), {
-    revision: "1",
-    batches: [{ revision: "1", payload: "{\"nanocodex_journal_state\":{}}" }],
+    revision: "2",
+    payload: "{\"nanocodex_durable_state\":{}}",
   });
-  assert.throws(() => store.load("other"), /unknown durability journal/);
+  assert.throws(() => store.load("other"), /unknown durability state/);
   assert.equal(durabilityRevision("18446744073709551615"), "18446744073709551615");
   assert.throws(
     () => durabilityRevision("18446744073709551616"),
@@ -82,10 +82,10 @@ test("the memory durability store carries opaque Rust batches across host steps"
   );
   const exhausted = createMemoryDurabilityStore("exhausted", {
     revision: "18446744073709551615",
-    batches: [],
+    payload: "retained",
   });
   const exhaustedOwner = exhausted.acquire("exhausted", { ownerId: "owner" });
-  assert.deepEqual(exhausted.append("exhausted", {
+  assert.deepEqual(exhausted.replace("exhausted", {
     ownerId: exhaustedOwner.ownerId,
     fence: exhaustedOwner.fence,
     expectedRevision: "18446744073709551615",
@@ -97,40 +97,26 @@ test("the memory durability store carries opaque Rust batches across host steps"
   assert.equal(exhausted.snapshot().revision, "18446744073709551615");
 });
 
-test("the SQLite durability store owns revision validation and compare-and-append", () => {
+test("the SQLite durability store owns revision validation and compare-and-replace", () => {
   const owners = new Map();
-  const revisions = new Map();
-  const batches = [];
+  const states = new Map();
   const query = (sql, args) => {
-    const [journalId, revision, payload] = args;
-    if (sql.startsWith("SELECT owner_id, fence FROM nanocodex_journal_owners")) {
-      const stored = owners.get(journalId);
+    const [stateId, revision, payload] = args;
+    if (sql.startsWith("SELECT owner_id, fence FROM nanocodex_durable_owners")) {
+      const stored = owners.get(stateId);
       return stored === undefined ? [] : [stored];
     }
-    if (sql.startsWith("INSERT INTO nanocodex_journal_owners")) {
+    if (sql.startsWith("INSERT INTO nanocodex_durable_owners")) {
       const [, ownerId, fence] = args;
-      owners.set(journalId, { owner_id: ownerId, fence });
+      owners.set(stateId, { owner_id: ownerId, fence });
       return [];
     }
-    if (sql.startsWith("SELECT revision FROM nanocodex_journals")) {
-      const stored = revisions.get(journalId);
-      return stored === undefined ? [] : [{ revision: stored }];
+    if (sql.startsWith("SELECT revision, payload FROM nanocodex_durable_states")) {
+      const stored = states.get(stateId);
+      return stored === undefined ? [] : [stored];
     }
-    if (sql.startsWith("SELECT revision, payload FROM nanocodex_journal_batches")) {
-      return batches.filter((batch) => batch.journalId === journalId);
-    }
-    if (sql.startsWith("INSERT INTO nanocodex_journals")) {
-      revisions.set(journalId, revision);
-      return [];
-    }
-    if (sql.startsWith("INSERT INTO nanocodex_journal_batches")) {
-      batches.push({ journalId, revision, payload });
-      return [];
-    }
-    if (sql.startsWith("DELETE FROM nanocodex_journal_batches")) {
-      for (let index = batches.length - 1; index >= 0; index -= 1) {
-        if (batches[index].journalId === journalId) batches.splice(index, 1);
-      }
+    if (sql.startsWith("INSERT INTO nanocodex_durable_states")) {
+      states.set(stateId, { revision, payload });
       return [];
     }
     throw new Error(`unexpected SQL: ${sql}`);
@@ -138,41 +124,41 @@ test("the SQLite durability store owns revision validation and compare-and-appen
   const store = createSqliteDurabilityStore({
     transaction: (callback) => callback(query),
   });
-  assert.equal(sqliteDurabilitySchema.length, 3);
+  assert.equal(sqliteDurabilitySchema.length, 2);
 
-  assert.deepEqual(store.load("journal-1"), { revision: "0", batches: [] });
-  const firstOwner = store.acquire("journal-1", { ownerId: "owner-1" });
+  assert.deepEqual(store.load("state-1"), { revision: "0", payload: null });
+  const firstOwner = store.acquire("state-1", { ownerId: "owner-1" });
   assert.deepEqual(firstOwner, {
     ownerId: "owner-1",
     fence: "1",
     revision: "0",
-    batches: [],
+    payload: null,
   });
-  assert.deepEqual(store.append("journal-1", {
+  assert.deepEqual(store.replace("state-1", {
     ownerId: firstOwner.ownerId,
     fence: firstOwner.fence,
     expectedRevision: "0",
     payload: "opaque",
-  }), { status: "appended", revision: "1" });
-  assert.deepEqual(store.append("journal-1", {
+  }), { status: "replaced", revision: "1" });
+  assert.deepEqual(store.replace("state-1", {
     ownerId: firstOwner.ownerId,
     fence: firstOwner.fence,
     expectedRevision: "0",
     payload: "stale",
   }), { status: "conflict", actualRevision: "1" });
-  assert.deepEqual(store.compact("journal-1", {
+  assert.deepEqual(store.replace("state-1", {
     ownerId: firstOwner.ownerId,
     fence: firstOwner.fence,
     expectedRevision: "1",
     payload: "checkpoint",
-  }), { status: "compacted", revision: "1" });
-  assert.deepEqual(store.load("journal-1"), {
-    revision: "1",
-    batches: [{ revision: "1", payload: "checkpoint" }],
+  }), { status: "replaced", revision: "2" });
+  assert.deepEqual(store.load("state-1"), {
+    revision: "2",
+    payload: "checkpoint",
   });
-  revisions.set("exhausted", "18446744073709551615");
+  states.set("exhausted", { revision: "18446744073709551615", payload: "retained" });
   const exhaustedOwner = store.acquire("exhausted", { ownerId: "owner-exhausted" });
-  assert.deepEqual(store.append("exhausted", {
+  assert.deepEqual(store.replace("exhausted", {
     ownerId: exhaustedOwner.ownerId,
     fence: exhaustedOwner.fence,
     expectedRevision: "18446744073709551615",
@@ -181,21 +167,20 @@ test("the SQLite durability store owns revision validation and compare-and-appen
     status: "not_committed",
     message: "SQLite durability revision overflow",
   });
-  assert.equal(batches.some((batch) => batch.journalId === "exhausted"), false);
-  assert.deepEqual(store.load("journal-1"), {
-    revision: "1",
-    batches: [{ revision: "1", payload: "checkpoint" }],
+  assert.equal(states.get("exhausted").payload, "retained");
+  assert.deepEqual(store.load("state-1"), {
+    revision: "2",
+    payload: "checkpoint",
   });
-  revisions.delete("journal-1");
-  batches.splice(0, batches.length);
-  const secondOwner = store.acquire("journal-1", { ownerId: "owner-2" });
+  states.delete("state-1");
+  const secondOwner = store.acquire("state-1", { ownerId: "owner-2" });
   assert.deepEqual(secondOwner, {
     ownerId: "owner-2",
     fence: "2",
     revision: "0",
-    batches: [],
+    payload: null,
   });
-  assert.deepEqual(store.append("journal-1", {
+  assert.deepEqual(store.replace("state-1", {
     ownerId: firstOwner.ownerId,
     fence: firstOwner.fence,
     expectedRevision: "0",
@@ -204,13 +189,13 @@ test("the SQLite durability store owns revision validation and compare-and-appen
 
   const roundedRevision = Number("9007199254740993");
   assert.equal(roundedRevision, 9007199254740992);
-  revisions.set("unsafe-revision", roundedRevision);
+  states.set("unsafe-revision", { revision: roundedRevision, payload: "unsafe" });
   assert.throws(
     () => store.load("unsafe-revision"),
     /revision numbers must be nonnegative safe integers; use exact unsigned decimal text/,
   );
 
-  revisions.set("exact-revision", "9007199254740993");
+  states.set("exact-revision", { revision: "9007199254740993", payload: "exact" });
   assert.equal(store.load("exact-revision").revision, "9007199254740993");
 
   owners.set("unsafe-fence", { owner_id: "old-owner", fence: roundedRevision });
@@ -344,10 +329,10 @@ test("a duplicate stable session rejects before touching durability authority", 
     },
     decorate: (agent) => agent.extend(Actions.agentActions()),
   });
-  const first = await createAgentClient(runtime, { sessionId, durabilityId: "journal-1" });
+  const first = await createAgentClient(runtime, { sessionId, durabilityId: "state-1" });
 
   await assert.rejects(
-    createAgentClient(runtime, { sessionId, durabilityId: "journal-1" }),
+    createAgentClient(runtime, { sessionId, durabilityId: "state-1" }),
     /session ID is already active/,
   );
   assert.equal(authorityAcquisitions, 1);
@@ -358,7 +343,7 @@ test("a duplicate stable session rejects before touching durability authority", 
 
   first.dispose();
   assert.equal(releases, 1);
-  const replacement = await createAgentClient(runtime, { sessionId, durabilityId: "journal-1" });
+  const replacement = await createAgentClient(runtime, { sessionId, durabilityId: "state-1" });
   assert.equal(authorityAcquisitions, 2);
   replacement.dispose();
   assert.equal(releases, 2);
@@ -447,16 +432,16 @@ test("turn acceptance forwards durable IDs and remains optional for custom runti
   agent.dispose();
 });
 
-test("the WASM config pairs a durability route with its journal", () => {
+test("the WASM config pairs a durability route with its state", () => {
   assert.deepEqual(toWasmConfig({
     apiKey: "test-key",
     hostDefinitionId: 1,
-    durabilityId: "journal-1",
+    durabilityId: "state-1",
     durabilityHostId: "durability-route-1",
     terminalReceiptRetention: 512,
   }), {
     api_key: "test-key",
-    durability_id: "journal-1",
+    durability_id: "state-1",
     durability_host_id: "durability-route-1",
     terminal_receipt_retention: 512,
     host_definition_id: 1,
@@ -464,34 +449,34 @@ test("the WASM config pairs a durability route with its journal", () => {
 });
 
 test("the WASM host bridge routes owner-fenced durability per Agent binding", async () => {
-  const batches = [];
+  let state = { revision: "0", payload: null };
   let owner;
   const durability = {
-    acquire(_journalId, { ownerId }) {
+    acquire(_stateId, { ownerId }) {
       const fence = String(BigInt(owner?.fence ?? "0") + 1n);
       owner = { ownerId, fence };
-      return { ...owner, revision: String(batches.length), batches };
+      return { ...owner, ...state };
     },
-    append(_journalId, { ownerId, fence, expectedRevision, payload }) {
+    replace(_stateId, { ownerId, fence, expectedRevision, payload }) {
       if (ownerId !== owner?.ownerId || fence !== owner?.fence) {
         return { status: "fenced" };
       }
       if (payload === "definite-failure") {
         return { status: "not_committed", message: "transaction rolled back" };
       }
-      if (expectedRevision !== String(batches.length)) {
-        return { status: "conflict", actualRevision: String(batches.length) };
+      if (expectedRevision !== state.revision) {
+        return { status: "conflict", actualRevision: state.revision };
       }
-      const revision = String(batches.length + 1);
-      batches.push({ revision, payload });
-      return { status: "appended", revision };
+      const revision = String(BigInt(state.revision) + 1n);
+      state = { revision, payload };
+      return { status: "replaced", revision };
     },
   };
   const firstHost = { connect() {} };
   const secondHost = { connect() {} };
   activateHost(firstHost);
-  const firstRoute = ownDurabilityHost(firstHost, durability, "journal-1");
-  const secondRoute = ownDurabilityHost(secondHost, durability, "journal-1");
+  const firstRoute = ownDurabilityHost(firstHost, durability, "state-1");
+  const secondRoute = ownDurabilityHost(secondHost, durability, "state-1");
   assert.notEqual(firstRoute.id, secondRoute.id);
   retainDurabilityHost(firstHost, firstRoute.id);
   retainDurabilityHost(firstHost, firstRoute.id);
@@ -500,26 +485,26 @@ test("the WASM host bridge routes owner-fenced durability per Agent binding", as
     assert.deepEqual(
       JSON.parse(await globalThis.nanocodexHost.durabilityAcquire(
         firstRoute.id,
-        "journal-1",
+        "state-1",
         "owner-1",
       )),
-      { owner_id: "owner-1", fence: "1", revision: "0", batches: [] },
+      { owner_id: "owner-1", fence: "1", revision: "0", payload: null },
     );
     assert.deepEqual(
-      JSON.parse(await globalThis.nanocodexHost.durabilityAppend(
+      JSON.parse(await globalThis.nanocodexHost.durabilityReplace(
         firstRoute.id,
-        "journal-1",
+        "state-1",
         "owner-1",
         "1",
         "0",
-        "opaque-rust-batch",
+        "opaque-rust-state",
       )),
-      { status: "appended", revision: "1" },
+      { status: "replaced", revision: "1" },
     );
     assert.deepEqual(
-      JSON.parse(await globalThis.nanocodexHost.durabilityAppend(
+      JSON.parse(await globalThis.nanocodexHost.durabilityReplace(
         firstRoute.id,
-        "journal-1",
+        "state-1",
         "owner-1",
         "1",
         "0",
@@ -528,9 +513,9 @@ test("the WASM host bridge routes owner-fenced durability per Agent binding", as
       { status: "conflict", actual_revision: "1" },
     );
     assert.deepEqual(
-      JSON.parse(await globalThis.nanocodexHost.durabilityAppend(
+      JSON.parse(await globalThis.nanocodexHost.durabilityReplace(
         firstRoute.id,
-        "journal-1",
+        "state-1",
         "owner-1",
         "1",
         "1",
@@ -541,20 +526,20 @@ test("the WASM host bridge routes owner-fenced durability per Agent binding", as
     assert.deepEqual(
       JSON.parse(await globalThis.nanocodexHost.durabilityAcquire(
         secondRoute.id,
-        "journal-1",
+        "state-1",
         "owner-2",
       )),
       {
         owner_id: "owner-2",
         fence: "2",
         revision: "1",
-        batches: [{ revision: "1", payload: "opaque-rust-batch" }],
+        payload: "opaque-rust-state",
       },
     );
     assert.deepEqual(
-      JSON.parse(await globalThis.nanocodexHost.durabilityAppend(
+      JSON.parse(await globalThis.nanocodexHost.durabilityReplace(
         firstRoute.id,
-        "journal-1",
+        "state-1",
         "owner-1",
         "1",
         "1",
@@ -565,26 +550,26 @@ test("the WASM host bridge routes owner-fenced durability per Agent binding", as
     await assert.rejects(
       globalThis.nanocodexHost.durabilityAcquire(
         firstRoute.id,
-        "another-journal",
+        "another-state",
         "owner-3",
       ),
-      /route does not own journal/,
+      /route does not own state/,
     );
     releaseDurabilityHost(firstHost, firstRoute.id);
     assert.equal(
       JSON.parse(await globalThis.nanocodexHost.durabilityAcquire(
         firstRoute.id,
-        "journal-1",
+        "state-1",
         "owner-3",
       )).fence,
       "3",
-      "releasing a child host reference must preserve its parent's journal binding",
+      "releasing a child host reference must preserve its parent's state binding",
     );
     releaseDurabilityHost(firstHost, firstRoute.id);
     await assert.rejects(
       globalThis.nanocodexHost.durabilityAcquire(
         firstRoute.id,
-        "journal-1",
+        "state-1",
         "owner-4",
       ),
       /no Nanocodex host owns durability route/,
@@ -592,18 +577,18 @@ test("the WASM host bridge routes owner-fenced durability per Agent binding", as
     assert.equal(
       JSON.parse(await globalThis.nanocodexHost.durabilityAcquire(
         secondRoute.id,
-        "journal-1",
+        "state-1",
         "owner-5",
       )).fence,
       "4",
-      "releasing one route must not release another route for the same journal",
+      "releasing one route must not release another route for the same state",
     );
   } finally {
     releaseDurabilityHost(firstHost, firstRoute.id);
     releaseDurabilityHost(secondHost, secondRoute.id);
   }
   await assert.rejects(
-    globalThis.nanocodexHost.durabilityAcquire(firstRoute.id, "journal-1", "owner-4"),
+    globalThis.nanocodexHost.durabilityAcquire(firstRoute.id, "state-1", "owner-4"),
     /no Nanocodex host owns durability route/,
   );
 });

--- a/js/bindings/test/cloudflare-agent.test.mjs
+++ b/js/bindings/test/cloudflare-agent.test.mjs
@@ -358,9 +358,10 @@ test("Cloudflare Agent exports and imports one stable state across a fresh runti
 
   const destinationStorage = new MemoryStorage();
   const destinationOwner = durableOwner(destinationStorage, egressBinding(), SECOND_OBJECT_ID);
-  await importDurabilityState(destinationOwner, JSON.parse(JSON.stringify(archive)));
+  const bound = bindAgent(module);
+  await bound.importDurabilityState(destinationOwner, JSON.parse(JSON.stringify(archive)));
   await assert.doesNotReject(
-    importDurabilityState(destinationOwner, JSON.parse(JSON.stringify(archive))),
+    bound.importDurabilityState(destinationOwner, JSON.parse(JSON.stringify(archive))),
   );
   await assert.rejects(
     importDurabilityState(destinationOwner, { ...archive, revision: 1.5 }),
@@ -378,6 +379,25 @@ test("Cloudflare Agent exports and imports one stable state across a fresh runti
     payload,
   });
   await destination.session.shutdown();
+});
+
+test("Cloudflare Agent rejects corrupt canonical state before importing it", async () => {
+  const module = await readFile(new URL("../pkg-web/nanocodex_bg.wasm", import.meta.url));
+  const storage = new MemoryStorage();
+  const owner = durableOwner(storage);
+  await assert.rejects(
+    bindAgent(module).importDurabilityState(owner, {
+      format: "nanocodex-durability-state-v1",
+      stateId: "corrupt-canonical-state",
+      revision: "1",
+      payload: "{}",
+    }),
+    /durability state at revision 1 is invalid/,
+  );
+  assert.equal(storage.sessionId, undefined);
+  assert.equal(storage.stateId, undefined);
+  assert.deepEqual(storage.states, []);
+  assert.equal(storage.owners.size, 0);
 });
 
 test("Cloudflare Agent portability refuses active and non-pristine owners", async () => {

--- a/js/bindings/test/cloudflare-agent.test.mjs
+++ b/js/bindings/test/cloudflare-agent.test.mjs
@@ -355,6 +355,20 @@ test("Cloudflare Agent exports and imports one stable state across a fresh runti
     revision: "1",
     payload,
   });
+  const pages = [];
+  let cursor;
+  do {
+    const page = await exportDurabilityState(sourceOwner, {
+      from: "0",
+      to: "1",
+      cursor,
+      limit: 19,
+    });
+    pages.push(page);
+    cursor = page.nextCursor ?? undefined;
+  } while (cursor !== undefined);
+  assert.equal(pages.map((page) => page.payload).join(""), payload);
+  assert(pages.length > 1, "the Cloudflare lifecycle API must expose resumable pages");
 
   const destinationStorage = new MemoryStorage();
   const destinationOwner = durableOwner(destinationStorage, egressBinding(), SECOND_OBJECT_ID);

--- a/js/bindings/test/cloudflare-agent.test.mjs
+++ b/js/bindings/test/cloudflare-agent.test.mjs
@@ -4,7 +4,7 @@ import { test } from "node:test";
 
 import {
   bindAgent,
-  compactDurability,
+  pruneDurableReceipts,
   create,
   createEphemeral,
   destroy,
@@ -18,10 +18,11 @@ const SECOND_OBJECT_ID = "b".repeat(64);
 
 class MemoryStorage {
   constructor() {
-    this.batches = [];
+    this.states = [];
     this.chunks = [];
+    this.chunkHeads = new Map();
     this.events = [];
-    this.journals = new Map();
+    this.stateRevisions = new Map();
     this.owners = new Map();
     this.meta = { total_bytes: 0, stream_error: null };
     this.sessionId = undefined;
@@ -35,6 +36,8 @@ class MemoryStorage {
     let rows = [];
     if (statement.startsWith("CREATE TABLE")) {
       // Schema setup is idempotent.
+    } else if (statement.startsWith("PRAGMA table_info")) {
+      rows = durabilityPragmaRows(statement);
     } else if (statement.startsWith("INSERT OR IGNORE INTO nanocodex_cloudflare_event_meta")) {
       // The in-memory meta row exists from construction.
     } else if (statement.startsWith("SELECT total_bytes, stream_error")) {
@@ -59,54 +62,53 @@ class MemoryStorage {
       rows = this.sessionId === undefined ? [] : [{ session_id: this.sessionId }];
     } else if (statement.startsWith("INSERT OR IGNORE INTO nanocodex_cloudflare_agent")) {
       this.sessionId ??= args[0];
-    } else if (statement.startsWith("SELECT owner_id, fence FROM nanocodex_journal_owners")) {
+    } else if (statement.startsWith("SELECT owner_id, fence FROM nanocodex_durable_owners")) {
       const owner = this.owners.get(args[0]);
       rows = owner === undefined ? [] : [{ owner_id: owner.ownerId, fence: owner.fence }];
-    } else if (statement.startsWith("SELECT fence FROM nanocodex_journal_owners")) {
+    } else if (statement.startsWith("SELECT fence FROM nanocodex_durable_owners")) {
       const owner = this.owners.get(args[0]);
       rows = owner === undefined ? [] : [{ fence: owner.fence }];
-    } else if (statement.startsWith("INSERT INTO nanocodex_journal_owners")) {
+    } else if (statement.startsWith("INSERT INTO nanocodex_durable_owners")) {
       this.owners.set(args[0], { ownerId: args[1], fence: args[2] });
-    } else if (statement.startsWith("SELECT revision FROM nanocodex_journals")) {
-      const revision = this.journals.get(args[0]);
-      rows = revision === undefined ? [] : [{ revision }];
-    } else if (statement.startsWith("SELECT revision, payload FROM nanocodex_journal_batches")) {
-      rows = this.batches
-        .filter((batch) => batch.journalId === args[0])
+    } else if (statement.startsWith("SELECT revision, payload FROM nanocodex_durable_states")) {
+      rows = this.states
+        .filter((batch) => batch.stateId === args[0])
         .map(({ revision, payload }) => ({ revision, payload }));
-      if (statement.includes("length(revision) > length(?)")) {
-        rows = rows.filter((batch) => BigInt(batch.revision) > BigInt(args[1]));
-      }
-      rows.sort((left, right) => Number(BigInt(left.revision) - BigInt(right.revision)));
-      if (statement.endsWith("LIMIT 9")) rows = rows.slice(0, 9);
     } else if (statement.startsWith(
-      "SELECT revision, chunk_index, payload FROM nanocodex_journal_batch_chunks",
+      "SELECT revision, chunk_count FROM nanocodex_durable_chunk_heads",
     )) {
-      const selected = new Set(args.slice(1));
+      const head = this.chunkHeads.get(args[0]);
+      rows = head ? [head] : [];
+    } else if (statement.startsWith(
+      "SELECT revision, chunk_index, payload FROM nanocodex_durable_state_chunks",
+    )) {
       rows = this.chunks
-        .filter((chunk) => chunk.journalId === args[0] && selected.has(chunk.revision))
+        .filter((chunk) => chunk.stateId === args[0])
         .map((chunk) => ({
           revision: chunk.revision,
           chunk_index: chunk.chunkIndex,
           payload: chunk.payload,
         }));
-    } else if (statement.startsWith("INSERT INTO nanocodex_journals")) {
-      this.journals.set(args[0], args[1]);
-    } else if (statement.startsWith("INSERT INTO nanocodex_journal_batches")) {
-      this.batches.push({ journalId: args[0], revision: args[1], payload: args[2] });
-    } else if (statement.startsWith("INSERT INTO nanocodex_journal_batch_chunks")) {
+    } else if (statement.startsWith("INSERT INTO nanocodex_durable_states")) {
+      this.stateRevisions.set(args[0], args[1]);
+      this.states = this.states.filter((batch) => batch.stateId !== args[0]);
+      this.states.push({ stateId: args[0], revision: args[1], payload: args[2] });
+    } else if (statement.startsWith("INSERT INTO nanocodex_durable_chunk_heads")) {
+      this.chunkHeads.set(args[0], { revision: args[1], chunk_count: args[2] });
+    } else if (statement.startsWith("INSERT INTO nanocodex_durable_state_chunks")) {
       this.chunks.push({
-        journalId: args[0],
+        stateId: args[0],
         revision: args[1],
         chunkIndex: args[2],
         payload: args[3],
       });
-    } else if (statement.startsWith("DELETE FROM nanocodex_journal_batch_chunks")) {
-      this.chunks = this.chunks.filter((chunk) => chunk.journalId !== args[0]);
-    } else if (statement.startsWith("DELETE FROM nanocodex_journal_batches")) {
-      this.batches = this.batches.filter((batch) => batch.journalId !== args[0]);
-    } else if (statement.startsWith("DELETE FROM nanocodex_journals")) {
-      this.journals.delete(args[0]);
+    } else if (statement.startsWith("DELETE FROM nanocodex_durable_chunk_heads")) {
+      this.chunkHeads.delete(args[0]);
+    } else if (statement.startsWith("DELETE FROM nanocodex_durable_state_chunks")) {
+      this.chunks = this.chunks.filter((chunk) => chunk.stateId !== args[0]);
+    } else if (statement.startsWith("DELETE FROM nanocodex_durable_states")) {
+      this.states = this.states.filter((batch) => batch.stateId !== args[0]);
+      this.stateRevisions.delete(args[0]);
     } else if (statement === "DELETE FROM nanocodex_cloudflare_events") {
       this.events = [];
     } else if (statement.startsWith("UPDATE nanocodex_cloudflare_event_meta SET total_bytes = 0")) {
@@ -116,6 +118,23 @@ class MemoryStorage {
     }
     return { toArray: () => rows };
   }
+}
+
+function durabilityPragmaRows(sql) {
+  let shapes;
+  if (sql.includes("nanocodex_durable_owners")) {
+    shapes = [["state_id", "TEXT", 0, 1], ["owner_id", "TEXT", 1, 0], ["fence", "TEXT", 1, 0]];
+  } else if (sql.includes("nanocodex_durable_states")) {
+    shapes = [["state_id", "TEXT", 0, 1], ["revision", "TEXT", 1, 0], ["payload", "TEXT", 1, 0]];
+  } else if (sql.includes("nanocodex_durable_chunk_heads")) {
+    shapes = [["state_id", "TEXT", 0, 1], ["revision", "TEXT", 1, 0], ["chunk_count", "INTEGER", 1, 0]];
+  } else {
+    shapes = [
+      ["state_id", "TEXT", 1, 1], ["revision", "TEXT", 1, 2],
+      ["chunk_index", "INTEGER", 1, 3], ["payload", "TEXT", 1, 0],
+    ];
+  }
+  return shapes.map(([name, type, notnull, pk], cid) => ({ cid, name, type, notnull, pk }));
 }
 
 class UpstreamSocket {
@@ -230,7 +249,7 @@ test("Cloudflare ephemeral Agent owns transport without durable state", async ()
 
   assert.deepEqual(subjects, [FIRST_OBJECT_ID]);
   assert.equal(storage.sessionId, undefined);
-  assert.equal(storage.journals.size, 0);
+  assert.equal(storage.stateRevisions.size, 0);
   assert.equal(storage.events.length, 0);
   await agent.session.shutdown();
 });
@@ -253,7 +272,7 @@ test("Cloudflare ephemeral Agent validates adapter-owned startup", async () => {
   );
 });
 
-test("Cloudflare Agent isolates journals per Durable Object and can recreate after shutdown", async () => {
+test("Cloudflare Agent isolates states per Durable Object and can recreate after shutdown", async () => {
   const module = await readFile(new URL("../pkg-web/nanocodex_bg.wasm", import.meta.url));
   const firstStorage = new MemoryStorage();
   const secondStorage = new MemoryStorage();
@@ -295,69 +314,85 @@ test("Cloudflare Agent disposal releases lifecycle authority without bypassing j
   await reopened.session.shutdown();
 });
 
-test("Cloudflare Agent compacts retained durability before runtime construction", async () => {
+test("Cloudflare Agent prunes retained receipts before runtime construction", async () => {
   const module = await readFile(new URL("../pkg-web/nanocodex_bg.wasm", import.meta.url));
   const storage = new MemoryStorage();
   storage.sessionId = "018f1f9a-7b3c-7a17-8000-000000000097";
-  const journalId = `cloudflare:${storage.sessionId}`;
-  for (let index = 0; index < 10; index += 1) {
-    const operationId = `turn-compacted-${index}`;
-    storage.batches.push(
-      {
-        journalId,
-        revision: String(index * 2 + 1),
-        payload: JSON.stringify({
-          operation_accepted: { operation_id: operationId, input: "prompt" },
-        }),
+  const stateId = `cloudflare:${storage.sessionId}`;
+  const operations = Object.fromEntries(Array.from({ length: 10 }, (_, index) => [
+    `turn-compacted-${index}`,
+    {
+      input: JSON.stringify("prompt"),
+      status: { cancelled: { checkpoint: null } },
+      steps: {},
+      accepted_order: index * 2 + 1,
+    },
+  ]));
+  storage.states.push({
+    stateId,
+    revision: "20",
+    payload: JSON.stringify({
+      nanocodex_durable_state: {
+        format: 1,
+        operations,
+        latest_checkpoint: null,
+        checkpoint_effect_pending: false,
       },
-      {
-        journalId,
-        revision: String(index * 2 + 2),
-        payload: JSON.stringify({
-          operation_cancelled: { operation_id: operationId },
-        }),
-      },
-    );
-  }
-  storage.journals.set(journalId, "20");
+    }),
+  });
+  storage.stateRevisions.set(stateId, "20");
 
   const owner = durableOwner(storage);
-  await compactDurability(module, owner, {
+  await pruneDurableReceipts(module, owner, {
     terminalReceiptRetention: 512,
   });
 
-  assert.equal(storage.journals.get(journalId), "20");
-  assert.equal(storage.batches.length, 1);
-  assert.equal(storage.batches[0].revision, "20");
-  let checkpoint = JSON.parse(storage.batches[0].payload).nanocodex_journal_state;
+  assert.equal(storage.stateRevisions.get(stateId), "20");
+  assert.equal(storage.states.length, 1);
+  assert.equal(storage.states[0].revision, "20");
+  let checkpoint = JSON.parse(storage.states[0].payload).nanocodex_durable_state;
+  assert.equal(checkpoint.format, 1);
   assert.equal(Object.keys(checkpoint.operations).length, 10);
 
-  await compactDurability(module, owner, {
+  await pruneDurableReceipts(module, owner, {
     terminalReceiptRetention: 0,
   });
 
-  assert.equal(storage.batches.length, 1);
-  assert.equal(storage.batches[0].revision, "20");
-  checkpoint = JSON.parse(storage.batches[0].payload).nanocodex_journal_state;
+  assert.equal(storage.states.length, 1);
+  assert.equal(storage.stateRevisions.get(stateId), "21");
+  assert.equal(storage.states[0].revision, "21");
+  checkpoint = JSON.parse(storage.states[0].payload).nanocodex_durable_state;
   assert.deepEqual(checkpoint.operations, {});
 });
 
-test("Cloudflare Agent compaction reserves lifecycle authority against create", async () => {
+test("Cloudflare receipt pruning reserves lifecycle authority against create", async () => {
   const module = await readFile(new URL("../pkg-web/nanocodex_bg.wasm", import.meta.url));
   const storage = new MemoryStorage();
   storage.sessionId = "018f1f9a-7b3c-7a17-8000-000000000098";
-  const journalId = `cloudflare:${storage.sessionId}`;
-  storage.batches.push({
-    journalId,
+  const stateId = `cloudflare:${storage.sessionId}`;
+  storage.states.push({
+    stateId,
     revision: "1",
     payload: JSON.stringify({
-      operation_accepted: { operation_id: "turn-compaction-race", input: "prompt" },
+      nanocodex_durable_state: {
+        format: 1,
+        operations: {
+          "turn-compaction-race": {
+            input: JSON.stringify("prompt"),
+            status: "pending",
+            steps: {},
+            accepted_order: 1,
+          },
+        },
+        latest_checkpoint: null,
+        checkpoint_effect_pending: false,
+      },
     }),
   });
-  storage.journals.set(journalId, "1");
+  storage.stateRevisions.set(stateId, "1");
   const owner = durableOwner(storage);
 
-  const compaction = compactDurability(module, owner);
+  const compaction = pruneDurableReceipts(module, owner);
   await assert.rejects(
     create(module, owner),
     /creation is already in progress/,
@@ -365,7 +400,7 @@ test("Cloudflare Agent compaction reserves lifecycle authority against create", 
   await compaction;
 });
 
-test("Cloudflare Agent releases its journal when event projection setup fails", async () => {
+test("Cloudflare Agent releases its state when event projection setup fails", async () => {
   const module = await readFile(new URL("../pkg-web/nanocodex_bg.wasm", import.meta.url));
   const storage = new MemoryStorage();
   const owner = durableOwner(storage);
@@ -482,16 +517,16 @@ test("Cloudflare Agent destroy owns idempotent adapter cleanup", async () => {
   destroy(owner);
   const agent = await create(module, owner);
   await agent.session.shutdown();
-  const journalId = `cloudflare:${agent.sessionId}`;
-  const staleOwner = { ...storage.owners.get(journalId) };
+  const stateId = `cloudflare:${agent.sessionId}`;
+  const staleOwner = { ...storage.owners.get(stateId) };
   assert.equal(staleOwner.fence, "2");
-  storage.chunks.push({ journalId, revision: "1", chunkIndex: 0, payload: "retained" });
+  storage.chunks.push({ stateId, revision: "1", chunkIndex: 0, payload: "retained" });
   destroy(owner);
-  const destroyedOwner = storage.owners.get(journalId);
+  const destroyedOwner = storage.owners.get(stateId);
   assert.equal(destroyedOwner.fence, "3");
   assert.match(destroyedOwner.ownerId, /^destroy:/);
   assert.deepEqual(
-    createCloudflareDurabilityStore(storage).append(journalId, {
+    createCloudflareDurabilityStore(storage).replace(stateId, {
       ...staleOwner,
       expectedRevision: "0",
       payload: "stale resurrection",
@@ -500,9 +535,9 @@ test("Cloudflare Agent destroy owns idempotent adapter cleanup", async () => {
   );
   destroy(owner);
 
-  assert.equal(storage.batches.length, 0);
+  assert.equal(storage.states.length, 0);
   assert.equal(storage.chunks.length, 0);
-  assert.equal(storage.journals.size, 0);
+  assert.equal(storage.stateRevisions.size, 0);
   assert.equal(storage.events.length, 0);
 });
 

--- a/js/bindings/test/cloudflare-agent.test.mjs
+++ b/js/bindings/test/cloudflare-agent.test.mjs
@@ -8,6 +8,8 @@ import {
   create,
   createEphemeral,
   destroy,
+  exportDurabilityState,
+  importDurabilityState,
 } from "../cloudflare/Agent.mjs";
 import * as HostAgent from "../host/Agent.mjs";
 import { createCloudflareDurabilityStore } from "../runtime/cloudflare-durability-store.mjs";
@@ -26,6 +28,7 @@ class MemoryStorage {
     this.owners = new Map();
     this.meta = { total_bytes: 0, stream_error: null };
     this.sessionId = undefined;
+    this.stateId = undefined;
     this.sql = { exec: (sql, ...args) => this.#exec(sql, args) };
   }
 
@@ -62,6 +65,16 @@ class MemoryStorage {
       rows = this.sessionId === undefined ? [] : [{ session_id: this.sessionId }];
     } else if (statement.startsWith("INSERT OR IGNORE INTO nanocodex_cloudflare_agent")) {
       this.sessionId ??= args[0];
+    } else if (statement.startsWith("INSERT INTO nanocodex_cloudflare_agent")) {
+      if (this.sessionId !== undefined) throw new Error("duplicate Cloudflare Agent identity");
+      this.sessionId = args[0];
+    } else if (statement.startsWith("SELECT state_id FROM nanocodex_cloudflare_durability")) {
+      rows = this.stateId === undefined ? [] : [{ state_id: this.stateId }];
+    } else if (statement.startsWith("INSERT OR IGNORE INTO nanocodex_cloudflare_durability")) {
+      this.stateId ??= args[0];
+    } else if (statement.startsWith("INSERT INTO nanocodex_cloudflare_durability")) {
+      if (this.stateId !== undefined) throw new Error("duplicate Cloudflare durability identity");
+      this.stateId = args[0];
     } else if (statement.startsWith("SELECT owner_id, fence FROM nanocodex_durable_owners")) {
       const owner = this.owners.get(args[0]);
       rows = owner === undefined ? [] : [{ owner_id: owner.ownerId, fence: owner.fence }];
@@ -109,6 +122,8 @@ class MemoryStorage {
     } else if (statement.startsWith("DELETE FROM nanocodex_durable_states")) {
       this.states = this.states.filter((batch) => batch.stateId !== args[0]);
       this.stateRevisions.delete(args[0]);
+    } else if (statement.startsWith("DELETE FROM nanocodex_durable_owners")) {
+      this.owners.delete(args[0]);
     } else if (statement === "DELETE FROM nanocodex_cloudflare_events") {
       this.events = [];
     } else if (statement.startsWith("UPDATE nanocodex_cloudflare_event_meta SET total_bytes = 0")) {
@@ -177,7 +192,7 @@ test("Cloudflare Agent owns credentials, transport, and durability options", asy
   await assert.rejects(create(module), /requires a Durable Object instance/);
   await assert.rejects(
     create(module, durableOwner(new MemoryStorage()), { apiKey: "managed-secret" }),
-    /does not accept apiKey; only eventPersistence, instructions, terminalReceiptRetention, and tools are configurable/,
+    /does not accept apiKey; only durabilityId, eventPersistence, instructions, terminalReceiptRetention, and tools are configurable/,
   );
   await assert.rejects(
     create(module, durableOwner(new MemoryStorage()), { CODEX_OAUTH_BOOTSTRAP: "managed-secret" }),
@@ -288,12 +303,97 @@ test("Cloudflare Agent isolates states per Durable Object and can recreate after
     create(module, owner(secondStorage, SECOND_OBJECT_ID)),
   ]);
   assert.notEqual(first.sessionId, second.sessionId);
+  assert.equal(firstStorage.stateId, first.sessionId);
+  assert.equal(secondStorage.stateId, second.sessionId);
   assert.deepEqual(new Set(subjects), new Set([FIRST_OBJECT_ID, SECOND_OBJECT_ID]));
   await Promise.all([first.session.shutdown(), second.session.shutdown()]);
 
   const recreated = await create(module, owner(firstStorage, FIRST_OBJECT_ID));
   assert.equal(recreated.sessionId, first.sessionId);
   await recreated.session.shutdown();
+
+  const explicitStorage = new MemoryStorage();
+  const explicitOwner = owner(explicitStorage, "c".repeat(64));
+  const explicit = await create(module, explicitOwner, { durabilityId: "managed-agent-id" });
+  assert.equal(explicitStorage.stateId, "managed-agent-id");
+  await explicit.session.shutdown();
+  await assert.rejects(
+    create(module, explicitOwner, { durabilityId: "rewritten-agent-id" }),
+    /does not match the retained state identity/,
+  );
+});
+
+test("Cloudflare Agent exports and imports one stable state across a fresh runtime identity", async () => {
+  const module = await readFile(new URL("../pkg-web/nanocodex_bg.wasm", import.meta.url));
+  const sourceStorage = new MemoryStorage();
+  const sourceOwner = durableOwner(sourceStorage);
+  const source = await create(module, sourceOwner);
+  await source.session.shutdown();
+  const sourceSessionId = source.sessionId;
+  const stateId = sourceStorage.stateId;
+  const store = createCloudflareDurabilityStore(sourceStorage);
+  const ownership = store.acquire(stateId, { ownerId: "seed" });
+  const payload = JSON.stringify({
+    nanocodex_durable_state: {
+      format: 1,
+      operations: {},
+      latest_checkpoint: null,
+      checkpoint_effect_pending: false,
+    },
+  });
+  assert.deepEqual(store.replace(stateId, {
+    ownerId: ownership.ownerId,
+    fence: ownership.fence,
+    expectedRevision: ownership.revision,
+    payload,
+  }), { status: "replaced", revision: "1" });
+
+  const archive = await exportDurabilityState(sourceOwner);
+  assert.deepEqual(archive, {
+    format: "nanocodex-durability-state-v1",
+    stateId,
+    revision: "1",
+    payload,
+  });
+
+  const destinationStorage = new MemoryStorage();
+  const destinationOwner = durableOwner(destinationStorage, egressBinding(), SECOND_OBJECT_ID);
+  await importDurabilityState(destinationOwner, JSON.parse(JSON.stringify(archive)));
+  await assert.doesNotReject(
+    importDurabilityState(destinationOwner, JSON.parse(JSON.stringify(archive))),
+  );
+  await assert.rejects(
+    importDurabilityState(destinationOwner, { ...archive, revision: 1.5 }),
+    /revision numbers must be nonnegative safe integers/,
+  );
+  await assert.rejects(
+    importDurabilityState(destinationOwner, { ...archive, unexpected: true }),
+    /invalid shape/,
+  );
+  const destination = await create(module, destinationOwner);
+  assert.notEqual(destination.sessionId, sourceSessionId);
+  assert.equal(destinationStorage.stateId, stateId);
+  assert.deepEqual(createCloudflareDurabilityStore(destinationStorage).load(stateId), {
+    revision: "1",
+    payload,
+  });
+  await destination.session.shutdown();
+});
+
+test("Cloudflare Agent portability refuses active and non-pristine owners", async () => {
+  const module = await readFile(new URL("../pkg-web/nanocodex_bg.wasm", import.meta.url));
+  const storage = new MemoryStorage();
+  const owner = durableOwner(storage);
+  const agent = await create(module, owner);
+  await assert.rejects(exportDurabilityState(owner), /shutdown must complete/);
+  await assert.rejects(importDurabilityState(owner, {}), /shutdown must complete/);
+  await agent.session.shutdown();
+  await assert.rejects(importDurabilityState(owner, {
+    format: "nanocodex-durability-state-v1",
+    stateId: "another-state",
+    revision: "0",
+    payload: null,
+  }), /pristine Durable Object/);
 });
 
 test("Cloudflare Agent disposal releases lifecycle authority without bypassing joined shutdown", async () => {
@@ -517,7 +617,7 @@ test("Cloudflare Agent destroy owns idempotent adapter cleanup", async () => {
   destroy(owner);
   const agent = await create(module, owner);
   await agent.session.shutdown();
-  const stateId = `cloudflare:${agent.sessionId}`;
+  const stateId = storage.stateId;
   const staleOwner = { ...storage.owners.get(stateId) };
   assert.equal(staleOwner.fence, "2");
   storage.chunks.push({ stateId, revision: "1", chunkIndex: 0, payload: "retained" });

--- a/js/bindings/test/cloudflare-durability.test.mjs
+++ b/js/bindings/test/cloudflare-durability.test.mjs
@@ -4,12 +4,11 @@ import test from "node:test";
 import { sqliteDurabilitySchema } from "nanocodex/durability";
 import { createCloudflareDurabilityStore } from "nanocodex/durability/cloudflare";
 
-test("Cloudflare durability owns schema setup and atomic SQLite adaptation", () => {
+test("Cloudflare durability stores one state and chunks only oversized payloads", () => {
   const owners = new Map();
-  const revisions = new Map();
-  const batches = [];
+  const states = new Map();
+  const heads = new Map();
   const chunks = [];
-  const chunkSelects = [];
   const schema = [];
   let transactions = 0;
   const storage = {
@@ -18,65 +17,44 @@ test("Cloudflare durability owns schema setup and atomic SQLite adaptation", () 
         if (args.some((value) => typeof value === "string" && Buffer.byteLength(value) > 2_000_000)) {
           throw new Error("string or blob too big: SQLITE_TOOBIG");
         }
+        const [stateId, revision, payload] = args;
         let rows;
-        const [journalId, revision, payload] = args;
         if (sql.startsWith("CREATE TABLE")) {
           schema.push(sql);
           rows = [];
-        } else if (sql.startsWith("SELECT owner_id, fence FROM nanocodex_journal_owners")) {
-          const stored = owners.get(journalId);
-          rows = stored === undefined ? [] : [stored];
-        } else if (sql.startsWith("INSERT INTO nanocodex_journal_owners")) {
-          const [, ownerId, fence] = args;
-          owners.set(journalId, { owner_id: ownerId, fence });
+        } else if (sql.startsWith("PRAGMA table_info")) {
+          rows = pragmaRows(sql);
+        } else if (sql.startsWith("SELECT owner_id, fence FROM nanocodex_durable_owners")) {
+          const stored = owners.get(stateId);
+          rows = stored ? [stored] : [];
+        } else if (sql.startsWith("INSERT INTO nanocodex_durable_owners")) {
+          owners.set(stateId, { owner_id: args[1], fence: args[2] });
           rows = [];
-        } else if (sql.startsWith("SELECT revision FROM nanocodex_journals")) {
-          const stored = revisions.get(journalId);
-          rows = stored === undefined ? [] : [{ revision: stored }];
-        } else if (sql.startsWith("SELECT revision, payload FROM nanocodex_journal_batches")) {
-          rows = batches
-            .filter((batch) => batch.journalId === journalId)
-            .map(({ revision: batchRevision, payload: batchPayload }) => ({
-              revision: batchRevision,
-              payload: batchPayload,
-            }));
-          if (sql.includes("length(revision) > length(?)")) {
-            rows = rows.filter((batch) => BigInt(batch.revision) > BigInt(args[1]));
-          }
-          rows.sort((left, right) => Number(BigInt(left.revision) - BigInt(right.revision)));
-          if (sql.includes("LIMIT 9")) rows = rows.slice(0, 9);
-        } else if (sql.startsWith("SELECT revision, chunk_index, payload FROM nanocodex_journal_batch_chunks")) {
-          const selectedRevisions = new Set(args.slice(1));
-          chunkSelects.push([...selectedRevisions]);
-          rows = chunks
-            .filter((chunk) =>
-              chunk.journalId === journalId && selectedRevisions.has(chunk.revision)
-            )
-            .map(({ revision: chunkRevision, chunkIndex, payload: chunkPayload }) => ({
-              revision: chunkRevision,
-              chunk_index: chunkIndex,
-              payload: chunkPayload,
-            }));
-        } else if (sql.startsWith("INSERT INTO nanocodex_journals")) {
-          revisions.set(journalId, revision);
+        } else if (sql.startsWith("SELECT revision, payload FROM nanocodex_durable_states")) {
+          const stored = states.get(stateId);
+          rows = stored ? [stored] : [];
+        } else if (sql.startsWith("INSERT INTO nanocodex_durable_states")) {
+          states.set(stateId, { revision, payload });
           rows = [];
-        } else if (sql.startsWith("INSERT INTO nanocodex_journal_batches")) {
-          batches.push({ journalId, revision, payload });
+        } else if (sql.startsWith("DELETE FROM nanocodex_durable_chunk_heads")) {
+          heads.delete(stateId);
           rows = [];
-        } else if (sql.startsWith("INSERT INTO nanocodex_journal_batch_chunks")) {
-          const [, , chunkIndex, chunkPayload] = args;
-          chunks.push({ journalId, revision, chunkIndex, payload: chunkPayload });
+        } else if (sql.startsWith("INSERT INTO nanocodex_durable_chunk_heads")) {
+          heads.set(stateId, { revision, chunk_count: payload });
           rows = [];
-        } else if (sql.startsWith("DELETE FROM nanocodex_journal_batch_chunks")) {
+        } else if (sql.startsWith("SELECT revision, chunk_count FROM nanocodex_durable_chunk_heads")) {
+          const stored = heads.get(stateId);
+          rows = stored ? [stored] : [];
+        } else if (sql.startsWith("DELETE FROM nanocodex_durable_state_chunks")) {
           for (let index = chunks.length - 1; index >= 0; index -= 1) {
-            if (chunks[index].journalId === journalId) chunks.splice(index, 1);
+            if (chunks[index].stateId === stateId) chunks.splice(index, 1);
           }
           rows = [];
-        } else if (sql.startsWith("DELETE FROM nanocodex_journal_batches")) {
-          for (let index = batches.length - 1; index >= 0; index -= 1) {
-            if (batches[index].journalId === journalId) batches.splice(index, 1);
-          }
+        } else if (sql.startsWith("INSERT INTO nanocodex_durable_state_chunks")) {
+          chunks.push({ stateId, revision, chunk_index: args[2], payload: args[3] });
           rows = [];
+        } else if (sql.startsWith("SELECT revision, chunk_index, payload FROM nanocodex_durable_state_chunks")) {
+          rows = chunks.filter((chunk) => chunk.stateId === stateId);
         } else {
           throw new Error(`unexpected SQL: ${sql}`);
         }
@@ -91,109 +69,81 @@ test("Cloudflare durability owns schema setup and atomic SQLite adaptation", () 
 
   const store = createCloudflareDurabilityStore(storage);
   assert.deepEqual(schema.slice(0, sqliteDurabilitySchema.length), sqliteDurabilitySchema);
-  assert.equal(schema.length, sqliteDurabilitySchema.length + 1);
-  assert.deepEqual(store.load("agent-1"), { revision: "0", batches: [] });
-  const firstOwner = store.acquire("agent-1", { ownerId: "worker-1" });
-  assert.deepEqual(firstOwner, {
+  assert.equal(schema.length, sqliteDurabilitySchema.length + 2);
+  assert.deepEqual(store.load("agent-1"), { revision: "0", payload: null });
+  const owner = store.acquire("agent-1", { ownerId: "worker-1" });
+  assert.deepEqual(owner, {
     ownerId: "worker-1",
     fence: "1",
     revision: "0",
-    batches: [],
+    payload: null,
   });
-  assert.deepEqual(store.append("agent-1", {
-    ownerId: firstOwner.ownerId,
-    fence: firstOwner.fence,
+  assert.deepEqual(store.replace("agent-1", {
+    ownerId: owner.ownerId,
+    fence: owner.fence,
     expectedRevision: "0",
-    payload: "opaque-rust-batch",
-  }), { status: "appended", revision: "1" });
+    payload: "opaque-rust-state",
+  }), { status: "replaced", revision: "1" });
   assert.deepEqual(store.load("agent-1"), {
     revision: "1",
-    batches: [{ revision: "1", payload: "opaque-rust-batch" }],
+    payload: "opaque-rust-state",
   });
-  assert.deepEqual(store.compact("agent-1", {
-    ownerId: firstOwner.ownerId,
-    fence: firstOwner.fence,
-    expectedRevision: "1",
-    payload: "compacted-rust-state",
-  }), { status: "compacted", revision: "1" });
-  assert.deepEqual(store.load("agent-1"), {
-    revision: "1",
-    batches: [{ revision: "1", payload: "compacted-rust-state" }],
-  });
-  revisions.delete("agent-1");
-  batches.splice(0, batches.length);
-  const secondOwner = store.acquire("agent-1", { ownerId: "worker-2" });
-  assert.deepEqual(secondOwner, {
-    ownerId: "worker-2",
-    fence: "2",
-    revision: "0",
-    batches: [],
-  });
-  assert.deepEqual(store.append("agent-1", {
-    ownerId: firstOwner.ownerId,
-    fence: firstOwner.fence,
-    expectedRevision: "9",
-    payload: "stale-owner",
-  }), { status: "fenced" });
-  assert.equal(transactions, 8);
 
   const largePayload = `${"x".repeat(255_999)}😀${"y".repeat(1_800_000)}`;
   const largeOwner = store.acquire("agent-large", { ownerId: "worker-large" });
-  assert.deepEqual(store.append("agent-large", {
+  assert.deepEqual(store.replace("agent-large", {
     ownerId: largeOwner.ownerId,
     fence: largeOwner.fence,
     expectedRevision: "0",
     payload: largePayload,
-  }), { status: "appended", revision: "1" });
-  assert.equal(batches.find((batch) => batch.journalId === "agent-large")?.payload, "");
-  assert.equal(chunks.filter((chunk) => chunk.journalId === "agent-large").length > 1, true);
-  assert.equal(
-    chunks.every((chunk) => chunk.payload.length <= 256_000),
-    true,
-  );
-  assert.equal(
-    chunks.every((chunk) => Buffer.byteLength(chunk.payload) <= 1_000_000),
-    true,
-  );
-  assert.equal(store.load("agent-large").batches[0]?.payload, largePayload);
-  const pagedOwner = store.acquirePage("agent-large", { ownerId: "worker-large-page" });
-  assert.equal(pagedOwner.batches[0]?.payload, largePayload);
-  const compactedPayload = `${"z".repeat(2_100_000)}😀`;
-  assert.deepEqual(store.compact("agent-large", {
-    ownerId: pagedOwner.ownerId,
-    fence: pagedOwner.fence,
-    expectedRevision: "1",
-    payload: compactedPayload,
-  }), { status: "compacted", revision: "1" });
-  assert.equal(store.load("agent-large").batches[0]?.payload, compactedPayload);
+  }), { status: "replaced", revision: "1" });
+  assert.equal(states.get("agent-large").payload, "");
+  assert.ok(chunks.filter((chunk) => chunk.stateId === "agent-large").length > 1);
+  assert.ok(chunks.every((chunk) => chunk.payload.length <= 256_000));
+  assert.equal(store.load("agent-large").payload, largePayload);
 
-  const pagedPayload = "p".repeat(1_050_000);
-  const pagesOwner = store.acquire("agent-pages", { ownerId: "worker-pages" });
-  let pageRevision = "0";
-  for (let index = 0; index < 10; index += 1) {
-    const appended = store.append("agent-pages", {
-      ownerId: pagesOwner.ownerId,
-      fence: pagesOwner.fence,
-      expectedRevision: pageRevision,
-      payload: pagedPayload,
-    });
-    assert.equal(appended.status, "appended");
-    pageRevision = appended.revision;
-  }
-  chunkSelects.splice(0, chunkSelects.length);
-  const firstPage = store.acquirePage("agent-pages", { ownerId: "worker-pages-reopen" });
-  assert.equal(firstPage.batches.length, 8);
-  assert.equal(firstPage.hasMore, true);
-  assert.deepEqual(chunkSelects, [["1", "2", "3", "4", "5", "6", "7", "8", "9"]]);
-  const secondPage = store.acquirePage("agent-pages", {
-    ownerId: firstPage.ownerId,
-    afterRevision: firstPage.batches.at(-1).revision,
-  });
-  assert.equal(secondPage.batches.length, 2);
-  assert.equal(secondPage.hasMore, false);
-  assert.deepEqual(chunkSelects.at(-1), ["9", "10"]);
+  const firstChunk = chunks.find((chunk) => chunk.stateId === "agent-large");
+  firstChunk.revision = "2";
+  assert.throws(() => store.load("agent-large"), /invalid Cloudflare durability chunks/);
+  firstChunk.revision = "1";
+  firstChunk.chunk_index = 99;
+  assert.throws(() => store.load("agent-large"), /invalid Cloudflare durability chunks/);
+  firstChunk.chunk_index = 0;
+  states.get("agent-large").payload = "unexpected-inline-state";
+  assert.throws(() => store.load("agent-large"), /invalid Cloudflare durability chunk head/);
+  states.get("agent-large").payload = "";
+  chunks.pop();
+  assert.throws(() => store.load("agent-large"), /missing Cloudflare durability chunks/);
+  assert.ok(transactions >= 6);
   assert.throws(
     () => createCloudflareDurabilityStore({}),
     /Durable Object storage with SQLite/,
   );
+  assert.throws(
+    () => createCloudflareDurabilityStore({
+      sql: { exec: () => ({ toArray: () => [] }) },
+      transactionSync: (callback) => callback(),
+    }),
+    /incompatible Cloudflare durability schema/,
+  );
 });
+
+function pragmaRows(sql) {
+  if (sql.includes("nanocodex_durable_owners")) {
+    return columns([["state_id", "TEXT", 0, 1], ["owner_id", "TEXT", 1, 0], ["fence", "TEXT", 1, 0]]);
+  }
+  if (sql.includes("nanocodex_durable_states")) {
+    return columns([["state_id", "TEXT", 0, 1], ["revision", "TEXT", 1, 0], ["payload", "TEXT", 1, 0]]);
+  }
+  if (sql.includes("nanocodex_durable_chunk_heads")) {
+    return columns([["state_id", "TEXT", 0, 1], ["revision", "TEXT", 1, 0], ["chunk_count", "INTEGER", 1, 0]]);
+  }
+  return columns([
+    ["state_id", "TEXT", 1, 1], ["revision", "TEXT", 1, 2],
+    ["chunk_index", "INTEGER", 1, 3], ["payload", "TEXT", 1, 0],
+  ]);
+}
+
+function columns(shapes) {
+  return shapes.map(([name, type, notnull, pk], cid) => ({ cid, name, type, notnull, pk }));
+}

--- a/js/bindings/test/cloudflare-durability.test.mjs
+++ b/js/bindings/test/cloudflare-durability.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { sqliteDurabilitySchema } from "nanocodex/durability";
+import {
+  DurabilityImportConflictError,
+  sqliteDurabilitySchema,
+} from "nanocodex/durability";
 import { createCloudflareDurabilityStore } from "nanocodex/durability/cloudflare";
 
 test("Cloudflare durability stores one state and chunks only oversized payloads", () => {
@@ -116,6 +119,23 @@ test("Cloudflare durability stores one state and chunks only oversized payloads"
     payload: new Uint8Array(),
   }), { status: "conflict", actualRevision: "1" });
 
+  assert.deepEqual(store.importState("agent-import", {
+    revision: "47",
+    payload: largePayload,
+  }), { revision: "47", payload: largePayload });
+  assert.equal(states.get("agent-import").payload, "");
+  assert.equal(store.load("agent-import").payload, largePayload);
+  assert.deepEqual(store.acquire("agent-import", { ownerId: "imported-agent" }), {
+    ownerId: "imported-agent",
+    fence: "2",
+    revision: "47",
+    payload: largePayload,
+  });
+  assert.throws(
+    () => store.importState("agent-import", { revision: "48", payload: "overwrite" }),
+    DurabilityImportConflictError,
+  );
+
   const firstChunk = chunks.find((chunk) => chunk.stateId === "agent-large");
   firstChunk.revision = "2";
   assert.throws(() => store.load("agent-large"), /invalid Cloudflare durability chunks/);
@@ -126,7 +146,7 @@ test("Cloudflare durability stores one state and chunks only oversized payloads"
   states.get("agent-large").payload = "unexpected-inline-state";
   assert.throws(() => store.load("agent-large"), /invalid Cloudflare durability chunk head/);
   states.get("agent-large").payload = "";
-  chunks.pop();
+  chunks.splice(chunks.findLastIndex((chunk) => chunk.stateId === "agent-large"), 1);
   assert.throws(() => store.load("agent-large"), /missing Cloudflare durability chunks/);
   assert.ok(transactions >= 6);
   assert.throws(

--- a/js/bindings/test/cloudflare-durability.test.mjs
+++ b/js/bindings/test/cloudflare-durability.test.mjs
@@ -102,6 +102,20 @@ test("Cloudflare durability stores one state and chunks only oversized payloads"
   assert.ok(chunks.every((chunk) => chunk.payload.length <= 256_000));
   assert.equal(store.load("agent-large").payload, largePayload);
 
+  const replacementOwner = store.acquire("agent-large", { ownerId: "worker-replacement" });
+  assert.deepEqual(store.replace("agent-large", {
+    ownerId: largeOwner.ownerId,
+    fence: largeOwner.fence,
+    expectedRevision: "not-a-revision",
+    payload: new Uint8Array(),
+  }), { status: "fenced" });
+  assert.deepEqual(store.replace("agent-large", {
+    ownerId: replacementOwner.ownerId,
+    fence: replacementOwner.fence,
+    expectedRevision: "0",
+    payload: new Uint8Array(),
+  }), { status: "conflict", actualRevision: "1" });
+
   const firstChunk = chunks.find((chunk) => chunk.stateId === "agent-large");
   firstChunk.revision = "2";
   assert.throws(() => store.load("agent-large"), /invalid Cloudflare durability chunks/);

--- a/js/bindings/test/cloudflare-durability.test.mjs
+++ b/js/bindings/test/cloudflare-durability.test.mjs
@@ -136,6 +136,22 @@ test("Cloudflare durability stores one state and chunks only oversized payloads"
     DurabilityImportConflictError,
   );
 
+  assert.deepEqual(store.importState("agent-range", {
+    revision: "4",
+    payload: "expected-lineage",
+  }), { revision: "4", payload: "expected-lineage" });
+  assert.throws(
+    () => store.importState("agent-range", { revision: "9", payload: "replacement" }, {
+      expectedRevision: "4",
+      expectedPayload: "divergent-lineage",
+    }),
+    DurabilityImportConflictError,
+  );
+  assert.deepEqual(store.load("agent-range"), {
+    revision: "4",
+    payload: "expected-lineage",
+  });
+
   const firstChunk = chunks.find((chunk) => chunk.stateId === "agent-large");
   firstChunk.revision = "2";
   assert.throws(() => store.load("agent-large"), /invalid Cloudflare durability chunks/);

--- a/js/bindings/test/durability-adversarial.test.mjs
+++ b/js/bindings/test/durability-adversarial.test.mjs
@@ -5,6 +5,7 @@ import {
   DurabilityImportConflictError,
   createMemoryDurabilityStore,
   durabilityRevision,
+  durabilityStateDigest,
   exportDurabilityState,
   exportDurabilityStatePage,
   importDurabilityState,
@@ -159,17 +160,25 @@ test("portable export fences the source and exact import refuses overwrite", asy
   );
 });
 
-test("cursor export resumes an exact from-exclusive to-inclusive total-state replacement", async () => {
+test("cursor export resumes only from the exact from-state lineage", async () => {
   const payload = "first-page:🧪:middle:second-page:tail";
+  const fromPayload = "older-total-state";
+  const fromDigest = await durabilityStateDigest({ revision: "4", payload: fromPayload });
   const source = createMemoryDurabilityStore("range", { revision: "9", payload });
-  const first = await exportDurabilityStatePage(source, "range", { from: "4", limit: 12 });
+  const first = await exportDurabilityStatePage(source, "range", {
+    from: "4",
+    fromDigest,
+    limit: 12,
+  });
   assert.equal(first.from, "4");
+  assert.match(first.fromDigest, /^sha256:[0-9a-f]{64}$/);
   assert.equal(first.to, "9");
   assert.equal(first.cursor, "v1:0");
   assert.notEqual(first.nextCursor, null);
 
   const repeated = await exportDurabilityStatePage(source, "range", {
     from: "4",
+    fromDigest,
     to: first.to,
     cursor: first.cursor,
     limit: 12,
@@ -180,6 +189,7 @@ test("cursor export resumes an exact from-exclusive to-inclusive total-state rep
   while (pages.at(-1).nextCursor !== null) {
     pages.push(await exportDurabilityStatePage(source, "range", {
       from: "4",
+      fromDigest,
       to: first.to,
       cursor: pages.at(-1).nextCursor,
       limit: 12,
@@ -189,13 +199,41 @@ test("cursor export resumes an exact from-exclusive to-inclusive total-state rep
 
   const destination = createMemoryDurabilityStore("range", {
     revision: "4",
-    payload: "older-total-state",
+    payload: fromPayload,
   });
   assert.deepEqual(await importDurabilityStatePages(destination, pages), {
     revision: "9",
     payload,
   });
   assert.deepEqual(destination.snapshot(), { revision: "9", payload });
+
+  const sameRevisionDivergence = createMemoryDurabilityStore("range", {
+    revision: "4",
+    payload: "unrelated-lineage-at-the-same-revision",
+  });
+  await assert.rejects(
+    importDurabilityStatePages(sameRevisionDivergence, pages),
+    (error) => error instanceof DurabilityImportConflictError
+      && error.expectedRevision === "4"
+      && error.actualRevision === "4",
+  );
+  assert.deepEqual(sameRevisionDivergence.snapshot(), {
+    revision: "4",
+    payload: "unrelated-lineage-at-the-same-revision",
+  });
+
+  const directGuard = createMemoryDurabilityStore("range", {
+    revision: "4",
+    payload: fromPayload,
+  });
+  assert.throws(
+    () => directGuard.importState("range", { revision: "9", payload }, {
+      expectedRevision: "4",
+      expectedPayload: "unrelated-lineage-at-the-same-revision",
+    }),
+    /different payload lineage/,
+  );
+  assert.deepEqual(directGuard.snapshot(), { revision: "4", payload: fromPayload });
 
   const divergent = createMemoryDurabilityStore("range", {
     revision: "5",
@@ -210,6 +248,31 @@ test("cursor export resumes an exact from-exclusive to-inclusive total-state rep
   await assert.rejects(
     importDurabilityStatePages(createMemoryDurabilityStore("range"), pages.slice(1)),
     /missing, duplicated, or out of order/,
+  );
+  await assert.rejects(
+    exportDurabilityStatePage(source, "range", { from: "4", limit: 12 }),
+    /require a from-state digest/,
+  );
+  const mixedLineage = pages.map((page, index) => index === 1
+    ? { ...page, fromDigest: `sha256:${"0".repeat(64)}` }
+    : page);
+  await assert.rejects(
+    importDurabilityStatePages(createMemoryDurabilityStore("range", {
+      revision: "4",
+      payload: fromPayload,
+    }), mixedLineage),
+    /different revision ranges/,
+  );
+  const uniformlyTamperedLineage = pages.map((page) => ({
+    ...page,
+    fromDigest: `sha256:${"0".repeat(64)}`,
+  }));
+  await assert.rejects(
+    importDurabilityStatePages(createMemoryDurabilityStore("range", {
+      revision: "4",
+      payload: fromPayload,
+    }), uniformlyTamperedLineage),
+    /different payload lineage/,
   );
 });
 

--- a/js/bindings/test/durability-adversarial.test.mjs
+++ b/js/bindings/test/durability-adversarial.test.mjs
@@ -6,7 +6,9 @@ import {
   createMemoryDurabilityStore,
   durabilityRevision,
   exportDurabilityState,
+  exportDurabilityStatePage,
   importDurabilityState,
+  importDurabilityStatePages,
 } from "nanocodex/durability";
 import {
   acquire,
@@ -154,6 +156,60 @@ test("portable export fences the source and exact import refuses overwrite", asy
   await assert.rejects(
     importDurabilityState(destination, archive),
     DurabilityImportConflictError,
+  );
+});
+
+test("cursor export resumes an exact from-exclusive to-inclusive total-state replacement", async () => {
+  const payload = "first-page:🧪:middle:second-page:tail";
+  const source = createMemoryDurabilityStore("range", { revision: "9", payload });
+  const first = await exportDurabilityStatePage(source, "range", { from: "4", limit: 12 });
+  assert.equal(first.from, "4");
+  assert.equal(first.to, "9");
+  assert.equal(first.cursor, "v1:0");
+  assert.notEqual(first.nextCursor, null);
+
+  const repeated = await exportDurabilityStatePage(source, "range", {
+    from: "4",
+    to: first.to,
+    cursor: first.cursor,
+    limit: 12,
+  });
+  assert.deepEqual(repeated, first, "retrying a cursor returns the identical page");
+
+  const pages = [first];
+  while (pages.at(-1).nextCursor !== null) {
+    pages.push(await exportDurabilityStatePage(source, "range", {
+      from: "4",
+      to: first.to,
+      cursor: pages.at(-1).nextCursor,
+      limit: 12,
+    }));
+  }
+  assert.equal(pages.map((page) => page.payload).join(""), payload);
+
+  const destination = createMemoryDurabilityStore("range", {
+    revision: "4",
+    payload: "older-total-state",
+  });
+  assert.deepEqual(await importDurabilityStatePages(destination, pages), {
+    revision: "9",
+    payload,
+  });
+  assert.deepEqual(destination.snapshot(), { revision: "9", payload });
+
+  const divergent = createMemoryDurabilityStore("range", {
+    revision: "5",
+    payload: "diverged",
+  });
+  await assert.rejects(
+    importDurabilityStatePages(divergent, pages),
+    (error) => error instanceof DurabilityImportConflictError
+      && error.expectedRevision === "4"
+      && error.actualRevision === "5",
+  );
+  await assert.rejects(
+    importDurabilityStatePages(createMemoryDurabilityStore("range"), pages.slice(1)),
+    /missing, duplicated, or out of order/,
   );
 });
 

--- a/js/bindings/test/durability-adversarial.test.mjs
+++ b/js/bindings/test/durability-adversarial.test.mjs
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { createMemoryDurabilityStore, durabilityRevision } from "nanocodex/durability";
+import {
+  DurabilityImportConflictError,
+  createMemoryDurabilityStore,
+  durabilityRevision,
+  exportDurabilityState,
+  importDurabilityState,
+} from "nanocodex/durability";
 import {
   acquire,
   own,
@@ -111,4 +117,80 @@ test("stale owners lose before revision comparison and replacement is total", ()
   assert.equal("append" in store, false);
   assert.equal("compact" in store, false);
   assert.equal("acquirePage" in store, false);
+});
+
+test("portable export fences the source and exact import refuses overwrite", async () => {
+  const source = createMemoryDurabilityStore("source");
+  const sourceOwner = source.acquire("source", { ownerId: "source-owner" });
+  assert.deepEqual(source.replace("source", {
+    ...sourceOwner,
+    expectedRevision: "0",
+    payload: "opaque-total-state",
+  }), { status: "replaced", revision: "1" });
+
+  const archive = await exportDurabilityState(source, "source");
+  assert.deepEqual(archive, {
+    format: "nanocodex-durability-state-v1",
+    stateId: "source",
+    revision: "1",
+    payload: "opaque-total-state",
+  });
+  assert.deepEqual(source.replace("source", {
+    ...sourceOwner,
+    expectedRevision: "1",
+    payload: "split-brain-write",
+  }), { status: "fenced" });
+
+  const serialized = JSON.parse(JSON.stringify(archive));
+  const destination = createMemoryDurabilityStore("source");
+  assert.deepEqual(
+    await importDurabilityState(destination, serialized),
+    { revision: "1", payload: "opaque-total-state" },
+  );
+  assert.deepEqual(destination.load("source"), {
+    revision: "1",
+    payload: "opaque-total-state",
+  });
+  await assert.rejects(
+    importDurabilityState(destination, archive),
+    DurabilityImportConflictError,
+  );
+});
+
+test("portable import rejects malformed or unsupported archives", async () => {
+  const destination = createMemoryDurabilityStore("destination");
+  await assert.rejects(
+    importDurabilityState(destination, {
+      format: "nanocodex-durability-state-v0",
+      stateId: "source",
+      revision: "1",
+      payload: "state",
+    }),
+    /unsupported durability export format/,
+  );
+  await assert.rejects(
+    importDurabilityState(destination, {
+      format: "nanocodex-durability-state-v1",
+      stateId: "source",
+      revision: "0",
+      payload: "impossible",
+    }),
+    /payload must be null exactly at revision zero/,
+  );
+});
+
+test("portable import reserves an empty revision and never fences an initialized target", async () => {
+  const source = createMemoryDurabilityStore("empty-portable");
+  const archive = await exportDurabilityState(source, "empty-portable");
+  const destination = createMemoryDurabilityStore("empty-portable");
+
+  assert.deepEqual(await importDurabilityState(destination, archive), {
+    revision: "0",
+    payload: null,
+  });
+  await assert.rejects(importDurabilityState(destination, archive), DurabilityImportConflictError);
+
+  const initialized = createMemoryDurabilityStore("empty-portable");
+  initialized.acquire("empty-portable", { ownerId: "live-owner" });
+  await assert.rejects(importDurabilityState(initialized, archive), DurabilityImportConflictError);
 });

--- a/js/bindings/test/durability-adversarial.test.mjs
+++ b/js/bindings/test/durability-adversarial.test.mjs
@@ -194,3 +194,23 @@ test("portable import reserves an empty revision and never fences an initialized
   initialized.acquire("empty-portable", { ownerId: "live-owner" });
   await assert.rejects(importDurabilityState(initialized, archive), DurabilityImportConflictError);
 });
+
+test("portable cutover has no random-number-generator dependency", async () => {
+  const cryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, "crypto");
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value: undefined,
+  });
+  try {
+    const source = createMemoryDurabilityStore("crypto-free");
+    const archive = await exportDurabilityState(source, "crypto-free");
+    const destination = createMemoryDurabilityStore("crypto-free");
+    assert.deepEqual(await importDurabilityState(destination, archive), {
+      revision: "0",
+      payload: null,
+    });
+  } finally {
+    if (cryptoDescriptor) Object.defineProperty(globalThis, "crypto", cryptoDescriptor);
+    else delete globalThis.crypto;
+  }
+});

--- a/js/bindings/test/durability-adversarial.test.mjs
+++ b/js/bindings/test/durability-adversarial.test.mjs
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createMemoryDurabilityStore, durabilityRevision } from "nanocodex/durability";
+import {
+  acquire,
+  own,
+  release,
+  replace,
+  retain,
+} from "../runtime/durability.mjs";
+
+test("durability rejects malformed identities, counters, payloads, and old state shapes", async () => {
+  for (const id of ["", "   ", null, 1, {}, []]) {
+    assert.throws(() => createMemoryDurabilityStore(id), /state ID must be a non-empty string/);
+  }
+  for (const counter of ["", "00", "-1", "+1", "1.0", " 1", 1.5, -1, {}, null]) {
+    assert.throws(() => durabilityRevision(counter), /durability revision/);
+  }
+  assert.throws(
+    () => createMemoryDurabilityStore("state", { revision: "0", payload: "impossible" }),
+    /payload must be null exactly at revision zero/,
+  );
+  assert.throws(
+    () => createMemoryDurabilityStore("state", { revision: "1", payload: null }),
+    /payload must be null exactly at revision zero/,
+  );
+  assert.throws(
+    () => createMemoryDurabilityStore("state", { revision: "1", batches: [] }),
+    /exactly payload and revision/,
+  );
+  assert.throws(
+    () => createMemoryDurabilityStore("state", { revision: "1", payload: "x", extra: true }),
+    /exactly payload and revision/,
+  );
+});
+
+test("the host boundary rejects every malformed acquired-state projection", async () => {
+  const invalid = [
+    null,
+    [],
+    { ownerId: "owner", fence: "1", revision: "0", payload: "present" },
+    { ownerId: "owner", fence: "1", revision: "1", payload: null },
+    { ownerId: "owner", fence: "01", revision: "0", payload: null },
+    { ownerId: "other", fence: "1", revision: "0", payload: null },
+    { ownerId: "owner", fence: "18446744073709551616", revision: "0", payload: null },
+    { ownerId: "owner", fence: "1", revision: "18446744073709551616", payload: "x" },
+    { ownerId: "owner", fence: "1", revision: "1", payload: new Uint8Array() },
+    { ownerId: "owner", fence: "1", revision: "0", payload: null, batches: [] },
+  ];
+  for (const [index, acquired] of invalid.entries()) {
+    const host = {};
+    const route = own(host, {
+      acquire: () => acquired,
+      replace: () => ({ status: "fenced" }),
+    }, `state-${index}`);
+    retain(host, route.id);
+    await assert.rejects(acquire(route.id, `state-${index}`, "owner"), /durability/);
+    release(host, route.id);
+  }
+});
+
+test("the host boundary accepts only the four exact replace outcomes", async () => {
+  const outcomes = [
+    undefined,
+    null,
+    {},
+    { status: "appended", revision: "1" },
+    { status: "replaced", revision: "01" },
+    { status: "conflict", actualRevision: "-1" },
+    { status: "not_committed", message: "" },
+    { status: "unknown" },
+    { status: "fenced", revision: "1" },
+    { status: "replaced", revision: "1", appended: true },
+  ];
+  for (const [index, outcome] of outcomes.entries()) {
+    const host = {};
+    const route = own(host, {
+      acquire: () => ({ ownerId: "owner", fence: "1", revision: "0", payload: null }),
+      replace: () => outcome,
+    }, `state-${index}`);
+    retain(host, route.id);
+    await assert.rejects(
+      replace(route.id, `state-${index}`, "owner", "1", "0", "payload"),
+      /durability/,
+    );
+    release(host, route.id);
+  }
+});
+
+test("stale owners lose before revision comparison and replacement is total", () => {
+  const store = createMemoryDurabilityStore("state");
+  const first = store.acquire("state", { ownerId: "first" });
+  assert.deepEqual(store.replace("state", {
+    ...first,
+    expectedRevision: "0",
+    payload: "first-state",
+  }), { status: "replaced", revision: "1" });
+  const second = store.acquire("state", { ownerId: "second" });
+  assert.deepEqual(store.replace("state", {
+    ...first,
+    expectedRevision: "999",
+    payload: "stale",
+  }), { status: "fenced" });
+  assert.deepEqual(store.replace("state", {
+    ...second,
+    expectedRevision: "1",
+    payload: "second-state",
+  }), { status: "replaced", revision: "2" });
+  assert.deepEqual(store.snapshot(), { revision: "2", payload: "second-state" });
+  assert.equal("append" in store, false);
+  assert.equal("compact" in store, false);
+  assert.equal("acquirePage" in store, false);
+});

--- a/js/bindings/test/indexeddb-durability-store.test.mjs
+++ b/js/bindings/test/indexeddb-durability-store.test.mjs
@@ -71,6 +71,22 @@ test("IndexedDB durability serializes atomic compare-and-replace transactions", 
     await store.replace("thread", { ...owner, expectedRevision: "0", payload: "stale" }),
     { status: "fenced" },
   );
+  assert.deepEqual(
+    await store.replace("thread", {
+      ...owner,
+      expectedRevision: "not-a-revision",
+      payload: new Uint8Array(),
+    }),
+    { status: "fenced" },
+  );
+  assert.deepEqual(
+    await store.replace("thread", {
+      ...replacement,
+      expectedRevision: "1",
+      payload: new Uint8Array(),
+    }),
+    { status: "conflict", actualRevision: "0" },
+  );
 });
 
 test("IndexedDB durability atomically increments concurrent owner acquisitions", async () => {
@@ -119,6 +135,17 @@ test("IndexedDB durability creates only owner and state stores", async () => {
   const store = createIndexedDbDurabilityStore({ indexedDB, databaseName: "upgrade" });
   await store.load("thread");
   assert.deepEqual(indexedDB.storeNames("upgrade"), ["owners", "states"]);
+});
+
+test("IndexedDB durability rejects stores with incompatible key semantics", async () => {
+  const indexedDB = createFakeIndexedDb();
+  await createIndexedDbDurabilityStore({ indexedDB, databaseName: "schema" }).load("thread");
+  indexedDB.alterStore("schema", "owners", { keyPath: "ownerId" });
+
+  await assert.rejects(
+    createIndexedDbDurabilityStore({ indexedDB, databaseName: "schema" }).load("thread"),
+    /incompatible IndexedDB durability schema/,
+  );
 });
 
 test("IndexedDB durability has no browser-global import-time dependency", () => {
@@ -203,6 +230,9 @@ function createFakeIndexedDb() {
     storeNames(name) {
       return [...databases.get(name).stores.keys()].sort();
     },
+    alterStore(name, storeName, shape) {
+      Object.assign(databases.get(name).stores.get(storeName), shape);
+    },
     seed(name, stateId, revision, payload) {
       const database = databases.get(name);
       if (!database) throw new Error(`database ${name} has not been opened`);
@@ -231,8 +261,8 @@ class FakeDatabase {
     this.writeTail = Promise.resolve();
   }
 
-  createObjectStore(name, { keyPath }) {
-    const definition = { keyPath, indexes: new Map(), records: new Map() };
+  createObjectStore(name, { keyPath, autoIncrement = false }) {
+    const definition = { keyPath, autoIncrement, indexes: new Map(), records: new Map() };
     this.stores.set(name, definition);
     return {
       createIndex: (indexName, indexKeyPath) => {
@@ -316,6 +346,14 @@ class FakeObjectStore {
     this.name = name;
   }
 
+  get keyPath() {
+    return this.transaction.database.stores.get(this.name).keyPath;
+  }
+
+  get autoIncrement() {
+    return this.transaction.database.stores.get(this.name).autoIncrement;
+  }
+
   get(key) {
     return this.transaction.enqueue(() => clone(this.definition.records.get(serializeKey(key))));
   }
@@ -363,6 +401,7 @@ class FakeObjectStore {
 function cloneStore(store) {
   return {
     keyPath: store.keyPath,
+    autoIncrement: store.autoIncrement,
     indexes: new Map(store.indexes),
     records: new Map([...store.records].map(([key, value]) => [key, clone(value)])),
   };

--- a/js/bindings/test/indexeddb-durability-store.test.mjs
+++ b/js/bindings/test/indexeddb-durability-store.test.mjs
@@ -3,27 +3,19 @@ import { test } from "node:test";
 
 import { createIndexedDbDurabilityStore } from "../browser/indexeddb-durability-store.mjs";
 
-test("IndexedDB durability validates revisions and loads numerically ordered batches", async () => {
+test("IndexedDB durability validates one complete retained state", async () => {
   const indexedDB = createFakeIndexedDb();
   const store = createIndexedDbDurabilityStore({ indexedDB, databaseName: "ordered" });
 
-  assert.deepEqual(await store.load("thread"), { revision: "0", batches: [] });
-  indexedDB.seed("ordered", "thread", "10", [
-    { revision: "10", payload: "ten" },
-    { revision: "2", payload: "two" },
-    { revision: "1", payload: "one" },
-  ]);
+  assert.deepEqual(await store.load("thread"), { revision: "0", payload: null });
+  indexedDB.seed("ordered", "thread", "10", "ten");
   assert.deepEqual(await store.load("thread"), {
     revision: "10",
-    batches: [
-      { revision: "1", payload: "one" },
-      { revision: "2", payload: "two" },
-      { revision: "10", payload: "ten" },
-    ],
+    payload: "ten",
   });
   const owner = await store.acquire("thread", { ownerId: "owner-1" });
   await assert.rejects(
-    store.append("thread", {
+    store.replace("thread", {
       ownerId: owner.ownerId,
       fence: owner.fence,
       expectedRevision: "01",
@@ -32,7 +24,7 @@ test("IndexedDB durability validates revisions and loads numerically ordered bat
     /unsigned 64-bit decimal string/,
   );
   await assert.rejects(
-    store.append("thread", {
+    store.replace("thread", {
       ownerId: owner.ownerId,
       fence: owner.fence,
       expectedRevision: "10",
@@ -42,30 +34,30 @@ test("IndexedDB durability validates revisions and loads numerically ordered bat
   );
 });
 
-test("IndexedDB durability serializes atomic compare-and-append transactions", async () => {
+test("IndexedDB durability serializes atomic compare-and-replace transactions", async () => {
   const indexedDB = createFakeIndexedDb();
   const store = createIndexedDbDurabilityStore({ indexedDB, databaseName: "atomic" });
   const owner = await store.acquire("thread", { ownerId: "owner-1" });
   const results = await Promise.all([
-    store.append("thread", { ...owner, expectedRevision: "0", payload: "left" }),
-    store.append("thread", { ...owner, expectedRevision: "0", payload: "right" }),
+    store.replace("thread", { ...owner, expectedRevision: "0", payload: "left" }),
+    store.replace("thread", { ...owner, expectedRevision: "0", payload: "right" }),
   ]);
 
-  assert.equal(results.filter(({ status }) => status === "appended").length, 1);
+  assert.equal(results.filter(({ status }) => status === "replaced").length, 1);
   assert.deepEqual(results.find(({ status }) => status === "conflict"), {
     status: "conflict",
     actualRevision: "1",
   });
-  const journal = await store.load("thread");
-  assert.equal(journal.revision, "1");
-  assert.equal(journal.batches.length, 1);
+  const state = await store.load("thread");
+  assert.equal(state.revision, "1");
+  assert.ok(state.payload === "left" || state.payload === "right");
 
-  indexedDB.failNextBatchAdd("atomic");
+  indexedDB.failNextStatePut("atomic");
   await assert.rejects(
-    store.append("thread", { ...owner, expectedRevision: "1", payload: "rolled back" }),
-    /injected batch failure/,
+    store.replace("thread", { ...owner, expectedRevision: "1", payload: "rolled back" }),
+    /injected state failure/,
   );
-  assert.deepEqual(await store.load("thread"), journal);
+  assert.deepEqual(await store.load("thread"), state);
 
   indexedDB.resetContent("atomic", "thread");
   const replacement = await store.acquire("thread", { ownerId: "owner-2" });
@@ -73,10 +65,10 @@ test("IndexedDB durability serializes atomic compare-and-append transactions", a
     ownerId: "owner-2",
     fence: "2",
     revision: "0",
-    batches: [],
+    payload: null,
   });
   assert.deepEqual(
-    await store.append("thread", { ...owner, expectedRevision: "0", payload: "stale" }),
+    await store.replace("thread", { ...owner, expectedRevision: "0", payload: "stale" }),
     { status: "fenced" },
   );
 });
@@ -92,12 +84,12 @@ test("IndexedDB durability atomically increments concurrent owner acquisitions",
   assert.equal(first.fence, "1");
   assert.equal(second.fence, "2");
   assert.deepEqual(
-    await store.append("thread", { ...first, expectedRevision: "99", payload: "stale" }),
+    await store.replace("thread", { ...first, expectedRevision: "99", payload: "stale" }),
     { status: "fenced" },
   );
   assert.deepEqual(
-    await store.append("thread", { ...second, expectedRevision: "0", payload: "current" }),
-    { status: "appended", revision: "1" },
+    await store.replace("thread", { ...second, expectedRevision: "0", payload: "current" }),
+    { status: "replaced", revision: "1" },
   );
 });
 
@@ -106,11 +98,11 @@ test("IndexedDB durability reports u64 overflow without committing", async () =>
   const store = createIndexedDbDurabilityStore({ indexedDB, databaseName: "overflow" });
   const maximum = "18446744073709551615";
   await store.load("thread");
-  indexedDB.seed("overflow", "thread", maximum, [{ revision: maximum, payload: "last" }]);
+  indexedDB.seed("overflow", "thread", maximum, "last");
   const owner = await store.acquire("thread", { ownerId: "owner" });
 
   assert.deepEqual(
-    await store.append("thread", { ...owner, expectedRevision: maximum, payload: "never" }),
+    await store.replace("thread", { ...owner, expectedRevision: maximum, payload: "never" }),
     {
       status: "not_committed",
       message: "IndexedDB durability revision overflow",
@@ -118,31 +110,22 @@ test("IndexedDB durability reports u64 overflow without committing", async () =>
   );
   assert.deepEqual(await store.load("thread"), {
     revision: maximum,
-    batches: [{ revision: maximum, payload: "last" }],
+    payload: "last",
   });
 });
 
-test("IndexedDB durability upgrades v1 databases with a separate v2 owner store", async () => {
+test("IndexedDB durability creates only owner and state stores", async () => {
   const indexedDB = createFakeIndexedDb();
-  indexedDB.seedVersionOne("upgrade", "thread", "1", [
-    { revision: "1", payload: "retained" },
-  ]);
   const store = createIndexedDbDurabilityStore({ indexedDB, databaseName: "upgrade" });
-
-  assert.deepEqual(await store.acquire("thread", { ownerId: "owner" }), {
-    ownerId: "owner",
-    fence: "1",
-    revision: "1",
-    batches: [{ revision: "1", payload: "retained" }],
-  });
-  assert.equal(indexedDB.version("upgrade"), 2);
+  await store.load("thread");
+  assert.deepEqual(indexedDB.storeNames("upgrade"), ["owners", "states"]);
 });
 
 test("IndexedDB durability has no browser-global import-time dependency", () => {
   assert.throws(() => createIndexedDbDurabilityStore(), /requires IndexedDB/);
 });
 
-test("IndexedDB durability retries failed opens and reopens retained journals after close", async () => {
+test("IndexedDB durability retries failed opens and reopens retained state after close", async () => {
   const indexedDB = createFakeIndexedDb();
   const store = createIndexedDbDurabilityStore({ indexedDB, databaseName: "reopen" });
   indexedDB.failNextOpen("reopen");
@@ -150,22 +133,22 @@ test("IndexedDB durability retries failed opens and reopens retained journals af
   await assert.rejects(store.load("thread"), /injected open failure/);
   const owner = await store.acquire("thread", { ownerId: "owner" });
   assert.deepEqual(
-    await store.append("thread", { ...owner, expectedRevision: "0", payload: "retained" }),
-    { status: "appended", revision: "1" },
+    await store.replace("thread", { ...owner, expectedRevision: "0", payload: "retained" }),
+    { status: "replaced", revision: "1" },
   );
   assert.equal(indexedDB.openCount("reopen"), 2, "a rejected open is not cached");
 
   indexedDB.triggerVersionChange("reopen");
   assert.deepEqual(await store.load("thread"), {
     revision: "1",
-    batches: [{ revision: "1", payload: "retained" }],
+    payload: "retained",
   });
   assert.equal(indexedDB.openCount("reopen"), 3, "a closed connection is not cached");
 
   indexedDB.triggerAbnormalClose("reopen");
   assert.deepEqual(await store.load("thread"), {
     revision: "1",
-    batches: [{ revision: "1", payload: "retained" }],
+    payload: "retained",
   });
   assert.equal(indexedDB.openCount("reopen"), 4, "an abnormal close is not cached");
 });
@@ -217,38 +200,20 @@ function createFakeIndexedDb() {
       database.closed = true;
       database.onclose?.();
     },
-    version(name) {
-      return databases.get(name)?.version;
+    storeNames(name) {
+      return [...databases.get(name).stores.keys()].sort();
     },
-    seedVersionOne(name, journalId, revision, batches) {
-      const database = new FakeDatabase(1);
-      database.createObjectStore("journals", { keyPath: "journalId" });
-      const batchStore = database.createObjectStore("batches", {
-        keyPath: ["journalId", "revision"],
-      });
-      batchStore.createIndex("journalId", "journalId");
-      databases.set(name, database);
-      this.seed(name, journalId, revision, batches);
-    },
-    seed(name, journalId, revision, batches) {
+    seed(name, stateId, revision, payload) {
       const database = databases.get(name);
       if (!database) throw new Error(`database ${name} has not been opened`);
-      database.stores.get("journals").records.set(journalId, { journalId, revision });
-      const records = database.stores.get("batches").records;
-      for (const batch of batches) {
-        records.set(JSON.stringify([journalId, batch.revision]), { journalId, ...batch });
-      }
+      database.stores.get("states").records.set(stateId, { stateId, revision, payload });
     },
-    failNextBatchAdd(name) {
-      databases.get(name).failNextBatchAdd = true;
+    failNextStatePut(name) {
+      databases.get(name).failNextStatePut = true;
     },
-    resetContent(name, journalId) {
+    resetContent(name, stateId) {
       const database = databases.get(name);
-      database.stores.get("journals").records.delete(journalId);
-      const records = database.stores.get("batches").records;
-      for (const [key, batch] of records) {
-        if (batch.journalId === journalId) records.delete(key);
-      }
+      database.stores.get("states").records.delete(stateId);
     },
   };
 }
@@ -258,8 +223,11 @@ class FakeDatabase {
     this.version = version;
     this.stores = new Map();
     this.closed = false;
-    this.failNextBatchAdd = false;
-    this.objectStoreNames = { contains: (name) => this.stores.has(name) };
+    this.failNextStatePut = false;
+    this.objectStoreNames = {
+      contains: (name) => this.stores.has(name),
+      [Symbol.iterator]: () => this.stores.keys(),
+    };
     this.writeTail = Promise.resolve();
   }
 
@@ -354,17 +322,21 @@ class FakeObjectStore {
 
   put(value) {
     return this.transaction.enqueue(() => {
+      if (this.name === "states" && this.transaction.database.failNextStatePut) {
+        this.transaction.database.failNextStatePut = false;
+        throw new Error("injected state failure");
+      }
       this.definition.records.set(recordKey(this.definition.keyPath, value), clone(value));
       return clone(value);
     });
   }
 
+  delete(key) {
+    return this.transaction.enqueue(() => this.definition.records.delete(serializeKey(key)));
+  }
+
   add(value) {
     return this.transaction.enqueue(() => {
-      if (this.name === "batches" && this.transaction.database.failNextBatchAdd) {
-        this.transaction.database.failNextBatchAdd = false;
-        throw new Error("injected batch failure");
-      }
       const key = recordKey(this.definition.keyPath, value);
       if (this.definition.records.has(key)) throw new Error("duplicate key");
       this.definition.records.set(key, clone(value));

--- a/js/bindings/test/lifecycle.test.mjs
+++ b/js/bindings/test/lifecycle.test.mjs
@@ -186,11 +186,11 @@ test("a duplicate durable session rejects without fencing the live Agent", async
   const stored = createMemoryDurabilityStore(durabilityId);
   let authorityAcquisitions = 0;
   const durability = {
-    acquire(journalId, request) {
+    acquire(stateId, request) {
       authorityAcquisitions += 1;
-      return stored.acquire(journalId, request);
+      return stored.acquire(stateId, request);
     },
-    append: (journalId, request) => stored.append(journalId, request),
+    replace: (stateId, request) => stored.replace(stateId, request),
   };
   const options = {
     transport: Transport.openAi({ apiKey: "test-key", websocketUrl: server.url }),
@@ -235,15 +235,15 @@ test("durability store failures preserve reopen and retry-safe dispositions", as
       "retryable",
     ],
   ];
-  for (const [name, appendOutcome, expectedCode] of cases) {
+  for (const [name, replaceOutcome, expectedCode] of cases) {
     const durabilityId = `lifecycle-store-${name}`;
     const durability = {
-      acquire(_journalId, { ownerId }) {
-        return { ownerId, fence: "1", revision: "0", batches: [] };
+      acquire(_stateId, { ownerId }) {
+        return { ownerId, fence: "1", revision: "0", payload: null };
       },
-      append() {
-        if (appendOutcome instanceof Error) throw appendOutcome;
-        return appendOutcome;
+      replace() {
+        if (replaceOutcome instanceof Error) throw replaceOutcome;
+        return replaceOutcome;
       },
     };
     const agent = await Agent.create({

--- a/js/bindings/test/package.test.mjs
+++ b/js/bindings/test/package.test.mjs
@@ -80,14 +80,16 @@ test("the packed package ships and resolves every public entry point", async () 
         DurabilityImportConflictError,
         durabilityRevision,
         exportDurabilityState,
+        exportDurabilityStatePage,
         importDurabilityState,
+        importDurabilityStatePages,
         sqliteDurabilitySchema,
       } from "nanocodex/durability";
       import * as durabilityExports from "nanocodex/durability";
       import { createCloudflareDurabilityStore } from "nanocodex/durability/cloudflare";
       import {
         createPostgresDurabilityStore,
-        UnknownPostgresCommitOutcomeError,
+        PostgresDurabilityUnavailableError,
       } from "nanocodex/durability/postgres";
       import { Agent as HostAgent, Transport as HostTransport } from "nanocodex/host";
       import * as hostExports from "nanocodex/host";
@@ -110,7 +112,9 @@ test("the packed package ships and resolves every public entry point", async () 
         "DurabilityImportConflictError",
         "durabilityRevision",
         "exportDurabilityState",
+        "exportDurabilityStatePage",
         "importDurabilityState",
+        "importDurabilityStatePages",
         "sqliteDurabilitySchema",
       ];
       assert.deepEqual(
@@ -142,6 +146,15 @@ test("the packed package ships and resolves every public entry point", async () 
       const packageArchive = await exportDurabilityState(packageSource, "portable-package-state");
       const packageDestination = createMemoryDurabilityStore("portable-package-state");
       assert.deepEqual(await importDurabilityState(packageDestination, packageArchive), {
+        revision: "1",
+        payload: "portable-package-payload",
+      });
+      const packagePage = await exportDurabilityStatePage(packageSource, "portable-package-state", {
+        from: durabilityRevision("0"),
+        limit: 1024,
+      });
+      const pageDestination = createMemoryDurabilityStore("portable-package-state");
+      assert.deepEqual(await importDurabilityStatePages(pageDestination, [packagePage]), {
         revision: "1",
         payload: "portable-package-payload",
       });
@@ -182,8 +195,8 @@ test("the packed package ships and resolves every public entry point", async () 
       assert.equal(Object.isFrozen(postgresStore), true);
       assert.equal(postgresCalls, 0);
       const commitCause = new Error("connection closed");
-      const commitError = new UnknownPostgresCommitOutcomeError("package-journal", commitCause);
-      assert.equal(commitError.name, "UnknownPostgresCommitOutcomeError");
+      const commitError = new PostgresDurabilityUnavailableError("package-journal", commitCause);
+      assert.equal(commitError.name, "PostgresDurabilityUnavailableError");
       assert.equal(commitError.cause, commitCause);
       assert.equal(typeof NodeWorkspace.open, "function");
       assert.equal(typeof BrowserWorkspace.open, "function");

--- a/js/bindings/test/package.test.mjs
+++ b/js/bindings/test/package.test.mjs
@@ -79,6 +79,7 @@ test("the packed package ships and resolves every public entry point", async () 
         createMemoryDurabilityStore,
         DurabilityImportConflictError,
         durabilityRevision,
+        durabilityStateDigest,
         exportDurabilityState,
         exportDurabilityStatePage,
         importDurabilityState,
@@ -111,6 +112,7 @@ test("the packed package ships and resolves every public entry point", async () 
         "createSqliteDurabilityStore",
         "DurabilityImportConflictError",
         "durabilityRevision",
+        "durabilityStateDigest",
         "exportDurabilityState",
         "exportDurabilityStatePage",
         "importDurabilityState",
@@ -134,6 +136,7 @@ test("the packed package ships and resolves every public entry point", async () 
         );
       }
       assert.equal(durabilityRevision(1n), "1");
+      assert.match(await durabilityStateDigest({ revision: "0", payload: null }), /^sha256:/);
       assert.equal(createMemoryDurabilityStore("package-state").stateId, "package-state");
       assert.equal(new DurabilityImportConflictError("package-state").name, "DurabilityImportConflictError");
       const packageSource = createMemoryDurabilityStore("portable-package-state");

--- a/js/bindings/test/package.test.mjs
+++ b/js/bindings/test/package.test.mjs
@@ -124,19 +124,30 @@ test("the packed package ships and resolves every public entry point", async () 
         );
       }
       assert.equal(durabilityRevision(1n), "1");
-      assert.equal(createMemoryDurabilityStore("package-journal").journalId, "package-journal");
+      assert.equal(createMemoryDurabilityStore("package-state").stateId, "package-state");
       let cloudflareSchemaStatements = 0;
       const cloudflareStore = createCloudflareDurabilityStore({
         sql: {
-          exec() {
-            cloudflareSchemaStatements += 1;
-            return { toArray: () => [] };
+          exec(sql) {
+            if (sql.startsWith("CREATE TABLE")) cloudflareSchemaStatements += 1;
+            let rows = [];
+            if (sql.startsWith("PRAGMA table_info")) {
+              const shapes = sql.includes("nanocodex_durable_owners")
+                ? [["state_id", "TEXT", 0, 1], ["owner_id", "TEXT", 1, 0], ["fence", "TEXT", 1, 0]]
+                : sql.includes("nanocodex_durable_states")
+                  ? [["state_id", "TEXT", 0, 1], ["revision", "TEXT", 1, 0], ["payload", "TEXT", 1, 0]]
+                  : sql.includes("nanocodex_durable_chunk_heads")
+                    ? [["state_id", "TEXT", 0, 1], ["revision", "TEXT", 1, 0], ["chunk_count", "INTEGER", 1, 0]]
+                    : [["state_id", "TEXT", 1, 1], ["revision", "TEXT", 1, 2], ["chunk_index", "INTEGER", 1, 3], ["payload", "TEXT", 1, 0]];
+              rows = shapes.map(([name, type, notnull, pk], cid) => ({ cid, name, type, notnull, pk }));
+            }
+            return { toArray: () => rows };
           },
         },
         transactionSync(callback) { return callback(); },
       });
       assert.equal(Object.isFrozen(cloudflareStore), true);
-      assert.equal(cloudflareSchemaStatements, sqliteDurabilitySchema.length + 1);
+      assert.equal(cloudflareSchemaStatements, sqliteDurabilitySchema.length + 2);
       let postgresCalls = 0;
       const postgresStore = createPostgresDurabilityStore({
         connect() {

--- a/js/bindings/test/package.test.mjs
+++ b/js/bindings/test/package.test.mjs
@@ -77,7 +77,10 @@ test("the packed package ships and resolves every public entry point", async () 
       import * as rootExports from "nanocodex";
       import {
         createMemoryDurabilityStore,
+        DurabilityImportConflictError,
         durabilityRevision,
+        exportDurabilityState,
+        importDurabilityState,
         sqliteDurabilitySchema,
       } from "nanocodex/durability";
       import * as durabilityExports from "nanocodex/durability";
@@ -104,7 +107,10 @@ test("the packed package ships and resolves every public entry point", async () 
       const durabilityValueNames = [
         "createMemoryDurabilityStore",
         "createSqliteDurabilityStore",
+        "DurabilityImportConflictError",
         "durabilityRevision",
+        "exportDurabilityState",
+        "importDurabilityState",
         "sqliteDurabilitySchema",
       ];
       assert.deepEqual(
@@ -125,6 +131,20 @@ test("the packed package ships and resolves every public entry point", async () 
       }
       assert.equal(durabilityRevision(1n), "1");
       assert.equal(createMemoryDurabilityStore("package-state").stateId, "package-state");
+      assert.equal(new DurabilityImportConflictError("package-state").name, "DurabilityImportConflictError");
+      const packageSource = createMemoryDurabilityStore("portable-package-state");
+      const packageOwner = packageSource.acquire("portable-package-state", { ownerId: "package-owner" });
+      assert.deepEqual(packageSource.replace("portable-package-state", {
+        ...packageOwner,
+        expectedRevision: "0",
+        payload: "portable-package-payload",
+      }), { status: "replaced", revision: "1" });
+      const packageArchive = await exportDurabilityState(packageSource, "portable-package-state");
+      const packageDestination = createMemoryDurabilityStore("portable-package-state");
+      assert.deepEqual(await importDurabilityState(packageDestination, packageArchive), {
+        revision: "1",
+        payload: "portable-package-payload",
+      });
       let cloudflareSchemaStatements = 0;
       const cloudflareStore = createCloudflareDurabilityStore({
         sql: {

--- a/js/bindings/test/postgres-durability.test.mjs
+++ b/js/bindings/test/postgres-durability.test.mjs
@@ -54,6 +54,30 @@ test("PostgreSQL fences owners before comparing complete-state revisions", async
     expectedRevision: "999",
     payload: "stale",
   }), { status: "fenced" });
+  assert.deepEqual(await store.replace("state", {
+    ownerId: first.ownerId,
+    fence: first.fence,
+    expectedRevision: "not-a-revision",
+    payload: new Uint8Array(),
+  }), { status: "fenced" });
+  assert.deepEqual(await store.replace("state", {
+    ownerId: second.ownerId,
+    fence: second.fence,
+    expectedRevision: "0",
+    payload: new Uint8Array(),
+  }), { status: "conflict", actualRevision: "1" });
+  await assert.rejects(store.replace("state", {
+    ownerId: second.ownerId,
+    fence: second.fence,
+    expectedRevision: "not-a-revision",
+    payload: "invalid",
+  }), /unsigned 64-bit decimal string/);
+  await assert.rejects(store.replace("state", {
+    ownerId: second.ownerId,
+    fence: second.fence,
+    expectedRevision: "1",
+    payload: new Uint8Array(),
+  }), /payload must be a string/);
 });
 
 test("PostgreSQL distinguishes rolled-back writes from unknown COMMIT outcomes", async () => {
@@ -90,6 +114,17 @@ test("PostgreSQL initialization rejects tables without the exact state primary k
     createPostgresDurabilityStore(pool).load("state"),
     /each state_id must be the sole primary key/,
   );
+});
+
+test("PostgreSQL discards a connection after an ambiguous initialization commit", async () => {
+  const pool = new MockPool();
+  pool.failNextCommit = true;
+  const store = createPostgresDurabilityStore(pool);
+
+  await assert.rejects(store.load("state"), /injected commit failure/);
+  assert.equal(pool.releases.at(-1), true);
+  assert.deepEqual(await store.load("state"), { revision: "0", payload: null });
+  assert.equal(pool.connects, 2);
 });
 
 test("the PostgreSQL commit error retains its exact unknown-outcome identity", () => {

--- a/js/bindings/test/postgres-durability.test.mjs
+++ b/js/bindings/test/postgres-durability.test.mjs
@@ -5,6 +5,7 @@ import {
   UnknownPostgresCommitOutcomeError,
   createPostgresDurabilityStore,
 } from "../runtime/postgres-durability-store.mjs";
+import { DurabilityImportConflictError } from "../runtime/durability-store.mjs";
 
 test("the PostgreSQL durability leaf is cold and validates its pool", async () => {
   assert.throws(
@@ -103,6 +104,40 @@ test("PostgreSQL distinguishes rolled-back writes from unknown COMMIT outcomes",
   assert.equal(pool.releases.at(-1), true, "an ambiguous connection must be discarded once");
 });
 
+test("PostgreSQL imports one exact portable revision and fences an empty destination", async () => {
+  const pool = new MockPool();
+  const store = createPostgresDurabilityStore(pool);
+
+  assert.deepEqual(await store.importState("portable", {
+    revision: "47",
+    payload: "opaque-provider-neutral-state",
+  }), {
+    revision: "47",
+    payload: "opaque-provider-neutral-state",
+  });
+  assert.deepEqual(await store.load("portable"), {
+    revision: "47",
+    payload: "opaque-provider-neutral-state",
+  });
+  assert.deepEqual(await store.acquire("portable", { ownerId: "restored-agent" }), {
+    ownerId: "restored-agent",
+    fence: "2",
+    revision: "47",
+    payload: "opaque-provider-neutral-state",
+  });
+  await assert.rejects(
+    store.importState("portable", { revision: "48", payload: "overwrite" }),
+    DurabilityImportConflictError,
+  );
+
+  const acquiredEmpty = await store.acquire("already-owned", { ownerId: "live-empty-owner" });
+  assert.equal(acquiredEmpty.revision, "0");
+  await assert.rejects(
+    store.importState("already-owned", { revision: "47", payload: "must-not-fence-live-owner" }),
+    DurabilityImportConflictError,
+  );
+});
+
 test("PostgreSQL initialization rejects tables without the exact state primary keys", async () => {
   const pool = new MockPool();
   pool.primaryKeys = [{
@@ -181,7 +216,9 @@ class MockClient {
     if (sql.startsWith("INSERT INTO nanocodex_durable_owners")) {
       const [stateId, ownerId] = values;
       const previous = this.pool.owners.get(stateId);
-      const fence = String(BigInt(previous?.fence ?? "0") + 1n);
+      const fence = values.length === 3
+        ? String(values[2])
+        : String(BigInt(previous?.fence ?? "0") + 1n);
       this.pool.owners.set(stateId, { owner_id: ownerId, fence });
       return { rows: [{ fence }] };
     }
@@ -192,6 +229,10 @@ class MockClient {
     if (sql.startsWith("SELECT revision::text, payload FROM nanocodex_durable_states")) {
       const state = this.pool.states.get(values[0]);
       return { rows: state ? [state] : [] };
+    }
+    if (sql.startsWith("SELECT revision::text FROM nanocodex_durable_states")) {
+      const state = this.pool.states.get(values[0]);
+      return { rows: state ? [{ revision: state.revision }] : [] };
     }
     if (sql.startsWith("INSERT INTO nanocodex_durable_states")) {
       if (this.pool.failNextUpsert) {

--- a/js/bindings/test/postgres-durability.test.mjs
+++ b/js/bindings/test/postgres-durability.test.mjs
@@ -1,10 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import {
-  UnknownPostgresCommitOutcomeError,
-  createPostgresDurabilityStore,
-} from "../runtime/postgres-durability-store.mjs";
+import { createPostgresDurabilityStore } from "../runtime/postgres-durability-store.mjs";
 import { DurabilityImportConflictError } from "../runtime/durability-store.mjs";
 
 test("the PostgreSQL durability leaf is cold and validates its pool", async () => {
@@ -81,7 +78,7 @@ test("PostgreSQL fences owners before comparing complete-state revisions", async
   }), /payload must be a string/);
 });
 
-test("PostgreSQL distinguishes rolled-back writes from unknown COMMIT outcomes", async () => {
+test("PostgreSQL distinguishes rolled-back writes and reconciles lost COMMIT responses", async () => {
   const pool = new MockPool();
   const store = createPostgresDurabilityStore(pool);
   const owner = await store.acquire("state", { ownerId: "owner" });
@@ -95,13 +92,14 @@ test("PostgreSQL distinguishes rolled-back writes from unknown COMMIT outcomes",
 
   pool.failNextCommit = true;
   const releasesBefore = pool.releases.length;
-  await assert.rejects(
-    store.replace("state", { ...owner, expectedRevision: "0", payload: "maybe" }),
-    (error) => error instanceof UnknownPostgresCommitOutcomeError
-      && error.cause?.message === "injected commit failure",
+  assert.deepEqual(
+    await store.replace("state", { ...owner, expectedRevision: "0", payload: "committed-once" }),
+    { status: "replaced", revision: "1" },
   );
-  assert.equal(pool.releases.length, releasesBefore + 1);
-  assert.equal(pool.releases.at(-1), true, "an ambiguous connection must be discarded once");
+  assert.deepEqual(await store.load("state"), { revision: "1", payload: "committed-once" });
+  assert.equal(pool.releases.length, releasesBefore + 2);
+  assert.equal(pool.releases.at(-2), true, "the connection with the lost response must be discarded");
+  assert.equal(pool.releases.at(-1), false, "verification uses a fresh healthy connection");
 });
 
 test("PostgreSQL imports one exact portable revision and fences an empty destination", async () => {
@@ -162,14 +160,6 @@ test("PostgreSQL discards a connection after an ambiguous initialization commit"
   assert.equal(pool.connects, 2);
 });
 
-test("the PostgreSQL commit error retains its exact unknown-outcome identity", () => {
-  const cause = new Error("lost connection");
-  const error = new UnknownPostgresCommitOutcomeError("state", cause);
-  assert.equal(error.name, "UnknownPostgresCommitOutcomeError");
-  assert.equal(error.cause, cause);
-  assert.match(error.message, /state "state"/);
-});
-
 class MockPool {
   constructor() {
     this.connects = 0;
@@ -223,7 +213,10 @@ class MockClient {
       }
       const fence = values.length === 3
         ? String(values[2])
-        : String(BigInt(previous?.fence ?? "0") + 1n);
+        : sql.includes("WHEN nanocodex_durable_owners.owner_id = excluded.owner_id")
+            && previous?.owner_id === ownerId
+          ? previous.fence
+          : String(BigInt(previous?.fence ?? "0") + 1n);
       this.pool.owners.set(stateId, { owner_id: ownerId, fence });
       return { rows: [{ fence }] };
     }

--- a/js/bindings/test/postgres-durability.test.mjs
+++ b/js/bindings/test/postgres-durability.test.mjs
@@ -1,283 +1,204 @@
 import assert from "node:assert/strict";
-import { test } from "node:test";
+import test from "node:test";
 
 import {
-  createPostgresDurabilityStore,
   UnknownPostgresCommitOutcomeError,
+  createPostgresDurabilityStore,
 } from "../runtime/postgres-durability-store.mjs";
 
-test("the PostgreSQL durability leaf is dependency-free and cold until first use", () => {
-  let calls = 0;
-  const store = createPostgresDurabilityStore({
-    connect() {
-      calls += 1;
-      throw new Error("cold store connected");
-    },
-    query() {
-      calls += 1;
-      throw new Error("cold store queried");
-    },
-  });
-
-  assert.equal(Object.isFrozen(store), true);
-  assert.equal(calls, 0);
+test("the PostgreSQL durability leaf is cold and validates its pool", async () => {
   assert.throws(
     () => createPostgresDurabilityStore({}),
-    /pool with connect and query methods/,
+    /requires a connection pool/,
   );
+  const pool = new MockPool();
+  const store = createPostgresDurabilityStore(pool);
+  assert.equal(pool.connects, 0);
+  assert.deepEqual(await store.load("state"), { revision: "0", payload: null });
+  assert.equal(pool.connects, 1);
+  await assert.rejects(store.load(""), /state ID must be a non-empty string/);
 });
 
-test("the PostgreSQL commit error retains its definite unknown-outcome identity", () => {
-  const cause = new Error("connection disappeared after COMMIT");
-  const error = new UnknownPostgresCommitOutcomeError("journal-1", cause);
-
-  assert.equal(error.name, "UnknownPostgresCommitOutcomeError");
-  assert.equal(error.cause, cause);
-  assert.match(error.message, /COMMIT outcome is unknown/);
-  assert.match(error.message, /journal-1/);
-});
-
-test("PostgreSQL retains owner fences separately and checks them before revisions", async () => {
-  const database = createPostgresDatabase();
-  const store = createPostgresDurabilityStore(database.pool);
-
-  const firstOwner = await store.acquire("journal-1", { ownerId: "worker-1" });
-  assert.deepEqual(firstOwner, {
-    ownerId: "worker-1",
+test("PostgreSQL fences owners before comparing complete-state revisions", async () => {
+  const pool = new MockPool();
+  const store = createPostgresDurabilityStore(pool);
+  const first = await store.acquire("state", { ownerId: "owner-1" });
+  assert.deepEqual(first, {
+    ownerId: "owner-1",
     fence: "1",
     revision: "0",
-    batches: [],
+    payload: null,
   });
-  assert.deepEqual(await store.append("journal-1", {
-    ownerId: firstOwner.ownerId,
-    fence: firstOwner.fence,
+  assert.deepEqual(await store.replace("state", {
+    ownerId: first.ownerId,
+    fence: first.fence,
     expectedRevision: "0",
     payload: "first",
-  }), { status: "appended", revision: "1" });
-
-  database.resetContent("journal-1");
-  const secondOwner = await store.acquire("journal-1", { ownerId: "worker-2" });
-  assert.deepEqual(secondOwner, {
-    ownerId: "worker-2",
+  }), { status: "replaced", revision: "1" });
+  assert.deepEqual(await store.replace("state", {
+    ownerId: first.ownerId,
+    fence: first.fence,
+    expectedRevision: "0",
+    payload: "conflict",
+  }), { status: "conflict", actualRevision: "1" });
+  const second = await store.acquire("state", { ownerId: "owner-2" });
+  assert.deepEqual(second, {
+    ownerId: "owner-2",
     fence: "2",
-    revision: "0",
-    batches: [],
+    revision: "1",
+    payload: "first",
   });
-
-  const queryBoundary = database.queries.length;
-  assert.deepEqual(await store.append("journal-1", {
-    ownerId: firstOwner.ownerId,
-    fence: firstOwner.fence,
+  assert.deepEqual(await store.replace("state", {
+    ownerId: first.ownerId,
+    fence: first.fence,
     expectedRevision: "999",
     payload: "stale",
   }), { status: "fenced" });
-  assert.deepEqual(
-    database.queries.slice(queryBoundary).map(normalizeSql),
-    [
-      "BEGIN",
-      "SELECT owner_id, fence::text AS fence FROM nanocodex_journal_owners WHERE journal_id = $1 FOR UPDATE",
-      "ROLLBACK",
-    ],
-  );
+});
 
-  assert.deepEqual(await store.append("journal-1", {
-    ownerId: secondOwner.ownerId,
-    fence: secondOwner.fence,
+test("PostgreSQL distinguishes rolled-back writes from unknown COMMIT outcomes", async () => {
+  const pool = new MockPool();
+  const store = createPostgresDurabilityStore(pool);
+  const owner = await store.acquire("state", { ownerId: "owner" });
+  pool.failNextUpsert = true;
+  assert.deepEqual(await store.replace("state", {
+    ...owner,
     expectedRevision: "0",
-    payload: "replacement",
-  }), { status: "appended", revision: "1" });
-  assert.deepEqual(await store.load("journal-1"), {
-    revision: "1",
-    batches: [{ revision: "1", payload: "replacement" }],
-  });
+    payload: "rolled-back",
+  }), { status: "not_committed", message: "injected upsert failure" });
+  assert.deepEqual(await store.load("state"), { revision: "0", payload: null });
+
+  pool.failNextCommit = true;
+  const releasesBefore = pool.releases.length;
+  await assert.rejects(
+    store.replace("state", { ...owner, expectedRevision: "0", payload: "maybe" }),
+    (error) => error instanceof UnknownPostgresCommitOutcomeError
+      && error.cause?.message === "injected commit failure",
+  );
+  assert.equal(pool.releases.length, releasesBefore + 1);
+  assert.equal(pool.releases.at(-1), true, "an ambiguous connection must be discarded once");
 });
 
-test("PostgreSQL rejects CHECK constraints that admit sampled values outside u64 domains", async () => {
-  for (const admittedProbe of [
-    { table: "nanocodex_journal_owners", value: "-1", label: "negative owner fence" },
-    { table: "nanocodex_journal_batches", value: "-1", label: "negative batch revision" },
-    {
-      table: "nanocodex_journals",
-      value: "18446744073709551617",
-      label: "journal revision farther above u64",
-    },
-  ]) {
-    const database = createPostgresDatabase({ admittedProbe });
-    const store = createPostgresDurabilityStore(database.pool);
-    await assert.rejects(
-      store.load("journal-1"),
-      new RegExp(`${admittedProbe.label} was accepted by its CHECK constraint`),
-    );
+test("PostgreSQL initialization rejects tables without the exact state primary keys", async () => {
+  const pool = new MockPool();
+  pool.primaryKeys = [{
+    table_name: "nanocodex_durable_owners",
+    column_name: "state_id",
+    ordinal_position: 1,
+  }];
+  await assert.rejects(
+    createPostgresDurabilityStore(pool).load("state"),
+    /each state_id must be the sole primary key/,
+  );
+});
+
+test("the PostgreSQL commit error retains its exact unknown-outcome identity", () => {
+  const cause = new Error("lost connection");
+  const error = new UnknownPostgresCommitOutcomeError("state", cause);
+  assert.equal(error.name, "UnknownPostgresCommitOutcomeError");
+  assert.equal(error.cause, cause);
+  assert.match(error.message, /state "state"/);
+});
+
+class MockPool {
+  constructor() {
+    this.connects = 0;
+    this.owners = new Map();
+    this.states = new Map();
+    this.failNextCommit = false;
+    this.failNextUpsert = false;
+    this.releases = [];
+    this.primaryKeys = schemaPrimaryKeys();
   }
-});
 
-function createPostgresDatabase({ admittedProbe } = {}) {
-  const owners = new Map();
-  const revisions = new Map();
-  const batches = [];
-  const queries = [];
-  const query = async (sql, args = []) => {
-    queries.push(sql);
-    const normalized = normalizeSql(sql);
-    const [journalId] = args;
-    if (
-      normalized === "BEGIN"
-      || normalized === "COMMIT"
-      || normalized === "ROLLBACK"
-      || normalized.startsWith("SAVEPOINT ")
-      || normalized.startsWith("ROLLBACK TO SAVEPOINT ")
-      || normalized.startsWith("RELEASE SAVEPOINT ")
-      || normalized.startsWith("SELECT pg_advisory_xact_lock")
-      || normalized.startsWith("CREATE TABLE")
-    ) {
+  async connect() {
+    this.connects += 1;
+    return new MockClient(this);
+  }
+
+  query(text, values) {
+    return new MockClient(this).query(text, values);
+  }
+}
+
+class MockClient {
+  constructor(pool) {
+    this.pool = pool;
+  }
+
+  async query(text, values = []) {
+    const sql = text.replace(/\s+/g, " ").trim();
+    if (sql === "BEGIN" || sql === "ROLLBACK" || sql.startsWith("CREATE TABLE")) {
       return { rows: [] };
     }
-    if (normalized.startsWith("SELECT table_name, column_name, data_type, is_nullable")) {
-      return { rows: canonicalPostgresColumns() };
-    }
-    if (normalized.includes("FROM pg_class AS retained_table")
-      && normalized.includes("JOIN pg_index AS retained_index")) {
-      return { rows: canonicalPostgresPrimaryKeys() };
-    }
-    if (normalized.includes("CROSS JOIN LATERAL unnest(retained_constraint.conkey, retained_constraint.confkey)")) {
-      return { rows: [{
-        source_column: "journal_id",
-        target_in_current_schema: true,
-        target_table: "nanocodex_journals",
-        target_column: "journal_id",
-        is_deferrable: false,
-        is_initially_deferred: false,
-      }] };
-    }
-    if (normalized.includes("retained_constraint.conkey = ARRAY[attribute.attnum]::smallint[]")) {
-      return { rows: canonicalPostgresChecks() };
-    }
-    if (typeof journalId === "string" && journalId.startsWith("nanocodex-schema-validator-")) {
-      const value = args[1];
-      const table = normalized.startsWith("INSERT INTO nanocodex_journal_owners")
-        ? "nanocodex_journal_owners"
-        : normalized.startsWith("INSERT INTO nanocodex_journals")
-          ? "nanocodex_journals"
-          : normalized.startsWith("INSERT INTO nanocodex_journal_batches")
-            ? "nanocodex_journal_batches"
-            : undefined;
-      const invalid = normalized.startsWith("INSERT INTO nanocodex_journal_owners")
-        ? ["-1", "0", "18446744073709551616", "18446744073709551617"].includes(value)
-        : normalized.startsWith("INSERT INTO nanocodex_journals")
-          ? ["-1", "18446744073709551616", "18446744073709551617"].includes(value)
-          : normalized.startsWith("INSERT INTO nanocodex_journal_batches")
-            && ["-1", "0", "18446744073709551616", "18446744073709551617"].includes(value);
-      const admitted = table === admittedProbe?.table && value === admittedProbe.value;
-      if (invalid && !admitted) {
-        const error = new Error("schema probe violated a CHECK constraint");
-        error.code = "23514";
-        throw error;
+    if (sql === "COMMIT") {
+      if (this.pool.failNextCommit) {
+        this.pool.failNextCommit = false;
+        throw new Error("injected commit failure");
       }
       return { rows: [] };
     }
-    if (normalized.startsWith("INSERT INTO nanocodex_journal_owners")) {
-      const previous = owners.get(journalId);
-      if (previous?.fence === "18446744073709551615") return { rows: [] };
+    if (sql.startsWith("SELECT pg_advisory_xact_lock")) return { rows: [{}] };
+    if (sql.includes("FROM information_schema.columns")) return { rows: schemaColumns() };
+    if (sql.includes("FROM information_schema.table_constraints")) {
+      return { rows: this.pool.primaryKeys };
+    }
+    if (sql.startsWith("INSERT INTO nanocodex_durable_owners")) {
+      const [stateId, ownerId] = values;
+      const previous = this.pool.owners.get(stateId);
       const fence = String(BigInt(previous?.fence ?? "0") + 1n);
-      owners.set(journalId, { owner_id: args[1], fence });
+      this.pool.owners.set(stateId, { owner_id: ownerId, fence });
       return { rows: [{ fence }] };
     }
-    if (normalized.startsWith("SELECT owner_id, fence::text AS fence")) {
-      const owner = owners.get(journalId);
-      return { rows: owner === undefined ? [] : [{ ...owner }] };
+    if (sql.startsWith("SELECT owner_id, fence::text FROM nanocodex_durable_owners")) {
+      const owner = this.pool.owners.get(values[0]);
+      return { rows: owner ? [owner] : [] };
     }
-    if (normalized.startsWith("INSERT INTO nanocodex_journals")) {
-      if (!revisions.has(journalId)) revisions.set(journalId, "0");
+    if (sql.startsWith("SELECT revision::text, payload FROM nanocodex_durable_states")) {
+      const state = this.pool.states.get(values[0]);
+      return { rows: state ? [state] : [] };
+    }
+    if (sql.startsWith("INSERT INTO nanocodex_durable_states")) {
+      if (this.pool.failNextUpsert) {
+        this.pool.failNextUpsert = false;
+        throw new Error("injected upsert failure");
+      }
+      this.pool.states.set(values[0], { revision: values[1], payload: values[2] });
       return { rows: [] };
     }
-    if (normalized.startsWith("UPDATE nanocodex_journals")) {
-      const expectedRevision = args[1];
-      const actualRevision = revisions.get(journalId);
-      if (actualRevision !== expectedRevision || actualRevision === "18446744073709551615") {
-        return { rows: [] };
-      }
-      const revision = String(BigInt(actualRevision) + 1n);
-      revisions.set(journalId, revision);
-      return { rows: [{ revision }] };
-    }
-    if (normalized.startsWith("SELECT revision::text AS revision")) {
-      const revision = revisions.get(journalId);
-      return { rows: revision === undefined ? [] : [{ revision }] };
-    }
-    if (normalized.startsWith("INSERT INTO nanocodex_journal_batches")) {
-      batches.push({ journalId, revision: args[1], payload: args[2] });
-      return { rows: [] };
-    }
-    if (normalized.startsWith("SELECT journal.revision::text AS head_revision")) {
-      const revision = revisions.get(journalId);
-      if (revision === undefined) return { rows: [] };
-      const storedBatches = batches.filter((batch) => batch.journalId === journalId);
-      return {
-        rows: storedBatches.length === 0
-          ? [{ head_revision: revision, batch_revision: null, payload: null }]
-          : storedBatches.map((batch) => ({
-            head_revision: revision,
-            batch_revision: batch.revision,
-            payload: batch.payload,
-          })),
-      };
-    }
-    throw new Error(`unexpected PostgreSQL query: ${normalized}`);
-  };
-  const client = { query, release() {} };
+    throw new Error(`unexpected SQL: ${sql}`);
+  }
+
+  release(discard = false) {
+    this.pool.releases.push(discard);
+  }
+}
+
+function schemaColumns() {
+  return [
+    column("nanocodex_durable_owners", "state_id", "text"),
+    column("nanocodex_durable_owners", "owner_id", "text"),
+    column("nanocodex_durable_owners", "fence", "numeric", 20, 0),
+    column("nanocodex_durable_states", "state_id", "text"),
+    column("nanocodex_durable_states", "revision", "numeric", 20, 0),
+    column("nanocodex_durable_states", "payload", "text"),
+  ];
+}
+
+function schemaPrimaryKeys() {
+  return [
+    { table_name: "nanocodex_durable_owners", column_name: "state_id", ordinal_position: 1 },
+    { table_name: "nanocodex_durable_states", column_name: "state_id", ordinal_position: 1 },
+  ];
+}
+
+function column(table_name, column_name, data_type, numeric_precision = null, numeric_scale = null) {
   return {
-    pool: { query, connect: async () => client },
-    queries,
-    resetContent(journalId) {
-      revisions.delete(journalId);
-      for (let index = batches.length - 1; index >= 0; index -= 1) {
-        if (batches[index].journalId === journalId) batches.splice(index, 1);
-      }
-    },
-  };
-}
-
-function canonicalPostgresColumns() {
-  return [
-    postgresColumn("nanocodex_journal_batches", "journal_id", "text"),
-    postgresColumn("nanocodex_journal_batches", "revision", "numeric", 20, 0),
-    postgresColumn("nanocodex_journal_batches", "payload", "text"),
-    postgresColumn("nanocodex_journal_owners", "journal_id", "text"),
-    postgresColumn("nanocodex_journal_owners", "owner_id", "text"),
-    postgresColumn("nanocodex_journal_owners", "fence", "numeric", 20, 0),
-    postgresColumn("nanocodex_journals", "journal_id", "text"),
-    postgresColumn("nanocodex_journals", "revision", "numeric", 20, 0),
-  ];
-}
-
-function canonicalPostgresPrimaryKeys() {
-  return [
-    { table_name: "nanocodex_journal_batches", column_name: "journal_id" },
-    { table_name: "nanocodex_journal_batches", column_name: "revision" },
-    { table_name: "nanocodex_journal_owners", column_name: "journal_id" },
-    { table_name: "nanocodex_journals", column_name: "journal_id" },
-  ];
-}
-
-function canonicalPostgresChecks() {
-  return [
-    { table_name: "nanocodex_journal_batches", column_name: "revision" },
-    { table_name: "nanocodex_journal_owners", column_name: "fence" },
-    { table_name: "nanocodex_journals", column_name: "revision" },
-  ];
-}
-
-function postgresColumn(tableName, columnName, dataType, numericPrecision = null, numericScale = null) {
-  return {
-    table_name: tableName,
-    column_name: columnName,
-    data_type: dataType,
+    table_name,
+    column_name,
+    data_type,
     is_nullable: "NO",
-    numeric_precision: numericPrecision,
-    numeric_scale: numericScale,
+    numeric_precision,
+    numeric_scale,
   };
-}
-
-function normalizeSql(sql) {
-  return sql.replace(/\s+/g, " ").trim();
 }

--- a/js/bindings/test/postgres-durability.test.mjs
+++ b/js/bindings/test/postgres-durability.test.mjs
@@ -134,6 +134,52 @@ test("PostgreSQL imports one exact portable revision and fences an empty destina
     store.importState("already-owned", { revision: "47", payload: "must-not-fence-live-owner" }),
     DurabilityImportConflictError,
   );
+
+  await store.importState("range", { revision: "4", payload: "expected-lineage" });
+  await assert.rejects(
+    store.importState("range", { revision: "9", payload: "replacement" }, {
+      expectedRevision: "4",
+      expectedPayload: "divergent-lineage",
+    }),
+    DurabilityImportConflictError,
+  );
+  assert.deepEqual(await store.load("range"), {
+    revision: "4",
+    payload: "expected-lineage",
+  });
+  assert.deepEqual(await store.importState("range", {
+    revision: "9",
+    payload: "replacement",
+  }, {
+    expectedRevision: "4",
+    expectedPayload: "expected-lineage",
+  }), {
+    revision: "9",
+    payload: "replacement",
+  });
+});
+
+test("PostgreSQL serializes an import before validating its expected state", async () => {
+  const pool = new MockPool();
+  const store = createPostgresDurabilityStore(pool);
+  await store.load("initialize");
+  const beforeImport = pool.clientQueries.length;
+
+  await store.importState("serialized-import", {
+    revision: "6",
+    payload: "replacement",
+  }, {
+    expectedRevision: "0",
+    expectedPayload: null,
+  });
+
+  const queries = pool.clientQueries.slice(beforeImport);
+  assert.equal(queries[0].sql, "BEGIN");
+  assert.match(queries[1].sql, /^SELECT pg_advisory_xact_lock\(hashtextextended\(/);
+  assert.match(queries[1].sql, /nanocodex-durability-v2:state/);
+  assert.deepEqual(queries[1].values, ["serialized-import"]);
+  assert.match(queries[2].sql, /^SELECT owner_id, fence::text/);
+  assert.match(queries[3].sql, /^SELECT revision::text, payload/);
 });
 
 test("PostgreSQL initialization rejects tables without the exact state primary keys", async () => {
@@ -167,6 +213,7 @@ class MockPool {
     this.states = new Map();
     this.failNextCommit = false;
     this.failNextUpsert = false;
+    this.clientQueries = [];
     this.releases = [];
     this.primaryKeys = schemaPrimaryKeys();
   }
@@ -188,6 +235,7 @@ class MockClient {
 
   async query(text, values = []) {
     const sql = text.replace(/\s+/g, " ").trim();
+    this.pool.clientQueries.push({ sql, values: [...values] });
     if (sql === "BEGIN" || sql === "ROLLBACK" || sql.startsWith("CREATE TABLE")) {
       return { rows: [] };
     }

--- a/js/bindings/test/postgres-durability.test.mjs
+++ b/js/bindings/test/postgres-durability.test.mjs
@@ -216,6 +216,11 @@ class MockClient {
     if (sql.startsWith("INSERT INTO nanocodex_durable_owners")) {
       const [stateId, ownerId] = values;
       const previous = this.pool.owners.get(stateId);
+      if (sql.includes("DO NOTHING")) {
+        if (previous) return { rows: [] };
+        this.pool.owners.set(stateId, { owner_id: ownerId, fence: "1" });
+        return { rows: [{ state_id: stateId }] };
+      }
       const fence = values.length === 3
         ? String(values[2])
         : String(BigInt(previous?.fence ?? "0") + 1n);
@@ -239,8 +244,13 @@ class MockClient {
         this.pool.failNextUpsert = false;
         throw new Error("injected upsert failure");
       }
+      if (sql.includes("DO NOTHING") && this.pool.states.has(values[0])) {
+        return { rows: [] };
+      }
       this.pool.states.set(values[0], { revision: values[1], payload: values[2] });
-      return { rows: [] };
+      return {
+        rows: sql.includes("RETURNING state_id") ? [{ state_id: values[0] }] : [],
+      };
     }
     throw new Error(`unexpected SQL: ${sql}`);
   }

--- a/js/bindings/test/types.test-d.mts
+++ b/js/bindings/test/types.test-d.mts
@@ -72,12 +72,17 @@ import { nanocodexTools } from "../tools/vite.mjs";
 import { nanocodex } from "../vite/index.mjs";
 import {
   createMemoryDurabilityStore,
+  DurabilityImportConflictError,
   durabilityRevision,
+  exportDurabilityState,
+  importDurabilityState,
   type DurabilityAcquiredState,
   type DurabilityAcquireRequest,
   type DurabilityReplaceRequest,
   type DurabilityReplaceResult,
   type DurabilityFence,
+  type DurabilityPortableStateArchive,
+  type DurabilityPortableStore,
   type DurabilityRevision,
   type DurabilitySqliteQuery,
   type DurabilitySqliteRow,
@@ -174,12 +179,20 @@ async function check() {
   };
   const revision: DurabilityRevision = storedState.revision;
   const memoryStore: MemoryDurabilityStore = createMemoryDurabilityStore("typed-memory");
+  const portableStore: DurabilityPortableStore = memoryStore;
+  const portableArchive: DurabilityPortableStateArchive = await exportDurabilityState(
+    portableStore,
+    "typed-memory",
+  );
+  await importDurabilityState(portableStore, portableArchive);
+  const importConflict: Error = new DurabilityImportConflictError("typed-memory");
   const sqliteValue: DurabilitySqliteValue = revision;
   const sqliteRow: DurabilitySqliteRow = { revision: sqliteValue };
   const sqliteQuery: DurabilitySqliteQuery = <Row extends DurabilitySqliteRow>() => [] as Row[];
   const sqliteTransaction: DurabilitySqliteTransaction = (callback) => callback(sqliteQuery);
   const sqliteOptions: SqliteDurabilityStoreOptions = { transaction: sqliteTransaction };
   void memoryStore;
+  void importConflict;
   void sqliteOptions;
   const durabilityStore: DurabilityStore = {
     load: () => storedState,

--- a/js/bindings/test/types.test-d.mts
+++ b/js/bindings/test/types.test-d.mts
@@ -73,10 +73,10 @@ import { nanocodex } from "../vite/index.mjs";
 import {
   createMemoryDurabilityStore,
   durabilityRevision,
-  type DurabilityAcquiredJournal,
+  type DurabilityAcquiredState,
   type DurabilityAcquireRequest,
-  type DurabilityAppendRequest,
-  type DurabilityAppendResult,
+  type DurabilityReplaceRequest,
+  type DurabilityReplaceResult,
   type DurabilityFence,
   type DurabilityRevision,
   type DurabilitySqliteQuery,
@@ -84,8 +84,7 @@ import {
   type DurabilitySqliteTransaction,
   type DurabilitySqliteValue,
   type DurabilityStore,
-  type DurabilityStoredBatch,
-  type DurabilityStoredJournal,
+  type DurabilityStoredState,
   type MemoryDurabilityStore,
   type SqliteDurabilityStoreOptions,
 } from "nanocodex/durability";
@@ -169,39 +168,37 @@ async function check() {
   parallelTool.supportsParallelToolCalls = "yes";
   // @ts-expect-error MCP parallel allowlists contain remote tool names.
   parallelMcp.parallelTools = [1];
-  const storedJournal: DurabilityStoredJournal = {
+  const storedState: DurabilityStoredState = {
     revision: durabilityRevision(0n),
-    batches: [],
+    payload: null,
   };
-  const revision: DurabilityRevision = storedJournal.revision;
-  const batch: DurabilityStoredBatch | undefined = storedJournal.batches[0];
+  const revision: DurabilityRevision = storedState.revision;
   const memoryStore: MemoryDurabilityStore = createMemoryDurabilityStore("typed-memory");
   const sqliteValue: DurabilitySqliteValue = revision;
   const sqliteRow: DurabilitySqliteRow = { revision: sqliteValue };
   const sqliteQuery: DurabilitySqliteQuery = <Row extends DurabilitySqliteRow>() => [] as Row[];
   const sqliteTransaction: DurabilitySqliteTransaction = (callback) => callback(sqliteQuery);
   const sqliteOptions: SqliteDurabilityStoreOptions = { transaction: sqliteTransaction };
-  void batch;
   void memoryStore;
   void sqliteOptions;
   const durabilityStore: DurabilityStore = {
-    load: () => storedJournal,
+    load: () => storedState,
     acquire: (
-      _journalId: string,
+      _stateId: string,
       request: DurabilityAcquireRequest,
-    ): DurabilityAcquiredJournal => ({
-      ...storedJournal,
+    ): DurabilityAcquiredState => ({
+      ...storedState,
       ownerId: request.ownerId,
       fence: "1" as DurabilityFence,
     }),
-    append: (_journalId: string, request: DurabilityAppendRequest): DurabilityAppendResult => ({
+    replace: (_stateId: string, request: DurabilityReplaceRequest): DurabilityReplaceResult => ({
       status: "not_committed",
       message: `revision ${request.expectedRevision} was not committed`,
     }),
   };
   const acquired = await durabilityStore.acquire("typed-leaf", { ownerId: "typed-owner" });
   const fence: DurabilityFence = acquired.fence;
-  await durabilityStore.append("typed-leaf", {
+  await durabilityStore.replace("typed-leaf", {
     ownerId: acquired.ownerId,
     fence,
     expectedRevision: acquired.revision,
@@ -224,7 +221,7 @@ async function check() {
   extendedCloudflareAgent.events.connect(new Request("https://agent.internal/events"));
   const cloudflareApplication: true = extendedCloudflareAgent.application;
   void cloudflareApplication;
-  await CloudflareAgent.compactDurability(cloudflareOwner, {
+  await CloudflareAgent.pruneDurableReceipts(cloudflareOwner, {
     terminalReceiptRetention: 0,
   });
   CloudflareAgent.destroy(cloudflareOwner);

--- a/js/bindings/test/types.test-d.mts
+++ b/js/bindings/test/types.test-d.mts
@@ -74,6 +74,7 @@ import {
   createMemoryDurabilityStore,
   DurabilityImportConflictError,
   durabilityRevision,
+  durabilityStateDigest,
   exportDurabilityState,
   exportDurabilityStatePage,
   importDurabilityState,
@@ -193,6 +194,7 @@ async function check() {
     "typed-memory",
     { from: durabilityRevision("0"), limit: 1024 },
   );
+  const stateDigest: string = await durabilityStateDigest(storedState);
   await importDurabilityStatePages(createMemoryDurabilityStore("typed-memory"), [portablePage]);
   const importConflict: Error = new DurabilityImportConflictError("typed-memory");
   const sqliteValue: DurabilitySqliteValue = revision;
@@ -202,6 +204,7 @@ async function check() {
   const sqliteOptions: SqliteDurabilityStoreOptions = { transaction: sqliteTransaction };
   void memoryStore;
   void importConflict;
+  void stateDigest;
   void sqliteOptions;
   const durabilityStore: DurabilityStore = {
     load: () => storedState,

--- a/js/bindings/test/types.test-d.mts
+++ b/js/bindings/test/types.test-d.mts
@@ -75,13 +75,16 @@ import {
   DurabilityImportConflictError,
   durabilityRevision,
   exportDurabilityState,
+  exportDurabilityStatePage,
   importDurabilityState,
+  importDurabilityStatePages,
   type DurabilityAcquiredState,
   type DurabilityAcquireRequest,
   type DurabilityReplaceRequest,
   type DurabilityReplaceResult,
   type DurabilityFence,
   type DurabilityPortableStateArchive,
+  type DurabilityPortableStatePage,
   type DurabilityPortableStore,
   type DurabilityRevision,
   type DurabilitySqliteQuery,
@@ -98,7 +101,7 @@ import {
   type PostgresDurabilityClient,
   type PostgresDurabilityPool,
   type PostgresDurabilityQueryResult,
-  UnknownPostgresCommitOutcomeError,
+  PostgresDurabilityUnavailableError,
 } from "../runtime/postgres-durability-store.mjs";
 import {
   createCloudflareDurabilityStore,
@@ -185,6 +188,12 @@ async function check() {
     "typed-memory",
   );
   await importDurabilityState(portableStore, portableArchive);
+  const portablePage: DurabilityPortableStatePage = await exportDurabilityStatePage(
+    portableStore,
+    "typed-memory",
+    { from: durabilityRevision("0"), limit: 1024 },
+  );
+  await importDurabilityStatePages(createMemoryDurabilityStore("typed-memory"), [portablePage]);
   const importConflict: Error = new DurabilityImportConflictError("typed-memory");
   const sqliteValue: DurabilitySqliteValue = revision;
   const sqliteRow: DurabilitySqliteRow = { revision: sqliteValue };
@@ -284,7 +293,7 @@ async function check() {
       "SELECT revision::text AS revision",
     );
   postgresClient.release(true);
-  new UnknownPostgresCommitOutcomeError("typed-leaf", new Error("connection closed"));
+  new PostgresDurabilityUnavailableError("typed-leaf", new Error("connection closed"));
   void postgresStore;
   void postgresResult;
   void cloudflareStore;

--- a/js/bindings/test/web-wasm.test.mjs
+++ b/js/bindings/test/web-wasm.test.mjs
@@ -1069,6 +1069,7 @@ test("web-target WASM executes the complete browser harness tool contract", asyn
       url: "https://demo.test/api/tools/web-search",
       body: {
         commands: { search_query: [{ q: "browser tools" }] },
+        model: "gpt-5.6-sol",
         session_id: agent.sessionId,
       },
     }]);

--- a/js/bindings/test/web-wasm.test.mjs
+++ b/js/bindings/test/web-wasm.test.mjs
@@ -674,6 +674,17 @@ test("web-target WASM executes the complete browser harness tool contract", asyn
     standard,
     threadId: "browser-harness-e2e",
     shell: {
+      descriptor: {
+        shell: "nanocodex-just-bash",
+        commands: ["bash"],
+        customCommands: [],
+        cwd: "/workspace",
+        limits: {},
+        network: { enabled: false, mode: "none" },
+        pty: false,
+        sessions: false,
+        sandboxEscalation: false,
+      },
       artifactTool: artifact({
         workspace,
         onArtifact: (document) => effects.artifacts.push(document),

--- a/js/bindings/types.d.mts
+++ b/js/bindings/types.d.mts
@@ -65,6 +65,8 @@ export type DurabilityPortableStatePage = Readonly<{
   format: "nanocodex-durability-state-page-v1";
   stateId: string;
   from: DurabilityRevision;
+  /** SHA-256 over the UTF-8 JSON tuple `[from, fromPayload]`. */
+  fromDigest: string;
   to: DurabilityRevision;
   cursor: DurabilityExportCursor;
   nextCursor: DurabilityExportCursor | null;
@@ -75,6 +77,8 @@ export type DurabilityPortableStatePage = Readonly<{
 
 export type DurabilityExportPageRequest = Readonly<{
   from: DurabilityRevision;
+  /** Digest of the exact state at `from`; omit only when `from` is revision zero. */
+  fromDigest?: string | undefined;
   /** Omit on the first request to select the current source revision; repeat the returned `to`. */
   to?: DurabilityRevision | undefined;
   cursor?: DurabilityExportCursor | undefined;
@@ -122,7 +126,11 @@ export type DurabilityPortableStore = DurabilityStore & Readonly<{
   importState(
     stateId: string,
     state: DurabilityStoredState,
-    options?: Readonly<{ expectedRevision?: DurabilityRevision | undefined }> | undefined,
+    options?: Readonly<{
+      expectedRevision?: DurabilityRevision | undefined;
+      /** When supplied, compare the complete expected state atomically before importing. */
+      expectedPayload?: string | null | undefined;
+    }> | undefined,
   ): DurabilityStoredState | Promise<DurabilityStoredState>;
 }>;
 

--- a/js/bindings/types.d.mts
+++ b/js/bindings/types.d.mts
@@ -47,67 +47,50 @@ export type DurabilityFence = string & {
   readonly [durabilityFenceBrand]: "NanocodexDurabilityFence";
 };
 
-export type DurabilityStoredBatch = Readonly<{
+export type DurabilityStoredState = Readonly<{
   revision: DurabilityRevision;
-  payload: string;
-}>;
-
-export type DurabilityStoredJournal = Readonly<{
-  revision: DurabilityRevision;
-  batches: readonly DurabilityStoredBatch[];
+  payload: string | null;
 }>;
 
 export type DurabilityAcquireRequest = Readonly<{
   ownerId: string;
 }>;
 
-export type DurabilityAcquiredJournal = DurabilityStoredJournal & Readonly<{
+export type DurabilityAcquiredState = DurabilityStoredState & Readonly<{
   ownerId: string;
   fence: DurabilityFence;
 }>;
 
-export type DurabilityAppendRequest = Readonly<{
+export type DurabilityReplaceRequest = Readonly<{
   ownerId: string;
   fence: DurabilityFence;
   expectedRevision: DurabilityRevision;
   payload: string;
 }>;
 
-export type DurabilityAppendResult =
-  | Readonly<{ status: "appended"; revision: DurabilityRevision }>
-  | Readonly<{ status: "fenced" }>
-  | Readonly<{ status: "conflict"; actualRevision: DurabilityRevision }>
-  | Readonly<{ status: "not_committed"; message: string }>;
-
-export type DurabilityCompactRequest = DurabilityAppendRequest;
-
-export type DurabilityCompactResult =
-  | Readonly<{ status: "compacted"; revision: DurabilityRevision }>
+export type DurabilityReplaceResult =
+  | Readonly<{ status: "replaced"; revision: DurabilityRevision }>
   | Readonly<{ status: "fenced" }>
   | Readonly<{ status: "conflict"; actualRevision: DurabilityRevision }>
   | Readonly<{ status: "not_committed"; message: string }>;
 
 /** Host capability consumed by the Rust/WASM durability driver. */
 export type DurabilityStore = Readonly<{
-  load(journalId: string): DurabilityStoredJournal | Promise<DurabilityStoredJournal>;
+  load(stateId: string): DurabilityStoredState | Promise<DurabilityStoredState>;
   acquire(
-    journalId: string,
+    stateId: string,
     request: DurabilityAcquireRequest,
-  ): DurabilityAcquiredJournal | Promise<DurabilityAcquiredJournal>;
-  append(
-    journalId: string,
-    request: DurabilityAppendRequest,
-  ): DurabilityAppendResult | Promise<DurabilityAppendResult>;
-  compact?(
-    journalId: string,
-    request: DurabilityCompactRequest,
-  ): DurabilityCompactResult | Promise<DurabilityCompactResult>;
+  ): DurabilityAcquiredState | Promise<DurabilityAcquiredState>;
+  replace(
+    stateId: string,
+    request: DurabilityReplaceRequest,
+  ): DurabilityReplaceResult | Promise<DurabilityReplaceResult>;
 }>;
 
 /** In-process store for hosts that carry its snapshot across durable steps. */
 export type MemoryDurabilityStore = DurabilityStore & Readonly<{
-  journalId: string;
-  snapshot(): DurabilityStoredJournal;
+  stateId: string;
+  snapshot(): DurabilityStoredState;
 }>;
 
 /**

--- a/js/bindings/types.d.mts
+++ b/js/bindings/types.d.mts
@@ -58,6 +58,30 @@ export type DurabilityPortableStateArchive = DurabilityStoredState & Readonly<{
   stateId: string;
 }>;
 
+export type DurabilityExportCursor = string;
+
+/** One deterministic page of the total-state replacement from `from` (exclusive) to `to` (inclusive). */
+export type DurabilityPortableStatePage = Readonly<{
+  format: "nanocodex-durability-state-page-v1";
+  stateId: string;
+  from: DurabilityRevision;
+  to: DurabilityRevision;
+  cursor: DurabilityExportCursor;
+  nextCursor: DurabilityExportCursor | null;
+  /** Total UTF-16 code units in the opaque state payload. */
+  payloadLength: number;
+  payload: string;
+}>;
+
+export type DurabilityExportPageRequest = Readonly<{
+  from: DurabilityRevision;
+  /** Omit on the first request to select the current source revision; repeat the returned `to`. */
+  to?: DurabilityRevision | undefined;
+  cursor?: DurabilityExportCursor | undefined;
+  /** UTF-16 code units per page. Defaults to 256 KiB and is capped at 1 MiB. */
+  limit?: number | undefined;
+}>;
+
 export type DurabilityAcquireRequest = Readonly<{
   ownerId: string;
 }>;
@@ -98,6 +122,7 @@ export type DurabilityPortableStore = DurabilityStore & Readonly<{
   importState(
     stateId: string,
     state: DurabilityStoredState,
+    options?: Readonly<{ expectedRevision?: DurabilityRevision | undefined }> | undefined,
   ): DurabilityStoredState | Promise<DurabilityStoredState>;
 }>;
 

--- a/js/bindings/types.d.mts
+++ b/js/bindings/types.d.mts
@@ -52,6 +52,12 @@ export type DurabilityStoredState = Readonly<{
   payload: string | null;
 }>;
 
+/** JSON-safe exact state archive used for an offline provider cutover. */
+export type DurabilityPortableStateArchive = DurabilityStoredState & Readonly<{
+  format: "nanocodex-durability-state-v1";
+  stateId: string;
+}>;
+
 export type DurabilityAcquireRequest = Readonly<{
   ownerId: string;
 }>;
@@ -87,8 +93,16 @@ export type DurabilityStore = Readonly<{
   ): DurabilityReplaceResult | Promise<DurabilityReplaceResult>;
 }>;
 
+/** Store that can atomically restore an exact revision into an empty destination. */
+export type DurabilityPortableStore = DurabilityStore & Readonly<{
+  importState(
+    stateId: string,
+    state: DurabilityStoredState,
+  ): DurabilityStoredState | Promise<DurabilityStoredState>;
+}>;
+
 /** In-process store for hosts that carry its snapshot across durable steps. */
-export type MemoryDurabilityStore = DurabilityStore & Readonly<{
+export type MemoryDurabilityStore = DurabilityPortableStore & Readonly<{
   stateId: string;
   snapshot(): DurabilityStoredState;
 }>;

--- a/js/react/agent/transcript.mjs
+++ b/js/react/agent/transcript.mjs
@@ -471,6 +471,7 @@ function eventIdentity(event) {
 function applyToolCall(entries, event, turnId) {
   const payload = event.payload ?? {};
   const callId = payloadString(payload, "call_id") ?? `tool-${eventIdentity(event)}`;
+  if (hasToolCall(entries, callId, turnId)) return;
   const name = payloadString(payload, "tool") ?? "tool";
   const tool = {
     callId, name, arguments: summarizeToolArguments(name, payload.arguments),
@@ -493,6 +494,13 @@ function applyToolCall(entries, event, turnId) {
     id: `tool-${callId}`, kind: "tool", tool,
     ...(turnId === undefined ? {} : { turnId }),
   });
+}
+
+function hasToolCall(entries, callId, turnId) {
+  return entries.some((entry) => entry.kind === "tool"
+    && (turnId === undefined || entry.turnId === turnId)
+    && (entry.tool.callId === callId
+      || entry.tool.children.some((child) => child.callId === callId)));
 }
 
 function applyToolResult(entries, event, turnId) {

--- a/js/react/cloud/connectAgentSource.mjs
+++ b/js/react/cloud/connectAgentSource.mjs
@@ -392,7 +392,6 @@ function envelopeGroups(envelopes) {
 function isOuterTerminal(envelope) {
   return envelope.data.type === "turn_completed"
     || envelope.data.type === "turn_cancelled"
-    || envelope.data.type === "turn_blocked"
     || envelope.data.type === "turn_failed"
     || envelope.data.type === "stream_failed";
 }
@@ -471,8 +470,7 @@ function envelopeEvents(envelope, rawAssistantTurns, sessionId, firstSequence) {
       turn_id: turnId,
     })];
   }
-  if (envelope.data.type === "turn_blocked" || envelope.data.type === "turn_failed") {
-    const disposition = envelope.data.type.slice("turn_".length);
+  if (envelope.data.type === "turn_failed") {
     return [
       historyEvent(sessionId, firstSequence, "run.error", {
         message: envelope.data.error,
@@ -480,7 +478,7 @@ function envelopeEvents(envelope, rawAssistantTurns, sessionId, firstSequence) {
       }),
       historyEvent(sessionId, firstSequence + 1, "run.failed", {
         status: "failed",
-        disposition,
+        disposition: "failed",
         turn_id: turnId,
       }),
     ];

--- a/js/react/test/agent-controller.test.mjs
+++ b/js/react/test/agent-controller.test.mjs
@@ -205,6 +205,44 @@ test("retained history merges older pages by durable turn and exposes load state
   }
 });
 
+test("retained history projects a repeated tool call once", async () => {
+  const frames = fakeAnimationFrames();
+  const source = fakeAgent();
+  source.history = [
+    event(1, "managed.prompt", { text: "use a tool", turn_id: "turn-1" }),
+    event(2, "tool.call", {
+      call_id: "call-retained", tool: "exec_command",
+      arguments: { cmd: "pwd" }, turn_id: "turn-1",
+    }),
+    event(2, "tool.call", {
+      call_id: "call-retained", tool: "exec_command",
+      arguments: { cmd: "pwd" }, turn_id: "turn-1",
+    }),
+    event(3, "tool.result", {
+      call_id: "call-retained", status: "completed", result: "done", turn_id: "turn-1",
+    }),
+  ];
+  let controller;
+
+  function Consumer() {
+    controller = useAgentController(source.agent);
+    return null;
+  }
+
+  let root;
+  try {
+    await act(async () => { root = create(createElement(Consumer)); });
+    await flushFrames(frames);
+    const tools = controller.entries.filter((entry) => entry.kind === "tool");
+    assert.equal(tools.length, 1);
+    assert.equal(tools[0].id, "tool-call-retained");
+    assert.equal(tools[0].tool.status, "completed");
+    await act(async () => root.unmount());
+  } finally {
+    frames.restore();
+  }
+});
+
 test("hidden controllers reduce bursts and publish one visible catch-up snapshot", async () => {
   const frames = fakeAnimationFrames();
   const source = fakeAgent();

--- a/js/terminal/dist/policy.d.ts
+++ b/js/terminal/dist/policy.d.ts
@@ -1,2 +1,2 @@
 export declare const COARSE_POINTER_QUERY = "(pointer: coarse), (any-pointer: coarse)";
-export declare function terminalComposerAction(running: boolean, draft: string): "send" | "stop";
+export declare function terminalComposerAction(running: boolean, _draft: string): "send" | "stop";

--- a/js/terminal/dist/policy.js
+++ b/js/terminal/dist/policy.js
@@ -1,4 +1,4 @@
 export const COARSE_POINTER_QUERY = "(pointer: coarse), (any-pointer: coarse)";
-export function terminalComposerAction(running, draft) {
-    return running && !draft.trim() ? "stop" : "send";
+export function terminalComposerAction(running, _draft) {
+    return running ? "stop" : "send";
 }

--- a/js/terminal/src/policy.ts
+++ b/js/terminal/src/policy.ts
@@ -1,5 +1,5 @@
 export const COARSE_POINTER_QUERY = "(pointer: coarse), (any-pointer: coarse)";
 
-export function terminalComposerAction(running: boolean, draft: string): "send" | "stop" {
-  return running && !draft.trim() ? "stop" : "send";
+export function terminalComposerAction(running: boolean, _draft: string): "send" | "stop" {
+  return running ? "stop" : "send";
 }

--- a/js/terminal/test/components.test.mjs
+++ b/js/terminal/test/components.test.mjs
@@ -156,9 +156,10 @@ test("ready voice control separates transport, coding-turn cancel, status, and f
   await act(async () => renderer.unmount());
 });
 
-test("composer keeps send stable while exposing stop separately", async () => {
+test("composer keeps stop available beside send throughout an active turn", async () => {
   assert.equal(terminalComposerAction(true, ""), "stop");
-  assert.equal(terminalComposerAction(true, "steer"), "send");
+  assert.equal(terminalComposerAction(true, "steer"), "stop");
+  assert.equal(terminalComposerAction(false, "steer"), "send");
   const changes = [];
   const submissions = [];
   const textareaNode = { value: "ship it" };
@@ -212,9 +213,10 @@ test("composer keeps send stable while exposing stop separately", async () => {
   assert.equal(prevented, 1);
   assert.deepEqual(
     renderer.root.findAllByType("button").map((button) => button.props["aria-label"]),
-    ["Send message"],
+    ["Stop response", "Send message"],
   );
-  assert.equal(cancelled, 0);
+  await act(async () => renderer.root.findByProps({ "aria-label": "Stop response" }).props.onClick());
+  assert.equal(cancelled, 1);
 
   await act(async () => renderer.update(React.createElement(TerminalComposer, {
     draft: "",
@@ -231,7 +233,7 @@ test("composer keeps send stable while exposing stop separately", async () => {
   );
   assert.equal(renderer.root.findByProps({ "aria-label": "Send message" }).props.disabled, false);
   await act(async () => renderer.root.findByProps({ "aria-label": "Stop response" }).props.onClick());
-  assert.equal(cancelled, 1);
+  assert.equal(cancelled, 2);
   await act(async () => renderer.unmount());
 });
 

--- a/py/bindings/tests/test_owned_lifecycle.py
+++ b/py/bindings/tests/test_owned_lifecycle.py
@@ -209,22 +209,25 @@ class OwnedLifecycleTests(unittest.TestCase):
                 child.shutdown()
 
             records = server.wait_for_requests(7)
-            replay_requests = [
-                record.body
-                for record in records
-                if any(
-                    prompt in user_texts(record.body)
-                    for prompt in (
-                        "historical branch",
-                        "latest branch",
-                        "resumed branch",
-                    )
+            branch_requests = {
+                prompt: next(
+                    record.body
+                    for record in records
+                    if prompt in user_texts(record.body)
                 )
-            ]
-            self.assertEqual(len(replay_requests), 3)
-            for request in replay_requests:
-                self.assertNotIn("previous_response_id", request)
-                self.assertIn("root checkpoint", user_texts(request))
+                for prompt in (
+                    "historical branch",
+                    "latest branch",
+                    "resumed branch",
+                )
+            }
+            for prompt in ("historical branch", "latest branch"):
+                request = branch_requests[prompt]
+                self.assertEqual(request["previous_response_id"], "resp-final-2")
+                self.assertEqual(user_texts(request), [prompt])
+            resumed_request = branch_requests["resumed branch"]
+            self.assertNotIn("previous_response_id", resumed_request)
+            self.assertIn("root checkpoint", user_texts(resumed_request))
 
     def test_steer_cancel_and_compact_cross_the_boundary(self) -> None:
         initial_started = threading.Event()

--- a/services/connect-api/src/devicePolicy.d.mts
+++ b/services/connect-api/src/devicePolicy.d.mts
@@ -5,6 +5,7 @@ export const cliApp: Readonly<{
 }>;
 export const cliAppResource: string;
 export const cliOriginResource: string;
+export const agentPortabilityResource: "urn:nanocodex:agent:durability:portability";
 export function parseCliWalletRequest(value: unknown): Readonly<{
   id: string | number;
   method: "wallet_connect";

--- a/services/connect-api/src/devicePolicy.mjs
+++ b/services/connect-api/src/devicePolicy.mjs
@@ -13,6 +13,7 @@ export const cliApp = Object.freeze({
 
 export const cliAppResource = `urn:nanocodex:app:${encodeURIComponent(cliApp.id)}`;
 export const cliOriginResource = `urn:nanocodex:origin:${encodeURIComponent(cliApp.origin)}`;
+export const agentPortabilityResource = "urn:nanocodex:agent:durability:portability";
 
 const requiredResources = new Set([
   "urn:nanocodex:agent:run",
@@ -24,6 +25,7 @@ const optionalResources = new Set([
   "urn:nanocodex:agent:output:actions",
   "urn:nanocodex:agent:history:read",
   "urn:nanocodex:agent:trace:read",
+  agentPortabilityResource,
   "urn:nanocodex:history:read",
   "urn:nanocodex:memory:read",
   "urn:nanocodex:memory:write",

--- a/services/connect-api/src/index.ts
+++ b/services/connect-api/src/index.ts
@@ -9,6 +9,7 @@ import {
 } from "./chatGptCredentialImport.mjs";
 import type { ChatGptCredentialImport } from "./chatGptCredentialImport.mjs";
 import {
+  agentPortabilityResource,
   cliApp,
   approvedCliAccessKeyMatches,
   parseCliRegisterBody,
@@ -38,6 +39,7 @@ import {
   validateMcpResources,
 } from "./mcpPolicy.mjs";
 import {
+  managedAgentPortabilityGranted,
   managedGrantHeaders,
   type ManagedGrantAssertion,
 } from "./managedGrant.mjs";
@@ -1917,6 +1919,18 @@ async function proxyManagedAgent(
   const suffix = slash === -1 ? "" : resource.slice(slash);
   if (requestedAgentId !== grant.agentId || request.method === "DELETE") {
     throw new ApiFailure(403, "agent_not_granted", "This durable agent is outside the signed Connect authorization.");
+  }
+  if (/^\/durability(?:\/|$)/.test(suffix)) {
+    if (suffix !== "/durability" || request.method !== "POST" || new URL(request.url).search !== "") {
+      throw new ApiFailure(405, "method_not_allowed", "Only an exact durability export request is supported.");
+    }
+    if (!managedAgentPortabilityGranted(grant.capabilities)) {
+      throw new ApiFailure(
+        403,
+        "agent_portability_not_granted",
+        "This connection does not include full agent portability access.",
+      );
+    }
   }
   if (suffix.startsWith("/realtime/")) {
     if (!grant.capabilities.includes("chatgpt")) {
@@ -4535,11 +4549,14 @@ function resourceValues(resources: readonly string[], prefix: string): string[] 
 
 function approvedAgentCapabilities(resources: readonly string[]): string[] {
   const approved = new Set(resources);
+  const portability = approved.has(agentPortabilityResource)
+    ? ["agent.durability.portability"]
+    : [];
   const compact = new Set(resources
     .filter((resource) => resource.startsWith(AGENT_VISIBILITY_RESOURCE_PREFIX))
     .flatMap((resource) => resource.slice(AGENT_VISIBILITY_RESOURCE_PREFIX.length).split(",")));
   if (approved.has("urn:nanocodex:agent:trace:read") || compact.has("traces")) {
-    return [...new Set(Object.values(AGENT_VISIBILITY_RESOURCES))];
+    return [...new Set([...Object.values(AGENT_VISIBILITY_RESOURCES), ...portability])];
   }
   const legacy = Object.entries(AGENT_VISIBILITY_RESOURCES)
     .filter(([resource]) => approved.has(resource))
@@ -4547,7 +4564,7 @@ function approvedAgentCapabilities(resources: readonly string[]): string[] {
   const combined = Object.entries(AGENT_VISIBILITY_NAMES)
     .filter(([name]) => compact.has(name))
     .map(([, capability]) => capability);
-  return [...new Set([...legacy, ...combined])];
+  return [...new Set([...legacy, ...combined, ...portability])];
 }
 
 function approvedHostedCapabilities(resources: readonly string[]): string[] {

--- a/services/connect-api/src/managedGrant.d.mts
+++ b/services/connect-api/src/managedGrant.d.mts
@@ -6,6 +6,7 @@ export type ManagedGrantAssertion = Readonly<{
   mcpIds: readonly string[];
 }>;
 
+export function managedAgentPortabilityGranted(capabilities: readonly string[]): boolean;
 export function managedGrantHeaders(
   assertion: ManagedGrantAssertion,
 ): Record<string, string>;

--- a/services/connect-api/src/managedGrant.mjs
+++ b/services/connect-api/src/managedGrant.mjs
@@ -1,14 +1,26 @@
 const managedBaseCapabilities = ["agents:read", "agents:write", "tools:use"];
 const managedOptionalCapabilities = ["history:read", "memory:read", "memory:write"];
+const managedPortabilityGrantCapabilities = [
+  "agent.durability.portability",
+  "agent.history.read",
+  "agent.trace.read",
+];
+
+export function managedAgentPortabilityGranted(capabilities) {
+  const granted = new Set(capabilities);
+  return managedPortabilityGrantCapabilities.every((capability) => granted.has(capability));
+}
 
 export function managedGrantHeaders(assertion) {
   const granted = new Set(assertion.capabilities);
+  const portability = managedAgentPortabilityGranted(assertion.capabilities);
   return {
     "x-nanocodex-connect-user": assertion.brokerUserId,
     "x-nanocodex-connect-grant-id": assertion.grantId,
     "x-nanocodex-connect-capabilities": JSON.stringify([
       ...managedBaseCapabilities,
       ...managedOptionalCapabilities.filter((capability) => granted.has(capability)),
+      ...(portability ? ["agents:portability"] : []),
     ]),
     "x-nanocodex-connect-connectors": JSON.stringify(assertion.connectors),
     "x-nanocodex-connect-mcp-ids": JSON.stringify(assertion.mcpIds),

--- a/services/connect-api/test/devicePolicy.test.mjs
+++ b/services/connect-api/test/devicePolicy.test.mjs
@@ -72,6 +72,20 @@ test("CLI device registration accepts exact hosted capabilities without implicit
   assert.deepEqual(parseCliRegisterBody(registration(resources)).resources, resources);
 });
 
+test("CLI durability portability must be an exact signed resource", () => {
+  const resources = [
+    ...base,
+    "urn:nanocodex:agent:history:read",
+    "urn:nanocodex:agent:trace:read",
+    "urn:nanocodex:agent:durability:portability",
+  ];
+  assert.deepEqual(parseCliRegisterBody(registration(resources)).resources, resources);
+  assert.throws(() => parseCliRegisterBody(registration([
+    ...base,
+    "urn:nanocodex:agent:durability:portability:export",
+  ])), /resources/);
+});
+
 test("CLI connector focus is signed, singular, and part of the granted connector set", () => {
   const focused = [
     ...base,

--- a/services/connect-api/test/managedGrant.test.mjs
+++ b/services/connect-api/test/managedGrant.test.mjs
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
-import { managedGrantHeaders } from "../src/managedGrant.mjs";
+import {
+  managedAgentPortabilityGranted,
+  managedGrantHeaders,
+} from "../src/managedGrant.mjs";
 
 const source = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
 
@@ -33,6 +36,50 @@ test("managed grant headers serialize only the exact delegated slice", () => {
   assert.deepEqual(JSON.parse(headers["x-nanocodex-connect-mcp-ids"]), ["mcp-1"]);
   assert.equal(headers["x-nanocodex-connect-user"], "account-1");
   assert.equal(headers["x-nanocodex-connect-grant-id"], `0x${"a".repeat(64)}`);
+});
+
+test("managed portability requires the exact grant plus full history and trace visibility", () => {
+  const assertion = {
+    brokerUserId: "account-1",
+    connectors: [],
+    grantId: `0x${"b".repeat(64)}`,
+    mcpIds: [],
+  };
+  const capabilities = (granted) => JSON.parse(managedGrantHeaders({
+    ...assertion,
+    capabilities: granted,
+  })["x-nanocodex-connect-capabilities"]);
+
+  const full = [
+    "agent.durability.portability",
+    "agent.history.read",
+    "agent.trace.read",
+  ];
+  assert.equal(managedAgentPortabilityGranted(full), true);
+  assert.ok(capabilities(full).includes("agents:portability"));
+  assert.equal(managedAgentPortabilityGranted([
+    "agent.durability.portability",
+    "agent.history.read",
+  ]), false);
+  assert.equal(managedAgentPortabilityGranted([
+    "agent.history.read",
+    "agent.trace.read",
+  ]), false);
+
+  const projection = section("function approvedAgentCapabilities(", "function approvedHostedCapabilities(");
+  assert.match(
+    projection,
+    /approved\.has\(agentPortabilityResource\)[\s\S]*?\["agent\.durability\.portability"\]/,
+  );
+});
+
+test("managed proxy denies durability unless the exact export route has full signed portability", () => {
+  const proxy = section("async function proxyManagedAgent(", "async function projectManagedResponse(");
+  assert.match(proxy, /\/\^\\\/durability\(\?:\\\/\|\$\)\//);
+  assert.match(proxy, /suffix !== "\/durability" \|\| request\.method !== "POST" \|\| new URL\(request\.url\)\.search !== ""/);
+  assert.match(proxy, /managedAgentPortabilityGranted\(grant\.capabilities\)/);
+  assert.match(proxy, /agent_portability_not_granted/);
+  assert.ok(proxy.indexOf("agent_portability_not_granted") < proxy.indexOf("env.ACCOUNTS.fetch"));
 });
 
 test("every Connect managed request uses the complete grant assertion", () => {

--- a/services/managed/README.md
+++ b/services/managed/README.md
@@ -11,7 +11,7 @@ credentials live in a separate ordinary Worker from the
 object, WASM, browser state, room events, or managed-agent events.
 
 ```text
-N humans -> website proxy -> MultiplayerRoom -> private NanocodexSession
+N humans -> website proxy -> MultiplayerRoom -> private DurableAgentSession
                 |                  |                    |- room conversational profile
                 |                  |                    |- Rust/WASM typed history
                 |                  |                    `- placeholder transport --.
@@ -19,7 +19,7 @@ N humans -> website proxy -> MultiplayerRoom -> private NanocodexSession
                 |                  `- global MultiplayerQuota -----------------------|
                 `- create-only allocator capability                                 |
                                                                                     v
-account-authenticated REST/SSE or WebSocket -> NanocodexSession -> private EGRESS Service Binding
+account-authenticated REST/SSE or WebSocket -> DurableAgentSession -> private EGRESS Service Binding
                                                         |
                                                         v
                                             ordinary credential-broker Worker
@@ -50,11 +50,12 @@ binding other than the private broker capability.
 
 Hot follow-on turns reuse the same WASM agent, cache identity, typed history,
 and upstream socket. The Durable Object supplies only atomic load and
-compare-and-append over opaque batches. Rust/WASM owns operation deduplication,
-typed checkpoints, model-step replay, and tool-step ambiguity. Repeating a
-completed client turn ID returns the Rust-journaled terminal result without
-another model call; an unsafe tool whose completion was not committed is
-reported as ambiguous and is never silently executed twice.
+compare-and-replace over one opaque complete state. Rust/WASM owns operation deduplication,
+typed checkpoints, and recovery for model, warmup, compaction, and tool steps.
+Repeating a completed client turn ID returns the Rust-retained terminal result
+without another model call. An unsafe tool whose completion was not committed
+becomes one in-band unknown-outcome tool result and is never silently executed
+twice.
 
 The managed REST API durably commits a normalized request hash, turn row, and
 `turn_accepted` cursor before returning HTTP 202. Terminal state and its event
@@ -67,7 +68,7 @@ An outbound WebSocket prevents a Durable Object from hibernating while it is
 retained. A one-shot idle alarm therefore shuts down Nanocodex after 30 seconds
 (configurable), closing the OpenAI socket. Client WebSockets use Cloudflare's
 hibernation API and remain connected. Their next command wakes the object and
-rebuilds complete client-owned typed history from the Rust journal in SQLite. See Cloudflare's
+rebuilds complete client-owned typed history from the Rust state in SQLite. See Cloudflare's
 [Durable Object lifecycle](https://developers.cloudflare.com/durable-objects/concepts/durable-object-lifecycle/)
 and [WebSocket hibernation](https://developers.cloudflare.com/durable-objects/best-practices/websockets/)
 documentation for the underlying behavior.
@@ -198,7 +199,7 @@ the next batch, so a cursor-zero client cannot enqueue the whole retained log.
 A member `agent` target also commits an
 outbox row in `quota_pending` state. Only after that local transaction commits
 does the room idempotently admit the deployment-wide turn and submit one stable
-internal managed turn to its private `NanocodexSession`; a failed local commit
+internal managed turn to its private `DurableAgentSession`; a failed local commit
 therefore cannot consume global turn capacity. The room projects only the final
 assistant text or a bounded durable room failure. Projected replies are
 UTF-8-bounded to 16 KiB. A definitive global limit appends `rate_limited` and
@@ -206,7 +207,7 @@ completes that outbox row, so the room can recover after the quota window.
 Ambiguous quota, submit, or observation failures retry with the same stable ID
 and then append a durable `blocked` terminal before fencing the outbox, rather
 than manufacturing success or letting later work pass silently.
-Room deletion deletes exactly that owned agent and its journal before clearing
+Room deletion deletes exactly that owned agent and its durable state before clearing
 room state and releasing the quota lease; the Multiplayer profile never creates
 a Computer workspace.
 
@@ -287,12 +288,15 @@ curl -fsS -X DELETE \
   http://127.0.0.1:8787/v1/agents/<agent-id>
 ```
 
-Cancellation first persists `turn_cancelling`, publishes its cursor, and only
-then returns 202. Retryable admission/cancellation failures retain a durable
-attempt count and exponential retry time; an ambiguous operation becomes
-`turn_blocked` and fences later work until the application explicitly replaces
-the agent. Deletion clears the journal, managed rows, event log, and Computer
-workspace.
+Cancellation first persists its intent and only then returns 202. If it arrives
+before admission, the session reserves that turn ID (up to 64 outstanding
+reservations); a later matching submission enters `turn_cancelling` without
+dispatching model or tool work. An admitted cancellation publishes its
+resumable cursor. Transient admission/cancellation failures remain `accepted`
+or `cancelling` with a durable attempt count and exponential retry time. A
+recovered at-most-once tool with an unknown external outcome becomes a failed
+tool result without replaying the effect. Deletion clears the durable state, managed
+rows, cancellation reservations, event log, and Computer workspace.
 
 ## Organization history and memory
 
@@ -390,9 +394,10 @@ prompt. Set `NANOCODEX_REPL_STATE` to isolate another local REPL state file.
 
 This demonstrates durable client detachment plus step recovery, not a claim
 that arbitrary external effects are magically exactly once. A completed model
-step is replayed from the journal after Worker loss. A tool start without a
-committed completion stops with an explicit ambiguous-outcome error so the
-application can reconcile the external system before retrying.
+step is replayed from retained state after Worker loss. A tool start without a
+committed completion becomes an explicit unknown-outcome tool result; the
+effect is not repeated and the model may inspect or reconcile the external
+system.
 
 `smoke:managed` drives the complete REST/SSE contract: durable acceptance,
 idempotent replay and conflict, strict monotonic cursors, standard
@@ -624,7 +629,6 @@ Client WebSocket commands are JSON objects:
 
 The object streams contractual Nanocodex events as `{ "type": "event", ... }`
 and emits exactly one application terminal message, `turn_completed`,
-`turn_cancelled`, or `turn_failed`, for each accepted client turn. A
-`turn_blocked` state is deliberately nonterminal and fences subsequent work
-because the application must reconcile the ambiguous side effect or replace the
-agent.
+`turn_cancelled`, or `turn_failed`, for each accepted client turn. A transient
+retry emits `turn_retryable` while the row remains `accepted` or `cancelling`;
+the event is scheduling information, not another durable state.

--- a/services/managed/package.json
+++ b/services/managed/package.json
@@ -12,6 +12,7 @@
     "dev": "node scripts/dev-brokered.mjs",
     "dev:api-key": "node scripts/dev-brokered.mjs --auth-mode=api_key",
     "dev:subscription": "node scripts/dev-brokered.mjs --auth-mode=chatgpt",
+    "e2e:local": "npm run prepare:code-evaluator && node scripts/local-e2e.mjs",
     "deploy:production:preflight": "npm run prepare:code-evaluator && node scripts/production-rollout.mjs preflight",
     "deploy:production:managed": "npm run prepare:code-evaluator && node scripts/production-rollout.mjs deploy-managed",
     "deploy:production:web": "node scripts/production-rollout.mjs deploy-web",

--- a/services/managed/scripts/child-process.mjs
+++ b/services/managed/scripts/child-process.mjs
@@ -72,7 +72,7 @@ export async function runBoundedProcess(command, arguments_, {
     stdio: ["ignore", "pipe", "pipe"],
   });
   onSpawn?.(handle);
-  const output = boundedOutput(handle.child, maxOutputBytes);
+  const output = boundedProcessOutput(handle.child, maxOutputBytes);
   let timeout;
   let onAbort;
   const interruption = new Promise((_, reject) => {
@@ -121,7 +121,11 @@ export function redactSecrets(value, secrets) {
   return redacted;
 }
 
-function boundedOutput(child, limit) {
+/** Retains the newest bounded stdout/stderr from a long-lived child process. */
+export function boundedProcessOutput(child, limit = 256 * 1024) {
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
+    throw new Error("child process output limit must be a positive integer");
+  }
   const chunks = [];
   let bytes = 0;
   for (const stream of [child.stdout, child.stderr]) {

--- a/services/managed/scripts/dev-brokered.mjs
+++ b/services/managed/scripts/dev-brokered.mjs
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { realpathSync } from "node:fs";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -43,11 +43,16 @@ async function main() {
   }
   const brokerProbeToken = randomBytes(32).toString("base64url");
   const temporaryDirectory = await mkdtemp(join(tmpdir(), "nanocodex-brokered-dev-"));
+  const externalStateRoot = process.env.NANOCODEX_DEV_STATE_ROOT?.trim()
+    ? resolve(process.env.NANOCODEX_DEV_STATE_ROOT)
+    : undefined;
+  if (externalStateRoot) await mkdir(externalStateRoot, { recursive: true, mode: 0o700 });
   const brokerEnvPath = join(temporaryDirectory, "broker.env");
   const agentEnvPath = join(temporaryDirectory, "agent.env");
-  const brokerStatePath = join(temporaryDirectory, "broker-state");
-  const agentStatePath = join(temporaryDirectory, "agent-state");
+  const brokerStatePath = join(externalStateRoot ?? temporaryDirectory, "broker-state");
+  const agentStatePath = join(externalStateRoot ?? temporaryDirectory, "agent-state");
   const managedConfigPath = join(temporaryDirectory, "wrangler.managed.json");
+  const localManagedConfigPath = join(workersRoot, "wrangler.test.jsonc");
   const processHandles = [];
   const children = [];
   const exits = [];
@@ -78,7 +83,16 @@ async function main() {
       );
       const configuredRelayUrl = process.env.NANOCODEX_CODEX_RELAY_URL?.trim();
       if (configuredRelayUrl) {
+        let relay;
+        try {
+          relay = new URL(configuredRelayUrl);
+        } catch {
+          throw new Error("NANOCODEX_CODEX_RELAY_URL must be a valid URL");
+        }
         brokerEnvironment.push(envLine("CODEX_RELAY_URL", configuredRelayUrl));
+        if (relay.protocol === "http:" && relay.hostname === "127.0.0.1" && relay.port) {
+          brokerEnvironment.push(envLine("ALLOW_INSECURE_LOOPBACK_RELAY", "true"));
+        }
       } else {
         localRelay = await startLocalChatGptRelay();
         brokerEnvironment.push(
@@ -97,7 +111,7 @@ async function main() {
     const historyAiSearchInstance = process.env.NANOCODEX_HISTORY_AI_SEARCH_INSTANCE?.trim();
     let managedConfig;
     if (!brokerOnly && historyAiSearchInstance) {
-      const base = JSON.parse(await readFile(join(workersRoot, "wrangler.jsonc"), "utf8"));
+      const base = JSON.parse(await readFile(localManagedConfigPath, "utf8"));
       managedConfig = managedDevConfig(base, historyAiSearchInstance);
     }
     const environmentWrites = [
@@ -167,7 +181,8 @@ async function main() {
       const managedHandle = spawnProcessGroup(process.execPath, [
         agentWrangler,
         "dev",
-        ...(managedConfig ? ["-c", managedConfigPath] : []),
+        "-c",
+        managedConfig ? managedConfigPath : localManagedConfigPath,
         "--env-file",
         agentEnvPath,
         "--persist-to",

--- a/services/managed/scripts/durability-load.mjs
+++ b/services/managed/scripts/durability-load.mjs
@@ -3,16 +3,20 @@ import { randomUUID } from "node:crypto";
 import {
   managedAccountFetch,
   parseManagedAgentReceipt,
-  requireManagedApiKey,
 } from "./managed-account-auth.mjs";
+import { resolveManagedSmokeCredentials } from "./local-smoke-account.mjs";
 
 const baseUrl = new URL(process.env.NANOCODEX_WORKER_URL ?? "http://127.0.0.1:8787");
-const apiKey = requireManagedApiKey();
+const credentials = await resolveManagedSmokeCredentials(baseUrl, "managed durability load");
+const { apiKey } = credentials;
 const mode = process.env.NANOCODEX_LOAD_MODE ?? "control";
 const agents = integer("NANOCODEX_LOAD_AGENTS", 1_000, 1, 100_000);
 const concurrency = integer("NANOCODEX_LOAD_CONCURRENCY", 128, 1, 1_000);
 const timeoutMs = integer("NANOCODEX_LOAD_TIMEOUT_MS", 30_000, 1_000, 600_000);
 const preserve = process.env.NANOCODEX_LOAD_PRESERVE === "true";
+if (preserve && credentials.temporary) {
+  throw new Error("NANOCODEX_LOAD_PRESERVE requires explicit persistent smoke credentials");
+}
 const runId = randomUUID();
 if (!new Set(["control", "turn"]).has(mode)) {
   throw new Error("NANOCODEX_LOAD_MODE must be control or turn");
@@ -110,7 +114,7 @@ try {
           terminalEndToEnd[index] = Date.now() - acceptedAt[index];
           return;
         }
-        if (["blocked", "cancelled", "failed"].includes(turn.state)) {
+        if (["cancelled", "failed"].includes(turn.state)) {
           throw new Error(`turn entered ${turn.state}`);
         }
         await waitWithFullJitter(pollDelayMs, deadline);
@@ -191,6 +195,13 @@ try {
         : error;
       return { error: errorMessage(error) };
     });
+  }
+  try {
+    await credentials.cleanup();
+  } catch (error) {
+    failure = failure
+      ? new AggregateError([failure, error], "load and credential cleanup failed")
+      : error;
   }
 }
 

--- a/services/managed/scripts/fanout.mjs
+++ b/services/managed/scripts/fanout.mjs
@@ -3,13 +3,14 @@ import WebSocket from "ws";
 
 import {
   managedAccountFetch,
-  managedAccountWebSocketOptions,
+  managedAccountSessionWebSocketOptions,
   parseManagedAgentReceipt,
-  requireManagedApiKey,
 } from "./managed-account-auth.mjs";
+import { resolveManagedSmokeCredentials } from "./local-smoke-account.mjs";
 
 const baseUrl = process.env.NANOCODEX_WORKER_URL ?? "http://127.0.0.1:8787";
-const apiKey = requireManagedApiKey();
+const credentials = await resolveManagedSmokeCredentials(baseUrl, "managed fanout");
+const { accountCookie, apiKey } = credentials;
 const clients = Number(process.env.NANOCODEX_FANOUT_CLIENTS ?? 64);
 const burst = Number(process.env.NANOCODEX_FANOUT_EVENTS ?? 512);
 const timeoutMs = Number(process.env.NANOCODEX_FANOUT_TIMEOUT_MS ?? 60_000);
@@ -28,7 +29,7 @@ try {
   const receivers = await Promise.all(Array.from({ length: clients }, async () => {
     const socket = new WebSocket(
       agent.websocket_url,
-      managedAccountWebSocketOptions(apiKey),
+      managedAccountSessionWebSocketOptions(accountCookie, baseUrl),
     );
     sockets.push(socket);
     let events = 0;
@@ -76,6 +77,7 @@ try {
   await managedAccountFetch(apiKey, `${baseUrl}/v1/agents/${agent.agent_id}`, {
     method: "DELETE",
   }).catch(() => {});
+  await credentials.cleanup();
 }
 
 function deferred() {

--- a/services/managed/scripts/live-multiplayer-cloudflare.mjs
+++ b/services/managed/scripts/live-multiplayer-cloudflare.mjs
@@ -255,7 +255,7 @@ function managedConfig() {
     services: [{ binding: "EGRESS", service: brokerName }],
     durable_objects: {
       bindings: [
-        { name: "NANOCODEX_SESSIONS", class_name: "NanocodexSession" },
+        { name: "NANOCODEX_SESSIONS", class_name: "DurableAgentSession" },
         { name: "NANOCODEX_ROOMS", class_name: "MultiplayerRoom" },
         { name: "NANOCODEX_MULTIPLAYER_QUOTA", class_name: "MultiplayerQuota" },
       ],
@@ -263,7 +263,7 @@ function managedConfig() {
     migrations: [
       {
         tag: "v1",
-        new_sqlite_classes: ["NanocodexSession", "MultiplayerRoom"],
+        new_sqlite_classes: ["DurableAgentSession", "MultiplayerRoom"],
       },
       { tag: "v5", new_sqlite_classes: ["MultiplayerQuota"] },
     ],

--- a/services/managed/scripts/live-smoke.mjs
+++ b/services/managed/scripts/live-smoke.mjs
@@ -5,16 +5,17 @@ import { deleteWith503Retry } from "./cleanup-resource.mjs";
 import { credentialSafeHttpOrigin, credentialSafeUrl } from "./credential-origin.mjs";
 import {
   managedAccountFetch,
-  managedAccountWebSocketOptions,
+  managedAccountSessionWebSocketOptions,
   parseManagedAgentReceipt,
-  requireManagedApiKey,
 } from "./managed-account-auth.mjs";
+import { resolveManagedSmokeCredentials } from "./local-smoke-account.mjs";
 
 const baseUrl = credentialSafeHttpOrigin(
   process.env.NANOCODEX_WORKER_URL ?? "http://127.0.0.1:8787",
   "NANOCODEX_WORKER_URL",
 ).origin;
-const apiKey = requireManagedApiKey();
+const credentials = await resolveManagedSmokeCredentials(baseUrl, "managed live smoke");
+const { accountCookie, apiKey } = credentials;
 const terminalTimeoutMs = Number(process.env.NANOCODEX_SMOKE_TIMEOUT_MS ?? 180_000);
 const idleTimeoutMs = Number(process.env.NANOCODEX_SMOKE_IDLE_TIMEOUT_MS ?? 45_000);
 const cleanupTimeoutMs = positiveInteger("NANOCODEX_SMOKE_CLEANUP_TIMEOUT_MS", 30_000);
@@ -183,6 +184,13 @@ try {
         : error;
     }
   }
+  try {
+    await credentials.cleanup();
+  } catch (error) {
+    failure = failure
+      ? new AggregateError([failure, error], "Live smoke and credential cleanup failed")
+      : error;
+  }
 }
 
 if (failure) throw failure;
@@ -247,7 +255,7 @@ async function pollState(predicate, timeoutMs) {
 function connectClient() {
   const socket = new WebSocket(
     agent.websocket_url,
-    managedAccountWebSocketOptions(apiKey),
+    managedAccountSessionWebSocketOptions(accountCookie, baseUrl),
   );
   const inbox = createInbox(socket, (message) => {
     if (message.type === "event") agentEvents.push(message.event);
@@ -272,12 +280,11 @@ function disconnect(socket) {
 
 async function terminal(inbox, id, timeoutMs) {
   const message = await inbox.next(
-    (candidate) => ["turn_completed", "turn_failed", "turn_blocked", "turn_cancelled"].includes(candidate.type)
+    (candidate) => ["turn_completed", "turn_failed", "turn_cancelled"].includes(candidate.type)
       && candidate.id === id,
     timeoutMs,
   );
   if (message.type === "turn_failed") throw new Error(`turn ${id} failed: ${message.error}`);
-  if (message.type === "turn_blocked") throw new Error(`turn ${id} was blocked: ${message.error}`);
   if (message.type === "turn_cancelled") throw new Error(`turn ${id} was cancelled`);
   return message;
 }

--- a/services/managed/scripts/local-e2e.mjs
+++ b/services/managed/scripts/local-e2e.mjs
@@ -9,7 +9,12 @@ import {
   managedAccountFetch,
   parseManagedAgentReceipt,
 } from "./managed-account-auth.mjs";
-import { runBoundedProcess, spawnProcessGroup } from "./child-process.mjs";
+import {
+  boundedProcessOutput,
+  redactSecrets,
+  runBoundedProcess,
+  spawnProcessGroup,
+} from "./child-process.mjs";
 import { createLocalSmokeAccount } from "./local-smoke-account.mjs";
 import { waitForReadiness } from "./dev-brokered.mjs";
 
@@ -153,7 +158,7 @@ try {
     results,
   })}\n`);
 } catch (error) {
-  failure = error;
+  failure = withStackDiagnostics(error, stack);
 } finally {
   if (restartAgent && restartCredentials && stack) {
     await deleteAgent(restartCredentials.apiKey, restartAgent.agent_id).catch(() => {});
@@ -179,8 +184,9 @@ async function startStack() {
     }),
     stdio: ["ignore", "pipe", "pipe"],
   });
-  drain(handle.child);
+  handle.diagnostics = boundedProcessOutput(handle.child);
   handles.add(handle);
+  stack = handle;
   await waitForReadiness({
     description: "managed local E2E stack",
     processes: [handle.child],
@@ -301,4 +307,12 @@ function assert(condition, message) {
 function drain(child) {
   child.stdout?.resume();
   child.stderr?.resume();
+}
+
+function withStackDiagnostics(error, handle) {
+  const diagnostics = handle?.diagnostics?.value().trim();
+  if (!diagnostics) return error;
+  const message = error instanceof Error ? error.message : String(error);
+  const redacted = redactSecrets(diagnostics, [accessToken]);
+  return new Error(`${message}\n\nManaged Wrangler diagnostics:\n${redacted}`, { cause: error });
 }

--- a/services/managed/scripts/local-e2e.mjs
+++ b/services/managed/scripts/local-e2e.mjs
@@ -1,0 +1,304 @@
+import { randomUUID } from "node:crypto";
+import { createServer } from "node:net";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  managedAccountFetch,
+  parseManagedAgentReceipt,
+} from "./managed-account-auth.mjs";
+import { runBoundedProcess, spawnProcessGroup } from "./child-process.mjs";
+import { createLocalSmokeAccount } from "./local-smoke-account.mjs";
+import { waitForReadiness } from "./dev-brokered.mjs";
+
+const managedRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const root = await mkdtemp(join(tmpdir(), "nanocodex-managed-e2e-"));
+const stateRoot = join(root, "state");
+const authPath = join(root, "auth.json");
+const [workerPort, brokerPort, mockPort] = await distinctFreePorts(3);
+const baseUrl = new URL(`http://127.0.0.1:${workerPort}`);
+const accountId = "nanocodex-local-e2e";
+const accessToken = jwt({ exp: Math.floor(Date.now() / 1_000) + 3_600 });
+const handles = new Set();
+let stack;
+let restartCredentials;
+let restartAgent;
+let failure;
+
+try {
+  await writeFile(authPath, JSON.stringify({
+    auth_mode: "chatgpt",
+    tokens: { access_token: accessToken, account_id: accountId },
+  }), { mode: 0o600 });
+
+  const mock = spawnProcessGroup(process.execPath, ["scripts/mock-openai.mjs"], {
+    cwd: managedRoot,
+    env: cleanLoopbackEnvironment({
+      ...process.env,
+      NANOCODEX_MOCK_ACCESS_TOKEN: accessToken,
+      NANOCODEX_MOCK_CHATGPT_ACCOUNT_ID: accountId,
+      NANOCODEX_MOCK_OPENAI_PORT: String(mockPort),
+    }),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  drain(mock.child);
+  handles.add(mock);
+  await waitForReadiness({
+    acceptResponse: () => true,
+    description: "mock OpenAI server",
+    processes: [mock.child],
+    url: `http://127.0.0.1:${mockPort}/ready`,
+  });
+
+  stack = await startStack();
+  restartCredentials = await createLocalSmokeAccount(baseUrl, "managed process restart smoke");
+  restartAgent = await createAgent(restartCredentials.apiKey, "restart-agent");
+  const turnId = `restart-${randomUUID()}`;
+  const idempotencyKey = `request-${turnId}`;
+  const input = [
+    "E2E_MANAGED_TOOLS.",
+    "Call runtimeInfo. Then use exec_command to write MANAGED_WORKSPACE_OK to durable.txt,",
+    "read it back, and print the working directory. Reply with exactly MANAGED_TOOLS_OK.",
+  ].join(" ");
+  const accepted = await submitTurn(restartCredentials.apiKey, restartAgent.agent_id, {
+    id: turnId,
+    idempotencyKey,
+    input,
+  });
+  assert(accepted.response.status === 202, `restart setup returned HTTP ${accepted.response.status}`);
+  const acceptedTurn = await accepted.response.json();
+  const terminalBeforeRestart = await waitForTurn(
+    restartCredentials.apiKey,
+    restartAgent.agent_id,
+    turnId,
+  );
+  assert(terminalBeforeRestart.state === "completed", "restart setup turn did not complete");
+
+  await stopStack();
+  stack = await startStack();
+
+  const restoredState = await accountJson(
+    restartCredentials.apiKey,
+    `/v1/agents/${restartAgent.agent_id}`,
+  );
+  assert(restoredState.completed_turns === 1, "process restart lost the completed turn");
+  const replay = await submitTurn(restartCredentials.apiKey, restartAgent.agent_id, {
+    id: turnId,
+    idempotencyKey,
+    input,
+  });
+  assert(replay.response.status === 200, `post-restart replay returned HTTP ${replay.response.status}`);
+  const replayedTurn = await replay.response.json();
+  assert(
+    replayedTurn.accepted_cursor === acceptedTurn.accepted_cursor,
+    "post-restart idempotent replay changed its durable acceptance",
+  );
+  const readbackId = `readback-${randomUUID()}`;
+  const readback = await submitTurn(restartCredentials.apiKey, restartAgent.agent_id, {
+    id: readbackId,
+    idempotencyKey: `request-${readbackId}`,
+    input: "E2E_MANAGED_READBACK. Use exec_command to read durable.txt and reply with exactly MANAGED_RESTORED_OK.",
+  });
+  assert(readback.response.status === 202, `post-restart readback returned HTTP ${readback.response.status}`);
+  await readback.response.body?.cancel();
+  const readbackTurn = await waitForTurn(
+    restartCredentials.apiKey,
+    restartAgent.agent_id,
+    readbackId,
+  );
+  assert(
+    readbackTurn.state === "completed"
+      && readbackTurn.terminal?.final_message === "MANAGED_RESTORED_OK",
+    "process restart lost the durable workspace",
+  );
+  await deleteAgent(restartCredentials.apiKey, restartAgent.agent_id);
+  restartAgent = undefined;
+  await restartCredentials.cleanup();
+  restartCredentials = undefined;
+
+  const runs = [
+    ["rest_sse", "managed-api-smoke.mjs", {}],
+    ["websocket", "live-smoke.mjs", {}],
+    ["multiclient", "multiclient-smoke.mjs", { NANOCODEX_MULTICLIENT_CLIENTS: "3" }],
+    ["multiplayer", "multiplayer-smoke.mjs", {}],
+    ["soak", "soak.mjs", { NANOCODEX_SOAK_SESSIONS: "4" }],
+    ["fanout", "fanout.mjs", { NANOCODEX_FANOUT_CLIENTS: "4", NANOCODEX_FANOUT_EVENTS: "32" }],
+    ["websocket_stress", "stress.mjs", { NANOCODEX_STRESS_CLIENTS: "4", NANOCODEX_STRESS_PINGS: "32" }],
+    ["durability_load", "durability-load.mjs", {
+      NANOCODEX_LOAD_AGENTS: "10",
+      NANOCODEX_LOAD_CONCURRENCY: "4",
+      NANOCODEX_LOAD_MODE: "turn",
+    }],
+  ];
+  const results = { process_restart: { status: "ok", idempotent_replay: true, workspace_restored: true } };
+  for (const [name, script, extraEnvironment] of runs) {
+    const output = await runBoundedProcess(process.execPath, [`scripts/${script}`], {
+      cwd: managedRoot,
+      env: cleanLoopbackEnvironment({
+        ...process.env,
+        ...extraEnvironment,
+        NANOCODEX_WORKER_URL: baseUrl.origin,
+      }),
+      label: `local E2E ${name}`,
+      maxOutputBytes: 4 * 1024 * 1024,
+      timeoutMs: 240_000,
+    });
+    results[name] = lastJsonLine(output);
+  }
+  process.stdout.write(`${JSON.stringify({
+    status: "ok",
+    topology: "mock-openai -> egress wrangler dev -> managed wrangler dev",
+    results,
+  })}\n`);
+} catch (error) {
+  failure = error;
+} finally {
+  if (restartAgent && restartCredentials && stack) {
+    await deleteAgent(restartCredentials.apiKey, restartAgent.agent_id).catch(() => {});
+  }
+  await restartCredentials?.cleanup().catch(() => {});
+  await stopStack().catch(() => {});
+  await Promise.allSettled([...handles].map((handle) => handle.terminate()));
+  await rm(root, { recursive: true, force: true });
+}
+
+if (failure) throw failure;
+
+async function startStack() {
+  const handle = spawnProcessGroup(process.execPath, ["scripts/dev-brokered.mjs", "--auth-mode=chatgpt"], {
+    cwd: managedRoot,
+    env: cleanLoopbackEnvironment({
+      ...process.env,
+      NANOCODEX_BROKER_PORT: String(brokerPort),
+      NANOCODEX_CODEX_AUTH_FILE: authPath,
+      NANOCODEX_CODEX_RELAY_URL: `http://127.0.0.1:${mockPort}`,
+      NANOCODEX_DEV_STATE_ROOT: stateRoot,
+      NANOCODEX_WORKER_PORT: String(workerPort),
+    }),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  drain(handle.child);
+  handles.add(handle);
+  await waitForReadiness({
+    description: "managed local E2E stack",
+    processes: [handle.child],
+    url: new URL("/health", baseUrl),
+  });
+  return handle;
+}
+
+async function stopStack() {
+  if (!stack) return;
+  const active = stack;
+  stack = undefined;
+  await active.terminate();
+  handles.delete(active);
+}
+
+async function createAgent(apiKey, key) {
+  const response = await managedAccountFetch(apiKey, new URL("/v1/agents", baseUrl), {
+    method: "POST",
+    headers: { "idempotency-key": key },
+  });
+  if (response.status !== 201) {
+    throw new Error(`restart agent creation failed with HTTP ${response.status}: ${await response.text()}`);
+  }
+  return parseManagedAgentReceipt(await response.json());
+}
+
+async function submitTurn(apiKey, agentId, { id, idempotencyKey, input }) {
+  const response = await managedAccountFetch(
+    apiKey,
+    new URL(`/v1/agents/${agentId}/turns`, baseUrl),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json", "idempotency-key": idempotencyKey },
+      body: JSON.stringify({ id, input }),
+    },
+  );
+  return { response };
+}
+
+async function waitForTurn(apiKey, agentId, turnId) {
+  const deadline = Date.now() + 180_000;
+  while (Date.now() < deadline) {
+    const turn = await accountJson(apiKey, `/v1/agents/${agentId}/turns/${turnId}`);
+    if (["completed", "cancelled", "failed"].includes(turn.state)) return turn;
+    await new Promise((resolveWait) => setTimeout(resolveWait, 50));
+  }
+  throw new Error(`turn ${turnId} did not become terminal`);
+}
+
+async function accountJson(apiKey, path) {
+  const response = await managedAccountFetch(apiKey, new URL(path, baseUrl));
+  if (!response.ok) throw new Error(`${path} returned HTTP ${response.status}`);
+  return response.json();
+}
+
+async function deleteAgent(apiKey, agentId) {
+  const response = await managedAccountFetch(apiKey, new URL(`/v1/agents/${agentId}`, baseUrl), {
+    method: "DELETE",
+  });
+  if (response.status !== 204 && response.status !== 404) {
+    throw new Error(`agent cleanup returned HTTP ${response.status}`);
+  }
+  await response.body?.cancel();
+}
+
+function lastJsonLine(output) {
+  for (const line of output.trim().split("\n").reverse()) {
+    try {
+      return JSON.parse(line);
+    } catch { /* continue */ }
+  }
+  throw new Error("E2E child returned no JSON result");
+}
+
+function jwt(payload) {
+  const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "none" })}.${encode(payload)}.local`;
+}
+
+function cleanLoopbackEnvironment(environment) {
+  const cleaned = { ...environment, NO_PROXY: "127.0.0.1,localhost", no_proxy: "127.0.0.1,localhost" };
+  for (const name of ["HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"]) {
+    delete cleaned[name];
+  }
+  return cleaned;
+}
+
+async function distinctFreePorts(count) {
+  const ports = [];
+  while (ports.length < count) {
+    const port = await freePort();
+    if (!ports.includes(port)) ports.push(port);
+  }
+  return ports;
+}
+
+function freePort() {
+  return new Promise((resolvePort, rejectPort) => {
+    const server = createServer();
+    server.once("error", rejectPort);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        rejectPort(new Error("failed to reserve a local E2E port"));
+        return;
+      }
+      server.close((error) => error ? rejectPort(error) : resolvePort(address.port));
+    });
+  });
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function drain(child) {
+  child.stdout?.resume();
+  child.stderr?.resume();
+}

--- a/services/managed/scripts/local-smoke-account.mjs
+++ b/services/managed/scripts/local-smoke-account.mjs
@@ -1,0 +1,173 @@
+import { randomBytes } from "node:crypto";
+
+import { Base64, P256, PublicKey, WebAuthnP256 } from "ox";
+
+const API_KEY = /^ncx_live_[A-Za-z0-9_-]{12}_[A-Za-z0-9_-]{43}$/;
+const ACCOUNT_COOKIE = /^nanocodex_account=[0-9a-f]{64}$/;
+
+export async function resolveManagedSmokeCredentials(baseUrl, label, environment = process.env) {
+  const url = new URL(baseUrl);
+  const apiKey = environment.NANOCODEX_API_KEY?.trim();
+  const accountCookie = environment.NANOCODEX_ACCOUNT_COOKIE?.trim();
+  if (apiKey || accountCookie) {
+    if (!API_KEY.test(apiKey ?? "") || !ACCOUNT_COOKIE.test(accountCookie ?? "")) {
+      throw new Error(
+        "NANOCODEX_API_KEY and NANOCODEX_ACCOUNT_COOKIE must both identify the same passkey-backed account",
+      );
+    }
+    return { apiKey, accountCookie, temporary: false, cleanup: async () => {} };
+  }
+  if (!localSmokeOrigin(url)) {
+    throw new Error(
+      "remote WebSocket smoke requires explicit NANOCODEX_API_KEY and NANOCODEX_ACCOUNT_COOKIE",
+    );
+  }
+  return createLocalSmokeAccount(url, label);
+}
+
+export async function createLocalSmokeAccount(baseUrl, label) {
+  const url = new URL(baseUrl);
+  if (!localSmokeOrigin(url)) throw new Error("local smoke account creation is loopback-only");
+
+  const bootstrap = await fetch(new URL("/v1/me", url));
+  if (!bootstrap.ok) throw new Error(`local account bootstrap failed with HTTP ${bootstrap.status}`);
+  const anonymousCookie = responseAccountCookie(bootstrap);
+  const account = await bootstrap.json();
+  if (!anonymousCookie || account?.user?.persistent !== false) {
+    throw new Error("local account bootstrap did not return one anonymous browser account");
+  }
+
+  const optionsResponse = await fetch(new URL("/webauthn/register/options", url), {
+    method: "POST",
+    headers: {
+      cookie: anonymousCookie,
+      "content-type": "application/json",
+      origin: url.origin,
+    },
+    body: "{}",
+  });
+  if (!optionsResponse.ok) {
+    throw new Error(`local passkey options failed with HTTP ${optionsResponse.status}`);
+  }
+  const options = await optionsResponse.json();
+  const publicKeyOptions = options?.options?.publicKey;
+  if (typeof publicKeyOptions?.challenge !== "string"
+    || typeof publicKeyOptions?.rp?.id !== "string") {
+    throw new Error("local passkey options returned an invalid challenge or RP ID");
+  }
+
+  const credentialId = randomBytes(32);
+  const { publicKey } = P256.createKeyPair();
+  const clientDataJSON = WebAuthnP256.getClientDataJSON({
+    challenge: publicKeyOptions.challenge,
+    origin: url.origin,
+    type: "webauthn.create",
+  });
+  const authData = WebAuthnP256.getAuthenticatorData({
+    credential: { id: credentialId, publicKey },
+    flag: 0x45,
+    rpId: publicKeyOptions.rp.id,
+  });
+  const attestationObject = WebAuthnP256.getAttestationObject({ authData });
+  const id = Base64.fromBytes(credentialId, { pad: false, url: true });
+  const encodedClientData = Base64.fromBytes(new TextEncoder().encode(clientDataJSON), {
+    pad: false,
+    url: true,
+  });
+  const encodedAttestation = Base64.fromHex(attestationObject, { pad: false, url: true });
+  const registration = await fetch(new URL("/webauthn/register", url), {
+    method: "POST",
+    headers: {
+      cookie: anonymousCookie,
+      "content-type": "application/json",
+      origin: url.origin,
+    },
+    body: JSON.stringify({
+      attestationObject: encodedAttestation,
+      clientDataJSON: encodedClientData,
+      id,
+      publicKey: PublicKey.toHex(publicKey),
+      raw: {
+        authenticatorAttachment: null,
+        id,
+        rawId: id,
+        response: {
+          attestationObject: encodedAttestation,
+          clientDataJSON: encodedClientData,
+        },
+        type: "public-key",
+      },
+    }),
+  });
+  if (!registration.ok) {
+    throw new Error(`local passkey registration failed with HTTP ${registration.status}: ${await registration.text()}`);
+  }
+  const accountCookie = responseAccountCookie(registration);
+  await registration.body?.cancel();
+  if (!accountCookie || !ACCOUNT_COOKIE.test(accountCookie)) {
+    throw new Error("local passkey registration returned no persistent account cookie");
+  }
+
+  const claim = await fetch(new URL("/v1/credentials/local-claim", url), {
+    method: "POST",
+    headers: { cookie: accountCookie, origin: url.origin },
+  });
+  if (!claim.ok) throw new Error(`local credential claim failed with HTTP ${claim.status}`);
+  await claim.body?.cancel();
+
+  const created = await fetch(new URL("/v1/api-keys", url), {
+    method: "POST",
+    headers: {
+      cookie: accountCookie,
+      "content-type": "application/json",
+      origin: url.origin,
+    },
+    body: JSON.stringify({ label }),
+  });
+  if (created.status !== 201) {
+    throw new Error(`local API key creation failed with HTTP ${created.status}`);
+  }
+  const value = await created.json();
+  if (!API_KEY.test(value?.api_key) || typeof value?.key?.id !== "string") {
+    throw new Error("local API key creation returned an invalid key");
+  }
+
+  let cleaned = false;
+  return {
+    apiKey: value.api_key,
+    accountCookie,
+    temporary: true,
+    async cleanup() {
+      if (cleaned) return;
+      cleaned = true;
+      const response = await fetch(new URL(`/v1/api-keys/${value.key.id}`, url), {
+        method: "DELETE",
+        headers: { cookie: accountCookie, origin: url.origin },
+      });
+      if (response.status !== 204 && response.status !== 404) {
+        throw new Error(`local API key cleanup failed with HTTP ${response.status}`);
+      }
+      await response.body?.cancel();
+    },
+  };
+}
+
+function responseAccountCookie(response) {
+  const values = typeof response.headers.getSetCookie === "function"
+    ? response.headers.getSetCookie()
+    : [response.headers.get("set-cookie")].filter(Boolean);
+  for (const value of values) {
+    const cookie = value.split(";", 1)[0];
+    if (cookie.startsWith("nanocodex_account=")) return cookie;
+  }
+  return undefined;
+}
+
+function localSmokeOrigin(url) {
+  return ["http:", "https:"].includes(url.protocol)
+    && (url.hostname === "127.0.0.1"
+      || url.hostname === "::1"
+      || url.hostname === "localhost"
+      || url.hostname === "nanocodex.localhost"
+      || url.hostname.endsWith(".nanocodex.localhost"));
+}

--- a/services/managed/scripts/managed-account-auth.mjs
+++ b/services/managed/scripts/managed-account-auth.mjs
@@ -1,4 +1,5 @@
 const ACCOUNT_API_KEY = /^ncx_live_[A-Za-z0-9_-]{12}_[A-Za-z0-9_-]{43}$/;
+const ACCOUNT_COOKIE = /^nanocodex_account=[0-9a-f]{64}$/;
 
 export function requireManagedApiKey(environment = process.env) {
   const apiKey = environment.NANOCODEX_API_KEY;
@@ -24,8 +25,23 @@ export async function managedAccountFetch(apiKey, input, init = {}) {
   });
 }
 
-export function managedAccountWebSocketOptions(apiKey, initial = {}) {
-  const headers = managedAccountHeaders(apiKey, initial.headers);
+export function requireManagedAccountCookie(environment = process.env) {
+  const cookie = environment.NANOCODEX_ACCOUNT_COOKIE;
+  if (typeof cookie !== "string" || !ACCOUNT_COOKIE.test(cookie)) {
+    throw new Error(
+      "NANOCODEX_ACCOUNT_COOKIE must be one exact passkey session cookie",
+    );
+  }
+  return cookie;
+}
+
+export function managedAccountSessionWebSocketOptions(cookie, origin, initial = {}) {
+  requireManagedAccountCookie({ NANOCODEX_ACCOUNT_COOKIE: cookie });
+  const parsedOrigin = new URL(origin).origin;
+  const headers = new Headers(initial.headers);
+  headers.set("cookie", cookie);
+  headers.set("origin", parsedOrigin);
+  headers.delete("authorization");
   return {
     ...initial,
     headers: Object.fromEntries(headers),

--- a/services/managed/scripts/managed-account-auth.mjs
+++ b/services/managed/scripts/managed-account-auth.mjs
@@ -49,9 +49,10 @@ export function managedAccountSessionWebSocketOptions(cookie, origin, initial = 
 }
 
 export function parseManagedAgentReceipt(value) {
-  const fields = ["agent_id", "session_id", "events_url", "websocket_url"];
+  const fields = ["agent_id", "durability_id", "session_id", "events_url", "websocket_url"];
   if (!isRecord(value)
     || typeof value.agent_id !== "string"
+    || typeof value.durability_id !== "string"
     || typeof value.session_id !== "string"
     || typeof value.events_url !== "string"
     || typeof value.websocket_url !== "string") {
@@ -62,6 +63,7 @@ export function parseManagedAgentReceipt(value) {
   }
   return {
     agent_id: value.agent_id,
+    durability_id: value.durability_id,
     session_id: value.session_id,
     events_url: value.events_url,
     websocket_url: value.websocket_url,

--- a/services/managed/scripts/managed-api-smoke.mjs
+++ b/services/managed/scripts/managed-api-smoke.mjs
@@ -6,14 +6,15 @@ import {
   managedAccountFetch,
   managedAccountHeaders,
   parseManagedAgentReceipt,
-  requireManagedApiKey,
 } from "./managed-account-auth.mjs";
+import { resolveManagedSmokeCredentials } from "./local-smoke-account.mjs";
 
 const baseUrl = credentialSafeHttpOrigin(
   process.env.NANOCODEX_WORKER_URL ?? "http://127.0.0.1:8787",
   "NANOCODEX_WORKER_URL",
 );
-const apiKey = requireManagedApiKey();
+const credentials = await resolveManagedSmokeCredentials(baseUrl, "managed REST smoke");
+const { apiKey } = credentials;
 const terminalTimeoutMs = numberFromEnv("NANOCODEX_SMOKE_TIMEOUT_MS", 180_000);
 const idleTimeoutMs = numberFromEnv("NANOCODEX_SMOKE_IDLE_TIMEOUT_MS", 45_000);
 const cleanupTimeoutMs = numberFromEnv("NANOCODEX_SMOKE_CLEANUP_TIMEOUT_MS", 30_000);
@@ -198,6 +199,13 @@ try {
         : error;
     }
   }
+  try {
+    await credentials.cleanup();
+  } catch (error) {
+    failure = failure
+      ? new AggregateError([failure, error], "Managed API smoke and credential cleanup failed")
+      : error;
+  }
 }
 
 if (failure) throw failure;
@@ -265,7 +273,7 @@ async function waitForTerminal(reader, turnId, startedAt, timeoutMs) {
       }
     }
     if (message.id !== turnId) continue;
-    if (["turn_completed", "turn_cancelled", "turn_failed", "turn_blocked"].includes(message.type)) {
+    if (["turn_completed", "turn_cancelled", "turn_failed"].includes(message.type)) {
       return {
         terminal: message,
         messages,

--- a/services/managed/scripts/mock-openai.mjs
+++ b/services/managed/scripts/mock-openai.mjs
@@ -7,7 +7,8 @@ const accountId = process.env.NANOCODEX_MOCK_CHATGPT_ACCOUNT_ID ?? "local-chatgp
 if (!Number.isFinite(responseDelayMs) || responseDelayMs < 0 || responseDelayMs > 60_000) {
   throw new Error("NANOCODEX_MOCK_DELAY_MS must be between 0 and 60000");
 }
-const accessToken = jwt({ exp: Math.floor(Date.now() / 1000) + 3_600 });
+const accessToken = process.env.NANOCODEX_MOCK_ACCESS_TOKEN
+  ?? jwt({ exp: Math.floor(Date.now() / 1000) + 3_600 });
 const idToken = jwt({
   exp: Math.floor(Date.now() / 1000) + 3_600,
   "https://api.openai.com/auth": {
@@ -123,6 +124,10 @@ sockets.on("connection", (socket) => {
     }
     if (activeEncoded.includes("E2E_MANAGED_CANCEL")) {
       await sendCompleted(socket, messageResponse("MANAGED_CANCEL_TOO_LATE"), 1_500);
+      return;
+    }
+    if (activeEncoded.includes("MULTIPLAYER_AGENT_OK")) {
+      await sendCompleted(socket, messageResponse("MULTIPLAYER_AGENT_OK"));
       return;
     }
     const exactToken = encoded.match(/Reply with exactly ([A-Z0-9_-]{1,128})/)?.[1];

--- a/services/managed/scripts/multiclient-smoke.mjs
+++ b/services/managed/scripts/multiclient-smoke.mjs
@@ -3,13 +3,14 @@ import WebSocket from "ws";
 
 import {
   managedAccountFetch,
-  managedAccountWebSocketOptions,
+  managedAccountSessionWebSocketOptions,
   parseManagedAgentReceipt,
-  requireManagedApiKey,
 } from "./managed-account-auth.mjs";
+import { resolveManagedSmokeCredentials } from "./local-smoke-account.mjs";
 
 const baseUrl = process.env.NANOCODEX_WORKER_URL ?? "http://127.0.0.1:8787";
-const apiKey = requireManagedApiKey();
+const credentials = await resolveManagedSmokeCredentials(baseUrl, "managed multiclient smoke");
+const { accountCookie, apiKey } = credentials;
 const clientCount = Number(process.env.NANOCODEX_MULTICLIENT_CLIENTS ?? 2);
 const timeoutMs = Number(process.env.NANOCODEX_MULTICLIENT_TIMEOUT_MS ?? 120_000);
 
@@ -28,7 +29,7 @@ try {
   const receivers = await Promise.all(Array.from({ length: clientCount }, async () => {
     const socket = new WebSocket(
       agent.websocket_url,
-      managedAccountWebSocketOptions(apiKey),
+      managedAccountSessionWebSocketOptions(accountCookie, baseUrl),
     );
     sockets.push(socket);
     const ready = deferred();
@@ -88,6 +89,7 @@ try {
   await managedAccountFetch(apiKey, `${baseUrl}/v1/agents/${agent.agent_id}`, {
     method: "DELETE",
   }).catch(() => {});
+  await credentials.cleanup();
 }
 
 function deferred() {

--- a/services/managed/scripts/multiplayer-smoke.mjs
+++ b/services/managed/scripts/multiplayer-smoke.mjs
@@ -1,4 +1,4 @@
-import { randomUUID } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 
 import WebSocket from "ws";
 
@@ -8,14 +8,16 @@ import {
   assertNoSecretDigestMatches,
   parseSecretDigestDescriptors,
 } from "./public-secret-scan.mjs";
+import { resolveManagedSmokeCredentials } from "./local-smoke-account.mjs";
 
 const baseUrl = credentialSafeHttpOrigin(
   process.env.NANOCODEX_WORKER_URL ?? "http://127.0.0.1:8787",
   "NANOCODEX_WORKER_URL",
 );
-const roomAllocatorToken = process.env.NANOCODEX_ROOM_ALLOCATOR_TOKEN
-  ?? "local-room-allocator-token";
 const serverAuthorized = process.env.NANOCODEX_MULTIPLAYER_SERVER_AUTH === "true";
+const credentials = serverAuthorized
+  ? undefined
+  : await resolveManagedSmokeCredentials(baseUrl, "managed multiplayer smoke");
 const forbiddenDigests = parseSecretDigestDescriptors(process.env.NANOCODEX_FORBIDDEN_DIGESTS);
 const timeoutMs = positiveInteger("NANOCODEX_MULTIPLAYER_TIMEOUT_MS", 180_000);
 const cleanupTimeoutMs = positiveInteger("NANOCODEX_SMOKE_CLEANUP_TIMEOUT_MS", 30_000);
@@ -179,9 +181,6 @@ try {
   if (process.env.OPENAI_API_KEY) {
     assert(!publicTraffic.includes(process.env.OPENAI_API_KEY), "public room traffic exposed OPENAI_API_KEY");
   }
-  if (!serverAuthorized) {
-    assert(!publicTraffic.includes(roomAllocatorToken), "public room traffic exposed the allocator token");
-  }
   assertNoSecretDigestMatches(publicTraffic, forbiddenDigests);
 
   result = {
@@ -210,6 +209,13 @@ try {
         : error;
     }
   }
+  try {
+    await credentials?.cleanup();
+  } catch (error) {
+    failure = failure
+      ? new AggregateError([failure, error], "Multiplayer smoke and credential cleanup failed")
+      : error;
+  }
 }
 
 if (failure) throw failure;
@@ -217,17 +223,19 @@ process.stdout.write(`${JSON.stringify(result)}\n`);
 }
 
 async function createRoom(displayName) {
+  const createId = randomReceiptId();
   const headers = new Headers({ "content-type": "application/json" });
   if (serverAuthorized) {
     headers.set("origin", baseUrl.origin);
     headers.set("authorization", "Bearer browser-supplied-token-must-be-stripped");
   } else {
-    headers.set("authorization", `Bearer ${roomAllocatorToken}`);
+    headers.set("cookie", credentials.accountCookie);
+    headers.set("origin", baseUrl.origin);
   }
   const response = await fetch(new URL("/v1/rooms", baseUrl), {
     method: "POST",
     headers,
-    body: JSON.stringify({ display_name: displayName }),
+    body: JSON.stringify({ create_id: createId, display_name: displayName }),
     signal: AbortSignal.timeout(30_000),
   });
   const receipt = await jsonResponse(response, "room creation");
@@ -237,19 +245,24 @@ async function createRoom(displayName) {
 }
 
 async function joinRoom(id, invite, displayName) {
+  const joinId = randomReceiptId();
   const response = await fetch(new URL(`/v1/rooms/${id}/join`, baseUrl), {
     method: "POST",
     headers: {
       "content-type": "application/json",
       ...(serverAuthorized ? { origin: baseUrl.origin } : {}),
     },
-    body: JSON.stringify({ invite, display_name: displayName }),
+    body: JSON.stringify({ invite, display_name: displayName, join_id: joinId }),
     signal: AbortSignal.timeout(30_000),
   });
   const receipt = await jsonResponse(response, `${displayName} join`);
   assert(response.status === 201, `${displayName} join returned HTTP ${response.status}`);
   assertRoomReceipt(receipt, false);
   return { receipt, cookie: responseCookie(response) };
+}
+
+function randomReceiptId() {
+  return randomBytes(32).toString("base64url");
 }
 
 async function deleteRoom(id, cookie) {

--- a/services/managed/scripts/nanocodex2-local-smoke.mjs
+++ b/services/managed/scripts/nanocodex2-local-smoke.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { runBoundedProcess } from "./child-process.mjs";
 import { credentialSafeHttpOrigin } from "./credential-origin.mjs";
 import { managedAccountFetch } from "./managed-account-auth.mjs";
+import { createLocalSmokeAccount } from "./local-smoke-account.mjs";
 
 const managedRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const baseUrl = credentialSafeHttpOrigin(
@@ -23,8 +24,7 @@ const alpha = join(root, "alpha");
 const beta = join(root, "beta");
 const home = join(root, "home");
 let apiKey;
-let apiKeyId;
-let browserCookie;
+let credentials;
 let agentId;
 let failure;
 
@@ -35,7 +35,8 @@ try {
     writeFile(join(alpha, "workspace-origin.txt"), "literal-local-workspace-alpha\n"),
     writeFile(join(beta, "workspace-origin.txt"), "literal-local-workspace-beta\n"),
   ]);
-  ({ apiKey, apiKeyId, browserCookie } = await createLocalApiKey());
+  credentials = await createLocalSmokeAccount(baseUrl, "nanocodex2 local smoke");
+  apiKey = credentials.apiKey;
   const environment = {
     ...process.env,
     NANOCODEX_MANAGED_URL: baseUrl.origin,
@@ -97,24 +98,11 @@ try {
         : error;
     });
   }
-  if (apiKeyId && browserCookie) {
-    const revoked = await fetch(new URL(`/v1/api-keys/${apiKeyId}`, baseUrl), {
-      method: "DELETE",
-      headers: { cookie: browserCookie, origin: baseUrl.origin },
-    }).catch((error) => {
-      failure = failure
-        ? new AggregateError([failure, error], "nanocodex2 smoke and credential cleanup failed")
-        : error;
-      return undefined;
-    });
-    if (revoked && revoked.status !== 204 && revoked.status !== 404) {
-      const error = new Error(`local API key cleanup failed with HTTP ${revoked.status}`);
-      failure = failure
-        ? new AggregateError([failure, error], "nanocodex2 smoke and credential cleanup failed")
-        : error;
-    }
-    await revoked?.body?.cancel();
-  }
+  await credentials?.cleanup().catch((error) => {
+    failure = failure
+      ? new AggregateError([failure, error], "nanocodex2 smoke and credential cleanup failed")
+      : error;
+  });
   await rm(root, { recursive: true, force: true });
 }
 
@@ -228,37 +216,6 @@ async function assertAbsent(path) {
     throw error;
   }
   throw new Error(`${path} unexpectedly exists`);
-}
-
-async function createLocalApiKey() {
-  const account = await fetch(new URL("/v1/me", baseUrl));
-  assert(account.ok, `local account bootstrap failed with HTTP ${account.status}`);
-  await account.body?.cancel();
-  const cookie = account.headers.getSetCookie()[0]?.split(";", 1)[0];
-  assert(cookie, "local account bootstrap returned no session cookie");
-  const claim = await fetch(new URL("/v1/credentials/local-claim", baseUrl), {
-    method: "POST",
-    headers: { cookie, origin: baseUrl.origin },
-  });
-  assert(claim.ok, `local credential claim failed with HTTP ${claim.status}`);
-  await claim.body?.cancel();
-  const response = await fetch(new URL("/v1/api-keys", baseUrl), {
-    method: "POST",
-    headers: {
-      cookie,
-      "content-type": "application/json",
-      origin: baseUrl.origin,
-    },
-    body: JSON.stringify({ label: "nanocodex2 local smoke" }),
-  });
-  assert(response.status === 201, `local API key creation failed with HTTP ${response.status}`);
-  const value = await response.json();
-  assert(
-    typeof value.api_key === "string" && /^ncx_live_[A-Za-z0-9_-]{12}_[A-Za-z0-9_-]{43}$/.test(value.api_key),
-    "local API key creation returned an invalid key",
-  );
-  assert(typeof value.key?.id === "string", "local API key creation returned no key id");
-  return { apiKey: value.api_key, apiKeyId: value.key.id, browserCookie: cookie };
 }
 
 async function run(command, arguments_, cwd, env, label) {

--- a/services/managed/scripts/production-rollout.mjs
+++ b/services/managed/scripts/production-rollout.mjs
@@ -373,11 +373,15 @@ export async function preflightProductionRollout(environment = process.env) {
   return result;
 }
 
-export async function deployProductionManaged(environment = process.env) {
+export async function deployProductionManaged(environment = process.env, {
+  run = runWrangler,
+  verifyArtifact = verifyManagedWasmArtifact,
+  verifyCheckout = verifyProductionCheckout,
+} = {}) {
   const cloudflare = cloudflareCredentials(environment);
   const revision = productionRevision(environment.TARGET_SHA);
-  verifyProductionCheckout(revision);
-  await verifyManagedWasmArtifact(revision);
+  verifyCheckout(revision);
+  await verifyArtifact(revision);
   const adminToken = requiredSecret(environment, "NANOCODEX_ADMIN_TOKEN");
   const baseConfig = await readJson(managedConfigPath);
   const config = buildManagedProductionConfig(baseConfig);
@@ -388,7 +392,7 @@ export async function deployProductionManaged(environment = process.env) {
     "managed-config.json": config,
     "managed-secrets.json": secrets,
   }, async (paths) => {
-    await runWrangler([
+    await run([
       "deploy",
       "--config",
       paths["managed-config.json"],
@@ -409,7 +413,7 @@ export async function deployProductionManaged(environment = process.env) {
 
   const result = {
     component: "private-managed",
-    migrations: MANAGED_DURABLE_OBJECT_MIGRATIONS.map(([tag]) => tag),
+    migrations: MANAGED_DURABLE_OBJECT_MIGRATIONS.map(({ tag }) => tag),
     revision,
     status: "deployed",
   };

--- a/services/managed/scripts/production-rollout.mjs
+++ b/services/managed/scripts/production-rollout.mjs
@@ -38,19 +38,32 @@ const BROKER_NAME = "nanocodex-egress";
 const MANAGED_TEMPLATE_NAME = "nanocodex-managed-development";
 const MANAGED_NAME = "nanocodex-durable-agent";
 const WEB_NAME = "nanocodex";
+const MANAGED_DURABLE_OBJECT_BINDINGS = [
+  ["NANOCODEX_SESSIONS", "DurableAgentSession"],
+  ["NANOCODEX_ROOMS", "MultiplayerRoom"],
+  ["NANOCODEX_MULTIPLAYER_QUOTA", "MultiplayerQuota"],
+  ["NANOCODEX_AUTH", "NonceStorage"],
+  ["NANOCODEX_USERS", "UserAccount"],
+  ["NANOCODEX_API_KEYS", "ApiKeyRecord"],
+  ["NANOCODEX_MEMORY", "MemoryScope"],
+  ["NANOCODEX_ORGANIZATIONS", "Organization"],
+];
 const MANAGED_DURABLE_OBJECT_MIGRATIONS = [
-  ["v1", [
-    ["NANOCODEX_SESSIONS", "NanocodexSession"],
-    ["NANOCODEX_ROOMS", "MultiplayerRoom"],
-    ["NANOCODEX_MULTIPLAYER_QUOTA", "MultiplayerQuota"],
-  ]],
-  ["v2", [
-    ["NANOCODEX_AUTH", "NonceStorage"],
-    ["NANOCODEX_USERS", "UserAccount"],
-    ["NANOCODEX_API_KEYS", "ApiKeyRecord"],
-  ]],
-  ["v3", [["NANOCODEX_MEMORY", "MemoryScope"]]],
-  ["v4", [["NANOCODEX_ORGANIZATIONS", "Organization"]]],
+  {
+    tag: "v1",
+    new_sqlite_classes: ["NanocodexSession", "MultiplayerRoom", "MultiplayerQuota"],
+  },
+  {
+    tag: "v2",
+    new_sqlite_classes: ["NonceStorage", "UserAccount", "ApiKeyRecord"],
+  },
+  { tag: "v3", new_sqlite_classes: ["MemoryScope"] },
+  { tag: "v4", new_sqlite_classes: ["Organization"] },
+  {
+    tag: "v5",
+    new_sqlite_classes: ["DurableAgentSession"],
+    deleted_classes: ["NanocodexSession"],
+  },
 ];
 const PROVIDER_NAMES = [
   "NANOCODEX_MANAGED_AUTH_MODE",
@@ -154,7 +167,7 @@ export function buildManagedProductionConfig(baseConfig, {
       binding?.class_name,
     ]),
   );
-  const expectedBindings = MANAGED_DURABLE_OBJECT_MIGRATIONS.flatMap(([, bindings]) => bindings);
+  const expectedBindings = MANAGED_DURABLE_OBJECT_BINDINGS;
   if ((baseConfig.durable_objects?.bindings ?? []).length !== expectedBindings.length
     || durableObjects.size !== expectedBindings.length) {
     throw new Error("production managed Worker has an unexpected Durable Object binding");
@@ -165,15 +178,14 @@ export function buildManagedProductionConfig(baseConfig, {
     }
   }
   const migrationTags = baseConfig.migrations?.map((migration) => migration?.tag);
-  const expectedTags = MANAGED_DURABLE_OBJECT_MIGRATIONS.map(([tag]) => tag);
+  const expectedTags = MANAGED_DURABLE_OBJECT_MIGRATIONS.map(({ tag }) => tag);
   if (JSON.stringify(migrationTags) !== JSON.stringify(expectedTags)) {
     throw new Error("production managed Worker requires the complete ordered migration history");
   }
-  for (const [index, [tag, bindings]] of MANAGED_DURABLE_OBJECT_MIGRATIONS.entries()) {
-    const actual = baseConfig.migrations[index]?.new_sqlite_classes;
-    const expected = bindings.map(([, className]) => className);
+  for (const [index, expected] of MANAGED_DURABLE_OBJECT_MIGRATIONS.entries()) {
+    const actual = baseConfig.migrations[index];
     if (JSON.stringify(actual) !== JSON.stringify(expected)) {
-      throw new Error(`production managed Worker requires the exact ${tag} SQLite migration`);
+      throw new Error(`production managed Worker requires the exact ${expected.tag} SQLite migration`);
     }
   }
   assertNoProviderConfiguration(baseConfig, "managed config");

--- a/services/managed/scripts/repl.mjs
+++ b/services/managed/scripts/repl.mjs
@@ -8,9 +8,10 @@ import WebSocket from "ws";
 import { credentialSafeHttpOrigin, credentialSafeUrl } from "./credential-origin.mjs";
 import {
   managedAccountFetch,
-  managedAccountWebSocketOptions,
+  managedAccountSessionWebSocketOptions,
   parseManagedAgentReceipt,
   parseManagedReplState,
+  requireManagedAccountCookie,
   requireManagedApiKey,
 } from "./managed-account-auth.mjs";
 
@@ -19,6 +20,7 @@ const baseUrl = credentialSafeHttpOrigin(
   "NANOCODEX_WORKER_URL",
 ).origin;
 const apiKey = requireManagedApiKey();
+const accountCookie = requireManagedAccountCookie();
 const statePath = resolve(process.env.NANOCODEX_REPL_STATE ?? ".nanocodex/cloudflare-repl.json");
 let state = await loadState();
 let client;
@@ -55,7 +57,7 @@ const detach = () => {
 process.once("SIGINT", detach);
 
 try {
-  client = connect(state.websocket_url, apiKey);
+  client = connect(state.websocket_url, accountCookie);
   const ready = await client.ready;
   process.stdout.write(
     `Nanocodex Cloudflare REPL (${state.agent_id}${ready.restored ? ", restored" : ""})\n`,
@@ -104,18 +106,15 @@ async function completePending(pending, resumed) {
   if (terminal.type === "turn_failed") {
     throw new Error(`turn ${terminal.id} failed: ${terminal.error}`);
   }
-  if (terminal.type === "turn_blocked") {
-    throw new Error(`turn ${terminal.id} was blocked: ${terminal.error}`);
-  }
   if (terminal.type === "turn_cancelled") {
     throw new Error(`turn ${terminal.id} was cancelled`);
   }
   process.stdout.write(`${terminal.final_message}\n`);
 }
 
-function connect(url, accountApiKey) {
+function connect(url, cookie) {
   credentialSafeUrl(url, "managed agent WebSocket URL");
-  const socket = new WebSocket(url, managedAccountWebSocketOptions(accountApiKey));
+  const socket = new WebSocket(url, managedAccountSessionWebSocketOptions(cookie, baseUrl));
   let readySettled = false;
   let resolveReady;
   let rejectReady;
@@ -132,7 +131,7 @@ function connect(url, accountApiKey) {
       resolveReady(message);
       return;
     }
-    if (!["turn_completed", "turn_failed", "turn_blocked", "turn_cancelled"].includes(message.type)) {
+    if (!["turn_completed", "turn_failed", "turn_cancelled"].includes(message.type)) {
       return;
     }
     const waiter = waiters.get(message.id);

--- a/services/managed/scripts/soak.mjs
+++ b/services/managed/scripts/soak.mjs
@@ -3,13 +3,14 @@ import WebSocket from "ws";
 
 import {
   managedAccountFetch,
-  managedAccountWebSocketOptions,
+  managedAccountSessionWebSocketOptions,
   parseManagedAgentReceipt,
-  requireManagedApiKey,
 } from "./managed-account-auth.mjs";
+import { resolveManagedSmokeCredentials } from "./local-smoke-account.mjs";
 
 const baseUrl = process.env.NANOCODEX_WORKER_URL ?? "http://127.0.0.1:8787";
-const apiKey = requireManagedApiKey();
+const credentials = await resolveManagedSmokeCredentials(baseUrl, "managed soak");
+const { accountCookie, apiKey } = credentials;
 const sessionCount = Number(process.env.NANOCODEX_SOAK_SESSIONS ?? 16);
 const timeoutMs = Number(process.env.NANOCODEX_SOAK_TIMEOUT_MS ?? 60_000);
 
@@ -27,7 +28,7 @@ try {
   const clients = await Promise.all(sessions.map(async (agent, index) => {
     const socket = new WebSocket(
       agent.websocket_url,
-      managedAccountWebSocketOptions(apiKey),
+      managedAccountSessionWebSocketOptions(accountCookie, baseUrl),
     );
     sockets.push(socket);
     const inbox = createInbox(socket);
@@ -81,6 +82,7 @@ try {
     `${baseUrl}/v1/agents/${agent.agent_id}`,
     { method: "DELETE" },
   ).catch(() => {})));
+  await credentials.cleanup();
 }
 
 async function createAgent() {

--- a/services/managed/scripts/stress.mjs
+++ b/services/managed/scripts/stress.mjs
@@ -2,13 +2,14 @@ import WebSocket from "ws";
 
 import {
   managedAccountFetch,
-  managedAccountWebSocketOptions,
+  managedAccountSessionWebSocketOptions,
   parseManagedAgentReceipt,
-  requireManagedApiKey,
 } from "./managed-account-auth.mjs";
+import { resolveManagedSmokeCredentials } from "./local-smoke-account.mjs";
 
 const baseUrl = process.env.NANOCODEX_WORKER_URL ?? "http://127.0.0.1:8787";
-const apiKey = requireManagedApiKey();
+const credentials = await resolveManagedSmokeCredentials(baseUrl, "managed WebSocket stress");
+const { accountCookie, apiKey } = credentials;
 const clients = Number(process.env.NANOCODEX_STRESS_CLIENTS ?? 32);
 const pingsPerClient = Number(process.env.NANOCODEX_STRESS_PINGS ?? 128);
 const expected = clients * pingsPerClient;
@@ -29,7 +30,7 @@ try {
   await Promise.all(Array.from({ length: clients }, async () => {
     const socket = new WebSocket(
       agent.websocket_url,
-      managedAccountWebSocketOptions(apiKey),
+      managedAccountSessionWebSocketOptions(accountCookie, baseUrl),
     );
     await onceMessage(socket, (message) => message.type === "ready", 10_000);
     sockets.push(socket);
@@ -67,6 +68,7 @@ try {
   await managedAccountFetch(apiKey, `${baseUrl}/v1/agents/${agent.agent_id}`, {
     method: "DELETE",
   }).catch(() => {});
+  await credentials.cleanup();
 }
 
 function onceMessage(socket, predicate, timeoutMs) {

--- a/services/managed/src/account-auth.ts
+++ b/services/managed/src/account-auth.ts
@@ -50,6 +50,7 @@ export type OrganizationRole = "owner" | "writer" | "reader";
 
 export type OrganizationCapability =
   | "agents:read"
+  | "agents:portability"
   | "agents:write"
   | "api_keys:read"
   | "api_keys:write"
@@ -70,6 +71,7 @@ export type ConnectGrantSlice = Readonly<{
 
 const OWNER_CAPABILITIES = [
   "agents:read",
+  "agents:portability",
   "agents:write",
   "api_keys:read",
   "api_keys:write",
@@ -1663,6 +1665,7 @@ export function isOrganizationCapabilities(value: unknown): value is readonly Or
   if (!Array.isArray(value) || new Set(value).size !== value.length) return false;
   return value.every((capability) =>
     capability === "agents:read"
+    || capability === "agents:portability"
     || capability === "agents:write"
     || capability === "api_keys:read"
     || capability === "api_keys:write"
@@ -1677,6 +1680,7 @@ export function isOrganizationCapabilities(value: unknown): value is readonly Or
 
 const CONNECT_CAPABILITIES = new Set<OrganizationCapability>([
   "agents:read",
+  "agents:portability",
   "agents:write",
   "history:read",
   "memory:read",

--- a/services/managed/src/account-auth.ts
+++ b/services/managed/src/account-auth.ts
@@ -14,7 +14,7 @@ const USER_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const API_KEY = /^ncx_live_([A-Za-z0-9_-]{12})_([A-Za-z0-9_-]{43})$/;
 const ANONYMOUS_SESSION_TOKEN = /^a_[A-Za-z0-9_-]{43}$/;
-const PASSKEY_SESSION_TOKEN = /^[A-Za-z0-9_-]{43}$/;
+const PASSKEY_SESSION_TOKEN = /^[0-9a-f]{64}$/;
 const PORTABLE_CREDENTIAL_ID = /^[A-Za-z0-9_-]{1,512}$/;
 const PORTABLE_PUBLIC_KEY = /^0x(?:[0-9a-fA-F]{2}){1,1024}$/;
 const BASE64_URL = /^[A-Za-z0-9_-]+$/;
@@ -410,7 +410,7 @@ export async function authenticate(
         `account_session:${await sha256(cookie)}`,
       );
     }
-  } else {
+  } else if (cookie && PASSKEY_SESSION_TOKEN.test(cookie)) {
     const passkey = await webAuthnHandler(env, url).getSession(request);
     const passkeyUserId = passkey?.userId ? decodeUserId(passkey.userId) : undefined;
     if (isUserId(passkeyUserId)) {
@@ -1078,7 +1078,8 @@ function decodeUserId(value: string): string | undefined {
 
 function cookieValue(request: Request, name: string): string | undefined {
   const cookie = rawCookie(request, name);
-  return cookie.present && /^(?:a_)?[A-Za-z0-9_-]{43}$/.test(cookie.value)
+  return cookie.present
+    && (ANONYMOUS_SESSION_TOKEN.test(cookie.value) || PASSKEY_SESSION_TOKEN.test(cookie.value))
     ? cookie.value
     : undefined;
 }
@@ -1240,12 +1241,10 @@ export async function revokeApiKey(
 }
 
 export class UserAccount extends DurableObject<AccountAuthEnv> {
-  readonly #registryReady: Promise<void>;
-
   constructor(ctx: DurableObjectState, env: AccountAuthEnv) {
     super(ctx, env);
     ctx.storage.sql.exec(`
-      CREATE TABLE IF NOT EXISTS user_agents (
+      CREATE TABLE IF NOT EXISTS agent_registry (
         id TEXT PRIMARY KEY,
         title TEXT NOT NULL DEFAULT '',
         created_at INTEGER NOT NULL,
@@ -1253,14 +1252,12 @@ export class UserAccount extends DurableObject<AccountAuthEnv> {
         turn_count INTEGER NOT NULL DEFAULT 0 CHECK (turn_count >= 0),
         deleted_at INTEGER
       );
-      CREATE INDEX IF NOT EXISTS user_agents_active_created
-        ON user_agents (created_at, id) WHERE deleted_at IS NULL;
+      CREATE INDEX IF NOT EXISTS agent_registry_active_created
+        ON agent_registry (created_at, id) WHERE deleted_at IS NULL;
     `);
-    this.#registryReady = ctx.blockConcurrencyWhile(() => this.#adoptLegacyAgentRegistry());
   }
 
   async fetch(request: Request): Promise<Response> {
-    await this.#registryReady;
     const url = new URL(request.url);
     if (url.pathname === "/account") {
       if (request.method === "PUT") {
@@ -1342,7 +1339,7 @@ export class UserAccount extends DurableObject<AccountAuthEnv> {
       if (request.method === "GET") {
         return json(this.ctx.storage.sql.exec<AgentRegistryRow>(
           `SELECT id, title, created_at, updated_at, turn_count, deleted_at
-           FROM user_agents
+           FROM agent_registry
            WHERE deleted_at IS NULL
            ORDER BY created_at, id`,
         ).toArray().map(agentSummary));
@@ -1354,7 +1351,7 @@ export class UserAccount extends DurableObject<AccountAuthEnv> {
           return json({ error: "invalid_agent" }, { status: 400 });
         }
         const existing = this.ctx.storage.sql.exec<{ deleted_at: number | null }>(
-          "SELECT deleted_at FROM user_agents WHERE id = ?",
+          "SELECT deleted_at FROM agent_registry WHERE id = ?",
           agentId,
         ).toArray()[0];
         if (existing?.deleted_at !== null && existing !== undefined) {
@@ -1363,7 +1360,7 @@ export class UserAccount extends DurableObject<AccountAuthEnv> {
         if (!existing) {
           const now = Date.now();
           this.ctx.storage.sql.exec(
-            `INSERT INTO user_agents
+            `INSERT INTO agent_registry
                (id, title, created_at, updated_at, turn_count, deleted_at)
              VALUES (?, '', ?, ?, 0, NULL)`,
             agentId,
@@ -1383,7 +1380,7 @@ export class UserAccount extends DurableObject<AccountAuthEnv> {
         ? Number(body.turnCount) : undefined;
       if (turnCount === undefined) return json({ error: "invalid_activity" }, { status: 400 });
       const updated = this.ctx.storage.sql.exec(
-        `UPDATE user_agents
+        `UPDATE agent_registry
          SET title = CASE WHEN title = '' THEN ? ELSE title END,
              updated_at = ?,
              turn_count = MAX(turn_count, ?)
@@ -1401,10 +1398,10 @@ export class UserAccount extends DurableObject<AccountAuthEnv> {
       const agentId = agentMatch[1]!;
       const now = Date.now();
       this.ctx.storage.sql.exec(
-        `INSERT INTO user_agents
+        `INSERT INTO agent_registry
            (id, title, created_at, updated_at, turn_count, deleted_at)
          VALUES (?, '', ?, ?, 0, ?)
-         ON CONFLICT(id) DO UPDATE SET deleted_at = COALESCE(user_agents.deleted_at, excluded.deleted_at)`,
+         ON CONFLICT(id) DO UPDATE SET deleted_at = COALESCE(agent_registry.deleted_at, excluded.deleted_at)`,
         agentId,
         now,
         now,
@@ -1415,56 +1412,6 @@ export class UserAccount extends DurableObject<AccountAuthEnv> {
     return json({ error: "not_found" }, { status: 404 });
   }
 
-  async #adoptLegacyAgentRegistry(): Promise<void> {
-    const [agents, summaries] = await Promise.all([
-      this.ctx.storage.get<string[]>("agents"),
-      this.ctx.storage.get<Record<string, AgentSummary>>("agentSummaries"),
-    ]);
-    for (const id of agents ?? []) {
-      const summary = summaries?.[id];
-      const now = Date.now();
-      this.ctx.storage.sql.exec(
-        `INSERT OR IGNORE INTO user_agents
-           (id, title, created_at, updated_at, turn_count, deleted_at)
-         VALUES (?, ?, ?, ?, ?, NULL)`,
-        id,
-        summary?.title ?? "",
-        summary?.createdAt ?? now,
-        summary?.updatedAt ?? now,
-        summary?.turnCount ?? 0,
-      );
-    }
-    await this.ctx.storage.delete(["agents", "agentSummaries"]);
-
-    let startAfter: string | undefined;
-    while (true) {
-      const tombstones = await this.ctx.storage.list({
-        prefix: "agent-tombstone:",
-        limit: 1_000,
-        ...(startAfter === undefined ? {} : { startAfter }),
-      });
-      if (tombstones.size === 0) break;
-      const now = Date.now();
-      for (const key of tombstones.keys()) {
-        const id = key.slice("agent-tombstone:".length);
-        if (/^[0-9a-f-]{36}$/.test(id)) {
-          this.ctx.storage.sql.exec(
-            `INSERT INTO user_agents
-               (id, title, created_at, updated_at, turn_count, deleted_at)
-             VALUES (?, '', ?, ?, 0, ?)
-             ON CONFLICT(id) DO UPDATE SET deleted_at = COALESCE(user_agents.deleted_at, excluded.deleted_at)`,
-            id,
-            now,
-            now,
-            now,
-          );
-        }
-        startAfter = key;
-      }
-      await this.ctx.storage.delete([...tombstones.keys()]);
-      if (tombstones.size < 1_000) break;
-    }
-  }
 }
 
 function agentSummary(row: AgentRegistryRow): AgentSummary {

--- a/services/managed/src/capacity.ts
+++ b/services/managed/src/capacity.ts
@@ -12,8 +12,7 @@ export type ManagedCapacitySnapshot = Readonly<{
   archived_realtime: ManagedRealtimeArchiveCapacity;
   archived_turns: ManagedTurnArchiveCapacity;
   database_size_bytes: number;
-  journal: CountAndBytes & Readonly<{
-    max_batch_bytes: number;
+  durable_state: CountAndBytes & Readonly<{
     revision: string;
   }>;
   known_payload_bytes: number;
@@ -21,8 +20,8 @@ export type ManagedCapacitySnapshot = Readonly<{
   raw_events: CountAndBytes;
   realtime_operations: CountAndBytes;
   turns: Readonly<{
-    blocked_rows: number;
     input_bytes: number;
+    retry_rows: number;
     terminal_bytes: number;
     terminal_rows: number;
     total_rows: number;
@@ -36,14 +35,13 @@ type AggregateRow = {
   rows: number;
 };
 
-type JournalRow = AggregateRow & {
-  max_batch_bytes: number;
+type DurableStateRow = AggregateRow & {
   revision: string;
 };
 
 type TurnRow = {
-  blocked_rows: number;
   input_bytes: number;
+  retry_rows: number;
   terminal_bytes: number;
   terminal_rows: number;
   total_rows: number;
@@ -66,7 +64,7 @@ export function managedCapacitySnapshot(
   archivedTurns: ManagedTurnArchiveCapacity,
   archivedRealtime: ManagedRealtimeArchiveCapacity,
 ): ManagedCapacitySnapshot {
-  const journal = journalCapacity(storage, cloudflareJournalId(storage, sessionId));
+  const durableState = durableStateCapacity(storage, cloudflareStateId(storage, sessionId));
   const managedEvents = managedEventCapacity(storage);
   const rawEvents = eventCapacity(
     storage,
@@ -79,7 +77,7 @@ export function managedCapacitySnapshot(
     "response_json",
   );
   const turns = turnCapacity(storage);
-  const knownPayloadBytes = journal.bytes
+  const knownPayloadBytes = durableState.bytes
     + managedEvents.bytes
     + rawEvents.bytes
     + realtimeOperations.bytes
@@ -92,7 +90,7 @@ export function managedCapacitySnapshot(
     archived_realtime: archivedRealtime,
     archived_turns: archivedTurns,
     database_size_bytes: databaseSizeBytes,
-    journal,
+    durable_state: durableState,
     known_payload_bytes: knownPayloadBytes,
     managed_events: managedEvents,
     raw_events: rawEvents,
@@ -102,7 +100,7 @@ export function managedCapacitySnapshot(
   };
 }
 
-function cloudflareJournalId(storage: DurableObjectStorage, fallbackSessionId: string): string {
+function cloudflareStateId(storage: DurableObjectStorage, fallbackSessionId: string): string {
   if (!tableExists(storage, "nanocodex_cloudflare_agent")) {
     return `cloudflare:${fallbackSessionId}`;
   }
@@ -112,45 +110,35 @@ function cloudflareJournalId(storage: DurableObjectStorage, fallbackSessionId: s
   return `cloudflare:${runtimeSessionId ?? fallbackSessionId}`;
 }
 
-function journalCapacity(
+function durableStateCapacity(
   storage: DurableObjectStorage,
-  journalId: string,
-): ManagedCapacitySnapshot["journal"] {
-  if (!tableExists(storage, "nanocodex_journal_batches")) {
-    return { ...EMPTY_AGGREGATE, max_batch_bytes: 0, revision: "0" };
+  stateId: string,
+): ManagedCapacitySnapshot["durable_state"] {
+  if (!tableExists(storage, "nanocodex_durable_states")) {
+    return { ...EMPTY_AGGREGATE, revision: "0" };
   }
-  if (tableExists(storage, "nanocodex_journal_batch_chunks")) {
-    return storage.sql.exec<JournalRow>(
-      `WITH batch_bytes AS (
-         SELECT b.revision,
-                LENGTH(CAST(b.payload AS BLOB))
-                  + COALESCE(SUM(LENGTH(CAST(c.payload AS BLOB))), 0) AS bytes
-         FROM nanocodex_journal_batches b
-         LEFT JOIN nanocodex_journal_batch_chunks c
-           ON c.journal_id = b.journal_id AND c.revision = b.revision
-         WHERE b.journal_id = ?
-         GROUP BY b.revision, b.payload
-       )
-       SELECT COUNT(*) AS rows,
-              COALESCE(SUM(bytes), 0) AS bytes,
-              COALESCE(MAX(bytes), 0) AS max_batch_bytes,
-              COALESCE((SELECT revision FROM nanocodex_journals WHERE journal_id = ?), '0')
-                AS revision
-       FROM batch_bytes`,
-      journalId,
-      journalId,
-    ).toArray()[0] ?? { ...EMPTY_AGGREGATE, max_batch_bytes: 0, revision: "0" };
+  if (tableExists(storage, "nanocodex_durable_state_chunks")) {
+    return storage.sql.exec<DurableStateRow>(
+      `SELECT COUNT(*) AS rows,
+              COALESCE(SUM(LENGTH(CAST(s.payload AS BLOB))), 0)
+                + COALESCE((SELECT SUM(LENGTH(CAST(c.payload AS BLOB)))
+                            FROM nanocodex_durable_state_chunks c
+                            WHERE c.state_id = ?), 0) AS bytes,
+              COALESCE(MAX(s.revision), '0') AS revision
+       FROM nanocodex_durable_states s
+       WHERE s.state_id = ?`,
+      stateId,
+      stateId,
+    ).toArray()[0] ?? { ...EMPTY_AGGREGATE, revision: "0" };
   }
-  return storage.sql.exec<JournalRow>(
+  return storage.sql.exec<DurableStateRow>(
     `SELECT COUNT(*) AS rows,
             COALESCE(SUM(LENGTH(CAST(payload AS BLOB))), 0) AS bytes,
-            COALESCE(MAX(LENGTH(CAST(payload AS BLOB))), 0) AS max_batch_bytes,
-            COALESCE((SELECT revision FROM nanocodex_journals WHERE journal_id = ?), '0') AS revision
-     FROM nanocodex_journal_batches
-     WHERE journal_id = ?`,
-    journalId,
-    journalId,
-  ).toArray()[0] ?? { ...EMPTY_AGGREGATE, max_batch_bytes: 0, revision: "0" };
+            COALESCE(MAX(revision), '0') AS revision
+     FROM nanocodex_durable_states
+     WHERE state_id = ?`,
+    stateId,
+  ).toArray()[0] ?? { ...EMPTY_AGGREGATE, revision: "0" };
 }
 
 function eventCapacity(
@@ -183,8 +171,8 @@ function managedEventCapacity(storage: DurableObjectStorage): CountAndBytes {
 function turnCapacity(storage: DurableObjectStorage): ManagedCapacitySnapshot["turns"] {
   if (!tableExists(storage, "managed_turns")) {
     return {
-      blocked_rows: 0,
       input_bytes: 0,
+      retry_rows: 0,
       terminal_bytes: 0,
       terminal_rows: 0,
       total_rows: 0,
@@ -199,13 +187,14 @@ function turnCapacity(storage: DurableObjectStorage): ManagedCapacitySnapshot["t
             COALESCE(SUM(LENGTH(CAST(terminal_json AS BLOB))), 0) AS terminal_bytes,
             SUM(CASE WHEN state IN ('completed', 'cancelled', 'failed') THEN 1 ELSE 0 END)
               AS terminal_rows,
-            SUM(CASE WHEN state = 'blocked' THEN 1 ELSE 0 END) AS blocked_rows,
-            SUM(CASE WHEN state NOT IN ('completed', 'cancelled', 'failed', 'blocked') THEN 1 ELSE 0 END)
+            SUM(CASE WHEN state IN ('accepted', 'cancelling') AND retry_at IS NOT NULL THEN 1 ELSE 0 END)
+              AS retry_rows,
+            SUM(CASE WHEN state NOT IN ('completed', 'cancelled', 'failed') THEN 1 ELSE 0 END)
               AS unfinished_rows
      FROM managed_turns`,
   ).toArray()[0] ?? {
-    blocked_rows: 0,
     input_bytes: 0,
+    retry_rows: 0,
     terminal_bytes: 0,
     terminal_rows: 0,
     total_rows: 0,

--- a/services/managed/src/capacity.ts
+++ b/services/managed/src/capacity.ts
@@ -101,6 +101,12 @@ export function managedCapacitySnapshot(
 }
 
 function cloudflareStateId(storage: DurableObjectStorage, fallbackSessionId: string): string {
+  if (tableExists(storage, "nanocodex_cloudflare_durability")) {
+    const stateId = storage.sql.exec<{ state_id: string }>(
+      "SELECT state_id FROM nanocodex_cloudflare_durability WHERE singleton = 1",
+    ).toArray()[0]?.state_id;
+    if (stateId) return stateId;
+  }
   if (!tableExists(storage, "nanocodex_cloudflare_agent")) {
     return `cloudflare:${fallbackSessionId}`;
   }

--- a/services/managed/src/durable-events.ts
+++ b/services/managed/src/durable-events.ts
@@ -36,6 +36,11 @@ export type DurableEventHistory<Message> = Readonly<{
   latest_cursor: string;
 }>;
 
+export type DurableEventTail<Message> = Readonly<{
+  events: readonly DurableEvent<Message>[];
+  high_water_cursor: string;
+}>;
+
 export class EventLogCapacityError extends Error {
   readonly code = "event_log_full";
 
@@ -162,6 +167,82 @@ export class DurableEventLog<Message extends { type: string }> {
     return this.#storage.sql.exec<{ cursor: string }>(
       "SELECT CAST(COALESCE(MAX(cursor), 0) AS TEXT) AS cursor FROM managed_events",
     ).toArray()[0]?.cursor ?? "0";
+  }
+
+  portableTail(after: string): DurableEventTail<Message> {
+    const events = this.page(after, REPLAY_PAGE_SIZE);
+    const sequence = this.#storage.sql.exec<{ cursor: string }>(
+      `SELECT CAST(COALESCE((
+         SELECT seq FROM sqlite_sequence WHERE name = 'managed_events'
+       ), (SELECT MAX(cursor) FROM managed_events), 0) AS TEXT) AS cursor`,
+    ).toArray()[0]?.cursor ?? "0";
+    return { events, high_water_cursor: sequence };
+  }
+
+  adoptTail(tail: DurableEventTail<Message>, withinTransaction = true): void {
+    const highWater = parseCursor(tail.high_water_cursor);
+    if (highWater === undefined || !Array.isArray(tail.events)) {
+      throw new Error("managed event portable tail is invalid");
+    }
+    let previous = "0";
+    let totalBytes = 0;
+    const encoded = tail.events.map((event) => {
+      if (!event || typeof event !== "object"
+        || typeof event.cursor !== "string" || parseCursor(event.cursor) !== event.cursor
+        || event.cursor === "0" || compareCursor(previous, event.cursor) >= 0
+        || compareCursor(event.cursor, highWater) > 0
+        || !Number.isSafeInteger(event.created_at) || event.created_at < 0
+        || (event.turn_id !== null && typeof event.turn_id !== "string")
+        || !event.message || typeof event.message !== "object"
+        || typeof event.message.type !== "string") {
+        throw new Error("managed event portable tail contains an invalid event");
+      }
+      previous = event.cursor;
+      const messageJson = JSON.stringify(event.message);
+      const bytes = sseEncoder.encode(messageJson).byteLength;
+      if (bytes > MAX_EVENT_BYTES) throw new Error("managed event portable tail exceeds event size");
+      totalBytes += bytes;
+      if (totalBytes > MAX_EVENT_LOG_BYTES) {
+        throw new Error("managed event portable tail exceeds the local event boundary");
+      }
+      return { event, messageJson, bytes };
+    });
+    const adopt = () => {
+      this.clear();
+      for (const { event, messageJson, bytes } of encoded) {
+        const chunked = bytes > DIRECT_EVENT_BYTES;
+        this.#storage.sql.exec(
+          `INSERT INTO managed_events (cursor, turn_id, message_json, created_at)
+           VALUES (CAST(? AS INTEGER), ?, ?, ?)`,
+          event.cursor,
+          event.turn_id,
+          chunked ? "" : messageJson,
+          event.created_at,
+        );
+        if (chunked) {
+          for (const [chunkIndex, chunk] of messageChunks(messageJson).entries()) {
+            this.#storage.sql.exec(
+              `INSERT INTO managed_event_chunks (cursor, chunk_index, message_json)
+               VALUES (CAST(? AS INTEGER), ?, ?)`,
+              event.cursor,
+              chunkIndex,
+              chunk,
+            );
+          }
+        }
+      }
+      this.#storage.sql.exec(
+        "UPDATE managed_event_meta SET total_bytes = ? WHERE singleton = 1",
+        totalBytes,
+      );
+      this.#storage.sql.exec("DELETE FROM sqlite_sequence WHERE name = 'managed_events'");
+      this.#storage.sql.exec(
+        "INSERT INTO sqlite_sequence (name, seq) VALUES ('managed_events', CAST(? AS INTEGER))",
+        highWater,
+      );
+    };
+    if (withinTransaction) this.#storage.transactionSync(adopt);
+    else adopt();
   }
 
   totalBytes(): number {

--- a/services/managed/src/hosted-tools-broker.ts
+++ b/services/managed/src/hosted-tools-broker.ts
@@ -142,7 +142,7 @@ export interface HostedToolsDynamicProvider {
   setCatalogValidator(validator: HostedToolsCatalogValidator | undefined): void;
 }
 
-/** Injectable durable journal boundary; the production default is Durable Object SQLite. */
+/** Injectable durable call ledger boundary; the production default is Durable Object SQLite. */
 export interface HostedToolsBrokerPersistence {
   initialize(now: number): HostedToolsStateRow | undefined;
   transaction<T>(callback: () => T): T;
@@ -682,9 +682,9 @@ export class HostedToolsBroker {
       const socket = state.lease_id === leaseId && state.generation === binding.generation
         ? this.#socketForState(state)
         : undefined;
-      if (socket) this.#fence(socket, "Hosted Tools generation exhausted its durable call journal");
+      if (socket) this.#fence(socket, "Hosted Tools generation exhausted its durable call ledger");
       else if (state.lease_id === leaseId && state.generation === binding.generation) {
-        this.#retireState(state, "Hosted Tools generation exhausted its durable call journal");
+        this.#retireState(state, "Hosted Tools generation exhausted its durable call ledger");
       }
       return Promise.resolve(unavailable("Hosted Tools generation reached its durable call limit"));
     }

--- a/services/managed/src/hosted-tools-broker.ts
+++ b/services/managed/src/hosted-tools-broker.ts
@@ -298,6 +298,8 @@ export class HostedToolsBroker {
 
   isReady(): boolean { return this.#definitions().length > 0; }
 
+  hasPendingCalls(): boolean { return this.#pending.size > 0; }
+
   provider(): HostedToolsDynamicProvider { return this.#provider; }
 
   upgrade(sessionId: string, allowedMcpIds?: readonly string[]): Response {

--- a/services/managed/src/index.ts
+++ b/services/managed/src/index.ts
@@ -1148,6 +1148,14 @@ export class DurableAgentSession extends DurableComputerSession {
         citations_json TEXT NOT NULL
       );
     `);
+    // A pending realtime mutation belonged to the previous in-memory owner.
+    // Its external outcome is unknown, so cold construction must not replay it.
+    this.ctx.storage.sql.exec(
+      `UPDATE managed_realtime_operations
+       SET blocked = 1, updated_at = ?
+       WHERE state = 'pending' AND blocked = 0`,
+      Date.now(),
+    );
     this.#hostedTools = new HostedToolsBroker(this.ctx, {
       providerAllowed: (provider) => this.#activeTurnHostedProviderAllowed(provider),
     });

--- a/services/managed/src/index.ts
+++ b/services/managed/src/index.ts
@@ -90,7 +90,8 @@ import {
 } from "./device-host-protocol";
 import {
   classifyTurnFailure,
-  materializeTurnTerminal,
+  materializeTurnResolution,
+  type TurnResolution,
   type TurnTerminal,
 } from "./turn-completion";
 import {
@@ -152,6 +153,7 @@ export { ApiKeyRecord, NonceStorage, Organization, UserAccount } from "./account
 
 const MAX_CLIENT_MESSAGE_BYTES = 1024 * 1024;
 const MAX_ACTIVE_TURNS = 16;
+const MAX_PRE_ADMISSION_CANCELLATIONS = 64;
 const MAX_CLIENT_CONNECTIONS = 64;
 const MAX_REQUEST_BODY_BYTES = 1024 * 1024;
 const MAX_REALTIME_REQUEST_BYTES = 64 * 1024;
@@ -181,7 +183,7 @@ const DEFAULT_MULTIPLAYER_IO_TIMEOUT_MS = 10_000;
 const MAX_CLEANUP_RETRY_MS = 60_000;
 const SESSION_OWNER_ASSERTION = "x-nanocodex-owner-id";
 // Exact completed-turn receipts are retained by ManagedTurnArchive, so the
-// runtime journal does not need to duplicate them in each compacted checkpoint.
+// runtime state does not need to duplicate them in each compacted checkpoint.
 const MANAGED_TERMINAL_RECEIPT_RETENTION = 0;
 const SESSION_ORGANIZATION_ASSERTION = "x-nanocodex-session-organization-id";
 const SESSION_TEAM_ASSERTION = "x-nanocodex-session-team-id";
@@ -214,7 +216,7 @@ const MEMORY_REVIEW_CHECKPOINT = [
 ].join("\n");
 
 export interface Env extends AccountAuthEnv {
-  NANOCODEX_SESSIONS: DurableObjectNamespace<NanocodexSession>;
+  NANOCODEX_SESSIONS: DurableObjectNamespace<DurableAgentSession>;
   NANOCODEX_ROOMS: DurableObjectNamespace<MultiplayerRoom>;
   NANOCODEX_MULTIPLAYER_QUOTA: DurableObjectNamespace<MultiplayerQuota>;
   NANOCODEX_MEMORY: DurableObjectNamespace<MemoryScope>;
@@ -294,8 +296,6 @@ type InitialAccountContext = Readonly<{
 type ManagedTurnState =
   | "accepted"
   | "cancelling"
-  | "retryable"
-  | "blocked"
   | "completed"
   | "cancelled"
   | "failed";
@@ -327,7 +327,6 @@ type StreamMessage = Extract<ServerMessage,
   | { type: "turn_completed" }
   | { type: "turn_cancelled" }
   | { type: "turn_retryable" }
-  | { type: "turn_blocked" }
   | { type: "turn_failed" }
   | { type: "event" }
   | { type: "stream_failed" }
@@ -368,8 +367,9 @@ type ManagedRealtimeRouteResult = Readonly<{
   voice_session_id: string;
 }>;
 
-type ManagedTransition =
-  TurnTerminal | Extract<StreamMessage, { type: "turn_cancelling" }>;
+type ManagedTransition = TurnTerminal | Extract<StreamMessage, {
+  type: "turn_cancelling" | "turn_retryable";
+}>;
 
 type TurnAuthorization = Readonly<{
   capabilities: readonly OrganizationCapability[];
@@ -993,7 +993,7 @@ const DurableComputerSession = withWorkspace(
   }),
 );
 
-export class NanocodexSession extends DurableComputerSession {
+export class DurableAgentSession extends DurableComputerSession {
   #agent?: CloudflareAgent.Agent;
   #agentPromise?: Promise<CloudflareAgent.Agent>;
   #agentConstruction?: AgentConstructionOwnership;
@@ -1038,8 +1038,6 @@ export class NanocodexSession extends DurableComputerSession {
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
     this.ctx.storage.sql.exec(`
-      DROP TABLE IF EXISTS terminal_turns;
-      DROP TABLE IF EXISTS completed_operations;
       CREATE TABLE IF NOT EXISTS session_state (
         singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
         session_id TEXT NOT NULL UNIQUE,
@@ -1070,7 +1068,7 @@ export class NanocodexSession extends DurableComputerSession {
         dispatch_input_chunks INTEGER CHECK (dispatch_input_chunks IS NULL OR dispatch_input_chunks > 0),
         authorization_json TEXT NOT NULL,
         state TEXT NOT NULL CHECK (
-          state IN ('accepted', 'cancelling', 'retryable', 'blocked', 'completed', 'cancelled', 'failed')
+          state IN ('accepted', 'cancelling', 'completed', 'cancelled', 'failed')
         ),
         accepted_cursor INTEGER NOT NULL,
         terminal_json TEXT,
@@ -1085,6 +1083,10 @@ export class NanocodexSession extends DurableComputerSession {
       );
       CREATE UNIQUE INDEX IF NOT EXISTS managed_turns_request_key
         ON managed_turns(request_key) WHERE request_key IS NOT NULL;
+      CREATE TABLE IF NOT EXISTS managed_turn_cancel_intents (
+        turn_id TEXT PRIMARY KEY,
+        created_at INTEGER NOT NULL
+      );
       CREATE TABLE IF NOT EXISTS managed_turn_dispatch_chunks (
         turn_id TEXT NOT NULL,
         chunk_index INTEGER NOT NULL,
@@ -1172,137 +1174,7 @@ export class NanocodexSession extends DurableComputerSession {
       this.ctx.id.toString(),
       optionalPositiveInteger(this.env.MANAGED_REALTIME_ARCHIVE_RECENT_OPERATIONS),
     );
-    const sessionColumns = new Set(
-      this.ctx.storage.sql
-        .exec<{ name: string }>("PRAGMA table_info(session_state)")
-        .toArray()
-        .map((column) => column.name),
-    );
-    if (!sessionColumns.has("public_origin")) {
-      this.ctx.storage.sql.exec(
-        "ALTER TABLE session_state ADD COLUMN public_origin TEXT NOT NULL DEFAULT ''",
-      );
-    }
-    if (!sessionColumns.has("owner_id")) {
-      this.ctx.storage.sql.exec(
-        "ALTER TABLE session_state ADD COLUMN owner_id TEXT NOT NULL DEFAULT ''",
-      );
-    }
-    if (!sessionColumns.has("organization_id")) {
-      this.ctx.storage.sql.exec(
-        "ALTER TABLE session_state ADD COLUMN organization_id TEXT NOT NULL DEFAULT ''",
-      );
-    }
-    if (!sessionColumns.has("team_id")) {
-      this.ctx.storage.sql.exec(
-        "ALTER TABLE session_state ADD COLUMN team_id TEXT NOT NULL DEFAULT ''",
-      );
-    }
-    if (!sessionColumns.has("authorization_epoch")) {
-      this.ctx.storage.sql.exec(
-        "ALTER TABLE session_state ADD COLUMN authorization_epoch INTEGER NOT NULL DEFAULT 0",
-      );
-    }
-    if (!sessionColumns.has("stream_error")) {
-      this.ctx.storage.sql.exec("ALTER TABLE session_state ADD COLUMN stream_error TEXT");
-    }
-    if (!sessionColumns.has("runtime_profile")) {
-      this.ctx.storage.sql.exec(
-        "ALTER TABLE session_state ADD COLUMN runtime_profile TEXT NOT NULL DEFAULT 'managed'",
-      );
-    }
-    if (!sessionColumns.has("accepted_turns")) {
-      this.ctx.storage.sql.exec(
-        "ALTER TABLE session_state ADD COLUMN accepted_turns INTEGER NOT NULL DEFAULT 0 CHECK (accepted_turns >= 0)",
-      );
-      this.ctx.storage.sql.exec(
-        "UPDATE session_state SET accepted_turns = (SELECT COUNT(*) FROM managed_turns)",
-      );
-    }
-    if (!sessionColumns.has("first_prompt")) {
-      this.ctx.storage.sql.exec(
-        "ALTER TABLE session_state ADD COLUMN first_prompt TEXT NOT NULL DEFAULT ''",
-      );
-      const retainedFirstPrompt = this.ctx.storage.sql.exec<{ input_json: string }>(
-        "SELECT input_json FROM managed_turns ORDER BY created_at, id LIMIT 1",
-      ).toArray()[0]?.input_json;
-      if (retainedFirstPrompt !== undefined) {
-        try {
-          this.ctx.storage.sql.exec(
-            "UPDATE session_state SET first_prompt = ? WHERE singleton = 1",
-            promptInputText(JSON.parse(retainedFirstPrompt) as PromptInput),
-          );
-        } catch { /* Invalid retained input fails through its normal recovery path. */ }
-      }
-    }
-    const managedTurnColumns = new Set(this.ctx.storage.sql.exec<{ name: string }>(
-      "PRAGMA table_info(managed_turns)",
-    ).toArray().map((column) => column.name));
-    if (!managedTurnColumns.has("may_have_inner_operation")) {
-      // Pre-upgrade unfinished rows may already own an inner Rust journal
-      // operation. Conservatively replay them instead of orphaning that work.
-      this.ctx.storage.sql.exec(
-        "ALTER TABLE managed_turns ADD COLUMN may_have_inner_operation INTEGER NOT NULL DEFAULT 1 CHECK (may_have_inner_operation IN (0, 1))",
-      );
-    }
-    if (!managedTurnColumns.has("dispatch_input_chunks")) {
-      this.ctx.storage.sql.exec(
-        "ALTER TABLE managed_turns ADD COLUMN dispatch_input_chunks INTEGER CHECK (dispatch_input_chunks IS NULL OR dispatch_input_chunks > 0)",
-      );
-    }
-    const realtimeOperationColumns = new Set(
-      this.ctx.storage.sql
-        .exec<{ name: string }>("PRAGMA table_info(managed_realtime_operations)")
-        .toArray()
-        .map((column) => column.name),
-    );
-    if (!realtimeOperationColumns.has("blocked")) {
-      this.ctx.storage.sql.exec(
-        "ALTER TABLE managed_realtime_operations ADD COLUMN blocked INTEGER NOT NULL DEFAULT 0 CHECK (blocked IN (0, 1))",
-      );
-    }
-    const realtimeSessionColumns = new Set(
-      this.ctx.storage.sql
-        .exec<{ name: string }>("PRAGMA table_info(managed_realtime_session)")
-        .toArray()
-        .map((column) => column.name),
-    );
-    if (!realtimeSessionColumns.has("authorization_json")) {
-      this.ctx.storage.sql.exec(
-        `ALTER TABLE managed_realtime_session ADD COLUMN authorization_json TEXT NOT NULL
-         DEFAULT '{"capabilities":[]}'`,
-      );
-    }
-    const migrationNow = Date.now();
-    this.ctx.storage.sql.exec(
-      `UPDATE managed_realtime_operations
-       SET blocked = 1, updated_at = ?
-       WHERE state = 'pending' AND blocked = 0`,
-      migrationNow,
-    );
-    // Older realtime routing persisted a synthetic managed ID while Rust
-    // admitted the operation under a different generated UUID. There is no
-    // retained authoritative mapping between them, so replay must fail closed
-    // instead of admitting duplicate work under the synthetic ID.
-    this.ctx.storage.sql.exec(
-      `UPDATE managed_turns
-       SET state = 'blocked', retry_at = NULL,
-           error = 'pre-upgrade realtime turn has an indeterminate durable operation identity',
-           updated_at = ?
-       WHERE request_key LIKE 'realtime:%'
-         AND length(id) = 57
-         AND substr(id, 1, 9) = 'realtime:'
-         AND substr(id, 10) NOT GLOB '*[^0-9a-f]*'
-         AND state IN ('accepted', 'cancelling', 'retryable')`,
-      migrationNow,
-    );
     this.#deleted = this.#initializationOwnership()?.state === "deleted";
-    if (!managedTurnColumns.has("authorization_json")) {
-      this.ctx.storage.sql.exec(
-        `ALTER TABLE managed_turns ADD COLUMN authorization_json TEXT NOT NULL
-         DEFAULT '{"capabilities":[]}'`,
-      );
-    }
     this.#streamError = this.#session()?.stream_error ?? undefined;
     this.ctx.blockConcurrencyWhile(async () => {
       const [deleting, credentialBinding, deletionGeneration] = await Promise.all([
@@ -2858,19 +2730,15 @@ export class NanocodexSession extends DurableComputerSession {
     let row: ManagedTurnRow | undefined;
     try { row = await this.#findManagedTurn(id); }
     catch (error) { return managedErrorResponse(error, "turn_archive_unavailable"); }
-    if (!row) return json({ error: "turn_not_found" }, { status: 404 });
-    if (isTerminalState(row.state)) return json(managedTurnView(row));
-    if (row.state === "blocked") {
-      return json(
-        {
-          error: "turn_blocked",
-          message:
-            row.error ??
-            "the durable operation requires explicit reconciliation",
-        },
-        { status: 409 },
-      );
+    if (!row) {
+      try {
+        row = this.#reservePreAdmissionCancellation(id);
+      } catch (error) {
+        return managedErrorResponse(error, "cancel_failed");
+      }
+      if (!row) return json({ turn_id: id, state: "cancelling" }, { status: 202 });
     }
+    if (isTerminalState(row.state)) return json(managedTurnView(row));
     try {
       const cancelling = this.#markCancelling(id);
       this.#scheduleCancellation(cancelling.id);
@@ -2893,16 +2761,6 @@ export class NanocodexSession extends DurableComputerSession {
         503,
         "event_stream_failed",
         this.#streamError,
-      );
-    }
-    const blocked = this.#managedTurns(
-      "WHERE state = 'blocked' ORDER BY updated_at LIMIT 1",
-    )[0];
-    if (blocked) {
-      throw new ManagedRequestError(
-        409,
-        "agent_blocked",
-        `turn ${blocked.id} requires reconciliation before new work`,
       );
     }
     if (this.#unfinishedTurnCount() >= MAX_ACTIVE_TURNS) {
@@ -3032,7 +2890,7 @@ export class NanocodexSession extends DurableComputerSession {
       turn.dispose();
       if (this.#deleting) return;
       const failure = classifyTurnFailure(id, error);
-      this.#commitManagedFailure(id, error, false, failure.terminal);
+      this.#commitManagedResolution(id, failure);
       if (failure.reopenAgent) await this.#reopenAgent(id);
       this.#scheduleRecovery();
       await this.#scheduleNextAlarm();
@@ -3079,9 +2937,8 @@ export class NanocodexSession extends DurableComputerSession {
       }
       if (existing.state === "cancelling") {
         this.#scheduleCancellation(existing.id);
-      } else if (!isTerminalState(existing.state) && existing.state !== "blocked") {
-        if (existing.state === "retryable"
-          && existing.retry_at !== null
+      } else if (!isTerminalState(existing.state)) {
+        if (existing.retry_at !== null
           && existing.retry_at > Date.now()) {
           // Idempotent polling must preserve the retained retry deadline. It
           // may race the recovery task that just wrote the row, so install the
@@ -3103,14 +2960,6 @@ export class NanocodexSession extends DurableComputerSession {
     if (this.#streamError) {
       throw new ManagedRequestError(503, "event_stream_failed", this.#streamError);
     }
-    const blocked = this.#managedTurns("WHERE state = 'blocked' ORDER BY updated_at LIMIT 1")[0];
-    if (blocked) {
-      throw new ManagedRequestError(
-        409,
-        "agent_blocked",
-        `turn ${blocked.id} requires reconciliation before new work`,
-      );
-    }
     if (this.#unfinishedTurnCount() >= MAX_ACTIVE_TURNS) {
       throw new ManagedRequestError(429, "turn_queue_full", `at most ${MAX_ACTIVE_TURNS} turns may be unfinished`);
     }
@@ -3122,26 +2971,42 @@ export class NanocodexSession extends DurableComputerSession {
     const accepted: StreamMessage = { type: "turn_accepted", id, input, replayed: false };
     const firstPrompt = promptInputText(input);
     let event: DurableEvent<StreamMessage> | undefined;
+    let cancellingEvent: DurableEvent<StreamMessage> | undefined;
+    let cancellationRequested = false;
     this.ctx.storage.transactionSync(() => {
       if (this.#deleting || !this.#sessionId()) {
         throw new ManagedRequestError(409, "agent_deleting", "the agent is being deleted");
       }
+      cancellationRequested = this.ctx.storage.sql.exec<{ turn_id: string }>(
+        "SELECT turn_id FROM managed_turn_cancel_intents WHERE turn_id = ?",
+        id,
+      ).toArray()[0] !== undefined;
       event = this.#eventLog.append(accepted, id);
+      if (cancellationRequested) {
+        cancellingEvent = this.#eventLog.append({ type: "turn_cancelling", id }, id, true);
+      }
       this.ctx.storage.sql.exec(
         `INSERT INTO managed_turns (
            id, request_key, request_hash, input_json, authorization_json, state,
            accepted_cursor, may_have_inner_operation, created_at, accepted_at, updated_at
-         ) VALUES (?, ?, ?, ?, ?, 'accepted', CAST(? AS INTEGER), 0, ?, ?, ?)`,
+         ) VALUES (?, ?, ?, ?, ?, ?, CAST(? AS INTEGER), 0, ?, ?, ?)`,
         id,
         requestKey,
         requestHash,
         JSON.stringify(input),
         JSON.stringify(authorization),
+        cancellationRequested ? "cancelling" : "accepted",
         event.cursor,
         now,
         now,
         now,
       );
+      if (cancellationRequested) {
+        this.ctx.storage.sql.exec(
+          "DELETE FROM managed_turn_cancel_intents WHERE turn_id = ?",
+          id,
+        );
+      }
       this.ctx.storage.sql.exec(
         `UPDATE session_state
          SET accepted_turns = accepted_turns + 1,
@@ -3151,6 +3016,7 @@ export class NanocodexSession extends DurableComputerSession {
       );
     });
     this.#publish(event!);
+    if (cancellingEvent) this.#publish(cancellingEvent);
     this.#observe("managed.turn.accepted", {
       turn_id: id,
       transport: "managed",
@@ -3160,17 +3026,44 @@ export class NanocodexSession extends DurableComputerSession {
     });
     const row = this.#managedTurn(id);
     if (!row) throw new Error("managed turn disappeared after acceptance");
-    this.#scheduleRecovery();
+    if (cancellationRequested) this.#scheduleCancellation(id);
+    else this.#scheduleRecovery();
     return { created: true, row };
+  }
+
+  #reservePreAdmissionCancellation(id: string): ManagedTurnRow | undefined {
+    let concurrent: ManagedTurnRow | undefined;
+    this.ctx.storage.transactionSync(() => {
+      concurrent = this.#managedTurn(id);
+      if (concurrent) return;
+      const existing = this.ctx.storage.sql.exec<{ turn_id: string }>(
+        "SELECT turn_id FROM managed_turn_cancel_intents WHERE turn_id = ?",
+        id,
+      ).toArray()[0];
+      if (existing) return;
+      const count = this.ctx.storage.sql.exec<{ count: number }>(
+        "SELECT COUNT(*) AS count FROM managed_turn_cancel_intents",
+      ).one().count;
+      if (count >= MAX_PRE_ADMISSION_CANCELLATIONS) {
+        throw new ManagedRequestError(
+          429,
+          "cancellation_queue_full",
+          `at most ${MAX_PRE_ADMISSION_CANCELLATIONS} pre-admission cancellations may be retained`,
+        );
+      }
+      this.ctx.storage.sql.exec(
+        "INSERT INTO managed_turn_cancel_intents (turn_id, created_at) VALUES (?, ?)",
+        id,
+        Date.now(),
+      );
+    });
+    return concurrent;
   }
 
   #markCancelling(id: string): ManagedTurnRow {
     const current = this.#managedTurn(id);
     if (!current) throw new ManagedRequestError(404, "turn_not_found", `turn ${id} does not exist`);
     if (isTerminalState(current.state) || current.state === "cancelling") return current;
-    if (current.state === "blocked") {
-      throw new ManagedRequestError(409, "turn_blocked", current.error ?? "turn requires reconciliation");
-    }
     const message: StreamMessage = { type: "turn_cancelling", id };
     let event: DurableEvent<StreamMessage> | undefined;
     this.ctx.storage.transactionSync(() => {
@@ -3180,7 +3073,7 @@ export class NanocodexSession extends DurableComputerSession {
       this.ctx.storage.sql.exec(
         `UPDATE managed_turns
          SET state = 'cancelling', error = NULL, retry_at = NULL, updated_at = ?
-         WHERE id = ? AND state IN ('accepted', 'retryable')`,
+         WHERE id = ? AND state = 'accepted'`,
         Date.now(),
         id,
       );
@@ -3204,7 +3097,7 @@ export class NanocodexSession extends DurableComputerSession {
 
   async #cancelManagedTurn(id: string): Promise<void> {
     let row = this.#managedTurn(id);
-    if (!row || isTerminalState(row.state) || row.state === "blocked") return;
+    if (!row || isTerminalState(row.state)) return;
     if (row.state === "cancelling" && row.retry_at !== null && row.retry_at > Date.now()) {
       await this.#scheduleNextAlarm();
       return;
@@ -3212,7 +3105,7 @@ export class NanocodexSession extends DurableComputerSession {
     const admission = this.#admissionTasks.get(id);
     if (admission) await admission;
     row = this.#managedTurn(id);
-    if (!row || isTerminalState(row.state) || row.state === "blocked") return;
+    if (!row || isTerminalState(row.state)) return;
     let turn = this.#turns.get(id);
     if (!turn && row.may_have_inner_operation === 0) {
       this.#commitManagedMessage(id, { type: "turn_cancelled", id });
@@ -3221,7 +3114,7 @@ export class NanocodexSession extends DurableComputerSession {
     }
     if (!turn) {
       row = await this.#admitManagedTurn(row, true);
-      if (isTerminalState(row.state) || row.state === "blocked") return;
+      if (isTerminalState(row.state)) return;
       turn = this.#turns.get(id);
     }
     if (!turn) {
@@ -3232,7 +3125,7 @@ export class NanocodexSession extends DurableComputerSession {
       await turn.cancel();
     } catch (error) {
       if (this.#managedTurn(id)?.state === "cancelling") {
-        this.#commitManagedFailure(id, error, true);
+        this.#commitManagedResolution(id, classifyTurnFailure(id, error));
       }
       throw error;
     }
@@ -3255,8 +3148,8 @@ export class NanocodexSession extends DurableComputerSession {
 
   async #startManagedTurn(row: ManagedTurnRow, replayed: boolean): Promise<ManagedTurnRow> {
     const latest = this.#managedTurn(row.id);
-    if (!latest || isTerminalState(latest.state) || latest.state === "blocked") return latest ?? row;
-    if (latest.state === "retryable" && latest.retry_at !== null && latest.retry_at > Date.now()) {
+    if (!latest || isTerminalState(latest.state)) return latest ?? row;
+    if (latest.retry_at !== null && latest.retry_at > Date.now()) {
       await this.#scheduleNextAlarm();
       return latest;
     }
@@ -3269,7 +3162,6 @@ export class NanocodexSession extends DurableComputerSession {
       const agent = await this.#ensureAgent();
       if (this.#deleting || this.#agent !== agent) throw retryableError("agent became unavailable during admission");
       let dispatchInputJson = this.#managedDispatchInput(row);
-      let legacyDispatchCandidates: string[] | undefined;
       if (dispatchInputJson === undefined) {
         const initialAccountContext = await this.#initialAccountContext();
         const accountInput = initialAccountContext?.turn_id === row.id
@@ -3280,17 +3172,9 @@ export class NanocodexSession extends DurableComputerSession {
         const checkpointed = initialAccountContext !== undefined
           && initialAccountContext.turn_id !== row.id;
         dispatchInputJson = checkpointed ? checkpointInputJson : plainInputJson;
-        if (row.may_have_inner_operation === 1) {
-          // Before dispatch freezing, ordinary turns used either enriched
-          // form. Rust's exact durable-input check selects the historical form
-          // that already owns this operation.
-          legacyDispatchCandidates = checkpointed
-            ? [checkpointInputJson, plainInputJson]
-            : [plainInputJson, checkpointInputJson];
-        }
       }
       const dispatchable = this.#managedTurn(row.id);
-      if (!dispatchable || isTerminalState(dispatchable.state) || dispatchable.state === "blocked") {
+      if (!dispatchable || isTerminalState(dispatchable.state)) {
         this.#pendingTurnIds.delete(row.id);
         this.#turnInputs.delete(row.id);
         return dispatchable ?? row;
@@ -3302,47 +3186,15 @@ export class NanocodexSession extends DurableComputerSession {
       }
       dispatchInputJson = this.#managedDispatchInput(dispatchable) ?? dispatchInputJson;
       this.#eventTurnQueue.push(row.id);
-      if (legacyDispatchCandidates === undefined) {
-        // This transaction must stay immediately before prompt dispatch with
-        // no await between them. It freezes the exact Rust admission input
-        // before the operation can exist. A false positive is safely
-        // replayable; a false negative could orphan an accepted operation.
-        this.#freezeManagedDispatchInput(row.id, dispatchInputJson);
-      }
-      const candidates = legacyDispatchCandidates ?? [dispatchInputJson];
-      let durableId: string | undefined;
-      let acceptedInputJson: string | undefined;
-      for (let index = 0; index < candidates.length; index += 1) {
-        const candidate = candidates[index]!;
-        turn = agent.turn.prompt({
-          id: row.id,
-          input: JSON.parse(candidate) as PromptInput,
-        });
-        this.#turns.set(row.id, turn);
-        try {
-          durableId = await turn.accepted();
-          acceptedInputJson = candidate;
-          break;
-        } catch (error) {
-          if (legacyDispatchCandidates === undefined
-            || index === candidates.length - 1
-            || !isDurableInputConflict(error)) {
-            throw error;
-          }
-          if (this.#turns.get(row.id) === turn) this.#turns.delete(row.id);
-          turn.dispose();
-          turn = undefined;
-        }
-      }
-      if (acceptedInputJson === undefined || !turn) {
-        throw new Error(`durable admission did not settle turn ${row.id}`);
-      }
-      if (legacyDispatchCandidates !== undefined) {
-        // The operation predates this schema, so Rust is authoritative for
-        // which historical enrichment form was admitted. Freeze the exact
-        // candidate it accepted for every later replay.
-        this.#freezeManagedDispatchInput(row.id, acceptedInputJson);
-      }
+      // Freeze the exact Rust admission input immediately before dispatch.
+      // This is the only accepted representation of a managed operation.
+      this.#freezeManagedDispatchInput(row.id, dispatchInputJson);
+      turn = agent.turn.prompt({
+        id: row.id,
+        input: JSON.parse(dispatchInputJson) as PromptInput,
+      });
+      this.#turns.set(row.id, turn);
+      const durableId = await turn.accepted();
       if (durableId !== undefined && durableId !== row.id) {
         throw new Error(`durable admission returned unexpected turn id ${durableId}`);
       }
@@ -3353,15 +3205,11 @@ export class NanocodexSession extends DurableComputerSession {
       this.#pendingTurnIds.delete(row.id);
       this.ctx.storage.sql.exec(
         `UPDATE managed_turns
-         SET state = CASE
-               WHEN state = 'cancelling' THEN 'cancelling'
-               WHEN state = 'retryable' THEN 'retryable'
-               ELSE 'accepted'
-             END,
-             error = CASE WHEN state = 'retryable' THEN error ELSE NULL END,
-             retry_at = CASE WHEN state = 'retryable' THEN retry_at ELSE NULL END,
+         SET state = CASE WHEN state = 'cancelling' THEN 'cancelling' ELSE 'accepted' END,
+             error = NULL,
+             retry_at = NULL,
              updated_at = ?
-         WHERE id = ? AND state IN ('accepted', 'retryable', 'cancelling')`,
+         WHERE id = ? AND state IN ('accepted', 'cancelling')`,
         Date.now(),
         row.id,
       );
@@ -3376,7 +3224,7 @@ export class NanocodexSession extends DurableComputerSession {
       this.#turnInputs.delete(row.id);
       if (this.#deleting) return this.#managedTurn(row.id) ?? row;
       const failure = classifyTurnFailure(row.id, error);
-      const failed = this.#commitManagedFailure(row.id, error, replayed, failure.terminal);
+      const failed = this.#commitManagedResolution(row.id, failure);
       if (failure.reopenAgent) await this.#reopenAgent(row.id);
       return failed;
     }
@@ -3488,7 +3336,7 @@ export class NanocodexSession extends DurableComputerSession {
     });
     // A socket or admission event may have resumed while external cleanup was
     // awaited. The durable deletion marker makes those paths fail closed; close
-    // once more before dropping the owned journal and event history.
+    // once more before dropping the owned state and event history.
     for (const socket of this.ctx.getWebSockets()) closeSocket(socket, 1000, "session deleted");
     this.#assertDeletionGeneration(generation);
     while (this.#eventArchiveTask || this.#turnArchiveTask || this.#realtimeArchiveTask) {
@@ -3508,6 +3356,7 @@ export class NanocodexSession extends DurableComputerSession {
     this.ctx.storage.transactionSync(() => {
       this.ctx.storage.sql.exec("DELETE FROM managed_turn_dispatch_chunks");
       this.ctx.storage.sql.exec("DELETE FROM managed_turns");
+      this.ctx.storage.sql.exec("DELETE FROM managed_turn_cancel_intents");
       this.ctx.storage.sql.exec("DELETE FROM history_projection_outbox");
       this.ctx.storage.sql.exec("DELETE FROM turn_history_citations");
       this.#eventLog.clear();
@@ -3627,16 +3476,14 @@ export class NanocodexSession extends DurableComputerSession {
   async #runRecovery(observedAt: number): Promise<void> {
     if (this.#deleting || !this.#sessionId() || this.#streamError) return;
     const rows = this.#managedTurns(
-      `WHERE state IN ('accepted', 'cancelling', 'retryable', 'blocked')
+      `WHERE state IN ('accepted', 'cancelling')
        ORDER BY created_at, rowid`,
     );
     for (const row of rows) {
       if (this.#deleting) return;
       const current = this.#managedTurn(row.id);
       if (!current || isTerminalState(current.state)) continue;
-      if (current.state === "blocked") break;
-      if ((current.state === "retryable" || current.state === "cancelling")
-        && current.retry_at !== null && current.retry_at > observedAt) break;
+      if (current.retry_at !== null && current.retry_at > observedAt) break;
       if (current.state === "cancelling") {
         const cancellation = this.#cancellationTasks.get(row.id);
         try {
@@ -3661,12 +3508,10 @@ export class NanocodexSession extends DurableComputerSession {
         validatePromptInput(JSON.parse(current.input_json));
         await this.#admitManagedTurn(current, true);
       } catch (error) {
-        this.#commitManagedFailure(current.id, error, true);
+        this.#commitManagedResolution(current.id, classifyTurnFailure(current.id, error));
       }
       const admitted = this.#managedTurn(current.id);
-      if (admitted && (admitted.state === "retryable"
-        || admitted.state === "cancelling"
-        || admitted.state === "blocked")) break;
+      if (admitted && (admitted.state === "cancelling" || admitted.retry_at !== null)) break;
     }
     await this.#scheduleNextAlarm();
   }
@@ -3935,17 +3780,6 @@ export class NanocodexSession extends DurableComputerSession {
     const constructionStartedAt = performance.now();
     const session = this.#session();
     if (!session) throw new Error("session is not initialized");
-    let retainedJournalBatches = 0;
-    try {
-      retainedJournalBatches = this.ctx.storage.sql.exec<{ batches: number }>(
-        "SELECT COUNT(*) AS batches FROM nanocodex_journal_batches",
-      ).one().batches;
-    } catch { /* The first construction has not initialized the journal yet. */ }
-    if (retainedJournalBatches > 1) {
-      await CloudflareAgent.compactDurability(this, {
-        terminalReceiptRetention: MANAGED_TERMINAL_RECEIPT_RETENTION,
-      });
-    }
     const multiplayer = session.runtime_profile === "multiplayer";
     if (!multiplayer) await this.#ensureCredentialBinding(session);
     const workspace = await getWorkspace(this);
@@ -4331,20 +4165,18 @@ export class NanocodexSession extends DurableComputerSession {
   async #complete(id: string, turn: Turn): Promise<void> {
     let reopenAgent = false;
     try {
-      let materialized = await materializeTurnTerminal(id, turn);
+      let materialized = await materializeTurnResolution(id, turn);
       if (this.#deleting) return;
       if (this.#reopenInterruptedTurnIds.has(id)
+        && materialized.kind === "terminal"
         && materialized.terminal.type === "turn_cancelled") {
         materialized = {
-          terminal: {
-            type: "turn_retryable",
-            id,
-            error: "turn was interrupted while reopening the durable Agent",
-          },
+          kind: "retry",
+          error: "turn was interrupted while reopening the durable Agent",
           reopenAgent: false,
         };
       }
-      if (materialized.terminal.type === "turn_completed") {
+      if (materialized.kind === "terminal" && materialized.terminal.type === "turn_completed") {
         materialized = {
           ...materialized,
           terminal: {
@@ -4355,7 +4187,7 @@ export class NanocodexSession extends DurableComputerSession {
       }
       reopenAgent = materialized.reopenAgent;
       try {
-        this.#commitManagedMessage(id, materialized.terminal);
+        this.#commitManagedResolution(id, materialized);
       } catch (error) {
         if (this.#deleting) return;
         try {
@@ -4381,21 +4213,25 @@ export class NanocodexSession extends DurableComputerSession {
     }
   }
 
-  #commitManagedFailure(
-    id: string,
-    error: unknown,
-    _replayed: boolean,
-    classified?: TurnTerminal,
-  ): ManagedTurnRow {
-    const failure = classified ?? classifyTurnFailure(id, error).terminal;
+  #commitManagedResolution(id: string, resolution: TurnResolution): ManagedTurnRow {
     const row = this.#managedTurn(id);
-    if (row?.state === "cancelling"
-      && failure.type !== "turn_cancelled"
-      && failure.type !== "turn_blocked") {
+    if (resolution.kind === "retry") {
+      return this.#commitManagedMessage(id, row?.state === "cancelling" ? {
+        type: "turn_cancelling",
+        id,
+        error: resolution.error,
+      } : {
+        type: "turn_retryable",
+        id,
+        error: resolution.error,
+      });
+    }
+    const failure = resolution.terminal;
+    if (row?.state === "cancelling" && failure.type !== "turn_cancelled") {
       return this.#commitManagedMessage(id, {
         type: "turn_cancelling",
         id,
-        error: "error" in failure ? failure.error : errorMessage(error),
+        error: "error" in failure ? failure.error : "cancellation did not settle",
       });
     }
     return this.#commitManagedMessage(id, failure);
@@ -4410,14 +4246,14 @@ export class NanocodexSession extends DurableComputerSession {
     this.ctx.storage.transactionSync(() => {
       const row = this.#managedTurn(id);
       if (!row) throw new Error(`managed turn ${id} disappeared`);
-      if (isTerminalState(row.state) || row.state === "blocked") {
+      if (isTerminalState(row.state)) {
         committed = row;
         return;
       }
 
       let message: ManagedTransition = requested;
       let state = managedStateForMessage(message);
-      if (row.state === "cancelling" && state === "retryable") {
+      if (row.state === "cancelling" && message.type === "turn_retryable") {
         message = {
           type: "turn_cancelling",
           id,
@@ -4427,7 +4263,7 @@ export class NanocodexSession extends DurableComputerSession {
       }
       let attemptCount = row.attempt_count;
       let retryAt: number | null = null;
-      const retrying = state === "retryable"
+      const retrying = message.type === "turn_retryable"
         || (state === "cancelling" && "error" in message && message.error !== undefined);
       if (retrying) {
         const detail = "error" in message ? message.error ?? null : null;
@@ -4438,25 +4274,6 @@ export class NanocodexSession extends DurableComputerSession {
         attemptCount = Math.min(Number.MAX_SAFE_INTEGER, attemptCount + 1);
         retryAt = now + retryDelayMs(attemptCount);
         if (message.type === "turn_cancelling") message = { ...message, retry_at: retryAt };
-        if (row.state === state) {
-          this.ctx.storage.sql.exec(
-            `UPDATE managed_turns
-             SET error = ?, attempt_count = ?, retry_at = ?, updated_at = ?
-             WHERE id = ? AND state = ?`,
-            detail,
-            attemptCount,
-            retryAt,
-            now,
-            id,
-            state,
-          );
-          this.ctx.storage.sql.exec(
-            "UPDATE session_state SET last_active = ? WHERE singleton = 1",
-            now,
-          );
-          committed = this.#managedTurn(id) ?? row;
-          return;
-        }
       }
 
       const terminal = isTerminalState(state);
@@ -4521,7 +4338,7 @@ export class NanocodexSession extends DurableComputerSession {
           ? "success"
           : committed.state === "cancelled"
           ? "cancelled"
-          : committed.state === "failed" || committed.state === "blocked"
+          : committed.state === "failed"
           ? "failure"
           : "pending",
         message_type: event.message.type,
@@ -5095,7 +4912,7 @@ export class NanocodexSession extends DurableComputerSession {
     const chunks = dispatchInputChunks(inputJson);
     this.ctx.storage.transactionSync(() => {
       const current = this.#managedTurn(id);
-      if (!current || isTerminalState(current.state) || current.state === "blocked") return;
+      if (!current || isTerminalState(current.state)) return;
       const retained = this.#managedDispatchInput(current);
       if (retained !== undefined) {
         if (retained !== inputJson) {
@@ -5116,7 +4933,7 @@ export class NanocodexSession extends DurableComputerSession {
         `UPDATE managed_turns
          SET dispatch_input_chunks = COALESCE(dispatch_input_chunks, ?),
              may_have_inner_operation = 1, updated_at = ?
-         WHERE id = ? AND state IN ('accepted', 'retryable', 'cancelling')`,
+         WHERE id = ? AND state IN ('accepted', 'cancelling')`,
         chunks.length,
         Date.now(),
         id,
@@ -5126,13 +4943,13 @@ export class NanocodexSession extends DurableComputerSession {
 
   #unfinishedTurnCount(): number {
     return this.ctx.storage.sql.exec<{ count: number }>(
-      "SELECT COUNT(*) AS count FROM managed_turns WHERE state IN ('accepted', 'cancelling', 'retryable', 'blocked')",
+      "SELECT COUNT(*) AS count FROM managed_turns WHERE state IN ('accepted', 'cancelling')",
     ).toArray()[0]?.count ?? 0;
   }
 
   #recoverableTurnCount(): number {
     return this.ctx.storage.sql.exec<{ count: number }>(
-      "SELECT COUNT(*) AS count FROM managed_turns WHERE state IN ('accepted', 'cancelling', 'retryable')",
+      "SELECT COUNT(*) AS count FROM managed_turns WHERE state IN ('accepted', 'cancelling')",
     ).toArray()[0]?.count ?? 0;
   }
 
@@ -5161,7 +4978,7 @@ export class NanocodexSession extends DurableComputerSession {
     }
     if (!this.#streamError) {
       for (const row of this.#managedTurns(
-        "WHERE state IN ('accepted', 'cancelling', 'retryable') ORDER BY created_at",
+        "WHERE state IN ('accepted', 'cancelling') ORDER BY created_at",
       )) {
         if (row.state === "cancelling") {
           if (!this.#cancellationTasks.has(row.id)) {
@@ -5177,7 +4994,7 @@ export class NanocodexSession extends DurableComputerSession {
           break;
         }
         if (this.#cancellationTasks.has(row.id)) break;
-        if (row.state === "retryable" && row.retry_at !== null) targets.push(row.retry_at);
+        if (row.retry_at !== null) targets.push(row.retry_at);
         else targets.push(now + 1);
         break;
       }
@@ -5364,10 +5181,6 @@ function dispatchInputChunks(input: string): string[] {
   return chunks;
 }
 
-function isDurableInputConflict(error: unknown): boolean {
-  return /durable operation `[^`]+` already has different input/.test(errorMessage(error));
-}
-
 function isHighSurrogate(codeUnit: number): boolean {
   return codeUnit >= 0xd800 && codeUnit <= 0xdbff;
 }
@@ -5419,11 +5232,8 @@ function messageForManagedTurn(row: ManagedTurnRow): ServerMessage {
     };
   }
   const input = JSON.parse(row.input_json) as PromptInput;
-  if (row.state === "retryable") {
+  if (row.state === "accepted" && row.retry_at !== null) {
     return { type: "turn_retryable", id: row.id, error: row.error ?? "turn will be retried" };
-  }
-  if (row.state === "blocked") {
-    return { type: "turn_blocked", id: row.id, error: row.error ?? "turn requires reconciliation" };
   }
   if (row.state === "cancelling") {
     return {
@@ -5451,8 +5261,7 @@ function managedStateForMessage(message: ManagedTransition): ManagedTurnState {
     case "turn_cancelling": return "cancelling";
     case "turn_completed": return "completed";
     case "turn_cancelled": return "cancelled";
-    case "turn_retryable": return "retryable";
-    case "turn_blocked": return "blocked";
+    case "turn_retryable": return "accepted";
     case "turn_failed": return "failed";
   }
 }
@@ -5486,7 +5295,7 @@ function managedMultiplayerTimeoutMs(env: Env): number {
 }
 
 async function requestSessionCleanup(
-  stub: DurableObjectStub<NanocodexSession>,
+  stub: DurableObjectStub<DurableAgentSession>,
   timeoutMs: number,
 ): Promise<void> {
   try {
@@ -5566,7 +5375,6 @@ function managedHttpError(error: unknown, fallbackCode = "managed_request_failed
   const code = (error as { code?: unknown } | null)?.code;
   if (code === "invalid_request") return { status: 400, code, message: errorMessage(error) };
   if (code === "conflict") return { status: 409, code, message: errorMessage(error) };
-  if (code === "blocked") return { status: 409, code, message: errorMessage(error) };
   if (code === "retryable") return { status: 503, code, message: errorMessage(error) };
   return { status: 500, code: fallbackCode, message: errorMessage(error) };
 }

--- a/services/managed/src/index.ts
+++ b/services/managed/src/index.ts
@@ -183,9 +183,9 @@ const DEFAULT_OWNERSHIP_IO_TIMEOUT_MS = 10_000;
 const DEFAULT_MULTIPLAYER_IO_TIMEOUT_MS = 10_000;
 const MAX_CLEANUP_RETRY_MS = 60_000;
 const SESSION_OWNER_ASSERTION = "x-nanocodex-owner-id";
-// Exact completed-turn receipts are retained by ManagedTurnArchive, so the
-// runtime state does not need to duplicate them in each compacted checkpoint.
-const MANAGED_TERMINAL_RECEIPT_RETENTION = 0;
+// ManagedTurnArchive owns the long-lived API projection. The portable Rust
+// state keeps a bounded exact-replay window so cutovers do not call the model.
+const MANAGED_TERMINAL_RECEIPT_RETENTION = 512;
 const SESSION_ORGANIZATION_ASSERTION = "x-nanocodex-session-organization-id";
 const SESSION_TEAM_ASSERTION = "x-nanocodex-session-team-id";
 const SESSION_AUTHORIZATION_EPOCH_ASSERTION = "x-nanocodex-authorization-epoch";

--- a/services/managed/src/index.ts
+++ b/services/managed/src/index.ts
@@ -177,6 +177,7 @@ const SESSION_DELETION_GENERATION_KEY = "nanocodex:session-deletion-generation";
 const INITIAL_ACCOUNT_CONTEXT_KEY = "nanocodex:initial-account-context";
 const CREDENTIAL_BINDING_KEY = "nanocodex:credential-binding";
 const CLEANUP_RETRY_ATTEMPT_KEY = "nanocodex:cleanup-retry-attempt";
+const DURABILITY_EXPORTED_KEY = "nanocodex:durability-exported";
 const CREDENTIAL_BINDING_PREPARE_TIMEOUT_MS = 60_000;
 const DEFAULT_OWNERSHIP_IO_TIMEOUT_MS = 10_000;
 const DEFAULT_MULTIPLAYER_IO_TIMEOUT_MS = 10_000;
@@ -668,6 +669,21 @@ export default {
       if (requestKey !== null && !IDEMPOTENCY_KEY.test(requestKey)) {
         return json({ error: "invalid_idempotency_key" }, { status: 400 });
       }
+      let durabilityArchive: unknown;
+      try {
+        const encoded = await request.text();
+        if (encoded.trim()) {
+          const body = JSON.parse(encoded) as { durability?: unknown };
+          if (!body || typeof body !== "object" || Array.isArray(body)
+            || Object.keys(body).some((key) => key !== "durability")
+            || body.durability === undefined) {
+            return json({ error: "invalid_durability_import" }, { status: 400 });
+          }
+          durabilityArchive = body.durability;
+        }
+      } catch {
+        return json({ error: "invalid_durability_import" }, { status: 400 });
+      }
       const agentId = requestKey === null
         ? uuidV7()
         : await idempotentAgentId(principal.userId, requestKey);
@@ -743,6 +759,24 @@ export default {
           ? json({ error: "credential_broker_unavailable" }, { status: 503 })
           : json({ error: "agent initialization failed" }, { status: 503 });
       }
+      if (durabilityArchive !== undefined) {
+        let imported: Response;
+        try {
+          imported = await fetchCreateStage(stub, "https://session.internal/durability/import", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(durabilityArchive),
+          }, ownershipTimeoutMs, "agent durability import");
+        } catch {
+          if (requestKey === null) await requestSessionCleanup(stub, ownershipTimeoutMs);
+          return json({ error: "durability_import_failed" }, { status: 503 });
+        }
+        await imported.body?.cancel();
+        if (!imported.ok) {
+          if (requestKey === null) await requestSessionCleanup(stub, ownershipTimeoutMs);
+          return json({ error: "invalid_durability_import" }, { status: imported.status });
+        }
+      }
       let committed: Response | undefined;
       try {
         committed = await fetchCreateStage(
@@ -770,6 +804,12 @@ export default {
       return json({
         agent_id: agentId,
         session_id: agentId,
+        durability_id: typeof durabilityArchive === "object"
+          && durabilityArchive !== null
+          && "stateId" in durabilityArchive
+          && typeof durabilityArchive.stateId === "string"
+          ? durabilityArchive.stateId
+          : agentId,
         events_url: new URL(`${routeBase}/${agentId}/events`, url).href,
         websocket_url: websocketUrl.href,
       }, {
@@ -830,6 +870,20 @@ export default {
       return stub.fetch(`https://session.internal/${resource}?${query}`, {
         headers: sessionHeaders,
         signal: request.signal,
+      });
+    }
+    if (resource === "durability") {
+      if (request.method !== "POST") {
+        return json({ error: "method_not_allowed" }, { status: 405 });
+      }
+      if (!principal.capabilities.includes("agents:write")) {
+        return json({ error: "forbidden" }, { status: 403 });
+      }
+      const originFailure = requireSameOriginMutation(request, url, principal);
+      if (originFailure) return originFailure;
+      return stub.fetch("https://session.internal/durability/export", {
+        method: "POST",
+        headers: sessionHeaders,
       });
     }
     if (resource === "turns") {
@@ -1029,6 +1083,7 @@ export class DurableAgentSession extends DurableComputerSession {
   #streamError?: string;
   #deleting = false;
   #deleted = false;
+  #durabilityExported = false;
   #credentialBinding?: CredentialBindingOwnership;
   #deletionMarkerTask?: Promise<void>;
   #deletionTask?: Promise<void>;
@@ -1185,14 +1240,16 @@ export class DurableAgentSession extends DurableComputerSession {
     this.#deleted = this.#initializationOwnership()?.state === "deleted";
     this.#streamError = this.#session()?.stream_error ?? undefined;
     this.ctx.blockConcurrencyWhile(async () => {
-      const [deleting, credentialBinding, deletionGeneration] = await Promise.all([
+      const [deleting, credentialBinding, deletionGeneration, durabilityExported] = await Promise.all([
         this.ctx.storage.get<boolean>(SESSION_DELETING_KEY),
         this.ctx.storage.get<CredentialBindingOwnership>(CREDENTIAL_BINDING_KEY),
         this.ctx.storage.get<number>(SESSION_DELETION_GENERATION_KEY),
+        this.ctx.storage.get<boolean>(DURABILITY_EXPORTED_KEY),
       ]);
       this.#deleting = deleting === true;
       this.#credentialBinding = credentialBinding;
       this.#deletionGeneration = deletionGeneration ?? 0;
+      this.#durabilityExported = durabilityExported === true;
       // Durable state and SSE replay are immediately usable after eviction.
       // Re-admission or deletion may load external resources, so neither sits
       // on the object's request-readiness boundary.
@@ -1308,6 +1365,57 @@ export class DurableAgentSession extends DurableComputerSession {
       }
       await this.#scheduleNextAlarm();
       return new Response(null, { status: 204 });
+    }
+    if (request.method === "POST" && url.pathname === "/durability/import") {
+      if (this.#deleting || this.#deleted || this.#durabilityExported) {
+        return json({ error: "durability_import_conflict" }, { status: 409 });
+      }
+      const session = this.#session();
+      if (!session || session.completed_turns !== 0 || this.#agent || this.#agentPromise
+        || this.#recoverableTurnCount() !== 0) {
+        return json({ error: "durability_import_conflict" }, { status: 409 });
+      }
+      let archive: unknown;
+      try { archive = await request.json(); }
+      catch { return json({ error: "invalid_durability_import" }, { status: 400 }); }
+      try {
+        const imported = await CloudflareAgent.importDurabilityState(
+          this,
+          archive as Parameters<typeof CloudflareAgent.importDurabilityState>[1],
+        );
+        return json(imported, { headers: { "cache-control": "no-store" } });
+      } catch (error) {
+        const message = errorMessage(error);
+        const conflict = message.includes("pristine Durable Object");
+        return json({ error: conflict ? "durability_import_conflict" : "invalid_durability_import", message }, {
+          status: conflict ? 409 : 400,
+          headers: { "cache-control": "no-store" },
+        });
+      }
+    }
+    if (request.method === "POST" && url.pathname === "/durability/export") {
+      if (this.#deleting || this.#deleted || !this.#sessionId()) {
+        return json({ error: "not_found" }, { status: 404 });
+      }
+      if (this.#turns.size > 0 || this.#pendingTurnIds.size > 0
+        || this.#admissionTasks.size > 0 || this.#recoverableTurnCount() > 0) {
+        return json({ error: "agent_busy" }, { status: 409 });
+      }
+      this.#durabilityExported = true;
+      await this.ctx.storage.put(DURABILITY_EXPORTED_KEY, true);
+      try {
+        await this.#shutdownAgent(true);
+        for (const socket of this.ctx.getWebSockets()) {
+          closeSocket(socket, 1000, "durability state exported");
+        }
+        const archive = await CloudflareAgent.exportDurabilityState(this);
+        return json(archive, { headers: { "cache-control": "no-store" } });
+      } catch (error) {
+        return json({ error: "durability_export_failed", message: errorMessage(error) }, {
+          status: 503,
+          headers: { "cache-control": "no-store", "retry-after": "1" },
+        });
+      }
     }
     const forwardedOrigin = url.searchParams.get("public_origin");
     if (!this.#deleting
@@ -1590,6 +1698,9 @@ export class DurableAgentSession extends DurableComputerSession {
       });
     }
     if (request.method === "POST" && url.pathname === "/turns") {
+      if (this.#durabilityExported) {
+        return json({ error: "durability_exported" }, { status: 409 });
+      }
       return this.#submitHttpTurn(request, turnAuthorization);
     }
     if (request.method === "POST" && url.pathname === "/turns/archive") {
@@ -1791,6 +1902,9 @@ export class DurableAgentSession extends DurableComputerSession {
 
   #upgrade(authorization: TurnAuthorization): Response {
     if (this.#deleting) return new Response("Agent is being deleted", { status: 409 });
+    if (this.#durabilityExported) {
+      return new Response("Agent durability state was exported", { status: 409 });
+    }
     const session = this.#sessionStatus();
     if (!session) return new Response("Unknown session", { status: 404 });
     if (authorization.connectGrant
@@ -2090,6 +2204,14 @@ export class DurableAgentSession extends DurableComputerSession {
   async #dispatch(socket: WebSocket, command: ClientCommand): Promise<void> {
     if (this.#deleting) {
       this.#send(socket, { type: "error", code: "agent_deleting", message: "the agent is being deleted" });
+      return;
+    }
+    if (this.#durabilityExported) {
+      this.#send(socket, {
+        type: "error",
+        code: "durability_exported",
+        message: "the agent durability state was exported",
+      });
       return;
     }
     if (command.type === "ping") {
@@ -3383,6 +3505,7 @@ export class DurableAgentSession extends DurableComputerSession {
       }
       await transaction.delete(CREDENTIAL_BINDING_KEY);
       await transaction.delete(CLEANUP_RETRY_ATTEMPT_KEY);
+      await transaction.delete(DURABILITY_EXPORTED_KEY);
       await transaction.delete(INITIAL_ACCOUNT_CONTEXT_KEY);
       await transaction.delete(SESSION_DELETING_KEY);
       await transaction.deleteAlarm();
@@ -3525,6 +3648,7 @@ export class DurableAgentSession extends DurableComputerSession {
   }
 
   async #ensureAgent(): Promise<CloudflareAgent.Agent> {
+    if (this.#durabilityExported) throw new Error("durability state was exported");
     if (this.#deleting) throw retryableError("agent is being deleted");
     if (this.#agentShutdownPromise) {
       try {
@@ -3952,7 +4076,14 @@ export class DurableAgentSession extends DurableComputerSession {
       preparedTools = multiplayer
         ? undefined
         : await createDefaultManagedTools(cloudTools);
+      let durabilityId = session.session_id;
+      try {
+        durabilityId = this.ctx.storage.sql.exec<{ state_id: string }>(
+          "SELECT state_id FROM nanocodex_cloudflare_durability WHERE singleton = 1",
+        ).toArray()[0]?.state_id ?? durabilityId;
+      } catch { /* The adapter creates its identity table on first construction. */ }
       const agentOptions: NonNullable<Parameters<typeof CloudflareAgent.create>[1]> = {
+        durabilityId,
         eventPersistence: "caller",
         terminalReceiptRetention: MANAGED_TERMINAL_RECEIPT_RETENTION,
         instructions: multiplayer

--- a/services/managed/src/index.ts
+++ b/services/managed/src/index.ts
@@ -33,21 +33,29 @@ import {
   MAX_HISTORY_PAGE_SIZE,
   parseCursor,
   type DurableEvent,
+  type DurableEventTail,
 } from "./durable-events";
 import {
   ManagedEventArchive,
+  type ManagedEventArchiveState,
   type ManagedEventSealResult,
 } from "./managed-event-archive";
 import {
   ManagedTurnArchive,
+  type ManagedTurnArchiveIdentity,
   type ManagedTurnReceipt,
   type ManagedTurnSealResult,
 } from "./managed-turn-archive";
 import {
   ManagedRealtimeArchive,
+  type ManagedRealtimeArchiveState,
   type ManagedRealtimeReceipt,
   type ManagedRealtimeSealResult,
 } from "./managed-realtime-archive";
+import {
+  ManagedPortabilityArchive,
+  type ManagedPortableArchiveIdentity,
+} from "./managed-portability-archive";
 import { webAsset } from "./web";
 import {
   MultiplayerRoom,
@@ -161,6 +169,7 @@ const MAX_REALTIME_CONTEXT_BYTES = 1024 * 1024;
 const DISPATCH_INPUT_CHUNK_CODE_UNITS = 256_000;
 const MAX_PENDING_REALTIME_OPERATIONS = 32;
 const MAX_RETRY_DELAY_MS = 60_000;
+const MAX_IMPORT_BATCHES_PER_CREATE = 4;
 const UUID =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const SESSION_ID = UUID;
@@ -178,6 +187,8 @@ const INITIAL_ACCOUNT_CONTEXT_KEY = "nanocodex:initial-account-context";
 const CREDENTIAL_BINDING_KEY = "nanocodex:credential-binding";
 const CLEANUP_RETRY_ATTEMPT_KEY = "nanocodex:cleanup-retry-attempt";
 const DURABILITY_EXPORTED_KEY = "nanocodex:durability-exported";
+const DURABILITY_IMPORT_STATE_KEY = "nanocodex:durability-import-state";
+const DURABILITY_IMPORT_RECEIPT_KEY = "nanocodex:durability-import-receipt";
 const CREDENTIAL_BINDING_PREPARE_TIMEOUT_MS = 60_000;
 const DEFAULT_OWNERSHIP_IO_TIMEOUT_MS = 10_000;
 const DEFAULT_MULTIPLAYER_IO_TIMEOUT_MS = 10_000;
@@ -399,12 +410,89 @@ type AgentConstructionOwnership = {
   shutdown?: Promise<void>;
 };
 
+type DurabilityImportOwnership = Readonly<{
+  deletionGeneration: number;
+  promise: Promise<Response>;
+}>;
+
 type CredentialBindingOwnership = Readonly<{
   cleanup_at: number;
   owner_id: string;
   session_id: string;
   state: "preparing" | "active";
   subject: string;
+}>;
+
+type PortableDurabilityArchive = Readonly<{
+  format: "nanocodex-durability-state-v1";
+  payload: string;
+  revision: string;
+  stateId: string;
+}>;
+
+type ManagedDurabilityArchive = Readonly<{
+  durability: PortableDurabilityArchive;
+  format: "nanocodex-managed-durability-state-v1";
+  managed_events: ManagedEventPortability;
+  managed_realtime: ManagedRealtimePortability;
+  managed_session: ManagedSessionPortability;
+  managed_turn_receipts: ManagedTurnArchiveIdentity;
+  source_agent_id: string;
+}>;
+
+type ManagedTurnArchiveAdoption = Readonly<{
+  events: ManagedEventPortability;
+  realtime: ManagedRealtimePortability;
+  session: ManagedSessionPortability;
+  source_storage_id: string;
+  turn_receipts: ManagedTurnArchiveIdentity;
+}>;
+
+type ManagedEventPortability = Readonly<{
+  archive: ManagedPortableArchiveIdentity;
+  state: ManagedEventArchiveState;
+  tail: DurableEventTail<StreamMessage>;
+}>;
+
+type ManagedRealtimePortableOperation = Readonly<{
+  blocked: 0 | 1;
+  created_at: number;
+  kind: ManagedRealtimeKind;
+  operation_id: string;
+  request_hash: string;
+  response_json: string | null;
+  state: "pending" | "completed";
+  updated_at: number;
+  voice_session_id: string;
+}>;
+
+type ManagedRealtimePortability = Readonly<{
+  archive: ManagedPortableArchiveIdentity;
+  state: ManagedRealtimeArchiveState;
+  tail: readonly ManagedRealtimePortableOperation[];
+}>;
+
+type ManagedSessionPortability = Readonly<{
+  accepted_turns: number;
+  completed_turns: number;
+  first_prompt: string;
+  last_active: number;
+  stream_error: string | null;
+  title: string;
+}>;
+
+type ManagedDurabilityImport = Readonly<{
+  durability: unknown;
+  turn_archive_adoption?: ManagedTurnArchiveAdoption;
+}>;
+
+type DurabilityImportReceipt = Readonly<{
+  adoption?: ManagedTurnArchiveAdoption;
+  owner_id: string;
+  request_hash: string;
+  source_agent_id: string | null;
+  stage: "pending" | "authorized" | "complete";
+  state_id: string;
 }>;
 
 type RoomInitializationReceipt = {
@@ -657,6 +745,7 @@ export default {
       return json({ error: "method_not_allowed" }, { status: 405 });
     }
     if (request.method === "POST" && url.pathname === "/v1/agents") {
+      if (url.search !== "") return json({ error: "invalid_request" }, { status: 400 });
       const principal = await authenticate(request, env, url);
       if (!principal) return json({ error: "unauthorized" }, { status: 401 });
       observeManagedPrincipal(env, "managed.agent.create_requested", principal, {
@@ -684,6 +773,35 @@ export default {
       } catch {
         return json({ error: "invalid_durability_import" }, { status: 400 });
       }
+      if (durabilityArchive !== undefined
+        && !principal.capabilities.includes("agents:portability")) {
+        return json({ error: "forbidden" }, { status: 403 });
+      }
+      let managedArchive: ManagedDurabilityArchive | undefined;
+      let durabilityRequestHash: string | undefined;
+      let durabilityStateId: string | undefined;
+      if (durabilityArchive !== undefined) {
+        try {
+          if (typeof durabilityArchive === "object" && durabilityArchive !== null
+            && (durabilityArchive as { format?: unknown }).format
+              === "nanocodex-managed-durability-state-v1") {
+            managedArchive = validateManagedDurabilityArchive(durabilityArchive);
+            durabilityStateId = managedArchive.durability.stateId;
+          } else {
+            durabilityStateId = portableDurabilityStateId(durabilityArchive);
+          }
+          durabilityRequestHash = await hashText(canonicalJson(durabilityArchive));
+        } catch (error) {
+          const message = error instanceof ManagedRequestError ? error.message : errorMessage(error);
+          return json({ error: "invalid_durability_import", message }, { status: 400 });
+        }
+      }
+      if (managedArchive !== undefined && requestKey === null) {
+        return json({
+          error: "idempotency_required",
+          message: "managed durability imports require Idempotency-Key",
+        }, { status: 400 });
+      }
       const agentId = requestKey === null
         ? uuidV7()
         : await idempotentAgentId(principal.userId, requestKey);
@@ -696,6 +814,11 @@ export default {
           method: "PUT",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({
+            durability_import: durabilityRequestHash === undefined ? null : {
+              request_hash: durabilityRequestHash,
+              source_agent_id: managedArchive?.source_agent_id ?? null,
+              state_id: durabilityStateId,
+            },
             owner_id: principal.userId,
             session_id: agentId,
             subject,
@@ -704,12 +827,48 @@ export default {
       } catch {
         return json({ error: "agent cleanup initialization failed" }, { status: 503 });
       }
-      await prepared.body?.cancel();
       if (!prepared.ok) {
+        await prepared.body?.cancel();
         if (prepared.status === 409) {
-          return json({ error: "agent_creation_expired" }, { status: 409 });
+          return json({
+            error: durabilityArchive === undefined
+              ? "agent_creation_expired"
+              : "durability_import_conflict",
+          }, { status: 409 });
         }
         return json({ error: "agent cleanup initialization failed" }, { status: 503 });
+      }
+      const retainedImport = durabilityArchive === undefined
+        ? undefined
+        : await prepared.json<DurabilityImportReceipt>();
+      if (durabilityArchive === undefined) await prepared.body?.cancel();
+      let durabilityImport: ManagedDurabilityImport | undefined;
+      if (durabilityArchive !== undefined && retainedImport?.stage !== "complete") {
+        if (retainedImport?.stage === "authorized") {
+          durabilityImport = {
+            durability: managedArchive?.durability ?? durabilityArchive,
+            ...(retainedImport.adoption === undefined
+              ? {}
+              : { turn_archive_adoption: retainedImport.adoption }),
+          };
+        } else {
+          try {
+            durabilityImport = await resolveManagedDurabilityImport(
+              env,
+              principal,
+              durabilityArchive,
+              ownershipTimeoutMs,
+            );
+          } catch (error) {
+            if (error instanceof ManagedRequestError) {
+              return json({ error: error.code, message: error.message }, { status: error.status });
+            }
+            return json({ error: "durability_import_failed" }, {
+              status: 503,
+              headers: { "retry-after": "1" },
+            });
+          }
+        }
       }
       const memory = env.NANOCODEX_MEMORY.getByName(principal.organizationId);
       const [credentialBinding, initialization, memoryInitialization] = await Promise.allSettled([
@@ -759,22 +918,34 @@ export default {
           ? json({ error: "credential_broker_unavailable" }, { status: 503 })
           : json({ error: "agent initialization failed" }, { status: 503 });
       }
-      if (durabilityArchive !== undefined) {
-        let imported: Response;
-        try {
-          imported = await fetchCreateStage(stub, "https://session.internal/durability/import", {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify(durabilityArchive),
-          }, ownershipTimeoutMs, "agent durability import");
-        } catch {
-          if (requestKey === null) await requestSessionCleanup(stub, ownershipTimeoutMs);
-          return json({ error: "durability_import_failed" }, { status: 503 });
+      if (durabilityImport !== undefined) {
+        let importComplete = false;
+        for (let batch = 0; batch < MAX_IMPORT_BATCHES_PER_CREATE; batch += 1) {
+          let imported: Response;
+          try {
+            imported = await fetchCreateStage(stub, "https://session.internal/durability/import", {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify(durabilityImport),
+            }, ownershipTimeoutMs, "agent durability import");
+          } catch {
+            if (requestKey === null) await requestSessionCleanup(stub, ownershipTimeoutMs);
+            return json({ error: "durability_import_failed" }, { status: 503 });
+          }
+          await imported.body?.cancel();
+          if (imported.status === 202) continue;
+          if (!imported.ok) {
+            if (requestKey === null) await requestSessionCleanup(stub, ownershipTimeoutMs);
+            return json({ error: "invalid_durability_import" }, { status: imported.status });
+          }
+          importComplete = true;
+          break;
         }
-        await imported.body?.cancel();
-        if (!imported.ok) {
-          if (requestKey === null) await requestSessionCleanup(stub, ownershipTimeoutMs);
-          return json({ error: "invalid_durability_import" }, { status: imported.status });
+        if (!importComplete) {
+          return json({ error: "durability_import_pending" }, {
+            status: 503,
+            headers: { "retry-after": "1" },
+          });
         }
       }
       let committed: Response | undefined;
@@ -793,6 +964,21 @@ export default {
         if (requestKey === null) await requestSessionCleanup(stub, ownershipTimeoutMs);
         return json({ error: "agent cleanup commit failed" }, { status: 503 });
       }
+      const importedSession = durabilityImport?.turn_archive_adoption?.session
+        ?? retainedImport?.adoption?.session;
+      if (importedSession && importedSession.accepted_turns > 0) {
+        try {
+          await recordAgentActivity(env, principal.userId, agentId, {
+            title: importedSession.title,
+            turnCount: importedSession.accepted_turns,
+          });
+        } catch {
+          return json({ error: "agent activity update failed" }, {
+            status: 503,
+            headers: { "retry-after": "1" },
+          });
+        }
+      }
       const routeBase = "/v1/agents";
       const websocketUrl = new URL(`${routeBase}/${agentId}/ws`, url);
       websocketUrl.protocol = websocketUrl.protocol === "https:" ? "wss:" : "ws:";
@@ -804,12 +990,7 @@ export default {
       return json({
         agent_id: agentId,
         session_id: agentId,
-        durability_id: typeof durabilityArchive === "object"
-          && durabilityArchive !== null
-          && "stateId" in durabilityArchive
-          && typeof durabilityArchive.stateId === "string"
-          ? durabilityArchive.stateId
-          : agentId,
+        durability_id: durabilityStateId ?? agentId,
         events_url: new URL(`${routeBase}/${agentId}/events`, url).href,
         websocket_url: websocketUrl.href,
       }, {
@@ -876,7 +1057,8 @@ export default {
       if (request.method !== "POST") {
         return json({ error: "method_not_allowed" }, { status: 405 });
       }
-      if (!principal.capabilities.includes("agents:write")) {
+      if (url.search !== "") return json({ error: "invalid_request" }, { status: 400 });
+      if (!principal.capabilities.includes("agents:portability")) {
         return json({ error: "forbidden" }, { status: 403 });
       }
       const originFailure = requireSameOriginMutation(request, url, principal);
@@ -1061,6 +1243,7 @@ export class DurableAgentSession extends DurableComputerSession {
   #turnArchiveTask?: Promise<ManagedTurnSealResult>;
   readonly #realtimeArchive: ManagedRealtimeArchive;
   #realtimeArchiveTask?: Promise<ManagedRealtimeSealResult>;
+  readonly #portabilityArchive: ManagedPortabilityArchive;
   readonly #turns = new Map<string, Turn>();
   readonly #reopenInterruptedTurnIds = new Set<string>();
   readonly #eventTurnQueue: string[] = [];
@@ -1084,6 +1267,8 @@ export class DurableAgentSession extends DurableComputerSession {
   #deleting = false;
   #deleted = false;
   #durabilityExported = false;
+  #durabilityImportState?: "pending" | "complete";
+  #durabilityImportTask?: DurabilityImportOwnership;
   #credentialBinding?: CredentialBindingOwnership;
   #deletionMarkerTask?: Promise<void>;
   #deletionTask?: Promise<void>;
@@ -1167,6 +1352,13 @@ export class DurableAgentSession extends DurableComputerSession {
         authorization_json TEXT NOT NULL DEFAULT '{"capabilities":[]}',
         updated_at INTEGER NOT NULL
       );
+      CREATE TABLE IF NOT EXISTS managed_portability_restoration (
+        singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+        source_storage_id TEXT NOT NULL,
+        events_digest TEXT NOT NULL,
+        realtime_digest TEXT NOT NULL,
+        turn_receipts_digest TEXT NOT NULL
+      );
       CREATE TABLE IF NOT EXISTS device_host_state (
         singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
         epoch INTEGER NOT NULL DEFAULT 0,
@@ -1237,19 +1429,26 @@ export class DurableAgentSession extends DurableComputerSession {
       this.ctx.id.toString(),
       optionalPositiveInteger(this.env.MANAGED_REALTIME_ARCHIVE_RECENT_OPERATIONS),
     );
+    this.#portabilityArchive = new ManagedPortabilityArchive(
+      this.ctx.storage,
+      this.env.NANOCODEX_HISTORY,
+      this.ctx.id.toString(),
+    );
     this.#deleted = this.#initializationOwnership()?.state === "deleted";
     this.#streamError = this.#session()?.stream_error ?? undefined;
     this.ctx.blockConcurrencyWhile(async () => {
-      const [deleting, credentialBinding, deletionGeneration, durabilityExported] = await Promise.all([
+      const [deleting, credentialBinding, deletionGeneration, durabilityExported, durabilityImportState] = await Promise.all([
         this.ctx.storage.get<boolean>(SESSION_DELETING_KEY),
         this.ctx.storage.get<CredentialBindingOwnership>(CREDENTIAL_BINDING_KEY),
         this.ctx.storage.get<number>(SESSION_DELETION_GENERATION_KEY),
         this.ctx.storage.get<boolean>(DURABILITY_EXPORTED_KEY),
+        this.ctx.storage.get<"pending" | "complete">(DURABILITY_IMPORT_STATE_KEY),
       ]);
       this.#deleting = deleting === true;
       this.#credentialBinding = credentialBinding;
       this.#deletionGeneration = deletionGeneration ?? 0;
       this.#durabilityExported = durabilityExported === true;
+      this.#durabilityImportState = durabilityImportState;
       // Durable state and SSE replay are immediately usable after eviction.
       // Re-admission or deletion may load external resources, so neither sits
       // on the object's request-readiness boundary.
@@ -1279,22 +1478,44 @@ export class DurableAgentSession extends DurableComputerSession {
     }
     if (request.method === "PUT" && url.pathname === "/credential-binding") {
       if (this.#deleting || this.#deleted) return new Response(null, { status: 409 });
-      let ownership: Partial<CredentialBindingOwnership>;
-      try { ownership = await request.json<Partial<CredentialBindingOwnership>>(); }
+      let ownership: Partial<CredentialBindingOwnership> & { durability_import?: unknown };
+      try {
+        ownership = await request.json<Partial<CredentialBindingOwnership> & {
+          durability_import?: unknown;
+        }>();
+      }
       catch { return new Response(null, { status: 400 }); }
       if (!isUserId(ownership.owner_id)
         || typeof ownership.session_id !== "string"
         || !SESSION_ID.test(ownership.session_id)
         || typeof ownership.subject !== "string"
-        || ownership.subject !== this.ctx.id.toString()) {
+        || ownership.subject !== this.ctx.id.toString()
+        || !validDurabilityImportPreparation(ownership.durability_import)) {
         return new Response(null, { status: 400 });
       }
+      const requestedImport = ownership.durability_import as {
+        request_hash: string;
+        source_agent_id: string | null;
+        state_id: string;
+      } | null;
+      const retainedImport = await this.ctx.storage.get<DurabilityImportReceipt>(
+        DURABILITY_IMPORT_RECEIPT_KEY,
+      );
       const current = this.#credentialBinding;
       if (current && (current.owner_id !== ownership.owner_id
         || current.session_id !== ownership.session_id
         || current.subject !== ownership.subject)) {
         return new Response(null, { status: 409 });
       }
+      if (current && (retainedImport !== undefined) !== (requestedImport !== null)) {
+        return new Response(null, { status: 409 });
+      }
+      if (retainedImport && requestedImport && (
+        retainedImport.owner_id !== ownership.owner_id
+        || retainedImport.request_hash !== requestedImport.request_hash
+        || retainedImport.source_agent_id !== requestedImport.source_agent_id
+        || retainedImport.state_id !== requestedImport.state_id
+      )) return new Response(null, { status: 409 });
       if (!current) {
         const prepared: CredentialBindingOwnership = {
           cleanup_at: Date.now() + this.#credentialPreparationLeaseMs(),
@@ -1305,9 +1526,20 @@ export class DurableAgentSession extends DurableComputerSession {
         };
         await this.ctx.storage.transaction(async (transaction) => {
           await transaction.put(CREDENTIAL_BINDING_KEY, prepared);
+          if (requestedImport) {
+            await transaction.put(DURABILITY_IMPORT_STATE_KEY, "pending");
+            await transaction.put(DURABILITY_IMPORT_RECEIPT_KEY, {
+              owner_id: ownership.owner_id!,
+              request_hash: requestedImport.request_hash,
+              source_agent_id: requestedImport.source_agent_id,
+              stage: "pending",
+              state_id: requestedImport.state_id,
+            } satisfies DurabilityImportReceipt);
+          }
           await transaction.setAlarm(prepared.cleanup_at);
         });
         this.#credentialBinding = prepared;
+        this.#durabilityImportState = requestedImport ? "pending" : undefined;
       } else if (current.state === "preparing") {
         const refreshed = {
           ...current,
@@ -1318,6 +1550,13 @@ export class DurableAgentSession extends DurableComputerSession {
           await transaction.setAlarm(refreshed.cleanup_at);
         });
         this.#credentialBinding = refreshed;
+      }
+      if (requestedImport) {
+        const receipt = await this.ctx.storage.get<DurabilityImportReceipt>(
+          DURABILITY_IMPORT_RECEIPT_KEY,
+        );
+        if (!receipt) return new Response(null, { status: 409 });
+        return json(receipt, { headers: { "cache-control": "no-store" } });
       }
       return new Response(null, { status: 204 });
     }
@@ -1340,6 +1579,7 @@ export class DurableAgentSession extends DurableComputerSession {
     }
     if (request.method === "POST" && url.pathname === "/credential-binding/commit") {
       if (this.#deleting || this.#deleted) return new Response(null, { status: 409 });
+      if (this.#durabilityImportState === "pending") return new Response(null, { status: 409 });
       const ownership = await this.#refreshCredentialPreparation();
       const session = this.#session();
       if (!ownership || !session
@@ -1367,48 +1607,90 @@ export class DurableAgentSession extends DurableComputerSession {
       return new Response(null, { status: 204 });
     }
     if (request.method === "POST" && url.pathname === "/durability/import") {
-      if (this.#deleting || this.#deleted || this.#durabilityExported) {
-        return json({ error: "durability_import_conflict" }, { status: 409 });
+      if (this.#durabilityImportTask) {
+        return json({ error: "durability_import_pending" }, {
+          status: 409,
+          headers: { "cache-control": "no-store", "retry-after": "1" },
+        });
       }
-      const session = this.#session();
-      if (!session || session.completed_turns !== 0 || this.#agent || this.#agentPromise
-        || this.#recoverableTurnCount() !== 0) {
-        return json({ error: "durability_import_conflict" }, { status: 409 });
-      }
-      let archive: unknown;
-      try { archive = await request.json(); }
-      catch { return json({ error: "invalid_durability_import" }, { status: 400 }); }
+      const ownership = {
+        deletionGeneration: this.#deletionGeneration,
+        promise: undefined as unknown as Promise<Response>,
+      };
+      ownership.promise = Promise.resolve().then(
+        () => this.#performDurabilityImport(request, ownership),
+      );
+      this.#durabilityImportTask = ownership;
       try {
-        const imported = await CloudflareAgent.importDurabilityState(
-          this,
-          archive as Parameters<typeof CloudflareAgent.importDurabilityState>[1],
-        );
-        return json(imported, { headers: { "cache-control": "no-store" } });
+        return await ownership.promise;
+      } finally {
+        if (this.#durabilityImportTask === ownership) this.#durabilityImportTask = undefined;
+      }
+    }
+    if (request.method === "POST" && url.pathname === "/durability/adoption") {
+      if (!this.#durabilityExported || this.#deleting || this.#deleted) {
+        return json({ error: "durability_adoption_conflict" }, { status: 409 });
+      }
+      const deletionGeneration = this.#deletionGeneration;
+      try {
+        const archive = await this.#managedDurabilityArchive();
+        if (this.#deleting || this.#deleted
+          || this.#deletionGeneration !== deletionGeneration) {
+          return json({ error: "durability_adoption_conflict" }, { status: 409 });
+        }
+        if (!archive) {
+          return json({ stage: "exporting" }, {
+            status: 202,
+            headers: { "cache-control": "no-store", "retry-after": "1" },
+          });
+        }
+        return json({
+          archive,
+          source_storage_id: this.ctx.id.toString(),
+        }, { headers: { "cache-control": "no-store" } });
       } catch (error) {
-        const message = errorMessage(error);
-        const conflict = message.includes("pristine Durable Object");
-        return json({ error: conflict ? "durability_import_conflict" : "invalid_durability_import", message }, {
-          status: conflict ? 409 : 400,
-          headers: { "cache-control": "no-store" },
+        return json({ error: "durability_adoption_failed", message: errorMessage(error) }, {
+          status: 503,
+          headers: { "cache-control": "no-store", "retry-after": "1" },
         });
       }
     }
     if (request.method === "POST" && url.pathname === "/durability/export") {
+      if (this.#durabilityImportState === "pending") {
+        return json({ error: "durability_import_pending" }, { status: 409 });
+      }
       if (this.#deleting || this.#deleted || !this.#sessionId()) {
         return json({ error: "not_found" }, { status: 404 });
       }
       if (this.#turns.size > 0 || this.#pendingTurnIds.size > 0
-        || this.#admissionTasks.size > 0 || this.#recoverableTurnCount() > 0) {
+        || this.#admissionTasks.size > 0 || this.#recoverableTurnCount() > 0
+        || this.#cancellationTasks.size > 0 || this.#realtimeOperations.size > 0
+        || this.#pendingDeviceToolCalls.size > 0 || this.#inFlight.size > 0
+        || this.#hostedTools.hasPendingCalls()
+        || this.#agentPromise !== undefined || this.#managedRealtimeSession() !== undefined
+        || this.ctx.storage.sql.exec<{ count: number }>(
+          "SELECT COUNT(*) AS count FROM managed_realtime_operations WHERE state = 'pending' AND blocked = 0",
+        ).one().count > 0) {
         return json({ error: "agent_busy" }, { status: 409 });
       }
       this.#durabilityExported = true;
+      // Fence socket-owned mutation synchronously with the admission flag.
+      // No request may cross an await between observing active admission and
+      // these owners being retired.
+      this.#hostedTools.shutdown("durability state exported");
+      for (const socket of this.ctx.getWebSockets()) {
+        closeSocket(socket, 1000, "durability state exported");
+      }
       await this.ctx.storage.put(DURABILITY_EXPORTED_KEY, true);
       try {
         await this.#shutdownAgent(true);
-        for (const socket of this.ctx.getWebSockets()) {
-          closeSocket(socket, 1000, "durability state exported");
+        const archive = await this.#managedDurabilityArchive();
+        if (!archive) {
+          return json({ stage: "exporting" }, {
+            status: 202,
+            headers: { "cache-control": "no-store", "retry-after": "1" },
+          });
         }
-        const archive = await CloudflareAgent.exportDurabilityState(this);
         return json(archive, { headers: { "cache-control": "no-store" } });
       } catch (error) {
         return json({ error: "durability_export_failed", message: errorMessage(error) }, {
@@ -1416,6 +1698,10 @@ export class DurableAgentSession extends DurableComputerSession {
           headers: { "cache-control": "no-store", "retry-after": "1" },
         });
       }
+    }
+    if (this.#durabilityExported
+      && !(request.method === "DELETE" && url.pathname === "/session")) {
+      return json({ error: "durability_exported" }, { status: 409 });
     }
     const forwardedOrigin = url.searchParams.get("public_origin");
     if (!this.#deleting
@@ -1563,6 +1849,13 @@ export class DurableAgentSession extends DurableComputerSession {
       }
       if (event) this.#publish(event);
       return new Response(null, { status: 204 });
+    }
+    if (this.#durabilityImportState === "pending"
+      && !(request.method === "DELETE" && url.pathname === "/session")) {
+      return json({ error: "durability_import_pending" }, {
+        status: 409,
+        headers: { "cache-control": "no-store", "retry-after": "1" },
+      });
     }
     if (request.method === "GET" && url.pathname === "/socket")
       return this.#upgrade(turnAuthorization);
@@ -1785,6 +2078,10 @@ export class DurableAgentSession extends DurableComputerSession {
   }
 
   async webSocketMessage(socket: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    if (this.#durabilityExported || this.#durabilityImportState === "pending") {
+      closeSocket(socket, 1008, "agent durability transfer fenced this connection");
+      return;
+    }
     if (this.#hostedTools.owns(socket)) {
       if (typeof message !== "string") {
         closeSocket(socket, 1003, "Hosted Tools requires text frames");
@@ -1934,6 +2231,9 @@ export class DurableAgentSession extends DurableComputerSession {
 
   #upgradeDeviceHost(): Response {
     if (this.#deleting) return new Response("Agent is being deleted", { status: 409 });
+    if (this.#durabilityExported || this.#durabilityImportState === "pending") {
+      return new Response("Agent durability transfer is pending", { status: 409 });
+    }
     const session = this.#sessionStatus();
     if (!session) return new Response("Unknown session", { status: 404 });
     if (this.#session()?.runtime_profile !== "managed") {
@@ -2232,6 +2532,7 @@ export class DurableAgentSession extends DurableComputerSession {
     if (command.type === "cancel") {
       try {
         const row = await this.#findManagedTurn(command.id);
+        this.#assertDurabilityAdmissionActive();
         if (!row) throw new ManagedRequestError(404, "turn_not_found", `turn ${command.id} does not exist`);
         if (isTerminalState(row.state)) {
           this.#send(socket, messageForManagedTurn(row));
@@ -2252,6 +2553,7 @@ export class DurableAgentSession extends DurableComputerSession {
         return;
       }
       try {
+        this.#assertDurabilityAdmissionActive();
         await turn.steer({ input: appendMemoryReviewCheckpoint(command.input) });
       } catch (error) {
         this.#send(socket, { type: "error", code: "steer_failed", message: errorMessage(error) });
@@ -2392,6 +2694,9 @@ export class DurableAgentSession extends DurableComputerSession {
     if (this.#deleting || this.#deleted) {
       return json({ error: "agent_deleting" }, { status: 409 });
     }
+    if (this.#durabilityExported) {
+      return json({ error: "durability_transfer_pending" }, { status: 409 });
+    }
     if (authorization.connectGrant
       && !authorization.connectGrant.connectors.includes("chatgpt")) {
       return json({ error: "connector_forbidden" }, { status: 403 });
@@ -2480,6 +2785,9 @@ export class DurableAgentSession extends DurableComputerSession {
         ...(parsed.input === undefined ? {} : { input: parsed.input }),
       }),
     );
+    if (this.#durabilityExported || this.#durabilityImportState === "pending") {
+      return json({ error: "durability_transfer_pending" }, { status: 409 });
+    }
     try {
       const result = await this.#runRealtimeOperation(
         parsed,
@@ -2653,19 +2961,22 @@ export class DurableAgentSession extends DurableComputerSession {
     }
 
     const now = Date.now();
-    this.ctx.storage.sql.exec(
-      `INSERT INTO managed_realtime_operations (
+    this.ctx.storage.transactionSync(() => {
+      this.#assertDurabilityAdmissionActive();
+      this.ctx.storage.sql.exec(
+        `INSERT INTO managed_realtime_operations (
          voice_session_id, operation_id, kind, request_hash, state, blocked,
          response_json, created_at, updated_at
        ) VALUES (?, ?, ?, ?, 'pending', 0, NULL, ?, ?)
        ON CONFLICT (voice_session_id, operation_id) DO UPDATE SET updated_at = excluded.updated_at`,
-      request.voiceSessionId,
-      request.operationId,
-      kind,
-      requestHash,
-      now,
-      now,
-    );
+        request.voiceSessionId,
+        request.operationId,
+        kind,
+        requestHash,
+        now,
+        now,
+      );
+    });
     const task = this.#track(
       (async () => {
         try {
@@ -2747,6 +3058,9 @@ export class DurableAgentSession extends DurableComputerSession {
     });
     await previous.catch(() => {});
     try {
+      // Waiting for the prior routed operation yields to export. Recheck
+      // immediately before the Rust route can create any model/tool effect.
+      this.#assertRealtimeRouteAvailable();
       this.#realtimeEventBuffer = [];
       let turn: Turn | undefined;
       try {
@@ -2812,6 +3126,9 @@ export class DurableAgentSession extends DurableComputerSession {
   }
 
   async #steerHttpTurn(id: string, request: Request): Promise<Response> {
+    if (this.#durabilityExported || this.#durabilityImportState === "pending") {
+      return json({ error: "durability_transfer_pending" }, { status: 409 });
+    }
     let row: ManagedTurnRow | undefined;
     try { row = await this.#findManagedTurn(id); }
     catch (error) { return managedErrorResponse(error, "turn_archive_unavailable"); }
@@ -2841,6 +3158,7 @@ export class DurableAgentSession extends DurableComputerSession {
         );
       }
       validatePromptInput(value.input);
+      this.#assertDurabilityAdmissionActive();
       await turn.steer({ input: appendMemoryReviewCheckpoint(value.input as PromptInput) });
       return json({ turn_id: id, state: "steering" }, { status: 202 });
     } catch (error) {
@@ -2857,6 +3175,9 @@ export class DurableAgentSession extends DurableComputerSession {
   }
 
   async #cancelHttpTurn(id: string): Promise<Response> {
+    if (this.#durabilityExported || this.#durabilityImportState === "pending") {
+      return json({ error: "durability_transfer_pending" }, { status: 409 });
+    }
     let row: ManagedTurnRow | undefined;
     try { row = await this.#findManagedTurn(id); }
     catch (error) { return managedErrorResponse(error, "turn_archive_unavailable"); }
@@ -2885,6 +3206,9 @@ export class DurableAgentSession extends DurableComputerSession {
         "agent_deleting",
         "the agent is being deleted",
       );
+    }
+    if (this.#durabilityExported || this.#durabilityImportState === "pending") {
+      throw new ManagedRequestError(409, "durability_transfer_pending", "durability transfer fenced admission");
     }
     if (this.#streamError) {
       throw new ManagedRequestError(
@@ -2943,6 +3267,7 @@ export class DurableAgentSession extends DurableComputerSession {
     const firstPrompt = promptInputText(input);
     let event: DurableEvent<StreamMessage> | undefined;
     this.ctx.storage.transactionSync(() => {
+      this.#assertDurabilityAdmissionActive();
       if (this.#managedTurn(id) || this.#managedTurnByRequestKey(requestKey)) {
         throw new ManagedRequestError(
           409,
@@ -3038,12 +3363,16 @@ export class DurableAgentSession extends DurableComputerSession {
     if (this.#deleting || this.#deleted) {
       throw new ManagedRequestError(409, "agent_deleting", "the agent is being deleted");
     }
+    if (this.#durabilityExported || this.#durabilityImportState === "pending") {
+      throw new ManagedRequestError(409, "durability_transfer_pending", "durability transfer fenced admission");
+    }
     const archived = await Promise.all([
       this.#managedTurn(id) ? Promise.resolve(undefined) : this.#archivedTurnById(id),
       requestKey === null || this.#managedTurnByRequestKey(requestKey)
         ? Promise.resolve(undefined)
         : this.#archivedTurnByRequestKey(requestKey),
     ]);
+    this.#assertDurabilityAdmissionActive();
     if (this.#deleting || this.#deleted) {
       throw new ManagedRequestError(409, "agent_deleting", "the agent is being deleted");
     }
@@ -3104,6 +3433,7 @@ export class DurableAgentSession extends DurableComputerSession {
     let cancellingEvent: DurableEvent<StreamMessage> | undefined;
     let cancellationRequested = false;
     this.ctx.storage.transactionSync(() => {
+      this.#assertDurabilityAdmissionActive();
       if (this.#deleting || !this.#sessionId()) {
         throw new ManagedRequestError(409, "agent_deleting", "the agent is being deleted");
       }
@@ -3164,6 +3494,7 @@ export class DurableAgentSession extends DurableComputerSession {
   #reservePreAdmissionCancellation(id: string): ManagedTurnRow | undefined {
     let concurrent: ManagedTurnRow | undefined;
     this.ctx.storage.transactionSync(() => {
+      this.#assertDurabilityAdmissionActive();
       concurrent = this.#managedTurn(id);
       if (concurrent) return;
       const existing = this.ctx.storage.sql.exec<{ turn_id: string }>(
@@ -3188,6 +3519,16 @@ export class DurableAgentSession extends DurableComputerSession {
       );
     });
     return concurrent;
+  }
+
+  #assertDurabilityAdmissionActive(): void {
+    if (this.#durabilityExported || this.#durabilityImportState === "pending") {
+      throw new ManagedRequestError(
+        409,
+        "durability_transfer_pending",
+        "durability transfer fenced admission",
+      );
+    }
   }
 
   #markCancelling(id: string): ManagedTurnRow {
@@ -3243,8 +3584,10 @@ export class DurableAgentSession extends DurableComputerSession {
       return;
     }
     if (!turn) {
+      const cancellingAdmission = row.state === "cancelling";
       row = await this.#admitManagedTurn(row, true);
       if (isTerminalState(row.state)) return;
+      if (cancellingAdmission) return;
       turn = this.#turns.get(id);
     }
     if (!turn) {
@@ -3324,7 +3667,8 @@ export class DurableAgentSession extends DurableComputerSession {
         input: JSON.parse(dispatchInputJson) as PromptInput,
       });
       this.#turns.set(row.id, turn);
-      const durableId = await turn.accepted();
+      const cancellation = dispatchable.state === "cancelling" ? turn.cancel() : undefined;
+      const [durableId] = await Promise.all([turn.accepted(), cancellation]);
       if (durableId !== undefined && durableId !== row.id) {
         throw new Error(`durable admission returned unexpected turn id ${durableId}`);
       }
@@ -3344,7 +3688,10 @@ export class DurableAgentSession extends DurableComputerSession {
         row.id,
       );
       this.ctx.waitUntil(this.#track(this.#complete(row.id, turn)));
-      if (this.#managedTurn(row.id)?.state === "cancelling") this.#scheduleCancellation(row.id);
+      if (cancellation === undefined
+        && this.#managedTurn(row.id)?.state === "cancelling") {
+        this.#scheduleCancellation(row.id);
+      }
       return this.#managedTurn(row.id) ?? row;
     } catch (error) {
       this.#releaseEventTurn(row.id);
@@ -3357,6 +3704,168 @@ export class DurableAgentSession extends DurableComputerSession {
       const failed = this.#commitManagedResolution(row.id, failure);
       if (failure.reopenAgent) await this.#reopenAgent(row.id);
       return failed;
+    }
+  }
+
+  async #performDurabilityImport(
+    request: Request,
+    ownership: DurabilityImportOwnership,
+  ): Promise<Response> {
+    if (this.#deleting || this.#deleted || this.#durabilityExported
+      || this.#durabilityImportState === undefined) {
+      return json({ error: "durability_import_conflict" }, { status: 409 });
+    }
+    const session = this.#session();
+    if (!session || session.completed_turns !== 0 || this.#agent || this.#agentPromise
+      || this.#recoverableTurnCount() !== 0) {
+      return json({ error: "durability_import_conflict" }, { status: 409 });
+    }
+    let archive: ManagedDurabilityImport;
+    try {
+      const value = await request.json<ManagedDurabilityImport>();
+      this.#assertDurabilityImportOwnership(ownership);
+      if (!value || typeof value !== "object" || Array.isArray(value)
+        || Object.keys(value).some((key) => key !== "durability" && key !== "turn_archive_adoption")
+        || !("durability" in value)) {
+        throw new Error("invalid managed durability import envelope");
+      }
+      archive = value;
+    } catch (error) {
+      if (!this.#ownsDurabilityImport(ownership)) {
+        return json({ error: "durability_import_conflict" }, { status: 409 });
+      }
+      return json({ error: "invalid_durability_import", message: errorMessage(error) }, {
+        status: 400,
+      });
+    }
+    let importReceipt = await this.ctx.storage.get<DurabilityImportReceipt>(
+      DURABILITY_IMPORT_RECEIPT_KEY,
+    );
+    this.#assertDurabilityImportOwnership(ownership);
+    if (!importReceipt || importReceipt.owner_id !== session.owner_id) {
+      return json({ error: "durability_import_conflict" }, { status: 409 });
+    }
+    if (importReceipt.stage === "pending") {
+      importReceipt = {
+        ...importReceipt,
+        ...(archive.turn_archive_adoption === undefined
+          ? {}
+          : { adoption: archive.turn_archive_adoption }),
+        stage: "authorized",
+      };
+      await this.ctx.storage.put(DURABILITY_IMPORT_RECEIPT_KEY, importReceipt);
+      this.#assertDurabilityImportOwnership(ownership);
+    } else if (importReceipt.stage === "authorized"
+      && JSON.stringify(importReceipt.adoption) !== JSON.stringify(archive.turn_archive_adoption)) {
+      return json({ error: "durability_import_conflict" }, { status: 409 });
+    }
+    try {
+      const imported = await CloudflareAgent.importDurabilityState(
+        this,
+        archive.durability as Parameters<typeof CloudflareAgent.importDurabilityState>[1],
+      );
+      this.#assertDurabilityImportOwnership(ownership);
+      try {
+        if (archive.turn_archive_adoption) {
+          await this.#refreshCredentialPreparation(ownership);
+          this.#assertDurabilityImportOwnership(ownership);
+          const adopted = await this.#turnArchive.adoptBatch(
+            archive.turn_archive_adoption.source_storage_id,
+            archive.turn_archive_adoption.turn_receipts,
+            () => this.#assertDurabilityImportOwnership(ownership),
+          );
+          this.#assertDurabilityImportOwnership(ownership);
+          await this.#refreshCredentialPreparation(ownership);
+          this.#assertDurabilityImportOwnership(ownership);
+          if (!adopted.complete) {
+            return json({ stage: "adopting" }, {
+              status: 202,
+              headers: { "cache-control": "no-store", "retry-after": "1" },
+            });
+          }
+          const adoptedEvents = await this.#portabilityArchive.adoptBatch(
+            "events",
+            archive.turn_archive_adoption.source_storage_id,
+            archive.turn_archive_adoption.events.archive,
+            () => this.#assertDurabilityImportOwnership(ownership),
+          );
+          this.#assertDurabilityImportOwnership(ownership);
+          if (!adoptedEvents.complete) {
+            return json({ stage: "adopting_events" }, {
+              status: 202,
+              headers: { "cache-control": "no-store", "retry-after": "1" },
+            });
+          }
+          const adoptedRealtime = await this.#portabilityArchive.adoptBatch(
+            "realtime",
+            archive.turn_archive_adoption.source_storage_id,
+            archive.turn_archive_adoption.realtime.archive,
+            () => this.#assertDurabilityImportOwnership(ownership),
+          );
+          this.#assertDurabilityImportOwnership(ownership);
+          if (!adoptedRealtime.complete) {
+            return json({ stage: "adopting_realtime" }, {
+              status: 202,
+              headers: { "cache-control": "no-store", "retry-after": "1" },
+            });
+          }
+          this.#restoreManagedPortability(archive.turn_archive_adoption, ownership);
+        } else if (this.#turnArchive.capacity().archived_receipts !== 0) {
+          throw new Error("unclaimed managed turn archive exists at import destination");
+        }
+      } catch (error) {
+        if (!this.#ownsDurabilityImport(ownership)) {
+          return json({ error: "durability_import_conflict" }, { status: 409 });
+        }
+        return json({ error: "durability_adoption_failed", message: errorMessage(error) }, {
+          status: 503,
+          headers: { "cache-control": "no-store", "retry-after": "1" },
+        });
+      }
+      await this.ctx.storage.transaction(async (transaction) => {
+        const [deleting, retainedGeneration] = await Promise.all([
+          transaction.get<boolean>(SESSION_DELETING_KEY),
+          transaction.get<number>(SESSION_DELETION_GENERATION_KEY),
+        ]);
+        this.#assertDurabilityImportOwnership(ownership);
+        if (deleting === true || (retainedGeneration ?? 0) !== ownership.deletionGeneration) {
+          throw new Error("managed durability import lost its durable deletion fence");
+        }
+        await transaction.put(DURABILITY_IMPORT_STATE_KEY, "complete");
+        await transaction.put(DURABILITY_IMPORT_RECEIPT_KEY, {
+          ...importReceipt,
+          stage: "complete",
+        } satisfies DurabilityImportReceipt);
+      });
+      this.#assertDurabilityImportOwnership(ownership);
+      this.#durabilityImportState = "complete";
+      return json(imported, { headers: { "cache-control": "no-store" } });
+    } catch (error) {
+      if (!this.#ownsDurabilityImport(ownership)) {
+        return json({ error: "durability_import_conflict" }, { status: 409 });
+      }
+      const message = errorMessage(error);
+      const conflict = message.includes("pristine Durable Object");
+      return json({
+        error: conflict ? "durability_import_conflict" : "invalid_durability_import",
+        message,
+      }, {
+        status: conflict ? 409 : 400,
+        headers: { "cache-control": "no-store" },
+      });
+    }
+  }
+
+  #ownsDurabilityImport(ownership: DurabilityImportOwnership): boolean {
+    return !this.#deleting
+      && !this.#deleted
+      && this.#durabilityImportTask === ownership
+      && this.#deletionGeneration === ownership.deletionGeneration;
+  }
+
+  #assertDurabilityImportOwnership(ownership: DurabilityImportOwnership): void {
+    if (!this.#ownsDurabilityImport(ownership)) {
+      throw new Error("managed durability import lost its deletion-generation fence");
     }
   }
 
@@ -3493,8 +4002,10 @@ export class DurableAgentSession extends DurableComputerSession {
       this.#eventArchive.clearLocalState();
       this.#turnArchive.clearLocalState();
       this.#realtimeArchive.clearLocalState();
+      this.#portabilityArchive.clearLocalState();
       this.ctx.storage.sql.exec("DELETE FROM managed_realtime_operations");
       this.ctx.storage.sql.exec("DELETE FROM managed_realtime_session");
+      this.ctx.storage.sql.exec("DELETE FROM managed_portability_restoration");
       this.ctx.storage.sql.exec("DELETE FROM session_state");
     });
     await this.ctx.storage.transaction(async (transaction) => {
@@ -3506,12 +4017,15 @@ export class DurableAgentSession extends DurableComputerSession {
       await transaction.delete(CREDENTIAL_BINDING_KEY);
       await transaction.delete(CLEANUP_RETRY_ATTEMPT_KEY);
       await transaction.delete(DURABILITY_EXPORTED_KEY);
+      await transaction.delete(DURABILITY_IMPORT_STATE_KEY);
+      await transaction.delete(DURABILITY_IMPORT_RECEIPT_KEY);
       await transaction.delete(INITIAL_ACCOUNT_CONTEXT_KEY);
       await transaction.delete(SESSION_DELETING_KEY);
       await transaction.deleteAlarm();
     });
     this.#assertDeletionGeneration(generation);
     this.#credentialBinding = undefined;
+    this.#durabilityImportState = undefined;
     this.#initialAccountContextTask = undefined;
     this.#deleting = false;
   }
@@ -3522,6 +4036,7 @@ export class DurableAgentSession extends DurableComputerSession {
     const shutdown = this.#agentShutdownPromise;
     const turns = [...this.#turns.values()];
     const inFlight = [...this.#inFlight];
+    if (this.#durabilityImportTask) inFlight.push(this.#durabilityImportTask.promise);
 
     this.#runtimeOwnershipGeneration += 1;
     this.#agent = undefined;
@@ -4749,14 +5264,19 @@ export class DurableAgentSession extends DurableComputerSession {
     return observed;
   }
 
-  #sealTurnArchive(force: boolean): Promise<ManagedTurnSealResult> {
+  #sealTurnArchive(
+    force: boolean,
+    retainTerminalTurns?: number,
+  ): Promise<ManagedTurnSealResult> {
     if (this.#deleting) return Promise.reject(new Error("agent deletion fenced turn archival"));
     const active = this.#turnArchiveTask;
     if (active) {
-      return force ? active.then(() => this.#sealTurnArchive(true)) : active;
+      return force
+        ? active.then(() => this.#sealTurnArchive(true, retainTerminalTurns))
+        : active;
     }
     const started = performance.now();
-    const observed = this.#turnArchive.seal(force).then((result) => {
+    const observed = this.#turnArchive.seal(force, retainTerminalTurns).then((result) => {
       if (result.sealed) {
         this.#logCapacity("archive_seal", {
           archived_receipt_bytes: result.archived_bytes,
@@ -4776,6 +5296,146 @@ export class DurableAgentSession extends DurableComputerSession {
     }).catch(() => {});
     this.ctx.waitUntil(observed.catch(() => {}));
     return observed;
+  }
+
+  async #managedDurabilityArchive(): Promise<ManagedDurabilityArchive | undefined> {
+    const session = this.#session();
+    if (!session) throw new Error("managed durability export has no session identity");
+    if ((await this.#sealEventArchive(true)).sealed) return undefined;
+    if ((await this.#sealTurnArchive(true, 0)).sealed) return undefined;
+    if ((await this.#sealRealtimeArchive(true)).sealed) return undefined;
+    const [turns, events, realtime] = await Promise.all([
+      this.#turnArchive.identityBatch(),
+      this.#portabilityArchive.identityBatch("events"),
+      this.#portabilityArchive.identityBatch("realtime"),
+    ]);
+    if (!turns.complete || !turns.identity
+      || !events.complete || !events.identity
+      || !realtime.complete || !realtime.identity) return undefined;
+    const sessionState = this.ctx.storage.sql.exec<{
+      accepted_turns: number;
+      completed_turns: number;
+      first_prompt: string;
+      last_active: number;
+      stream_error: string | null;
+    }>(
+      `SELECT accepted_turns, completed_turns, first_prompt, last_active, stream_error
+       FROM session_state WHERE singleton = 1`,
+    ).one();
+    const durability = await CloudflareAgent.exportDurabilityState(this);
+    return {
+      durability: durability as PortableDurabilityArchive,
+      format: "nanocodex-managed-durability-state-v1",
+      managed_events: {
+        archive: events.identity,
+        state: this.#eventArchive.portableState(),
+        tail: this.#eventLog.portableTail(this.#eventArchive.archivedThrough()),
+      },
+      managed_realtime: {
+        archive: realtime.identity,
+        state: this.#realtimeArchive.portableState(),
+        tail: this.#portableRealtimeTail(),
+      },
+      managed_session: {
+        ...sessionState,
+        title: conversationTitle(sessionState.first_prompt),
+      },
+      managed_turn_receipts: turns.identity,
+      source_agent_id: session.session_id,
+    };
+  }
+
+  #portableRealtimeTail(): ManagedRealtimePortableOperation[] {
+    return this.ctx.storage.sql.exec<ManagedRealtimePortableOperation>(
+      `SELECT voice_session_id, operation_id, kind, request_hash, state, blocked,
+              response_json, created_at, updated_at
+       FROM managed_realtime_operations
+       ORDER BY created_at, updated_at, voice_session_id, operation_id`,
+    ).toArray();
+  }
+
+  #restoreManagedPortability(
+    adoption: ManagedTurnArchiveAdoption,
+    ownership: DurabilityImportOwnership,
+  ): void {
+    this.#assertDurabilityImportOwnership(ownership);
+    this.ctx.storage.transactionSync(() => {
+      this.#assertDurabilityImportOwnership(ownership);
+      const restored = this.ctx.storage.sql.exec<{
+        events_digest: string;
+        realtime_digest: string;
+        source_storage_id: string;
+        turn_receipts_digest: string;
+      }>(
+        `SELECT source_storage_id, events_digest, realtime_digest, turn_receipts_digest
+         FROM managed_portability_restoration WHERE singleton = 1`,
+      ).toArray()[0];
+      if (restored) {
+        if (restored.source_storage_id !== adoption.source_storage_id
+          || restored.events_digest !== adoption.events.archive.digest
+          || restored.realtime_digest !== adoption.realtime.archive.digest
+          || restored.turn_receipts_digest !== adoption.turn_receipts.digest) {
+          throw new Error("managed portability restoration conflicts with retained identity");
+        }
+        return;
+      }
+      const session = this.ctx.storage.sql.exec<{
+        accepted_turns: number;
+        completed_turns: number;
+      }>(
+        "SELECT accepted_turns, completed_turns FROM session_state WHERE singleton = 1",
+      ).one();
+      const realtimeRows = this.ctx.storage.sql.exec<{ count: number }>(
+        "SELECT COUNT(*) AS count FROM managed_realtime_operations",
+      ).one().count;
+      if (session.accepted_turns !== 0 || session.completed_turns !== 0
+        || realtimeRows !== 0 || this.#eventArchive.capacity().archived_events !== 0
+        || this.#realtimeArchive.capacity().archived_receipts !== 0) {
+        throw new Error("managed portability adoption requires a pristine destination");
+      }
+      this.#eventArchive.adoptState(adoption.events.state);
+      this.#eventLog.adoptTail(adoption.events.tail, false);
+      this.#realtimeArchive.adoptState(adoption.realtime.state);
+      for (const operation of adoption.realtime.tail) {
+        this.ctx.storage.sql.exec(
+          `INSERT INTO managed_realtime_operations (
+             voice_session_id, operation_id, kind, request_hash, state, blocked,
+             response_json, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          operation.voice_session_id,
+          operation.operation_id,
+          operation.kind,
+          operation.request_hash,
+          operation.state,
+          operation.blocked,
+          operation.response_json,
+          operation.created_at,
+          operation.updated_at,
+        );
+      }
+      this.ctx.storage.sql.exec(
+        `UPDATE session_state
+         SET accepted_turns = ?, completed_turns = ?, first_prompt = ?,
+             last_active = ?, stream_error = ?
+         WHERE singleton = 1`,
+        adoption.session.accepted_turns,
+        adoption.session.completed_turns,
+        adoption.session.first_prompt,
+        adoption.session.last_active,
+        adoption.session.stream_error,
+      );
+      this.ctx.storage.sql.exec(
+        `INSERT INTO managed_portability_restoration (
+           singleton, source_storage_id, events_digest, realtime_digest, turn_receipts_digest
+         ) VALUES (1, ?, ?, ?, ?)`,
+        adoption.source_storage_id,
+        adoption.events.archive.digest,
+        adoption.realtime.archive.digest,
+        adoption.turn_receipts.digest,
+      );
+      this.#assertDurabilityImportOwnership(ownership);
+    });
+    this.#streamError = adoption.session.stream_error ?? undefined;
   }
 
   #sealRealtimeArchive(force: boolean): Promise<ManagedRealtimeSealResult> {
@@ -5207,12 +5867,16 @@ export class DurableAgentSession extends DurableComputerSession {
     this.#deleted = true;
   }
 
-  async #refreshCredentialPreparation(): Promise<CredentialBindingOwnership | undefined> {
+  async #refreshCredentialPreparation(
+    importOwnership?: DurabilityImportOwnership,
+  ): Promise<CredentialBindingOwnership | undefined> {
     const current = this.#credentialBinding;
     if (!current || current.state !== "preparing") return current;
     let retained: CredentialBindingOwnership | undefined;
     await this.ctx.storage.transaction(async (transaction) => {
+      if (importOwnership) this.#assertDurabilityImportOwnership(importOwnership);
       const stored = await transaction.get<CredentialBindingOwnership>(CREDENTIAL_BINDING_KEY);
+      if (importOwnership) this.#assertDurabilityImportOwnership(importOwnership);
       if (!stored || stored.state !== "preparing") {
         retained = stored;
         return;
@@ -5227,6 +5891,7 @@ export class DurableAgentSession extends DurableComputerSession {
       await transaction.put(CREDENTIAL_BINDING_KEY, retained);
       await transaction.setAlarm(retained.cleanup_at);
     });
+    if (importOwnership) this.#assertDurabilityImportOwnership(importOwnership);
     const observed = this.#credentialBinding;
     if (!observed || observed.state === "active") return observed;
     this.#credentialBinding = retained;
@@ -5431,6 +6096,271 @@ function managedMultiplayerTimeoutMs(env: Env): number {
   return Number.isFinite(configured)
     ? Math.min(60_000, Math.max(1, configured))
     : DEFAULT_MULTIPLAYER_IO_TIMEOUT_MS;
+}
+
+async function resolveManagedDurabilityImport(
+  env: Env,
+  principal: Principal,
+  value: unknown,
+  timeoutMs: number,
+): Promise<ManagedDurabilityImport> {
+  if (!value || typeof value !== "object" || Array.isArray(value)
+    || (value as { format?: unknown }).format !== "nanocodex-managed-durability-state-v1") {
+    return { durability: value };
+  }
+  const archive = validateManagedDurabilityArchive(value);
+  const headers = new Headers();
+  forwardPrincipalAssertions(headers, principal);
+  const source = env.NANOCODEX_SESSIONS.getByName(archive.source_agent_id);
+  const response = await fetchWithDeadline(
+    source,
+    "https://session.internal/durability/adoption",
+    { method: "POST", headers },
+    timeoutMs,
+    "managed durability adoption authorization",
+  );
+  if (!response.ok) {
+    await response.body?.cancel();
+    if (response.status === 404 || response.status === 409) {
+      throw new ManagedRequestError(
+        400,
+        "invalid_durability_import",
+        "managed durability source is unavailable for adoption",
+      );
+    }
+    throw new Error(`managed durability source returned ${response.status}`);
+  }
+  const adopted = await response.json<{
+    archive?: unknown;
+    source_storage_id?: unknown;
+  }>();
+  const authoritative = validateManagedDurabilityArchive(adopted.archive);
+  if (JSON.stringify(authoritative) !== JSON.stringify(archive)
+    || typeof adopted.source_storage_id !== "string"
+    || !/^[0-9a-f]{64}$/.test(adopted.source_storage_id)) {
+    throw new ManagedRequestError(
+      400,
+      "invalid_durability_import",
+      "managed durability archive does not match its authoritative source",
+    );
+  }
+  return {
+    durability: authoritative.durability,
+    turn_archive_adoption: {
+      events: authoritative.managed_events,
+      realtime: authoritative.managed_realtime,
+      session: authoritative.managed_session,
+      source_storage_id: adopted.source_storage_id,
+      turn_receipts: authoritative.managed_turn_receipts,
+    },
+  };
+}
+
+function validateManagedDurabilityArchive(value: unknown): ManagedDurabilityArchive {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ManagedRequestError(400, "invalid_durability_import", "managed durability archive is invalid");
+  }
+  const archive = value as Record<string, unknown>;
+  const durability = archive.durability as Record<string, unknown> | undefined;
+  const identity = archive.managed_turn_receipts as Record<string, unknown> | undefined;
+  const events = archive.managed_events;
+  const realtime = archive.managed_realtime;
+  const session = archive.managed_session;
+  if (Object.keys(archive).some((key) => ![
+    "durability",
+    "format",
+    "managed_events",
+    "managed_realtime",
+    "managed_session",
+    "managed_turn_receipts",
+    "source_agent_id",
+  ].includes(key))
+    || archive.format !== "nanocodex-managed-durability-state-v1"
+    || typeof archive.source_agent_id !== "string" || !SESSION_ID.test(archive.source_agent_id)
+    || !durability || Array.isArray(durability)
+    || Object.keys(durability).some((key) => !["format", "stateId", "revision", "payload"].includes(key))
+    || durability.format !== "nanocodex-durability-state-v1"
+    || typeof durability.stateId !== "string" || durability.stateId.length === 0
+    || typeof durability.revision !== "string" || !/^[1-9][0-9]*$/.test(durability.revision)
+    || typeof durability.payload !== "string"
+    || !identity || Array.isArray(identity)
+    || Object.keys(identity).some((key) => ![
+      "archived_bytes",
+      "archived_receipts",
+      "digest",
+      "objects",
+      "version",
+    ].includes(key))
+    || identity.version !== 1
+    || !Number.isSafeInteger(identity.archived_bytes) || Number(identity.archived_bytes) < 0
+    || !Number.isSafeInteger(identity.archived_receipts) || Number(identity.archived_receipts) < 0
+    || !Number.isSafeInteger(identity.objects) || Number(identity.objects) < 0
+    || Number(identity.archived_receipts) > Number(identity.objects)
+    || typeof identity.digest !== "string" || !/^[0-9a-f]{64}$/.test(identity.digest)
+    || !validManagedEventPortability(events)
+    || !validManagedRealtimePortability(realtime)
+    || !validManagedSessionPortability(session)) {
+    throw new ManagedRequestError(400, "invalid_durability_import", "managed durability archive is invalid");
+  }
+  return value as ManagedDurabilityArchive;
+}
+
+function validManagedEventPortability(value: unknown): value is ManagedEventPortability {
+  if (!isRecord(value) || !exactKeys(value, ["archive", "state", "tail"])
+    || !validManagedPortableArchiveIdentity(value.archive)
+    || !isRecord(value.state) || !exactKeys(value.state, [
+      "archived_bytes", "archived_events", "archived_through", "index_node_count",
+      "index_root_key", "recent_json", "segment_count",
+    ])
+    || !nonnegativeSafeInteger(value.state.archived_bytes)
+    || !nonnegativeSafeInteger(value.state.archived_events)
+    || !validCursor(value.state.archived_through)
+    || !nonnegativeSafeInteger(value.state.index_node_count)
+    || (value.state.index_root_key !== null && typeof value.state.index_root_key !== "string")
+    || typeof value.state.recent_json !== "string"
+    || !nonnegativeSafeInteger(value.state.segment_count)
+    || !validManagedEventTail(value.tail)) return false;
+  let recent: unknown;
+  try { recent = JSON.parse(value.state.recent_json); } catch { return false; }
+  const archivedThrough = value.state.archived_through;
+  return Array.isArray(recent) && recent.length <= 16
+    && (value.state.index_node_count === 0) === (value.state.index_root_key === null)
+    && value.state.archived_events >= value.state.segment_count
+    && value.archive.objects === value.state.segment_count + value.state.index_node_count
+    && value.archive.bytes >= value.state.archived_bytes
+    && BigInt(value.tail.high_water_cursor) >= BigInt(value.state.archived_through)
+    && value.tail.events.every(
+      (event) => BigInt(event.cursor) > BigInt(archivedThrough),
+    );
+}
+
+function validManagedEventTail(value: unknown): value is DurableEventTail<StreamMessage> {
+  if (!isRecord(value) || !exactKeys(value, ["events", "high_water_cursor"])
+    || !validCursor(value.high_water_cursor) || !Array.isArray(value.events)
+    || value.events.length > 256) return false;
+  let previous = "0";
+  for (const event of value.events) {
+    if (!isRecord(event) || !exactKeys(event, ["created_at", "cursor", "message", "turn_id"])
+      || !validCursor(event.cursor) || event.cursor === "0"
+      || BigInt(event.cursor) <= BigInt(previous)
+      || BigInt(event.cursor) > BigInt(value.high_water_cursor)
+      || !nonnegativeSafeInteger(event.created_at)
+      || (event.turn_id !== null && typeof event.turn_id !== "string")
+      || !isRecord(event.message) || typeof event.message.type !== "string") return false;
+    previous = event.cursor;
+  }
+  return true;
+}
+
+function validManagedRealtimePortability(value: unknown): value is ManagedRealtimePortability {
+  if (!isRecord(value) || !exactKeys(value, ["archive", "state", "tail"])
+    || !validManagedPortableArchiveIdentity(value.archive)
+    || !isRecord(value.state) || !exactKeys(value.state, [
+      "archived_bytes", "archived_receipts", "object_count",
+    ])
+    || !nonnegativeSafeInteger(value.state.archived_bytes)
+    || !nonnegativeSafeInteger(value.state.archived_receipts)
+    || !nonnegativeSafeInteger(value.state.object_count)
+    || value.state.archived_receipts !== value.state.object_count
+    || !Array.isArray(value.tail) || value.tail.length > 512) return false;
+  const identities = new Set<string>();
+  return value.archive.objects === value.state.object_count
+    && value.archive.bytes === value.state.archived_bytes
+    && value.tail.every((operation) => {
+    if (!isRecord(operation) || !exactKeys(operation, [
+      "blocked", "created_at", "kind", "operation_id", "request_hash", "response_json",
+      "state", "updated_at", "voice_session_id",
+    ])) return false;
+    const complete = operation.state === "completed";
+    if ((operation.blocked !== 0 && operation.blocked !== 1)
+      || !nonnegativeSafeInteger(operation.created_at)
+      || !nonnegativeSafeInteger(operation.updated_at)
+      || Number(operation.updated_at) < Number(operation.created_at)
+      || !["start", "delegate", "stop"].includes(String(operation.kind))
+      || typeof operation.operation_id !== "string" || operation.operation_id.length === 0
+      || typeof operation.voice_session_id !== "string" || operation.voice_session_id.length === 0
+      || typeof operation.request_hash !== "string" || !/^[0-9a-f]{64}$/.test(operation.request_hash)
+      || (complete ? typeof operation.response_json !== "string" : operation.response_json !== null)
+      || (!complete && operation.state !== "pending")
+      || (complete && operation.blocked !== 0)
+      || (!complete && operation.blocked !== 1)) return false;
+    const identity = `${operation.voice_session_id}\0${operation.operation_id}`;
+    if (identities.has(identity)) return false;
+    identities.add(identity);
+    if (complete) {
+      try { JSON.parse(operation.response_json as string); } catch { return false; }
+    }
+    return true;
+    });
+}
+
+function validManagedSessionPortability(value: unknown): value is ManagedSessionPortability {
+  return isRecord(value) && exactKeys(value, [
+    "accepted_turns", "completed_turns", "first_prompt", "last_active", "stream_error", "title",
+  ])
+    && nonnegativeSafeInteger(value.accepted_turns)
+    && nonnegativeSafeInteger(value.completed_turns)
+    && Number(value.completed_turns) <= Number(value.accepted_turns)
+    && typeof value.first_prompt === "string"
+    && nonnegativeSafeInteger(value.last_active)
+    && (value.stream_error === null || typeof value.stream_error === "string")
+    && typeof value.title === "string"
+    && value.title === conversationTitle(value.first_prompt);
+}
+
+function validManagedPortableArchiveIdentity(value: unknown): value is ManagedPortableArchiveIdentity {
+  return isRecord(value) && exactKeys(value, ["bytes", "digest", "objects", "version"])
+    && value.version === 1
+    && nonnegativeSafeInteger(value.bytes)
+    && nonnegativeSafeInteger(value.objects)
+    && typeof value.digest === "string" && /^[0-9a-f]{64}$/.test(value.digest);
+}
+
+function validCursor(value: unknown): value is string {
+  return typeof value === "string" && parseCursor(value) === value;
+}
+
+function nonnegativeSafeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && Number(value) >= 0;
+}
+
+function exactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return Object.keys(value).length === keys.length
+    && Object.keys(value).every((key) => keys.includes(key));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function portableDurabilityStateId(value: unknown): string {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("portable durability archive is invalid");
+  }
+  const archive = value as Record<string, unknown>;
+  if (Object.keys(archive).some((key) => !["format", "stateId", "revision", "payload"].includes(key))
+    || archive.format !== "nanocodex-durability-state-v1"
+    || typeof archive.stateId !== "string" || archive.stateId.length === 0
+    || typeof archive.revision !== "string" || !/^[1-9][0-9]*$/.test(archive.revision)
+    || typeof archive.payload !== "string") {
+    throw new Error("portable durability archive is invalid");
+  }
+  return archive.stateId;
+}
+
+function validDurabilityImportPreparation(value: unknown): boolean {
+  if (value === null) return true;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const prepared = value as Record<string, unknown>;
+  return !Object.keys(prepared).some((key) => ![
+    "request_hash",
+    "source_agent_id",
+    "state_id",
+  ].includes(key))
+    && typeof prepared.request_hash === "string" && /^[0-9a-f]{64}$/.test(prepared.request_hash)
+    && (prepared.source_agent_id === null
+      || (typeof prepared.source_agent_id === "string" && SESSION_ID.test(prepared.source_agent_id)))
+    && typeof prepared.state_id === "string" && prepared.state_id.length > 0;
 }
 
 async function requestSessionCleanup(

--- a/services/managed/src/managed-event-archive.ts
+++ b/services/managed/src/managed-event-archive.ts
@@ -26,7 +26,7 @@ type EventIndexRow = Omit<EventRow, "message_json"> & {
   message_bytes: number;
 };
 
-type ArchiveStateRow = {
+export type ManagedEventArchiveState = Readonly<{
   archived_bytes: number;
   archived_events: number;
   archived_through: string;
@@ -34,7 +34,9 @@ type ArchiveStateRow = {
   index_root_key: string | null;
   recent_json: string;
   segment_count: number;
-};
+}>;
+
+type ArchiveStateRow = ManagedEventArchiveState;
 
 type ArchiveReadFence = Readonly<{
   archived_events: number;
@@ -160,6 +162,33 @@ export class ManagedEventArchive<Message extends { type: string }> {
       recent_descriptors: this.#decodeDescriptors(state.recent_json).length,
       segments: state.segment_count,
     };
+  }
+
+  portableState(): ManagedEventArchiveState {
+    return { ...this.#state() };
+  }
+
+  adoptState(state: ManagedEventArchiveState): void {
+    validatePortableState(state);
+    const current = this.#state();
+    if (current.archived_events !== 0 || current.segment_count !== 0
+      || current.index_node_count !== 0) {
+      throw new Error("managed event archive adoption requires an empty destination archive");
+    }
+    this.#decodeDescriptors(state.recent_json);
+    this.#storage.sql.exec(
+      `UPDATE managed_event_archive_state
+       SET archived_through = CAST(? AS INTEGER), archived_events = ?, archived_bytes = ?,
+           segment_count = ?, index_node_count = ?, index_root_key = ?, recent_json = ?
+       WHERE singleton = 1`,
+      state.archived_through,
+      state.archived_events,
+      state.archived_bytes,
+      state.segment_count,
+      state.index_node_count,
+      state.index_root_key,
+      state.recent_json,
+    );
   }
 
   archivedThrough(): string {
@@ -551,7 +580,7 @@ export class ManagedEventArchive<Message extends { type: string }> {
     cache: SegmentReadCache<Message>,
   ): Promise<DurableEvent<Message>[]> {
     if (cache.segment?.key === descriptor.key) return cache.segment.events;
-    const object = await this.#bucket.get(descriptor.key);
+    const object = await this.#bucket.get(this.#portableObjectKey(descriptor.key));
     if (!object || !object.body) throw new Error("managed event archive segment is unavailable");
     if (object.size !== descriptor.bytes || object.size > MAX_ARCHIVE_OBJECT_BYTES) {
       await object.body.cancel();
@@ -612,6 +641,13 @@ export class ManagedEventArchive<Message extends { type: string }> {
     return value;
   }
 
+  #portableObjectKey(key: string): string {
+    const marker = "/managed-events/";
+    const markerOffset = key.indexOf(marker);
+    const suffix = markerOffset === -1 ? key : key.slice(markerOffset + marker.length);
+    return key.startsWith(this.#prefix) ? key : `${this.#prefix}${suffix}`;
+  }
+
   async #putImmutable(
     key: string,
     body: Uint8Array,
@@ -653,14 +689,16 @@ export class ManagedEventArchive<Message extends { type: string }> {
     if (!row) throw new Error("managed event archive state is unavailable");
     this.#decodeDescriptors(row.recent_json);
     if (row.index_root_key !== null
-      && !row.index_root_key.startsWith(`${this.#prefix}indexes/`)) {
+      && !/^agents\/[0-9a-f]{64}\/managed-events\/indexes\/[0-9]{16}\.json$/.test(
+        row.index_root_key,
+      )) {
       throw new Error("managed event archive root escapes its agent namespace");
     }
     if ((row.index_node_count === 0) !== (row.index_root_key === null)) {
       throw new Error("managed event archive index manifest is inconsistent");
     }
     if (row.index_node_count > 0
-      && row.index_root_key !== this.#indexKey(row.index_node_count - 1)) {
+      && this.#portableObjectKey(row.index_root_key!) !== this.#indexKey(row.index_node_count - 1)) {
       throw new Error("managed event archive index root does not match its manifest");
     }
     return row;
@@ -683,7 +721,11 @@ export class ManagedEventArchive<Message extends { type: string }> {
 
   #decodeDescriptors(encoded: string): SegmentDescriptor[] {
     const descriptors = decodeDescriptors(encoded);
-    if (descriptors.some(({ key }) => !key.startsWith(`${this.#prefix}segments/`))) {
+    if (descriptors.some(({ key }) => (
+      !/^agents\/[0-9a-f]{64}\/managed-events\/segments\/[0-9]{19}-[0-9]{19}-[0-9a-f]{64}\.json$/.test(
+        key,
+      )
+    ))) {
       throw new Error("managed event archive descriptor escapes its agent namespace");
     }
     return descriptors;
@@ -716,6 +758,22 @@ function decodeDescriptors(encoded: string): SegmentDescriptor[] {
     }
   }
   return descriptors as SegmentDescriptor[];
+}
+
+function validatePortableState(value: ManagedEventArchiveState): void {
+  if (!value || typeof value !== "object"
+    || typeof value.archived_through !== "string"
+    || !/^[0-9]+$/.test(value.archived_through)
+    || !Number.isSafeInteger(value.archived_events) || value.archived_events < 0
+    || !Number.isSafeInteger(value.archived_bytes) || value.archived_bytes < 0
+    || !Number.isSafeInteger(value.segment_count) || value.segment_count < 0
+    || !Number.isSafeInteger(value.index_node_count) || value.index_node_count < 0
+    || (value.index_root_key !== null && typeof value.index_root_key !== "string")
+    || typeof value.recent_json !== "string"
+    || (value.index_node_count === 0) !== (value.index_root_key === null)
+    || value.archived_events < value.segment_count) {
+    throw new Error("managed event archive portable state is invalid");
+  }
 }
 
 function boundedInteger(

--- a/services/managed/src/managed-portability-archive.ts
+++ b/services/managed/src/managed-portability-archive.ts
@@ -1,0 +1,340 @@
+const VERSION = 1;
+const BATCH_OBJECTS = 64;
+const BATCH_BYTES = 8 * 1024 * 1024;
+const COPY_CONCURRENCY = 4;
+const EMPTY_DIGEST = "0".repeat(64);
+const encoder = new TextEncoder();
+
+export type ManagedPortableArchiveKind = "events" | "realtime";
+
+export type ManagedPortableArchiveIdentity = Readonly<{
+  bytes: number;
+  digest: string;
+  objects: number;
+  version: 1;
+}>;
+
+export type ManagedPortableArchiveBatch = Readonly<{
+  complete: boolean;
+  identity?: ManagedPortableArchiveIdentity;
+  objects: number;
+}>;
+
+type Progress = {
+  bytes: number;
+  complete: number;
+  digest: string;
+  last_key: string | null;
+  objects: number;
+};
+
+type PortableObject = Readonly<{
+  kind: string;
+  sha256: string;
+  size: number;
+  suffix: string;
+}>;
+
+/** Bounded immutable R2 transfer for managed event and realtime archives. */
+export class ManagedPortabilityArchive {
+  readonly #bucket: R2Bucket;
+  readonly #storageId: string;
+  readonly #storage: DurableObjectStorage;
+
+  constructor(storage: DurableObjectStorage, bucket: R2Bucket, storageId: string) {
+    this.#bucket = bucket;
+    this.#storageId = storageId;
+    this.#storage = storage;
+    storage.sql.exec(`
+      CREATE TABLE IF NOT EXISTS managed_portability_manifest_progress (
+        kind TEXT PRIMARY KEY CHECK (kind IN ('events', 'realtime')),
+        last_key TEXT,
+        digest TEXT NOT NULL,
+        bytes INTEGER NOT NULL DEFAULT 0,
+        objects INTEGER NOT NULL DEFAULT 0,
+        complete INTEGER NOT NULL DEFAULT 0 CHECK (complete IN (0, 1))
+      );
+      CREATE TABLE IF NOT EXISTS managed_portability_adoption_progress (
+        kind TEXT PRIMARY KEY CHECK (kind IN ('events', 'realtime')),
+        source_storage_id TEXT NOT NULL,
+        manifest_digest TEXT NOT NULL,
+        last_key TEXT,
+        scan_digest TEXT NOT NULL,
+        bytes INTEGER NOT NULL DEFAULT 0,
+        objects INTEGER NOT NULL DEFAULT 0,
+        complete INTEGER NOT NULL DEFAULT 0 CHECK (complete IN (0, 1))
+      );
+    `);
+  }
+
+  async identityBatch(kind: ManagedPortableArchiveKind): Promise<ManagedPortableArchiveBatch> {
+    let progress = this.#storage.sql.exec<Progress>(
+      `SELECT last_key, digest, bytes, objects, complete
+       FROM managed_portability_manifest_progress WHERE kind = ?`,
+      kind,
+    ).toArray()[0];
+    if (!progress) {
+      this.#storage.sql.exec(
+        `INSERT INTO managed_portability_manifest_progress (kind, digest)
+         VALUES (?, ?)`,
+        kind,
+        EMPTY_DIGEST,
+      );
+      progress = emptyProgress();
+    }
+    if (progress.complete === 1) {
+      return { complete: true, identity: identity(progress), objects: 0 };
+    }
+    const page = await this.#page(kind, this.#storageId, progress.last_key);
+    const next = await advance(progress, page.items);
+    const complete = !page.truncated;
+    this.#storage.sql.exec(
+      `UPDATE managed_portability_manifest_progress
+       SET last_key = ?, digest = ?, bytes = ?, objects = ?, complete = ?
+       WHERE kind = ?`,
+      page.lastKey ?? progress.last_key,
+      next.digest,
+      next.bytes,
+      next.objects,
+      complete ? 1 : 0,
+      kind,
+    );
+    return {
+      complete,
+      ...(complete ? { identity: identity(next) } : {}),
+      objects: page.items.length,
+    };
+  }
+
+  async adoptBatch(
+    kind: ManagedPortableArchiveKind,
+    sourceStorageId: string,
+    expected: ManagedPortableArchiveIdentity,
+    assertOwnership: () => void,
+  ): Promise<ManagedPortableArchiveBatch> {
+    assertOwnership();
+    if (!/^[0-9a-f]{64}$/.test(sourceStorageId) || sourceStorageId === this.#storageId) {
+      throw new Error(`managed ${kind} archive adoption source is invalid`);
+    }
+    validateIdentity(expected);
+    let progress = this.#storage.sql.exec<Progress & {
+      manifest_digest: string;
+      source_storage_id: string;
+    }>(
+      `SELECT source_storage_id, manifest_digest, last_key, scan_digest AS digest,
+              bytes, objects, complete
+       FROM managed_portability_adoption_progress WHERE kind = ?`,
+      kind,
+    ).toArray()[0];
+    if (progress) {
+      if (progress.source_storage_id !== sourceStorageId
+        || progress.manifest_digest !== expected.digest) {
+        throw new Error(`managed ${kind} archive adoption conflicts with retained identity`);
+      }
+      if (progress.complete === 1) {
+        return { complete: true, identity: expected, objects: 0 };
+      }
+    } else {
+      this.#storage.sql.exec(
+        `INSERT INTO managed_portability_adoption_progress (
+           kind, source_storage_id, manifest_digest, scan_digest
+         ) VALUES (?, ?, ?, ?)`,
+        kind,
+        sourceStorageId,
+        expected.digest,
+        EMPTY_DIGEST,
+      );
+      progress = {
+        ...emptyProgress(),
+        manifest_digest: expected.digest,
+        source_storage_id: sourceStorageId,
+      };
+    }
+    const page = await this.#page(kind, sourceStorageId, progress.last_key, assertOwnership);
+    assertOwnership();
+    await mapWithConcurrency(page.items, COPY_CONCURRENCY, async (item) => {
+      assertOwnership();
+      const sourceKey = `${prefix(sourceStorageId, kind)}${item.suffix}`;
+      const source = await this.#bucket.get(sourceKey);
+      assertOwnership();
+      if (!source?.body || source.size !== item.size
+        || source.customMetadata?.kind !== item.kind
+        || source.customMetadata?.version !== String(VERSION)
+        || source.customMetadata?.sha256 !== item.sha256) {
+        await source?.body?.cancel();
+        throw new Error(`managed ${kind} archive source object is unavailable`);
+      }
+      const body = new Uint8Array(await source.arrayBuffer());
+      assertOwnership();
+      if (await sha256Hex(body) !== item.sha256) {
+        throw new Error(`managed ${kind} archive source checksum mismatch`);
+      }
+      assertOwnership();
+      const destinationKey = `${prefix(this.#storageId, kind)}${item.suffix}`;
+      const stored = await this.#bucket.put(destinationKey, body, {
+        onlyIf: { etagDoesNotMatch: "*" },
+        httpMetadata: { contentType: "application/json" },
+        customMetadata: { kind: item.kind, sha256: item.sha256, version: String(VERSION) },
+        sha256: item.sha256,
+      });
+      assertOwnership();
+      if (stored) return;
+      const retained = await this.#bucket.head(destinationKey);
+      assertOwnership();
+      if (!retained || retained.size !== item.size
+        || retained.customMetadata?.kind !== item.kind
+        || retained.customMetadata?.sha256 !== item.sha256) {
+        throw new Error(`managed ${kind} archive immutable destination conflicts`);
+      }
+    });
+    assertOwnership();
+    const next = await advance(progress, page.items);
+    assertOwnership();
+    const complete = !page.truncated;
+    if (complete && JSON.stringify(identity(next)) !== JSON.stringify(expected)) {
+      throw new Error(`managed ${kind} archive source identity changed during adoption`);
+    }
+    this.#storage.transactionSync(() => {
+      assertOwnership();
+      this.#storage.sql.exec(
+        `UPDATE managed_portability_adoption_progress
+         SET last_key = ?, scan_digest = ?, bytes = ?, objects = ?, complete = ?
+         WHERE kind = ?`,
+        page.lastKey ?? progress.last_key,
+        next.digest,
+        next.bytes,
+        next.objects,
+        complete ? 1 : 0,
+        kind,
+      );
+    });
+    return {
+      complete,
+      ...(complete ? { identity: expected } : {}),
+      objects: page.items.length,
+    };
+  }
+
+  clearLocalState(): void {
+    this.#storage.sql.exec(`
+      DELETE FROM managed_portability_manifest_progress;
+      DELETE FROM managed_portability_adoption_progress;
+    `);
+  }
+
+  async #page(
+    kind: ManagedPortableArchiveKind,
+    storageId: string,
+    lastKey: string | null,
+    assertOwnership: () => void = () => {},
+  ): Promise<{ items: PortableObject[]; lastKey?: string; truncated: boolean }> {
+    assertOwnership();
+    const archivePrefix = prefix(storageId, kind);
+    const page = await this.#bucket.list({
+      prefix: archivePrefix,
+      limit: BATCH_OBJECTS,
+      ...(lastKey === null ? {} : { startAfter: lastKey }),
+      include: ["customMetadata"],
+    });
+    assertOwnership();
+    const items: PortableObject[] = [];
+    let bytes = 0;
+    for (const object of page.objects) {
+      const suffix = object.key.slice(archivePrefix.length);
+      const objectKind = object.customMetadata?.kind ?? "";
+      if (!validObject(kind, suffix, objectKind)
+        || object.size <= 0 || object.size > 16 * 1024 * 1024
+        || object.customMetadata?.version !== String(VERSION)
+        || !/^[0-9a-f]{64}$/.test(object.customMetadata?.sha256 ?? "")) {
+        throw new Error(`managed ${kind} archive contains an invalid object identity`);
+      }
+      if (items.length > 0 && bytes + object.size > BATCH_BYTES) break;
+      items.push({
+        kind: objectKind,
+        sha256: object.customMetadata!.sha256!,
+        size: object.size,
+        suffix,
+      });
+      bytes += object.size;
+    }
+    items.sort((left, right) => left.suffix.localeCompare(right.suffix));
+    return {
+      items,
+      lastKey: items.length === 0
+        ? undefined
+        : `${archivePrefix}${items.at(-1)!.suffix}`,
+      truncated: page.truncated || items.length < page.objects.length,
+    };
+  }
+}
+
+function prefix(storageId: string, kind: ManagedPortableArchiveKind): string {
+  return `agents/${storageId}/managed-${kind}/`;
+}
+
+function validObject(kind: ManagedPortableArchiveKind, suffix: string, objectKind: string): boolean {
+  if (kind === "realtime") {
+    return /^by-id\/[0-9a-f]{64}\.json$/.test(suffix)
+      && objectKind === "managed_realtime_receipt";
+  }
+  return (/^segments\/[0-9]{19}-[0-9]{19}-[0-9a-f]{64}\.json$/.test(suffix)
+      && objectKind === "managed_event_segment")
+    || (/^indexes\/[0-9]{16}\.json$/.test(suffix)
+      && objectKind === "managed_event_index");
+}
+
+function emptyProgress(): Progress {
+  return { bytes: 0, complete: 0, digest: EMPTY_DIGEST, last_key: null, objects: 0 };
+}
+
+async function advance(progress: Progress, items: readonly PortableObject[]): Promise<Progress> {
+  return {
+    bytes: progress.bytes + items.reduce((sum, item) => sum + item.size, 0),
+    complete: 0,
+    digest: items.length === 0
+      ? progress.digest
+      : await sha256Hex(encoder.encode(`${progress.digest}\n${JSON.stringify(items)}`)),
+    last_key: progress.last_key,
+    objects: progress.objects + items.length,
+  };
+}
+
+function identity(progress: Progress): ManagedPortableArchiveIdentity {
+  return { bytes: progress.bytes, digest: progress.digest, objects: progress.objects, version: 1 };
+}
+
+function validateIdentity(value: ManagedPortableArchiveIdentity): void {
+  if (!value || value.version !== VERSION
+    || !Number.isSafeInteger(value.bytes) || value.bytes < 0
+    || !Number.isSafeInteger(value.objects) || value.objects < 0
+    || !/^[0-9a-f]{64}$/.test(value.digest)) {
+    throw new Error("managed portable archive identity is invalid");
+  }
+}
+
+async function sha256Hex(value: Uint8Array): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", value));
+  return [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function mapWithConcurrency<T>(
+  values: readonly T[],
+  concurrency: number,
+  operation: (value: T) => Promise<void>,
+): Promise<void> {
+  let next = 0;
+  const settled = await Promise.allSettled(Array.from(
+    { length: Math.min(concurrency, values.length) },
+    async () => {
+      while (next < values.length) {
+        const index = next;
+        next += 1;
+        await operation(values[index]!);
+      }
+    },
+  ));
+  const failure = settled.find(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (failure) throw failure.reason;
+}

--- a/services/managed/src/managed-realtime-archive.ts
+++ b/services/managed/src/managed-realtime-archive.ts
@@ -21,11 +21,13 @@ type ReceiptEnvelope = Readonly<{
   version: 1;
 }>;
 
-type ArchiveState = {
+export type ManagedRealtimeArchiveState = Readonly<{
   archived_bytes: number;
   archived_receipts: number;
   object_count: number;
-};
+}>;
+
+type ArchiveState = ManagedRealtimeArchiveState;
 
 export type ManagedRealtimeArchiveCapacity = Readonly<{
   archived_bytes: number;
@@ -74,6 +76,32 @@ export class ManagedRealtimeArchive {
       archived_receipts: state.archived_receipts,
       objects: state.object_count,
     };
+  }
+
+  portableState(): ManagedRealtimeArchiveState {
+    return { ...this.#state() };
+  }
+
+  adoptState(state: ManagedRealtimeArchiveState): void {
+    if (!state || typeof state !== "object"
+      || !Number.isSafeInteger(state.archived_bytes) || state.archived_bytes < 0
+      || !Number.isSafeInteger(state.archived_receipts) || state.archived_receipts < 0
+      || !Number.isSafeInteger(state.object_count) || state.object_count < 0
+      || state.archived_receipts !== state.object_count) {
+      throw new Error("managed realtime archive portable state is invalid");
+    }
+    const current = this.#state();
+    if (current.archived_receipts !== 0 || current.object_count !== 0) {
+      throw new Error("managed realtime archive adoption requires an empty destination archive");
+    }
+    this.#storage.sql.exec(
+      `UPDATE managed_realtime_archive_state
+       SET archived_receipts = ?, archived_bytes = ?, object_count = ?
+       WHERE singleton = 1`,
+      state.archived_receipts,
+      state.archived_bytes,
+      state.object_count,
+    );
   }
 
   needsSeal(): boolean {

--- a/services/managed/src/managed-turn-archive.ts
+++ b/services/managed/src/managed-turn-archive.ts
@@ -2,6 +2,10 @@ const VERSION = 1;
 const DEFAULT_RECENT_TERMINAL_TURNS = 512;
 const MAX_SEAL_RECEIPTS = 32;
 const MAX_RECEIPT_BYTES = 4 * 1024 * 1024;
+const TRANSFER_BATCH_OBJECTS = 64;
+const TRANSFER_BATCH_BYTES = 8 * 1024 * 1024;
+const TRANSFER_COPY_CONCURRENCY = 4;
+const EMPTY_TRANSFER_DIGEST = "0".repeat(64);
 const encoder = new TextEncoder();
 
 export type ManagedTurnReceipt = Readonly<{
@@ -47,6 +51,35 @@ export type ManagedTurnSealResult = Readonly<{
   sealed: boolean;
 }>;
 
+export type ManagedTurnArchiveIdentity = Readonly<{
+  archived_bytes: number;
+  archived_receipts: number;
+  digest: string;
+  objects: number;
+  version: 1;
+}>;
+
+export type ManagedTurnArchiveTransferResult = Readonly<{
+  complete: boolean;
+  identity?: ManagedTurnArchiveIdentity;
+  objects: number;
+}>;
+
+type ArchivedObject = Readonly<{
+  sha256: string;
+  size: number;
+  suffix: string;
+}>;
+
+type TransferProgress = {
+  archived_bytes: number;
+  archived_receipts: number;
+  complete: number;
+  digest: string;
+  last_key: string | null;
+  object_count: number;
+};
+
 /** Immutable terminal receipts kept outside the bounded coordination head. */
 export class ManagedTurnArchive {
   readonly #bucket: R2Bucket;
@@ -74,6 +107,34 @@ export class ManagedTurnArchive {
         object_count INTEGER NOT NULL DEFAULT 0 CHECK (object_count >= 0)
       );
       INSERT OR IGNORE INTO managed_turn_archive_state (singleton) VALUES (1);
+      CREATE TABLE IF NOT EXISTS managed_turn_archive_adoption (
+        singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+        manifest_digest TEXT NOT NULL,
+        source_storage_id TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS managed_turn_archive_manifest_progress (
+        singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+        last_key TEXT,
+        digest TEXT NOT NULL,
+        archived_bytes INTEGER NOT NULL DEFAULT 0,
+        archived_receipts INTEGER NOT NULL DEFAULT 0,
+        object_count INTEGER NOT NULL DEFAULT 0,
+        complete INTEGER NOT NULL DEFAULT 0 CHECK (complete IN (0, 1))
+      );
+      INSERT OR IGNORE INTO managed_turn_archive_manifest_progress (
+        singleton, digest
+      ) VALUES (1, '${EMPTY_TRANSFER_DIGEST}');
+      CREATE TABLE IF NOT EXISTS managed_turn_archive_adoption_progress (
+        singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+        source_storage_id TEXT NOT NULL,
+        manifest_digest TEXT NOT NULL,
+        last_key TEXT,
+        scan_digest TEXT NOT NULL,
+        archived_bytes INTEGER NOT NULL DEFAULT 0,
+        archived_receipts INTEGER NOT NULL DEFAULT 0,
+        object_count INTEGER NOT NULL DEFAULT 0,
+        complete INTEGER NOT NULL DEFAULT 0 CHECK (complete IN (0, 1))
+      );
     `);
   }
 
@@ -110,11 +171,17 @@ export class ManagedTurnArchive {
     return receipt;
   }
 
-  async seal(force = false): Promise<ManagedTurnSealResult> {
+  async seal(
+    force = false,
+    retainTerminalTurns?: number,
+  ): Promise<ManagedTurnSealResult> {
     const terminalCount = this.#terminalCount();
+    const retained = retainTerminalTurns === undefined
+      ? (force ? Math.min(1, terminalCount) : this.#recentTerminalTurns)
+      : Math.min(terminalCount, Math.max(0, retainTerminalTurns));
     const available = Math.max(
       0,
-      terminalCount - (force ? Math.min(1, terminalCount) : this.#recentTerminalTurns),
+      terminalCount - retained,
     );
     if (available === 0) return emptySeal();
     const receipts = this.#storage.sql.exec<ManagedTurnReceipt>(
@@ -186,6 +253,167 @@ export class ManagedTurnArchive {
     };
   }
 
+  async identityBatch(): Promise<ManagedTurnArchiveTransferResult> {
+    const progress = this.#storage.sql.exec<TransferProgress>(
+      `SELECT last_key, digest, archived_bytes, archived_receipts,
+              object_count, complete
+       FROM managed_turn_archive_manifest_progress WHERE singleton = 1`,
+    ).one();
+    if (progress.complete === 1) {
+      return { complete: true, identity: identityFromProgress(progress), objects: 0 };
+    }
+    const page = await this.#archivePage(this.#prefix, progress.last_key);
+    const next = await advanceProgress(progress, page.items);
+    const complete = !page.truncated;
+    if (complete) this.#assertCommittedIdentity(next);
+    this.#storage.sql.exec(
+      `UPDATE managed_turn_archive_manifest_progress
+       SET last_key = ?, digest = ?, archived_bytes = ?, archived_receipts = ?,
+           object_count = ?, complete = ? WHERE singleton = 1`,
+      page.lastKey ?? progress.last_key,
+      next.digest,
+      next.archived_bytes,
+      next.archived_receipts,
+      next.object_count,
+      complete ? 1 : 0,
+    );
+    return {
+      complete,
+      ...(complete ? { identity: identityFromProgress(next) } : {}),
+      objects: page.items.length,
+    };
+  }
+
+  async adoptBatch(
+    sourceStorageId: string,
+    expected: ManagedTurnArchiveIdentity,
+    assertOwnership: () => void = () => {},
+  ): Promise<ManagedTurnArchiveTransferResult> {
+    assertOwnership();
+    if (!/^[0-9a-f]{64}$/.test(sourceStorageId)) {
+      throw new Error("managed turn archive adoption source is invalid");
+    }
+    validateIdentity(expected);
+    let progress = this.#storage.sql.exec<TransferProgress & {
+      manifest_digest: string;
+      source_storage_id: string;
+    }>(
+      `SELECT source_storage_id, manifest_digest, last_key,
+              scan_digest AS digest, archived_bytes, archived_receipts,
+              object_count, complete
+       FROM managed_turn_archive_adoption_progress WHERE singleton = 1`,
+    ).toArray()[0];
+    if (progress) {
+      if (progress.manifest_digest !== expected.digest
+        || progress.source_storage_id !== sourceStorageId) {
+        throw new Error("managed turn archive adoption conflicts with retained identity");
+      }
+      if (progress.complete === 1) return { complete: true, identity: expected, objects: 0 };
+    } else {
+      this.#storage.sql.exec(
+        `INSERT INTO managed_turn_archive_adoption_progress (
+           singleton, source_storage_id, manifest_digest, scan_digest
+         ) VALUES (1, ?, ?, ?)`,
+        sourceStorageId,
+        expected.digest,
+        EMPTY_TRANSFER_DIGEST,
+      );
+      progress = {
+        archived_bytes: 0,
+        archived_receipts: 0,
+        complete: 0,
+        digest: EMPTY_TRANSFER_DIGEST,
+        last_key: null,
+        manifest_digest: expected.digest,
+        object_count: 0,
+        source_storage_id: sourceStorageId,
+      };
+    }
+    if (sourceStorageId === this.#prefix.split("/")[1]) {
+      throw new Error("managed turn archive cannot adopt itself");
+    }
+    const sourcePrefix = `agents/${sourceStorageId}/managed-turns/`;
+    const page = await this.#archivePage(sourcePrefix, progress.last_key, assertOwnership);
+    assertOwnership();
+    await mapWithConcurrency(page.items, TRANSFER_COPY_CONCURRENCY, async (item) => {
+      assertOwnership();
+      const source = await this.#bucket.get(`${sourcePrefix}${item.suffix}`);
+      assertOwnership();
+      if (!source || !source.body || source.size !== item.size) {
+        await source?.body?.cancel();
+        throw new Error("managed turn archive adoption source object is unavailable");
+      }
+      const body = new Uint8Array(await source.arrayBuffer());
+      assertOwnership();
+      if (await sha256Hex(body) !== item.sha256
+        || source.customMetadata?.kind !== "managed_turn_receipt"
+        || source.customMetadata?.version !== String(VERSION)
+        || source.customMetadata?.sha256 !== item.sha256) {
+        throw new Error("managed turn archive adoption source checksum mismatch");
+      }
+      assertOwnership();
+      const envelope = JSON.parse(new TextDecoder().decode(body)) as ReceiptEnvelope;
+      if (envelope.version !== VERSION || envelope.kind !== "managed_turn_receipt") {
+        throw new Error("managed turn archive adoption source envelope is invalid");
+      }
+      validateReceipt(envelope.receipt);
+      const expectedSuffix = item.suffix.startsWith("by-id/")
+        ? `by-id/${await sha256Hex(encoder.encode(envelope.receipt.id))}.json`
+        : envelope.receipt.request_key === null
+        ? undefined
+        : `by-request/${await sha256Hex(encoder.encode(envelope.receipt.request_key))}.json`;
+      assertOwnership();
+      if (expectedSuffix !== item.suffix) {
+        throw new Error("managed turn archive adoption source key conflicts with receipt");
+      }
+      await this.#putImmutable(
+        `${this.#prefix}${item.suffix}`,
+        body,
+        item.sha256,
+        assertOwnership,
+      );
+    });
+    assertOwnership();
+    const next = await advanceProgress(progress, page.items);
+    assertOwnership();
+    const complete = !page.truncated;
+    if (complete && JSON.stringify(identityFromProgress(next)) !== JSON.stringify(expected)) {
+      throw new Error("managed turn archive source identity changed during adoption");
+    }
+    this.#storage.transactionSync(() => {
+      assertOwnership();
+      this.#storage.sql.exec(
+        `UPDATE managed_turn_archive_adoption_progress
+         SET last_key = ?, scan_digest = ?, archived_bytes = ?, archived_receipts = ?,
+             object_count = ?, complete = ? WHERE singleton = 1`,
+        page.lastKey ?? progress.last_key,
+        next.digest,
+        next.archived_bytes,
+        next.archived_receipts,
+        next.object_count,
+        complete ? 1 : 0,
+      );
+      if (!complete) return;
+      const state = this.#state();
+      if (state.archived_bytes !== 0 || state.archived_receipts !== 0 || state.object_count !== 0) {
+        throw new Error("managed turn archive adoption requires an empty destination archive");
+      }
+      this.#storage.sql.exec(
+        `UPDATE managed_turn_archive_state
+         SET archived_receipts = ?, archived_bytes = ?, object_count = ? WHERE singleton = 1`,
+        expected.archived_receipts, expected.archived_bytes, expected.objects,
+      );
+      this.#storage.sql.exec(
+        `INSERT INTO managed_turn_archive_adoption (
+           singleton, manifest_digest, source_storage_id
+         ) VALUES (1, ?, ?)`,
+        expected.digest,
+        sourceStorageId,
+      );
+    });
+    return { complete, ...(complete ? { identity: expected } : {}), objects: page.items.length };
+  }
+
   async deleteAll(): Promise<number> {
     let deleted = 0;
     while (true) {
@@ -201,8 +429,70 @@ export class ManagedTurnArchive {
     this.#storage.sql.exec(`
       UPDATE managed_turn_archive_state
       SET archived_receipts = 0, archived_bytes = 0, object_count = 0
-      WHERE singleton = 1
+      WHERE singleton = 1;
+      DELETE FROM managed_turn_archive_adoption;
+      DELETE FROM managed_turn_archive_adoption_progress;
+      UPDATE managed_turn_archive_manifest_progress
+      SET last_key = NULL, digest = '${EMPTY_TRANSFER_DIGEST}', archived_bytes = 0,
+          archived_receipts = 0, object_count = 0, complete = 0
+      WHERE singleton = 1;
     `);
+  }
+
+  async #archivePage(
+    prefix: string,
+    lastKey: string | null,
+    assertOwnership: () => void = () => {},
+  ): Promise<{
+    items: ArchivedObject[];
+    lastKey?: string;
+    truncated: boolean;
+  }> {
+      assertOwnership();
+      const page = await this.#bucket.list({
+        prefix,
+        limit: TRANSFER_BATCH_OBJECTS,
+        ...(lastKey === null ? {} : { startAfter: lastKey }),
+        include: ["customMetadata"],
+      });
+      assertOwnership();
+      const items: ArchivedObject[] = [];
+      let selectedBytes = 0;
+      for (const object of page.objects) {
+        const suffix = object.key.slice(prefix.length);
+        if (!/^(?:by-id|by-request)\/[0-9a-f]{64}\.json$/.test(suffix)
+          || object.size <= 0 || object.size > MAX_RECEIPT_BYTES
+          || object.customMetadata?.kind !== "managed_turn_receipt"
+          || object.customMetadata?.version !== String(VERSION)
+          || !/^[0-9a-f]{64}$/.test(object.customMetadata?.sha256 ?? "")) {
+          throw new Error("managed turn archive contains an invalid object identity");
+        }
+        // Always make progress on the first valid object, then stop before the
+        // aggregate body budget is exceeded. The durable last key makes the
+        // unselected suffix of this list page the next resumable batch.
+        if (items.length > 0 && selectedBytes + object.size > TRANSFER_BATCH_BYTES) break;
+        items.push({
+          sha256: object.customMetadata.sha256,
+          size: object.size,
+          suffix,
+        });
+        selectedBytes += object.size;
+      }
+    items.sort((left, right) => left.suffix.localeCompare(right.suffix));
+    return {
+      items,
+      lastKey: items.length === 0 ? undefined : `${prefix}${items.at(-1)!.suffix}`,
+      truncated: page.truncated || items.length < page.objects.length,
+    };
+  }
+
+  #assertCommittedIdentity(progress: TransferProgress): void {
+    const state = this.#state();
+    if (progress.archived_bytes !== state.archived_bytes
+      || progress.archived_receipts !== state.archived_receipts
+      || progress.object_count !== state.object_count) {
+      throw new Error("managed turn archive objects do not match committed state");
+    }
   }
 
   async #read(key: string): Promise<ManagedTurnReceipt | undefined> {
@@ -227,15 +517,23 @@ export class ManagedTurnArchive {
     return envelope.receipt;
   }
 
-  async #putImmutable(key: string, body: Uint8Array, sha256: string): Promise<void> {
+  async #putImmutable(
+    key: string,
+    body: Uint8Array,
+    sha256: string,
+    assertOwnership: () => void = () => {},
+  ): Promise<void> {
+    assertOwnership();
     const stored = await this.#bucket.put(key, body, {
       onlyIf: { etagDoesNotMatch: "*" },
       httpMetadata: { contentType: "application/json" },
       customMetadata: { kind: "managed_turn_receipt", sha256, version: String(VERSION) },
       sha256,
     });
+    assertOwnership();
     if (stored) return;
     const existing = await this.#bucket.head(key);
+    assertOwnership();
     if (!existing || existing.size !== body.byteLength
       || existing.customMetadata?.sha256 !== sha256
       || existing.customMetadata?.kind !== "managed_turn_receipt") {
@@ -298,11 +596,74 @@ function validateReceipt(value: ManagedTurnReceipt): void {
   }
 }
 
+function validateIdentity(value: ManagedTurnArchiveIdentity): void {
+  if (!value || typeof value !== "object"
+    || value.version !== VERSION
+    || !Number.isSafeInteger(value.archived_bytes) || value.archived_bytes < 0
+    || !Number.isSafeInteger(value.archived_receipts) || value.archived_receipts < 0
+    || !Number.isSafeInteger(value.objects) || value.objects < 0
+    || value.archived_receipts > value.objects
+    || typeof value.digest !== "string" || !/^[0-9a-f]{64}$/.test(value.digest)) {
+    throw new Error("managed turn archive identity is invalid");
+  }
+}
+
 function emptySeal(): ManagedTurnSealResult {
   return { archived_bytes: 0, archived_receipts: 0, objects: 0, sealed: false };
+}
+
+async function advanceProgress(
+  progress: TransferProgress,
+  items: readonly ArchivedObject[],
+): Promise<TransferProgress> {
+  const digest = items.length === 0
+    ? progress.digest
+    : await sha256Hex(encoder.encode(`${progress.digest}\n${JSON.stringify(items)}`));
+  return {
+    archived_bytes: progress.archived_bytes
+      + items.reduce((sum, item) => sum + item.size, 0),
+    archived_receipts: progress.archived_receipts
+      + items.filter(({ suffix }) => suffix.startsWith("by-id/")).length,
+    complete: 0,
+    digest,
+    last_key: progress.last_key,
+    object_count: progress.object_count + items.length,
+  };
+}
+
+function identityFromProgress(progress: TransferProgress): ManagedTurnArchiveIdentity {
+  return {
+    archived_bytes: progress.archived_bytes,
+    archived_receipts: progress.archived_receipts,
+    digest: progress.digest,
+    objects: progress.object_count,
+    version: VERSION,
+  };
 }
 
 async function sha256Hex(value: Uint8Array): Promise<string> {
   const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", value));
   return [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function mapWithConcurrency<T>(
+  values: readonly T[],
+  concurrency: number,
+  operation: (value: T) => Promise<void>,
+): Promise<void> {
+  let next = 0;
+  const settled = await Promise.allSettled(Array.from(
+    { length: Math.min(concurrency, values.length) },
+    async () => {
+      while (next < values.length) {
+        const index = next;
+        next += 1;
+        await operation(values[index]!);
+      }
+    },
+  ));
+  const failure = settled.find(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (failure) throw failure.reason;
 }

--- a/services/managed/src/multiplayer-room.ts
+++ b/services/managed/src/multiplayer-room.ts
@@ -1207,18 +1207,8 @@ export class MultiplayerRoom extends DurableObject<MultiplayerRoomEnv> {
         await this.#rescheduleAlarm();
         return;
       }
-      if (["accepted", "retryable", "cancelling"].includes(String(turn.state))) {
+      if (["accepted", "cancelling"].includes(String(turn.state))) {
         this.#touchSubmittedJob(job.source_cursor);
-        await this.#rescheduleAlarm();
-        return;
-      }
-      if (turn.state === "blocked") {
-        try {
-          this.#projectAgentFailure(job, "blocked", true);
-        } catch (error) {
-          if (!(error instanceof EventLogCapacityError)) throw error;
-          this.#blockJob(job.source_cursor);
-        }
         await this.#rescheduleAlarm();
         return;
       }
@@ -2280,8 +2270,6 @@ function isManagedTurnState(value: unknown): value is string {
   return [
     "accepted",
     "cancelling",
-    "retryable",
-    "blocked",
     "completed",
     "cancelled",
     "failed",

--- a/services/managed/src/protocol.ts
+++ b/services/managed/src/protocol.ts
@@ -41,7 +41,6 @@ export type ServerMessage = (
   | TurnCompleted
   | { type: "turn_cancelled"; id: string }
   | { type: "turn_retryable"; id: string; error: string }
-  | { type: "turn_blocked"; id: string; error: string }
   | { type: "turn_failed"; id: string; error: string }
   | { type: "event"; event: AgentEvent }
   | { type: "stream_failed"; error: string }

--- a/services/managed/src/sandbox-smoke.ts
+++ b/services/managed/src/sandbox-smoke.ts
@@ -154,6 +154,7 @@ async function invoke(tools: ToolMap, name: string, input: unknown): Promise<unk
   if (!tool) throw new Error(`missing tool: ${name}`);
   return tool.handler(input, {
     callId: "smoke",
+    model: "gpt-5.6-sol",
     parentCallId: "smoke",
     sessionId: "smoke",
     signal: new AbortController().signal,

--- a/services/managed/src/turn-completion.ts
+++ b/services/managed/src/turn-completion.ts
@@ -3,18 +3,17 @@ import type { Turn, TurnResult } from "nanocodex";
 import type { ServerMessage, TurnCompleted } from "./protocol";
 
 export type TurnTerminal = Extract<ServerMessage, {
-  type: "turn_completed" | "turn_cancelled" | "turn_retryable" | "turn_blocked" | "turn_failed";
+  type: "turn_completed" | "turn_cancelled" | "turn_failed";
 }>;
 
-export type MaterializedTurnTerminal = Readonly<{
-  terminal: TurnTerminal;
-  reopenAgent: boolean;
-}>;
+export type TurnResolution =
+  | Readonly<{ kind: "terminal"; terminal: TurnTerminal; reopenAgent: false }>
+  | Readonly<{ kind: "retry"; error: string; reopenAgent: boolean }>;
 
-export async function materializeTurnTerminal(
+export async function materializeTurnResolution(
   id: string,
   turn: Turn,
-): Promise<MaterializedTurnTerminal> {
+): Promise<TurnResolution> {
   let result: TurnResult | undefined;
   try {
     result = await turn.result();
@@ -26,6 +25,7 @@ export async function materializeTurnTerminal(
       usageError = errorMessage(error);
     }
     return {
+      kind: "terminal",
       terminal: {
         type: "turn_completed",
         id,
@@ -43,55 +43,26 @@ export async function materializeTurnTerminal(
   }
 }
 
-export function classifyTurnFailure(id: string, error: unknown): MaterializedTurnTerminal {
-  const failures = errorTree(error);
-  const selected = selectFailure(failures);
-  const code = selected.code;
-  const message = selected.message;
-  if (code === "cancelled") {
-    return { terminal: { type: "turn_cancelled", id }, reopenAgent: false };
-  }
-  if (code === "blocked") {
+export function classifyTurnFailure(id: string, error: unknown): TurnResolution {
+  const selected = selectFailure(errorTree(error));
+  if (selected.code === "cancelled" || /\bturn was cancelled\b/i.test(selected.message)) {
     return {
-      terminal: { type: "turn_blocked", id, error: message },
+      kind: "terminal",
+      terminal: { type: "turn_cancelled", id },
       reopenAgent: false,
     };
   }
-  if (code === "reopen_required") {
+  if (isRetryable(selected)) {
     return {
-      terminal: { type: "turn_retryable", id, error: message },
-      reopenAgent: true,
-    };
-  }
-  if (code === "retryable") {
-    return {
-      terminal: { type: "turn_retryable", id, error: message },
-      reopenAgent: false,
-    };
-  }
-  if (/\bagent (?:has been |was |is )?(?:already )?disposed\b/i.test(message)) {
-    return {
-      terminal: { type: "turn_retryable", id, error: message },
-      reopenAgent: true,
-    };
-  }
-  if (/\bturn was cancelled\b/i.test(message)) {
-    return { terminal: { type: "turn_cancelled", id }, reopenAgent: false };
-  }
-  if (/ambiguous outcome/i.test(message)) {
-    return {
-      terminal: { type: "turn_blocked", id, error: message },
-      reopenAgent: false,
-    };
-  }
-  if (/blocked by unfinished operation|already active|agent stopped|turn completed|durability (?:store|driver)|transport|websocket|startup (?:validation )?timed out|connection rejected with HTTP 5\d\d/i.test(message)) {
-    return {
-      terminal: { type: "turn_retryable", id, error: message },
-      reopenAgent: false,
+      kind: "retry",
+      error: selected.message,
+      reopenAgent: selected.code === "reopen_required"
+        || /\bagent (?:has been |was |is )?(?:already )?disposed\b/i.test(selected.message),
     };
   }
   return {
-    terminal: { type: "turn_failed", id, error: message },
+    kind: "terminal",
+    terminal: { type: "turn_failed", id, error: selected.message },
     reopenAgent: false,
   };
 }
@@ -117,26 +88,21 @@ function errorTree(root: unknown): ClassifiedError[] {
 }
 
 function selectFailure(failures: readonly ClassifiedError[]): ClassifiedError {
-  const codePrecedence = ["reopen_required", "blocked", "cancelled", "retryable"];
-  for (const code of codePrecedence) {
+  for (const code of ["reopen_required", "cancelled", "retryable"]) {
     const match = failures.find((failure) => failure.code === code);
     if (match) return match;
   }
-  const reopen = failures.find((failure) =>
-    /\bagent (?:has been |was |is )?(?:already )?disposed\b/i.test(failure.message)
-  );
-  if (reopen) return { code: "reopen_required", message: reopen.message };
-  const blocked = failures.find((failure) => /ambiguous outcome/i.test(failure.message));
-  if (blocked) return { code: "blocked", message: blocked.message };
-  const cancelled = failures.find((failure) => /\bturn was cancelled\b/i.test(failure.message));
-  if (cancelled) return { code: "cancelled", message: cancelled.message };
-  const retryable = failures.find((failure) =>
-    /blocked by unfinished operation|already active|agent stopped|turn completed|durability (?:store|driver)|transport|websocket|startup (?:validation )?timed out|connection rejected with HTTP 5\d\d/i.test(failure.message)
-  );
-  if (retryable) return { code: "retryable", message: retryable.message };
-  const failed = failures.find((failure) => failure.code === "failed");
-  if (failed) return failed;
-  return failures[0] ?? { code: undefined, message: "unknown turn failure" };
+  return failures.find((failure) => isRetryable(failure))
+    ?? failures.find((failure) => /\bturn was cancelled\b/i.test(failure.message))
+    ?? failures.find((failure) => failure.code === "failed")
+    ?? failures[0]
+    ?? { code: undefined, message: "unknown turn failure" };
+}
+
+function isRetryable(failure: ClassifiedError): boolean {
+  return failure.code === "reopen_required"
+    || failure.code === "retryable"
+    || /\bagent (?:has been |was |is )?(?:already )?disposed\b|already active|agent stopped|turn completed|durability (?:store|driver)|transport|websocket|startup (?:validation )?timed out|connection rejected with HTTP 5\d\d/i.test(failure.message);
 }
 
 function errorCode(error: unknown): string | undefined {
@@ -147,3 +113,5 @@ function errorCode(error: unknown): string | undefined {
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
+
+export type { TurnCompleted };

--- a/services/managed/src/web.ts
+++ b/services/managed/src/web.ts
@@ -262,14 +262,6 @@ function onMessage(message) {
   } else if (message.type === "turn_retryable") {
     setStatus("retrying", "warn");
     setActivity(message.error, true);
-  } else if (message.type === "turn_blocked") {
-    if (!state) return;
-    finishTurn(message.id);
-    state.messages.push({ role: "error", text: message.error, turn_id: message.id });
-    saveState();
-    renderMessages();
-    setStatus("blocked · replace agent", "bad");
-    setActivity(message.error, true);
   } else if (message.type === "error") {
     setActivity(message.code + ": " + message.message, true);
   }

--- a/services/managed/test-node/managed-account-auth.test.mjs
+++ b/services/managed/test-node/managed-account-auth.test.mjs
@@ -3,12 +3,15 @@ import { test } from "node:test";
 
 import {
   managedAccountHeaders,
+  managedAccountSessionWebSocketOptions,
   parseManagedAgentReceipt,
   parseManagedReplState,
+  requireManagedAccountCookie,
   requireManagedApiKey,
 } from "../scripts/managed-account-auth.mjs";
 
 const API_KEY = `ncx_live_${"i".repeat(12)}_${"s".repeat(43)}`;
+const ACCOUNT_COOKIE = `nanocodex_account=${"c".repeat(64)}`;
 const RECEIPT = {
   agent_id: "0198d3b9-a02a-7000-8000-000000000001",
   session_id: "0198d3b9-a02a-7000-8000-000000000001",
@@ -33,6 +36,27 @@ test("managed account headers override caller authorization", () => {
   });
   assert.equal(headers.get("authorization"), `Bearer ${API_KEY}`);
   assert.equal(headers.get("x-test"), "preserved");
+});
+
+test("managed WebSockets use a same-origin passkey session and strip bearer authority", () => {
+  assert.equal(
+    requireManagedAccountCookie({ NANOCODEX_ACCOUNT_COOKIE: ACCOUNT_COOKIE }),
+    ACCOUNT_COOKIE,
+  );
+  const options = managedAccountSessionWebSocketOptions(
+    ACCOUNT_COOKIE,
+    "https://worker.example/path",
+    { headers: { authorization: `Bearer ${API_KEY}`, "x-test": "preserved" } },
+  );
+  assert.deepEqual(options.headers, {
+    cookie: ACCOUNT_COOKIE,
+    origin: "https://worker.example",
+    "x-test": "preserved",
+  });
+  assert.throws(
+    () => requireManagedAccountCookie({ NANOCODEX_ACCOUNT_COOKIE: API_KEY }),
+    /must be one exact passkey session cookie/,
+  );
 });
 
 test("managed agent receipts are token-free and exact", () => {

--- a/services/managed/test-node/managed-account-auth.test.mjs
+++ b/services/managed/test-node/managed-account-auth.test.mjs
@@ -14,6 +14,7 @@ const API_KEY = `ncx_live_${"i".repeat(12)}_${"s".repeat(43)}`;
 const ACCOUNT_COOKIE = `nanocodex_account=${"c".repeat(64)}`;
 const RECEIPT = {
   agent_id: "0198d3b9-a02a-7000-8000-000000000001",
+  durability_id: "0198d3b9-a02a-7000-8000-000000000001",
   session_id: "0198d3b9-a02a-7000-8000-000000000001",
   events_url: "https://worker.example/v1/agents/0198d3b9-a02a-7000-8000-000000000001/events",
   websocket_url: "wss://worker.example/v1/agents/0198d3b9-a02a-7000-8000-000000000001/ws",

--- a/services/managed/test-node/production-rollout.test.mjs
+++ b/services/managed/test-node/production-rollout.test.mjs
@@ -206,7 +206,16 @@ test("managed production config retains the exact private eight-DO topology", as
     { binding: "NANOCODEX", service: "nanocodex-egress" },
   ]);
   assert.equal(config.durable_objects.bindings.length, 8);
-  assert.deepEqual(config.migrations.map(({ tag }) => tag), ["v1", "v2", "v3", "v4"]);
+  assert.deepEqual(
+    config.durable_objects.bindings.find(({ name }) => name === "NANOCODEX_SESSIONS"),
+    { name: "NANOCODEX_SESSIONS", class_name: "DurableAgentSession" },
+  );
+  assert.deepEqual(config.migrations.map(({ tag }) => tag), ["v1", "v2", "v3", "v4", "v5"]);
+  assert.deepEqual(config.migrations.at(-1), {
+    tag: "v5",
+    new_sqlite_classes: ["DurableAgentSession"],
+    deleted_classes: ["NanocodexSession"],
+  });
   assert.doesNotMatch(JSON.stringify(config), /NANOCODEX_AUTH_MODE|OPENAI_API_KEY|CODEX_OAUTH_BOOTSTRAP|CODEX_RELAY_URL/);
   assert.deepEqual(managedSecretPayload(adminToken), { NANOCODEX_ADMIN_TOKEN: adminToken });
   assert.deepEqual(webSecretPayload("g".repeat(43)), {

--- a/services/managed/test-node/production-rollout.test.mjs
+++ b/services/managed/test-node/production-rollout.test.mjs
@@ -10,6 +10,7 @@ import {
   buildManagedProductionConfig,
   buildWebBootstrapConfig,
   buildWebProductionConfig,
+  deployProductionManaged,
   managedSecretPayload,
   productionWranglerEnvironment,
   webSecretPayload,
@@ -225,6 +226,47 @@ test("managed production config retains the exact private eight-DO topology", as
     () => buildManagedProductionConfig({ ...base, name: "nanocodex-durable-agent" }),
     /non-production template name/,
   );
+});
+
+test("managed deployment reports the object-shaped migration tags after Wrangler succeeds", async () => {
+  let deployment;
+  const result = await deployProductionManaged({
+    CLOUDFLARE_ACCOUNT_ID: "account-id",
+    CLOUDFLARE_API_TOKEN: "cloudflare-token",
+    NANOCODEX_ADMIN_TOKEN: adminToken,
+    TARGET_SHA: revision,
+  }, {
+    run: async (arguments_, options) => {
+      const configPath = arguments_[arguments_.indexOf("--config") + 1];
+      const secretsPath = arguments_[arguments_.indexOf("--secrets-file") + 1];
+      deployment = {
+        arguments_,
+        config: JSON.parse(await readFile(configPath, "utf8")),
+        environment: options.environment,
+        secrets: JSON.parse(await readFile(secretsPath, "utf8")),
+      };
+      return "Successfully published nanocodex-durable-agent";
+    },
+    verifyArtifact: async (actualRevision) => assert.equal(actualRevision, revision),
+    verifyCheckout: (actualRevision) => assert.equal(actualRevision, revision),
+  });
+
+  assert.deepEqual(result, {
+    component: "private-managed",
+    migrations: ["v1", "v2", "v3", "v4", "v5"],
+    revision,
+    status: "deployed",
+  });
+  assert.deepEqual(deployment.arguments_.slice(0, 3), [
+    "deploy",
+    "--config",
+    deployment.arguments_[2],
+  ]);
+  assert.deepEqual(deployment.config.migrations.map(({ tag }) => tag), result.migrations);
+  assert.deepEqual(deployment.secrets, { NANOCODEX_ADMIN_TOKEN: adminToken });
+  assert.equal(deployment.environment.CLOUDFLARE_ACCOUNT_ID, "account-id");
+  assert.equal(deployment.environment.CLOUDFLARE_API_TOKEN, "cloudflare-token");
+  assert.equal(deployment.environment.NANOCODEX_ADMIN_TOKEN, undefined);
 });
 
 test("boundary probe and website configs preserve the private service chain", () => {

--- a/services/managed/test-node/smoke-safety.test.mjs
+++ b/services/managed/test-node/smoke-safety.test.mjs
@@ -102,6 +102,10 @@ test("managed agents have no provider-credential or direct transport path", asyn
   assert.match(launcher, /envLine\("LOCAL_CHATGPT_BOOTSTRAP", \{/);
   assert.match(launcher, /envLine\("NANOCODEX_BROKER_PROBE_TOKEN", brokerProbeToken\)/);
   assert.match(launcher, /env: agentProcessEnvironment\(\)/);
+  assert.match(launcher, /const localManagedConfigPath = join\(workersRoot, "wrangler\.test\.jsonc"\)/);
+  assert.match(launcher, /managedConfig \? managedConfigPath : localManagedConfigPath/);
+  assert.match(launcher, /process\.env\.NANOCODEX_DEV_STATE_ROOT/);
+  assert.match(launcher, /relay\.protocol === "http:" && relay\.hostname === "127\.0\.0\.1"/);
   const brokerSpawn = launcher.indexOf("const brokerHandle = spawnProcessGroup");
   const brokerProof = launcher.indexOf('description: "private broker deep readiness"');
   const managedSpawn = launcher.indexOf("const managedHandle = spawnProcessGroup");
@@ -414,6 +418,8 @@ test("multiplayer smoke reaches its RoomClient after async room setup", async ()
         env: {
           ...process.env,
           NANOCODEX_WORKER_URL: origin,
+          NANOCODEX_API_KEY: `ncx_live_${"a".repeat(12)}_${"b".repeat(43)}`,
+          NANOCODEX_ACCOUNT_COOKIE: `nanocodex_account=${"c".repeat(64)}`,
           NANOCODEX_MULTIPLAYER_TIMEOUT_MS: "1000",
           NANOCODEX_SMOKE_CLEANUP_TIMEOUT_MS: "1000",
         },

--- a/services/managed/test/account-auth.test.ts
+++ b/services/managed/test/account-auth.test.ts
@@ -131,7 +131,7 @@ describe("local WebAuthn credential portability", () => {
 
   it("carries one signed credential into an isolated local auth store", async () => {
     const source = portableEnv();
-    const sessionToken = "s".repeat(43);
+    const sessionToken = "a".repeat(64);
     source.set("webauthn", `session:${sessionToken}`, {
       credentialId: CREDENTIAL_ID,
       publicKey: PUBLIC_KEY,
@@ -189,7 +189,7 @@ describe("local WebAuthn credential portability", () => {
 
   it("targets the selected older account after logout while the portable hint is newer", async () => {
     const target = portableEnv();
-    const latestSessionToken = "n".repeat(43);
+    const latestSessionToken = "b".repeat(64);
     target.set("webauthn", `credential:${CREDENTIAL_ID}`, {
       publicKey: PUBLIC_KEY,
       userId: encodeUserId(USER_ID),
@@ -255,7 +255,7 @@ describe("local WebAuthn credential portability", () => {
 
   it("refuses an unknown selected credential instead of falling back to the portable hint", async () => {
     const source = portableEnv();
-    const sessionToken = "x".repeat(43);
+    const sessionToken = "b".repeat(64);
     source.set("webauthn", `session:${sessionToken}`, {
       credentialId: SECOND_CREDENTIAL_ID,
       publicKey: SECOND_PUBLIC_KEY,
@@ -284,7 +284,7 @@ describe("local WebAuthn credential portability", () => {
 
   it("leaves an untargeted login discoverable even when a portable hint exists", async () => {
     const source = portableEnv();
-    const sessionToken = "d".repeat(43);
+    const sessionToken = "d".repeat(64);
     source.set("webauthn", `session:${sessionToken}`, {
       credentialId: SECOND_CREDENTIAL_ID,
       publicKey: SECOND_PUBLIC_KEY,
@@ -314,7 +314,7 @@ describe("local WebAuthn credential portability", () => {
 
   it("does not import tampered, mismatched, unsigned, or differently signed records", async () => {
     const source = portableEnv();
-    const sessionToken = "t".repeat(43);
+    const sessionToken = "c".repeat(64);
     source.set("webauthn", `session:${sessionToken}`, {
       credentialId: CREDENTIAL_ID,
       publicKey: PUBLIC_KEY,
@@ -348,7 +348,7 @@ describe("local WebAuthn credential portability", () => {
 
   it("issues the same portable record on the browser-safe localhost fallback", async () => {
     const source = portableEnv();
-    const sessionToken = "w".repeat(43);
+    const sessionToken = "e".repeat(64);
     source.set("webauthn", `session:${sessionToken}`, {
       credentialId: CREDENTIAL_ID,
       publicKey: PUBLIC_KEY,
@@ -399,7 +399,7 @@ describe("local WebAuthn credential portability", () => {
 
   it("never issues or imports the portable record on production or generic loopback origins", async () => {
     const source = portableEnv();
-    const portableSessionToken = "v".repeat(43);
+    const portableSessionToken = "c".repeat(64);
     source.set("webauthn", `session:${portableSessionToken}`, {
       credentialId: CREDENTIAL_ID,
       publicKey: PUBLIC_KEY,
@@ -421,7 +421,7 @@ describe("local WebAuthn credential portability", () => {
       "http://nested.branch.nanocodex.localhost:20735",
     ]) {
       const local = portableEnv();
-      const sessionToken = "u".repeat(43);
+      const sessionToken = "f".repeat(64);
       local.set("webauthn", `session:${sessionToken}`, {
         credentialId: CREDENTIAL_ID,
         publicKey: PUBLIC_KEY,

--- a/services/managed/test/computer-runtime.test.ts
+++ b/services/managed/test/computer-runtime.test.ts
@@ -16,6 +16,7 @@ describe("managed Computer runtime", () => {
 
     const context = {
       callId: "shared-computer",
+      model: "gpt-5.6-sol",
       parentCallId: "",
       sessionId: "test",
       signal: new AbortController().signal,
@@ -60,6 +61,7 @@ describe("managed Computer runtime", () => {
       cmd: "gh repo clone paradigmxyz/centaur centaur -- --depth 1 && cat centaur/README.md",
     }, {
       callId: "clone-centaur",
+      model: "gpt-5.6-sol",
       parentCallId: "",
       sessionId: "test",
       signal: new AbortController().signal,
@@ -94,6 +96,7 @@ describe("managed Computer runtime", () => {
       workdir: "/workspace",
     }, {
       callId: "absolute-clone-centaur",
+      model: "gpt-5.6-sol",
       parentCallId: "",
       sessionId: "test",
       signal: new AbortController().signal,
@@ -130,6 +133,7 @@ describe("managed Computer runtime", () => {
     });
     const context = {
       callId: "retry-clone-centaur",
+      model: "gpt-5.6-sol",
       parentCallId: "",
       sessionId: "test",
       signal: new AbortController().signal,

--- a/services/managed/test/computer-shell.test.ts
+++ b/services/managed/test/computer-shell.test.ts
@@ -32,6 +32,7 @@ describe("Nanocodex managed Just Bash commands", () => {
       cmd: "curl -s 'https://www.googleapis.com/drive/v3/files?pageSize=1&fields=files(id)'",
     }, {
       callId: "drive-curl",
+      model: "gpt-5.6-sol",
       parentCallId: "",
       sessionId: "test",
       signal: new AbortController().signal,

--- a/services/managed/test/device-host.test.ts
+++ b/services/managed/test/device-host.test.ts
@@ -6,7 +6,7 @@ import type { Env } from "../src/index";
 const testEnv = env as unknown as Env;
 const USER_ID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
 const API_KEY = `ncx_live_${"d".repeat(12)}_${"h".repeat(43)}`;
-const ACCOUNT_SESSION = "s".repeat(43);
+const ACCOUNT_SESSION = "a".repeat(64);
 const DEVICE_HOST_MESSAGE_TIMEOUT_MS = 10_000;
 const createdAgents = new Set<string>();
 

--- a/services/managed/test/hosted-tools.test.ts
+++ b/services/managed/test/hosted-tools.test.ts
@@ -8,7 +8,7 @@ import type { Env } from "../src/index";
 const testEnv = env as unknown as Env;
 const USER_ID = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
 const API_KEY = `ncx_live_${"d".repeat(12)}_${"h".repeat(43)}`;
-const ACCOUNT_SESSION = "t".repeat(43);
+const ACCOUNT_SESSION = "b".repeat(64);
 const MESSAGE_TIMEOUT_MS = 20_000;
 const createdAgents = new Set<string>();
 

--- a/services/managed/test/managed-api.test.ts
+++ b/services/managed/test/managed-api.test.ts
@@ -5466,17 +5466,48 @@ describe("managed agents REST and resumable SSE", () => {
     expect(BigInt(followingStarted!.cursor)).toBeLessThan(BigInt(followingCompleted!.cursor));
   });
 
-  it("exports and imports a live managed Agent through real Durable Object SQLite", async () => {
+  it("ports a compacted multi-turn Agent with tools and subagents through real Durable Object SQLite", async () => {
     expect((await testEnv.NANOCODEX.fetch(
       "https://broker.internal/test/model-commands",
       { method: "DELETE" },
     )).status).toBe(204);
     const source = await createAgent();
-    const turnId = "turn-portable-cloudflare";
-    const input = "retain this portable Cloudflare turn";
-    await submit(source, turnId, input);
-    const sourceTerminal = await waitForTurnState(source, turnId, "completed", 10_000);
-    await expect(modelCommandCount()).resolves.toBe(1);
+    const sourceTurns = [
+      {
+        id: "turn-portable-compaction-seed",
+        input: "E2E_PORTABILITY_COMPACTION_SEED",
+        finalMessage: "PORTABILITY_COMPACTION_SEEDED",
+      },
+      {
+        id: "turn-portable-computer",
+        input: "E2E_COMPUTER_RUNTIME",
+        finalMessage: "COMPUTER_TOOLS_OK",
+      },
+      {
+        id: "turn-portable-web-image",
+        input: "E2E_MANAGED_WEB",
+        finalMessage: "MANAGED_WEB_OK",
+      },
+      {
+        id: "turn-portable-core-tools",
+        input: "E2E_MANAGED_CORE_TOOLS",
+        finalMessage: "MANAGED_CORE_TOOLS_OK",
+      },
+      {
+        id: "turn-portable-subagents",
+        input: "E2E_MANAGED_SUBAGENTS",
+        finalMessage: "MANAGED_SUBAGENTS_OK",
+      },
+    ] as const;
+    const sourceTerminals = new Map<string, Awaited<ReturnType<typeof waitForTurnState>>>();
+    for (const turn of sourceTurns) {
+      await submit(source, turn.id, turn.input);
+      const terminal = await waitForTurnState(source, turn.id, "completed", 15_000);
+      expect(terminal.terminal).toMatchObject({ final_message: turn.finalMessage });
+      sourceTerminals.set(turn.id, terminal);
+    }
+    const commandsBeforeExport = await modelCommandCount();
+    expect(commandsBeforeExport).toBeGreaterThan(sourceTurns.length);
     const sourceCapacity = await testEnv.NANOCODEX_SESSIONS
       .getByName(source.agent_id)
       .fetch("https://session.internal/capacity");
@@ -5499,9 +5530,29 @@ describe("managed agents REST and resumable SSE", () => {
       revision: expect.stringMatching(/^[1-9][0-9]*$/),
       payload: expect.any(String),
     });
-    expect(JSON.parse(archive.payload).nanocodex_durable_state.operations)
-      .toHaveProperty(turnId);
-    await evictDurableObject(testEnv.NANOCODEX_SESSIONS.getByName(source.agent_id));
+    const portableState = JSON.parse(archive.payload).nanocodex_durable_state;
+    expect(portableState.latest_checkpoint).toBeTruthy();
+    expect(JSON.stringify(portableState.latest_checkpoint)).toContain(
+      "portable-managed-compaction",
+    );
+    for (const turn of sourceTurns) {
+      expect(portableState.operations).toHaveProperty(turn.id);
+    }
+    const sourceSession = testEnv.NANOCODEX_SESSIONS.getByName(source.agent_id);
+    let pendingProjections = Number.POSITIVE_INFINITY;
+    for (let attempt = 0; attempt < 8 && pendingProjections > 0; attempt += 1) {
+      await runInDurableObject(sourceSession, async (_instance, state) => {
+        await state.storage.setAlarm(Date.now());
+      });
+      await runDurableObjectAlarm(sourceSession);
+      pendingProjections = await runInDurableObject(sourceSession, (_instance, state) => (
+        state.storage.sql.exec<{ count: number }>(
+          "SELECT COUNT(*) AS count FROM history_projection_outbox",
+        ).one().count
+      ));
+    }
+    expect(pendingProjections).toBe(0);
+    await evictDurableObject(sourceSession);
     const repeatedExport = await SELF.fetch(
       source.events_url.replace(/\/events$/, "/durability"),
       { method: "POST" },
@@ -5537,13 +5588,33 @@ describe("managed agents REST and resumable SSE", () => {
       durability_id: archive.stateId,
     });
 
-    await submit(imported, turnId, input);
-    const importedTerminal = await waitForTurnState(imported, turnId, "completed", 10_000);
-    expect(importedTerminal.terminal).toEqual(sourceTerminal.terminal);
-    await expect(modelCommandCount()).resolves.toBe(1);
-    await submit(imported, "turn-after-cutover", "continue on the imported managed Agent");
-    await waitForTurnState(imported, "turn-after-cutover", "completed", 10_000);
-    await expect(modelCommandCount()).resolves.toBe(2);
+    for (const turn of sourceTurns) {
+      await submit(imported, turn.id, turn.input);
+      const importedTerminal = await waitForTurnState(imported, turn.id, "completed", 10_000);
+      expect(importedTerminal.terminal).toEqual(sourceTerminals.get(turn.id)!.terminal);
+      await expect(modelCommandCount()).resolves.toBe(commandsBeforeExport);
+    }
+
+    const destinationTurns = [
+      {
+        id: "turn-tool-after-cutover",
+        input: "E2E_COMPUTER_RUNTIME",
+        finalMessage: "COMPUTER_TOOLS_OK",
+      },
+      {
+        id: "turn-subagent-after-cutover",
+        input: "E2E_MANAGED_SUBAGENTS",
+        finalMessage: "MANAGED_SUBAGENTS_OK",
+      },
+    ] as const;
+    for (const turn of destinationTurns) {
+      await submit(imported, turn.id, turn.input);
+      const terminal = await waitForTurnState(imported, turn.id, "completed", 15_000);
+      expect(terminal.terminal).toMatchObject({
+        final_message: expect.stringContaining(turn.finalMessage),
+      });
+    }
+    await expect(modelCommandCount()).resolves.toBeGreaterThan(commandsBeforeExport);
     const identities = await Promise.all([
       runInDurableObject(
         testEnv.NANOCODEX_SESSIONS.getByName(source.agent_id),
@@ -5563,7 +5634,7 @@ describe("managed agents REST and resumable SSE", () => {
     ]);
     expect(identities[1]).toMatchObject({ state_id: archive.stateId });
     expect(identities[1].session_id).not.toBe(identities[0]);
-  }, 30_000);
+  }, 90_000);
 
   it("rejects corrupt canonical durability before creating a managed Agent", async () => {
     const response = await SELF.fetch("https://example.test/v1/agents", {

--- a/services/managed/test/managed-api.test.ts
+++ b/services/managed/test/managed-api.test.ts
@@ -1537,13 +1537,14 @@ describe("managed agents REST and resumable SSE", () => {
       );
     }
 
+    const expiredPasskeyToken = "9".repeat(64);
     const expiredPasskey = await RAW_SELF.fetch("https://example.test/v1/me", {
-      headers: { cookie: `nanocodex_account=${"a".repeat(64)}` },
+      headers: { cookie: `nanocodex_account=${expiredPasskeyToken}` },
     });
     expect(expiredPasskey.status).toBe(401);
     expect(await expiredPasskey.json()).toEqual({ error: "reauthentication_required" });
     expect(expiredPasskey.headers.get("set-cookie")).toBe(
-      `nanocodex_account=${"a".repeat(64)}; Path=/; Max-Age=31536000; HttpOnly; SameSite=Lax; Secure`,
+      `nanocodex_account=${expiredPasskeyToken}; Path=/; Max-Age=31536000; HttpOnly; SameSite=Lax; Secure`,
     );
 
     const unrelatedCookie = await RAW_SELF.fetch("https://example.test/v1/me", {
@@ -5119,7 +5120,9 @@ describe("managed agents REST and resumable SSE", () => {
           if (!failed
             && query.includes("INSERT INTO nanocodex_durable_states")
             && bindings.some((binding) => (
-              typeof binding === "string" && binding.includes("\"operation_cancelled\"")
+              typeof binding === "string"
+              && binding.includes(id)
+              && binding.includes("\"cancelled\"")
             ))) {
             failed = true;
             throw new Error("injected cancellation state failure");
@@ -5326,14 +5329,14 @@ describe("managed agents REST and resumable SSE", () => {
 
     try {
       await submit(agent, id, "remain retryable under capped backoff");
-      let turn = await waitForTurnAttempt(agent, id, 1);
+      let turn = await waitForTurnRetry(agent, id, 1);
       for (let expected = 2; expected <= 10; expected += 1) {
         expect(turn.state).toBe("accepted");
         expect(turn.retry_at).not.toBeNull();
         expect(turn.retry_at! - turn.updated_at).toBeLessThanOrEqual(60_000);
         vi.setSystemTime(turn.retry_at!);
         expect(await runDurableObjectAlarm(session)).toBe(true);
-        turn = await waitForTurnAttempt(agent, id, expected);
+        turn = await waitForTurnRetry(agent, id, expected);
       }
       expect(turn).toMatchObject({ attempt_count: 10, state: "accepted" });
       expect(turn.error).not.toMatch(/retry limit reached/i);
@@ -5420,7 +5423,7 @@ describe("managed agents REST and resumable SSE", () => {
     });
     expect(replay.status).toBe(200);
     await waitForTurnState(agent, replayId, "completed");
-    expect(await runInDurableObject(session, (_instance, state) => ({
+    const replayed = await runInDurableObject(session, (_instance, state) => ({
       dispatchInputJson: state.storage.sql.exec<{ input_json: string }>(
         `SELECT input_json FROM managed_turn_dispatch_chunks
          WHERE turn_id = ? ORDER BY chunk_index`,
@@ -5433,11 +5436,12 @@ describe("managed agents REST and resumable SSE", () => {
         "SELECT terminal_json FROM managed_turns WHERE id = ?",
         replayId,
       ).one().terminal_json,
-    }))).toEqual({
+    }));
+    expect(replayed).toMatchObject({
       dispatchInputJson: frozen.dispatchInputJson,
-      stateRevision: frozen.stateRevision,
       terminalJson: frozen.terminalJson,
     });
+    expect(BigInt(replayed.stateRevision)).toBeGreaterThan(BigInt(frozen.stateRevision));
     await submit(agent, "turn-after-raw-replay", "start only after replay attribution");
     await waitForTurnState(agent, "turn-after-raw-replay", "completed");
     await waitForHistoryEvent(agent, ({ cursor, event, turn_id }) => (

--- a/services/managed/test/managed-api.test.ts
+++ b/services/managed/test/managed-api.test.ts
@@ -5467,11 +5467,16 @@ describe("managed agents REST and resumable SSE", () => {
   });
 
   it("exports and imports a live managed Agent through real Durable Object SQLite", async () => {
+    expect((await testEnv.NANOCODEX.fetch(
+      "https://broker.internal/test/model-commands",
+      { method: "DELETE" },
+    )).status).toBe(204);
     const source = await createAgent();
     const turnId = "turn-portable-cloudflare";
     const input = "retain this portable Cloudflare turn";
     await submit(source, turnId, input);
     const sourceTerminal = await waitForTurnState(source, turnId, "completed", 10_000);
+    await expect(modelCommandCount()).resolves.toBe(1);
     const sourceCapacity = await testEnv.NANOCODEX_SESSIONS
       .getByName(source.agent_id)
       .fetch("https://session.internal/capacity");
@@ -5494,6 +5499,15 @@ describe("managed agents REST and resumable SSE", () => {
       revision: expect.stringMatching(/^[1-9][0-9]*$/),
       payload: expect.any(String),
     });
+    expect(JSON.parse(archive.payload).nanocodex_durable_state.operations)
+      .toHaveProperty(turnId);
+    await evictDurableObject(testEnv.NANOCODEX_SESSIONS.getByName(source.agent_id));
+    const repeatedExport = await SELF.fetch(
+      source.events_url.replace(/\/events$/, "/durability"),
+      { method: "POST" },
+    );
+    expect(repeatedExport.status).toBe(200);
+    await expect(repeatedExport.json()).resolves.toEqual(archive);
     expect((await SELF.fetch(source.events_url.replace(/\/events$/, "/turns"), {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -5526,6 +5540,10 @@ describe("managed agents REST and resumable SSE", () => {
     await submit(imported, turnId, input);
     const importedTerminal = await waitForTurnState(imported, turnId, "completed", 10_000);
     expect(importedTerminal.terminal).toEqual(sourceTerminal.terminal);
+    await expect(modelCommandCount()).resolves.toBe(1);
+    await submit(imported, "turn-after-cutover", "continue on the imported managed Agent");
+    await waitForTurnState(imported, "turn-after-cutover", "completed", 10_000);
+    await expect(modelCommandCount()).resolves.toBe(2);
     const identities = await Promise.all([
       runInDurableObject(
         testEnv.NANOCODEX_SESSIONS.getByName(source.agent_id),
@@ -5546,6 +5564,25 @@ describe("managed agents REST and resumable SSE", () => {
     expect(identities[1]).toMatchObject({ state_id: archive.stateId });
     expect(identities[1].session_id).not.toBe(identities[0]);
   }, 30_000);
+
+  it("rejects corrupt canonical durability before creating a managed Agent", async () => {
+    const response = await SELF.fetch("https://example.test/v1/agents", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        durability: {
+          format: "nanocodex-durability-state-v1",
+          stateId: `corrupt-${crypto.randomUUID()}`,
+          revision: "1",
+          payload: "{}",
+        },
+      }),
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "invalid_durability_import",
+    });
+  });
 
   it("persists cursors across eviction and tails strictly after the acknowledged cursor", async () => {
     const agent = await createAgent();
@@ -5748,6 +5785,14 @@ async function managedFetch(input: RequestInfo | URL, init?: RequestInit): Promi
   const headers = new Headers(request.headers);
   headers.set("authorization", `Bearer ${API_KEY}`);
   return RAW_SELF.fetch(new Request(request, { headers }));
+}
+
+async function modelCommandCount(): Promise<number> {
+  const response = await testEnv.NANOCODEX.fetch(
+    "https://broker.internal/test/model-commands",
+  );
+  expect(response.status).toBe(200);
+  return (await response.json<{ count: number }>()).count;
 }
 
 function connectGrantHeaders(

--- a/services/managed/test/managed-api.test.ts
+++ b/services/managed/test/managed-api.test.ts
@@ -7,7 +7,7 @@ import {
 } from "cloudflare:test";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-import { MemoryScope, NanocodexSession, UserAccount, type Env } from "../src/index";
+import { DurableAgentSession, MemoryScope, UserAccount, type Env } from "../src/index";
 import { DurableEventLog } from "../src/durable-events";
 import { ManagedEventArchive } from "../src/managed-event-archive";
 import type { OrganizationCapability } from "../src/account-auth";
@@ -223,13 +223,13 @@ describe("managed agents REST and resumable SSE", () => {
     const capacity = await response.json<{
       archived_turns: { archived_bytes: number; archived_receipts: number; objects: number };
       database_size_bytes: number;
-      journal: { bytes: number; max_batch_bytes: number; revision: string; rows: number };
+      durable_state: { bytes: number; revision: string; rows: number };
       known_payload_bytes: number;
       managed_events: { bytes: number; rows: number };
       raw_events: { bytes: number; rows: number };
       turns: {
-        blocked_rows: number;
         input_bytes: number;
+        retry_rows: number;
         terminal_bytes: number;
         terminal_rows: number;
         total_rows: number;
@@ -239,16 +239,14 @@ describe("managed agents REST and resumable SSE", () => {
     }>();
 
     expect(capacity.database_size_bytes).toBeGreaterThan(0);
-    expect(capacity.journal).toMatchObject({ rows: expect.any(Number) });
-    expect(capacity.journal.rows).toBeGreaterThan(0);
-    expect(capacity.journal.bytes).toBeGreaterThan(0);
-    expect(capacity.journal.max_batch_bytes).toBeGreaterThan(0);
-    expect(BigInt(capacity.journal.revision)).toBeGreaterThan(0n);
+    expect(capacity.durable_state).toMatchObject({ rows: 1 });
+    expect(capacity.durable_state.bytes).toBeGreaterThan(0);
+    expect(BigInt(capacity.durable_state.revision)).toBeGreaterThan(0n);
     expect(capacity.managed_events.rows).toBeGreaterThan(0);
     expect(capacity.managed_events.bytes).toBeGreaterThan(0);
     expect(capacity.raw_events).toEqual({ rows: 0, bytes: 0 });
     expect(capacity.turns).toMatchObject({
-      blocked_rows: 0,
+      retry_rows: 0,
       terminal_rows: 1,
       total_rows: 1,
       unfinished_rows: 0,
@@ -560,7 +558,7 @@ describe("managed agents REST and resumable SSE", () => {
     expect(await corrupt.json()).toMatchObject({ error: "turn_archive_unavailable" });
   }, 30_000);
 
-  it("compacts a terminal journal prefix and cold-reopens from the retained checkpoint", async () => {
+  it("prunes terminal receipts and cold-reopens from the retained state", async () => {
     const agent = await createAgent();
     for (let index = 0; index < 22; index += 1) {
       const id = `turn-compaction-${index}`;
@@ -570,10 +568,10 @@ describe("managed agents REST and resumable SSE", () => {
 
     const session = testEnv.NANOCODEX_SESSIONS.getByName(agent.agent_id);
     const before = await (await session.fetch("https://session.internal/capacity")).json<{
-      journal: { revision: string; rows: number };
+      durable_state: { revision: string; rows: number };
     }>();
-    expect(BigInt(before.journal.revision)).toBeGreaterThanOrEqual(66n);
-    expect(BigInt(before.journal.rows)).toBeLessThan(BigInt(before.journal.revision));
+    expect(BigInt(before.durable_state.revision)).toBeGreaterThanOrEqual(44n);
+    expect(before.durable_state.rows).toBe(1);
 
     let pendingProjections = Number.POSITIVE_INFINITY;
     for (let attempt = 0; attempt < 4 && pendingProjections > 0; attempt += 1) {
@@ -601,34 +599,37 @@ describe("managed agents REST and resumable SSE", () => {
     await submit(agent, "turn-after-compaction-reopen", "AFTER_COMPACTION_REOPEN");
     await waitForTurnState(agent, "turn-after-compaction-reopen", "completed");
     const after = await (await session.fetch("https://session.internal/capacity")).json<{
-      journal: { revision: string; rows: number };
+      durable_state: { revision: string; rows: number };
       turns: { terminal_rows: number };
     }>();
-    expect(BigInt(after.journal.revision)).toBeGreaterThan(BigInt(before.journal.revision));
-    expect(BigInt(after.journal.rows)).toBeLessThan(BigInt(after.journal.revision));
+    expect(BigInt(after.durable_state.revision)).toBeGreaterThan(
+      BigInt(before.durable_state.revision),
+    );
+    expect(after.durable_state.rows).toBe(1);
     expect(after.turns.terminal_rows).toBe(23);
   }, 60_000);
 
-  it("compacts multiple retained journal batches before cold Agent construction", async () => {
+  it("retains exactly one total state across cold Agent construction", async () => {
     const agent = await createAgent();
     await submit(agent, "turn-before-cold-preconstruction", "BEFORE_COLD_PRECONSTRUCTION");
     await waitForTurnState(agent, "turn-before-cold-preconstruction", "completed");
 
     const session = testEnv.NANOCODEX_SESSIONS.getByName(agent.agent_id);
     const before = await (await session.fetch("https://session.internal/capacity")).json<{
-      journal: { revision: string; rows: number };
+      durable_state: { revision: string; rows: number };
     }>();
-    expect(before.journal.rows).toBeGreaterThan(1);
+    expect(before.durable_state.rows).toBe(1);
     await evictDurableObject(session);
 
     await submit(agent, "turn-after-cold-preconstruction", "AFTER_COLD_PRECONSTRUCTION");
     await waitForTurnState(agent, "turn-after-cold-preconstruction", "completed");
     const after = await (await session.fetch("https://session.internal/capacity")).json<{
-      journal: { revision: string; rows: number };
+      durable_state: { revision: string; rows: number };
     }>();
-    const appended = Number(BigInt(after.journal.revision) - BigInt(before.journal.revision));
-    expect(appended).toBeGreaterThan(0);
-    expect(after.journal.rows).toBe(1 + appended);
+    expect(BigInt(after.durable_state.revision)).toBeGreaterThan(
+      BigInt(before.durable_state.revision),
+    );
+    expect(after.durable_state.rows).toBe(1);
   }, 30_000);
 
   it("keeps connector OAuth state and credentials behind a persistent account", async () => {
@@ -679,7 +680,7 @@ describe("managed agents REST and resumable SSE", () => {
     expect(anonymousEgress.status).toBe(401);
 
     const connectorUserId = "55555555-5555-4555-8555-555555555555";
-    const connectorToken = "c".repeat(43);
+    const connectorToken = "c".repeat(64);
     await seedPasskeySession(connectorUserId, connectorToken);
     const cookie = `nanocodex_account=${connectorToken}`;
 
@@ -831,7 +832,7 @@ describe("managed agents REST and resumable SSE", () => {
 
   it("projects an owner-bound MCP catalog without broker-private connection material", async () => {
     const userId = "66666666-6666-4666-8666-666666666666";
-    const token = "m".repeat(43);
+    const token = "a".repeat(64);
     const cookie = `nanocodex_account=${token}`;
     const connectionId = "L".repeat(43);
     await seedPasskeySession(userId, token);
@@ -1100,7 +1101,7 @@ describe("managed agents REST and resumable SSE", () => {
       expect(brokerRequests).toHaveLength(0);
 
       const userId = "88888888-8888-4888-8888-888888888888";
-      const token = "p".repeat(43);
+      const token = "b".repeat(64);
       await seedPasskeySession(userId, token);
       const cookie = `nanocodex_account=${token}`;
 
@@ -1179,7 +1180,7 @@ describe("managed agents REST and resumable SSE", () => {
 
   it("links a Tempo account to one persistent Nanocodex profile through a one-time code", async () => {
     const userId = "66666666-6666-4666-8666-666666666666";
-    const sessionToken = "l".repeat(43);
+    const sessionToken = "c".repeat(64);
     const cookie = `nanocodex_account=${sessionToken}`;
     const accountAddress = "0x1111111111111111111111111111111111111111";
     const state = "s".repeat(43);
@@ -1291,7 +1292,7 @@ describe("managed agents REST and resumable SSE", () => {
 
   it("authorizes the signed Connect account from its existing first-party session", async () => {
     const userId = "77777777-7777-4777-8777-777777777777";
-    const sessionToken = "m".repeat(43);
+    const sessionToken = "a".repeat(64);
     const cookie = `nanocodex_account=${sessionToken}`;
     const accountAddress = "0x2222222222222222222222222222222222222222";
     const state = "t".repeat(43);
@@ -1338,8 +1339,8 @@ describe("managed agents REST and resumable SSE", () => {
   it("issues and atomically exchanges a hosted authorization derived from the active passkey", async () => {
     const userId = "88888888-8888-4888-8888-888888888888";
     const otherUserId = "99999999-9999-4999-8999-999999999999";
-    const token = "h".repeat(43);
-    const otherToken = "j".repeat(43);
+    const token = "d".repeat(64);
+    const otherToken = "a".repeat(64);
     const cookie = `nanocodex_account=${token}`;
     const resources = [
       "urn:nanocodex:capability:agent.run",
@@ -1432,7 +1433,7 @@ describe("managed agents REST and resumable SSE", () => {
 
   it("strictly bounds hosted authorization authority and rejects MPP", async () => {
     const userId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
-    const token = "i".repeat(43);
+    const token = "e".repeat(64);
     const cookie = `nanocodex_account=${token}`;
     await seedPasskeySession(userId, token, HOSTED_PASSKEY_PUBLIC_KEY);
     const authorize = (body: unknown) => RAW_SELF.fetch(
@@ -1453,7 +1454,7 @@ describe("managed agents REST and resumable SSE", () => {
     const sessionUserId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
     const passkeyUserId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
     const mismatchedToken = `a_${"p".repeat(43)}`;
-    await seedPasskeySession(sessionUserId, "k".repeat(43), HOSTED_PASSKEY_PUBLIC_KEY);
+    await seedPasskeySession(sessionUserId, "b".repeat(64), HOSTED_PASSKEY_PUBLIC_KEY);
     await seedPasskeySession(passkeyUserId, mismatchedToken, HOSTED_PASSKEY_PUBLIC_KEY);
     await seedBrowserAccountSession(sessionUserId, mismatchedToken);
     const mismatchedIdentity = await RAW_SELF.fetch(
@@ -1537,12 +1538,12 @@ describe("managed agents REST and resumable SSE", () => {
     }
 
     const expiredPasskey = await RAW_SELF.fetch("https://example.test/v1/me", {
-      headers: { cookie: `nanocodex_account=${"z".repeat(43)}` },
+      headers: { cookie: `nanocodex_account=${"a".repeat(64)}` },
     });
     expect(expiredPasskey.status).toBe(401);
     expect(await expiredPasskey.json()).toEqual({ error: "reauthentication_required" });
     expect(expiredPasskey.headers.get("set-cookie")).toBe(
-      `nanocodex_account=${"z".repeat(43)}; Path=/; Max-Age=31536000; HttpOnly; SameSite=Lax; Secure`,
+      `nanocodex_account=${"a".repeat(64)}; Path=/; Max-Age=31536000; HttpOnly; SameSite=Lax; Secure`,
     );
 
     const unrelatedCookie = await RAW_SELF.fetch("https://example.test/v1/me", {
@@ -1554,8 +1555,11 @@ describe("managed agents REST and resumable SSE", () => {
     );
   });
 
-  it("recognizes passkey sessions even when their random token begins with the anonymous prefix", async () => {
-    const tokens = ["w".repeat(43), `a_${"w".repeat(41)}`];
+  it("recognizes only the exact generated passkey-session token shape", async () => {
+    const tokens = [
+      "0123456789abcdef".repeat(4),
+      "fedcba9876543210".repeat(4),
+    ];
     for (const [index, token] of tokens.entries()) {
       const userId = `22222222-2222-4222-8222-22222222222${index}`;
       await seedPasskeySession(userId, token);
@@ -2062,7 +2066,7 @@ describe("managed agents REST and resumable SSE", () => {
       { headers: { upgrade: "websocket" } },
     )).status).toBe(400);
 
-    const token = "v".repeat(43);
+    const token = "f".repeat(64);
     await seedPasskeySession(USER_ID, token);
     const cookie = `nanocodex_account=${token}`;
     const crossOrigin = await RAW_SELF.fetch(`${route}/calls`, {
@@ -2105,7 +2109,7 @@ describe("managed agents REST and resumable SSE", () => {
     expect(anonymousCookie).toMatch(/^nanocodex_account=a_[A-Za-z0-9_-]{43}$/);
 
     const passkeyUserId = "44444444-4444-4444-8444-444444444444";
-    const passkeyToken = `a_${"z".repeat(41)}`;
+    const passkeyToken = "d".repeat(64);
     await seedPasskeySession(passkeyUserId, passkeyToken);
     const principals = [
       { kind: "anonymous", cookie: anonymousCookie! },
@@ -2589,7 +2593,7 @@ describe("managed agents REST and resumable SSE", () => {
   it("keeps managed realtime mutations same-origin, owner-asserted, and bounded", async () => {
     const agent = await createAgent();
     const realtimeUrl = agent.events_url.replace(/\/events$/, "/realtime/start");
-    const token = "r".repeat(43);
+    const token = "1".repeat(64);
     await seedPasskeySession(USER_ID, token);
     const cookie = `nanocodex_account=${token}`;
     const body = JSON.stringify({
@@ -2925,7 +2929,7 @@ describe("managed agents REST and resumable SSE", () => {
     await runInDurableObject(session, (_instance, state) => {
       state.storage.sql.exec(
         `UPDATE managed_turns
-         SET state = 'retryable', terminal_json = NULL,
+         SET state = 'accepted', terminal_json = NULL,
              terminal_cursor = NULL, error = 'injected routed projection gap', retry_at = 0
          WHERE id = ?`,
         routed.turn_id,
@@ -3220,7 +3224,7 @@ describe("managed agents REST and resumable SSE", () => {
   it("forwards one owner-asserted session request and overwrites caller assertions", async () => {
     const agent = await createAgent();
     const stateUrl = agent.events_url.replace(/\/events$/, "");
-    const originalFetch = NanocodexSession.prototype.fetch;
+    const originalFetch = DurableAgentSession.prototype.fetch;
     const forwarded: Array<{
       owner: string | null;
       organization: string | null;
@@ -3229,8 +3233,8 @@ describe("managed agents REST and resumable SSE", () => {
       capabilities: string | null;
       path: string;
     }> = [];
-    const fetchSpy = vi.spyOn(NanocodexSession.prototype, "fetch").mockImplementation(
-      async function (this: NanocodexSession, request: Request): Promise<Response> {
+    const fetchSpy = vi.spyOn(DurableAgentSession.prototype, "fetch").mockImplementation(
+      async function (this: DurableAgentSession, request: Request): Promise<Response> {
         forwarded.push({
           owner: request.headers.get("x-nanocodex-owner-id"),
           organization: request.headers.get("x-nanocodex-session-organization-id"),
@@ -3510,7 +3514,7 @@ describe("managed agents REST and resumable SSE", () => {
     try {
       await submit(agent, "turn-bounded-cold-rebind", "retry after a nonsettling rebind");
       await within(started, "nonsettling cold rebind");
-      const retryable = await waitForTurnState(agent, "turn-bounded-cold-rebind", "retryable");
+      const retryable = await waitForTurnRetry(agent, "turn-bounded-cold-rebind");
       expect(retryable.attempt_count).toBe(1);
       expect(retryable.error).toMatch(/credential subject binding timed out/i);
       expect(retryable.retry_at).not.toBeNull();
@@ -3753,7 +3757,7 @@ describe("managed agents REST and resumable SSE", () => {
 
   it("retains durable cleanup ownership when binding and the first unbind both fail", async () => {
     const originalBroker = testEnv.NANOCODEX;
-    let session: DurableObjectStub<NanocodexSession> | undefined;
+    let session: DurableObjectStub<DurableAgentSession> | undefined;
     let subject: string | undefined;
     let unbindAttempts = 0;
     let rejectUnbind = true;
@@ -3808,7 +3812,7 @@ describe("managed agents REST and resumable SSE", () => {
 
   it("keeps a bound subject owned after initialization and first cleanup fail", async () => {
     const originalBroker = testEnv.NANOCODEX;
-    let session: DurableObjectStub<NanocodexSession> | undefined;
+    let session: DurableObjectStub<DurableAgentSession> | undefined;
     let subject: string | undefined;
     let unbindAttempts = 0;
     let rejectUnbind = true;
@@ -3826,9 +3830,9 @@ describe("managed agents REST and resumable SSE", () => {
         return originalBroker.fetch(request);
       },
     } as Fetcher;
-    const originalFetch = NanocodexSession.prototype.fetch;
-    const fetchSpy = vi.spyOn(NanocodexSession.prototype, "fetch").mockImplementation(
-      async function (this: NanocodexSession, request: Request): Promise<Response> {
+    const originalFetch = DurableAgentSession.prototype.fetch;
+    const fetchSpy = vi.spyOn(DurableAgentSession.prototype, "fetch").mockImplementation(
+      async function (this: DurableAgentSession, request: Request): Promise<Response> {
         if (request.method === "PUT" && new URL(request.url).pathname === "/initialize") {
           return Response.json({ error: "injected_initialize_failure" }, { status: 503 });
         }
@@ -4139,7 +4143,7 @@ describe("managed agents REST and resumable SSE", () => {
       const now = Date.now();
       for (const agentId of ids) {
         state.storage.sql.exec(
-          `INSERT INTO user_agents
+          `INSERT INTO agent_registry
              (id, title, created_at, updated_at, turn_count, deleted_at)
            VALUES (?, '', ?, ?, 0, NULL)`,
           agentId,
@@ -4163,46 +4167,6 @@ describe("managed agents REST and resumable SSE", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ agentId: ids[2_048] }),
     })).status).toBe(410);
-  });
-
-  it("adopts the aggregate account registry without losing deletion fences", async () => {
-    const account = testEnv.NANOCODEX_USERS.getByName(`registry-migration-${crypto.randomUUID()}`);
-    const activeId = "10000000-0000-4000-8000-000000000001";
-    const deletedId = "10000000-0000-4000-8000-000000000002";
-    await runInDurableObject(account, async (_instance, state) => {
-      await state.storage.put({
-        agents: [activeId],
-        agentSummaries: {
-          [activeId]: {
-            id: activeId,
-            title: "Retained title",
-            createdAt: 10,
-            updatedAt: 20,
-            turnCount: 3,
-          },
-        },
-        [`agent-tombstone:${deletedId}`]: true,
-      });
-    });
-    await evictDurableObject(account);
-
-    expect(await (await account.fetch("https://user.internal/agents")).json()).toEqual([{
-      id: activeId,
-      title: "Retained title",
-      createdAt: 10,
-      updatedAt: 20,
-      turnCount: 3,
-    }]);
-    expect((await account.fetch("https://user.internal/agents", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ agentId: deletedId }),
-    })).status).toBe(410);
-    expect(await runInDurableObject(account, async (_instance, state) => ({
-      agents: await state.storage.get("agents"),
-      summaries: await state.storage.get("agentSummaries"),
-      tombstone: await state.storage.get(`agent-tombstone:${deletedId}`),
-    }))).toEqual({ agents: undefined, summaries: undefined, tombstone: undefined });
   });
 
   it("lists durable conversation summaries without probing every agent session", async () => {
@@ -4232,10 +4196,10 @@ describe("managed agents REST and resumable SSE", () => {
   it("carries Unicode conversation summaries through an ASCII-only internal header", async () => {
     const agent = await createAgent();
     const prompt = "Ship 🦀 a durable conversation title that is deliberately longer than fifty-six characters";
-    const originalFetch = NanocodexSession.prototype.fetch;
+    const originalFetch = DurableAgentSession.prototype.fetch;
     let internalHeader: string | null = null;
-    const fetchSpy = vi.spyOn(NanocodexSession.prototype, "fetch").mockImplementation(
-      async function (this: NanocodexSession, request: Request): Promise<Response> {
+    const fetchSpy = vi.spyOn(DurableAgentSession.prototype, "fetch").mockImplementation(
+      async function (this: DurableAgentSession, request: Request): Promise<Response> {
         const response = await originalFetch.call(this, request);
         if (request.method === "POST" && new URL(request.url).pathname === "/turns") {
           internalHeader = response.headers.get("x-nanocodex-turn-summary");
@@ -4515,6 +4479,63 @@ describe("managed agents REST and resumable SSE", () => {
     );
   });
 
+  it("retains cancellation that arrives before turn admission", async () => {
+    const agent = await createAgent();
+    const id = "turn-cancel-before-admission";
+    const turnsUrl = agent.events_url.replace(/\/events$/, "/turns");
+    const cancelUrl = `${turnsUrl}/${id}/cancel`;
+
+    const firstCancel = await SELF.fetch(cancelUrl, { method: "POST" });
+    expect(firstCancel.status).toBe(202);
+    expect(await firstCancel.json()).toEqual({ turn_id: id, state: "cancelling" });
+    const duplicateCancel = await SELF.fetch(cancelUrl, { method: "POST" });
+    expect(duplicateCancel.status).toBe(202);
+    expect(await duplicateCancel.json()).toEqual({ turn_id: id, state: "cancelling" });
+
+    const submitted = await SELF.fetch(turnsUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "idempotency-key": `request-${id}`,
+      },
+      body: JSON.stringify({ id, input: "must never reach the runtime" }),
+    });
+    expect(submitted.status).toBe(202);
+    expect(await submitted.json<ManagedTurnView>()).toMatchObject({
+      state: "cancelling",
+      turn_id: id,
+    });
+
+    await waitForTurnState(agent, id, "cancelled");
+    const history = await managedHistory(agent);
+    expect(history.data.filter(({ type, turn_id }) => turn_id === id && (
+      type === "turn_accepted" || type === "turn_cancelling" || type === "turn_cancelled"
+    )).map(({ type }) => type)).toEqual([
+      "turn_accepted",
+      "turn_cancelling",
+      "turn_cancelled",
+    ]);
+    expect(history.data.some(({ type, turn_id }) => (
+      turn_id === id && type === "event"
+    ))).toBe(false);
+    expect(await runInDurableObject(
+      testEnv.NANOCODEX_SESSIONS.getByName(agent.agent_id),
+      (_instance, state) => ({
+        intentCount: state.storage.sql.exec<{ count: number }>(
+          "SELECT COUNT(*) AS count FROM managed_turn_cancel_intents WHERE turn_id = ?",
+          id,
+        ).one().count,
+        turn: state.storage.sql.exec<{ may_have_inner_operation: number; state: string }>(
+          "SELECT may_have_inner_operation, state FROM managed_turns WHERE id = ?",
+          id,
+        ).one(),
+      }),
+    )).toEqual({
+      intentCount: 0,
+      turn: { may_have_inner_operation: 0, state: "cancelled" },
+    });
+  });
+
   it("uses Last-Event-ID before the query cursor and rejects cursors ahead of storage", async () => {
     const agent = await createAgent();
     await submit(agent, "turn-a", "alpha");
@@ -4611,11 +4632,11 @@ describe("managed agents REST and resumable SSE", () => {
     await waitForTurnState(agent, "turn-before-alarm", "completed");
     const id = new URL(agent.events_url).pathname.split("/").at(-2)!;
     const stub = testEnv.NANOCODEX_SESSIONS.getByName(id);
-    const originalAlarm = NanocodexSession.prototype.alarm;
+    const originalAlarm = DurableAgentSession.prototype.alarm;
     let entered!: () => void;
     const alarmEntered = new Promise<void>((resolve) => { entered = resolve; });
-    const alarmSpy = vi.spyOn(NanocodexSession.prototype, "alarm").mockImplementation(
-      async function (this: NanocodexSession): Promise<void> {
+    const alarmSpy = vi.spyOn(DurableAgentSession.prototype, "alarm").mockImplementation(
+      async function (this: DurableAgentSession): Promise<void> {
         entered();
         return originalAlarm.call(this);
       },
@@ -4636,7 +4657,7 @@ describe("managed agents REST and resumable SSE", () => {
       ))).toHaveLength(1);
       expect(history.data.some(({ type, turn_id }) => (
         turn_id === "turn-during-alarm"
-          && (type === "turn_failed" || type === "turn_retryable" || type === "turn_blocked")
+          && (type === "turn_failed" || type === "turn_retryable")
       ))).toBe(false);
     } finally {
       alarmSpy.mockRestore();
@@ -4866,7 +4887,7 @@ describe("managed agents REST and resumable SSE", () => {
     } as Fetcher;
     try {
       expect((await SELF.fetch(turnsUrl, request)).status).toBe(202);
-      const retryable = await waitForTurnState(agent, id, "retryable");
+      const retryable = await waitForTurnRetry(agent, id);
       expect(retryable.error).toMatch(/HTTP 503/i);
     } finally {
       testEnv.NANOCODEX = originalBroker;
@@ -4896,7 +4917,7 @@ describe("managed agents REST and resumable SSE", () => {
       turn_id === id && type === "turn_completed"
     ))).toHaveLength(1);
     expect(history.data.some(({ type, turn_id }) => (
-      turn_id === id && (type === "turn_failed" || type === "turn_blocked")
+      turn_id === id && type === "turn_failed"
     ))).toBe(false);
   });
 
@@ -4929,7 +4950,7 @@ describe("managed agents REST and resumable SSE", () => {
     try {
       expect((await SELF.fetch(turnsUrl, turnRequest)).status).toBe(202);
       const retryable = await waitForTurnAttempt(agent, id, 1);
-      expect(retryable.state).toBe("retryable");
+      expect(retryable.state).toBe("accepted");
       expect(retryable.error).toMatch(/HTTP 503/i);
       const upgradesBeforeCancel = upgradeCount;
 
@@ -4967,7 +4988,7 @@ describe("managed agents REST and resumable SSE", () => {
         type === "turn_cancelled" && turn_id === id
       ))).toHaveLength(1);
       expect(history.data.some(({ type, turn_id }) => (
-        turn_id === id && (type === "turn_failed" || type === "turn_blocked")
+        turn_id === id && type === "turn_failed"
       ))).toBe(false);
       expect(await runInDurableObject(
         testEnv.NANOCODEX_SESSIONS.getByName(agent.agent_id),
@@ -5096,12 +5117,12 @@ describe("managed agents REST and resumable SSE", () => {
         let failed = false;
         sql.exec = function injectedJournalFailure(query, ...bindings) {
           if (!failed
-            && query.includes("INSERT INTO nanocodex_journal_batches")
+            && query.includes("INSERT INTO nanocodex_durable_states")
             && bindings.some((binding) => (
               typeof binding === "string" && binding.includes("\"operation_cancelled\"")
             ))) {
             failed = true;
-            throw new Error("injected cancellation journal failure");
+            throw new Error("injected cancellation state failure");
           }
           return originalExec.call(sql, query, ...bindings);
         };
@@ -5186,7 +5207,7 @@ describe("managed agents REST and resumable SSE", () => {
 
     try {
       expect((await submit("turn-fifo-first")).status).toBe(202);
-      await waitForTurnState(agent, "turn-fifo-first", "retryable");
+      await waitForTurnRetry(agent, "turn-fifo-first");
       expect(upgradeCount).toBe(1);
 
       expect((await submit("turn-fifo-second")).status).toBe(202);
@@ -5205,143 +5226,10 @@ describe("managed agents REST and resumable SSE", () => {
       })).status).toBe(202);
       await waitForTurnState(agent, "turn-fifo-first", "cancelled");
       await waitForTurnState(agent, "turn-fifo-second", "completed");
-
-      const history = await managedHistory(agent);
-      expect(history.data.some(({ type, turn_id }) => (
-        type === "turn_blocked"
-        && (turn_id === "turn-fifo-first" || turn_id === "turn-fifo-second")
-      ))).toBe(false);
     } finally {
       testEnv.NANOCODEX = originalBroker;
     }
   });
-
-  it("conservatively marks legacy unfinished turns as possibly dispatched", async () => {
-    const agent = await createAgent();
-    const session = testEnv.NANOCODEX_SESSIONS.getByName(agent.agent_id);
-    const turnsUrl = agent.events_url.replace(/\/events$/, "/turns");
-    await runInDurableObject(session, (_instance, state) => {
-      state.storage.sql.exec("DROP TABLE managed_turns");
-      state.storage.sql.exec(`
-        CREATE TABLE managed_turns (
-          id TEXT PRIMARY KEY,
-          request_key TEXT,
-          request_hash TEXT NOT NULL,
-          input_json TEXT NOT NULL,
-          state TEXT NOT NULL CHECK (
-            state IN ('accepted', 'cancelling', 'retryable', 'blocked', 'completed', 'cancelled', 'failed')
-          ),
-          accepted_cursor INTEGER NOT NULL,
-          terminal_json TEXT,
-          terminal_cursor INTEGER,
-          error TEXT,
-          attempt_count INTEGER NOT NULL DEFAULT 0,
-          retry_at INTEGER,
-          created_at INTEGER NOT NULL,
-          accepted_at INTEGER NOT NULL,
-          updated_at INTEGER NOT NULL
-        )
-      `);
-      state.storage.sql.exec(
-        `INSERT INTO managed_turns (
-           id, request_key, request_hash, input_json, state, accepted_cursor,
-           error, created_at, accepted_at, updated_at
-         ) VALUES (?, NULL, ?, ?, 'blocked', 0, ?, ?, ?, ?)`,
-        "legacy-unfinished-turn",
-        "legacy-request-hash",
-        JSON.stringify("legacy input"),
-        "legacy row requires conservative reconciliation",
-        Date.now(),
-        Date.now(),
-        Date.now(),
-      );
-    });
-
-    await evictDurableObject(session);
-    expect((await SELF.fetch(`${turnsUrl}/legacy-unfinished-turn`)).status).toBe(200);
-    expect(await runInDurableObject(session, (_instance, state) => ({
-      dispatchColumn: state.storage.sql.exec<{ name: string }>(
-        "PRAGMA table_info(managed_turns)",
-      ).toArray().some(({ name }) => name === "dispatch_input_chunks"),
-      dispatchTable: state.storage.sql.exec<{ count: number }>(
-        `SELECT COUNT(*) AS count FROM sqlite_master
-         WHERE type = 'table' AND name = 'managed_turn_dispatch_chunks'`,
-      ).one().count,
-      ownershipColumn: state.storage.sql.exec<{ name: string }>(
-        "PRAGMA table_info(managed_turns)",
-      ).toArray().some(({ name }) => name === "may_have_inner_operation"),
-      marker: state.storage.sql.exec<{ may_have_inner_operation: number }>(
-        "SELECT may_have_inner_operation FROM managed_turns WHERE id = 'legacy-unfinished-turn'",
-      ).one().may_have_inner_operation,
-    }))).toEqual({
-      dispatchColumn: true,
-      dispatchTable: 1,
-      marker: 1,
-      ownershipColumn: true,
-    });
-  });
-
-  it("quarantines legacy realtime rows whose managed and durable identities diverged", async () => {
-    const agent = await createAgent();
-    const session = testEnv.NANOCODEX_SESSIONS.getByName(agent.agent_id);
-    const legacyId = `realtime:${"a".repeat(48)}`;
-    await runInDurableObject(session, (_instance, state) => {
-      state.storage.sql.exec("DROP TABLE managed_turns");
-      state.storage.sql.exec(`
-        CREATE TABLE managed_turns (
-          id TEXT PRIMARY KEY,
-          request_key TEXT,
-          request_hash TEXT NOT NULL,
-          input_json TEXT NOT NULL,
-          authorization_json TEXT NOT NULL,
-          state TEXT NOT NULL CHECK (
-            state IN ('accepted', 'cancelling', 'retryable', 'blocked', 'completed', 'cancelled', 'failed')
-          ),
-          accepted_cursor INTEGER NOT NULL,
-          terminal_json TEXT,
-          terminal_cursor INTEGER,
-          error TEXT,
-          may_have_inner_operation INTEGER NOT NULL DEFAULT 1,
-          attempt_count INTEGER NOT NULL DEFAULT 0,
-          retry_at INTEGER,
-          created_at INTEGER NOT NULL,
-          accepted_at INTEGER NOT NULL,
-          updated_at INTEGER NOT NULL
-        )
-      `);
-      state.storage.sql.exec(
-        `INSERT INTO managed_turns (
-           id, request_key, request_hash, input_json, authorization_json, state,
-           accepted_cursor, created_at, accepted_at, updated_at
-         ) VALUES (?, 'realtime:legacy-voice:legacy-operation', ?, ?, '{}',
-                   'accepted', 0, ?, ?, ?)`,
-        legacyId,
-        "legacy-request-hash",
-        JSON.stringify("legacy routed input"),
-        Date.now(),
-        Date.now(),
-        Date.now(),
-      );
-    });
-
-    await evictDurableObject(session);
-    expect(await runInDurableObject(session, (_instance, state) => ({
-      journalRows: state.storage.sql.exec<{ count: number }>(
-        `SELECT COUNT(*) AS count FROM sqlite_master
-         WHERE type = 'table' AND name = 'nanocodex_journals'`,
-      ).one().count,
-      row: state.storage.sql.exec<{ error: string; state: string }>(
-        "SELECT state, error FROM managed_turns WHERE id = ?",
-        legacyId,
-      ).one(),
-    }))).toEqual({
-      journalRows: 0,
-      row: {
-        error: "pre-upgrade realtime turn has an indeterminate durable operation identity",
-        state: "blocked",
-      },
-    });
-  }, 30_000);
 
   it("does not let an idempotent submission bypass a durable admission retry deadline", async () => {
     const agent = await createAgent();
@@ -5372,7 +5260,7 @@ describe("managed agents REST and resumable SSE", () => {
     try {
       expect((await SELF.fetch(turnsUrl, request)).status).toBe(202);
       const retryable = await waitForTurnAttempt(agent, id, 1);
-      expect(retryable.state).toBe("retryable");
+      expect(retryable.state).toBe("accepted");
       expect(retryable.retry_at).not.toBeNull();
       await waitForScheduledAlarm(session);
       const retryAt = await runInDurableObject(session, async (_instance, state) => {
@@ -5396,7 +5284,7 @@ describe("managed agents REST and resumable SSE", () => {
       expect(beforeDeadline).toMatchObject({
         attempt_count: 1,
         retry_at: retryAt,
-        state: "retryable",
+        state: "accepted",
       });
       expect(upgradeCount).toBe(upgradesBeforeDeadline);
       expect(await runInDurableObject(session, (_instance, state) => state.storage.getAlarm()))
@@ -5413,7 +5301,7 @@ describe("managed agents REST and resumable SSE", () => {
       });
       expect(await runDurableObjectAlarm(session)).toBe(true);
       const retried = await waitForTurnAttempt(agent, id, 2);
-      expect(retried.state).toBe("retryable");
+      expect(retried.state).toBe("accepted");
       expect(upgradeCount).toBe(upgradesBeforeDeadline + 1);
     } finally {
       testEnv.NANOCODEX = originalBroker;
@@ -5440,14 +5328,14 @@ describe("managed agents REST and resumable SSE", () => {
       await submit(agent, id, "remain retryable under capped backoff");
       let turn = await waitForTurnAttempt(agent, id, 1);
       for (let expected = 2; expected <= 10; expected += 1) {
-        expect(turn.state).toBe("retryable");
+        expect(turn.state).toBe("accepted");
         expect(turn.retry_at).not.toBeNull();
         expect(turn.retry_at! - turn.updated_at).toBeLessThanOrEqual(60_000);
         vi.setSystemTime(turn.retry_at!);
         expect(await runDurableObjectAlarm(session)).toBe(true);
         turn = await waitForTurnAttempt(agent, id, expected);
       }
-      expect(turn).toMatchObject({ attempt_count: 10, state: "retryable" });
+      expect(turn).toMatchObject({ attempt_count: 10, state: "accepted" });
       expect(turn.error).not.toMatch(/retry limit reached/i);
       const history = await managedHistory(agent);
       expect(history.data.filter(({ type, turn_id }) => (
@@ -5467,7 +5355,7 @@ describe("managed agents REST and resumable SSE", () => {
     await submit(agent, "turn-reopen-sibling", "remain retryable across sibling reopen");
     await runInDurableObject(session, (_instance, state) => {
       state.storage.sql.exec(
-        `UPDATE nanocodex_journal_owners
+        `UPDATE nanocodex_durable_owners
          SET owner_id = 'injected-new-owner', fence = CAST(fence AS INTEGER) + 1`,
       );
     });
@@ -5500,8 +5388,8 @@ describe("managed agents REST and resumable SSE", () => {
          WHERE turn_id = ? ORDER BY chunk_index`,
         replayId,
       ).toArray().map(({ input_json }) => input_json).join(""),
-      journalRevision: state.storage.sql.exec<{ revision: string }>(
-        "SELECT revision FROM nanocodex_journals",
+      stateRevision: state.storage.sql.exec<{ revision: string }>(
+        "SELECT revision FROM nanocodex_durable_states",
       ).one().revision,
       terminalJson: state.storage.sql.exec<{ terminal_json: string }>(
         "SELECT terminal_json FROM managed_turns WHERE id = ?",
@@ -5514,7 +5402,7 @@ describe("managed agents REST and resumable SSE", () => {
     await runInDurableObject(session, (_instance, state) => {
       state.storage.sql.exec(
         `UPDATE managed_turns
-         SET state = 'retryable', terminal_json = NULL, terminal_cursor = NULL,
+         SET state = 'accepted', terminal_json = NULL, terminal_cursor = NULL,
              error = 'injected outer projection gap', retry_at = 0
          WHERE id = ?`,
         replayId,
@@ -5538,8 +5426,8 @@ describe("managed agents REST and resumable SSE", () => {
          WHERE turn_id = ? ORDER BY chunk_index`,
         replayId,
       ).toArray().map(({ input_json }) => input_json).join(""),
-      journalRevision: state.storage.sql.exec<{ revision: string }>(
-        "SELECT revision FROM nanocodex_journals",
+      stateRevision: state.storage.sql.exec<{ revision: string }>(
+        "SELECT revision FROM nanocodex_durable_states",
       ).one().revision,
       terminalJson: state.storage.sql.exec<{ terminal_json: string }>(
         "SELECT terminal_json FROM managed_turns WHERE id = ?",
@@ -5547,7 +5435,7 @@ describe("managed agents REST and resumable SSE", () => {
       ).one().terminal_json,
     }))).toEqual({
       dispatchInputJson: frozen.dispatchInputJson,
-      journalRevision: frozen.journalRevision,
+      stateRevision: frozen.stateRevision,
       terminalJson: frozen.terminalJson,
     });
     await submit(agent, "turn-after-raw-replay", "start only after replay attribution");
@@ -5575,58 +5463,6 @@ describe("managed agents REST and resumable SSE", () => {
     expect(followingCompleted).toBeTruthy();
     expect(BigInt(replayCompleted[0]!.cursor)).toBeLessThan(BigInt(followingStarted!.cursor));
     expect(BigInt(followingStarted!.cursor)).toBeLessThan(BigInt(followingCompleted!.cursor));
-  });
-
-  it("recovers and freezes a pre-upgrade durable dispatch form", async () => {
-    const agent = await createAgent();
-    const id = "turn-legacy-dispatch-input";
-    const input = "retain the pre-upgrade dispatch input";
-    await submit(agent, id, input);
-    await waitForTurnState(agent, id, "completed");
-    const session = testEnv.NANOCODEX_SESSIONS.getByName(agent.agent_id);
-    const original = await runInDurableObject(session, (_instance, state) => (
-      state.storage.sql.exec<{ input_json: string }>(
-        `SELECT input_json FROM managed_turn_dispatch_chunks
-         WHERE turn_id = ? ORDER BY chunk_index`,
-        id,
-      ).toArray().map(({ input_json }) => input_json).join("")
-    ));
-    expect(original).not.toContain("<memory_review_checkpoint>");
-
-    await runInDurableObject(session, (_instance, state) => {
-      state.storage.transactionSync(() => {
-        state.storage.sql.exec(
-          "DELETE FROM managed_turn_dispatch_chunks WHERE turn_id = ?",
-          id,
-        );
-        state.storage.sql.exec(
-          `UPDATE managed_turns
-           SET dispatch_input_chunks = NULL, state = 'retryable', terminal_json = NULL,
-               terminal_cursor = NULL, error = 'injected pre-upgrade projection gap', retry_at = 0
-           WHERE id = ?`,
-          id,
-        );
-      });
-    });
-    await evictDurableObject(session);
-
-    const replay = await SELF.fetch(agent.events_url.replace(/\/events$/, "/turns"), {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "idempotency-key": `request-${id}`,
-      },
-      body: JSON.stringify({ id, input }),
-    });
-    expect(replay.status).toBe(200);
-    await waitForTurnState(agent, id, "completed");
-    expect(await runInDurableObject(session, (_instance, state) => (
-      state.storage.sql.exec<{ input_json: string }>(
-        `SELECT input_json FROM managed_turn_dispatch_chunks
-         WHERE turn_id = ? ORDER BY chunk_index`,
-        id,
-      ).toArray().map(({ input_json }) => input_json).join("")
-    ))).toBe(original);
   });
 
   it("persists cursors across eviction and tails strictly after the acknowledged cursor", async () => {
@@ -6132,7 +5968,7 @@ async function waitForTurnState(
     if (response.ok) {
       const turn = await response.json<ManagedTurnView>();
       if (turn.state === expected) return turn;
-      if (turn.state === "failed" || turn.state === "blocked") {
+      if (turn.state === "failed") {
         throw new Error(
           `turn ${id} entered ${turn.state} while waiting for ${expected}: ${turn.error ?? "unknown error"}`,
         );
@@ -6153,13 +5989,36 @@ async function waitForTurnAttempt(
     if (response.ok) {
       const turn = await response.json<ManagedTurnView>();
       if (turn.attempt_count >= expected) return turn;
-      if (turn.state === "failed" || turn.state === "blocked" || turn.state === "cancelled") {
+      if (turn.state === "failed" || turn.state === "cancelled") {
         throw new Error(`turn ${id} entered ${turn.state} before retry attempt ${expected}`);
       }
     }
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   throw new Error(`timed out waiting for turn ${id} retry attempt ${expected}`);
+}
+
+async function waitForTurnRetry(
+  agent: AgentReceipt,
+  id: string,
+  expectedAttempt = 1,
+): Promise<ManagedTurnView> {
+  for (let poll = 0; poll < 200; poll += 1) {
+    const response = await SELF.fetch(agent.events_url.replace(/\/events$/, `/turns/${id}`));
+    if (response.ok) {
+      const turn = await response.json<ManagedTurnView>();
+      if (turn.state === "accepted"
+        && turn.attempt_count >= expectedAttempt
+        && turn.retry_at !== null) {
+        return turn;
+      }
+      if (turn.state === "failed" || turn.state === "cancelled") {
+        throw new Error(`turn ${id} entered ${turn.state} before retry was scheduled`);
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`timed out waiting for turn ${id} retry schedule`);
 }
 
 async function managedHistory(agent: AgentReceipt): Promise<ManagedHistory> {
@@ -6181,7 +6040,7 @@ async function waitForHistoryEvent(
 }
 
 async function waitForScheduledAlarm(
-  stub: DurableObjectStub<NanocodexSession>,
+  stub: DurableObjectStub<DurableAgentSession>,
 ): Promise<void> {
   const deadline = Date.now() + 2_000;
   while (Date.now() < deadline) {
@@ -6193,7 +6052,7 @@ async function waitForScheduledAlarm(
 }
 
 async function cleanupMarkers(
-  stub: DurableObjectStub<NanocodexSession>,
+  stub: DurableObjectStub<DurableAgentSession>,
 ): Promise<{ binding: boolean; deleting: boolean }> {
   return runInDurableObject(stub, async (_instance, state) => ({
     binding: await state.storage.get("nanocodex:credential-binding") !== undefined,
@@ -6206,7 +6065,7 @@ function expireCredentialPreparation(): void {
 }
 
 async function waitForCleanupDeletion(
-  stub: DurableObjectStub<NanocodexSession>,
+  stub: DurableObjectStub<DurableAgentSession>,
 ): Promise<void> {
   const deadline = Date.now() + 2_000;
   while (Date.now() < deadline) {
@@ -6217,7 +6076,7 @@ async function waitForCleanupDeletion(
 }
 
 async function runCleanupAlarmsUntilDeleted(
-  stub: DurableObjectStub<NanocodexSession>,
+  stub: DurableObjectStub<DurableAgentSession>,
 ): Promise<void> {
   const deadline = Date.now() + 2_000;
   while (Date.now() < deadline) {
@@ -6228,7 +6087,7 @@ async function runCleanupAlarmsUntilDeleted(
   throw new Error("timed out running Durable Object cleanup alarms");
 }
 
-function sessionForSubject(subject: string): DurableObjectStub<NanocodexSession> {
+function sessionForSubject(subject: string): DurableObjectStub<DurableAgentSession> {
   return testEnv.NANOCODEX_SESSIONS.get(
     testEnv.NANOCODEX_SESSIONS.idFromString(subject),
   );

--- a/services/managed/test/managed-api.test.ts
+++ b/services/managed/test/managed-api.test.ts
@@ -24,6 +24,7 @@ const HOSTED_PASSKEY_PUBLIC_KEY = "0x046b17d1f2e12c4247f8bce6e563a440f277037d812
 const HOSTED_PASSKEY_ADDRESS = "0xd3a9f047ad43d7e2e4e7e491f1fe2e657a2651b6";
 const OWNER_CAPABILITIES = [
   "agents:read",
+  "agents:portability",
   "agents:write",
   "api_keys:read",
   "api_keys:write",
@@ -3175,6 +3176,25 @@ describe("managed agents REST and resumable SSE", () => {
     });
     expect(missingTools.status).toBe(403);
 
+    const durabilityUrl = agent.events_url.replace(/\/events$/, "/durability");
+    expect((await RAW_SELF.fetch(durabilityUrl, {
+      method: "POST",
+      headers: writeOnly,
+    })).status).toBe(403);
+    expect((await RAW_SELF.fetch(`${durabilityUrl}?unexpected=1`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${API_KEY}` },
+    })).status).toBe(400);
+    expect((await RAW_SELF.fetch("https://example.test/v1/agents?unexpected=1", {
+      method: "POST",
+      headers: { authorization: `Bearer ${API_KEY}` },
+    })).status).toBe(400);
+    expect((await RAW_SELF.fetch("https://example.test/v1/agents", {
+      method: "POST",
+      headers: { ...writeOnly, "content-type": "application/json" },
+      body: JSON.stringify({ durability: { format: "unauthorized-import" } }),
+    })).status).toBe(403);
+
     const websocket = await RAW_SELF.fetch(agent.websocket_url.replace("wss:", "https:"), {
       headers: {
         authorization: `Bearer ${API_KEY}`,
@@ -5093,7 +5113,7 @@ describe("managed agents REST and resumable SSE", () => {
         },
         body: JSON.stringify({ id, input: "wait for cancellation" }),
       })).status).toBe(202);
-      for (let attempt = 0; attempt < 100; attempt += 1) {
+      for (let attempt = 0; attempt < 1_000; attempt += 1) {
         const dispatched = await runInDurableObject(session, (_instance, state) => (
           state.storage.sql.exec<{ may_have_inner_operation: number }>(
             "SELECT may_have_inner_operation FROM managed_turns WHERE id = ?",
@@ -5137,7 +5157,7 @@ describe("managed agents REST and resumable SSE", () => {
       const retryAt = cancelling.retry_at!;
       restoreJournal();
 
-      for (let attempt = 0; attempt < 100; attempt += 1) {
+      for (let attempt = 0; attempt < 1_000; attempt += 1) {
         const alarm = await runInDurableObject(
           session,
           (_instance, state) => state.storage.getAlarm(),
@@ -5177,7 +5197,7 @@ describe("managed agents REST and resumable SSE", () => {
       errorSpy.mockRestore();
       vi.useRealTimers();
     }
-  });
+  }, 15_000);
 
   it("does not dispatch a newer turn past a pre-runtime retry", async () => {
     const agent = await createAgent();
@@ -5509,6 +5529,20 @@ describe("managed agents REST and resumable SSE", () => {
       expect(terminal.terminal).toMatchObject({ final_message: turn.finalMessage });
       sourceTerminals.set(turn.id, terminal);
     }
+    const realtimeStartRequest = {
+      operation_id: "portable-realtime-start",
+      voice_session_id: "portable-realtime-session",
+    } as const;
+    const realtimeStopRequest = {
+      operation_id: "portable-realtime-stop",
+      voice_session_id: "portable-realtime-session",
+    } as const;
+    const realtimeStart = await managedRealtime(source, "start", realtimeStartRequest);
+    expect(realtimeStart.status).toBe(200);
+    const realtimeStartValue = await realtimeStart.json<ManagedRealtimeLifecycleResponse>();
+    const realtimeStop = await managedRealtime(source, "stop", realtimeStopRequest);
+    expect(realtimeStop.status).toBe(200);
+    const realtimeStopValue = await realtimeStop.json<ManagedRealtimeLifecycleResponse>();
     const commandsBeforeExport = await modelCommandCount();
     expect(commandsBeforeExport).toBeGreaterThan(sourceTurns.length);
     const sourceCapacity = await testEnv.NANOCODEX_SESSIONS
@@ -5516,24 +5550,60 @@ describe("managed agents REST and resumable SSE", () => {
       .fetch("https://session.internal/capacity");
     expect((await sourceCapacity.json<{ durable_state: { rows: number } }>()).durable_state.rows)
       .toBe(1);
+    const sourceStateBeforeExport = await (await SELF.fetch(
+      source.events_url.replace(/\/events$/, ""),
+    )).json<{
+      completed_turns: number;
+      first_prompt: string;
+      latest_event_cursor: string;
+    }>();
+    const sourceHistoryBeforeExport = await managedHistory(source);
 
-    const exported = await SELF.fetch(
-      source.events_url.replace(/\/events$/, "/durability"),
-      { method: "POST" },
-    );
+    const exported = await pollDurabilityExport(source);
     expect(exported.status).toBe(200);
     const archive = await exported.json<{
       format: string;
-      stateId: string;
-      revision: string;
-      payload: string;
+      durability: { stateId: string; revision: string; payload: string };
+      managed_events: { archive: { digest: string }; tail: { high_water_cursor: string } };
+      managed_realtime: {
+        archive: { digest: string };
+        state: { archived_receipts: number; object_count: number };
+        tail: unknown[];
+      };
+      managed_session: {
+        accepted_turns: number;
+        completed_turns: number;
+        first_prompt: string;
+        title: string;
+      };
+      managed_turn_receipts: { archived_receipts: number; digest: string; objects: number };
+      source_agent_id: string;
     }>();
     expect(archive).toMatchObject({
-      format: "nanocodex-durability-state-v1",
-      revision: expect.stringMatching(/^[1-9][0-9]*$/),
-      payload: expect.any(String),
+      format: "nanocodex-managed-durability-state-v1",
+      durability: {
+        revision: expect.stringMatching(/^[1-9][0-9]*$/),
+        payload: expect.any(String),
+      },
+      managed_turn_receipts: {
+        digest: expect.stringMatching(/^[0-9a-f]{64}$/),
+      },
+      managed_events: {
+        archive: { digest: expect.stringMatching(/^[0-9a-f]{64}$/) },
+        tail: { high_water_cursor: sourceStateBeforeExport.latest_event_cursor },
+      },
+      managed_realtime: {
+        archive: { digest: expect.stringMatching(/^[0-9a-f]{64}$/) },
+        state: { archived_receipts: 1, object_count: 1 },
+        tail: [expect.objectContaining({ operation_id: realtimeStopRequest.operation_id })],
+      },
+      managed_session: {
+        completed_turns: sourceStateBeforeExport.completed_turns,
+        first_prompt: sourceStateBeforeExport.first_prompt,
+      },
+      source_agent_id: source.agent_id,
     });
-    const portableState = JSON.parse(archive.payload).nanocodex_durable_state;
+    const portableState = JSON.parse(archive.durability.payload).nanocodex_durable_state;
     expect(portableState.latest_checkpoint).toBeTruthy();
     expect(JSON.stringify(portableState.latest_checkpoint)).toContain(
       "portable-managed-compaction",
@@ -5582,17 +5652,56 @@ describe("managed agents REST and resumable SSE", () => {
     const imported = await importedResponse.json<AgentReceipt>();
     createdAgents.add(imported.agent_id);
     expect(imported.agent_id).not.toBe(source.agent_id);
-    expect(imported.durability_id).toBe(archive.stateId);
+    expect(imported.durability_id).toBe(archive.durability.stateId);
+    const importedState = await (await SELF.fetch(
+      imported.events_url.replace(/\/events$/, ""),
+    )).json<{
+      completed_turns: number;
+      first_prompt: string;
+      latest_event_cursor: string;
+    }>();
+    expect(importedState).toMatchObject({
+      completed_turns: sourceStateBeforeExport.completed_turns,
+      first_prompt: sourceStateBeforeExport.first_prompt,
+      latest_event_cursor: sourceStateBeforeExport.latest_event_cursor,
+    });
+    await expect(managedHistory(imported)).resolves.toEqual(sourceHistoryBeforeExport);
+    const importedListing = await (await SELF.fetch(
+      "https://example.test/v1/agents",
+    )).json<{ summaries: Record<string, { title: string; turn_count: number }> }>();
+    expect(importedListing.summaries[imported.agent_id]).toMatchObject({
+      title: archive.managed_session.title,
+      turn_count: archive.managed_session.accepted_turns,
+    });
+    await expect((await managedRealtime(
+      imported,
+      "start",
+      realtimeStartRequest,
+    )).json()).resolves.toEqual(realtimeStartValue);
+    await expect((await managedRealtime(
+      imported,
+      "stop",
+      realtimeStopRequest,
+    )).json()).resolves.toEqual(realtimeStopValue);
+    await expect(modelCommandCount()).resolves.toBe(commandsBeforeExport);
 
     const replayedCreate = await createImported();
     expect(replayedCreate.status).toBe(201);
     await expect(replayedCreate.json()).resolves.toMatchObject({
       agent_id: imported.agent_id,
-      durability_id: archive.stateId,
+      durability_id: archive.durability.stateId,
     });
 
     for (const turn of sourceTurns) {
-      await submit(imported, turn.id, turn.input);
+      const replay = await SELF.fetch(imported.events_url.replace(/\/events$/, "/turns"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "idempotency-key": `request-${turn.id}`,
+        },
+        body: JSON.stringify({ id: turn.id, input: turn.input }),
+      });
+      expect([200, 202]).toContain(replay.status);
       const importedTerminal = await waitForTurnState(imported, turn.id, "completed", 10_000);
       expect(importedTerminal.terminal).toEqual(sourceTerminals.get(turn.id)!.terminal);
       await expect(modelCommandCount()).resolves.toBe(commandsBeforeExport);
@@ -5611,8 +5720,14 @@ describe("managed agents REST and resumable SSE", () => {
       },
     ] as const;
     for (const turn of destinationTurns) {
-      await submit(imported, turn.id, turn.input);
+      const accepted = await submit(imported, turn.id, turn.input);
+      expect(BigInt(accepted.accepted_cursor)).toBeGreaterThan(
+        BigInt(archive.managed_events.tail.high_water_cursor),
+      );
       const terminal = await waitForTurnState(imported, turn.id, "completed", 15_000);
+      expect(BigInt(terminal.terminal_cursor!)).toBeGreaterThan(
+        BigInt(archive.managed_events.tail.high_water_cursor),
+      );
       expect(terminal.terminal).toMatchObject({
         final_message: expect.stringContaining(turn.finalMessage),
       });
@@ -5635,9 +5750,383 @@ describe("managed agents REST and resumable SSE", () => {
         ).one(),
       ),
     ]);
-    expect(identities[1]).toMatchObject({ state_id: archive.stateId });
+    expect(identities[1]).toMatchObject({ state_id: archive.durability.stateId });
     expect(identities[1].session_id).not.toBe(identities[0]);
+    const deletedSource = await SELF.fetch(
+      `https://example.test/v1/agents/${source.agent_id}`,
+      { method: "DELETE" },
+    );
+    expect(deletedSource.status).toBe(204);
+    createdAgents.delete(source.agent_id);
+    await expect((await managedRealtime(
+      imported,
+      "start",
+      realtimeStartRequest,
+    )).json()).resolves.toEqual(realtimeStartValue);
+    await expect((await managedRealtime(
+      imported,
+      "stop",
+      realtimeStopRequest,
+    )).json()).resolves.toEqual(realtimeStopValue);
   }, 90_000);
+
+  it("adopts archived receipts beyond the Rust replay window before destination admission", async () => {
+    expect((await testEnv.NANOCODEX.fetch(
+      "https://broker.internal/test/model-commands",
+      { method: "DELETE" },
+    )).status).toBe(204);
+    const source = await createAgent();
+    const oldestId = "turn-portable-archive-000";
+    const oldestInput = "E2E_COMPUTER_RUNTIME";
+    const totalTurns = 513;
+    await submit(source, "turn-portable-state-seed", "establish real portable Rust state");
+    await waitForTurnState(source, "turn-portable-state-seed", "completed", 15_000);
+    const seeded = await Promise.all(Array.from({ length: totalTurns }, async (_unused, index) => {
+      const id = `turn-portable-archive-${String(index).padStart(3, "0")}`;
+      const input = index === 0 ? oldestInput : `portable archived receipt ${index}`;
+      return {
+        id,
+        inputJson: JSON.stringify(input),
+        requestHash: await testHash(JSON.stringify(input)),
+        requestKey: `request-${id}`,
+        terminalJson: JSON.stringify({
+          type: "turn_completed",
+          id,
+          final_message: `retained terminal ${index}`,
+        }),
+      };
+    }));
+    const seededCursors = new Map<string, { accepted: string; terminal: string }>();
+    const sourceSession = testEnv.NANOCODEX_SESSIONS.getByName(source.agent_id);
+    await runInDurableObject(sourceSession, (_instance, state) => {
+      const eventLog = new DurableEventLog<{ type: string } & Record<string, unknown>>(state.storage);
+      state.storage.transactionSync(() => {
+        for (let index = 0; index < seeded.length; index += 1) {
+          const turn = seeded[index]!;
+          const createdAt = index * 3 + 1;
+          const accepted = eventLog.append({
+            type: "turn_accepted",
+            id: turn.id,
+            input: JSON.parse(turn.inputJson),
+          }, turn.id);
+          const terminal = eventLog.append(JSON.parse(turn.terminalJson), turn.id, true);
+          seededCursors.set(turn.id, {
+            accepted: accepted.cursor,
+            terminal: terminal.cursor,
+          });
+          state.storage.sql.exec(
+            `INSERT INTO managed_turns (
+               id, request_key, request_hash, input_json, authorization_json, state,
+               accepted_cursor, terminal_json, terminal_cursor, may_have_inner_operation,
+               attempt_count, created_at, accepted_at, updated_at
+             ) VALUES (?, ?, ?, ?, '{"capabilities":[]}', 'completed', ?, ?, ?, 0, 0, ?, ?, ?)`,
+            turn.id,
+            turn.requestKey,
+            turn.requestHash,
+            turn.inputJson,
+            accepted.cursor,
+            turn.terminalJson,
+            terminal.cursor,
+            createdAt,
+            createdAt + 1,
+            createdAt + 2,
+          );
+        }
+        state.storage.sql.exec(
+          `UPDATE session_state
+           SET accepted_turns = accepted_turns + ?, completed_turns = completed_turns + ?
+           WHERE singleton = 1`,
+          totalTurns,
+          totalTurns,
+        );
+      });
+    });
+    const commandsBeforeExport = await modelCommandCount();
+    expect(commandsBeforeExport).toBe(1);
+
+    const { response: exported, pendingResponses } = await pollDurabilityExportWithProgress(source);
+    expect(pendingResponses).toBeGreaterThan(1);
+    expect(exported.status).toBe(200);
+    const archive = await exported.json<{
+      durability: { stateId: string };
+      managed_events: {
+        archive: { bytes: number; objects: number };
+        state: { archived_bytes: number; archived_through: string; segment_count: number };
+        tail: { events: Array<{ cursor: string }>; high_water_cursor: string };
+      };
+      managed_realtime: {
+        archive: { bytes: number; objects: number };
+        state: { archived_bytes: number; object_count: number };
+        tail: unknown[];
+      };
+      managed_session: { title: string };
+      managed_turn_receipts: { archived_receipts: number; digest: string; objects: number };
+    }>();
+    expect(archive.managed_turn_receipts).toMatchObject({
+      archived_receipts: 514,
+      objects: 1_028,
+    });
+
+    const originalSessions = testEnv.NANOCODEX_SESSIONS;
+    const destinationLookups: string[] = [];
+    testEnv.NANOCODEX_SESSIONS = {
+      ...originalSessions,
+      getByName(name: string) {
+        destinationLookups.push(name);
+        return originalSessions.getByName(name);
+      },
+    } as Env["NANOCODEX_SESSIONS"];
+    try {
+      const keylessImport = await SELF.fetch("https://example.test/v1/agents", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ durability: archive }),
+      });
+      expect(keylessImport.status).toBe(400);
+      await expect(keylessImport.json()).resolves.toEqual({
+        error: "idempotency_required",
+        message: "managed durability imports require Idempotency-Key",
+      });
+      expect(destinationLookups).toEqual([]);
+    } finally {
+      testEnv.NANOCODEX_SESSIONS = originalSessions;
+    }
+
+    const incoherentArchives = [
+      (() => {
+        const changed = structuredClone(archive);
+        changed.managed_events.archive.objects += 1;
+        return changed;
+      })(),
+      (() => {
+        const changed = structuredClone(archive);
+        changed.managed_events.tail.events[0]!.cursor = changed.managed_events.state.archived_through;
+        return changed;
+      })(),
+      (() => {
+        const changed = structuredClone(archive);
+        changed.managed_realtime.archive.bytes += 1;
+        return changed;
+      })(),
+      (() => {
+        const changed = structuredClone(archive);
+        changed.managed_session.title = "conflicting imported title";
+        return changed;
+      })(),
+    ];
+    for (const [index, incoherent] of incoherentArchives.entries()) {
+      const rejected = await SELF.fetch("https://example.test/v1/agents", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "idempotency-key": `incoherent-${index}-${crypto.randomUUID()}`,
+        },
+        body: JSON.stringify({ durability: incoherent }),
+      });
+      expect(rejected.status).toBe(400);
+      await expect(rejected.json()).resolves.toMatchObject({
+        error: "invalid_durability_import",
+      });
+    }
+
+    const importKey = `portable-archive-${crypto.randomUUID()}`;
+    const pendingImport = await SELF.fetch("https://example.test/v1/agents", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "idempotency-key": importKey,
+      },
+      body: JSON.stringify({ durability: archive }),
+    });
+    expect(pendingImport.status).toBe(503);
+    await expect(pendingImport.json()).resolves.toMatchObject({
+      error: "durability_import_pending",
+    });
+    const pendingAgentId = await testIdempotentAgentId(USER_ID, importKey);
+    createdAgents.add(pendingAgentId);
+    const pendingDestination = testEnv.NANOCODEX_SESSIONS.getByName(pendingAgentId);
+    const partialCapacity = await runInDurableObject(
+      pendingDestination,
+      (_instance, state) => state.storage.sql.exec<{
+        archived_bytes: number;
+        archived_receipts: number;
+        objects: number;
+      }>(
+        `SELECT archived_bytes, archived_receipts, object_count AS objects
+         FROM managed_turn_archive_state WHERE singleton = 1`,
+      ).one(),
+    );
+    expect(partialCapacity).toEqual({
+      archived_bytes: 0,
+      archived_receipts: 0,
+      objects: 0,
+    });
+    await evictDurableObject(pendingDestination);
+    const poisonedExport = await pendingDestination.fetch(
+      "https://session.internal/durability/export",
+      { method: "POST" },
+    );
+    expect(poisonedExport.status).toBe(409);
+    await expect(poisonedExport.json()).resolves.toMatchObject({
+      error: "durability_import_pending",
+    });
+    await expect(runInDurableObject(
+      pendingDestination,
+      async (_instance, state) => state.storage.get("nanocodex:durability-exported"),
+    )).resolves.toBeUndefined();
+    const importedResponse = await pollImportedCreate(importKey, archive);
+    expect(importedResponse.status).toBe(201);
+    const imported = await importedResponse.json<AgentReceipt>();
+    createdAgents.add(imported.agent_id);
+    expect(imported.durability_id).toBe(archive.durability.stateId);
+
+    const destination = testEnv.NANOCODEX_SESSIONS.getByName(imported.agent_id);
+    const adopted = await (await destination.fetch(
+      "https://session.internal/capacity",
+    )).json<{ archived_turns: { archived_receipts: number; objects: number } }>();
+    expect(adopted.archived_turns).toMatchObject({
+      archived_receipts: 514,
+      objects: 1_028,
+    });
+
+    const replay = await SELF.fetch(imported.events_url.replace(/\/events$/, "/turns"), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "idempotency-key": `request-${oldestId}`,
+      },
+      body: JSON.stringify({ id: oldestId, input: oldestInput }),
+    });
+    expect(replay.status).toBe(200);
+    expect(replay.headers.get("x-nanocodex-turn-created")).toBeNull();
+    await expect(replay.json()).resolves.toMatchObject({
+      state: "completed",
+      turn_id: oldestId,
+    });
+    await expect(modelCommandCount()).resolves.toBe(commandsBeforeExport);
+    const oldestCursors = seededCursors.get(oldestId)!;
+    const oldestHistory = await (await SELF.fetch(
+      `${imported.events_url}/history?before=${BigInt(oldestCursors.terminal) + 1n}&limit=2`,
+    )).json<{ data: Array<{ cursor: string }> }>();
+    expect(oldestHistory.data.map(({ cursor }) => cursor)).toEqual([
+      oldestCursors.accepted,
+      oldestCursors.terminal,
+    ]);
+
+    const raceKey = `portable-delete-race-${crypto.randomUUID()}`;
+    const raceAgentId = await testIdempotentAgentId(USER_ID, raceKey);
+    const raceStorageId = testEnv.NANOCODEX_SESSIONS.idFromName(raceAgentId).toString();
+    createdAgents.add(raceAgentId);
+    const originalHistory = testEnv.NANOCODEX_HISTORY;
+    let notifyCopyStarted!: () => void;
+    let releaseCopy!: () => void;
+    const copyStarted = new Promise<void>((resolve) => { notifyCopyStarted = resolve; });
+    const copyHeld = new Promise<void>((resolve) => { releaseCopy = resolve; });
+    let held = false;
+    testEnv.NANOCODEX_HISTORY = new Proxy(originalHistory, {
+      get(target, property) {
+        if (property === "put") {
+          return async (...args: Parameters<R2Bucket["put"]>) => {
+            const key = String(args[0]);
+            if (!held && key.startsWith(`agents/${raceStorageId}/managed-`)) {
+              held = true;
+              notifyCopyStarted();
+              await copyHeld;
+            }
+            return target.put(...args);
+          };
+        }
+        const retained = Reflect.get(target, property);
+        return typeof retained === "function" ? retained.bind(target) : retained;
+      },
+    });
+    try {
+      const racingCreate = SELF.fetch("https://example.test/v1/agents", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "idempotency-key": raceKey,
+        },
+        body: JSON.stringify({ durability: archive }),
+      });
+      await within(copyStarted, "managed durability adoption copy", 5_000);
+      const racingDestination = testEnv.NANOCODEX_SESSIONS.getByName(raceAgentId);
+      const deleting = SELF.fetch(
+        `https://example.test/v1/agents/${raceAgentId}`,
+        { method: "DELETE" },
+      );
+      for (let attempt = 0; attempt < 100; attempt += 1) {
+        const marked = await runInDurableObject(
+          racingDestination,
+          async (_instance, state) => state.storage.get("nanocodex:session-deleting"),
+        );
+        if (marked === true) break;
+        if (attempt === 99) throw new Error("delete did not fence the paused durability import");
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      releaseCopy();
+      const [creationResponse, deletionResponse] = await Promise.all([racingCreate, deleting]);
+      expect(creationResponse.status).not.toBe(201);
+      expect([409, 503]).toContain(creationResponse.status);
+      expect(deletionResponse.status).toBe(204);
+      createdAgents.delete(raceAgentId);
+      const retainedObjects = await originalHistory.list({
+        prefix: `agents/${raceStorageId}/`,
+      });
+      expect(retainedObjects.objects).toHaveLength(0);
+      expect((await SELF.fetch(
+        `https://example.test/v1/agents/${raceAgentId}`,
+      )).status).toBe(404);
+    } finally {
+      releaseCopy();
+      testEnv.NANOCODEX_HISTORY = originalHistory;
+    }
+
+    const deletedSource = await SELF.fetch(
+      `https://example.test/v1/agents/${source.agent_id}`,
+      { method: "DELETE" },
+    );
+    expect(deletedSource.status).toBe(204);
+    createdAgents.delete(source.agent_id);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await evictDurableObject(testEnv.NANOCODEX_SESSIONS.getByName(imported.agent_id));
+    const replayWithoutSource = await pollImportedCreate(importKey, archive);
+    expect(replayWithoutSource.status).toBe(201);
+    await expect(replayWithoutSource.json()).resolves.toMatchObject({
+      agent_id: imported.agent_id,
+      durability_id: imported.durability_id,
+    });
+
+    const changedArchive = structuredClone(archive);
+    changedArchive.managed_turn_receipts.digest = "0".repeat(64);
+    const changedReplay = await SELF.fetch("https://example.test/v1/agents", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "idempotency-key": importKey,
+      },
+      body: JSON.stringify({ durability: changedArchive }),
+    });
+    expect(changedReplay.status).toBe(409);
+    await expect(changedReplay.json()).resolves.toMatchObject({
+      error: "durability_import_conflict",
+    });
+
+    const unavailableKey = `portable-archive-unavailable-${crypto.randomUUID()}`;
+    createdAgents.add(await testIdempotentAgentId(USER_ID, unavailableKey));
+    const unavailableSource = await SELF.fetch("https://example.test/v1/agents", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "idempotency-key": unavailableKey,
+      },
+      body: JSON.stringify({ durability: archive }),
+    });
+    expect(unavailableSource.status).toBe(400);
+    await expect(unavailableSource.json()).resolves.toMatchObject({
+      error: "invalid_durability_import",
+    });
+  }, 60_000);
 
   it("rejects corrupt canonical durability before creating a managed Agent", async () => {
     const response = await SELF.fetch("https://example.test/v1/agents", {
@@ -5852,6 +6341,58 @@ async function createAgent(): Promise<AgentReceipt> {
   const receipt = await response.json<AgentReceipt>();
   createdAgents.add(receipt.agent_id);
   return receipt;
+}
+
+async function pollDurabilityExport(agent: AgentReceipt): Promise<Response> {
+  return (await pollDurabilityExportWithProgress(agent)).response;
+}
+
+async function pollDurabilityExportWithProgress(
+  agent: AgentReceipt,
+): Promise<{ pendingResponses: number; response: Response }> {
+  let pendingResponses = 0;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    const response = await SELF.fetch(
+      agent.events_url.replace(/\/events$/, "/durability"),
+      { method: "POST" },
+    );
+    if (response.status !== 202) return { pendingResponses, response };
+    pendingResponses += 1;
+    await response.body?.cancel();
+  }
+  throw new Error("managed durability export did not complete within 80 bounded batches");
+}
+
+async function pollImportedCreate(importKey: string, archive: unknown): Promise<Response> {
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    const response = await SELF.fetch("https://example.test/v1/agents", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "idempotency-key": importKey,
+      },
+      body: JSON.stringify({ durability: archive }),
+    });
+    if (response.status !== 503) return response;
+    const body: { error?: string } = await response.clone()
+      .json<{ error?: string }>()
+      .catch(() => ({}));
+    if (body.error !== "durability_import_pending") return response;
+    await response.body?.cancel();
+  }
+  throw new Error("managed durability import did not complete within 80 bounded retries");
+}
+
+async function testIdempotentAgentId(userId: string, requestKey: string): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`${userId}\0${requestKey}`),
+  ));
+  const bytes = digest.slice(0, 16);
+  bytes[6] = (bytes[6]! & 0x0f) | 0x80;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
 async function managedFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {

--- a/services/managed/test/managed-api.test.ts
+++ b/services/managed/test/managed-api.test.ts
@@ -5121,7 +5121,6 @@ describe("managed agents REST and resumable SSE", () => {
             && query.includes("INSERT INTO nanocodex_durable_states")
             && bindings.some((binding) => (
               typeof binding === "string"
-              && binding.includes(id)
               && binding.includes("\"cancelled\"")
             ))) {
             failed = true;
@@ -5343,7 +5342,7 @@ describe("managed agents REST and resumable SSE", () => {
       const history = await managedHistory(agent);
       expect(history.data.filter(({ type, turn_id }) => (
         type === "turn_retryable" && turn_id === id
-      ))).toHaveLength(1);
+      ))).toHaveLength(turn.attempt_count);
     } finally {
       testEnv.NANOCODEX = originalBroker;
       vi.useRealTimers();

--- a/services/managed/test/managed-api.test.ts
+++ b/services/managed/test/managed-api.test.ts
@@ -5438,7 +5438,7 @@ describe("managed agents REST and resumable SSE", () => {
       dispatchInputJson: frozen.dispatchInputJson,
       terminalJson: frozen.terminalJson,
     });
-    expect(BigInt(replayed.stateRevision)).toBeGreaterThan(BigInt(frozen.stateRevision));
+    expect(replayed.stateRevision).toBe(frozen.stateRevision);
     await submit(agent, "turn-after-raw-replay", "start only after replay attribution");
     await waitForTurnState(agent, "turn-after-raw-replay", "completed");
     await waitForHistoryEvent(agent, ({ cursor, event, turn_id }) => (

--- a/services/managed/test/managed-api.test.ts
+++ b/services/managed/test/managed-api.test.ts
@@ -5118,7 +5118,8 @@ describe("managed agents REST and resumable SSE", () => {
         let failed = false;
         sql.exec = function injectedJournalFailure(query, ...bindings) {
           if (!failed
-            && query.includes("INSERT INTO nanocodex_durable_states")
+            && (query.includes("INSERT INTO nanocodex_durable_states")
+              || query.includes("INSERT INTO nanocodex_durable_state_chunks"))
             && bindings.some((binding) => (
               typeof binding === "string"
               && binding.includes("\"cancelled\"")
@@ -5333,7 +5334,13 @@ describe("managed agents REST and resumable SSE", () => {
         expect(turn.state).toBe("accepted");
         expect(turn.retry_at).not.toBeNull();
         expect(turn.retry_at! - turn.updated_at).toBeLessThanOrEqual(60_000);
-        vi.setSystemTime(turn.retry_at!);
+        await waitForScheduledAlarm(session);
+        const alarm = await runInDurableObject(
+          session,
+          (_instance, state) => state.storage.getAlarm(),
+        );
+        expect(alarm).not.toBeNull();
+        vi.setSystemTime(Math.max(turn.retry_at!, alarm!));
         expect(await runDurableObjectAlarm(session)).toBe(true);
         turn = await waitForTurnRetry(agent, id, expected);
       }

--- a/services/managed/test/managed-api.test.ts
+++ b/services/managed/test/managed-api.test.ts
@@ -5466,6 +5466,87 @@ describe("managed agents REST and resumable SSE", () => {
     expect(BigInt(followingStarted!.cursor)).toBeLessThan(BigInt(followingCompleted!.cursor));
   });
 
+  it("exports and imports a live managed Agent through real Durable Object SQLite", async () => {
+    const source = await createAgent();
+    const turnId = "turn-portable-cloudflare";
+    const input = "retain this portable Cloudflare turn";
+    await submit(source, turnId, input);
+    const sourceTerminal = await waitForTurnState(source, turnId, "completed", 10_000);
+    const sourceCapacity = await testEnv.NANOCODEX_SESSIONS
+      .getByName(source.agent_id)
+      .fetch("https://session.internal/capacity");
+    expect((await sourceCapacity.json<{ durable_state: { rows: number } }>()).durable_state.rows)
+      .toBe(1);
+
+    const exported = await SELF.fetch(
+      source.events_url.replace(/\/events$/, "/durability"),
+      { method: "POST" },
+    );
+    expect(exported.status).toBe(200);
+    const archive = await exported.json<{
+      format: string;
+      stateId: string;
+      revision: string;
+      payload: string;
+    }>();
+    expect(archive).toMatchObject({
+      format: "nanocodex-durability-state-v1",
+      revision: expect.stringMatching(/^[1-9][0-9]*$/),
+      payload: expect.any(String),
+    });
+    expect((await SELF.fetch(source.events_url.replace(/\/events$/, "/turns"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "after-export", input: "must not resume source" }),
+    })).status).toBe(409);
+
+    const importKey = `portable-${crypto.randomUUID()}`;
+    const createImported = () => SELF.fetch("https://example.test/v1/agents", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "idempotency-key": importKey,
+      },
+      body: JSON.stringify({ durability: archive }),
+    });
+    const importedResponse = await createImported();
+    expect(importedResponse.status).toBe(201);
+    const imported = await importedResponse.json<AgentReceipt>();
+    createdAgents.add(imported.agent_id);
+    expect(imported.agent_id).not.toBe(source.agent_id);
+    expect(imported.durability_id).toBe(archive.stateId);
+
+    const replayedCreate = await createImported();
+    expect(replayedCreate.status).toBe(201);
+    await expect(replayedCreate.json()).resolves.toMatchObject({
+      agent_id: imported.agent_id,
+      durability_id: archive.stateId,
+    });
+
+    await submit(imported, turnId, input);
+    const importedTerminal = await waitForTurnState(imported, turnId, "completed", 10_000);
+    expect(importedTerminal.terminal).toEqual(sourceTerminal.terminal);
+    const identities = await Promise.all([
+      runInDurableObject(
+        testEnv.NANOCODEX_SESSIONS.getByName(source.agent_id),
+        (_instance, state) => state.storage.sql.exec<{ session_id: string }>(
+          "SELECT session_id FROM nanocodex_cloudflare_agent WHERE singleton = 1",
+        ).one().session_id,
+      ),
+      runInDurableObject(
+        testEnv.NANOCODEX_SESSIONS.getByName(imported.agent_id),
+        (_instance, state) => state.storage.sql.exec<{ session_id: string; state_id: string }>(
+          `SELECT a.session_id, d.state_id
+           FROM nanocodex_cloudflare_agent a
+           CROSS JOIN nanocodex_cloudflare_durability d
+           WHERE a.singleton = 1 AND d.singleton = 1`,
+        ).one(),
+      ),
+    ]);
+    expect(identities[1]).toMatchObject({ state_id: archive.stateId });
+    expect(identities[1].session_id).not.toBe(identities[0]);
+  }, 30_000);
+
   it("persists cursors across eviction and tails strictly after the acknowledged cursor", async () => {
     const agent = await createAgent();
     const id = new URL(agent.events_url).pathname.split("/").at(-2)!;
@@ -5601,6 +5682,7 @@ describe("managed agents REST and resumable SSE", () => {
 
 type AgentReceipt = {
   agent_id: string;
+  durability_id: string;
   events_url: string;
   websocket_url: string;
 };
@@ -5612,6 +5694,7 @@ type ManagedTurnView = {
   input: unknown;
   retry_at: number | null;
   state: string;
+  terminal?: unknown;
   terminal_cursor: string | null;
   turn_id: string;
   updated_at: number;

--- a/services/managed/test/managed-api.test.ts
+++ b/services/managed/test/managed-api.test.ts
@@ -5332,7 +5332,10 @@ describe("managed agents REST and resumable SSE", () => {
         expect(turn.retry_at! - turn.updated_at).toBeLessThanOrEqual(60_000);
         const alarm = await waitForScheduledAlarm(session, turn.retry_at!);
         vi.setSystemTime(alarm);
-        expect(await runDurableObjectAlarm(session)).toBe(true);
+        // Advancing fake time can let Miniflare dispatch the due alarm before
+        // the explicit runner wins the race. Either path is valid; the next
+        // retry attempt is the observable contract we need to prove.
+        await runDurableObjectAlarm(session);
         turn = await waitForTurnRetry(agent, id, expected);
       }
       expect(turn).toMatchObject({ attempt_count: 10, state: "accepted" });

--- a/services/managed/test/managed-api.test.ts
+++ b/services/managed/test/managed-api.test.ts
@@ -5116,14 +5116,10 @@ describe("managed agents REST and resumable SSE", () => {
         };
         const originalExec = sql.exec;
         let failed = false;
-        sql.exec = function injectedJournalFailure(query, ...bindings) {
+        sql.exec = function injectedStateFailure(query, ...bindings) {
           if (!failed
             && (query.includes("INSERT INTO nanocodex_durable_states")
-              || query.includes("INSERT INTO nanocodex_durable_state_chunks"))
-            && bindings.some((binding) => (
-              typeof binding === "string"
-              && binding.includes("\"cancelled\"")
-            ))) {
+              || query.includes("INSERT INTO nanocodex_durable_state_chunks"))) {
             failed = true;
             throw new Error("injected cancellation state failure");
           }
@@ -5334,13 +5330,8 @@ describe("managed agents REST and resumable SSE", () => {
         expect(turn.state).toBe("accepted");
         expect(turn.retry_at).not.toBeNull();
         expect(turn.retry_at! - turn.updated_at).toBeLessThanOrEqual(60_000);
-        await waitForScheduledAlarm(session);
-        const alarm = await runInDurableObject(
-          session,
-          (_instance, state) => state.storage.getAlarm(),
-        );
-        expect(alarm).not.toBeNull();
-        vi.setSystemTime(Math.max(turn.retry_at!, alarm!));
+        const alarm = await waitForScheduledAlarm(session, turn.retry_at!);
+        vi.setSystemTime(alarm);
         expect(await runDurableObjectAlarm(session)).toBe(true);
         turn = await waitForTurnRetry(agent, id, expected);
       }
@@ -6051,11 +6042,11 @@ async function waitForHistoryEvent(
 
 async function waitForScheduledAlarm(
   stub: DurableObjectStub<DurableAgentSession>,
-): Promise<void> {
-  const deadline = Date.now() + 2_000;
-  while (Date.now() < deadline) {
+  earliest = Number.NEGATIVE_INFINITY,
+): Promise<number> {
+  for (let poll = 0; poll < 200; poll += 1) {
     const alarm = await runInDurableObject(stub, (_instance, state) => state.storage.getAlarm());
-    if (alarm !== null) return;
+    if (alarm !== null && alarm >= earliest) return alarm;
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   throw new Error("timed out waiting for a scheduled Durable Object alarm");

--- a/services/managed/test/multiplayer.test.ts
+++ b/services/managed/test/multiplayer.test.ts
@@ -423,7 +423,11 @@ describe("durable Multiplayer rooms", () => {
     const originalTimeout = testEnv.MANAGED_MULTIPLAYER_IO_TIMEOUT_MS;
     const createId = randomCreateId();
     let roomId: string | undefined;
-    testEnv.MANAGED_MULTIPLAYER_IO_TIMEOUT_MS = "20";
+    // This timeout covers both the real quota reservation and the deliberately
+    // nonsettling room hop. Leave enough headroom for the production quota DO
+    // on a loaded CI worker so this test reaches the boundary it intends to
+    // exercise.
+    testEnv.MANAGED_MULTIPLAYER_IO_TIMEOUT_MS = "250";
     testEnv.NANOCODEX_ROOMS = {
       getByName(name: string) {
         roomId = name;
@@ -431,15 +435,16 @@ describe("durable Multiplayer rooms", () => {
       },
     } as unknown as Env["NANOCODEX_ROOMS"];
 
+    let failed: Response | undefined;
     try {
-      const failed = await within(createRoomResponse("Ada", createId), "room initialization headers");
-      expect(failed.status).toBe(503);
-      expect(await failed.json()).toEqual({ error: "room_initialization_failed" });
-      expect(await quotaLeaseCount(roomId!)).toBe(1);
+      failed = await within(createRoomResponse("Ada", createId), "room initialization headers");
     } finally {
       testEnv.NANOCODEX_ROOMS = originalRooms;
       testEnv.MANAGED_MULTIPLAYER_IO_TIMEOUT_MS = originalTimeout;
     }
+    expect(failed!.status).toBe(503);
+    expect(await failed!.json()).toEqual({ error: "room_initialization_failed" });
+    expect(await quotaLeaseCount(roomId!)).toBe(1);
 
     const recovered = await createRoomResponse("Ada", createId);
     expect(recovered.status).toBe(201);

--- a/services/managed/test/multiplayer.test.ts
+++ b/services/managed/test/multiplayer.test.ts
@@ -2095,7 +2095,10 @@ async function within<Result>(promise: Promise<Result>, operation: string): Prom
     return await Promise.race([
       promise,
       new Promise<never>((_resolve, reject) => {
-        timer = setTimeout(() => reject(new Error(`${operation} test timed out`)), 1_000);
+        // This is a test-only deadlock guard around deliberately nonsettling
+        // Worker hops. Leave scheduling headroom below Vitest's 15 s timeout;
+        // the production deadline under test remains independently asserted.
+        timer = setTimeout(() => reject(new Error(`${operation} test timed out`)), 5_000);
       }),
     ]);
   } finally {

--- a/services/managed/test/organization-auth.test.ts
+++ b/services/managed/test/organization-auth.test.ts
@@ -12,6 +12,7 @@ const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12
 const testEnv = env as unknown as AccountAuthEnv;
 const OWNER_CAPABILITIES = [
   "agents:read",
+  "agents:portability",
   "agents:write",
   "api_keys:read",
   "api_keys:write",
@@ -23,7 +24,8 @@ const OWNER_CAPABILITIES = [
   "organization:write",
 ] as const satisfies readonly OrganizationCapability[];
 const LEGACY_OWNER_CAPABILITIES = OWNER_CAPABILITIES.filter((capability) => (
-  capability !== "history:read"
+  capability !== "agents:portability"
+  && capability !== "history:read"
   && capability !== "memory:read"
   && capability !== "memory:write"
 ));
@@ -71,6 +73,7 @@ describe("organization authorization foundation", () => {
       authorizationEpoch: 1,
       capabilities: [
         "agents:read",
+        "agents:portability",
         "agents:write",
         "api_keys:read",
         "api_keys:write",

--- a/services/managed/test/sandbox-tools.test.ts
+++ b/services/managed/test/sandbox-tools.test.ts
@@ -11,6 +11,7 @@ const MIB = 1024 * 1024;
 const OUTPUT_LIMIT = 128 * 1024;
 const context = {
   callId: "call",
+  model: "gpt-5.6-sol",
   parentCallId: "parent",
   sessionId: "session",
   signal: new AbortController().signal,

--- a/services/managed/test/turn-completion.test.ts
+++ b/services/managed/test/turn-completion.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { Turn, TurnResult, TurnUsage } from "nanocodex";
-import { classifyTurnFailure, materializeTurnTerminal } from "../src/turn-completion";
+import { classifyTurnFailure, materializeTurnResolution } from "../src/turn-completion";
 
 const usage = {
   input_tokens: 10,
@@ -14,12 +14,13 @@ const usage = {
   cost_status: "usage_not_reported",
 } satisfies TurnUsage;
 
-describe("materializeTurnTerminal", () => {
+describe("materializeTurnResolution", () => {
   it("awaits usage, preserves the protocol shape, and releases the result", async () => {
     const dispose = vi.fn();
     const result = turnResult({ dispose, usage: vi.fn(async () => usage) });
 
-    await expect(materializeTurnTerminal("turn-1", turnWith(result))).resolves.toEqual({
+    await expect(materializeTurnResolution("turn-1", turnWith(result))).resolves.toEqual({
+      kind: "terminal",
       terminal: {
         type: "turn_completed",
         id: "turn-1",
@@ -40,7 +41,8 @@ describe("materializeTurnTerminal", () => {
       usage: vi.fn(async () => { throw new Error("usage payload is invalid"); }),
     });
 
-    await expect(materializeTurnTerminal("turn-2", turnWith(result))).resolves.toEqual({
+    await expect(materializeTurnResolution("turn-2", turnWith(result))).resolves.toEqual({
+      kind: "terminal",
       terminal: {
         type: "turn_completed",
         id: "turn-2",
@@ -64,59 +66,40 @@ describe("materializeTurnTerminal", () => {
       },
     } as unknown as Turn;
 
-    await expect(materializeTurnTerminal("turn-3", turn)).resolves.toEqual({
-      terminal: {
-        type: "turn_retryable",
-        id: "turn-3",
-        error: "Agent connection rejected with HTTP 503: credential_broker_rejected",
-      },
+    await expect(materializeTurnResolution("turn-3", turn)).resolves.toEqual({
+      kind: "retry",
+      error: "Agent connection rejected with HTTP 503: credential_broker_rejected",
       reopenAgent: false,
     });
   });
 
   it.each([
-    ["retryable", "turn_retryable"],
-    ["blocked", "turn_blocked"],
+    ["retryable", "retry"],
     ["failed", "turn_failed"],
   ] as const)("preserves the WASM %s completion class", async (code, type) => {
     const error = Object.assign(new Error(`${code} turn`), { code });
     const turn = { result: async () => { throw error; } } as unknown as Turn;
 
-    await expect(materializeTurnTerminal("turn-4", turn)).resolves.toEqual({
-      terminal: {
-        type,
-        id: "turn-4",
-        error: `${code} turn`,
-      },
+    await expect(materializeTurnResolution("turn-4", turn)).resolves.toEqual(type === "retry" ? {
+      kind: "retry",
+      error: `${code} turn`,
+      reopenAgent: false,
+    } : {
+      kind: "terminal",
+      terminal: { type, id: "turn-4", error: `${code} turn` },
       reopenAgent: false,
     });
   });
 
   it("keeps reopen_required retryable while requiring a fresh Agent", () => {
-    const error = Object.assign(new Error("ambiguous outcome after durability owner was fenced"), {
+    const error = Object.assign(new Error("durability owner was fenced"), {
       code: "reopen_required",
     });
 
     expect(classifyTurnFailure("turn-reopen", error)).toEqual({
-      terminal: {
-        type: "turn_retryable",
-        id: "turn-reopen",
-        error: "ambiguous outcome after durability owner was fenced",
-      },
+      kind: "retry",
+      error: "durability owner was fenced",
       reopenAgent: true,
-    });
-  });
-
-  it("does not conflate blocked with reopen_required", () => {
-    const error = Object.assign(new Error("ambiguous durable step"), { code: "blocked" });
-
-    expect(classifyTurnFailure("turn-blocked", error)).toEqual({
-      terminal: {
-        type: "turn_blocked",
-        id: "turn-blocked",
-        error: "ambiguous durable step",
-      },
-      reopenAgent: false,
     });
   });
 
@@ -133,11 +116,8 @@ describe("materializeTurnTerminal", () => {
     );
 
     expect(classifyTurnFailure("turn-aggregate", aggregate)).toEqual({
-      terminal: {
-        type: "turn_retryable",
-        id: "turn-aggregate",
-        error: "durability owner must reopen",
-      },
+      kind: "retry",
+      error: "durability owner must reopen",
       reopenAgent: true,
     });
   });
@@ -150,11 +130,8 @@ describe("materializeTurnTerminal", () => {
     });
 
     expect(classifyTurnFailure("turn-nested-retry", failed)).toEqual({
-      terminal: {
-        type: "turn_retryable",
-        id: "turn-nested-retry",
-        error: "Agent connection rejected with HTTP 503: broker restarting",
-      },
+      kind: "retry",
+      error: "Agent connection rejected with HTTP 503: broker restarting",
       reopenAgent: false,
     });
   });
@@ -165,11 +142,8 @@ describe("materializeTurnTerminal", () => {
     ["Agent connection rejected with HTTP 503: upstream unavailable", false],
   ] as const)("keeps transient pre-admission failure retryable: %s", (message, reopenAgent) => {
     expect(classifyTurnFailure("turn-pre-admission", new Error(message))).toEqual({
-      terminal: {
-        type: "turn_retryable",
-        id: "turn-pre-admission",
-        error: message,
-      },
+      kind: "retry",
+      error: message,
       reopenAgent,
     });
   });

--- a/services/managed/vitest.config.ts
+++ b/services/managed/vitest.config.ts
@@ -10,9 +10,18 @@ let heldSubjectBinds = 0;
 let heldSubjectUnbinds = 0;
 let heldSubjectResponses = 0;
 let heldSubjectOrder = [];
+let modelCommands = 0;
 export default {
   async fetch(request) {
     const url = new URL(request.url);
+    if (url.pathname === "/test/model-commands") {
+      if (request.method === "GET") return Response.json({ count: modelCommands });
+      if (request.method === "DELETE") {
+        modelCommands = 0;
+        return new Response(null, { status: 204 });
+      }
+      return Response.json({ error: "method_not_allowed" }, { status: 405 });
+    }
     if (url.pathname === "/test/hold-subject-bind") {
       if (request.method === "POST") {
         let body;
@@ -257,6 +266,7 @@ export default {
       const latest = messages.at(-1);
       const content = Array.isArray(latest?.content) ? latest.content : [];
       const text = content.map((item) => item?.text ?? "").join("").trim();
+      modelCommands += 1;
       const latestUserIndex = input.findLastIndex((item) => (
         item?.type === "message" && item.role === "user"
       ));

--- a/services/managed/vitest.config.ts
+++ b/services/managed/vitest.config.ts
@@ -271,57 +271,90 @@ export default {
         item?.type === "message" && item.role === "user"
       ));
       const activeInput = latestUserIndex < 0 ? input : input.slice(latestUserIndex);
-      const toolOutput = input.find((item) => (
+      const toolOutput = activeInput.find((item) => (
         item?.type === "function_call_output" && item.call_id === "managed-web"
       ));
-      const imageOutput = input.find((item) => (
+      const imageOutput = activeInput.find((item) => (
         item?.type === "function_call_output" && item.call_id === "managed-image"
       ));
-      const computerOutput = input.find((item) => (
+      const computerOutput = activeInput.find((item) => (
         item?.type === "function_call_output" && item.call_id === "computer-runtime"
       ));
-      const multiplayerConnectorOutput = input.find((item) => (
+      const runtimeInfoOutput = activeInput.find((item) => (
+        item?.type === "function_call_output" && item.call_id === "managed-runtime-info"
+      ));
+      const updatePlanOutput = activeInput.find((item) => (
+        item?.type === "function_call_output" && item.call_id === "managed-update-plan"
+      ));
+      const multiplayerConnectorOutput = activeInput.find((item) => (
         item?.type === "function_call_output" && item.call_id === "multiplayer-no-connectors"
       ));
-      const hostedToolsOutput = input.find((item) => (
+      const hostedToolsOutput = activeInput.find((item) => (
         item?.type === "custom_tool_call_output" && item.call_id === "managed-hosted-exec"
       ));
       const hostedPriorityOutput = activeInput.slice().reverse().find((item) => (
         item?.type === "custom_tool_call_output"
         && (item.call_id === "hosted-priority-local" || item.call_id === "hosted-priority-cloud")
       ));
-      const phoneOutput = input.find((item) => (
+      const phoneOutput = activeInput.find((item) => (
         item?.type === "function_call_output" && item.call_id === "managed-phone"
       ));
-      const spawnOutput = input.find((item) => (
+      const spawnOutput = activeInput.find((item) => (
         item?.type === "function_call_output" && item.call_id === "managed-spawn"
       ));
-      const waitOutput = input.find((item) => (
+      const waitOutput = activeInput.find((item) => (
         item?.type === "function_call_output" && item.call_id === "managed-wait"
       ));
-      const submitOutput = input.find((item) => (
+      const submitOutput = activeInput.find((item) => (
         item?.type === "function_call_output" && item.call_id === "managed-submit"
       ));
-      const managedMemoryFind = input.find((item) => (
+      const compaction = input.some((item) => item?.type === "compaction_trigger");
+      const managedMemoryFind = activeInput.find((item) => (
         item?.type === "function_call_output" && item.call_id === "managed-memory-find"
       ));
-      const managedMemoryRead = input.find((item) => (
+      const managedMemoryRead = activeInput.find((item) => (
         item?.type === "function_call_output" && item.call_id === "managed-memory-read"
       ));
-      const atomicStoreScan = input.find((item) => (
+      const atomicStoreScan = activeInput.find((item) => (
         item?.type === "function_call_output" && item.call_id === "atomic-store-scan"
       ));
-      const atomicStorePut = input.find((item) => (
+      const atomicStorePut = activeInput.find((item) => (
         item?.type === "function_call_output" && item.call_id === "atomic-store-put"
       ));
-      const atomicRecallScan = input.find((item) => (
+      const atomicRecallScan = activeInput.find((item) => (
         item?.type === "function_call_output" && item.call_id === "atomic-recall-scan"
       ));
-      const atomicRecallRead = input.find((item) => (
+      const atomicRecallRead = activeInput.find((item) => (
         item?.type === "function_call_output" && item.call_id === "atomic-recall-read"
       ));
       pendingResponse = setTimeout(() => {
         pendingResponse = undefined;
+        if (compaction) {
+          server.send(JSON.stringify({
+            type: "response.output_item.done",
+            item: {
+              id: "managed-portability-compaction",
+              type: "compaction",
+              encrypted_content: "portable-managed-compaction",
+            },
+          }));
+          server.send(JSON.stringify({
+            type: "response.completed",
+            response: {
+              id: crypto.randomUUID(),
+              status: "completed",
+              output: [],
+              usage: {
+                input_tokens: 100,
+                input_tokens_details: { cached_tokens: 0 },
+                output_tokens: 20,
+                output_tokens_details: { reasoning_tokens: 0 },
+                total_tokens: 120,
+              },
+            },
+          }));
+          return;
+        }
         if (hostedPriorityOutput) {
           const local = hostedPriorityOutput.call_id === "hosted-priority-local";
           const output = JSON.stringify(hostedPriorityOutput.output);
@@ -486,6 +519,27 @@ export default {
           }));
           return;
         }
+        if (runtimeInfoOutput && updatePlanOutput) {
+          const valid = String(runtimeInfoOutput.output).includes("cloudflare-durable-object")
+            && String(updatePlanOutput.output).includes("updated");
+          server.send(JSON.stringify({
+            type: "response.completed",
+            response: {
+              id: crypto.randomUUID(),
+              status: "completed",
+              output: [{
+                type: "message",
+                role: "assistant",
+                content: [{
+                  type: "output_text",
+                  text: valid ? "MANAGED_CORE_TOOLS_OK" : "MANAGED_CORE_TOOLS_BAD",
+                }],
+              }],
+              usage: null,
+            },
+          }));
+          return;
+        }
         if (atomicRecallRead) {
           const valid = String(atomicRecallRead.output).includes("Production deploys happen on Tuesdays.");
           server.send(JSON.stringify({
@@ -644,6 +698,28 @@ export default {
           }));
           return;
         }
+        if (text.includes("E2E_PORTABILITY_COMPACTION_SEED")) {
+          server.send(JSON.stringify({
+            type: "response.completed",
+            response: {
+              id: crypto.randomUUID(),
+              status: "completed",
+              output: [{
+                type: "message",
+                role: "assistant",
+                content: [{ type: "output_text", text: "PORTABILITY_COMPACTION_SEEDED" }],
+              }],
+              usage: {
+                input_tokens: 244_700,
+                input_tokens_details: { cached_tokens: 0 },
+                output_tokens: 100,
+                output_tokens_details: { reasoning_tokens: 0 },
+                total_tokens: 244_800,
+              },
+            },
+          }));
+          return;
+        }
         if (text.includes("E2E_HOSTED_TOOLS")) {
           server.send(JSON.stringify({
             type: "response.completed",
@@ -692,6 +768,31 @@ export default {
                 name: "exec_command",
                 arguments: JSON.stringify({
                   cmd: "printf 'COMPUTER_RUNTIME_OK\\n' > /workspace/computer.txt && cat /workspace/computer.txt && gh api repos/gakonst/nanocodex | jq -r .full_name",
+                }),
+              }],
+              usage: null,
+            },
+          }));
+          return;
+        }
+        if (text.includes("E2E_MANAGED_CORE_TOOLS")) {
+          server.send(JSON.stringify({
+            type: "response.completed",
+            response: {
+              id: crypto.randomUUID(),
+              status: "completed",
+              output: [{
+                type: "function_call",
+                call_id: "managed-runtime-info",
+                name: "runtimeInfo",
+                arguments: "{}",
+              }, {
+                type: "function_call",
+                call_id: "managed-update-plan",
+                name: "update_plan",
+                arguments: JSON.stringify({
+                  explanation: "exercise agent-local tool state",
+                  plan: [{ step: "verify managed core tools", status: "completed" }],
                 }),
               }],
               usage: null,

--- a/services/managed/wrangler.jsonc
+++ b/services/managed/wrangler.jsonc
@@ -43,7 +43,7 @@
     "bindings": [
       {
         "name": "NANOCODEX_SESSIONS",
-        "class_name": "NanocodexSession"
+        "class_name": "DurableAgentSession"
       },
       {
         "name": "NANOCODEX_ROOMS",
@@ -91,6 +91,11 @@
     {
       "tag": "v4",
       "new_sqlite_classes": ["Organization"]
+    },
+    {
+      "tag": "v5",
+      "new_sqlite_classes": ["DurableAgentSession"],
+      "deleted_classes": ["NanocodexSession"]
     }
   ],
   "vars": {

--- a/services/managed/wrangler.test.jsonc
+++ b/services/managed/wrangler.test.jsonc
@@ -18,7 +18,7 @@
   ],
   "durable_objects": {
     "bindings": [
-      { "name": "NANOCODEX_SESSIONS", "class_name": "NanocodexSession" },
+      { "name": "NANOCODEX_SESSIONS", "class_name": "DurableAgentSession" },
       { "name": "NANOCODEX_ROOMS", "class_name": "MultiplayerRoom" },
       { "name": "NANOCODEX_MULTIPLAYER_QUOTA", "class_name": "MultiplayerQuota" },
       { "name": "NANOCODEX_AUTH", "class_name": "NonceStorage" },
@@ -38,7 +38,12 @@
       "new_sqlite_classes": ["NonceStorage", "UserAccount", "ApiKeyRecord"]
     },
     { "tag": "v3", "new_sqlite_classes": ["MemoryScope"] },
-    { "tag": "v4", "new_sqlite_classes": ["Organization"] }
+    { "tag": "v4", "new_sqlite_classes": ["Organization"] },
+    {
+      "tag": "v5",
+      "new_sqlite_classes": ["DurableAgentSession"],
+      "deleted_classes": ["NanocodexSession"]
+    }
   ],
   "vars": {
     "AGENT_IDLE_TIMEOUT_MS": "30000"

--- a/typos.toml
+++ b/typos.toml
@@ -25,6 +25,11 @@ caf = "caf"
 # and `ded4eacdbd`.
 ede = "ede"
 ded = "ded"
+# These are hexadecimal fragments in reviewed Codex commit hashes, not prose.
+daed = "daed"
+abd = "abd"
+dbe = "dbe"
+daa = "daa"
 # `iz` appears inside the exact retained benchmark flag
 # `flag{gc0d3_iz_ch4LLenGiNg}`.
 iz = "iz"

--- a/web/docs/src/pages/deployments/cloudflare.mdx
+++ b/web/docs/src/pages/deployments/cloudflare.mdx
@@ -11,7 +11,7 @@ sockets, and opaque durability journal. A separate Cloudflare Sandbox owns
 Linux execution; R2 backs its per-session workspace.
 
 ```text
-client -> Worker router -> NanocodexSession Durable Object
+client -> Worker router -> DurableAgentSession Durable Object
                           |- Rust/WASM agent
                           |- SQLite journal batches
                           |- hibernatable client sockets

--- a/web/src/managedAgentRuntime.ts
+++ b/web/src/managedAgentRuntime.ts
@@ -507,7 +507,6 @@ function managedEnvelopeGroups(envelopes: readonly ManagedEvent[]): Map<string, 
 function managedOuterTerminal(envelope: ManagedEvent): boolean {
   return envelope.data.type === "turn_completed"
     || envelope.data.type === "turn_cancelled"
-    || envelope.data.type === "turn_blocked"
     || envelope.data.type === "turn_failed"
     || envelope.data.type === "stream_failed";
 }
@@ -647,11 +646,7 @@ function managedEnvelopeEvents(
       turn_id: turnId,
     })];
   }
-  if (
-    envelope.data.type === "turn_blocked"
-    || envelope.data.type === "turn_failed"
-  ) {
-    const disposition = envelope.data.type.slice("turn_".length);
+  if (envelope.data.type === "turn_failed") {
     return [
       historyEvent(sessionId, firstSequence, "run.error", {
         message: envelope.data.error,
@@ -659,7 +654,7 @@ function managedEnvelopeEvents(
       }),
       historyEvent(sessionId, firstSequence + 1, "run.failed", {
         status: "failed",
-        disposition,
+        disposition: "failed",
         turn_id: turnId,
       }),
     ];

--- a/web/test/managedAgentRuntime.test.ts
+++ b/web/test/managedAgentRuntime.test.ts
@@ -209,9 +209,6 @@ test("managed history projects exact outer terminals without duplicate raw assis
     managedOuterEnvelope("5", "turn-failed", {
       type: "turn_failed", id: "turn-failed", error: "permanent failure",
     }),
-    managedOuterEnvelope("6", "turn-blocked", {
-      type: "turn_blocked", id: "turn-blocked", error: "needs reconciliation",
-    }),
     managedOuterEnvelope("7", "turn-retryable", {
       type: "turn_retryable", id: "turn-retryable", error: "try this turn again",
     }),
@@ -246,7 +243,6 @@ test("managed history projects exact outer terminals without duplicate raw assis
     turnId: payload.turn_id,
   })), [
     { disposition: "failed", status: "failed", turnId: "turn-failed" },
-    { disposition: "blocked", status: "failed", turnId: "turn-blocked" },
     { disposition: "cancelled", status: "cancelled", turnId: "turn-cancelled" },
     { disposition: "stream_failed", status: "failed", turnId: undefined },
   ]);


### PR DESCRIPTION
## Summary

- replace the append-only journal introduced in #181 with a single Rust-owned total durable state
- reduce the store contract to `StateStore { acquire, replace }`: one fenced owner and one opaque state value per session
- make every transition an atomic compare-and-replace of the complete canonical state across memory, SQLite, Postgres, host/WASM, IndexedDB, and Cloudflare
- carry the hard cutover through the Rust agent, JS bindings, managed API, Durable Objects, React consumer, scripts, tests, and docs
- remove journal batches, legacy envelopes, compatibility readers, migration paths, and duplicate managed completion state

## Model

Rust remains the only durability state machine. The retained value contains the complete canonical operation queue, active claim/attempt, staged model and tool work, checkpoint, terminal receipts, and compaction boundary.

The host owns only:

- owner acquisition/fencing
- exact revision comparison
- atomic replacement of the complete opaque value
- classification of a replace as committed, definitely not committed, ambiguous, or fenced

Stale owners lose before revision comparison. Definitely-uncommitted writes may retry. Ambiguous outcomes and fencing require reopening from authoritative state. Unsafe tool boundaries are recovered in-band without silently repeating the tool.

## Hard cutover

This intentionally provides **zero compatibility** with the deleted journal representation. Existing durable state must be discarded; old envelopes are rejected explicitly instead of migrated or guessed.

## Managed/runtime changes

- use the same total-state contract through browser, Node/WASM, Cloudflare Durable Objects, Postgres, and the managed service
- unify queued/active cancellation, restart replay, terminal retention, and workspace restoration around the Rust-owned checkpoint
- retain cancellation before admission and recover ambiguous tool completion through the durable execution policy
- add mocked local managed E2E coverage for restart/replay and the REST, SSE, WebSocket, and multiplayer surfaces
- delete parallel managed durability fields and compatibility protocol branches

## Validation

Fresh on the published tree:

- `cargo fmt --all -- --check`
- `cargo test -p nanocodex-durability --all-targets` — 79 passed
- focused JS durability/binding tests — 55 passed
- managed Node tests — 58 passed
- managed TypeScript check
- Wrangler production dry build
- `git diff --check origin/master...HEAD`

During development the full mocked local `wrangler dev` E2E was also run twice, including restart/replay and workspace restoration.

The broad managed Worker suite was not completed in the current publishing sandbox because its configured external documentation/MCP hosts were blocked by DNS; the focused durability gates above are clean.
