### PR TITLE
feat(connect): bridge existing application auth

### DIFF
--- a/examples/connect-existing-auth/README.md
+++ b/examples/connect-existing-auth/README.md
@@ -1,0 +1,44 @@
+# Connect with existing authentication
+
+These three server adapters keep the website's existing login as the source of
+truth and use Nanocodex only for connector authorization:
+
+- `auth0/session.mjs` reads the server-side Auth0 session and bridges `user.sub`.
+- `better-auth/session.mjs` resolves the incoming request through
+  `auth.api.getSession` and bridges `session.user.id`.
+- `privy/session.mjs` verifies the Privy access token on the server and bridges
+  the returned `userId`.
+
+Each adapter plugs into the same application-owned route:
+
+```js
+import { Session } from "nanocodex/connect/server";
+import { createAuth0SessionRoute } from "./auth0/session.mjs";
+
+const sessions = Session.create({
+  appId: "acme",
+  appOrigin: "https://app.example.com",
+  secret: process.env.NANOCODEX_PROJECT_SECRET,
+});
+
+export const POST = createAuth0SessionRoute({ auth0, sessions });
+```
+
+The browser is provider-independent:
+
+```js
+import { Client, Identity } from "nanocodex/connect";
+
+const connect = Client.create({
+  appId: "acme",
+  identity: Identity.host(),
+});
+
+await connect.connect({
+  capabilities: { cloudAccounts: { github: true, gmail: true } },
+});
+```
+
+Run the provider-boundary tests with `npm test` from this directory. They use
+the real Nanocodex session handler and mock only the external auth SDK response
+and Connect HTTP endpoint.

--- a/examples/connect-existing-auth/auth0/session.mjs
+++ b/examples/connect-existing-auth/auth0/session.mjs
@@ -1,0 +1,19 @@
+/**
+ * Auth0 remains the application's login authority. Nanocodex receives only
+ * the stable Auth0 subject after the host server has verified its session.
+ */
+export function createAuth0SessionRoute({ auth0, sessions }) {
+  if (!auth0 || typeof auth0.getSession !== "function") {
+    throw new TypeError("Auth0 example requires an Auth0 server client");
+  }
+  return sessions.handler({
+    async authenticate() {
+      const session = await auth0.getSession();
+      if (!session?.user?.sub) return undefined;
+      return {
+        subject: session.user.sub,
+        ...(session.user.org_id ? { organization: session.user.org_id } : {}),
+      };
+    },
+  });
+}

--- a/examples/connect-existing-auth/better-auth/session.mjs
+++ b/examples/connect-existing-auth/better-auth/session.mjs
@@ -1,0 +1,13 @@
+/** Bridge a Better Auth cookie-backed session into Nanocodex Connect. */
+export function createBetterAuthSessionRoute({ auth, sessions }) {
+  if (!auth?.api || typeof auth.api.getSession !== "function") {
+    throw new TypeError("Better Auth example requires an auth server instance");
+  }
+  return sessions.handler({
+    async authenticate(request) {
+      const session = await auth.api.getSession({ headers: request.headers });
+      if (!session?.user?.id) return undefined;
+      return { subject: session.user.id };
+    },
+  });
+}

--- a/examples/connect-existing-auth/browser.mjs
+++ b/examples/connect-existing-auth/browser.mjs
@@ -1,0 +1,16 @@
+import { Client, Identity } from "../../js/bindings/cloud/index.mjs";
+
+/** The browser setup is identical for Auth0, Better Auth, and Privy. */
+export function createConnectClient(parameters = {}) {
+  return Client.create({
+    appId: parameters.appId ?? "existing-auth-example",
+    appOrigin: parameters.appOrigin,
+    identity: Identity.host({
+      url: parameters.sessionUrl ?? "/api/nanocodex/session",
+      ...(parameters.fetch ? { fetch: parameters.fetch } : {}),
+    }),
+    ...(parameters.dialog ? { dialog: parameters.dialog } : {}),
+    ...(parameters.provider ? { provider: parameters.provider } : {}),
+    ...(parameters.transport ? { transport: parameters.transport } : {}),
+  });
+}

--- a/examples/connect-existing-auth/package.json
+++ b/examples/connect-existing-auth/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@nanocodex/example-connect-existing-auth",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test test/*.test.mjs"
+  }
+}

--- a/examples/connect-existing-auth/privy/session.mjs
+++ b/examples/connect-existing-auth/privy/session.mjs
@@ -1,0 +1,30 @@
+/** Verify Privy's host token and bridge only its user DID into Connect. */
+export function createPrivySessionRoute({
+  privy,
+  sessions,
+  readAccessToken = privyCookie,
+}) {
+  if (!privy || typeof privy.verifyAuthToken !== "function") {
+    throw new TypeError("Privy example requires a Privy server client");
+  }
+  if (typeof readAccessToken !== "function") {
+    throw new TypeError("Privy example requires an access-token reader");
+  }
+  return sessions.handler({
+    async authenticate(request) {
+      const token = await readAccessToken(request);
+      if (!token) return undefined;
+      const claims = await privy.verifyAuthToken(token);
+      return claims?.userId ? { subject: claims.userId } : undefined;
+    },
+  });
+}
+
+function privyCookie(request) {
+  const cookie = request.headers.get("cookie") ?? "";
+  for (const part of cookie.split(";")) {
+    const [name, ...value] = part.trim().split("=");
+    if (name === "privy-token") return decodeURIComponent(value.join("="));
+  }
+  return undefined;
+}

--- a/examples/connect-existing-auth/test/integrations.test.mjs
+++ b/examples/connect-existing-auth/test/integrations.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Session } from "../../../js/bindings/cloud/server/index.mjs";
+import { createConnectClient } from "../browser.mjs";
+import { createAuth0SessionRoute } from "../auth0/session.mjs";
+import { createBetterAuthSessionRoute } from "../better-auth/session.mjs";
+import { createPrivySessionRoute } from "../privy/session.mjs";
+
+const appOrigin = "https://app.example.test";
+const opaqueToken = "s".repeat(43);
+
+test("the shared browser integration is importable for every provider", () => {
+  assert.equal(typeof createConnectClient, "function");
+});
+
+function harness() {
+  const exchanges = [];
+  const sessions = Session.create({
+    appId: "existing-auth-example",
+    appOrigin,
+    secret: "project-secret-that-is-long-enough-123",
+    async fetch(input, init) {
+      exchanges.push(new Request(input, init));
+      return Response.json({ token: opaqueToken, expires_at: 1_900_000_000 }, { status: 201 });
+    },
+  });
+  const request = new Request(`${appOrigin}/api/nanocodex/session`, {
+    method: "POST",
+    headers: {
+      cookie: "host-session=valid; privy-token=privy-access-token",
+      origin: appOrigin,
+      "sec-fetch-site": "same-origin",
+    },
+  });
+  return { exchanges, request, sessions };
+}
+
+async function exchangedSubject(route, state) {
+  const response = await route(state.request);
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { token: opaqueToken, expires_at: 1_900_000_000 });
+  assert.equal(state.exchanges.length, 1);
+  const body = await state.exchanges[0].json();
+  assert.equal(JSON.stringify(body).includes("privy-access-token"), false);
+  return body;
+}
+
+test("Auth0 example bridges sub and organization without forwarding its session", async () => {
+  const state = harness();
+  const route = createAuth0SessionRoute({
+    auth0: {
+      async getSession() {
+        return { user: { sub: "auth0|user-123", org_id: "org_acme" } };
+      },
+    },
+    sessions: state.sessions,
+  });
+  assert.deepEqual(await exchangedSubject(route, state), {
+    app_origin: appOrigin,
+    subject: "auth0|user-123",
+    organization: "org_acme",
+  });
+});
+
+test("Better Auth example resolves the incoming host headers", async () => {
+  const state = harness();
+  const route = createBetterAuthSessionRoute({
+    auth: {
+      api: {
+        async getSession({ headers }) {
+          assert.equal(headers.get("cookie")?.includes("host-session=valid"), true);
+          return { user: { id: "better-auth-user-123" } };
+        },
+      },
+    },
+    sessions: state.sessions,
+  });
+  assert.deepEqual(await exchangedSubject(route, state), {
+    app_origin: appOrigin,
+    subject: "better-auth-user-123",
+  });
+});
+
+test("Privy example verifies its token server-side and forwards only userId", async () => {
+  const state = harness();
+  const route = createPrivySessionRoute({
+    privy: {
+      async verifyAuthToken(token) {
+        assert.equal(token, "privy-access-token");
+        return { userId: "did:privy:user-123" };
+      },
+    },
+    sessions: state.sessions,
+  });
+  assert.deepEqual(await exchangedSubject(route, state), {
+    app_origin: appOrigin,
+    subject: "did:privy:user-123",
+  });
+});
+
+test("all examples fail closed when the host login is absent", async () => {
+  const request = new Request(`${appOrigin}/api/nanocodex/session`, {
+    method: "POST",
+    headers: { origin: appOrigin, "sec-fetch-site": "same-origin" },
+  });
+  const routes = [
+    createAuth0SessionRoute({ auth0: { async getSession() {} }, sessions: harness().sessions }),
+    createBetterAuthSessionRoute({ auth: { api: { async getSession() {} } }, sessions: harness().sessions }),
+    createPrivySessionRoute({ privy: { async verifyAuthToken() { throw new Error("must not run"); } }, sessions: harness().sessions }),
+  ];
+  for (const route of routes) assert.equal((await route(request.clone())).status, 401);
+});

--- a/js/bindings/cloud/Client.d.mts
+++ b/js/bindings/cloud/Client.d.mts
@@ -1,5 +1,6 @@
 import type { ConnectActions } from "./Decorator.mjs";
 import type { Instance as DialogInstance, Dialog } from "./Dialog.mjs";
+import type { Identity, Instance as IdentityInstance } from "./Identity.mjs";
 import type { Request, Transport } from "./Transport.mjs";
 import type { Auth, AuthorizeAccessKey } from "./actions/connection.mjs";
 
@@ -31,6 +32,7 @@ export type Base = Readonly<{
   accessKey: Readonly<{ authorize?: AuthorizeAccessKey | undefined }> | undefined;
   auth: Auth | undefined;
   dialog: DialogInstance;
+  identity: IdentityInstance | undefined;
   key: string;
   name: string;
   provider: Provider;
@@ -54,6 +56,8 @@ export type Parameters = Readonly<{
   /** Accounts-compatible default access-key authorization policy. */
   accessKey?: Readonly<{ authorize?: AuthorizeAccessKey | undefined }> | undefined;
   dialog?: Dialog | undefined;
+  /** Existing application login bridged into the signed Connect grant. */
+  identity?: Identity | undefined;
   key?: string | undefined;
   name?: string | undefined;
   /** Advanced override for the remote wallet provider that owns the access key. */

--- a/js/bindings/cloud/Client.mjs
+++ b/js/bindings/cloud/Client.mjs
@@ -15,6 +15,10 @@ export function create(parameters) {
   const dialog = parameters.dialog ?? iframe();
   const transportInstance = transport.setup({ appId: parameters.appId });
   const dialogInstance = dialog.setup({ appId: parameters.appId });
+  const identityInstance = parameters.identity?.setup({
+    appId: parameters.appId,
+    appOrigin,
+  });
   const provider = parameters.provider ?? createRemoteProvider({
     host: dialogInstance.host,
     async target(options) {
@@ -63,6 +67,7 @@ export function create(parameters) {
     appOrigin,
     auth: parameters.auth,
     dialog: dialogInstance,
+    identity: identityInstance,
     key: parameters.key ?? "connect",
     name: parameters.name ?? "Nanocodex Connect",
     provider,

--- a/js/bindings/cloud/Identity.d.mts
+++ b/js/bindings/cloud/Identity.d.mts
@@ -1,0 +1,46 @@
+export type Session = Readonly<{ token: string; expiresAt: number }>;
+
+export type Instance = Readonly<{
+  getSession(options?: Readonly<{ signal?: AbortSignal | undefined }>): Promise<Session>;
+}>;
+
+export type Identity<type extends string = string> = Readonly<{
+  key: string;
+  name: string;
+  type: type;
+  setup(context: Readonly<{
+    appId: string;
+    appOrigin: string | undefined;
+  }>): Instance;
+}>;
+
+export function from<const type extends string>(parameters: Readonly<{
+  key: string;
+  name: string;
+  type: type;
+  setup(context: Readonly<{
+    appId: string;
+    appOrigin: string | undefined;
+  }>): Instance;
+}>): Identity<type>;
+
+export function host(options?: Readonly<{
+  /** Same-origin application route that returns a Nanocodex identity session. */
+  url?: string | URL | undefined;
+  fetch?: typeof globalThis.fetch | undefined;
+  key?: string | undefined;
+  name?: string | undefined;
+}>): Identity<"host">;
+
+export function custom(parameters: Readonly<{
+  getSession(context: Readonly<{
+    appId: string;
+    appOrigin: string | undefined;
+    signal?: AbortSignal | undefined;
+  }>): Promise<Readonly<{ token: string; expires_at: number }>> | Readonly<{
+    token: string;
+    expires_at: number;
+  }>;
+  key?: string | undefined;
+  name?: string | undefined;
+}>): Identity<"custom">;

--- a/js/bindings/cloud/Identity.mjs
+++ b/js/bindings/cloud/Identity.mjs
@@ -1,0 +1,106 @@
+const SESSION_TOKEN = /^[A-Za-z0-9_-]{43}$/;
+
+export function from(parameters) {
+  if (!parameters || typeof parameters !== "object") {
+    throw new TypeError("Identity.from requires parameters");
+  }
+  if (typeof parameters.setup !== "function") {
+    throw new TypeError("Identity.from requires setup");
+  }
+  return Object.freeze({
+    key: requiredString(parameters.key, "identity key"),
+    name: requiredString(parameters.name, "identity name"),
+    type: requiredString(parameters.type, "identity type"),
+    setup: parameters.setup,
+  });
+}
+
+/**
+ * Reads a short-lived Nanocodex identity session from an application-owned,
+ * same-origin route. The route authenticates with Auth0, Better Auth, Privy,
+ * or any other host session and mints the opaque session server-to-server.
+ */
+export function host(options = {}) {
+  const fetchFn = options.fetch ?? globalThis.fetch;
+  if (typeof fetchFn !== "function") throw new TypeError("host identity requires fetch");
+  return from({
+    key: options.key ?? "host-session",
+    name: options.name ?? "Host application session",
+    type: "host",
+    setup({ appId, appOrigin }) {
+      const endpoint = identityEndpoint(options.url ?? "/api/nanocodex/session", appOrigin);
+      return Object.freeze({
+        async getSession({ signal } = {}) {
+          const response = await fetchFn(endpoint, {
+            method: "POST",
+            credentials: "include",
+            headers: {
+              accept: "application/json",
+              "x-nanocodex-app-id": appId,
+            },
+            signal,
+          });
+          const body = await response.json().catch(() => undefined);
+          if (!response.ok) {
+            throw new Error(
+              body?.error?.message ?? `The host identity session failed with ${response.status}.`,
+            );
+          }
+          return identitySession(body);
+        },
+      });
+    },
+  });
+}
+
+/** Advanced adapter for frameworks that already expose a safe opaque session. */
+export function custom(parameters) {
+  if (!parameters || typeof parameters.getSession !== "function") {
+    throw new TypeError("custom identity requires getSession");
+  }
+  return from({
+    key: parameters.key ?? "custom-session",
+    name: parameters.name ?? "Custom host session",
+    type: "custom",
+    setup(context) {
+      return Object.freeze({
+        async getSession(options = {}) {
+          return identitySession(await parameters.getSession({ ...context, ...options }));
+        },
+      });
+    },
+  });
+}
+
+function identityEndpoint(value, appOrigin) {
+  let endpoint;
+  try {
+    endpoint = new URL(String(value), appOrigin);
+  } catch {
+    throw new TypeError("host identity url requires an absolute application origin");
+  }
+  if (!appOrigin || endpoint.origin !== appOrigin) {
+    throw new TypeError("host identity url must stay on the embedding application's origin");
+  }
+  if (endpoint.username || endpoint.password || endpoint.hash) {
+    throw new TypeError("host identity url cannot contain credentials or a fragment");
+  }
+  return endpoint;
+}
+
+function identitySession(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)
+    || !SESSION_TOKEN.test(value.token)
+    || !Number.isSafeInteger(value.expires_at)
+    || value.expires_at <= Math.floor(Date.now() / 1_000)) {
+    throw new TypeError("host identity returned an invalid Nanocodex session");
+  }
+  return Object.freeze({ token: value.token, expiresAt: value.expires_at });
+}
+
+function requiredString(value, label) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(`${label} must be a non-empty string`);
+  }
+  return value;
+}

--- a/js/bindings/cloud/actions/connection.mjs
+++ b/js/bindings/cloud/actions/connection.mjs
@@ -11,6 +11,8 @@ const CONNECTOR_RESOURCE_PREFIX = "urn:nanocodex:connector:";
 const CONNECTORS_RESOURCE_PREFIX = "urn:nanocodex:connectors:";
 const APP_RESOURCE_PREFIX = "urn:nanocodex:app:";
 const APP_ORIGIN_RESOURCE_PREFIX = "urn:nanocodex:origin:";
+const IDENTITY_SESSION_RESOURCE_PREFIX = "urn:nanocodex:identity-session:";
+const IDENTITY_SESSION_TOKEN = /^[A-Za-z0-9_-]{43}$/;
 const MCP_CONNECTION_ID = /^[A-Za-z0-9_-]{43}$/;
 const MCP_CONNECTION_RESOURCE_PREFIX = "urn:nanocodex:mcp:";
 const MCP_FOCUS_RESOURCE_PREFIX = "urn:nanocodex:mcp-focus:";
@@ -42,6 +44,9 @@ export async function connect(client, options) {
     permission,
     visibility: agentVisibility,
   });
+  const identitySession = client.identity
+    ? await client.identity.getSession({ signal: options.signal })
+    : undefined;
   const auth = withConnectionResources(
     options.capabilities?.auth ?? client.auth,
     client.appId,
@@ -50,6 +55,7 @@ export async function connect(client, options) {
     agentVisibility,
     mcpConnections,
     focusMcpConnectionId,
+    identitySession,
   );
   const walletAuth = delegateAuthVerification(auth);
   client.dialog.showWallet?.();
@@ -211,6 +217,7 @@ function withConnectionResources(
   agentVisibility,
   mcpConnections,
   focusMcpConnectionId,
+  identitySession,
 ) {
   const configured = typeof auth === "object" && auth !== null
     ? (auth.resources ?? []).filter((resource) =>
@@ -221,7 +228,8 @@ function withConnectionResources(
       && !resource.startsWith(MCP_CONNECTION_RESOURCE_PREFIX)
       && !resource.startsWith(MCP_FOCUS_RESOURCE_PREFIX)
       && !resource.startsWith(APP_RESOURCE_PREFIX)
-      && !resource.startsWith(APP_ORIGIN_RESOURCE_PREFIX))
+      && !resource.startsWith(APP_ORIGIN_RESOURCE_PREFIX)
+      && !resource.startsWith(IDENTITY_SESSION_RESOURCE_PREFIX))
     : [];
   const visibility = Object.entries(AGENT_VISIBILITY_NAMES)
     .filter(([name]) => agentVisibility[name])
@@ -230,6 +238,9 @@ function withConnectionResources(
     ...configured,
     `${APP_RESOURCE_PREFIX}${encodeURIComponent(appId)}`,
     ...(appOrigin ? [`${APP_ORIGIN_RESOURCE_PREFIX}${encodeURIComponent(appOrigin)}`] : []),
+    ...(identitySession
+      ? [`${IDENTITY_SESSION_RESOURCE_PREFIX}${identitySessionToken(identitySession)}`]
+      : []),
     ...(requestedConnectors.length === 0
       ? []
       : [`${CONNECTORS_RESOURCE_PREFIX}${requestedConnectors.join(",")}`]),
@@ -241,6 +252,15 @@ function withConnectionResources(
   ])];
   if (typeof auth === "string") return { url: auth, resources };
   return { ...auth, resources };
+}
+
+function identitySessionToken(session) {
+  if (!session || typeof session !== "object" || !IDENTITY_SESSION_TOKEN.test(session.token)
+    || !Number.isSafeInteger(session.expiresAt)
+    || session.expiresAt <= Math.floor(Date.now() / 1_000)) {
+    throw new TypeError("Connect identity returned an invalid session");
+  }
+  return session.token;
 }
 
 function reusableAccessKeys(provider, accountAddress) {

--- a/js/bindings/cloud/index.d.mts
+++ b/js/bindings/cloud/index.d.mts
@@ -2,6 +2,7 @@ export * as Actions from "./actions/index.mjs";
 export * as Client from "./Client.mjs";
 export * as Dialog from "./Dialog.mjs";
 export * as Errors from "./Errors.mjs";
+export * as Identity from "./Identity.mjs";
 export * as Transport from "./Transport.mjs";
 export { connectActions } from "./Decorator.mjs";
 export { iframe, popup } from "./Dialog.mjs";

--- a/js/bindings/cloud/index.mjs
+++ b/js/bindings/cloud/index.mjs
@@ -2,6 +2,7 @@ export * as Actions from "./actions/index.mjs";
 export * as Client from "./Client.mjs";
 export * as Dialog from "./Dialog.mjs";
 export * as Errors from "./Errors.mjs";
+export * as Identity from "./Identity.mjs";
 export * as Transport from "./Transport.mjs";
 export { connectActions } from "./Decorator.mjs";
 export { iframe, popup } from "./Dialog.mjs";

--- a/js/bindings/cloud/server/Session.d.mts
+++ b/js/bindings/cloud/server/Session.d.mts
@@ -1,0 +1,27 @@
+export type Client = Readonly<{
+  create(options: Readonly<{
+    subject: string;
+    organization?: string | undefined;
+    expiresIn?: number | undefined;
+    signal?: AbortSignal | undefined;
+  }>): Promise<Readonly<{ token: string; expires_at: number }>>;
+  handler(options: Readonly<{
+    authenticate(request: Request): Promise<Readonly<{
+      subject: string;
+      organization?: string | undefined;
+      expiresIn?: number | undefined;
+    }> | undefined> | Readonly<{
+      subject: string;
+      organization?: string | undefined;
+      expiresIn?: number | undefined;
+    }> | undefined;
+  }>): (request: Request) => Promise<Response>;
+}>;
+
+export function create(parameters: Readonly<{
+  appId: string;
+  appOrigin: string;
+  secret: string;
+  baseUrl?: string | URL | undefined;
+  fetch?: typeof globalThis.fetch | undefined;
+}>): Client;

--- a/js/bindings/cloud/server/Session.mjs
+++ b/js/bindings/cloud/server/Session.mjs
@@ -1,0 +1,103 @@
+const APP_ID = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const SUBJECT = /^[^\u0000-\u001f\u007f]{1,512}$/;
+
+export function create(parameters) {
+  if (!parameters || typeof parameters !== "object") {
+    throw new TypeError("Session.create requires parameters");
+  }
+  if (!APP_ID.test(parameters.appId)) throw new TypeError("Session.create requires appId");
+  if (typeof parameters.secret !== "string" || !/^\S{32,512}$/.test(parameters.secret)) {
+    throw new TypeError("Session.create requires a 32 to 512 character project secret");
+  }
+  const appOrigin = publicOrigin(parameters.appOrigin);
+  const baseUrl = new URL(parameters.baseUrl ?? "https://api.nanocodex.xyz");
+  const fetchFn = parameters.fetch ?? globalThis.fetch;
+  if (typeof fetchFn !== "function") throw new TypeError("Session.create requires fetch");
+
+  const client = {
+    async create(options) {
+      if (!options || typeof options !== "object" || !SUBJECT.test(options.subject)) {
+        throw new TypeError("identity session subject must be a bounded opaque string");
+      }
+      if (options.organization !== undefined && !SUBJECT.test(options.organization)) {
+        throw new TypeError("identity session organization must be a bounded opaque string");
+      }
+      if (options.expiresIn !== undefined
+        && (!Number.isSafeInteger(options.expiresIn)
+          || options.expiresIn < 30
+          || options.expiresIn > 300)) {
+        throw new TypeError("identity session expiresIn must be between 30 and 300 seconds");
+      }
+      const response = await fetchFn(new URL("/v1/embed/sessions", baseUrl), {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          authorization: `Bearer ${parameters.secret}`,
+          "content-type": "application/json",
+          "x-nanocodex-app-id": parameters.appId,
+        },
+        body: JSON.stringify({
+          app_origin: appOrigin,
+          subject: options.subject,
+          ...(options.organization === undefined ? {} : { organization: options.organization }),
+          ...(options.expiresIn === undefined ? {} : { expires_in: options.expiresIn }),
+        }),
+        signal: options.signal,
+      });
+      const body = await response.json().catch(() => undefined);
+      if (!response.ok) {
+        throw new Error(
+          body?.error?.message ?? `Nanocodex identity session creation failed with ${response.status}.`,
+        );
+      }
+      if (!body || typeof body !== "object"
+        || !/^[A-Za-z0-9_-]{43}$/.test(body.token)
+        || !Number.isSafeInteger(body.expires_at)) {
+        throw new Error("Nanocodex returned an invalid identity session.");
+      }
+      return Object.freeze({ token: body.token, expires_at: body.expires_at });
+    },
+    handler(options) {
+      if (!options || typeof options.authenticate !== "function") {
+        throw new TypeError("identity session handler requires authenticate");
+      }
+      return async function nanocodexIdentitySession(request) {
+        if (!request || request.method !== "POST") {
+          return Response.json({ error: { message: "Method not allowed." } }, {
+            status: 405,
+            headers: { allow: "POST", "cache-control": "no-store" },
+          });
+        }
+        const origin = request.headers?.get?.("origin");
+        const fetchSite = request.headers?.get?.("sec-fetch-site");
+        if (origin !== appOrigin || (fetchSite && fetchSite !== "same-origin")) {
+          return Response.json({ error: { message: "Origin not allowed." } }, {
+            status: 403,
+            headers: { "cache-control": "no-store" },
+          });
+        }
+        const identity = await options.authenticate(request);
+        if (!identity) {
+          return Response.json({ error: { message: "Authentication required." } }, {
+            status: 401,
+            headers: { "cache-control": "no-store" },
+          });
+        }
+        const session = await client.create(identity);
+        return Response.json(session, { headers: { "cache-control": "no-store" } });
+      };
+    },
+  };
+  return Object.freeze(client);
+}
+
+function publicOrigin(value) {
+  if (typeof value !== "string") throw new TypeError("Session.create requires appOrigin");
+  const url = new URL(value);
+  const loopback = ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname.toLowerCase());
+  if (url.origin !== value || (url.protocol !== "https:" && !(url.protocol === "http:" && loopback))
+    || url.username || url.password) {
+    throw new TypeError("Session.create appOrigin must be an exact HTTPS or loopback origin");
+  }
+  return url.origin;
+}

--- a/js/bindings/cloud/server/index.d.mts
+++ b/js/bindings/cloud/server/index.d.mts
@@ -1,0 +1,1 @@
+export * as Session from "./Session.mjs";

--- a/js/bindings/cloud/server/index.mjs
+++ b/js/bindings/cloud/server/index.mjs
@@ -1,0 +1,1 @@
+export * as Session from "./Session.mjs";

--- a/js/bindings/package.json
+++ b/js/bindings/package.json
@@ -75,6 +75,14 @@
       "types": "./cloud/actions/index.d.mts",
       "import": "./cloud/actions/index.mjs"
     },
+    "./connect/identity": {
+      "types": "./cloud/Identity.d.mts",
+      "import": "./cloud/Identity.mjs"
+    },
+    "./connect/server": {
+      "types": "./cloud/server/index.d.mts",
+      "import": "./cloud/server/index.mjs"
+    },
     "./durability": {
       "types": "./runtime/durability-store.d.mts",
       "import": "./runtime/durability-store.mjs"

--- a/js/bindings/scripts/check-package.mjs
+++ b/js/bindings/scripts/check-package.mjs
@@ -26,6 +26,12 @@ const requiredFiles = [
   "cloud/Client.d.mts",
   "cloud/Dialog.mjs",
   "cloud/Dialog.d.mts",
+  "cloud/Identity.mjs",
+  "cloud/Identity.d.mts",
+  "cloud/server/index.mjs",
+  "cloud/server/index.d.mts",
+  "cloud/server/Session.mjs",
+  "cloud/server/Session.d.mts",
   "cloud/actions/index.mjs",
   "cloud/actions/index.d.mts",
   "browser/index.mjs",
@@ -125,6 +131,8 @@ export async function checkPackage(packageRoot = root) {
   assert.equal(packageJson.exports?.["./connect"]?.import, "./cloud/index.mjs");
   assert.equal(packageJson.exports?.["./connect"]?.types, "./cloud/index.d.mts");
   assert.equal(packageJson.exports?.["./connect/actions"]?.import, "./cloud/actions/index.mjs");
+  assert.equal(packageJson.exports?.["./connect/identity"]?.import, "./cloud/Identity.mjs");
+  assert.equal(packageJson.exports?.["./connect/server"]?.import, "./cloud/server/index.mjs");
   assert.equal(packageJson.exports?.["./durability"]?.import, "./runtime/durability-store.mjs");
   assert.equal(
     packageJson.exports?.["./durability/cloudflare"]?.import,

--- a/js/bindings/test/cloud-connect.test-d.mts
+++ b/js/bindings/test/cloud-connect.test-d.mts
@@ -1,9 +1,12 @@
-import { Actions, Client, Dialog, Transport, type Connection } from "nanocodex/connect";
+import { Actions, Client, Dialog, Identity, Transport, type Connection } from "nanocodex/connect";
+import { Session } from "nanocodex/connect/server";
 import { Voice } from "nanocodex/browser";
 
 const client = Client.create({
   appId: "type-probe",
+  appOrigin: "https://app.example.com",
   dialog: Dialog.memory(),
+  identity: Identity.host(),
   transport: Transport.mock(),
 });
 Dialog.popup({ target: "nanocodex-connect", features: "popup=yes" });
@@ -58,3 +61,15 @@ client.mpp.charge({
   grantId: connection.grant.id,
   origin: "https://models.example",
 });
+
+const sessions = Session.create({
+  appId: "type-probe",
+  appOrigin: "https://app.example.com",
+  secret: "project-secret-that-is-long-enough-123",
+});
+const sessionRoute: (request: Request) => Promise<Response> = sessions.handler({
+  async authenticate(request) {
+    return request.headers.has("cookie") ? { subject: "user-123" } : undefined;
+  },
+});
+void sessionRoute;

--- a/js/bindings/test/connect-identity.test.mjs
+++ b/js/bindings/test/connect-identity.test.mjs
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { Actions, Client, Dialog, Identity, Transport } from "../cloud/index.mjs";
+import { Session } from "../cloud/server/index.mjs";
+
+const token = "s".repeat(43);
+
+test("host identity reads only an opaque Nanocodex session from a same-origin route", async () => {
+  const requests = [];
+  const expiresAt = Math.floor(Date.now() / 1_000) + 120;
+  const identity = Identity.host({
+    async fetch(input, init) {
+      requests.push(new Request(input, init));
+      return Response.json({
+        token,
+        expires_at: expiresAt,
+      });
+    },
+  }).setup({ appId: "acme", appOrigin: "https://app.acme.test" });
+
+  assert.deepEqual(await identity.getSession(), {
+    token,
+    expiresAt,
+  });
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].url, "https://app.acme.test/api/nanocodex/session");
+  assert.equal(requests[0].method, "POST");
+  assert.equal(requests[0].credentials, "include");
+  assert.equal(requests[0].headers.get("x-nanocodex-app-id"), "acme");
+  assert.equal(requests[0].headers.has("authorization"), false);
+  assert.equal(await requests[0].text(), "");
+});
+
+test("host identity cannot send the application session to another origin", () => {
+  assert.throws(() => Identity.host({
+    url: "https://attacker.test/session",
+    fetch() { throw new Error("must not fetch"); },
+  }).setup({ appId: "acme", appOrigin: "https://app.acme.test" }), /same|origin/);
+});
+
+test("server helper exchanges a verified host subject without exposing the project secret", async () => {
+  const requests = [];
+  const sessions = Session.create({
+    appId: "acme",
+    appOrigin: "https://app.acme.test",
+    baseUrl: "https://connect.example",
+    secret: "project-secret-that-is-long-enough-123",
+    async fetch(input, init) {
+      requests.push(new Request(input, init));
+      return Response.json({
+        token,
+        expires_at: 1_900_000_000,
+      }, { status: 201 });
+    },
+  });
+
+  assert.deepEqual(await sessions.create({
+    subject: "auth0|user-123",
+    organization: "org_456",
+    expiresIn: 90,
+  }), { token, expires_at: 1_900_000_000 });
+  assert.equal(requests[0].url, "https://connect.example/v1/embed/sessions");
+  assert.equal(requests[0].headers.get("authorization"), "Bearer project-secret-that-is-long-enough-123");
+  assert.equal(requests[0].headers.get("x-nanocodex-app-id"), "acme");
+  assert.equal(requests[0].headers.has("origin"), false);
+  assert.deepEqual(await requests[0].json(), {
+    app_origin: "https://app.acme.test",
+    subject: "auth0|user-123",
+    organization: "org_456",
+    expires_in: 90,
+  });
+});
+
+test("server handler verifies the host login behind an exact-origin POST", async () => {
+  let authenticated = 0;
+  const sessions = Session.create({
+    appId: "acme",
+    appOrigin: "https://app.acme.test",
+    secret: "project-secret-that-is-long-enough-123",
+    async fetch() {
+      return Response.json({ token, expires_at: 1_900_000_000 }, { status: 201 });
+    },
+  });
+  const handler = sessions.handler({
+    authenticate(request) {
+      authenticated += 1;
+      assert.equal(request.headers.get("cookie"), "host-session=valid");
+      return { subject: "existing-user-123" };
+    },
+  });
+
+  const rejected = await handler(new Request("https://app.acme.test/api/nanocodex/session", {
+    method: "POST",
+    headers: { origin: "https://attacker.test", cookie: "host-session=valid" },
+  }));
+  assert.equal(rejected.status, 403);
+  assert.equal(authenticated, 0);
+
+  const accepted = await handler(new Request("https://app.acme.test/api/nanocodex/session", {
+    method: "POST",
+    headers: {
+      origin: "https://app.acme.test",
+      "sec-fetch-site": "same-origin",
+      cookie: "host-session=valid",
+    },
+  }));
+  assert.equal(accepted.status, 200);
+  assert.equal(accepted.headers.get("cache-control"), "no-store");
+  assert.deepEqual(await accepted.json(), { token, expires_at: 1_900_000_000 });
+  assert.equal(authenticated, 1);
+});
+
+test("Connect signs the opaque host session and replaces injected identity resources", async () => {
+  const captured = [];
+  const expiry = Math.floor(Date.now() / 1_000) + 120;
+  const client = Client.create({
+    appId: "acme",
+    appOrigin: "https://app.acme.test",
+    dialog: Dialog.memory(),
+    identity: Identity.custom({
+      async getSession() {
+        return { token, expires_at: expiry };
+      },
+    }),
+    provider: {
+      async request(request) {
+        captured.push(request);
+        throw new Error("stop after signed request capture");
+      },
+    },
+    transport: Transport.mock({ appName: "Acme" }),
+  });
+
+  await assert.rejects(Actions.connection.connect(client, {
+    capabilities: {
+      auth: {
+        resources: [
+          `urn:nanocodex:identity-session:${"x".repeat(43)}`,
+          "documents",
+        ],
+      },
+      cloudAccounts: { github: true },
+    },
+  }), /signed request capture/);
+
+  const resources = captured[0].params[0].capabilities.auth.resources;
+  assert.ok(resources.includes(`urn:nanocodex:identity-session:${token}`));
+  assert.equal(resources.some((resource) => resource.includes("x".repeat(43))), false);
+  assert.ok(resources.includes("urn:nanocodex:connectors:github"));
+  assert.ok(resources.includes("urn:nanocodex:app:acme"));
+  assert.ok(resources.includes("urn:nanocodex:origin:https%3A%2F%2Fapp.acme.test"));
+});

--- a/services/connect-api/src/embedIdentity.d.mts
+++ b/services/connect-api/src/embedIdentity.d.mts
@@ -1,0 +1,32 @@
+export const identitySessionResourcePrefix: "urn:nanocodex:identity-session:";
+
+export type EmbedProject = Readonly<{
+  appId: string;
+  appOrigin: string;
+  secretSha256: string;
+}>;
+
+export type EmbedIdentity = Readonly<{
+  appId: string;
+  appOrigin: string;
+  issuer: string;
+  subject: string;
+  organization?: string | undefined;
+}>;
+
+export function parseEmbedProjects(encoded: string | undefined): readonly EmbedProject[];
+export function authenticateEmbedProject(encoded: string | undefined, parameters: Readonly<{
+  appId: string;
+  appOrigin: string;
+  secret: string;
+}>): Promise<EmbedProject | undefined>;
+export function parseEmbedSessionBody(value: unknown): Readonly<{
+  appOrigin: string;
+  expiresIn: number;
+  subject: string;
+  organization?: string | undefined;
+}>;
+export function identitySessionToken(resources: unknown): string | undefined;
+export function embedPrincipalId(identity: EmbedIdentity): Promise<string>;
+export function isEmbedIdentity(value: unknown): value is EmbedIdentity;
+export function sha256Base64Url(value: string): Promise<string>;

--- a/services/connect-api/src/embedIdentity.mjs
+++ b/services/connect-api/src/embedIdentity.mjs
@@ -1,0 +1,138 @@
+export const identitySessionResourcePrefix = "urn:nanocodex:identity-session:";
+
+const appIdPattern = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
+const secretDigestPattern = /^[A-Za-z0-9_-]{43}$/;
+const subjectPattern = /^[^\u0000-\u001f\u007f]{1,512}$/;
+const tokenPattern = /^[A-Za-z0-9_-]{43}$/;
+
+export function parseEmbedProjects(encoded) {
+  if (encoded === undefined || encoded === "") return Object.freeze([]);
+  let value;
+  try {
+    value = JSON.parse(encoded);
+  } catch {
+    throw new Error("NANOCODEX_EMBED_PROJECTS must be valid JSON.");
+  }
+  if (!Array.isArray(value) || value.length > 128) {
+    throw new Error("NANOCODEX_EMBED_PROJECTS must be a bounded array.");
+  }
+  const identities = new Set();
+  return Object.freeze(value.map((entry) => {
+    if (!isRecord(entry)
+      || Object.keys(entry).some((key) => !["app_id", "app_origin", "secret_sha256"].includes(key))
+      || !appIdPattern.test(entry.app_id)
+      || !secretDigestPattern.test(entry.secret_sha256)) {
+      throw new Error("NANOCODEX_EMBED_PROJECTS contains an invalid project.");
+    }
+    const appOrigin = publicOrigin(entry.app_origin);
+    const identity = `${entry.app_id}\u0000${appOrigin}`;
+    if (identities.has(identity)) {
+      throw new Error("NANOCODEX_EMBED_PROJECTS contains a duplicate app and origin.");
+    }
+    identities.add(identity);
+    return Object.freeze({
+      appId: entry.app_id,
+      appOrigin,
+      secretSha256: entry.secret_sha256,
+    });
+  }));
+}
+
+export async function authenticateEmbedProject(encoded, parameters) {
+  if (!parameters || !appIdPattern.test(parameters.appId)
+    || typeof parameters.secret !== "string" || !/^\S{32,512}$/.test(parameters.secret)) return undefined;
+  let appOrigin;
+  try { appOrigin = publicOrigin(parameters.appOrigin); } catch { return undefined; }
+  const project = parseEmbedProjects(encoded).find((candidate) => (
+    candidate.appId === parameters.appId && candidate.appOrigin === appOrigin
+  ));
+  if (!project) return undefined;
+  const actual = await sha256Base64Url(parameters.secret);
+  return constantTimeEqual(actual, project.secretSha256) ? project : undefined;
+}
+
+export function parseEmbedSessionBody(value) {
+  if (!isRecord(value)
+    || Object.keys(value).some((key) => !["app_origin", "expires_in", "organization", "subject"].includes(key))
+    || !subjectPattern.test(value.subject)
+    || (value.organization !== undefined && !subjectPattern.test(value.organization))) {
+    throw new Error("The embedded identity session is invalid.");
+  }
+  const expiresIn = value.expires_in ?? 300;
+  if (!Number.isSafeInteger(expiresIn) || expiresIn < 30 || expiresIn > 300) {
+    throw new Error("The embedded identity session expiry is invalid.");
+  }
+  return Object.freeze({
+    appOrigin: publicOrigin(value.app_origin),
+    expiresIn,
+    subject: value.subject,
+    ...(value.organization === undefined ? {} : { organization: value.organization }),
+  });
+}
+
+export function identitySessionToken(resources) {
+  if (!Array.isArray(resources)) throw new Error("Connect resources are invalid.");
+  const tokens = resources.flatMap((resource) => (
+    typeof resource === "string" && resource.startsWith(identitySessionResourcePrefix)
+      ? [resource.slice(identitySessionResourcePrefix.length)]
+      : []
+  ));
+  if (tokens.length === 0) return undefined;
+  if (tokens.length !== 1 || !tokenPattern.test(tokens[0])) {
+    throw new Error("The embedded identity session resource is invalid.");
+  }
+  return tokens[0];
+}
+
+export async function embedPrincipalId(identity) {
+  if (!isEmbedIdentity(identity)) throw new Error("The embedded identity is invalid.");
+  return sha256Base64Url(`${identity.appId}\u0000${identity.issuer}\u0000${identity.subject}`);
+}
+
+export function isEmbedIdentity(value) {
+  return isRecord(value)
+    && appIdPattern.test(value.appId)
+    && publicOriginOrFalse(value.appOrigin)
+    && typeof value.issuer === "string"
+    && value.issuer === `urn:nanocodex:app:${value.appId}`
+    && subjectPattern.test(value.subject)
+    && (value.organization === undefined || subjectPattern.test(value.organization));
+}
+
+export async function sha256Base64Url(value) {
+  const digest = new Uint8Array(await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  ));
+  let binary = "";
+  for (const byte of digest) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function constantTimeEqual(left, right) {
+  if (typeof left !== "string" || typeof right !== "string" || left.length !== right.length) return false;
+  let difference = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    difference |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+  return difference === 0;
+}
+
+function publicOrigin(value) {
+  if (typeof value !== "string") throw new Error("The embedded app origin is invalid.");
+  const url = new URL(value);
+  const loopback = ["localhost", "127.0.0.1", "[::1]"].includes(url.hostname.toLowerCase());
+  if (url.origin !== value || (url.protocol !== "https:" && !(url.protocol === "http:" && loopback))
+    || url.username || url.password) {
+    throw new Error("The embedded app origin is invalid.");
+  }
+  return url.origin;
+}
+
+function publicOriginOrFalse(value) {
+  try { return publicOrigin(value) === value; } catch { return false; }
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/services/connect-api/src/index.ts
+++ b/services/connect-api/src/index.ts
@@ -41,6 +41,14 @@ import {
   managedGrantHeaders,
   type ManagedGrantAssertion,
 } from "./managedGrant.mjs";
+import {
+  authenticateEmbedProject,
+  embedPrincipalId,
+  identitySessionToken,
+  isEmbedIdentity,
+  parseEmbedSessionBody,
+  type EmbedIdentity,
+} from "./embedIdentity.mjs";
 
 type WorkerWebSocket = WebSocket & { accept(): void };
 declare const WebSocketPair: {
@@ -143,6 +151,7 @@ const MAX_PINNED_RUNTIME_RESPONSE_BYTES = 32 * 1024 * 1024;
 const MAX_ACCOUNT_AUTHORIZATIONS = 64;
 const MAX_DEVICE_REGISTER_BYTES = 64 * 1024;
 const MAX_CONNECTION_REQUEST_BYTES = 128 * 1024;
+const MAX_EMBED_SESSION_REQUEST_BYTES = 4 * 1024;
 const MAX_CHATGPT_IMPORT_BODY_BYTES = 64 * 1024;
 const EGRESS_SUBJECT = /^[A-Za-z0-9_-]{43,128}$/;
 const CONNECTOR_METHODS = new Set(["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]);
@@ -243,6 +252,7 @@ type ConnectApproval = Readonly<{
   profileLinked?: boolean;
   resources: readonly string[];
   authorization: "signed" | "hosted";
+  externalPrincipalId?: string;
 }>;
 type Fetcher = Readonly<{
   fetch(request: Request): Promise<Response>;
@@ -266,6 +276,7 @@ type Env = Readonly<{
   EGRESS: Fetcher;
   NANOCODEX: Fetcher;
   NANOCODEX_LOCAL_OAUTH_RELAY_HMAC_KEY?: string;
+  NANOCODEX_EMBED_PROJECTS?: string;
   DEPLOYMENT_SHA?: string;
 }>;
 
@@ -287,6 +298,12 @@ type GrantRecord = Readonly<{
   egressSubject: string;
   settlementBalanceAtomics?: string;
   sharedEgressSubject?: boolean;
+  externalPrincipalId?: string;
+}>;
+type EmbedIdentitySession = EmbedIdentity & Readonly<{ expiresAt: number }>;
+type EmbedIdentityBinding = Readonly<{
+  brokerUserId: string;
+  principalId: string;
 }>;
 type HostedBrowserSession = Readonly<{
   accountAddress: `0x${string}`;
@@ -297,6 +314,7 @@ type GrantPrincipal = Readonly<{
   appId: string;
   appOrigin: string;
   grantId: `0x${string}`;
+  externalPrincipalId?: string;
 }>;
 type ConnectAgentRecord = Readonly<{ agentId: string }>;
 type ConnectIdentityRecord = Readonly<{
@@ -345,6 +363,10 @@ export default {
     try {
       const url = new URL(request.url);
       const store = Kv.durableObject(env.CONNECT_STATE);
+
+      if (request.method === "POST" && url.pathname === "/v1/embed/sessions") {
+        return cors(await createEmbedIdentitySession(request, env, store), request);
+      }
 
       if (url.pathname.startsWith("/v1/device/")) {
         if (request.method === "POST" && url.pathname === "/v1/device/register") {
@@ -881,6 +903,63 @@ function isMcpIntent(value: unknown): value is McpIntent {
     && Number.isSafeInteger(value.expiresAt);
 }
 
+async function createEmbedIdentitySession(
+  request: Request,
+  env: Env,
+  store: Kv.Kv,
+): Promise<Response> {
+  if (request.headers.has("origin")) {
+    throw new ApiFailure(
+      403,
+      "embed_session_server_required",
+      "Embedded identity sessions must be minted by the application server.",
+    );
+  }
+  const appId = request.headers.get("x-nanocodex-app-id");
+  const secret = request.headers.get("authorization")?.match(/^Bearer ([^\s]{32,512})$/)?.[1];
+  let body: ReturnType<typeof parseEmbedSessionBody>;
+  try {
+    body = parseEmbedSessionBody(await boundedJson(
+      request,
+      MAX_EMBED_SESSION_REQUEST_BYTES,
+      "embedded identity session",
+    ));
+  } catch (cause) {
+    if (cause instanceof ApiFailure) throw cause;
+    throw new ApiFailure(400, "invalid_embed_session", errorText(cause));
+  }
+  const project = appId && secret
+    ? await authenticateEmbedProject(env.NANOCODEX_EMBED_PROJECTS, {
+        appId,
+        appOrigin: body.appOrigin,
+        secret,
+      })
+    : undefined;
+  if (!project) {
+    throw new ApiFailure(401, "invalid_embed_project", "The Nanocodex embed project is not authorized.");
+  }
+  if (!store.create) {
+    throw new ApiFailure(503, "embed_session_unavailable", "Atomic embedded identity sessions are unavailable.");
+  }
+  const token = randomSubject();
+  const expiresAt = Math.floor(Date.now() / 1_000) + body.expiresIn;
+  const identity: EmbedIdentitySession = {
+    appId: project.appId,
+    appOrigin: project.appOrigin,
+    issuer: `urn:nanocodex:app:${project.appId}`,
+    subject: body.subject,
+    ...(body.organization === undefined ? {} : { organization: body.organization }),
+    expiresAt,
+  };
+  if (!await store.create(`embed-session:${token}`, identity, { ttl: body.expiresIn })) {
+    throw new ApiFailure(503, "embed_session_conflict", "The embedded identity session could not be reserved.");
+  }
+  return Response.json({ token, expires_at: expiresAt }, {
+    status: 201,
+    headers: { "cache-control": "no-store" },
+  });
+}
+
 async function createHostedAuthorization(
   request: Request,
   env: Env,
@@ -1200,6 +1279,10 @@ async function createConnection(
   if (!identity.linked) {
     throw new ApiFailure(403, "account_link_required", "Link this Tempo account to your Nanocodex profile before authorizing a durable agent.");
   }
+  const externalPrincipalId = approval.externalPrincipalId
+    ? await bindEmbedPrincipal(store, approval.externalPrincipalId, identity.userId)
+    : undefined;
+  if (externalPrincipalId) mark("external-identity");
   const credential = await connectionCredential(
     store,
     body,
@@ -1242,6 +1325,7 @@ async function createConnection(
   const grantId = await digestHex(`grant:${randomSubject()}`);
   const grantCapabilities = [
     "nanocodex.agent",
+    ...(externalPrincipalId ? ["identity.external"] : []),
     ...approvedHostedCapabilities(approval.resources),
     ...agentCapabilities,
     ...connectors,
@@ -1280,6 +1364,7 @@ async function createConnection(
     spentAtomics: "0",
     egressSubject,
     sharedEgressSubject: true,
+    ...(externalPrincipalId ? { externalPrincipalId } : {}),
   };
 
   try {
@@ -1296,6 +1381,7 @@ async function createConnection(
         appId,
         appOrigin: app.origin,
         grantId: grant.id,
+        ...(externalPrincipalId ? { externalPrincipalId } : {}),
       } satisfies GrantPrincipal, { ttl: grantTtl }),
       ...(persist && accessKey ? [store.set(accessKeyStorageKey(accountAddress, accessKey.key_id), {
         accountAddress,
@@ -1840,6 +1926,49 @@ function isConnectIdentityRecord(
     && typeof value.accountAddress === "string"
     && value.accountAddress.toLowerCase() === accountAddress.toLowerCase()
     && isBrokerUserId(value.brokerUserId);
+}
+
+async function bindEmbedPrincipal(
+  store: Kv.Kv,
+  principalId: string,
+  brokerUserId: string,
+): Promise<string> {
+  if (!/^[A-Za-z0-9_-]{43}$/.test(principalId) || !isBrokerUserId(brokerUserId) || !store.create) {
+    throw new ApiFailure(503, "embed_identity_unavailable", "Atomic embedded identity linking is unavailable.");
+  }
+  const key = `embed-identity:${principalId}`;
+  const retained = await store.get<unknown>(key);
+  if (isEmbedIdentityBinding(retained, principalId)) {
+    if (retained.brokerUserId !== brokerUserId) {
+      throw new ApiFailure(
+        409,
+        "embed_identity_conflict",
+        "This application identity is already linked to another Nanocodex profile.",
+      );
+    }
+    return retained.principalId;
+  }
+  const candidate: EmbedIdentityBinding = { brokerUserId, principalId };
+  if (await store.create(key, candidate)) return principalId;
+  const winner = await store.get<unknown>(key);
+  if (!isEmbedIdentityBinding(winner, principalId) || winner.brokerUserId !== brokerUserId) {
+    throw new ApiFailure(
+      409,
+      "embed_identity_conflict",
+      "This application identity is already linked to another Nanocodex profile.",
+    );
+  }
+  return winner.principalId;
+}
+
+function isEmbedIdentityBinding(
+  value: unknown,
+  principalId: string,
+): value is EmbedIdentityBinding {
+  return isRecord(value)
+    && isBrokerUserId(value.brokerUserId)
+    && value.principalId === principalId
+    && /^[A-Za-z0-9_-]{43}$/.test(value.principalId);
 }
 
 async function connectEgressSubject(
@@ -3047,6 +3176,7 @@ async function authenticatedGrant(
     || grant.id.toLowerCase() !== principal.grantId.toLowerCase()
     || grant.appId !== principal.appId
     || grant.appOrigin !== principal.appOrigin
+    || grant.externalPrincipalId !== principal.externalPrincipalId
     || grant.accountAddress.toLowerCase() !== principal.accountAddress.toLowerCase()) {
     throw new ApiFailure(401, "invalid_grant_token", "The grant session is not bound to this grant, app, and account.");
   }
@@ -3065,7 +3195,9 @@ function isGrantPrincipal(value: unknown): value is GrantPrincipal {
     && validAppId(value.appId)
     && isPublicAppOrigin(value.appOrigin)
     && /^0x[0-9a-fA-F]{40}$/.test(String(value.accountAddress))
-    && /^0x[0-9a-fA-F]{64}$/.test(String(value.grantId));
+    && /^0x[0-9a-fA-F]{64}$/.test(String(value.grantId))
+    && (value.externalPrincipalId === undefined
+      || /^[A-Za-z0-9_-]{43}$/.test(String(value.externalPrincipalId)));
 }
 
 function isGrantRecord(value: unknown): value is GrantRecord {
@@ -3093,6 +3225,8 @@ function isGrantRecord(value: unknown): value is GrantRecord {
     && (value.balanceAtomics === undefined || /^\d+$/.test(String(value.balanceAtomics)))
     && typeof value.spentAtomics === "string"
     && typeof value.egressSubject === "string"
+    && (value.externalPrincipalId === undefined
+      || /^[A-Za-z0-9_-]{43}$/.test(String(value.externalPrincipalId)))
     && (value.settlementBalanceAtomics === undefined || /^\d+$/.test(String(value.settlementBalanceAtomics)))
     && (value.sharedEgressSubject === undefined || typeof value.sharedEgressSubject === "boolean");
 }
@@ -4352,6 +4486,10 @@ function createAuth(
       const approvalId = randomSubject();
       const resources = siweResources(message);
       const app = approvedAppContext(resources);
+      const externalIdentity = await takeEmbedIdentitySession(store, resources, app);
+      const externalPrincipalId = externalIdentity
+        ? await embedPrincipalId(externalIdentity)
+        : undefined;
       let connectorsDuration = 0;
       const identity = await connectBrokerIdentity(env, store, accountAddress);
       mark("identity");
@@ -4373,6 +4511,7 @@ function createAuth(
         connectedConnectors,
         mcpConnections,
         ...(context.keyAuthorization ? { keyAuthorization: context.keyAuthorization } : {}),
+        ...(externalPrincipalId ? { externalPrincipalId } : {}),
         profileLinked: identity.linked,
         resources,
       } satisfies ConnectApproval, { ttl: CONNECT_APPROVAL_TTL });
@@ -4422,6 +4561,42 @@ async function authRequestContext(request: Request, url: URL): Promise<AuthReque
       ? { keyAuthorization: keyAuthorization as `0x${string}` }
       : {}),
   };
+}
+
+async function takeEmbedIdentitySession(
+  store: Kv.Kv,
+  resources: readonly string[],
+  app: CallerApp,
+): Promise<EmbedIdentity | undefined> {
+  let token: string | undefined;
+  try {
+    token = identitySessionToken(resources);
+  } catch (cause) {
+    throw new ApiFailure(403, "invalid_embed_session", errorText(cause));
+  }
+  if (!token) return undefined;
+  if (!store.take) {
+    throw new ApiFailure(503, "embed_session_unavailable", "One-time embedded identity sessions are unavailable.");
+  }
+  const session = await store.take<EmbedIdentitySession>(`embed-session:${token}`);
+  if (!isEmbedIdentitySession(session)
+    || session.expiresAt <= Math.floor(Date.now() / 1_000)
+    || session.appId !== app.appId
+    || session.appOrigin !== app.origin) {
+    throw new ApiFailure(403, "invalid_embed_session", "The embedded identity session is invalid or expired.");
+  }
+  return {
+    appId: session.appId,
+    appOrigin: session.appOrigin,
+    issuer: session.issuer,
+    subject: session.subject,
+    ...(session.organization === undefined ? {} : { organization: session.organization }),
+  };
+}
+
+function isEmbedIdentitySession(value: unknown): value is EmbedIdentitySession {
+  if (!isRecord(value) || !Number.isSafeInteger(value.expiresAt)) return false;
+  return isEmbedIdentity(value);
 }
 
 async function takeConnectApproval(
@@ -4474,6 +4649,8 @@ function isConnectApproval(value: unknown): value is ConnectApproval {
     && value.resources.every((resource) => typeof resource === "string")
     && (value.authorization === "signed" || value.authorization === "hosted")
     && (value.profileLinked === undefined || typeof value.profileLinked === "boolean")
+    && (value.externalPrincipalId === undefined
+      || /^[A-Za-z0-9_-]{43}$/.test(String(value.externalPrincipalId)))
     && (value.keyAuthorization === undefined
       || (typeof value.keyAuthorization === "string" && /^0x[0-9a-fA-F]+$/.test(value.keyAuthorization)));
 }

--- a/services/connect-api/test/embedIdentity.test.mjs
+++ b/services/connect-api/test/embedIdentity.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  authenticateEmbedProject,
+  embedPrincipalId,
+  identitySessionToken,
+  parseEmbedProjects,
+  parseEmbedSessionBody,
+  sha256Base64Url,
+} from "../src/embedIdentity.mjs";
+
+const secret = "project-secret-that-is-long-enough-123";
+const app = {
+  appId: "acme",
+  appOrigin: "https://app.acme.test",
+};
+
+async function projects() {
+  return JSON.stringify([{
+    app_id: app.appId,
+    app_origin: app.appOrigin,
+    secret_sha256: await sha256Base64Url(secret),
+  }]);
+}
+
+test("embed project configuration authenticates an exact app, origin, and secret", async () => {
+  const encoded = await projects();
+  assert.deepEqual(parseEmbedProjects(encoded), [{
+    ...app,
+    secretSha256: await sha256Base64Url(secret),
+  }]);
+  assert.deepEqual(await authenticateEmbedProject(encoded, { ...app, secret }), {
+    ...app,
+    secretSha256: await sha256Base64Url(secret),
+  });
+  assert.equal(await authenticateEmbedProject(encoded, { ...app, secret: `${secret}x` }), undefined);
+  assert.equal(await authenticateEmbedProject(encoded, {
+    ...app,
+    appOrigin: "https://other.acme.test",
+    secret,
+  }), undefined);
+});
+
+test("embed session request is strict, short lived, and opaque", () => {
+  assert.deepEqual(parseEmbedSessionBody({
+    app_origin: app.appOrigin,
+    subject: "better-auth-user-id",
+    organization: "tenant-7",
+    expires_in: 60,
+  }), {
+    appOrigin: app.appOrigin,
+    subject: "better-auth-user-id",
+    organization: "tenant-7",
+    expiresIn: 60,
+  });
+  assert.throws(() => parseEmbedSessionBody({
+    app_origin: app.appOrigin,
+    subject: "user",
+    provider_access_token: "must-never-cross-this-boundary",
+  }), /invalid/);
+  assert.throws(() => parseEmbedSessionBody({
+    app_origin: app.appOrigin,
+    subject: "user",
+    expires_in: 301,
+  }), /expiry/);
+});
+
+test("Connect accepts exactly one well-formed embedded session resource", () => {
+  const token = "s".repeat(43);
+  assert.equal(identitySessionToken(["documents", `urn:nanocodex:identity-session:${token}`]), token);
+  assert.equal(identitySessionToken(["documents"]), undefined);
+  assert.throws(() => identitySessionToken([
+    `urn:nanocodex:identity-session:${token}`,
+    `urn:nanocodex:identity-session:${"t".repeat(43)}`,
+  ]), /invalid/);
+});
+
+test("external principal IDs are stable within an app and unlinkable across apps", async () => {
+  const base = {
+    appId: app.appId,
+    appOrigin: app.appOrigin,
+    issuer: `urn:nanocodex:app:${app.appId}`,
+    subject: "privy-user-id",
+  };
+  assert.equal(await embedPrincipalId(base), await embedPrincipalId(base));
+  assert.notEqual(await embedPrincipalId(base), await embedPrincipalId({
+    ...base,
+    appId: "other-app",
+    issuer: "urn:nanocodex:app:other-app",
+  }));
+});
+
+test("embed project configuration rejects duplicates and non-HTTPS origins", async () => {
+  const entry = {
+    app_id: app.appId,
+    app_origin: app.appOrigin,
+    secret_sha256: await sha256Base64Url(secret),
+  };
+  assert.throws(() => parseEmbedProjects(JSON.stringify([entry, entry])), /duplicate/);
+  assert.throws(() => parseEmbedProjects(JSON.stringify([{ ...entry, app_origin: "http://app.acme.test" }])), /origin/);
+  assert.doesNotThrow(() => parseEmbedProjects(JSON.stringify([{
+    ...entry,
+    app_origin: "http://localhost:5190",
+  }])));
+});

--- a/web/docs/src/pages/sdks/javascript.mdx
+++ b/web/docs/src/pages/sdks/javascript.mdx
@@ -49,6 +49,7 @@ materialization or historical fork.
 - [Install the right entrypoint](/sdks/javascript/install-entrypoints).
 - [Own turns, events, and cleanup](/sdks/javascript/agent-lifecycle).
 - [Choose authentication and socket routing](/sdks/javascript/transports-auth).
+- [Add Connect to an existing login](/sdks/javascript/connect-existing-auth).
 - [Build a browser Worker and persistent workspace](/sdks/javascript/browser-workspace).
 - [Own a browser Worker from React](/sdks/javascript/react).
 - [Add tools, Code Mode, and Rust-backed subagents](/sdks/javascript/tools-code-mode-subagents).

--- a/web/docs/src/pages/sdks/javascript/connect-existing-auth.mdx
+++ b/web/docs/src/pages/sdks/javascript/connect-existing-auth.mdx
@@ -1,0 +1,152 @@
+---
+title: Connect with existing authentication
+description: Add Nanocodex connectors to an Auth0, Better Auth, Privy, or custom-authenticated site without replacing its login.
+---
+
+# Connect with existing authentication
+
+Keep the application's login. Nanocodex Connect adds connector approval and a
+grant-scoped agent session; it does not need to become the site's identity
+provider.
+
+The bridge is deliberately small:
+
+1. The browser calls an application-owned, same-origin session route.
+2. That route verifies the application's existing cookie or access token.
+3. The application server exchanges only its stable user ID for a short-lived,
+   one-time Nanocodex identity session.
+4. Connect includes that opaque session in the passkey-signed connector
+   approval and binds the resulting grant to the application user.
+
+Auth0, Better Auth, or Privy credentials never go to the Connect iframe. The
+Nanocodex project secret never goes to the browser.
+
+## Add the browser adapter
+
+```js
+import { Client, Identity } from "nanocodex/connect";
+
+export const connect = Client.create({
+  appId: "acme",
+  identity: Identity.host(),
+});
+
+const connection = await connect.connect({
+  capabilities: {
+    cloudAccounts: { github: true, gmail: true },
+  },
+});
+```
+
+`Identity.host()` posts to `/api/nanocodex/session` with the site's normal
+same-origin credentials. A different same-origin path can be passed as
+`Identity.host({ url: "/api/agent/session" })`.
+
+## Add the server route
+
+```js
+import { Session } from "nanocodex/connect/server";
+
+const sessions = Session.create({
+  appId: "acme",
+  appOrigin: "https://app.example.com",
+  secret: process.env.NANOCODEX_PROJECT_SECRET,
+});
+
+export const POST = sessions.handler({
+  async authenticate(request) {
+    const user = await authenticateWithYourExistingSystem(request);
+    if (!user) return undefined;
+    return {
+      subject: user.id,
+      organization: user.organizationId,
+    };
+  },
+});
+```
+
+The handler accepts only an exact-origin `POST`, returns `401` when the host
+session is absent, and emits only `{ token, expires_at }`. `subject` must be a
+stable, opaque ID. Do not use email addresses, display names, provider tokens,
+or wallet addresses as the subject.
+
+## Auth0
+
+In a Next.js App Router route, use the Auth0 server session you already have:
+
+```js
+export const POST = sessions.handler({
+  async authenticate() {
+    const session = await auth0.getSession();
+    if (!session) return undefined;
+    return {
+      subject: session.user.sub,
+      organization: session.user.org_id,
+    };
+  },
+});
+```
+
+## Better Auth
+
+Pass the incoming headers to the Better Auth server API:
+
+```js
+export const POST = sessions.handler({
+  async authenticate(request) {
+    const session = await auth.api.getSession({ headers: request.headers });
+    if (!session) return undefined;
+    return { subject: session.user.id };
+  },
+});
+```
+
+## Privy
+
+Verify the Privy access token on the server, then use the returned Privy DID:
+
+```js
+export const POST = sessions.handler({
+  async authenticate(request) {
+    const accessToken = readPrivyTokenFromRequest(request);
+    if (!accessToken) return undefined;
+    const claims = await privy.verifyAuthToken(accessToken);
+    return { subject: claims.userId };
+  },
+});
+```
+
+Use the provider's server SDK and your existing cookie/header policy to obtain
+and verify the token. Never return that token to the browser route.
+
+## Configure the Connect service
+
+Each application and exact production origin has a project secret. Loopback
+HTTP origins are also accepted for local development. Store only
+its SHA-256 base64url digest in the Connect service's
+`NANOCODEX_EMBED_PROJECTS` secret:
+
+```json
+[
+  {
+    "app_id": "acme",
+    "app_origin": "https://app.example.com",
+    "secret_sha256": "base64url-sha256-of-the-project-secret"
+  }
+]
+```
+
+Keep the original project secret only in the application server's secret
+manager. Sessions live for 30 to 300 seconds, are consumed once by Connect,
+and are bound to the exact `app_id` and origin.
+
+## Where OIDC fits
+
+OIDC is an optional way to standardize the server-side `authenticate` step. An
+OIDC adapter can verify the issuer, audience, signature, expiry, and nonce, then
+use the verified `sub` to mint the same opaque Nanocodex session. It should not
+replace the bridge or forward an ID/access token into the browser approval.
+
+Start with the native server SDK for the auth system already installed. Add an
+OIDC adapter when supporting many compatible issuers makes that operationally
+simpler.

--- a/web/src/docsNavigation.ts
+++ b/web/src/docsNavigation.ts
@@ -54,6 +54,7 @@ export const docsNavigation: readonly DocsNavigationGroup[] = [
           page("Install from npm", "/docs/sdks/javascript/install-entrypoints"),
           page("Agent lifecycle", "/docs/sdks/javascript/agent-lifecycle"),
           page("Transports and auth", "/docs/sdks/javascript/transports-auth"),
+          page("Connect with existing auth", "/docs/sdks/javascript/connect-existing-auth"),
           page("Browser WASM and workspace", "/docs/sdks/javascript/browser-workspace"),
           page("React", "/docs/sdks/javascript/react"),
         ],


### PR DESCRIPTION
## Summary

- add a server-side `Session.handler` boundary that exchanges a verified host identity for a short-lived, opaque Nanocodex session
- add a same-origin browser identity adapter so Connect keeps owning connector grants while Auth0, Better Auth, Privy, or another host system remains the primary login
- bind sessions to the configured app and origin, keep project secrets and provider tokens server-side, and derive unlinkable per-app principals
- add runnable Auth0, Better Auth, and Privy integrations under `examples/connect-existing-auth`
- document the architecture and public JavaScript API

## Tested

- `node --test js/bindings/test/connect-identity.test.mjs` — 5 passed
- `node --test services/connect-api/test/embedIdentity.test.mjs` — 5 passed
- `npm test` in `examples/connect-existing-auth` — 5 passed
- interactive reference site: https://nanocodex-auth-integrations.gakonst-consulting.chatgpt.site

The hosted examples simulate the upstream provider session because tenant credentials are deployment-specific; the server adapters in this PR use each provider's real session-verification interface and are covered by contract tests.